### PR TITLE
KEYCLOAK-1476 NotSerializableException: org.keycloak.models.cache.entities.CachedClientRole

### DIFF
--- a/core/src/main/java/org/keycloak/enums/SslRequired.java
+++ b/core/src/main/java/org/keycloak/enums/SslRequired.java
@@ -14,8 +14,6 @@ public enum SslRequired {
     EXTERNAL,
     NONE;
 
-    private static final long serialVersionUID = 1L;
-
     public boolean isRequired(ClientConnection connection) {
         return isRequired(connection.getRemoteAddr());
     }


### PR DESCRIPTION
- Remove noop code (Enum serialization 101 - http://docs.oracle.com/javase/6/docs/platform/serialization/spec/serial-arch.html#6469)
