### PR TITLE
Prefix "ROLE_" in Spring Security Adapter.

### DIFF
--- a/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/authentication/KeycloakAuthenticationProvider.java
+++ b/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/authentication/KeycloakAuthenticationProvider.java
@@ -36,6 +36,7 @@ import java.util.List;
  * @version $Revision: 1 $
  */
 public class KeycloakAuthenticationProvider implements AuthenticationProvider {
+    private String prefixRole = "ROLE_";
     private GrantedAuthoritiesMapper grantedAuthoritiesMapper;
 
     public void setGrantedAuthoritiesMapper(GrantedAuthoritiesMapper grantedAuthoritiesMapper) {
@@ -48,7 +49,7 @@ public class KeycloakAuthenticationProvider implements AuthenticationProvider {
         List<GrantedAuthority> grantedAuthorities = new ArrayList<GrantedAuthority>();
 
         for (String role : token.getAccount().getRoles()) {
-            grantedAuthorities.add(new KeycloakRole(role));
+            grantedAuthorities.add(new KeycloakRole( this.prefixRole + role ));
         }
         return new KeycloakAuthenticationToken(token.getAccount(), mapAuthorities(grantedAuthorities));
     }


### PR DESCRIPTION
The spring security need that the roles have the prefix "ROLE_" to do the authorization process out of the box.
Example in the Ldap provider of "spring-security-ldap" [here](https://github.com/spring-projects/spring-security/blob/master/ldap/src/main/java/org/springframework/security/ldap/userdetails/DefaultLdapAuthoritiesPopulator.java)
