### PR TITLE
KEYCLOAK-1724: Removed second security-constraint as it stops Tomcat from redirecting to Keycloak

### DIFF
--- a/docbook/reference/en/en-US/modules/tomcat-adapter.xml
+++ b/docbook/reference/en/en-US/modules/tomcat-adapter.xml
@@ -73,18 +73,9 @@ $ unzip keycloak-tomcat8-adapter-dist.zip
         </auth-constraint>
     </security-constraint>
 
-    <security-constraint>
-        <web-resource-collection>
-            <url-pattern>/*</url-pattern>
-        </web-resource-collection>
-        <user-data-constraint>
-            <transport-guarantee>CONFIDENTIAL</transport-guarantee>
-        </user-data-constraint>
-    </security-constraint>
-
     <login-config>
         <auth-method>BASIC</auth-method>
-        <realm-name>this is ignored currently/realm-name>
+        <realm-name>this is ignored currently</realm-name>
     </login-config>
 
     <security-role>


### PR DESCRIPTION
Removed second security-constraint as it seems to stop Tomcat from redirecting users that aren’t logged in to Keycloak. Also added missing tag start.
Tested with Tomcat 8.
