### PR TITLE
Add Servlet 2.x support to the Spring Security adapter

### DIFF
--- a/integration/spring-security/src/test/java/org/keycloak/adapters/springsecurity/facade/WrappedHttpServletResponseTest.java
+++ b/integration/spring-security/src/test/java/org/keycloak/adapters/springsecurity/facade/WrappedHttpServletResponseTest.java
@@ -48,6 +48,7 @@ public class WrappedHttpServletResponseTest {
         assertEquals(COOKIE_DOMAIN, mockResponse.getCookie(COOKIE_NAME).getDomain());
         assertEquals(maxAge, mockResponse.getCookie(COOKIE_NAME).getMaxAge());
         assertEquals(COOKIE_VALUE, mockResponse.getCookie(COOKIE_NAME).getValue());
+        assertEquals(true, mockResponse.getCookie(COOKIE_NAME).isHttpOnly());
     }
 
     @Test


### PR DESCRIPTION
Fixes [KEYCLOAK-1299](https://issues.jboss.org/browse/KEYCLOAK-1299).

Cookie.setHttpOnly() was added in Servlet 3.0. Make setting a cookie as HttpOnly dependent on method availability.
