### PR TITLE
KEYCLOAK-2068 - Fix Potential NPE when using Servlet-Filter Adapter.

### DIFF
--- a/integration/servlet-adapter-spi/src/main/java/org/keycloak/adapters/servlet/FilterSessionStore.java
+++ b/integration/servlet-adapter-spi/src/main/java/org/keycloak/adapters/servlet/FilterSessionStore.java
@@ -90,6 +90,9 @@ public class FilterSessionStore implements AdapterSessionStore {
 
                 MultivaluedHashMap<String, String> getParams() {
                     if (parameters != null) return parameters;
+
+                    if (body == null) return new MultivaluedHashMap<String, String>();
+
                     String contentType = getContentType();
                     contentType = contentType.toLowerCase();
                     if (contentType.startsWith("application/x-www-form-urlencoded")) {


### PR DESCRIPTION
When using the `org.keycloak.adapters.servlet.KeycloakOIDCFilter` a `NullPointerException`
can be thrown in the `org.keycloak.adapters.servlet.FilterSessionStore` within the `getParam`
method of the generated wrapper in `buildWrapper` when the `content-type` is not set.

Since the `content-type` is only used to parse the body. We just check whether the `body`
is `null` and if so avoid touching the `content-type` which prevents the NPE.
If the `body` is null we return an empty `MultivaluedHashMap` for the parameters.
