### PR TITLE
KEYCLOAK-1776 / JettySessionTokenStore sets content type on restoring form values

### DIFF
--- a/integration/jetty/jetty8.1/src/main/java/org/keycloak/adapters/jetty/JettySessionTokenStore.java
+++ b/integration/jetty/jetty8.1/src/main/java/org/keycloak/adapters/jetty/JettySessionTokenStore.java
@@ -47,6 +47,7 @@ public class JettySessionTokenStore extends AbstractJettySessionTokenStore {
                     myRequest.setMethod(method);
                     MultivaluedHashMap<String, String> j_post = (MultivaluedHashMap<String, String>) session.getAttribute(CACHED_FORM_PARAMETERS);
                     if (j_post != null) {
+                        myRequest.setContentType("application/x-www-form-urlencoded");
                         MultiMap<String> map = new MultiMap<String>();
                         for (String key : j_post.keySet()) {
                             for (String val : j_post.getList(key)) {

--- a/integration/jetty/jetty9.1/src/main/java/org/keycloak/adapters/jetty/JettySessionTokenStore.java
+++ b/integration/jetty/jetty9.1/src/main/java/org/keycloak/adapters/jetty/JettySessionTokenStore.java
@@ -48,6 +48,7 @@ public class JettySessionTokenStore extends AbstractJettySessionTokenStore {
                     myRequest.setMethod(HttpMethod.valueOf(method.toUpperCase()), method);
                     MultivaluedHashMap<String, String> j_post = (MultivaluedHashMap<String, String>) session.getAttribute(CACHED_FORM_PARAMETERS);
                     if (j_post != null) {
+                        myRequest.setContentType("application/x-www-form-urlencoded");
                         MultiMap<String> map = new MultiMap<String>();
                         for (String key : j_post.keySet()) {
                             for (String val : j_post.getList(key)) {

--- a/integration/jetty/jetty9.2/src/main/java/org/keycloak/adapters/jetty/JettySessionTokenStore.java
+++ b/integration/jetty/jetty9.2/src/main/java/org/keycloak/adapters/jetty/JettySessionTokenStore.java
@@ -48,6 +48,7 @@ public class JettySessionTokenStore extends AbstractJettySessionTokenStore {
                     myRequest.setMethod(HttpMethod.valueOf(method.toUpperCase()), method);
                     MultivaluedHashMap<String, String> j_post = (MultivaluedHashMap<String, String>) session.getAttribute(CACHED_FORM_PARAMETERS);
                     if (j_post != null) {
+                        myRequest.setContentType("application/x-www-form-urlencoded");
                         MultiMap<String> map = new MultiMap<String>();
                         for (String key : j_post.keySet()) {
                             for (String val : j_post.getList(key)) {

--- a/testsuite/integration/src/test/java/org/keycloak/testsuite/adapter/InputServlet.java
+++ b/testsuite/integration/src/test/java/org/keycloak/testsuite/adapter/InputServlet.java
@@ -13,6 +13,8 @@ import java.io.PrintWriter;
  */
 public class InputServlet extends HttpServlet {
 
+    private static final String FORM_URLENCODED = "application/x-www-form-urlencoded";
+
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
         String appBase = System.getProperty("app.server.base.url", "http://localhost:8081");
@@ -33,6 +35,15 @@ public class InputServlet extends HttpServlet {
 
     @Override
     protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        if (!FORM_URLENCODED.equals(req.getContentType())) {
+            resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            PrintWriter pw = resp.getWriter();
+            resp.setContentType("text/plain");
+            pw.printf("Expecting content type " + FORM_URLENCODED +
+                    ", received " + req.getContentType() + " instead");
+            pw.flush();
+            return;
+        }
         resp.setContentType("text/plain");
         PrintWriter pw = resp.getWriter();
         pw.printf("parameter="+req.getParameter("parameter"));


### PR DESCRIPTION
JettySessionTokenStore will call saveRequest() to preserve data submitted by a form. The subsequent call to restoreRequest() will restore the form parameters, but not the content type. 

see: [KEYCLOAK-1776](https://issues.jboss.org/browse/KEYCLOAK-1776)
