### PR TITLE
Update dependency management for eap6/tomcat adapters

### DIFF
--- a/adapters/oidc/as7-eap6/as7-subsystem/pom.xml
+++ b/adapters/oidc/as7-eap6/as7-subsystem/pom.xml
@@ -88,7 +88,6 @@
         <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>
-            <version>3.1.0.GA</version>
         </dependency>
 
         <dependency>
@@ -98,13 +97,11 @@
 projects that depend on this project.-->
             <scope>provided</scope>
             <optional>true</optional>
-            <version>1.0.0.Final</version>
         </dependency>
 
         <dependency>
             <groupId>org.jboss.msc</groupId>
             <artifactId>jboss-msc</artifactId>
-            <version>1.0.2.GA</version>
         </dependency>
 
         <dependency>

--- a/adapters/oidc/as7-eap6/pom.xml
+++ b/adapters/oidc/as7-eap6/pom.xml
@@ -30,6 +30,18 @@
     <artifactId>keycloak-as7-integration-pom</artifactId>
     <packaging>pom</packaging>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.jboss.as</groupId>
+                <artifactId>jboss-as-parent</artifactId>
+                <version>${jboss.as.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <modules>
         <module>as7-adapter-spi</module>
         <module>as7-adapter</module>

--- a/adapters/saml/as7-eap6/pom.xml
+++ b/adapters/saml/as7-eap6/pom.xml
@@ -30,6 +30,18 @@
     <artifactId>keycloak-saml-eap-integration-pom</artifactId>
     <packaging>pom</packaging>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.jboss.as</groupId>
+                <artifactId>jboss-as-parent</artifactId>
+                <version>${jboss.as.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <modules>
         <module>adapter</module>
         <module>subsystem</module>

--- a/adapters/saml/as7-eap6/subsystem/pom.xml
+++ b/adapters/saml/as7-eap6/subsystem/pom.xml
@@ -88,7 +88,6 @@
         <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>
-            <version>3.1.0.GA</version>
         </dependency>
 
         <dependency>
@@ -98,7 +97,6 @@
 projects that depend on this project.-->
             <scope>provided</scope>
             <optional>true</optional>
-            <version>1.0.0.Final</version>
         </dependency>
 
         <dependency>

--- a/distribution/adapters/as7-eap6-adapter/pom.xml
+++ b/distribution/adapters/as7-eap6-adapter/pom.xml
@@ -30,6 +30,18 @@
     <artifactId>keycloak-as7-eap6-adapter-dist-pom</artifactId>
     <packaging>pom</packaging>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.jboss.as</groupId>
+                <artifactId>jboss-as-parent</artifactId>
+                <version>${jboss.as.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <modules>
         <module>as7-modules</module>
         <module>as7-adapter-zip</module>

--- a/distribution/saml-adapters/as7-eap6-adapter/pom.xml
+++ b/distribution/saml-adapters/as7-eap6-adapter/pom.xml
@@ -30,6 +30,18 @@
     <artifactId>keycloak-saml-as7-eap6-adapter-dist-pom</artifactId>
     <packaging>pom</packaging>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.jboss.as</groupId>
+                <artifactId>jboss-as-parent</artifactId>
+                <version>${jboss.as.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <modules>
         <module>as7-modules</module>
         <module>as7-adapter-zip</module>


### PR DESCRIPTION
Update dependency management for EAP 6 and Tomcat adapters. EAP 6.4.6.GA artifacts are publicly available in redhat GA repository.
