### PR TITLE
[KEYCLOAK-1932] Unable to create flow named exactly the same as removed NON-top level flow

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/AuthenticationManagementResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/AuthenticationManagementResource.java
@@ -323,6 +323,14 @@ public class AuthenticationManagementResource {
         if (flow.isBuiltIn()) {
             throw new BadRequestException("Can't delete built in flow");
         }
+        List<AuthenticationExecutionModel> executions = realm.getAuthenticationExecutions(id);
+        for (AuthenticationExecutionModel execution : executions) {
+        	if(execution.getFlowId() != null) {
+        		AuthenticationFlowModel nonTopLevelFlow = realm.getAuthenticationFlowById(execution.getFlowId());
+        		realm.removeAuthenticationFlow(nonTopLevelFlow);
+        	}
+        	realm.removeAuthenticatorExecution(execution);
+        }
         realm.removeAuthenticationFlow(flow);
     }
 


### PR DESCRIPTION
All tests passed on my local travis-CI instance (https://s3.amazonaws.com/archive.travis-ci.org/jobs/84568975/log.txt) but keycloak CI instance did fail some issues(https://s3.amazonaws.com/archive.travis-ci.org/jobs/84569351/log.txt). It might be just due to current instability of arquillian or base testsuite.
