### PR TITLE
Add 'password' configuration field type for federation providers

### DIFF
--- a/forms/common-themes/src/main/resources/theme/base/admin/resources/templates/kc-provider-config.html
+++ b/forms/common-themes/src/main/resources/theme/base/admin/resources/templates/kc-provider-config.html
@@ -2,8 +2,11 @@
     <div data-ng-repeat="option in properties" class="form-group" data-ng-controller="ProviderConfigCtrl">
         <label class="col-md-2 control-label">{{:: option.label | translate}}</label>
 
-        <div class="col-sm-6" data-ng-hide="option.type == 'boolean' || option.type == 'List' || option.type == 'Role' || option.type == 'ClientList'">
+        <div class="col-sm-6" data-ng-hide="option.type == 'boolean' || option.type == 'List' || option.type == 'Role' || option.type == 'ClientList' || option.type == 'Password'">
             <input class="form-control" type="text" data-ng-model="config[ option.name ]" >
+        </div>
+        <div class="col-sm-6" data-ng-show="option.type == 'Password'">
+            <input class="form-control" type="password" data-ng-model="config[ option.name ]" >
         </div>
         <div class="col-sm-6" data-ng-show="option.type == 'boolean'">
             <input ng-model="config[ option.name ]" value="'true'" name="option.name" id="option.name" onoffswitchstring on-text="{{:: 'onText' | translate}}" off-text="{{:: 'offText' | translate}}"/>

--- a/model/api/src/main/java/org/keycloak/provider/ProviderConfigProperty.java
+++ b/model/api/src/main/java/org/keycloak/provider/ProviderConfigProperty.java
@@ -10,6 +10,7 @@ public class ProviderConfigProperty {
     public static final String ROLE_TYPE="Role";
     public static final String LIST_TYPE="List";
     public static final String CLIENT_LIST_TYPE="ClientList";
+    public static final String PASSWORD="Password";
 
     protected String name;
     protected String label;


### PR DESCRIPTION
I've got a UserFederationProvider that needs a password input as part of it's configuration on KC.  Didn't see of an existing way to do this, so added a ProviderConfigProperty.Password type and made corresponding changes to html partial.

Tested by configuring provider and verifying all other fields remained unchanged and password field rendered correctly.
