### PR TITLE
Brute force detector active for non-existing accounts

### DIFF
--- a/testsuite/integration/src/test/java/org/keycloak/testsuite/forms/BruteForceTest.java
+++ b/testsuite/integration/src/test/java/org/keycloak/testsuite/forms/BruteForceTest.java
@@ -41,6 +41,7 @@ import org.keycloak.testsuite.pages.AppPage;
 import org.keycloak.testsuite.pages.AppPage.RequestType;
 import org.keycloak.testsuite.pages.LoginPage;
 import org.keycloak.testsuite.pages.LoginTotpPage;
+import org.keycloak.testsuite.pages.RegisterPage;
 import org.keycloak.testsuite.rule.GreenMailRule;
 import org.keycloak.testsuite.rule.KeycloakRule;
 import org.keycloak.testsuite.rule.KeycloakRule.KeycloakSetup;
@@ -102,11 +103,13 @@ public class BruteForceTest {
     protected LoginPage loginPage;
 
     @WebResource
+    private RegisterPage registerPage;
+
+    @WebResource
     protected LoginTotpPage loginTotpPage;
 
     @WebResource
     protected OAuthClient oauth;
-
 
     private TimeBasedOTP totp = new TimeBasedOTP();
 
@@ -340,6 +343,17 @@ public class BruteForceTest {
         loginSuccess();
     }
 
+    @Test
+    public void testNonExistingAccounts() throws Exception {
+
+        loginInvalidPassword("non-existent-user");
+        loginInvalidPassword("non-existent-user");
+        loginInvalidPassword("non-existent-user");
+
+        registerUser("non-existent-user");
+
+    }
+
     public void expectTemporarilyDisabled() throws Exception {
         expectTemporarilyDisabled("test-user@localhost");
     }
@@ -427,6 +441,18 @@ public class BruteForceTest {
         loginPage.assertCurrent();
 
         Assert.assertEquals("Invalid username or password.", loginPage.getError());
+        events.clear();
+    }
+
+    public void registerUser(String username){
+        loginPage.open();
+        loginPage.clickRegister();
+        registerPage.assertCurrent();
+
+        registerPage.register("user", "name",  username + "@localhost", username, "password", "password");
+
+        Assert.assertNull(registerPage.getInstruction());
+
         events.clear();
     }
 

--- a/testsuite/integration/src/test/java/org/keycloak/testsuite/pages/RegisterPage.java
+++ b/testsuite/integration/src/test/java/org/keycloak/testsuite/pages/RegisterPage.java
@@ -57,6 +57,10 @@ public class RegisterPage extends AbstractPage {
     @FindBy(className = "alert-error")
     private WebElement loginErrorMessage;
 
+    @FindBy(className = "instruction")
+    private WebElement loginInstructionMessage;
+
+
     public void register(String firstName, String lastName, String email, String username, String password, String passwordConfirm) {
         firstNameInput.clear();
         if (firstName != null) {
@@ -129,6 +133,15 @@ public class RegisterPage extends AbstractPage {
 
     public String getError() {
         return loginErrorMessage != null ? loginErrorMessage.getText() : null;
+    }
+
+    public String getInstruction() {
+        try {
+            return loginInstructionMessage != null ? loginInstructionMessage.getText() : null;
+        } catch (NoSuchElementException e){
+            // OK
+        }
+        return null;
     }
 
     public String getFirstName() {


### PR DESCRIPTION
There we go, the integration tests should fail against master and just pass with this PR.

Not sure what do you think, but I think we could replace in the future `instructions` by `error` here  https://github.com/keycloak/keycloak/pull/2122/files#diff-cd052d6d01968545c299f849d004b4c6R60
