### PR TITLE
KEYCLOAK-3585 Valid Redirect URL Wildcard Match

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,7 @@
         <hamcrest.version>1.3</hamcrest.version>
         <jmeter.version>2.10</jmeter.version>
         <junit.version>4.12</junit.version>
+        <mockito.version>1.10.19</mockito.version>
         <picketlink.version>2.7.0.Final</picketlink.version>
         <selenium.version>2.35.0</selenium.version>
         <xml-apis.version>1.4.01</xml-apis.version>
@@ -361,6 +362,12 @@
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest-all</artifactId>
                 <version>${hamcrest.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>${mockito.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -154,6 +154,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.icegreen</groupId>
             <artifactId>greenmail</artifactId>
             <scope>test</scope>

--- a/services/src/main/java/org/keycloak/protocol/oidc/utils/RedirectUtils.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/utils/RedirectUtils.java
@@ -49,10 +49,11 @@ public class RedirectUtils {
         // If the valid redirect URI is relative (no scheme, host, port) then use the request's scheme, host, and port
         final Set<String> resolveValidRedirects = new HashSet<>();
         for (String validRedirect : validRedirects) {
-            resolveValidRedirects.add(validRedirect); // add even relative urls.
             if (validRedirect.startsWith("/")) {
                 validRedirect = relativeToAbsoluteURI(uriInfo, rootUrl, validRedirect);
                 logger.debugv("replacing relative valid redirect with: {0}", validRedirect);
+                resolveValidRedirects.add(validRedirect);
+            } else { // already full url
                 resolveValidRedirects.add(validRedirect);
             }
         }
@@ -76,6 +77,9 @@ public class RedirectUtils {
             redirectUri = null;
         } else {
             redirectUri = lowerCaseHostname(redirectUri);
+            if (redirectUri.startsWith("/")) {
+                redirectUri = relativeToAbsoluteURI(uriInfo, rootUrl, redirectUri);
+            }
 
             String r = redirectUri;
             final Set<String> resolveValidRedirects = resolveValidRedirects(uriInfo, rootUrl, validRedirects);
@@ -96,9 +100,6 @@ public class RedirectUtils {
                 r = sb.toString();
 
                 valid = matchesRedirects(resolveValidRedirects, r);
-            }
-            if (valid && redirectUri.startsWith("/")) {
-                redirectUri = relativeToAbsoluteURI(uriInfo, rootUrl, redirectUri);
             }
             redirectUri = valid ? redirectUri : null;
         }

--- a/services/src/main/java/org/keycloak/protocol/oidc/utils/RedirectUtils.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/utils/RedirectUtils.java
@@ -132,20 +132,13 @@ public class RedirectUtils {
         return relative;
     }
 
-    private static boolean matchesRedirects(final Set<String> validRedirects, final String redirect) {
-        for (String validRedirect : validRedirects) {
-            if (validRedirect.endsWith("*") && !validRedirect.contains("?")) {
-                // strip off the query component - we don't check them when wildcards are effective
-                final String r = redirect.contains("?") ? redirect.substring(0, redirect.indexOf("?")) : redirect;
-                // strip off *
-                int length = validRedirect.length() - 1;
-                validRedirect = validRedirect.substring(0, length);
-                if (r.startsWith(validRedirect)) return true;
-                // strip off trailing '/'
-                if (length - 1 > 0 && validRedirect.charAt(length - 1) == '/') length--;
-                validRedirect = validRedirect.substring(0, length);
-                if (validRedirect.equals(r)) return true;
-            } else if (validRedirect.equals(redirect)) return true;
+    private static boolean matchesRedirects(final Set<String> validRedirects, final String requestedRedirect) {
+        for (final String validRedirect : validRedirects) {
+            if (validRedirect.equals(requestedRedirect)) {
+                return true;
+            } else if (validRedirect.contains("*") && new WildcardUrlStringMatches(validRedirect).test(requestedRedirect)) {
+                return true;
+            }
         }
         return false;
     }

--- a/services/src/main/java/org/keycloak/protocol/oidc/utils/RedirectUtils.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/utils/RedirectUtils.java
@@ -20,8 +20,8 @@ package org.keycloak.protocol.oidc.utils;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.Constants;
 import org.keycloak.models.RealmModel;
-import org.keycloak.services.Urls;
 import org.keycloak.services.ServicesLogger;
+import org.keycloak.services.Urls;
 
 import javax.ws.rs.core.UriInfo;
 import java.net.URI;
@@ -35,19 +35,19 @@ public class RedirectUtils {
 
     private static final ServicesLogger logger = ServicesLogger.ROOT_LOGGER;
 
-    public static String verifyRealmRedirectUri(UriInfo uriInfo, String redirectUri, RealmModel realm) {
-        Set<String> validRedirects = getValidateRedirectUris(uriInfo, realm);
+    public static String verifyRealmRedirectUri(final UriInfo uriInfo, final String redirectUri, final RealmModel realm) {
+        final Set<String> validRedirects = getValidateRedirectUris(uriInfo, realm);
         return verifyRedirectUri(uriInfo, null, redirectUri, realm, validRedirects);
     }
 
-    public static String verifyRedirectUri(UriInfo uriInfo, String redirectUri, RealmModel realm, ClientModel client) {
-        Set<String> validRedirects = client.getRedirectUris();
+    public static String verifyRedirectUri(final UriInfo uriInfo, final String redirectUri, final RealmModel realm, final ClientModel client) {
+        final Set<String> validRedirects = client.getRedirectUris();
         return verifyRedirectUri(uriInfo, client.getRootUrl(), redirectUri, realm, validRedirects);
     }
 
-    public static Set<String> resolveValidRedirects(UriInfo uriInfo, String rootUrl, Set<String> validRedirects) {
+    public static Set<String> resolveValidRedirects(final UriInfo uriInfo, final String rootUrl, final Set<String> validRedirects) {
         // If the valid redirect URI is relative (no scheme, host, port) then use the request's scheme, host, and port
-        Set<String> resolveValidRedirects = new HashSet<String>();
+        final Set<String> resolveValidRedirects = new HashSet<>();
         for (String validRedirect : validRedirects) {
             resolveValidRedirects.add(validRedirect); // add even relative urls.
             if (validRedirect.startsWith("/")) {
@@ -59,15 +59,15 @@ public class RedirectUtils {
         return resolveValidRedirects;
     }
 
-    private static Set<String> getValidateRedirectUris(UriInfo uriInfo, RealmModel realm) {
-        Set<String> redirects = new HashSet<>();
-        for (ClientModel client : realm.getClients()) {
+    private static Set<String> getValidateRedirectUris(final UriInfo uriInfo, final RealmModel realm) {
+        final Set<String> redirects = new HashSet<>();
+        for (final ClientModel client : realm.getClients()) {
             redirects.addAll(resolveValidRedirects(uriInfo, client.getRootUrl(), client.getRedirectUris()));
         }
         return redirects;
     }
 
-    private static String verifyRedirectUri(UriInfo uriInfo, String rootUrl, String redirectUri, RealmModel realm, Set<String> validRedirects) {
+    private static String verifyRedirectUri(final UriInfo uriInfo, final String rootUrl, String redirectUri, final RealmModel realm, final Set<String> validRedirects) {
         if (redirectUri == null) {
             logger.debug("No Redirect URI parameter specified");
             return null;
@@ -78,14 +78,14 @@ public class RedirectUtils {
             redirectUri = lowerCaseHostname(redirectUri);
 
             String r = redirectUri;
-            Set<String> resolveValidRedirects = resolveValidRedirects(uriInfo, rootUrl, validRedirects);
+            final Set<String> resolveValidRedirects = resolveValidRedirects(uriInfo, rootUrl, validRedirects);
 
             boolean valid = matchesRedirects(resolveValidRedirects, r);
 
             if (!valid && r.startsWith(Constants.INSTALLED_APP_URL) && r.indexOf(':', Constants.INSTALLED_APP_URL.length()) >= 0) {
                 int i = r.indexOf(':', Constants.INSTALLED_APP_URL.length());
 
-                StringBuilder sb = new StringBuilder();
+                final StringBuilder sb = new StringBuilder();
                 sb.append(r.substring(0, i));
 
                 i = r.indexOf('/', i);
@@ -110,8 +110,8 @@ public class RedirectUtils {
         }
     }
 
-    private static String lowerCaseHostname(String redirectUri) {
-        int n = redirectUri.indexOf('/', 7);
+    private static String lowerCaseHostname(final String redirectUri) {
+        final int n = redirectUri.indexOf('/', 7);
         if (n == -1) {
             return redirectUri.toLowerCase();
         } else {
@@ -119,9 +119,9 @@ public class RedirectUtils {
         }
     }
 
-    private static String relativeToAbsoluteURI(UriInfo uriInfo, String rootUrl, String relative) {
+    private static String relativeToAbsoluteURI(final UriInfo uriInfo, String rootUrl, String relative) {
         if (rootUrl == null || rootUrl.isEmpty()) {
-            URI baseUri = uriInfo.getBaseUri();
+            final URI baseUri = uriInfo.getBaseUri();
             String uri = baseUri.getScheme() + "://" + baseUri.getHost();
             if (baseUri.getPort() != -1) {
                 uri += ":" + baseUri.getPort();
@@ -132,11 +132,11 @@ public class RedirectUtils {
         return relative;
     }
 
-    private static boolean matchesRedirects(Set<String> validRedirects, String redirect) {
+    private static boolean matchesRedirects(final Set<String> validRedirects, final String redirect) {
         for (String validRedirect : validRedirects) {
             if (validRedirect.endsWith("*") && !validRedirect.contains("?")) {
                 // strip off the query component - we don't check them when wildcards are effective
-                String r = redirect.contains("?") ? redirect.substring(0, redirect.indexOf("?")) : redirect;
+                final String r = redirect.contains("?") ? redirect.substring(0, redirect.indexOf("?")) : redirect;
                 // strip off *
                 int length = validRedirect.length() - 1;
                 validRedirect = validRedirect.substring(0, length);

--- a/services/src/main/java/org/keycloak/protocol/oidc/utils/UrlString.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/utils/UrlString.java
@@ -1,0 +1,116 @@
+package org.keycloak.protocol.oidc.utils;
+
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Url String representation
+ */
+public class UrlString {
+    // Per RFC 3986, Appendix B
+    public final static String URL_REGEX = "^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?";
+
+    private String protocol;
+    private String host;
+    private Optional<String> port;
+    private Optional<String> path;
+    private Optional<String> queryParams;
+    private Optional<String> fragment;
+
+    public UrlString(final String urlString) {
+        final Pattern pattern = Pattern.compile(URL_REGEX);
+        final Matcher matcher = pattern.matcher(urlString);
+        if (matcher.find()) {
+            protocol = matcher.group(2);
+            if (protocol == null || protocol.isEmpty()) {
+                throw new IllegalArgumentException("Cannot create UrlString with empty or null protocol: " + urlString);
+            }
+
+            final String authority = matcher.group(4);
+            final String[] authorityParts = authority.split(":");
+            host = authorityParts[0];
+            if (host == null || host.isEmpty()) {
+                throw new IllegalArgumentException("Cannot create UrlString with empty or null host: " + urlString);
+            }
+            if (authorityParts.length > 1 && authorityParts[1] != null) {
+                port = Optional.of(authorityParts[1]);
+            } else {
+                port = Optional.empty();
+            }
+
+            final String path = matcher.group(5);
+            this.path = path != null && !path.isEmpty() ? Optional.of(path) : Optional.empty();
+
+            final String queryParams = matcher.group(7);
+            this.queryParams = queryParams != null && !queryParams.isEmpty() ? Optional.of(queryParams) : Optional.empty();
+
+            final String fragment = matcher.group(9);
+            this.fragment = fragment != null && !fragment.isEmpty() ? Optional.of(fragment) : Optional.empty();
+        }
+    }
+
+    public String getProtocol() {
+        return protocol;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public Optional<String> getPort() {
+        return port;
+    }
+
+    public Optional<String> getPath() {
+        return path;
+    }
+
+    public Optional<String> getQueryParams() {
+        return queryParams;
+    }
+
+    public Optional<String> getFragment() {
+        return fragment;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (!(o instanceof UrlString)) return false;
+
+        final UrlString urlString = (UrlString) o;
+
+        if (protocol != null ? !protocol.equals(urlString.protocol) : urlString.protocol != null) return false;
+        if (host != null ? !host.equals(urlString.host) : urlString.host != null) return false;
+        if (port != null ? !port.equals(urlString.port) : urlString.port != null) return false;
+        if (path != null ? !path.equals(urlString.path) : urlString.path != null) return false;
+        if (queryParams != null ? !queryParams.equals(urlString.queryParams) : urlString.queryParams != null)
+            return false;
+        return fragment != null ? fragment.equals(urlString.fragment) : urlString.fragment == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = protocol != null ? protocol.hashCode() : 0;
+        result = 31 * result + (host != null ? host.hashCode() : 0);
+        result = 31 * result + (port != null ? port.hashCode() : 0);
+        result = 31 * result + (path != null ? path.hashCode() : 0);
+        result = 31 * result + (queryParams != null ? queryParams.hashCode() : 0);
+        result = 31 * result + (fragment != null ? fragment.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "UrlString{" +
+                "protocol='" + protocol + '\'' +
+                ", host='" + host + '\'' +
+                ", port=" + port +
+                ", path=" + path +
+                ", queryParams=" + queryParams +
+                ", fragment=" + fragment +
+                '}';
+    }
+}

--- a/services/src/main/java/org/keycloak/protocol/oidc/utils/WildcardUrlStringMatches.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/utils/WildcardUrlStringMatches.java
@@ -1,0 +1,58 @@
+package org.keycloak.protocol.oidc.utils;
+
+import java.util.function.Predicate;
+
+/**
+ * Attempts to determine whether the given wildcard url string matches an input string assumed to be a normal url.  Note that
+ * this *only* currently evaluates protocol, host, port, and path.  Query parameters and fragments are not evaluated.
+ *
+ * E.X.
+ * new WildcardUrlStringMatch(http://www.redhat.com/*).test("http://www.redhat.com/foo.html?lang=en) = true
+ */
+public class WildcardUrlStringMatches implements Predicate<String> {
+
+    private final UrlString wildcardUrlString;
+
+    public WildcardUrlStringMatches(final String wildcardString) {
+        this.wildcardUrlString = new UrlString(wildcardString);
+    }
+
+    @Override
+    public boolean test(final String regularString) {
+        final UrlString regularUrlString = new UrlString(regularString);
+
+        // first check on the protocol, host, and port
+        boolean matches = regularUrlString.getProtocol().matches(toRegex(wildcardUrlString.getProtocol())) &&
+                regularUrlString.getHost().matches(toRegex(wildcardUrlString.getHost())) &&
+                regularUrlString.getPort().orElse("").matches(toRegex(wildcardUrlString.getPort().orElse("")));
+
+        // Special Snowflake Case = when the path ends in 'foo/*', then 'foo' must also be accepted as valid
+        final String wildcardPathString = wildcardUrlString.getPath().orElse("");
+        final boolean specialSnowflakeCase = wildcardPathString.endsWith("/*");
+        if (matches) {
+            final String regularUrlPathString = regularUrlString.getPath().orElse("");
+            matches = regularUrlPathString.matches(toRegex(wildcardPathString)) ||
+                    (specialSnowflakeCase && regularUrlPathString.matches(toRegex(wildcardPathString.substring(0, wildcardPathString.length() - 2))));
+        }
+
+        // Now perform a naive check on the query params (if applicable)
+        if (matches && !specialSnowflakeCase) {
+            matches = regularUrlString.getQueryParams().orElse("").equals(wildcardUrlString.getQueryParams().orElse(""));
+        }
+
+        return matches;
+    }
+
+    /**
+     * Converts a wildcard string to a regex string by escaping all of Java's special chars, the subsituting
+     * '.*' wildcards for '*'.
+     *
+     * @param wildcardString Input string that may or may not contain wildcard characters
+     * @return regex pattern string
+     */
+    public static String toRegex(final String wildcardString) {
+        // Per http://docs.oracle.com/javase/tutorial/essential/regex/literals.html
+        // the Java regex metachars are: <([{\^-=$!|]})?*+.>
+        return "^" + wildcardString.replaceAll("[\\<\\(\\[\\{\\\\\\^\\-\\=\\$\\!\\|\\]\\}\\)‌​\\?\\+\\.\\>]", "\\\\$0").replaceAll("\\*", ".*") + "$";
+    }
+}

--- a/services/src/test/java/org/keycloak/protocol/oidc/utils/RedirectUtilsTest.java
+++ b/services/src/test/java/org/keycloak/protocol/oidc/utils/RedirectUtilsTest.java
@@ -36,7 +36,7 @@ public class RedirectUtilsTest {
 
         validRedirects = new HashSet<>(Arrays.asList("http://example.com", "http://with-dash.example.com/*",
                 "http://sub.domain.example.com/foo", "http://localhost:8180/*", "http://*.subwildcard.example.com"));
-        uriInfo = new ResteasyUriInfo(new URI("http://localhost:8080/auth/realms/test/protocol/openid-connect/auth"));
+        uriInfo = new ResteasyUriInfo(new URI("http://localhost:8180/auth/realms/test/protocol/openid-connect/auth"));
 
         when(realm.getName()).thenReturn("test-realm");
         when(client.getRedirectUris()).thenReturn(validRedirects);
@@ -95,6 +95,11 @@ public class RedirectUtilsTest {
     @Test
     public void testWildcardSubdomain() throws Exception {
         checkRedirectUri("http://dev1.subwildcard.example.com");
+    }
+
+    @Test
+    public void testRelativeUrl() throws Exception {
+        checkRedirectUri("/client1/landing", equalTo("http://localhost:8180/client1/landing"));
     }
 
     private void checkRedirectUri(final String redirect) {

--- a/services/src/test/java/org/keycloak/protocol/oidc/utils/RedirectUtilsTest.java
+++ b/services/src/test/java/org/keycloak/protocol/oidc/utils/RedirectUtilsTest.java
@@ -1,0 +1,101 @@
+package org.keycloak.protocol.oidc.utils;
+
+import org.hamcrest.Matcher;
+import org.jboss.resteasy.spi.ResteasyUriInfo;
+import org.junit.Before;
+import org.junit.Test;
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.RealmModel;
+import org.mockito.Mock;
+
+import javax.ws.rs.core.UriInfo;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class RedirectUtilsTest {
+
+    @Mock
+    ClientModel client;
+    @Mock
+    RealmModel realm;
+    private Set<String> validRedirects;
+    private UriInfo uriInfo;
+
+    @Before
+    public void setUp() throws Exception {
+        initMocks(this);
+
+        validRedirects = new HashSet<>(Arrays.asList("http://example.com", "http://with-dash.example.com/*", "http://sub.domain.example.com/foo", "http://localhost:8180/*"));
+        uriInfo = new ResteasyUriInfo(new URI("http://localhost:8080/auth/realms/test/protocol/openid-connect/auth"));
+
+        when(realm.getName()).thenReturn("test-realm");
+        when(client.getRedirectUris()).thenReturn(validRedirects);
+    }
+
+    @Test
+    public void testNoParamMultipleValidUris() throws Exception {
+        assertThat(RedirectUtils.verifyRedirectUri(uriInfo, null, realm, client), nullValue());
+    }
+
+    @Test
+    public void testNoParamNoValidUris() throws Exception {
+        when(client.getRedirectUris()).thenReturn(Collections.EMPTY_SET);
+        assertThat(RedirectUtils.verifyRedirectUri(uriInfo, null, realm, client), nullValue());
+    }
+
+    @Test
+    public void testNoValidUris() throws Exception {
+        when(client.getRedirectUris()).thenReturn(Collections.EMPTY_SET);
+        assertThat(RedirectUtils.verifyRedirectUri(uriInfo, "http://with-dash.example.com", realm, client), nullValue());
+    }
+
+    @Test
+    public void testValid() throws Exception {
+        checkRedirectUri("http://with-dash.example.com");
+    }
+
+    @Test
+    public void testWithParams() throws Exception {
+        checkRedirectUri("http://with-dash.example.com/return?key=value&otherKey=otherValue");
+    }
+
+    @Test
+    public void testQueryComponents() throws Exception {
+        checkRedirectUri("http://with-dash.example.com/return?key=value/");
+        checkRedirectUri("http://with-dash.example.com/return?key");
+        checkRedirectUri("http://with-dash.example.com/return?key&otherKey=otherValue");
+        checkRedirectUri("http://with-dash.example.com/return?key&otherKey");
+    }
+
+    @Test
+    public void testWildcard() throws Exception {
+        checkRedirectUri("http://with-dash.example.com:8080", nullValue());
+        checkRedirectUri("http://with-dash.example.com/somepath");
+        checkRedirectUri("http://with-dash.example.com/somepath/with/long/path");
+        checkRedirectUri("http://localhost:8180/somepath/with/long/path");
+    }
+
+    @Test
+    public void testDifferentCaseInHostname() throws Exception {
+        checkRedirectUri("http://wItH-DaSh.example.com", equalTo("http://with-dash.example.com"));
+        checkRedirectUri("hTTP://wItH-DaSh.example.com", equalTo("http://with-dash.example.com"));
+        checkRedirectUri("httP://sub.dOMAIn.example.com/foo", equalTo("http://sub.domain.example.com/foo"));
+    }
+
+    private void checkRedirectUri(final String redirect) {
+        assertThat(RedirectUtils.verifyRedirectUri(uriInfo, redirect, realm, client), equalTo(redirect));
+    }
+
+    private void checkRedirectUri(final String redirect, final Matcher matcher) {
+        assertThat(RedirectUtils.verifyRedirectUri(uriInfo, redirect, realm, client), matcher);
+    }
+}

--- a/services/src/test/java/org/keycloak/protocol/oidc/utils/RedirectUtilsTest.java
+++ b/services/src/test/java/org/keycloak/protocol/oidc/utils/RedirectUtilsTest.java
@@ -34,7 +34,8 @@ public class RedirectUtilsTest {
     public void setUp() throws Exception {
         initMocks(this);
 
-        validRedirects = new HashSet<>(Arrays.asList("http://example.com", "http://with-dash.example.com/*", "http://sub.domain.example.com/foo", "http://localhost:8180/*"));
+        validRedirects = new HashSet<>(Arrays.asList("http://example.com", "http://with-dash.example.com/*",
+                "http://sub.domain.example.com/foo", "http://localhost:8180/*", "http://*.subwildcard.example.com"));
         uriInfo = new ResteasyUriInfo(new URI("http://localhost:8080/auth/realms/test/protocol/openid-connect/auth"));
 
         when(realm.getName()).thenReturn("test-realm");
@@ -89,6 +90,11 @@ public class RedirectUtilsTest {
         checkRedirectUri("http://wItH-DaSh.example.com", equalTo("http://with-dash.example.com"));
         checkRedirectUri("hTTP://wItH-DaSh.example.com", equalTo("http://with-dash.example.com"));
         checkRedirectUri("httP://sub.dOMAIn.example.com/foo", equalTo("http://sub.domain.example.com/foo"));
+    }
+
+    @Test
+    public void testWildcardSubdomain() throws Exception {
+        checkRedirectUri("http://dev1.subwildcard.example.com");
     }
 
     private void checkRedirectUri(final String redirect) {

--- a/services/src/test/java/org/keycloak/protocol/oidc/utils/UrlStringTest.java
+++ b/services/src/test/java/org/keycloak/protocol/oidc/utils/UrlStringTest.java
@@ -1,0 +1,158 @@
+package org.keycloak.protocol.oidc.utils;
+
+import org.junit.Test;
+
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+
+public class UrlStringTest {
+
+    @Test
+    public void shouldExtractProtocolWhenPresent() {
+        UrlString reader = new UrlString("http://www.example.com/path/to/content/page.html?lang=en");
+        assertThat(reader.getProtocol(), equalTo("http"));
+
+        reader = new UrlString("https://www.example.com/path/to/content/page.html?lang=en");
+        assertThat(reader.getProtocol(), equalTo("https"));
+
+        reader = new UrlString("ftp://www.example.com/path/to/content/page.html?lang=en");
+        assertThat(reader.getProtocol(), equalTo("ftp"));
+    }
+
+    @Test
+    public void shouldWildcardProtocolWhenWildcard() {
+        UrlString reader = new UrlString("*://www.example.com/path/to/content/page.html?lang=en");
+        assertThat(reader.getProtocol(), equalTo("*"));
+
+        reader = new UrlString("http*://www.example.com/path/to/content/page.html?lang=en");
+        assertThat(reader.getProtocol(), equalTo("http*"));
+
+        reader = new UrlString("*tp*://www.example.com/path/to/content/page.html?lang=en");
+        assertThat(reader.getProtocol(), equalTo("*tp*"));
+    }
+
+    @Test
+    public void shouldExtractHostnameWhenPresent() {
+        UrlString reader = new UrlString("http://www.example.com/path/to/content/page.html?lang=en");
+        assertThat(reader.getHost(), equalTo("www.example.com"));
+
+        reader = new UrlString("http://localhost:8080/path/to/content/page.html?lang=en");
+        assertThat(reader.getHost(), equalTo("localhost"));
+
+        reader = new UrlString("http://localhost.localdomain:8080/path/to/content/page.html?lang=en");
+        assertThat(reader.getHost(), equalTo("localhost.localdomain"));
+    }
+
+    @Test
+    public void shouldWildcardHostnameWhenWildcard() {
+        UrlString reader = new UrlString("http://*/path/to/content/page.html?lang=en");
+        assertThat(reader.getHost(), equalTo("*"));
+
+        reader = new UrlString("http://*.example.com/path/to/content/page.html?lang=en");
+        assertThat(reader.getHost(), equalTo("*.example.com"));
+
+        reader = new UrlString("http://sandbox.*.example.com/path/to/content/page.html?lang=en");
+        assertThat(reader.getHost(), equalTo("sandbox.*.example.com"));
+
+        reader = new UrlString("http://sandbox.*.dev.*.example.com/path/to/content/page.html?lang=en");
+        assertThat(reader.getHost(), equalTo("sandbox.*.dev.*.example.com"));
+
+        reader = new UrlString("http://sandbox.*.dev.*.example.com:8080/path/to/content/page.html?lang=en");
+        assertThat(reader.getHost(), equalTo("sandbox.*.dev.*.example.com"));
+
+        reader = new UrlString("http://*:8443/path/to/content/page.html?lang=en");
+        assertThat(reader.getHost(), equalTo("*"));
+    }
+
+    @Test
+    public void shouldExtractPortWhenPresent() {
+        UrlString reader = new UrlString("http://www.example.com:80/path/to/content/page.html?lang=en");
+        assertThat(reader.getPort(), equalTo(Optional.of("80")));
+
+        reader = new UrlString("http://www.example.com:*/path/to/content/page.html?lang=en");
+        assertThat(reader.getPort(), equalTo(Optional.of("*")));
+
+        reader = new UrlString("http://www.example.com:*443/path/to/content/page.html?lang=en");
+        assertThat(reader.getPort(), equalTo(Optional.of("*443")));
+    }
+
+    @Test
+    public void shouldExtractEmptyWhenPortAbsent() {
+        final UrlString reader = new UrlString("http://www.example.com/path/to/content/page.html?lang=en");
+        assertThat(reader.getPort(), equalTo(Optional.empty()));
+    }
+
+    @Test
+    public void shouldExtractPathWhenPresent() {
+        final UrlString reader = new UrlString("http://www.example.com/path/to/content/page.html?lang=en");
+        assertThat(reader.getPath(), equalTo(Optional.of("/path/to/content/page.html")));
+    }
+
+    @Test
+    public void shouldExtractEmptyWhenPathAbsent() {
+        final UrlString reader = new UrlString("http://www.example.com?lang=en");
+        assertThat(reader.getPath(), equalTo(Optional.empty()));
+    }
+
+    @Test
+    public void shouldWildcardPathWhenWildcard() {
+        UrlString reader = new UrlString("http://www.example.com/*");
+        assertThat(reader.getPath(), equalTo(Optional.of("/*")));
+
+        reader = new UrlString("http://www.example.com/user1/*");
+        assertThat(reader.getPath(), equalTo(Optional.of("/user1/*")));
+
+        reader = new UrlString("http://www.example.com/user1/*?region=us");
+        assertThat(reader.getPath(), equalTo(Optional.of("/user1/*")));
+    }
+
+    @Test
+    public void shouldExtractQueryArgumentsWhenPresent() {
+        UrlString reader = new UrlString("http://www.example.com/path/to/content/page.html?lang=en");
+        assertThat(reader.getQueryParams(), equalTo(Optional.of("lang=en")));
+
+        reader = new UrlString("http://www.example.com/path/to/content/page.html?lang=en&region=us");
+        assertThat(reader.getQueryParams(), equalTo(Optional.of("lang=en&region=us")));
+
+        reader = new UrlString("http://www.example.com/path/to/content/page.html?lang&region=us");
+        assertThat(reader.getQueryParams(), equalTo(Optional.of("lang&region=us")));
+
+        reader = new UrlString("http://www.example.com/path/to/content/page.html?lang&region");
+        assertThat(reader.getQueryParams(), equalTo(Optional.of("lang&region")));
+    }
+
+    @Test
+    public void shouldExtractEmptyWhenQueryArgumentsAbsent() {
+        final UrlString reader = new UrlString("http://www.example.com/path/to/content/page.html");
+        assertThat(reader.getQueryParams(), equalTo(Optional.empty()));
+    }
+
+    @Test
+    public void shouldExtractWildcardWhenQueryArgumentsWildcard() {
+        UrlString reader = new UrlString("http://www.example.com/path/to/content/page.html?lang=*");
+        assertThat(reader.getQueryParams(), equalTo(Optional.of("lang=*")));
+
+        reader = new UrlString("http://www.example.com/path/to/content/page.html?lang=*&region=us");
+        assertThat(reader.getQueryParams(), equalTo(Optional.of("lang=*&region=us")));
+
+        reader = new UrlString("http://www.example.com/path/to/content/page.html?*region=us*");
+        assertThat(reader.getQueryParams(), equalTo(Optional.of("*region=us*")));
+
+        reader = new UrlString("http://www.example.com/path/to/content/page.html?locale=en_*");
+        assertThat(reader.getQueryParams(), equalTo(Optional.of("locale=en_*")));
+    }
+
+    @Test
+    public void shouldExtractFragmentWhenPresent() {
+        final UrlString reader = new UrlString("http://www.example.com/path/to/content/page.html#section5");
+        assertThat(reader.getFragment(), equalTo(Optional.of("section5")));
+    }
+
+    @Test
+    public void shouldExtractEmptyWhenFragmentAbsent() {
+        final UrlString reader = new UrlString("http://www.example.com/path/to/content/page.html");
+        assertThat(reader.getFragment(), equalTo(Optional.empty()));
+    }
+}

--- a/services/src/test/java/org/keycloak/protocol/oidc/utils/WildcardUrlStringMatchesTest.java
+++ b/services/src/test/java/org/keycloak/protocol/oidc/utils/WildcardUrlStringMatchesTest.java
@@ -1,0 +1,169 @@
+package org.keycloak.protocol.oidc.utils;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+
+public class WildcardUrlStringMatchesTest {
+
+    @Test
+    public void testToRegexString_basic() {
+        assertThat(WildcardUrlStringMatches.toRegex("http://"), equalTo("^http://$"));
+    }
+
+    @Test
+    public void testToRegexString_wildcardStart() {
+        assertThat(WildcardUrlStringMatches.toRegex("*tp://"), equalTo("^.*tp://$"));
+    }
+
+    @Test
+    public void testToRegexString_wildcardEnd() {
+        assertThat(WildcardUrlStringMatches.toRegex("http*://"), equalTo("^http.*://$"));
+    }
+
+    @Test
+    public void testToRegexString_escapeMetachars() {
+        assertThat(WildcardUrlStringMatches.toRegex("with-dash.example.com"), equalTo("^with\\-dash\\.example\\.com$"));
+    }
+
+    @Test
+    public void testToRegexString_escapeMetacharsWithWidlcard() {
+        assertThat(WildcardUrlStringMatches.toRegex("dev.*.example.com"), equalTo("^dev\\..*\\.example\\.com$"));
+    }
+
+    @Test
+    public void testWildcardMatch_base_url() {
+        assertThat(new WildcardUrlStringMatches("http://www.example.com").test("http://www.example.com"), equalTo(true));
+    }
+
+    @Test
+    public void testWildcardMatch_base_queryParamsAndRefs() {
+        assertThat(new WildcardUrlStringMatches("http://www.example.com/path/to/page.html?lang=em#section5")
+                .test("http://www.example.com/path/to/page.html?lang=em#section5"), equalTo(true));
+    }
+
+    @Test
+    public void testWildcardMatch_protocol_wildcard() {
+        assertThat(new WildcardUrlStringMatches("*://www.example.com").test("http://www.example.com"), equalTo(true));
+    }
+
+    @Test
+    public void testWildcardMatch_protocol_wildcardPartial() {
+        assertThat(new WildcardUrlStringMatches("http*://www.example.com").test("https://www.example.com"), equalTo(true));
+    }
+
+    @Test
+    public void testWildcardMatch_protocol_wildcardWrongParam() {
+        assertThat(new WildcardUrlStringMatches("http://www.example.com").test("*://www.example.com"), equalTo(false));
+    }
+
+    @Test
+    public void testWildcardMatch_hostname_wildcardStart() {
+        assertThat(new WildcardUrlStringMatches("http://*.com").test("http://www.example.com"), equalTo(true));
+    }
+
+    @Test
+    public void testWildcardMatch_hostname_wildcardMiddle() {
+        assertThat(new WildcardUrlStringMatches("http://group.*.example.com").test("http://group.sales.example.com"), equalTo(true));
+    }
+
+    @Test
+    public void testWildcardMatch_hostname_wildcardDouble() {
+        assertThat(new WildcardUrlStringMatches("http://group.*.region.*.example.com").test("http://group.sales.region.us.example.com"), equalTo(true));
+    }
+
+    @Test
+    public void testWildcardMatch_hostname_wildcardInvalid() {
+        assertThat(new WildcardUrlStringMatches("http://group.*.example.com").test("http://sales.example.com"), equalTo(false));
+    }
+
+    @Test
+    public void testWildcardMatch_port_match() {
+        assertThat(new WildcardUrlStringMatches("http://www.example.com:80").test("http://www.example.com:80"), equalTo(true));
+    }
+
+    @Test
+    public void testWildcardMatch_port_wildcard() {
+        assertThat(new WildcardUrlStringMatches("http://www.example.com:*").test("http://www.example.com:8080"), equalTo(true));
+    }
+
+    @Test
+    public void testWildcardMatch_port_startWildcard() {
+        assertThat(new WildcardUrlStringMatches("http://www.example.com:*443").test("http://www.example.com:8443"), equalTo(true));
+    }
+
+    @Test
+    public void testWildcardMatch_port_startWildcardMismatch() {
+        assertThat(new WildcardUrlStringMatches("http://www.example.com:*443").test("http://www.example.com:80"), equalTo(false));
+    }
+
+    @Test
+    public void testWildcardMatch_port_mismatch() {
+        assertThat(new WildcardUrlStringMatches("http://www.example.com:443").test("http://www.example.com"), equalTo(false));
+    }
+
+    @Test
+    public void testWildcardMatch_port_unspecifiedMismatch() {
+        assertThat(new WildcardUrlStringMatches("http://www.example.com").test("http://www.example.com:80"), equalTo(false));
+    }
+
+    @Test
+    public void testWildcardMatch_port_unspecifiedWhenWildcardRequired() {
+        assertThat(new WildcardUrlStringMatches("http://www.example.com:*443").test("http://www.example.com"), equalTo(false));
+    }
+
+    @Test
+    public void testWildcardMatch_path_matching() {
+        assertThat(new WildcardUrlStringMatches("http://www.example.com/path/to/file.html")
+                .test("http://www.example.com/path/to/file.html"), equalTo(true));
+    }
+
+    @Test
+    public void testWildcardMatch_path_wildcard() {
+        assertThat(new WildcardUrlStringMatches("http://www.example.com/*")
+                .test("http://www.example.com/path/to/file.html"), equalTo(true));
+    }
+
+    @Test
+    public void testWildcardMatch_path_wildcardWithQueryParams() {
+        assertThat(new WildcardUrlStringMatches("http://www.example.com/*")
+                .test("http://www.example.com/path/to/file.html?lang=en"), equalTo(true));
+    }
+
+    @Test
+    public void testWildcardMatch_path_subpathWildcard() {
+        assertThat(new WildcardUrlStringMatches("http://www.example.com/*/file.html")
+                .test("http://www.example.com/path/to/file.html"), equalTo(true));
+    }
+
+    @Test
+    public void testWildcardMatch_path_mismatch() {
+        assertThat(new WildcardUrlStringMatches("http://www.example.com/path/landing.html")
+                .test("http://www.example.com/path/to/file.html"), equalTo(false));
+    }
+
+    @Test
+    public void testWildcardMatch_path_wildcardMismatch() {
+        assertThat(new WildcardUrlStringMatches("http://www.example.com/*landing.html")
+                .test("http://www.example.com/path/to/file.html"), equalTo(false));
+    }
+
+    @Test
+    public void testWildcardMatch_path_matchWithTrailingPathSlashWildcard() {
+        assertThat(new WildcardUrlStringMatches("http://localhost:8180/foo/*")
+                .test("http://localhost:8180/foo"), equalTo(true));
+    }
+
+    @Test
+    public void testWildcardMatch_path_matchWithTrailingHostSlashWildcard() {
+        assertThat(new WildcardUrlStringMatches("http://www.example.com/*")
+                .test("http://www.example.com"), equalTo(true));
+    }
+
+    @Test
+    public void testWildcardMatch_path_noMatchWithTrailingSlash() {
+        assertThat(new WildcardUrlStringMatches("http://www.example.com/splash/")
+                .test("http://www.example.com/splash"), equalTo(false));
+    }
+}


### PR DESCRIPTION
KEYCLOAK-3585: Improve the valid redirect wildcard matching to handle wildcards in the protocol, hostname, port, or path.  Also preserved legacy functionality - particularly around edge cases to include:
- http://hostname.com/path/* allows http://hostname.com/pth
- Query parameters are not evaluated when regex is present, but are evaluated via string equality when regex is not

Did my best to both enumerate existing use cases and provide representative cases of most possible permutations for URL syntax.  Added lots of coverage to validate.  Related Documentation PR's to follow.
