### PR TITLE
always resolve keycloak.init's promise

### DIFF
--- a/adapters/oidc/js/src/main/resources/keycloak.js
+++ b/adapters/oidc/js/src/main/resources/keycloak.js
@@ -166,6 +166,8 @@
                                     kc.onAuthError && kc.onAuthError();
                                     if (initOptions.onLoad) {
                                         onLoad();
+                                    } else {
+                                        initPromise.setError();
                                     }
                                 });
                             });
@@ -177,6 +179,8 @@
                                 kc.onAuthError && kc.onAuthError();
                                 if (initOptions.onLoad) {
                                     onLoad();
+                                } else {
+                                    initPromise.setError();
                                 }
                             });
                         }


### PR DESCRIPTION
I found two cases where `keycloak.init()` (internally, `processInit()`), would return a promise but leave it unresolved.  Here's my call to keycloak.init():

```
    keycloak
        .init(KEYCLOAK_INIT_OPTIONS)
        .success(keycloakInitSuccess)
        .error(keycloakInitError);
```

I expected either `keycloakInitSuccess` or `keycloakInitError` to be run, but in certain cases neither function would be run and so I had no way of knowing when keycloak initialization was complete.

How does the patch look?  I deliberately did not resolve the promise in the `onLoad` case, since I am guessing that when onLoad is defined, the promise wouldn't be used anwyay.

I'm happy to make any changes or take this to the mailing list if further discussion is needed.
