### PR TITLE
KEYCLOAK-2257: Store user attribute when accepting terms and conditions

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/requiredactions/TermsAndConditions.java
+++ b/services/src/main/java/org/keycloak/authentication/requiredactions/TermsAndConditions.java
@@ -1,5 +1,9 @@
 package org.keycloak.authentication.requiredactions;
 
+import java.text.SimpleDateFormat;
+import java.util.Arrays;
+import java.util.Date;
+
 import org.keycloak.Config;
 import org.keycloak.authentication.RequiredActionContext;
 import org.keycloak.authentication.RequiredActionFactory;
@@ -14,8 +18,8 @@ import javax.ws.rs.core.Response;
  * @version $Revision: 1 $
  */
 public class TermsAndConditions implements RequiredActionProvider, RequiredActionFactory {
-
     public static final String PROVIDER_ID = "terms_and_conditions";
+    public static final String USER_ATTRIBUTE = PROVIDER_ID;
 
     @Override
     public RequiredActionProvider create(KeycloakSession session) {
@@ -46,18 +50,22 @@ public class TermsAndConditions implements RequiredActionProvider, RequiredActio
 
     @Override
     public void requiredActionChallenge(RequiredActionContext context) {
-        Response challenge =  context.form().createForm("terms.ftl");
+        Response challenge = context.form().createForm("terms.ftl");
         context.challenge(challenge);
     }
 
     @Override
     public void processAction(RequiredActionContext context) {
         if (context.getHttpRequest().getDecodedFormParameters().containsKey("cancel")) {
+            context.getUser().removeAttribute(USER_ATTRIBUTE);
             context.failure();
             return;
         }
-        context.success();
 
+        SimpleDateFormat dateTimeFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
+        context.getUser().setAttribute(USER_ATTRIBUTE, Arrays.asList(dateTimeFormat.format(new Date())));
+
+        context.success();
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/authentication/requiredactions/TermsAndConditions.java
+++ b/services/src/main/java/org/keycloak/authentication/requiredactions/TermsAndConditions.java
@@ -8,6 +8,7 @@ import org.keycloak.Config;
 import org.keycloak.authentication.RequiredActionContext;
 import org.keycloak.authentication.RequiredActionFactory;
 import org.keycloak.authentication.RequiredActionProvider;
+import org.keycloak.common.util.Time;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 
@@ -62,8 +63,7 @@ public class TermsAndConditions implements RequiredActionProvider, RequiredActio
             return;
         }
 
-        SimpleDateFormat dateTimeFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
-        context.getUser().setAttribute(USER_ATTRIBUTE, Arrays.asList(dateTimeFormat.format(new Date())));
+        context.getUser().setAttribute(USER_ATTRIBUTE, Arrays.asList(Integer.toString(Time.currentTime())));
 
         context.success();
     }

--- a/testsuite/integration/src/test/java/org/keycloak/testsuite/actions/TermsAndConditionsTest.java
+++ b/testsuite/integration/src/test/java/org/keycloak/testsuite/actions/TermsAndConditionsTest.java
@@ -110,8 +110,15 @@ public class TermsAndConditionsTest {
         List<String> termsAndConditions = attributes.get(TermsAndConditions.USER_ATTRIBUTE);
         assertTrue("timestamp for terms acceptance was not stored in user attributes as "
                 + TermsAndConditions.USER_ATTRIBUTE, termsAndConditions.size() == 1);
+        String timestamp = termsAndConditions.get(0);
         assertNotNull("expected non-null timestamp for terms acceptance in user attribute "
-                + TermsAndConditions.USER_ATTRIBUTE, termsAndConditions.get(0));
+                + TermsAndConditions.USER_ATTRIBUTE, timestamp);
+        try {
+            Integer.parseInt(timestamp);
+        }
+        catch (NumberFormatException e) {
+            fail("timestamp for terms acceptance is not a valid integer: '" + timestamp + "'");
+        }
     }
 
     @Test


### PR DESCRIPTION
Required action `TermsAndConditions` now stores user attribute indicating acceptance of terms and conditions.
