### PR TITLE
KEYCLOAK-3513 Prevent clearing all registered sessions when invalidating some by se…

### DIFF
--- a/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/management/HttpSessionManager.java
+++ b/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/management/HttpSessionManager.java
@@ -69,6 +69,5 @@ public class HttpSessionManager implements HttpSessionListener, UserSessionManag
                 session.invalidate();
             }
         }
-        sessions.clear();
     }
 }


### PR DESCRIPTION
…ssionId

This bug can cause problems invalidating sessions when a single-logout request is processed, because all sessions are removed from the map whether they are invalidated or not.
