### PR TITLE
KEYCLOAK-2746: By default, allow for concurrent usage

### DIFF
--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/Keycloak.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/Keycloak.java
@@ -46,7 +46,7 @@ public class Keycloak {
 
     Keycloak(String serverUrl, String realm, String username, String password, String clientId, String clientSecret, ResteasyClient resteasyClient){
         config = new Config(serverUrl, realm, username, password, clientId, clientSecret);
-        client = resteasyClient != null ? resteasyClient : new ResteasyClientBuilder().build();
+        client = resteasyClient != null ? resteasyClient : new ResteasyClientBuilder().connectionPoolSize(10).build();
 
         tokenManager = new TokenManager(config, client);
 


### PR DESCRIPTION
The nature of Keycloak makes it very plausible that it is used in
a concurrent setting. With that in mind, it would make sense to,
by default, allow for more than one concurrent Resteasy connection
in the admin client code.
