### PR TITLE
KEYCLOAK-1174: NPE on WildFly 9

### DIFF
--- a/integration/keycloak-subsystem/src/main/java/org/keycloak/subsystem/extension/CredentialAddHandler.java
+++ b/integration/keycloak-subsystem/src/main/java/org/keycloak/subsystem/extension/CredentialAddHandler.java
@@ -40,7 +40,7 @@ public class CredentialAddHandler extends AbstractAddStepHandler {
 
     @Override
     protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model, ServiceVerificationHandler verificationHandler, List<ServiceController<?>> newControllers) throws OperationFailedException {
-        KeycloakAdapterConfigService ckService = KeycloakAdapterConfigService.find(context);
+        KeycloakAdapterConfigService ckService = KeycloakAdapterConfigService.getInstance();
         ckService.addCredential(operation, context.resolveExpressions(model));
     }
 

--- a/integration/keycloak-subsystem/src/main/java/org/keycloak/subsystem/extension/CredentialReadWriteAttributeHandler.java
+++ b/integration/keycloak-subsystem/src/main/java/org/keycloak/subsystem/extension/CredentialReadWriteAttributeHandler.java
@@ -33,7 +33,7 @@ public class CredentialReadWriteAttributeHandler extends AbstractWriteAttributeH
     protected boolean applyUpdateToRuntime(OperationContext context, ModelNode operation, String attributeName,
                                            ModelNode resolvedValue, ModelNode currentValue, AbstractWriteAttributeHandler.HandbackHolder<KeycloakAdapterConfigService> hh) throws OperationFailedException {
 
-        KeycloakAdapterConfigService ckService = KeycloakAdapterConfigService.find(context);
+        KeycloakAdapterConfigService ckService = KeycloakAdapterConfigService.getInstance();
         ckService.updateCredential(operation, attributeName, resolvedValue);
 
         hh.setHandback(ckService);

--- a/integration/keycloak-subsystem/src/main/java/org/keycloak/subsystem/extension/CredentialRemoveHandler.java
+++ b/integration/keycloak-subsystem/src/main/java/org/keycloak/subsystem/extension/CredentialRemoveHandler.java
@@ -35,7 +35,7 @@ public final class CredentialRemoveHandler extends AbstractRemoveStepHandler {
 
     @Override
     protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
-        KeycloakAdapterConfigService ckService = KeycloakAdapterConfigService.find(context);
+        KeycloakAdapterConfigService ckService = KeycloakAdapterConfigService.getInstance();
         ckService.removeCredential(operation);
     }
 

--- a/integration/keycloak-subsystem/src/main/java/org/keycloak/subsystem/extension/KeycloakAdapterConfigDeploymentProcessor.java
+++ b/integration/keycloak-subsystem/src/main/java/org/keycloak/subsystem/extension/KeycloakAdapterConfigDeploymentProcessor.java
@@ -68,8 +68,7 @@ public class KeycloakAdapterConfigDeploymentProcessor implements DeploymentUnitP
         DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
 
         String deploymentName = deploymentUnit.getName();
-        KeycloakAdapterConfigService service = KeycloakAdapterConfigService.find(phaseContext.getServiceRegistry());
-        //log.info("********* CHECK KEYCLOAK DEPLOYMENT: " + deploymentName);
+        KeycloakAdapterConfigService service = KeycloakAdapterConfigService.getInstance();
         if (service.isSecureDeployment(deploymentName)) {
             addKeycloakAuthData(phaseContext, deploymentName, service);
         }

--- a/integration/keycloak-subsystem/src/main/java/org/keycloak/subsystem/extension/KeycloakAdapterConfigDeploymentProcessorEAP6.java
+++ b/integration/keycloak-subsystem/src/main/java/org/keycloak/subsystem/extension/KeycloakAdapterConfigDeploymentProcessorEAP6.java
@@ -50,7 +50,7 @@ public class KeycloakAdapterConfigDeploymentProcessorEAP6 implements DeploymentU
         DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
         String deploymentName = deploymentUnit.getName();
 
-        KeycloakAdapterConfigService service = KeycloakAdapterConfigService.find(phaseContext.getServiceRegistry());
+        KeycloakAdapterConfigService service = KeycloakAdapterConfigService.getInstance();
         //log.info("********* CHECK KEYCLOAK DEPLOYMENT: " + deploymentName);
         if (service.isSecureDeployment(deploymentName)) {
             addKeycloakAuthData(phaseContext, deploymentName, service);

--- a/integration/keycloak-subsystem/src/main/java/org/keycloak/subsystem/extension/KeycloakAdapterConfigService.java
+++ b/integration/keycloak-subsystem/src/main/java/org/keycloak/subsystem/extension/KeycloakAdapterConfigService.java
@@ -17,17 +17,9 @@
 
 package org.keycloak.subsystem.extension;
 
-import org.jboss.as.controller.OperationContext;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.Property;
 import org.jboss.logging.Logger;
-import org.jboss.msc.service.Service;
-import org.jboss.msc.service.ServiceController;
-import org.jboss.msc.service.ServiceName;
-import org.jboss.msc.service.ServiceRegistry;
-import org.jboss.msc.service.StartContext;
-import org.jboss.msc.service.StartException;
-import org.jboss.msc.service.StopContext;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -40,41 +32,27 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD
  *
  * @author Stan Silvert ssilvert@redhat.com (C) 2013 Red Hat Inc.
  */
-public final class KeycloakAdapterConfigService implements Service<KeycloakAdapterConfigService> {
+public final class KeycloakAdapterConfigService {
     protected Logger log = Logger.getLogger(KeycloakAdapterConfigService.class);
     private static final String CREDENTIALS_JSON_NAME = "credentials";
 
-    // Right now this is used as a service, but I'm not sure it really needs to be implemented that way.
-    // It's also a singleton serving the entire subsystem, but the INSTANCE variable is currently only
-    // used during initialization of the subsystem.
-    public static final ServiceName SERVICE_NAME = ServiceName.JBOSS.append("KeycloakAdapterConfigService");
-    public static final KeycloakAdapterConfigService INSTANCE = new KeycloakAdapterConfigService();
+    private static final KeycloakAdapterConfigService INSTANCE = new KeycloakAdapterConfigService();
 
-    private Map<String, ModelNode> realms = new HashMap<String, ModelNode>();
+    public static KeycloakAdapterConfigService getInstance() {
+        return INSTANCE;
+    }
+
+    private final Map<String, ModelNode> realms = new HashMap<String, ModelNode>();
 
     // keycloak-secured deployments
-    private Map<String, ModelNode> secureDeployments = new HashMap<String, ModelNode>();
+    private final Map<String, ModelNode> secureDeployments = new HashMap<String, ModelNode>();
 
     // key=auth-server deployment name; value=web-context
-    private Map<String, String> webContexts = new HashMap<String, String>();
+    private final Map<String, String> webContexts = new HashMap<String, String>();
+
+
 
     private KeycloakAdapterConfigService() {
-
-    }
-
-    @Override
-    public void start(StartContext sc) throws StartException {
-
-    }
-
-    @Override
-    public void stop(StopContext sc) {
-
-    }
-
-    @Override
-    public KeycloakAdapterConfigService getValue() throws IllegalStateException, IllegalArgumentException {
-        return this;
     }
 
     public void addServerDeployment(String deploymentName, String webContext) {
@@ -222,18 +200,5 @@ public final class KeycloakAdapterConfigService implements Service<KeycloakAdapt
 
     public boolean isKeycloakServerDeployment(String deploymentName) {
         return this.webContexts.containsKey(deploymentName);
-    }
-
-    public static KeycloakAdapterConfigService find(ServiceRegistry registry) {
-        ServiceController<?> container = registry.getService(KeycloakAdapterConfigService.SERVICE_NAME);
-        if (container != null) {
-            KeycloakAdapterConfigService service = (KeycloakAdapterConfigService)container.getValue();
-            return service;
-        }
-        return null;
-    }
-
-    public static KeycloakAdapterConfigService find(OperationContext context) {
-        return find(context.getServiceRegistry(true));
     }
 }

--- a/integration/keycloak-subsystem/src/main/java/org/keycloak/subsystem/extension/KeycloakSubsystemAdd.java
+++ b/integration/keycloak-subsystem/src/main/java/org/keycloak/subsystem/extension/KeycloakSubsystemAdd.java
@@ -83,18 +83,6 @@ class KeycloakSubsystemAdd extends AbstractBoottimeAddStepHandler {
     }
 
     @Override
-    protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model, ServiceVerificationHandler verificationHandler, List<ServiceController<?>> newControllers) throws OperationFailedException {
-        super.performRuntime(context, operation, model, verificationHandler, newControllers);
-
-        ServiceController<KeycloakAdapterConfigService> controller = context.getServiceTarget()
-                .addService(KeycloakAdapterConfigService.SERVICE_NAME, KeycloakAdapterConfigService.INSTANCE)
-                .addListener(verificationHandler)
-                .setInitialMode(ServiceController.Mode.ACTIVE)
-                .install();
-        newControllers.add(controller);
-    }
-
-    @Override
     protected boolean requiresRuntimeVerification() {
         return false;
     }

--- a/integration/keycloak-subsystem/src/main/java/org/keycloak/subsystem/extension/RealmAddHandler.java
+++ b/integration/keycloak-subsystem/src/main/java/org/keycloak/subsystem/extension/RealmAddHandler.java
@@ -60,7 +60,7 @@ public final class RealmAddHandler extends AbstractAddStepHandler {
 
     @Override
     protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model, ServiceVerificationHandler verificationHandler, List<ServiceController<?>> newControllers) throws OperationFailedException {
-        KeycloakAdapterConfigService ckService = KeycloakAdapterConfigService.find(context);
+        KeycloakAdapterConfigService ckService = KeycloakAdapterConfigService.getInstance();
         ckService.addRealm(operation, context.resolveExpressions(model));
     }
 }

--- a/integration/keycloak-subsystem/src/main/java/org/keycloak/subsystem/extension/RealmRemoveHandler.java
+++ b/integration/keycloak-subsystem/src/main/java/org/keycloak/subsystem/extension/RealmRemoveHandler.java
@@ -35,7 +35,7 @@ public final class RealmRemoveHandler extends AbstractRemoveStepHandler {
 
     @Override
     protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
-        KeycloakAdapterConfigService ckService = KeycloakAdapterConfigService.find(context);
+        KeycloakAdapterConfigService ckService = KeycloakAdapterConfigService.getInstance();
         ckService.removeRealm(operation);
     }
 }

--- a/integration/keycloak-subsystem/src/main/java/org/keycloak/subsystem/extension/RealmWriteAttributeHandler.java
+++ b/integration/keycloak-subsystem/src/main/java/org/keycloak/subsystem/extension/RealmWriteAttributeHandler.java
@@ -43,7 +43,7 @@ public class RealmWriteAttributeHandler extends AbstractWriteAttributeHandler<Ke
     @Override
     protected boolean applyUpdateToRuntime(OperationContext context, ModelNode operation, String attributeName,
                                            ModelNode resolvedValue, ModelNode currentValue, HandbackHolder<KeycloakAdapterConfigService> hh) throws OperationFailedException {
-        KeycloakAdapterConfigService ckService = KeycloakAdapterConfigService.find(context);
+        KeycloakAdapterConfigService ckService = KeycloakAdapterConfigService.getInstance();
         ckService.updateRealm(operation, attributeName, resolvedValue);
 
         hh.setHandback(ckService);

--- a/integration/keycloak-subsystem/src/main/java/org/keycloak/subsystem/extension/SecureDeploymentAddHandler.java
+++ b/integration/keycloak-subsystem/src/main/java/org/keycloak/subsystem/extension/SecureDeploymentAddHandler.java
@@ -55,7 +55,7 @@ public final class SecureDeploymentAddHandler extends AbstractAddStepHandler {
 
     @Override
     protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model, ServiceVerificationHandler verificationHandler, List<ServiceController<?>> newControllers) throws OperationFailedException {
-        KeycloakAdapterConfigService ckService = KeycloakAdapterConfigService.find(context);
+        KeycloakAdapterConfigService ckService = KeycloakAdapterConfigService.getInstance();
         ckService.addSecureDeployment(operation, context.resolveExpressions(model));
     }
 }

--- a/integration/keycloak-subsystem/src/main/java/org/keycloak/subsystem/extension/SecureDeploymentRemoveHandler.java
+++ b/integration/keycloak-subsystem/src/main/java/org/keycloak/subsystem/extension/SecureDeploymentRemoveHandler.java
@@ -35,7 +35,7 @@ public final class SecureDeploymentRemoveHandler extends AbstractRemoveStepHandl
 
     @Override
     protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
-        KeycloakAdapterConfigService ckService = KeycloakAdapterConfigService.find(context);
+        KeycloakAdapterConfigService ckService = KeycloakAdapterConfigService.getInstance();
         ckService.removeSecureDeployment(operation);
     }
 }

--- a/integration/keycloak-subsystem/src/main/java/org/keycloak/subsystem/extension/SecureDeploymentWriteAttributeHandler.java
+++ b/integration/keycloak-subsystem/src/main/java/org/keycloak/subsystem/extension/SecureDeploymentWriteAttributeHandler.java
@@ -44,7 +44,7 @@ public class SecureDeploymentWriteAttributeHandler extends AbstractWriteAttribut
     @Override
     protected boolean applyUpdateToRuntime(OperationContext context, ModelNode operation, String attributeName,
                                            ModelNode resolvedValue, ModelNode currentValue, HandbackHolder<KeycloakAdapterConfigService> hh) throws OperationFailedException {
-        KeycloakAdapterConfigService ckService = KeycloakAdapterConfigService.find(context);
+        KeycloakAdapterConfigService ckService = KeycloakAdapterConfigService.getInstance();
         hh.setHandback(ckService);
         ckService.updateSecureDeployment(operation, attributeName, resolvedValue);
         return false;

--- a/integration/keycloak-subsystem/src/main/java/org/keycloak/subsystem/extension/authserver/AuthServerAddHandler.java
+++ b/integration/keycloak-subsystem/src/main/java/org/keycloak/subsystem/extension/authserver/AuthServerAddHandler.java
@@ -69,7 +69,7 @@ public final class AuthServerAddHandler extends AbstractAddStepHandler {
 
         AuthServerUtil authServerUtil = new AuthServerUtil(operation);
         authServerUtil.addStepToUploadAuthServer(context, enabled);
-        KeycloakAdapterConfigService.INSTANCE.addServerDeployment(authServerUtil.getDeploymentName(), webContext);
+        KeycloakAdapterConfigService.getInstance().addServerDeployment(authServerUtil.getDeploymentName(), webContext);
     }
 
     @Override

--- a/integration/keycloak-subsystem/src/main/java/org/keycloak/subsystem/extension/authserver/AuthServerDefinition.java
+++ b/integration/keycloak-subsystem/src/main/java/org/keycloak/subsystem/extension/authserver/AuthServerDefinition.java
@@ -116,7 +116,7 @@ public class AuthServerDefinition extends SimpleResourceDefinition {
         @Override
         public void validateParameter(String paramName, ModelNode value) throws OperationFailedException {
             String strValue = value.asString();
-            if (KeycloakAdapterConfigService.INSTANCE.isWebContextUsed(strValue)) {
+            if (KeycloakAdapterConfigService.getInstance().isWebContextUsed(strValue)) {
                 throw new OperationFailedException("Can not set web-context to '" + strValue + "'. web-context must be unique among all deployments.");
             }
         }
@@ -124,7 +124,7 @@ public class AuthServerDefinition extends SimpleResourceDefinition {
         @Override
         public void validateResolvedParameter(String paramName, ModelNode value) throws OperationFailedException {
             String strValue = value.asString();
-            if (KeycloakAdapterConfigService.INSTANCE.isWebContextUsed(strValue)) {
+            if (KeycloakAdapterConfigService.getInstance().isWebContextUsed(strValue)) {
                 throw new OperationFailedException("Can not set web-context to '" + strValue + "'. web-context must be unique among all deployments.");
             }
         }

--- a/integration/keycloak-subsystem/src/main/java/org/keycloak/subsystem/extension/authserver/AuthServerRemoveHandler.java
+++ b/integration/keycloak-subsystem/src/main/java/org/keycloak/subsystem/extension/authserver/AuthServerRemoveHandler.java
@@ -45,7 +45,7 @@ public final class AuthServerRemoveHandler extends AbstractRemoveStepHandler {
     @Override
     protected void performRemove(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
         String deploymentName = AuthServerUtil.getDeploymentName(operation);
-        KeycloakAdapterConfigService.INSTANCE.removeServerDeployment(deploymentName);
+        KeycloakAdapterConfigService.getInstance().removeServerDeployment(deploymentName);
 
         if (requiresRuntime(context)) { // don't do this on a domain controller
             addStepToRemoveAuthServer(context, deploymentName);

--- a/integration/keycloak-subsystem/src/main/java/org/keycloak/subsystem/extension/authserver/AuthServerUtil.java
+++ b/integration/keycloak-subsystem/src/main/java/org/keycloak/subsystem/extension/authserver/AuthServerUtil.java
@@ -46,6 +46,7 @@ import org.jboss.dmr.ModelNode;
 import org.jboss.modules.Module;
 import org.jboss.modules.ModuleIdentifier;
 import org.jboss.modules.ModuleLoadException;
+import org.keycloak.subsystem.extension.KeycloakExtension;
 
 /**
  * Utility methods that help assemble and start an auth server.
@@ -104,6 +105,9 @@ public class AuthServerUtil {
         ModelNode op = Util.createOperation(ADD, deploymentAddress);
         op.get(ENABLED).set(isEnabled);
         op.get(PERSISTENT).set(false); // prevents writing this deployment out to standalone.xml
+
+        // Owner attribute is valid starting with WidlFly 9.  Ignored in WildFly 8
+        op.get("owner").set(new ModelNode().add("subsystem", KeycloakExtension.SUBSYSTEM_NAME));
 
         if (authServerUri == null) {
             throw new OperationFailedException("Keycloak Auth Server WAR not found in keycloak-subsystem module");

--- a/integration/keycloak-subsystem/src/main/java/org/keycloak/subsystem/extension/authserver/AuthServerWriteAttributeHandler.java
+++ b/integration/keycloak-subsystem/src/main/java/org/keycloak/subsystem/extension/authserver/AuthServerWriteAttributeHandler.java
@@ -55,8 +55,8 @@ public class AuthServerWriteAttributeHandler extends ModelOnlyWriteAttributeHand
 
         if (attributeName.equals(AuthServerDefinition.WEB_CONTEXT.getName())) {
 
-            KeycloakAdapterConfigService.INSTANCE.removeServerDeployment(deploymentName);
-            KeycloakAdapterConfigService.INSTANCE.addServerDeployment(deploymentName, newValue.asString());
+            KeycloakAdapterConfigService.getInstance().removeServerDeployment(deploymentName);
+            KeycloakAdapterConfigService.getInstance().addServerDeployment(deploymentName, newValue.asString());
             if (isEnabled) {
                 AuthServerUtil.addStepToRedeployAuthServer(context, deploymentName);
             }

--- a/integration/keycloak-subsystem/src/main/java/org/keycloak/subsystem/extension/authserver/KeycloakServerDeploymentProcessor.java
+++ b/integration/keycloak-subsystem/src/main/java/org/keycloak/subsystem/extension/authserver/KeycloakServerDeploymentProcessor.java
@@ -34,7 +34,7 @@ public class KeycloakServerDeploymentProcessor implements DeploymentUnitProcesso
     public void deploy(DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {
         DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
         String deploymentName = deploymentUnit.getName();
-        KeycloakAdapterConfigService service = KeycloakAdapterConfigService.find(phaseContext.getServiceRegistry());
+        KeycloakAdapterConfigService service = KeycloakAdapterConfigService.getInstance();
         if (!service.isKeycloakServerDeployment(deploymentName)) {
             return;
         }


### PR DESCRIPTION
This fixes the NPE, but we still need to wait on a fix for WFCORE-632 before the Keycloak subsystem will work on WildFly 9 again.

This is a refactoring I've been considering for a long time.  KeycloakAdapterConfigService doesn't really need to be an msc service because it is not using the lifecycle callbacks.
