### PR TITLE
[KEYCLOAK-2121] Adding user or group attributes using ENTER key deletes first attribute

### DIFF
--- a/forms/common-themes/src/main/resources/theme/base/admin/resources/partials/group-attributes.html
+++ b/forms/common-themes/src/main/resources/theme/base/admin/resources/partials/group-attributes.html
@@ -20,14 +20,14 @@
                 <td>{{key}}</td>
                 <td><input ng-model="group.attributes[key]" class="form-control" type="text" name="{{key}}" id="attribute-{{key}}" /></td>
                 <td class="kc-action-cell">
-                    <button class="btn btn-default btn-block btn-sm" data-ng-click="removeAttribute(key)">Delete</button>
+                    <button type="button" class="btn btn-default btn-block btn-sm" data-ng-click="removeAttribute(key)">Delete</button>
                 </td>
             </tr>
             <tr>
                 <td><input ng-model="newAttribute.key" class="form-control" type="text" id="newAttributeKey" /></td>
                 <td><input ng-model="newAttribute.value" class="form-control" type="text" id="newAttributeValue" /></td>
                 <td class="kc-action-cell">
-                    <button class="btn btn-default btn-block btn-sm" data-ng-click="addAttribute()">Add</button>
+                    <button type="button" class="btn btn-default btn-block btn-sm" data-ng-click="addAttribute()">Add</button>
                 </td>
             </tr>
             </tbody>

--- a/forms/common-themes/src/main/resources/theme/base/admin/resources/partials/user-attributes.html
+++ b/forms/common-themes/src/main/resources/theme/base/admin/resources/partials/user-attributes.html
@@ -20,14 +20,14 @@
                 <td>{{key}}</td>
                 <td><input ng-model="user.attributes[key]" class="form-control" type="text" name="{{key}}" id="attribute-{{key}}" /></td>
                 <td class="kc-action-cell">
-                    <button class="btn btn-default btn-block btn-sm" data-ng-click="removeAttribute(key)">Delete</button>
+                    <button type="button" class="btn btn-default btn-block btn-sm" data-ng-click="removeAttribute(key)">Delete</button>
                 </td>
             </tr>
             <tr>
                 <td><input ng-model="newAttribute.key" class="form-control" type="text" id="newAttributeKey" /></td>
                 <td><input ng-model="newAttribute.value" class="form-control" type="text" id="newAttributeValue" /></td>
                 <td class="kc-action-cell">
-                    <button class="btn btn-default btn-block btn-sm" data-ng-click="addAttribute()">Add</button>
+                    <button type="button" class="btn btn-default btn-block btn-sm" data-ng-click="addAttribute()">Add</button>
                 </td>
             </tr>
             </tbody>


### PR DESCRIPTION
The reason is because a button inside a form has it's type implicitly set to `submit`. The first button or input with type="submit" is what is triggered when enter key is pressed. If we specifically set type="button", then it's removed from consideration by the browser.
