### PR TITLE
add missing tag start type to sample jboss configuration in docbook

### DIFF
--- a/docbook/reference/en/en-US/modules/jboss-adapter.xml
+++ b/docbook/reference/en/en-US/modules/jboss-adapter.xml
@@ -189,7 +189,7 @@ public class CustomerService {
 
     <login-config>
         <auth-method>KEYCLOAK</auth-method>
-        <realm-name>this is ignored currently/realm-name>
+        <realm-name>this is ignored currently</realm-name>
     </login-config>
 
     <security-role>


### PR DESCRIPTION
Copy-pasted the login-config section off the docs and the web server failed to start due to parse error.  Just a missing char on the end tag.
