### PR TITLE
KEYCLOAK-3816: Broken OTP setup with smaller resolutions

### DIFF
--- a/themes/src/main/resources/theme/keycloak/login/resources/css/login.css
+++ b/themes/src/main/resources/theme/keycloak/login/resources/css/login.css
@@ -244,18 +244,26 @@ ol#kc-totp-settings li:first-of-type {
 .zocial.microsoft {background-color: #0052a4; color: #fff;}
 .zocial.microsoft:before { content: "\f15d"; }
 
+@media (min-width: 801px) {
+    #kc-container-wrapper {
+        bottom: 13%;        
+    }
+    
+    #kc-logo-wrapper {
+        position: absolute;
+        top: 50px;
+        right: 50px;
+    }
+}
 
 @media (min-width: 768px) {
     #kc-container-wrapper {
-        bottom: 13%;
         position: absolute;
         width: 100%;
     }
 
     #kc-logo-wrapper {
-        position: absolute;
-        top: 50px;
-        right: 50px;
+        margin-left: auto;
     }
 
     .login-pf .container {


### PR DESCRIPTION
Should be fixed now, even with low DPI settings.