### PR TITLE
KEYCLOAK-3988: Multiple missing indexes on FKs.

### DIFF
--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-3.2.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-3.2.0.xml
@@ -24,4 +24,139 @@
         <addPrimaryKey columnNames="USER_SESSION_ID,CLIENT_ID, OFFLINE_FLAG" constraintName="CONSTRAINT_OFFL_CL_SES_PK3" tableName="OFFLINE_CLIENT_SESSION"/>
     </changeSet>
 
+    <changeSet author="glavoie@gmail.com" id="3.2.0.idx">
+        <createIndex indexName="IDX_ASSOC_POL_ASSOC_POL_ID" tableName="ASSOCIATED_POLICY">
+            <column name="ASSOCIATED_POLICY_ID" type="VARCHAR(36)"/>
+        </createIndex>
+        <createIndex indexName="IDX_AUTH_EXEC_REALM_FLOW" tableName="AUTHENTICATION_EXECUTION">
+            <column name="REALM_ID" type="VARCHAR(36)"/>
+            <column name="FLOW_ID" type="VARCHAR(36)"/>
+        </createIndex>
+        <createIndex indexName="IDX_AUTH_EXEC_FLOW" tableName="AUTHENTICATION_EXECUTION">
+            <column name="FLOW_ID" type="VARCHAR(36)"/>
+        </createIndex>
+        <createIndex indexName="IDX_AUTH_FLOW_REALM" tableName="AUTHENTICATION_FLOW">
+            <column name="REALM_ID" type="VARCHAR(36)"/>
+        </createIndex>
+        <createIndex indexName="IDX_AUTH_CONFIG_REALM" tableName="AUTHENTICATOR_CONFIG">
+            <column name="REALM_ID" type="VARCHAR(36)"/>
+        </createIndex>
+        <createIndex indexName="IDX_CLIENT_CLIENT_TEMPL_ID" tableName="CLIENT">
+            <column name="CLIENT_TEMPLATE_ID" type="VARCHAR(36)"/>
+        </createIndex>
+        <createIndex indexName="IDX_CLIENT_DEF_ROLES_CLIENT" tableName="CLIENT_DEFAULT_ROLES">
+            <column name="CLIENT_ID" type="VARCHAR(36)"/>
+        </createIndex>
+        <createIndex indexName="IDX_CLIENT_ID_PROV_MAP_CLIENT" tableName="CLIENT_IDENTITY_PROV_MAPPING">
+            <column name="CLIENT_ID" type="VARCHAR(36)"/>
+        </createIndex>
+        <createIndex indexName="IDX_CLIENT_SESSION_SESSION" tableName="CLIENT_SESSION">
+            <column name="SESSION_ID" type="VARCHAR(36)"/>
+        </createIndex>
+        <createIndex indexName="IDX_COMPONENT_REALM" tableName="COMPONENT">
+            <column name="REALM_ID" type="VARCHAR(36)"/>
+        </createIndex>
+        <createIndex indexName="IDX_COMPO_CONFIG_COMPO" tableName="COMPONENT_CONFIG">
+            <column name="COMPONENT_ID" type="VARCHAR(36)"/>
+        </createIndex>
+        <createIndex indexName="IDX_COMPOSITE" tableName="COMPOSITE_ROLE">
+            <column name="COMPOSITE" type="VARCHAR(36)"/>
+        </createIndex>
+        <createIndex indexName="IDX_COMPOSITE_CHILD" tableName="COMPOSITE_ROLE">
+            <column name="CHILD_ROLE" type="VARCHAR(36)"/>
+        </createIndex>
+        <createIndex indexName="IDX_CREDENTIAL_ATTR_CRED" tableName="CREDENTIAL_ATTRIBUTE">
+            <column name="CREDENTIAL_ID" type="VARCHAR(36)"/>
+        </createIndex>
+        <createIndex indexName="IDX_FED_CRED_ATTR_CRED" tableName="FED_CREDENTIAL_ATTRIBUTE">
+            <column name="CREDENTIAL_ID" type="VARCHAR(36)"/>
+        </createIndex>
+        <createIndex indexName="IDX_GROUP_ATTR_GROUP" tableName="GROUP_ATTRIBUTE">
+            <column name="GROUP_ID" type="VARCHAR(36)"/>
+        </createIndex>
+        <createIndex indexName="IDX_GROUP_ROLE_MAPP_GROUP" tableName="GROUP_ROLE_MAPPING">
+            <column name="GROUP_ID" type="VARCHAR(36)"/>
+        </createIndex>
+        <createIndex indexName="IDX_IDENT_PROV_REALM" tableName="IDENTITY_PROVIDER">
+            <column name="REALM_ID" type="VARCHAR(36)"/>
+        </createIndex>
+        <createIndex indexName="IDX_ID_PROV_MAPP_REALM" tableName="IDENTITY_PROVIDER_MAPPER">
+            <column name="REALM_ID" type="VARCHAR(36)"/>
+        </createIndex>
+        <createIndex indexName="IDX_KEYCLOAK_ROLE_CLIENT" tableName="KEYCLOAK_ROLE">
+            <column name="CLIENT" type="VARCHAR(36)"/>
+        </createIndex>
+        <createIndex indexName="IDX_KEYCLOAK_ROLE_REALM" tableName="KEYCLOAK_ROLE">
+            <column name="REALM" type="VARCHAR(36)"/>
+        </createIndex>
+        <createIndex indexName="IDX_PROTOCOL_MAPPER_CLIENT" tableName="PROTOCOL_MAPPER">
+            <column name="CLIENT_ID" type="VARCHAR(36)"/>
+        </createIndex>
+        <createIndex indexName="IDX_PROTO_MAPP_CLIENT_TEMPL" tableName="PROTOCOL_MAPPER">
+            <column name="CLIENT_TEMPLATE_ID" type="VARCHAR(36)"/>
+        </createIndex>
+        <createIndex indexName="IDX_REALM_MASTER_ADM_CLI" tableName="REALM">
+            <column name="MASTER_ADMIN_CLIENT" type="VARCHAR(36)"/>
+        </createIndex>
+        <createIndex indexName="IDX_REALM_ATTR_REALM" tableName="REALM_ATTRIBUTE">
+            <column name="REALM_ID" type="VARCHAR(36)"/>
+        </createIndex>
+        <createIndex indexName="IDX_REALM_DEF_GRP_REALM" tableName="REALM_DEFAULT_GROUPS">
+            <column name="REALM_ID" type="VARCHAR(36)"/>
+        </createIndex>
+        <createIndex indexName="IDX_REALM_DEF_ROLES_REALM" tableName="REALM_DEFAULT_ROLES">
+            <column name="REALM_ID" type="VARCHAR(36)"/>
+        </createIndex>
+        <createIndex indexName="IDX_REALM_EVT_TYPES_REALM" tableName="REALM_ENABLED_EVENT_TYPES">
+            <column name="REALM_ID" type="VARCHAR(36)"/>
+        </createIndex>
+        <createIndex indexName="IDX_REALM_EVT_LIST_REALM" tableName="REALM_EVENTS_LISTENERS">
+            <column name="REALM_ID" type="VARCHAR(36)"/>
+        </createIndex>
+        <createIndex indexName="IDX_REALM_SUPP_LOCAL_REALM" tableName="REALM_SUPPORTED_LOCALES">
+            <column name="REALM_ID" type="VARCHAR(36)"/>
+        </createIndex>
+        <createIndex indexName="IDX_REDIR_URI_CLIENT" tableName="REDIRECT_URIS">
+            <column name="CLIENT_ID" type="VARCHAR(36)"/>
+        </createIndex>
+        <createIndex indexName="IDX_REQ_ACT_PROV_REALM" tableName="REQUIRED_ACTION_PROVIDER">
+            <column name="REALM_ID" type="VARCHAR(36)"/>
+        </createIndex>
+        <createIndex indexName="IDX_RES_POLICY_POLICY" tableName="RESOURCE_POLICY">
+            <column name="POLICY_ID" type="VARCHAR(36)"/>
+        </createIndex>
+        <createIndex indexName="IDX_RES_SCOPE_SCOPE" tableName="RESOURCE_SCOPE">
+            <column name="SCOPE_ID" type="VARCHAR(36)"/>
+        </createIndex>
+        <createIndex indexName="IDX_RES_SERV_POL_RES_SERV" tableName="RESOURCE_SERVER_POLICY">
+            <column name="RESOURCE_SERVER_ID" type="VARCHAR(36)"/>
+        </createIndex>
+        <createIndex indexName="IDX_RES_SRV_RES_RES_SRV" tableName="RESOURCE_SERVER_RESOURCE">
+            <column name="RESOURCE_SERVER_ID" type="VARCHAR(36)"/>
+        </createIndex>
+        <createIndex indexName="IDX_RES_SRV_SCOPE_RES_SRV" tableName="RESOURCE_SERVER_SCOPE">
+            <column name="RESOURCE_SERVER_ID" type="VARCHAR(36)"/>
+        </createIndex>
+        <createIndex indexName="IDX_SCOPE_MAPPING_ROLE" tableName="SCOPE_MAPPING">
+            <column name="ROLE_ID" type="VARCHAR(36)"/>
+        </createIndex>
+        <createIndex indexName="IDX_SCOPE_POLICY_POLICY" tableName="SCOPE_POLICY">
+            <column name="POLICY_ID" type="VARCHAR(36)"/>
+        </createIndex>
+        <createIndex indexName="IDX_TEMPL_SCOPE_MAPP_ROLE" tableName="TEMPLATE_SCOPE_MAPPING">
+            <column name="ROLE_ID" type="VARCHAR(36)"/>
+        </createIndex>
+        <createIndex indexName="IDX_USR_FED_MAP_FED_PRV" tableName="USER_FEDERATION_MAPPER">
+            <column name="FEDERATION_PROVIDER_ID" type="VARCHAR(36)"/>
+        </createIndex>
+        <createIndex indexName="IDX_USR_FED_MAP_REALM" tableName="USER_FEDERATION_MAPPER">
+            <column name="REALM_ID" type="VARCHAR(36)"/>
+        </createIndex>
+        <createIndex indexName="IDX_USR_FED_PRV_REALM" tableName="USER_FEDERATION_PROVIDER">
+            <column name="REALM_ID" type="VARCHAR(36)"/>
+        </createIndex>
+        <createIndex indexName="IDX_WEB_ORIG_CLIENT" tableName="WEB_ORIGINS">
+            <column name="CLIENT_ID" type="VARCHAR(36)"/>
+        </createIndex>
+     </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
During performance testing with a large number of realms, we found out that many indexes are missing for FKs, at least on an Oracle database. As indexes are not created automatically on FKs at least on Oracle, MSSQL and PostgreSQL.