### PR TITLE
KEYCLOAK-2281 added ldap tests over ssl

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/LDAPRule.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/LDAPRule.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.Properties;
 
 import org.junit.rules.ExternalResource;
+import org.keycloak.models.LDAPConstants;
 import org.keycloak.util.ldap.LDAPEmbeddedServer;
 
 /**
@@ -29,6 +30,14 @@ import org.keycloak.util.ldap.LDAPEmbeddedServer;
 public class LDAPRule extends ExternalResource {
 
     public static final String LDAP_CONNECTION_PROPERTIES_LOCATION = "classpath:ldap/ldap-connection.properties";
+
+    private static final String PROPERTY_ENABLE_SSL = "enableSSL";
+
+    private static final String PROPERTY_KEYSTORE_FILE = "keystoreFile";
+
+    private static final String PRIVATE_KEY = "keystore/keycloak.jks";
+
+    private static final String PROPERTY_CERTIFICATE_PASSWORD = "certificatePassword";
 
     protected LDAPTestConfiguration ldapTestConfiguration;
     protected LDAPEmbeddedServer ldapEmbeddedServer;
@@ -66,6 +75,11 @@ public class LDAPRule extends ExternalResource {
         Properties defaultProperties = new Properties();
         defaultProperties.setProperty(LDAPEmbeddedServer.PROPERTY_DSF, LDAPEmbeddedServer.DSF_INMEMORY);
         defaultProperties.setProperty(LDAPEmbeddedServer.PROPERTY_LDIF_FILE, "classpath:ldap/users.ldif");
+        defaultProperties.setProperty(LDAPConstants.CONNECTION_URL, "ldaps://localhost:10636");
+        defaultProperties.setProperty(LDAPEmbeddedServer.PROPERTY_BIND_PORT, "10636");
+        defaultProperties.setProperty(PROPERTY_ENABLE_SSL, "true");
+        defaultProperties.setProperty(PROPERTY_CERTIFICATE_PASSWORD, "secret");
+        defaultProperties.setProperty(PROPERTY_KEYSTORE_FILE, this.getClass().getClassLoader().getResource(LDAPRule.PRIVATE_KEY).getFile());
 
         return new LDAPEmbeddedServer(defaultProperties);
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/UserFederationLdapConnectionTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/UserFederationLdapConnectionTest.java
@@ -57,6 +57,22 @@ public class UserFederationLdapConnectionTest extends AbstractAdminTest {
 
     }
 
+    @Test
+    public void testLdapConnectionsSsl() {
+
+        Response response = realm.testLDAPConnection(LDAPConnectionTestManager.TEST_CONNECTION, "ldaps://localhost:10636", "foo", "bar", "false");
+        assertStatus(response, 204);
+
+        response = realm.testLDAPConnection(LDAPConnectionTestManager.TEST_CONNECTION, "ldaps://localhostt:10636", "foo", "bar", "false");
+        assertStatus(response, 400);
+
+        response = realm.testLDAPConnection(LDAPConnectionTestManager.TEST_AUTHENTICATION, "ldaps://localhost:10636", "foo", "bar", "false");
+        assertStatus(response, 400);
+
+        response = realm.testLDAPConnection(LDAPConnectionTestManager.TEST_AUTHENTICATION, "ldaps://localhost:10636", "uid=admin,ou=system", "secret", "true");
+        assertStatus(response, 204);
+    }
+
     private void assertStatus(Response response, int status) {
         Assert.assertEquals(status, response.getStatus());
         response.close();

--- a/util/embedded-ldap/src/main/java/org/keycloak/util/ldap/LDAPEmbeddedServer.java
+++ b/util/embedded-ldap/src/main/java/org/keycloak/util/ldap/LDAPEmbeddedServer.java
@@ -219,13 +219,15 @@ public class LDAPEmbeddedServer {
         ldapServer.setSearchBaseDn(this.baseDN);
 
         // Read the transports
-        Transport ldap = new TcpTransport(this.bindHost, this.bindPort, 3, 50);
+        Transport ldaps = new TcpTransport(this.bindHost, this.bindPort, 3, 50);
         if (enableSSL) {
-            ldap.setEnableSSL(true);
+            ldaps.setEnableSSL(true);
             ldapServer.setKeystoreFile(keystoreFile);
             ldapServer.setCertificatePassword(certPassword);
+            Transport ldap = new TcpTransport(this.bindHost, 10389, 3, 50);
+            ldapServer.addTransports( ldap );
         }
-        ldapServer.addTransports( ldap );
+        ldapServer.addTransports( ldaps );
 
         // Associate the DS to this LdapServer
         ldapServer.setDirectoryService( directoryService );


### PR DESCRIPTION
Needed to change LDAPEmbeddedServer in order to run tests on both 389 and 636 ports
