### PR TITLE
KEYCLOAK-1415 server cli script

### DIFF
--- a/distribution/server-overlay/eap6/eap6-server-overlay/assembly.xml
+++ b/distribution/server-overlay/eap6/eap6-server-overlay/assembly.xml
@@ -40,6 +40,14 @@
             <source>src/main/providers/README.txt</source>
             <outputDirectory>standalone/configuration/providers</outputDirectory>
         </file>
+        <file>
+            <source>cli/keycloak-prepare.cli</source>
+            <outputDirectory>bin</outputDirectory>
+        </file>
+        <file>
+            <source>cli/keycloak-install.cli</source>
+            <outputDirectory>bin</outputDirectory>
+        </file>
     </files>
 
 </assembly>

--- a/distribution/server-overlay/eap6/eap6-server-overlay/cli/keycloak-install.cli
+++ b/distribution/server-overlay/eap6/eap6-server-overlay/cli/keycloak-install.cli
@@ -1,0 +1,2 @@
+/extension=org.keycloak.keycloak-server-subsystem/:add(module=org.keycloak.keycloak-server-subsystem)
+/subsystem=keycloak-server:add(web-context=auth)

--- a/distribution/server-overlay/eap6/eap6-server-overlay/cli/keycloak-prepare.cli
+++ b/distribution/server-overlay/eap6/eap6-server-overlay/cli/keycloak-prepare.cli
@@ -1,0 +1,8 @@
+/subsystem=datasources/data-source=KeycloakDS/:add(connection-url="jdbc:h2:${jboss.server.data.dir}/keycloak;AUTO_SERVER=TRUE",driver-name=h2,jndi-name=java:jboss/datasources/KeycloakDS,password=sa,user-name=sa,use-java-context=true,enabled=true)
+/subsystem=logging/logger=org.jboss.resteasy.resteasy_jaxrs.i18n/:add(level=ERROR)
+/subsystem=security/security-domain=keycloak/:add
+/subsystem=security/security-domain=keycloak/authentication=classic:add
+/subsystem=security/security-domain=keycloak/authentication=classic/login-module=keycloak/:add(flag=required,code=org.keycloak.adapters.jboss.KeycloakLoginModule)
+/subsystem=security/security-domain=sp/:add(cache-type=default)
+/subsystem=security/security-domain=sp/authentication=classic:add
+/subsystem=security/security-domain=sp/authentication=classic/login-module=saml/:add(flag=required,code=org.picketlink.identity.federation.bindings.wildfly.SAML2LoginModule)

--- a/distribution/server-overlay/eap6/eap6-server-overlay/cli/keycloak-prepare.cli
+++ b/distribution/server-overlay/eap6/eap6-server-overlay/cli/keycloak-prepare.cli
@@ -1,8 +1,2 @@
 /subsystem=datasources/data-source=KeycloakDS/:add(connection-url="jdbc:h2:${jboss.server.data.dir}/keycloak;AUTO_SERVER=TRUE",driver-name=h2,jndi-name=java:jboss/datasources/KeycloakDS,password=sa,user-name=sa,use-java-context=true,enabled=true)
 /subsystem=logging/logger=org.jboss.resteasy.resteasy_jaxrs.i18n/:add(level=ERROR)
-/subsystem=security/security-domain=keycloak/:add
-/subsystem=security/security-domain=keycloak/authentication=classic:add
-/subsystem=security/security-domain=keycloak/authentication=classic/login-module=keycloak/:add(flag=required,code=org.keycloak.adapters.jboss.KeycloakLoginModule)
-/subsystem=security/security-domain=sp/:add(cache-type=default)
-/subsystem=security/security-domain=sp/authentication=classic:add
-/subsystem=security/security-domain=sp/authentication=classic/login-module=saml/:add(flag=required,code=org.picketlink.identity.federation.bindings.wildfly.SAML2LoginModule)

--- a/distribution/server-overlay/eap6/eap6-server-overlay/src/main/xslt/standalone.xsl
+++ b/distribution/server-overlay/eap6/eap6-server-overlay/src/main/xslt/standalone.xsl
@@ -44,22 +44,6 @@
         </xsl:copy>
     </xsl:template>
 
-    <xsl:template match="//sec:security-domains">
-        <xsl:copy>
-            <xsl:apply-templates select="node()[name(.)='security-domain']"/>
-            <security-domain name="keycloak">
-                <authentication>
-                    <login-module code="org.keycloak.adapters.jboss.KeycloakLoginModule" flag="required"/>
-                </authentication>
-            </security-domain>
-            <security-domain name="sp" cache-type="default">
-                <authentication>
-                    <login-module code="org.picketlink.identity.federation.bindings.wildfly.SAML2LoginModule" flag="required"/>
-                </authentication>
-            </security-domain>
-        </xsl:copy>
-    </xsl:template>
-
     <xsl:template match="//*[local-name()='subsystem' and starts-with(namespace-uri(), $log)]">
         <xsl:copy>
             <xsl:apply-templates select="node()|@*"/>

--- a/distribution/server-overlay/wf9-server-overlay/assembly.xml
+++ b/distribution/server-overlay/wf9-server-overlay/assembly.xml
@@ -62,6 +62,10 @@
             <source>${project.build.directory}/unpacked/keycloak-${project.version}/standalone/configuration/keycloak-server.json</source>
             <outputDirectory>standalone/configuration</outputDirectory>
         </file>
+        <file>
+            <source>cli/keycloak-install.cli</source>
+            <outputDirectory>bin</outputDirectory>
+        </file>
     </files>
 
 </assembly>

--- a/distribution/server-overlay/wf9-server-overlay/cli/keycloak-install.cli
+++ b/distribution/server-overlay/wf9-server-overlay/cli/keycloak-install.cli
@@ -1,0 +1,3 @@
+/subsystem=datasources/data-source=KeycloakDS/:add(connection-url="jdbc:h2:${jboss.server.data.dir}/keycloak;AUTO_SERVER=TRUE",driver-name=h2,jndi-name=java:jboss/datasources/KeycloakDS,password=sa,user-name=sa,use-java-context=true)
+/extension=org.keycloak.keycloak-server-subsystem/:add(module=org.keycloak.keycloak-server-subsystem)
+/subsystem=keycloak-server:add(web-context=auth)

--- a/docbook/reference/en/en-US/modules/server-installation.xml
+++ b/docbook/reference/en/en-US/modules/server-installation.xml
@@ -49,9 +49,9 @@
                 <literal>keycloak-overlay-&project.version;.zip</literal> or <literal>keycloak-overlay-&project.version;.tar.gz</literal>.
                 Once downloaded extract into the root directory of your WildFly installation. To start WildFly with Keycloak
                 run:
-                <programlisting>keycloak-&project.version;/bin/standalone.sh --server-config=standalone-keycloak.xml</programlisting>
+                <programlisting>&lt;WILDFLY_HOME&gt;/bin/standalone.sh --server-config=standalone-keycloak.xml</programlisting>
                 or:
-                <programlisting>keycloak-&project.version;/bin/standalone.bat --server-config=standalone-keycloak.xml</programlisting>
+                <programlisting>&lt;WILDFLY_HOME&gt;/bin/standalone.bat --server-config=standalone-keycloak.xml</programlisting>
             </para>
             <para>
                 Once the server is started log into the admin console at
@@ -60,21 +60,28 @@
                 enter in a new password.
             </para>
             <para>
-                To add Keycloak to other sever configurations (standalone.xml, standalone-ha.xml, etc.) open
-                <literal>standalone/configuration/standalone-keycloak.xml</literal> and the configuration you want to add it
-                to, for example <literal>standalone/configuration/standalone.xml</literal>. From <literal>standalone-keycloak.xml</literal>
-                you need to copy 3 elements:
-                <itemizedlist>
-                    <listitem><literal>&lt;extension module="org.keycloak.keycloak-server-subsystem"/&gt;</literal></listitem>
-                    <listitem><literal>&lt;datasource jndi-name="java:jboss/datasources/KeycloakDS" ...&gt;</literal></listitem>
-                    <listitem><literal>&lt;subsystem xmlns="urn:jboss:domain:keycloak-server:1.1" ...&gt;</literal></listitem>
-                </itemizedlist>
+                To add Keycloak to other sever configurations (standalone.xml, standalone-ha.xml, etc.) start the server with
+                the desired server-config.  Then execute the following CLI script:
+                <programlisting>&lt;WILDFLY_HOME&gt;/bin/jboss-cli.sh -c --file=keycloak-install.cli</programlisting>
             </para>
         </section>
         <section>
             <title>Install on existing JBoss EAP 6.4.0.GA</title>
             <para>
                 Same procedure as WildFly 9.0.0.Final, but download <literal>keycloak-overlay-eap6-&project.version;.zip</literal> or <literal>keycloak-overlay-eap6-&project.version;.tar.gz</literal>.
+            </para>
+            <para>
+                However, for EAP, adding Keycloak to other sever configurations (standalone.xml, standalone-ha.xml, etc.) requires two CLI scripts. Start the server with
+                the desired server-config.  Then execute the following CLI scripts with a restart in between:
+                <orderedlist>
+                    <listitem>
+                        <programlisting>&lt;EAP_HOME&gt;/bin/jboss-cli.sh -c --file=keycloak-prepare.cli</programlisting>
+                    </listitem>
+                    <listitem>Restart the server with the same server-config.</listitem>
+                    <listitem>
+                        <programlisting>&lt;EAP_HOME&gt;/bin/jboss-cli.sh -c --file=keycloak-install.cli</programlisting>
+                    </listitem>
+                </orderedlist>
             </para>
         </section>
         <section>


### PR DESCRIPTION
EAP requires two CLI scripts. You need to run keycloak-prepare.cli, restart, and then run keycloak-install.cli. Unfortunately, EAP doesn't register the datasource in JNDI without a restart. I guess this behavior was changed in WildFly 9.
