### PR TITLE
KEYCLOAK-1962 update realm overwrites supported locales with empty list

### DIFF
--- a/core/src/main/java/org/keycloak/representations/idm/RealmRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/idm/RealmRepresentation.java
@@ -611,10 +611,14 @@ public class RealmRepresentation {
     }
 
     public Set<String> getSupportedLocales() {
-        if(supportedLocales == null){
-            supportedLocales = new HashSet<String>();
-        }
         return supportedLocales;
+    }
+
+    public void addSupportedLocales(String locale) {
+        if(supportedLocales == null){
+            supportedLocales = new HashSet<>();
+        }
+        supportedLocales.add(locale);
     }
 
     public void setSupportedLocales(Set<String> supportedLocales) {

--- a/model/api/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
+++ b/model/api/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
@@ -210,7 +210,10 @@ public class ModelToRepresentation {
         }
 
         rep.setInternationalizationEnabled(realm.isInternationalizationEnabled());
-        rep.getSupportedLocales().addAll(realm.getSupportedLocales());
+        if(realm.getSupportedLocales() != null){
+            rep.setSupportedLocales(new HashSet<String>());
+            rep.getSupportedLocales().addAll(realm.getSupportedLocales());
+        }
         rep.setDefaultLocale(realm.getDefaultLocale());
         if (internal) {
             exportAuthenticationFlows(realm, rep);

--- a/testsuite/integration/src/test/java/org/keycloak/testsuite/admin/RealmTest.java
+++ b/testsuite/integration/src/test/java/org/keycloak/testsuite/admin/RealmTest.java
@@ -15,6 +15,8 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.HashSet;
+import java.util.Arrays;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -100,6 +102,31 @@ public class RealmTest extends AbstractClientTest {
         assertEquals(Boolean.FALSE, rep.isRegistrationAllowed());
         assertEquals(Boolean.FALSE, rep.isRegistrationEmailAsUsername());
         assertEquals(Boolean.FALSE, rep.isEditUsernameAllowed());
+    }
+
+    @Test
+    public void updateRealmWithNewRepresentation() {
+        // first change
+        RealmRepresentation rep = new RealmRepresentation();
+        rep.setEditUsernameAllowed(true);
+        rep.setSupportedLocales(new HashSet<>(Arrays.asList("en", "de")));
+
+        realm.update(rep);
+
+        rep = realm.toRepresentation();
+
+        assertEquals(Boolean.TRUE, rep.isEditUsernameAllowed());
+        assertEquals(2, rep.getSupportedLocales().size());
+
+        // second change
+        rep = new RealmRepresentation();
+        rep.setEditUsernameAllowed(false);
+
+        realm.update(rep);
+
+        rep = realm.toRepresentation();
+        assertEquals(Boolean.FALSE, rep.isEditUsernameAllowed());
+        assertEquals(2, rep.getSupportedLocales().size());
     }
 
     @Test


### PR DESCRIPTION
getSupportedLocales() in the RealmRepresentation returned allways a Set and never null. 
