### PR TITLE
Added support for GrantedAuthoritiesMapper in KeycloakAuthenticationProvider

### DIFF
--- a/integration/spring-security/src/main/java/org/keycloak/adapters/springsecurity/authentication/KeycloakAuthenticationProvider.java
+++ b/integration/spring-security/src/main/java/org/keycloak/adapters/springsecurity/authentication/KeycloakAuthenticationProvider.java
@@ -6,8 +6,10 @@ import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -17,18 +19,28 @@ import java.util.List;
  * @version $Revision: 1 $
  */
 public class KeycloakAuthenticationProvider implements AuthenticationProvider {
+    private GrantedAuthoritiesMapper grantedAuthoritiesMapper;
+
+    public void setGrantedAuthoritiesMapper(GrantedAuthoritiesMapper grantedAuthoritiesMapper) {
+        this.grantedAuthoritiesMapper = grantedAuthoritiesMapper;
+    }
 
     @Override
     public Authentication authenticate(Authentication authentication) throws AuthenticationException {
-
         KeycloakAuthenticationToken token = (KeycloakAuthenticationToken) authentication;
         List<GrantedAuthority> grantedAuthorities = new ArrayList<GrantedAuthority>();
 
         for (String role : token.getAccount().getRoles()) {
             grantedAuthorities.add(new KeycloakRole(role));
         }
+        return new KeycloakAuthenticationToken(token.getAccount(), mapAuthorities(grantedAuthorities));
+    }
 
-        return new KeycloakAuthenticationToken(token.getAccount(), grantedAuthorities);
+    private Collection<? extends GrantedAuthority> mapAuthorities(
+            Collection<? extends GrantedAuthority> authorities) {
+        return grantedAuthoritiesMapper != null
+            ? grantedAuthoritiesMapper.mapAuthorities(authorities)
+            : authorities;
     }
 
     @Override

--- a/integration/spring-security/src/test/java/org/keycloak/adapters/springsecurity/authentication/KeycloakAuthenticationProviderTest.java
+++ b/integration/spring-security/src/test/java/org/keycloak/adapters/springsecurity/authentication/KeycloakAuthenticationProviderTest.java
@@ -8,6 +8,8 @@ import org.keycloak.adapters.springsecurity.account.SimpleKeycloakAccount;
 import org.keycloak.adapters.springsecurity.token.KeycloakAuthenticationToken;
 import org.mockito.internal.util.collections.Sets;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.authority.mapping.SimpleAuthorityMapper;
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
 
 import java.security.Principal;
@@ -20,14 +22,12 @@ import static org.mockito.Mockito.*;
  * Keycloak authentication provider tests.
  */
 public class KeycloakAuthenticationProviderTest {
-
     private KeycloakAuthenticationProvider provider = new KeycloakAuthenticationProvider();
     private KeycloakAuthenticationToken token;
     private Set<String> roles = Sets.newSet("user", "admin");
 
     @Before
     public void setUp() throws Exception {
-
         Principal principal = mock(Principal.class);
         RefreshableKeycloakSecurityContext securityContext = mock(RefreshableKeycloakSecurityContext.class);
         KeycloakAccount account = new SimpleKeycloakAccount(principal, roles, securityContext);
@@ -39,7 +39,7 @@ public class KeycloakAuthenticationProviderTest {
     public void testAuthenticate() throws Exception {
         Authentication result = provider.authenticate(token);
         assertNotNull(result);
-        assertEquals(roles.size(), result.getAuthorities().size());
+        assertEquals(roles, AuthorityUtils.authorityListToSet(result.getAuthorities()));
         assertTrue(result.isAuthenticated());
         assertNotNull(result.getPrincipal());
         assertNotNull(result.getCredentials());
@@ -50,5 +50,17 @@ public class KeycloakAuthenticationProviderTest {
     public void testSupports() throws Exception {
         assertTrue(provider.supports(KeycloakAuthenticationToken.class));
         assertFalse(provider.supports(PreAuthenticatedAuthenticationToken.class));
+    }
+
+    @Test
+    public void testGrantedAuthoritiesMapper() throws Exception {
+        SimpleAuthorityMapper grantedAuthorityMapper = new SimpleAuthorityMapper();
+        grantedAuthorityMapper.setPrefix("ROLE_");
+        grantedAuthorityMapper.setConvertToUpperCase(true);
+        provider.setGrantedAuthoritiesMapper(grantedAuthorityMapper);
+
+        Authentication result = provider.authenticate(token);
+        assertEquals(Sets.newSet("ROLE_USER", "ROLE_ADMIN"),
+            AuthorityUtils.authorityListToSet(result.getAuthorities()));
     }
 }


### PR DESCRIPTION
Regarding issue KEYCLOAK-1294 I have added support for converting roles from the format they are received from Keycloak to the format required by the application utilizing Spring Security.

I wanted to use the GrantedAuthoritiesMapper interface that was already available in Spring Security. For many users the SimpleAuthorityMapper which is also provided by Spring Security may be a sufficient implementation. 

The side effect, however, is that GrantedAuthoritiesMapper processes GrantedAuthority objects directly which may result in the authority type being changed from KeycloakRole to something else. Do you think this is a problem? 
