### PR TITLE
Fix missing group in angular $scope in GroupMembersCtrl.

### DIFF
--- a/forms/common-themes/src/main/resources/theme/base/admin/resources/js/controllers/groups.js
+++ b/forms/common-themes/src/main/resources/theme/base/admin/resources/js/controllers/groups.js
@@ -323,7 +323,7 @@ module.controller('GroupRoleMappingCtrl', function($scope, $http, realm, group, 
 module.controller('GroupMembersCtrl', function($scope, realm, group, GroupMembership) {
     $scope.realm = realm;
     $scope.page = 0;
-
+    $scope.group = group;
 
     $scope.query = {
         realm: realm.realm,


### PR DESCRIPTION
Previously navigating to the group members tab of a group breaks other groups links (RoleMappings, Attributes etc.) because the groupId part of the url is missing.
 One sees:
 /auth/admin/master/console/#/realms/master/groups//role-mappings
 Instead of:
 /auth/admin/master/console/#/realms/master/groups/0f77aeed-7d16-4938-9fcc-c74b1125e5e0/role-mappings
