### PR TITLE
KEYCLOAK-3392 Use authUrl prefix for OIDC Configuration link

### DIFF
--- a/themes/src/main/resources/theme/base/admin/resources/partials/realm-detail.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/realm-detail.html
@@ -34,7 +34,7 @@
             <div class="form-group">
                 <label class="col-md-2 control-label">{{:: 'endpoints' | translate}}</label>
                 <div class="col-md-6">
-                    <a lass="form-control" ng-href="/auth/realms/{{realm.id}}/.well-known/openid-configuration" target="_blank">OpenID Endpoint Configuration</a>
+                    <a class="form-control" ng-href="{{authUrl}}/realms/{{realm.id}}/.well-known/openid-configuration" target="_blank">OpenID Endpoint Configuration</a>
                 </div>
                 <kc-tooltip>{{:: 'realm-detail.oidc-endpoints.tooltip' | translate}}</kc-tooltip>
             </div>


### PR DESCRIPTION
We now use the {{authUrl}} prefix for the OIDC configuration link
in the admin-console to honor different web-context paths.

Previously when a different web-context than /auth was configured
the generated link pointed to the wrong location.

Signed-off-by: Thomas Darimont thomas.darimont@gmail.com
