### PR TITLE
KEYCLOAK-2054 - Allow to configure proxy for auth-server requests in adapters.

### DIFF
--- a/core/src/main/java/org/keycloak/representations/adapters/config/AdapterConfig.java
+++ b/core/src/main/java/org/keycloak/representations/adapters/config/AdapterConfig.java
@@ -35,7 +35,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
         "allow-any-hostname", "disable-trust-manager", "truststore", "truststore-password",
         "client-keystore", "client-keystore-password", "client-key-password",
         "always-refresh-token",
-        "register-node-at-startup", "register-node-period", "token-store", "principal-attribute"
+        "register-node-at-startup", "register-node-period", "token-store", "principal-attribute",
+        "proxy-url"
 })
 public class AdapterConfig extends BaseAdapterConfig {
 
@@ -67,6 +68,12 @@ public class AdapterConfig extends BaseAdapterConfig {
     protected String principalAttribute;
     @JsonProperty("turn-off-change-session-id-on-login")
     protected Boolean turnOffChangeSessionIdOnLogin;
+
+    /**
+     * The Proxy url to use for requests to the auth-server, configurable via the adapter config property {@code proxy-url}.
+     */
+    @JsonProperty("proxy-url")
+    protected String proxyUrl;
 
     public boolean isAllowAnyHostname() {
         return allowAnyHostname;
@@ -178,5 +185,13 @@ public class AdapterConfig extends BaseAdapterConfig {
 
     public void setTurnOffChangeSessionIdOnLogin(Boolean turnOffChangeSessionIdOnLogin) {
         this.turnOffChangeSessionIdOnLogin = turnOffChangeSessionIdOnLogin;
+    }
+
+    public String getProxyUrl() {
+        return proxyUrl;
+    }
+
+    public void setProxyUrl(String proxyUrl) {
+        this.proxyUrl = proxyUrl;
     }
 }

--- a/docbook/auth-server-docs/reference/en/en-US/modules/adapter-config.xml
+++ b/docbook/auth-server-docs/reference/en/en-US/modules/adapter-config.xml
@@ -405,6 +405,17 @@
                     </para>
                 </listitem>
             </varlistentry>
+            <varlistentry>
+                <term>proxy-url</term>
+                <listitem>
+                    <para>
+                        Defines the proxy to use for requests sent to the auth-server-url.
+                        This is <emphasis>OPTIONAL</emphasis>. Note that only the <emphasis>scheme</emphasis>,
+                        <emphasis>host</emphasis> and <emphasis>port</emphasis> of the proxy URL are used.
+                        Proxies that require authentication are currently not supported.
+                    </para>
+                </listitem>
+            </varlistentry>
         </variablelist>
     </para>
 </section>


### PR DESCRIPTION
Previously the adapter configuration did not support to specify a proxy
to use for auth-server requests issued via the Apache HTTP Client used by
Keycloak. 
This made it very difficult to connect an Application with that was required to use a proxy.

Introduced 4 new attributes to the adapter configuration
(e.g. keycloak.json) which makes it possible to
configure a proxy to be used for auth-server requests.
- proxy-enabled: Whether to use Proxy configuration, defaults to false
- proxy-host: The Proxy Host configuration, defaults to null
- proxy-port: The Proxy Port configuration, defaults to null
- proxy-protocol-scheme: The Proxy Protocol configuration, defaults to
  http

Added documentation.
