### PR TITLE
Fixed parent version of some modules in testsuite and examples

### DIFF
--- a/examples/demo-template/angular2-product-app/pom.xml
+++ b/examples/demo-template/angular2-product-app/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-examples-demo-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>1.9.0.Final-SNAPSHOT</version>
+        <version>2.0.0.CR1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/integration/client-registration-cli/pom.xml
+++ b/integration/client-registration-cli/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-integration-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>1.9.0.Final-SNAPSHOT</version>
+        <version>2.0.0.CR1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/testsuite/integration-arquillian/servers/migration/pom.xml
+++ b/testsuite/integration-arquillian/servers/migration/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.testsuite</groupId>
         <artifactId>integration-arquillian-servers</artifactId>
-        <version>1.9.0.CR1-SNAPSHOT</version>
+        <version>2.0.0.CR1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/testsuite/integration-arquillian/servers/migration/wildfly_kc12/pom.xml
+++ b/testsuite/integration-arquillian/servers/migration/wildfly_kc12/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.testsuite</groupId>
         <artifactId>integration-arquillian-migration-servers</artifactId>
-        <version>1.9.0.CR1-SNAPSHOT</version>
+        <version>2.0.0.CR1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/testsuite/integration-arquillian/servers/migration/wildfly_kc13/pom.xml
+++ b/testsuite/integration-arquillian/servers/migration/wildfly_kc13/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.testsuite</groupId>
         <artifactId>integration-arquillian-migration-servers</artifactId>
-        <version>1.9.0.CR1-SNAPSHOT</version>
+        <version>2.0.0.CR1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/testsuite/integration-arquillian/servers/migration/wildfly_kc14/pom.xml
+++ b/testsuite/integration-arquillian/servers/migration/wildfly_kc14/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.testsuite</groupId>
         <artifactId>integration-arquillian-migration-servers</artifactId>
-        <version>1.9.0.CR1-SNAPSHOT</version>
+        <version>2.0.0.CR1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/testsuite/integration-arquillian/servers/migration/wildfly_kc15/pom.xml
+++ b/testsuite/integration-arquillian/servers/migration/wildfly_kc15/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.testsuite</groupId>
         <artifactId>integration-arquillian-migration-servers</artifactId>
-        <version>1.9.0.CR1-SNAPSHOT</version>
+        <version>2.0.0.CR1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/testsuite/integration-arquillian/servers/migration/wildfly_kc16/pom.xml
+++ b/testsuite/integration-arquillian/servers/migration/wildfly_kc16/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.testsuite</groupId>
         <artifactId>integration-arquillian-migration-servers</artifactId>
-        <version>1.9.0.CR1-SNAPSHOT</version>
+        <version>2.0.0.CR1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
After the keycloak parent's version was updated last time, some modules still depend on older parent version.
