### PR TITLE
Fixed typo in 22.2. Event Listener

### DIFF
--- a/docbook/auth-server-docs/reference/en/en-US/modules/events.xml
+++ b/docbook/auth-server-docs/reference/en/en-US/modules/events.xml
@@ -55,7 +55,7 @@
             You can exclude one or more events by editing <literal>standalone/configuration/keycloak-server.json</literal>
             and adding for example:
 <programlisting><![CDATA[
-"eventListener": {
+"eventsListener": {
     "email": {
         "exclude-events": [ "UPDATE_TOTP", "REMOVE_TOTP" ]
     }


### PR DESCRIPTION
While developing the JMS event listener I discovered a little but annoying typo in the documentation.
