### PR TITLE
Added bindIp support to embedmongo-maven-plugin configuration. Solves is...

### DIFF
--- a/audit/mongo/pom.xml
+++ b/audit/mongo/pom.xml
@@ -59,6 +59,7 @@
         <keycloak.audit.mongo.port>27018</keycloak.audit.mongo.port>
         <keycloak.audit.mongo.db>keycloak</keycloak.audit.mongo.db>
         <keycloak.audit.mongo.clearOnStartup>true</keycloak.audit.mongo.clearOnStartup>
+        <keycloak.audit.mongo.bindIp>127.0.0.1</keycloak.audit.mongo.bindIp>
     </properties>
 
     <build>
@@ -89,6 +90,7 @@
                                 <keycloak.audit.mongo.port>${keycloak.audit.mongo.port}</keycloak.audit.mongo.port>
                                 <keycloak.audit.mongo.db>${keycloak.audit.mongo.db}</keycloak.audit.mongo.db>
                                 <keycloak.audit.mongo.clearOnStartup>${keycloak.audit.mongo.clearOnStartup}</keycloak.audit.mongo.clearOnStartup>
+                                <keycloak.audit.mongo.bindIp>${keycloak.model.mongo.bindIp}</keycloak.audit.mongo.bindIp>
                             </systemPropertyVariables>
                         </configuration>
                     </execution>
@@ -116,6 +118,7 @@
                             <port>${keycloak.audit.mongo.port}</port>
                             <logging>file</logging>
                             <logFile>${project.build.directory}/mongodb.log</logFile>
+                            <bindIp>${keycloak.audit.mongo.bindIp}</bindIp>
                         </configuration>
                     </execution>
                     <execution>

--- a/export-import/export-import-impl/pom.xml
+++ b/export-import/export-import-impl/pom.xml
@@ -152,6 +152,7 @@
         <keycloak.model.mongo.port>27018</keycloak.model.mongo.port>
         <keycloak.model.mongo.db>keycloak</keycloak.model.mongo.db>
         <keycloak.model.mongo.clearOnStartup>true</keycloak.model.mongo.clearOnStartup>
+        <keycloak.model.mongo.bindIp>127.0.0.1</keycloak.model.mongo.bindIp>
     </properties>
 
     <build>
@@ -182,6 +183,7 @@
                                 <keycloak.model.mongo.port>${keycloak.model.mongo.port}</keycloak.model.mongo.port>
                                 <keycloak.model.mongo.db>${keycloak.model.mongo.db}</keycloak.model.mongo.db>
                                 <keycloak.model.mongo.clearOnStartup>${keycloak.model.mongo.clearOnStartup}</keycloak.model.mongo.clearOnStartup>
+                                <keycloak.model.mongo.bindIp>${keycloak.model.mongo.bindIp}</keycloak.model.mongo.bindIp>
                             </systemPropertyVariables>
                         </configuration>
                     </execution>
@@ -209,6 +211,7 @@
                             <port>${keycloak.model.mongo.port}</port>
                             <logging>file</logging>
                             <logFile>${project.build.directory}/mongodb.log</logFile>
+                            <bindIp>${keycloak.model.mongo.bindIp}</bindIp>
                         </configuration>
                     </execution>
                     <execution>

--- a/model/mongo/pom.xml
+++ b/model/mongo/pom.xml
@@ -95,6 +95,7 @@
         <keycloak.model.mongo.port>27018</keycloak.model.mongo.port>
         <keycloak.model.mongo.db>keycloak</keycloak.model.mongo.db>
         <keycloak.model.mongo.clearOnStartup>true</keycloak.model.mongo.clearOnStartup>
+        <keycloak.model.mongo.bindIp>127.0.0.1</keycloak.model.mongo.bindIp>
     </properties>
 
     <build>
@@ -125,6 +126,7 @@
                                 <keycloak.model.mongo.port>${keycloak.model.mongo.port}</keycloak.model.mongo.port>
                                 <keycloak.model.mongo.db>${keycloak.model.mongo.db}</keycloak.model.mongo.db>
                                 <keycloak.model.mongo.clearOnStartup>${keycloak.model.mongo.clearOnStartup}</keycloak.model.mongo.clearOnStartup>
+                                <keycloak.model.mongo.bindIp>${keycloak.model.mongo.bindIp}</keycloak.model.mongo.bindIp>
                             </systemPropertyVariables>
                             <dependenciesToScan>
                                 <dependency>org.keycloak:keycloak-model-tests</dependency>
@@ -155,6 +157,7 @@
                             <port>${keycloak.model.mongo.port}</port>
                             <logging>file</logging>
                             <logFile>${project.build.directory}/mongodb.log</logFile>
+                            <bindIp>${keycloak.model.mongo.bindIp}</bindIp>
                         </configuration>
                     </execution>
                     <execution>

--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -449,6 +449,7 @@
                 <keycloak.model.mongo.port>27018</keycloak.model.mongo.port>
                 <keycloak.model.mongo.db>keycloak</keycloak.model.mongo.db>
                 <keycloak.model.mongo.clearOnStartup>true</keycloak.model.mongo.clearOnStartup>
+                <keycloak.model.mongo.bindIp>127.0.0.1</keycloak.model.mongo.bindIp>
             </properties>
 
             <build>
@@ -472,12 +473,14 @@
                                         <keycloak.model.mongo.port>${keycloak.model.mongo.port}</keycloak.model.mongo.port>
                                         <keycloak.model.mongo.db>${keycloak.model.mongo.db}</keycloak.model.mongo.db>
                                         <keycloak.model.mongo.clearOnStartup>${keycloak.model.mongo.clearOnStartup}</keycloak.model.mongo.clearOnStartup>
+                                        <keycloak.model.mongo.bindIp>${keycloak.model.mongo.bindIp}</keycloak.model.mongo.bindIp>
 
                                         <keycloak.audit.provider>mongo</keycloak.audit.provider>
                                         <keycloak.audit.mongo.host>${keycloak.model.mongo.host}</keycloak.audit.mongo.host>
                                         <keycloak.audit.mongo.port>${keycloak.model.mongo.port}</keycloak.audit.mongo.port>
                                         <keycloak.audit.mongo.db>${keycloak.model.mongo.db}</keycloak.audit.mongo.db>
                                         <keycloak.audit.mongo.clearOnStartup>${keycloak.model.mongo.clearOnStartup}</keycloak.audit.mongo.clearOnStartup>
+                                        <keycloak.audit.mongo.bindIp>${keycloak.audit.mongo.bindIp}</keycloak.audit.mongo.bindIp>
                                     </systemPropertyVariables>
                                 </configuration>
                             </execution>
@@ -505,6 +508,7 @@
                                     <port>${keycloak.model.mongo.port}</port>
                                     <logging>file</logging>
                                     <logFile>${project.build.directory}/mongodb.log</logFile>
+                                    <bindIp>${keycloak.model.mongo.bindIp}</bindIp>
                                 </configuration>
                             </execution>
                             <execution>

--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -480,7 +480,7 @@
                                         <keycloak.audit.mongo.port>${keycloak.model.mongo.port}</keycloak.audit.mongo.port>
                                         <keycloak.audit.mongo.db>${keycloak.model.mongo.db}</keycloak.audit.mongo.db>
                                         <keycloak.audit.mongo.clearOnStartup>${keycloak.model.mongo.clearOnStartup}</keycloak.audit.mongo.clearOnStartup>
-                                        <keycloak.audit.mongo.bindIp>${keycloak.audit.mongo.bindIp}</keycloak.audit.mongo.bindIp>
+                                        <keycloak.audit.mongo.bindIp>${keycloak.model.mongo.bindIp}</keycloak.audit.mongo.bindIp>
                                     </systemPropertyVariables>
                                 </configuration>
                             </execution>


### PR DESCRIPTION
...sue of firewall pop-ups consistently displaying on every Microsoft Windows build.
