### PR TITLE
[PULL-REQUEST-3181 & PULL-REQUEST-3233] Username is not displayed on the login screen with that email

### DIFF
--- a/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
@@ -416,7 +416,7 @@ public class AuthenticationManager {
         // refresh the cookies!
         createLoginCookie(session, realm, userSession.getUser(), userSession, uriInfo, clientConnection);
         if (userSession.getState() != UserSessionModel.State.LOGGED_IN) userSession.setState(UserSessionModel.State.LOGGED_IN);
-        if (userSession.isRememberMe()) createRememberMeCookie(realm, userSession.getUser().getUsername(), uriInfo, clientConnection);
+        if (userSession.isRememberMe()) createRememberMeCookie(realm, userSession.getLoginUsername(), uriInfo, clientConnection);
         return protocol.authenticated(userSession, new ClientSessionCode(realm, clientSession));
 
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/LoginTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/LoginTest.java
@@ -477,6 +477,40 @@ public class LoginTest extends TestRealmKeycloakTest {
             setRememberMe(false);
         }
     }
+    
+    @Test
+    // KEYCLOAK-3181
+    public void loginWithEmailUserAndRememberMe() {
+        setRememberMe(true);
+
+        try {
+            loginPage.open();
+            loginPage.setRememberMe(true);
+            assertTrue(loginPage.isRememberMeChecked());
+            loginPage.login("login@test.com", "password");
+
+            Assert.assertEquals(RequestType.AUTH_RESPONSE, appPage.getRequestType());
+            Assert.assertNotNull(oauth.getCurrentQuery().get(OAuth2Constants.CODE));
+            EventRepresentation loginEvent = events.expectLogin().user(userId)
+                                                   .detail(Details.USERNAME, "login@test.com")
+                                                   .detail(Details.REMEMBER_ME, "true")
+                                                   .assertEvent();
+            String sessionId = loginEvent.getSessionId();
+
+            // Expire session
+            testingClient.testing().removeUserSession("test", sessionId);
+
+            // Assert rememberMe checked and username/email prefilled
+            loginPage.open();
+            assertTrue(loginPage.isRememberMeChecked());
+            
+            Assert.assertEquals("login@test.com", loginPage.getUsername());
+
+            loginPage.setRememberMe(false);
+        } finally {
+            setRememberMe(false);
+        }
+    }
 
     // KEYCLOAK-1037
     @Test


### PR DESCRIPTION
When keycloak is set to login email and Username is different from email, to check the "Remember Me" username is not displayed on the login screen with that email because the KEYCLOAK_REMEMBER_ME cookie is always recorded the username field.
