### PR TITLE
KEYCLOAK-2068 - Fix Potential NPE when using Servlet-Filter Adapter.

### DIFF
--- a/integration/servlet-adapter-spi/src/main/java/org/keycloak/adapters/servlet/FilterSessionStore.java
+++ b/integration/servlet-adapter-spi/src/main/java/org/keycloak/adapters/servlet/FilterSessionStore.java
@@ -90,6 +90,9 @@ public class FilterSessionStore implements AdapterSessionStore {
 
                 MultivaluedHashMap<String, String> getParams() {
                     if (parameters != null) return parameters;
+
+                    if (body == null) return new MultivaluedHashMap<String, String>();
+
                     String contentType = getContentType();
                     contentType = contentType.toLowerCase();
                     if (contentType.startsWith("application/x-www-form-urlencoded")) {

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/RealmEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/RealmEntity.java
@@ -120,7 +120,7 @@ public class RealmEntity {
     Collection<RequiredCredentialEntity> requiredCredentials = new ArrayList<RequiredCredentialEntity>();
 
     @OneToMany(cascade ={CascadeType.REMOVE}, orphanRemoval = true)
-    @JoinTable(name="FED_PROVIDERS", joinColumns={ @JoinColumn(name="REALM_ID") })
+    @JoinTable(name="FED_PROVIDERS", joinColumns={ @JoinColumn(name="REALM_ID") }, inverseJoinColumns={ @JoinColumn(name = "USERFEDERATIONPROVIDERS_ID") })
     List<UserFederationProviderEntity> userFederationProviders = new ArrayList<UserFederationProviderEntity>();
 
     @OneToMany(cascade ={CascadeType.REMOVE}, orphanRemoval = true, mappedBy = "realm")

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/RoleEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/RoleEntity.java
@@ -30,7 +30,7 @@ import java.util.Collection;
 
 public class RoleEntity {
     @Id
-    @Column(name="id", length = 36)
+    @Column(name="ID", length = 36)
     private String id;
 
     @Column(name = "NAME")

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/UserEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/UserEntity.java
@@ -77,7 +77,7 @@ public class UserEntity {
     @OneToMany(cascade = CascadeType.REMOVE, orphanRemoval = true, mappedBy="user")
     protected Collection<CredentialEntity> credentials = new ArrayList<CredentialEntity>();
 
-    @Column(name="federation_link")
+    @Column(name="FEDERATION_LINK")
     protected String federationLink;
 
     @Column(name="SERVICE_ACCOUNT_CLIENT_LINK")

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/UserFederationProviderEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/UserFederationProviderEntity.java
@@ -35,7 +35,7 @@ public class UserFederationProviderEntity {
 
     @ElementCollection
     @MapKeyColumn(name="name")
-    @Column(name="value")
+    @Column(name="VALUE")
     @CollectionTable(name="USER_FEDERATION_CONFIG", joinColumns={ @JoinColumn(name="USER_FEDERATION_PROVIDER_ID") })
     private Map<String, String> config;
 


### PR DESCRIPTION
When using the {{org.keycloak.adapters.servlet.KeycloakOIDCFilter}} a {{NullPointerException}} can be thrown in the {{org.keycloak.adapters.servlet.FilterSessionStore}} within the {{getParam}} method of the  generated wrapper in {{buildWrapper}} when the {{content-type}} is not set.
Since the {{content-type}} is only used to parse the body. We just check whether the {{body}} is {{null}} and if so avoid touching the {{content-type}} which prevents the NPE.
If the {{body}} is null we return an empty {{MultivaluedHashMap}} for the parameters.
