### PR TITLE
KEYCLOAK-4047 WebOrigins not expanded in CORS handling of token endpoints

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/LogoutEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/LogoutEndpoint.java
@@ -196,7 +196,7 @@ public class LogoutEndpoint {
             event.error(Errors.INVALID_TOKEN);
             throw new ErrorResponseException(e.getError(), e.getDescription(), Response.Status.BAD_REQUEST);
         }
-        return Cors.add(request, Response.noContent()).auth().allowedOrigins(client).allowedMethods("POST").exposedHeaders(Cors.ACCESS_CONTROL_ALLOW_METHODS).build();
+        return Cors.add(request, Response.noContent()).auth().allowedOrigins(uriInfo, client).allowedMethods("POST").exposedHeaders(Cors.ACCESS_CONTROL_ALLOW_METHODS).build();
     }
 
     private void logout(UserSessionModel userSession) {

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
@@ -277,7 +277,7 @@ public class TokenEndpoint {
 
         event.success();
 
-        return Cors.add(request, Response.ok(res).type(MediaType.APPLICATION_JSON_TYPE)).auth().allowedOrigins(client).allowedMethods("POST").exposedHeaders(Cors.ACCESS_CONTROL_ALLOW_METHODS).build();
+        return Cors.add(request, Response.ok(res).type(MediaType.APPLICATION_JSON_TYPE)).auth().allowedOrigins(uriInfo, client).allowedMethods("POST").exposedHeaders(Cors.ACCESS_CONTROL_ALLOW_METHODS).build();
     }
 
     public Response buildRefreshToken() {
@@ -304,7 +304,7 @@ public class TokenEndpoint {
 
         event.success();
 
-        return Cors.add(request, Response.ok(res, MediaType.APPLICATION_JSON_TYPE)).auth().allowedOrigins(client).allowedMethods("POST").exposedHeaders(Cors.ACCESS_CONTROL_ALLOW_METHODS).build();
+        return Cors.add(request, Response.ok(res, MediaType.APPLICATION_JSON_TYPE)).auth().allowedOrigins(uriInfo, client).allowedMethods("POST").exposedHeaders(Cors.ACCESS_CONTROL_ALLOW_METHODS).build();
     }
 
     private void updateClientSession(ClientSessionModel clientSession) {
@@ -406,7 +406,7 @@ public class TokenEndpoint {
 
         event.success();
 
-        return Cors.add(request, Response.ok(res, MediaType.APPLICATION_JSON_TYPE)).auth().allowedOrigins(client).allowedMethods("POST").exposedHeaders(Cors.ACCESS_CONTROL_ALLOW_METHODS).build();
+        return Cors.add(request, Response.ok(res, MediaType.APPLICATION_JSON_TYPE)).auth().allowedOrigins(uriInfo, client).allowedMethods("POST").exposedHeaders(Cors.ACCESS_CONTROL_ALLOW_METHODS).build();
     }
 
     public Response buildClientCredentialsGrant() {
@@ -470,7 +470,7 @@ public class TokenEndpoint {
 
         event.success();
 
-        return Cors.add(request, Response.ok(res, MediaType.APPLICATION_JSON_TYPE)).auth().allowedOrigins(client).allowedMethods("POST").exposedHeaders(Cors.ACCESS_CONTROL_ALLOW_METHODS).build();
+        return Cors.add(request, Response.ok(res, MediaType.APPLICATION_JSON_TYPE)).auth().allowedOrigins(uriInfo, client).allowedMethods("POST").exposedHeaders(Cors.ACCESS_CONTROL_ALLOW_METHODS).build();
     }
 
 }

--- a/services/src/main/java/org/keycloak/protocol/oidc/utils/WebOriginsUtils.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/utils/WebOriginsUtils.java
@@ -36,9 +36,8 @@ public class WebOriginsUtils {
         if (client.getWebOrigins() != null) {
             origins.addAll(client.getWebOrigins());
         }
-        if (origins.contains("+")) {
+        if (origins.contains(INCLUDE_REDIRECTS)) {
             origins.remove(INCLUDE_REDIRECTS);
-            client.getRedirectUris();
             for (String redirectUri : RedirectUtils.resolveValidRedirects(uriInfo, client.getRootUrl(), client.getRedirectUris())) {
                 if (redirectUri.startsWith("http://") || redirectUri.startsWith("https://")) {
                     origins.add(UriUtils.getOrigin(redirectUri));

--- a/services/src/main/java/org/keycloak/services/resources/Cors.java
+++ b/services/src/main/java/org/keycloak/services/resources/Cors.java
@@ -16,24 +16,27 @@
  */
 package org.keycloak.services.resources;
 
-import org.jboss.logging.Logger;
-import org.jboss.resteasy.spi.HttpRequest;
-import org.jboss.resteasy.spi.HttpResponse;
-import org.keycloak.common.util.CollectionUtil;
-import org.keycloak.models.ClientModel;
-import org.keycloak.representations.AccessToken;
-
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.ResponseBuilder;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.ResponseBuilder;
+import javax.ws.rs.core.UriInfo;
+import org.jboss.logging.Logger;
+import org.jboss.resteasy.spi.HttpRequest;
+import org.jboss.resteasy.spi.HttpResponse;
+import org.keycloak.common.util.CollectionUtil;
+import org.keycloak.common.util.UriUtils;
+import org.keycloak.models.ClientModel;
+import org.keycloak.protocol.oidc.utils.WebOriginsUtils;
+import org.keycloak.representations.AccessToken;
 
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
  */
 public class Cors {
+
     private static final Logger logger = Logger.getLogger(Cors.class);
 
     public static final long DEFAULT_MAX_AGE = TimeUnit.HOURS.toSeconds(1);
@@ -51,6 +54,7 @@ public class Cors {
     public static final String ACCESS_CONTROL_MAX_AGE = "Access-Control-Max-Age";
 
     public static final String ACCESS_CONTROL_ALLOW_ORIGIN_WILDCARD = "*";
+    public static final String INCLUDE_REDIRECTS = "+";
 
     private HttpRequest request;
     private ResponseBuilder builder;
@@ -88,9 +92,9 @@ public class Cors {
         return this;
     }
 
-    public Cors allowedOrigins(ClientModel client) {
+    public Cors allowedOrigins(UriInfo uriInfo, ClientModel client) {
         if (client != null) {
-            allowedOrigins = client.getWebOrigins();
+            allowedOrigins = WebOriginsUtils.resolveValidWebOrigins(uriInfo, client);
         }
         return this;
     }

--- a/services/src/main/java/org/keycloak/services/resources/IdentityBrokerService.java
+++ b/services/src/main/java/org/keycloak/services/resources/IdentityBrokerService.java
@@ -898,7 +898,7 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
     }
 
     private Response corsResponse(Response response, ClientModel clientModel) {
-        return Cors.add(this.request, Response.fromResponse(response)).auth().allowedOrigins(clientModel).build();
+        return Cors.add(this.request, Response.fromResponse(response)).auth().allowedOrigins(uriInfo, clientModel).build();
     }
 
     private void fireErrorEvent(String message, Throwable throwable) {


### PR DESCRIPTION
CORS handling was incomplete. **+** wasn't expanded to allowed origins from redirect URLs in most endpoints.