### PR TITLE
KEYCLOAK-4074 Decoupling of default provider implementations

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/directgrant/ValidateOTP.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/directgrant/ValidateOTP.java
@@ -53,9 +53,7 @@ public class ValidateOTP extends AbstractDirectGrantAuthenticator {
             }
             return;
         }
-        MultivaluedMap<String, String> inputData = context.getHttpRequest().getDecodedFormParameters();
-        List<UserCredentialModel> credentials = new LinkedList<>();
-        String otp = inputData.getFirst(CredentialRepresentation.TOTP);
+        String otp = retrieveOTP(context);
         if (otp == null) {
             if (context.getUser() != null) {
                 context.getEvent().user(context.getUser());
@@ -141,5 +139,10 @@ public class ValidateOTP extends AbstractDirectGrantAuthenticator {
     @Override
     public String getId() {
         return PROVIDER_ID;
+    }
+    
+    protected String retrieveOTP(AuthenticationFlowContext context) {
+        MultivaluedMap<String, String> inputData = context.getHttpRequest().getDecodedFormParameters();
+        return inputData.getFirst(CredentialRepresentation.TOTP);
     }
 }

--- a/services/src/main/java/org/keycloak/authentication/authenticators/directgrant/ValidatePassword.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/directgrant/ValidatePassword.java
@@ -43,9 +43,7 @@ public class ValidatePassword extends AbstractDirectGrantAuthenticator {
 
     @Override
     public void authenticate(AuthenticationFlowContext context) {
-        MultivaluedMap<String, String> inputData = context.getHttpRequest().getDecodedFormParameters();
-        List<UserCredentialModel> credentials = new LinkedList<>();
-        String password = inputData.getFirst(CredentialRepresentation.PASSWORD);
+        String password = retrievePassword(context);
         boolean valid = context.getSession().userCredentialManager().isValid(context.getRealm(), context.getUser(), UserCredentialModel.password(password));
         if (!valid) {
             context.getEvent().user(context.getUser());
@@ -117,5 +115,10 @@ public class ValidatePassword extends AbstractDirectGrantAuthenticator {
     @Override
     public String getId() {
         return PROVIDER_ID;
+    }
+
+    protected String retrievePassword(AuthenticationFlowContext context) {
+        MultivaluedMap<String, String> inputData = context.getHttpRequest().getDecodedFormParameters();
+        return inputData.getFirst(CredentialRepresentation.PASSWORD);
     }
 }

--- a/services/src/main/java/org/keycloak/authentication/authenticators/directgrant/ValidateUsername.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/directgrant/ValidateUsername.java
@@ -47,8 +47,7 @@ public class ValidateUsername extends AbstractDirectGrantAuthenticator {
 
     @Override
     public void authenticate(AuthenticationFlowContext context) {
-        MultivaluedMap<String, String> inputData = context.getHttpRequest().getDecodedFormParameters();
-        String username = inputData.getFirst(AuthenticationManager.FORM_USERNAME);
+        String username = retrieveUsername(context);
         if (username == null) {
             context.getEvent().error(Errors.USER_NOT_FOUND);
             Response challengeResponse = errorResponse(Response.Status.UNAUTHORIZED.getStatusCode(), "invalid_request", "Missing parameter: username");
@@ -153,5 +152,10 @@ public class ValidateUsername extends AbstractDirectGrantAuthenticator {
     @Override
     public String getId() {
         return PROVIDER_ID;
+    }
+ 
+    protected String retrieveUsername(AuthenticationFlowContext context) {
+        MultivaluedMap<String, String> inputData = context.getHttpRequest().getDecodedFormParameters();
+        return inputData.getFirst(AuthenticationManager.FORM_USERNAME);
     }
 }

--- a/services/src/main/java/org/keycloak/email/DefaultEmailSenderProvider.java
+++ b/services/src/main/java/org/keycloak/email/DefaultEmailSenderProvider.java
@@ -57,7 +57,7 @@ public class DefaultEmailSenderProvider implements EmailSenderProvider {
     public void send(RealmModel realm, UserModel user, String subject, String textBody, String htmlBody) throws EmailException {
         Transport transport = null;
         try {
-            String address = user.getEmail();
+            String address = retrieveEmailAddress(user);
             Map<String, String> config = realm.getSmtpConfig();
 
             Properties props = new Properties();
@@ -135,6 +135,10 @@ public class DefaultEmailSenderProvider implements EmailSenderProvider {
                 }
             }
         }
+    }
+    
+    protected String retrieveEmailAddress(UserModel user) {
+        return user.getEmail();
     }
 
     private void setupTruststore(Properties props) throws NoSuchAlgorithmException, KeyManagementException {


### PR DESCRIPTION
I am writing some custom direct grant authenticators and want to reuse the existing authentication logic, but fetch parameters from a SOAP message instead of form parameters. This is a simple PR that just moves the form parameter decoding to an overridable method.