### PR TITLE
KeycloakKEYCLOAK-1368: Not able to forward to error page.

### DIFF
--- a/integration/adapter-core/src/main/java/org/keycloak/adapters/BearerTokenRequestAuthenticator.java
+++ b/integration/adapter-core/src/main/java/org/keycloak/adapters/BearerTokenRequestAuthenticator.java
@@ -136,7 +136,7 @@ public class BearerTokenRequestAuthenticator {
         return new AuthChallenge() {
             @Override
             public boolean errorPage() {
-                return false;
+                return true;
             }
 
             @Override


### PR DESCRIPTION
Setting errorPage() to true solves issue.
