### PR TITLE
KEYCLOAK-3054: Use string format for log message

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/RealmsResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/RealmsResource.java
@@ -100,7 +100,7 @@ public class RealmsResource {
 
         LoginProtocolFactory factory = (LoginProtocolFactory)session.getKeycloakSessionFactory().getProviderFactory(LoginProtocol.class, protocol);
         if(factory == null){
-            logger.debugv("protocol %s not found", protocol);
+            logger.debugf("protocol %s not found", protocol);
             throw new NotFoundException("Protocol not found");
         }
 


### PR DESCRIPTION
Need to use log.debugf(..) to correctly resolve the %s placeholder.
