### PR TITLE
KEYCLOAK-3050 - fix npe on deployment

### DIFF
--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/RefreshableKeycloakSecurityContext.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/RefreshableKeycloakSecurityContext.java
@@ -74,7 +74,7 @@ public class RefreshableKeycloakSecurityContext extends KeycloakSecurityContext 
     }
 
     public boolean isActive() {
-        return token != null && this.token.isActive() && this.token.getIssuedAt() > deployment.getNotBefore();
+        return token != null && this.token.isActive() && deployment!=null && this.token.getIssuedAt() > deployment.getNotBefore();
     }
 
     public KeycloakDeployment getDeployment() {

--- a/adapters/oidc/adapter-core/src/test/java/org/keycloak/adapters/RefreshableKeycloakSecurityContextTest.java
+++ b/adapters/oidc/adapter-core/src/test/java/org/keycloak/adapters/RefreshableKeycloakSecurityContextTest.java
@@ -1,0 +1,23 @@
+package org.keycloak.adapters;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.keycloak.representations.oidc.TokenMetadataRepresentation;
+/**
+ * @author github.com/tubbynl
+ *
+ */
+public class RefreshableKeycloakSecurityContextTest {
+
+	@Test
+	public void isActive() {
+		TokenMetadataRepresentation token = new TokenMetadataRepresentation();
+		token.setActive(true);
+		token.issuedNow();
+		RefreshableKeycloakSecurityContext sut = new RefreshableKeycloakSecurityContext(null,null,null,token,null, null, null);
+		
+		// verify false if null deployment (KEYCLOAK-3050; yielded a npe)
+		assertFalse(sut.isActive());
+	}
+}


### PR DESCRIPTION
Fix on npe in RefreshableKeycloakSecurityContext

fixed on the 1.9.x branch but it's also eligible for the master as far as i can tell
