### PR TITLE
KEYCLOAK-2713 Cannot start keycloak server from keycloak-server-dist

### DIFF
--- a/distribution/feature-packs/server-feature-pack/src/main/resources/modules/system/layers/keycloak/org/keycloak/keycloak-model-jpa/main/module.xml
+++ b/distribution/feature-packs/server-feature-pack/src/main/resources/modules/system/layers/keycloak/org/keycloak/keycloak-model-jpa/main/module.xml
@@ -30,6 +30,7 @@
         <module name="org.keycloak.keycloak-common"/>
         <module name="org.keycloak.keycloak-core"/>
         <module name="org.keycloak.keycloak-server-spi"/>
+        <module name="org.keycloak.keycloak-services"/>
         <module name="javax.persistence.api"/>
         <module name="org.jboss.logging"/>
         <module name="org.liquibase"/>


### PR DESCRIPTION
This addresses the startup crash, but @mposolda should check if this is a proper fix.
