### PR TITLE
KEYCLOAK-1083: Provide a way for admin to unlock user account

### DIFF
--- a/model/api/src/main/java/org/keycloak/models/entities/UsernameLoginFailureEntity.java
+++ b/model/api/src/main/java/org/keycloak/models/entities/UsernameLoginFailureEntity.java
@@ -60,4 +60,11 @@ public class UsernameLoginFailureEntity extends AbstractIdentifiableEntity {
     public void setRealmId(String realmId) {
         this.realmId = realmId;
     }
+
+    public void clearFailures() {
+        this.numFailures = 0;
+        this.lastFailure = 0;
+        this.lastIPFailure = null;
+        this.failedLoginNotBefore = 0;
+    }
 }

--- a/model/sessions-infinispan/src/main/java/org/keycloak/models/sessions/infinispan/UsernameLoginFailureAdapter.java
+++ b/model/sessions-infinispan/src/main/java/org/keycloak/models/sessions/infinispan/UsernameLoginFailureAdapter.java
@@ -51,7 +51,7 @@ public class UsernameLoginFailureAdapter implements UsernameLoginFailureModel {
 
     @Override
     public void clearFailures() {
-        entity.setNumFailures(0);
+        entity.clearFailures();
         update();
     }
 

--- a/model/sessions-infinispan/src/main/java/org/keycloak/models/sessions/infinispan/entities/LoginFailureEntity.java
+++ b/model/sessions-infinispan/src/main/java/org/keycloak/models/sessions/infinispan/entities/LoginFailureEntity.java
@@ -62,4 +62,10 @@ public class LoginFailureEntity implements Serializable {
         this.lastIPFailure = lastIPFailure;
     }
 
+    public void clearFailures() {
+        this.failedLoginNotBefore = 0;
+        this.numFailures = 0;
+        this.lastFailure = 0;
+        this.lastIPFailure = null;
+    }
 }

--- a/model/sessions-jpa/src/main/java/org/keycloak/models/sessions/jpa/UsernameLoginFailureAdapter.java
+++ b/model/sessions-jpa/src/main/java/org/keycloak/models/sessions/jpa/UsernameLoginFailureAdapter.java
@@ -43,7 +43,7 @@ public class UsernameLoginFailureAdapter implements UsernameLoginFailureModel
 
    @Override
    public void clearFailures() {
-      user.setNumFailures(0);
+      user.clearFailures();
    }
 
    @Override

--- a/model/sessions-jpa/src/main/java/org/keycloak/models/sessions/jpa/entities/UsernameLoginFailureEntity.java
+++ b/model/sessions-jpa/src/main/java/org/keycloak/models/sessions/jpa/entities/UsernameLoginFailureEntity.java
@@ -91,6 +91,13 @@ public class UsernameLoginFailureEntity {
         this.realmId = realmId;
     }
 
+    public void clearFailures() {
+        setFailedLoginNotBefore(0);
+        setLastFailure(0);
+        setLastIPFailure(null);
+        setNumFailures(0);
+    }
+
     public static class Key implements Serializable {
 
         private String realmId;

--- a/model/sessions-mem/src/main/java/org/keycloak/models/sessions/mem/UsernameLoginFailureAdapter.java
+++ b/model/sessions-mem/src/main/java/org/keycloak/models/sessions/mem/UsernameLoginFailureAdapter.java
@@ -45,7 +45,7 @@ public class UsernameLoginFailureAdapter implements UsernameLoginFailureModel {
 
     @Override
     public void clearFailures() {
-        entity.getNumFailures().set(0);
+        entity.clearFailures();
     }
 
     @Override

--- a/model/sessions-mem/src/main/java/org/keycloak/models/sessions/mem/entities/UsernameLoginFailureEntity.java
+++ b/model/sessions-mem/src/main/java/org/keycloak/models/sessions/mem/entities/UsernameLoginFailureEntity.java
@@ -62,4 +62,11 @@ public class UsernameLoginFailureEntity {
         this.lastIpFailure = lastIpFailure;
     }
 
+    public void clearFailures() {
+        this.failedLoginNotBefore = new AtomicInteger();
+        this.lastFailure = new AtomicLong();
+        this.lastIpFailure = new AtomicReference<String>();
+        this.numFailures = new AtomicInteger();
+    }
+
 }

--- a/model/sessions-mongo/src/main/java/org/keycloak/models/sessions/mongo/UsernameLoginFailureAdapter.java
+++ b/model/sessions-mongo/src/main/java/org/keycloak/models/sessions/mongo/UsernameLoginFailureAdapter.java
@@ -50,7 +50,7 @@ public class UsernameLoginFailureAdapter  extends AbstractMongoAdapter<MongoUser
 
     @Override
     public void clearFailures() {
-        user.setNumFailures(0);
+        user.clearFailures();
         updateMongoEntity();
     }
 

--- a/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
@@ -68,6 +68,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import org.keycloak.models.UsernameLoginFailureModel;
+import org.keycloak.services.managers.BruteForceProtector;
 
 /**
  * Base resource for managing users
@@ -81,9 +83,9 @@ public class UsersResource {
     protected RealmModel realm;
 
     private RealmAuth auth;
-    
+
     private AdminEventBuilder adminEvent;
-    
+
     @Context
     protected ClientConnection clientConnection;
 
@@ -95,6 +97,9 @@ public class UsersResource {
 
     @Context
     protected HttpHeaders headers;
+
+    @Context
+    protected BruteForceProtector protector;
 
     public UsersResource(RealmModel realm, RealmAuth auth, TokenManager tokenManager, AdminEventBuilder adminEvent) {
         this.auth = auth;
@@ -129,6 +134,13 @@ public class UsersResource {
                 attrsToRemove.removeAll(rep.getAttributes().keySet());
             } else {
                 attrsToRemove = Collections.emptySet();
+            }
+
+            if (rep.isEnabled()) {
+                UsernameLoginFailureModel failureModel = session.sessions().getUserLoginFailure(realm, rep.getUsername());
+                if (failureModel != null) {
+                    failureModel.clearFailures();
+                }
             }
 
             updateUserFromRep(user, rep, attrsToRemove);
@@ -169,13 +181,13 @@ public class UsersResource {
             UserModel user = session.users().addUser(realm, rep.getUsername());
             Set<String> emptySet = Collections.emptySet();
             updateUserFromRep(user, rep, emptySet);
-            
+
             adminEvent.operation(OperationType.CREATE).resourcePath(uriInfo, user.getId()).representation(rep).success();
-            
+
             if (session.getTransaction().isActive()) {
                 session.getTransaction().commit();
             }
-            
+
             return Response.created(uriInfo.getAbsolutePathBuilder().path(user.getId()).build()).build();
         } catch (ModelDuplicateException e) {
             if (session.getTransaction().isActive()) {
@@ -237,7 +249,7 @@ public class UsersResource {
         if (user == null) {
             throw new NotFoundException("User not found");
         }
-        
+
         UserRepresentation rep = ModelToRepresentation.toRepresentation(user);
 
         if (realm.isIdentityFederationEnabled()) {
@@ -249,6 +261,10 @@ public class UsersResource {
                 }
                 rep.setFederatedIdentities(reps);
             }
+        }
+
+        if ((protector != null) && protector.isTemporarilyDisabled(session, realm, rep.getUsername())) {
+            rep.setEnabled(false);
         }
 
         return rep;
@@ -689,7 +705,7 @@ public class UsersResource {
                 adminEvent.operation(OperationType.DELETE).resourcePath(uriInfo, role.getId()).representation(roles).success();
             }
         }
-        
+
     }
 
     @Path("{id}/role-mappings/clients/{client}")
@@ -703,7 +719,7 @@ public class UsersResource {
         if (client == null) {
             throw new NotFoundException("Client not found");
         }
-        
+
         return new UserClientRoleMappingsResource(uriInfo, realm, auth, user, clientModel, adminEvent);
 
     }
@@ -737,7 +753,7 @@ public class UsersResource {
             throw new BadRequestException("Can't reset password as account is read only");
         }
         if (pass.isTemporary()) user.addRequiredAction(UserModel.RequiredAction.UPDATE_PASSWORD);
-        
+
         adminEvent.operation(OperationType.ACTION).resourcePath(uriInfo).success();
     }
 


### PR DESCRIPTION
If user is disabled via brute force protection, admin UI will now properly display that user as disabled.  If administrator then manually enables the user then the UsernameLoginFailureModel will be cleared and the user will be able to log in again.

There are small changes to each of the four session models to properly clear out the failure model.  I was able to verify this working with mem, jpa, and mongo.  I'm not sure how to test infinispan but let me know if you want me to dig into that.
