### PR TITLE
KEYCLOAK-3240: No tooltip shown for Client Mapper Type

### DIFF
--- a/themes/src/main/resources/theme/base/admin/resources/js/controllers/clients.js
+++ b/themes/src/main/resources/theme/base/admin/resources/js/controllers/clients.js
@@ -1699,6 +1699,8 @@ module.controller('ClientProtocolMapperCreateCtrl', function($scope, realm, serv
         changed: false,
         mapperTypes: serverInfo.protocolMapperTypes[protocol]
     }
+    
+    $scope.model.mapperType = $scope.model.mapperTypes[0];
 
     $scope.$watch(function() {
         return $location.path();
@@ -1963,6 +1965,8 @@ module.controller('ClientTemplateProtocolMapperCreateCtrl', function($scope, rea
         changed: false,
         mapperTypes: serverInfo.protocolMapperTypes[protocol]
     }
+    
+    $scope.model.mapperType = $scope.model.mapperTypes[0];
 
     $scope.$watch(function() {
         return $location.path();


### PR DESCRIPTION
Real problem was that the initial dropdown had no default value.  The tooltip changes based on the value of the dropdown.  So with nothing selected, the tooltip would contain no text.
