### PR TITLE
KEYCLOAK-3725: return Unauthorized when accessing bearer only in inte…

### DIFF
--- a/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/config/KeycloakWebSecurityConfigurerAdapter.java
+++ b/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/config/KeycloakWebSecurityConfigurerAdapter.java
@@ -71,8 +71,8 @@ public abstract class KeycloakWebSecurityConfigurerAdapter extends WebSecurityCo
         return factoryBean.getObject();
     }
 
-    protected AuthenticationEntryPoint authenticationEntryPoint(AdapterDeploymentContext adapterDeploymentContext) throws Exception {
-        return new KeycloakAuthenticationEntryPoint(adapterDeploymentContext);
+    protected AuthenticationEntryPoint authenticationEntryPoint() throws Exception {
+        return new KeycloakAuthenticationEntryPoint(adapterDeploymentContext());
     }
 
     protected KeycloakAuthenticationProvider keycloakAuthenticationProvider() {
@@ -117,7 +117,7 @@ public abstract class KeycloakWebSecurityConfigurerAdapter extends WebSecurityCo
                 .and()
                 .addFilterBefore(keycloakPreAuthActionsFilter(), LogoutFilter.class)
                 .addFilterBefore(keycloakAuthenticationProcessingFilter(), BasicAuthenticationFilter.class)
-                .exceptionHandling().authenticationEntryPoint(authenticationEntryPoint(adapterDeploymentContext()))
+                .exceptionHandling().authenticationEntryPoint(authenticationEntryPoint())
                 .and()
                 .logout()
                 .addLogoutHandler(keycloakLogoutHandler())

--- a/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/config/KeycloakWebSecurityConfigurerAdapter.java
+++ b/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/config/KeycloakWebSecurityConfigurerAdapter.java
@@ -71,8 +71,8 @@ public abstract class KeycloakWebSecurityConfigurerAdapter extends WebSecurityCo
         return factoryBean.getObject();
     }
 
-    protected AuthenticationEntryPoint authenticationEntryPoint() {
-        return new KeycloakAuthenticationEntryPoint();
+    protected AuthenticationEntryPoint authenticationEntryPoint(AdapterDeploymentContext adapterDeploymentContext) throws Exception {
+        return new KeycloakAuthenticationEntryPoint(adapterDeploymentContext);
     }
 
     protected KeycloakAuthenticationProvider keycloakAuthenticationProvider() {
@@ -117,7 +117,7 @@ public abstract class KeycloakWebSecurityConfigurerAdapter extends WebSecurityCo
                 .and()
                 .addFilterBefore(keycloakPreAuthActionsFilter(), LogoutFilter.class)
                 .addFilterBefore(keycloakAuthenticationProcessingFilter(), BasicAuthenticationFilter.class)
-                .exceptionHandling().authenticationEntryPoint(authenticationEntryPoint())
+                .exceptionHandling().authenticationEntryPoint(authenticationEntryPoint(adapterDeploymentContext()))
                 .and()
                 .logout()
                 .addLogoutHandler(keycloakLogoutHandler())

--- a/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/filter/KeycloakAuthenticationProcessingFilter.java
+++ b/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/filter/KeycloakAuthenticationProcessingFilter.java
@@ -142,6 +142,7 @@ public class KeycloakAuthenticationProcessingFilter extends AbstractAuthenticati
         if (AuthOutcome.FAILED.equals(result)) {
             throw new KeycloakAuthenticationException("Auth outcome: " + result);
         }
+       
         else if (AuthOutcome.AUTHENTICATED.equals(result)) {
             Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
             Assert.notNull(authentication, "Authentication SecurityContextHolder was null");

--- a/adapters/oidc/spring-security/src/test/java/org/keycloak/adapters/springsecurity/authentication/KeycloakAuthenticationEntryPointTest.java
+++ b/adapters/oidc/spring-security/src/test/java/org/keycloak/adapters/springsecurity/authentication/KeycloakAuthenticationEntryPointTest.java
@@ -26,6 +26,15 @@ import org.springframework.mock.web.MockHttpServletResponse;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import org.keycloak.adapters.AdapterDeploymentContext;
+import org.keycloak.adapters.KeycloakDeployment;
+import org.keycloak.adapters.spi.HttpFacade;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import org.mockito.Mock;
+import static org.mockito.Mockito.when;
+import org.mockito.MockitoAnnotations;
+import org.springframework.context.ApplicationContext;
 
 /**
  * Keycloak authentication entry point tests.
@@ -35,12 +44,24 @@ public class KeycloakAuthenticationEntryPointTest {
     private KeycloakAuthenticationEntryPoint authenticationEntryPoint;
     private MockHttpServletRequest request;
     private MockHttpServletResponse response;
+    @Mock
+    private ApplicationContext applicationContext;
+   
+    @Mock
+    private AdapterDeploymentContext adapterDeploymentContext;
+    
+    @Mock
+    private KeycloakDeployment keycloakDeployment;
 
     @Before
     public void setUp() throws Exception {
-        authenticationEntryPoint = new KeycloakAuthenticationEntryPoint();
+        MockitoAnnotations.initMocks(this);
+        authenticationEntryPoint = new KeycloakAuthenticationEntryPoint(adapterDeploymentContext);
         request = new MockHttpServletRequest();
         response = new MockHttpServletResponse();
+        when(applicationContext.getBean(eq(AdapterDeploymentContext.class))).thenReturn(adapterDeploymentContext);
+        when(adapterDeploymentContext.resolveDeployment(any(HttpFacade.class))).thenReturn(keycloakDeployment);
+        when(keycloakDeployment.isBearerOnly()).thenReturn(Boolean.FALSE);
     }
 
     @Test

--- a/adapters/oidc/spring-security/src/test/java/org/keycloak/adapters/springsecurity/filter/KeycloakAuthenticationProcessingFilterTest.java
+++ b/adapters/oidc/spring-security/src/test/java/org/keycloak/adapters/springsecurity/filter/KeycloakAuthenticationProcessingFilterTest.java
@@ -154,6 +154,7 @@ public class KeycloakAuthenticationProcessingFilterTest {
         when(keycloakDeployment.getResourceName()).thenReturn("resource-name");
         when(keycloakDeployment.getStateCookieName()).thenReturn("kc-cookie");
         when(keycloakDeployment.getSslRequired()).thenReturn(SslRequired.NONE);
+        when(keycloakDeployment.isBearerOnly()).thenReturn(Boolean.FALSE);
         filter.attemptAuthentication(request, response);
 
         verify(response).setStatus(302);


### PR DESCRIPTION
…ractive mode. Before that fix, instead of returning a 401 the application entered an infinite redirect loop.

@foo4u Do you mind reviewing this since you are the main author of the Spring Sec adapter ? 

