### PR TITLE
Fixing callback sequence for JSON based config

### DIFF
--- a/adapters/oidc/js/src/main/resources/keycloak.js
+++ b/adapters/oidc/js/src/main/resources/keycloak.js
@@ -107,8 +107,6 @@
                 promise.setError();
             });
 
-            var configPromise = loadConfig(config);
-
             function onLoad() {
                 var doLogin = function(prompt) {
                     if (!prompt) {
@@ -179,9 +177,8 @@
                     initPromise.setSuccess();
                 }
             }
-
-            configPromise.success(processInit);
-            configPromise.error(function() {
+            
+            var configPromise = loadConfig(config,processInit,function() {
                 promise.setError();
             });
 
@@ -531,8 +528,8 @@
 
         }
 
-        function loadConfig(url) {
-            var promise = createPromise();
+        function loadConfig(url,successCallback,errorCallback) {
+            var promise = createPromise(successCallback,errorCallback);
             var configUrl;
 
             if (!config) {
@@ -715,7 +712,7 @@
             }
         }
 
-        function createPromise() {
+        function createPromise(successCallback,errorCallback) {
             var p = {
                 setSuccess: function(result) {
                     p.success = true;
@@ -752,6 +749,8 @@
                     }
                 }
             }
+            if(successCallback) p.promise.success(successCallback);
+            if(errorCallback) p.promise.error(errorCallback);
             return p;
         }
 


### PR DESCRIPTION
In the case where the config is a json Object in function loadConfig, the promise.setSuccess() was being called before the success callback was being set.
