### PR TITLE
KEYCLOAK-3308: Return -1 from getDateHeader() when request is restored.

### DIFF
--- a/adapters/spi/servlet-adapter-spi/src/main/java/org/keycloak/adapters/servlet/FilterSessionStore.java
+++ b/adapters/spi/servlet-adapter-spi/src/main/java/org/keycloak/adapters/servlet/FilterSessionStore.java
@@ -192,7 +192,7 @@ public class FilterSessionStore implements AdapterSessionStore {
                 @Override
                 public long getDateHeader(String name) {
                    if (!needRequestRestore) return super.getDateHeader(name);
-                   throw new RuntimeException("This method is not supported in a restored authenticated request");
+                   return -1;
                 }
 
                 @Override


### PR DESCRIPTION
Certain containers will attempt to access date (such as when
checking If-Modified-Since header)  and fail when accessing restored
request. The javax.servlet.http.HttpServletRequest#getDateHeader()
javadocs indicate that -1 should be returned when date is not available
