### PR TITLE
fix create-realm link

### DIFF
--- a/examples/demo-template/README.md
+++ b/examples/demo-template/README.md
@@ -112,7 +112,7 @@ Next thing you have to do is import the test realm for the demo.  Clicking on th
 create realm page in the Admin UI.  The username/password is admin/admin to login in.  Keycloak will ask you to
 create a new admin password before you can go to the create realm page.
 
-[http://localhost:8080/auth/admin/index.html#/create/realm](http://localhost:8080/auth/admin/index.html#/create/realm)
+[http://localhost:8080/auth/admin/master/console/#/create/realm](http://localhost:8080/auth/admin/master/console/#/create/realm)
 
 Import the testrealm.json file that is in the preconfigured-demo/ example directory.
 


### PR DESCRIPTION
update link to point to correct location for 'Add Realm'
