### PR TITLE
squid:LowerCaseLongSuffixCheck - Long suffix "L" should be upper case

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/federation/ldap/mappers/msad/UserAccountControl.java
+++ b/federation/ldap/src/main/java/org/keycloak/federation/ldap/mappers/msad/UserAccountControl.java
@@ -7,28 +7,28 @@ package org.keycloak.federation.ldap.mappers.msad;
  */
 public class UserAccountControl {
 
-    public static final long SCRIPT = 0x0001l;
-    public static final long ACCOUNTDISABLE = 0x0002l;
-    public static final long HOMEDIR_REQUIRED = 0x0008l;
-    public static final long LOCKOUT = 0x0010l;
-    public static final long PASSWD_NOTREQD = 0x0020l;
-    public static final long PASSWD_CANT_CHANGE = 0x0040l;
-    public static final long ENCRYPTED_TEXT_PWD_ALLOWED = 0x0080l;
-    public static final long TEMP_DUPLICATE_ACCOUNT = 0x0100l;
-    public static final long NORMAL_ACCOUNT = 0x0200l;
-    public static final long INTERDOMAIN_TRUST_ACCOUNT = 0x0800l;
-    public static final long WORKSTATION_TRUST_ACCOUNT = 0x1000l;
-    public static final long SERVER_TRUST_ACCOUNT = 0x2000l;
-    public static final long DONT_EXPIRE_PASSWORD = 0x10000l;
-    public static final long MNS_LOGON_ACCOUNT = 0x20000l;
-    public static final long SMARTCARD_REQUIRED = 0x40000l;
-    public static final long TRUSTED_FOR_DELEGATION = 0x80000l;
-    public static final long NOT_DELEGATED = 0x100000l;
-    public static final long USE_DES_KEY_ONLY = 0x200000l;
-    public static final long DONT_REQ_PREAUTH = 0x400000l;
-    public static final long PASSWORD_EXPIRED = 0x800000l;
-    public static final long TRUSTED_TO_AUTH_FOR_DELEGATION = 0x1000000l;
-    public static final long PARTIAL_SECRETS_ACCOUNT = 0x04000000l;
+    public static final long SCRIPT = 0x0001L;
+    public static final long ACCOUNTDISABLE = 0x0002L;
+    public static final long HOMEDIR_REQUIRED = 0x0008L;
+    public static final long LOCKOUT = 0x0010L;
+    public static final long PASSWD_NOTREQD = 0x0020L;
+    public static final long PASSWD_CANT_CHANGE = 0x0040L;
+    public static final long ENCRYPTED_TEXT_PWD_ALLOWED = 0x0080L;
+    public static final long TEMP_DUPLICATE_ACCOUNT = 0x0100L;
+    public static final long NORMAL_ACCOUNT = 0x0200L;
+    public static final long INTERDOMAIN_TRUST_ACCOUNT = 0x0800L;
+    public static final long WORKSTATION_TRUST_ACCOUNT = 0x1000L;
+    public static final long SERVER_TRUST_ACCOUNT = 0x2000L;
+    public static final long DONT_EXPIRE_PASSWORD = 0x10000L;
+    public static final long MNS_LOGON_ACCOUNT = 0x20000L;
+    public static final long SMARTCARD_REQUIRED = 0x40000L;
+    public static final long TRUSTED_FOR_DELEGATION = 0x80000L;
+    public static final long NOT_DELEGATED = 0x100000L;
+    public static final long USE_DES_KEY_ONLY = 0x200000L;
+    public static final long DONT_REQ_PREAUTH = 0x400000L;
+    public static final long PASSWORD_EXPIRED = 0x800000L;
+    public static final long TRUSTED_TO_AUTH_FOR_DELEGATION = 0x1000000L;
+    public static final long PARTIAL_SECRETS_ACCOUNT = 0x04000000L;
 
     private long value;
 

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/RealmAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/RealmAdapter.java
@@ -264,7 +264,7 @@ public class RealmAdapter implements RealmModel {
 
     @Override
     public long getQuickLoginCheckMilliSeconds() {
-        return getAttribute("quickLoginCheckMilliSeconds", 0l);
+        return getAttribute("quickLoginCheckMilliSeconds", 0L);
     }
 
     @Override

--- a/server-spi/src/main/java/org/keycloak/models/ClaimMask.java
+++ b/server-spi/src/main/java/org/keycloak/models/ClaimMask.java
@@ -5,16 +5,16 @@ package org.keycloak.models;
  * @version $Revision: 1 $
  */
 public class ClaimMask {
-    public static final long NAME = 0x01l;
-    public static final long USERNAME = 0x02l;
-    public static final long PROFILE = 0x04l;
-    public static final long PICTURE = 0x08l;
-    public static final long WEBSITE = 0x10l;
-    public static final long EMAIL = 0x20l;
-    public static final long GENDER = 0x40l;
-    public static final long LOCALE = 0x80l;
-    public static final long ADDRESS = 0x100l;
-    public static final long PHONE = 0x200l;
+    public static final long NAME = 0x01L;
+    public static final long USERNAME = 0x02L;
+    public static final long PROFILE = 0x04L;
+    public static final long PICTURE = 0x08L;
+    public static final long WEBSITE = 0x10L;
+    public static final long EMAIL = 0x20L;
+    public static final long GENDER = 0x40L;
+    public static final long LOCALE = 0x80L;
+    public static final long ADDRESS = 0x100L;
+    public static final long PHONE = 0x200L;
 
     public static final long ALL = NAME | USERNAME | PROFILE | PICTURE | WEBSITE | EMAIL | GENDER | LOCALE | ADDRESS | PHONE;
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:LowerCaseLongSuffixCheck - Long suffix "L" should be upper case.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3ALowerCaseLongSuffixCheck
Please let me know if you have any questions.
George Kankava
