### PR TITLE
KEYCLOAK-2891: Fix label alignment for OIDC Endpoint link.

### DIFF
--- a/themes/src/main/resources/theme/base/admin/resources/partials/realm-detail.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/realm-detail.html
@@ -32,7 +32,7 @@
             </div>
 
             <div class="form-group">
-                <label class="col-md-2 contr    ol-label">{{:: 'endpoints' | translate}}</label>
+                <label class="col-md-2 control-label">{{:: 'endpoints' | translate}}</label>
                 <div class="col-md-6">
                     <a lass="form-control" ng-href="/auth/realms/{{realm.id}}/.well-known/openid-configuration" target="_blank">OpenID Endpoint Configuration</a>
                 </div>


### PR DESCRIPTION
This probably happend during merge.
