### PR TITLE
grant the new role from the saml token if it exist

### DIFF
--- a/services/src/main/java/org/keycloak/broker/saml/mappers/AttributeToRoleMapper.java
+++ b/services/src/main/java/org/keycloak/broker/saml/mappers/AttributeToRoleMapper.java
@@ -139,10 +139,12 @@ public class AttributeToRoleMapper extends AbstractIdentityProviderMapper {
     @Override
     public void updateBrokeredUser(KeycloakSession session, RealmModel realm, UserModel user, IdentityProviderMapperModel mapperModel, BrokeredIdentityContext context) {
         String roleName = mapperModel.getConfig().get(ConfigConstants.ROLE);
+        RoleModel role = KeycloakModelUtils.getRoleFromString(realm, roleName);
+        if (role == null) throw new IdentityBrokerException("Unable to find role: " + roleName);
         if (!isAttributePresent(mapperModel, context)) {
-            RoleModel role = KeycloakModelUtils.getRoleFromString(realm, roleName);
-            if (role == null) throw new IdentityBrokerException("Unable to find role: " + roleName);
             user.deleteRoleMapping(role);
+        }else{
+            user.grantRole(role);
         }
 
     }


### PR DESCRIPTION
Grant the user with the new role from the saml token if it is a realm role in keycloak. This case is missing. The user should be able to change his role to another role if the new role exist as a realm role in keycloak.
