### PR TITLE
[KEYCLOAK-883] - More SAML configuration. Using SAML builders to create AuthnRequest.

### DIFF
--- a/broker/core/src/main/java/org/keycloak/broker/provider/AuthenticationResponse.java
+++ b/broker/core/src/main/java/org/keycloak/broker/provider/AuthenticationResponse.java
@@ -54,4 +54,7 @@ public class AuthenticationResponse {
         return new AuthenticationResponse(Response.temporaryRedirect(url).build());
     }
 
+    public static AuthenticationResponse fromResponse(Response response) {
+        return new AuthenticationResponse(response);
+    }
 }

--- a/broker/saml/pom.xml
+++ b/broker/saml/pom.xml
@@ -22,6 +22,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-saml-protocol</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.picketlink</groupId>
             <artifactId>picketlink-federation</artifactId>
         </dependency>

--- a/broker/saml/src/main/java/org/keycloak/broker/saml/SAMLIdentityProviderConfig.java
+++ b/broker/saml/src/main/java/org/keycloak/broker/saml/SAMLIdentityProviderConfig.java
@@ -89,4 +89,20 @@ public class SAMLIdentityProviderConfig extends IdentityProviderModel {
     public void setEncryptionPublicKey(String encryptionPublicKey) {
         getConfig().put("encryptionPublicKey", encryptionPublicKey);
     }
+
+    public boolean isPostBindingAuthnRequest() {
+        return Boolean.valueOf(getConfig().get("postBindingAuthnRequest"));
+    }
+
+    public void setPostBindingAuthnRequest(boolean postBindingAuthnRequest) {
+        getConfig().put("postBindingAuthnRequest", String.valueOf(postBindingAuthnRequest));
+    }
+
+    public boolean isPostBindingResponse() {
+        return Boolean.valueOf(getConfig().get("postBindingResponse"));
+    }
+
+    public void setPostBindingResponse(boolean postBindingResponse) {
+        getConfig().put("postBindingResponse", String.valueOf(postBindingResponse));
+    }
 }

--- a/forms/common-themes/src/main/resources/theme/admin/base/resources/partials/realm-identity-provider-saml.html
+++ b/forms/common-themes/src/main/resources/theme/admin/base/resources/partials/realm-identity-provider-saml.html
@@ -73,6 +73,20 @@
                         <span tooltip-placement="right" tooltip="Enable/disable signature validation of SAML responses." class="fa fa-info-circle"></span>
                     </div>
                     <div class="form-group">
+                        <label class="col-sm-2 control-label" for="postBindingResponse">HTTP-POST Binding Response</label>
+                        <div class="col-sm-4">
+                            <input ng-model="identityProvider.config.postBindingResponse" id="postBindingResponse" onoffswitch />
+                        </div>
+                        <span tooltip-placement="right" tooltip="Indicates whether the identity provider must respond to the AuthnRequest using HTTP-POST binding. If false, HTTP-REDIRECT binding will be used." class="fa fa-info-circle"></span>
+                    </div>
+                    <div class="form-group">
+                        <label class="col-sm-2 control-label" for="postBindingAuthnRequest">HTTP-POST Binding for AuthnRequest</label>
+                        <div class="col-sm-4">
+                            <input ng-model="identityProvider.config.postBindingAuthnRequest" id="postBindingAuthnRequest" onoffswitch />
+                        </div>
+                        <span tooltip-placement="right" tooltip="Indicates whether the AuthnRequest must be sent using HTTP-POST binding. If false, HTTP-REDIRECT binding will be used." class="fa fa-info-circle"></span>
+                    </div>
+                    <div class="form-group">
                         <label class="col-sm-2 control-label" for="enabled">Enabled</label>
                         <div class="col-sm-4">
                             <input ng-model="identityProvider.enabled" id="enabled" onoffswitch />

--- a/saml/saml-protocol/src/main/java/org/keycloak/protocol/saml/SALM2LoginResponseBuilder.java
+++ b/saml/saml-protocol/src/main/java/org/keycloak/protocol/saml/SALM2LoginResponseBuilder.java
@@ -127,7 +127,7 @@ public class SALM2LoginResponseBuilder extends SAML2BindingBuilder<SALM2LoginRes
         // Create a response type
         String id = IDGenerator.create("ID_");
 
-        IssuerInfoHolder issuerHolder = new IssuerInfoHolder(responseIssuer);
+        IssuerInfoHolder issuerHolder = new IssuerInfoHolder(issuer);
         issuerHolder.setStatusCode(JBossSAMLURIConstants.STATUS_SUCCESS.get());
 
         IDPInfoHolder idp = new IDPInfoHolder();

--- a/saml/saml-protocol/src/main/java/org/keycloak/protocol/saml/SAML2AuthnRequestBuilder.java
+++ b/saml/saml-protocol/src/main/java/org/keycloak/protocol/saml/SAML2AuthnRequestBuilder.java
@@ -1,0 +1,98 @@
+/*
+ * JBoss, Home of Professional Open Source
+ *
+ * Copyright 2013 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.protocol.saml;
+
+import org.picketlink.common.exceptions.ConfigurationException;
+import org.picketlink.identity.federation.api.saml.v2.request.SAML2Request;
+import org.picketlink.identity.federation.core.saml.v2.common.IDGenerator;
+import org.picketlink.identity.federation.core.saml.v2.util.XMLTimeUtil;
+import org.picketlink.identity.federation.saml.v2.assertion.NameIDType;
+import org.picketlink.identity.federation.saml.v2.protocol.AuthnRequestType;
+import org.w3c.dom.Document;
+
+import java.net.URI;
+
+/**
+ * @author pedroigor
+ */
+public class SAML2AuthnRequestBuilder extends SAML2BindingBuilder<SAML2AuthnRequestBuilder> {
+
+    private final AuthnRequestType authnRequestType;
+
+    public SAML2AuthnRequestBuilder() {
+        try {
+            this.authnRequestType = new AuthnRequestType(IDGenerator.create("ID_"), XMLTimeUtil.getIssueInstant());
+        } catch (ConfigurationException e) {
+            throw new RuntimeException("Could not create SAML AuthnRequest builder.", e);
+        }
+    }
+
+    public SAML2AuthnRequestBuilder assertionConsumerUrl(String assertionConsumerUrl) {
+        this.authnRequestType.setAssertionConsumerServiceURL(URI.create(assertionConsumerUrl));
+        return this;
+    }
+
+    public SAML2AuthnRequestBuilder forceAuthn(boolean forceAuthn) {
+        this.authnRequestType.setForceAuthn(forceAuthn);
+        return this;
+    }
+
+    public SAML2AuthnRequestBuilder nameIdPolicy(SAML2NameIDPolicyBuilder nameIDPolicy) {
+        this.authnRequestType.setNameIDPolicy(nameIDPolicy.build());
+        return this;
+    }
+
+    public SAML2AuthnRequestBuilder protocolBinding(String protocolBinding) {
+        this.authnRequestType.setProtocolBinding(URI.create(protocolBinding));
+        return this;
+    }
+
+    public RedirectBindingBuilder redirectBinding() {
+        try {
+            return new RedirectBindingBuilder(toDocument());
+        } catch (Exception e) {
+            throw new RuntimeException("Could not build authn request for post binding.", e);
+        }
+    }
+
+    public PostBindingBuilder postBinding() {
+        try {
+            return new PostBindingBuilder(toDocument());
+        } catch (Exception e) {
+            throw new RuntimeException("Could not build authn request for post binding.", e);
+        }
+    }
+
+    private Document toDocument()  {
+        try {
+            AuthnRequestType authnRequestType = this.authnRequestType;
+
+            NameIDType nameIDType = new NameIDType();
+
+            nameIDType.setValue(this.issuer);
+
+            authnRequestType.setIssuer(nameIDType);
+
+            authnRequestType.setDestination(URI.create(this.destination));
+
+            return new SAML2Request().convert(authnRequestType);
+        } catch (Exception e) {
+            throw new RuntimeException("Could not convert " + authnRequestType + " to a document.", e);
+        }
+    }
+}

--- a/saml/saml-protocol/src/main/java/org/keycloak/protocol/saml/SAML2ErrorResponseBuilder.java
+++ b/saml/saml-protocol/src/main/java/org/keycloak/protocol/saml/SAML2ErrorResponseBuilder.java
@@ -47,7 +47,7 @@ public class SAML2ErrorResponseBuilder extends SAML2BindingBuilder<SAML2ErrorRes
         // Create a response type
         String id = IDGenerator.create("ID_");
 
-        IssuerInfoHolder issuerHolder = new IssuerInfoHolder(responseIssuer);
+        IssuerInfoHolder issuerHolder = new IssuerInfoHolder(issuer);
         issuerHolder.setStatusCode(status);
 
         IDPInfoHolder idp = new IDPInfoHolder();

--- a/saml/saml-protocol/src/main/java/org/keycloak/protocol/saml/SAML2LogoutRequestBuilder.java
+++ b/saml/saml-protocol/src/main/java/org/keycloak/protocol/saml/SAML2LogoutRequestBuilder.java
@@ -1,19 +1,15 @@
 package org.keycloak.protocol.saml;
 
-import org.picketlink.common.constants.JBossSAMLURIConstants;
 import org.picketlink.common.exceptions.ConfigurationException;
 import org.picketlink.common.exceptions.ParsingException;
 import org.picketlink.common.exceptions.ProcessingException;
 import org.picketlink.identity.federation.api.saml.v2.request.SAML2Request;
-import org.picketlink.identity.federation.core.saml.v2.util.DocumentUtil;
 import org.picketlink.identity.federation.core.saml.v2.util.XMLTimeUtil;
 import org.picketlink.identity.federation.core.sts.PicketLinkCoreSTS;
 import org.picketlink.identity.federation.saml.v2.assertion.NameIDType;
 import org.picketlink.identity.federation.saml.v2.protocol.LogoutRequestType;
-import org.picketlink.identity.federation.web.util.PostBindingUtil;
 import org.w3c.dom.Document;
 
-import java.io.IOException;
 import java.net.URI;
 
 /**
@@ -48,7 +44,7 @@ public class SAML2LogoutRequestBuilder extends SAML2BindingBuilder<SAML2LogoutRe
     }
 
     private LogoutRequestType createLogoutRequest() throws ConfigurationException {
-        LogoutRequestType lort = new SAML2Request().createLogoutRequest(responseIssuer);
+        LogoutRequestType lort = new SAML2Request().createLogoutRequest(issuer);
 
         NameIDType nameID = new NameIDType();
         nameID.setValue(userPrincipal);

--- a/saml/saml-protocol/src/main/java/org/keycloak/protocol/saml/SAML2LogoutResponseBuilder.java
+++ b/saml/saml-protocol/src/main/java/org/keycloak/protocol/saml/SAML2LogoutResponseBuilder.java
@@ -6,13 +6,8 @@ import org.picketlink.common.exceptions.ParsingException;
 import org.picketlink.common.exceptions.ProcessingException;
 import org.picketlink.identity.federation.api.saml.v2.response.SAML2Response;
 import org.picketlink.identity.federation.core.saml.v2.common.IDGenerator;
-import org.picketlink.identity.federation.core.saml.v2.factories.JBossSAMLAuthnResponseFactory;
-import org.picketlink.identity.federation.core.saml.v2.holders.IDPInfoHolder;
-import org.picketlink.identity.federation.core.saml.v2.holders.IssuerInfoHolder;
-import org.picketlink.identity.federation.core.saml.v2.holders.SPInfoHolder;
 import org.picketlink.identity.federation.core.saml.v2.util.XMLTimeUtil;
 import org.picketlink.identity.federation.saml.v2.assertion.NameIDType;
-import org.picketlink.identity.federation.saml.v2.protocol.ResponseType;
 import org.picketlink.identity.federation.saml.v2.protocol.StatusCodeType;
 import org.picketlink.identity.federation.saml.v2.protocol.StatusResponseType;
 import org.picketlink.identity.federation.saml.v2.protocol.StatusType;
@@ -60,7 +55,7 @@ public class SAML2LogoutResponseBuilder extends SAML2BindingBuilder<SAML2LogoutR
             statusResponse.setStatus(statusType);
             statusResponse.setInResponseTo(logoutRequestID);
             NameIDType issuer = new NameIDType();
-            issuer.setValue(responseIssuer);
+            issuer.setValue(this.issuer);
 
             statusResponse.setIssuer(issuer);
             statusResponse.setDestination(destination);

--- a/saml/saml-protocol/src/main/java/org/keycloak/protocol/saml/SAML2NameIDPolicyBuilder.java
+++ b/saml/saml-protocol/src/main/java/org/keycloak/protocol/saml/SAML2NameIDPolicyBuilder.java
@@ -1,0 +1,44 @@
+/*
+ * JBoss, Home of Professional Open Source
+ *
+ * Copyright 2013 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.protocol.saml;
+
+import org.picketlink.identity.federation.saml.v2.protocol.NameIDPolicyType;
+
+import java.net.URI;
+
+/**
+ * @author pedroigor
+ */
+public class SAML2NameIDPolicyBuilder {
+
+    private final NameIDPolicyType policyType;
+
+    private SAML2NameIDPolicyBuilder(String format) {
+        this.policyType = new NameIDPolicyType();
+        this.policyType.setFormat(URI.create(format));
+    }
+
+    public static SAML2NameIDPolicyBuilder format(String format) {
+        return new SAML2NameIDPolicyBuilder(format);
+    }
+
+    public NameIDPolicyType build() {
+        this.policyType.setAllowCreate(Boolean.TRUE);
+        return this.policyType;
+    }
+}

--- a/saml/saml-protocol/src/main/java/org/keycloak/protocol/saml/SamlProtocol.java
+++ b/saml/saml-protocol/src/main/java/org/keycloak/protocol/saml/SamlProtocol.java
@@ -114,7 +114,7 @@ public class SamlProtocol implements LoginProtocol {
         SAML2ErrorResponseBuilder builder = new SAML2ErrorResponseBuilder()
                 .relayState(clientSession.getNote(GeneralConstants.RELAY_STATE))
                 .destination(clientSession.getRedirectUri())
-                .responseIssuer(getResponseIssuer(realm))
+                .issuer(getResponseIssuer(realm))
                 .status(status);
       try {
           if (isPostBinding(clientSession)) {
@@ -191,7 +191,7 @@ public class SamlProtocol implements LoginProtocol {
         builder.requestID(requestID)
                .relayState(relayState)
                .destination(redirectUri)
-               .responseIssuer(responseIssuer)
+               .issuer(responseIssuer)
                .requestIssuer(clientSession.getClient().getClientId())
                .nameIdentifier(nameIdFormat, nameId)
                .authMethod(JBossSAMLURIConstants.AC_UNSPECIFIED.get());

--- a/services/src/main/java/org/keycloak/services/resources/AuthenticationBrokerResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/AuthenticationBrokerResource.java
@@ -156,7 +156,7 @@ public class AuthenticationBrokerResource {
             String relayState = provider.getRelayState(createAuthenticationRequest(providerId, null, realm, null));
 
             if (relayState == null) {
-                return redirectToErrorPage(realm, "No authorization code provided.");
+                return redirectToErrorPage(realm, "No relay state from identity provider.");
             }
 
             ClientSessionCode clientCode = isValidAuthorizationCode(relayState, realm);


### PR DESCRIPTION
Added two more configuration options for SAML brokering:
- Users can choose what is the expected protocol binding for responses
- Users can choose which protocol binding should be used to send AuthnRequest

A little refactoring on how AuthnRequest is built to use SAML builders and abstract PL codebase usage.
