### PR TITLE
KEYCLOAK-1486 fixed User link in Clients' Active Sessions page

### DIFF
--- a/core/src/main/java/org/keycloak/representations/idm/UserSessionRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/idm/UserSessionRepresentation.java
@@ -11,7 +11,8 @@ import java.util.Set;
  */
 public class UserSessionRepresentation {
     private String id;
-    private String user;
+    private String username;
+    private String userId;
     private String ipAddress;
     private long start;
     private long lastAccess;
@@ -25,12 +26,20 @@ public class UserSessionRepresentation {
         this.id = id;
     }
 
-    public String getUser() {
-        return user;
+    public String getUsername() {
+        return username;
     }
 
-    public void setUser(String user) {
-        this.user = user;
+    public void setUsername(String username) {
+        this.username = username;
+    }
+    
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
     }
 
     public String getIpAddress() {

--- a/forms/common-themes/src/main/resources/theme/base/admin/resources/partials/client-sessions.html
+++ b/forms/common-themes/src/main/resources/theme/base/admin/resources/partials/client-sessions.html
@@ -48,7 +48,7 @@
         </tfoot>
         <tbody>
         <tr data-ng-repeat="session in sessions">
-            <td><a href="#/realms/{{realm.realm}}/users/{{session.user}}">{{session.user}}</a></td>
+            <td><a href="#/realms/{{realm.realm}}/users/{{session.userId}}">{{session.username}}</a></td>
             <td>{{session.ipAddress}}</td>
             <td>{{session.start | date:'medium'}}</td>
         </tr>

--- a/model/api/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
+++ b/model/api/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
@@ -230,7 +230,8 @@ public class ModelToRepresentation {
         rep.setId(session.getId());
         rep.setStart(Time.toMillis(session.getStarted()));
         rep.setLastAccess(Time.toMillis(session.getLastSessionRefresh()));
-        rep.setUser(session.getUser().getUsername());
+        rep.setUsername(session.getUser().getUsername());
+        rep.setUserId(session.getUser().getId());
         rep.setIpAddress(session.getIpAddress());
         for (ClientSessionModel clientSession : session.getClientSessions()) {
             ClientModel client = clientSession.getClient();


### PR DESCRIPTION
Changed User link in Clients' Active Sessions page to use userId
instead of username to show User details instead of Resource not found.
Renamed UserSessionRepresentation’s user attribute to username as it
was ambiguous and only used in 1 place (i.e. client-sessions.html).
