### PR TITLE
KEYCLOAK-3752 : Include programmatically created resources in the resource cache

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/authorization/infinispan/CachedResourceStore.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/authorization/infinispan/CachedResourceStore.java
@@ -108,13 +108,9 @@ public class CachedResourceStore implements ResourceStore {
 
     @Override
     public List<Resource> findByOwner(String ownerId) {
-        List<String> cachedIds = this.cache.get(getResourceOwnerCacheKey(ownerId));
 
-        if (cachedIds == null) {
-            for (Resource resource : getDelegate().findByOwner(ownerId)) {
-                updateCachedIds(getResourceOwnerCacheKey(ownerId), resource, true);
-            }
-            cachedIds = this.cache.getOrDefault(getResourceOwnerCacheKey(ownerId), Collections.emptyList());
+        for (Resource resource : getDelegate().findByOwner(ownerId)) {
+            updateCachedIds(getResourceOwnerCacheKey(ownerId), resource, true);
         }
 
         return  ((List<String>) this.cache.getOrDefault(getResourceOwnerCacheKey(ownerId), Collections.emptyList())).stream().map(this::findById)


### PR DESCRIPTION
PR for [KEYCLOAK-3752](https://issues.jboss.org/browse/KEYCLOAK-3752)

The problem occurs when creating a resource programmatically via the authorization client, for the case of scope based permissions. Any RPT retrieved subsequently does not include valid permissions for the newly created resource.

This seems to happen due to the resource not loaded in the cache when the permissions are being generated / evaluated by the entitlement api.

The _CachedResourceStore.findByOwner_ method seems to be the point where the attempt is made to cache the resource. The current logic will only allow the first resource for a particular owner to be cached. Any subsequent call to the method will skip any newly created resource. 
