### PR TITLE
Increase CERTIFICATE column size

### DIFF
--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-1.9.1.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-1.9.1.xml
@@ -19,5 +19,6 @@
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
     <changeSet author="keycloak" id="1.9.1">
         <modifyDataType tableName="REALM" columnName="PRIVATE_KEY" newDataType="VARCHAR(4096)"/>
+        <modifyDataType tableName="REALM" columnName="CERTIFICATE" newDataType="VARCHAR(4096)"/>
     </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
With #2289 we can now upload our own certificates for realms (awesome!) and the column size for the private keys was increased, but the certificate size needs to get bumped up as well.
