### PR TITLE
[KEYCLOAK-1427] Move delete buttons

### DIFF
--- a/forms/common-themes/src/main/resources/theme/base/admin/resources/partials/client-clustering-node.html
+++ b/forms/common-themes/src/main/resources/theme/base/admin/resources/partials/client-clustering-node.html
@@ -8,7 +8,8 @@
 
     <form class="form-horizontal" name="clusteringForm" novalidate kc-read-only="!access.manageClients" data-ng-show="create || registered">
         <fieldset >
-            <legend><span class="text">Configuration of cluster node</span></legend>
+            <legend><span class="text">Configuration of cluster node<i style="padding-left: 20px" class="pficon pficon-delete" data-ng-show="access.manageRealm" 
+    			data-ng-hide="create" data-ng-click="unregisterNode()"></i></span></legend>
             <div class="form-group">
                 <label class="col-md-2 control-label" for="host">Host</label>
                 <div class="col-sm-6">
@@ -25,7 +26,6 @@
         <div class="form-group">
             <div class="col-md-10 col-md-offset-2" data-ng-show="access.manageRealm">
                 <button data-kc-save   data-ng-show="create">Save</button>
-                <button data-kc-delete data-ng-hide="create" data-ng-click="unregisterNode()">Delete</button>
             </div>
         </div>
     </form>

--- a/forms/common-themes/src/main/resources/theme/base/admin/resources/partials/client-detail.html
+++ b/forms/common-themes/src/main/resources/theme/base/admin/resources/partials/client-detail.html
@@ -7,7 +7,8 @@
     </ol>
 
     <h1 data-ng-show="create">Add Client</h1>
-    <h1 data-ng-hide="create">{{client.clientId|capitalize}}</h1>
+    <h1 data-ng-hide="create">{{client.clientId|capitalize}}<i style="padding-left: 20px" class="pficon pficon-delete" data-ng-show="!create && access.manageClients" 
+    	data-ng-hide="changed" data-ng-click="remove()"></i></h1>
 
     <kc-tabs-client></kc-tabs-client>
 
@@ -265,7 +266,6 @@
             <div class="col-md-10 col-md-offset-2" data-ng-show="!create && access.manageClients">
                 <button kc-save  data-ng-show="changed">Save</button>
                 <button kc-reset data-ng-show="changed">Cancel</button>
-                <button kc-delete data-ng-click="remove()" data-ng-hide="changed">Delete Client</button>
             </div>
         </div>
     </form>

--- a/forms/common-themes/src/main/resources/theme/base/admin/resources/partials/client-role-detail.html
+++ b/forms/common-themes/src/main/resources/theme/base/admin/resources/partials/client-role-detail.html
@@ -9,7 +9,8 @@
     </ol>
 
     <h1 data-ng-show="create">Add Role</h1>
-    <h1 data-ng-hide="create">{{role.name|capitalize}}</h1>
+    <h1 data-ng-hide="create">{{role.name|capitalize}}<i style="padding-left: 20px" class="pficon pficon-delete" data-ng-show="!create && access.manageClients" 
+    	data-ng-hide="changed" data-ng-click="remove()"></i></h1>
 
     <form class="form-horizontal" name="realmForm" novalidate kc-read-only="!access.manageClients">
 
@@ -50,7 +51,6 @@
             <div class="col-md-10 col-md-offset-2" data-ng-show="!create && access.manageClients">
                 <button kc-save  data-ng-show="changed">Save</button>
                 <button kc-reset data-ng-show="changed">Cancel</button>
-                <button kc-delete data-ng-click="remove()" data-ng-hide="changed">Delete</button>
             </div>
         </div>
 

--- a/forms/common-themes/src/main/resources/theme/base/admin/resources/partials/federated-generic.html
+++ b/forms/common-themes/src/main/resources/theme/base/admin/resources/partials/federated-generic.html
@@ -5,7 +5,8 @@
         <li data-ng-show="create">Add User Federation Provider</li>
     </ol>
 
-    <h1 data-ng-hide="create">{{instance.providerName|capitalize}}</h1>
+    <h1 data-ng-hide="create">{{instance.providerName|capitalize}}<i style="padding-left: 20px" class="pficon pficon-delete" data-ng-show="!create && access.manageUsers" 
+    	data-ng-hide="changed" data-ng-click="remove()"></i></h1>
     <h1 data-ng-show="create">Add {{instance.providerName|capitalize}} User Federation Provide</h1>
 
     <ul class="nav nav-tabs" data-ng-hide="create">
@@ -90,7 +91,6 @@
                 <button kc-reset data-ng-show="changed">Cancel</button>
                 <button class="btn btn-primary" data-ng-click="triggerChangedUsersSync()" data-ng-hide="changed">Synchronize changed users</button>
                 <button class="btn btn-primary" data-ng-click="triggerFullSync()" data-ng-hide="changed">Synchronize all users</button>
-                <button class="btn btn-danger" data-ng-click="remove()" data-ng-hide="changed">Delete</button>
             </div>
         </div>
     </form>

--- a/forms/common-themes/src/main/resources/theme/base/admin/resources/partials/federated-kerberos.html
+++ b/forms/common-themes/src/main/resources/theme/base/admin/resources/partials/federated-kerberos.html
@@ -5,7 +5,8 @@
         <li data-ng-show="create">Add User Federation Provider</li>
     </ol>
 
-    <h1 data-ng-hide="create">Kerberos</h1>
+    <h1 data-ng-hide="create">Kerberos<i style="padding-left: 20px" class="pficon pficon-delete" data-ng-show="!create && access.manageUsers" 
+    	data-ng-hide="changed" data-ng-click="remove()"></i></h1>
     <h1 data-ng-show="create">Add Kerberos User Federation Provider</h1>
 
     <ul class="nav nav-tabs" data-ng-hide="create">
@@ -107,7 +108,6 @@
             <div class="col-md-10 col-md-offset-2" data-ng-show="!create && access.manageUsers">
                 <button kc-save  data-ng-show="changed">Save</button>
                 <button kc-reset data-ng-show="changed">Cancel</button>
-                <button kc-delete data-ng-click="remove()" data-ng-hide="changed">Delete</button>
             </div>
         </div>
     </form>

--- a/forms/common-themes/src/main/resources/theme/base/admin/resources/partials/federated-ldap.html
+++ b/forms/common-themes/src/main/resources/theme/base/admin/resources/partials/federated-ldap.html
@@ -5,7 +5,8 @@
         <li data-ng-show="create">Add User Federation Provider</li>
     </ol>
 
-    <h1 data-ng-hide="create">LDAP</h1>
+    <h1 data-ng-hide="create">LDAP<i style="padding-left: 20px" class="pficon pficon-delete" data-ng-show="!create && access.manageUsers" 
+    	data-ng-hide="changed" data-ng-click="remove()"></i></h1>
     <h1 data-ng-show="create">Add LDAP User Federation Provider</h1>
 
     <ul class="nav nav-tabs" data-ng-hide="create">
@@ -283,7 +284,6 @@
                 <button kc-reset data-ng-show="changed">Cancel</button>
                 <button class="btn btn-primary" data-ng-click="triggerChangedUsersSync()" data-ng-hide="changed">Synchronize changed users</button>
                 <button class="btn btn-primary" data-ng-click="triggerFullSync()" data-ng-hide="changed">Synchronize all users</button>
-                <button class="btn btn-danger" data-ng-click="remove()" data-ng-hide="changed">Delete</button>
             </div>
         </div>
     </form>

--- a/forms/common-themes/src/main/resources/theme/base/admin/resources/partials/federated-mapper-detail.html
+++ b/forms/common-themes/src/main/resources/theme/base/admin/resources/partials/federated-mapper-detail.html
@@ -7,7 +7,8 @@
         <li class="active" data-ng-hide="create">{{mapper.name}}</li>
     </ol>
 
-    <h1 data-ng-hide="create">{{mapper.name|capitalize}}</h1>
+    <h1 data-ng-hide="create">{{mapper.name|capitalize}}<i style="padding-left: 20px" class="pficon pficon-delete" data-ng-show="!create && access.manageRealm" 
+    	data-ng-hide="changed" data-ng-click="remove()"></i></h1>
     <h1 data-ng-show="create">Add User Federation Mapper</h1>
 
     <form class="form-horizontal" name="realmForm" novalidate kc-read-only="!access.manageRealm">
@@ -75,7 +76,6 @@
         <div class="pull-right form-actions" data-ng-show="!create && access.manageRealm">
             <button kc-reset data-ng-show="changed">Clear changes</button>
             <button kc-save  data-ng-show="changed">Save</button>
-            <button kc-delete data-ng-click="remove()" data-ng-hide="changed">Delete</button>
         </div>
     </form>
 </div>

--- a/forms/common-themes/src/main/resources/theme/base/admin/resources/partials/identity-provider-mapper-detail.html
+++ b/forms/common-themes/src/main/resources/theme/base/admin/resources/partials/identity-provider-mapper-detail.html
@@ -7,7 +7,8 @@
         <li class="active" data-ng-hide="create">{{mapper.name|capitalize}}</li>
     </ol>
 
-    <h1 data-ng-hide="create">{{mapper.name|capitalize}}</h1>
+    <h1 data-ng-hide="create">{{mapper.name|capitalize}}<i style="padding-left: 20px" class="pficon pficon-delete" data-ng-show="!create && access.manageRealm" 
+    	data-ng-hide="changed" data-ng-click="remove()"></i></h1>
     <h1 data-ng-show="create">Add Identity Provider Mapper</h1>
 
     <form class="form-horizontal" name="realmForm" novalidate kc-read-only="!access.manageRealm">
@@ -70,7 +71,6 @@
         <div class="pull-right form-actions" data-ng-show="!create && access.manageRealm">
             <button kc-reset data-ng-show="changed">Clear changes</button>
             <button kc-save  data-ng-show="changed">Save</button>
-            <button kc-delete data-ng-click="remove()" data-ng-hide="changed">Delete</button>
         </div>
     </form>
 </div>

--- a/forms/common-themes/src/main/resources/theme/base/admin/resources/partials/protocol-mapper-detail.html
+++ b/forms/common-themes/src/main/resources/theme/base/admin/resources/partials/protocol-mapper-detail.html
@@ -9,7 +9,8 @@
     </ol>
 
     <h1 data-ng-show="create">Create Protocol Mapper</h1>
-    <h1 data-ng-hide="create">{{mapper.name|capitalize}}</h1>
+    <h1 data-ng-hide="create">{{mapper.name|capitalize}}<i style="padding-left: 20px" class="pficon pficon-delete" data-ng-show="!create && access.manageRealm" 
+    	data-ng-hide="changed" data-ng-click="remove()"></i></h1>
 
     <form class="form-horizontal" name="realmForm" novalidate kc-read-only="!access.manageRealm">
 
@@ -98,7 +99,6 @@
             <div class="col-md-10 col-md-offset-2" data-ng-show="!create && access.manageRealm">
                 <button kc-save  data-ng-show="changed">Save</button>
                 <button kc-reset data-ng-show="changed">Cancel</button>
-                <button kc-delete data-ng-click="remove()" data-ng-hide="changed">Delete</button>
             </div>
         </div>
     </form>

--- a/forms/common-themes/src/main/resources/theme/base/admin/resources/partials/realm-identity-provider-oidc.html
+++ b/forms/common-themes/src/main/resources/theme/base/admin/resources/partials/realm-identity-provider-oidc.html
@@ -4,7 +4,8 @@
         <li>{{identityProvider.alias}}</li>
     </ol>
 
-    <h1 data-ng-hide="create">{{identityProvider.alias|capitalize}}</h1>
+    <h1 data-ng-hide="create">{{identityProvider.alias|capitalize}}<i style="padding-left: 20px" class="pficon pficon-delete" 
+    	data-ng-hide="newIdentityProvider || changed" data-ng-click="remove()"></i></h1>
     <h1 data-ng-show="create">Add OpenID Connect Identity Provider</h1>
 
     <ul class="nav nav-tabs" data-ng-hide="newIdentityProvider">
@@ -218,7 +219,6 @@
             <div class="col-md-10 col-md-offset-2">
                 <button kc-save data-ng-show="changed">Save</button>
                 <button kc-cancel data-ng-click="cancel()" data-ng-show="changed">Cancel</button>
-                <button kc-delete data-ng-click="remove()" data-ng-hide="newIdentityProvider || changed">Delete</button>
             </div>
         </div>
     </form>

--- a/forms/common-themes/src/main/resources/theme/base/admin/resources/partials/realm-identity-provider-saml.html
+++ b/forms/common-themes/src/main/resources/theme/base/admin/resources/partials/realm-identity-provider-saml.html
@@ -4,7 +4,8 @@
         <li>{{identityProvider.alias}}</li>
     </ol>
 
-    <h1 data-ng-hide="create">{{identityProvider.alias|capitalize}}</h1>
+    <h1 data-ng-hide="create">{{identityProvider.alias|capitalize}}<i style="padding-left: 20px" class="pficon pficon-delete" 
+    	data-ng-hide="newIdentityProvider || changed" data-ng-click="remove()"></i></h1>
     <h1 data-ng-show="create">Add SAML Identity Provider</h1>
 
     <ul class="nav nav-tabs" data-ng-hide="newIdentityProvider">
@@ -197,7 +198,6 @@
             <div class="col-md-10 col-md-offset-2">
                 <button kc-save data-ng-show="changed">Save</button>
                 <button kc-cancel data-ng-click="cancel()" data-ng-show="changed">Cancel</button>
-                <button kc-delete data-ng-click="remove()" data-ng-hide="newIdentityProvider || changed">Delete</button>
             </div>
         </div>
     </form>

--- a/forms/common-themes/src/main/resources/theme/base/admin/resources/partials/realm-identity-provider-social.html
+++ b/forms/common-themes/src/main/resources/theme/base/admin/resources/partials/realm-identity-provider-social.html
@@ -4,7 +4,8 @@
         <li>{{identityProvider.alias}}</li>
     </ol>
 
-    <h1 data-ng-hide="create">{{identityProvider.alias|capitalize}}</h1>
+    <h1 data-ng-hide="create">{{identityProvider.alias|capitalize}}<i style="padding-left: 20px" class="pficon pficon-delete" 
+    	data-ng-hide="newIdentityProvider || changed" data-ng-click="remove()"></i></h1>
     <h1 data-ng-show="create">Add Social Identity Provider</h1>
 
     <ul class="nav nav-tabs" data-ng-hide="newIdentityProvider">
@@ -109,7 +110,6 @@
             <div class="col-md-10 col-md-offset-2">
                 <button kc-save data-ng-show="changed">Save</button>
                 <button kc-cancel data-ng-click="cancel()" data-ng-show="changed">Cancel</button>
-                <button kc-delete data-ng-click="remove()" data-ng-hide="newIdentityProvider || changed">Delete</button>
             </div>
         </div>
     </form>

--- a/forms/common-themes/src/main/resources/theme/base/admin/resources/partials/role-detail.html
+++ b/forms/common-themes/src/main/resources/theme/base/admin/resources/partials/role-detail.html
@@ -6,7 +6,8 @@
         <li data-ng-show="create">Add Role</li>
     </ol>
 
-    <h1 data-ng-hide="create">{{role.name|capitalize}}</h1>
+    <h1 data-ng-hide="create">{{role.name|capitalize}} <i style="padding-left: 20px" class="pficon pficon-delete" data-ng-show="!create && access.manageRealm" 
+    	data-ng-hide="changed" data-ng-click="remove()"></i></h1>
     <h1 data-ng-show="create">Add Role</h1>
 
     <form class="form-horizontal clearfix" name="realmForm" novalidate kc-read-only="!access.manageRealm">
@@ -47,7 +48,6 @@
             <div class="col-md-10 col-md-offset-2" data-ng-show="!create && access.manageRealm">
                 <button kc-save data-ng-show="changed">Save</button>
                 <button kc-reset data-ng-show="changed">Cancel</button>
-                <button kc-delete data-ng-click="remove()" data-ng-hide="changed">Delete</button>
             </div>
         </div>
 

--- a/forms/common-themes/src/main/resources/theme/base/admin/resources/partials/user-detail.html
+++ b/forms/common-themes/src/main/resources/theme/base/admin/resources/partials/user-detail.html
@@ -5,7 +5,8 @@
         <li data-ng-show="create">Add User</li>
     </ol>
 
-    <h1 data-ng-hide="create">{{user.username|capitalize}}</h1>
+    <h1 data-ng-hide="create">{{user.username|capitalize}}<i style="padding-left: 20px" class="pficon pficon-delete" data-ng-show="!create && access.manageUsers" 
+    	data-ng-hide="changed" data-ng-click="remove()"></i></h1>
     <h1 data-ng-show="create">Add User</h1>
 
     <kc-tabs-user></kc-tabs-user>
@@ -111,7 +112,6 @@
             <div class="col-md-10 col-md-offset-2" data-ng-show="!create && access.manageUsers">
                 <button kc-save  data-ng-show="changed">Save</button>
                 <button kc-reset data-ng-show="changed">Cancel</button>
-                <button kc-delete data-ng-click="remove()" data-ng-hide="changed">Delete</button>
             </div>
         </div>
 


### PR DESCRIPTION
Delete glyph-icon is not added for following page titles :

realm-detail : a delete button "Delete Realm" is more appealing and sensible as compared to a delete glyph-icon next to the label "Settings"

realm-events-config : We have two buttons "Clear Events" and "Clear Admin Events" . If we even introduce two glyph-icons, the icon will mean as deleting the entire user or admin configuration. But, the purpose of delete buttons is only to clear the respective events (user/admin). So, better is two have two buttons rather than icons.
