### PR TITLE
Only update user name and email attributes if they have changed.

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
@@ -70,6 +70,7 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import org.keycloak.models.UsernameLoginFailureModel;
@@ -207,9 +208,15 @@ public class UsersResource {
         if (realm.isEditUsernameAllowed()) {
             user.setUsername(rep.getUsername());
         }
-        user.setEmail(rep.getEmail());
-        user.setFirstName(rep.getFirstName());
-        user.setLastName(rep.getLastName());
+        if (!Objects.equals(user.getEmail(), rep.getEmail())) {
+            user.setEmail(rep.getEmail());
+        }
+        if (!Objects.equals(user.getFirstName(), rep.getFirstName())) {
+            user.setFirstName(rep.getFirstName());
+        }
+        if (!Objects.equals(user.getLastName(), rep.getLastName())) {
+            user.setLastName(rep.getLastName());
+        }
 
         if (rep.isEnabled() != null) user.setEnabled(rep.isEnabled());
         if (rep.isTotp() != null) user.setOtpEnabled(rep.isTotp());


### PR DESCRIPTION
Recently was testing to verify that a provider disallowed first/last name editing.  However, when the first or last name was changed, I received an error message about how the email address cannot be changed (which my provider also disallowed).  Since this can be confusing to users, updated the code to only attempt to update these fields when they've changed.

Used the Java 7 objects class - figured it was safe, but couldn't find a source/target compile version to validate in poms.  Let me know if you're targeting a lower compatibility and I'll update to match.
