### PR TITLE
KEYCLOAK-1748 Expired users removal task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ catalog.xml
 # Logs and databases #
 ######################
 *.log
+*.db
 
 # Maven #
 #########

--- a/model/api/src/main/java/org/keycloak/models/UserFederationManager.java
+++ b/model/api/src/main/java/org/keycloak/models/UserFederationManager.java
@@ -4,7 +4,7 @@ import org.jboss.logging.Logger;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -312,6 +312,11 @@ public class UserFederationManager implements UserProvider {
                 return session.userStorage().searchForUserByAttributes(attributes, realm, first, max);
             }
         }, realm, firstResult, maxResults);
+    }
+
+    @Override
+    public List<UserModel> searchForExpiredUsers(Date olderThan, RealmModel realm) {
+        throw new UnsupportedOperationException("Method not supported by FederationManager");
     }
 
     @Override

--- a/model/api/src/main/java/org/keycloak/models/UserProvider.java
+++ b/model/api/src/main/java/org/keycloak/models/UserProvider.java
@@ -2,7 +2,7 @@ package org.keycloak.models;
 
 import org.keycloak.provider.Provider;
 
-import java.util.Collection;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -36,6 +36,15 @@ public interface UserProvider extends Provider {
     List<UserModel> searchForUser(String search, RealmModel realm, int firstResult, int maxResults);
     List<UserModel> searchForUserByAttributes(Map<String, String> attributes, RealmModel realm);
     List<UserModel> searchForUserByAttributes(Map<String, String> attributes, RealmModel realm, int firstResult, int maxResults);
+
+    /**
+     * Returns a list of expired users (who had not verified their email for certain time).
+     *
+     * @param olderThan Expiration date threshold.
+     * @param realm Realm to be checked.
+     * @return List of expired users.
+     */
+    List<UserModel> searchForExpiredUsers(Date olderThan, RealmModel realm);
 
     // Searching by UserModel.attribute (not property)
     List<UserModel> searchForUserByUserAttribute(String attrName, String attrValue, RealmModel realm);

--- a/model/file/pom.xml
+++ b/model/file/pom.xml
@@ -45,6 +45,22 @@
             <artifactId>jboss-logging</artifactId>
             <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/model/file/src/main/java/org/keycloak/models/file/FileUserProvider.java
+++ b/model/file/src/main/java/org/keycloak/models/file/FileUserProvider.java
@@ -23,9 +23,6 @@ import org.keycloak.models.CredentialValidationOutput;
 import org.keycloak.models.FederatedIdentityModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.ModelDuplicateException;
-import org.keycloak.models.ModelException;
-import org.keycloak.models.session.PersistentClientSessionModel;
-import org.keycloak.models.session.PersistentUserSessionModel;
 import org.keycloak.models.ProtocolMapperModel;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.RequiredActionProviderModel;
@@ -35,8 +32,6 @@ import org.keycloak.models.UserFederationProviderModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.UserProvider;
 import org.keycloak.models.entities.FederatedIdentityEntity;
-import org.keycloak.models.entities.PersistentClientSessionEntity;
-import org.keycloak.models.entities.PersistentUserSessionEntity;
 import org.keycloak.models.entities.UserEntity;
 import org.keycloak.models.file.adapter.UserAdapter;
 import org.keycloak.models.utils.CredentialValidation;
@@ -45,8 +40,8 @@ import org.keycloak.models.utils.KeycloakModelUtils;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -258,6 +253,20 @@ public class FileUserProvider implements UserProvider {
         }
 
         return sortedSubList(found, firstResult, maxResults);
+    }
+
+    @Override
+    public List<UserModel> searchForExpiredUsers(Date olderThan, RealmModel realm) {
+        Collection<UserModel> users = inMemoryModel.getUsers(realm.getId());
+
+        List<UserModel> matchedUsers = new ArrayList<>();
+        for (UserModel user : users) {
+            if(!user.isEmailVerified() && new Date(user.getCreatedTimestamp()).before(olderThan)) {
+                matchedUsers.add(user);
+            }
+        }
+
+        return matchedUsers;
     }
 
     @Override

--- a/model/file/src/test/java/org/keycloak/models/file/FileUserProviderTest.java
+++ b/model/file/src/test/java/org/keycloak/models/file/FileUserProviderTest.java
@@ -1,0 +1,91 @@
+package org.keycloak.models.file;
+
+import org.junit.Test;
+import org.keycloak.connections.file.FileConnectionProvider;
+import org.keycloak.connections.file.InMemoryModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.file.assembler.InMemoryModelAssembler;
+
+import java.util.Calendar;
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+public class FileUserProviderTest {
+
+    @Test
+    public void shouldFindExpiredUsers() throws Exception {
+        //given
+        Calendar yesterday = Calendar.getInstance();
+        yesterday.add(Calendar.DATE, -1);
+
+        Calendar today = Calendar.getInstance();
+
+        InMemoryModel memoryModel = InMemoryModelAssembler
+                .emptyModel()
+                .withExpiredUser("test", "notExpired", yesterday.getTime())
+                .assemble();
+
+        FileUserProvider fileUserProvider = createFileUserProvider(memoryModel);
+
+        //when
+        List<UserModel> users = fileUserProvider.searchForExpiredUsers(today.getTime(), memoryModel.getRealm("test"));
+
+        //then
+        assertThat(users).hasSize(1);
+    }
+
+    @Test
+    public void shouldNotFindVerifiedUsers() throws Exception {
+        //given
+        Calendar yesterday = Calendar.getInstance();
+        yesterday.add(Calendar.DATE, -1);
+
+        Calendar today = Calendar.getInstance();
+
+        InMemoryModel memoryModel = InMemoryModelAssembler
+                .emptyModel()
+                .withVerifiedUser("test", "notExpired", yesterday.getTime())
+                .assemble();
+
+        FileUserProvider fileUserProvider = createFileUserProvider(memoryModel);
+
+        //when
+        List<UserModel> users = fileUserProvider.searchForExpiredUsers(today.getTime(), memoryModel.getRealm("test"));
+
+        //then
+        assertThat(users).isEmpty();
+    }
+
+    @Test
+    public void shouldNotFindNotExpiredUsers() throws Exception {
+        //given
+        Calendar yesterday = Calendar.getInstance();
+        yesterday.add(Calendar.DATE, -1);
+
+        Calendar today = Calendar.getInstance();
+
+        InMemoryModel memoryModel = InMemoryModelAssembler
+                .emptyModel()
+                .withVerifiedUser("test", "notExpired", today.getTime())
+                .assemble();
+
+        FileUserProvider fileUserProvider = createFileUserProvider(memoryModel);
+
+        //when
+        List<UserModel> users = fileUserProvider.searchForExpiredUsers(yesterday.getTime(), memoryModel.getRealm("test"));
+
+        //then
+        assertThat(users).isEmpty();
+    }
+
+    private FileUserProvider createFileUserProvider(InMemoryModel memoryModel) {
+        FileConnectionProvider fileConnectionProvider = mock(FileConnectionProvider.class);
+        doReturn(memoryModel).when(fileConnectionProvider).getModel();
+        return new FileUserProvider(mock(KeycloakSession.class), fileConnectionProvider);
+    }
+
+}

--- a/model/file/src/test/java/org/keycloak/models/file/assembler/InMemoryModelAssembler.java
+++ b/model/file/src/test/java/org/keycloak/models/file/assembler/InMemoryModelAssembler.java
@@ -1,0 +1,66 @@
+package org.keycloak.models.file.assembler;
+
+import org.keycloak.connections.file.InMemoryModel;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.entities.RealmEntity;
+import org.keycloak.models.entities.UserEntity;
+import org.keycloak.models.file.adapter.RealmAdapter;
+import org.keycloak.models.file.adapter.UserAdapter;
+
+import java.util.Date;
+
+public class InMemoryModelAssembler {
+
+    private InMemoryModel inMemoryModel;
+
+    private InMemoryModelAssembler() {
+        inMemoryModel = new InMemoryModel();
+    }
+
+    public static InMemoryModelAssembler emptyModel() {
+        return new InMemoryModelAssembler();
+    }
+
+    public InMemoryModelAssembler withRealm(String id) {
+        if(inMemoryModel.getRealm(id) == null) {
+            RealmEntity realmEntity = new RealmEntity();
+            realmEntity.setId(id);
+            RealmAdapter realmAdapter = new RealmAdapter(null, realmEntity, inMemoryModel);
+            inMemoryModel.putRealm(id, realmAdapter);
+        }
+        return this;
+    }
+
+    public InMemoryModelAssembler withExpiredUser(String realmId, String userId, Date created) {
+        withRealm(realmId);
+
+        UserEntity user = new UserEntity();
+        user.setId(userId);
+        user.setCreatedTimestamp(created.getTime());
+        user.setEmailVerified(false);
+        addUser(user, inMemoryModel.getRealm(realmId));
+
+        return this;
+    }
+
+    public InMemoryModelAssembler withVerifiedUser(String realmId, String userId, Date created) {
+        withRealm(realmId);
+
+        UserEntity user = new UserEntity();
+        user.setId(userId);
+        user.setCreatedTimestamp(created.getTime());
+        user.setEmailVerified(true);
+        addUser(user, inMemoryModel.getRealm(realmId));
+
+        return this;
+    }
+
+    private void addUser(UserEntity userEntity, RealmModel realm) {
+        UserAdapter userAdapter = new UserAdapter(realm, userEntity, inMemoryModel);
+        inMemoryModel.putUser(realm.getId(), userEntity.getId(), userAdapter);
+    }
+
+    public InMemoryModel assemble() {
+        return inMemoryModel;
+    }
+}

--- a/model/invalidation-cache/infinispan/src/main/java/org/keycloak/models/cache/infinispan/DefaultCacheUserProvider.java
+++ b/model/invalidation-cache/infinispan/src/main/java/org/keycloak/models/cache/infinispan/DefaultCacheUserProvider.java
@@ -1,13 +1,27 @@
 package org.keycloak.models.cache.infinispan;
 
-import org.keycloak.models.*;
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.CredentialValidationOutput;
+import org.keycloak.models.FederatedIdentityModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakTransaction;
+import org.keycloak.models.ProtocolMapperModel;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.RoleModel;
+import org.keycloak.models.UserCredentialModel;
+import org.keycloak.models.UserFederationProviderModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.UserProvider;
 import org.keycloak.models.cache.CacheUserProvider;
 import org.keycloak.models.cache.UserCache;
 import org.keycloak.models.cache.entities.CachedUser;
-import org.keycloak.models.session.PersistentClientSessionModel;
-import org.keycloak.models.session.PersistentUserSessionModel;
 
-import java.util.*;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -235,6 +249,11 @@ public class DefaultCacheUserProvider implements CacheUserProvider {
     @Override
     public List<UserModel> searchForUserByAttributes(Map<String, String> attributes, RealmModel realm, int firstResult, int maxResults) {
         return getDelegate().searchForUserByAttributes(attributes, realm, firstResult, maxResults);
+    }
+
+    @Override
+    public List<UserModel> searchForExpiredUsers(Date olderThan, RealmModel realm) {
+        return getDelegate().searchForExpiredUsers(olderThan, realm);
     }
 
     @Override

--- a/model/jpa/pom.xml
+++ b/model/jpa/pom.xml
@@ -61,6 +61,28 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
     <build>
         <plugins>

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserProvider.java
@@ -21,6 +21,7 @@ import org.keycloak.models.utils.KeycloakModelUtils;
 import javax.persistence.EntityManager;
 import javax.persistence.TypedQuery;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -395,6 +396,20 @@ public class JpaUserProvider implements UserProvider {
         List<UserEntity> results = query.getResultList();
         List<UserModel> users = new ArrayList<UserModel>();
         for (UserEntity entity : results) users.add(new UserAdapter(realm, em, entity));
+        return users;
+    }
+
+    @Override
+    public List<UserModel> searchForExpiredUsers(Date olderThan, RealmModel realm) {
+        TypedQuery<UserEntity> query = em.createNamedQuery("getAllExpiredUsersByRealmAndDate", UserEntity.class);
+        query.setParameter("realmId", realm.getId());
+        query.setParameter("date", olderThan.getTime());
+        List<UserEntity> results = query.getResultList();
+
+        List<UserModel> users = new ArrayList<UserModel>();
+        for (UserEntity user : results) {
+            users.add(new UserAdapter(realm, em, user));
+        }
         return users;
     }
 

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/UserEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/UserEntity.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 @NamedQueries({
         @NamedQuery(name="getAllUsersByRealm", query="select u from UserEntity u where u.realmId = :realmId order by u.username"),
         @NamedQuery(name="getAllUsersByRealmExcludeServiceAccount", query="select u from UserEntity u where u.realmId = :realmId and (u.serviceAccountClientLink is null) order by u.username"),
+        @NamedQuery(name="getAllExpiredUsersByRealmAndDate", query="select u from UserEntity u where u.realmId = :realmId and u.createdTimestamp < :date and u.emailVerified = false order by u.username"),
         @NamedQuery(name="searchForUser", query="select u from UserEntity u where u.realmId = :realmId and (u.serviceAccountClientLink is null) and " +
                 "( lower(u.username) like :search or lower(concat(u.firstName, ' ', u.lastName)) like :search or u.email like :search ) order by u.username"),
         @NamedQuery(name="getRealmUserById", query="select u from UserEntity u where u.id = :id and u.realmId = :realmId"),

--- a/model/jpa/src/test/java/org/keycloak/models/jpa/JpaUserProviderTest.java
+++ b/model/jpa/src/test/java/org/keycloak/models/jpa/JpaUserProviderTest.java
@@ -1,0 +1,106 @@
+package org.keycloak.models.jpa;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.jpa.assembler.JPAUserAssembler;
+import org.keycloak.models.jpa.entities.RealmEntity;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.Persistence;
+import java.util.Calendar;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+public class JpaUserProviderTest {
+
+    private EntityManagerFactory entityManagerFactory;
+    private EntityManager entityManager;
+
+    @Before
+    public void before() {
+        entityManagerFactory = Persistence.createEntityManagerFactory("keycloak-test");
+        entityManager = entityManagerFactory.createEntityManager();
+    }
+
+    @After
+    public void after() {
+        entityManager.close();
+        entityManagerFactory.close();
+    }
+
+    @Test
+    public void shouldFindExpiredUsers() throws Exception {
+        //given
+        Calendar today = Calendar.getInstance();
+        Calendar yesterday = Calendar.getInstance();
+        yesterday.add(Calendar.DATE, -1);
+
+        JPAUserAssembler.defaultAssembler(entityManager)
+                .withRealm("test")
+                .withExpiredUser("test", "test", yesterday.getTime())
+                .commit();
+
+        JpaUserProvider jpaUserProvider = new JpaUserProvider(mock(KeycloakSession.class), entityManager);
+
+        RealmAdapter realm = new RealmAdapter(mock(KeycloakSession.class), entityManager, entityManager.find(RealmEntity.class, "test"));
+
+        //when
+        List<UserModel> users = jpaUserProvider.searchForExpiredUsers(today.getTime(), realm);
+
+        //then
+        assertThat(users).hasSize(1);
+    }
+
+    @Test
+    public void shouldNotFindVerifiedUsers() throws Exception {
+        //given
+        Calendar today = Calendar.getInstance();
+        Calendar yesterday = Calendar.getInstance();
+        yesterday.add(Calendar.DATE, -1);
+
+        JPAUserAssembler.defaultAssembler(entityManager)
+                .withRealm("test")
+                .withVerifiedUser("test", "test", yesterday.getTime())
+                .commit();
+
+        JpaUserProvider jpaUserProvider = new JpaUserProvider(mock(KeycloakSession.class), entityManager);
+
+        RealmAdapter realm = new RealmAdapter(mock(KeycloakSession.class), entityManager, entityManager.find(RealmEntity.class, "test"));
+
+        //when
+        List<UserModel> users = jpaUserProvider.searchForExpiredUsers(today.getTime(), realm);
+
+        //then
+        assertThat(users).isEmpty();
+    }
+
+    @Test
+    public void shouldNotFindNotExpiredUsers() throws Exception {
+        //given
+        Calendar today = Calendar.getInstance();
+        Calendar yesterday = Calendar.getInstance();
+        yesterday.add(Calendar.DATE, -1);
+
+        JPAUserAssembler.defaultAssembler(entityManager)
+                .withRealm("test")
+                .withExpiredUser("test", "test", today.getTime())
+                .commit();
+
+        JpaUserProvider jpaUserProvider = new JpaUserProvider(mock(KeycloakSession.class), entityManager);
+
+        RealmAdapter realm = new RealmAdapter(mock(KeycloakSession.class), entityManager, entityManager.find(RealmEntity.class, "test"));
+
+        //when
+        List<UserModel> users = jpaUserProvider.searchForExpiredUsers(yesterday.getTime(), realm);
+
+        //then
+        assertThat(users).isEmpty();
+    }
+
+}

--- a/model/jpa/src/test/java/org/keycloak/models/jpa/assembler/JPAUserAssembler.java
+++ b/model/jpa/src/test/java/org/keycloak/models/jpa/assembler/JPAUserAssembler.java
@@ -1,0 +1,64 @@
+package org.keycloak.models.jpa.assembler;
+
+import org.keycloak.models.jpa.entities.RealmEntity;
+import org.keycloak.models.jpa.entities.UserEntity;
+
+import javax.persistence.EntityManager;
+import java.util.Date;
+
+public class JPAUserAssembler {
+
+    private EntityManager entityManager;
+
+    private JPAUserAssembler(EntityManager entityManager) {
+        this.entityManager = entityManager;
+    }
+
+    public static JPAUserAssembler defaultAssembler(EntityManager entityManager) {
+        entityManager.getTransaction().begin();
+        return new JPAUserAssembler(entityManager);
+    }
+
+    public JPAUserAssembler withRealm(String realmId) {
+        if(entityManager.find(RealmEntity.class, realmId) == null) {
+            RealmEntity realmEntity = new RealmEntity();
+            realmEntity.setId(realmId);
+            realmEntity.setName(realmId);
+            entityManager.persist(realmEntity);
+        }
+        return this;
+    }
+
+    public JPAUserAssembler withExpiredUser(String userName, String realmId, Date createdDate) {
+        withRealm(realmId);
+
+        UserEntity userEntity = new UserEntity();
+        userEntity.setUsername(userName);
+        userEntity.setId(userName);
+        userEntity.setRealmId(realmId);
+        userEntity.setEmailVerified(false);
+        userEntity.setCreatedTimestamp(createdDate.getTime());
+        entityManager.persist(userEntity);
+
+        return this;
+    }
+
+    public JPAUserAssembler withVerifiedUser(String userName, String realmId, Date createdDate) {
+        withRealm(realmId);
+
+        UserEntity userEntity = new UserEntity();
+        userEntity.setUsername(userName);
+        userEntity.setId(userName);
+        userEntity.setRealmId(realmId);
+        userEntity.setEmailVerified(true);
+        userEntity.setCreatedTimestamp(createdDate.getTime());
+        entityManager.persist(userEntity);
+
+        return this;
+    }
+
+    public void commit() {
+        entityManager.getTransaction().commit();
+    }
+
+}

--- a/model/jpa/src/test/resources/META-INF/persistence.xml
+++ b/model/jpa/src/test/resources/META-INF/persistence.xml
@@ -1,0 +1,45 @@
+<persistence xmlns="http://java.sun.com/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_1_0.xsd"
+             version="1.0">
+
+  <persistence-unit name="keycloak-test" transaction-type="RESOURCE_LOCAL">
+    <class>org.keycloak.models.jpa.entities.ClientEntity</class>
+    <class>org.keycloak.models.jpa.entities.CredentialEntity</class>
+    <class>org.keycloak.models.jpa.entities.RealmEntity</class>
+    <class>org.keycloak.models.jpa.entities.RealmAttributeEntity</class>
+    <class>org.keycloak.models.jpa.entities.RequiredCredentialEntity</class>
+    <class>org.keycloak.models.jpa.entities.UserFederationProviderEntity</class>
+    <class>org.keycloak.models.jpa.entities.UserFederationMapperEntity</class>
+    <class>org.keycloak.models.jpa.entities.RoleEntity</class>
+    <class>org.keycloak.models.jpa.entities.FederatedIdentityEntity</class>
+    <class>org.keycloak.models.jpa.entities.MigrationModelEntity</class>
+    <class>org.keycloak.models.jpa.entities.UserEntity</class>
+    <class>org.keycloak.models.jpa.entities.UserRequiredActionEntity</class>
+    <class>org.keycloak.models.jpa.entities.UserAttributeEntity</class>
+    <class>org.keycloak.models.jpa.entities.UserRoleMappingEntity</class>
+    <class>org.keycloak.models.jpa.entities.ScopeMappingEntity</class>
+    <class>org.keycloak.models.jpa.entities.IdentityProviderEntity</class>
+    <class>org.keycloak.models.jpa.entities.IdentityProviderMapperEntity</class>
+    <class>org.keycloak.models.jpa.entities.ClientIdentityProviderMappingEntity</class>
+    <class>org.keycloak.models.jpa.entities.ProtocolMapperEntity</class>
+    <class>org.keycloak.models.jpa.entities.UserConsentEntity</class>
+    <class>org.keycloak.models.jpa.entities.UserConsentRoleEntity</class>
+    <class>org.keycloak.models.jpa.entities.UserConsentProtocolMapperEntity</class>
+    <class>org.keycloak.models.jpa.entities.AuthenticationFlowEntity</class>
+    <class>org.keycloak.models.jpa.entities.AuthenticationExecutionEntity</class>
+    <class>org.keycloak.models.jpa.entities.AuthenticatorConfigEntity</class>
+    <class>org.keycloak.models.jpa.entities.RequiredActionProviderEntity</class>
+    <class>org.keycloak.models.jpa.session.PersistentUserSessionEntity</class>
+    <class>org.keycloak.models.jpa.session.PersistentClientSessionEntity</class>
+
+    <exclude-unlisted-classes>true</exclude-unlisted-classes>
+
+    <properties>
+      <property name="hibernate.dialect" value="org.hibernate.dialect.H2Dialect"/>
+      <property name="hibernate.connection.driver_class" value="org.h2.Driver"/>
+      <property name="hibernate.connection.url" value="jdbc:h2:mem:test"/>
+      <property name="hibernate.hbm2ddl.auto" value="create-drop"/>
+    </properties>
+  </persistence-unit>
+</persistence>

--- a/model/mongo/pom.xml
+++ b/model/mongo/pom.xml
@@ -45,5 +45,38 @@
             <artifactId>mongo-java-driver</artifactId>
             <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.jongo</groupId>
+            <artifactId>jongo</artifactId>
+            <version>1.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.fakemongo</groupId>
+            <artifactId>fongo</artifactId>
+            <version>1.3.6</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/model/mongo/src/main/java/org/keycloak/models/mongo/keycloak/adapters/MongoUserProvider.java
+++ b/model/mongo/src/main/java/org/keycloak/models/mongo/keycloak/adapters/MongoUserProvider.java
@@ -25,6 +25,7 @@ import org.keycloak.models.utils.CredentialValidation;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -227,6 +228,19 @@ public class MongoUserProvider implements UserProvider {
         DBObject sort = new BasicDBObject("username", 1);
 
         List<MongoUserEntity> users = getMongoStore().loadEntities(MongoUserEntity.class, queryBuilder.get(), sort, firstResult, maxResults, invocationContext);
+        return convertUserEntities(realm, users);
+    }
+
+    @Override
+    public List<UserModel> searchForExpiredUsers(Date olderThan, RealmModel realm) {
+        QueryBuilder queryBuilder = new QueryBuilder()
+                .and("realmId").is(realm.getId())
+                .and("emailVerified").is(false)
+                .and("createdTimestamp").lessThan(olderThan.getTime());
+
+        DBObject query = queryBuilder.get();
+        DBObject sort = new BasicDBObject("username", 1);
+        List<MongoUserEntity> users = getMongoStore().loadEntities(MongoUserEntity.class, query, sort, 0, Integer.MAX_VALUE, invocationContext);
         return convertUserEntities(realm, users);
     }
 

--- a/model/mongo/src/test/java/org/keycloak/models/mongo/keycloak/adapters/MongoUserProviderTest.java
+++ b/model/mongo/src/test/java/org/keycloak/models/mongo/keycloak/adapters/MongoUserProviderTest.java
@@ -1,0 +1,126 @@
+package org.keycloak.models.mongo.keycloak.adapters;
+
+import com.github.fakemongo.Fongo;
+import com.mongodb.DB;
+import org.jongo.Jongo;
+import org.junit.Before;
+import org.junit.Test;
+import org.keycloak.connections.mongo.impl.MongoStoreImpl;
+import org.keycloak.connections.mongo.impl.context.SimpleMongoStoreInvocationContext;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.mongo.keycloak.adapters.assembler.MongoUserAssembler;
+import org.keycloak.models.mongo.keycloak.entities.MongoClientEntity;
+import org.keycloak.models.mongo.keycloak.entities.MongoMigrationModelEntity;
+import org.keycloak.models.mongo.keycloak.entities.MongoOfflineUserSessionEntity;
+import org.keycloak.models.mongo.keycloak.entities.MongoOnlineUserSessionEntity;
+import org.keycloak.models.mongo.keycloak.entities.MongoRealmEntity;
+import org.keycloak.models.mongo.keycloak.entities.MongoRoleEntity;
+import org.keycloak.models.mongo.keycloak.entities.MongoUserConsentEntity;
+import org.keycloak.models.mongo.keycloak.entities.MongoUserEntity;
+import org.keycloak.models.mongo.keycloak.entities.MongoUserSessionEntity;
+
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+public class MongoUserProviderTest {
+
+    private DB mongoDB;
+    private Jongo jongoFacade;
+    private SimpleMongoStoreInvocationContext mongoStoreInvocationContext;
+
+    @Before
+    public void before() {
+        mongoDB = new Fongo("Test").getDB("Database");
+        jongoFacade = new Jongo(mongoDB);
+
+        List<Class<?>> mongoManagedClasses = new ArrayList<>();
+        mongoManagedClasses.add(MongoClientEntity.class);
+        mongoManagedClasses.add(MongoMigrationModelEntity.class);
+        mongoManagedClasses.add(MongoOfflineUserSessionEntity.class);
+        mongoManagedClasses.add(MongoOnlineUserSessionEntity.class);
+        mongoManagedClasses.add(MongoRealmEntity.class);
+        mongoManagedClasses.add(MongoRoleEntity.class);
+        mongoManagedClasses.add(MongoUserConsentEntity.class);
+        mongoManagedClasses.add(MongoUserEntity .class);
+        mongoManagedClasses.add(MongoUserSessionEntity.class);
+
+        MongoStoreImpl mongoStore = new MongoStoreImpl(mongoDB, mongoManagedClasses.toArray(new Class<?>[0]));
+
+        mongoStoreInvocationContext = new SimpleMongoStoreInvocationContext(mongoStore);
+    }
+
+    @Test
+    public void shouldFindExpiredUsers() throws Exception {
+        //given
+        Calendar today = Calendar.getInstance();
+        Calendar yesterday = Calendar.getInstance();
+        yesterday.add(Calendar.DATE, -1);
+
+        MongoUserAssembler.defaultAssembler(mongoDB)
+                .withRealm("test")
+                .withExpiredUser("test", "test", yesterday.getTime());
+
+        MongoRealmEntity realmEntity = jongoFacade.getCollection("realms").findOne("{id: #}", "test").as(MongoRealmEntity.class);
+        RealmAdapter realm = new RealmAdapter(mock(KeycloakSession.class), realmEntity, mongoStoreInvocationContext);
+
+        MongoUserProvider mongoUserProvider = new MongoUserProvider(mock(KeycloakSession.class), mongoStoreInvocationContext);
+
+        //when
+        List<UserModel> users = mongoUserProvider.searchForExpiredUsers(today.getTime(), realm);
+
+        //then
+        assertThat(users).hasSize(1);
+    }
+
+    @Test
+    public void shouldNotFindVerifiedUsers() throws Exception {
+        //given
+        Calendar today = Calendar.getInstance();
+        Calendar yesterday = Calendar.getInstance();
+        yesterday.add(Calendar.DATE, -1);
+
+        MongoUserAssembler.defaultAssembler(mongoDB)
+                .withRealm("test")
+                .withVerifiedUser("test", "test", yesterday.getTime());
+
+        MongoRealmEntity realmEntity = jongoFacade.getCollection("realms").findOne("{id: #}", "test").as(MongoRealmEntity.class);
+        RealmAdapter realm = new RealmAdapter(mock(KeycloakSession.class), realmEntity, mongoStoreInvocationContext);
+
+        MongoUserProvider mongoUserProvider = new MongoUserProvider(mock(KeycloakSession.class), mongoStoreInvocationContext);
+
+        //when
+        List<UserModel> users = mongoUserProvider.searchForExpiredUsers(today.getTime(), realm);
+
+        //then
+        assertThat(users).isEmpty();
+    }
+
+    @Test
+    public void shouldNotFindNotExpiredUsers() throws Exception {
+        //given
+        Calendar today = Calendar.getInstance();
+        Calendar yesterday = Calendar.getInstance();
+        yesterday.add(Calendar.DATE, -1);
+
+        MongoUserAssembler.defaultAssembler(mongoDB)
+                .withRealm("test")
+                .withExpiredUser("test", "test", today.getTime());
+
+        MongoRealmEntity realmEntity = jongoFacade.getCollection("realms").findOne("{id: #}", "test").as(MongoRealmEntity.class);
+        RealmAdapter realm = new RealmAdapter(mock(KeycloakSession.class), realmEntity, mongoStoreInvocationContext);
+
+        MongoUserProvider mongoUserProvider = new MongoUserProvider(mock(KeycloakSession.class), mongoStoreInvocationContext);
+
+        //when
+        List<UserModel> users = mongoUserProvider.searchForExpiredUsers(yesterday.getTime(), realm);
+
+        //then
+        assertThat(users).isEmpty();
+    }
+
+}

--- a/model/mongo/src/test/java/org/keycloak/models/mongo/keycloak/adapters/assembler/MongoUserAssembler.java
+++ b/model/mongo/src/test/java/org/keycloak/models/mongo/keycloak/adapters/assembler/MongoUserAssembler.java
@@ -1,0 +1,64 @@
+package org.keycloak.models.mongo.keycloak.adapters.assembler;
+
+import com.mongodb.DB;
+import org.jongo.Jongo;
+import org.jongo.MongoCollection;
+import org.keycloak.models.mongo.keycloak.entities.MongoRealmEntity;
+import org.keycloak.models.mongo.keycloak.entities.MongoUserEntity;
+
+import java.util.Date;
+
+public class MongoUserAssembler {
+
+    private DB mongo;
+    private Jongo jongo;
+
+    private MongoUserAssembler(DB mongo) {
+        this.mongo = mongo;
+        this.jongo = new Jongo(mongo);
+    }
+
+    public static MongoUserAssembler defaultAssembler(DB mongo) {
+        return new MongoUserAssembler(mongo);
+    }
+
+    public MongoUserAssembler withRealm(String realmId) {
+        MongoCollection realmsCollection = jongo.getCollection("realms");
+        if(realmsCollection.count("{id: #}", realmId) == 0) {
+            MongoRealmEntity realmEntity = new MongoRealmEntity();
+            realmEntity.setId(realmId);
+            realmsCollection.insert(realmEntity);
+        }
+        return this;
+    }
+
+    public MongoUserAssembler withExpiredUser(String userName, String realmId, Date createdDate) {
+        withRealm(realmId);
+
+        MongoCollection realmsCollection = jongo.getCollection("users");
+        MongoUserEntity userEntity = new MongoUserEntity();
+        userEntity.setUsername(userName);
+        userEntity.setId(userName);
+        userEntity.setRealmId(realmId);
+        userEntity.setEmailVerified(false);
+        userEntity.setCreatedTimestamp(createdDate.getTime());
+        realmsCollection.insert(userEntity);
+
+        return this;
+    }
+
+    public MongoUserAssembler withVerifiedUser(String userName, String realmId, Date createdDate) {
+        withRealm(realmId);
+
+        MongoCollection realmsCollection = jongo.getCollection("users");
+        MongoUserEntity userEntity = new MongoUserEntity();
+        userEntity.setUsername(userName);
+        userEntity.setId(userName);
+        userEntity.setRealmId(realmId);
+        userEntity.setEmailVerified(true);
+        userEntity.setCreatedTimestamp(createdDate.getTime());
+        realmsCollection.insert(userEntity);
+
+        return this;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,8 @@
         <undertow.version>1.1.1.Final</undertow.version>
         <picketlink.version>2.7.0.Final</picketlink.version>
         <mongo.driver.version>2.11.3</mongo.driver.version>
+        <jongo.version>1.0</jongo.version>
+        <fongo.version>1.3.6</fongo.version>
         <jboss.logging.version>3.1.4.GA</jboss.logging.version>
         <syslog4j.version>0.9.30</syslog4j.version>
         <jboss-logging-tools.version>1.2.0.Beta1</jboss-logging-tools.version>
@@ -73,6 +75,8 @@
         <jmeter.version>2.10</jmeter.version>
         <junit.version>4.12</junit.version>
         <hamcrest.version>1.3</hamcrest.version>
+        <assertj.version>3.2.0</assertj.version>
+        <mockito.version>1.10.19</mockito.version>
         <log4j.version>1.2.17</log4j.version>
         <greenmail.version>1.3.1b</greenmail.version>
         <xmlsec.version>1.5.1</xmlsec.version>
@@ -301,6 +305,16 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>${assertj.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-all</artifactId>
+                <version>${mockito.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest-all</artifactId>
                 <version>${hamcrest.version}</version>
@@ -411,6 +425,16 @@
                 <groupId>org.mongodb</groupId>
                 <artifactId>mongo-java-driver</artifactId>
                 <version>${mongo.driver.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jongo</groupId>
+                <artifactId>jongo</artifactId>
+                <version>${jongo.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.github.fakemongo</groupId>
+                <artifactId>fongo</artifactId>
+                <version>${fongo.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.jmeter</groupId>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -139,6 +139,16 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.icegreen</groupId>
             <artifactId>greenmail</artifactId>
             <scope>test</scope>

--- a/services/src/main/java/org/keycloak/services/resources/KeycloakApplication.java
+++ b/services/src/main/java/org/keycloak/services/resources/KeycloakApplication.java
@@ -20,6 +20,7 @@ import org.keycloak.services.managers.RealmManager;
 import org.keycloak.services.managers.UsersSyncManager;
 import org.keycloak.services.resources.admin.AdminRoot;
 import org.keycloak.services.scheduled.ClearExpiredEvents;
+import org.keycloak.services.scheduled.ClearExpiredUserRegistrations;
 import org.keycloak.services.scheduled.ClearExpiredUserSessions;
 import org.keycloak.services.scheduled.ScheduledTaskRunner;
 import org.keycloak.services.util.JsonConfigProvider;
@@ -88,7 +89,11 @@ public class KeycloakApplication extends Application {
 
         AdminRecovery.recover(sessionFactory);
 
-        setupScheduledTasks(sessionFactory);
+        setupScheduledTasks(sessionFactory, getScheduledTasksInterval());
+    }
+
+    private long getScheduledTasksInterval() {
+        return Config.scope("scheduled").getLong("interval", 60L) * 1000;
     }
 
     protected void migrateModel() {
@@ -160,12 +165,11 @@ public class KeycloakApplication extends Application {
         return factory;
     }
 
-    public static void setupScheduledTasks(final KeycloakSessionFactory sessionFactory) {
-        long interval = Config.scope("scheduled").getLong("interval", 60L) * 1000;
-
+    public static void setupScheduledTasks(final KeycloakSessionFactory sessionFactory, long interval) {
         TimerProvider timer = sessionFactory.create().getProvider(TimerProvider.class);
         timer.schedule(new ScheduledTaskRunner(sessionFactory, new ClearExpiredEvents()), interval, "ClearExpiredEvents");
         timer.schedule(new ScheduledTaskRunner(sessionFactory, new ClearExpiredUserSessions()), interval, "ClearExpiredUserSessions");
+        timer.schedule(new ScheduledTaskRunner(sessionFactory, new ClearExpiredUserRegistrations()), interval, "ClearExpiredUserRegistrations");
         new UsersSyncManager().bootstrapPeriodic(sessionFactory, timer);
     }
 

--- a/services/src/main/java/org/keycloak/services/scheduled/ClearExpiredUserRegistrations.java
+++ b/services/src/main/java/org/keycloak/services/scheduled/ClearExpiredUserRegistrations.java
@@ -1,0 +1,56 @@
+package org.keycloak.services.scheduled;
+
+import org.jboss.logging.Logger;
+import org.keycloak.Config;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+
+import java.lang.invoke.MethodHandles;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * Removes expired users who didn't verify their email addresses.
+ */
+public class ClearExpiredUserRegistrations implements ScheduledTask {
+
+    public static final String CONFIGURATION_NAMESPACE = "user";
+    public static final String ENABLED_KEY = "enableExpiredUsersEviction";
+    public static final String EXPIRATION_KEY = "expiredUsersEvictionTimeInDays";
+
+    private static final Logger logger = Logger.getLogger(MethodHandles.lookup().lookupClass());
+
+    @Override
+    public void run(KeycloakSession session) {
+        if(isEnabled()) {
+            Date expirationTime = getExpirationTime();
+            for(RealmModel realmModel : session.realms().getRealms()) {
+                logger.debug("Clearing expired user registrations (realm: " + realmModel.getName() + ", expirationTime: " + expirationTime + ")");
+                List<UserModel> expiredUsers = session.userStorage().searchForExpiredUsers(expirationTime, realmModel);
+                for(UserModel user : expiredUsers) {
+                    logger.debug("Removing expired user: " + user.getUsername());
+                    session.userStorage().removeUser(realmModel, user);
+                }
+            }
+        }
+    }
+
+    /**
+     * @return <code>true</code> is eviction mechanism is enabled.
+     */
+    public boolean isEnabled() {
+        return Config.scope(CONFIGURATION_NAMESPACE).getBoolean(ENABLED_KEY, true);
+    }
+
+    /**
+     * @return Expiration date for evicted users.
+     */
+    public Date getExpirationTime() {
+        int daysToExpire = Config.scope(CONFIGURATION_NAMESPACE).getInt(EXPIRATION_KEY, 30);
+        Calendar expiredBefore = Calendar.getInstance();
+        expiredBefore.add(Calendar.DATE, -daysToExpire);
+        return expiredBefore.getTime();
+    }
+}

--- a/services/src/test/java/org/keycloak/services/scheduled/ClearExpiredUserRegistrationsTest.java
+++ b/services/src/test/java/org/keycloak/services/scheduled/ClearExpiredUserRegistrationsTest.java
@@ -1,0 +1,95 @@
+package org.keycloak.services.scheduled;
+
+import org.junit.Test;
+import org.keycloak.Config;
+
+import java.util.Calendar;
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+public class ClearExpiredUserRegistrationsTest {
+
+    @Test
+    public void shouldBeEnabledByDefault() throws Exception {
+        //given
+        Config.init(new Config.SystemPropertiesConfigProvider());
+        ClearExpiredUserRegistrations testedTask = new ClearExpiredUserRegistrations();
+
+        //when
+        boolean isEnabled = testedTask.isEnabled();
+
+        //then
+        assertThat(isEnabled).isTrue();
+    }
+
+    @Test
+    public void shouldBeDisabledByConfiguration() throws Exception {
+        //given
+        Config.Scope scope = mock(Config.Scope.class);
+        Config.ConfigProvider configProvider = mock(Config.ConfigProvider.class);
+
+        doReturn(scope).when(configProvider).scope(eq("user"));
+        doReturn(false).when(scope).getBoolean(eq("enableExpiredUsersEviction"), anyBoolean());
+        Config.init(configProvider);
+
+        ClearExpiredUserRegistrations testedTask = new ClearExpiredUserRegistrations();
+
+        //when
+        boolean isEnabled = testedTask.isEnabled();
+
+        //then
+        assertThat(isEnabled).isFalse();
+    }
+
+    @Test
+    public void shouldExpireInAMonthByDefault() throws Exception {
+        //given
+        Calendar thirtyOneDaysAgo = Calendar.getInstance();
+        thirtyOneDaysAgo.add(Calendar.DAY_OF_YEAR, -29);
+
+        Calendar twentyNineDaysAgo = Calendar.getInstance();
+        twentyNineDaysAgo.add(Calendar.DAY_OF_YEAR, -31);
+
+        Config.init(new Config.SystemPropertiesConfigProvider());
+
+        ClearExpiredUserRegistrations testedTask = new ClearExpiredUserRegistrations();
+
+        //when
+        Date expirationDate = testedTask.getExpirationTime();
+
+        //than
+        assertThat(expirationDate).isBetween(twentyNineDaysAgo.getTime(), thirtyOneDaysAgo.getTime());
+    }
+
+    @Test
+    public void shouldExpireInConfiguredTime() throws Exception {
+        //given
+        Calendar yesterday = Calendar.getInstance();
+        yesterday.add(Calendar.DATE, -1);
+
+        Calendar tomorrow = Calendar.getInstance();
+        tomorrow.add(Calendar.DATE, 1);
+
+        Config.Scope scope = mock(Config.Scope.class);
+        Config.ConfigProvider configProvider = mock(Config.ConfigProvider.class);
+
+        doReturn(scope).when(configProvider).scope(eq("user"));
+        doReturn(0).when(scope).getInt(eq("expiredUsersEvictionTimeInDays"), anyInt());
+        Config.init(configProvider);
+
+        ClearExpiredUserRegistrations testedTask = new ClearExpiredUserRegistrations();
+
+        //when
+        Date expirationDate = testedTask.getExpirationTime();
+
+        //than
+        assertThat(expirationDate).isBetween(yesterday.getTime(), tomorrow.getTime());
+    }
+
+}

--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -154,6 +154,11 @@
             <artifactId>junit</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>
         </dependency>

--- a/testsuite/integration/src/test/java/org/keycloak/testsuite/KeycloakServer.java
+++ b/testsuite/integration/src/test/java/org/keycloak/testsuite/KeycloakServer.java
@@ -275,6 +275,7 @@ public class KeycloakServer {
             RealmModel adminRealm = manager.getKeycloakAdminstrationRealm();
             UserModel admin = session.users().getUserByUsername("admin", adminRealm);
             admin.removeRequiredAction(UserModel.RequiredAction.UPDATE_PASSWORD);
+            admin.setEmailVerified(true);
 
             session.getTransaction().commit();
         } finally {

--- a/testsuite/integration/src/test/java/org/keycloak/testsuite/Waiter.java
+++ b/testsuite/integration/src/test/java/org/keycloak/testsuite/Waiter.java
@@ -1,0 +1,42 @@
+package org.keycloak.testsuite;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Simple waiting utility.
+ */
+public class Waiter {
+
+    /**
+     * Condition evaluated while waiting.
+     */
+    public interface Condition {
+
+        /**
+         * @return <code>true</code> to stop waiting.
+         */
+        boolean check();
+    }
+
+    /**
+     * Waits for condition.
+     *
+     * @param condition Wait condition.
+     * @param timeout Max timeout for waiting.
+     * @param unit Time units for waiting.
+     */
+    public static void waitForCondition(Condition condition, long timeout, TimeUnit unit) {
+        long timeoutCondition = System.currentTimeMillis() + TimeUnit.MILLISECONDS.convert(timeout, unit);
+        do {
+            if(System.currentTimeMillis() > timeoutCondition) {
+                throw new AssertionError("Timeout!");
+            }
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                throw new AssertionError("Interruption occurred", e);
+            }
+        } while(!condition.check());
+    }
+
+}


### PR DESCRIPTION
Hey!

Please take a look at proposed solution for https://issues.jboss.org/browse/KEYCLOAK-1748.

The implementation allows to turn on/off the feature using `user.enableExpiredUsersEviction` (which is set to `true` by default). Inactivity period might be configured using `user.expiredUsersEvictionTimeInDays`.

Implementation highlights:
- Added tests for different model implementations
- Added AssertJ which makes assertions look a little bit better
- Added Mockito for mocks
- Added Fongo and Jongo for MongoDB testing (in-memory DB and a nice facade which makes Mongo interactions a bit easier)

Thanks!
