### PR TITLE
Add SAML NameID Formats and include certificate in signature

### DIFF
--- a/saml/saml-protocol/src/main/java/org/keycloak/protocol/saml/SALM2LoginResponseBuilder.java
+++ b/saml/saml-protocol/src/main/java/org/keycloak/protocol/saml/SALM2LoginResponseBuilder.java
@@ -38,7 +38,8 @@ public class SALM2LoginResponseBuilder extends SAML2BindingBuilder<SALM2LoginRes
     protected static final PicketLinkLogger logger = PicketLinkLoggerFactory.getLogger();
 
     protected List<String> roles = new LinkedList<String>();
-    protected String userPrincipal;
+    protected String nameId;
+    protected String nameIdFormat;
     protected boolean multiValuedRoles;
     protected boolean disableAuthnStatement;
     protected String requestID;
@@ -88,8 +89,9 @@ public class SALM2LoginResponseBuilder extends SAML2BindingBuilder<SALM2LoginRes
         return this;
     }
 
-    public SALM2LoginResponseBuilder userPrincipal(String userPrincipal) {
-        this.userPrincipal = userPrincipal;
+    public SALM2LoginResponseBuilder nameIdentifier(String nameIdFormat, String nameId) {
+        this.nameIdFormat = nameIdFormat;
+        this.nameId = nameId;
         return this;
     }
 
@@ -129,8 +131,8 @@ public class SALM2LoginResponseBuilder extends SAML2BindingBuilder<SALM2LoginRes
         issuerHolder.setStatusCode(JBossSAMLURIConstants.STATUS_SUCCESS.get());
 
         IDPInfoHolder idp = new IDPInfoHolder();
-        idp.setNameIDFormatValue(userPrincipal);
-        idp.setNameIDFormat(JBossSAMLURIConstants.NAMEID_FORMAT_PERSISTENT.get());
+        idp.setNameIDFormatValue(nameId);
+        idp.setNameIDFormat(nameIdFormat);
 
         SPInfoHolder sp = new SPInfoHolder();
         sp.setResponseDestinationURI(destination);

--- a/saml/saml-protocol/src/main/resources/idp-metadata-template.xml
+++ b/saml/saml-protocol/src/main/resources/idp-metadata-template.xml
@@ -5,8 +5,10 @@
 	<EntityDescriptor entityID="${idp.entityID}">
 		<IDPSSODescriptor WantAuthnRequestsSigned="true"
 			protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
-			<NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient
-			</NameIDFormat>
+			<NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
+			<NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified</NameIDFormat>
+			<NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</NameIDFormat>
+
 			<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
 				Location="${idp.sso.HTTP-POST}" />
 			<SingleSignOnService


### PR DESCRIPTION
The NameID Format in the AuthnRequest NameIDPolicy is now respected,
and support has been added for the following NameID Formats:
- urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified
- urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress
- urn:oasis:names:tc:SAML:2.0:nameid-format:transient

The persistent NameID format was previously used in all responses
and mapped to the principal's username. Now, unspecified is mapped
to the principal's username and used by default if no NameIDPolicy
is specified by the SP.

The persistent format requires generating a pseudo-random identifier
that must be generated by the IdP on first login and stored in the
user's profile. Persistent NameID Format is not yet implemented.

The certificate is now added to the signature to enable support for
integration with Service Providers where only the IdP's certificate
fingerprint is configured (e.g. Zendesk).
