### PR TITLE
[KEYCLOAK-3918] - Server won't boot on Windows

### DIFF
--- a/distribution/feature-packs/server-feature-pack/src/main/resources/modules/system/layers/keycloak/org/keycloak/keycloak-services/main/module.xml
+++ b/distribution/feature-packs/server-feature-pack/src/main/resources/modules/system/layers/keycloak/org/keycloak/keycloak-services/main/module.xml
@@ -30,7 +30,7 @@
         <module name="org.keycloak.keycloak-js-adapter" services="import"/>
         <module name="org.keycloak.keycloak-kerberos-federation" services="import"/>
         <module name="org.keycloak.keycloak-ldap-federation" services="import"/>
-        <module name="org.keycloak.keycloak-sssd-federation" services="import"/>
+        <module name="org.keycloak.keycloak-sssd-federation" optional="true" services="import"/>
         <module name="org.keycloak.keycloak-server-spi" services="import"/>
         <module name="org.keycloak.keycloak-server-spi-private" services="import"/>
         <module name="org.keycloak.keycloak-model-jpa" services="import"/>


### PR DESCRIPTION
@stianst our human CI  for Windows aka @ssilvert found this issue today. I managed to reproduce the issue and he already tested the fix.

We are all good now, I already ran our integration tests for SSSD federation provider and nothing was affected by this change.