### PR TITLE
KEYCLOAK-2681 JS adapter init function with initOptions argument does…

### DIFF
--- a/adapters/oidc/js/src/main/resources/keycloak.js
+++ b/adapters/oidc/js/src/main/resources/keycloak.js
@@ -163,6 +163,8 @@
                         }
                     } else if (initOptions.onLoad) {
                         onLoad();
+                    } else {
+                        initPromise.setSuccess();
                     }
                 } else {
                     initPromise.setSuccess();


### PR DESCRIPTION
…n't call success callback
