### PR TITLE
Display the realm name for OTP QR code scan

### DIFF
--- a/forms/account-freemarker/src/main/java/org/keycloak/account/freemarker/FreeMarkerAccountProvider.java
+++ b/forms/account-freemarker/src/main/java/org/keycloak/account/freemarker/FreeMarkerAccountProvider.java
@@ -131,7 +131,7 @@ public class FreeMarkerAccountProvider implements AccountProvider {
                 attributes.put("account", new AccountBean(user, profileFormData));
                 break;
             case TOTP:
-                attributes.put("totp", new TotpBean(user, baseUri));
+                attributes.put("totp", new TotpBean(realm, user, baseUri));
                 break;
             case SOCIAL:
                 attributes.put("social", new AccountSocialBean(session, realm, user, uriInfo.getBaseUri(), stateChecker));

--- a/forms/account-freemarker/src/main/java/org/keycloak/account/freemarker/model/TotpBean.java
+++ b/forms/account-freemarker/src/main/java/org/keycloak/account/freemarker/model/TotpBean.java
@@ -21,6 +21,7 @@
  */
 package org.keycloak.account.freemarker.model;
 
+import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.utils.Base32;
 
@@ -35,17 +36,19 @@ import java.security.SecureRandom;
  */
 public class TotpBean {
 
-    private String totpSecret;
-    private String totpSecretEncoded;
-    private boolean enabled;
-    private String contextUrl;
+    private final String totpSecret;
+    private final String totpSecretEncoded;
+    private final boolean enabled;
+    private final String contextUrl;
+    private final String realmName;
 
-    public TotpBean(UserModel user, URI baseUri) {
+    public TotpBean(RealmModel realm, UserModel user, URI baseUri) {
+        this.realmName = realm.getName();
         this.enabled = user.isTotp();
         this.contextUrl = baseUri.getPath();
 
-        totpSecret = randomString(20);
-        totpSecretEncoded = Base32.encode(totpSecret.getBytes());
+        this.totpSecret = randomString(20);
+        this.totpSecretEncoded = Base32.encode(totpSecret.getBytes());
     }
 
     private static String randomString(int length) {
@@ -86,7 +89,7 @@ public class TotpBean {
     }
 
     public String getTotpSecretQrCodeUrl() throws UnsupportedEncodingException {
-        String contents = URLEncoder.encode("otpauth://totp/keycloak?secret=" + totpSecretEncoded, "utf-8");
+        String contents = URLEncoder.encode("otpauth://totp/" + realmName + "?secret=" + totpSecretEncoded, "utf-8");
         return contextUrl + "qrcode" + "?size=246x246&contents=" + contents;
     }
 

--- a/forms/login-freemarker/src/main/java/org/keycloak/login/freemarker/model/TotpBean.java
+++ b/forms/login-freemarker/src/main/java/org/keycloak/login/freemarker/model/TotpBean.java
@@ -35,19 +35,19 @@ import java.util.Random;
  */
 public class TotpBean {
 
-    private String totpSecret;
-    private String totpSecretEncoded;
-    private boolean enabled;
-    private String contextUrl;
-    private String realmName;
+    private final String totpSecret;
+    private final String totpSecretEncoded;
+    private final boolean enabled;
+    private final String contextUrl;
+    private final String realmName;
 
     public TotpBean(RealmModel realm, UserModel user, URI baseUri) {
         this.realmName = realm.getName();
         this.enabled = user.isTotp();
         this.contextUrl = baseUri.getPath();
-
-        totpSecret = randomString(20);
-        totpSecretEncoded = Base32.encode(totpSecret.getBytes());
+        
+        this.totpSecret = randomString(20);
+        this.totpSecretEncoded = Base32.encode(totpSecret.getBytes());
     }
 
     private static String randomString(int length) {


### PR DESCRIPTION
Details about this PR:
- When you attempt to configure OTP on your profile, the ID is hardcoded to "keycloak". This pull request change it, to get the current realm name
