### PR TITLE
KEYCLOAK-2311 - Allow to specify role to skip conditional OTP authentication.

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/ConditionalOtpFormAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/ConditionalOtpFormAuthenticator.java
@@ -72,7 +72,7 @@ public class ConditionalOtpFormAuthenticator extends OTPFormAuthenticator {
 
     public static final String FORCE_OTP_ROLE = "forceOtpRole";
 
-    public static final String NO_OTP_REQUIRED_FOR_HTTP_HEADER = "noOtpRequiredForHeaderPattern";
+    public static final String SKIP_OTP_FOR_HTTP_HEADER = "noOtpRequiredForHeaderPattern";
 
     public static final String FORCE_OTP_FOR_HTTP_HEADER = "forceOtpForHeaderPattern";
 
@@ -99,14 +99,14 @@ public class ConditionalOtpFormAuthenticator extends OTPFormAuthenticator {
             return;
         }
 
-        if (tryConcludeBasedOn(voteForDefaultFallback(context, config), context)) {
+        if (tryConcludeBasedOn(voteForDefaultFallback(config), context)) {
             return;
         }
 
         showOtpForm(context);
     }
 
-    private OtpDecision voteForDefaultFallback(AuthenticationFlowContext context, Map<String, String> config) {
+    private OtpDecision voteForDefaultFallback(Map<String, String> config) {
 
         if (!config.containsKey(DEFAULT_OTP_OUTCOME)) {
             return ABSTAIN;
@@ -174,14 +174,14 @@ public class ConditionalOtpFormAuthenticator extends OTPFormAuthenticator {
 
     private OtpDecision voteForHttpHeaderMatchesPattern(AuthenticationFlowContext context, Map<String, String> config) {
 
-        if (!config.containsKey(FORCE_OTP_FOR_HTTP_HEADER) && !config.containsKey(NO_OTP_REQUIRED_FOR_HTTP_HEADER)) {
+        if (!config.containsKey(FORCE_OTP_FOR_HTTP_HEADER) && !config.containsKey(SKIP_OTP_FOR_HTTP_HEADER)) {
             return ABSTAIN;
         }
 
         MultivaluedMap<String, String> requestHeaders = context.getHttpRequest().getHttpHeaders().getRequestHeaders();
 
         //Inverted to allow white-lists, e.g. for specifying trusted remote hosts: X-Forwarded-Host: (1.2.3.4|1.2.3.5)
-        if (containsMatchingRequestHeader(requestHeaders, config.get(NO_OTP_REQUIRED_FOR_HTTP_HEADER))) {
+        if (containsMatchingRequestHeader(requestHeaders, config.get(SKIP_OTP_FOR_HTTP_HEADER))) {
             return SKIP_OTP;
         }
 

--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/ConditionalOtpFormAuthenticatorFactory.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/ConditionalOtpFormAuthenticatorFactory.java
@@ -98,6 +98,12 @@ public class ConditionalOtpFormAuthenticatorFactory implements AuthenticatorFact
                 "If attribute value is 'force' then OTP is always required. " +
                 "If value is 'skip' the OTP auth is skipped. Otherwise this check is ignored.");
 
+        ProviderConfigProperty skipOtpRole = new ProviderConfigProperty();
+        skipOtpRole.setType(ROLE_TYPE);
+        skipOtpRole.setName(SKIP_OTP_ROLE);
+        skipOtpRole.setLabel("Skip OTP for Role");
+        skipOtpRole.setHelpText("OTP is always skipped if user has the given Role.");
+
         ProviderConfigProperty forceOtpRole = new ProviderConfigProperty();
         forceOtpRole.setType(ROLE_TYPE);
         forceOtpRole.setName(FORCE_OTP_ROLE);
@@ -127,6 +133,6 @@ public class ConditionalOtpFormAuthenticatorFactory implements AuthenticatorFact
         defaultOutcome.setDefaultValue(asList(SKIP, FORCE));
         defaultOutcome.setHelpText("What to do in case of every check abstains. Defaults to force OTP authentication.");
 
-        return asList(forceOtpUserAttribute, forceOtpRole, noOtpRequiredForHttpHeader, forceOtpForHttpHeader, defaultOutcome);
+        return asList(forceOtpUserAttribute, skipOtpRole, forceOtpRole, noOtpRequiredForHttpHeader, forceOtpForHttpHeader, defaultOutcome);
     }
 }

--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/ConditionalOtpFormAuthenticatorFactory.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/ConditionalOtpFormAuthenticatorFactory.java
@@ -110,14 +110,14 @@ public class ConditionalOtpFormAuthenticatorFactory implements AuthenticatorFact
         forceOtpRole.setLabel("Force OTP for Role");
         forceOtpRole.setHelpText("OTP is always required if user has the given Role.");
 
-        ProviderConfigProperty noOtpRequiredForHttpHeader = new ProviderConfigProperty();
-        noOtpRequiredForHttpHeader.setType(STRING_TYPE);
-        noOtpRequiredForHttpHeader.setName(NO_OTP_REQUIRED_FOR_HTTP_HEADER);
-        noOtpRequiredForHttpHeader.setLabel("No OTP for Header");
-        noOtpRequiredForHttpHeader.setHelpText("OTP required if a HTTP request header does not match the given pattern." +
+        ProviderConfigProperty skipOtpForHttpHeader = new ProviderConfigProperty();
+        skipOtpForHttpHeader.setType(STRING_TYPE);
+        skipOtpForHttpHeader.setName(SKIP_OTP_FOR_HTTP_HEADER);
+        skipOtpForHttpHeader.setLabel("Skip OTP for Header");
+        skipOtpForHttpHeader.setHelpText("OTP is skipped if a HTTP request header does matches the given pattern." +
                 "Can be used to specify trusted networks via: X-Forwarded-Host: (1.2.3.4|1.2.3.5)." +
                 "In this case requests from 1.2.3.4 and 1.2.3.5 come from a trusted source.");
-        noOtpRequiredForHttpHeader.setDefaultValue("");
+        skipOtpForHttpHeader.setDefaultValue("");
 
         ProviderConfigProperty forceOtpForHttpHeader = new ProviderConfigProperty();
         forceOtpForHttpHeader.setType(STRING_TYPE);
@@ -133,6 +133,6 @@ public class ConditionalOtpFormAuthenticatorFactory implements AuthenticatorFact
         defaultOutcome.setDefaultValue(asList(SKIP, FORCE));
         defaultOutcome.setHelpText("What to do in case of every check abstains. Defaults to force OTP authentication.");
 
-        return asList(forceOtpUserAttribute, skipOtpRole, forceOtpRole, noOtpRequiredForHttpHeader, forceOtpForHttpHeader, defaultOutcome);
+        return asList(forceOtpUserAttribute, skipOtpRole, forceOtpRole, skipOtpForHttpHeader, forceOtpForHttpHeader, defaultOutcome);
     }
 }


### PR DESCRIPTION
We now allow to specify a role to skip OTP.

Previously it was  not possible to specify that OTP authentication should be skipped if a role has a certain role. However the ConditionalOtpAuthenticator allowed to specify to show/skip OTP via a user attribute or HTTP request header pattern.
Having the "skip role" aligns the role based configuration options with the user attribute and HTTP request header configuration.
