### PR TITLE
KEYCLOAK-107 fix for login form error feedback issues

### DIFF
--- a/forms/src/main/resources/META-INF/resources/forms/theme/default/template-login.ftl
+++ b/forms/src/main/resources/META-INF/resources/forms/theme/default/template-login.ftl
@@ -31,17 +31,15 @@
             <div class="form-area ${(realm.social)?string('social','')} clearfix">
                 <div class="section app-form">
                     <h3>Application login area</h3>
+                    <#if error?has_content>
+                        <div class="feedback error bottom-left show">
+                            <p>
+                                <strong id="loginError">${rb.getString(error.summary)}</strong><br/>${rb.getString('emailErrorInfo')}
+                            </p>
+                        </div>
+                    </#if>
                     <#nested "form">
                 </div>
-
-                <#if error?has_content>
-                    <div class="
-                     error bottom-left show">
-                        <p>
-                            <strong id="loginError">${rb.getString(error.summary)}</strong>
-                        </p>
-                    </div>
-                </#if>
 
                 <#if social.displaySocialProviders>
                     <div class="section social-login"> <span>or</span>

--- a/forms/src/main/resources/org/keycloak/forms/messages.properties
+++ b/forms/src/main/resources/org/keycloak/forms/messages.properties
@@ -53,4 +53,5 @@ emailForgotHeader=Forgot Your Password?
 emailUpdateHeader=Update password
 emailSent=You should receive an email shortly with further instructions.
 emailError=Invalid username or email.
+emailErrorInfo=Please, fill in the fields again.
 emailInstruction=Enter your username and email address and we will send you instructions on how to create a new password.

--- a/services/src/main/java/org/keycloak/services/resources/TokenService.java
+++ b/services/src/main/java/org/keycloak/services/resources/TokenService.java
@@ -192,6 +192,11 @@ public class TokenService {
         String username = formData.getFirst("username");
         UserModel user = realm.getUser(username);
 
+        if (user == null){
+            return Flows.forms(realm, request, uriInfo).setError(Messages.INVALID_USER).setFormData(formData)
+                    .forwardToLogin();
+        }
+
         isTotpConfigurationRequired(user);
         isEmailVerificationRequired(user);
 


### PR DESCRIPTION
- fixed the alert-box alignment (which makes https://github.com/keycloak/keycloak/pull/63 invalid)
- fixed the issue with alert-box not rendering on the page
- fixed NPE when logging in with invalid data on totp-login form
