### PR TITLE
KEYCLOAK-3669: Fix Tomcat Adapter for 8.5.5

### DIFF
--- a/adapters/oidc/tomcat/tomcat8/src/main/java/org/keycloak/adapters/tomcat/KeycloakAuthenticatorValve.java
+++ b/adapters/oidc/tomcat/tomcat8/src/main/java/org/keycloak/adapters/tomcat/KeycloakAuthenticatorValve.java
@@ -39,8 +39,19 @@ import java.util.List;
  * @version $Revision: 1 $
  */
 public class KeycloakAuthenticatorValve extends AbstractKeycloakAuthenticatorValve {
+    
+    /**
+     * Method called by Tomcat < 8.5.5
+     */
     public boolean authenticate(Request request, HttpServletResponse response) throws IOException {
        return authenticateInternal(request, response, request.getContext().getLoginConfig());
+    }
+    
+    /**
+     * Method called by Tomcat >= 8.5.5
+     */
+    protected boolean doAuthenticate(Request request, HttpServletResponse response) throws IOException {
+       return this.authenticate(request, response);
     }
 
     @Override


### PR DESCRIPTION
tested with springboot 1.4.0 (using tomcat 8.5.4) and springboot 1.4.1 (using tomcat 8.5.5) 
