### PR TITLE
[KEYCLOAK-4083] and [KEYCLOAK-4085] SSSD federation provider should load libunix from alternative paths

### DIFF
--- a/federation/sssd/src/main/java/cx/ath/matthew/LibraryLoader.java
+++ b/federation/sssd/src/main/java/cx/ath/matthew/LibraryLoader.java
@@ -21,7 +21,14 @@ package cx.ath.matthew;
  */
 public class LibraryLoader {
 
-    private static final String[] PATHS = {"/usr/lib/", "/usr/lib64/", "/usr/local/lib/", "/opt/local/lib/"};
+    private static final String[] PATHS = {
+            "/opt/rh/rh-sso7/root/lib/",
+            "/opt/rh/rh-sso7/root/lib64/",
+            "/usr/lib/",
+            "/usr/lib64/",
+            "/usr/local/lib/",
+            "/opt/local/lib/"
+    };
     private static final String LIBRARY_NAME = "libunix_dbus_java";
     private static final String VERSION = "0.0.8";
     private static boolean loadSucceeded;

--- a/federation/sssd/src/main/java/cx/ath/matthew/unix/UnixSocket.java
+++ b/federation/sssd/src/main/java/cx/ath/matthew/unix/UnixSocket.java
@@ -26,7 +26,6 @@
  */
 package cx.ath.matthew.unix;
 
-import cx.ath.matthew.LibraryLoader;
 import cx.ath.matthew.debug.Debug;
 
 import java.io.IOException;
@@ -37,9 +36,6 @@ import java.io.OutputStream;
  * Represents a UnixSocket.
  */
 public class UnixSocket {
-    static {
-        LibraryLoader.load();
-    }
 
     private native void native_set_pass_cred(int sock, boolean passcred) throws IOException;
 

--- a/federation/sssd/src/main/java/org/freedesktop/sssd/infopipe/InfoPipe.java
+++ b/federation/sssd/src/main/java/org/freedesktop/sssd/infopipe/InfoPipe.java
@@ -34,11 +34,13 @@ public interface InfoPipe extends DBusInterface {
     String OBJECTPATH = "/org/freedesktop/sssd/infopipe";
     String BUSNAME = "org.freedesktop.sssd.infopipe";
 
-
     @DBusMemberName("GetUserAttr")
     Map<String, Variant> getUserAttributes(String user, List<String> attr);
 
     @DBusMemberName("GetUserGroups")
     List<String> getUserGroups(String user);
+
+    @DBusMemberName("Ping")
+    String ping(String ping);
 
 }


### PR DESCRIPTION
@stianst @pdrozd FYI it was tested with RHEL 7.2 and our RPMs

I included two issues in the same PR, because they are related. But let me know if you prefer this separated.