### PR TITLE
KEYCLOAK-2057: DB error with JPA EventStore and long value of not-existing client

### DIFF
--- a/events/api/src/main/java/org/keycloak/events/Event.java
+++ b/events/api/src/main/java/org/keycloak/events/Event.java
@@ -47,7 +47,7 @@ public class Event {
     }
 
     public void setRealmId(String realmId) {
-        this.realmId = realmId;
+        this.realmId = maxLength(realmId, 255);
     }
 
     public String getClientId() {
@@ -55,7 +55,7 @@ public class Event {
     }
 
     public void setClientId(String clientId) {
-        this.clientId = clientId;
+        this.clientId = maxLength(clientId, 255);
     }
 
     public String getUserId() {
@@ -63,7 +63,7 @@ public class Event {
     }
 
     public void setUserId(String userId) {
-        this.userId = userId;
+        this.userId = maxLength(userId, 255);
     }
 
     public String getSessionId() {
@@ -110,6 +110,13 @@ public class Event {
         clone.error = error;
         clone.details = details != null ? new HashMap<>(details) : null;
         return clone;
+    }
+
+    static String maxLength(String string, int length){
+        if (string != null && string.length() > length) {
+            return string.substring(0, length - 1);
+        }
+        return string;
     }
 
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/console/events/LoginEventsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/console/events/LoginEventsTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.testsuite.admin.Users;
 import org.keycloak.testsuite.console.AbstractConsoleTest;
+import org.keycloak.testsuite.console.page.clients.Client;
 import org.keycloak.testsuite.console.page.events.Config;
 import org.keycloak.testsuite.console.page.events.LoginEvents;
 import org.openqa.selenium.By;
@@ -83,5 +84,7 @@ public class LoginEventsTest extends AbstractConsoleTest {
         resultList.get(0).findElement(By.xpath("//td[text()='Client']/../td[text()='security-admin-console']"));
         resultList.get(0).findElement(By.xpath("//td[text()='Error']/../td[text()='invalid_user_credentials']"));
         resultList.get(0).findElement(By.xpath("//td[text()='IP Address']/../td[text()='127.0.0.1']"));
+
+
     }
 }

--- a/testsuite/integration/src/test/java/org/keycloak/testsuite/events/EventStoreProviderTest.java
+++ b/testsuite/integration/src/test/java/org/keycloak/testsuite/events/EventStoreProviderTest.java
@@ -1,5 +1,6 @@
 package org.keycloak.testsuite.events;
 
+import org.apache.commons.lang3.StringUtils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -167,6 +168,19 @@ public class EventStoreProviderTest {
         eventStore.clear("realmId");
 
         Assert.assertEquals(1, eventStore.createQuery().getResultList().size());
+    }
+
+    @Test
+    public void lengthExceedLimit(){
+        eventStore.onEvent(create(System.currentTimeMillis() - 30000, EventType.LOGIN, "realmId", StringUtils.repeat("clientId", 100), "userId", "127.0.0.1", "error"));
+        eventStore.onEvent(create(System.currentTimeMillis() - 30000, EventType.LOGIN, StringUtils.repeat("realmId", 100), "clientId", "userId", "127.0.0.1", "error"));
+        eventStore.onEvent(create(System.currentTimeMillis() - 30000, EventType.LOGIN, "realmId", "clientId", StringUtils.repeat("userId", 100), "127.0.0.1", "error"));
+
+    }
+
+    @Test
+    public void maxLengthWithNull(){
+        eventStore.onEvent(create(System.currentTimeMillis() - 30000, EventType.LOGIN, null, null, null, "127.0.0.1", "error"));
     }
 
     @Test


### PR DESCRIPTION
See: https://issues.jboss.org/browse/KEYCLOAK-2057

I also included scenarios for realmId and userId
