### PR TITLE
KEYCLOAK-2726: Invalidate token upon failure

### DIFF
--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/token/TokenManager.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/token/TokenManager.java
@@ -118,4 +118,18 @@ public class TokenManager {
         return (Time.currentTime() + minTokenValidity) >= expirationTime;
     }
 
+    /**
+     * Invalidates the current token, but only when it is equal to the token passed as an argument.
+     *
+     * @param token the token to invalidate (cannot be null).
+     */
+    public void invalidate(String token) {
+        if (currentToken == null) {
+            return; // There's nothing to invalidate.
+        }
+        if (token.equals(currentToken.getToken())) {
+            // When used next, this cause a refresh attempt, that in turn will cause a grant attempt if refreshing fails.
+            expirationTime = -1;
+        }
+    }
 }


### PR DESCRIPTION
When a token managed by TokenManager is known to be invalid, it should no longer be used. This commit adds a response listener to the only filter using TokenManager, which causes, upon authentication failure, to invalidate the token that was used.

See [KEYCLOAK-2726](https://issues.jboss.org/browse/KEYCLOAK-2726) for more details.
