### PR TITLE
Updated target java to 1.7 in parent pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,8 +56,8 @@
         <pax.web.version>3.1.2</pax.web.version>
 
         <!-- maven-compiler-plugin -->
-        <maven.compiler.target>1.6</maven.compiler.target>
-        <maven.compiler.source>1.6</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
+        <maven.compiler.source>1.7</maven.compiler.source>
 
     </properties>
 


### PR DESCRIPTION
Updated target java to 1.7 as Keycloak source codes are not compilable under java 1.6 due some core java classes (unknown constructor in AssertionError, bad visibility of method in InetAddress). 
This change eases import of Keycloak project into Eclipse also as Eclipse uses this maven property to set Java version for project. Without this change there are compilation errors in Eclipse after project import.
