### PR TITLE
KEYCLOAK-2425

### DIFF
--- a/common/src/main/java/org/keycloak/common/Version.java
+++ b/common/src/main/java/org/keycloak/common/Version.java
@@ -45,14 +45,10 @@ public class Version {
             Version.VERSION = props.getProperty("version");
             Version.BUILD_TIME = props.getProperty("build-time");
             Version.RESOURCES_VERSION = Version.VERSION.toLowerCase();
-            if (Version.RESOURCES_VERSION.endsWith("-snapshot")) {
-                Version.RESOURCES_VERSION = Version.RESOURCES_VERSION.replace("-snapshot", "-" + Time.currentTime());
-            }
         } catch (IOException e) {
-            Version.VERSION= Version.UNKNOWN;
-            Version.BUILD_TIME= Version.UNKNOWN;
+            Version.VERSION = Version.UNKNOWN;
+            Version.BUILD_TIME = Version.UNKNOWN;
         }
-
     }
 
 }


### PR DESCRIPTION
Replacing SNAPSHOT with timestamp in /auth/resources/<VERSION> path doesn't work well with load balancing
