### PR TITLE
KEYCLOAK-74 email verification fixes

### DIFF
--- a/forms/src/main/resources/META-INF/resources/forms/theme/default/css/login-register.css
+++ b/forms/src/main/resources/META-INF/resources/forms/theme/default/css/login-register.css
@@ -330,6 +330,12 @@ a.zocial:before {
     text-align: right;
 }
 
+.rcue-login-register .background-area p.instruction {
+    font-size: 1.3em;
+    line-height: 1.3em;
+    margin-bottom: 1.53846em;
+}
+
 .rcue-login-register .background-area p.instruction.instruction.second {
     color: #999999;
 }

--- a/forms/src/main/resources/META-INF/resources/forms/theme/default/login-verify-email.ftl
+++ b/forms/src/main/resources/META-INF/resources/forms/theme/default/login-verify-email.ftl
@@ -1,24 +1,25 @@
 <#import "template-login-action.ftl" as layout>
-<@layout.registrationLayout bodyClass=""; section>
+<@layout.registrationLayout bodyClass="reset"; section>
     <#if section = "title">
 
-    Verify email
+    Email verification
 
     <#elseif section = "header">
 
-    Verify email
+    Email verification
 
     <#elseif section = "form">
 
-    <div id="form">
-    	An email with instructions to verify your email address has been sent to you. If you don't receive this email, 
-    	<a href="${url.emailVerificationUrl}">click here</a> to re-send the email.
+    <div class="app-form">
+        <p class="instruction">
+            Your account is not enabled. An email with instructions to verify your email address has been sent to you.
+        </p>
+        <p class="instruction">Haven't received a verification code in your email?
+            <a href="${url.emailVerificationUrl}">Click here</a> to re-send the email.
+        </p>
     </div>
 
     <#elseif section = "info" >
-
-    <div id="info">
-    </div>
 
     </#if>
 </@layout.registrationLayout>

--- a/services/src/main/java/org/keycloak/services/email/EmailSender.java
+++ b/services/src/main/java/org/keycloak/services/email/EmailSender.java
@@ -85,9 +85,15 @@ public class EmailSender {
         URI uri = builder.build(realm.getId());
 
         StringBuilder sb = new StringBuilder();
+        sb.append("Hi ").append(user.getFirstName()).append(",\n\n");
+        sb.append("Someone has created a Keycloak account with this email address. ");
+        sb.append("If this was you, click the link below to verify your email address:\n");
         sb.append(uri.toString());
-        sb.append("\n");
-        sb.append("Expires in " + TimeUnit.SECONDS.toMinutes(realm.getAccessCodeLifespanUserAction()));
+        sb.append("\n\nThis link will expire within ").append(TimeUnit.SECONDS.toMinutes(realm.getAccessCodeLifespanUserAction()));
+        sb.append(" minutes.\n\n");
+        sb.append("If you didn't create this account, just ignore this message.\n\n");
+        sb.append("Thanks,\n");
+        sb.append("The Keycloak Team");
 
         try {
             send(user.getEmail(), "Verify email", sb.toString());

--- a/services/src/main/java/org/keycloak/services/resources/AccountService.java
+++ b/services/src/main/java/org/keycloak/services/resources/AccountService.java
@@ -281,8 +281,6 @@ public class AccountService {
                 return Response.status(Status.FORBIDDEN).build();
             }
 
-            new EmailSender().sendEmailVerification(user, realm, accessCode, uriInfo);
-
             return Flows.forms(realm, request, uriInfo).setAccessCode(accessCode).setUser(user)
                     .forwardToAction(RequiredAction.VERIFY_EMAIL);
         }

--- a/testsuite/src/test/java/org/keycloak/testsuite/pages/VerifyEmailPage.java
+++ b/testsuite/src/test/java/org/keycloak/testsuite/pages/VerifyEmailPage.java
@@ -1,0 +1,53 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.keycloak.testsuite.pages;
+
+import org.keycloak.testsuite.OAuthClient;
+import org.keycloak.testsuite.rule.WebResource;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+/**
+ * @author <a href="mailto:vrockai@redhat.com">Viliam Rockai</a>
+ */
+public class VerifyEmailPage extends Page {
+
+    @WebResource
+    protected OAuthClient oauth;
+
+    @FindBy(linkText = "Click here")
+    private WebElement resendEmailLink;
+
+    @Override
+    public void open() {
+
+    }
+
+    public boolean isCurrent() {
+        return driver.getTitle().equals("Email verification");
+    }
+
+    public void clickResendEmail() {
+        resendEmailLink.click();
+    }
+
+}


### PR DESCRIPTION
- Fixed the L&F of template
- Fixed the error with sending two emails on "resend link"
- Added new asserts to tests + test for "resend link"
- New email body message
