### PR TITLE
Updated parent POM version for saml sub module in examples-pom module.

### DIFF
--- a/examples/saml/pom.xml
+++ b/examples/saml/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>examples-pom</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>1.1.0-Alpha1-SNAPSHOT</version>
+        <version>1.2.0.Beta1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <name>Provider Examples</name>


### PR DESCRIPTION
This also fixes war-distribution testing for examples (saml sub-module) deployment against as7.1.1, eap 6.2, eap 6.3 and wildfly 8.2.
