### PR TITLE
KEYCLOAK-2572 - Inconsistencies between Keycloak distribution and overlay

### DIFF
--- a/distribution/server-overlay/assembly.xml
+++ b/distribution/server-overlay/assembly.xml
@@ -82,12 +82,12 @@
         <file>
             <source>${project.build.directory}/unpacked/keycloak-${project.version}/bin/add-user.sh</source>
             <outputDirectory>bin</outputDirectory>
-            <destName>add-user-keycloak.sh</destName>
+            <destName>add-user.sh</destName>
         </file>
         <file>
             <source>${project.build.directory}/unpacked/keycloak-${project.version}/bin/add-user.bat</source>
             <outputDirectory>bin</outputDirectory>
-            <destName>add-user-keycloak.bat</destName>
+            <destName>add-user.bat</destName>
         </file>
     </files>
 


### PR DESCRIPTION
There is a mismatch between our distribution and overlay. At our distribution we have $JBOSS_HOME/bin/add-user.sh while overlay has add-user-keycloak.sh which makes some users confuse about it. See the thread: http://lists.jboss.org/pipermail/keycloak-user/2016-March/005221.html
