### PR TITLE
KEYCLOAK-2891: Add link to OpenID Endpoint Configuration to realm details page.

### DIFF
--- a/themes/src/main/resources/theme/base/admin/messages/admin-messages_en.properties
+++ b/themes/src/main/resources/theme/base/admin/messages/admin-messages_en.properties
@@ -17,9 +17,11 @@ selectOne=Select One...
 true=True
 false=False
 
+endpoints=Endpoints
 
 # Realm settings
 realm-detail.enabled.tooltip=Users and clients can only access a realm if it's enabled
+realm-detail.oidc-endpoints.tooltip=Shows the configuration of the OpenID Connect endpoints
 registrationAllowed=User registration
 registrationAllowed.tooltip=Enable/disable the registration page. A link for registration will show on login page too.
 registrationEmailAsUsername=Email as username

--- a/themes/src/main/resources/theme/base/admin/resources/partials/realm-detail.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/realm-detail.html
@@ -32,6 +32,14 @@
             </div>
 
             <div class="form-group">
+                <label class="col-md-2 contr    ol-label">{{:: 'endpoints' | translate}}</label>
+                <div class="col-md-6">
+                    <a lass="form-control" ng-href="/auth/realms/{{realm.id}}/.well-known/openid-configuration" target="_blank">OpenID Endpoint Configuration</a>
+                </div>
+                <kc-tooltip>{{:: 'realm-detail.oidc-endpoints.tooltip' | translate}}</kc-tooltip>
+            </div>
+
+            <div class="form-group">
                 <div class="col-md-10 col-md-offset-2" data-ng-show="createRealm && access.manageRealm">
                     <button kc-save data-ng-show="changed">{{:: 'save' | translate}}</button>
                     <button kc-cancel data-ng-click="cancel()">{{:: 'cancel' | translate}}</button>


### PR DESCRIPTION
We now show a link to the OIDC Endpoints configuration in the realm details page.
This makes it easier for users to find the OIDC endpoints.

Could also be back-ported to 1.9.x.

See the JIRA for a quick demo gif: https://issues.jboss.org/browse/KEYCLOAK-2891 
