### PR TITLE
KEYCLOAK-2898 Fix GroupMappersTest on wildfly. Clearing AssertEvents …

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/AbstractKeycloakTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/AbstractKeycloakTest.java
@@ -133,7 +133,7 @@ public abstract class AbstractKeycloakTest {
                 MASTER, ADMIN, ADMIN, Constants.ADMIN_CLI_CLIENT_ID);
         deleteMeOAuthClient = new DeleteMeOAuthClient(AuthServerTestEnricher.getAuthServerContextRoot() + "/auth");
 
-        testingClient = KeycloakTestingClient.getInstance(AuthServerTestEnricher.getAuthServerContextRoot() + "/auth");
+        getTestingClient();
 
         adminUser = createAdminUserRepresentation();
 
@@ -186,6 +186,13 @@ public abstract class AbstractKeycloakTest {
     public void setDefaultPageUriParameters() {
         masterRealmPage.setAuthRealm(MASTER);
         loginPage.setAuthRealm(MASTER);
+    }
+
+    protected KeycloakTestingClient getTestingClient() {
+        if (testingClient == null) {
+            testingClient = KeycloakTestingClient.getInstance(AuthServerTestEnricher.getAuthServerContextRoot() + "/auth");
+        }
+        return testingClient;
     }
 
     public abstract void addTestRealms(List<RealmRepresentation> testRealms);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/AssertEvents.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/AssertEvents.java
@@ -63,12 +63,9 @@ public class AssertEvents implements TestRule {
         return new Statement() {
             @Override
             public void evaluate() throws Throwable {
-                try {
-                    base.evaluate();
-                } finally {
-                    // TODO Test should fail if there are leftover events
-                    context.testingClient.testing().clearQueue();
-                }
+                context.getTestingClient().testing().clearQueue();
+                base.evaluate();
+                // TODO Test should fail if there are leftover events
             }
         };
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/group/GroupMappersTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/group/GroupMappersTest.java
@@ -109,7 +109,6 @@ public class GroupMappersTest extends AbstractGroupTest {
     @Test
     @SuppressWarnings("unchecked")
     public void testGroupMappers() throws Exception {
-        events.clear();
         RealmResource realm = adminClient.realms().realm("test");
         {
             UserRepresentation user = realm.users().search("topGroupUser", -1, -1).get(0);


### PR DESCRIPTION
…events queue before test instead of after
