### PR TITLE
Removed keycloak-wildfly-adapter-subsystem dependency from keycloak-jboss-modules.

### DIFF
--- a/distribution/modules/build.xml
+++ b/distribution/modules/build.xml
@@ -339,9 +339,6 @@
         <module-def name="org.keycloak.keycloak-server-subsystem">
             <maven-resource group="org.keycloak" artifact="keycloak-wildfly-server-subsystem"/>
         </module-def>
-        <module-def name="org.keycloak.keycloak-adapter-subsystem">
-            <maven-resource group="org.keycloak" artifact="keycloak-wildfly-adapter-subsystem"/>
-        </module-def>
         <module-def name="org.keycloak.keycloak-as7-subsystem">
             <maven-resource group="org.keycloak" artifact="keycloak-as7-subsystem"/>
         </module-def>

--- a/distribution/modules/pom.xml
+++ b/distribution/modules/pom.xml
@@ -60,11 +60,6 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.keycloak</groupId>
-            <artifactId>keycloak-wildfly-adapter-subsystem</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.keycloak.subsystem</groupId>
             <artifactId>keycloak-server</artifactId>
             <type>war</type>


### PR DESCRIPTION
Fix for broken build of keycloak-jboss-modules.
