### PR TITLE
[KEYCLOAK-1427] Move delete buttons-github like modal for deleting realm

### DIFF
--- a/forms/common-themes/src/main/resources/theme/base/admin/resources/js/services.js
+++ b/forms/common-themes/src/main/resources/theme/base/admin/resources/js/services.js
@@ -5,12 +5,19 @@ var module = angular.module('keycloak.services', [ 'ngResource', 'ngRoute' ]);
 module.service('Dialog', function($modal) {
 	var dialog = {};
 
-    var openDialog = function(title, message, btns) {
+    var openDialog = function(name, type, title, message, btns) {
         var controller = function($scope, $modalInstance, title, message, btns) {
             $scope.title = title;
             $scope.message = message;
             $scope.btns = btns;
-
+            
+            $scope.verifyRealm = {
+                currentTypeName : name,
+                type : type,
+                realmName : null,
+                realmDeleteMessage : "Please enter the name of the realm you wish to delete ?"
+            }
+            
             $scope.ok = function () {
                 $modalInstance.close();
             };
@@ -56,7 +63,7 @@ module.service('Dialog', function($modal) {
             }
         }
 
-        openDialog(title, msg, btns).then(success);
+        openDialog(name, type, title, msg, btns).then(success);
 	}
 
     dialog.confirmGenerateKeys = function(name, type, success) {

--- a/forms/common-themes/src/main/resources/theme/base/admin/resources/templates/kc-modal.html
+++ b/forms/common-themes/src/main/resources/theme/base/admin/resources/templates/kc-modal.html
@@ -5,7 +5,13 @@
     <h4 class="modal-title">{{title}}</h4>
 </div>
 <div class="modal-body">{{message}}</div>
+
+<div ng-show="(verifyRealm.type == 'realm')" class="modal-body">{{verifyRealm.realmDeleteMessage}}
+<input class="form-control" type="realmName" name="realmName" id="realmName" data-ng-model="verifyRealm.realmName">
+</div>
+  
 <div class="modal-footer">
     <button type="button" data-ng-class="btns.cancel.cssClass" ng-click="cancel()">{{btns.cancel.label}}</button>
-    <button type="button" data-ng-class="btns.ok.cssClass" ng-click="ok()">{{btns.ok.label}}</button>
+    <button type="button" data-ng-class="btns.ok.cssClass" ng-show="(verifyRealm.type == 'realm')" ng-click="ok()" ng-disabled ="!(verifyRealm.realmName == verifyRealm.currentTypeName)">{{btns.ok.label}}</button>
+    <button type="button" data-ng-class="btns.ok.cssClass" ng-show="!(verifyRealm.type == 'realm')" ng-click="ok()">{{btns.ok.label}}</button>
 </div>


### PR DESCRIPTION
Updated realm delete modal similar to github like repository delete modal. Modal for deletion of all other entities remains the same.
