### PR TITLE
Change "${jboss.home.dir}" to "${jboss.server.config.dir}" in standalone keycloak-server.json config

### DIFF
--- a/distribution/feature-packs/server-feature-pack/src/main/resources/content/standalone/configuration/keycloak-server.json
+++ b/distribution/feature-packs/server-feature-pack/src/main/resources/content/standalone/configuration/keycloak-server.json
@@ -1,6 +1,6 @@
 {
     "providers": [
-        "classpath:${jboss.home.dir}/providers/*"
+        "classpath:${jboss.server.config.dir}/providers/*"
     ],
 
     "admin": {
@@ -41,7 +41,7 @@
         "cacheTemplates": true,
         "cacheThemes": true,
         "folder": {
-          "dir": "${jboss.home.dir}/themes"
+          "dir": "${jboss.server.config.dir}/themes"
         }
     },
 


### PR DESCRIPTION
The ${jboss.home.dir} var causes things such as themes to break in keycloak-server.json

For example, KC can't find the 'apiman' theme as it's being pointed to the wrong location by  ${jboss.home.dir}. 

I noticed your documentation now uses ${jboss.server.config.dir}, so I flipped it over to use that and things started working as expected (which makes sense, given the location).
