### PR TITLE
KEYCLOAK-3969 Allow use of ScriptAuthenticator without user

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/ScriptBasedAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/ScriptBasedAuthenticator.java
@@ -52,6 +52,10 @@ import java.util.Map;
  * </ol>
  * </p>
  * <p>
+ * Note that the {@code user} variable is only defined when the user was identified by a preceeding
+ * authentication step, e.g. by the {@link UsernamePasswordForm} authenticator.
+ * </p>
+ * <p>
  * Additional context information can be extracted from the {@code context} argument passed to the {@code authenticate(context)}
  * or {@code action(context)} function.
  * <p>
@@ -63,9 +67,10 @@ import java.util.Map;
  *
  *   function authenticate(context) {
  *
- *     LOG.info(script.name + " --> trace auth for: " + user.username);
+ *     var username = user ? user.username : "anonymous";
+ *     LOG.info(script.name + " --> trace auth for: " + username);
  *
- *     if (   user.username === "tester"
+ *     if (   username === "tester"
  *         && user.getAttribute("someAttribute")
  *         && user.getAttribute("someAttribute").contains("someValue")) {
  *
@@ -160,7 +165,7 @@ public class ScriptBasedAuthenticator implements Authenticator {
 
     @Override
     public boolean requiresUser() {
-        return true;
+        return false;
     }
 
     @Override

--- a/services/src/main/resources/scripts/authenticator-template.js
+++ b/services/src/main/resources/scripts/authenticator-template.js
@@ -24,7 +24,8 @@ AuthenticationFlowError = Java.type("org.keycloak.authentication.AuthenticationF
  */
 function authenticate(context) {
 
-    LOG.info(script.name + " trace auth for: " + user.username);
+    var username = user ? user.username : "anonymous";
+    LOG.info(script.name + " trace auth for: " + username);
 
     var authShouldFail = false;
     if (authShouldFail) {


### PR DESCRIPTION
Previously ScriptAuthenticator required a user to be authenticated
before it could be used as an additional authentication step which
limited the usage scenarios for the authenticator.

We now allow ScriptAuthenticators to be used without requiring an
user to be authenticated before.
Adapted the authenticator-template.js with a null safe username check.

Note that existing custom ScriptAuthenticators might need some additional
null checks since the user can now be undefined.