### PR TITLE
KEYCLOAK-1893 - Allow to configure OTP period in admin console.

### DIFF
--- a/forms/common-themes/src/main/resources/theme/base/admin/resources/partials/otp-policy.html
+++ b/forms/common-themes/src/main/resources/theme/base/admin/resources/partials/otp-policy.html
@@ -59,6 +59,15 @@
             <kc-tooltip>What should the initial counter value be?</kc-tooltip>
         </div>
 
+        <div class="form-group" data-ng-show="realm.otpPolicyType == 'totp'">
+            <label class="col-md-2 control-label" for="counter">OTP Token Period</label>
+            <div class="col-md-6">
+                <input class="form-control" type="text" id="period" name="period" data-ng-model="realm.otpPolicyPeriod">
+            </div>
+            <kc-tooltip>How many seconds should an OTP token be valid? Defaults to 30 seconds.</kc-tooltip>
+        </div>
+
+
         <div class="form-group" data-ng-show="access.manageRealm">
             <div class="col-md-10 col-md-offset-2">
                 <button kc-save data-ng-disabled="!changed">Save</button>


### PR DESCRIPTION
Added input form that allows to specify the OTP token period
in the `OTP Policy` section of the `Authentication` settings.

Since the value is already backed by the provided `otpPolicyPeriod`
field in the `RealmRepresentation` class we only needed to show the value
in the admin ui.

Note:
This is my first PR for keycloak - I couldn't find the right spot for UI tests any suggestions how to test this? 
