### PR TITLE
KEYCLOAK-3259 Specify UTF-8 encoding for freemarker template files

### DIFF
--- a/services/src/main/java/org/keycloak/theme/FreeMarkerUtil.java
+++ b/services/src/main/java/org/keycloak/theme/FreeMarkerUtil.java
@@ -68,7 +68,7 @@ public class FreeMarkerUtil {
     private Template getTemplate(String templateName, Theme theme) throws IOException {
         Configuration cfg = new Configuration();
         cfg.setTemplateLoader(new ThemeTemplateLoader(theme));
-        return cfg.getTemplate(templateName);
+        return cfg.getTemplate(templateName, "UTF-8");
     }
 
     class ThemeTemplateLoader extends URLTemplateLoader {


### PR DESCRIPTION
I added `"UTF-8"` encoding when the template files were loaded.
