### PR TITLE
added new configuration to authenticate from a different url.

### DIFF
--- a/adapters/oidc/js/src/main/resources/keycloak.js
+++ b/adapters/oidc/js/src/main/resources/keycloak.js
@@ -63,6 +63,10 @@
                     kc.loginRequired = true;
                 }
 
+                if (typeof initOptions.predefindUri !== 'undefined') {
+                    kc.predefindUri = initOptions.predefindUri;
+                }
+
                 if (initOptions.responseMode) {
                     if (initOptions.responseMode === 'query' || initOptions.responseMode === 'fragment') {
                         kc.responseMode = initOptions.responseMode;
@@ -145,7 +149,7 @@
             }
 
             function processInit() {
-                var callback = parseCallback(window.location.href);
+                var callback = parseCallback(kc.predefindUri || window.location.href);
 
                 if (callback) {
                     setupCheckLoginIframe();


### PR DESCRIPTION
after successful keycloak login with a js adapter, the keycloak data (code, state) is removed in the routing mechanism as it searches for a valid route. 

this causes an endless loop between the application and keycloak authentication.

if this configuration not passed, keycloak will continue working as is.

to use it, we can just add a new field to the init object predefindUri which will take the url with the state and config data and pass it to keycloak
