### PR TITLE
Updated docs for KEYCLOAK-1020

### DIFF
--- a/docbook/auth-server-docs/reference/en/en-US/modules/proxy.xml
+++ b/docbook/auth-server-docs/reference/en/en-US/modules/proxy.xml
@@ -364,7 +364,7 @@ $ java -jar bin/launcher.jar [your-config.json]
             OIDC identity token it received for authentication.
             <variablelist>
                 <varlistentry>
-                    <term>KEYCLOAK_SUBJECT</term>
+                    <term>KEYCLOAK-SUBJECT</term>
                     <listitem>
                         <para>
                             User id. Corresponds to JWT <literal>sub</literal> and will be the user id Keycloak uses to store
@@ -373,7 +373,7 @@ $ java -jar bin/launcher.jar [your-config.json]
                     </listitem>
                 </varlistentry>
                 <varlistentry>
-                    <term>KEYCLOAK_USERNAME</term>
+                    <term>KEYCLOAK-USERNAME</term>
                     <listitem>
                         <para>
                             Username. Corresponds to JWT <literal>preferred_username</literal>
@@ -381,7 +381,7 @@ $ java -jar bin/launcher.jar [your-config.json]
                     </listitem>
                 </varlistentry>
                 <varlistentry>
-                    <term>KEYCLOAK_EMAIL</term>
+                    <term>KEYCLOAK-EMAIL</term>
                     <listitem>
                         <para>
                             Email address of user if set.
@@ -389,7 +389,7 @@ $ java -jar bin/launcher.jar [your-config.json]
                     </listitem>
                 </varlistentry>
                 <varlistentry>
-                    <term>KEYCLOAK_NAME</term>
+                    <term>KEYCLOAK-NAME</term>
                     <listitem>
                         <para>
                             Full name of user if set.
@@ -397,7 +397,7 @@ $ java -jar bin/launcher.jar [your-config.json]
                     </listitem>
                 </varlistentry>
                 <varlistentry>
-                    <term>KEYCLOAK_ACCESS_TOKEN</term>
+                    <term>KEYCLOAK-ACCESS-TOKEN</term>
                     <listitem>
                         <para>
                             Send the access token in this header if the proxy was configured to send it.  This token can
@@ -410,7 +410,7 @@ $ java -jar bin/launcher.jar [your-config.json]
             <programlisting><![CDATA[
 {
     "header-names" {
-        "keycloak-subject": "MY_SUBJECT"
+        "keycloak-subject": "MY-SUBJECT"
     }
 }
             ]]></programlisting>


### PR DESCRIPTION
KEYCLOAK-1020 changed underscores in Keycloak Proxy headers to dashes, however the documentation was not updated.
