### PR TITLE
KEYCLOAK-2433

### DIFF
--- a/distribution/feature-packs/server-feature-pack/src/main/resources/modules/system/layers/base/org/keycloak/keycloak-server-spi/main/module.xml
+++ b/distribution/feature-packs/server-feature-pack/src/main/resources/modules/system/layers/base/org/keycloak/keycloak-server-spi/main/module.xml
@@ -29,6 +29,7 @@
         <module name="org.keycloak.keycloak-core"/>
         <module name="org.bouncycastle" />
         <module name="javax.api"/>
+        <module name="javax.ws.rs.api"/>
         <module name="org.apache.httpcomponents"/>
     </dependencies>
 


### PR DESCRIPTION
ClassNotFoundException: javax.ws.rs.core.Response from Module 'org.keycloak.keycloak-server-spi:main'
