### PR TITLE
KEYCLOAK-1350 client_session_state should be updated when refreshing a token

### DIFF
--- a/events/api/src/main/java/org/keycloak/events/Details.java
+++ b/events/api/src/main/java/org/keycloak/events/Details.java
@@ -24,5 +24,7 @@ public interface Details {
     String NODE_HOST = "node_host";
     String REASON = "reason";
     String REVOKED_CLIENT = "revoked_client";
+    String CLIENT_SESSION_STATE = "client_session_state";
+    String CLIENT_SESSION_HOST = "client_session_host";
 
 }

--- a/testsuite/integration/src/test/java/org/keycloak/testsuite/OAuthClient.java
+++ b/testsuite/integration/src/test/java/org/keycloak/testsuite/OAuthClient.java
@@ -35,6 +35,7 @@ import org.junit.Assert;
 import org.keycloak.OAuth2Constants;
 import org.keycloak.RSATokenVerifier;
 import org.keycloak.VerificationException;
+import org.keycloak.constants.AdapterConstants;
 import org.keycloak.freemarker.LocaleHelper;
 import org.keycloak.jose.jws.JWSInput;
 import org.keycloak.jose.jws.crypto.RSAProvider;
@@ -77,6 +78,10 @@ public class OAuthClient {
     private String uiLocales = null;
 
     private PublicKey realmPublicKey;
+
+    private String clientSessionState;
+
+    private String clientSessionHost;
 
     public OAuthClient(WebDriver driver) {
         this.driver = driver;
@@ -128,6 +133,14 @@ public class OAuthClient {
             parameters.add(new BasicNameValuePair(OAuth2Constants.CLIENT_ID, clientId));
         }
 
+        if(clientSessionState != null) {
+            parameters.add(new BasicNameValuePair(AdapterConstants.CLIENT_SESSION_STATE, clientSessionState));
+        }
+
+        if(clientSessionHost != null) {
+            parameters.add(new BasicNameValuePair(AdapterConstants.CLIENT_SESSION_HOST, clientSessionHost));
+        }
+
         UrlEncodedFormEntity formEntity = null;
         try {
             formEntity = new UrlEncodedFormEntity(parameters, "UTF-8");
@@ -154,6 +167,13 @@ public class OAuthClient {
         parameters.add(new BasicNameValuePair(OAuth2Constants.GRANT_TYPE, OAuth2Constants.PASSWORD));
         parameters.add(new BasicNameValuePair("username", username));
         parameters.add(new BasicNameValuePair("password", password));
+
+        if(clientSessionState != null) {
+            parameters.add(new BasicNameValuePair(AdapterConstants.CLIENT_SESSION_STATE, clientSessionState));
+        }
+        if(clientSessionHost != null) {
+            parameters.add(new BasicNameValuePair(AdapterConstants.CLIENT_SESSION_HOST, clientSessionHost));
+        }
 
         UrlEncodedFormEntity formEntity;
         try {
@@ -209,6 +229,13 @@ public class OAuthClient {
         }
         else if (clientId != null) {
             parameters.add(new BasicNameValuePair(OAuth2Constants.CLIENT_ID, clientId));
+        }
+
+        if(clientSessionState != null) {
+            parameters.add(new BasicNameValuePair(AdapterConstants.CLIENT_SESSION_STATE, clientSessionState));
+        }
+        if(clientSessionHost != null) {
+            parameters.add(new BasicNameValuePair(AdapterConstants.CLIENT_SESSION_HOST, clientSessionHost));
         }
 
         UrlEncodedFormEntity formEntity;
@@ -357,6 +384,16 @@ public class OAuthClient {
 
     public OAuthClient uiLocales(String uiLocales){
         this.uiLocales = uiLocales;
+        return this;
+    }
+
+    public OAuthClient clientSessionState(String client_session_state) {
+        this.clientSessionState = client_session_state;
+        return this;
+    }
+
+    public OAuthClient clientSessionHost(String client_session_host) {
+        this.clientSessionHost = client_session_host;
         return this;
     }
 

--- a/testsuite/integration/src/test/java/org/keycloak/testsuite/oauth/OAuthDanceClientSessionExtensionTest.java
+++ b/testsuite/integration/src/test/java/org/keycloak/testsuite/oauth/OAuthDanceClientSessionExtensionTest.java
@@ -1,0 +1,71 @@
+package org.keycloak.testsuite.oauth;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.keycloak.OAuth2Constants;
+import org.keycloak.events.Details;
+import org.keycloak.events.Event;
+import org.keycloak.testsuite.AssertEvents;
+import org.keycloak.testsuite.OAuthClient;
+import org.keycloak.testsuite.rule.KeycloakRule;
+import org.keycloak.testsuite.rule.WebResource;
+import org.keycloak.testsuite.rule.WebRule;
+
+/**
+ * @author Sebastian Rose, AOE on 02.06.15.
+ */
+public class OAuthDanceClientSessionExtensionTest {
+
+    @ClassRule
+    public static KeycloakRule keycloakRule = new KeycloakRule();
+
+    @Rule
+    public WebRule webRule = new WebRule(this);
+
+    @WebResource
+    protected OAuthClient oauth;
+
+    @Rule
+    public AssertEvents events = new AssertEvents(keycloakRule);
+
+    @Test
+    public void doOauthDanceWithClientSessionStateAndHost() throws Exception {
+        oauth.doLogin("test-user@localhost", "password");
+
+        Event loginEvent = events.expectLogin().assertEvent();
+
+        String sessionId = loginEvent.getSessionId();
+        String codeId = loginEvent.getDetails().get(Details.CODE_ID);
+
+        String code = oauth.getCurrentQuery().get(OAuth2Constants.CODE);
+
+        String clientSessionState = "1234";
+        String clientSessionHost = "test-client-host";
+
+        OAuthClient.AccessTokenResponse tokenResponse = oauth.clientSessionState(clientSessionState)
+                                                             .clientSessionHost(clientSessionHost)
+                                                             .doAccessTokenRequest(code, "password");
+
+        String refreshTokenString = tokenResponse.getRefreshToken();
+
+        Event tokenEvent = events.expectCodeToToken(codeId, sessionId)
+                                 .detail(Details.CLIENT_SESSION_STATE, clientSessionState)
+                                 .detail(Details.CLIENT_SESSION_HOST, clientSessionHost)
+                                 .assertEvent();
+
+
+        String updatedClientSessionState = "5678";
+
+        oauth.clientSessionState(updatedClientSessionState)
+             .clientSessionHost(clientSessionHost)
+             .doRefreshTokenRequest(refreshTokenString, "password");
+
+        events.expectRefresh(tokenEvent.getDetails().get(Details.REFRESH_TOKEN_ID), sessionId)
+              .detail(Details.CLIENT_SESSION_STATE, updatedClientSessionState)
+              .detail(Details.CLIENT_SESSION_HOST, clientSessionHost)
+              .assertEvent();
+
+    }
+
+}


### PR DESCRIPTION
This feature was discussed on the mailing list (please see Issue comment).

In our environment the session_id of a external application, secured by keycloak changes its session_id after a successful login. Therefore we need an update to this session_id in keycloak to have a working logout.
