### PR TITLE
Upgrade to build-tools.version 1.1.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <slf4j.version>1.7.7</slf4j.version>
         <wildfly.version>9.0.2.Final</wildfly.version>
         <wildfly.core.version>1.0.2.Final</wildfly.core.version>
-        <wildfly.build-tools.version>1.0.0.Final</wildfly.build-tools.version>
+        <wildfly.build-tools.version>1.1.0.Final</wildfly.build-tools.version>
 
         <!-- this is EAP 6.4 alpha, publicly available -->
         <jboss.version>7.5.0.Final-redhat-15</jboss.version>


### PR DESCRIPTION
The build is expected to fail with an NPE from `wildfly-server-provisioning-maven-plugin`
