### PR TITLE
KEYCLOAK-3755: isBearerTokenRequest and isBasicAuthRequest are now case-insensitive

### DIFF
--- a/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/filter/KeycloakAuthenticationProcessingFilter.java
+++ b/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/filter/KeycloakAuthenticationProcessingFilter.java
@@ -63,6 +63,8 @@ import java.io.IOException;
 public class KeycloakAuthenticationProcessingFilter extends AbstractAuthenticationProcessingFilter implements ApplicationContextAware {
     public static final String DEFAULT_LOGIN_URL = "/sso/login";
     public static final String AUTHORIZATION_HEADER = "Authorization";
+    public static final String SCHEME_BEARER = "bearer ";
+    public static final String SCHEME_BASIC = "basic ";
 
     /**
      * Request matcher that matches requests to the {@link KeycloakAuthenticationEntryPoint#DEFAULT_LOGIN_URI default login URI}
@@ -164,7 +166,7 @@ public class KeycloakAuthenticationProcessingFilter extends AbstractAuthenticati
      */
     protected boolean isBearerTokenRequest(HttpServletRequest request) {
         String authValue = request.getHeader(AUTHORIZATION_HEADER);
-        return authValue != null && authValue.startsWith("Bearer");
+        return authValue != null && authValue.toLowerCase().startsWith(SCHEME_BEARER);
     }
 
     /**
@@ -176,7 +178,7 @@ public class KeycloakAuthenticationProcessingFilter extends AbstractAuthenticati
      */
     protected boolean isBasicAuthRequest(HttpServletRequest request) {
         String authValue = request.getHeader(AUTHORIZATION_HEADER);
-        return authValue != null && authValue.startsWith("Basic");
+        return authValue != null && authValue.toLowerCase().startsWith(SCHEME_BASIC);
     }
 
     @Override

--- a/adapters/oidc/spring-security/src/test/java/org/keycloak/adapters/springsecurity/filter/KeycloakAuthenticationProcessingFilterTest.java
+++ b/adapters/oidc/spring-security/src/test/java/org/keycloak/adapters/springsecurity/filter/KeycloakAuthenticationProcessingFilterTest.java
@@ -128,9 +128,23 @@ public class KeycloakAuthenticationProcessingFilterTest {
     }
 
     @Test
+    public void testIsBearerTokenRequestCaseInsensitive() throws Exception {
+        assertFalse(filter.isBearerTokenRequest(request));
+        this.setAuthorizationHeader(request, "bearer");
+        assertTrue(filter.isBearerTokenRequest(request));
+    }
+
+    @Test
     public void testIsBasicAuthRequest() throws Exception {
         assertFalse(filter.isBasicAuthRequest(request));
         this.setBasicAuthHeader(request);
+        assertTrue(filter.isBasicAuthRequest(request));
+    }
+
+    @Test
+    public void testIsBasicAuthRequestCaseInsensitive() throws Exception {
+        assertFalse(filter.isBasicAuthRequest(request));
+        this.setAuthorizationHeader(request, "basic");
         assertTrue(filter.isBasicAuthRequest(request));
     }
 
@@ -221,11 +235,14 @@ public class KeycloakAuthenticationProcessingFilterTest {
     }
 
     private void setBearerAuthHeader(MockHttpServletRequest request) {
-        request.addHeader(KeycloakAuthenticationProcessingFilter.AUTHORIZATION_HEADER, "Bearer " + UUID.randomUUID().toString());
+        setAuthorizationHeader(request, "Bearer");
     }
 
     private void setBasicAuthHeader(MockHttpServletRequest request) {
-        request.addHeader(KeycloakAuthenticationProcessingFilter.AUTHORIZATION_HEADER, "Basic " + UUID.randomUUID().toString());
+        setAuthorizationHeader(request, "Basic");
     }
 
+    private void setAuthorizationHeader(MockHttpServletRequest request, String scheme) {
+      request.addHeader(KeycloakAuthenticationProcessingFilter.AUTHORIZATION_HEADER, scheme + " " + UUID.randomUUID().toString());
+    }
 }


### PR DESCRIPTION
The methods `isBearerTokenRequest` and `isBasicAuthRequest` are now case-insensitive in class `KeycloakAuthenticationProcessingFilter`.
