### PR TITLE
KEYCLOAK-3879 Allow search by userId in UserResource.searchForUser(..)

### DIFF
--- a/server-spi/src/main/java/org/keycloak/models/UserFederationManager.java
+++ b/server-spi/src/main/java/org/keycloak/models/UserFederationManager.java
@@ -387,12 +387,21 @@ public class UserFederationManager implements UserProvider {
             attributes.put(UserModel.USERNAME, search.trim().toLowerCase());
         }
         federationLoad(realm, attributes);
-        return query(new PaginatedQuery() {
+
+        List<UserModel> result = query(new PaginatedQuery() {
             @Override
             public List<UserModel> query(RealmModel realm, int first, int max) {
                 return session.userStorage().searchForUser(search, realm, first, max);
             }
         }, realm, firstResult, maxResults);
+
+        // see KEYCLOAK-3879
+        UserModel userById = getUserById(search.trim(), realm);
+        if (userById != null) {
+            result.add(userById);
+        }
+
+        return result;
     }
 
     @Override

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/UserTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/UserTest.java
@@ -219,7 +219,9 @@ public class UserTest extends AbstractAdminTest {
 
     }
     
-    private void createUsers() {
+    private List<String> createUsers() {
+
+        List<String> userIds = new ArrayList<>();
         for (int i = 1; i < 10; i++) {
             UserRepresentation user = new UserRepresentation();
             user.setUsername("username" + i);
@@ -227,8 +229,9 @@ public class UserTest extends AbstractAdminTest {
             user.setFirstName("First" + i);
             user.setLastName("Last" + i);
 
-            createUser(user);
+            userIds.add(createUser(user));
         }
+        return userIds;
     }
 
     @Test
@@ -265,6 +268,22 @@ public class UserTest extends AbstractAdminTest {
 
         users = realm.users().search("last", null, null);
         assertEquals(9, users.size());
+    }
+
+
+    /**
+     * See https://issues.jboss.org/browse/KEYCLOAK-3879
+     */
+    @Test
+    public void searchByUserId() {
+        List<String> userIds = createUsers();
+
+        for (int i = 0; i < 2; i++) {
+            UserRepresentation userById = realm.users().get(userIds.get(i)).toRepresentation();
+            List<UserRepresentation> users = realm.users().search(userIds.get(i), null, null);
+            assertEquals(1, users.size());
+            assertEquals(userById.getUsername(), users.get(0).getUsername());
+        }
     }
 
     @Test


### PR DESCRIPTION
In practice it is often helpful to lookup a user by it's userId.
This PR adds an additional userId lookup when user searches
are performed with a single search-term.
We now try to find a user with it's userId equal to the given searchTerm.
This enables user lookups by their id's in the admin-console via the
user search.