### PR TITLE
KEYCLOAK-3065 Remove 'provider' from realmCache in keycloak-server.js…

### DIFF
--- a/distribution/feature-packs/server-feature-pack/src/main/resources/content/standalone/configuration/keycloak-server.json
+++ b/distribution/feature-packs/server-feature-pack/src/main/resources/content/standalone/configuration/keycloak-server.json
@@ -61,7 +61,6 @@
     },
 
     "realmCache": {
-        "provider": "default",
         "default" : {
             "enabled": true
         }


### PR DESCRIPTION
…on to have 'enabled' switch working
