### PR TITLE
Revert accidentally removed ResteasyClient configuration in admin

### DIFF
--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/Keycloak.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/Keycloak.java
@@ -46,7 +46,7 @@ public class Keycloak {
 
     Keycloak(String serverUrl, String realm, String username, String password, String clientId, String clientSecret, String grantType, ResteasyClient resteasyClient) {
         config = new Config(serverUrl, realm, username, password, clientId, clientSecret, grantType);
-        client = resteasyClient != null ? resteasyClient : new ResteasyClientBuilder().build();
+        client = resteasyClient != null ? resteasyClient : new ResteasyClientBuilder().connectionPoolSize(10).build();
 
         tokenManager = new TokenManager(config, client);
 


### PR DESCRIPTION
Fixes accidentally removed in PR #2449 ResteasyClient pool size parameter in
`org.keycloak.admin.client.Keycloak`.
