### PR TITLE
KEYCLOAK-1863 added both issuer and account name to otp configuration

### DIFF
--- a/forms/account-freemarker/src/main/java/org/keycloak/account/freemarker/model/TotpBean.java
+++ b/forms/account-freemarker/src/main/java/org/keycloak/account/freemarker/model/TotpBean.java
@@ -51,7 +51,7 @@ public class TotpBean {
 
         this.totpSecret = randomString(20);
         this.totpSecretEncoded = Base32.encode(totpSecret.getBytes());
-        this.keyUri = realm.getOTPPolicy().getKeyURI(realm, this.totpSecret);
+        this.keyUri = realm.getOTPPolicy().getKeyURI(realm, user, this.totpSecret);
     }
 
     private static String randomString(int length) {

--- a/forms/login-freemarker/src/main/java/org/keycloak/login/freemarker/model/TotpBean.java
+++ b/forms/login-freemarker/src/main/java/org/keycloak/login/freemarker/model/TotpBean.java
@@ -49,7 +49,7 @@ public class TotpBean {
         
         this.totpSecret = HmacOTP.generateSecret(20);
         this.totpSecretEncoded = Base32.encode(totpSecret.getBytes());
-        this.keyUri = realm.getOTPPolicy().getKeyURI(realm, this.totpSecret);
+        this.keyUri = realm.getOTPPolicy().getKeyURI(realm, user, this.totpSecret);
     }
 
     public boolean isEnabled() {


### PR DESCRIPTION
Updated to use the username instead of email.
