### PR TITLE
KEYCLOAK-3462 Report problems during KeycloakApplication initialization

### DIFF
--- a/services/src/main/java/org/keycloak/services/ServicesLogger.java
+++ b/services/src/main/java/org/keycloak/services/ServicesLogger.java
@@ -430,4 +430,7 @@ public interface ServicesLogger extends BasicLogger {
     @Message(id=96, value="Not found JWK of supported keyType under jwks_uri for usage: %s")
     void supportedJwkNotFound(String usage);
 
+    @LogMessage(level = ERROR)
+    @Message(id=97, value="KeycloakApplication initialization failed: %s")
+    void applicationInitializationFailed(@Cause Throwable t, String usage);
 }

--- a/services/src/main/java/org/keycloak/services/resources/KeycloakApplication.java
+++ b/services/src/main/java/org/keycloak/services/resources/KeycloakApplication.java
@@ -134,6 +134,7 @@ public class KeycloakApplication extends Application {
 
             setupScheduledTasks(sessionFactory);
         } catch (Throwable t) {
+            logger.applicationInitializationFailed(t, t.getMessage());
             exit(1);
             throw t;
         }


### PR DESCRIPTION
Previously KeycloakApplication exited quietly in case the initialization
failed. We now print an error message with some details to
ease troubleshooting.
