### PR TITLE
Keycloak Multi Tenants - First draft

### DIFF
--- a/integration/adapter-core/src/main/java/org/keycloak/adapters/AdapterDeploymentContext.java
+++ b/integration/adapter-core/src/main/java/org/keycloak/adapters/AdapterDeploymentContext.java
@@ -18,6 +18,7 @@ import java.io.InputStream;
 import java.net.URI;
 import java.security.PublicKey;
 import java.util.Map;
+import org.keycloak.adapters.HttpFacade.Request;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -26,6 +27,7 @@ import java.util.Map;
 public class AdapterDeploymentContext {
     private static final Logger log = Logger.getLogger(AdapterDeploymentContext.class);
     protected KeycloakDeployment deployment;
+    protected KeycloakConfigResolver configResolver;
 
     public AdapterDeploymentContext() {
     }
@@ -34,7 +36,14 @@ public class AdapterDeploymentContext {
         this.deployment = deployment;
     }
 
-    public KeycloakDeployment getDeployment() {
+    public AdapterDeploymentContext(KeycloakConfigResolver configResolver) {
+        this.configResolver = configResolver;
+    }
+
+    public KeycloakDeployment getDeployment(Request request) {
+        if (null != configResolver) {
+            return configResolver.resolve(request);
+        }
         return deployment;
     }
 
@@ -46,6 +55,10 @@ public class AdapterDeploymentContext {
      * @return
      */
     public KeycloakDeployment resolveDeployment(HttpFacade facade) {
+        if (null != configResolver) {
+            return configResolver.resolve(facade.getRequest());
+        }
+
         KeycloakDeployment deployment = this.deployment;
         if (deployment == null) return null;
         if (deployment.getAuthServerBaseUrl() == null) return deployment;

--- a/integration/adapter-core/src/main/java/org/keycloak/adapters/KeycloakConfigResolver.java
+++ b/integration/adapter-core/src/main/java/org/keycloak/adapters/KeycloakConfigResolver.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2014 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.adapters;
+
+import org.keycloak.adapters.HttpFacade.Request;
+
+/**
+ *
+ * @author Juraci Paixão Kröhling <juraci at kroehling.de>
+ */
+public abstract class KeycloakConfigResolver {
+
+    public abstract KeycloakDeployment resolve(Request facade);
+
+}

--- a/integration/adapter-core/src/main/java/org/keycloak/adapters/PreAuthActionsHandler.java
+++ b/integration/adapter-core/src/main/java/org/keycloak/adapters/PreAuthActionsHandler.java
@@ -65,7 +65,7 @@ public class PreAuthActionsHandler {
 
     public boolean preflightCors() {
         // don't need to resolve deployment on cors requests.  Just need to know local cors config.
-        KeycloakDeployment deployment = deploymentContext.getDeployment();
+        KeycloakDeployment deployment = deploymentContext.getDeployment(facade.getRequest());
         if (!deployment.isCors()) return false;
         log.debugv("checkCorsPreflight {0}", facade.getRequest().getURI());
         if (!facade.getRequest().getMethod().equalsIgnoreCase("OPTIONS")) {

--- a/integration/undertow/src/main/java/org/keycloak/adapters/undertow/KeycloakServletExtension.java
+++ b/integration/undertow/src/main/java/org/keycloak/adapters/undertow/KeycloakServletExtension.java
@@ -44,6 +44,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.util.Map;
+import org.keycloak.adapters.KeycloakConfigResolver;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -94,22 +95,65 @@ public class KeycloakServletExtension implements ServletExtension {
 
 
     @Override
+    @SuppressWarnings("UseSpecificCatch")
     public void handleDeployment(DeploymentInfo deploymentInfo, ServletContext servletContext) {
         if (!isAuthenticationMechanismPresent(deploymentInfo, "KEYCLOAK")) {
             log.debug("auth-method is not keycloak!");
             return;
         }
         log.debug("KeycloakServletException initialization");
-        InputStream is = getConfigInputStream(servletContext);
-        final KeycloakDeployment deployment;
-        if (is == null) {
-            log.warn("No adapter configuration.  Keycloak is unconfigured and will deny all requests.");
-            deployment = new KeycloakDeployment();
-        } else {
-            deployment = KeycloakDeploymentBuilder.build(is);
 
+        KeycloakConfigResolver configResolver = null;
+        String configResolverClass = servletContext.getInitParameter("keycloak.config.resolver");
+        if (configResolverClass != null) {
+            try {
+                configResolver = (KeycloakConfigResolver) deploymentInfo.getClassLoader().loadClass(configResolverClass).newInstance();
+                log.info("Using " + configResolverClass + " to resolve Keycloak configuration on a per-request basis.");
+            } catch (Exception ex) {
+                // TODO: should it re-throw the exception?
+                //
+                // Reasoning: if the explicitly defined `resolver` wasn't found, it *will* behave differently
+                // than the user expects!
+                //
+                // Counter-reasoning: the original code doesn't throws an exception if keycloak is unconfigured, ie,
+                // it's already not doing what the user would generally expect, but might be OK for development environments
+                // so, we probably shouldn't block the deployment of the user's application because of keycloak's configuration
+                // problem
+                log.warn("The specified resolver " + configResolverClass + " could NOT be loaded. Falling back to standard behavior. Reason: " + ex.getMessage());
+            }
         }
-        AdapterDeploymentContext deploymentContext = new AdapterDeploymentContext(deployment);
+
+        AdapterDeploymentContext deploymentContext;
+        if (configResolver != null) {
+            deploymentContext = new AdapterDeploymentContext(configResolver);
+            log.debug("Keycloak is using a per-request configuration resolver.");
+        } else {
+            InputStream is = getConfigInputStream(servletContext);
+            final KeycloakDeployment deployment;
+            if (is == null) {
+                log.warn("No adapter configuration.  Keycloak is unconfigured and will deny all requests.");
+                deployment = new KeycloakDeployment();
+            } else {
+                deployment = KeycloakDeploymentBuilder.build(is);
+            }
+            deploymentContext = new AdapterDeploymentContext(deployment);
+            log.debug("Keycloak is using a per-deployment configuration.");
+
+            deploymentInfo.addListener(new ListenerInfo(UndertowNodesRegistrationLifecycleWrapper.class, new InstanceFactory<UndertowNodesRegistrationLifecycleWrapper>() {
+
+                // TODO: got this during a rebase, so, need to figure out what to do with it
+                // one option is to require a generic keycloak.json, with no realm information
+                // and use it for the node registration, but needs some testing
+                @Override
+                public InstanceHandle<UndertowNodesRegistrationLifecycleWrapper> createInstance() throws InstantiationException {
+                    NodesRegistrationLifecycle nodesRegistration = new NodesRegistrationLifecycle(deployment);
+                    UndertowNodesRegistrationLifecycleWrapper listener = new UndertowNodesRegistrationLifecycleWrapper(nodesRegistration);
+                    return new ImmediateInstanceHandle<UndertowNodesRegistrationLifecycleWrapper>(listener);
+                }
+
+            }));
+        }
+
         servletContext.setAttribute(AdapterDeploymentContext.class.getName(), deploymentContext);
         UndertowUserSessionManagement userSessionManagement = new UndertowUserSessionManagement();
         final ServletKeycloakAuthMech mech = createAuthenticationMechanism(deploymentInfo, deploymentContext, userSessionManagement);
@@ -148,17 +192,6 @@ public class KeycloakServletExtension implements ServletExtension {
         ServletSessionConfig cookieConfig = new ServletSessionConfig();
         cookieConfig.setPath(deploymentInfo.getContextPath());
         deploymentInfo.setServletSessionConfig(cookieConfig);
-
-        deploymentInfo.addListener(new ListenerInfo(UndertowNodesRegistrationLifecycleWrapper.class, new InstanceFactory<UndertowNodesRegistrationLifecycleWrapper>() {
-
-            @Override
-            public InstanceHandle<UndertowNodesRegistrationLifecycleWrapper> createInstance() throws InstantiationException {
-                NodesRegistrationLifecycle nodesRegistration = new NodesRegistrationLifecycle(deployment);
-                UndertowNodesRegistrationLifecycleWrapper listener = new UndertowNodesRegistrationLifecycleWrapper(nodesRegistration);
-                return new ImmediateInstanceHandle<UndertowNodesRegistrationLifecycleWrapper>(listener);
-            }
-
-        }));
     }
 
     protected ServletKeycloakAuthMech createAuthenticationMechanism(DeploymentInfo deploymentInfo, AdapterDeploymentContext deploymentContext, UndertowUserSessionManagement userSessionManagement) {

--- a/integration/undertow/src/main/java/org/keycloak/adapters/undertow/ServletKeycloakAuthMech.java
+++ b/integration/undertow/src/main/java/org/keycloak/adapters/undertow/ServletKeycloakAuthMech.java
@@ -67,6 +67,7 @@ public class ServletKeycloakAuthMech extends UndertowKeycloakAuthMech {
         final NotificationReceiver logoutReceiver = new NotificationReceiver() {
             @Override
             public void handleNotification(SecurityNotification notification) {
+                UndertowHttpFacade facade = new UndertowHttpFacade(notification.getExchange());
                 if (notification.getEventType() != SecurityNotification.EventType.LOGGED_OUT) return;
                 final ServletRequestContext servletRequestContext = notification.getExchange().getAttachment(ServletRequestContext.ATTACHMENT_KEY);
                 HttpServletRequest req = (HttpServletRequest) servletRequestContext.getServletRequest();
@@ -79,7 +80,7 @@ public class ServletKeycloakAuthMech extends UndertowKeycloakAuthMech {
                 session.removeAttribute(KeycloakSecurityContext.class.getName());
                 session.removeAttribute(KeycloakUndertowAccount.class.getName());
                 if (account.getKeycloakSecurityContext() != null) {
-                    account.getKeycloakSecurityContext().logout(deploymentContext.getDeployment());
+                    account.getKeycloakSecurityContext().logout(deploymentContext.getDeployment(facade.getRequest()));
                 }
             }
         };

--- a/integration/undertow/src/main/java/org/keycloak/adapters/undertow/UndertowKeycloakAuthMech.java
+++ b/integration/undertow/src/main/java/org/keycloak/adapters/undertow/UndertowKeycloakAuthMech.java
@@ -59,6 +59,7 @@ public abstract class UndertowKeycloakAuthMech implements AuthenticationMechanis
         final NotificationReceiver logoutReceiver = new NotificationReceiver() {
             @Override
             public void handleNotification(SecurityNotification notification) {
+                UndertowHttpFacade facade = new UndertowHttpFacade(notification.getExchange());
                 if (notification.getEventType() != SecurityNotification.EventType.LOGGED_OUT) return;
                 Session session = Sessions.getSession(notification.getExchange());
                 if (session == null) return;
@@ -66,7 +67,7 @@ public abstract class UndertowKeycloakAuthMech implements AuthenticationMechanis
                 if (account == null) return;
                 session.removeAttribute(KeycloakUndertowAccount.class.getName());
                 if (account.getKeycloakSecurityContext() != null) {
-                    account.getKeycloakSecurityContext().logout(deploymentContext.getDeployment());
+                    account.getKeycloakSecurityContext().logout(deploymentContext.getDeployment(facade.getRequest()));
                 }
             }
         };


### PR DESCRIPTION
This is a first draft for a proposal on the implementation of multi tenancy for Keycloak and is intended only to start a discussion on this feature. 

This is based on the assumption that Keycloak will defer the resolution of the realm to the application, if the application so chooses. As such, the incoming request has a more important role as before for this. Thus, the HttpFacade.Request is now a dependency on some other places. 

Some notes:
- All tests passes (ie: no regressions, it seems), but no new tests were added (will be, if this is the right direction for this feature)
- Perhaps the KeycloakDeployment should be renamed or split. One part of it could be about the "keycloak server", and the second part could be about the "realm". This is more evident with the new clustering support
- Talking about the clustering support: it was committed after I started working on this PoC, so, I haven't thought about it when coding and just fixed the merge conflicts. 
- The basic idea is that if an application defines "keycloak.config.resolver" as a context param, Keycloak will defer the resolution of KeycloakDeployment to the class specified on this property. It provides the HttpFacade.Request to this resolver. If this property is not available, the previous behavior takes place (ie: loading the KeycloakDeployment based on WEB-INF/keycloak.json). 
- I have tested this Wildfly/Undertow adapter deployed on Wildfly 8.1.0.Final and running the application at  https://github.com/jpkrohling/keycloak-tenants-poc against a 1.0.1.Final server.
