### PR TITLE
KEYCLOAK-4060 Arquillian test deployments have redundant jboss module dependencies

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/resources/adapter-test/jboss-deployment-structure.xml
+++ b/testsuite/integration-arquillian/tests/base/src/test/resources/adapter-test/jboss-deployment-structure.xml
@@ -18,18 +18,15 @@
 <jboss-deployment-structure>
     <deployment>
         <dependencies>
+
             <!-- the Demo code uses classes in these modules.  These are optional to import if you are not using
             Apache Http Client or the HttpClientBuilder that comes with the adapter core -->
             <module name="org.apache.httpcomponents"/>
 
-            <!--These are needed when keycloak adapter libs are bundled in war.-->
-            <module name="org.codehaus.jackson.jackson-xc" />
-            <module name="org.codehaus.jackson.jackson-mapper-asl" />
-            <module name="org.bouncycastle" />
-            <module name="org.jboss.xnio" />
+            <!--required by SAML test servlets-->
             <module name="org.keycloak.keycloak-adapter-spi" />
             <module name="org.keycloak.keycloak-saml-core" />
-
+            
         </dependencies>
     </deployment>
 </jboss-deployment-structure>


### PR DESCRIPTION
 removed redundant jboss module dependencies from test deployments