### PR TITLE
Server Cache documentation is out of date

### DIFF
--- a/docbook/auth-server-docs/reference/en/en-US/modules/cache.xml
+++ b/docbook/auth-server-docs/reference/en/en-US/modules/cache.xml
@@ -25,61 +25,46 @@
     <section>
         <title>Disabling Caches</title>
         <para>
-            The realm and user caches can be disabled through configuration or through the management console.  To
-            manally disable the realm or user cache, you must edit the <literal>keycloak-server.json</literal> file
+            The realm and user caches can be cleared through the management console.  To
+            disable the realm or user cache, you must edit the <literal>keycloak-server.json</literal> file
             in your distribution.  Here's what the config looks like initially.
         </para>
         <para>
             <programlisting><![CDATA[
-    "realmCache": {
-        "provider": "${keycloak.realm.cache.provider:mem}"
+    "userCache": {
+        "infinispan" : {
+            "enabled": true
+        }
     },
 
-    "userCache": {
-        "provider": "${keycloak.user.cache.provider:mem}",
-        "mem": {
-            "maxSize": 20000
+    "realmCache": {
+        "infinispan" : {
+            "enabled": true
         }
     },
 ]]></programlisting>
         </para>
         <para>You must then change it to:
             <programlisting><![CDATA[
-    "realmCache": {
-        "provider": "${keycloak.realm.cache.provider:none}"
+    "userCache": {
+        "infinispan" : {
+            "enabled": false
+        }
     },
 
-    "userCache": {
-        "provider": "${keycloak.user.cache.provider:none}"
+    "realmCache": {
+        "infinispan" : {
+            "enabled": false
+        }
     },
 ]]></programlisting>
-        </para>
-        <para>
-           You can also disable either of the caches at runtime through the Keycloak admin console Realm Settings page.
-           This will not permanently disable the cache.  If you reboot the server, the cache will be re-enabled unless
-            you manualy disable the cache in the <literal>keycloak-server.json</literal> file.
         </para>
     </section>
     <section>
         <title>Clear Caches</title>
         <para>
             To clear the realm or user cache, go to the Keycloak admin console Realm Settings->Cache Config page.  Disable the cache
-            you want.  Save the settings.  Then re-enable the cache.  This will cause the cache to be cleared.
-        </para>
-    </section>
-    <section>
-        <title>Cache Config</title>
-        <para>
-            Cache configuration is done within <literal>keycloak-server.json</literal>.  Changes to this file will not
-            be seen by the server until you reboot.  Currently you can only configure the max size of the user cache.
-            <programlisting><![CDATA[
-    "userCache": {
-        "provider": "${keycloak.user.cache.provider:mem}",
-        "mem": {
-            "maxSize": 20000
-        }
-    },
-]]></programlisting>
+            you want. This will cause the cache to be cleared.
         </para>
     </section>
 </chapter>


### PR DESCRIPTION
I believe that everything which was out of date was removed now. See: https://issues.jboss.org/browse/KEYCLOAK-2452
