### PR TITLE
KEYCLOAK-1835 Add initial support for sending welcome emails

### DIFF
--- a/server-spi/src/main/java/org/keycloak/email/EmailTemplateProvider.java
+++ b/server-spi/src/main/java/org/keycloak/email/EmailTemplateProvider.java
@@ -62,4 +62,6 @@ public interface EmailTemplateProvider extends Provider {
 
     public void sendVerifyEmail(String link, long expirationInMinutes) throws EmailException;
 
+    void sendWelcomeEmail(String link) throws EmailException;
+
 }

--- a/services/src/main/java/org/keycloak/email/freemarker/FreeMarkerEmailTemplateProvider.java
+++ b/services/src/main/java/org/keycloak/email/freemarker/FreeMarkerEmailTemplateProvider.java
@@ -26,6 +26,7 @@ import org.keycloak.email.freemarker.beans.EventBean;
 import org.keycloak.email.freemarker.beans.ProfileBean;
 import org.keycloak.events.Event;
 import org.keycloak.events.EventType;
+import org.keycloak.models.ClientModel;
 import org.keycloak.theme.FreeMarkerException;
 import org.keycloak.theme.FreeMarkerUtil;
 import org.keycloak.theme.Theme;
@@ -144,6 +145,19 @@ public class FreeMarkerEmailTemplateProvider implements EmailTemplateProvider {
         attributes.put("realmName", getRealmName());
 
         send("emailVerificationSubject", "email-verification.ftl", attributes);
+    }
+
+    @Override
+    public void sendWelcomeEmail(String link) throws EmailException{
+
+        String realmName = getRealmName();
+
+        Map<String, Object> attributes = new HashMap<String, Object>();
+        attributes.put("user", new ProfileBean(user));
+        attributes.put("realmName", realmName);
+        attributes.put("link", link);
+
+        send("welcomeSubject", Arrays.asList(realmName, user.getUsername()), "welcome.ftl", attributes);
     }
 
     private void send(String subjectKey, String template, Map<String, Object> attributes) throws EmailException {

--- a/themes/src/main/resources/theme/base/email/html/welcome.ftl
+++ b/themes/src/main/resources/theme/base/email/html/welcome.ftl
@@ -1,0 +1,5 @@
+<html>
+<body>
+${msg("welcomeBodyHtml", link, realmName, user.username)}
+</body>
+</html>

--- a/themes/src/main/resources/theme/base/email/messages/messages_de.properties
+++ b/themes/src/main/resources/theme/base/email/messages/messages_de.properties
@@ -14,3 +14,6 @@ eventUpdatePasswordBodyHtml=<p>Ihr Passwort wurde am {0} von {1} ge\u00E4ndert. 
 eventUpdateTotpSubject=TOTP Aktualisiert
 eventUpdateTotpBody=TOTP wurde am {0} von {1} ge\u00E4ndert. Falls das nicht Sie waren, dann kontaktieren Sie bitte Ihren Admin.
 eventUpdateTotpBodyHtml=<p>TOTP wurde am {0} von {1} ge\u00E4ndert. Falls das nicht Sie waren, dann kontaktieren Sie bitte Ihren Admin.</p>
+welcomeSubject=Willkommen bei {0}
+welcomeBody=Hallo {2}, herzlich willkommen zu {1}. Mit klick auf diesen Link: {0} kommen Sie zu ihrem {1} Benutzerkonto.
+welcomeBodyHtml=<p>Hallo <b>{2}</b>, herzlich willkommen zu {1}!<p><p>Mit klick auf <a href="{0}">diesen Link</a> kommen Sie zu ihrem {1} Benutzerkonto.</p>

--- a/themes/src/main/resources/theme/base/email/messages/messages_en.properties
+++ b/themes/src/main/resources/theme/base/email/messages/messages_en.properties
@@ -22,3 +22,6 @@ eventUpdatePasswordBodyHtml=<p>Your password was changed on {0} from {1}. If thi
 eventUpdateTotpSubject=Update TOTP
 eventUpdateTotpBody=TOTP was updated for your account on {0} from {1}. If this was not you, please contact an admin.
 eventUpdateTotpBodyHtml=<p>TOTP was updated for your account on {0} from {1}. If this was not you, please contact an admin.</p>
+welcomeSubject=Welcome to {0}
+welcomeBody=Hello {2}, welcome to {1}. Please click on this link: {0} to go to your {1} account.
+welcomeBodyHtml=<p>Hello {2}, welcome to {1}!<p><p>Please click on <a href="{0}">this link</a> to go to your {1} account.</p>

--- a/themes/src/main/resources/theme/base/email/text/welcome.ftl
+++ b/themes/src/main/resources/theme/base/email/text/welcome.ftl
@@ -1,0 +1,1 @@
+${msg("welcomeBodyHtml",link, realmName, user.username)}


### PR DESCRIPTION
KEYCLOAK-1835 Add support for sending welcome emails

Introduced sendWelcomeEmail to EmailTemplateProvider to provide
infrastructure for sending welcome emails in custom extensions.

Email templates can be configured via the welcome.ftl
html and text templates.
