### PR TITLE
KEYCLOAK-2229

### DIFF
--- a/distribution/server-overlay/eap6/eap6-server-modules/src/main/resources/modules/org/keycloak/keycloak-login-freemarker/main/module.xml
+++ b/distribution/server-overlay/eap6/eap6-server-modules/src/main/resources/modules/org/keycloak/keycloak-login-freemarker/main/module.xml
@@ -16,6 +16,7 @@
         <module name="org.keycloak.keycloak-core"/>
         <module name="org.keycloak.keycloak-services"/>
         <module name="org.keycloak.keycloak-social-core"/>
+        <module name="org.keycloak.keycloak-broker-core"/>
         <module name="javax.ws.rs.api"/>
         <module name="org.jboss.logging"/>
         <module name="org.freemarker"/>


### PR DESCRIPTION
First broker login throws NoClassDefFoundError: org/keycloak/broker/provider/BrokeredIdentityContext
