### PR TITLE
KEYCLOAK-3052 Admin theme can't be extended with javascript

### DIFF
--- a/themes/src/main/resources/theme/base/admin/index.ftl
+++ b/themes/src/main/resources/theme/base/admin/index.ftl
@@ -50,6 +50,13 @@
     <script src="${resourceUrl}/js/controllers/groups.js" type="text/javascript"></script>
     <script src="${resourceUrl}/js/loaders.js" type="text/javascript"></script>
     <script src="${resourceUrl}/js/services.js" type="text/javascript"></script>
+
+    <#if properties.scripts?has_content>
+        <#list properties.scripts?split(' ') as script>
+            <script type="text/javascript" src="${url.resourcesPath}/${script}"></script>
+        </#list>
+    </#if>
+
 </head>
 <body data-ng-controller="GlobalCtrl" data-ng-cloak data-ng-show="auth.user">
 

--- a/themes/src/main/resources/theme/base/admin/index.ftl
+++ b/themes/src/main/resources/theme/base/admin/index.ftl
@@ -53,7 +53,7 @@
 
     <#if properties.scripts?has_content>
         <#list properties.scripts?split(' ') as script>
-            <script type="text/javascript" src="${url.resourcesPath}/${script}"></script>
+            <script type="text/javascript" src="${resourceUrl}/${script}"></script>
         </#list>
     </#if>
 


### PR DESCRIPTION
Pick up scripts from theme.properties. Fixes [KEYCLOAK-3052](https://issues.jboss.org/browse/KEYCLOAK-3052)
