### PR TITLE
KEYCLOAK-3348 Introduce updatedTimestamp property to UserEntity

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/UserAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/UserAdapter.java
@@ -96,6 +96,18 @@ public class UserAdapter implements UserModel {
     }
 
     @Override
+    public Long getUpdatedTimestamp() {
+        if (updated != null) return updated.getUpdatedTimestamp();
+        return cached.getUpdatedTimestamp();
+    }
+
+    @Override
+    public void setUpdatedTimestamp(Long timestamp) {
+        getDelegateForUpdate();
+        updated.setUpdatedTimestamp(timestamp);
+    }
+
+    @Override
     public boolean isEnabled() {
         if (updated != null) return updated.isEnabled();
         return cached.isEnabled();

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/entities/CachedUser.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/entities/CachedUser.java
@@ -40,6 +40,7 @@ public class CachedUser extends AbstractRevisioned implements InRealm  {
     private String realm;
     private String username;
     private Long createdTimestamp;
+    private Long updatedTimestamp;
     private String firstName;
     private String lastName;
     private String email;
@@ -61,6 +62,7 @@ public class CachedUser extends AbstractRevisioned implements InRealm  {
         this.realm = realm.getId();
         this.username = user.getUsername();
         this.createdTimestamp = user.getCreatedTimestamp();
+        this.updatedTimestamp = user.getUpdatedTimestamp();
         this.firstName = user.getFirstName();
         this.lastName = user.getLastName();
         this.attributes.putAll(user.getAttributes());
@@ -93,6 +95,10 @@ public class CachedUser extends AbstractRevisioned implements InRealm  {
 
     public Long getCreatedTimestamp() {
         return createdTimestamp;
+    }
+
+    public Long getUpdatedTimestamp() {
+        return updatedTimestamp;
     }
 
     public String getFirstName() {

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/UserAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/UserAdapter.java
@@ -109,6 +109,16 @@ public class UserAdapter implements UserModel, JpaModel<UserEntity> {
     }
 
     @Override
+    public Long getUpdatedTimestamp() {
+        return user.getUpdatedTimestamp();
+    }
+
+    @Override
+    public void setUpdatedTimestamp(Long timestamp) {
+        user.setUpdatedTimestamp(timestamp);
+    }
+
+    @Override
     public boolean isEnabled() {
         return user.isEnabled();
     }

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/UserEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/UserEntity.java
@@ -28,6 +28,7 @@ import javax.persistence.Id;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.persistence.OneToMany;
+import javax.persistence.PreUpdate;
 import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
 
@@ -70,6 +71,8 @@ public class UserEntity {
     protected String firstName;
     @Column(name = "CREATED_TIMESTAMP")
     protected Long createdTimestamp;
+    @Column(name = "UPDATED_TIMESTAMP")
+    protected Long updatedTimestamp;
     @Column(name = "LAST_NAME")
     protected String lastName;
     @Column(name = "EMAIL")
@@ -125,6 +128,14 @@ public class UserEntity {
 
     public void setCreatedTimestamp(Long timestamp) {
         createdTimestamp = timestamp;
+    }
+
+    public Long getUpdatedTimestamp() {
+        return updatedTimestamp;
+    }
+
+    public void setUpdatedTimestamp(Long timestamp) {
+        this.updatedTimestamp = timestamp;
     }
 
     public String getFirstName() {
@@ -248,5 +259,12 @@ public class UserEntity {
     @Override
     public int hashCode() {
         return id.hashCode();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+
+        //TODO use appropriate time-source to derive updatedTimestamp
+        this.updatedTimestamp = System.currentTimeMillis();
     }
 }

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-2.1.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-2.1.0.xml
@@ -191,4 +191,12 @@
         <addForeignKeyConstraint baseColumnNames="REALM_ID" baseTableName="STORAGE_PROVIDER" constraintName="FK_STORAGE_PROVIDER_REALM" referencedColumnNames="ID" referencedTableName="REALM"/>
         -->
     </changeSet>
+
+    <changeSet author="thomas.darimont@gmail.com" id="2.1.0-1">
+        <addColumn tableName="USER_ENTITY">
+            <column name="UPDATED_TIMESTAMP" type="BIGINT">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+    </changeSet>
 </databaseChangeLog>

--- a/model/mongo/src/main/java/org/keycloak/models/mongo/keycloak/adapters/UserAdapter.java
+++ b/model/mongo/src/main/java/org/keycloak/models/mongo/keycloak/adapters/UserAdapter.java
@@ -101,6 +101,16 @@ public class UserAdapter extends AbstractMongoAdapter<MongoUserEntity> implement
     }
 
     @Override
+    public Long getUpdatedTimestamp() {
+        return user.getUpdatedTimestamp();
+    }
+
+    @Override
+    public void setUpdatedTimestamp(Long timestamp) {
+        user.setUpdatedTimestamp(timestamp);
+    }
+
+    @Override
     public boolean isEnabled() {
         return user.isEnabled();
     }
@@ -454,6 +464,7 @@ public class UserAdapter extends AbstractMongoAdapter<MongoUserEntity> implement
     }
 
     protected void updateUser() {
+        setUpdatedTimestamp(System.currentTimeMillis());
         super.updateMongoEntity();
     }
 

--- a/server-spi/src/main/java/org/keycloak/models/UserModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/UserModel.java
@@ -52,6 +52,13 @@ public interface UserModel extends RoleMapperModel {
     
     void setCreatedTimestamp(Long timestamp);
 
+    /**
+     * Get timestamp of the most recent user update. May be null for old users created before this feature introduction.
+     */
+    Long getUpdatedTimestamp();
+
+    void setUpdatedTimestamp(Long timestamp);
+
     boolean isEnabled();
 
     boolean isOtpEnabled();

--- a/server-spi/src/main/java/org/keycloak/models/entities/UserEntity.java
+++ b/server-spi/src/main/java/org/keycloak/models/entities/UserEntity.java
@@ -28,6 +28,7 @@ public class UserEntity extends AbstractIdentifiableEntity {
 
     private String username;
     private Long createdTimestamp;
+    private Long updatedTimestamp;
     private String firstName;
     private String lastName;
     private String email;
@@ -63,6 +64,13 @@ public class UserEntity extends AbstractIdentifiableEntity {
         this.createdTimestamp = timestamp;
     }
 
+    public Long getUpdatedTimestamp() {
+        return updatedTimestamp;
+    }
+
+    public void setUpdatedTimestamp(Long updatedTimestamp) {
+        this.updatedTimestamp = updatedTimestamp;
+    }
 
     public String getFirstName() {
         return firstName;

--- a/server-spi/src/main/java/org/keycloak/models/utils/UserModelDelegate.java
+++ b/server-spi/src/main/java/org/keycloak/models/utils/UserModelDelegate.java
@@ -250,6 +250,16 @@ public class UserModelDelegate implements UserModel {
     }
 
     @Override
+    public Long getUpdatedTimestamp() {
+        return delegate.getUpdatedTimestamp();
+    }
+
+    @Override
+    public void setUpdatedTimestamp(Long timestamp) {
+        delegate.setUpdatedTimestamp(timestamp);
+    }
+
+    @Override
     public Set<GroupModel> getGroups() {
         return delegate.getGroups();
     }

--- a/server-spi/src/main/java/org/keycloak/storage/adapter/AbstractUserAdapter.java
+++ b/server-spi/src/main/java/org/keycloak/storage/adapter/AbstractUserAdapter.java
@@ -231,7 +231,16 @@ public abstract class AbstractUserAdapter implements UserModel {
     @Override
     public void setOtpEnabled(boolean totp) {
         throw new ReadOnlyException("user is read only for this update");
+    }
 
+    @Override
+    public Long getUpdatedTimestamp() {
+        return null;
+    }
+
+    @Override
+    public void setUpdatedTimestamp(Long timestamp) {
+        throw new ReadOnlyException("user is read only for this update");
     }
 
     /**

--- a/server-spi/src/main/java/org/keycloak/storage/adapter/AbstractUserAdapterFederatedStorage.java
+++ b/server-spi/src/main/java/org/keycloak/storage/adapter/AbstractUserAdapterFederatedStorage.java
@@ -56,6 +56,7 @@ public abstract class AbstractUserAdapterFederatedStorage implements UserModel {
     public static String CREATED_TIMESTAMP_ATTRIBUTE = "CREATED_TIMESTAMP";
     public static String ENABLED_ATTRIBUTE = "ENABLED";
     public static String OTP_ENABLED_ATTRIBUTE = "OTP_ENABLED";
+    public static String UPDATED_TIMESTAMP_ATTRIBUTE = "UPDATED_TIMESTAMP";
 
 
     protected KeycloakSession session;
@@ -247,6 +248,20 @@ public abstract class AbstractUserAdapterFederatedStorage implements UserModel {
     public void setOtpEnabled(boolean totp) {
         setSingleAttribute(OTP_ENABLED_ATTRIBUTE, Boolean.toString(totp));
 
+    }
+
+    @Override
+    public Long getUpdatedTimestamp() {
+        String val = getFirstAttribute(UPDATED_TIMESTAMP_ATTRIBUTE);
+        if(val == null) {
+            return null;
+        }
+        return Long.valueOf(val);
+    }
+
+    @Override
+    public void setUpdatedTimestamp(Long timestamp) {
+        setSingleAttribute(UPDATED_TIMESTAMP_ATTRIBUTE, timestamp.toString());
     }
 
     /**

--- a/server-spi/src/main/java/org/keycloak/storage/changeset/UserData.java
+++ b/server-spi/src/main/java/org/keycloak/storage/changeset/UserData.java
@@ -39,6 +39,8 @@ public class UserData {
     private boolean usernameChanged;
     private Long createdTimestamp;
     private boolean createdTimestampChanged;
+    private Long updatedTimestamp;
+    private boolean updatedTimestampChanged;
     private String firstName;
     private boolean firstNameChanged;
     private String lastName;
@@ -69,6 +71,7 @@ public class UserData {
         original.id = id;
         original.username = username;
         original.createdTimestamp = createdTimestamp;
+        original.updatedTimestamp = updatedTimestamp;
         original.firstName = firstName;
         original.lastName = lastName;
         original.email = email;
@@ -87,6 +90,7 @@ public class UserData {
         idChanged = false;
         usernameChanged = false;
         createdTimestampChanged = false;
+        updatedTimestampChanged = false;
         firstNameChanged = false;
         lastNameChanged = false;
         emailChanged = false;
@@ -104,6 +108,7 @@ public class UserData {
         return !idChanged
         && !usernameChanged
         && !createdTimestampChanged
+        && !updatedTimestampChanged
         && !firstNameChanged
         && !lastNameChanged
         && !emailChanged
@@ -127,6 +132,10 @@ public class UserData {
 
     public boolean isCreatedTimestampChanged() {
         return createdTimestampChanged;
+    }
+
+    public boolean isUpdatedTimestampChanged() {
+        return updatedTimestampChanged;
     }
 
     public boolean isFirstNameChanged() {
@@ -200,6 +209,14 @@ public class UserData {
         createdTimestampChanged = true;
     }
 
+    public Long getUpdatedTimestamp() {
+        return updatedTimestamp;
+    }
+
+    public void setUpdatedTimestamp(Long timestamp) {
+        this.updatedTimestamp = timestamp;
+        updatedTimestampChanged = true;
+    }
 
     public String getFirstName() {
         return firstName;

--- a/server-spi/src/main/java/org/keycloak/storage/changeset/UserDataAdapter.java
+++ b/server-spi/src/main/java/org/keycloak/storage/changeset/UserDataAdapter.java
@@ -84,7 +84,16 @@ public class UserDataAdapter implements UserModel {
     @Override
     public void setCreatedTimestamp(Long timestamp) {
         userData.setCreatedTimestamp(timestamp);
+    }
 
+    @Override
+    public Long getUpdatedTimestamp() {
+        return userData.getUpdatedTimestamp();
+    }
+
+    @Override
+    public void setUpdatedTimestamp(Long timestamp) {
+        userData.setUpdatedTimestamp(timestamp);
     }
 
     @Override


### PR DESCRIPTION
This helps to detect which version of two UserEntity instances is newer.
Propagated updatedTimestamp property through UserModel down to
all UserAdapter and UserEntity implementations.
In case of a JPA based user store the updatedTimestamp is maintained by a @PrePersist hook in UserEntity. 
In case of MongoDB the updatedTimestamp is maintained in maintained by the Mongo UserAdapter#updateUser.
