### PR TITLE
KEYCLOAK-3412 - Remove erroneous AdminEventBuilder.error method

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/AdminEventBuilder.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/AdminEventBuilder.java
@@ -184,12 +184,6 @@ public class AdminEventBuilder {
         return path.substring(path.indexOf(realmRelative) + realmRelative.length());
     }
 
-    public void error(String error) {
-        adminEvent.setOperationType(OperationType.valueOf(adminEvent.getOperationType().name() + "_ERROR"));
-        adminEvent.setError(error);
-        send();
-    }
-
     public AdminEventBuilder representation(Object value) {
         if (value == null || value.equals("")) {
             return this;


### PR DESCRIPTION
Wasn't used within the Keycloak codebase and wouldn't have worked either
since the OperationType lookup would always fail since there are no
"_ERROR" operation types.

Signed-off-by: Thomas Darimont thomas.darimont@gmail.com
