### PR TITLE
[KEYCLOAK-4083] SSSD Federation is only enabled with superuser permissions

### DIFF
--- a/federation/sssd/src/main/java/org/keycloak/federation/sssd/api/Sssd.java
+++ b/federation/sssd/src/main/java/org/keycloak/federation/sssd/api/Sssd.java
@@ -96,8 +96,8 @@ public class Sssd {
     public static boolean isAvailable() {
         boolean sssdAvailable = false;
         try {
-            Path path = Paths.get("/etc/sssd");
-            if (!Files.exists(path)) {
+            final boolean isLinux = System.getProperty("os.name").toLowerCase().contains("linux");
+            if (!isLinux) {
                 logger.debugv("SSSD is not available in your system. Federation provider will be disabled.");
             } else {
                 sssdAvailable = true;


### PR DESCRIPTION
@pdrozd @wyvie I already ran the integration tests on Docker, but could you please double check if everything is alright with our CI?