### PR TITLE
[KEYCLOAK-1334] Forgot password page does not return validation error

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/LoginActionsService.java
+++ b/services/src/main/java/org/keycloak/services/resources/LoginActionsService.java
@@ -892,6 +892,13 @@ public class LoginActionsService {
         ClientSessionModel clientSession = accessCode.getClientSession();
 
         String username = formData.getFirst("username");
+        if(username == null || username.isEmpty()) {
+            event.error(Errors.USERNAME_MISSING);
+            return session.getProvider(LoginFormsProvider.class)
+                    .setError(Messages.MISSING_USERNAME)
+                    .setClientSessionCode(accessCode.getCode())
+                    .createPasswordReset();
+        }
 
         ClientModel client = clientSession.getClient();
         if (client == null) {

--- a/testsuite/integration/src/test/java/org/keycloak/testsuite/forms/ResetPasswordTest.java
+++ b/testsuite/integration/src/test/java/org/keycloak/testsuite/forms/ResetPasswordTest.java
@@ -324,6 +324,25 @@ public class ResetPasswordTest {
 
         events.expectRequiredAction(EventType.SEND_RESET_PASSWORD).user((String) null).session((String) null).detail(Details.USERNAME, "invalid").removeDetail(Details.EMAIL).removeDetail(Details.CODE_ID).error("user_not_found").assertEvent();
     }
+    
+    @Test
+    public void resetPasswordMissingUsername() throws IOException, MessagingException, InterruptedException {
+        loginPage.open();
+        loginPage.resetPassword();
+
+        resetPasswordPage.assertCurrent();
+
+        resetPasswordPage.changePassword("");
+
+        resetPasswordPage.assertCurrent();
+
+        assertEquals("Please specify username.", resetPasswordPage.getErrorMessage());
+
+        assertEquals(0, greenMail.getReceivedMessages().length);
+        
+        events.expectRequiredAction(EventType.SEND_RESET_PASSWORD).client((String) null).user((String) null).session((String) null).clearDetails().error("username_missing").assertEvent();
+        
+    }
 
     @Test
     public void resetPasswordExpiredCode() throws IOException, MessagingException, InterruptedException {


### PR DESCRIPTION
[KEYCLOAK-1334] Forgot password page does not return validation error message when input field is empty
