### PR TITLE
Remove multiple declaration of jboss-logging dependency

### DIFF
--- a/testsuite/tomcat6/pom.xml
+++ b/testsuite/tomcat6/pom.xml
@@ -104,10 +104,6 @@
            <groupId>org.keycloak</groupId>
            <artifactId>keycloak-tomcat6-adapter</artifactId>
        </dependency>
-       <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging</artifactId>
-        </dependency>
         <dependency>
             <groupId>io.undertow</groupId>
             <artifactId>undertow-servlet</artifactId>


### PR DESCRIPTION
 Remove multiple declaration of jboss-logging dependency from testsuite/tomcat6/pom.xml
