### PR TITLE
KEYCLOAK-224 KEYCLOAK-226 KEYCLOAK-225

### DIFF
--- a/examples/as7-eap-demo/server/src/main/webapp/WEB-INF/web.xml
+++ b/examples/as7-eap-demo/server/src/main/webapp/WEB-INF/web.xml
@@ -21,6 +21,10 @@
         <async-supported>true</async-supported>
     </servlet>
 
+    <listener>
+        <listener-class>org.keycloak.services.listeners.KeycloakSessionDestroyListener</listener-class>
+    </listener>
+
     <filter>
         <filter-name>Keycloak Session Management</filter-name>
         <filter-class>org.keycloak.services.filters.KeycloakSessionServletFilter</filter-class>

--- a/examples/wildfly-demo/server/src/main/webapp/WEB-INF/web.xml
+++ b/examples/wildfly-demo/server/src/main/webapp/WEB-INF/web.xml
@@ -22,7 +22,7 @@
     </servlet>
 
     <listener>
-        <listener-class>org.keycloak.services.listeners.MongoRunnerListener</listener-class>
+        <listener-class>org.keycloak.services.listeners.KeycloakSessionDestroyListener</listener-class>
     </listener>
 
     <filter>

--- a/services/src/main/java/org/keycloak/services/email/EmailSender.java
+++ b/services/src/main/java/org/keycloak/services/email/EmailSender.java
@@ -55,33 +55,33 @@ public class EmailSender {
     }
 
     public void send(String address, String subject, String body) throws EmailException {
-        Properties props = new Properties();
-        props.setProperty("mail.smtp.host", config.get("host"));
-
-        boolean auth = "true".equals(config.get("auth"));
-        boolean ssl = "true".equals(config.get("ssl"));
-        boolean starttls = "true".equals(config.get("starttls"));
-
-        if (config.containsKey("port")) {
-            props.setProperty("mail.smtp.port", config.get("port"));
-        }
-
-        if (auth) {
-            props.put("mail.smtp.auth", "true");
-        }
-
-        if (ssl) {
-            props.put("mail.smtp.socketFactory.port", config.get("port"));
-            props.put("mail.smtp.socketFactory.class", "javax.net.ssl.SSLSocketFactory");
-        }
-
-        if (starttls) {
-            props.put("mail.smtp.starttls.enable", "true");
-        }
-
-        String from = config.get("from");
-
         try {
+            Properties props = new Properties();
+            props.setProperty("mail.smtp.host", config.get("host"));
+
+            boolean auth = "true".equals(config.get("auth"));
+            boolean ssl = "true".equals(config.get("ssl"));
+            boolean starttls = "true".equals(config.get("starttls"));
+
+            if (config.containsKey("port")) {
+                props.setProperty("mail.smtp.port", config.get("port"));
+            }
+
+            if (auth) {
+                props.put("mail.smtp.auth", "true");
+            }
+
+            if (ssl) {
+                props.put("mail.smtp.socketFactory.port", config.get("port"));
+                props.put("mail.smtp.socketFactory.class", "javax.net.ssl.SSLSocketFactory");
+            }
+
+            if (starttls) {
+                props.put("mail.smtp.starttls.enable", "true");
+            }
+
+            String from = config.get("from");
+
             Session session = Session.getInstance(props);
 
             Message msg = new MimeMessage(session);

--- a/services/src/main/java/org/keycloak/services/email/EmailSender.java
+++ b/services/src/main/java/org/keycloak/services/email/EmailSender.java
@@ -86,6 +86,7 @@ public class EmailSender {
 
             Message msg = new MimeMessage(session);
             msg.setFrom(new InternetAddress(from));
+            msg.setHeader("To", address);
             msg.setSubject(subject);
             msg.setText(body);
             msg.saveChanges();


### PR DESCRIPTION
KEYCLOAK-224 Adding KeycloakSessionDestroyListener to web.xml of AS7 and Wildfly demo. Removing MongoRunnerListener from WildFly demo as Mongo is disabled

KEYCLOAK-226 Adding email header "To" when sending mail

KEYCLOAK-225 NPe after login when 'Verify email' is enabled but SMTP is not configured
