### PR TITLE
KEYCLOAK-2028: Support preemptively refreshing access token

### DIFF
--- a/core/src/main/java/org/keycloak/representations/adapters/config/AdapterConfig.java
+++ b/core/src/main/java/org/keycloak/representations/adapters/config/AdapterConfig.java
@@ -18,7 +18,8 @@ import org.codehaus.jackson.annotate.JsonPropertyOrder;
         "allow-any-hostname", "disable-trust-manager", "truststore", "truststore-password",
         "client-keystore", "client-keystore-password", "client-key-password",
         "auth-server-url-for-backend-requests", "always-refresh-token",
-        "register-node-at-startup", "register-node-period", "token-store", "principal-attribute"
+        "register-node-at-startup", "register-node-period", "token-store", "principal-attribute",
+        "token-minimum-time-to-live"
 })
 public class AdapterConfig extends BaseAdapterConfig {
 
@@ -50,6 +51,8 @@ public class AdapterConfig extends BaseAdapterConfig {
     protected String tokenStore;
     @JsonProperty("principal-attribute")
     protected String principalAttribute;
+    @JsonProperty("token-minimum-time-to-live")
+    protected int tokenMinimumTimeToLive = 5;
 
     public boolean isAllowAnyHostname() {
         return allowAnyHostname;
@@ -161,5 +164,13 @@ public class AdapterConfig extends BaseAdapterConfig {
 
     public void setPrincipalAttribute(String principalAttribute) {
         this.principalAttribute = principalAttribute;
+    }
+
+    public int getTokenMinimumTimeToLive() {
+        return tokenMinimumTimeToLive;
+    }
+
+    public void setTokenMinimumTimeToLive(final int tokenMinimumTimeToLive) {
+        this.tokenMinimumTimeToLive = tokenMinimumTimeToLive;
     }
 }

--- a/docbook/auth-server-docs/reference/en/en-US/modules/adapter-config.xml
+++ b/docbook/auth-server-docs/reference/en/en-US/modules/adapter-config.xml
@@ -30,6 +30,7 @@
    "client-keystore" : "path/to/client-keystore.jks",
    "client-keystore-password" : "geheim",
    "client-key-password" : "geheim"
+   "token-minimum-time-to-live" : 60
 }]]>
 
 </programlisting>
@@ -376,6 +377,17 @@
                     <para>
                         OpenID Connection ID Token attribute to populate the UserPrincipal name with.  If token attribute is null, defaults to <literal>sub</literal>.
                         Possible values are <literal>sub</literal>, <literal>preferred_username</literal>, <literal>email</literal>, <literal>name</literal>, <literal>nickname</literal>, <literal>given_name</literal>, <literal>family_name</literal>.
+                    </para>
+                </listitem>
+            </varlistentry>
+            <varlistentry>
+                <term>token-minimum-time-to-live</term>
+                <listitem>
+                    <para>
+                        Amount of time, in seconds, to preemptively refresh an active access token with the Keycloak server before it expires.
+                        This is especially useful in when the access token is sent to another client where it could expire before being evaluated.
+                        This value should never exceed the realm's access token lifespan.
+                        This is <emphasis>OPTIONAL</emphasis>.  The default value is <literal>5</literal> seconds.
                     </para>
                 </listitem>
             </varlistentry>

--- a/integration/adapter-core/pom.xml
+++ b/integration/adapter-core/pom.xml
@@ -69,6 +69,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>1.10.19</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <scope>provided</scope>

--- a/integration/adapter-core/src/main/java/org/keycloak/adapters/AdapterDeploymentContext.java
+++ b/integration/adapter-core/src/main/java/org/keycloak/adapters/AdapterDeploymentContext.java
@@ -433,6 +433,16 @@ public class AdapterDeploymentContext {
         public void setPrincipalAttribute(String principalAttribute) {
             delegate.setPrincipalAttribute(principalAttribute);
         }
+
+        @Override
+        public int getTokenMinimumTimeToLive() {
+            return delegate.getTokenMinimumTimeToLive();
+        }
+
+        @Override
+        public void setTokenMinimumTimeToLive(final int tokenMinimumTimeToLive) {
+            delegate.setTokenMinimumTimeToLive(tokenMinimumTimeToLive);
+        }
     }
 
     protected KeycloakUriBuilder getBaseBuilder(HttpFacade facade, String base) {

--- a/integration/adapter-core/src/main/java/org/keycloak/adapters/KeycloakDeployment.java
+++ b/integration/adapter-core/src/main/java/org/keycloak/adapters/KeycloakDeployment.java
@@ -58,6 +58,7 @@ public class KeycloakDeployment {
     protected boolean registerNodeAtStartup;
     protected int registerNodePeriod;
     protected volatile int notBefore;
+    protected int tokenMinimumTimeToLive;
 
     public KeycloakDeployment() {
     }
@@ -360,5 +361,13 @@ public class KeycloakDeployment {
 
     public void setPrincipalAttribute(String principalAttribute) {
         this.principalAttribute = principalAttribute;
+    }
+
+    public int getTokenMinimumTimeToLive() {
+        return tokenMinimumTimeToLive;
+    }
+
+    public void setTokenMinimumTimeToLive(final int tokenMinimumTimeToLive) {
+        this.tokenMinimumTimeToLive = tokenMinimumTimeToLive;
     }
 }

--- a/integration/adapter-core/src/main/java/org/keycloak/adapters/KeycloakDeploymentBuilder.java
+++ b/integration/adapter-core/src/main/java/org/keycloak/adapters/KeycloakDeploymentBuilder.java
@@ -77,6 +77,7 @@ public class KeycloakDeploymentBuilder {
         deployment.setAlwaysRefreshToken(adapterConfig.isAlwaysRefreshToken());
         deployment.setRegisterNodeAtStartup(adapterConfig.isRegisterNodeAtStartup());
         deployment.setRegisterNodePeriod(adapterConfig.getRegisterNodePeriod());
+        deployment.setTokenMinimumTimeToLive(adapterConfig.getTokenMinimumTimeToLive());
 
         if (realmKeyPem == null && adapterConfig.isBearerOnly() && adapterConfig.getAuthServerUrl() == null) {
             throw new IllegalArgumentException("For bearer auth, you must set the realm-public-key or auth-server-url");

--- a/integration/adapter-core/src/main/java/org/keycloak/adapters/RefreshableKeycloakSecurityContext.java
+++ b/integration/adapter-core/src/main/java/org/keycloak/adapters/RefreshableKeycloakSecurityContext.java
@@ -4,6 +4,7 @@ import org.jboss.logging.Logger;
 import org.keycloak.KeycloakSecurityContext;
 import org.keycloak.RSATokenVerifier;
 import org.keycloak.common.VerificationException;
+import org.keycloak.common.util.Time;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.AccessTokenResponse;
 import org.keycloak.representations.IDToken;
@@ -60,6 +61,10 @@ public class RefreshableKeycloakSecurityContext extends KeycloakSecurityContext 
         return token != null && this.token.isActive() && this.token.getIssuedAt() > deployment.getNotBefore();
     }
 
+    public boolean isTokenTimeToLiveSufficient(AccessToken token) {
+        return token != null && (token.getExpiration() - this.deployment.getTokenMinimumTimeToLive()) > Time.currentTime();
+    }
+
     public KeycloakDeployment getDeployment() {
         return deployment;
     }
@@ -78,7 +83,7 @@ public class RefreshableKeycloakSecurityContext extends KeycloakSecurityContext 
             if (log.isTraceEnabled()) {
                 log.trace("checking whether to refresh.");
             }
-            if (isActive()) return true;
+            if (isActive() && isTokenTimeToLiveSufficient(this.token)) return true;
         }
 
         if (this.deployment == null || refreshToken == null) return false; // Might be serialized in HttpSession?
@@ -113,6 +118,13 @@ public class RefreshableKeycloakSecurityContext extends KeycloakSecurityContext 
             log.error("failed verification of token");
             return false;
         }
+
+        // If the TTL is greater-or-equal to the expire time on the refreshed token, have to abort or go into an infinite refresh loop
+        if (!isTokenTimeToLiveSufficient(token)) {
+            log.error("failed to refresh the token with a longer time-to-live than the minimum");
+            return false;
+        }
+
         if (response.getNotBeforePolicy() > deployment.getNotBefore()) {
             deployment.setNotBefore(response.getNotBeforePolicy());
         }

--- a/integration/adapter-core/src/test/java/org/keycloak/adapters/KeycloakDeploymentBuilderTest.java
+++ b/integration/adapter-core/src/test/java/org/keycloak/adapters/KeycloakDeploymentBuilderTest.java
@@ -44,6 +44,7 @@ public class KeycloakDeploymentBuilderTest {
         assertEquals(1000, deployment.getRegisterNodePeriod());
         assertEquals(TokenStore.COOKIE, deployment.getTokenStore());
         assertEquals("email", deployment.getPrincipalAttribute());
+        assertEquals(10, deployment.getTokenMinimumTimeToLive());
     }
 
     @Test

--- a/integration/adapter-core/src/test/java/org/keycloak/adapters/RefreshableKeycloakSecurityContextTest.java
+++ b/integration/adapter-core/src/test/java/org/keycloak/adapters/RefreshableKeycloakSecurityContextTest.java
@@ -1,0 +1,70 @@
+package org.keycloak.adapters;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.keycloak.common.util.Time;
+import org.keycloak.representations.AccessToken;
+import org.keycloak.representations.IDToken;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.mockito.Mockito.*;
+
+public class RefreshableKeycloakSecurityContextTest
+{
+    private static final String TOKEN_STRING = "token_string";
+    private static final String ID_TOKEN_STRING = "id_token_string";
+    private static final String REFRESH_STRING = "refresh_token";
+
+    @Mock
+    private KeycloakDeployment deployment;
+    @Mock
+    private AdapterTokenStore  tokenStore;
+    @Mock
+    private AccessToken token;
+    @Mock
+    private IDToken     idToken;
+
+    private String tokenString;
+    private String idTokenString;
+    private String refreshToken;
+
+    @InjectMocks
+    private RefreshableKeycloakSecurityContext context;
+
+    @Before
+    public void setUp() throws Exception {
+        this.tokenString = TOKEN_STRING;
+        this.idTokenString = ID_TOKEN_STRING;
+        this.refreshToken = REFRESH_STRING;
+
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void testIsTokenTimeToLiveSufficient() throws Exception {
+        Assert.assertFalse(context.isTokenTimeToLiveSufficient(null));
+
+        when(deployment.getTokenMinimumTimeToLive()).thenReturn(10);
+        when(token.getExpiration()).thenReturn(Time.currentTime() + 20);
+        Assert.assertTrue(context.isTokenTimeToLiveSufficient(token));
+
+        when(token.getExpiration()).thenReturn(Time.currentTime() + 5);
+        Assert.assertFalse(context.isTokenTimeToLiveSufficient(token));
+    }
+
+    @Test
+    public void testRefreshExpiredTokenTimeToLiveForTimeToLive() throws Exception {
+        when(token.isActive()).thenReturn(true);
+        when(token.getIssuedAt()).thenReturn(5);
+        when(token.getNotBefore()).thenReturn(4);
+
+        when(deployment.getTokenMinimumTimeToLive()).thenReturn(10);
+        when(token.getExpiration()).thenReturn(Time.currentTime() + 20);
+
+        Assert.assertTrue(context.refreshExpiredToken(true));
+        verify(tokenStore, never()).refreshCallback(context);
+    }
+}

--- a/integration/adapter-core/src/test/resources/keycloak.json
+++ b/integration/adapter-core/src/test/resources/keycloak.json
@@ -29,5 +29,6 @@
     "register-node-at-startup": true,
     "register-node-period": 1000,
     "token-store": "cookie",
-    "principal-attribute": "email"
+    "principal-attribute": "email",
+    "token-minimum-time-to-live": 10
 }

--- a/testsuite/integration/src/test/resources/adapter-test/cust-app-cookie-keycloak.json
+++ b/testsuite/integration/src/test/resources/adapter-test/cust-app-cookie-keycloak.json
@@ -8,5 +8,6 @@
     "token-store": "cookie",
     "credentials": {
         "secret": "password"
-    }
+    },
+    "token-minimum-time-to-live": 1
 }


### PR DESCRIPTION
Add a new keycloak.json property and mechanism to automatically
refresh access tokens if they are going to expire in less than a configurable
amount of time.
