### PR TITLE
KEYCLOAK-1882 Also add locale mapper when new realm is created.

### DIFF
--- a/model/api/src/main/java/org/keycloak/migration/migrators/MigrateTo1_6_0.java
+++ b/model/api/src/main/java/org/keycloak/migration/migrators/MigrateTo1_6_0.java
@@ -1,8 +1,23 @@
+/*
+ * Copyright 2015 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package org.keycloak.migration.migrators;
 
 import java.util.List;
 
-import org.keycloak.Config;
 import org.keycloak.migration.MigrationProvider;
 import org.keycloak.migration.ModelVersion;
 import org.keycloak.models.*;
@@ -52,10 +67,14 @@ public class MigrateTo1_6_0 {
             }
 
             ClientModel adminConsoleClient = realm.getClientByClientId(Constants.ADMIN_CONSOLE_CLIENT_ID);
-            if (adminConsoleClient != null) {
+            if ((adminConsoleClient != null) && !localeMapperAdded(adminConsoleClient)) {
                 adminConsoleClient.addProtocolMapper(localeMapper);
             }
         }
+    }
+
+    private boolean localeMapperAdded(ClientModel adminConsoleClient) {
+        return adminConsoleClient.getProtocolMapperByName("openid-connect", "locale") != null;
     }
 
 }

--- a/services/src/main/java/org/keycloak/protocol/ProtocolMapperUtils.java
+++ b/services/src/main/java/org/keycloak/protocol/ProtocolMapperUtils.java
@@ -1,12 +1,13 @@
 package org.keycloak.protocol;
 
-import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.ProtocolMapperModel;
 import org.keycloak.models.UserModel;
-import org.keycloak.representations.AccessToken;
+import org.keycloak.protocol.oidc.OIDCLoginProtocol;
+import org.keycloak.protocol.oidc.OIDCLoginProtocolFactory;
+import org.keycloak.provider.ProviderFactory;
 
 import java.lang.reflect.Method;
-import java.util.List;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -58,5 +59,26 @@ public class ProtocolMapperUtils {
             return rtn;
 
         }
+    }
+
+    /**
+     * Find the builtin locale mapper.
+     *
+     * @param session A KeycloakSession
+     * @return The builtin locale mapper.
+     */
+    public static ProtocolMapperModel findLocaleMapper(KeycloakSession session) {
+        ProtocolMapperModel found = null;
+        for (ProviderFactory p : session.getKeycloakSessionFactory().getProviderFactories(LoginProtocol.class)) {
+            LoginProtocolFactory factory = (LoginProtocolFactory) p;
+            for (ProtocolMapperModel mapper : factory.getBuiltinMappers()) {
+                if (mapper.getName().equals(OIDCLoginProtocolFactory.LOCALE) && mapper.getProtocol().equals(OIDCLoginProtocol.LOGIN_PROTOCOL)) {
+                    found = mapper;
+                    break;
+                }
+            }
+            if (found != null) break;
+        }
+        return found;
     }
 }

--- a/services/src/main/java/org/keycloak/services/managers/RealmManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/RealmManager.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package org.keycloak.services.managers;
 
 import org.jboss.logging.Logger;
@@ -33,6 +49,8 @@ import org.keycloak.timer.TimerProvider;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import org.keycloak.models.ProtocolMapperModel;
+import org.keycloak.protocol.ProtocolMapperUtils;
 
 /**
  * Per request object
@@ -124,6 +142,9 @@ public class RealmManager implements RealmImporter {
         adminConsole.addRedirectUri(baseUrl + "/*");
         adminConsole.setFullScopeAllowed(false);
 
+        ProtocolMapperModel localeMapper = ProtocolMapperUtils.findLocaleMapper(session);
+        if (localeMapper != null) adminConsole.addProtocolMapper(localeMapper);
+
         RoleModel adminRole;
         if (realm.getName().equals(Config.getAdminRealm())) {
             adminRole = realm.getRole(AdminRoles.ADMIN);
@@ -194,7 +215,7 @@ public class RealmManager implements RealmImporter {
         if(rep.getEnabledEventTypes() != null) {
             realm.setEnabledEventTypes(new HashSet<String>(rep.getEnabledEventTypes()));
         }
-        
+
         realm.setAdminEventsEnabled(rep.isAdminEventsEnabled());
         realm.setAdminEventsDetailsEnabled(rep.isAdminEventsDetailsEnabled());
     }


### PR DESCRIPTION
We left out the part where the locale mapper needs to be added on realm creation.  Also need to check if it was already added, which happens on brand new server.
