### PR TITLE
KEYCLOAK-2570

### DIFF
--- a/testsuite/integration-arquillian/tests/other/console/src/test/java/org/keycloak/testsuite/console/events/LoginEventsTest.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/test/java/org/keycloak/testsuite/console/events/LoginEventsTest.java
@@ -39,7 +39,6 @@ public class LoginEventsTest extends AbstractConsoleTest {
     }
 
     @Test
-    @Ignore("KEYCLOAK-2570")
     public void userAccessEventsTest() {
         testRealmAdminConsolePage.navigateTo();
         Users.setPasswordFor(testUser, "Wrong_password");

--- a/themes/src/main/resources/theme/base/admin/messages/admin-messages_en.properties
+++ b/themes/src/main/resources/theme/base/admin/messages/admin-messages_en.properties
@@ -908,4 +908,4 @@ clear-events=Clear events
 saved-types=Saved Types
 clear-admin-events=Clear admin events
 clear-changes=Clear changes
-
+error=Error


### PR DESCRIPTION
Login event error field typo (lower case)
