### PR TITLE
Fixed an integer overflow that caused the token to be refreshed too often

### DIFF
--- a/integration/installed/src/main/java/org/keycloak/adapters/installed/KeycloakInstalled.java
+++ b/integration/installed/src/main/java/org/keycloak/adapters/installed/KeycloakInstalled.java
@@ -173,7 +173,7 @@ public class KeycloakInstalled {
     }
 
     public String getTokenString(long minValidity, TimeUnit unit) throws VerificationException, IOException, ServerRequest.HttpFailure {
-        long expires = token.getExpiration() * 1000 - unit.toMillis(minValidity);
+        long expires = ((long) token.getExpiration()) * 1000 - unit.toMillis(minValidity);
         if (expires < System.currentTimeMillis()) {
             refreshToken();
         }


### PR DESCRIPTION
Hi all, here is just a quick fix for an integer overflow that causes the expires variable in most cases to always be lower than the current time, which means that the token is always refreshed.
