### PR TITLE
KEYCLOAK-3651 Keycloak not adding NameID field from the request to th…

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/saml/SamlService.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/SamlService.java
@@ -23,6 +23,9 @@ import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.keycloak.common.VerificationException;
 import org.keycloak.common.util.StreamUtil;
 import org.keycloak.dom.saml.v2.SAML2Object;
+import org.keycloak.dom.saml.v2.assertion.BaseIDAbstractType;
+import org.keycloak.dom.saml.v2.assertion.NameIDType;
+import org.keycloak.dom.saml.v2.assertion.SubjectType;
 import org.keycloak.dom.saml.v2.protocol.AuthnRequestType;
 import org.keycloak.dom.saml.v2.protocol.LogoutRequestType;
 import org.keycloak.dom.saml.v2.protocol.NameIDPolicyType;
@@ -266,6 +269,19 @@ public class SamlService extends AuthorizationEndpointBase {
                     event.detail(Details.REASON, "unsupported_nameid_format");
                     event.error(Errors.INVALID_SAML_AUTHN_REQUEST);
                     return ErrorPage.error(session, Messages.UNSUPPORTED_NAME_ID_FORMAT);
+                }
+            }
+            //Reading subject/nameID in the saml request
+            SubjectType subject = requestAbstractType.getSubject();
+            if (subject != null) {
+                SubjectType.STSubType subType = subject.getSubType();
+                if (subType != null) {
+                    BaseIDAbstractType baseID = subject.getSubType().getBaseID();
+                    if (baseID != null && baseID instanceof NameIDType) {
+                        NameIDType nameID = (NameIDType) baseID;
+                        clientSession.setNote(SamlProtocol.SAML_NAME_ID, nameID.getValue());
+                    }
+
                 }
             }
 


### PR DESCRIPTION
Some SP's Send username as part of the saml request in the <NameID> field inside the <subject> as shown below

<saml2:Subject

xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"><saml2:NameID

Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified">username/saml2:NameID/saml2:Subject

Keycloak could then receive that value in a custom authenticator and send it to the tokenvalidator to continue the further flow. The idea here is to omit the step to ask user name from user again.

Current behavior of keycloak is not adding the NameID field value to the client session. Because of this custom authentication won't be able to get the username and pass it to the tokenvalidator.

Could we add this feature so that SP's that send userid part of the SAML inside the Subject and custom authenticator can use it according to their needs. 
