### PR TITLE
KEYCLOAK-1053 patch of email validation during social login without email

### DIFF
--- a/events/api/src/main/java/org/keycloak/events/Errors.java
+++ b/events/api/src/main/java/org/keycloak/events/Errors.java
@@ -41,7 +41,6 @@ public interface Errors {
     String NOT_ALLOWED = "not_allowed";
 
     String FEDERATED_IDENTITY_EMAIL_EXISTS = "federated_identity_email_exists";
-    String FEDERATED_IDENTITY_REGISTRATION_EMAIL_MISSING = "federated_identity_registration_email_missing";
     String FEDERATED_IDENTITY_USERNAME_EXISTS = "federated_identity_username_exists";
     String SSL_REQUIRED = "ssl_required";
 

--- a/forms/common-themes/src/main/resources/theme/login/base/messages/messages_de.properties
+++ b/forms/common-themes/src/main/resources/theme/login/base/messages/messages_de.properties
@@ -79,7 +79,6 @@ invalidTotpMessage=Ungültiger One-time Code.
 usernameExistsMessage=Benutzermane exisitert bereits.
 emailExistsMessage=E-Mail existiert bereits.
 
-federatedIdentityRegistrationEmailMissingMessage=Die E-Mail Adresse ist nicht vorhanden. Bitte verwenden Sie einen anderen Provider um das Benutzerkonto zu erstellen.
 federatedIdentityEmailExistsMessage=Es exisitert bereits ein Benutzer mit dieser E-Mail Adresse. Bitte melden Sie sich bei der Benutzerverwaltung an um das Benutzerkonto zu verknüpfen.
 federatedIdentityUsernameExistsMessage=Es exisitert bereits ein Benutzer mit diesem Benutzernamen. Bitte melden Sie sich bei der Benutzerverwaltung an um das Benutzerkonto zu verknüpfen.
 

--- a/forms/common-themes/src/main/resources/theme/login/base/messages/messages_en.properties
+++ b/forms/common-themes/src/main/resources/theme/login/base/messages/messages_en.properties
@@ -143,4 +143,3 @@ backToApplication=&laquo; Back to Application
 missingParameterMessage=Missing parameters\: {0}
 clientNotFoundMessage=Client not found.
 invalidParameterMessage=Invalid parameter\: {0}
-federatedIdentityRegistrationEmailMissingMessage=Email is not provided. Use another provider to create account please.

--- a/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
@@ -20,6 +20,7 @@ import org.keycloak.models.RequiredCredentialModel;
 import org.keycloak.models.RoleModel;
 import org.keycloak.models.UserCredentialModel;
 import org.keycloak.models.UserModel;
+import org.keycloak.models.UserModel.RequiredAction;
 import org.keycloak.models.UserSessionModel;
 import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.protocol.LoginProtocol;
@@ -30,6 +31,7 @@ import org.keycloak.services.resources.LoginActionsService;
 import org.keycloak.services.resources.RealmsResource;
 import org.keycloak.services.resources.flows.Flows;
 import org.keycloak.services.util.CookieHelper;
+import org.keycloak.services.validation.Validation;
 import org.keycloak.util.Time;
 
 import javax.ws.rs.core.Cookie;
@@ -43,6 +45,7 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
+import java.util.Iterator;
 
 /**
  * Stateless object that manages authentication
@@ -366,17 +369,28 @@ public class AuthenticationManager {
 
         Set<UserModel.RequiredAction> requiredActions = user.getRequiredActions();
         if (!requiredActions.isEmpty()) {
-            UserModel.RequiredAction action = user.getRequiredActions().iterator().next();
-            accessCode.setRequiredAction(action);
-
-            LoginFormsProvider loginFormsProvider = Flows.forms(session, realm, client, uriInfo, request.getHttpHeaders()).setClientSessionCode(accessCode.getCode()).setUser(user);
-            if (action.equals(UserModel.RequiredAction.VERIFY_EMAIL)) {
-                event.clone().event(EventType.SEND_VERIFY_EMAIL).detail(Details.EMAIL, user.getEmail()).success();
-                LoginActionsService.createActionCookie(realm, uriInfo, clientConnection, userSession.getId());
+            Iterator<RequiredAction> i = user.getRequiredActions().iterator();
+            UserModel.RequiredAction action = i.next();
+            
+            if (action.equals(UserModel.RequiredAction.VERIFY_EMAIL) && Validation.isEmpty(user.getEmail())) {
+                if (i.hasNext())
+                    action = i.next();
+                else
+                    action = null;
             }
 
-            return loginFormsProvider
-                    .createResponse(action);
+            if (action != null) {
+                accessCode.setRequiredAction(action);
+
+                LoginFormsProvider loginFormsProvider = Flows.forms(session, realm, client, uriInfo, request.getHttpHeaders()).setClientSessionCode(accessCode.getCode())
+                        .setUser(user);
+                if (action.equals(UserModel.RequiredAction.VERIFY_EMAIL)) {
+                    event.clone().event(EventType.SEND_VERIFY_EMAIL).detail(Details.EMAIL, user.getEmail()).success();
+                    LoginActionsService.createActionCookie(realm, uriInfo, clientConnection, userSession.getId());
+                }
+
+                return loginFormsProvider.createResponse(action);
+            }
         }
 
         if (!isResource) {

--- a/services/src/main/java/org/keycloak/services/messages/Messages.java
+++ b/services/src/main/java/org/keycloak/services/messages/Messages.java
@@ -171,6 +171,4 @@ public class Messages {
     public static final String CLIENT_NOT_FOUND = "clientNotFoundMessage";
 
     public static final String INVALID_PARAMETER = "invalidParameterMessage";
-
-    public static final String FEDERATED_IDENTITY_REGISTRATION_EMAIL_MISSING = "federatedIdentityRegistrationEmailMissingMessage";
 }

--- a/services/src/main/java/org/keycloak/services/resources/IdentityBrokerService.java
+++ b/services/src/main/java/org/keycloak/services/resources/IdentityBrokerService.java
@@ -49,6 +49,7 @@ import org.keycloak.services.managers.EventsManager;
 import org.keycloak.services.messages.Messages;
 import org.keycloak.services.resources.flows.Flows;
 import org.keycloak.services.resources.flows.Urls;
+import org.keycloak.services.validation.Validation;
 import org.keycloak.social.SocialIdentityProvider;
 
 import javax.ws.rs.Consumes;
@@ -521,15 +522,10 @@ public class IdentityBrokerService {
         }
 
         String username = updatedIdentity.getUsername();
-        if (this.realmModel.isRegistrationEmailAsUsername()) {
+        if (this.realmModel.isRegistrationEmailAsUsername() && !Validation.isEmpty(updatedIdentity.getEmail())) {
             username = updatedIdentity.getEmail();
-            if (username == null || username.trim().length() == 0) {
-                fireErrorEvent(Errors.FEDERATED_IDENTITY_REGISTRATION_EMAIL_MISSING);
-                throw new IdentityBrokerException(Messages.FEDERATED_IDENTITY_REGISTRATION_EMAIL_MISSING);
-                // TODO KEYCLOAK-1053 (ask user to enter email address) should be implemented instead of plain exception as better solution for this case
-            }
-            username = username.trim();
-        } else if (username != null) {
+        } 
+        if (username != null) {
             username = username.trim();
         }
 

--- a/testsuite/integration/src/test/java/org/keycloak/testsuite/broker/SAMLKeyCloakServerBrokerBasicTest.java
+++ b/testsuite/integration/src/test/java/org/keycloak/testsuite/broker/SAMLKeyCloakServerBrokerBasicTest.java
@@ -45,14 +45,24 @@ public class SAMLKeyCloakServerBrokerBasicTest extends AbstractIdentityProviderT
     }
 
     @Override
-    protected void doAssertFederatedUser(UserModel federatedUser, IdentityProviderModel identityProviderModel) {
+    protected void doAssertFederatedUser(UserModel federatedUser, IdentityProviderModel identityProviderModel, String expectedEmail) {
         if (identityProviderModel.isUpdateProfileFirstLogin()) {
-            super.doAssertFederatedUser(federatedUser, identityProviderModel);
+            super.doAssertFederatedUser(federatedUser, identityProviderModel, expectedEmail);
         } else {
-            assertEquals("test-user@localhost", federatedUser.getEmail());
+            if (expectedEmail == null)
+                expectedEmail = "";
+            assertEquals(expectedEmail, federatedUser.getEmail());
             assertNull(federatedUser.getFirstName());
             assertNull(federatedUser.getLastName());
         }
+    }
+
+    @Override
+    protected void doAssertFederatedUserNoEmail(UserModel federatedUser) {
+        assertEquals("", federatedUser.getUsername());
+        assertEquals("", federatedUser.getEmail());
+        assertEquals(null, federatedUser.getFirstName());
+        assertEquals(null, federatedUser.getLastName());
     }
 
     @Override

--- a/testsuite/integration/src/test/java/org/keycloak/testsuite/broker/SAMLKeyCloakServerBrokerWithSignatureTest.java
+++ b/testsuite/integration/src/test/java/org/keycloak/testsuite/broker/SAMLKeyCloakServerBrokerWithSignatureTest.java
@@ -45,14 +45,24 @@ public class SAMLKeyCloakServerBrokerWithSignatureTest extends AbstractIdentityP
     }
 
     @Override
-    protected void doAssertFederatedUser(UserModel federatedUser, IdentityProviderModel identityProviderModel) {
+    protected void doAssertFederatedUser(UserModel federatedUser, IdentityProviderModel identityProviderModel, String expectedEmail) {
         if (identityProviderModel.isUpdateProfileFirstLogin()) {
-            super.doAssertFederatedUser(federatedUser, identityProviderModel);
+            super.doAssertFederatedUser(federatedUser, identityProviderModel, expectedEmail);
         } else {
-            assertEquals("test-user@localhost", federatedUser.getEmail());
+            if (expectedEmail == null)
+                expectedEmail = "";
+            assertEquals(expectedEmail, federatedUser.getEmail());
             assertNull(federatedUser.getFirstName());
             assertNull(federatedUser.getLastName());
         }
+    }
+
+    @Override
+    protected void doAssertFederatedUserNoEmail(UserModel federatedUser) {
+        assertEquals("", federatedUser.getUsername());
+        assertEquals("", federatedUser.getEmail());
+        assertEquals(null, federatedUser.getFirstName());
+        assertEquals(null, federatedUser.getLastName());
     }
 
     @Override


### PR DESCRIPTION
KEYCLOAK-1053 - code patched so social login do not fail when email validation is enabled for realm but email is not provided by social login provider (eg. Twitter)
