### PR TITLE
KEYCLOAK-2664 - QRCodeResource should prohibit caching of the generated image

### DIFF
--- a/services/src/main/java/org/keycloak/services/util/CacheControlUtil.java
+++ b/services/src/main/java/org/keycloak/services/util/CacheControlUtil.java
@@ -46,9 +46,14 @@ public class CacheControlUtil {
     }
 
     public static CacheControl noCache() {
+
         CacheControl cacheControl = new CacheControl();
+        cacheControl.setMustRevalidate(true);
         cacheControl.setNoCache(true);
+        cacheControl.setNoStore(true);
+
         return cacheControl;
     }
+
 
 }


### PR DESCRIPTION
Added cache-control headers to avoid caching for generated QRCode images.
