### PR TITLE
KEYCLOAK-3683 Updated OIDC adapter test for secure-deployments

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/adapter/page/ProductPortalSubsystem.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/adapter/page/ProductPortalSubsystem.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite.adapter.page;
+
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.keycloak.testsuite.page.AbstractPageWithInjectedUrl;
+
+import java.net.URL;
+
+/**
+ *
+ * @author tkyjovsk
+ */
+public class ProductPortalSubsystem extends AbstractPageWithInjectedUrl {
+
+    public static final String DEPLOYMENT_NAME = "product-portal-subsystem";
+
+    @ArquillianResource
+    @OperateOnDeployment(DEPLOYMENT_NAME)
+    private URL url;
+
+    @Override
+    public URL getInjectedUrl() {
+        return url;
+    }
+
+}

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/AbstractDemoFilterServletAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/AbstractDemoFilterServletAdapterTest.java
@@ -16,13 +16,6 @@ public abstract class AbstractDemoFilterServletAdapterTest extends AbstractDemoS
     @Test
     @Override
     @Ignore
-    public void testCustomerPortalWithSubsystemSettings() {
-
-    }
-
-    @Test
-    @Override
-    @Ignore
     public void testAuthenticated() {
 
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/AbstractDemoServletsAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/AbstractDemoServletsAdapterTest.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.keycloak.testsuite.adapter.servlet;
 
 import org.apache.commons.io.FileUtils;
@@ -32,7 +31,6 @@ import org.keycloak.common.util.MultivaluedHashMap;
 import org.keycloak.common.util.Time;
 import org.keycloak.constants.AdapterConstants;
 import org.keycloak.keys.KeyProvider;
-import org.keycloak.models.Constants;
 import org.keycloak.protocol.oidc.OIDCAdvancedConfigWrapper;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.protocol.oidc.OIDCLoginProtocolService;
@@ -48,7 +46,6 @@ import org.keycloak.testsuite.adapter.page.BasicAuth;
 import org.keycloak.testsuite.adapter.page.CustomerDb;
 import org.keycloak.testsuite.adapter.page.CustomerDbErrorPage;
 import org.keycloak.testsuite.adapter.page.CustomerPortal;
-import org.keycloak.testsuite.adapter.page.CustomerPortalSubsystem;
 import org.keycloak.testsuite.adapter.page.InputPortal;
 import org.keycloak.testsuite.adapter.page.ProductPortal;
 import org.keycloak.testsuite.adapter.page.SecurePortal;
@@ -58,7 +55,6 @@ import org.keycloak.testsuite.auth.page.account.Applications;
 import org.keycloak.testsuite.auth.page.login.OAuthGrant;
 import org.keycloak.testsuite.console.page.events.Config;
 import org.keycloak.testsuite.console.page.events.LoginEvents;
-import org.keycloak.testsuite.util.URLAssert;
 import org.keycloak.testsuite.util.URLUtils;
 import org.keycloak.util.BasicAuthHelper;
 import org.openqa.selenium.By;
@@ -86,7 +82,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import org.keycloak.testsuite.adapter.page.CustomerPortalNoConf;
 import static org.keycloak.testsuite.auth.page.AuthRealm.DEMO;
@@ -106,8 +101,6 @@ public abstract class AbstractDemoServletsAdapterTest extends AbstractServletsAd
     private CustomerPortal customerPortal;
     @Page
     private CustomerPortalNoConf customerPortalNoConf;
-    @Page
-    private CustomerPortalSubsystem customerPortalSubsystem;
     @Page
     private SecurePortal securePortal;
     @Page
@@ -135,15 +128,10 @@ public abstract class AbstractDemoServletsAdapterTest extends AbstractServletsAd
     protected static WebArchive customerPortal() {
         return servletDeployment(CustomerPortal.DEPLOYMENT_NAME, CustomerServlet.class, ErrorServlet.class);
     }
-    
+
     @Deployment(name = CustomerPortalNoConf.DEPLOYMENT_NAME)
     protected static WebArchive customerPortalNoConf() {
         return servletDeployment(CustomerPortalNoConf.DEPLOYMENT_NAME, CustomerServletNoConf.class, ErrorServlet.class);
-    }
-
-    @Deployment(name = CustomerPortalSubsystem.DEPLOYMENT_NAME)
-    protected static WebArchive customerPortalSubsystem() {
-        return servletDeployment(CustomerPortalSubsystem.DEPLOYMENT_NAME, CustomerServlet.class, ErrorServlet.class);
     }
 
     @Deployment(name = SecurePortal.DEPLOYMENT_NAME)
@@ -195,14 +183,6 @@ public abstract class AbstractDemoServletsAdapterTest extends AbstractServletsAd
         // Delete all cookies from token-min-ttl page to be sure we are logged out
         tokenMinTTLPage.navigateTo();
         driver.manage().deleteAllCookies();
-    }
-
-    @Test
-    public void testCustomerPortalWithSubsystemSettings() {
-        customerPortalSubsystem.navigateTo();
-        assertCurrentUrlStartsWithLoginUrlOf(testRealmPage);
-        testRealmLoginPage.form().login("bburke@redhat.com", "password");
-        assertTrue(driver.getPageSource().contains("Bill Burke") && driver.getPageSource().contains("Stian Thorgersen"));
     }
 
     @Test
@@ -843,13 +823,12 @@ public abstract class AbstractDemoServletsAdapterTest extends AbstractServletsAd
             log.info("Checking app server log on app-server: \"" + System.getProperty("app.server") + "\" is not supported.");
         }
     }
-    
+
     @Test
     public void testWithoutKeycloakConf() {
         customerPortalNoConf.navigateTo();
         String pageSource = driver.getPageSource();
         assertTrue(pageSource.contains("Forbidden") || pageSource.contains("HTTP Status 401"));
     }
-
 
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/AbstractJBossOIDCServletsAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/AbstractJBossOIDCServletsAdapterTest.java
@@ -1,0 +1,48 @@
+package org.keycloak.testsuite.adapter.servlet;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.graphene.page.Page;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+import org.keycloak.testsuite.adapter.page.CustomerPortalSubsystem;
+import org.keycloak.testsuite.adapter.page.ProductPortalSubsystem;
+import static org.keycloak.testsuite.util.URLAssert.assertCurrentUrlEquals;
+import static org.keycloak.testsuite.util.URLAssert.assertCurrentUrlStartsWithLoginUrlOf;
+
+/**
+ * OIDC adapter test specific for JBoss-based containers.
+ * @author tkyjovsk
+ */
+public abstract class AbstractJBossOIDCServletsAdapterTest extends AbstractDemoServletsAdapterTest {
+
+    @Page
+    private CustomerPortalSubsystem customerPortalSubsystem;
+
+    @Page
+    private ProductPortalSubsystem productPortalSubsystem;
+
+    @Deployment(name = CustomerPortalSubsystem.DEPLOYMENT_NAME)
+    protected static WebArchive customerPortalSubsystem() {
+        return servletDeployment(CustomerPortalSubsystem.DEPLOYMENT_NAME, CustomerServlet.class, ErrorServlet.class);
+    }
+
+    @Deployment(name = ProductPortalSubsystem.DEPLOYMENT_NAME)
+    protected static WebArchive productPortalSubsystem() {
+        return servletDeployment(ProductPortalSubsystem.DEPLOYMENT_NAME, ProductServlet.class);
+    }
+
+    @Test
+    public void testSecureDeployments() {
+        customerPortalSubsystem.navigateTo();
+        assertCurrentUrlStartsWithLoginUrlOf(testRealmPage);
+        testRealmLoginPage.form().login("bburke@redhat.com", "password");
+        assertTrue(driver.getPageSource().contains("Bill Burke") && driver.getPageSource().contains("Stian Thorgersen"));
+
+        productPortalSubsystem.navigateTo();
+        assertCurrentUrlEquals(productPortalSubsystem);
+        String pageSource = driver.getPageSource();
+        assertTrue(pageSource.contains("iPhone") && pageSource.contains("iPad"));
+    }
+
+}

--- a/testsuite/integration-arquillian/tests/base/src/test/resources/adapter-test/demorealm.json
+++ b/testsuite/integration-arquillian/tests/base/src/test/resources/adapter-test/demorealm.json
@@ -176,6 +176,16 @@
             "secret": "password"
         },
         {
+            "clientId": "product-portal-subsystem",
+            "enabled": true,
+            "adminUrl": "/product-portal-subsystem",
+            "baseUrl": "/product-portal-subsystem",
+            "redirectUris": [
+                "/product-portal-subsystem/*"
+            ],
+            "secret": "password"
+        },
+        {
             "clientId": "secure-portal",
             "enabled": true,
             "adminUrl": "/secure-portal",

--- a/testsuite/integration-arquillian/tests/base/src/test/resources/adapter-test/product-portal-subsystem/META-INF/context.xml
+++ b/testsuite/integration-arquillian/tests/base/src/test/resources/adapter-test/product-portal-subsystem/META-INF/context.xml
@@ -1,0 +1,20 @@
+<!--
+  ~ Copyright 2016 Red Hat, Inc. and/or its affiliates
+  ~ and other contributors as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<Context path="/customer-portal">
+    <Valve className="org.keycloak.adapters.tomcat.KeycloakAuthenticatorValve"/>
+</Context>

--- a/testsuite/integration-arquillian/tests/base/src/test/resources/adapter-test/product-portal-subsystem/WEB-INF/jetty-web.xml
+++ b/testsuite/integration-arquillian/tests/base/src/test/resources/adapter-test/product-portal-subsystem/WEB-INF/jetty-web.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<!--
+  ~ Copyright 2016 Red Hat, Inc. and/or its affiliates
+  ~ and other contributors as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!DOCTYPE Configure PUBLIC "-//Mort Bay Consulting//DTD Configure//EN" "http://www.eclipse.org/jetty/configure_9_0.dtd">
+<Configure class="org.eclipse.jetty.webapp.WebAppContext">
+    <Get name="securityHandler">
+        <Set name="authenticator">
+            <New class="org.keycloak.adapters.jetty.KeycloakJettyAuthenticator">
+                <!--
+                <Set name="adapterConfig">
+                    <New class="org.keycloak.representations.adapters.config.AdapterConfig">
+                        <Set name="realm">tomcat</Set>
+                        <Set name="resource">customer-portal</Set>
+                        <Set name="authServerUrl">http://localhost:8180/auth</Set>
+                        <Set name="sslRequired">external</Set>
+                        <Set name="credentials">
+                            <Map>
+                                <Entry>
+                                    <Item>secret</Item>
+                                    <Item>password</Item>
+                                </Entry>
+                            </Map>
+                        </Set>
+                        <Set name="realmKey">MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCrVrCuTtArbgaZzL1hvh0xtL5mc7o0NqPVnYXkLvgcwiC3BjLGw1tGEGoJaXDuSaRllobm53JBhjx33UNv+5z/UMG4kytBWxheNVKnL6GgqlNabMaFfPLPCF8kAgKnsi79NMo+n6KnSY8YeUmec/p2vjO2NjsSAVcWEQMVhJ31LwIDAQAB</Set>
+                    </New>
+                </Set>
+                -->
+            </New>
+        </Set>
+    </Get>
+</Configure>

--- a/testsuite/integration-arquillian/tests/base/src/test/resources/adapter-test/product-portal-subsystem/WEB-INF/web.xml
+++ b/testsuite/integration-arquillian/tests/base/src/test/resources/adapter-test/product-portal-subsystem/WEB-INF/web.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2016 Red Hat, Inc. and/or its affiliates
+  ~ and other contributors as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
+
+    <module-name>product-portal-subsystem</module-name>
+
+    <servlet>
+        <servlet-name>Servlet</servlet-name>
+        <servlet-class>org.keycloak.testsuite.adapter.servlet.ProductServlet</servlet-class>
+    </servlet>
+
+    <servlet-mapping>
+        <servlet-name>Servlet</servlet-name>
+        <url-pattern>/*</url-pattern>
+    </servlet-mapping>
+
+    <security-constraint>
+        <web-resource-collection>
+            <web-resource-name>Users</web-resource-name>
+            <url-pattern>/*</url-pattern>
+        </web-resource-collection>
+        <auth-constraint>
+            <role-name>user</role-name>
+        </auth-constraint>
+    </security-constraint>
+
+    <login-config>
+        <auth-method>KEYCLOAK</auth-method>
+        <realm-name>demo</realm-name>
+    </login-config>
+
+    <security-role>
+        <role-name>admin</role-name>
+    </security-role>
+    <security-role>
+        <role-name>user</role-name>
+    </security-role>
+</web-app>

--- a/testsuite/integration-arquillian/tests/other/adapters/jboss/as7/src/test/java/org/keycloak/testsuite/adapter/AS7OIDCAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/other/adapters/jboss/as7/src/test/java/org/keycloak/testsuite/adapter/AS7OIDCAdapterTest.java
@@ -1,6 +1,6 @@
 package org.keycloak.testsuite.adapter;
 
-import org.keycloak.testsuite.adapter.servlet.AbstractDemoServletsAdapterTest;
+import org.keycloak.testsuite.adapter.servlet.AbstractJBossOIDCServletsAdapterTest;
 import org.keycloak.testsuite.arquillian.annotation.AppServerContainer;
 
 /**
@@ -8,6 +8,6 @@ import org.keycloak.testsuite.arquillian.annotation.AppServerContainer;
  * @author tkyjovsk
  */
 @AppServerContainer("app-server-as7")
-public class AS7OIDCAdapterTest extends AbstractDemoServletsAdapterTest {
+public class AS7OIDCAdapterTest extends AbstractJBossOIDCServletsAdapterTest {
 
 }

--- a/testsuite/integration-arquillian/tests/other/adapters/jboss/common/xslt/keycloak-subsystem.xsl
+++ b/testsuite/integration-arquillian/tests/other/adapters/jboss/common/xslt/keycloak-subsystem.xsl
@@ -21,6 +21,16 @@
                     <resource>customer-portal-subsystem</resource>
                     <credential name="secret">password</credential>
                 </secure-deployment>
+                
+                <secure-deployment name="product-portal-subsystem.war">
+                    <realm>demo</realm>
+                    <realm-public-key>MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCrVrCuTtArbgaZzL1hvh0xtL5mc7o0NqPVnYXkLvgcwiC3BjLGw1tGEGoJaXDuSaRllobm53JBhjx33UNv+5z/UMG4kytBWxheNVKnL6GgqlNabMaFfPLPCF8kAgKnsi79NMo+n6KnSY8YeUmec/p2vjO2NjsSAVcWEQMVhJ31LwIDAQAB</realm-public-key>
+                    <auth-server-url><xsl:value-of select="$auth-server-host"/>/auth</auth-server-url>
+                    <ssl-required>EXTERNAL</ssl-required>
+                    <resource>product-portal-subsystem</resource>
+                    <credential name="secret">password</credential>
+                </secure-deployment>
+                
             </xsl:copy>
     </xsl:template>
 

--- a/testsuite/integration-arquillian/tests/other/adapters/jboss/common/xslt/keycloak-subsystem_separate-realm-def.xsl
+++ b/testsuite/integration-arquillian/tests/other/adapters/jboss/common/xslt/keycloak-subsystem_separate-realm-def.xsl
@@ -1,0 +1,45 @@
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xalan="http://xml.apache.org/xalan"
+                version="2.0"
+                exclude-result-prefixes="xalan">
+
+    <xsl:output method="xml" version="1.0" encoding="UTF-8" indent="yes" xalan:indent-amount="4" standalone="no"/>
+    <xsl:strip-space elements="*"/>
+
+    <xsl:variable name="keycloakSubsystem" select="'urn:jboss:domain:keycloak:1.1'"/>
+    <xsl:param name="auth-server-host"/>
+
+    <xsl:template match="//*[local-name()='subsystem' and starts-with(namespace-uri(), $keycloakSubsystem)]">
+        <xsl:copy>
+            <xsl:apply-templates select="@* | node()" />
+
+            <realm name="demo">
+                <realm-public-key>MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCrVrCuTtArbgaZzL1hvh0xtL5mc7o0NqPVnYXkLvgcwiC3BjLGw1tGEGoJaXDuSaRllobm53JBhjx33UNv+5z/UMG4kytBWxheNVKnL6GgqlNabMaFfPLPCF8kAgKnsi79NMo+n6KnSY8YeUmec/p2vjO2NjsSAVcWEQMVhJ31LwIDAQAB</realm-public-key>
+                <auth-server-url>
+                    <xsl:value-of select="$auth-server-host"/>/auth
+                </auth-server-url>
+                <ssl-required>EXTERNAL</ssl-required>
+            </realm>
+                
+            <secure-deployment name="customer-portal-subsystem.war">
+                <realm>demo</realm>
+                <resource>customer-portal-subsystem</resource>
+                <credential name="secret">password</credential>
+            </secure-deployment>
+            
+            <secure-deployment name="product-portal-subsystem.war">
+                <realm>demo</realm>
+                <resource>product-portal-subsystem</resource>
+                <credential name="secret">password</credential>
+            </secure-deployment>
+            
+        </xsl:copy>
+    </xsl:template>
+
+    <xsl:template match="@*|node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@*|node()" />
+        </xsl:copy>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/testsuite/integration-arquillian/tests/other/adapters/jboss/eap/src/test/java/org/keycloak/testsuite/adapter/EAPOIDCAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/other/adapters/jboss/eap/src/test/java/org/keycloak/testsuite/adapter/EAPOIDCAdapterTest.java
@@ -1,6 +1,6 @@
 package org.keycloak.testsuite.adapter;
 
-import org.keycloak.testsuite.adapter.servlet.AbstractDemoServletsAdapterTest;
+import org.keycloak.testsuite.adapter.servlet.AbstractJBossOIDCServletsAdapterTest;
 import org.keycloak.testsuite.arquillian.annotation.AppServerContainer;
 
 /**
@@ -8,6 +8,6 @@ import org.keycloak.testsuite.arquillian.annotation.AppServerContainer;
  * @author tkyjovsk
  */
 @AppServerContainer("app-server-eap")
-public class EAPOIDCAdapterTest extends AbstractDemoServletsAdapterTest {
+public class EAPOIDCAdapterTest extends AbstractJBossOIDCServletsAdapterTest {
 
 }

--- a/testsuite/integration-arquillian/tests/other/adapters/jboss/eap6-fuse/pom.xml
+++ b/testsuite/integration-arquillian/tests/other/adapters/jboss/eap6-fuse/pom.xml
@@ -29,7 +29,7 @@
 
     <artifactId>integration-arquillian-tests-adapters-eap6-fuse</artifactId>
 
-    <name>Adapter Tests - JBoss - EAP 6</name>
+    <name>Adapter Tests - JBoss - EAP 6 Fuse</name>
     
     <properties>
         <app.server>eap6-fuse</app.server>

--- a/testsuite/integration-arquillian/tests/other/adapters/jboss/eap6/src/test/java/org/keycloak/testsuite/adapter/EAP6OIDCAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/other/adapters/jboss/eap6/src/test/java/org/keycloak/testsuite/adapter/EAP6OIDCAdapterTest.java
@@ -1,6 +1,6 @@
 package org.keycloak.testsuite.adapter;
 
-import org.keycloak.testsuite.adapter.servlet.AbstractDemoServletsAdapterTest;
+import org.keycloak.testsuite.adapter.servlet.AbstractJBossOIDCServletsAdapterTest;
 import org.keycloak.testsuite.arquillian.annotation.AppServerContainer;
 
 /**
@@ -8,6 +8,6 @@ import org.keycloak.testsuite.arquillian.annotation.AppServerContainer;
  * @author tkyjovsk
  */
 @AppServerContainer("app-server-eap6")
-public class EAP6OIDCAdapterTest extends AbstractDemoServletsAdapterTest {
+public class EAP6OIDCAdapterTest extends AbstractJBossOIDCServletsAdapterTest {
 
 }

--- a/testsuite/integration-arquillian/tests/other/adapters/jboss/pom.xml
+++ b/testsuite/integration-arquillian/tests/other/adapters/jboss/pom.xml
@@ -36,6 +36,8 @@
     <properties>
         <common.resources>${project.parent.basedir}/common</common.resources>
         <app.server.type>managed</app.server.type>
+        <auth.server.actual.http.port>${auth.server.http.port}</auth.server.actual.http.port>
+        <keycloak.subsystem.xsl>keycloak-subsystem.xsl</keycloak.subsystem.xsl>
     </properties>
 
     <build>
@@ -57,12 +59,12 @@
                                     <includes>
                                         <include>standalone.xml</include>
                                     </includes>
-                                    <stylesheet>${common.resources}/xslt/keycloak-subsystem.xsl</stylesheet>
+                                    <stylesheet>${common.resources}/xslt/${keycloak.subsystem.xsl}</stylesheet>
                                     <outputDir>${app.server.home}/standalone/configuration</outputDir>
                                     <parameters>
                                         <parameter>
                                             <name>auth-server-host</name>
-                                            <value>http://localhost:${auth.server.http.port}</value>
+                                            <value>http://localhost:${auth.server.actual.http.port}</value>
                                         </parameter>
                                     </parameters>
                                 </transformationSet>
@@ -83,41 +85,17 @@
                     <value>true</value>
                 </property>
             </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>xml-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>configure-keycloak-subsystem</id>
-                                <phase>process-test-resources</phase>
-                                <goals>
-                                    <goal>transform</goal>
-                                </goals>
-                                <configuration>
-                                    <transformationSets>
-                                        <transformationSet>
-                                            <dir>${app.server.home}/standalone/configuration</dir>
-                                            <includes>
-                                                <include>standalone.xml</include>
-                                            </includes>
-                                            <stylesheet>${common.resources}/xslt/keycloak-subsystem.xsl</stylesheet>
-                                            <outputDir>${app.server.home}/standalone/configuration</outputDir>
-                                            <parameters>
-                                                <parameter>
-                                                    <name>auth-server-host</name>
-                                                    <value>https://localhost:${auth.server.https.port}</value>
-                                                </parameter>
-                                            </parameters>
-                                        </transformationSet>
-                                    </transformationSets>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
+            <properties>
+                <!-- one realm definition for each secure-deployment -->
+                <auth.server.actual.http.port>${auth.server.https.port}</auth.server.actual.http.port>
+            </properties>
+        </profile>
+        <profile>
+            <id>keycloak-subsystem-separate-realm</id>
+            <properties>
+                <!-- single realm definition, multiple secure-deployments -->
+                <keycloak.subsystem.xsl>keycloak-subsystem_separate-realm-def.xsl</keycloak.subsystem.xsl>
+            </properties>
         </profile>
         <profile>
             <id>adapter-test-jboss-submodules</id>

--- a/testsuite/integration-arquillian/tests/other/adapters/jboss/relative/eap/src/test/java/org/keycloak/testsuite/adapter/RelativeEAPOIDCAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/other/adapters/jboss/relative/eap/src/test/java/org/keycloak/testsuite/adapter/RelativeEAPOIDCAdapterTest.java
@@ -1,11 +1,11 @@
 package org.keycloak.testsuite.adapter;
 
-import org.keycloak.testsuite.adapter.servlet.AbstractDemoServletsAdapterTest;
+import org.keycloak.testsuite.adapter.servlet.AbstractJBossOIDCServletsAdapterTest;
 
 /**
  *
  * @author tkyjovsk
  */
-public class RelativeEAPOIDCAdapterTest extends AbstractDemoServletsAdapterTest {
+public class RelativeEAPOIDCAdapterTest extends AbstractJBossOIDCServletsAdapterTest {
 
 }

--- a/testsuite/integration-arquillian/tests/other/adapters/jboss/relative/wildfly/src/test/java/org/keycloak/testsuite/adapter/RelativeWildflyOIDCAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/other/adapters/jboss/relative/wildfly/src/test/java/org/keycloak/testsuite/adapter/RelativeWildflyOIDCAdapterTest.java
@@ -1,11 +1,11 @@
 package org.keycloak.testsuite.adapter;
 
-import org.keycloak.testsuite.adapter.servlet.AbstractDemoServletsAdapterTest;
+import org.keycloak.testsuite.adapter.servlet.AbstractJBossOIDCServletsAdapterTest;
 
 /**
  *
  * @author tkyjovsk
  */
-public class RelativeWildflyOIDCAdapterTest extends AbstractDemoServletsAdapterTest {
+public class RelativeWildflyOIDCAdapterTest extends AbstractJBossOIDCServletsAdapterTest {
 
 }

--- a/testsuite/integration-arquillian/tests/other/adapters/jboss/wildfly/src/test/java/org/keycloak/testsuite/adapter/WildflyOIDCAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/other/adapters/jboss/wildfly/src/test/java/org/keycloak/testsuite/adapter/WildflyOIDCAdapterTest.java
@@ -1,6 +1,6 @@
 package org.keycloak.testsuite.adapter;
 
-import org.keycloak.testsuite.adapter.servlet.AbstractDemoServletsAdapterTest;
+import org.keycloak.testsuite.adapter.servlet.AbstractJBossOIDCServletsAdapterTest;
 import org.keycloak.testsuite.arquillian.annotation.AppServerContainer;
 
 /**
@@ -8,6 +8,6 @@ import org.keycloak.testsuite.arquillian.annotation.AppServerContainer;
  * @author tkyjovsk
  */
 @AppServerContainer("app-server-wildfly")
-public class WildflyOIDCAdapterTest extends AbstractDemoServletsAdapterTest {
+public class WildflyOIDCAdapterTest extends AbstractJBossOIDCServletsAdapterTest {
 
 }

--- a/testsuite/integration-arquillian/tests/other/adapters/jboss/wildfly8/src/test/java/org/keycloak/testsuite/adapter/Wildfly8OIDCAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/other/adapters/jboss/wildfly8/src/test/java/org/keycloak/testsuite/adapter/Wildfly8OIDCAdapterTest.java
@@ -1,6 +1,6 @@
 package org.keycloak.testsuite.adapter;
 
-import org.keycloak.testsuite.adapter.servlet.AbstractDemoServletsAdapterTest;
+import org.keycloak.testsuite.adapter.servlet.AbstractJBossOIDCServletsAdapterTest;
 import org.keycloak.testsuite.arquillian.annotation.AppServerContainer;
 
 /**
@@ -8,6 +8,6 @@ import org.keycloak.testsuite.arquillian.annotation.AppServerContainer;
  * @author tkyjovsk
  */
 @AppServerContainer("app-server-wildfly8")
-public class Wildfly8OIDCAdapterTest extends AbstractDemoServletsAdapterTest {
+public class Wildfly8OIDCAdapterTest extends AbstractJBossOIDCServletsAdapterTest {
 
 }

--- a/testsuite/integration-arquillian/tests/other/adapters/jboss/wildfly9/src/test/java/org/keycloak/testsuite/adapter/Wildfly9OIDCAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/other/adapters/jboss/wildfly9/src/test/java/org/keycloak/testsuite/adapter/Wildfly9OIDCAdapterTest.java
@@ -1,6 +1,6 @@
 package org.keycloak.testsuite.adapter;
 
-import org.keycloak.testsuite.adapter.servlet.AbstractDemoServletsAdapterTest;
+import org.keycloak.testsuite.adapter.servlet.AbstractJBossOIDCServletsAdapterTest;
 import org.keycloak.testsuite.arquillian.annotation.AppServerContainer;
 
 /**
@@ -8,6 +8,6 @@ import org.keycloak.testsuite.arquillian.annotation.AppServerContainer;
  * @author tkyjovsk
  */
 @AppServerContainer("app-server-wildfly9")
-public class Wildfly9OIDCAdapterTest extends AbstractDemoServletsAdapterTest {
+public class Wildfly9OIDCAdapterTest extends AbstractJBossOIDCServletsAdapterTest {
 
 }


### PR DESCRIPTION
- added 2nd secure-deployment
- added option to test with separate real configuration in keycloak subsystem
- moved jboss-specific test to a separate class