### PR TITLE
[KEYCLOAK-3628] - Using JBPM/BRMS BOM to resolve dependencies versions

### DIFF
--- a/dependencies/server-all/pom.xml
+++ b/dependencies/server-all/pom.xml
@@ -32,28 +32,21 @@
 	<description />
 
     <properties>
-        <!-- Drools dependencies versions -->
-        <version.org.eclipse.sisu>0.3.0.M1</version.org.eclipse.sisu>
-        <version.org.eclipse.aether>1.0.0.v20140518</version.org.eclipse.aether>
-        <version.org.apache.ant>1.8.3</version.org.apache.ant>
-        <version.org.antlr>3.5</version.org.antlr>
-        <version.aopalliance>1.0</version.aopalliance>
-        <version.org.apache.maven>3.2.5</version.org.apache.maven>
-        <version.org.mvel>2.2.8.Final</version.org.mvel>
-        <version.org.sonatype.plexus.plexus-cipher>1.7</version.org.sonatype.plexus.plexus-cipher>
-        <version.org.codehaus.plexus.plexus-classworlds>2.5.2</version.org.codehaus.plexus.plexus-classworlds>
-        <version.org.codehaus.plexus.plexus-component-annotations>1.5.5</version.org.codehaus.plexus.plexus-component-annotations>
-        <version.org.codehaus.plexus.plexus-interpolation>1.21</version.org.codehaus.plexus.plexus-interpolation>
-        <version.org.codehaus.plexus.plexus-sec-dispatcher>1.3</version.org.codehaus.plexus.plexus-sec-dispatcher>
-        <version.org.codehaus.plexus.plexus-utils>3.0.20</version.org.codehaus.plexus.plexus-utils>
-        <version.org.apache.maven.wagon>2.6</version.org.apache.maven.wagon>
-        <version.com.thoughtworks.xstream>1.4.7</version.com.thoughtworks.xstream>
-        <version.com.google.guava>13.0.1</version.com.google.guava>
-        <version.org.eclipse.jdt.core.compiler>4.4.2</version.org.eclipse.jdt.core.compiler>
-        <version.com.lowagie>2.1.2</version.com.lowagie>
-        <version.org.sonatype.sisu>3.2.3</version.org.sonatype.sisu>
-        <version.com.google.inject.extensions.guice-servlet>3.0</version.com.google.inject.extensions.guice-servlet>
+        <!-- Bill of Materials (BOM) for Drools dependencies -->
+        <org.jboss.integration-platform.jboss-integration-platform-bom>6.0.6.Final</org.jboss.integration-platform.jboss-integration-platform-bom>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.jboss.integration-platform</groupId>
+                <artifactId>jboss-integration-platform-bom</artifactId>
+                <version>${org.jboss.integration-platform.jboss-integration-platform-bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -158,122 +151,98 @@
         <dependency>
             <groupId>org.eclipse.aether</groupId>
             <artifactId>aether-api</artifactId>
-            <version>${version.org.eclipse.aether}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.aether</groupId>
             <artifactId>aether-connector-basic</artifactId>
-            <version>${version.org.eclipse.aether}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.aether</groupId>
             <artifactId>aether-spi</artifactId>
-            <version>${version.org.eclipse.aether}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.aether</groupId>
             <artifactId>aether-impl</artifactId>
-            <version>${version.org.eclipse.aether}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.aether</groupId>
             <artifactId>aether-transport-file</artifactId>
-            <version>${version.org.eclipse.aether}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.aether</groupId>
             <artifactId>aether-transport-http</artifactId>
-            <version>${version.org.eclipse.aether}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.aether</groupId>
             <artifactId>aether-transport-wagon</artifactId>
-            <version>${version.org.eclipse.aether}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.aether</groupId>
             <artifactId>aether-util</artifactId>
-            <version>${version.org.eclipse.aether}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.ant</groupId>
             <artifactId>ant</artifactId>
-            <version>${version.org.apache.ant}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.ant</groupId>
             <artifactId>ant-launcher</artifactId>
-            <version>${version.org.apache.ant}</version>
         </dependency>
         <dependency>
             <groupId>org.antlr</groupId>
             <artifactId>antlr-runtime</artifactId>
-            <version>${version.org.antlr}</version>
         </dependency>
         <dependency>
             <groupId>aopalliance</groupId>
             <artifactId>aopalliance</artifactId>
-            <version>${version.aopalliance}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-aether-provider</artifactId>
-            <version>${version.org.apache.maven}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-artifact</artifactId>
-            <version>${version.org.apache.maven}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-compat</artifactId>
-            <version>${version.org.apache.maven}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
-            <version>${version.org.apache.maven}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-model</artifactId>
-            <version>${version.org.apache.maven}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-model-builder</artifactId>
-            <version>${version.org.apache.maven}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
-            <version>${version.org.apache.maven}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-repository-metadata</artifactId>
-            <version>${version.org.apache.maven}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-settings</artifactId>
-            <version>${version.org.apache.maven}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-settings-builder</artifactId>
-            <version>${version.org.apache.maven}</version>
         </dependency>
         <dependency>
             <groupId>org.mvel</groupId>
             <artifactId>mvel2</artifactId>
-            <version>${version.org.mvel}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.sisu</groupId>
             <artifactId>org.eclipse.sisu.inject</artifactId>
-            <version>${version.org.eclipse.sisu}</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.google.inject</groupId>
@@ -282,14 +251,8 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>com.google.inject.extensions</groupId>
-            <artifactId>guice-servlet</artifactId>
-            <version>${version.com.google.inject.extensions.guice-servlet}</version>
-        </dependency>
-        <dependency>
             <groupId>org.eclipse.sisu</groupId>
             <artifactId>org.eclipse.sisu.plexus</artifactId>
-            <version>${version.org.eclipse.sisu}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.sonatype.sisu</groupId>
@@ -300,62 +263,50 @@
         <dependency>
             <groupId>org.sonatype.plexus</groupId>
             <artifactId>plexus-cipher</artifactId>
-            <version>${version.org.sonatype.plexus.plexus-cipher}</version>
         </dependency>
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-classworlds</artifactId>
-            <version>${version.org.codehaus.plexus.plexus-classworlds}</version>
         </dependency>
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-component-annotations</artifactId>
-            <version>${version.org.codehaus.plexus.plexus-component-annotations}</version>
         </dependency>
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-interpolation</artifactId>
-            <version>${version.org.codehaus.plexus.plexus-interpolation}</version>
         </dependency>
         <dependency>
             <groupId>org.sonatype.plexus</groupId>
             <artifactId>plexus-sec-dispatcher</artifactId>
-            <version>${version.org.codehaus.plexus.plexus-sec-dispatcher}</version>
         </dependency>
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-utils</artifactId>
-            <version>${version.org.codehaus.plexus.plexus-utils}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.wagon</groupId>
             <artifactId>wagon-http</artifactId>
-            <version>${version.org.apache.maven.wagon}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.wagon</groupId>
             <artifactId>wagon-http-shared</artifactId>
-            <version>${version.org.apache.maven.wagon}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.wagon</groupId>
             <artifactId>wagon-provider-api</artifactId>
-            <version>${version.org.apache.maven.wagon}</version>
         </dependency>
         <dependency>
             <groupId>com.thoughtworks.xstream</groupId>
             <artifactId>xstream</artifactId>
-            <version>${version.com.thoughtworks.xstream}</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>${version.com.google.guava}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jdt.core.compiler</groupId>
             <artifactId>ecj</artifactId>
-            <version>${version.org.eclipse.jdt.core.compiler}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
@@ -368,7 +319,6 @@
         <dependency>
             <groupId>com.lowagie</groupId>
             <artifactId>itext</artifactId>
-            <version>${version.com.lowagie}</version>
             <exclusions>
                 <exclusion>
                     <groupId>bouncycastle</groupId>
@@ -387,7 +337,6 @@
         <dependency>
             <groupId>org.sonatype.sisu</groupId>
             <artifactId>sisu-guice</artifactId>
-            <version>${version.org.sonatype.sisu}</version>
             <classifier>no_aop</classifier>
         </dependency>
     </dependencies>

--- a/distribution/feature-packs/server-feature-pack/src/main/resources/modules/system/layers/keycloak/org/sonatype/sisu/main/module.xml
+++ b/distribution/feature-packs/server-feature-pack/src/main/resources/modules/system/layers/keycloak/org/sonatype/sisu/main/module.xml
@@ -20,7 +20,6 @@
         <property name="jboss.api" value="private"/>
     </properties>
     <resources>
-        <artifact name="${com.google.inject.extensions:guice-servlet}"/>
         <artifact name="${org.sonatype.sisu:sisu-guice::no_aop}"/>
     </resources>
     <dependencies>


### PR DESCRIPTION
@stianst,

The reason for having `jboss-integration-platform-bom` declared in `keycloak-dependencies-server-all` is that the first defines a lot of versions and dependencies that may conflict with some Keycloak dependencies. That is why I`ve not defined it within root pom.xml.
