### PR TITLE
Added option to skip replacing the state.

### DIFF
--- a/integration/js/src/main/resources/keycloak.js
+++ b/integration/js/src/main/resources/keycloak.js
@@ -53,7 +53,9 @@
                 var callback = parseCallback(window.location.search);
 
                 if (callback) {
-                    window.history.replaceState({}, null, location.protocol + '//' + location.host + location.pathname + (callback.fragment ? '#' + callback.fragment : ''));
+                    if (!(initOptions.skipReplaceState === false)) {
+                        window.history.replaceState({}, null, location.protocol + '//' + location.host + location.pathname + (callback.fragment ? '#' + callback.fragment : ''));
+                    }
                     processCallback(callback, initPromise);
                     return;
                 } else if (initOptions) {


### PR DESCRIPTION
When writing an application that makes use of some frameworks, touching the window.history/location is not encouraged, and might cause undesired side effects. As such, I've added an option to skip replacing the state when getting the callback from the auth server. This means that the URL will still have the parameters sent by the auth server when the option `skipReplaceState` is set to `false`. For all other cases (non-existing property, or set to anything else), it's the same behavior as before this commit. 
