### PR TITLE
KEYCLOAK-3880 Fix duplicated entries in User federation providers list

### DIFF
--- a/themes/src/main/resources/theme/base/admin/resources/js/controllers/users.js
+++ b/themes/src/main/resources/theme/base/admin/resources/js/controllers/users.js
@@ -630,6 +630,14 @@ module.controller('UserFederationCtrl', function($scope, $location, $route, real
     UserFederationProviders.query({realm: realm.realm}, function(data) {
         for (var i = 0; i < data.length; i++) {
             data[i].isUserFederationProvider = true;
+
+            // avoid adding duplicate entries to providers list
+            var existingProvider = $scope.providers.find(function(provider){ return provider.id == data[i].id });
+            if (existingProvider) {
+                angular.copy(data[i], existingProvider);
+                continue;
+            }
+
             $scope.providers.push(data[i]);
         }
     });


### PR DESCRIPTION
This avoids duplicate entries in the User federation providers list
when switching back and forth between "user federation" and
other views in the admin-console.