### PR TITLE
URI based configuration of MongoDB to support Replica Sets

### DIFF
--- a/connections/mongo/src/main/java/org/keycloak/connections/mongo/DefaultMongoConnectionFactoryProvider.java
+++ b/connections/mongo/src/main/java/org/keycloak/connections/mongo/DefaultMongoConnectionFactoryProvider.java
@@ -148,15 +148,25 @@ public class DefaultMongoConnectionFactoryProvider implements MongoConnectionPro
      * @throws UnknownHostException
      */
     protected MongoClient createMongoClient() throws UnknownHostException {
+        operationalInfo = new LinkedHashMap<>();
+        String dbName = config.get("db", "keycloak");
+
         String uriString = config.get("uri");
         if (uriString != null) {
             MongoClientURI uri = new MongoClientURI(uriString);
             MongoClient client = new MongoClient(uri);
+
+            String hosts = String.join(", ", uri.getHosts());
+            operationalInfo.put("mongoHosts", hosts);
+            operationalInfo.put("mongoDatabaseName", dbName);
+            operationalInfo.put("mongoUser", uri.getUsername());
+            operationalInfo.put("mongoDriverVersion", client.getVersion());
+
+            logger.debugv("Initialized mongo model. host(s): %s, db: %s", uri.getHosts(), dbName);
             return client;
         } else {
             String host = config.get("host", ServerAddress.defaultHost());
             int port = config.getInt("port", ServerAddress.defaultPort());
-            String dbName = config.get("db", "keycloak");
 
             String user = config.get("user");
             String password = config.get("password");
@@ -171,7 +181,6 @@ public class DefaultMongoConnectionFactoryProvider implements MongoConnectionPro
                 client = new MongoClient(new ServerAddress(host, port), clientOptions);
             }
 
-            operationalInfo = new LinkedHashMap<>();
             operationalInfo.put("mongoServerAddress", client.getAddress().toString());
             operationalInfo.put("mongoDatabaseName", dbName);
             operationalInfo.put("mongoUser", user);

--- a/docbook/auth-server-docs/reference/en/en-US/modules/server-installation.xml
+++ b/docbook/auth-server-docs/reference/en/en-US/modules/server-installation.xml
@@ -329,6 +329,30 @@
                 Supported long option is <literal>maxAutoConnectRetryTime</literal>. See <ulink url="http://api.mongodb.org/java/2.11.4/com/mongodb/MongoClientOptions.html">Mongo documentation</ulink>
                 for details about those options and their default values.
             </para>
+            <para>
+                Alternatively, you can configure MongoDB using a MongoDB <ulink url="http://docs.mongodb.org/manual/reference/connection-string/">connection URI</ulink>.
+                In this case, you define all information concerning the connection and authentication within the URI, as described in the MongoDB documentation.
+                Please note that the database specified within the URI is only used for authentication. To change the database used by keycloak you have to set
+                <literal>db</literal> property as before. Therefore, a configuration like the
+                following
+                <programlisting><![CDATA[
+"connectionsMongo": {
+    "default": {
+        "uri": "mongodb://user:password@127.0.0.1/authentication",
+        "db": "keycloak"
+    }
+}
+]]></programlisting>
+                will authenticate the user against the authentication database, but store all keycloak related data in the keycloak database.
+
+            </para>
+            <section>
+                <title>MongoDB Replica Sets</title>
+                <para>
+                    In order to use a mongo replica set for Keycloak, one has to use URI based configuration, which supports the
+                    definition of replica sets out of the box: <literal>mongodb://host1:27017,host2:27017,host3:27017/</literal>.
+                </para>
+            </section>
         </section>
         
         <section>


### PR DESCRIPTION
A mongodb connection can now be configured via a [mongodb:// URI](http://docs.mongodb.org/manual/reference/connection-string/). This also enables one to configure a mongo replica set.

The database that keycloak uses to store information is still defined by the `db` configuration property. The database name within the mongodb URI is only used for authentication.
