### PR TITLE
Client UI fix

### DIFF
--- a/themes/src/main/resources/theme/base/admin/resources/js/controllers/clients.js
+++ b/themes/src/main/resources/theme/base/admin/resources/js/controllers/clients.js
@@ -738,8 +738,7 @@ module.controller('ClientDetailCtrl', function($scope, realm, client, templates,
         "bearer-only"
     ];
 
-    $scope.protocols = ['openid-connect',
-                        'saml'];//Object.keys(serverInfo.providers['login-protocol'].providers).sort();
+    $scope.protocols = Object.keys(serverInfo.providers['login-protocol'].providers).sort();
 
     $scope.templates = [ {name:'NONE'}];
     for (var i = 0; i < templates.length; i++) {
@@ -2125,10 +2124,3 @@ module.controller('ClientTemplateScopeMappingCtrl', function($scope, $http, real
 
     updateTemplateRealmRoles();
 });
-
-
-
-
-
-
-


### PR DESCRIPTION
At the moment, custom login protocols are not selectable in the client edit view in the admin console. This PR restores the commented out code to resolve this issue.
