### PR TITLE
docs: fixing a typo ("..metadata for for a set .."); listed adapters were all the same

### DIFF
--- a/docbook/reference/en/en-US/modules/Overview.xml
+++ b/docbook/reference/en/en-US/modules/Overview.xml
@@ -67,7 +67,7 @@
     <section>
         <title>Key Concepts in Keycloak</title>
         <para>
-            The core concept in Keycloak is a <emphasis>Realm</emphasis>.  A realm secures and manages security metadata for
+            The core concept in Keycloak is a <emphasis>Realm</emphasis>.  A realm secures and manages security metadata
             for a set of users, applications, and registered oauth clients.  Users can be created within a specific realm
             within the Administration console.  Roles (permission types) can be defined at the realm level and you can also
             set up user role mappings to assign these permissions to specific users.

--- a/docbook/reference/en/en-US/modules/server-installation.xml
+++ b/docbook/reference/en/en-US/modules/server-installation.xml
@@ -42,8 +42,8 @@ keycloak-appliance-dist-all-1.0-alpha-1/
 
     adapters/
         keycloak-as7-adapter-dist-1.0-alpha-1.zip
-        keycloak-as7-adapter-dist-1.0-alpha-1.zip
-        keycloak-as7-adapter-dist-1.0-alpha-1.zip
+        keycloak-eap6-adapter-dist-1.0-alpha-1.zip
+        keycloak-wildfly-adapter-dist-1.0-alpha-1.zip
     examples/
     docs/
 </programlisting>
@@ -85,8 +85,8 @@ keycloak-war-dist-all-1.0-alpha-1/
         keycloak-ds.xml
     adapters/
         keycloak-as7-adapter-dist-1.0-alpha-1.zip
-        keycloak-as7-adapter-dist-1.0-alpha-1.zip
-        keycloak-as7-adapter-dist-1.0-alpha-1.zip
+        keycloak-eap6-adapter-dist-1.0-alpha-1.zip
+        keycloak-wildfly-adapter-dist-1.0-alpha-1.zip
     examples/
     docs/
 </programlisting>


### PR DESCRIPTION
Noticing and fixing some typos when reading the docs..
