### PR TITLE
KEYCLOAK-2329 - fix wrong resourcePath in AdminEvent after creating new IdentityProvider stored via JPA.

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/models/jpa/RealmAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/RealmAdapter.java
@@ -1324,6 +1324,8 @@ public class RealmAdapter implements RealmModel {
 
         realm.addIdentityProvider(entity);
 
+        identityProvider.setInternalId(entity.getInternalId());
+
         em.persist(entity);
         em.flush();
     }


### PR DESCRIPTION
We now propagate the generated internal id to the given IdentityProvider instance.
Previously if one creates a new IdentityProvider in a Realm with activated admin event listeners,
then a admin event is created that contains a resourcePath that ends with /null instead of /some-uuid.
