### PR TITLE
send cookies along with keycloak.updateToken()

### DIFF
--- a/adapters/oidc/js/src/main/resources/keycloak.js
+++ b/adapters/oidc/js/src/main/resources/keycloak.js
@@ -380,6 +380,7 @@
                         var req = new XMLHttpRequest();
                         req.open('POST', url, true);
                         req.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
+                        req.withCredentials = true;
 
                         if (kc.clientId && kc.clientSecret) {
                             req.setRequestHeader('Authorization', 'Basic ' + btoa(kc.clientId + ':' + kc.clientSecret));


### PR DESCRIPTION
_Mailing list discussion: http://lists.jboss.org/pipermail/keycloak-user/2016-August/007432.html_

We have multiple keycloak nodes clustered behind a load balancer. On first request, the load balancer sticks users to a node by handing a cookie to the browser. Currently, when keycloak.js sends the updateToken() POST to the load balancer, it's a cross-origin call and thus the browser omits cookies. As a result, the load balancer doesn't know which keycloak node to route the request to.

By setting withCredentials = true, the browser will send cookies to our keycloak load balancer so we can be routed properly.

I would be surprised if this was desired behavior in _all_ cases, so a blanket "always send cookies" may not be everyone's top choice.  I'd be happy to create alternate patch where a configuration parameter dictates whether to send cookies.  The mailing list post got one ACK, but not much discussion, so I'm open to alternatives.

Thoughts/warnings/alternatives/pitfalls?

Thanks!
