### PR TITLE
KEYCLOAK-1829 unsuccessfulAuthentication now returns HTTP response status 401 instead of 403

### DIFF
--- a/integration/spring-security/src/main/java/org/keycloak/adapters/springsecurity/filter/KeycloakAuthenticationProcessingFilter.java
+++ b/integration/spring-security/src/main/java/org/keycloak/adapters/springsecurity/filter/KeycloakAuthenticationProcessingFilter.java
@@ -190,12 +190,12 @@ public class KeycloakAuthenticationProcessingFilter extends AbstractAuthenticati
 
         if (this.isBearerTokenRequest(request)) {
             SecurityContextHolder.clearContext();
-            response.sendError(HttpServletResponse.SC_FORBIDDEN, "Unable to authenticate bearer token");
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unable to authenticate bearer token");
             return;
         }
         else if (this.isBasicAuthRequest(request)) {
             SecurityContextHolder.clearContext();
-            response.sendError(HttpServletResponse.SC_FORBIDDEN, "Unable to authenticate with basic authentication");
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unable to authenticate with basic authentication");
             return;
         }
 

--- a/integration/spring-security/src/test/java/org/keycloak/adapters/springsecurity/filter/KeycloakAuthenticationProcessingFilterTest.java
+++ b/integration/spring-security/src/test/java/org/keycloak/adapters/springsecurity/filter/KeycloakAuthenticationProcessingFilterTest.java
@@ -148,7 +148,7 @@ public class KeycloakAuthenticationProcessingFilterTest {
         AuthenticationException exception = new BadCredentialsException("OOPS");
         this.setBearerAuthHeader(request);
         filter.unsuccessfulAuthentication(request, response, exception);
-        verify(response).sendError(eq(HttpServletResponse.SC_FORBIDDEN), anyString());
+        verify(response).sendError(eq(HttpServletResponse.SC_UNAUTHORIZED), anyString());
         verify(failureHandler, never()).onAuthenticationFailure(any(HttpServletRequest.class), any(HttpServletResponse.class),
                 any(AuthenticationException.class));
     }
@@ -158,7 +158,7 @@ public class KeycloakAuthenticationProcessingFilterTest {
         AuthenticationException exception = new BadCredentialsException("OOPS");
         this.setBasicAuthHeader(request);
         filter.unsuccessfulAuthentication(request, response, exception);
-        verify(response).sendError(eq(HttpServletResponse.SC_FORBIDDEN), anyString());
+        verify(response).sendError(eq(HttpServletResponse.SC_UNAUTHORIZED), anyString());
         verify(failureHandler, never()).onAuthenticationFailure(any(HttpServletRequest.class), any(HttpServletResponse.class),
                 any(AuthenticationException.class));
     }


### PR DESCRIPTION
If pull request #1610 is accepted, then authentication failure when using Bearer or Basic authentication results in 403 Forbidden because the response is now generated by `org.keycloak.adapters.springsecurity.filter.KeycloakAuthenticationProcessingFilter#unsuccessfulAuthentication`. Previously this method was not called because `attemptAuthentication` did not throw `AuthenticationException`. 

This pull request changes `unsuccessfulAuthentication` to return the correct status code of 401 Unauthorized.
