### PR TITLE
Migration docs, fixes

### DIFF
--- a/docbook/reference/en/en-US/modules/MigrationFromOlderVersions.xml
+++ b/docbook/reference/en/en-US/modules/MigrationFromOlderVersions.xml
@@ -124,6 +124,37 @@
                     to describe the themes included in a JAR. See the <link linkend='themes'>themes</link> section in the docs for more information.
                 </para>
             </simplesect>
+            <simplesect>
+                <title>Claims changes</title>
+                <para>
+                    Previously there was <literal>Claims</literal> tab in admin console for application and OAuth clients. This
+                    was used to configure which attributes should go into access token for particular application/client. This was removed
+                    and replaced with <link linkend='mappers'>Protocol mappers</link>, which are more flexible.
+                </para>
+                <para>
+                    You don't need to care about migration of database from previous version.
+                    We did migration scripts for both RDBMS and Mongo, which should ensure that claims configured for particular application/client
+                    will be converted into corresponding protocol mappers (Still it's safer to backup DB before migrating to newer version though).
+                    Same applies for exported JSON representation from previous version.
+                </para>
+            </simplesect>
+            <simplesect>
+                <title>Social migration to identity brokering</title>
+                <para>
+                    We refactored social providers SPI and replaced it with <link linkend="identity-broker">identity brokering SPI</link>,
+                    which is more flexible. The <literal>Social</literal> tab in admin console is renamed to <literal>Identity Provider</literal> tab.
+                </para>
+                <para>
+                    Again you don't need to care about migration of database from previous version similarly like for Claims/protocol mappers.
+                    Both configuration of social providers and "social links" to your users will be converted to corresponding Identity providers.
+                </para>
+                <para>
+                    Only required action from you would be to change allowed <literal>Redirect URI</literal> in the admin console of
+                    particular 3rd party social providers. You can first go to the Keycloak admin console and copy Redirect URI from the page where
+                    you configure the identity provider. Then you can simply paste this as allowed Redirect URI to the admin console
+                    of 3rd party provider (IE. Facebook admin console).
+                </para>
+            </simplesect>
         </section>
         <section>
             <title>Migrating from 1.1.0.Beta2 to 1.1.0.Final</title>

--- a/docbook/reference/en/en-US/modules/application-clustering.xml
+++ b/docbook/reference/en/en-US/modules/application-clustering.xml
@@ -65,8 +65,15 @@
 </programlisting>
         </para>
         <para>
-            Default value of <literal>token-store</literal> is <literal>session</literal>, hence saving data in HTTP session. One disadvantage of cookie store is,
-            that whole info about account is passed in cookie KEYCLOAK_ADAPTER_STATE in each HTTP request. Hence it's not the best for network performance.
+            Default value of <literal>token-store</literal> is <literal>session</literal>, hence saving data in HTTP session.
+        </para>
+        <para>
+            One limitation of cookie store is, that whole info about account is passed in cookie KEYCLOAK_ADAPTER_STATE in each HTTP request.
+            Hence it's not the best for network performance.
+            Another small limitation is limited support for Single-Sign out. It works without issues if you init servlet logout (HttpServletRequest.logout)
+            from this application itself as the adapter will delete the KEYCLOAK_ADAPTER_STATE cookie. But back-channel logout initialized from different application can't be
+            propagated by Keycloak to this application with cookie store. Hence it's recommended to use very short value of access token
+            timeout (1 minute for example).
         </para>
     </section>
 

--- a/docbook/reference/en/en-US/modules/identity-broker.xml
+++ b/docbook/reference/en/en-US/modules/identity-broker.xml
@@ -1,4 +1,4 @@
-<chapter>
+<chapter id="identity-broker">
     <title>Identity Broker</title>
 
     <para>

--- a/forms/common-themes/src/main/resources/theme/base/admin/resources/partials/realm-identity-provider-oidc.html
+++ b/forms/common-themes/src/main/resources/theme/base/admin/resources/partials/realm-identity-provider-oidc.html
@@ -13,7 +13,7 @@
                 <fieldset>
                     <div class="form-group clearfix">
                         <label class="col-sm-2 control-label" for="redirectUri">Redirect URI</label>
-                        <div class="col-sm-6">
+                        <div class="col-sm-8">
                             <input class="form-control" id="redirectUri" type="text" value="{{callbackUrl}}{{identityProvider.alias}}/endpoint" readonly kc-select-action="click">
                         </div>
                         <span tooltip-placement="right" tooltip="The redirect uri to use when configuring the identity provider" class="fa fa-info-circle"></span>

--- a/forms/common-themes/src/main/resources/theme/base/admin/resources/partials/realm-identity-provider-saml.html
+++ b/forms/common-themes/src/main/resources/theme/base/admin/resources/partials/realm-identity-provider-saml.html
@@ -13,7 +13,7 @@
                 <fieldset>
                     <div class="form-group clearfix">
                         <label class="col-sm-2 control-label" for="redirectUri">Redirect URI</label>
-                        <div class="col-sm-6">
+                        <div class="col-sm-8">
                             <input class="form-control" id="redirectUri" type="text" value="{{callbackUrl}}{{identityProvider.alias}}/endpoint" readonly kc-select-action="click">
                         </div>
                         <span tooltip-placement="right" tooltip="The redirect uri to use when configuring the identity provider" class="fa fa-info-circle"></span>

--- a/forms/common-themes/src/main/resources/theme/base/admin/resources/partials/realm-identity-provider-social.html
+++ b/forms/common-themes/src/main/resources/theme/base/admin/resources/partials/realm-identity-provider-social.html
@@ -13,7 +13,7 @@
                 <fieldset>
                     <div class="form-group clearfix">
                         <label class="col-sm-2 control-label" for="redirectUri">Redirect URI</label>
-                        <div class="col-sm-6">
+                        <div class="col-sm-8">
                             <input class="form-control" id="redirectUri" type="text" value="{{callbackUrl}}{{identityProvider.alias}}/endpoint" readonly kc-select-action="click">
                         </div>
                         <span tooltip-placement="right" tooltip="The redirect uri to use when configuring the identity provider" class="fa fa-info-circle"></span>

--- a/integration/adapter-core/src/main/java/org/keycloak/adapters/CookieTokenStore.java
+++ b/integration/adapter-core/src/main/java/org/keycloak/adapters/CookieTokenStore.java
@@ -18,7 +18,7 @@ import org.keycloak.util.KeycloakUriBuilder;
 public class CookieTokenStore {
 
     private static final Logger log = Logger.getLogger(CookieTokenStore.class);
-    private static final String DELIM = "@";
+    private static final String DELIM = "___";
 
     public static void setTokenCookie(KeycloakDeployment deployment, HttpFacade facade, RefreshableKeycloakSecurityContext session) {
         log.debugf("Set new %s cookie now", AdapterConstants.KEYCLOAK_ADAPTER_STATE_COOKIE);

--- a/integration/tomcat/tomcat-core/src/main/java/org/keycloak/adapters/tomcat/CatalinaHttpFacade.java
+++ b/integration/tomcat/tomcat-core/src/main/java/org/keycloak/adapters/tomcat/CatalinaHttpFacade.java
@@ -119,7 +119,7 @@ public class CatalinaHttpFacade implements HttpFacade {
 
         @Override
         public void resetCookie(String name, String path) {
-            setCookie(name, "", null, path, 0, false, false);
+            setCookie(name, "", path, null, 0, false, false);
         }
 
         @Override

--- a/model/api/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
+++ b/model/api/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
@@ -265,6 +265,7 @@ public class RepresentationToModel {
             Boolean updateProfileFirstLogin = rep.isUpdateProfileOnInitialSocialLogin() != null && rep.isUpdateProfileOnInitialSocialLogin();
             if (rep.getSocialProviders() != null) {
 
+                logger.warn("Using deprecated 'social' configuration in JSON representation. It will be removed in future versions");
                 List<IdentityProviderRepresentation> identityProviders = new LinkedList<>();
                 for (String k : rep.getSocialProviders().keySet()) {
                     if (k.endsWith(".key")) {
@@ -297,6 +298,8 @@ public class RepresentationToModel {
 
     private static void convertDeprecatedSocialProviders(UserRepresentation user) {
         if (user.getSocialLinks() != null && !user.getSocialLinks().isEmpty() && user.getFederatedIdentities() == null) {
+
+            logger.warnf("Using deprecated 'socialLinks' configuration in JSON representation for user '%s'. It will be removed in future versions", user.getUsername());
             List<FederatedIdentityRepresentation> federatedIdentities = new LinkedList<>();
             for (SocialLinkRepresentation social : user.getSocialLinks()) {
                 FederatedIdentityRepresentation federatedIdentity = new FederatedIdentityRepresentation();
@@ -316,6 +319,7 @@ public class RepresentationToModel {
             return null;
         }
 
+        logger.warn("Using deprecated 'claims' configuration in JSON representation. It will be removed in future versions");
         long mask = getClaimsMask(claimRep);
         MigrationProvider migrationProvider = session.getProvider(MigrationProvider.class);
         return migrationProvider.getMappersForClaimMask(mask);


### PR DESCRIPTION
-  CookieTokenStore not working correctly on EAP 6.3
-  Bigger 'redirect URI' field in admin console, so it's not partially hidden
-  Migration docs (protocol mappersm identity brokering)
