### PR TITLE
[KEYCLOAK-1211] Fixed AD users authenticating without providing a password

### DIFF
--- a/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
@@ -551,7 +551,7 @@ public class AuthenticationManager {
                 credentials.add(UserCredentialModel.totp(totp));
             }
 
-            if (password == null && passwordToken == null) {
+            if ((password == null || password.isEmpty()) && (passwordToken == null || passwordToken.isEmpty())) {
                 logger.debug("Password not provided");
                 return AuthenticationStatus.MISSING_PASSWORD;
             }

--- a/testsuite/integration/src/test/java/org/keycloak/testsuite/federation/FederationProvidersIntegrationTest.java
+++ b/testsuite/integration/src/test/java/org/keycloak/testsuite/federation/FederationProvidersIntegrationTest.java
@@ -203,6 +203,14 @@ public class FederationProvidersIntegrationTest {
     }
 
     @Test
+    public void loginLdapWithoutPassword() {
+        loginPage.open();
+        loginPage.login("john@email.org", "");
+
+        Assert.assertEquals("Invalid username or password.", loginPage.getError());
+    }
+
+    @Test
     public void passwordChangeLdap() throws Exception {
         changePasswordPage.open();
         loginPage.login("johnkeycloak", "Password1");


### PR DESCRIPTION
I've also added an additional test case even though the issue is not present on the embedded directory server which is used for tests (ApacheDS).
