### PR TITLE
Better password hashing for JPA model.

### DIFF
--- a/model/api/src/main/java/org/keycloak/models/UserCredentialModel.java
+++ b/model/api/src/main/java/org/keycloak/models/UserCredentialModel.java
@@ -1,5 +1,7 @@
 package org.keycloak.models;
 
+import java.security.SecureRandom;
+
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
@@ -11,7 +13,21 @@ public class UserCredentialModel {
 
     protected String type;
     protected String value;
+    protected String salt;
     protected String device;
+
+    public UserCredentialModel() {
+        SecureRandom random = new SecureRandom();
+        byte saltBytes[] = new byte[16];
+        random.nextBytes(saltBytes);
+
+        StringBuilder sb = new StringBuilder();
+        for (byte b : saltBytes) {
+            sb.append(String.format("%02X", b));
+        }
+
+        this.salt = sb.toString();
+    }
 
     public String getType() {
         return type;
@@ -35,5 +51,13 @@ public class UserCredentialModel {
 
     public void setDevice(String device) {
         this.device = device;
+    }
+
+    public String getSalt() {
+        return salt;
+    }
+
+    public void setSalt(String salt) {
+        this.salt = salt;
     }
 }

--- a/model/api/src/main/java/org/keycloak/models/utils/SHAPasswordEncoder.java
+++ b/model/api/src/main/java/org/keycloak/models/utils/SHAPasswordEncoder.java
@@ -23,14 +23,24 @@ public class SHAPasswordEncoder {
         this.strength = strength;
     }
 
-    public String encode(String rawPassword) {
+    public String encode(String rawPassword, String salt) {
         MessageDigest messageDigest = getMessageDigest();
 
-        String encodedPassword = null;
+        // TODO: externalize it, so that it can be configured by the application
+        int iterations = 5000;
+
+        // TODO: externalize it, perhaps generating it on first-deploy with SecureRandom
+        String pepper = "fNY07rZXP2epfJxrvgw6l2wAmZ6uadqX";
+
+        String encodedPassword = pepper + salt + rawPassword;
 
         try {
-            byte[] digest = messageDigest.digest(rawPassword.getBytes("UTF-8"));
-            encodedPassword = Base64.encodeBytes(digest);
+            for (int i = 0 ; i < iterations ; i++) {
+                encodedPassword += salt;
+                byte[] digest = messageDigest.digest(encodedPassword.getBytes("UTF-8"));
+                encodedPassword = Base64.encodeBytes(digest);
+            }
+
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException("Credential could not be encoded");
         }
@@ -38,8 +48,8 @@ public class SHAPasswordEncoder {
         return encodedPassword;
     }
 
-    public boolean verify(String rawPassword, String encodedPassword) {
-        return encode(rawPassword).equals(encodedPassword);
+    public boolean verify(String rawPassword, String encodedPassword, String salt) {
+        return encode(rawPassword, salt).equals(encodedPassword);
     }
 
     protected final MessageDigest getMessageDigest() throws IllegalArgumentException {

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/RealmAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/RealmAdapter.java
@@ -996,7 +996,7 @@ public class RealmAdapter implements RealmModel {
     public boolean validatePassword(UserModel user, String password) {
         for (CredentialEntity cred : ((UserAdapter)user).getUser().getCredentials()) {
             if (cred.getType().equals(UserCredentialModel.PASSWORD)) {
-                return new SHAPasswordEncoder(512).verify(password, cred.getValue());
+                return new SHAPasswordEncoder(512).verify(password, cred.getValue(), cred.getSalt());
             }
         }
         return false;
@@ -1031,7 +1031,8 @@ public class RealmAdapter implements RealmModel {
             userEntity.getCredentials().add(credentialEntity);
         }
         if (cred.getType().equals(UserCredentialModel.PASSWORD)) {
-            credentialEntity.setValue(new SHAPasswordEncoder(512).encode(cred.getValue()));
+            credentialEntity.setSalt(cred.getSalt());
+            credentialEntity.setValue(new SHAPasswordEncoder(512).encode(cred.getValue(), cred.getSalt()));
         } else {
             credentialEntity.setValue(cred.getValue());
         }

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/CredentialEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/CredentialEntity.java
@@ -23,6 +23,7 @@ public class CredentialEntity {
 
     protected String type;
     protected String value;
+    protected String salt;
     protected String device;
 
     @ManyToOne
@@ -66,5 +67,13 @@ public class CredentialEntity {
 
     public void setUser(UserEntity user) {
         this.user = user;
+    }
+
+    public String getSalt() {
+        return salt;
+    }
+
+    public void setSalt(String salt) {
+        this.salt = salt;
     }
 }


### PR DESCRIPTION
Added salt to the JPA model, added pepper to the hashing and added 5000 iterations to the hashing, to improve the password security.

Note: I'm not very familiar with the code, so, not sure if it's appropriate to add the salt property to the places I've added. In any case, I've did some manual testing (couldn't find any unit tests for it), and it works. 
