### PR TITLE
KEYCLOAK-2721: Do not recreate TokenService proxy

### DIFF
--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/token/TokenManager.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/token/TokenManager.java
@@ -18,7 +18,6 @@
 package org.keycloak.admin.client.token;
 
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
-import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
 import org.keycloak.admin.client.Config;
 import org.keycloak.admin.client.resource.BasicAuthFilter;
@@ -27,8 +26,6 @@ import org.keycloak.representations.AccessTokenResponse;
 
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.core.Form;
-import java.util.Calendar;
-import java.util.Date;
 
 /**
  * @author rodrigo.sasaki@icarros.com.br
@@ -41,11 +38,15 @@ public class TokenManager {
     private long expirationTime;
     private long minTokenValidity = DEFAULT_MIN_VALIDITY;
     private final Config config;
-    private final ResteasyClient client;
+    private final TokenService tokenService;
 
     public TokenManager(Config config, ResteasyClient client){
         this.config = config;
-        this.client = client;
+        ResteasyWebTarget target = client.target(config.getServerUrl());
+        if(!config.isPublicClient()){
+            target.register(new BasicAuthFilter(config.getClientId(), config.getClientSecret()));
+        }
+        tokenService = target.proxy(TokenService.class);
     }
 
     public String getAccessTokenString(){
@@ -62,8 +63,6 @@ public class TokenManager {
     }
 
     public AccessTokenResponse grantToken(){
-        ResteasyWebTarget target = client.target(config.getServerUrl());
-
         Form form = new Form()
                 .param("grant_type", "password")
                 .param("username", config.getUsername())
@@ -71,11 +70,7 @@ public class TokenManager {
 
         if(config.isPublicClient()){
             form.param("client_id", config.getClientId());
-        } else {
-            target.register(new BasicAuthFilter(config.getClientId(), config.getClientSecret()));
         }
-
-        TokenService tokenService = target.proxy(TokenService.class);
 
         int requestTime = Time.currentTime();
         currentToken = tokenService.grantToken(config.getRealm(), form.asMap());
@@ -85,19 +80,13 @@ public class TokenManager {
     }
 
     public AccessTokenResponse refreshToken(){
-        ResteasyWebTarget target = client.target(config.getServerUrl());
-
         Form form = new Form()
                 .param("grant_type", "refresh_token")
                 .param("refresh_token", currentToken.getRefreshToken());
 
         if(config.isPublicClient()){
             form.param("client_id", config.getClientId());
-        } else {
-            target.register(new BasicAuthFilter(config.getClientId(), config.getClientSecret()));
         }
-
-        TokenService tokenService = target.proxy(TokenService.class);
 
         try {
             int requestTime = Time.currentTime();


### PR DESCRIPTION
By re-using the service proxy, classloading issues can be prevented.

Description copied from [KEYCLOAK-2721](https://issues.jboss.org/browse/KEYCLOAK-2721):

> This JIRA issue relates to this thread on the keycloak-user mailinglist.
> org.keycloak.admin.client.token.TokenManager, part of the admin client (Keycloak), makes use of a proxied web service (TokenService)
> 
> When building a proxy, org.jboss.resteasy.client.jaxrs.ProxyBuilder is used. Through it's loader field, a classloader is referenced which is used for the reflection that is needed to do that. The loader field defaults to the context classloader for the thread that's creating the ProxyBuilder instance. There is no practical way to override this field (there's a setter, but that's not usable for the users of the TokenManager or Keycloak API).
> 
> As the TokenService proxy is created on demand (over and over again), it is typically created in the classloader that's used by the thread that's executing/invocating whatever functionality is needed. In contrast: other proxies are (or can easily be) created in the classloader of the thread that created/instantiated the admin service itself (the Keycloak instance).
> 
> This subtle difference becomes problematic when the threads that is doing the instantiation, and the thread that's doing the invocation, are from different classloaders. This can occur when the admin service is being used in a modular system.
> 
> In my case, the admin client is loaded in a plugin framework, where the plugin classloader is a child of the classloader that is performing most of the actions. When the parent classloader performs an action and enough time has passed for a token to be expired, TokenManager attempts to refresh. To do this, an attempt is made to create a new proxy for TokenService, which fails: the TokenService class isn't visible to the parent classloader, as keycloak was instantiated in the child classloader. As other services than the TokenService get instantiated as part of (or immediately following) the Keycloak instance, I am faced with an application that works just fine up until the token that's being used needs refreshing. That's when classloading problems occur.
> 
> TokenManager can be modified in an easy way to prevent this problem. Instead of creating the proxy on-demand, it can be created at construction time. There, it's pretty likely that the correct classloader is available.
> 
> The suggested change is not bullet-proof, but does lead to a solution that is more tolerant.
