### PR TITLE
KEYCLOAK-3807: Calling 'setHandler' is forbidden

### DIFF
--- a/adapters/oidc/spring-boot/src/main/java/org/keycloak/adapters/springboot/KeycloakSpringBootConfiguration.java
+++ b/adapters/oidc/spring-boot/src/main/java/org/keycloak/adapters/springboot/KeycloakSpringBootConfiguration.java
@@ -215,7 +215,7 @@ public class KeycloakSpringBootConfiguration {
             securityHandler.setConstraintMappings(jettyConstraintMappings);
             securityHandler.setAuthenticator(keycloakJettyAuthenticator);
 
-            webAppContext.setHandler(securityHandler);
+            webAppContext.insertHandler(securityHandler);
         }
     }
 

--- a/adapters/oidc/spring-boot/src/main/java/org/keycloak/adapters/springboot/KeycloakSpringBootConfiguration.java
+++ b/adapters/oidc/spring-boot/src/main/java/org/keycloak/adapters/springboot/KeycloakSpringBootConfiguration.java
@@ -215,7 +215,7 @@ public class KeycloakSpringBootConfiguration {
             securityHandler.setConstraintMappings(jettyConstraintMappings);
             securityHandler.setAuthenticator(keycloakJettyAuthenticator);
 
-            webAppContext.insertHandler(securityHandler);
+            webAppContext.setSecurityHandler(securityHandler);
         }
     }
 


### PR DESCRIPTION
Use 'insertHandler' as suggested in the 'setHandler's log warning.
