### PR TITLE
KEYCLOAK-2686 - Fix failing migration from 1.9.1 to 1.9.2.

### DIFF
--- a/server-spi/src/main/java/org/keycloak/migration/migrators/MigrateTo1_9_2.java
+++ b/server-spi/src/main/java/org/keycloak/migration/migrators/MigrateTo1_9_2.java
@@ -18,9 +18,12 @@
 package org.keycloak.migration.migrators;
 
 import org.keycloak.migration.ModelVersion;
-import org.keycloak.models.BrowserSecurityHeaders;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 public class MigrateTo1_9_2 {
 
@@ -29,7 +32,11 @@ public class MigrateTo1_9_2 {
     public void migrate(KeycloakSession session) {
         for (RealmModel realm : session.realms().getRealms()) {
             if (realm.getBrowserSecurityHeaders() != null) {
-                realm.getBrowserSecurityHeaders().put("xFrameOptions", "nosniff");
+
+                Map<String, String> browserSecurityHeaders = new HashMap<>(realm.getBrowserSecurityHeaders());
+                browserSecurityHeaders.put("xFrameOptions", "nosniff");
+
+                realm.setBrowserSecurityHeaders(Collections.unmodifiableMap(browserSecurityHeaders));
             }
         }
     }

--- a/services/src/main/java/org/keycloak/services/util/CacheControlUtil.java
+++ b/services/src/main/java/org/keycloak/services/util/CacheControlUtil.java
@@ -46,9 +46,14 @@ public class CacheControlUtil {
     }
 
     public static CacheControl noCache() {
+
         CacheControl cacheControl = new CacheControl();
+        cacheControl.setMustRevalidate(true);
         cacheControl.setNoCache(true);
+        cacheControl.setNoStore(true);
+
         return cacheControl;
     }
+
 
 }


### PR DESCRIPTION
Since the `Map` returned by `realm.getBrowserSecurityHeaders()` is unmodifiable
we need to add the new header setting to a copy of the map which we then set
on the realm.
