### PR TITLE
KEYCLOAK-3369 Fire RealmPostCreateEvent

### DIFF
--- a/server-spi/src/main/java/org/keycloak/models/RealmModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/RealmModel.java
@@ -38,6 +38,11 @@ public interface RealmModel extends RoleContainerModel {
         RealmModel getCreatedRealm();
     }
 
+    interface RealmPostCreateEvent extends ProviderEvent {
+        RealmModel getCreatedRealm();
+        KeycloakSession getKeycloakSession();
+    }
+
     interface RealmRemovedEvent extends ProviderEvent {
         RealmModel getRealm();
         KeycloakSession getKeycloakSession();
@@ -342,19 +347,19 @@ public interface RealmModel extends RoleContainerModel {
     Set<String> getEventsListeners();
 
     void setEventsListeners(Set<String> listeners);
-    
+
     Set<String> getEnabledEventTypes();
 
     void setEnabledEventTypes(Set<String> enabledEventTypes);
-    
+
     boolean isAdminEventsEnabled();
 
     void setAdminEventsEnabled(boolean enabled);
-    
+
     boolean isAdminEventsDetailsEnabled();
 
     void setAdminEventsDetailsEnabled(boolean enabled);
-    
+
     ClientModel getMasterAdminClient();
 
     void setMasterAdminClient(ClientModel client);

--- a/services/src/main/java/org/keycloak/services/managers/RealmManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/RealmManager.java
@@ -121,6 +121,8 @@ public class RealmManager implements RealmImporter {
         setupOfflineTokens(realm);
         setupAuthorizationServices(realm);
 
+        fireRealmPostCreate(realm);
+
         return realm;
     }
 
@@ -491,6 +493,7 @@ public class RealmManager implements RealmImporter {
         }
 
         setupAuthorizationServices(realm);
+        fireRealmPostCreate(realm);
 
         return realm;
     }
@@ -587,4 +590,19 @@ public class RealmManager implements RealmImporter {
     private void setupAuthorizationServices(RealmModel realm) {
         KeycloakModelUtils.setupAuthorizationServices(realm);
     }
+
+    private void fireRealmPostCreate(RealmModel realm) {
+        session.getKeycloakSessionFactory().publish(new RealmModel.RealmPostCreateEvent() {
+            @Override
+            public RealmModel getCreatedRealm() {
+                return realm;
+            }
+            @Override
+            public KeycloakSession getKeycloakSession() {
+                return session;
+            }
+        });
+
+    }
+
 }


### PR DESCRIPTION
Note: RealmPostCreateEvent holds a KeycloakSession object so that extensions could apply modifications in the same session/transaction. Using separate session/transaction will lead to multiple concurrent data modification issues (at least with H2).
