### PR TITLE
Examine query parameters for redirect URI

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/utils/RedirectUtils.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/utils/RedirectUtils.java
@@ -83,9 +83,10 @@ public class RedirectUtils {
             redirectUri = lowerCaseHostname(redirectUri);
 
             Set<String> resolveValidRedirects = resolveValidRedirects(uriInfo, rootUrl, validRedirects);
-            boolean valid = matchesRedirects(resolveValidRedirects, redirectUri);
+            String r = redirectUri;
+            boolean valid = matchesRedirects(resolveValidRedirects, r);
             if (!valid && redirectUri.indexOf('?') != -1) {
-                String r = redirectUri.substring(0, redirectUri.indexOf('?'));
+                r = redirectUri.substring(0, redirectUri.indexOf('?'));
                 valid = matchesRedirects(resolveValidRedirects, r);
             }
             if (!valid && r.startsWith(Constants.INSTALLED_APP_URL) && r.indexOf(':', Constants.INSTALLED_APP_URL.length()) >= 0) {

--- a/services/src/main/java/org/keycloak/protocol/oidc/utils/RedirectUtils.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/utils/RedirectUtils.java
@@ -82,11 +82,12 @@ public class RedirectUtils {
         } else {
             redirectUri = lowerCaseHostname(redirectUri);
 
-            String r = redirectUri.indexOf('?') != -1 ? redirectUri.substring(0, redirectUri.indexOf('?')) : redirectUri;
             Set<String> resolveValidRedirects = resolveValidRedirects(uriInfo, rootUrl, validRedirects);
-
-            boolean valid = matchesRedirects(resolveValidRedirects, r);
-
+            boolean valid = matchesRedirects(resolveValidRedirects, redirectUri);
+            if (!valid && redirectUri.indexOf('?') != -1) {
+                String r = redirectUri.substring(0, redirectUri.indexOf('?'));
+                valid = matchesRedirects(resolveValidRedirects, r);
+            }
             if (!valid && r.startsWith(Constants.INSTALLED_APP_URL) && r.indexOf(':', Constants.INSTALLED_APP_URL.length()) >= 0) {
                 int i = r.indexOf(':', Constants.INSTALLED_APP_URL.length());
 


### PR DESCRIPTION
The 'Valid Redirect URI' field effectively doesn't allow query parameters. RedirectUtil strips query parameters out of the requested redirectUri before comparing them to the set of valid redirects configured for the client.

So if my requested redirect is http://foo.com?bar=baz and I have http://foo.com?bar=baz as a valid redirect URI, RedirectUtil will return null because it strips ?bar=baz out of the requested redirect URI. I would have to allow all redirects to http://foo.com and not care about the query parameters.

Now RedirectUtils will check the requested redirect uri against the list of valid redirects before and after stripping the query parameters.
