### PR TITLE
Fix for TOTP's look ahead window

### DIFF
--- a/server-spi/src/main/java/org/keycloak/models/utils/TimeBasedOTP.java
+++ b/server-spi/src/main/java/org/keycloak/models/utils/TimeBasedOTP.java
@@ -76,8 +76,8 @@ public class TimeBasedOTP extends HmacOTP {
     public boolean validateTOTP(String token, byte[] secret) {
         long currentInterval = this.clock.getCurrentInterval();
 
-        for (int i = this.lookAheadWindow; i >= 0; --i) {
-            String steps = Long.toHexString(currentInterval - i).toUpperCase();
+        for (int i = -this.lookAheadWindow; i <= this.lookAheadWindow; ++i) {
+            String steps = Long.toHexString(currentInterval + i).toUpperCase();
 
             // Just get a 16 digit string
             while (steps.length() < 16)


### PR DESCRIPTION
After fix TOTP window will check past and future OTP codes, instead of only past ones