### PR TITLE
KEYCLOAK-2838: Add cookie storage fallback to keycloak.js

### DIFF
--- a/adapters/oidc/js/src/main/resources/keycloak.js
+++ b/adapters/oidc/js/src/main/resources/keycloak.js
@@ -25,6 +25,7 @@
         var kc = this;
         var adapter;
         var refreshQueue = [];
+        var storage;
 
         var loginIframe = {
             enable: true,
@@ -45,8 +46,14 @@
                     adapter = loadAdapter();
                 }
             }
-            
+
             if (initOptions) {
+                if (typeof initOptions.storage !== 'undefined') {
+                    storage = initOptions.storage;
+                } else {
+                    storage = window.localStorage;
+                }
+
                 if (typeof initOptions.checkLoginIframe !== 'undefined') {
                     loginIframe.enable = initOptions.checkLoginIframe;
                 }
@@ -197,7 +204,7 @@
                 redirectUri += (redirectUri.indexOf('?') == -1 ? '?' : '&') + 'prompt=' + options.prompt;
             }
 
-            localStorage.oauthState = JSON.stringify({ state: state, nonce: nonce, redirectUri: encodeURIComponent(redirectUri) });
+            storage.oauthState = JSON.stringify({ state: state, nonce: nonce, redirectUri: encodeURIComponent(redirectUri) });
 
             var action = 'auth';
             if (options && options.action == 'register') {
@@ -694,10 +701,10 @@
         function parseCallback(url) {
             var oauth = new CallbackParser(url, kc.responseMode).parseUri();
 
-            var sessionState = localStorage.oauthState && JSON.parse(localStorage.oauthState);
+            var sessionState = storage.oauthState && JSON.parse(storage.oauthState);
 
             if (sessionState && (oauth.code || oauth.error || oauth.access_token || oauth.id_token) && oauth.state && oauth.state == sessionState.state) {
-                delete localStorage.oauthState;
+                delete storage.oauthState;
 
                 oauth.redirectUri = sessionState.redirectUri;
                 oauth.storedNonce = sessionState.nonce;

--- a/docbook/auth-server-docs/reference/en/en-US/modules/javascript-adapter.xml
+++ b/docbook/auth-server-docs/reference/en/en-US/modules/javascript-adapter.xml
@@ -260,6 +260,8 @@ new Keycloak({ url: 'http://localhost/auth', realm: 'myrealm', clientId: 'myApp'
                         </listitem>
                         <listitem>flow - set the OpenID Connect flow. Valid values are <literal>standard</literal>, <literal>implicit</literal> or <literal>hybrid</literal>.
                             See <link linkend="javascript-implicit-flow">Implicit flow</link> for details.</listitem>
+                        <listitem>storage - provide a storage object. The default is <literal>window.localStorage</literal>.
+                            You can also provide <literal>window.sessionStorage</literal> or your custom implementation.</listitem>
                     </itemizedlist>
                 </para>
                 <para>Returns promise to set functions to be invoked on success or error.</para>


### PR DESCRIPTION
This adds support to switch the storage backend in the keycloak.js adapter.

**Why?**
Because Safari (and probably other browsers, too) do not allow to write to `localStorage` or `sessionStorage` when in private mode. This allows us to change the storage without 
monkey patching 🎉. Our implementation roughly works like this:

``` javascript
let sessionStorage = window.sessionStorage;
try {
  const key = cookieName('test');
  sessionStorage.setItem(key, 'test');
  sessionStorage.removeItem(key);
} catch (err) {
  if (err.name === QuotaExceededError || sessionStorage.length === 0) {
    // Probably in Safari "private mode" where sessionStorage quota is 0.
    console.error('Warning: [keycloak] sessionStorage is not available in Safari private mode, switching to cookie storage.');
    // Replace sessionStorage with cookie storage.
}  
```
