### PR TITLE
KEYCLOAK-2609 Use createCredential so that authentication will work with both 2.x a…

### DIFF
--- a/model/mongo/src/main/java/org/keycloak/connections/mongo/DefaultMongoConnectionFactoryProvider.java
+++ b/model/mongo/src/main/java/org/keycloak/connections/mongo/DefaultMongoConnectionFactoryProvider.java
@@ -239,7 +239,7 @@ public class DefaultMongoConnectionFactoryProvider implements MongoConnectionPro
 
             MongoClient client;
             if (user != null && password != null) {
-                MongoCredential credential = MongoCredential.createMongoCRCredential(user, dbName, password.toCharArray());
+                MongoCredential credential = MongoCredential.createCredential(user, dbName, password.toCharArray());
                 client = new MongoClient(new ServerAddress(host, port), Collections.singletonList(credential), clientOptions);
             } else {
                 client = new MongoClient(new ServerAddress(host, port), clientOptions);


### PR DESCRIPTION
…nd 3.x MongoDB servers
