### PR TITLE
Replaced SHA hashing by scrypt

### DIFF
--- a/model/api/pom.xml
+++ b/model/api/pom.xml
@@ -14,6 +14,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk15on</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/model/api/src/main/java/org/keycloak/models/UserCredentialModel.java
+++ b/model/api/src/main/java/org/keycloak/models/UserCredentialModel.java
@@ -1,5 +1,7 @@
 package org.keycloak.models;
 
+import java.security.SecureRandom;
+
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
@@ -11,7 +13,21 @@ public class UserCredentialModel {
 
     protected String type;
     protected String value;
+    protected String salt;
     protected String device;
+
+    public UserCredentialModel() {
+        SecureRandom random = new SecureRandom();
+        byte saltBytes[] = new byte[16];
+        random.nextBytes(saltBytes);
+
+        StringBuilder sb = new StringBuilder();
+        for (byte b : saltBytes) {
+            sb.append(String.format("%02X", b));
+        }
+
+        this.salt = sb.toString();
+    }
 
     public String getType() {
         return type;
@@ -35,5 +51,13 @@ public class UserCredentialModel {
 
     public void setDevice(String device) {
         this.device = device;
+    }
+
+    public String getSalt() {
+        return salt;
+    }
+
+    public void setSalt(String salt) {
+        this.salt = salt;
     }
 }

--- a/model/api/src/main/java/org/keycloak/models/utils/PasswordEncoder.java
+++ b/model/api/src/main/java/org/keycloak/models/utils/PasswordEncoder.java
@@ -1,0 +1,13 @@
+package org.keycloak.models.utils;
+
+import org.keycloak.models.UserCredentialModel;
+
+/**
+ * User: jpkroehling
+ * Date: 12/5/13
+ * Time: 2:24 PM
+ */
+public interface PasswordEncoder {
+    public String encode(UserCredentialModel credentialModel);
+    public boolean verify(UserCredentialModel real, UserCredentialModel provided);
+}

--- a/model/api/src/main/java/org/keycloak/models/utils/SCryptPasswordEncoder.java
+++ b/model/api/src/main/java/org/keycloak/models/utils/SCryptPasswordEncoder.java
@@ -1,0 +1,33 @@
+package org.keycloak.models.utils;
+
+import org.bouncycastle.crypto.generators.SCrypt;
+import org.keycloak.models.UserCredentialModel;
+
+import java.io.UnsupportedEncodingException;
+
+/**
+ * User: jpkroehling
+ * Date: 12/5/13
+ * Time: 2:25 PM
+ */
+public class SCryptPasswordEncoder implements PasswordEncoder {
+
+    @Override
+    public String encode(UserCredentialModel credentialModel) {
+
+        try {
+            byte[] passwordBytes = credentialModel.getValue().getBytes("UTF-8");
+            byte[] saltBytes = credentialModel.getSalt().getBytes("UTF-8");
+            byte[] digest = SCrypt.generate(passwordBytes, saltBytes, 16384, 8, 1, 218);
+
+            return Base64.encodeBytes(digest);
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException("Credential could not be encoded", e);
+        }
+    }
+
+    @Override
+    public boolean verify(UserCredentialModel real, UserCredentialModel provided) {
+        return encode(provided).equals(real.getValue());
+    }
+}

--- a/model/api/src/main/java/org/keycloak/models/utils/SHAPasswordEncoder.java
+++ b/model/api/src/main/java/org/keycloak/models/utils/SHAPasswordEncoder.java
@@ -23,14 +23,24 @@ public class SHAPasswordEncoder {
         this.strength = strength;
     }
 
-    public String encode(String rawPassword) {
+    public String encode(String rawPassword, String salt) {
         MessageDigest messageDigest = getMessageDigest();
 
-        String encodedPassword = null;
+        // TODO: externalize it, so that it can be configured by the application
+        int iterations = 5000;
+
+        // TODO: externalize it, perhaps generating it on first-deploy with SecureRandom
+        String pepper = "fNY07rZXP2epfJxrvgw6l2wAmZ6uadqX";
+
+        String encodedPassword = pepper + salt + rawPassword;
 
         try {
-            byte[] digest = messageDigest.digest(rawPassword.getBytes("UTF-8"));
-            encodedPassword = Base64.encodeBytes(digest);
+            for (int i = 0 ; i < iterations ; i++) {
+                encodedPassword += salt;
+                byte[] digest = messageDigest.digest(encodedPassword.getBytes("UTF-8"));
+                encodedPassword = Base64.encodeBytes(digest);
+            }
+
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException("Credential could not be encoded");
         }
@@ -38,8 +48,8 @@ public class SHAPasswordEncoder {
         return encodedPassword;
     }
 
-    public boolean verify(String rawPassword, String encodedPassword) {
-        return encode(rawPassword).equals(encodedPassword);
+    public boolean verify(String rawPassword, String encodedPassword, String salt) {
+        return encode(rawPassword, salt).equals(encodedPassword);
     }
 
     protected final MessageDigest getMessageDigest() throws IllegalArgumentException {

--- a/model/jpa/pom.xml
+++ b/model/jpa/pom.xml
@@ -15,8 +15,12 @@
     <dependencies>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk16</artifactId>
+            <artifactId>bcprov-jdk15on</artifactId>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk15on</artifactId>
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/RealmAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/RealmAdapter.java
@@ -996,7 +996,7 @@ public class RealmAdapter implements RealmModel {
     public boolean validatePassword(UserModel user, String password) {
         for (CredentialEntity cred : ((UserAdapter)user).getUser().getCredentials()) {
             if (cred.getType().equals(UserCredentialModel.PASSWORD)) {
-                return new SHAPasswordEncoder(512).verify(password, cred.getValue());
+                return new SHAPasswordEncoder(512).verify(password, cred.getValue(), cred.getSalt());
             }
         }
         return false;
@@ -1031,7 +1031,8 @@ public class RealmAdapter implements RealmModel {
             userEntity.getCredentials().add(credentialEntity);
         }
         if (cred.getType().equals(UserCredentialModel.PASSWORD)) {
-            credentialEntity.setValue(new SHAPasswordEncoder(512).encode(cred.getValue()));
+            credentialEntity.setSalt(cred.getSalt());
+            credentialEntity.setValue(new SHAPasswordEncoder(512).encode(cred.getValue(), cred.getSalt()));
         } else {
             credentialEntity.setValue(cred.getValue());
         }

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/CredentialEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/CredentialEntity.java
@@ -1,12 +1,8 @@
 package org.keycloak.models.jpa.entities;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.ManyToOne;
-import javax.persistence.NamedQueries;
-import javax.persistence.NamedQuery;
+import org.keycloak.models.UserCredentialModel;
+
+import javax.persistence.*;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -21,8 +17,10 @@ public class CredentialEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     protected String id;
 
-    protected String type;
+    @Column(length = 344)
     protected String value;
+
+    protected String type;
     protected String salt;
     protected String device;
 
@@ -75,5 +73,12 @@ public class CredentialEntity {
 
     public void setSalt(String salt) {
         this.salt = salt;
+    }
+
+    public UserCredentialModel toUserCredentialModel() {
+        UserCredentialModel model = new UserCredentialModel();
+        model.setSalt(this.getSalt());
+        model.setValue(this.getValue());
+        return model;
     }
 }

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/CredentialEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/CredentialEntity.java
@@ -23,6 +23,7 @@ public class CredentialEntity {
 
     protected String type;
     protected String value;
+    protected String salt;
     protected String device;
 
     @ManyToOne
@@ -66,5 +67,13 @@ public class CredentialEntity {
 
     public void setUser(UserEntity user) {
         this.user = user;
+    }
+
+    public String getSalt() {
+        return salt;
+    }
+
+    public void setSalt(String salt) {
+        this.salt = salt;
     }
 }

--- a/model/picketlink/pom.xml
+++ b/model/picketlink/pom.xml
@@ -15,7 +15,7 @@
     <dependencies>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk16</artifactId>
+            <artifactId>bcpkix-jdk15on</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -83,13 +83,18 @@
         <dependencies>
             <dependency>
                 <groupId>org.bouncycastle</groupId>
-                <artifactId>bcprov-jdk16</artifactId>
-                <version>1.46</version>
+                <artifactId>bcprov-jdk15on</artifactId>
+                <version>1.50</version>
             </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>
-                <artifactId>bcmail-jdk16</artifactId>
-                <version>1.46</version>
+                <artifactId>bcpkix-jdk15on</artifactId>
+                <version>1.50</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcmail-jdk15on</artifactId>
+                <version>1.50</version>
             </dependency>
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -15,7 +15,7 @@
     <dependencies>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk16</artifactId>
+            <artifactId>bcprov-jdk15on</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -156,11 +156,11 @@
             <artifactId>hibernate-entitymanager</artifactId>
             <scope>test</scope>
         </dependency>
-		<dependency>
-    		<groupId>com.icegreen</groupId>
-    		<artifactId>greenmail</artifactId>
+        <dependency>
+            <groupId>com.icegreen</groupId>
+            <artifactId>greenmail</artifactId>
             <scope>test</scope>
-		</dependency>        
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -29,7 +29,7 @@
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk16</artifactId>
+            <artifactId>bcprov-jdk15on</artifactId>
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>


### PR DESCRIPTION
Do not merge this into master, as there are test failures. This commit is mainly to show how an integration of scrypt could be done on the current code base. This requires a newer version of bouncycastle, which is included on this changeset, but Wildfly/EAP already provides this. So, just like one needs to upgrade resteasy before using keycloak, one needs also to update bouncycastle to the version specified on these pom files.

Ignoring the test failures which are not related to SCrypt itself, the feature works as expected. The failures are most likely related to the upgrade of bouncycastle.

Again, do not merge this, as this is meant only for feedback. 
