### PR TITLE
KEYCLOAK-4088 Http wrapper of Angular 2 demo app doesn't forward http…

### DIFF
--- a/examples/demo-template/angular2-product-app/src/main/webapp/app/keycloak.http.ts
+++ b/examples/demo-template/angular2-product-app/src/main/webapp/app/keycloak.http.ts
@@ -47,7 +47,7 @@ export class KeycloakHttp extends Http {
             result.subscribe((response) => {
                 observer.next(response);
                 observer.complete();
-            });
+            }, (err) => observer.error(err));
         });
 
         return <Observable<Response>>Observable


### PR DESCRIPTION
I'm using Keycloak to authorize an Angular 2 app against a server providing a REST API.
When a server side exception occurs, there the API returns a HTTP 500.
Using the Http implementation of Angular 2 results in an error handling of the used observable.
Using the Http wrapper of the angular2-product-app, no error handling is called, because of the missing error handling of the wrapper's observable.