### PR TITLE
KEYCLOAK-1722 Client-Specific Permissions in the Admin Console

### DIFF
--- a/connections/jpa-liquibase/src/main/resources/META-INF/jpa-changelog-1.5.0.xml
+++ b/connections/jpa-liquibase/src/main/resources/META-INF/jpa-changelog-1.5.0.xml
@@ -60,6 +60,11 @@
                 <constraints nullable="true"/>
             </column>
         </addColumn>
+        <addColumn tableName="CLIENT">
+            <column name="CLIENT_MANAGE_AUTH_ENABLED" type="BOOLEAN" defaultValue="false">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
 
     </changeSet>
 </databaseChangeLog>

--- a/core/src/main/java/org/keycloak/representations/idm/ClientRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/idm/ClientRepresentation.java
@@ -23,6 +23,7 @@ public class ClientRepresentation {
     protected Boolean bearerOnly;
     protected Boolean consentRequired;
     protected Boolean serviceAccountsEnabled;
+    protected Boolean clientManageAuthEnabled;
     protected Boolean directGrantsOnly;
     protected Boolean publicClient;
     protected Boolean frontchannelLogout;
@@ -151,6 +152,14 @@ public class ClientRepresentation {
 
     public void setServiceAccountsEnabled(Boolean serviceAccountsEnabled) {
         this.serviceAccountsEnabled = serviceAccountsEnabled;
+    }
+
+    public Boolean isClientManageAuthEnabled() {
+        return clientManageAuthEnabled;
+    }
+
+    public void setClientManageAuthEnabled(Boolean clientManageAuthEnabled) {
+        this.clientManageAuthEnabled = clientManageAuthEnabled;
     }
 
     public Boolean isDirectGrantsOnly() {

--- a/forms/common-themes/src/main/resources/theme/base/admin/resources/partials/client-detail.html
+++ b/forms/common-themes/src/main/resources/theme/base/admin/resources/partials/client-detail.html
@@ -45,6 +45,13 @@
                 </div>
                 <kc-tooltip>When enabled, client can only obtain grants from grant REST API.</kc-tooltip>
             </div>
+            <div class="form-group clearfix block">
+                <label class="col-md-2 control-label" for="clientManageAuthEnabled">Management Authorization</label>
+                <div class="col-sm-6">
+                    <input ng-model="client.clientManageAuthEnabled" name="clientManageAuthEnabled" id="clientManageAuthEnabled" onoffswitch />
+                </div>
+                <kc-tooltip>When enabled, client management is restricted to users who are mapped to the corresponding 'keycloak-client' roles.</kc-tooltip>
+            </div>
             <div class="form-group">
                 <label class="col-md-2 control-label" for="protocol">Client Protocol</label>
                 <div class="col-sm-6">

--- a/model/api/src/main/java/org/keycloak/models/ClientModel.java
+++ b/model/api/src/main/java/org/keycloak/models/ClientModel.java
@@ -106,6 +106,9 @@ public interface ClientModel extends RoleContainerModel {
     boolean isServiceAccountsEnabled();
     void setServiceAccountsEnabled(boolean serviceAccountsEnabled);
 
+    boolean isClientManageAuthEnabled();
+    void setClientManageAuthEnabled(boolean clientManageAuthEnabled);
+
     Set<RoleModel> getScopeMappings();
     void addScopeMapping(RoleModel role);
     void deleteScopeMapping(RoleModel role);

--- a/model/api/src/main/java/org/keycloak/models/ClientRoles.java
+++ b/model/api/src/main/java/org/keycloak/models/ClientRoles.java
@@ -1,5 +1,9 @@
 package org.keycloak.models;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 public class ClientRoles {
 
     public static String CLIENT_ADMIN = "keycloak-client-admin";
@@ -7,6 +11,6 @@ public class ClientRoles {
     public static String MANAGE_CLIENT = "keycloak-client-manage";
     public static String MANAGE_USER_ROLES = "keycloak-client-manage-users";
 
-    public static String[] ALL_ROLES = {CLIENT_ADMIN, VIEW_CLIENT, MANAGE_CLIENT, MANAGE_USER_ROLES};
-    public static String[] MANAGEMENT_ROLES = {VIEW_CLIENT, MANAGE_CLIENT, MANAGE_USER_ROLES};
+    public static List<String> ALL_ROLES = new ArrayList<>(Arrays.asList(CLIENT_ADMIN, VIEW_CLIENT, MANAGE_CLIENT, MANAGE_USER_ROLES));
+    public static List<String> MANAGEMENT_ROLES = new ArrayList<>(Arrays.asList(VIEW_CLIENT, MANAGE_CLIENT, MANAGE_USER_ROLES));
 }

--- a/model/api/src/main/java/org/keycloak/models/ClientRoles.java
+++ b/model/api/src/main/java/org/keycloak/models/ClientRoles.java
@@ -1,0 +1,12 @@
+package org.keycloak.models;
+
+public class ClientRoles {
+
+    public static String CLIENT_ADMIN = "keycloak-client-admin";
+    public static String VIEW_CLIENT = "keycloak-client-view";
+    public static String MANAGE_CLIENT = "keycloak-client-manage";
+    public static String MANAGE_USER_ROLES = "keycloak-client-manage-users";
+
+    public static String[] ALL_ROLES = {CLIENT_ADMIN, VIEW_CLIENT, MANAGE_CLIENT, MANAGE_USER_ROLES};
+    public static String[] MANAGEMENT_ROLES = {VIEW_CLIENT, MANAGE_CLIENT, MANAGE_USER_ROLES};
+}

--- a/model/api/src/main/java/org/keycloak/models/entities/ClientEntity.java
+++ b/model/api/src/main/java/org/keycloak/models/entities/ClientEntity.java
@@ -29,6 +29,7 @@ public class ClientEntity extends AbstractIdentifiableEntity {
     private boolean serviceAccountsEnabled;
     private boolean directGrantsOnly;
     private int nodeReRegistrationTimeout;
+    private boolean clientManageAuthEnabled;
 
     // We are using names of defaultRoles (not ids)
     private List<String> defaultRoles = new ArrayList<String>();
@@ -249,6 +250,14 @@ public class ClientEntity extends AbstractIdentifiableEntity {
 
     public void setRegisteredNodes(Map<String, Integer> registeredNodes) {
         this.registeredNodes = registeredNodes;
+    }
+
+    public boolean isClientManageAuthEnabled() {
+        return clientManageAuthEnabled;
+    }
+
+    public void setClientManageAuthEnabled(boolean clientManageAuthEnabled) {
+        this.clientManageAuthEnabled = clientManageAuthEnabled;
     }
 }
 

--- a/model/api/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
+++ b/model/api/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
@@ -302,6 +302,7 @@ public class ModelToRepresentation {
         rep.setBearerOnly(clientModel.isBearerOnly());
         rep.setConsentRequired(clientModel.isConsentRequired());
         rep.setServiceAccountsEnabled(clientModel.isServiceAccountsEnabled());
+        rep.setClientManageAuthEnabled(clientModel.isClientManageAuthEnabled());
         rep.setDirectGrantsOnly(clientModel.isDirectGrantsOnly());
         rep.setSurrogateAuthRequired(clientModel.isSurrogateAuthRequired());
         rep.setBaseUrl(clientModel.getBaseUrl());

--- a/model/api/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
+++ b/model/api/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
@@ -672,6 +672,7 @@ public class RepresentationToModel {
         if (resourceRep.isBearerOnly() != null) client.setBearerOnly(resourceRep.isBearerOnly());
         if (resourceRep.isConsentRequired() != null) client.setConsentRequired(resourceRep.isConsentRequired());
         if (resourceRep.isServiceAccountsEnabled() != null) client.setServiceAccountsEnabled(resourceRep.isServiceAccountsEnabled());
+        if (resourceRep.isClientManageAuthEnabled() != null) client.setClientManageAuthEnabled(resourceRep.isClientManageAuthEnabled());
         if (resourceRep.isDirectGrantsOnly() != null) client.setDirectGrantsOnly(resourceRep.isDirectGrantsOnly());
         if (resourceRep.isPublicClient() != null) client.setPublicClient(resourceRep.isPublicClient());
         if (resourceRep.isFrontchannelLogout() != null) client.setFrontchannelLogout(resourceRep.isFrontchannelLogout());
@@ -762,6 +763,7 @@ public class RepresentationToModel {
         if (rep.isBearerOnly() != null) resource.setBearerOnly(rep.isBearerOnly());
         if (rep.isConsentRequired() != null) resource.setConsentRequired(rep.isConsentRequired());
         if (rep.isServiceAccountsEnabled() != null) resource.setServiceAccountsEnabled(rep.isServiceAccountsEnabled());
+        if (rep.isClientManageAuthEnabled() != null) resource.setClientManageAuthEnabled(rep.isClientManageAuthEnabled());
         if (rep.isDirectGrantsOnly() != null) resource.setDirectGrantsOnly(rep.isDirectGrantsOnly());
         if (rep.isPublicClient() != null) resource.setPublicClient(rep.isPublicClient());
         if (rep.isFullScopeAllowed() != null) resource.setFullScopeAllowed(rep.isFullScopeAllowed());

--- a/model/file/src/main/java/org/keycloak/models/file/adapter/ClientAdapter.java
+++ b/model/file/src/main/java/org/keycloak/models/file/adapter/ClientAdapter.java
@@ -452,6 +452,16 @@ public class ClientAdapter implements ClientModel {
     }
 
     @Override
+    public boolean isClientManageAuthEnabled() {
+        return entity.isClientManageAuthEnabled();
+    }
+
+    @Override
+    public void setClientManageAuthEnabled(boolean clientManageAuthEnabled) {
+        entity.setClientManageAuthEnabled(clientManageAuthEnabled);
+    }
+
+    @Override
     public boolean isDirectGrantsOnly() {
         return entity.isDirectGrantsOnly();
     }

--- a/model/invalidation-cache/infinispan/src/main/java/org/keycloak/models/cache/infinispan/ClientAdapter.java
+++ b/model/invalidation-cache/infinispan/src/main/java/org/keycloak/models/cache/infinispan/ClientAdapter.java
@@ -419,6 +419,18 @@ public class ClientAdapter implements ClientModel {
     }
 
     @Override
+    public boolean isClientManageAuthEnabled() {
+        if (updated != null) return updated.isClientManageAuthEnabled();
+        return cached.isClientManageAuthEnabled();
+    }
+
+    @Override
+    public void setClientManageAuthEnabled(boolean clientManageAuthEnabled) {
+        getDelegateForUpdate();
+        updated.setClientManageAuthEnabled(clientManageAuthEnabled);
+    }
+
+    @Override
     public RoleModel getRole(String name) {
         if (updated != null) return updated.getRole(name);
         String id = cached.getRoles().get(name);

--- a/model/invalidation-cache/model-adapters/src/main/java/org/keycloak/models/cache/entities/CachedClient.java
+++ b/model/invalidation-cache/model-adapters/src/main/java/org/keycloak/models/cache/entities/CachedClient.java
@@ -47,6 +47,7 @@ public class CachedClient implements Serializable {
     private boolean bearerOnly;
     private boolean consentRequired;
     private boolean serviceAccountsEnabled;
+    private boolean clientManageAuthEnabled;
     private Map<String, String> roles = new HashMap<String, String>();
     private int nodeReRegistrationTimeout;
     private Map<String, Integer> registeredNodes;
@@ -80,6 +81,7 @@ public class CachedClient implements Serializable {
         bearerOnly = model.isBearerOnly();
         consentRequired = model.isConsentRequired();
         serviceAccountsEnabled = model.isServiceAccountsEnabled();
+        clientManageAuthEnabled = model.isClientManageAuthEnabled();
         for (RoleModel role : model.getRoles()) {
             roles.put(role.getName(), role.getId());
             cache.addCachedRole(new CachedClientRole(id, role, realm));
@@ -182,6 +184,10 @@ public class CachedClient implements Serializable {
 
     public boolean isServiceAccountsEnabled() {
         return serviceAccountsEnabled;
+    }
+
+    public boolean isClientManageAuthEnabled() {
+        return clientManageAuthEnabled;
     }
 
     public Map<String, String> getRoles() {

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/ClientAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/ClientAdapter.java
@@ -471,6 +471,16 @@ public class ClientAdapter implements ClientModel {
     }
 
     @Override
+    public boolean isClientManageAuthEnabled() {
+        return entity.isClientManageAuthEnabled();
+    }
+
+    @Override
+    public void setClientManageAuthEnabled(boolean clientManageAuthEnabled) {
+        entity.setClientManageAuthEnabled(clientManageAuthEnabled);
+    }
+
+    @Override
     public boolean isDirectGrantsOnly() {
         return entity.isDirectGrantsOnly();
     }

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/ClientEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/ClientEntity.java
@@ -98,6 +98,9 @@ public class ClientEntity {
     @Column(name="SERVICE_ACCOUNTS_ENABLED")
     private boolean serviceAccountsEnabled;
 
+    @Column(name="CLIENT_MANAGE_AUTH_ENABLED")
+    private boolean clientManageAuthEnabled;
+
     @Column(name="NODE_REREG_TIMEOUT")
     private int nodeReRegistrationTimeout;
 
@@ -304,6 +307,14 @@ public class ClientEntity {
 
     public void setServiceAccountsEnabled(boolean serviceAccountsEnabled) {
         this.serviceAccountsEnabled = serviceAccountsEnabled;
+    }
+
+    public boolean isClientManageAuthEnabled() {
+        return clientManageAuthEnabled;
+    }
+
+    public void setClientManageAuthEnabled(boolean clientManageAuthEnabled) {
+        this.clientManageAuthEnabled = clientManageAuthEnabled;
     }
 
     public boolean isDirectGrantsOnly() {

--- a/model/mongo/src/main/java/org/keycloak/models/mongo/keycloak/adapters/ClientAdapter.java
+++ b/model/mongo/src/main/java/org/keycloak/models/mongo/keycloak/adapters/ClientAdapter.java
@@ -473,6 +473,16 @@ public class ClientAdapter extends AbstractMongoAdapter<MongoClientEntity> imple
     }
 
     @Override
+    public boolean isClientManageAuthEnabled() {
+        return getMongoEntity().isClientManageAuthEnabled();
+    }
+
+    @Override
+    public void setClientManageAuthEnabled(boolean clientManageAuthEnabled) {
+        getMongoEntity().setClientManageAuthEnabled(clientManageAuthEnabled);
+    }
+
+    @Override
     public boolean isDirectGrantsOnly() {
         return getMongoEntity().isDirectGrantsOnly();
     }

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientAuth.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientAuth.java
@@ -36,6 +36,10 @@ public class ClientAuth {
         return getAuth().hasRealmRole(AdminRoles.ADMIN);
     }
 
+    public boolean isAdmin() {
+        return isClientAdmin() || isRealmAdmin();
+    }
+
     public boolean hasAppRole(ClientModel app, String role) {
         RoleModel roleModel = app.getRole(role);
         return roleModel != null && getAuth().getUser().hasRole(roleModel);

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientAuth.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientAuth.java
@@ -1,0 +1,61 @@
+package org.keycloak.services.resources.admin;
+
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.ClientRoles;
+import org.keycloak.services.ForbiddenException;
+
+public class ClientAuth {
+
+    private RealmAuth realmAuth;
+    private ClientModel clientApp;
+
+    public ClientAuth(RealmAuth realmAuth, ClientModel clientApp) {
+        this.realmAuth = realmAuth;
+        this.clientApp = clientApp;
+    }
+
+    public AdminAuth getAuth() {
+        return getRealmAuth().getAuth();
+    }
+
+    public RealmAuth getRealmAuth() {
+        return realmAuth;
+    }
+
+    public boolean isAdmin() {
+        return getAuth().hasAppRole(clientApp, ClientRoles.CLIENT_ADMIN);
+    }
+
+    public boolean canView() {
+        return getRealmAuth().hasView() && (!clientApp.isClientManageAuthEnabled() ||
+                getAuth().hasOneOfAppRole(clientApp, ClientRoles.MANAGE_CLIENT, ClientRoles.VIEW_CLIENT));
+    }
+
+    public boolean canManage() {
+        return getRealmAuth().hasManage() && (!clientApp.isClientManageAuthEnabled() ||
+                getAuth().hasOneOfAppRole(clientApp, ClientRoles.MANAGE_CLIENT));
+    }
+
+    public boolean canDelegate() {
+        return getRealmAuth().hasManage() && (!clientApp.isClientManageAuthEnabled() ||
+                getAuth().hasOneOfAppRole(clientApp, ClientRoles.MANAGE_USER_ROLES));
+    }
+
+    public void requireView() {
+        if (!canView()) {
+            throw new ForbiddenException();
+        }
+    }
+
+    public void requireManage() {
+        if (!canManage()) {
+            throw new ForbiddenException();
+        }
+    }
+
+    public void requireDelegate() {
+        if (!canDelegate()) {
+            throw new ForbiddenException();
+        }
+    }
+}

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientResource.java
@@ -59,7 +59,7 @@ import java.util.Set;
 public class ClientResource {
     protected static final Logger logger = Logger.getLogger(ClientResource.class);
     protected RealmModel realm;
-    private RealmAuth auth;
+    private ClientAuth auth;
     private AdminEventBuilder adminEvent;
     protected ClientModel client;
     protected KeycloakSession session;
@@ -76,7 +76,7 @@ public class ClientResource {
 
     public ClientResource(RealmModel realm, RealmAuth auth, ClientModel clientModel, KeycloakSession session, AdminEventBuilder adminEvent) {
         this.realm = realm;
-        this.auth = auth;
+        this.auth = new ClientAuth(auth, clientModel);
         this.client = clientModel;
         this.session = session;
         this.adminEvent = adminEvent;
@@ -86,7 +86,7 @@ public class ClientResource {
 
     @Path("protocol-mappers")
     public ProtocolMappersResource getProtocolMappers() {
-        ProtocolMappersResource mappers = new ProtocolMappersResource(client, auth, adminEvent);
+        ProtocolMappersResource mappers = new ProtocolMappersResource(client, auth.getRealmAuth(), adminEvent);
         ResteasyProviderFactory.getInstance().injectProperties(mappers);
         return mappers;
     }
@@ -135,7 +135,7 @@ public class ClientResource {
      */
     @Path("certificates/{attr}")
     public ClientAttributeCertificateResource getCertficateResource(@PathParam("attr") String attributePrefix) {
-        return new ClientAttributeCertificateResource(realm, auth, client, session, attributePrefix, adminEvent);
+        return new ClientAttributeCertificateResource(realm, auth.getRealmAuth(), client, session, attributePrefix, adminEvent);
     }
 
 
@@ -233,12 +233,12 @@ public class ClientResource {
      */
     @Path("scope-mappings")
     public ScopeMappedResource getScopeMappedResource() {
-        return new ScopeMappedResource(realm, auth, client, session, adminEvent);
+        return new ScopeMappedResource(realm, auth.getRealmAuth(), client, session, adminEvent);
     }
 
     @Path("roles")
     public RoleContainerResource getRoleContainerResource() {
-        return new RoleContainerResource(uriInfo, realm, auth, client, adminEvent);
+        return new RoleContainerResource(uriInfo, realm, auth.getRealmAuth(), client, adminEvent);
     }
 
     /**

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientsResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientsResource.java
@@ -5,10 +5,7 @@ import org.jboss.resteasy.annotations.cache.NoCache;
 import org.jboss.resteasy.spi.NotFoundException;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.keycloak.events.admin.OperationType;
-import org.keycloak.models.ClientModel;
-import org.keycloak.models.KeycloakSession;
-import org.keycloak.models.ModelDuplicateException;
-import org.keycloak.models.RealmModel;
+import org.keycloak.models.*;
 import org.keycloak.models.utils.ModelToRepresentation;
 import org.keycloak.models.utils.RepresentationToModel;
 import org.keycloak.representations.idm.ClientRepresentation;
@@ -65,9 +62,16 @@ public class ClientsResource {
         List<ClientRepresentation> rep = new ArrayList<>();
         List<ClientModel> clientModels = realm.getClients();
 
-        boolean view = auth.hasView();
         for (ClientModel clientModel : clientModels) {
-            if (view) {
+
+            // Check for client-wise permissions
+            boolean hasPermissions = true;
+            if (clientModel.isClientManageAuthEnabled()) {
+                ClientAuth clientAuth = new ClientAuth(auth, clientModel);
+                hasPermissions = clientAuth.canView();
+            }
+
+            if (hasPermissions) {
                 rep.add(ModelToRepresentation.toRepresentation(clientModel));
             } else {
                 ClientRepresentation client = new ClientRepresentation();
@@ -93,6 +97,16 @@ public class ClientsResource {
 
         try {
             ClientModel clientModel = RepresentationToModel.createClient(session, realm, rep, true);
+
+            // Add admin & management roles
+            RoleModel adminRole = clientModel.addRole(ClientRoles.CLIENT_ADMIN);
+            for (String role : ClientRoles.MANAGEMENT_ROLES) {
+                RoleModel roleModel = clientModel.addRole(role);
+                adminRole.addCompositeRole(roleModel);
+            }
+
+            // Assign current user to client admin role
+            auth.getAuth().getUser().grantRole(adminRole);
             
             adminEvent.operation(OperationType.CREATE).resourcePath(uriInfo, clientModel.getId()).representation(rep).success();
             

--- a/services/src/main/java/org/keycloak/services/resources/admin/RealmAuth.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RealmAuth.java
@@ -40,6 +40,10 @@ public class RealmAuth {
         }
     }
 
+    public boolean hasAdmin() {
+        return auth.hasOneOfAppRole(realmAdminApp, getViewRole(resource), getManageRole(resource));
+    }
+
     public boolean hasView() {
         return auth.hasOneOfAppRole(realmAdminApp, getViewRole(resource), getManageRole(resource));
     }

--- a/services/src/main/java/org/keycloak/services/resources/admin/UserClientRoleMappingsResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UserClientRoleMappingsResource.java
@@ -35,7 +35,7 @@ public class UserClientRoleMappingsResource {
     protected static final Logger logger = Logger.getLogger(UserClientRoleMappingsResource.class);
 
     protected RealmModel realm;
-    protected RealmAuth auth;
+    protected ClientAuth auth;
     protected UserModel user;
     protected ClientModel client;
     protected AdminEventBuilder adminEvent;
@@ -44,7 +44,7 @@ public class UserClientRoleMappingsResource {
     public UserClientRoleMappingsResource(UriInfo uriInfo, RealmModel realm, RealmAuth auth, UserModel user, ClientModel client, AdminEventBuilder adminEvent) {
         this.uriInfo = uriInfo;
         this.realm = realm;
-        this.auth = auth;
+        this.auth = new ClientAuth(auth, client);
         this.user = user;
         this.client = client;
         this.adminEvent = adminEvent;
@@ -59,7 +59,7 @@ public class UserClientRoleMappingsResource {
     @Produces(MediaType.APPLICATION_JSON)
     @NoCache
     public List<RoleRepresentation> getClientRoleMappings() {
-        auth.requireView();
+        auth.requireDelegate();
 
         Set<RoleModel> mappings = user.getClientRoleMappings(client);
         List<RoleRepresentation> mapRep = new ArrayList<RoleRepresentation>();
@@ -79,7 +79,7 @@ public class UserClientRoleMappingsResource {
     @Produces(MediaType.APPLICATION_JSON)
     @NoCache
     public List<RoleRepresentation> getCompositeClientRoleMappings() {
-        auth.requireView();
+        auth.requireDelegate();
 
         Set<RoleModel> roles = client.getRoles();
         List<RoleRepresentation> mapRep = new ArrayList<RoleRepresentation>();
@@ -99,7 +99,7 @@ public class UserClientRoleMappingsResource {
     @Produces(MediaType.APPLICATION_JSON)
     @NoCache
     public List<RoleRepresentation> getAvailableClientRoleMappings() {
-        auth.requireView();
+        auth.requireDelegate();
 
         Set<RoleModel> available = client.getRoles();
         return getAvailableRoles(user, available);
@@ -127,7 +127,7 @@ public class UserClientRoleMappingsResource {
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     public void addClientRoleMapping(List<RoleRepresentation> roles) {
-        auth.requireManage();
+        auth.requireDelegate();
 
         for (RoleRepresentation role : roles) {
             RoleModel roleModel = client.getRole(role.getName());
@@ -148,7 +148,7 @@ public class UserClientRoleMappingsResource {
     @DELETE
     @Consumes(MediaType.APPLICATION_JSON)
     public void deleteClientRoleMapping(List<RoleRepresentation> roles) {
-        auth.requireManage();
+        auth.requireDelegate();
 
         if (roles == null) {
             Set<RoleModel> roleModels = user.getClientRoleMappings(client);


### PR DESCRIPTION
https://issues.jboss.org/browse/KEYCLOAK-1722

Added an optional setting (disabled by default) to all clients for client-specific management permissions. Realm and global administrators have access to all clients regardless. Roles are set as traditional client roles, and are hard-coded upon creating a client. Currently deletion of the roles are possible.

This may require additional code to add the hard-coded roles back to existing clients on migration to 1.5.0, but is not required for the code to work as it's disabled by default.
