### PR TITLE
KEYCLOAK-3820 The attributes firstname/lastname are not mapped correctly

### DIFF
--- a/services/src/main/java/org/keycloak/broker/oidc/OIDCIdentityProvider.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/OIDCIdentityProvider.java
@@ -242,6 +242,8 @@ public class OIDCIdentityProvider extends AbstractOAuth2IdentityProvider<OIDCIde
             String name = (String)idToken.getOtherClaims().get(IDToken.NAME);
             String preferredUsername = (String)idToken.getOtherClaims().get(IDToken.PREFERRED_USERNAME);
             String email = (String)idToken.getOtherClaims().get(IDToken.EMAIL);
+            String firstName = (String)idToken.getOtherClaims().get(IDToken.GIVEN_NAME);
+            String lastName = (String)idToken.getOtherClaims().get(IDToken.FAMILY_NAME);
 
             if (!getConfig().isDisableUserInfoService()) {
                 String userInfoUrl = getUserInfoUrl();
@@ -254,6 +256,8 @@ public class OIDCIdentityProvider extends AbstractOAuth2IdentityProvider<OIDCIde
                     name = getJsonProperty(userInfo, "name");
                     preferredUsername = getJsonProperty(userInfo, "preferred_username");
                     email = getJsonProperty(userInfo, "email");
+                    firstName = getJsonProperty(userInfo, IDToken.GIVEN_NAME);
+                    lastName = getJsonProperty(userInfo, IDToken.FAMILY_NAME);
                     AbstractJsonUserAttributeMapper.storeUserProfileForMapper(identity, userInfo, getConfig().getAlias());
                 }
             }
@@ -264,7 +268,9 @@ public class OIDCIdentityProvider extends AbstractOAuth2IdentityProvider<OIDCIde
             identity.setId(id);
             identity.setName(name);
             identity.setEmail(email);
-
+            identity.setFirstName(firstName);
+            identity.setLastName(lastName);
+ 
             identity.setBrokerUserId(getConfig().getAlias() + "." + id);
             if (tokenResponse.getSessionState() != null) {
                 identity.setBrokerSessionId(getConfig().getAlias() + "." + tokenResponse.getSessionState());


### PR DESCRIPTION
The properties "firstname" and "lastname" are mapped to "given_name" and "family_name"

2016-09-27 19:12:16,225 DEBUG [org.keycloak.social.user_profile_dump](default task-3) User Profile JSON Data for provider DemoFranceConnect: {"sub":"4356a6bb05ba721fb0ad22f0256e20dba2a579fe6cfd499f9519d72671c26f7bv1","given_name":"Philippe","family_name":"Brown","gender":"male","birthdate":"1985-01-03","preferred_username":"","birthplace":"49007","birthcountry":"99100","phone_number":"06.88.48.76.85","email":"Philippe.BROWN@armyspy.com","address":{"formatted":"26 rue Desaix, 75015 Paris","street_address":"26 rue Desaix","locality":"Paris","region":"Ile-de-France","postal_code":"75015","country":"France"}}

This already has the "given_name":"Philippe" and "family_name":"Brown".
