### PR TITLE
Fixes displaying message on login using base theme

### DIFF
--- a/themes/src/main/resources/theme/base/login/template.ftl
+++ b/themes/src/main/resources/theme/base/login/template.ftl
@@ -62,10 +62,10 @@
                     <#if displayMessage && message?has_content>
                         <div class="${properties.kcFeedbackAreaClass!}">
                             <div class="alert alert-${message.type}">
-                                <#if message.type = 'success'><span class="${properties.kcFeedbackSuccessIcon}"></span></#if>
-                                <#if message.type = 'warning'><span class="${properties.kcFeedbackWarningIcon}"></span></#if>
-                                <#if message.type = 'error'><span class="${properties.kcFeedbackErrorIcon}"></span></#if>
-                                <#if message.type = 'info'><span class="${properties.kcFeedbackInfoIcon}"></span></#if>
+                                <#if message.type = 'success'><span class="${properties.kcFeedbackSuccessIcon!}"></span></#if>
+                                <#if message.type = 'warning'><span class="${properties.kcFeedbackWarningIcon!}"></span></#if>
+                                <#if message.type = 'error'><span class="${properties.kcFeedbackErrorIcon!}"></span></#if>
+                                <#if message.type = 'info'><span class="${properties.kcFeedbackInfoIcon!}"></span></#if>
                                 <span class="kc-feedback-text">${message.summary}</span>
                             </div>
                         </div>


### PR DESCRIPTION
Using base theme produces an error when login page tries to display a message.
The following properties that are not defined in base theme (only in keycloak theme) are being called without default_value operator "!"
- Steps to Reproduce:
- Set `base` theme as `Login Theme`
- Sign out
- Try to sign in using and invalid username/password
- Expected behaviour:
  - Message `Invalid username or password.`is shown
- Actual behavior:
  - Bank page is shown and following stackatrace in logs:

```
15:58:19,575 ERROR [freemarker.runtime] (default task-9) Error executing FreeMarker template: freemarker.core.InvalidReferenceException: The following has evaluated to null or missing:
==> properties.kcFeedbackErrorIcon  [in template "template.ftl" at line 67, column 76]

----
Tip: It's the step after the last dot that caused this error, not those before it.
----
Tip: If the failing expression is known to be legally refer to something that's sometimes null or missing, either specify a default value like myOptionalVar!myDefault, or use <#if myOptionalVar??>when-present<#else>when-missing</#if>. (These only cover the last step of the expression; to cover the whole expression, use parenthesis: (myOptionalVar.foo)!myDefault, (myOptionalVar.foo)??
----

----
FTL stack trace ("~" means nesting-related):
    - Failed at: ${properties.kcFeedbackErrorIcon}  [in template "template.ftl" in macro "registrationLayout" at line 67, column 74]
    - Reached through: @layout.registrationLayout displayInf...  [in template "login.ftl" at line 2, column 1]
----
    at freemarker.core.InvalidReferenceException.getInstance(InvalidReferenceException.java:131)
    at freemarker.core.EvalUtil.coerceModelToString(EvalUtil.java:355)
    at freemarker.core.Expression.evalAndCoerceToString(Expression.java:82)
    at freemarker.core.DollarVariable.accept(DollarVariable.java:41)
    at freemarker.core.Environment.visit(Environment.java:324)
    at freemarker.core.MixedContent.accept(MixedContent.java:54)
    at freemarker.core.Environment.visitByHiddingParent(Environment.java:345)
    at freemarker.core.ConditionalBlock.accept(ConditionalBlock.java:48)
    at freemarker.core.Environment.visit(Environment.java:324)
    at freemarker.core.MixedContent.accept(MixedContent.java:54)
    at freemarker.core.Environment.visitByHiddingParent(Environment.java:345)
    at freemarker.core.ConditionalBlock.accept(ConditionalBlock.java:48)
    at freemarker.core.Environment.visit(Environment.java:324)
    at freemarker.core.MixedContent.accept(MixedContent.java:54)
    at freemarker.core.Environment.visit(Environment.java:324)
    at freemarker.core.Macro$Context.runMacro(Macro.java:184)
    at freemarker.core.Environment.invoke(Environment.java:701)
    at freemarker.core.UnifiedCall.accept(UnifiedCall.java:84)
    at freemarker.core.Environment.visit(Environment.java:324)
    at freemarker.core.MixedContent.accept(MixedContent.java:54)
    at freemarker.core.Environment.visit(Environment.java:324)
    at freemarker.core.Environment.process(Environment.java:302)
    at freemarker.template.Template.process(Template.java:325)
    at org.keycloak.theme.FreeMarkerUtil.processTemplate(FreeMarkerUtil.java:61)
    at org.keycloak.forms.login.freemarker.FreeMarkerLoginFormsProvider.createResponse(FreeMarkerLoginFormsProvider.java:314)
    at org.keycloak.forms.login.freemarker.FreeMarkerLoginFormsProvider.createLogin(FreeMarkerLoginFormsProvider.java:431)
    at org.keycloak.authentication.authenticators.browser.AbstractUsernameFormAuthenticator.invalidUser(AbstractUsernameFormAuthenticator.java:58)
    at org.keycloak.authentication.authenticators.browser.AbstractUsernameFormAuthenticator.invalidUser(AbstractUsernameFormAuthenticator.java:87)
    at org.keycloak.authentication.authenticators.browser.AbstractUsernameFormAuthenticator.validateUserAndPassword(AbstractUsernameFormAuthenticator.java:141)
    at org.keycloak.authentication.authenticators.browser.UsernamePasswordForm.validateForm(UsernamePasswordForm.java:56)
    at org.keycloak.authentication.authenticators.browser.UsernamePasswordForm.action(UsernamePasswordForm.java:49)
    at org.keycloak.authentication.DefaultAuthenticationFlow.processAction(DefaultAuthenticationFlow.java:84)
    at org.keycloak.authentication.DefaultAuthenticationFlow.processAction(DefaultAuthenticationFlow.java:75)
    at org.keycloak.authentication.AuthenticationProcessor.authenticationAction(AuthenticationProcessor.java:756)
    at org.keycloak.services.resources.LoginActionsService.processFlow(LoginActionsService.java:359)
    at org.keycloak.services.resources.LoginActionsService.processAuthentication(LoginActionsService.java:341)
    at org.keycloak.services.resources.LoginActionsService.authenticateForm(LoginActionsService.java:386)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:498)
    at org.jboss.resteasy.core.MethodInjectorImpl.invoke(MethodInjectorImpl.java:139)
    at org.jboss.resteasy.core.ResourceMethodInvoker.invokeOnTarget(ResourceMethodInvoker.java:295)
    at org.jboss.resteasy.core.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:249)
    at org.jboss.resteasy.core.ResourceLocatorInvoker.invokeOnTargetObject(ResourceLocatorInvoker.java:138)
    at org.jboss.resteasy.core.ResourceLocatorInvoker.invoke(ResourceLocatorInvoker.java:101)
    at org.jboss.resteasy.core.SynchronousDispatcher.invoke(SynchronousDispatcher.java:395)
    at org.jboss.resteasy.core.SynchronousDispatcher.invoke(SynchronousDispatcher.java:202)
    at org.jboss.resteasy.plugins.server.servlet.ServletContainerDispatcher.service(ServletContainerDispatcher.java:221)
    at org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher.service(HttpServletDispatcher.java:56)
    at org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher.service(HttpServletDispatcher.java:51)
    at javax.servlet.http.HttpServlet.service(HttpServlet.java:790)
    at io.undertow.servlet.handlers.ServletHandler.handleRequest(ServletHandler.java:85)
    at io.undertow.servlet.handlers.FilterHandler$FilterChainImpl.doFilter(FilterHandler.java:129)
    at org.keycloak.services.filters.KeycloakSessionServletFilter.doFilter(KeycloakSessionServletFilter.java:88)
    at io.undertow.servlet.core.ManagedFilter.doFilter(ManagedFilter.java:60)
    at io.undertow.servlet.handlers.FilterHandler$FilterChainImpl.doFilter(FilterHandler.java:131)
    at io.undertow.servlet.handlers.FilterHandler.handleRequest(FilterHandler.java:84)
    at io.undertow.servlet.handlers.security.ServletSecurityRoleHandler.handleRequest(ServletSecurityRoleHandler.java:62)
    at io.undertow.servlet.handlers.ServletDispatchingHandler.handleRequest(ServletDispatchingHandler.java:36)
    at org.wildfly.extension.undertow.security.SecurityContextAssociationHandler.handleRequest(SecurityContextAssociationHandler.java:78)
    at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
    at io.undertow.servlet.handlers.security.SSLInformationAssociationHandler.handleRequest(SSLInformationAssociationHandler.java:131)
    at io.undertow.servlet.handlers.security.ServletAuthenticationCallHandler.handleRequest(ServletAuthenticationCallHandler.java:57)
    at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
    at io.undertow.security.handlers.AbstractConfidentialityHandler.handleRequest(AbstractConfidentialityHandler.java:46)
    at io.undertow.servlet.handlers.security.ServletConfidentialityConstraintHandler.handleRequest(ServletConfidentialityConstraintHandler.java:64)
    at io.undertow.security.handlers.AuthenticationMechanismsHandler.handleRequest(AuthenticationMechanismsHandler.java:60)
    at io.undertow.servlet.handlers.security.CachedAuthenticatedSessionHandler.handleRequest(CachedAuthenticatedSessionHandler.java:77)
    at io.undertow.security.handlers.NotificationReceiverHandler.handleRequest(NotificationReceiverHandler.java:50)
    at io.undertow.security.handlers.AbstractSecurityContextAssociationHandler.handleRequest(AbstractSecurityContextAssociationHandler.java:43)
    at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
    at org.wildfly.extension.undertow.security.jacc.JACCContextIdHandler.handleRequest(JACCContextIdHandler.java:61)
    at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
    at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
    at io.undertow.servlet.handlers.ServletInitialHandler.handleFirstRequest(ServletInitialHandler.java:284)
    at io.undertow.servlet.handlers.ServletInitialHandler.dispatchRequest(ServletInitialHandler.java:263)
    at io.undertow.servlet.handlers.ServletInitialHandler.access$000(ServletInitialHandler.java:81)
    at io.undertow.servlet.handlers.ServletInitialHandler$1.handleRequest(ServletInitialHandler.java:174)
    at io.undertow.server.Connectors.executeRootHandler(Connectors.java:202)
    at io.undertow.server.HttpServerExchange$1.run(HttpServerExchange.java:793)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
    at java.lang.Thread.run(Thread.java:745)
```
