### PR TITLE
Passwort reset dialog shows an error message if the user has an invalid email

### DIFF
--- a/events/api/src/main/java/org/keycloak/events/Errors.java
+++ b/events/api/src/main/java/org/keycloak/events/Errors.java
@@ -41,4 +41,5 @@ public interface Errors {
     String USER_SESSION_NOT_FOUND = "user_session_not_found";
 
     String EMAIL_SEND_FAILED = "email_send_failed";
+    String INVALID_EMAIL = "invalid_email";
 }

--- a/services/src/main/java/org/keycloak/services/resources/LoginActionsService.java
+++ b/services/src/main/java/org/keycloak/services/resources/LoginActionsService.java
@@ -826,7 +826,10 @@ public class LoginActionsService {
             event.error(Errors.USER_NOT_FOUND);
         } else if(!user.isEnabled()) {
             event.user(user).error(Errors.USER_DISABLED);
-        } else {
+        }
+        else if(user.getEmail() == null || user.getEmail().trim().length() == 0) {
+            event.user(user).error(Errors.INVALID_EMAIL);
+        } else{
             event.user(user);
 
             UserSessionModel userSession = session.sessions().createUserSession(realm, user, username, clientConnection.getRemoteAddr(), "form", false);


### PR DESCRIPTION
https://issues.jboss.org/browse/KEYCLOAK-956
