### PR TITLE
Add 'register' and 'createRegisterUrl' methods to Javascript Adapter API

### DIFF
--- a/docbook/auth-server-docs/reference/en/en-US/modules/javascript-adapter.xml
+++ b/docbook/auth-server-docs/reference/en/en-US/modules/javascript-adapter.xml
@@ -209,6 +209,7 @@ new Keycloak({ url: 'http://localhost/auth', realm: 'myrealm', clientId: 'myApp'
                         <listitem>redirectUri - specifies the uri to redirect to after login</listitem>
                         <listitem>prompt - can be set to 'none' to check if the user is logged in already (if not logged in, a login form is not displayed)</listitem>
                         <listitem>loginHint - used to pre-fill the username/email field on the login form</listitem>
+                        <listitem>action - if value is 'register' then user is redirected to registration page, otherwise to login page</listitem>
                     </itemizedlist>
                 </para>
             </simplesect>
@@ -244,6 +245,20 @@ new Keycloak({ url: 'http://localhost/auth', realm: 'myrealm', clientId: 'myApp'
                         <listitem>redirectUri - specifies the uri to redirect to after logout</listitem>
                     </itemizedlist>
                 </para>
+            </simplesect>
+
+            <simplesect>
+                <title>register(options)</title>
+
+                <para>Redirects to registration form. It's a shortcut for doing login with option action = 'register'</para>
+                <para>Options are same as login method but 'action' is overwritten to 'register'</para>
+            </simplesect>
+
+            <simplesect>
+                <title>createRegisterUrl(options)</title>
+
+                <para>Returns the url to registration page. It's a shortcut for doing createRegisterUrl with option action = 'register'</para>
+                <para>Options are same as createLoginUrl method but 'action' is overwritten to 'register'</para>
             </simplesect>
 
             <simplesect>

--- a/examples/js-console/README.md
+++ b/examples/js-console/README.md
@@ -12,6 +12,6 @@ Open the Keycloak admin console, click on Add Realm, click on 'Choose a JSON fil
 
 Deploy the JS Console to Keycloak by running:
 
-    mvn install jboss-as:deploy
+    mvn install wildfly:deploy
 
 Open the console at http://localhost:8080/js-console and login with username: 'user', and password: 'password'.

--- a/examples/js-console/src/main/webapp/index.html
+++ b/examples/js-console/src/main/webapp/index.html
@@ -7,6 +7,7 @@
 <div>
     <button onclick="keycloak.login()">Login</button>
     <button onclick="keycloak.logout()">Logout</button>
+    <button onclick="keycloak.register()">Register</button>
     <button onclick="refreshToken(9999)">Refresh Token</button>
     <button onclick="refreshToken(30)">Refresh Token (if <30s validity)</button>
     <button onclick="loadProfile()">Get Profile</button>
@@ -18,6 +19,7 @@
     <button onclick="output(keycloak)">Show Details</button>
     <button onclick="output(keycloak.createLoginUrl())">Show Login URL</button>
     <button onclick="output(keycloak.createLogoutUrl())">Show Logout URL</button>
+    <button onclick="output(keycloak.createRegisterUrl())">Show Register URL</button>
 </div>
 
 <h2>Result</h2>

--- a/integration/js/src/main/resources/keycloak.js
+++ b/integration/js/src/main/resources/keycloak.js
@@ -183,6 +183,18 @@
             return url;
         }
 
+        kc.register = function (options) {
+            return adapter.register(options);
+        }
+
+        kc.createRegisterUrl = function(options) {
+            if (!options) {
+                options = {};
+            }
+            options.action = 'register';
+            return kc.createLoginUrl(options);
+        }
+
         kc.createAccountUrl = function(options) {
             var url = getRealmUrl()
                 + '/account'
@@ -760,6 +772,11 @@
                         return createPromise().promise;
                     },
 
+                    register: function(options) {
+                        window.location.href = kc.createRegisterUrl(options);
+                        return createPromise().promise;
+                    },
+
                     accountManagement : function() {
                         window.location.href = kc.createAccountUrl();
                         return createPromise().promise;
@@ -856,6 +873,16 @@
                         });
 
                         return promise.promise;
+                    },
+
+                    register : function() {
+                        var registerUrl = kc.createRegisterUrl();
+                        var ref = window.open(registerUrl, '_blank', 'location=no');
+                        ref.addEventListener('loadstart', function(event) {
+                            if (event.url.indexOf('http://localhost') == 0) {
+                                ref.close();
+                            }
+                        });
                     },
 
                     accountManagement : function() {


### PR DESCRIPTION
Implements #KEYCLOAK-1904

Everything seems to be working from JS Adapter point of view.
I haven't chance to test "cordova" adapter.

However KC itself has problem with rendering registration page when user comes from JS adapter.
stacktrace:

```
14:00:51,551 ERROR [org.keycloak.login.freemarker.FreeMarkerLoginFormsProvider] (default task-6) Failed to process template: org.keycloak.freemarker.FreeMarkerException: Failed to process template register.ftl
    at org.keycloak.freemarker.FreeMarkerUtil.processTemplate(FreeMarkerUtil.java:47)

Caused by: freemarker.core.InvalidReferenceException: The following has evaluated to null or missing:
==> passwordRequired  [in template "register.ftl" at line 46, column 18]
```

However when I go form login page to registration page everything is ok. So it looks like the form bean is initialized from two different places where the way from openid-protocol is initialized somehow differently.
