### PR TITLE
Add service account support to Keycloak admin client

### DIFF
--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/Config.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/Config.java
@@ -17,6 +17,9 @@
 
 package org.keycloak.admin.client;
 
+import static org.keycloak.OAuth2Constants.CLIENT_CREDENTIALS;
+import static org.keycloak.OAuth2Constants.PASSWORD;
+
 /**
  * @author rodrigo.sasaki@icarros.com.br
  */
@@ -28,14 +31,21 @@ public class Config {
     private String password;
     private String clientId;
     private String clientSecret;
+    private String grantType;
 
     public Config(String serverUrl, String realm, String username, String password, String clientId, String clientSecret) {
+        this(serverUrl, realm, username, password, clientId, clientSecret, PASSWORD);
+    }
+
+    public Config(String serverUrl, String realm, String username, String password, String clientId, String clientSecret, String grantType) {
         this.serverUrl = serverUrl;
         this.realm = realm;
         this.username = username;
         this.password = password;
         this.clientId = clientId;
         this.clientSecret = clientSecret;
+        this.grantType = grantType;
+        checkGrantType(grantType);
     }
 
     public String getServerUrl() {
@@ -86,8 +96,23 @@ public class Config {
         this.clientSecret = clientSecret;
     }
 
-    public boolean isPublicClient(){
+    public boolean isPublicClient() {
         return clientSecret == null;
     }
 
+    public String getGrantType() {
+        return grantType;
+    }
+
+    public void setGrantType(String grantType) {
+        this.grantType = grantType;
+        checkGrantType(grantType);
+    }
+
+    public static void checkGrantType(String grantType) {
+        if (!PASSWORD.equals(grantType) && !CLIENT_CREDENTIALS.equals(grantType)) {
+            throw new IllegalArgumentException("Unsupported grantType: " + grantType +
+                    " (only " + PASSWORD + " and " + CLIENT_CREDENTIALS + " are supported)");
+        }
+    }
 }

--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/Keycloak.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/Keycloak.java
@@ -28,25 +28,25 @@ import org.keycloak.admin.client.token.TokenManager;
 
 import java.net.URI;
 
+import static org.keycloak.OAuth2Constants.PASSWORD;
+
 /**
  * Provides a Keycloak client. By default, this implementation uses a {@link ResteasyClient RESTEasy client} with the
  * default {@link ResteasyClientBuilder} settings. To customize the underling client, use a {@link KeycloakBuilder} to
  * create a Keycloak client.
  *
- * @see KeycloakBuilder
- *
  * @author rodrigo.sasaki@icarros.com.br
+ * @see KeycloakBuilder
  */
 public class Keycloak {
-
     private final Config config;
     private final TokenManager tokenManager;
     private final ResteasyWebTarget target;
     private final ResteasyClient client;
 
-    Keycloak(String serverUrl, String realm, String username, String password, String clientId, String clientSecret, ResteasyClient resteasyClient){
-        config = new Config(serverUrl, realm, username, password, clientId, clientSecret);
-        client = resteasyClient != null ? resteasyClient : new ResteasyClientBuilder().connectionPoolSize(10).build();
+    Keycloak(String serverUrl, String realm, String username, String password, String clientId, String clientSecret, String grantType, ResteasyClient resteasyClient) {
+        config = new Config(serverUrl, realm, username, password, clientId, clientSecret, grantType);
+        client = resteasyClient != null ? resteasyClient : new ResteasyClientBuilder().build();
 
         tokenManager = new TokenManager(config, client);
 
@@ -55,27 +55,27 @@ public class Keycloak {
         target.register(new BearerAuthFilter(tokenManager));
     }
 
-    public static Keycloak getInstance(String serverUrl, String realm, String username, String password, String clientId, String clientSecret){
-        return new Keycloak(serverUrl, realm, username, password, clientId, clientSecret, null);
+    public static Keycloak getInstance(String serverUrl, String realm, String username, String password, String clientId, String clientSecret) {
+        return new Keycloak(serverUrl, realm, username, password, clientId, clientSecret, PASSWORD, null);
     }
 
-    public static Keycloak getInstance(String serverUrl, String realm, String username, String password, String clientId){
-        return new Keycloak(serverUrl, realm, username, password, clientId, null, null);
+    public static Keycloak getInstance(String serverUrl, String realm, String username, String password, String clientId) {
+        return new Keycloak(serverUrl, realm, username, password, clientId, null, PASSWORD, null);
     }
 
-    public RealmsResource realms(){
+    public RealmsResource realms() {
         return target.proxy(RealmsResource.class);
     }
 
-    public RealmResource realm(String realmName){
+    public RealmResource realm(String realmName) {
         return realms().realm(realmName);
     }
 
-    public ServerInfoResource serverInfo(){
+    public ServerInfoResource serverInfo() {
         return target.proxy(ServerInfoResource.class);
     }
 
-    public TokenManager tokenManager(){
+    public TokenManager tokenManager() {
         return tokenManager;
     }
 
@@ -98,5 +98,4 @@ public class Keycloak {
     public void close() {
         client.close();
     }
-
 }

--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/KeycloakBuilder.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/KeycloakBuilder.java
@@ -20,21 +20,33 @@ package org.keycloak.admin.client;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 
+import static org.keycloak.OAuth2Constants.CLIENT_CREDENTIALS;
+import static org.keycloak.OAuth2Constants.PASSWORD;
+
 /**
  * Provides a {@link Keycloak} client builder with the ability to customize the underlying
  * {@link ResteasyClient RESTEasy client} used to communicate with the Keycloak server.
- *
+ * <p>
  * <p>Example usage with a connection pool size of 20:</p>
- *
  * <pre>
  *   Keycloak keycloak = KeycloakBuilder.builder()
- *     .serverUrl("https:/sso.example.com/auth")
+ *     .serverUrl("https://sso.example.com/auth")
  *     .realm("realm")
  *     .username("user")
  *     .password("pass")
  *     .clientId("client")
  *     .clientSecret("secret")
  *     .resteasyClient(new ResteasyClientBuilder().connectionPoolSize(20).build())
+ *     .build();
+ * </pre>
+ * <p>Example usage with grant_type=client_credentials</p>
+ * <pre>
+ *   Keycloak keycloak = KeycloakBuilder.builder()
+ *     .serverUrl("https://sso.example.com/auth")
+ *     .realm("example")
+ *     .grantType(OAuth2Constants.CLIENT_CREDENTIALS)
+ *     .clientId("client")
+ *     .clientSecret("secret")
  *     .build();
  * </pre>
  *
@@ -48,6 +60,7 @@ public class KeycloakBuilder {
     private String password;
     private String clientId;
     private String clientSecret;
+    private String grantType = PASSWORD;
     private ResteasyClient resteasyClient;
 
     public KeycloakBuilder serverUrl(String serverUrl) {
@@ -57,6 +70,12 @@ public class KeycloakBuilder {
 
     public KeycloakBuilder realm(String realm) {
         this.realm = realm;
+        return this;
+    }
+
+    public KeycloakBuilder grantType(String grantType) {
+        Config.checkGrantType(grantType);
+        this.grantType = grantType;
         return this;
     }
 
@@ -97,19 +116,25 @@ public class KeycloakBuilder {
             throw new IllegalStateException("realm required");
         }
 
-        if (username == null) {
-            throw new IllegalStateException("username required");
-        }
+        if (PASSWORD.equals(grantType)) {
+            if (username == null) {
+                throw new IllegalStateException("username required");
+            }
 
-        if (password == null) {
-            throw new IllegalStateException("password required");
+            if (password == null) {
+                throw new IllegalStateException("password required");
+            }
+        } else if (CLIENT_CREDENTIALS.equals(grantType)) {
+            if (clientSecret == null) {
+                throw new IllegalStateException("clientSecret required with grant_type=client_credentials");
+            }
         }
 
         if (clientId == null) {
             throw new IllegalStateException("clientId required");
         }
 
-        return new Keycloak(serverUrl, realm, username, password, clientId, clientSecret, resteasyClient);
+        return new Keycloak(serverUrl, realm, username, password, clientId, clientSecret, grantType, resteasyClient);
     }
 
     private KeycloakBuilder() {


### PR DESCRIPTION
Added grant_type=client_credentials support to keycloak-admin-client
so `keycloak-admin-client` can be used with service client account.

Fixes #KEYCLOAK-2236
