### PR TITLE
Populate the KEYCLOAK_USERNAME header 

### DIFF
--- a/proxy/proxy-server/src/main/java/org/keycloak/proxy/ConstraintAuthorizationHandler.java
+++ b/proxy/proxy-server/src/main/java/org/keycloak/proxy/ConstraintAuthorizationHandler.java
@@ -33,7 +33,7 @@ public class ConstraintAuthorizationHandler implements HttpHandler {
 
         this.httpHeaderNames = new HashMap<>();
         this.httpHeaderNames.put(KEYCLOAK_SUBJECT, new HttpString(getOrDefault(headerNames, "keycloak-subject", KEYCLOAK_SUBJECT)));
-        this.httpHeaderNames.put(KEYCLOAK_SUBJECT, new HttpString(getOrDefault(headerNames, "keycloak-username", KEYCLOAK_USERNAME)));
+        this.httpHeaderNames.put(KEYCLOAK_USERNAME, new HttpString(getOrDefault(headerNames, "keycloak-username", KEYCLOAK_USERNAME)));
         this.httpHeaderNames.put(KEYCLOAK_EMAIL, new HttpString(getOrDefault(headerNames, "keycloak-email", KEYCLOAK_EMAIL)));
         this.httpHeaderNames.put(KEYCLOAK_NAME, new HttpString(getOrDefault(headerNames, "keycloak-name", KEYCLOAK_NAME)));
         this.httpHeaderNames.put(KEYCLOAK_ACCESS_TOKEN, new HttpString(getOrDefault(headerNames, "keycloak-access-token", KEYCLOAK_ACCESS_TOKEN)));


### PR DESCRIPTION
This fixes the authenticate and roles-allowed constraints in the proxy.

It looks like this bug was introduced in this commit:

https://github.com/keycloak/keycloak/commit/2b5e0e238dce81c2eb09a7d78ffb956f29f9c726#diff-33cc233a631baa644106d9442ccd6487R36

If the header is not set, any attempt to use authenticate or roles-allowed constraints results in null header trace-back in undertow.
