### PR TITLE
Fix k_query_bearer_token endpoint in proxy

### DIFF
--- a/proxy/proxy-server/src/main/java/org/keycloak/proxy/ProxyServerBuilder.java
+++ b/proxy/proxy-server/src/main/java/org/keycloak/proxy/ProxyServerBuilder.java
@@ -240,8 +240,7 @@ public class ProxyServerBuilder {
         }
 
         private HttpHandler addSecurity(final HttpHandler toWrap) {
-            HttpHandler handler = toWrap;
-            handler = new UndertowAuthenticatedActionsHandler(deploymentContext, toWrap);
+            HttpHandler handler = new UndertowAuthenticatedActionsHandler(deploymentContext, toWrap);
             if (errorPage != null) {
                 if (base.endsWith("/")) {
                     errorPage = base + errorPage;
@@ -249,6 +248,7 @@ public class ProxyServerBuilder {
                     errorPage = base + "/" + errorPage;
                 }
             }
+            handler = new TokenRequestPreHandler(handler);
             handler = new ConstraintAuthorizationHandler(handler, errorPage, sendAccessToken, headerNameConfig);
             handler = new ProxyAuthenticationCallHandler(handler);
             handler = new ConstraintMatcherHandler(matches, handler, toWrap, errorPage);

--- a/proxy/proxy-server/src/main/java/org/keycloak/proxy/TokenRequestPreHandler.java
+++ b/proxy/proxy-server/src/main/java/org/keycloak/proxy/TokenRequestPreHandler.java
@@ -1,0 +1,27 @@
+package org.keycloak.proxy;
+
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import org.keycloak.constants.AdapterConstants;
+
+/**
+ * Dispatches requests for k_query_bearer_token through a worker thread (handler for this
+ * resource performs blocking IO).
+ */
+public class TokenRequestPreHandler implements HttpHandler {
+
+    private final HttpHandler next;
+
+    public TokenRequestPreHandler(HttpHandler next) {
+        this.next = next;
+    }
+
+    @Override
+    public void handleRequest(HttpServerExchange exchange) throws Exception {
+        if (exchange.getRequestURI().endsWith(AdapterConstants.K_QUERY_BEARER_TOKEN)) {
+            exchange.dispatch(next);
+        } else {
+            next.handleRequest(exchange);
+        }
+    }
+}


### PR DESCRIPTION
`org.keycloak.adapters.AuthenticatedActionsHandler` which handles token
requests performs blocking IO. However, the exchange is in non-blocking
mode when it reaches this handler in Keycloak proxy.
