### PR TITLE
KEYCLOAK-2041 Use sendError instead of setStatus to report errors

### DIFF
--- a/integration/adapter-core/src/main/java/org/keycloak/adapters/AuthenticatedActionsHandler.java
+++ b/integration/adapter-core/src/main/java/org/keycloak/adapters/AuthenticatedActionsHandler.java
@@ -57,7 +57,7 @@ public class AuthenticatedActionsHandler {
     protected boolean abortTokenResponse() {
         if (facade.getSecurityContext() == null) {
             log.debugv("Not logged in, sending back 401: {0}",facade.getRequest().getURI());
-            facade.getResponse().setStatus(401);
+            facade.getResponse().sendError(401);
             facade.getResponse().end();
             return true;
         }
@@ -94,7 +94,7 @@ public class AuthenticatedActionsHandler {
                     log.debugv("allowedOrigins did not contain origin");
 
                 }
-                facade.getResponse().setStatus(403);
+                facade.getResponse().sendError(403);
                 facade.getResponse().end();
                 return true;
             }

--- a/integration/adapter-core/src/main/java/org/keycloak/adapters/OAuthRequestAuthenticator.java
+++ b/integration/adapter-core/src/main/java/org/keycloak/adapters/OAuthRequestAuthenticator.java
@@ -174,23 +174,7 @@ public class OAuthRequestAuthenticator {
         final String state = getStateCode();
         final String redirect = getRedirectUri(state);
         if (redirect == null) {
-            return new AuthChallenge() {
-                @Override
-                public boolean challenge(HttpFacade exchange) {
-                    exchange.getResponse().setStatus(403);
-                    return true;
-                }
-
-                @Override
-                public boolean errorPage() {
-                    return true;
-                }
-
-                @Override
-                public int getResponseCode() {
-                    return 403;
-                }
-            };
+            return challenge(403);
         }
         return new AuthChallenge() {
 
@@ -283,7 +267,7 @@ public class OAuthRequestAuthenticator {
 
             @Override
             public boolean challenge(HttpFacade exchange) {
-                exchange.getResponse().setStatus(code);
+                exchange.getResponse().sendError(code);
                 return true;
             }
         };

--- a/integration/adapter-spi/src/main/java/org/keycloak/adapters/spi/HttpFacade.java
+++ b/integration/adapter-spi/src/main/java/org/keycloak/adapters/spi/HttpFacade.java
@@ -56,6 +56,7 @@ public interface HttpFacade {
         void resetCookie(String name, String path);
         void setCookie(String name, String value, String path, String domain, int maxAge, boolean secure, boolean httpOnly);
         OutputStream getOutputStream();
+        void sendError(int code);
         void sendError(int code, String message);
 
         /**

--- a/integration/jaxrs-oauth-client/src/main/java/org/keycloak/jaxrs/JaxrsHttpFacade.java
+++ b/integration/jaxrs-oauth-client/src/main/java/org/keycloak/jaxrs/JaxrsHttpFacade.java
@@ -133,6 +133,13 @@ public class JaxrsHttpFacade implements OIDCHttpFacade {
         }
 
         @Override
+        public void sendError(int code) {
+            javax.ws.rs.core.Response response = responseBuilder.status(code).build();
+            requestContext.abortWith(response);
+            responseFinished = true;
+        }
+
+        @Override
         public void sendError(int code, String message) {
             javax.ws.rs.core.Response response = responseBuilder.status(code).entity(message).build();
             requestContext.abortWith(response);

--- a/integration/jetty/jetty-adapter-spi/src/main/java/org/keycloak/adapters/jetty/spi/JettyHttpFacade.java
+++ b/integration/jetty/jetty-adapter-spi/src/main/java/org/keycloak/adapters/jetty/spi/JettyHttpFacade.java
@@ -171,6 +171,15 @@ public class JettyHttpFacade implements HttpFacade {
         }
 
         @Override
+        public void sendError(int code) {
+            try {
+                response.sendError(code);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
         public void sendError(int code, String message) {
             try {
                 response.sendError(code, message);

--- a/integration/servlet-adapter-spi/src/main/java/org/keycloak/adapters/servlet/ServletHttpFacade.java
+++ b/integration/servlet-adapter-spi/src/main/java/org/keycloak/adapters/servlet/ServletHttpFacade.java
@@ -157,6 +157,15 @@ public class ServletHttpFacade implements HttpFacade {
         }
 
         @Override
+        public void sendError(int code) {
+            try {
+                response.sendError(code);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
         public void sendError(int code, String message) {
             try {
                 response.sendError(code, message);

--- a/integration/spring-security/src/main/java/org/keycloak/adapters/springsecurity/facade/WrappedHttpServletResponse.java
+++ b/integration/spring-security/src/main/java/org/keycloak/adapters/springsecurity/facade/WrappedHttpServletResponse.java
@@ -96,6 +96,15 @@ class WrappedHttpServletResponse implements Response {
     }
 
     @Override
+    public void sendError(int code) {
+        try {
+            response.sendError(code);
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to set HTTP status", e);
+        }
+    }
+
+    @Override
     public void sendError(int code, String message) {
         try {
             response.sendError(code, message);

--- a/integration/tomcat/tomcat-adapter-spi/src/main/java/org/keycloak/adapters/tomcat/CatalinaHttpFacade.java
+++ b/integration/tomcat/tomcat-adapter-spi/src/main/java/org/keycloak/adapters/tomcat/CatalinaHttpFacade.java
@@ -168,6 +168,15 @@ public class CatalinaHttpFacade implements HttpFacade {
         }
 
         @Override
+        public void sendError(int code) {
+            try {
+                response.sendError(code);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
         public void sendError(int code, String message) {
             try {
                 response.sendError(code, message);
@@ -175,6 +184,7 @@ public class CatalinaHttpFacade implements HttpFacade {
                 throw new RuntimeException(e);
             }
         }
+
 
         @Override
         public void end() {

--- a/integration/undertow-adapter-spi/src/main/java/org/keycloak/adapters/undertow/UndertowHttpFacade.java
+++ b/integration/undertow-adapter-spi/src/main/java/org/keycloak/adapters/undertow/UndertowHttpFacade.java
@@ -171,6 +171,12 @@ public class UndertowHttpFacade implements HttpFacade {
         }
 
         @Override
+        public void sendError(int code) {
+            exchange.setResponseCode(code);
+            exchange.endExchange();
+        }
+
+        @Override
         public void sendError(int code, String message) {
             exchange.setResponseCode(code);
             exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "text/html");


### PR DESCRIPTION
I have added `sendError(int)` to `HttpFacade.Response` and replaced calls to `setStatus(int)` where an error is reported to use it instead.

Please let me know if it's a problem to modify the `HttpFacade.Response` interface.
