### PR TITLE
Restore Java 7 compatibility for adapters.

### DIFF
--- a/authz/client/pom.xml
+++ b/authz/client/pom.xml
@@ -63,6 +63,14 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+		    <source>${maven.compiler.source}</source>
+		    <target>${maven.compiler.target}</target>
+                </configuration>
+            </plugin>
             <!-- Adding OSGI metadata to the JAR without changing the packaging type. -->
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>

--- a/authz/client/src/main/java/org/keycloak/authorization/client/util/HttpMethod.java
+++ b/authz/client/src/main/java/org/keycloak/authorization/client/util/HttpMethod.java
@@ -48,7 +48,7 @@ public class HttpMethod<R> {
     private HttpMethodResponse<R> response;
 
     public HttpMethod(Configuration configuration, RequestBuilder builder) {
-        this(configuration, builder, new HashMap<>(), new HashMap<>());
+        this(configuration, builder, new HashMap<String, String>(), new HashMap<String, String>());
     }
 
     public HttpMethod(Configuration configuration, RequestBuilder builder, HashMap<String, String> params, HashMap<String, String> headers) {

--- a/authz/client/src/main/java/org/keycloak/authorization/client/util/HttpMethodResponse.java
+++ b/authz/client/src/main/java/org/keycloak/authorization/client/util/HttpMethodResponse.java
@@ -41,7 +41,7 @@ public class HttpMethodResponse<R> {
         });
     }
 
-    public HttpMethodResponse<R> json(Class<R> responseType) {
+    public HttpMethodResponse<R> json(final Class<R> responseType) {
         return new HttpMethodResponse<R>(this.method) {
             @Override
             public R execute() {


### PR DESCRIPTION
The latest Keycloak versions silently lost Java 7 compatibility for the adapters.

This is bad as Java 7 is still widespread in the enterprise world. Although Oracle discontinued public support for Java 7, extended support is still available until July 2022. My client is just rolling out a new application that only supports Java 7.

The incompatibility is caused by the fact that the following modules are used by both the server and the adapters, but are built for Java 8 only:
- `keycloak-core`
- `keycloak-common`
- `keycloak-saml-core`
- `keycloak-saml-core-public`
-  `keycloak-authz-client`

I've set the target version to Java 1.7 in the respective poms to restore compatibility.

Some of the adapters were targeted at 1.6, but restoring 1.6 compatibility would require some more work as the diamond operator is already present at many places in the common modules.

I've removed the dozens of Java version settings in the adapter modules and just set the version to 1.7 in the adapters parent `pom.xml` as the versions in the poms were inconsistent.