### PR TITLE
KEYCLOAK-2767: Should return a primitive if possible.

### DIFF
--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/UsersResource.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/UsersResource.java
@@ -29,7 +29,6 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.List;
-import java.util.Map;
 
 public interface UsersResource {
 
@@ -55,7 +54,7 @@ public interface UsersResource {
     @Path("count")
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    Map<String, Integer> count();
+    Integer count();
 
     @Path("{id}")
     UserResource get(@PathParam("id") String id);

--- a/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
@@ -685,10 +685,10 @@ public class UsersResource {
     @GET
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
-    public Map<String, Integer> getUsersCount() {
+    public Integer getUsersCount() {
         auth.requireView();
 
-        return Collections.singletonMap("count", session.users().getUsersCount(realm));
+        return session.users().getUsersCount(realm);
     }
 
     @Path("{id}/role-mappings")

--- a/testsuite/integration/src/test/java/org/keycloak/testsuite/admin/UserTest.java
+++ b/testsuite/integration/src/test/java/org/keycloak/testsuite/admin/UserTest.java
@@ -235,7 +235,7 @@ public class UserTest extends AbstractClientTest {
     public void count() {
         createUsers();
 
-        Integer count = realm.users().count().get("count");
+        Integer count = realm.users().count();
         assertEquals(9, count.intValue());
     }
 


### PR DESCRIPTION
A JSON primitive is valid JSON. There is no need to construct a JSON object
just for the sake of being JSON complient. This keeps things nice and simple.
