### PR TITLE
Reenable AuthProvidersIntegrationTest.registerUserLdapSuccess. Add varia...

### DIFF
--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -80,7 +80,6 @@
         <dependency>
             <groupId>com.google.zxing</groupId>
             <artifactId>javase</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
@@ -192,7 +191,6 @@
         <dependency>
             <groupId>org.freemarker</groupId>
             <artifactId>freemarker</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>

--- a/testsuite/integration/src/test/java/org/keycloak/testsuite/forms/AuthProvidersIntegrationTest.java
+++ b/testsuite/integration/src/test/java/org/keycloak/testsuite/forms/AuthProvidersIntegrationTest.java
@@ -3,7 +3,6 @@ package org.keycloak.testsuite.forms;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.FixMethodOrder;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
@@ -25,7 +24,6 @@ import org.keycloak.testsuite.pages.AccountUpdateProfilePage;
 import org.keycloak.testsuite.pages.AppPage;
 import org.keycloak.testsuite.pages.LoginPage;
 import org.keycloak.testsuite.pages.RegisterPage;
-import org.keycloak.testsuite.rule.AbstractKeycloakRule;
 import org.keycloak.testsuite.rule.KeycloakRule;
 import org.keycloak.testsuite.rule.LDAPRule;
 import org.keycloak.testsuite.rule.WebResource;
@@ -218,7 +216,6 @@ public class AuthProvidersIntegrationTest {
     }
 
     @Test
-    @Ignore
     public void registerUserLdapSuccess() {
         loginPage.open();
         loginPage.clickRegister();

--- a/testsuite/integration/src/test/java/org/keycloak/testsuite/rule/AbstractKeycloakRule.java
+++ b/testsuite/integration/src/test/java/org/keycloak/testsuite/rule/AbstractKeycloakRule.java
@@ -113,6 +113,14 @@ public abstract class AbstractKeycloakRule extends ExternalResource {
     @Override
     protected void after() {
         server.stop();
+
+        // Add some variable delay (Some windows envs have issues as server is not stopped immediately after server.stop)
+        try {
+            int sleepInterval = Integer.parseInt(System.getProperty("testsuite.delay", "0"));
+            Thread.sleep(sleepInterval);
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+        }
     }
 
     public RealmRepresentation loadJson(String path) throws IOException {


### PR DESCRIPTION
...ble sleep after undertow stop in testsuite (some windows envs have issues when server is not fully stopped)
