### PR TITLE
KEYCLOAK-3769 Workaround for ChangeLogService stale instance

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/connections/jpa/updater/liquibase/LiquibaseJpaUpdaterProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/connections/jpa/updater/liquibase/LiquibaseJpaUpdaterProvider.java
@@ -114,7 +114,7 @@ public class LiquibaseJpaUpdaterProvider implements JpaUpdaterProvider {
     }
 
     protected void updateChangeSet(Liquibase liquibase, String changelog, Writer exportWriter) throws LiquibaseException, IOException {
-        List<ChangeSet> changeSets = getChangeSets(liquibase);
+        List<ChangeSet> changeSets = getLiquibaseUnrunChangeSets(liquibase);
         if (!changeSets.isEmpty()) {
             List<RanChangeSet> ranChangeSets = liquibase.getDatabase().getRanChangeSetList();
             if (ranChangeSets.isEmpty()) {
@@ -139,11 +139,11 @@ public class LiquibaseJpaUpdaterProvider implements JpaUpdaterProvider {
             logger.debugv("Completed database update for changelog {0}", changelog);
         } else {
             logger.debugv("Database is up to date for changelog {0}", changelog);
-
-            // Needs to restart liquibase services to clear changeLogHistory.
-            Method resetServices = Reflections.findDeclaredMethod(Liquibase.class, "resetServices");
-            Reflections.invokeMethod(true, resetServices, liquibase);
         }
+
+        // Needs to restart liquibase services to clear ChangeLogHistoryServiceFactory.getInstance().
+        // See https://issues.jboss.org/browse/KEYCLOAK-3769 for discussion relevant to why reset needs to be here
+        resetLiquibaseServices(liquibase);
     }
 
     private void outputChangeLogTableCreationScript(Liquibase liquibase, final Writer exportWriter) throws DatabaseException {
@@ -202,23 +202,35 @@ public class LiquibaseJpaUpdaterProvider implements JpaUpdaterProvider {
     }
 
     protected Status validateChangeSet(Liquibase liquibase, String changelog) throws LiquibaseException {
-        List<ChangeSet> changeSets = getChangeSets(liquibase);
+        final Status result;
+        List<ChangeSet> changeSets = getLiquibaseUnrunChangeSets(liquibase);
 
         if (!changeSets.isEmpty()) {
             if (changeSets.size() == liquibase.getDatabaseChangeLog().getChangeSets().size()) {
-                return Status.EMPTY;
+                result = Status.EMPTY;
             } else {
                 logger.debugf("Validation failed. Database is not up-to-date for changelog %s", changelog);
-                return Status.OUTDATED;
+                result = Status.OUTDATED;
             }
         } else {
             logger.debugf("Validation passed. Database is up-to-date for changelog %s", changelog);
-            return Status.VALID;
+            result = Status.VALID;
         }
+
+        // Needs to restart liquibase services to clear ChangeLogHistoryServiceFactory.getInstance().
+        // See https://issues.jboss.org/browse/KEYCLOAK-3769 for discussion relevant to why reset needs to be here
+        resetLiquibaseServices(liquibase);
+
+        return result;
+    }
+
+    private void resetLiquibaseServices(Liquibase liquibase) {
+        Method resetServices = Reflections.findDeclaredMethod(Liquibase.class, "resetServices");
+        Reflections.invokeMethod(true, resetServices, liquibase);
     }
 
     @SuppressWarnings("unchecked")
-    private List<ChangeSet> getChangeSets(Liquibase liquibase) {
+    private List<ChangeSet> getLiquibaseUnrunChangeSets(Liquibase liquibase) {
         // TODO tracked as: https://issues.jboss.org/browse/KEYCLOAK-3730
         // TODO: When https://liquibase.jira.com/browse/CORE-2919 is resolved, replace the following two lines with:
         // List<ChangeSet> changeSets = liquibase.listUnrunChangeSets((Contexts) null, new LabelExpression(), false);


### PR DESCRIPTION
Before applying update or validation operation, Liquibase
ChangeLogService needs to be reset to forget about previously set
change log table. Reason is that the factory creating the
ChangeLogService caches this service per DB connection, not per
Liquibase object, hence changes in name of change log table needed for
custom JpaEntityProvider are not reflected and use only the first
change log table name, i.e. the change log table of the main database.
