### PR TITLE
[KEYCLOAK-3536] - Add integration tests for SSSD federation provider

### DIFF
--- a/federation/sssd/pom.xml
+++ b/federation/sssd/pom.xml
@@ -23,6 +23,20 @@
                     <target>${maven.compiler.target}</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>2.3</version>
+                <executions>
+                    <!-- Run shade goal on package phase -->
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/testsuite/integration-arquillian/tests/base/pom.xml
+++ b/testsuite/integration-arquillian/tests/base/pom.xml
@@ -153,5 +153,5 @@
         </plugins>
 
     </build>
-    
+
 </project>

--- a/testsuite/integration-arquillian/tests/base/pom.xml
+++ b/testsuite/integration-arquillian/tests/base/pom.xml
@@ -153,5 +153,5 @@
         </plugins>
 
     </build>
-
+    
 </project>

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/LoginPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/LoginPage.java
@@ -71,6 +71,9 @@ public class LoginPage extends AbstractPage {
     @FindBy(className = "alert-info")
     private WebElement loginInfoMessage;
 
+    @FindBy(className = "instruction")
+    private WebElement instruction;
+
 
     @FindBy(id = "kc-current-locale-link")
     private WebElement languageText;
@@ -126,6 +129,10 @@ public class LoginPage extends AbstractPage {
 
     public String getError() {
         return loginErrorMessage != null ? loginErrorMessage.getText() : null;
+    }
+
+    public String getInstruction() {
+        return instruction != null ? instruction.getText() : null;
     }
 
     public String getSuccessMessage() {

--- a/testsuite/integration-arquillian/tests/other/pom.xml
+++ b/testsuite/integration-arquillian/tests/other/pom.xml
@@ -38,8 +38,9 @@
 
     <modules>
         <module>adapters</module>
+        <module>sssd</module>
     </modules>
-    
+
     <build>
         <pluginManagement>
             <plugins>
@@ -65,7 +66,7 @@
                             </configuration>
                         </execution>
                     </executions>
-                </plugin> 
+                </plugin>
                 <plugin>
                     <artifactId>maven-resources-plugin</artifactId>
                     <executions>

--- a/testsuite/integration-arquillian/tests/other/sssd/README.md
+++ b/testsuite/integration-arquillian/tests/other/sssd/README.md
@@ -1,0 +1,27 @@
+What is this module about?
+-------------------------
+
+This module containes integration tests for testing the SSSD features of Keycloak.
+
+Prerequisites
+-------------
+
+To run tests inside this module, one needs to have a linux machine configured as an `IPA` client having sssd
+  service started with infopipe support.
+
+How does one run the tests?
+--------------------------
+
+*All the commands are intended to be run from the root `keycloak` project directory.*
+
+First build the distribution of keycloak:
+`mvn clean install -B -DskipTests -Pdistribution`
+
+It may fail in the end, but it's not a problem as far as it creates a zip distribution of Keycloak inside
+distribution/server-dist/target.
+
+Then build the integration-arquillian-servers-auth-server-wildfly artifact:
+`mvn clean install -B -Pauth-server-wildfly -f testsuite/integration-arquillian/servers/pom.xml`
+
+And then, finally, it's possible to run the tests:
+`mvn test -f testsuite/integration-arquillian/tests/other/sssd/ -Pauth-server-wildfly -Psssd-testing`

--- a/testsuite/integration-arquillian/tests/other/sssd/pom.xml
+++ b/testsuite/integration-arquillian/tests/other/sssd/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>integration-arquillian-tests-other</artifactId>
+        <groupId>org.keycloak.testsuite</groupId>
+        <version>2.2.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>integration-arquillian-tests-sssd</artifactId>
+
+    <name>SSSD tests</name>
+
+    <properties>
+        <exclude.sssd>**/sssd/**/*Test.java</exclude.sssd>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.2</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>${exclude.sssd}</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+
+        </plugins>
+
+    </build>
+
+    <profiles>
+        <profile>
+            <id>sssd-testing</id>
+            <properties>
+                <exclude.sssd>-</exclude.sssd>
+            </properties>
+        </profile>
+    </profiles>
+
+</project>

--- a/testsuite/integration-arquillian/tests/other/sssd/src/test/java/org/keycloak/testsuite/sssd/SSSDTest.java
+++ b/testsuite/integration-arquillian/tests/other/sssd/src/test/java/org/keycloak/testsuite/sssd/SSSDTest.java
@@ -1,0 +1,121 @@
+package org.keycloak.testsuite.sssd;
+
+import org.jboss.arquillian.graphene.page.Page;
+import org.junit.Before;
+import org.junit.Test;
+import org.keycloak.representations.idm.GroupRepresentation;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.representations.idm.UserFederationProviderRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.testsuite.AbstractKeycloakTest;
+import org.keycloak.testsuite.Assert;
+import org.keycloak.testsuite.pages.LoginPage;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class SSSDTest extends AbstractKeycloakTest {
+
+    private static final String DISPLAY_NAME = "Test user federation";
+    private static final String PROVIDER_NAME = "sssd";
+    private static final String REALM_NAME = "test";
+
+    private static final String USERNAME = "emily";
+    private static final String PASSWORD = "emily123";
+    private static final String DEFINITELY_NOT_PASSWORD = "not" + PASSWORD;
+
+    private static final String ADMIN_USERNAME = "admin";
+    private static final String ADMIN_PASSWORD = "password";
+
+    @Page
+    private LoginPage accountLoginPage;
+
+    @Override
+    public void addTestRealms(List<RealmRepresentation> testRealms) {
+        RealmRepresentation realm = new RealmRepresentation();
+
+        realm.setRealm(REALM_NAME);
+        realm.setEnabled(true);
+
+        testRealms.add(realm);
+    }
+
+    @Before
+    public void createUserFederation() {
+        UserFederationProviderRepresentation userFederation = new UserFederationProviderRepresentation();
+
+        Map<String, String> config = new HashMap<>();
+        userFederation.setConfig(config);
+
+        userFederation.setDisplayName(DISPLAY_NAME);
+        userFederation.setPriority(0);
+        userFederation.setProviderName(PROVIDER_NAME);
+
+        adminClient.realm(REALM_NAME).userFederation().create(userFederation);
+    }
+
+    @Test
+    public void testWrongUser() {
+        log.debug("Testing wrong password for user " + USERNAME);
+
+        driver.navigate().to(getAccountUrl());
+        Assert.assertEquals("Browser should be on login page now", "Log in to " + REALM_NAME, driver.getTitle());
+        accountLoginPage.login(USERNAME, DEFINITELY_NOT_PASSWORD);
+
+        Assert.assertEquals("Invalid username or password.", accountLoginPage.getError());
+    }
+
+    @Test
+    public void testAdmin() {
+        log.debug("Testing wrong password for user " + ADMIN_USERNAME);
+
+        driver.navigate().to(getAccountUrl());
+        Assert.assertEquals("Browser should be on login page now", "Log in to " + REALM_NAME, driver.getTitle());
+        accountLoginPage.login(ADMIN_USERNAME, ADMIN_PASSWORD);
+
+        Assert.assertEquals("Unexpected error when handling authentication request to identity provider.", accountLoginPage.getInstruction());
+    }
+
+    @Test
+    public void testExistingUserLogIn() {
+        log.debug("Testing correct password");
+
+        driver.navigate().to(getAccountUrl());
+        Assert.assertEquals("Browser should be on login page now", "Log in to " + REALM_NAME, driver.getTitle());
+        accountLoginPage.login(USERNAME, PASSWORD);
+        Assert.assertEquals("Browser should be on account page now, logged in", "Keycloak Account Management", driver.getTitle());
+
+        testUserGroups();
+    }
+
+    private void testUserGroups() {
+        log.debug("Testing user groups");
+
+        List<UserRepresentation> users = adminClient.realm(REALM_NAME).users().search(USERNAME, 0, 1);
+
+        Assert.assertTrue("There must be at least one user", users.size() > 0);
+        Assert.assertEquals("Exactly our test user", USERNAME, users.get(0).getUsername());
+
+        List<GroupRepresentation> groups = adminClient.realm(REALM_NAME).users().get(users.get(0).getId()).groups();
+
+        Assert.assertEquals("User must have exactly two groups", 2, groups.size());
+        boolean wrongGroup = false;
+        for (GroupRepresentation group : groups) {
+            if (!group.getName().equalsIgnoreCase("ipausers") && !group.getName().equalsIgnoreCase("testgroup")) {
+                wrongGroup = true;
+                break;
+            }
+        }
+
+        Assert.assertFalse("There exists some wrong group", wrongGroup);
+    }
+
+    private String getAccountUrl() {
+        return getAuthRoot() + "/auth/realms/" + REALM_NAME + "/account";
+    }
+
+    private String getAuthRoot() {
+        return suiteContext.getAuthServerInfo().getContextRoot().toString();
+    }
+}


### PR DESCRIPTION
In order to test this PR, follow the instructions here: https://github.com/keycloak/keycloak-test-docker-images/blob/master/keycloak-sssd-integration-tests/README.md

These tests cases tests scenarios where is up and running on the host machine. [For scenarios where SSSD is not present](https://issues.jboss.org/browse/KEYCLOAK-3535), I believe that what we have  running on Travis is already enough to test if SSSD is disabled.

@wyvie I included a scenario [where user is disabled](https://github.com/keycloak/keycloak-test-docker-images/blob/master/keycloak-sssd-integration-tests/scripts/ipa-populate-data#L25). Could you please make sure that have the same script on Jenkins?
