### PR TITLE
KEYCLOAK-3612

### DIFF
--- a/distribution/feature-packs/server-feature-pack/src/main/resources/modules/system/layers/keycloak/org/drools/main/module.xml
+++ b/distribution/feature-packs/server-feature-pack/src/main/resources/modules/system/layers/keycloak/org/drools/main/module.xml
@@ -20,6 +20,9 @@
   -->
 
 <module xmlns="urn:jboss:module:1.3" name="org.drools">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
     <resources>
         <artifact name="${org.kie:kie-api}"/>
         <artifact name="${org.kie:kie-ci}"/>

--- a/distribution/feature-packs/server-feature-pack/src/main/resources/modules/system/layers/keycloak/org/keycloak/keycloak-authz-policy-common/main/module.xml
+++ b/distribution/feature-packs/server-feature-pack/src/main/resources/modules/system/layers/keycloak/org/keycloak/keycloak-authz-policy-common/main/module.xml
@@ -17,6 +17,9 @@
   ~
   -->
 <module xmlns="urn:jboss:module:1.3" name="org.keycloak.keycloak-authz-policy-common">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
     <resources>
         <artifact name="${org.keycloak:keycloak-authz-policy-common}"/>
     </resources>

--- a/distribution/feature-packs/server-feature-pack/src/main/resources/modules/system/layers/keycloak/org/keycloak/keycloak-authz-policy-drools/main/module.xml
+++ b/distribution/feature-packs/server-feature-pack/src/main/resources/modules/system/layers/keycloak/org/keycloak/keycloak-authz-policy-drools/main/module.xml
@@ -20,6 +20,9 @@
   -->
 
 <module xmlns="urn:jboss:module:1.3" name="org.keycloak.keycloak-authz-policy-drools">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
     <resources>
         <artifact name="${org.keycloak:keycloak-authz-policy-drools}"/>
     </resources>


### PR DESCRIPTION
Mark keycloak-authz-policy-common and keycloak-authz-policy-drools modules as private
