### PR TITLE
Add option do exclude KEYCLOAK_NAME header from proxy

### DIFF
--- a/docbook/auth-server-docs/reference/en/en-US/modules/proxy.xml
+++ b/docbook/auth-server-docs/reference/en/en-US/modules/proxy.xml
@@ -120,6 +120,16 @@ $ java -jar bin/launcher.jar [your-config.json]
                     </listitem>
                 </varlistentry>
                 <varlistentry>
+                    <term>send-name</term>
+                    <listitem>
+                        <para>
+                            Boolean flag.  If true, this will send full name of the user via the KEYCLOAK_NAME header to the
+                            proxied server. Note that if name contains non-ASCII characters, proxied server may have problems
+                            decoding the request. <emphasis>OPTIONAL.</emphasis>. Default is true.
+                        </para>
+                    </listitem>
+                </varlistentry>
+                <varlistentry>
                     <term>bind-address</term>
                     <listitem>
                         <para>

--- a/proxy/proxy-server/src/main/java/org/keycloak/proxy/ConstraintAuthorizationHandler.java
+++ b/proxy/proxy-server/src/main/java/org/keycloak/proxy/ConstraintAuthorizationHandler.java
@@ -42,11 +42,13 @@ public class ConstraintAuthorizationHandler implements HttpHandler {
     protected HttpHandler next;
     protected String errorPage;
     protected boolean sendAccessToken;
+    protected boolean sendName;
 
-    public ConstraintAuthorizationHandler(HttpHandler next, String errorPage, boolean sendAccessToken, Map<String, String> headerNames) {
+    public ConstraintAuthorizationHandler(HttpHandler next, String errorPage, boolean sendAccessToken, boolean sendName, Map<String, String> headerNames) {
         this.next = next;
         this.errorPage = errorPage;
         this.sendAccessToken = sendAccessToken;
+        this.sendName = sendName;
 
         this.httpHeaderNames = new HashMap<>();
         this.httpHeaderNames.put(KEYCLOAK_SUBJECT, new HttpString(getOrDefault(headerNames, "keycloak-subject", KEYCLOAK_SUBJECT)));
@@ -112,7 +114,7 @@ public class ConstraintAuthorizationHandler implements HttpHandler {
             if (idToken.getEmail() != null) {
                 exchange.getRequestHeaders().put(httpHeaderNames.get(KEYCLOAK_EMAIL), idToken.getEmail());
             }
-            if (idToken.getName() != null) {
+            if (sendName && idToken.getName() != null) {
                 exchange.getRequestHeaders().put(httpHeaderNames.get(KEYCLOAK_NAME), idToken.getName());
             }
             if (sendAccessToken) {

--- a/proxy/proxy-server/src/main/java/org/keycloak/proxy/ProxyConfig.java
+++ b/proxy/proxy-server/src/main/java/org/keycloak/proxy/ProxyConfig.java
@@ -27,6 +27,8 @@ import java.util.*;
  * @version $Revision: 1 $
  */
 public class ProxyConfig {
+    private static final boolean SEND_NAME_DEFAULT = true;
+
     @JsonProperty("bind-address")
     protected String bindAddress = "localhost";
     @JsonProperty("http-port")
@@ -53,6 +55,8 @@ public class ProxyConfig {
     protected String targetUrl;
     @JsonProperty("send-access-token")
     protected boolean sendAccessToken;
+    @JsonProperty("send-name")
+    private Boolean sendName;
     @JsonProperty("applications")
     protected List<Application> applications = new LinkedList<Application>();
     @JsonProperty("header-names")
@@ -168,6 +172,14 @@ public class ProxyConfig {
 
     public void setSendAccessToken(boolean sendAccessToken) {
         this.sendAccessToken = sendAccessToken;
+    }
+
+    public boolean isSendName() {
+        return sendName == null ? SEND_NAME_DEFAULT : sendName;
+    }
+
+    public void setSendName(boolean sendName) {
+        this.sendName = sendName;
     }
 
     public void setHeaderNames(Map<String, String> headerNames) {

--- a/proxy/proxy-server/src/main/java/org/keycloak/proxy/ProxyServerBuilder.java
+++ b/proxy/proxy-server/src/main/java/org/keycloak/proxy/ProxyServerBuilder.java
@@ -89,6 +89,7 @@ public class ProxyServerBuilder {
     protected PathHandler root = new PathHandler(NOT_FOUND);
     protected HttpHandler proxyHandler;
     protected boolean sendAccessToken;
+    protected boolean sendName;
 
     protected Map<String, String> headerNameConfig;
 
@@ -112,6 +113,11 @@ public class ProxyServerBuilder {
 
     public ProxyServerBuilder sendAccessToken(boolean flag) {
         this.sendAccessToken = flag;
+        return this;
+    }
+
+    public ProxyServerBuilder sendName(boolean flag) {
+        this.sendName = flag;
         return this;
     }
 
@@ -249,7 +255,7 @@ public class ProxyServerBuilder {
                     errorPage = base + "/" + errorPage;
                 }
             }
-            handler = new ConstraintAuthorizationHandler(handler, errorPage, sendAccessToken, headerNameConfig);
+            handler = new ConstraintAuthorizationHandler(handler, errorPage, sendAccessToken, sendName, headerNameConfig);
             handler = new ProxyAuthenticationCallHandler(handler);
             handler = new ConstraintMatcherHandler(matches, handler, toWrap, errorPage);
             final List<AuthenticationMechanism> mechanisms = new LinkedList<AuthenticationMechanism>();
@@ -411,6 +417,7 @@ public class ProxyServerBuilder {
 
     public static void initOptions(ProxyConfig config, ProxyServerBuilder builder) {
         builder.sendAccessToken(config.isSendAccessToken());
+        builder.sendName(config.isSendName());
         builder.headerNameConfig(config.getHeaderNames());
         if (config.getBufferSize() != null) builder.setBufferSize(config.getBufferSize());
         if (config.getBuffersPerRegion() != null) builder.setBuffersPerRegion(config.getBuffersPerRegion());


### PR DESCRIPTION
User's first name / surname will often include non-ASCII characters, which cannot be used in header values. There's no well-supported standard for encoding of non-ASCII characters in HTTP headers (RFC 2047 calls for MIME Encoded-Word in headers, but clients seem to lack support for this arcane-looking encoding).

Unfortunately, our upstream nginx server doesn't like non-ASCII headers and responds with 400 to any such request. The simplest workaround for us seems to be to exclude the header entirely (through a new flag).
