### PR TITLE
KEYCLOAK-3139 - Support loading keycloack.json from classpath

### DIFF
--- a/adapters/oidc/tomcat/tomcat-core/src/main/java/org/keycloak/adapters/tomcat/AbstractKeycloakAuthenticatorValve.java
+++ b/adapters/oidc/tomcat/tomcat-core/src/main/java/org/keycloak/adapters/tomcat/AbstractKeycloakAuthenticatorValve.java
@@ -61,6 +61,7 @@ import org.keycloak.adapters.KeycloakConfigResolver;
 public abstract class AbstractKeycloakAuthenticatorValve extends FormAuthenticator implements LifecycleListener {
 
     public static final String TOKEN_STORE_NOTE = "TOKEN_STORE_NOTE";
+    private static final String PROTOCOL_CLASSPATH = "classpath:";
 
 	private final static Logger log = Logger.getLogger(""+AbstractKeycloakAuthenticatorValve.class);
 	protected CatalinaUserSessionManagement userSessionManagement = new CatalinaUserSessionManagement();
@@ -163,7 +164,10 @@ public abstract class AbstractKeycloakAuthenticatorValve extends FormAuthenticat
                 is = context.getServletContext().getResourceAsStream("/WEB-INF/keycloak.json");
             } else {
                 try {
-                    is = new FileInputStream(path);
+                    is = (path.startsWith(PROTOCOL_CLASSPATH))
+                            ?AbstractKeycloakAuthenticatorValve.class.getResourceAsStream(path.replace(PROTOCOL_CLASSPATH, ""))
+                            :
+                            new FileInputStream(path);
                 } catch (FileNotFoundException e) {
                     log.log(Level.SEVERE, "NOT FOUND {0}", path);
                     throw new RuntimeException(e);


### PR DESCRIPTION
When using tomcat adapter, it is possible to set keycloak.config.file property to point adapter to keycloak.json on the file system (i.e. keycloak.config.file -> /etc/somepath).
It would be useful to have this property support classpath resources as well (i.e. keycloak.config.file -> classpath:/etc/somepath).
