### PR TITLE
Added null email check in duplicate email check code

### DIFF
--- a/model/invalidation-cache/model-adapters/src/main/java/org/keycloak/models/cache/DefaultCacheUserProvider.java
+++ b/model/invalidation-cache/model-adapters/src/main/java/org/keycloak/models/cache/DefaultCacheUserProvider.java
@@ -172,6 +172,7 @@ public class DefaultCacheUserProvider implements CacheUserProvider {
 
     @Override
     public UserModel getUserByEmail(String email, RealmModel realm) {
+        if (email == null) return null;
         
         email = email.toLowerCase();
         

--- a/testsuite/integration/src/test/java/org/keycloak/testsuite/federation/FederationProvidersIntegrationTest.java
+++ b/testsuite/integration/src/test/java/org/keycloak/testsuite/federation/FederationProvidersIntegrationTest.java
@@ -520,6 +520,8 @@ public class FederationProvidersIntegrationTest {
                 LDAPFederationProvider ldapFedProvider = FederationTestUtils.getLdapProvider(session, ldapModel);
                 FederationTestUtils.addLDAPUser(ldapFedProvider, appRealm, "marykeycloak", "Mary1", "Kelly1", "mary1@email.org", null, "123");
                 FederationTestUtils.addLDAPUser(ldapFedProvider, appRealm, "mary-duplicatemail", "Mary2", "Kelly2", "mary@test.com", null, "123");
+                LDAPObject marynoemail = FederationTestUtils.addLDAPUser(ldapFedProvider, appRealm, "marynoemail", "Mary1", "Kelly1", null, null, "123");
+                ldapFedProvider.getLdapIdentityStore().updatePassword(marynoemail, "Password1");
             }
 
         });
@@ -531,6 +533,8 @@ public class FederationProvidersIntegrationTest {
 
         loginPage.login("mary1@email.org", "password");
         Assert.assertEquals("Username already exists.", loginPage.getError());
+
+        loginSuccessAndLogout("marynoemail", "Password1");
     }
 
     @Test


### PR DESCRIPTION
While testing the fix for "duplicate emails" and the "multiple attribute value" fix, i ran across a bug caused by this particular fix.  If an existing ldap user has no email address, keycloak will fail on the import.  

The issue is caused by a null pointer exception in DefaultCacheUserProvider.java in getUserByEmail.  email.toLowerCase() throws a NullPointerException when email is null.
