### PR TITLE
minor text edit for an error message on customer example

### DIFF
--- a/examples/demo-template/customer-app/src/main/webapp/customers/view.jsp
+++ b/examples/demo-template/customer-app/src/main/webapp/customers/view.jsp
@@ -33,7 +33,7 @@ Servlet User Principal <b><%=request.getUserPrincipal().getName()%>
     try {
         list = CustomerDatabaseClient.getCustomers(request);
     } catch (CustomerDatabaseClient.Failure failure) {
-        out.println("There was a failure processing request.  You either didn't configure Keycloak properly, or maybe" +
+        out.println("There was a failure processing request.  You either didn't configure Keycloak properly, or maybe " +
                 "you just forgot to secure the database service?");
         out.println("Status from database service invocation was: " + failure.getStatus());
         return;


### PR DESCRIPTION
Simply missing a space in an error message on one of the examples. 
