### PR TITLE
Fix the documentation mismatch at basic auth

### DIFF
--- a/examples/basic-auth/README.md
+++ b/examples/basic-auth/README.md
@@ -21,8 +21,8 @@ Step 2: Deploy and run the example
 - Open a command window and perform the following command:
 
     curl http://admin:password@localhost:8080/basicauth/service/echo?value=hello
-	
-(If we navigate directly to http://localhost:8080/basicauth/service/echo?value=hello, we get "Invalid parameter: redirect_uri" error due to missing Valid Redirect URI in realm).
+
+(If we navigate directly to http://localhost:8080/basicauth/service/echo?value=hello, we get "Client is not allowed to initiate browser login with given response_type. Standard flow is disabled for the client.").
 
 This should result in the value 'hello' being returned as a response.
 


### PR DESCRIPTION
I just found a documentation mismatch while testing the examples with Basic.
