### PR TITLE
Minor change for client registration documentation

### DIFF
--- a/docbook/auth-server-docs/reference/en/en-US/modules/client-registration.xml
+++ b/docbook/auth-server-docs/reference/en/en-US/modules/client-registration.xml
@@ -193,8 +193,8 @@ String initialAccessToken = "eyJhbGciOiJSUzI1NiJ9.eyJqdGkiOiJmMjJmNzQyYy04ZjNlLT
 ClientRepresentation client = new ClientRepresentation();
 client.setClientId(CLIENT_ID);
 
-ClientRegistration reg = ClientRegistration.create().url("http://keycloak/auth/realms/myrealm").build();
-reg.auth(initialAccessToken);
+ClientRegistration reg = ClientRegistration.create().url("http://keycloak/auth/realms/myrealm/clients").build();
+reg.auth(Auth.token(initialAccessToken));
 
 client = reg.create(client);
 


### PR DESCRIPTION
The code available at client registration will only accept Auth object as argument.
