### PR TITLE
Changed window.location.href to search.

### DIFF
--- a/integration/js/src/main/resources/keycloak.js
+++ b/integration/js/src/main/resources/keycloak.js
@@ -50,7 +50,7 @@
             var configPromise = loadConfig(config);
 
             function processInit() {
-                var callback = parseCallback(window.location.href);
+                var callback = parseCallback(window.location.search);
 
                 if (callback) {
                     window.history.replaceState({}, null, location.protocol + '//' + location.host + location.pathname + (callback.fragment ? '#' + callback.fragment : ''));


### PR DESCRIPTION
When receiving a call back with extra non-query chars at the end of the URL, the Adapter adds these extra non-query chars to the end of the "state" var. For instance: 

?abc=def#/

The appropriate value for 'abc' is 'def', and before this change, it was parsing as 'def#/'. 
