### PR TITLE
Fixed charset issue while decoding token with atob

### DIFF
--- a/integration/js/src/main/resources/META-INF/resources/js/keycloak.js
+++ b/integration/js/src/main/resources/META-INF/resources/js/keycloak.js
@@ -348,7 +348,7 @@ var Keycloak = function (config) {
     function setToken(token, refreshToken) {
         if (token) {
             kc.token = token;
-            kc.tokenParsed = JSON.parse(atob(token.split('.')[1]));
+            kc.tokenParsed = JSON.parse(decodeURIComponent(escape(window.atob( token.split('.')[1] ))));
             kc.authenticated = true;
             kc.subject = kc.tokenParsed.sub;
             kc.realmAccess = kc.tokenParsed.realm_access;


### PR DESCRIPTION
With this patch, special characters like "ö" or "ã" are properly decoded from the token. 

When the user's name has special chars, like "ö" or "ã", the keycloak.js incorrectly decodes the values without taking into consideration that they are in UTF-8. 

See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Base64_encoding_and_decoding#The_.22Unicode_Problem.22
