### PR TITLE
Unify jetty 8.1 artifacts version with fabric8-bom-1.2.0.redhat-133.pom

### DIFF
--- a/integration/jetty/jetty-core/pom.xml
+++ b/integration/jetty/jetty-core/pom.xml
@@ -12,7 +12,7 @@
 	<artifactId>keycloak-jetty-core</artifactId>
 	<name>Keycloak Jetty Core Integration</name>
     <properties>
-        <jetty9.version>8.1.16.v20140903</jetty9.version>
+        <jetty9.version>8.1.17.v20150415</jetty9.version>
         <keycloak.osgi.export>
             org.keycloak.adapters.jetty.core.*
         </keycloak.osgi.export>

--- a/integration/jetty/jetty8.1/pom.xml
+++ b/integration/jetty/jetty8.1/pom.xml
@@ -12,7 +12,7 @@
 	<artifactId>keycloak-jetty81-adapter</artifactId>
 	<name>Keycloak Jetty 8.1.x Integration</name>
     <properties>
-        <jetty9.version>8.1.16.v20140903</jetty9.version>
+        <jetty9.version>8.1.17.v20150415</jetty9.version>
         <keycloak.osgi.export>
             org.keycloak.adapters.jetty.*
         </keycloak.osgi.export>

--- a/integration/osgi-adapter/pom.xml
+++ b/integration/osgi-adapter/pom.xml
@@ -14,7 +14,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <jetty9.version>8.1.16.v20140903</jetty9.version>
+        <jetty9.version>8.1.17.v20150415</jetty9.version>
         <keycloak.osgi.export>
             org.keycloak.adapters.osgi.*
         </keycloak.osgi.export>

--- a/testsuite/jetty/jetty81/pom.xml
+++ b/testsuite/jetty/jetty81/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>keycloak-testsuite-jetty81</artifactId>
     <name>Keycloak Jetty 8.1.x Integration TestSuite</name>
     <properties>
-        <jetty9.version>8.1.16.v20140903</jetty9.version>
+        <jetty9.version>8.1.17.v20150415</jetty9.version>
     </properties>
     <description />
 


### PR DESCRIPTION
Hi, are we able to unify jetty 8.1 artifacts version with what is used in fabric8-bom-1.2.0.redhat-133.pom?
http://central.maven.org/maven2/io/fabric8/bom/fabric8-bom/1.2.0.redhat-133/fabric8-bom-1.2.0.redhat-133.pom
