### PR TITLE
KEYCLOAK-569 Check application roles for scope

### DIFF
--- a/model/invalidation-cache/model-adapters/src/main/java/org/keycloak/models/cache/ApplicationAdapter.java
+++ b/model/invalidation-cache/model-adapters/src/main/java/org/keycloak/models/cache/ApplicationAdapter.java
@@ -185,6 +185,20 @@ public class ApplicationAdapter extends ClientAdapter implements ApplicationMode
     }
 
     @Override
+    public boolean hasScope(RoleModel role) {
+        if (super.hasScope(role)) {
+            return true;
+        }
+        Set<RoleModel> roles = getRoles();
+        if (roles.contains(role)) return true;
+
+        for (RoleModel mapping : roles) {
+            if (mapping.hasRole(role)) return true;
+        }
+        return false;
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || !(o instanceof ApplicationModel)) return false;

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/ApplicationAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/ApplicationAdapter.java
@@ -167,6 +167,20 @@ public class ApplicationAdapter extends ClientAdapter implements ApplicationMode
     }
 
     @Override
+    public boolean hasScope(RoleModel role) {
+        if (super.hasScope(role)) {
+            return true;
+        }
+        Set<RoleModel> roles = getRoles();
+        if (roles.contains(role)) return true;
+
+        for (RoleModel mapping : roles) {
+            if (mapping.hasRole(role)) return true;
+        }
+        return false;
+    }
+
+    @Override
     public Set<RoleModel> getApplicationScopeMappings(ClientModel client) {
         Set<RoleModel> roleMappings = client.getScopeMappings();
 

--- a/model/mongo/src/main/java/org/keycloak/models/mongo/keycloak/adapters/ApplicationAdapter.java
+++ b/model/mongo/src/main/java/org/keycloak/models/mongo/keycloak/adapters/ApplicationAdapter.java
@@ -161,6 +161,20 @@ public class ApplicationAdapter extends ClientAdapter<MongoApplicationEntity> im
     }
 
     @Override
+    public boolean hasScope(RoleModel role) {
+        if (super.hasScope(role)) {
+            return true;
+        }
+        Set<RoleModel> roles = getRoles();
+        if (roles.contains(role)) return true;
+
+        for (RoleModel mapping : roles) {
+            if (mapping.hasRole(role)) return true;
+        }
+        return false;
+    }
+
+    @Override
     public Set<RoleModel> getApplicationScopeMappings(ClientModel client) {
         Set<RoleModel> result = new HashSet<RoleModel>();
         List<MongoRoleEntity> roles = MongoModelUtils.getAllScopesOfClient(client, invocationContext);
@@ -203,6 +217,7 @@ public class ApplicationAdapter extends ClientAdapter<MongoApplicationEntity> im
         getMongoEntity().setDefaultRoles(roleNames);
         updateMongoEntity();
     }
+
 
     @Override
     public boolean equals(Object o) {

--- a/testsuite/integration/src/test/java/org/keycloak/testsuite/composites/CompositeRoleTest.java
+++ b/testsuite/integration/src/test/java/org/keycloak/testsuite/composites/CompositeRoleTest.java
@@ -184,6 +184,9 @@ public class CompositeRoleTest {
         Assert.assertEquals(1, token.getRealmAccess().getRoles().size());
         Assert.assertTrue(token.getResourceAccess("APP_ROLE_APPLICATION").isUserInRole("APP_ROLE_1"));
         Assert.assertTrue(token.getRealmAccess().isUserInRole("REALM_ROLE_1"));
+
+        AccessTokenResponse refreshResponse = oauth.doRefreshTokenRequest(response.getRefreshToken(), "password");
+        Assert.assertEquals(200, refreshResponse.getStatusCode());
     }
 
 
@@ -207,9 +210,10 @@ public class CompositeRoleTest {
 
         Assert.assertEquals(1, token.getResourceAccess("APP_ROLE_APPLICATION").getRoles().size());
         Assert.assertTrue(token.getResourceAccess("APP_ROLE_APPLICATION").isUserInRole("APP_ROLE_1"));
+
+        AccessTokenResponse refreshResponse = oauth.doRefreshTokenRequest(response.getRefreshToken(), "password");
+        Assert.assertEquals(200, refreshResponse.getStatusCode());
     }
-
-
 
     @Test
     public void testRealmOnlyWithUserCompositeAppComposite() throws Exception {
@@ -232,6 +236,9 @@ public class CompositeRoleTest {
         Assert.assertEquals(2, token.getRealmAccess().getRoles().size());
         Assert.assertTrue(token.getRealmAccess().isUserInRole("REALM_COMPOSITE_1"));
         Assert.assertTrue(token.getRealmAccess().isUserInRole("REALM_ROLE_1"));
+
+        AccessTokenResponse refreshResponse = oauth.doRefreshTokenRequest(response.getRefreshToken(), "password");
+        Assert.assertEquals(200, refreshResponse.getStatusCode());
     }
 
     @Test
@@ -254,6 +261,9 @@ public class CompositeRoleTest {
 
         Assert.assertEquals(1, token.getRealmAccess().getRoles().size());
         Assert.assertTrue(token.getRealmAccess().isUserInRole("REALM_ROLE_1"));
+
+        AccessTokenResponse refreshResponse = oauth.doRefreshTokenRequest(response.getRefreshToken(), "password");
+        Assert.assertEquals(200, refreshResponse.getStatusCode());
     }
 
     @Test
@@ -276,6 +286,9 @@ public class CompositeRoleTest {
 
         Assert.assertEquals(1, token.getRealmAccess().getRoles().size());
         Assert.assertTrue(token.getRealmAccess().isUserInRole("REALM_ROLE_1"));
+
+        AccessTokenResponse refreshResponse = oauth.doRefreshTokenRequest(response.getRefreshToken(), "password");
+        Assert.assertEquals(200, refreshResponse.getStatusCode());
     }
 
 }


### PR DESCRIPTION
This is required as application roles may be composite roles that grant access to realm or other application roles
