### PR TITLE
KEYCLOAK-2315 Remove jboss-earlyaccess-repository repository

### DIFF
--- a/adapters/oidc/as7-eap6/as7-subsystem/src/main/java/org/keycloak/subsystem/as7/KeycloakAdapterConfigService.java
+++ b/adapters/oidc/as7-eap6/as7-subsystem/src/main/java/org/keycloak/subsystem/as7/KeycloakAdapterConfigService.java
@@ -85,7 +85,7 @@ public final class KeycloakAdapterConfigService {
         }
 
         String credentialName = credentialNameFromOp(operation);
-        if (!credentialName.contains("")) {
+        if (!credentialName.contains(".")) {
             credentials.get(credentialName).set(model.get("value").asString());
         } else {
             String[] parts = credentialName.split("\\.");

--- a/adapters/saml/as7-eap6/subsystem/src/main/java/org/keycloak/subsystem/saml/as7/IdentityProviderAddHandler.java
+++ b/adapters/saml/as7-eap6/subsystem/src/main/java/org/keycloak/subsystem/saml/as7/IdentityProviderAddHandler.java
@@ -17,6 +17,7 @@
 package org.keycloak.subsystem.saml.as7;
 
 import org.jboss.as.controller.AbstractAddStepHandler;
+import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.ServiceVerificationHandler;
@@ -31,11 +32,17 @@ import java.util.List;
 class IdentityProviderAddHandler extends AbstractAddStepHandler {
 
     IdentityProviderAddHandler() {
-        super(IdentityProviderDefinition.ALL_ATTRIBUTES);
     }
 
     @Override
     protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model, ServiceVerificationHandler verificationHandler, List<ServiceController<?>> newControllers) throws OperationFailedException {
         Configuration.INSTANCE.updateModel(operation, model);
+    }
+
+    @Override
+    protected void populateModel(ModelNode operation, ModelNode model) throws OperationFailedException {
+        for (AttributeDefinition attr : IdentityProviderDefinition.ALL_ATTRIBUTES) {
+            attr.validateAndSet(operation, model);
+        }
     }
 }

--- a/adapters/saml/as7-eap6/subsystem/src/main/java/org/keycloak/subsystem/saml/as7/KeyAddHandler.java
+++ b/adapters/saml/as7-eap6/subsystem/src/main/java/org/keycloak/subsystem/saml/as7/KeyAddHandler.java
@@ -17,6 +17,7 @@
 package org.keycloak.subsystem.saml.as7;
 
 import org.jboss.as.controller.AbstractAddStepHandler;
+import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.ServiceVerificationHandler;
@@ -31,11 +32,17 @@ import java.util.List;
 class KeyAddHandler extends AbstractAddStepHandler {
 
     KeyAddHandler() {
-        super(KeyDefinition.ALL_ATTRIBUTES);
     }
 
     @Override
     protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model, ServiceVerificationHandler verificationHandler, List<ServiceController<?>> newControllers) throws OperationFailedException {
         Configuration.INSTANCE.updateModel(operation, model);
+    }
+
+    @Override
+    protected void populateModel(ModelNode operation, ModelNode model) throws OperationFailedException {
+        for (AttributeDefinition attr : KeyDefinition.ALL_ATTRIBUTES) {
+            attr.validateAndSet(operation, model);
+        }
     }
 }

--- a/adapters/saml/as7-eap6/subsystem/src/main/java/org/keycloak/subsystem/saml/as7/KeycloakSubsystemAdd.java
+++ b/adapters/saml/as7-eap6/subsystem/src/main/java/org/keycloak/subsystem/saml/as7/KeycloakSubsystemAdd.java
@@ -18,6 +18,7 @@ package org.keycloak.subsystem.saml.as7;
 
 import org.jboss.as.controller.AbstractBoottimeAddStepHandler;
 import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.ServiceVerificationHandler;
 import org.jboss.as.server.AbstractDeploymentChainStep;
 import org.jboss.as.server.DeploymentProcessorTarget;
@@ -57,5 +58,9 @@ class KeycloakSubsystemAdd extends AbstractBoottimeAddStepHandler {
 
     private DeploymentUnitProcessor chooseConfigDeploymentProcessor() {
         return new KeycloakAdapterConfigDeploymentProcessor();
+    }
+
+    @Override
+    protected void populateModel(ModelNode operation, ModelNode model) throws OperationFailedException {
     }
 }

--- a/adapters/saml/as7-eap6/subsystem/src/main/java/org/keycloak/subsystem/saml/as7/KeycloakSubsystemParser.java
+++ b/adapters/saml/as7-eap6/subsystem/src/main/java/org/keycloak/subsystem/saml/as7/KeycloakSubsystemParser.java
@@ -32,11 +32,11 @@ import org.jboss.staxmapper.XMLExtendedStreamWriter;
 
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 
 /**
  * The subsystem parser, which uses stax to read and write to and from xml
@@ -265,7 +265,7 @@ class KeycloakSubsystemParser implements XMLStreamConstants, XMLElementReader<Li
             throw new XMLStreamException("KeyStore element must have 'file' or 'resource' attribute set", reader.getLocation());
         }
         if (!addKeyStore.hasDefined(Constants.Model.PASSWORD)) {
-            throw ParseUtils.missingRequired(reader, Constants.XML.PASSWORD);
+            throw ParseUtils.missingRequired(reader, asSet(Constants.XML.PASSWORD));
         }
 
         while (reader.hasNext() && nextTag(reader) != END_ELEMENT) {
@@ -294,10 +294,10 @@ class KeycloakSubsystemParser implements XMLStreamConstants, XMLElementReader<Li
         }
 
         if (!addKeyStore.hasDefined(Constants.Model.PRIVATE_KEY_ALIAS)) {
-            throw ParseUtils.missingRequired(reader, Constants.XML.PRIVATE_KEY_ALIAS);
+            throw ParseUtils.missingRequired(reader, asSet(Constants.XML.PRIVATE_KEY_ALIAS));
         }
         if (!addKeyStore.hasDefined(Constants.Model.PRIVATE_KEY_PASSWORD)) {
-            throw ParseUtils.missingRequired(reader, Constants.XML.PRIVATE_KEY_PASSWORD);
+            throw ParseUtils.missingRequired(reader, asSet(Constants.XML.PRIVATE_KEY_PASSWORD));
         }
 
         ParseUtils.requireNoContent(reader);
@@ -316,7 +316,7 @@ class KeycloakSubsystemParser implements XMLStreamConstants, XMLElementReader<Li
         }
 
         if (!addKeyStore.hasDefined(Constants.Model.CERTIFICATE_ALIAS)) {
-            throw ParseUtils.missingRequired(reader, Constants.XML.CERTIFICATE_ALIAS);
+            throw ParseUtils.missingRequired(reader, asSet(Constants.XML.CERTIFICATE_ALIAS));
         }
 
         ParseUtils.requireNoContent(reader);
@@ -358,7 +358,7 @@ class KeycloakSubsystemParser implements XMLStreamConstants, XMLElementReader<Li
         }
 
         if (!policySet) {
-            throw ParseUtils.missingRequired(reader, Constants.XML.PRINCIPAL_NAME_MAPPING_POLICY);
+            throw ParseUtils.missingRequired(reader, asSet(Constants.XML.PRINCIPAL_NAME_MAPPING_POLICY));
         }
         ParseUtils.requireNoContent(reader);
     }
@@ -565,5 +565,14 @@ class KeycloakSubsystemParser implements XMLStreamConstants, XMLElementReader<Li
             writer.writeAttribute(Constants.XML.PRINCIPAL_NAME_MAPPING_ATTRIBUTE_NAME, value.asString());
         }
         writer.writeEndElement();
+    }
+
+
+    private static Set<String> asSet(String ... values) {
+        HashSet ret = new HashSet();
+        for (String value: values) {
+            ret.add(value);
+        }
+        return ret;
     }
 }

--- a/adapters/saml/as7-eap6/subsystem/src/main/java/org/keycloak/subsystem/saml/as7/SecureDeploymentAddHandler.java
+++ b/adapters/saml/as7-eap6/subsystem/src/main/java/org/keycloak/subsystem/saml/as7/SecureDeploymentAddHandler.java
@@ -39,4 +39,8 @@ class SecureDeploymentAddHandler extends AbstractAddStepHandler {
     protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model, ServiceVerificationHandler verificationHandler, List<ServiceController<?>> newControllers) throws OperationFailedException {
         Configuration.INSTANCE.updateModel(operation, model);
     }
+
+    @Override
+    protected void populateModel(ModelNode operation, ModelNode model) throws OperationFailedException {
+    }
 }

--- a/adapters/saml/as7-eap6/subsystem/src/main/java/org/keycloak/subsystem/saml/as7/ServiceProviderAddHandler.java
+++ b/adapters/saml/as7-eap6/subsystem/src/main/java/org/keycloak/subsystem/saml/as7/ServiceProviderAddHandler.java
@@ -17,6 +17,7 @@
 package org.keycloak.subsystem.saml.as7;
 
 import org.jboss.as.controller.AbstractAddStepHandler;
+import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.ServiceVerificationHandler;
@@ -33,11 +34,17 @@ class ServiceProviderAddHandler extends AbstractAddStepHandler {
     static final ServiceProviderAddHandler INSTANCE = new ServiceProviderAddHandler();
 
     ServiceProviderAddHandler() {
-        super(ServiceProviderDefinition.ALL_ATTRIBUTES);
     }
 
     @Override
     protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model, ServiceVerificationHandler verificationHandler, List<ServiceController<?>> newControllers) throws OperationFailedException {
         Configuration.INSTANCE.updateModel(operation, model);
+    }
+
+    @Override
+    protected void populateModel(ModelNode operation, ModelNode model) throws OperationFailedException {
+        for (AttributeDefinition attr : ServiceProviderDefinition.ALL_ATTRIBUTES) {
+            attr.validateAndSet(operation, model);
+        }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -55,8 +55,7 @@
 
         <eap.version>7.0.0.Beta</eap.version>
 
-        <!-- this is EAP 6.4 alpha, publicly available -->
-        <jboss.version>7.5.0.Final-redhat-15</jboss.version>
+        <jboss.version>7.2.0.Final</jboss.version>
 
         <servlet.api.30.version>1.0.2.Final</servlet.api.30.version>
         <google.zxing.version>3.2.1</google.zxing.version>
@@ -1331,40 +1330,6 @@
                     </plugin>
                 </plugins>
             </build>
-        </profile>
-
-        <!-- Configure the JBoss Early Access Maven repository -->
-        <profile>
-            <id>jboss-earlyaccess-repository</id>
-            <activation>
-                <property>
-                    <name>!no-jboss-ea-repo</name>
-                </property>
-            </activation>
-            <repositories>
-                <repository>
-                    <id>jboss-earlyaccess-repository</id>
-                    <url>http://maven.repository.redhat.com/earlyaccess/all/</url>
-                    <releases>
-                        <enabled>true</enabled>
-                    </releases>
-                    <snapshots>
-                        <enabled>false</enabled>
-                    </snapshots>
-                </repository>
-            </repositories>
-            <pluginRepositories>
-                <pluginRepository>
-                    <id>jboss-earlyaccess-plugin-repository</id>
-                    <url>http://maven.repository.redhat.com/earlyaccess/all/</url>
-                    <releases>
-                        <enabled>true</enabled>
-                    </releases>
-                    <snapshots>
-                        <enabled>false</enabled>
-                    </snapshots>
-                </pluginRepository>
-            </pluginRepositories>
         </profile>
     </profiles>
 </project>


### PR DESCRIPTION
EAP6 / AS7 subsystems now only use JBossAS 7.2.0 compatible APIs, we can thus build it all using Maven Central.

RedHat Early Access Repository is still available on demand - by using -Djboss-ea-repo - in that case EAP 6.4 Alpha version is used as dependency during build.
