### PR TITLE
KEYCLOAK-3244: Required Action "Configure Totp" should be "Configure OTP"

### DIFF
--- a/server-spi/src/main/java/org/keycloak/migration/MigrationModel.java
+++ b/server-spi/src/main/java/org/keycloak/migration/MigrationModel.java
@@ -26,7 +26,7 @@ public interface MigrationModel {
     /**
      * Must have the form of major.minor.micro as the version is parsed and numbers are compared
      */
-    String LATEST_VERSION = "2.0.0";
+    String LATEST_VERSION = "2.1.0";
 
     String getStoredVersion();
     void setStoredVersion(String version);

--- a/server-spi/src/main/java/org/keycloak/migration/MigrationModelManager.java
+++ b/server-spi/src/main/java/org/keycloak/migration/MigrationModelManager.java
@@ -27,6 +27,7 @@ import org.keycloak.migration.migrators.MigrateTo1_8_0;
 import org.keycloak.migration.migrators.MigrateTo1_9_0;
 import org.keycloak.migration.migrators.MigrateTo1_9_2;
 import org.keycloak.migration.migrators.MigrateTo2_0_0;
+import org.keycloak.migration.migrators.MigrateTo2_1_0;
 import org.keycloak.migration.migrators.MigrationTo1_2_0_CR1;
 import org.keycloak.models.KeycloakSession;
 
@@ -105,6 +106,12 @@ public class MigrationModelManager {
                 logger.debug("Migrating older model to 2.0.0 updates");
             }
             new MigrateTo2_0_0().migrate(session);
+        }
+        if (stored == null || stored.lessThan(MigrateTo2_1_0.VERSION)) {
+            if (stored != null) {
+                logger.debug("Migrating older model to 2.1.0 updates");
+            }
+            new MigrateTo2_1_0().migrate(session);
         }
 
         model.setStoredVersion(MigrationModel.LATEST_VERSION);

--- a/server-spi/src/main/java/org/keycloak/migration/migrators/MigrateTo2_1_0.java
+++ b/server-spi/src/main/java/org/keycloak/migration/migrators/MigrateTo2_1_0.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2016 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.keycloak.migration.migrators;
+
+import org.keycloak.migration.ModelVersion;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.RequiredActionProviderModel;
+import org.keycloak.models.UserModel;
+
+/**
+ *
+ * @author Stan Silvert ssilvert@redhat.com (C) 2016 Red Hat Inc.
+ */
+public class MigrateTo2_1_0 {
+    public static final ModelVersion VERSION = new ModelVersion("2.1.0");
+
+    public void migrate(KeycloakSession session) {
+        for (RealmModel realm : session.realms().getRealms()) {
+            migrateDefaultRequiredAction(realm);
+        }
+    }
+    
+    // KEYCLOAK-3244: Required Action "Configure Totp" should be "Configure OTP"
+    private void migrateDefaultRequiredAction(RealmModel realm) {
+        RequiredActionProviderModel otpAction = realm.getRequiredActionProviderByAlias(UserModel.RequiredAction.CONFIGURE_TOTP.name());
+
+        if (otpAction == null) return;
+        if (!otpAction.getProviderId().equals(UserModel.RequiredAction.CONFIGURE_TOTP.name())) return;
+        if (!otpAction.getName().equals("Configure Totp")) return;
+
+        otpAction.setName("Configure OTP");
+    }
+}

--- a/server-spi/src/main/java/org/keycloak/models/utils/DefaultRequiredActions.java
+++ b/server-spi/src/main/java/org/keycloak/models/utils/DefaultRequiredActions.java
@@ -52,7 +52,7 @@ public class DefaultRequiredActions {
             RequiredActionProviderModel totp = new RequiredActionProviderModel();
             totp.setEnabled(true);
             totp.setAlias(UserModel.RequiredAction.CONFIGURE_TOTP.name());
-            totp.setName("Configure Totp");
+            totp.setName("Configure OTP");
             totp.setProviderId(UserModel.RequiredAction.CONFIGURE_TOTP.name());
             totp.setDefaultAction(false);
             realm.addRequiredActionProvider(totp);

--- a/services/src/main/java/org/keycloak/authentication/requiredactions/UpdateTotp.java
+++ b/services/src/main/java/org/keycloak/authentication/requiredactions/UpdateTotp.java
@@ -113,7 +113,7 @@ public class UpdateTotp implements RequiredActionProvider, RequiredActionFactory
 
     @Override
     public String getDisplayText() {
-        return "Configure Totp";
+        return "Configure OTP";
     }
 
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/authentication/RequiredActionsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/authentication/RequiredActionsTest.java
@@ -44,7 +44,7 @@ public class RequiredActionsTest extends AbstractAuthenticationTest {
         List<RequiredActionProviderRepresentation> result = authMgmtResource.getRequiredActions();
 
         List<RequiredActionProviderRepresentation> expected = new ArrayList<>();
-        addRequiredAction(expected, "CONFIGURE_TOTP", "Configure Totp", true, false, null);
+        addRequiredAction(expected, "CONFIGURE_TOTP", "Configure OTP", true, false, null);
         addRequiredAction(expected, "UPDATE_PASSWORD", "Update Password", true, false, null);
         addRequiredAction(expected, "UPDATE_PROFILE", "Update Profile", true, false, null);
         addRequiredAction(expected, "VERIFY_EMAIL", "Verify Email", true, false, null);


### PR DESCRIPTION
Implemented the "trivial" fix as indicated on the JIRA.  However, there are a few other things to think about.

First, the displayed value actually comes from totp.setName() in DefaultRequiredActions.  The value is stored in the database.  So for upgraded servers, it will always say "Configure TOTP".  That is, unless we want to change it as part of an upgrade script.

Second, the code uses the term "totp" all over the place.  I assume that sometimes this is appropriate, but most of the time we really just mean "otp"?
