### PR TITLE
KEYCLOAK-681 - HTML emails

### DIFF
--- a/forms/email-freemarker/src/main/java/org/keycloak/email/freemarker/FreeMarkerEmailProvider.java
+++ b/forms/email-freemarker/src/main/java/org/keycloak/email/freemarker/FreeMarkerEmailProvider.java
@@ -139,7 +139,7 @@ public class FreeMarkerEmailProvider implements EmailProvider {
             msg.setFrom(new InternetAddress(from));
             msg.setHeader("To", address);
             msg.setSubject(subject);
-            msg.setText(body);
+            msg.setContent(body,"text/html; charset=utf-8");
             msg.saveChanges();
             msg.setSentDate(new Date());
 


### PR DESCRIPTION
Changed content-type of emails so that we can include html in the email templates.
