### PR TITLE
Instead of using username, LDAP_ID must be used for user lookup

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/federation/ldap/LDAPFederationProvider.java
+++ b/federation/ldap/src/main/java/org/keycloak/federation/ldap/LDAPFederationProvider.java
@@ -225,6 +225,23 @@ public class LDAPFederationProvider implements UserFederationProvider {
         return Collections.emptyList();
     }
 
+    public List<UserModel> loadUsersByUids(List<String> uids, RealmModel realm) {
+        List<UserModel> result = new ArrayList<>();
+        for (String uid : uids) {
+            List<UserModel> userModels = session.users().searchForUserByUserAttribute(LDAPConstants.LDAP_ID, uid, realm);
+            if (userModels == null || userModels.size() == 0) {
+                logger.warnf("User with uid '%s' referenced by membership wasn't found in LDAP", uid);
+            } else if (userModels.size() > 1) {
+                logger.warnf("User with uid '%s' referenced by membership found multiple times in LDAP", uid);
+            } else if (!model.getId().equals(userModels.get(0).getFederationLink())) {
+                logger.warnf("Incorrect federation provider of user '%s'", userModels.get(0).getUsername());
+            } else {
+                result.add(userModels.get(0));
+            }
+        }
+        return result;
+    }
+
     public List<UserModel> loadUsersByUsernames(List<String> usernames, RealmModel realm) {
         List<UserModel> result = new ArrayList<>();
         for (String username : usernames) {

--- a/federation/ldap/src/main/java/org/keycloak/federation/ldap/mappers/membership/MembershipType.java
+++ b/federation/ldap/src/main/java/org/keycloak/federation/ldap/mappers/membership/MembershipType.java
@@ -146,7 +146,7 @@ public enum MembershipType {
             int max = Math.min(memberUids.size(), firstResult + maxResults);
             uids = uids.subList(firstResult, max);
 
-            return groupMapper.getLdapProvider().loadUsersByUsernames(uids, groupMapper.getRealm());
+            return groupMapper.getLdapProvider().loadUsersByUids(uids, groupMapper.getRealm());
         }
 
     };


### PR DESCRIPTION
Small bugfix. If GroupMapper for LDAP groups is used and the memberUID mode is enabled, the assignment between groups and users is not correctly calculated. Instead of searching user by username it must be searched by UID attribute.
Its a fix for implementation of this JIRA: https://issues.jboss.org/browse/KEYCLOAK-2053
