### PR TITLE
KEYCLOAK-2608

### DIFF
--- a/common/src/main/java/org/keycloak/common/util/Time.java
+++ b/common/src/main/java/org/keycloak/common/util/Time.java
@@ -30,6 +30,10 @@ public class Time {
         return ((int) (System.currentTimeMillis() / 1000)) + offset;
     }
 
+    public static long currentTimeMillis() {
+        return System.currentTimeMillis() + (offset * 1000);
+    }
+
     public static Date toDate(int time) {
         return new Date(((long) time ) * 1000);
     }

--- a/server-spi/src/main/java/org/keycloak/events/EventBuilder.java
+++ b/server-spi/src/main/java/org/keycloak/events/EventBuilder.java
@@ -169,7 +169,7 @@ public class EventBuilder {
     }
 
     private void send() {
-        event.setTime(Time.toMillis(Time.currentTime()));
+        event.setTime(Time.currentTimeMillis());
 
         if (store != null) {
             if (realm.getEnabledEventTypes() != null && !realm.getEnabledEventTypes().isEmpty() ? realm.getEnabledEventTypes().contains(event.getType().name()) : event.getType().isSaveByDefault()) {


### PR DESCRIPTION
Timestamp resolution of 1s for Event.time is inappropriate for use with tests
