### PR TITLE
squid:S1125 - Literal boolean values should not be used in condition expressions

### DIFF
--- a/adapters/oidc/as7-eap6/as7-adapter-spi/src/main/java/org/keycloak/adapters/jbossweb/JBossWebPrincipalFactory.java
+++ b/adapters/oidc/as7-eap6/as7-adapter-spi/src/main/java/org/keycloak/adapters/jbossweb/JBossWebPrincipalFactory.java
@@ -125,7 +125,7 @@ public class JBossWebPrincipalFactory extends GenericPrincipalFactory {
         Iterator<Principal> iter = principals.iterator();
         while (iter.hasNext()) {
             Object next = iter.next();
-            if ((next instanceof Group) == false)
+            if (!(next instanceof Group))
                 continue;
             Group grp = (Group) next;
             if (grp.getName().equals(name)) {

--- a/adapters/oidc/jetty/jetty9.1/src/main/java/org/keycloak/adapters/jetty/Jetty91RequestAuthenticator.java
+++ b/adapters/oidc/jetty/jetty9.1/src/main/java/org/keycloak/adapters/jetty/Jetty91RequestAuthenticator.java
@@ -24,7 +24,7 @@ public class Jetty91RequestAuthenticator extends JettyRequestAuthenticator {
         if (session == null) {
             return request.getSession(true).getId();
         }
-        if (deployment.isTurnOffChangeSessionIdOnLogin() == false) return request.changeSessionId();
+        if (!deployment.isTurnOffChangeSessionIdOnLogin()) return request.changeSessionId();
         else return session.getId();
     }
 }

--- a/adapters/oidc/jetty/jetty9.2/src/main/java/org/keycloak/adapters/jetty/Jetty92RequestAuthenticator.java
+++ b/adapters/oidc/jetty/jetty9.2/src/main/java/org/keycloak/adapters/jetty/Jetty92RequestAuthenticator.java
@@ -24,7 +24,7 @@ public class Jetty92RequestAuthenticator extends JettyRequestAuthenticator {
         if (session == null) {
             return request.getSession(true).getId();
         }
-        if (deployment.isTurnOffChangeSessionIdOnLogin() == false) return request.changeSessionId();
+        if (!deployment.isTurnOffChangeSessionIdOnLogin()) return request.changeSessionId();
         else return session.getId();
     }
 }

--- a/adapters/oidc/tomcat/tomcat8/src/main/java/org/keycloak/adapters/tomcat/Tomcat8RequestAuthenticator.java
+++ b/adapters/oidc/tomcat/tomcat8/src/main/java/org/keycloak/adapters/tomcat/Tomcat8RequestAuthenticator.java
@@ -22,7 +22,7 @@ public class Tomcat8RequestAuthenticator extends CatalinaRequestAuthenticator {
         if (session == null) {
             return request.getSession(true).getId();
         }
-        if (deployment.isTurnOffChangeSessionIdOnLogin() == false) return request.changeSessionId();
+        if (!deployment.isTurnOffChangeSessionIdOnLogin()) return request.changeSessionId();
         else return session.getId();
     }
 }

--- a/adapters/oidc/undertow/src/main/java/org/keycloak/adapters/undertow/ServletRequestAuthenticator.java
+++ b/adapters/oidc/undertow/src/main/java/org/keycloak/adapters/undertow/ServletRequestAuthenticator.java
@@ -64,7 +64,7 @@ public class ServletRequestAuthenticator extends AbstractUndertowRequestAuthenti
 
     @Override
     protected String changeHttpSessionId(boolean create) {
-        if (deployment.isTurnOffChangeSessionIdOnLogin() == false) return ChangeSessionId.changeSessionId(exchange, create);
+        if (!deployment.isTurnOffChangeSessionIdOnLogin()) return ChangeSessionId.changeSessionId(exchange, create);
         else return getHttpSessionId(create);
     }
 

--- a/adapters/oidc/wildfly/wildfly-adapter/src/main/java/org/keycloak/adapters/wildfly/SecurityInfoHelper.java
+++ b/adapters/oidc/wildfly/wildfly-adapter/src/main/java/org/keycloak/adapters/wildfly/SecurityInfoHelper.java
@@ -89,7 +89,7 @@ public class SecurityInfoHelper {
         Iterator<Principal> iter = principals.iterator();
         while (iter.hasNext()) {
             Object next = iter.next();
-            if ((next instanceof Group) == false)
+            if (!(next instanceof Group))
                 continue;
             Group grp = (Group) next;
             if (grp.getName().equals(name)) {

--- a/adapters/oidc/wildfly/wildfly-adapter/src/main/java/org/keycloak/adapters/wildfly/WildflyRequestAuthenticator.java
+++ b/adapters/oidc/wildfly/wildfly-adapter/src/main/java/org/keycloak/adapters/wildfly/WildflyRequestAuthenticator.java
@@ -108,7 +108,7 @@ public class WildflyRequestAuthenticator extends ServletRequestAuthenticator {
         Iterator<Principal> iter = principals.iterator();
         while (iter.hasNext()) {
             Object next = iter.next();
-            if ((next instanceof Group) == false)
+            if (!(next instanceof Group))
                 continue;
             Group grp = (Group) next;
             if (grp.getName().equals(name)) {

--- a/adapters/saml/jetty/jetty9.1/src/main/java/org/keycloak/adapters/saml/jetty/Jetty9SamlSessionStore.java
+++ b/adapters/saml/jetty/jetty9.1/src/main/java/org/keycloak/adapters/saml/jetty/Jetty9SamlSessionStore.java
@@ -21,7 +21,7 @@ public class Jetty9SamlSessionStore extends JettySamlSessionStore {
     @Override
     protected String changeSessionId(HttpSession session) {
         Request request = this.request;
-        if (deployment.turnOffChangeSessionIdOnLogin() == false) return request.changeSessionId();
+        if (!deployment.turnOffChangeSessionIdOnLogin()) return request.changeSessionId();
         else return session.getId();
     }
 }

--- a/adapters/saml/jetty/jetty9.2/src/main/java/org/keycloak/adapters/saml/jetty/Jetty9SamlSessionStore.java
+++ b/adapters/saml/jetty/jetty9.2/src/main/java/org/keycloak/adapters/saml/jetty/Jetty9SamlSessionStore.java
@@ -21,7 +21,7 @@ public class Jetty9SamlSessionStore extends JettySamlSessionStore {
     @Override
     protected String changeSessionId(HttpSession session) {
         Request request = this.request;
-        if (deployment.turnOffChangeSessionIdOnLogin() == false) return request.changeSessionId();
+        if (!deployment.turnOffChangeSessionIdOnLogin()) return request.changeSessionId();
         else return session.getId();
     }
 }

--- a/adapters/saml/tomcat/tomcat8/src/main/java/org/keycloak/adapters/saml/tomcat/Tomcat8SamlSessionStore.java
+++ b/adapters/saml/tomcat/tomcat8/src/main/java/org/keycloak/adapters/saml/tomcat/Tomcat8SamlSessionStore.java
@@ -22,7 +22,7 @@ public class Tomcat8SamlSessionStore extends CatalinaSamlSessionStore {
     @Override
     protected String changeSessionId(Session session) {
         Request request = this.request;
-        if (deployment.turnOffChangeSessionIdOnLogin() == false) return request.changeSessionId();
+        if (!deployment.turnOffChangeSessionIdOnLogin()) return request.changeSessionId();
         else return session.getId();
     }
 }

--- a/adapters/saml/undertow/src/main/java/org/keycloak/adapters/saml/undertow/ServletSamlSessionStore.java
+++ b/adapters/saml/undertow/src/main/java/org/keycloak/adapters/saml/undertow/ServletSamlSessionStore.java
@@ -165,7 +165,7 @@ public class ServletSamlSessionStore implements SamlSessionStore {
     }
 
     protected String changeSessionId(HttpSession session) {
-        if (deployment.turnOffChangeSessionIdOnLogin() == false) return ChangeSessionId.changeSessionId(exchange, false);
+        if (!deployment.turnOffChangeSessionIdOnLogin()) return ChangeSessionId.changeSessionId(exchange, false);
         else return session.getId();
     }
 

--- a/adapters/saml/wildfly/wildfly-adapter/src/main/java/org/keycloak/adapters/saml/wildfly/SecurityInfoHelper.java
+++ b/adapters/saml/wildfly/wildfly-adapter/src/main/java/org/keycloak/adapters/saml/wildfly/SecurityInfoHelper.java
@@ -89,7 +89,7 @@ public class SecurityInfoHelper {
         Iterator<Principal> iter = principals.iterator();
         while (iter.hasNext()) {
             Object next = iter.next();
-            if ((next instanceof Group) == false)
+            if (!(next instanceof Group))
                 continue;
             Group grp = (Group) next;
             if (grp.getName().equals(name)) {

--- a/adapters/spi/jboss-adapter-core/src/main/java/org/keycloak/adapters/jboss/KeycloakLoginModule.java
+++ b/adapters/spi/jboss-adapter-core/src/main/java/org/keycloak/adapters/jboss/KeycloakLoginModule.java
@@ -30,7 +30,7 @@ public class KeycloakLoginModule extends AbstractServerLoginModule {
     @Override
     public boolean login() throws LoginException {
         log.debug("KeycloakLoginModule.login()");
-        if (super.login() == true) {
+        if (super.login()) {
             log.debug("super.login()==true");
             return true;
         }

--- a/adapters/spi/tomcat-adapter-spi/src/main/java/org/keycloak/adapters/tomcat/GenericPrincipalFactory.java
+++ b/adapters/spi/tomcat-adapter-spi/src/main/java/org/keycloak/adapters/tomcat/GenericPrincipalFactory.java
@@ -81,7 +81,7 @@ public abstract class GenericPrincipalFactory {
         Iterator<Principal> iter = principals.iterator();
         while (iter.hasNext()) {
             Object next = iter.next();
-            if ((next instanceof Group) == false)
+            if (!(next instanceof Group))
                 continue;
             Group grp = (Group) next;
             if (grp.getName().equals(name)) {

--- a/common/src/main/java/org/keycloak/common/util/StringPropertyReplacer.java
+++ b/common/src/main/java/org/keycloak/common/util/StringPropertyReplacer.java
@@ -207,7 +207,7 @@ public final class StringPropertyReplacer
         }
 
         // No properties
-        if (properties == false)
+        if (!properties)
             return string;
 
         // Collect the trailing characters

--- a/saml-core/src/main/java/org/keycloak/saml/common/util/StringUtil.java
+++ b/saml-core/src/main/java/org/keycloak/saml/common/util/StringUtil.java
@@ -130,7 +130,7 @@ public class StringUtil {
      * @param second
      */
     public static void match(String first, String second) {
-        if (first.equals(second) == false)
+        if (!first.equals(second))
             throw logger.notEqualError(first, second);
     }
 

--- a/saml-core/src/main/java/org/keycloak/saml/common/util/TransformerUtil.java
+++ b/saml-core/src/main/java/org/keycloak/saml/common/util/TransformerUtil.java
@@ -191,7 +191,7 @@ public class TransformerUtil {
         public void transform(Source xmlSource, Result outputTarget) throws TransformerException {
             if (!(xmlSource instanceof StAXSource))
                 throw logger.wrongTypeError("xmlSource should be a stax source");
-            if (outputTarget instanceof DOMResult == false)
+            if (!(outputTarget instanceof DOMResult))
                 throw logger.wrongTypeError("outputTarget should be a dom result");
 
             String rootTag = null;
@@ -208,7 +208,7 @@ public class TransformerUtil {
 
             try {
                 XMLEvent xmlEvent = StaxParserUtil.getNextEvent(xmlEventReader);
-                if (xmlEvent instanceof StartElement == false)
+                if (!(xmlEvent instanceof StartElement))
                     throw new TransformerException(ErrorCodes.WRITER_SHOULD_START_ELEMENT);
 
                 StartElement rootElement = (StartElement) xmlEvent;

--- a/saml-core/src/main/java/org/keycloak/saml/processing/core/saml/v2/util/StatementUtil.java
+++ b/saml-core/src/main/java/org/keycloak/saml/processing/core/saml/v2/util/StatementUtil.java
@@ -167,7 +167,7 @@ public class StatementUtil {
      * @return
      */
     public static AttributeStatementType createAttributeStatementForRoles(List<String> roles, boolean multivalued) {
-        if (multivalued == false) {
+        if (!multivalued) {
             return createAttributeStatement(roles);
         }
         AttributeStatementType attrStatement = new AttributeStatementType();

--- a/saml-core/src/main/java/org/keycloak/saml/processing/core/util/JAXPValidationUtil.java
+++ b/saml-core/src/main/java/org/keycloak/saml/processing/core/util/JAXPValidationUtil.java
@@ -136,7 +136,7 @@ public class JAXPValidationUtil {
 
         public void error(SAXParseException ex) throws SAXException {
             logException(ex);
-            if (ex.getMessage().contains("null") == false) {
+            if (!ex.getMessage().contains("null")) {
                 throw ex;
             }
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1125 - Literal boolean values should not be used in condition expressions.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1125
Please let me know if you have any questions.
George Kankava
