### PR TITLE
Add client.name as a second parameter to the title expressions in login template

### DIFF
--- a/themes/src/main/resources/theme/base/login/login.ftl
+++ b/themes/src/main/resources/theme/base/login/login.ftl
@@ -1,9 +1,17 @@
 <#import "template.ftl" as layout>
 <@layout.registrationLayout displayInfo=social.displayInfo; section>
     <#if section = "title">
-        ${msg("loginTitle",(realm.displayName!''))}
+	<#if client??>
+        	${msg("loginTitle",(realm.displayName!''),(client.name!''))}
+	<#else>
+        	${msg("loginTitle",(realm.displayName!''))}
+	</#if>
     <#elseif section = "header">
-        ${msg("loginTitleHtml",(realm.displayNameHtml!''))}
+	<#if client??>
+        	${msg("loginTitleHtml",(realm.displayNameHtml!''),(client.name!''))}
+	<#else>
+        	${msg("loginTitleHtml",(realm.displayNameHtml!''))}
+	</#if>
     <#elseif section = "form">
         <#if realm.password>
             <form id="kc-form-login" class="${properties.kcFormClass!}" action="${url.loginAction}" method="post">


### PR DESCRIPTION
Add client.name as a new parameter to title expressions in login template so people extending the default template have the option to use the client name instead of just using the realm name (parameter {1}).
