### PR TITLE
KEYCLOAK-2533: Test values of events in LoginEventsTest

### DIFF
--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/ClientResource.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/ClientResource.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.admin.client.resource;
 
+import org.jboss.resteasy.annotations.cache.NoCache;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.CredentialRepresentation;
 import org.keycloak.representations.idm.UserSessionRepresentation;
@@ -80,14 +81,9 @@ public interface ClientResource {
     public CredentialRepresentation getSecret();
 
     @GET
-    @Path("installation/jboss")
-    @Produces(MediaType.APPLICATION_XML)
-    public String getInstallationJbossXml();
-
-    @GET
-    @Path("installation/json")
-    @Produces(MediaType.APPLICATION_JSON)
-    public String getInstallationJson();
+    @NoCache
+    @Path("installation/providers/{providerId}")
+    public String getInstallationProvider(@PathParam("providerId") String providerId);
 
     @POST
     @Path("logout-all")

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/AbstractClientTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/AbstractClientTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2016 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.keycloak.testsuite.admin.client;
+
+import javax.ws.rs.core.Response;
+import org.keycloak.admin.client.resource.ClientResource;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.testsuite.AbstractAuthTest;
+import org.keycloak.testsuite.admin.ApiUtil;
+
+/**
+ *
+ * @author Stan Silvert ssilvert@redhat.com (C) 2016 Red Hat Inc.
+ */
+public abstract class AbstractClientTest extends AbstractAuthTest {
+
+    protected RealmRepresentation realmRep() {
+        return testRealmResource().toRepresentation();
+    }
+
+    protected void createOidcClient(String name) {
+        ClientRepresentation clientRep = new ClientRepresentation();
+        clientRep.setClientId(name);
+        clientRep.setName(name);
+        clientRep.setRootUrl("foo");
+        clientRep.setProtocol("openid-connect");
+        createClient(clientRep);
+    }
+
+        protected void createSamlClient(String name) {
+        ClientRepresentation clientRep = new ClientRepresentation();
+        clientRep.setClientId(name);
+        clientRep.setName(name);
+        clientRep.setProtocol("saml");
+        clientRep.setAdminUrl("samlEndpoint");
+        createClient(clientRep);
+    }
+
+    protected void createClient(ClientRepresentation clientRep) {
+        Response resp = testRealmResource().clients().create(clientRep);
+        // for some reason, findAll() will later fail unless readEntity is called here
+        resp.readEntity(String.class);
+        //testRealmResource().clients().findAll();
+    }
+
+    protected ClientRepresentation findClientRepresentation(String name) {
+        ClientResource clientRsc = findClientResource(name);
+        if (clientRsc == null) return null;
+        return findClientResource(name).toRepresentation();
+    }
+
+    protected ClientResource findClientResource(String name) {
+        return ApiUtil.findClientResourceByName(testRealmResource(), name);
+    }
+
+}

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/ClientRolesTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/ClientRolesTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2016 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.keycloak.testsuite.admin.client;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.keycloak.admin.client.resource.ClientResource;
+import org.keycloak.admin.client.resource.RolesResource;
+import org.keycloak.representations.idm.RoleRepresentation;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ *
+ * @author Stan Silvert ssilvert@redhat.com (C) 2016 Red Hat Inc.
+ */
+public class ClientRolesTest extends AbstractClientTest {
+
+    private ClientResource clientRsc;
+    private RolesResource rolesRsc;
+
+    @Before
+    public void init() {
+        createOidcClient("roleClient");
+        clientRsc = findClientResource("roleClient");
+        rolesRsc = clientRsc.roles();
+    }
+
+    private RoleRepresentation makeRole(String name) {
+        RoleRepresentation role = new RoleRepresentation();
+        role.setName(name);
+        return role;
+    }
+
+  /*  private boolean hasRole(RolesResource rolesRsc, String name) {
+        return rolesRsc.get(name) != null;
+    }*/
+
+    private boolean hasRole(RolesResource rolesRsc, String name) {
+        for (RoleRepresentation role : rolesRsc.list()) {
+            if (role.getName().equals(name)) return true;
+        }
+
+        return false;
+    }
+
+    @Test
+    public void testAddRole() {
+        rolesRsc.create(makeRole("role1"));
+        assertTrue(hasRole(rolesRsc, "role1"));
+    }
+
+    @Test
+    public void testRemoveRole() {
+        rolesRsc.create(makeRole("role2"));
+        rolesRsc.deleteRole("role2");
+        assertFalse(hasRole(rolesRsc, "role2"));
+    }
+
+}

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/ClientTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/ClientTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2016 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.keycloak.testsuite.admin.client;
+
+import java.util.List;
+import org.junit.Test;
+import org.keycloak.admin.client.resource.ClientResource;
+import org.keycloak.representations.idm.ClientRepresentation;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ *
+ * @author Stan Silvert ssilvert@redhat.com (C) 2016 Red Hat Inc.
+ */
+public class ClientTest extends AbstractClientTest {
+
+
+    public static void assertEqualClients(ClientRepresentation expected, ClientRepresentation actual) {
+        assertEquals(expected.getClientId(), actual.getClientId());
+        assertEquals(expected.getName(), actual.getName());
+        assertEquals(expected.getDescription(), actual.getDescription());
+        assertEquals(expected.getBaseUrl(), actual.getBaseUrl());
+
+        assertTrue(expected.getRedirectUris().containsAll(actual.getRedirectUris()));
+        assertTrue(expected.getWebOrigins().containsAll(actual.getWebOrigins()));
+        assertEquals(expected.getRegisteredNodes(), actual.getRegisteredNodes());
+    }
+
+    @Test
+    public void testCreateClient() {
+        createOidcClient("foo");
+        assertEquals("foo", findClientRepresentation("foo").getName());
+    }
+
+    @Test
+    public void testDeleteClient() {
+        createOidcClient("deleteMe");
+        ClientResource clientRsc = findClientResource("deleteMe");
+        assertNotNull(clientRsc);
+        clientRsc.remove();
+        assertNull(findClientResource("deleteMe"));
+    }
+
+    @Test
+    public void testUpdateClient() {
+        createOidcClient("updateMe");
+        ClientRepresentation clientRep = findClientRepresentation("updateMe");
+        assertEquals("updateMe", clientRep.getName());
+
+        clientRep.setName("iWasUpdated");
+        findClientResource("updateMe").update(clientRep);
+
+        ClientRepresentation updatedClient = findClientRepresentation("iWasUpdated");
+        assertNotNull(updatedClient);
+        assertEquals("updateMe", updatedClient.getClientId());
+        assertEquals("iWasUpdated", updatedClient.getName());
+    }
+
+    @Test
+    public void testGetAllClients() {
+        List<ClientRepresentation> allClients = testRealmResource().clients().findAll();
+        assertNotNull(allClients);
+        assertFalse(allClients.isEmpty());
+    }
+
+    @Test
+    public void getClientByIdTest() {
+        createOidcClient("byidclient");
+        ClientRepresentation rep = findClientRepresentation("byidclient");
+        ClientRepresentation gotById = testRealmResource().clients().get(rep.getId()).toRepresentation();
+        assertEqualClients(rep, gotById);
+    }
+
+    /*  DEPRECATED?
+    @Test
+    public void testAllowedOrigins() {
+        createOidcClient("originsClient");
+        ClientResource client = findClientResource("originsClient");
+        java.util.Set<String> origins = client.getAllowedOrigins();
+        assertEquals(1, origins.size());
+        assertTrue(origins.contains("foo/*"));
+
+        origins.add("bar/*");
+        client.updateAllowedOrigins(origins); //<-- STACK OVERFLOW
+        origins = client.getAllowedOrigins();
+        assertEquals(2, origins.size());
+        assertTrue(origins.contains("foo/*"));
+        assertTrue(origins.contains("bar/*"));
+
+        java.util.Set<String> toRemove = new java.util.HashSet<>();
+        toRemove.add("bar/*");
+        client.removeAllowedOrigins(origins);
+        origins = client.getAllowedOrigins();
+        assertEquals(1, origins.size());
+        assertTrue(origins.contains("foo/*"));
+    } */
+
+}

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/InstallationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/InstallationTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2016 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.keycloak.testsuite.admin.client;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.keycloak.admin.client.resource.ClientResource;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.testsuite.arquillian.AuthServerTestEnricher;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test getting the installation/configuration files for OIDC and SAML.
+ *
+ * @author Stan Silvert ssilvert@redhat.com (C) 2016 Red Hat Inc.
+ */
+public class InstallationTest extends AbstractClientTest {
+
+    private static final String OIDC_NAME = "oidcInstallationClient";
+    private static final String SAML_NAME = "samlInstallationClient";
+
+    private ClientResource oidcClient;
+    private ClientResource samlClient;
+
+    @Before
+    public void createClients() {
+        createOidcClient(OIDC_NAME);
+        oidcClient = findClientResource(OIDC_NAME);
+
+        createSamlClient(SAML_NAME);
+        samlClient = findClientResource(SAML_NAME);
+    }
+
+    private String authServerUrl() {
+        return AuthServerTestEnricher.getAuthServerContextRoot() + "/auth";
+    }
+
+    private String samlUrl(RealmRepresentation realmRep) {
+        return authServerUrl() + "/realms/" + realmRep.getId() + "/protocol/saml";
+    }
+
+    @Test
+    public void testOidcJBossXml() {
+        String xml = oidcClient.getInstallationProvider("keycloak-oidc-jboss-subsystem");
+        assertOidcInstallationConfig(xml);
+        assertTrue(xml.contains("<secure-deployment"));
+    }
+
+    @Test
+    public void testOidcJson() {
+        String json = oidcClient.getInstallationProvider("keycloak-oidc-keycloak-json");
+        assertOidcInstallationConfig(json);
+    }
+
+    private void assertOidcInstallationConfig(String config) {
+        RealmRepresentation realmRep = realmRep();
+        assertTrue(config.contains(realmRep.getId()));
+        assertTrue(config.contains(realmRep.getPublicKey()));
+        assertTrue(config.contains(authServerUrl()));
+    }
+
+    @Test
+    public void testSamlMetadataIdpDescriptor() {
+        String xml = samlClient.getInstallationProvider("saml-idp-descriptor");
+        RealmRepresentation realmRep = realmRep();
+        assertTrue(xml.contains("<EntityDescriptor"));
+        assertTrue(xml.contains("<IDPSSODescriptor"));
+        assertTrue(xml.contains(realmRep.getCertificate()));
+        assertTrue(xml.contains(samlUrl(realmRep)));
+    }
+
+    @Test
+    public void testSamlAdapterXml() {
+        String xml = samlClient.getInstallationProvider("keycloak-saml");
+        RealmRepresentation realmRep = realmRep();
+        assertTrue(xml.contains("<keycloak-saml-adapter>"));
+        assertTrue(xml.contains(SAML_NAME));
+        assertTrue(xml.contains(realmRep.getCertificate()));
+        assertTrue(xml.contains(samlUrl(realmRep)));
+    }
+
+    @Test
+    public void testSamlMetadataSpDescriptor() {
+        String xml = samlClient.getInstallationProvider("saml-sp-descriptor");
+        assertTrue(xml.contains("<EntityDescriptor"));
+        assertTrue(xml.contains("<SPSSODescriptor"));
+        assertTrue(xml.contains(SAML_NAME));
+    }
+
+    @Test
+    public void testSamlJBossXml() {
+        String xml = samlClient.getInstallationProvider("keycloak-saml-subsystem");
+        RealmRepresentation realmRep = realmRep();
+        assertTrue(xml.contains("<secure-deployment"));
+        assertTrue(xml.contains(SAML_NAME));
+        assertTrue(xml.contains(realmRep.getCertificate()));
+        assertTrue(xml.contains(samlUrl(realmRep)));
+    }
+}

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/event/AbstractEventTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/event/AbstractEventTest.java
@@ -54,4 +54,8 @@ public abstract class AbstractEventTest extends AbstractAuthTest {
 
         saveConfig();
     }
+
+    protected String realmName() {
+        return testRealmResource().toRepresentation().getId();
+    }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/event/AdminEventTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/event/AdminEventTest.java
@@ -23,6 +23,7 @@ import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 import org.keycloak.representations.idm.AdminEventRepresentation;
+import org.keycloak.representations.idm.AuthDetailsRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.testsuite.admin.ApiUtil;
@@ -60,16 +61,32 @@ public class AdminEventTest extends AbstractEventTest {
         testRealmResource().update(realm);
     }
 
-    private String realmName() {
-        return testRealmResource().toRepresentation().getId();
-    }
-
     @Test
     public void clearAdminEventsTest() {
         createUser("user0");
         assertEquals(1, events().size());
         testRealmResource().clearAdminEvents();
         assertEquals(Collections.EMPTY_LIST, events());
+    }
+
+    @Test
+    public void adminEventAttributeTest() {
+        createUser("user5");
+        List<AdminEventRepresentation> events = events();
+        assertEquals(1, events.size());
+
+        AdminEventRepresentation event = events.get(0);
+        assertTrue(event.getTime() > 0);
+        assertEquals(realmName(), event.getRealmId());
+        assertEquals("CREATE", event.getOperationType());
+        assertNotNull(event.getResourcePath());
+        assertNull(event.getError());
+
+        AuthDetailsRepresentation details = event.getAuthDetails();
+        assertEquals(realmName(), details.getRealmId());
+        assertNotNull(details.getClientId());
+        assertNotNull(details.getUserId());
+        assertNotNull(details.getIpAddress());
     }
 
     @Test
@@ -95,6 +112,7 @@ public class AdminEventTest extends AbstractEventTest {
         AdminEventRepresentation event = events().get(0);
         assertNotNull(event.getRepresentation());
         assertTrue(event.getRepresentation().contains("foo"));
+        assertTrue(event.getRepresentation().contains("bar"));
     }
 
     @Test

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/event/LoginEventsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/event/LoginEventsTest.java
@@ -19,6 +19,7 @@ package org.keycloak.testsuite.admin.event;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import org.jboss.arquillian.graphene.page.Page;
 import org.junit.Before;
 import org.junit.Test;
@@ -26,6 +27,9 @@ import org.keycloak.representations.idm.EventRepresentation;
 import org.keycloak.testsuite.console.page.events.LoginEvents;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
@@ -60,6 +64,28 @@ public class LoginEventsTest extends AbstractEventTest {
         } catch (InterruptedException e) {
             fail(e.getMessage());
         }
+    }
+
+    @Test
+    public void eventAttributesTest() {
+        badLogin();
+        List<EventRepresentation> events = events();
+        assertEquals(1, events.size());
+        EventRepresentation event = events.get(0);
+        assertTrue(event.getTime() > 0);
+        assertNotNull(event.getIpAddress());
+        assertEquals("LOGIN_ERROR", event.getType());
+        assertEquals(realmName(), event.getRealmId());
+        assertNull(event.getUserId()); // no user for bad login
+        assertNull(event.getSessionId()); // no session for bad login
+        assertEquals("user_not_found", event.getError());
+
+        Map<String, String> details = event.getDetails();
+        assertEquals("openid-connect", details.get("auth_method"));
+        assertEquals("code", details.get("auth_type"));
+        assertNotNull(details.get("redirect_uri"));
+        assertNotNull(details.get("code_id"));
+        assertEquals("bad", details.get("username"));
     }
 
     @Test


### PR DESCRIPTION
This PR also includes some new tests for admin client that test endpoints for managing Keycloak clients.  I figured that it didn't hurt to go ahead and get those merged even though there will be more tests to come.
