### PR TITLE
Fixed an NPE when the social users name is null

### DIFF
--- a/social/core/src/main/java/org/keycloak/social/SocialUser.java
+++ b/social/core/src/main/java/org/keycloak/social/SocialUser.java
@@ -34,12 +34,14 @@ public class SocialUser {
     }
 
     public void setName(String name) {
-        int i = name.lastIndexOf(' ');
-        if (i != -1) {
-            firstName  = name.substring(0, i);
-            lastName = name.substring(i + 1);
-        } else {
-            firstName = name;
+        if (name != null) {
+            int i = name.lastIndexOf(' ');
+            if (i != -1) {
+                firstName  = name.substring(0, i);
+                lastName = name.substring(i + 1);
+            } else {
+                firstName = name;
+            }
         }
     }
 


### PR DESCRIPTION
Hi all, just another simple fix for when the social user has no name which can happen when using GitHub for example, as name isn't a mandatory field.
