### PR TITLE
corrected URL of XML entity descriptor for the IDP

### DIFF
--- a/docbook/reference/en/en-US/modules/saml.xml
+++ b/docbook/reference/en/en-US/modules/saml.xml
@@ -183,7 +183,7 @@
             format described in SAML 2.0.  You should review all the information there to make sure everything is set up correctly.
         </para>
         <para>
-            Each realm has a URL where you can view the XML entity descriptor for the IDP.  <literal>root/realms/{realm}/protocol/saml/descriptor</literal>
+            Each realm has a URL where you can view the XML entity descriptor for the IDP.  <literal>root/auth/realms/{realm}/protocol/saml/descriptor</literal>
         </para>
     </section>
 </chapter>


### PR DESCRIPTION
 the documentation said that URL where you can view the XML entity descriptor for the IDP is 

```
    root/realms/{realm}/protocol/saml/descriptor
```

 but after trail and error found the URL to be

```
   root/auth/realms/{realm}/protocol/saml/descriptor
```

corrected the same here
