### PR TITLE
KEYCLOAK-3016: BasicAuthRequestAuthenticator consumes HttpEntity on errors

### DIFF
--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/BasicAuthRequestAuthenticator.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/BasicAuthRequestAuthenticator.java
@@ -24,6 +24,7 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.util.EntityUtils;
 import org.jboss.logging.Logger;
 import org.keycloak.OAuth2Constants;
 import org.keycloak.adapters.authentication.ClientCredentialsProviderUtils;
@@ -104,6 +105,7 @@ public class BasicAuthRequestAuthenticator extends BearerTokenRequestAuthenticat
         int status = response.getStatusLine().getStatusCode();
         HttpEntity entity = response.getEntity();
         if (status != 200) {
+            EntityUtils.consumeQuietly(entity);
             throw new java.io.IOException("Bad status: " + status);
         }
         if (entity == null) {

--- a/testsuite/integration/src/test/java/org/keycloak/testsuite/adapter/AdapterTest.java
+++ b/testsuite/integration/src/test/java/org/keycloak/testsuite/adapter/AdapterTest.java
@@ -144,6 +144,11 @@ public class AdapterTest {
         testStrategy.testNullBearerTokenCustomErrorPage();
     }
 
+    @Test
+    public void testBasicAuthErrorHandling() throws Exception {
+        testStrategy.testBasicAuthErrorHandling();
+    }
+
     /**
      * KEYCLOAK-518
      * @throws Exception

--- a/testsuite/integration/src/test/resources/log4j.properties
+++ b/testsuite/integration/src/test/resources/log4j.properties
@@ -68,3 +68,6 @@ log4j.logger.org.jboss.resteasy=warn
 log4j.logger.org.apache.directory.api=warn
 log4j.logger.org.apache.directory.server.core=warn
 log4j.logger.org.apache.directory.server.ldap.LdapProtocolHandler=error
+
+# Enable to view HttpClient connection pool activity
+#log4j.logger.org.apache.http.impl.conn=debug


### PR DESCRIPTION
To properly release HttpClient's resources HttpEntity is consumed also when response status is non-200.
