### PR TITLE
WrappedHttpServletRequest may throw an exception returning cookies

### DIFF
--- a/integration/spring-security/src/main/java/org/keycloak/adapters/springsecurity/facade/WrappedHttpServletRequest.java
+++ b/integration/spring-security/src/main/java/org/keycloak/adapters/springsecurity/facade/WrappedHttpServletRequest.java
@@ -64,6 +64,12 @@ class WrappedHttpServletRequest implements Request {
     @Override
     public Cookie getCookie(String cookieName) {
 
+        javax.servlet.http.Cookie[] cookies = request.getCookies();
+
+        if (cookies == null) {
+            return null;
+        }
+
         for (javax.servlet.http.Cookie cookie : request.getCookies()) {
             if (cookie.getName().equals(cookieName)) {
                 return new Cookie(cookie.getName(), cookie.getValue(), cookie.getVersion(), cookie.getDomain(), cookie.getPath());

--- a/integration/spring-security/src/test/java/org/keycloak/adapters/springsecurity/facade/WrappedHttpServletRequestTest.java
+++ b/integration/spring-security/src/test/java/org/keycloak/adapters/springsecurity/facade/WrappedHttpServletRequestTest.java
@@ -24,10 +24,11 @@ public class WrappedHttpServletRequestTest {
     private static final String QUERY_PARM_2 = "code2";
 
     private WrappedHttpServletRequest request;
+    private MockHttpServletRequest mockHttpServletRequest;
 
     @Before
     public void setUp() throws Exception {
-        MockHttpServletRequest mockHttpServletRequest = new MockHttpServletRequest();
+        mockHttpServletRequest = new MockHttpServletRequest();
         request = new WrappedHttpServletRequest(mockHttpServletRequest);
 
         mockHttpServletRequest.setMethod(REQUEST_METHOD);
@@ -73,6 +74,13 @@ public class WrappedHttpServletRequestTest {
     @Test
     public void testGetCookie() throws Exception {
         assertNotNull(request.getCookie(COOKIE_NAME));
+    }
+
+    @Test
+    public void testGetCookieCookiesNull() throws Exception
+    {
+        mockHttpServletRequest.setCookies(null);
+        request.getCookie(COOKIE_NAME);
     }
 
     @Test


### PR DESCRIPTION
Fixes [KEYCLOAK-1892](https://issues.jboss.org/browse/KEYCLOAK-1892)
HttpServletRequest.getCookies() may return null.
