### PR TITLE
KEYCLOAK-2974: Handle ModelException in UsersResource

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
@@ -184,6 +184,8 @@ public class UsersResource {
             return ErrorResponse.exists("User exists with same username or email");
         } catch (ModelReadOnlyException re) {
             return ErrorResponse.exists("User is read only!");
+        } catch (ModelException me) {
+            return ErrorResponse.exists("Could not update user!");
         }
     }
 
@@ -226,6 +228,11 @@ public class UsersResource {
                 session.getTransaction().setRollbackOnly();
             }
             return ErrorResponse.exists("User exists with same username or email");
+        } catch (ModelException me){
+            if (session.getTransaction().isActive()) {
+                session.getTransaction().setRollbackOnly();
+            }
+            return ErrorResponse.exists("Could not create user");
         }
     }
 


### PR DESCRIPTION
We now handle ModelExceptions thrown while creating or updating
a new User by rolling back the transaction and presenting
an error message with a HTTP 409 (conflict) code.
Previously only ModelDuplicateExceptions were handled whilst
ModelExceptions, e.g. due to a failed database operation
lead to a HTTP 500 server error.
