### PR TITLE
KEYCLOAK-2791 - Proxy handling for X-Forwarded headers

### DIFF
--- a/proxy/proxy-server/src/main/java/org/keycloak/proxy/ProxyConfig.java
+++ b/proxy/proxy-server/src/main/java/org/keycloak/proxy/ProxyConfig.java
@@ -185,6 +185,8 @@ public class ProxyConfig {
         protected AdapterConfig adapterConfig;
         @JsonProperty("error-page")
         protected String errorPage;
+        @JsonProperty("proxy-address-forwarding")
+        protected boolean proxyAddressForwarding;
         @JsonProperty("constraints")
         protected List<Constraint> constraints = new LinkedList<Constraint>();
 
@@ -210,6 +212,14 @@ public class ProxyConfig {
 
         public void setErrorPage(String errorPage) {
             this.errorPage = errorPage;
+        }
+		
+        public boolean isProxyAddressForwarding() {
+            return proxyAddressForwarding;
+        }
+
+        public void setProxyAddressForwarding(boolean proxyAddressForwarding) {
+            this.proxyAddressForwarding = proxyAddressForwarding;
         }
 
         public List<Constraint> getConstraints() {


### PR DESCRIPTION
I cannot see a reasonable way to add headers to a request with the Selenium test suite, so I ended up testing this manually. You can see that the redirect_uri is modified based on configuration below.

When proxy-address-forwarding is false:

```
[vagrant@localhost keycloak-proxy-2.0.0.CR1-SNAPSHOT]$ curl -v -H 'X-Forwarded-Proto: https' localhost:8080/customer-portal/users
* About to connect() to localhost port 8080 (#0)
*   Trying ::1...
* Connection refused
*   Trying 127.0.0.1...
* Connected to localhost (127.0.0.1) port 8080 (#0)
> GET /customer-portal/users HTTP/1.1
> User-Agent: curl/7.29.0
> Host: localhost:8080
> Accept: */*
> X-Forwarded-Proto: https
>
< HTTP/1.1 302 Found
< Connection: keep-alive
< Set-Cookie: OAuth_Token_Request_State=1/9cb56ccb-f037-4770-aac7-6ee0ec0b6b45; HttpOnly
< Location: http://localhost:8081/auth/realms/demo/protocol/openid-connect/auth?response_type=code&client_id=customer-portal&redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Fcustomer-portal%2Fusers&state=1%2F9cb56ccb-f037-4770-aac7-6ee0ec0b6b45&login=true
< Content-Length: 0
< Date: Sat, 09 Apr 2016 05:11:37 GMT
<
* Connection #0 to host localhost left intact
```

And when it is enabled:

```
[vagrant@localhost keycloak-proxy-2.0.0.CR1-SNAPSHOT]$ curl -v -H 'X-Forwarded-Proto: https' localhost:8080/customer-portal/users
* About to connect() to localhost port 8080 (#0)
*   Trying ::1...
* Connection refused
*   Trying 127.0.0.1...
* Connected to localhost (127.0.0.1) port 8080 (#0)
> GET /customer-portal/users HTTP/1.1
> User-Agent: curl/7.29.0
> Host: localhost:8080
> Accept: */*
> X-Forwarded-Proto: https
>
< HTTP/1.1 302 Found
< Connection: keep-alive
< Set-Cookie: OAuth_Token_Request_State=0/d9c48538-f03d-460f-b7aa-c9d0bc770e94; HttpOnly
< Location: http://localhost:8081/auth/realms/demo/protocol/openid-connect/auth?response_type=code&client_id=customer-portal&redirect_uri=https%3A%2F%2Flocalhost%3A8080%2Fcustomer-portal%2Fusers&state=0%2Fd9c48538-f03d-460f-b7aa-c9d0bc770e94&login=true
< Content-Length: 0
< Date: Sat, 09 Apr 2016 05:12:27 GMT
<
* Connection #0 to host localhost left intact
```
