### PR TITLE
 MS Active directory LDAP federation password constraint and locked accounts

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/federation/ldap/idm/store/ldap/LDAPIdentityStore.java
+++ b/federation/ldap/src/main/java/org/keycloak/federation/ldap/idm/store/ldap/LDAPIdentityStore.java
@@ -220,6 +220,8 @@ public class LDAPIdentityStore implements IdentityStore {
                 mods[0] = new ModificationItem(DirContext.REPLACE_ATTRIBUTE, mod0);
 
                 operationManager.modifyAttribute(userDN, mod0);
+            } catch (ModelException e) {
+                throw e;
             } catch (Exception e) {
                 throw new ModelException("Error updating password.", e);
             }


### PR DESCRIPTION
KEYCLOAK-2634 - This change supports allowing to pass information to the user about password constraint violations to the web layer as well as information to the user that their account has been locked in that case.

https://issues.jboss.org/browse/KEYCLOAK-2634
