### PR TITLE
KEYCLOAK-2977: fix re-binding problem with spring-cloud

### DIFF
--- a/adapters/oidc/spring-boot/src/main/java/org/keycloak/adapters/springboot/KeycloakSpringBootProperties.java
+++ b/adapters/oidc/spring-boot/src/main/java/org/keycloak/adapters/springboot/KeycloakSpringBootProperties.java
@@ -17,14 +17,26 @@
 
 package org.keycloak.adapters.springboot;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.keycloak.representations.adapters.config.AdapterConfig;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @ConfigurationProperties(prefix = "keycloak", ignoreUnknownFields = false)
 public class KeycloakSpringBootProperties extends AdapterConfig {
+
+    /* this is a dummy property to avoid re-rebinding problem with property keycloak.config.resolver
+       when using spring cloud - see KEYCLOAK-2977 */
+    @JsonIgnore
+    private Map config = new HashMap();
+
+    public Map getConfig() {
+        return config;
+    }
 
     private List<SecurityConstraint> securityConstraints = new ArrayList<SecurityConstraint>();
 


### PR DESCRIPTION
I've tested this using the example given referenced in the JIRA ticket: https://github.com/wwadge/slackspace-angular-spring-keycloak.git

It is not working with release 2.2, but it works after this change. 

Therefore I consider this issue fixed with this commit.
