### PR TITLE
Update README.md

### DIFF
--- a/examples/providers/rest/README.md
+++ b/examples/providers/rest/README.md
@@ -12,5 +12,5 @@ Then registering the provider by editing `standalone/configuration/standalone.xm
         <provider>module:org.keycloak.examples.hello-rest-example</provider>
     </providers>
 
-Then start (or restart) the server. Once started open http://localhost:8080/realms/master/hello and you should see the message _Hello master_.
+Then start (or restart) the server. Once started open http://localhost:8080/auth/realms/master/hello and you should see the message _Hello master_.
 You can also invoke the endpoint for other realms by replacing `master` with the realm name in the above url.


### PR DESCRIPTION
I don't know if it is correct, but I can only access to the example REST service from the URL:

    http://localhost:8080/auth/realms/master/hello

The following URL as shown in README gives a 404 - Not found:

    http://localhost:8080/realms/master/hello