### PR TITLE
KEYCLOAK-4061 Testsuite URLProvider not working right on remote EAP6/AS7 app server

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/provider/URLProvider.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/provider/URLProvider.java
@@ -74,7 +74,7 @@ public class URLProvider extends URLResourceProvider {
         }
 
         try {
-            if (System.getProperty("app.server","").startsWith("eap6")) {
+            if (System.getProperty("app.server.management.protocol","").equals("remote")) {
                 if (url == null) {
                     url = new URL("http://localhost:8080/");
                 }

--- a/testsuite/integration-arquillian/tests/other/adapters/jboss/remote/pom.xml
+++ b/testsuite/integration-arquillian/tests/other/adapters/jboss/remote/pom.xml
@@ -127,6 +127,14 @@
             <!--dummy profile for enforcer-->
         </profile>
         <profile>
+            <id>app-server-remote-as7-eap6</id>
+            <!--this profile is required if remote app server is AS7 or EAP6-->
+            <properties>
+                <app.server.management.protocol>remote</app.server.management.protocol>
+                <app.server.management.port>${app.server.management.port.jmx}</app.server.management.port>
+            </properties>
+        </profile>
+        <profile>
             <id>no-offset</id>
             <properties>
                 <app.server.port.offset>0</app.server.port.offset>

--- a/testsuite/integration-arquillian/tests/other/adapters/jboss/remote/src/test/resources/xslt/arquillian.xsl
+++ b/testsuite/integration-arquillian/tests/other/adapters/jboss/remote/src/test/resources/xslt/arquillian.xsl
@@ -32,6 +32,7 @@
                 <configuration>
                     <property name="adapterImplClass">org.jboss.as.arquillian.container.remote.RemoteDeployableContainer</property>
 
+                    <property name="managementProtocol">${app.server.management.protocol}</property>
                     <property name="managementAddress">${app.server.host}</property>
                     <property name="managementPort">${app.server.management.port}</property>
                     <property name="username">admin</property>


### PR DESCRIPTION
 fixed testsuite URLProvider for AS7/EAP6 app server (managed and remote mode)