### PR TITLE
Fix HttpClient issues in example demos on AS7 / Wildfly

### DIFF
--- a/examples/demo-template/admin-access-app/src/main/java/org/keycloak/example/AdminClient.java
+++ b/examples/demo-template/admin-access-app/src/main/java/org/keycloak/example/AdminClient.java
@@ -7,10 +7,10 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.message.BasicNameValuePair;
 import org.keycloak.OAuth2Constants;
 import org.keycloak.constants.ServiceUrlConstants;
-import org.keycloak.adapters.HttpClientBuilder;
 import org.keycloak.representations.AccessTokenResponse;
 import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.util.HostUtils;
@@ -70,8 +70,7 @@ public class AdminClient {
 
     public static AccessTokenResponse getToken(HttpServletRequest request) throws IOException {
 
-        HttpClient client = new HttpClientBuilder()
-                .disableTrustManager().build();
+        HttpClient client = new DefaultHttpClient();
 
 
         try {
@@ -104,8 +103,7 @@ public class AdminClient {
 
     public static void logout(HttpServletRequest request, AccessTokenResponse res) throws IOException {
 
-        HttpClient client = new HttpClientBuilder()
-                .disableTrustManager().build();
+        HttpClient client = new DefaultHttpClient();
 
 
         try {
@@ -135,8 +133,7 @@ public class AdminClient {
 
     public static List<RoleRepresentation> getRealmRoles(HttpServletRequest request, AccessTokenResponse res) throws Failure {
 
-        HttpClient client = new HttpClientBuilder()
-                .disableTrustManager().build();
+        HttpClient client = new DefaultHttpClient();
         try {
             HttpGet get = new HttpGet(getBaseUrl(request) + "/auth/admin/realms/demo/roles");
             get.addHeader("Authorization", "Bearer " + res.getToken());

--- a/examples/demo-template/customer-app/src/main/java/org/keycloak/example/AdminClient.java
+++ b/examples/demo-template/customer-app/src/main/java/org/keycloak/example/AdminClient.java
@@ -4,9 +4,9 @@ import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.DefaultHttpClient;
 import org.keycloak.KeycloakSecurityContext;
 import org.keycloak.adapters.AdapterUtils;
-import org.keycloak.adapters.HttpClientBuilder;
 import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.util.JsonSerialization;
 
@@ -40,8 +40,7 @@ public class AdminClient {
     public static List<RoleRepresentation> getRealmRoles(HttpServletRequest req) throws Failure {
         KeycloakSecurityContext session = (KeycloakSecurityContext) req.getAttribute(KeycloakSecurityContext.class.getName());
 
-        HttpClient client = new HttpClientBuilder()
-                .disableTrustManager().build();
+        HttpClient client = new DefaultHttpClient();
         try {
             HttpGet get = new HttpGet(AdapterUtils.getOriginForRestCalls(req.getRequestURL().toString(), session) + "/auth/admin/realms/demo/roles");
             get.addHeader("Authorization", "Bearer " + session.getTokenString());

--- a/examples/demo-template/customer-app/src/main/java/org/keycloak/example/CustomerDatabaseClient.java
+++ b/examples/demo-template/customer-app/src/main/java/org/keycloak/example/CustomerDatabaseClient.java
@@ -4,13 +4,11 @@ import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.DefaultHttpClient;
 import org.keycloak.KeycloakSecurityContext;
 import org.keycloak.adapters.AdapterUtils;
-import org.keycloak.adapters.HttpClientBuilder;
-import org.keycloak.constants.ServiceUrlConstants;
 import org.keycloak.representations.IDToken;
 import org.keycloak.util.JsonSerialization;
-import org.keycloak.util.KeycloakUriBuilder;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
@@ -49,8 +47,7 @@ public class CustomerDatabaseClient {
     public static List<String> getCustomers(HttpServletRequest req) throws Failure {
         KeycloakSecurityContext session = (KeycloakSecurityContext) req.getAttribute(KeycloakSecurityContext.class.getName());
 
-        HttpClient client = new HttpClientBuilder()
-                .disableTrustManager().build();
+        HttpClient client = new DefaultHttpClient();
         try {
             HttpGet get = new HttpGet(AdapterUtils.getOriginForRestCalls(req.getRequestURL().toString(), session) + "/database/customers");
             get.addHeader("Authorization", "Bearer " + session.getTokenString());

--- a/examples/demo-template/product-app/src/main/java/org/keycloak/example/oauth/ProductDatabaseClient.java
+++ b/examples/demo-template/product-app/src/main/java/org/keycloak/example/oauth/ProductDatabaseClient.java
@@ -4,9 +4,9 @@ import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.DefaultHttpClient;
 import org.keycloak.KeycloakSecurityContext;
 import org.keycloak.adapters.AdapterUtils;
-import org.keycloak.adapters.HttpClientBuilder;
 import org.keycloak.util.JsonSerialization;
 
 import javax.servlet.http.HttpServletRequest;
@@ -37,8 +37,8 @@ public class ProductDatabaseClient
 
     public static List<String> getProducts(HttpServletRequest req) throws Failure {
         KeycloakSecurityContext session = (KeycloakSecurityContext)req.getAttribute(KeycloakSecurityContext.class.getName());
-        HttpClient client = new HttpClientBuilder()
-                .disableTrustManager().build();
+
+        HttpClient client = new DefaultHttpClient();
         try {
             HttpGet get = new HttpGet(AdapterUtils.getOriginForRestCalls(req.getRequestURL().toString(), session) + "/database/products");
             get.addHeader("Authorization", "Bearer " + session.getTokenString());


### PR DESCRIPTION
- don't use org.keycloak.adapters.HttpClientBuilder - it's Keycloak internals
- don't use HttpClient 4.2 or 4.3 APIs (not default in AS7, and Wildfly 8)
  so we can use the same jboss-deployment-structure.xml
