### PR TITLE
Add support for SessionNotOnOrAfter attribute

### DIFF
--- a/saml-core-api/src/main/java/org/keycloak/saml/common/constants/JBossSAMLConstants.java
+++ b/saml-core-api/src/main/java/org/keycloak/saml/common/constants/JBossSAMLConstants.java
@@ -52,7 +52,7 @@ public enum JBossSAMLConstants {
             "protocolSupportEnumeration"), PROVIDER_NAME("ProviderName"), REQUESTED_AUTHN_CONTEXT("RequestedAuthnContext"), REASON(
             "Reason"), RECIPIENT("Recipient"), REQUEST("Request"), REQUESTED_ATTRIBUTE("RequestedAttribute"), REQUEST_ABSTRACT(
             "RequestAbstract"), RESPONSE("Response"), RESPONSE_LOCATION("ResponseLocation"), RETURN_CONTEXT("ReturnContext"), SESSION_INDEX(
-            "SessionIndex"), SERVICE_NAME("ServiceName"), SERVICE_DESCRIPTION("ServiceDescription"), SP_PROVIDED_ID(
+            "SessionIndex"), SERVICE_NAME("ServiceName"), SERVICE_DESCRIPTION("ServiceDescription"), SESSION_NOT_ON_OR_AFTER("SessionNotOnOrAfter"), SP_PROVIDED_ID(
             "SPProvidedID"), SP_NAME_QUALIFIER("SPNameQualifier"), SP_SSO_DESCRIPTOR("SPSSODescriptor"), SIGNATURE("Signature"), SIGNATURE_SHA1_WITH_DSA(
             "http://www.w3.org/2000/09/xmldsig#dsa-sha1"), SIGNATURE_SHA1_WITH_RSA("http://www.w3.org/2000/09/xmldsig#rsa-sha1"), SINGLE_SIGNON_SERVICE(
             "SingleSignOnService"), SINGLE_LOGOUT_SERVICE("SingleLogoutService"), STATEMENT("Statement"), STATUS("Status"), STATUS_CODE(

--- a/saml-core/src/main/java/org/keycloak/saml/SAML2LoginResponseBuilder.java
+++ b/saml-core/src/main/java/org/keycloak/saml/SAML2LoginResponseBuilder.java
@@ -55,6 +55,7 @@ public class SAML2LoginResponseBuilder {
     protected String issuer;
     protected int subjectExpiration;
     protected int assertionExpiration;
+    protected int sessionExpiration;
     protected String nameId;
     protected String nameIdFormat;
     protected boolean multiValuedRoles;
@@ -101,6 +102,18 @@ public class SAML2LoginResponseBuilder {
      */
     public SAML2LoginResponseBuilder assertionExpiration(int assertionExpiration) {
         this.assertionExpiration = assertionExpiration;
+        return this;
+    }
+
+    /**
+     * Length of time in seconds the client session can be valid for
+     * See SAML core specification 2.7.2 SessionNotOnOrAfter
+     *
+     * @param assertionExpiration Number of seconds the assertion should be valid
+     * @return
+     */
+    public SAML2LoginResponseBuilder sessionExpiration(int sessionExpiration) {
+        this.sessionExpiration = sessionExpiration;
         return this;
     }
 
@@ -202,6 +215,10 @@ public class SAML2LoginResponseBuilder {
                     authContextRef);
             if (sessionIndex != null) authnStatement.setSessionIndex(sessionIndex);
             else authnStatement.setSessionIndex(assertion.getID());
+
+            if (sessionExpiration > 0) {
+                authnStatement.setSessionNotOnOrAfter(XMLTimeUtil.add(XMLTimeUtil.getIssueInstant(), sessionExpiration * 1000));
+            }
 
             assertion.addStatement(authnStatement);
         }

--- a/saml-core/src/main/java/org/keycloak/saml/processing/core/saml/v2/writers/SAMLAssertionWriter.java
+++ b/saml-core/src/main/java/org/keycloak/saml/processing/core/saml/v2/writers/SAMLAssertionWriter.java
@@ -205,6 +205,12 @@ public class SAMLAssertionWriter extends BaseWriter {
             StaxUtil.writeAttribute(writer, JBossSAMLConstants.SESSION_INDEX.get(), sessionIndex);
         }
 
+        XMLGregorianCalendar sessionNotOnOrAfter = authnStatement.getSessionNotOnOrAfter();
+
+        if (sessionNotOnOrAfter != null) {
+            StaxUtil.writeAttribute(writer, JBossSAMLConstants.SESSION_NOT_ON_OR_AFTER.get(), sessionNotOnOrAfter.toString());
+        }
+
         AuthnContextType authnContext = authnStatement.getAuthnContext();
         if (authnContext != null)
             write(authnContext);

--- a/services/src/main/java/org/keycloak/protocol/saml/SamlProtocol.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/SamlProtocol.java
@@ -345,7 +345,7 @@ public class SamlProtocol implements LoginProtocol {
         clientSession.setNote(SAML_NAME_ID_FORMAT, nameIdFormat);
 
         SAML2LoginResponseBuilder builder = new SAML2LoginResponseBuilder();
-        builder.requestID(requestID).destination(redirectUri).issuer(responseIssuer).assertionExpiration(realm.getAccessCodeLifespan()).subjectExpiration(realm.getAccessTokenLifespan()).sessionIndex(clientSession.getId())
+        builder.requestID(requestID).destination(redirectUri).issuer(responseIssuer).assertionExpiration(realm.getAccessCodeLifespan()).subjectExpiration(realm.getAccessTokenLifespan()).sessionIndex(clientSession.getId()).sessionExpiration(realm.getSsoSessionMaxLifespan())
                 .requestIssuer(clientSession.getClient().getClientId()).nameIdentifier(nameIdFormat, nameId).authMethod(JBossSAMLURIConstants.AC_UNSPECIFIED.get());
         if (!samlClient.includeAuthnStatement()) {
             builder.disableAuthnStatement(true);


### PR DESCRIPTION
This adds the SessionNotOnOrAfter attribute as defined by 2.7.2 in the saml core spec.

This attribute specifies the maximum lifetime allows for client sessions derived from the enclosing assertion, which is a useful way of allowing clients to know when users must reauthenticate.
