### PR TITLE
KEYCLOAK-3618: Extensible ResourceType for provider-created AdminEvents

### DIFF
--- a/examples/providers/event-store-mem/src/main/java/org/keycloak/examples/providers/events/MemAdminEventQuery.java
+++ b/examples/providers/event-store-mem/src/main/java/org/keycloak/examples/providers/events/MemAdminEventQuery.java
@@ -20,7 +20,7 @@ package org.keycloak.examples.providers.events;
 import org.keycloak.events.admin.AdminEvent;
 import org.keycloak.events.admin.AdminEventQuery;
 import org.keycloak.events.admin.OperationType;
-import org.keycloak.events.admin.ResourceType;
+import org.keycloak.events.admin.IResourceType;
 
 import java.util.Collections;
 import java.util.Date;
@@ -74,13 +74,13 @@ public class MemAdminEventQuery implements AdminEventQuery {
     }
 
     @Override
-    public AdminEventQuery resourceType(ResourceType... resourceTypes) {
+    public AdminEventQuery resourceType(IResourceType... resourceTypes) {
 
         Iterator<AdminEvent> itr = this.adminEvents.iterator();
         while (itr.hasNext()) {
             AdminEvent next = itr.next();
             boolean include = false;
-            for (ResourceType e : resourceTypes) {
+            for (IResourceType e : resourceTypes) {
                 if (next.getResourceType().equals(e)) {
                     include = true;
                     break;

--- a/model/jpa/src/main/java/org/keycloak/events/jpa/JpaAdminEventQuery.java
+++ b/model/jpa/src/main/java/org/keycloak/events/jpa/JpaAdminEventQuery.java
@@ -20,7 +20,7 @@ package org.keycloak.events.jpa;
 import org.keycloak.events.admin.AdminEvent;
 import org.keycloak.events.admin.AdminEventQuery;
 import org.keycloak.events.admin.OperationType;
-import org.keycloak.events.admin.ResourceType;
+import org.keycloak.events.admin.IResourceType;
 
 import javax.persistence.EntityManager;
 import javax.persistence.TypedQuery;
@@ -73,10 +73,10 @@ public class JpaAdminEventQuery implements AdminEventQuery {
     }
 
     @Override
-    public AdminEventQuery resourceType(ResourceType... resourceTypes) {
+    public AdminEventQuery resourceType(IResourceType... resourceTypes) {
 
         List<String> resourceTypeStrings = new LinkedList<String>();
-        for (ResourceType e : resourceTypes) {
+        for (IResourceType e : resourceTypes) {
             resourceTypeStrings.add(e.toString());
         }
         predicates.add(root.get("resourceType").in(resourceTypeStrings));

--- a/model/jpa/src/main/java/org/keycloak/events/jpa/JpaEventStoreProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/events/jpa/JpaEventStoreProvider.java
@@ -172,7 +172,7 @@ public class JpaEventStoreProvider implements EventStoreProvider {
         adminEvent.setOperationType(OperationType.valueOf(adminEventEntity.getOperationType()));
 
         if (adminEventEntity.getResourceType() != null) {
-            adminEvent.setResourceType(ResourceType.valueOf(adminEventEntity.getResourceType()));
+            adminEvent.setResourceType(ResourceType.of(adminEventEntity.getResourceType()));
         }
 
         adminEvent.setResourcePath(adminEventEntity.getResourcePath());

--- a/model/mongo/src/main/java/org/keycloak/events/mongo/MongoAdminEventQuery.java
+++ b/model/mongo/src/main/java/org/keycloak/events/mongo/MongoAdminEventQuery.java
@@ -23,7 +23,7 @@ import com.mongodb.DBCursor;
 import org.keycloak.events.admin.AdminEvent;
 import org.keycloak.events.admin.AdminEventQuery;
 import org.keycloak.events.admin.OperationType;
-import org.keycloak.events.admin.ResourceType;
+import org.keycloak.events.admin.IResourceType;
 
 import java.util.Date;
 import java.util.LinkedList;
@@ -59,10 +59,10 @@ public class MongoAdminEventQuery implements AdminEventQuery{
     }
 
     @Override
-    public AdminEventQuery resourceType(ResourceType... resourceTypes) {
+    public AdminEventQuery resourceType(IResourceType... resourceTypes) {
 
         List<String> resourceTypeStrings = new LinkedList<String>();
-        for (ResourceType e : resourceTypes) {
+        for (IResourceType e : resourceTypes) {
             resourceTypeStrings.add(e.toString());
         }
         query.put("resourceType", new BasicDBObject("$in", resourceTypeStrings));

--- a/server-spi/src/main/java/org/keycloak/events/admin/AdminEvent.java
+++ b/server-spi/src/main/java/org/keycloak/events/admin/AdminEvent.java
@@ -31,7 +31,7 @@ public class AdminEvent {
     /**
      * The resource type an AdminEvent was triggered for.
      */
-    private ResourceType resourceType;
+    private IResourceType resourceType;
 
     private OperationType operationType;
 
@@ -143,11 +143,11 @@ public class AdminEvent {
      *
      * @return
      */
-    public ResourceType getResourceType() {
+    public IResourceType getResourceType() {
         return resourceType;
     }
 
-    public void setResourceType(ResourceType resourceType) {
+    public void setResourceType(IResourceType resourceType) {
         this.resourceType = resourceType;
     }
 }

--- a/server-spi/src/main/java/org/keycloak/events/admin/AdminEventQuery.java
+++ b/server-spi/src/main/java/org/keycloak/events/admin/AdminEventQuery.java
@@ -78,7 +78,7 @@ public interface AdminEventQuery {
      * @param resourceTypes
      * @return <code>this</code> for method chaining
      */
-    AdminEventQuery resourceType(ResourceType ... resourceTypes);
+    AdminEventQuery resourceType(IResourceType ... resourceTypes);
 
     /**
      * Search by resource path. Supports wildcards <code>*</code> and <code>**</code>. For example:

--- a/server-spi/src/main/java/org/keycloak/events/admin/IResourceType.java
+++ b/server-spi/src/main/java/org/keycloak/events/admin/IResourceType.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.events.admin;
+
+/**
+ * Interface to be implemented by ResourceType and subclasses
+ *
+ * @author <a href="mailto:mitya@cargosoft.ru">Dmitry Telegin</a>
+ */
+public interface IResourceType {
+
+}

--- a/server-spi/src/main/java/org/keycloak/events/admin/ResourceType.java
+++ b/server-spi/src/main/java/org/keycloak/events/admin/ResourceType.java
@@ -16,12 +16,15 @@
  */
 package org.keycloak.events.admin;
 
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
 /**
  * Represents Keycloak resource types for which {@link AdminEvent AdminEvent's} can be triggered.
  *
  * @author <a href="mailto:thomas.darimont@gmail.com">Thomas Darimont</a>
  */
-public enum ResourceType {
+public enum ResourceType implements IResourceType {
 
     /**
      *
@@ -157,4 +160,26 @@ public enum ResourceType {
      *
      */
     , CLUSTER_NODE;
+
+    private static final ConcurrentMap<String, IResourceType> types = new ConcurrentHashMap<>();
+
+    public static IResourceType of(final String name) {
+
+        if (types.isEmpty()) {
+            for (ResourceType type : values()) {
+                types.putIfAbsent(type.name(), type);
+            }
+        }
+
+        types.putIfAbsent(name.toString(/* null-check */), new IResourceType() {
+            @Override
+            public String toString() {
+                return name;
+            }
+        });
+
+        return types.get(name);
+
+    }
+
 }

--- a/services/src/main/java/org/keycloak/services/resources/admin/AdminEventBuilder.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/AdminEventBuilder.java
@@ -23,7 +23,7 @@ import org.keycloak.events.EventStoreProvider;
 import org.keycloak.events.admin.AdminEvent;
 import org.keycloak.events.admin.AuthDetails;
 import org.keycloak.events.admin.OperationType;
-import org.keycloak.events.admin.ResourceType;
+import org.keycloak.events.admin.IResourceType;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
@@ -91,7 +91,7 @@ public class AdminEventBuilder {
         return this;
     }
 
-    public AdminEventBuilder resource(ResourceType resourceType){
+    public AdminEventBuilder resource(IResourceType resourceType){
         adminEvent.setResourceType(resourceType);
         return this;
     }

--- a/services/src/main/java/org/keycloak/services/resources/admin/RealmAdminResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RealmAdminResource.java
@@ -33,6 +33,7 @@ import org.keycloak.events.admin.AdminEvent;
 import org.keycloak.events.admin.AdminEventQuery;
 import org.keycloak.events.admin.OperationType;
 import org.keycloak.events.admin.ResourceType;
+import org.keycloak.events.admin.IResourceType;
 import org.keycloak.exportimport.ClientDescriptionConverter;
 import org.keycloak.exportimport.ClientDescriptionConverterFactory;
 import org.keycloak.models.ClientModel;
@@ -650,9 +651,9 @@ public class RealmAdminResource {
         }
 
         if (resourceTypes != null && !resourceTypes.isEmpty()) {
-            ResourceType[] t = new ResourceType[resourceTypes.size()];
+            IResourceType[] t = new IResourceType[resourceTypes.size()];
             for (int i = 0; i < t.length; i++) {
-                t[i] = ResourceType.valueOf(resourceTypes.get(i));
+                t[i] = ResourceType.of(resourceTypes.get(i));
             }
             query.resourceType(t);
         }


### PR DESCRIPTION
The implementation is based on the [extensible enum](https://blogs.oracle.com/darcy/entry/enums_and_mixins) pattern. It requires that the enum implement an interface (an empty one in our case).

There were two options for refactoring:

1) leave `ResourceType` as is, introduce `IResourceType`:
`public enum ResourceType implements IResourceType`
This mostly requires changes to imports and method signatures (about 20 code locations), but introduces that ugly `IResourceType`. `ResourceType` enum fields are referenced just like before, with `ResourceType.of("FOO")` used to obtain custom value;

2) make `ResourceType` interface, rename `ResourceType` to something like `StandardResourceType`:
`public enum StandardResourceType implements ResourceType`
This would require changes to all the enum field references (~100 locations).

I've implemented the first variant because of its relative simplicity. Please let me know if the second variant is preferable, I'll reimplement the PR.
