### PR TITLE
Update adapter-config.xml

### DIFF
--- a/docbook/reference/en/en-US/modules/adapter-config.xml
+++ b/docbook/reference/en/en-US/modules/adapter-config.xml
@@ -19,10 +19,10 @@
   "expose-token" : true,
    "credentials" : {
       "secret" : "234234-234234-234234"
-   }
+   },
 
    "connection-pool-size" : 20,
-   "disable-trust-manager" false,
+   "disable-trust-manager": false,
    "allow-any-hostname" : false,
    "truststore" : "path/to/truststore.jks",
    "truststore-password" : "geheim",


### PR DESCRIPTION
Fix some minor typos in the json, Otherwise it is invalid.

Also deploying in the keycloak 1.0.1 appliance, the line

"cors-allowed-methods" : [ "POST", "PUT", "DELETE", "GET" ],

makes parsing fail with 

11:19:10,121 ERROR [org.jboss.as.controller.management-operation](DeploymentScanner-threads - 1) JBAS014613: Operation ("full-replace-deployment") failed - address: ([]) - failure description: {"JBAS014671: Failed services" => {"jboss.undertow.deployment.default-server.default-host./rhq-metrics" => "org.jboss.msc.service.StartException in service jboss.undertow.deployment.default-server.default-host./rhq-metrics: Failed to start service
    Caused by: java.lang.RuntimeException: org.codehaus.jackson.map.JsonMappingException: Can not deserialize instance of java.lang.String out of START_ARRAY token
 at [Source: java.io.BufferedInputStream@1605c2fe; line: 9, column: 24](through reference chain: org.keycloak.representations.adapters.config.AdapterConfig["cors-allowed-methods"])
    Caused by: org.codehaus.jackson.map.JsonMappingException: Can not deserialize instance of java.lang.String out of START_ARRAY token
 at [Source: java.io.BufferedInputStream@1605c2fe; line: 9, column: 24](through reference chain: org.keycloak.representations.adapters.config.AdapterConfig["cors-allowed-methods"])"}}
