### PR TITLE
KEYCLOAK-1741 - Login form keeps "Username or email" field value after reshown due validation error

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/AuthenticationProcessor.java
+++ b/services/src/main/java/org/keycloak/authentication/AuthenticationProcessor.java
@@ -419,6 +419,7 @@ public class AuthenticationProcessor {
             LoginFormsProvider provider = getSession().getProvider(LoginFormsProvider.class)
                     .setUser(getUser())
                     .setActionUri(action)
+                    .setFormData(request.getDecodedFormParameters())
                     .setClientSessionCode(accessCode);
             if (getForwardedErrorMessage() != null) {
                 provider.addError(getForwardedErrorMessage());

--- a/testsuite/integration/src/test/java/org/keycloak/testsuite/forms/LoginTest.java
+++ b/testsuite/integration/src/test/java/org/keycloak/testsuite/forms/LoginTest.java
@@ -129,6 +129,10 @@ public class LoginTest {
 
         loginPage.assertCurrent();
 
+        // KEYCLOAK-1741 - assert form field values kept
+        Assert.assertEquals("login-test", loginPage.getUsername());
+        Assert.assertEquals("", loginPage.getPassword());
+
         Assert.assertEquals("Invalid username or password.", loginPage.getError());
 
         events.expectLogin().user(userId).session((String) null).error("invalid_user_credentials")
@@ -143,6 +147,10 @@ public class LoginTest {
         loginPage.missingPassword("login-test");
 
         loginPage.assertCurrent();
+
+        // KEYCLOAK-1741 - assert form field values kept
+        Assert.assertEquals("login-test", loginPage.getUsername());
+        Assert.assertEquals("", loginPage.getPassword());
 
         Assert.assertEquals("Invalid username or password.", loginPage.getError());
 
@@ -166,6 +174,10 @@ public class LoginTest {
             loginPage.login("login-test", "invalid");
 
             loginPage.assertCurrent();
+
+            // KEYCLOAK-1741 - assert form field values kept
+            Assert.assertEquals("login-test", loginPage.getUsername());
+            Assert.assertEquals("", loginPage.getPassword());
 
             Assert.assertEquals("Account is disabled, contact admin.", loginPage.getError());
 
@@ -198,6 +210,10 @@ public class LoginTest {
 
             loginPage.assertCurrent();
 
+            // KEYCLOAK-1741 - assert form field values kept
+            Assert.assertEquals("login-test", loginPage.getUsername());
+            Assert.assertEquals("", loginPage.getPassword());
+
             Assert.assertEquals("Account is disabled, contact admin.", loginPage.getError());
 
             events.expectLogin().user(userId).session((String) null).error("user_disabled")
@@ -220,6 +236,10 @@ public class LoginTest {
         loginPage.login("invalid", "password");
 
         loginPage.assertCurrent();
+
+        // KEYCLOAK-1741 - assert form field values kept
+        Assert.assertEquals("invalid", loginPage.getUsername());
+        Assert.assertEquals("", loginPage.getPassword());
 
         Assert.assertEquals("Invalid username or password.", loginPage.getError());
 

--- a/testsuite/integration/src/test/java/org/keycloak/testsuite/pages/LoginPage.java
+++ b/testsuite/integration/src/test/java/org/keycloak/testsuite/pages/LoginPage.java
@@ -112,6 +112,10 @@ public class LoginPage extends AbstractPage {
         return usernameInput.getAttribute("value");
     }
 
+    public String getPassword() {
+        return passwordInput.getAttribute("value");
+    }
+
     public void cancel() {
         cancelButton.click();
     }


### PR DESCRIPTION
PR contains relevant tests also
