### PR TITLE
KEYCLOAK-3989: Replacing COMPOSITE_ROLE Collection with Set.

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/models/jpa/RoleAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/RoleAdapter.java
@@ -107,10 +107,7 @@ public class RoleAdapter implements RoleModel, JpaModel<RoleEntity> {
     @Override
     public void removeCompositeRole(RoleModel role) {
         RoleEntity entity = RoleAdapter.toRoleEntity(role, em);
-        Iterator<RoleEntity> it = getEntity().getCompositeRoles().iterator();
-        while (it.hasNext()) {
-            if (it.next().equals(entity)) it.remove();
-        }
+        getEntity().getCompositeRoles().remove(entity);
     }
 
     @Override

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/RoleEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/RoleEntity.java
@@ -31,8 +31,8 @@ import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
-import java.util.ArrayList;
-import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -89,7 +89,7 @@ public class RoleEntity {
 
     @ManyToMany(fetch = FetchType.LAZY, cascade = {})
     @JoinTable(name = "COMPOSITE_ROLE", joinColumns = @JoinColumn(name = "COMPOSITE"), inverseJoinColumns = @JoinColumn(name = "CHILD_ROLE"))
-    private Collection<RoleEntity> compositeRoles = new ArrayList<RoleEntity>();
+    private Set<RoleEntity> compositeRoles = new HashSet<>();
 
     public String getId() {
         return id;
@@ -133,11 +133,11 @@ public class RoleEntity {
         this.scopeParamRequired = scopeParamRequired;
     }
 
-    public Collection<RoleEntity> getCompositeRoles() {
+    public Set<RoleEntity> getCompositeRoles() {
         return compositeRoles;
     }
 
-    public void setCompositeRoles(Collection<RoleEntity> compositeRoles) {
+    public void setCompositeRoles(Set<RoleEntity> compositeRoles) {
         this.compositeRoles = compositeRoles;
     }
 


### PR DESCRIPTION
During performance testing with a large number of realms, we found out that every times a realm is created/deleted, all composites roles on the admin role are dropped and re-inserted (COMPOSITE_ROLE table). This causes a significant slow down in the operation.

This is caused by the use of a Collection rather than a Set in the JPA mapping. With Collection, Hibernate can't track additions/deletions on the collection and re-create all the entries. Using a set, individual additions/deletions are tracked properly.