### PR TITLE
KEYCLOAK-1241 Can't build release with Java 8

### DIFF
--- a/services/src/docs/asciidoc/index.adoc
+++ b/services/src/docs/asciidoc/index.adoc
@@ -1,3 +1,3 @@
-include::{generated}/overview.adoc[]
+include::overview.adoc[]
 include::{generated}/paths.adoc[]
 include::{generated}/definitions.adoc[]

--- a/services/src/docs/asciidoc/overview.adoc
+++ b/services/src/docs/asciidoc/overview.adoc
@@ -1,0 +1,13 @@
+= Keycloak Admin REST API
+
+== Overview
+This is a REST API reference for the Keycloak Admin
+
+=== Version information
+Version: 1
+
+=== URI scheme
+Host: localhost:8080
+BasePath: /auth
+Schemes: HTTP
+


### PR DESCRIPTION
- Fix Null title in some build environments
