### PR TITLE
KEYCLOAK-4028 Fix ModelDuplicateException when logging in with updated email address

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProvider.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProvider.java
@@ -420,7 +420,12 @@ public class LDAPStorageProvider implements UserStorageProvider,
 
         // Check here if user already exists
         String ldapUsername = LDAPUtils.getUsername(ldapUser, ldapIdentityStore.getConfig());
-        if (session.userLocalStorage().getUserByUsername(ldapUsername, realm) != null) {
+        UserModel user = session.userLocalStorage().getUserByUsername(ldapUsername, realm);
+        
+        if (user != null) {
+            LDAPUtils.checkUuid(ldapUser, ldapIdentityStore.getConfig());
+            // If email attribute mapper is set to "Always Read Value From LDAP" the user may be in Keycloak DB with an old email address
+            if (ldapUser.getUuid().equals(user.getFirstAttribute(LDAPConstants.LDAP_ID))) return user;
             throw new ModelDuplicateException("User with username '" + ldapUsername + "' already exists in Keycloak. It conflicts with LDAP user with email '" + email + "'");
         }
 


### PR DESCRIPTION
This fixes a ModelDuplicateException that is thrown when the email attribute mapper is set to "Always Read Value From LDAP" and a user tries to log in with an updated email address while his old email address is still stored in the Keycloak DB.