### PR TITLE
KEYCLOAK-2924: Fire AdminEvents on user group membership changes.

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
@@ -960,7 +960,10 @@ public class UsersResource {
         }
 
         try {
-            if (user.isMemberOf(group)) user.leaveGroup(group);
+            if (user.isMemberOf(group)){
+                user.leaveGroup(group);
+                adminEvent.operation(OperationType.DELETE).resourcePath(uriInfo).success();
+            }
         } catch (ModelException me) {
             Properties messages = AdminRoot.getMessages(session, realm, auth.getAuth().getToken().getLocale());
             throw new ErrorResponseException(me.getMessage(), MessageFormat.format(messages.getProperty(me.getMessage(), me.getMessage()), me.getParameters()),
@@ -982,7 +985,10 @@ public class UsersResource {
         if (group == null) {
             throw new NotFoundException("Group not found");
         }
-        if (!user.isMemberOf(group)) user.joinGroup(group);
+        if (!user.isMemberOf(group)){
+            user.joinGroup(group);
+            adminEvent.operation(OperationType.CREATE).resourcePath(uriInfo).success();
+        }
     }
 
 


### PR DESCRIPTION
We now fire AdminEvents if a user joins or leaves a group.
This information can be used to deduce potential role changes
in custom event listeners.
