### PR TITLE
[KEYCLOAK-3213] getResponseCode was deprecated in Undertow 1.3

### DIFF
--- a/adapters/oidc/undertow/src/main/java/org/keycloak/adapters/undertow/AbstractUndertowKeycloakAuthMech.java
+++ b/adapters/oidc/undertow/src/main/java/org/keycloak/adapters/undertow/AbstractUndertowKeycloakAuthMech.java
@@ -58,7 +58,7 @@ public abstract class AbstractUndertowKeycloakAuthMech implements Authentication
         if (challenge != null) {
             UndertowHttpFacade facade = createFacade(exchange);
             if (challenge.challenge(facade)) {
-                return new ChallengeResult(true, exchange.getResponseCode());
+                return new ChallengeResult(true, exchange.getStatusCode());
             }
         }
         return new ChallengeResult(false);


### PR DESCRIPTION
- Use getStatusCode instead of the deprecated getResponseCode
