### PR TITLE
KEYCLOAK-1828 attemptAuthentication throws KeycloakAuthenticationException if authentication fails

### DIFF
--- a/integration/spring-security/src/main/java/org/keycloak/adapters/springsecurity/KeycloakAuthenticationException.java
+++ b/integration/spring-security/src/main/java/org/keycloak/adapters/springsecurity/KeycloakAuthenticationException.java
@@ -1,0 +1,13 @@
+package org.keycloak.adapters.springsecurity;
+
+import org.springframework.security.core.AuthenticationException;
+
+public class KeycloakAuthenticationException extends AuthenticationException {
+    public KeycloakAuthenticationException(String msg, Throwable t) {
+        super(msg, t);
+    }
+
+    public KeycloakAuthenticationException(String msg) {
+        super(msg);
+    }
+}


### PR DESCRIPTION
Added `KeycloakAuthenticationException` which is thrown by `org.keycloak.adapters.springsecurity.filter.KeycloakAuthenticationProcessingFilter#attemptAuthentication` if authentication fails (instead of just returning with `null`). 

Also `authenticationFailureHandler` is by default set to `SimpleUrlAuthenticationFailureHandler`
with default login url set to `/sso/login`. This will cause a redirection to Keycloak with a fresh code and state cookie. As the user previously authenticated successfully this redirection is not really visible to the user.

These changes fix the blank screen problem which happens if there is a mismatch between the code and state cookie.
