### PR TITLE
KEYCLOAK-2828: Add P3P header to LoginStatusIframeEndpoint

### DIFF
--- a/themes/src/main/resources/theme/base/login/theme.properties
+++ b/themes/src/main/resources/theme/base/login/theme.properties
@@ -1,1 +1,2 @@
 locales=ca,de,en,es,fr,it,pt-BR
+sessionIframeP3P=CP="This is not a P3P policy!"


### PR DESCRIPTION
IE requires a P3P header to be present in <iframe /> response. Otherwise cookies are forbidden. The value of the header does not seem to matter.
