### PR TITLE
make locale retrieval null-safe

### DIFF
--- a/services/src/main/java/org/keycloak/services/util/LocaleHelper.java
+++ b/services/src/main/java/org/keycloak/services/util/LocaleHelper.java
@@ -135,21 +135,23 @@ public class LocaleHelper {
 
     private static Locale findLocale(Set<String> supportedLocales, String... localeStrings) {
         for (String localeString : localeStrings) {
-            Locale result = null;
-            Locale search = Locale.forLanguageTag(localeString);
-            for (String languageTag : supportedLocales) {
-                Locale locale = Locale.forLanguageTag(languageTag);
-                if (locale.getLanguage().equals(search.getLanguage())) {
-                    if (locale.getCountry().equals("") && result == null) {
-                        result = locale;
-                    }
-                    if (locale.getCountry().equals(search.getCountry())) {
-                        return locale;
+            if (localeString != null) {
+                Locale result = null;
+                Locale search = Locale.forLanguageTag(localeString);
+                for (String languageTag : supportedLocales) {
+                    Locale locale = Locale.forLanguageTag(languageTag);
+                    if (locale.getLanguage().equals(search.getLanguage())) {
+                        if (locale.getCountry().equals("") && result == null) {
+                            result = locale;
+                        }
+                        if (locale.getCountry().equals(search.getCountry())) {
+                            return locale;
+                        }
                     }
                 }
-            }
-            if (result != null) {
-                return result;
+                if (result != null) {
+                    return result;
+                }
             }
         }
         return null;

--- a/services/src/test/java/org/keycloak/services/util/LocaleHelperTest.java
+++ b/services/src/test/java/org/keycloak/services/util/LocaleHelperTest.java
@@ -1,0 +1,23 @@
+package org.keycloak.services.util;
+
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsNull.nullValue;
+
+public class LocaleHelperTest {
+
+    @Test
+    public void shouldNotExceptionOnNullLocaleAttributeItem() throws Exception {
+        final Method method = LocaleHelper.class.getDeclaredMethod("findLocale", Set.class, String[].class);
+        method.setAccessible(true);
+        Locale foundLocale = (Locale) method.invoke(null, Stream.of("en", "es", "fr").collect(Collectors.toSet()), new String[]{null});
+        assertThat(foundLocale, nullValue());
+    }
+}


### PR DESCRIPTION
We hit an error where AuthenticationManager.redirectAfterSuccessfulFlow was attempting to retrieve a Locale from a user with a null list item for Locale.  This resulted in a slow, masked failure.  

This change makes locale retrieval null-safe.  

Alternatively, we could throw/log the exception more clearly.  However, it seemed reasonable to account for nulls here since operations in which the LOCALE attribute is not populated are allowed.
