### PR TITLE
KEYCLOAK-3703 Fix entitlement function call in authorization

### DIFF
--- a/adapters/oidc/js/src/main/resources/keycloak-authz.js
+++ b/adapters/oidc/js/src/main/resources/keycloak-authz.js
@@ -17,7 +17,7 @@
  */
 
 (function( window, undefined ) {
-    
+
     var KeycloakAuthorization = function (keycloak) {
         var _instance = this;
         this.rpt = null;
@@ -112,44 +112,44 @@
                 }
             };
 
-            /**
-             * Obtains all entitlements from a Keycloak Server based on a give resourceServerId.
-             */
-            this.entitlement = function (resourceSeververId) {
-                this.then = function (onGrant, onDeny, onError) {
-                    var request = new XMLHttpRequest();
+            return this;
+        };
 
-                    request.open('GET', keycloak.authServerUrl + '/realms/' + keycloak.realm + '/authz/entitlement/' + resourceSeververId, true);
-                    request.setRequestHeader('Authorization', 'Bearer ' + keycloak.token)
+        /**
+         * Obtains all entitlements from a Keycloak Server based on a give resourceServerId.
+         */
+        this.entitlement = function (resourceSeververId) {
+            this.then = function (onGrant, onDeny, onError) {
+                var request = new XMLHttpRequest();
 
-                    request.onreadystatechange = function () {
-                        if (request.readyState == 4) {
-                            var status = request.status;
+                request.open('GET', keycloak.authServerUrl + '/realms/' + keycloak.realm + '/authz/entitlement/' + resourceSeververId, true);
+                request.setRequestHeader('Authorization', 'Bearer ' + keycloak.token)
 
-                            if (status >= 200 && status < 300) {
-                                var rpt = JSON.parse(request.responseText).rpt;
-                                _instance.rpt = rpt;
-                                onGrant(rpt);
-                            } else if (status == 403) {
-                                if (onDeny) {
-                                    onDeny();
-                                } else {
-                                    console.error('Authorization request was denied by the server.');
-                                }
+                request.onreadystatechange = function () {
+                    if (request.readyState == 4) {
+                        var status = request.status;
+
+                        if (status >= 200 && status < 300) {
+                            var rpt = JSON.parse(request.responseText).rpt;
+                            _instance.rpt = rpt;
+                            onGrant(rpt);
+                        } else if (status == 403) {
+                            if (onDeny) {
+                                onDeny();
                             } else {
-                                if (onError) {
-                                    onError();
-                                } else {
-                                    console.error('Could not obtain authorization data from server.');
-                                }
+                                console.error('Authorization request was denied by the server.');
+                            }
+                        } else {
+                            if (onError) {
+                                onError();
+                            } else {
+                                console.error('Could not obtain authorization data from server.');
                             }
                         }
-                    };
-
-                    request.send(null);
+                    }
                 };
 
-                return this;
+                request.send(null);
             };
 
             return this;


### PR DESCRIPTION
To solve [KEYCLOAK-3703](https://issues.jboss.org/browse/KEYCLOAK-3703)

This seems to be due to an encapsulation issue - the _entitlement_ function in fact does not belong to _KeycloakAuthorization_ but to _KeycloakAuthorization.authorize_, hence the error.

Not sure if this is intended, but (as far as I understand) the _entitlement_ client should be independent of the _authorize_ client.

This PR moves _entitlement_ to _KeycloakAuthorization_.
