### PR TITLE
KEYCLOAK-4101: jboss-cli script to do migration of configuration

### DIFF
--- a/distribution/feature-packs/server-feature-pack/src/main/resources/content/bin/migrate-domain.cli
+++ b/distribution/feature-packs/server-feature-pack/src/main/resources/content/bin/migrate-domain.cli
@@ -1,0 +1,263 @@
+embed-host-controller --domain-config=domain.xml
+
+# Early versions of keycloak used "default" for the standalone profile name.
+# Yours maybe be something completely different.
+set standaloneProfile=auth-server-standalone
+
+# Early versions of keycloak used "ha" for the clustered profile name.
+# Yours maybe be something completely different.
+set clusteredProfile=auth-server-clustered
+
+# keycloak-server.json is not normally on this path.
+set pathToJson=../domain/configuration/keycloak-server.json
+
+
+echo *** Begin Migration of /profile=$standaloneProfile ***
+echo
+
+# Migrate from 1.8.1 to 1.9.1
+if (outcome == failed) of /profile=$standaloneProfile/subsystem=infinispan/cache-container=keycloak/local-cache=work/:read-resource
+  echo Adding local-cache=work to keycloak cache container...
+  /profile=$standaloneProfile/subsystem=infinispan/cache-container=keycloak/local-cache=work/:add(indexing=NONE,start=LAZY)
+  echo
+end-if
+# realmVersions cache deprecated in 2.1.0
+#if (outcome == failed) of /profile=$standaloneProfile/subsystem=infinispan/cache-container=keycloak/local-cache=realmVersions/:read-resource
+#  echo Adding local-cache=realmVersions to keycloak cache container...
+#  /profile=$standaloneProfile/subsystem=infinispan/cache-container=keycloak/local-cache=realmVersions/:add(indexing=NONE,start=LAZY)
+#  /profile=$standaloneProfile/subsystem=infinispan/cache-container=keycloak/local-cache=realmVersions/component=transaction/:write-attribute(name=mode,value=BATCH)
+#  echo
+#end-if
+
+
+# Migrate from 1.9.1 to 1.9.2
+if (result == NONE) of /profile=$standaloneProfile/subsystem=infinispan/cache-container=keycloak/local-cache=users/component=eviction/:read-attribute(name=strategy)
+  echo Adding eviction strategy to keycloak users cache container...
+  /profile=$standaloneProfile/subsystem=infinispan/cache-container=keycloak/local-cache=users/component=eviction/:write-attribute(name=strategy,value=LRU)
+  /profile=$standaloneProfile/subsystem=infinispan/cache-container=keycloak/local-cache=users/component=eviction/:write-attribute(name=max-entries,value=10000)
+  echo
+end-if
+
+# Migrate from 1.9.2 to 1.9.8
+# NO CHANGES
+
+# Migrate from 1.9.8 to 2.0.0
+if (outcome == failed) of /profile=$standaloneProfile/subsystem=infinispan/cache-container=keycloak/local-cache=authorization/:read-resource
+  echo Adding local-cache=authorization to keycloak cache container...
+  /profile=$standaloneProfile/subsystem=infinispan/cache-container=keycloak/local-cache=authorization/:add(indexing=NONE,start=LAZY)
+  echo
+end-if
+if (result == undefined) of /profile=$standaloneProfile/subsystem=infinispan/cache-container=keycloak/local-cache=authorization/component=eviction/:read-attribute(name=strategy,include-defaults=false)
+  echo Updating authorization cache container..
+  /profile=$standaloneProfile/subsystem=infinispan/cache-container=keycloak/local-cache=authorization/component=eviction/:write-attribute(name=strategy,value=LRU)
+  /profile=$standaloneProfile/subsystem=infinispan/cache-container=keycloak/local-cache=authorization/component=eviction/:write-attribute(name=max-entries,value=100)
+end-if
+
+# Migrate from 2.0.0 to 2.1.0
+if (outcome == success) of /profile=$standaloneProfile/subsystem=infinispan/cache-container=keycloak/local-cache=realmVersions/:read-resource
+  echo Removing deprecated cache 'realmVersions'
+  /profile=$standaloneProfile/subsystem=infinispan/cache-container=keycloak/local-cache=realmVersions/:remove
+  echo
+end-if
+
+# Migrate kecloak-server.json (deprecated in 2.2.0)
+if (result == []) of /profile=$standaloneProfile/subsystem=keycloak-server/:read-children-names(child-type=spi)
+  echo Migrating keycloak-server.json to keycloak-server subsystem...
+  /profile=$standaloneProfile/subsystem=keycloak-server/:migrate-json(file=$pathToJson)
+  echo
+end-if
+
+# Find if we are using jpa or mongo
+if (result == mongo) of /profile=$standaloneProfile/subsystem=keycloak-server/spi=realm/:read-attribute(name=default-provider)
+  set persistenceProvider=mongo
+else
+  set persistenceProvider=jpa
+end-if
+
+# Migrate from 2.1.0 to 2.2.0
+if (result == update) of /profile=$standaloneProfile/subsystem=keycloak-server/spi=connectionsJpa/provider=default/:map-get(name=properties,key=databaseSchema)
+  echo Updating connectionsJpa default properties...
+  /profile=$standaloneProfile/subsystem=keycloak-server/spi=connectionsJpa/provider=default/:map-remove(name=properties,key=databaseSchema)
+  /profile=$standaloneProfile/subsystem=keycloak-server/spi=connectionsJpa/provider=default/:map-put(name=properties,key=initializeEmpty,value=true)
+  /profile=$standaloneProfile/subsystem=keycloak-server/spi=connectionsJpa/provider=default/:map-put(name=properties,key=migrationStrategy,value=update)
+  /profile=$standaloneProfile/subsystem=keycloak-server/spi=connectionsJpa/provider=default/:map-put(name=properties,key=migrationExport,value=${jboss.home.dir}/keycloak-database-update.sql)
+  echo
+end-if
+if (outcome == failed) of /profile=$standaloneProfile/subsystem=keycloak-server/spi=userFederatedStorage/:read-resource
+  echo Adding spi=userFederatedStorage...
+  /profile=$standaloneProfile/subsystem=keycloak-server/spi=userFederatedStorage/:add(default-provider=$persistenceProvider)
+  echo
+end-if
+if (outcome == failed) of /profile=$standaloneProfile/subsystem=keycloak-server/spi=jta-lookup/:read-resource
+  echo Adding spi=jta-lookup...
+  /profile=$standaloneProfile/subsystem=keycloak-server/spi=jta-lookup/:add(default-provider=${keycloak.jta.lookup.provider:jboss})
+  /profile=$standaloneProfile/subsystem=keycloak-server/spi=jta-lookup/provider=jboss/:add(enabled=true)
+  echo
+end-if
+
+# Migrate from 2.2.0 to 2.2.1
+# NO CHANGES
+
+# Migrate from 2.2.1 to 2.3.0
+if (outcome == failed) of /profile=$standaloneProfile/subsystem=infinispan/cache-container=keycloak/local-cache=keys/:read-resource
+  echo Adding local-cache=keys to keycloak cache container...
+  /profile=$standaloneProfile/subsystem=infinispan/cache-container=keycloak/local-cache=keys/:add(indexing=NONE,start=LAZY)
+  echo
+end-if
+if (result == undefined) of /profile=$standaloneProfile/subsystem=infinispan/cache-container=keycloak/local-cache=keys/component=eviction/:read-attribute(name=strategy,include-defaults=false)
+  echo Updating eviction and expiration in local-cache=keys...
+  /profile=$standaloneProfile/subsystem=infinispan/cache-container=keycloak/local-cache=keys/component=eviction/:write-attribute(name=strategy,value=LRU)
+  /profile=$standaloneProfile/subsystem=infinispan/cache-container=keycloak/local-cache=keys/component=eviction/:write-attribute(name=max-entries,value=1000)
+  /profile=$standaloneProfile/subsystem=infinispan/cache-container=keycloak/local-cache=keys/component=expiration/:write-attribute(name=max-idle,value=3600000)
+  echo
+end-if
+if (outcome == failed) of /profile=$standaloneProfile/subsystem=keycloak-server/spi=publicKeyStorage/:read-resource  
+  echo Adding spi=publicKeyStorage...
+  /profile=$standaloneProfile/subsystem=keycloak-server/spi=publicKeyStorage/:add
+  /profile=$standaloneProfile/subsystem=keycloak-server/spi=publicKeyStorage/provider=infinispan/:add(properties={minTimeBetweenRequests => "10"},enabled=true)
+  echo
+end-if
+
+# Migrate from 2.3.0 to 2.4.0
+# NO CHANGES
+
+# Migrate from 2.4.0 to 2.5.0
+if (result == NONE) of /profile=$standaloneProfile/subsystem=infinispan/cache-container=keycloak/local-cache=realms/component=eviction/:read-attribute(name=strategy)  
+  echo Adding eviction strategy to keycloak realms cache...
+  /profile=$standaloneProfile/subsystem=infinispan/cache-container=keycloak/local-cache=realms/component=eviction/:write-attribute(name=strategy,value=LRU)
+  /profile=$standaloneProfile/subsystem=infinispan/cache-container=keycloak/local-cache=realms/component=eviction/:write-attribute(name=max-entries,value=10000)
+  echo
+end-if
+
+echo *** End Migration of /profile=$standaloneProfile ***
+echo
+echo
+echo *** Begin Migration of /profile=$clusteredProfile ***
+echo
+
+# Migrate from 1.8.1 to 1.9.1
+if (outcome == failed) of /profile=$clusteredProfile/subsystem=infinispan/cache-container=keycloak/replicated-cache=work/:read-resource
+  echo Adding replicated-cache=work to keycloak cache container...
+  /profile=$clusteredProfile/subsystem=infinispan/cache-container=keycloak/replicated-cache=work/:add(mode=SYNC)
+  echo
+end-if
+# realmVersions cache deprecated in 2.1.0
+#if (outcome == failed) of /profile=$clusteredProfile/subsystem=infinispan/cache-container=keycloak/local-cache=realmVersions/:read-resource
+#  echo Adding local-cache=realmVersions to keycloak cache container...
+#  /profile=$clusteredProfile/subsystem=infinispan/cache-container=keycloak/local-cache=realmVersions/:add(indexing=NONE,start=LAZY)
+#  /profile=$clusteredProfile/subsystem=infinispan/cache-container=keycloak/local-cache=realmVersions/component=transaction/:write-attribute(name=mode,value=BATCH)
+#  echo
+#end-if
+
+# Migrate from 1.9.1 to 1.9.2
+if (result == NONE) of /profile=$clusteredProfile/subsystem=infinispan/cache-container=keycloak/invalidation-cache=users/component=eviction/:read-attribute(name=strategy)
+  echo Adding eviction strategy to keycloak users cache container...
+  /profile=$clusteredProfile/subsystem=infinispan/cache-container=keycloak/invalidation-cache=users/component=eviction/:write-attribute(name=strategy,value=LRU)
+  /profile=$clusteredProfile/subsystem=infinispan/cache-container=keycloak/invalidation-cache=users/component=eviction/:write-attribute(name=max-entries,value=10000)
+  echo
+end-if
+
+# Migrate from 1.9.2 to 2.0.0
+# NO CHANGES
+
+# Migrate from 2.0.0 to 2.1.0
+if (outcome == success) of /profile=$clusteredProfile/subsystem=infinispan/cache-container=keycloak/local-cache=realmVersions/:read-resource
+  echo Removing deprecated cache 'realmVersions'
+  /profile=$clusteredProfile/subsystem=infinispan/cache-container=keycloak/local-cache=realmVersions/:remove
+  echo
+end-if
+
+# Migrate kecloak-server.json (deprecated in 2.2.0)
+if (result == []) of /profile=$clusteredProfile/subsystem=keycloak-server/:read-children-names(child-type=spi)
+  echo Migrating keycloak-server.json to keycloak-server subsystem...
+  /profile=$clusteredProfile/subsystem=keycloak-server/:migrate-json(file=$pathToJson)
+  echo
+end-if
+
+# Find if we are using jpa or mongo
+if (result == mongo) of /profile=$clusteredProfile/subsystem=keycloak-server/spi=realm/:read-attribute(name=default-provider)
+  set persistenceProvider=mongo
+else
+  set persistenceProvider=jpa
+end-if
+
+# Migrate from 2.1.0 to 2.2.0
+if (outcome == failed) of /profile=$clusteredProfile/subsystem=infinispan/cache-container=keycloak/distributed-cache=authorization/:read-resource
+  echo Additing distributed-cache=authorization
+  /profile=$clusteredProfile/subsystem=infinispan/cache-container=keycloak/distributed-cache=authorization/:add(mode=SYNC,owners=1)
+  echo
+end-if
+if (result == update) of /profile=$clusteredProfile/subsystem=keycloak-server/spi=connectionsJpa/provider=default/:map-get(name=properties,key=databaseSchema)
+  echo Updating connectionsJpa default properties...
+  /profile=$clusteredProfile/subsystem=keycloak-server/spi=connectionsJpa/provider=default/:map-remove(name=properties,key=databaseSchema)
+  /profile=$clusteredProfile/subsystem=keycloak-server/spi=connectionsJpa/provider=default/:map-put(name=properties,key=initializeEmpty,value=true)
+  /profile=$clusteredProfile/subsystem=keycloak-server/spi=connectionsJpa/provider=default/:map-put(name=properties,key=migrationStrategy,value=update)
+  /profile=$clusteredProfile/subsystem=keycloak-server/spi=connectionsJpa/provider=default/:map-put(name=properties,key=migrationExport,value=${jboss.home.dir}/keycloak-database-update.sql)
+  echo
+end-if
+if (outcome == failed) of /profile=$clusteredProfile/subsystem=keycloak-server/spi=userFederatedStorage/:read-resource
+  echo Adding spi=userFederatedStorage...
+  /profile=$clusteredProfile/subsystem=keycloak-server/spi=userFederatedStorage/:add(default-provider=$persistenceProvider)
+  echo
+end-if
+if (outcome == failed) of /profile=$clusteredProfile/subsystem=keycloak-server/spi=jta-lookup/:read-resource
+  echo Adding spi=jta-lookup...
+  /profile=$clusteredProfile/subsystem=keycloak-server/spi=jta-lookup/:add(default-provider=${keycloak.jta.lookup.provider:jboss})
+  /profile=$clusteredProfile/subsystem=keycloak-server/spi=jta-lookup/provider=jboss/:add(enabled=true)
+  echo
+end-if
+
+# Migrate from 2.2.0 to 2.2.1
+# NO CHANGES
+
+# Migrate from 2.2.1 to 2.3.0
+if (outcome == failed) of /profile=$clusteredProfile/subsystem=infinispan/cache-container=keycloak/local-cache=keys/:read-resource
+  echo Adding local-cache=keys to keycloak cache container...
+  /profile=$clusteredProfile/subsystem=infinispan/cache-container=keycloak/local-cache=keys/:add(indexing=NONE,start=LAZY)
+  echo
+end-if
+if (result == undefined) of /profile=$clusteredProfile/subsystem=infinispan/cache-container=keycloak/local-cache=keys/component=eviction/:read-attribute(name=strategy,include-defaults=false)
+  echo Updating eviction and expiration in local-cache=keys...
+  /profile=$clusteredProfile/subsystem=infinispan/cache-container=keycloak/local-cache=keys/component=eviction/:write-attribute(name=strategy,value=LRU)
+  /profile=$clusteredProfile/subsystem=infinispan/cache-container=keycloak/local-cache=keys/component=eviction/:write-attribute(name=max-entries,value=1000)
+  /profile=$clusteredProfile/subsystem=infinispan/cache-container=keycloak/local-cache=keys/component=expiration/:write-attribute(name=max-idle,value=3600000)
+  echo
+end-if
+
+if (outcome == failed) of /profile=$clusteredProfile/subsystem=keycloak-server/spi=publicKeyStorage/:read-resource  
+  echo Adding spi=publicKeyStorage...
+  /profile=$clusteredProfile/subsystem=keycloak-server/spi=publicKeyStorage/:add
+  /profile=$clusteredProfile/subsystem=keycloak-server/spi=publicKeyStorage/provider=infinispan/:add(properties={minTimeBetweenRequests => "10"},enabled=true)
+  echo
+end-if
+
+# Migrate from 2.3.0 to 2.4.0
+if (outcome == success) of /profile=$clusteredProfile/subsystem=infinispan/cache-container=keycloak/invalidation-cache=users/:read-resource
+  echo Replacing invalidation-cache=users with local-cache=users
+  /profile=$clusteredProfile/subsystem=infinispan/cache-container=keycloak/invalidation-cache=users/:remove
+  /profile=$clusteredProfile/subsystem=infinispan/cache-container=keycloak/local-cache=users/:add
+  echo
+end-if
+if (result == undefined) of /profile=$clusteredProfile/subsystem=infinispan/cache-container=keycloak/local-cache=users/component=eviction/:read-attribute(name=strategy,include-defaults=false)
+  echo Updating eviction in local-cache=users
+  /profile=$clusteredProfile/subsystem=infinispan/cache-container=keycloak/local-cache=users/component=eviction/:write-attribute(name=strategy,value=LRU)
+  /profile=$clusteredProfile/subsystem=infinispan/cache-container=keycloak/local-cache=users/component=eviction/:write-attribute(name=max-entries,value=10000)
+  echo
+end-if
+if (outcome == success) of /profile=$clusteredProfile/subsystem=infinispan/cache-container=keycloak/invalidation-cache=realms/:read-resource
+  echo Replacing invalidation-cache=realms with local-cache=realms
+  /profile=$clusteredProfile/subsystem=infinispan/cache-container=keycloak/invalidation-cache=realms/:remove
+  /profile=$clusteredProfile/subsystem=infinispan/cache-container=keycloak/local-cache=realms/:add
+  echo
+end-if
+
+
+# Migrate from 2.4.0 to 2.5.0
+if (result == NONE) of /profile=$clusteredProfile/subsystem=infinispan/cache-container=keycloak/local-cache=realms/component=eviction/:read-attribute(name=strategy)  
+  echo Adding eviction strategy to keycloak realms cache...
+  /profile=$clusteredProfile/subsystem=infinispan/cache-container=keycloak/local-cache=realms/component=eviction/:write-attribute(name=strategy,value=LRU)
+  /profile=$clusteredProfile/subsystem=infinispan/cache-container=keycloak/local-cache=realms/component=eviction/:write-attribute(name=max-entries,value=10000)
+  echo
+end-if
+
+echo *** End Migration ***

--- a/distribution/feature-packs/server-feature-pack/src/main/resources/content/bin/migrate-standalone-ha.cli
+++ b/distribution/feature-packs/server-feature-pack/src/main/resources/content/bin/migrate-standalone-ha.cli
@@ -1,0 +1,145 @@
+embed-server --server-config=standalone-ha.xml
+
+echo *** Begin Migration ***
+echo
+
+# Migrate from 1.8.1 to 1.9.1
+if (outcome == failed) of /subsystem=infinispan/cache-container=keycloak/replicated-cache=work/:read-resource
+  echo Adding replicated-cache=work to keycloak cache container...
+  /subsystem=infinispan/cache-container=keycloak/replicated-cache=work/:add(mode=SYNC)
+  echo
+end-if
+# realmVersions cache deprecated in 2.1.0
+#if (outcome == failed) of /subsystem=infinispan/cache-container=keycloak/local-cache=realmVersions/:read-resource
+#  echo Adding local-cache=realmVersions to keycloak cache container...
+#  /subsystem=infinispan/cache-container=keycloak/local-cache=realmVersions/:add(indexing=NONE,start=LAZY)
+#  /subsystem=infinispan/cache-container=keycloak/local-cache=realmVersions/component=transaction/:write-attribute(name=mode,value=BATCH)
+#  echo
+#end-if
+
+# Migrate from 1.9.1 to 1.9.2
+if (result == NONE) of /subsystem=infinispan/cache-container=keycloak/invalidation-cache=users/component=eviction/:read-attribute(name=strategy)
+  echo Adding eviction strategy to keycloak users cache container...
+  /subsystem=infinispan/cache-container=keycloak/invalidation-cache=users/component=eviction/:write-attribute(name=strategy,value=LRU)
+  /subsystem=infinispan/cache-container=keycloak/invalidation-cache=users/component=eviction/:write-attribute(name=max-entries,value=10000)
+  echo
+end-if
+
+# Migrate from 1.9.2 to 2.0.0
+# NO CHANGES
+
+# Migrate from 2.0.0 to 2.1.0
+if (outcome == success) of /subsystem=infinispan/cache-container=keycloak/local-cache=realmVersions/:read-resource
+  echo Removing deprecated cache 'realmVersions'
+  /subsystem=infinispan/cache-container=keycloak/local-cache=realmVersions/:remove
+  echo
+end-if
+
+# Migrate kecloak-server.json (deprecated in 2.2.0)
+if (result == []) of /subsystem=keycloak-server/:read-children-names(child-type=spi)
+  echo Migrating keycloak-server.json to server cofig xml...
+  /subsystem=keycloak-server/:migrate-json
+  echo
+end-if
+
+# Find if we are using jpa or mongo
+if (result == mongo) of /subsystem=keycloak-server/spi=realm/:read-attribute(name=default-provider)
+  set persistenceProvider=mongo
+else
+  set persistenceProvider=jpa
+end-if
+
+# Migrate from 2.1.0 to 2.2.0
+if (outcome == failed) of /extension=org.jboss.as.deployment-scanner/:read-resource
+  echo Adding deployment-scanner extension...
+  /extension=org.jboss.as.deployment-scanner/:add(module=org.jboss.as.deployment-scanner)
+  echo
+end-if
+if (outcome == failed) of /subsystem=deployment-scanner/:read-resource
+  echo Adding deployment-scanner...
+  /subsystem=deployment-scanner/:add  
+  echo
+end-if
+if (outcome == failed) of /subsystem=deployment-scanner/scanner=default/:read-resource
+  echo Adding scanner=default
+  /subsystem=deployment-scanner/scanner=default/:add(path=deployments,relative-to=jboss.server.base.dir,runtime-failure-causes-rollback=${jboss.deployment.scanner.rollback.on.failure:false},scan-interval=5000)
+  echo
+end-if
+if (outcome == failed) of /subsystem=infinispan/cache-container=keycloak/distributed-cache=authorization/:read-resource
+  echo Additing distributed-cache=authorization
+  /subsystem=infinispan/cache-container=keycloak/distributed-cache=authorization/:add(mode=SYNC,owners=1)
+  echo
+end-if
+if (result == update) of /subsystem=keycloak-server/spi=connectionsJpa/provider=default/:map-get(name=properties,key=databaseSchema)
+  echo Updating connectionsJpa default properties...
+  /subsystem=keycloak-server/spi=connectionsJpa/provider=default/:map-remove(name=properties,key=databaseSchema)
+  /subsystem=keycloak-server/spi=connectionsJpa/provider=default/:map-put(name=properties,key=initializeEmpty,value=true)
+  /subsystem=keycloak-server/spi=connectionsJpa/provider=default/:map-put(name=properties,key=migrationStrategy,value=update)
+  /subsystem=keycloak-server/spi=connectionsJpa/provider=default/:map-put(name=properties,key=migrationExport,value=${jboss.home.dir}/keycloak-database-update.sql)
+  echo
+end-if
+if (outcome == failed) of /subsystem=keycloak-server/spi=userFederatedStorage/:read-resource
+  echo Adding spi=userFederatedStorage...
+  /subsystem=keycloak-server/spi=userFederatedStorage/:add(default-provider=$persistenceProvider)
+  echo
+end-if
+if (outcome == failed) of /subsystem=keycloak-server/spi=jta-lookup/:read-resource
+  echo Adding spi=jta-lookup...
+  /subsystem=keycloak-server/spi=jta-lookup/:add(default-provider=${keycloak.jta.lookup.provider:jboss})
+  /subsystem=keycloak-server/spi=jta-lookup/provider=jboss/:add(enabled=true)
+  echo
+end-if
+
+# Migrate from 2.2.0 to 2.2.1
+# NO CHANGES
+
+# Migrate from 2.2.1 to 2.3.0
+if (outcome == failed) of /subsystem=infinispan/cache-container=keycloak/local-cache=keys/:read-resource
+  echo Adding local-cache=keys to keycloak cache container...
+  /subsystem=infinispan/cache-container=keycloak/local-cache=keys/:add(indexing=NONE,start=LAZY)
+  echo
+end-if
+if (result == undefined) of /subsystem=infinispan/cache-container=keycloak/local-cache=keys/component=eviction/:read-attribute(name=strategy,include-defaults=false)
+  echo Updating eviction and expiration in local-cache=keys...
+  /subsystem=infinispan/cache-container=keycloak/local-cache=keys/component=eviction/:write-attribute(name=strategy,value=LRU)
+  /subsystem=infinispan/cache-container=keycloak/local-cache=keys/component=eviction/:write-attribute(name=max-entries,value=1000)
+  /subsystem=infinispan/cache-container=keycloak/local-cache=keys/component=expiration/:write-attribute(name=max-idle,value=3600000)
+  echo
+end-if
+if (outcome == failed) of /subsystem=keycloak-server/spi=publicKeyStorage/:read-resource  
+  echo Adding spi=publicKeyStorage...
+  /subsystem=keycloak-server/spi=publicKeyStorage/:add
+  /subsystem=keycloak-server/spi=publicKeyStorage/provider=infinispan/:add(properties={minTimeBetweenRequests => "10"},enabled=true)
+  echo
+end-if
+
+# Migrate from 2.3.0 to 2.4.0
+if (outcome == success) of /subsystem=infinispan/cache-container=keycloak/invalidation-cache=users/:read-resource
+  echo Replacing invalidation-cache=users with local-cache=users
+  /subsystem=infinispan/cache-container=keycloak/invalidation-cache=users/:remove
+  /subsystem=infinispan/cache-container=keycloak/local-cache=users/:add
+  echo
+end-if
+if (result == undefined) of /subsystem=infinispan/cache-container=keycloak/local-cache=users/component=eviction/:read-attribute(name=strategy,include-defaults=false)
+  echo Updating eviction in local-cache=users...
+  /subsystem=infinispan/cache-container=keycloak/local-cache=users/component=eviction/:write-attribute(name=strategy,value=LRU)
+  /subsystem=infinispan/cache-container=keycloak/local-cache=users/component=eviction/:write-attribute(name=max-entries,value=10000)
+  echo
+end-if
+if (outcome == success) of /subsystem=infinispan/cache-container=keycloak/invalidation-cache=realms/:read-resource
+  echo Replacing invalidation-cache=realms with local-cache=realms
+  /subsystem=infinispan/cache-container=keycloak/invalidation-cache=realms/:remove
+  /subsystem=infinispan/cache-container=keycloak/local-cache=realms/:add
+  echo
+end-if
+
+
+# Migrate from 2.4.0 to 2.5.0
+if (result == NONE) of /subsystem=infinispan/cache-container=keycloak/local-cache=realms/component=eviction/:read-attribute(name=strategy)  
+  echo Adding eviction strategy to keycloak realms cache...
+  /subsystem=infinispan/cache-container=keycloak/local-cache=realms/component=eviction/:write-attribute(name=strategy,value=LRU)
+  /subsystem=infinispan/cache-container=keycloak/local-cache=realms/component=eviction/:write-attribute(name=max-entries,value=10000)
+  echo
+end-if
+
+echo *** End Migration ***

--- a/distribution/feature-packs/server-feature-pack/src/main/resources/content/bin/migrate-standalone.cli
+++ b/distribution/feature-packs/server-feature-pack/src/main/resources/content/bin/migrate-standalone.cli
@@ -1,0 +1,135 @@
+embed-server --server-config=standalone.xml
+
+echo *** Begin Migration ***
+echo
+
+# Migrate from 1.8.1 to 1.9.1
+if (outcome == failed) of /subsystem=infinispan/cache-container=keycloak/local-cache=work/:read-resource
+  echo Adding local-cache=work to keycloak cache container...
+  /subsystem=infinispan/cache-container=keycloak/local-cache=work/:add(indexing=NONE,start=LAZY)
+  echo
+end-if
+# realmVersions cache deprecated in 2.1.0
+#if (outcome == failed) of /subsystem=infinispan/cache-container=keycloak/local-cache=realmVersions/:read-resource
+#  echo Adding local-cache=realmVersions to keycloak cache container...
+#  /subsystem=infinispan/cache-container=keycloak/local-cache=realmVersions/:add(indexing=NONE,start=LAZY)
+#  /subsystem=infinispan/cache-container=keycloak/local-cache=realmVersions/component=transaction/:write-attribute(name=mode,value=BATCH)
+#  echo
+#end-if
+
+
+# Migrate from 1.9.1 to 1.9.2
+if (result == NONE) of /subsystem=infinispan/cache-container=keycloak/local-cache=users/component=eviction/:read-attribute(name=strategy)
+  echo Adding eviction strategy to keycloak users cache container...
+  /subsystem=infinispan/cache-container=keycloak/local-cache=users/component=eviction/:write-attribute(name=strategy,value=LRU)
+  /subsystem=infinispan/cache-container=keycloak/local-cache=users/component=eviction/:write-attribute(name=max-entries,value=10000)
+  echo
+end-if
+
+# Migrate from 1.9.2 to 1.9.8
+# NO CHANGES
+
+# Migrate from 1.9.8 to 2.0.0
+if (outcome == failed) of /subsystem=infinispan/cache-container=keycloak/local-cache=authorization/:read-resource
+  echo Adding local-cache=authorization to keycloak cache container...
+  /subsystem=infinispan/cache-container=keycloak/local-cache=authorization/:add(indexing=NONE,start=LAZY)
+  echo
+end-if
+if (result == undefined) of /subsystem=infinispan/cache-container=keycloak/local-cache=authorization/component=eviction/:read-attribute(name=strategy,include-defaults=false)
+  echo Updating authorization cache container..
+  /subsystem=infinispan/cache-container=keycloak/local-cache=authorization/component=eviction/:write-attribute(name=strategy,value=LRU)
+  /subsystem=infinispan/cache-container=keycloak/local-cache=authorization/component=eviction/:write-attribute(name=max-entries,value=100)
+end-if
+
+# Migrate from 2.0.0 to 2.1.0
+if (outcome == success) of /subsystem=infinispan/cache-container=keycloak/local-cache=realmVersions/:read-resource
+  echo Removing deprecated cache 'realmVersions'
+  /subsystem=infinispan/cache-container=keycloak/local-cache=realmVersions/:remove
+  echo
+end-if
+
+# Migrate kecloak-server.json (deprecated in 2.2.0)
+if (result == []) of /subsystem=keycloak-server/:read-children-names(child-type=spi)
+  echo Migrating keycloak-server.json to server cofig xml...
+  /subsystem=keycloak-server/:migrate-json
+  echo
+end-if
+
+# Find if we are using jpa or mongo
+if (result == mongo) of /subsystem=keycloak-server/spi=realm/:read-attribute(name=default-provider)
+  set persistenceProvider=mongo
+else
+  set persistenceProvider=jpa
+end-if
+
+# Migrate from 2.1.0 to 2.2.0
+if (outcome == failed) of /extension=org.jboss.as.deployment-scanner/:read-resource
+  echo Adding deployment-scanner extension...
+  /extension=org.jboss.as.deployment-scanner/:add(module=org.jboss.as.deployment-scanner)
+  echo
+end-if
+if (outcome == failed) of /subsystem=deployment-scanner/:read-resource
+  echo Adding deployment-scanner...
+  /subsystem=deployment-scanner/:add  
+  echo
+end-if
+if (outcome == failed) of /subsystem=deployment-scanner/scanner=default/:read-resource
+  echo Adding scanner=default
+  /subsystem=deployment-scanner/scanner=default/:add(path=deployments,relative-to=jboss.server.base.dir,runtime-failure-causes-rollback=${jboss.deployment.scanner.rollback.on.failure:false},scan-interval=5000)
+  echo
+end-if
+if (result == update) of /subsystem=keycloak-server/spi=connectionsJpa/provider=default/:map-get(name=properties,key=databaseSchema)
+  echo Updating connectionsJpa default properties...
+  /subsystem=keycloak-server/spi=connectionsJpa/provider=default/:map-remove(name=properties,key=databaseSchema)
+  /subsystem=keycloak-server/spi=connectionsJpa/provider=default/:map-put(name=properties,key=initializeEmpty,value=true)
+  /subsystem=keycloak-server/spi=connectionsJpa/provider=default/:map-put(name=properties,key=migrationStrategy,value=update)
+  /subsystem=keycloak-server/spi=connectionsJpa/provider=default/:map-put(name=properties,key=migrationExport,value=${jboss.home.dir}/keycloak-database-update.sql)
+  echo
+end-if
+if (outcome == failed) of /subsystem=keycloak-server/spi=userFederatedStorage/:read-resource
+  echo Adding spi=userFederatedStorage...
+  /subsystem=keycloak-server/spi=userFederatedStorage/:add(default-provider=$persistenceProvider)
+  echo
+end-if
+if (outcome == failed) of /subsystem=keycloak-server/spi=jta-lookup/:read-resource
+  echo Adding spi=jta-lookup...
+  /subsystem=keycloak-server/spi=jta-lookup/:add(default-provider=${keycloak.jta.lookup.provider:jboss})
+  /subsystem=keycloak-server/spi=jta-lookup/provider=jboss/:add(enabled=true)
+  echo
+end-if
+
+# Migrate from 2.2.0 to 2.2.1
+# NO CHANGES
+
+# Migrate from 2.2.1 to 2.3.0
+if (outcome == failed) of /subsystem=infinispan/cache-container=keycloak/local-cache=keys/:read-resource
+  echo Adding local-cache=keys to keycloak cache container...
+  /subsystem=infinispan/cache-container=keycloak/local-cache=keys/:add(indexing=NONE,start=LAZY)
+  echo
+end-if
+if (result == undefined) of /subsystem=infinispan/cache-container=keycloak/local-cache=keys/component=eviction/:read-attribute(name=strategy,include-defaults=false)
+  echo Updating eviction and expiration in local-cache=keys...
+  /subsystem=infinispan/cache-container=keycloak/local-cache=keys/component=eviction/:write-attribute(name=strategy,value=LRU)
+  /subsystem=infinispan/cache-container=keycloak/local-cache=keys/component=eviction/:write-attribute(name=max-entries,value=1000)
+  /subsystem=infinispan/cache-container=keycloak/local-cache=keys/component=expiration/:write-attribute(name=max-idle,value=3600000)
+  echo
+end-if
+if (outcome == failed) of /subsystem=keycloak-server/spi=publicKeyStorage/:read-resource  
+  echo Adding spi=publicKeyStorage...
+  /subsystem=keycloak-server/spi=publicKeyStorage/:add
+  /subsystem=keycloak-server/spi=publicKeyStorage/provider=infinispan/:add(properties={minTimeBetweenRequests => "10"},enabled=true)
+  echo
+end-if
+
+# Migrate from 2.3.0 to 2.4.0
+# NO CHANGES
+
+# Migrate from 2.4.0 to 2.5.0
+if (result == NONE) of /subsystem=infinispan/cache-container=keycloak/local-cache=realms/component=eviction/:read-attribute(name=strategy)  
+  echo Adding eviction strategy to keycloak realms cache...
+  /subsystem=infinispan/cache-container=keycloak/local-cache=realms/component=eviction/:write-attribute(name=strategy,value=LRU)
+  /subsystem=infinispan/cache-container=keycloak/local-cache=realms/component=eviction/:write-attribute(name=max-entries,value=10000)
+  echo
+end-if
+
+echo *** End Migration ***

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
         <apache.httpcomponents.version>4.5</apache.httpcomponents.version>
         <apache.httpcomponents.httpcore.version>4.4.1</apache.httpcomponents.httpcore.version>
         <apache.mime4j.version>0.6</apache.mime4j.version>
+        <jboss.dmr.version>1.3.0.Final</jboss.dmr.version>
         <bouncycastle.version>1.52</bouncycastle.version>
         <cxf.version>3.1.5</cxf.version>
         <dom4j.version>1.6.1</dom4j.version>
@@ -112,6 +113,7 @@
         <!-- Maven Plugins -->
         <embedmongo.plugin.version>0.1.12</embedmongo.plugin.version>
         <enforcer.plugin.version>1.4</enforcer.plugin.version>
+        <replacer.plugin.version>1.3.5</replacer.plugin.version>
         <jboss.as.plugin.version>7.5.Final</jboss.as.plugin.version>
         <jmeter.plugin.version>1.9.0</jmeter.plugin.version>
         <jmeter.analysis.plugin.version>1.0.4</jmeter.analysis.plugin.version>
@@ -193,6 +195,11 @@
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+               <groupId>org.jboss</groupId>
+               <artifactId>jboss-dmr</artifactId>
+               <version>${jboss.dmr.version}</version>
+            </dependency>
             <dependency>
                 <groupId>com.github.relaxng</groupId>
                 <artifactId>relaxngDatatype</artifactId>
@@ -1367,6 +1374,11 @@
                         <forkMode>once</forkMode>
                         <argLine>${surefire.memory.settings}</argLine>
                     </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>com.google.code.maven-replacer-plugin</groupId>
+                    <artifactId>maven-replacer-plugin</artifactId>
+                    <version>${replacer.plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -57,6 +57,7 @@
         <module>tomcat8</module>
         <module>jetty</module>
         <module>integration-arquillian</module>
+        <module>server-config-migration</module>
     </modules>
         
 </project>

--- a/testsuite/server-config-migration/pom.xml
+++ b/testsuite/server-config-migration/pom.xml
@@ -1,0 +1,359 @@
+<?xml version="1.0"?>
+<!--
+~ Copyright 2016 Red Hat, Inc. and/or its affiliates
+~ and other contributors as indicated by the @author tags.
+~
+~ Licensed under the Apache License, Version 2.0 (the "License");
+~ you may not use this file except in compliance with the License.
+~ You may obtain a copy of the License at
+~
+~ http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing, software
+~ distributed under the License is distributed on an "AS IS" BASIS,
+~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~ See the License for the specific language governing permissions and
+~ limitations under the License.
+-->
+
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.keycloak</groupId>
+        <artifactId>keycloak-testsuite-pom</artifactId>
+        <version>2.5.0.Final-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    
+    <groupId>org.keycloak.testsuite</groupId>
+    <artifactId>server-config-migration</artifactId>
+
+    <name>Keycloak Migration TestSuite For Server Config</name>
+
+    <properties>
+        <jbossHome>${project.build.directory}/keycloak-${project.version}</jbossHome>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss</groupId>
+            <artifactId>jboss-dmr</artifactId>
+        </dependency>
+    </dependencies>
+    
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.keycloak</groupId>
+                                    <artifactId>keycloak-server-dist</artifactId>
+                                    <version>${project.version}</version>
+                                    <type>zip</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${project.build.directory}</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-standalone</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <overwrite>true</overwrite>
+                            <outputDirectory>${jbossHome}/standalone/configuration</outputDirectory>
+                            <resources>          
+                                <resource>
+                                    <directory>src/test/resources/standalone</directory>
+                                    <filtering>false</filtering>
+                                </resource>
+                            </resources>              
+                        </configuration>            
+                    </execution>
+                    <execution>
+                        <id>copy-domain</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <overwrite>true</overwrite>
+                            <outputDirectory>${jbossHome}/domain/configuration</outputDirectory>
+                            <resources>          
+                                <resource>
+                                    <directory>src/test/resources/domain</directory>
+                                    <filtering>false</filtering>
+                                </resource>
+                            </resources>              
+                        </configuration>            
+                    </execution>
+                </executions>
+            </plugin>
+            
+            <plugin>
+                <groupId>com.google.code.maven-replacer-plugin</groupId>
+                <artifactId>maven-replacer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>replaceTokens</id>
+                        <phase>process-test-sources</phase>
+                        <goals>
+                            <goal>replace</goal>
+                        </goals>
+                        <configuration>
+                            <!-- Comment out embeds.  For wildfly-maven-plugin,
+                                 CLI commands have to execute against a running
+                                 server. BTW, CLI Comments only work if the # is in the
+                                 first column.
+                            -->
+                            <replacements>
+                                <replacement>
+                                    <token>embed-server</token>
+                                    <value>#embed-server</value>
+                                </replacement>
+                                <replacement>
+                                    <token>embed-host-controller</token>
+                                    <value>#embed-host-controller</value>
+                                </replacement>
+                                <replacement>
+                                    <token>:migrate-json(file=$pathToJson)</token>
+                                    <value>:migrate-json</value>
+                                </replacement>
+                            </replacements>
+                        </configuration>
+                    </execution>
+                </executions>
+                <configuration>
+                    <regex>false</regex>
+                    <basedir>${jbossHome}</basedir>
+                    <filesToInclude>bin\migrate**.cli</filesToInclude>
+                </configuration>
+            </plugin>
+            
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <configuration>
+                    <skip>false</skip>
+                    <jbossHome>${project.build.directory}/keycloak-${project.version}</jbossHome>
+                    <javaOpts>-Djboss.socket.binding.port-offset=1000</javaOpts> <!-- ignored on domain -->
+                    <port>10990</port>
+                </configuration>
+                
+                <executions>
+                    
+                    <!-- standalone.xml -->
+                    <execution>
+                        <id>migrate-standalone</id>
+                        <phase>generate-test-resources</phase>
+                        <goals>
+                            <goal>start</goal>
+                            <goal>execute-commands</goal>
+                            <goal>shutdown</goal>
+                        </goals>
+                        <configuration>
+                            <serverConfig>standalone-1.8.1.xml</serverConfig>
+                            <execute-commands>
+                                <scripts>
+                                    <script>${jbossHome}/bin/migrate-standalone.cli</script>
+                                </scripts>
+                            </execute-commands>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>read-migrated-standalone</id>
+                        <phase>process-test-resources</phase>
+                        <goals>
+                            <goal>start</goal>
+                            <goal>execute-commands</goal>
+                            <goal>shutdown</goal>
+                        </goals>
+                        <configuration>
+                            <serverConfig>standalone-1.8.1.xml</serverConfig>
+                            <execute-commands>
+                                <commands>
+                                    <command>echo Reading subsystems for migrated standalone-1.8.1.xml</command>
+                                    <command>/subsystem=*/:read-resource(recursive=true)>${project.build.directory}/migrated-standalone-1.8.1.txt</command>
+                                </commands>
+                            </execute-commands>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>read-master-standalone</id>
+                        <phase>process-test-resources</phase>
+                        <goals>
+                            <goal>start</goal>
+                            <goal>execute-commands</goal>
+                            <goal>shutdown</goal>
+                        </goals>
+                        <configuration>
+                            <serverConfig>standalone.xml</serverConfig>
+                            <execute-commands>
+                                <commands>
+                                    <command>echo Reading subsystems for master standalone.xml</command>
+                                    <command>/subsystem=*/:read-resource(recursive=true)>${project.build.directory}/master-standalone.txt</command>
+                                </commands>
+                            </execute-commands>
+                        </configuration>
+                    </execution>
+                    
+                    <!-- standalone-ha.xml -->
+                    <execution>
+                        <id>migrate-standalone-ha</id>
+                        <phase>generate-test-resources</phase>
+                        <goals>
+                            <goal>start</goal>
+                            <goal>execute-commands</goal>
+                            <goal>shutdown</goal>
+                        </goals>
+                        <configuration>
+                            <serverConfig>standalone-ha-1.8.1.xml</serverConfig>
+                            <execute-commands>
+                                <scripts>
+                                    <script>${jbossHome}/bin/migrate-standalone-ha.cli</script>
+                                </scripts>
+                            </execute-commands>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>read-migrated-standalone-ha</id>
+                        <phase>process-test-resources</phase>
+                        <goals>
+                            <goal>start</goal>
+                            <goal>execute-commands</goal>
+                            <goal>shutdown</goal>
+                        </goals>
+                        <configuration>
+                            <serverConfig>standalone-ha-1.8.1.xml</serverConfig>
+                            <execute-commands>
+                                <commands>
+                                    <command>echo Reading subsystems for migrated standalone-ha-1.8.1.xml</command>
+                                    <command>/subsystem=*/:read-resource(recursive=true)>${project.build.directory}/migrated-standalone-ha-1.8.1.txt</command>
+                                </commands>
+                            </execute-commands>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>read-master-standalone-ha</id>
+                        <phase>process-test-resources</phase>
+                        <goals>
+                            <goal>start</goal>
+                            <goal>execute-commands</goal>
+                            <goal>shutdown</goal>
+                        </goals>
+                        <configuration>
+                            <serverConfig>standalone-ha.xml</serverConfig>
+                            <execute-commands>
+                                <commands>
+                                    <command>echo Reading subsystems for master standalone-ha.xml</command>
+                                    <command>/subsystem=*/:read-resource(recursive=true)>${project.build.directory}/master-standalone-ha.txt</command>
+                                </commands>
+                            </execute-commands>
+                        </configuration>
+                    </execution>
+                    
+                    <!-- domain.xml -->
+                    <execution>
+                        <id>migrate-domain</id>
+                        <phase>generate-test-resources</phase>
+                        <goals>
+                            <goal>start</goal>
+                            <goal>execute-commands</goal>
+                            <goal>shutdown</goal>
+                        </goals>
+                        <configuration>
+                            <serverType>DOMAIN</serverType>
+                            <domainConfig>domain-1.8.1.xml</domainConfig>
+                            <serverArgs>--host-config=host-master-1.8.1.xml</serverArgs>
+                            <!-- jboss.server.config.dir is set to trick the migrate-json operation into -->
+                            <!-- finding keycloak-server.json.  Normally, that would be uploaded using   -->
+                            <!-- a file=<localfile> parameter.                                           -->
+                            <!-- Ports are set to avoid conflicts with other server instances.           -->
+                            <javaOpts>-Djboss.management.http.port=10990,-Djboss.management.native.port=10999,-Djboss.server.config.dir=${jbossHome}/domain/configuration/</javaOpts>
+                            <execute-commands>
+                                <scripts>
+                                    <script>${jbossHome}/bin/migrate-domain.cli</script>
+                                </scripts>
+                            </execute-commands>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>read-migrated-domain</id>
+                        <phase>process-test-resources</phase>
+                        <goals>
+                            <goal>start</goal>
+                            <goal>execute-commands</goal>
+                            <goal>shutdown</goal>
+                        </goals>
+                        <configuration>
+                            <serverType>DOMAIN</serverType>
+                            <domainConfig>domain-1.8.1.xml</domainConfig>
+                            <serverArgs>--host-config=host-master-1.8.1.xml</serverArgs>
+                            <javaOpts>-Djboss.management.http.port=10990,-Djboss.management.native.port=10999</javaOpts>
+                            <execute-commands>
+                                <commands>
+                                    <command>echo Reading subsystems for migrated domain-1.8.1.xml</command>
+                                    <command>/profile=auth-server-standalone/subsystem=*/:read-resource(recursive=true)>${project.build.directory}/migrated-domain-standalone-1.8.1.txt</command>
+                                    <command>/profile=auth-server-clustered/subsystem=*/:read-resource(recursive=true)>${project.build.directory}/migrated-domain-clustered-1.8.1.txt</command>
+                                </commands>
+                            </execute-commands>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>read-master-domain</id>
+                        <phase>process-test-resources</phase>
+                        <goals>
+                            <goal>start</goal>
+                            <goal>execute-commands</goal>
+                            <goal>shutdown</goal>
+                        </goals>
+                        <configuration>
+                            <serverType>DOMAIN</serverType>
+                            <domainConfig>domain.xml</domainConfig>
+                            <javaOpts>-Djboss.management.http.port=10990,-Djboss.management.native.port=10999</javaOpts>
+                            <serverArgs>--host-config=host-master.xml</serverArgs>
+                            <execute-commands>
+                                <commands>
+                                    <command>echo Reading subsystems for master domain.xml</command>
+                                    <command>/profile=auth-server-standalone/subsystem=*/:read-resource(recursive=true)>${project.build.directory}/master-domain-standalone.txt</command>
+                                    <command>/profile=auth-server-clustered/subsystem=*/:read-resource(recursive=true)>${project.build.directory}/master-domain-clustered.txt</command>
+                                </commands>
+                            </execute-commands>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/testsuite/server-config-migration/src/test/java/org/keycloak/test/config/migration/ConfigMigrationTest.java
+++ b/testsuite/server-config-migration/src/test/java/org/keycloak/test/config/migration/ConfigMigrationTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2016 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.keycloak.test.config.migration;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import org.jboss.dmr.ModelNode;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Compare outputs from jboss-cli read-resource operations.  This compare the total
+ * configuration of all subsystems to make sure that the version in master
+ * matches the migrated version.
+ *
+ * @author Stan Silvert ssilvert@redhat.com (C) 2016 Red Hat Inc.
+ */
+public class ConfigMigrationTest {
+    
+    private static final File TARGET_DIR = new File("./target");
+
+    @Test
+    public void testStandalone() throws IOException {
+        compareConfigs("master-standalone.txt", "migrated-standalone-1.8.1.txt");
+    }
+    
+    @Test
+    public void testStandaloneHA() throws IOException {
+        compareConfigs("master-standalone-ha.txt", "migrated-standalone-ha-1.8.1.txt");
+    }
+    
+    @Test
+    public void testDomain() throws IOException {
+        compareConfigs("master-domain-standalone.txt", "migrated-domain-standalone-1.8.1.txt");
+        compareConfigs("master-domain-clustered.txt", "migrated-domain-clustered-1.8.1.txt");
+    }
+    
+    private void compareConfigs(String masterConfig, String migratedConfig) throws IOException {
+        File masterFile = new File(TARGET_DIR, masterConfig);
+        Assert.assertTrue(masterFile.exists());
+        File migratedFile = new File(TARGET_DIR, migratedConfig);
+        Assert.assertTrue(migratedFile.exists());
+        
+        try (
+            FileInputStream masterStream = new FileInputStream(masterFile);
+            FileInputStream migratedStream = new FileInputStream(migratedFile);
+        ) {
+            // Convert to ModelNode to test equality.
+            // A textual diff might have things out of order.
+            ModelNode master = ModelNode.fromStream(masterStream);
+            ModelNode migrated = ModelNode.fromStream(migratedStream);
+            Assert.assertEquals(master, migrated);
+        }
+    }
+}

--- a/testsuite/server-config-migration/src/test/resources/domain/domain-1.8.1.xml
+++ b/testsuite/server-config-migration/src/test/resources/domain/domain-1.8.1.xml
@@ -1,0 +1,733 @@
+<?xml version="1.0" ?>
+
+<domain xmlns="urn:jboss:domain:4.0">
+    <extensions>
+        <extension module="org.jboss.as.clustering.infinispan"/>
+        <extension module="org.jboss.as.clustering.jgroups"/>
+        <extension module="org.jboss.as.connector"/>
+        <extension module="org.jboss.as.ee"/>
+        <extension module="org.jboss.as.ejb3"/>
+        <extension module="org.jboss.as.jaxrs"/>
+        <extension module="org.jboss.as.jdr"/>
+        <extension module="org.jboss.as.jmx"/>
+        <extension module="org.jboss.as.jpa"/>
+        <extension module="org.jboss.as.jsf"/>
+        <extension module="org.jboss.as.logging"/>
+        <extension module="org.jboss.as.mail"/>
+        <extension module="org.jboss.as.modcluster"/>
+        <extension module="org.jboss.as.naming"/>
+        <extension module="org.jboss.as.remoting"/>
+        <extension module="org.jboss.as.security"/>
+        <extension module="org.jboss.as.transactions"/>
+        <extension module="org.keycloak.keycloak-server-subsystem"/>
+        <extension module="org.wildfly.extension.bean-validation"/>
+        <extension module="org.wildfly.extension.io"/>
+        <extension module="org.wildfly.extension.request-controller"/>
+        <extension module="org.wildfly.extension.security.manager"/>
+        <extension module="org.wildfly.extension.undertow"/>
+    </extensions>
+    <system-properties>
+        <!-- IPv4 is not required, but setting this helps avoid unintended use of IPv6 -->
+        <property name="java.net.preferIPv4Stack" value="true"/>
+    </system-properties>
+    <management>
+        <access-control provider="simple">
+            <role-mapping>
+                <role name="SuperUser">
+                    <include>
+                        <user name="$local"/>
+                    </include>
+                </role>
+            </role-mapping>
+        </access-control>
+    </management>
+    <profiles>
+        <profile name="auth-server-standalone">
+            <subsystem xmlns="urn:jboss:domain:logging:3.0">
+                <console-handler name="CONSOLE">
+                    <level name="INFO"/>
+                    <formatter>
+                        <named-formatter name="COLOR-PATTERN"/>
+                    </formatter>
+                </console-handler>
+                <periodic-rotating-file-handler name="FILE" autoflush="true">
+                    <formatter>
+                        <named-formatter name="PATTERN"/>
+                    </formatter>
+                    <file relative-to="jboss.server.log.dir" path="server.log"/>
+                    <suffix value=".yyyy-MM-dd"/>
+                    <append value="true"/>
+                </periodic-rotating-file-handler>
+                <logger category="com.arjuna">
+                    <level name="WARN"/>
+                </logger>
+                <logger category="org.jboss.as.config">
+                    <level name="DEBUG"/>
+                </logger>
+                <logger category="sun.rmi">
+                    <level name="WARN"/>
+                </logger>
+                <root-logger>
+                    <level name="INFO"/>
+                    <handlers>
+                        <handler name="CONSOLE"/>
+                        <handler name="FILE"/>
+                    </handlers>
+                </root-logger>
+                <formatter name="PATTERN">
+                    <pattern-formatter pattern="%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n"/>
+                </formatter>
+                <formatter name="COLOR-PATTERN">
+                    <pattern-formatter pattern="%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n"/>
+                </formatter>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:bean-validation:1.0"/>
+            <subsystem xmlns="urn:jboss:domain:datasources:4.0">
+                <datasources>
+                    <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
+                        <connection-url>jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE</connection-url>
+                        <driver>h2</driver>
+                        <security>
+                            <user-name>sa</user-name>
+                            <password>sa</password>
+                        </security>
+                    </datasource>
+                    <datasource jndi-name="java:jboss/datasources/KeycloakDS" pool-name="KeycloakDS" enabled="true" use-java-context="true">
+                        <connection-url>jdbc:h2:${jboss.server.data.dir}/keycloak;AUTO_SERVER=TRUE</connection-url>
+                        <driver>h2</driver>
+                        <security>
+                            <user-name>sa</user-name>
+                            <password>sa</password>
+                        </security>
+                    </datasource>
+                    <drivers>
+                        <driver name="h2" module="com.h2database.h2">
+                            <xa-datasource-class>org.h2.jdbcx.JdbcDataSource</xa-datasource-class>
+                        </driver>
+                    </drivers>
+                </datasources>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:ee:4.0">
+                <spec-descriptor-property-replacement>false</spec-descriptor-property-replacement>
+                <concurrent>
+                    <context-services>
+                        <context-service name="default" jndi-name="java:jboss/ee/concurrency/context/default" use-transaction-setup-provider="true"/>
+                    </context-services>
+                    <managed-thread-factories>
+                        <managed-thread-factory name="default" jndi-name="java:jboss/ee/concurrency/factory/default" context-service="default"/>
+                    </managed-thread-factories>
+                    <managed-executor-services>
+                        <managed-executor-service name="default" jndi-name="java:jboss/ee/concurrency/executor/default" context-service="default" hung-task-threshold="60000" keepalive-time="5000"/>
+                    </managed-executor-services>
+                    <managed-scheduled-executor-services>
+                        <managed-scheduled-executor-service name="default" jndi-name="java:jboss/ee/concurrency/scheduler/default" context-service="default" hung-task-threshold="60000" keepalive-time="3000"/>
+                    </managed-scheduled-executor-services>
+                </concurrent>
+                <default-bindings context-service="java:jboss/ee/concurrency/context/default" datasource="java:jboss/datasources/ExampleDS" managed-executor-service="java:jboss/ee/concurrency/executor/default" managed-scheduled-executor-service="java:jboss/ee/concurrency/scheduler/default" managed-thread-factory="java:jboss/ee/concurrency/factory/default"/>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:ejb3:4.0">
+                <session-bean>
+                    <stateless>
+                        <bean-instance-pool-ref pool-name="slsb-strict-max-pool"/>
+                    </stateless>
+                    <stateful default-access-timeout="5000" cache-ref="simple" passivation-disabled-cache-ref="simple"/>
+                    <singleton default-access-timeout="5000"/>
+                </session-bean>
+                <pools>
+                    <bean-instance-pools>
+                        <!-- Automatically configure pools. Alternatively, max-pool-size can be set to a specific value -->
+                        <strict-max-pool name="slsb-strict-max-pool" derive-size="from-worker-pools" instance-acquisition-timeout="5" instance-acquisition-timeout-unit="MINUTES"/>
+                        <strict-max-pool name="mdb-strict-max-pool" derive-size="from-cpu-count" instance-acquisition-timeout="5" instance-acquisition-timeout-unit="MINUTES"/>
+                    </bean-instance-pools>
+                </pools>
+                <caches>
+                    <cache name="simple"/>
+                    <cache name="distributable" passivation-store-ref="infinispan" aliases="passivating clustered"/>
+                </caches>
+                <passivation-stores>
+                    <passivation-store name="infinispan" cache-container="ejb" max-size="10000"/>
+                </passivation-stores>
+                <async thread-pool-name="default"/>
+                <timer-service thread-pool-name="default" default-data-store="default-file-store">
+                    <data-stores>
+                        <file-data-store name="default-file-store" path="timer-service-data" relative-to="jboss.server.data.dir"/>
+                    </data-stores>
+                </timer-service>
+                <remote connector-ref="http-remoting-connector" thread-pool-name="default"/>
+                <thread-pools>
+                    <thread-pool name="default">
+                        <max-threads count="10"/>
+                        <keepalive-time time="100" unit="milliseconds"/>
+                    </thread-pool>
+                </thread-pools>
+                <default-security-domain value="other"/>
+                <default-missing-method-permissions-deny-access value="true"/>
+                <log-system-exceptions value="true"/>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:io:1.1">
+                <worker name="default"/>
+                <buffer-pool name="default"/>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:infinispan:4.0">
+                <cache-container name="keycloak" jndi-name="infinispan/Keycloak">
+                    <local-cache name="realms"/>
+                    <local-cache name="users"/>
+                    <local-cache name="sessions"/>
+                    <local-cache name="offlineSessions"/>
+                    <local-cache name="loginFailures"/>
+                </cache-container>
+                <cache-container name="server" default-cache="default" module="org.wildfly.clustering.server">
+                    <local-cache name="default">
+                        <transaction mode="BATCH"/>
+                    </local-cache>
+                </cache-container>
+                <cache-container name="web" default-cache="passivation" module="org.wildfly.clustering.web.infinispan">
+                    <local-cache name="passivation">
+                        <locking isolation="REPEATABLE_READ"/>
+                        <transaction mode="BATCH"/>
+                        <file-store passivation="true" purge="false"/>
+                    </local-cache>
+                    <local-cache name="persistent">
+                        <locking isolation="REPEATABLE_READ"/>
+                        <transaction mode="BATCH"/>
+                        <file-store passivation="false" purge="false"/>
+                    </local-cache>
+                </cache-container>
+                <cache-container name="ejb" aliases="sfsb" default-cache="passivation" module="org.wildfly.clustering.ejb.infinispan">
+                    <local-cache name="passivation">
+                        <locking isolation="REPEATABLE_READ"/>
+                        <transaction mode="BATCH"/>
+                        <file-store passivation="true" purge="false"/>
+                    </local-cache>
+                    <local-cache name="persistent">
+                        <transaction mode="BATCH"/>
+                        <file-store passivation="false" purge="false"/>
+                    </local-cache>
+                </cache-container>
+                <cache-container name="hibernate" default-cache="local-query" module="org.hibernate.infinispan">
+                    <local-cache name="entity">
+                        <transaction mode="NON_XA"/>
+                        <eviction strategy="LRU" max-entries="10000"/>
+                        <expiration max-idle="100000"/>
+                    </local-cache>
+                    <local-cache name="immutable-entity">
+                        <transaction mode="NON_XA"/>
+                        <eviction strategy="LRU" max-entries="10000"/>
+                        <expiration max-idle="100000"/>
+                    </local-cache>
+                    <local-cache name="local-query">
+                        <eviction strategy="LRU" max-entries="10000"/>
+                        <expiration max-idle="100000"/>
+                    </local-cache>
+                    <local-cache name="timestamps"/>
+                </cache-container>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:jaxrs:1.0"/>
+            <subsystem xmlns="urn:jboss:domain:jca:4.0">
+                <archive-validation enabled="true" fail-on-error="true" fail-on-warn="false"/>
+                <bean-validation enabled="true"/>
+                <default-workmanager>
+                    <short-running-threads>
+                        <core-threads count="50"/>
+                        <queue-length count="50"/>
+                        <max-threads count="50"/>
+                        <keepalive-time time="10" unit="seconds"/>
+                    </short-running-threads>
+                    <long-running-threads>
+                        <core-threads count="50"/>
+                        <queue-length count="50"/>
+                        <max-threads count="50"/>
+                        <keepalive-time time="10" unit="seconds"/>
+                    </long-running-threads>
+                </default-workmanager>
+                <cached-connection-manager/>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:jdr:1.0"/>
+            <subsystem xmlns="urn:jboss:domain:jmx:1.3">
+                <expose-resolved-model/>
+                <expose-expression-model/>
+                <!--<remoting-connector use-management-endpoint="false"/>-->
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:jpa:1.1">
+                <jpa default-datasource="" default-extended-persistence-inheritance="DEEP"/>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:jsf:1.0"/>
+            <subsystem xmlns="urn:jboss:domain:mail:2.0">
+                <mail-session name="default" jndi-name="java:jboss/mail/Default">
+                    <smtp-server outbound-socket-binding-ref="mail-smtp"/>
+                </mail-session>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:naming:2.0">
+                <remote-naming/>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:remoting:3.0">
+                <endpoint/>
+                <http-connector name="http-remoting-connector" connector-ref="default" security-realm="ApplicationRealm"/>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:request-controller:1.0"/>
+            <subsystem xmlns="urn:jboss:domain:security:1.2">
+                <security-domains>
+                    <security-domain name="other" cache-type="default">
+                        <authentication>
+                            <login-module code="Remoting" flag="optional">
+                                <module-option name="password-stacking" value="useFirstPass"/>
+                            </login-module>
+                            <login-module code="RealmDirect" flag="required">
+                                <module-option name="password-stacking" value="useFirstPass"/>
+                            </login-module>
+                        </authentication>
+                    </security-domain>
+                    <security-domain name="jboss-web-policy" cache-type="default">
+                        <authorization>
+                            <policy-module code="Delegating" flag="required"/>
+                        </authorization>
+                    </security-domain>
+                    <security-domain name="jboss-ejb-policy" cache-type="default">
+                        <authorization>
+                            <policy-module code="Delegating" flag="required"/>
+                        </authorization>
+                    </security-domain>
+                    <security-domain name="jaspitest" cache-type="default">
+                        <authentication-jaspi>
+                            <login-module-stack name="dummy">
+                                <login-module code="Dummy" flag="optional"/>
+                            </login-module-stack>
+                            <auth-module code="Dummy"/>
+                        </authentication-jaspi>
+                    </security-domain>
+                </security-domains>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:security-manager:1.0">
+                <deployment-permissions>
+                    <maximum-set>
+                        <permission class="java.security.AllPermission"/>
+                    </maximum-set>
+                </deployment-permissions>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:transactions:3.0">
+                <core-environment>
+                    <process-id>
+                        <uuid/>
+                    </process-id>
+                </core-environment>
+                <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:undertow:3.0">
+                <buffer-cache name="default"/>
+                <server name="default-server">
+                    <http-listener name="default" socket-binding="http" redirect-socket="https"/>
+                    <host name="default-host" alias="localhost">
+                        <location name="/" handler="welcome-content"/>
+                        <filter-ref name="server-header"/>
+                        <filter-ref name="x-powered-by-header"/>
+                    </host>
+                </server>
+                <servlet-container name="default">
+                    <jsp-config/>
+                    <websockets/>
+                </servlet-container>
+                <handlers>
+                    <file name="welcome-content" path="${jboss.home.dir}/welcome-content"/>
+                </handlers>
+                <filters>
+                    <response-header name="server-header" header-name="Server" header-value="WildFly/10"/>
+                    <response-header name="x-powered-by-header" header-name="X-Powered-By" header-value="Undertow/1"/>
+                </filters>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:keycloak-server:1.1">
+                <web-context>auth</web-context>
+            </subsystem>
+        </profile>
+        <profile name="auth-server-clustered">
+            <subsystem xmlns="urn:jboss:domain:logging:3.0">
+                <console-handler name="CONSOLE">
+                    <level name="INFO"/>
+                    <formatter>
+                        <named-formatter name="COLOR-PATTERN"/>
+                    </formatter>
+                </console-handler>
+                <periodic-rotating-file-handler name="FILE" autoflush="true">
+                    <formatter>
+                        <named-formatter name="PATTERN"/>
+                    </formatter>
+                    <file relative-to="jboss.server.log.dir" path="server.log"/>
+                    <suffix value=".yyyy-MM-dd"/>
+                    <append value="true"/>
+                </periodic-rotating-file-handler>
+                <logger category="com.arjuna">
+                    <level name="WARN"/>
+                </logger>
+                <logger category="org.jboss.as.config">
+                    <level name="DEBUG"/>
+                </logger>
+                <logger category="sun.rmi">
+                    <level name="WARN"/>
+                </logger>
+                <root-logger>
+                    <level name="INFO"/>
+                    <handlers>
+                        <handler name="CONSOLE"/>
+                        <handler name="FILE"/>
+                    </handlers>
+                </root-logger>
+                <formatter name="PATTERN">
+                    <pattern-formatter pattern="%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n"/>
+                </formatter>
+                <formatter name="COLOR-PATTERN">
+                    <pattern-formatter pattern="%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n"/>
+                </formatter>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:bean-validation:1.0"/>
+            <subsystem xmlns="urn:jboss:domain:datasources:4.0">
+                <datasources>
+                    <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
+                        <connection-url>jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE</connection-url>
+                        <driver>h2</driver>
+                        <security>
+                            <user-name>sa</user-name>
+                            <password>sa</password>
+                        </security>
+                    </datasource>
+                    <datasource jndi-name="java:jboss/datasources/KeycloakDS" pool-name="KeycloakDS" enabled="true" use-java-context="true">
+                        <connection-url>jdbc:h2:${jboss.server.data.dir}/../../shared-database/keycloak;AUTO_SERVER=TRUE</connection-url>
+                        <driver>h2</driver>
+                        <security>
+                            <user-name>sa</user-name>
+                            <password>sa</password>
+                        </security>
+                    </datasource>
+                    <drivers>
+                        <driver name="h2" module="com.h2database.h2">
+                            <xa-datasource-class>org.h2.jdbcx.JdbcDataSource</xa-datasource-class>
+                        </driver>
+                    </drivers>
+                </datasources>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:ee:4.0">
+                <spec-descriptor-property-replacement>false</spec-descriptor-property-replacement>
+                <concurrent>
+                    <context-services>
+                        <context-service name="default" jndi-name="java:jboss/ee/concurrency/context/default" use-transaction-setup-provider="true"/>
+                    </context-services>
+                    <managed-thread-factories>
+                        <managed-thread-factory name="default" jndi-name="java:jboss/ee/concurrency/factory/default" context-service="default"/>
+                    </managed-thread-factories>
+                    <managed-executor-services>
+                        <managed-executor-service name="default" jndi-name="java:jboss/ee/concurrency/executor/default" context-service="default" hung-task-threshold="60000" keepalive-time="5000"/>
+                    </managed-executor-services>
+                    <managed-scheduled-executor-services>
+                        <managed-scheduled-executor-service name="default" jndi-name="java:jboss/ee/concurrency/scheduler/default" context-service="default" hung-task-threshold="60000" keepalive-time="3000"/>
+                    </managed-scheduled-executor-services>
+                </concurrent>
+                <default-bindings context-service="java:jboss/ee/concurrency/context/default" datasource="java:jboss/datasources/ExampleDS" managed-executor-service="java:jboss/ee/concurrency/executor/default" managed-scheduled-executor-service="java:jboss/ee/concurrency/scheduler/default" managed-thread-factory="java:jboss/ee/concurrency/factory/default"/>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:ejb3:4.0">
+                <session-bean>
+                    <stateless>
+                        <bean-instance-pool-ref pool-name="slsb-strict-max-pool"/>
+                    </stateless>
+                    <stateful default-access-timeout="5000" cache-ref="distributable" passivation-disabled-cache-ref="simple"/>
+                    <singleton default-access-timeout="5000"/>
+                </session-bean>
+                <pools>
+                    <bean-instance-pools>
+                        <!-- Automatically configure pools. Alternatively, max-pool-size can be set to a specific value -->
+                        <strict-max-pool name="slsb-strict-max-pool" derive-size="from-worker-pools" instance-acquisition-timeout="5" instance-acquisition-timeout-unit="MINUTES"/>
+                        <strict-max-pool name="mdb-strict-max-pool" derive-size="from-cpu-count" instance-acquisition-timeout="5" instance-acquisition-timeout-unit="MINUTES"/>
+                    </bean-instance-pools>
+                </pools>
+                <caches>
+                    <cache name="simple"/>
+                    <cache name="distributable" passivation-store-ref="infinispan" aliases="passivating clustered"/>
+                </caches>
+                <passivation-stores>
+                    <passivation-store name="infinispan" cache-container="ejb" max-size="10000"/>
+                </passivation-stores>
+                <async thread-pool-name="default"/>
+                <timer-service thread-pool-name="default" default-data-store="default-file-store">
+                    <data-stores>
+                        <file-data-store name="default-file-store" path="timer-service-data" relative-to="jboss.server.data.dir"/>
+                    </data-stores>
+                </timer-service>
+                <remote connector-ref="http-remoting-connector" thread-pool-name="default"/>
+                <thread-pools>
+                    <thread-pool name="default">
+                        <max-threads count="10"/>
+                        <keepalive-time time="100" unit="milliseconds"/>
+                    </thread-pool>
+                </thread-pools>
+                <default-security-domain value="other"/>
+                <default-missing-method-permissions-deny-access value="true"/>
+                <log-system-exceptions value="true"/>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:io:1.1">
+                <worker name="default"/>
+                <buffer-pool name="default"/>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:infinispan:4.0">
+                <cache-container name="keycloak" jndi-name="infinispan/Keycloak">
+                    <transport lock-timeout="60000"/>
+                    <invalidation-cache name="realms" mode="SYNC"/>
+                    <invalidation-cache name="users" mode="SYNC"/>
+                    <distributed-cache name="sessions" mode="SYNC" owners="1"/>
+                    <distributed-cache name="offlineSessions" mode="SYNC" owners="1"/>
+                    <distributed-cache name="loginFailures" mode="SYNC" owners="1"/>
+                </cache-container>
+                <cache-container name="server" aliases="singleton cluster" default-cache="default" module="org.wildfly.clustering.server">
+                    <transport lock-timeout="60000"/>
+                    <replicated-cache name="default" mode="SYNC">
+                        <transaction mode="BATCH"/>
+                    </replicated-cache>
+                </cache-container>
+                <cache-container name="web" default-cache="dist" module="org.wildfly.clustering.web.infinispan">
+                    <transport lock-timeout="60000"/>
+                    <distributed-cache name="dist" mode="ASYNC" l1-lifespan="0" owners="2">
+                        <locking isolation="REPEATABLE_READ"/>
+                        <transaction mode="BATCH"/>
+                        <file-store/>
+                    </distributed-cache>
+                </cache-container>
+                <cache-container name="ejb" aliases="sfsb" default-cache="dist" module="org.wildfly.clustering.ejb.infinispan">
+                    <transport lock-timeout="60000"/>
+                    <distributed-cache name="dist" mode="ASYNC" l1-lifespan="0" owners="2">
+                        <locking isolation="REPEATABLE_READ"/>
+                        <transaction mode="BATCH"/>
+                        <file-store/>
+                    </distributed-cache>
+                </cache-container>
+                <cache-container name="hibernate" default-cache="local-query" module="org.hibernate.infinispan">
+                    <transport lock-timeout="60000"/>
+                    <invalidation-cache name="entity" mode="SYNC">
+                        <transaction mode="NON_XA"/>
+                        <eviction strategy="LRU" max-entries="10000"/>
+                        <expiration max-idle="100000"/>
+                    </invalidation-cache>
+                    <local-cache name="local-query">
+                        <eviction strategy="LRU" max-entries="10000"/>
+                        <expiration max-idle="100000"/>
+                    </local-cache>
+                    <replicated-cache name="timestamps" mode="ASYNC"/>
+                </cache-container>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:jaxrs:1.0"/>
+            <subsystem xmlns="urn:jboss:domain:jca:4.0">
+                <archive-validation enabled="true" fail-on-error="true" fail-on-warn="false"/>
+                <bean-validation enabled="true"/>
+                <default-workmanager>
+                    <short-running-threads>
+                        <core-threads count="50"/>
+                        <queue-length count="50"/>
+                        <max-threads count="50"/>
+                        <keepalive-time time="10" unit="seconds"/>
+                    </short-running-threads>
+                    <long-running-threads>
+                        <core-threads count="50"/>
+                        <queue-length count="50"/>
+                        <max-threads count="50"/>
+                        <keepalive-time time="10" unit="seconds"/>
+                    </long-running-threads>
+                </default-workmanager>
+                <cached-connection-manager/>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:jdr:1.0"/>
+            <subsystem xmlns="urn:jboss:domain:jgroups:4.0">
+                <channels default="ee">
+                    <channel name="ee" stack="udp"/>
+                </channels>
+                <stacks>
+                    <stack name="udp">
+                        <transport type="UDP" socket-binding="jgroups-udp"/>
+                        <protocol type="PING"/>
+                        <protocol type="MERGE3"/>
+                        <protocol type="FD_SOCK" socket-binding="jgroups-udp-fd"/>
+                        <protocol type="FD_ALL"/>
+                        <protocol type="VERIFY_SUSPECT"/>
+                        <protocol type="pbcast.NAKACK2"/>
+                        <protocol type="UNICAST3"/>
+                        <protocol type="pbcast.STABLE"/>
+                        <protocol type="pbcast.GMS"/>
+                        <protocol type="UFC"/>
+                        <protocol type="MFC"/>
+                        <protocol type="FRAG2"/>
+                    </stack>
+                    <stack name="tcp">
+                        <transport type="TCP" socket-binding="jgroups-tcp"/>
+                        <protocol type="MPING" socket-binding="jgroups-mping"/>
+                        <protocol type="MERGE3"/>
+                        <protocol type="FD_SOCK" socket-binding="jgroups-tcp-fd"/>
+                        <protocol type="FD"/>
+                        <protocol type="VERIFY_SUSPECT"/>
+                        <protocol type="pbcast.NAKACK2"/>
+                        <protocol type="UNICAST3"/>
+                        <protocol type="pbcast.STABLE"/>
+                        <protocol type="pbcast.GMS"/>
+                        <protocol type="MFC"/>
+                        <protocol type="FRAG2"/>
+                    </stack>
+                </stacks>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:jmx:1.3">
+                <expose-resolved-model/>
+                <expose-expression-model/>
+                <!--<remoting-connector use-management-endpoint="false"/>-->
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:jpa:1.1">
+                <jpa default-datasource="" default-extended-persistence-inheritance="DEEP"/>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:jsf:1.0"/>
+            <subsystem xmlns="urn:jboss:domain:mail:2.0">
+                <mail-session name="default" jndi-name="java:jboss/mail/Default">
+                    <smtp-server outbound-socket-binding-ref="mail-smtp"/>
+                </mail-session>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:modcluster:2.0">
+                <mod-cluster-config advertise-socket="modcluster" connector="ajp">
+                    <dynamic-load-provider>
+                        <load-metric type="cpu"/>
+                    </dynamic-load-provider>
+                </mod-cluster-config>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:naming:2.0">
+                <remote-naming/>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:remoting:3.0">
+                <endpoint/>
+                <http-connector name="http-remoting-connector" connector-ref="default" security-realm="ApplicationRealm"/>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:request-controller:1.0"/>
+            <subsystem xmlns="urn:jboss:domain:security:1.2">
+                <security-domains>
+                    <security-domain name="other" cache-type="default">
+                        <authentication>
+                            <login-module code="Remoting" flag="optional">
+                                <module-option name="password-stacking" value="useFirstPass"/>
+                            </login-module>
+                            <login-module code="RealmDirect" flag="required">
+                                <module-option name="password-stacking" value="useFirstPass"/>
+                            </login-module>
+                        </authentication>
+                    </security-domain>
+                    <security-domain name="jboss-web-policy" cache-type="default">
+                        <authorization>
+                            <policy-module code="Delegating" flag="required"/>
+                        </authorization>
+                    </security-domain>
+                    <security-domain name="jboss-ejb-policy" cache-type="default">
+                        <authorization>
+                            <policy-module code="Delegating" flag="required"/>
+                        </authorization>
+                    </security-domain>
+                    <security-domain name="jaspitest" cache-type="default">
+                        <authentication-jaspi>
+                            <login-module-stack name="dummy">
+                                <login-module code="Dummy" flag="optional"/>
+                            </login-module-stack>
+                            <auth-module code="Dummy"/>
+                        </authentication-jaspi>
+                    </security-domain>
+                </security-domains>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:security-manager:1.0">
+                <deployment-permissions>
+                    <maximum-set>
+                        <permission class="java.security.AllPermission"/>
+                    </maximum-set>
+                </deployment-permissions>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:transactions:3.0">
+                <core-environment>
+                    <process-id>
+                        <uuid/>
+                    </process-id>
+                </core-environment>
+                <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:undertow:3.0">
+                <buffer-cache name="default"/>
+                <server name="default-server">
+                    <ajp-listener name="ajp" socket-binding="ajp"/>
+                    <http-listener name="default" socket-binding="http" redirect-socket="https"/>
+                    <host name="default-host" alias="localhost">
+                        <location name="/" handler="welcome-content"/>
+                        <filter-ref name="server-header"/>
+                        <filter-ref name="x-powered-by-header"/>
+                    </host>
+                </server>
+                <servlet-container name="default">
+                    <jsp-config/>
+                    <websockets/>
+                </servlet-container>
+                <handlers>
+                    <file name="welcome-content" path="${jboss.home.dir}/welcome-content"/>
+                </handlers>
+                <filters>
+                    <response-header name="server-header" header-name="Server" header-value="WildFly/10"/>
+                    <response-header name="x-powered-by-header" header-name="X-Powered-By" header-value="Undertow/1"/>
+                </filters>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:keycloak-server:1.1">
+                <web-context>auth</web-context>
+            </subsystem>
+        </profile>
+    </profiles>
+    <!--
+      ~ 
+      ~          Named interfaces that can be referenced elsewhere in the configuration. The configuration
+      ~          for how to associate these logical names with an actual network interface can either
+      ~          be specified here or can be declared on a per-host basis in the equivalent element in host.xml.
+      ~ 
+      ~          These default configurations require the binding specification to be done in host.xml.
+      ~     
+      -->
+    <interfaces>
+        <interface name="management"/>
+        <interface name="public"/>
+        <interface name="private">
+            <inet-address value="${jboss.bind.address.private:127.0.0.1}"/>
+        </interface>
+    </interfaces>
+    <socket-binding-groups>
+        <socket-binding-group name="standard-sockets" default-interface="public">
+            <!-- Needed for server groups using the 'default' profile  -->
+            <socket-binding name="ajp" port="${jboss.ajp.port:8009}"/>
+            <socket-binding name="http" port="${jboss.http.port:8080}"/>
+            <socket-binding name="https" port="${jboss.https.port:8443}"/>
+            <socket-binding name="txn-recovery-environment" port="4712"/>
+            <socket-binding name="txn-status-manager" port="4713"/>
+            <outbound-socket-binding name="mail-smtp">
+                <remote-destination host="localhost" port="25"/>
+            </outbound-socket-binding>
+        </socket-binding-group>
+        <socket-binding-group name="ha-sockets" default-interface="public">
+            <!-- Needed for server groups using the 'ha' profile  -->
+            <socket-binding name="ajp" port="${jboss.ajp.port:8009}"/>
+            <socket-binding name="http" port="${jboss.http.port:8080}"/>
+            <socket-binding name="https" port="${jboss.https.port:8443}"/>
+            <socket-binding name="jgroups-mping" interface="private" port="0" multicast-address="${jboss.default.multicast.address:230.0.0.4}" multicast-port="45700"/>
+            <socket-binding name="jgroups-tcp" interface="private" port="7600"/>
+            <socket-binding name="jgroups-tcp-fd" interface="private" port="57600"/>
+            <socket-binding name="jgroups-udp" interface="private" port="55200" multicast-address="${jboss.default.multicast.address:230.0.0.4}" multicast-port="45688"/>
+            <socket-binding name="jgroups-udp-fd" interface="private" port="54200"/>
+            <socket-binding name="modcluster" port="0" multicast-address="224.0.1.105" multicast-port="23364"/>
+            <socket-binding name="txn-recovery-environment" port="4712"/>
+            <socket-binding name="txn-status-manager" port="4713"/>
+            <outbound-socket-binding name="mail-smtp">
+                <remote-destination host="localhost" port="25"/>
+            </outbound-socket-binding>
+        </socket-binding-group>
+    </socket-binding-groups>
+    <server-groups>
+        <server-group name="main-server-group" profile="auth-server-standalone">
+            <jvm name="default">
+                <heap size="64m" max-size="512m"/>
+            </jvm>
+            <socket-binding-group ref="standard-sockets"/>
+        </server-group>
+        <server-group name="other-server-group" profile="auth-server-clustered">
+            <jvm name="default">
+                <heap size="64m" max-size="512m"/>
+            </jvm>
+            <socket-binding-group ref="ha-sockets"/>
+        </server-group>
+    </server-groups>
+</domain>

--- a/testsuite/server-config-migration/src/test/resources/domain/host-master-1.8.1.xml
+++ b/testsuite/server-config-migration/src/test/resources/domain/host-master-1.8.1.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" ?>
+
+<host xmlns="urn:jboss:domain:4.0" name="master">
+    <extensions>
+        <extension module="org.jboss.as.jmx"/>
+    </extensions>
+    <management>
+        <security-realms>
+            <security-realm name="ManagementRealm">
+                <authentication>
+                    <local default-user="$local" skip-group-loading="true"/>
+                    <properties path="mgmt-users.properties" relative-to="jboss.domain.config.dir"/>
+                </authentication>
+                <authorization map-groups-to-roles="false">
+                    <properties path="mgmt-groups.properties" relative-to="jboss.domain.config.dir"/>
+                </authorization>
+            </security-realm>
+            <security-realm name="ApplicationRealm">
+                <authentication>
+                    <local default-user="$local" allowed-users="*" skip-group-loading="true"/>
+                    <properties path="application-users.properties" relative-to="jboss.domain.config.dir"/>
+                </authentication>
+                <authorization>
+                    <properties path="application-roles.properties" relative-to="jboss.domain.config.dir"/>
+                </authorization>
+            </security-realm>
+        </security-realms>
+        <audit-log>
+            <formatters>
+                <json-formatter name="json-formatter"/>
+            </formatters>
+            <handlers>
+                <file-handler name="host-file" formatter="json-formatter" relative-to="jboss.domain.data.dir" path="audit-log.log"/>
+                <file-handler name="server-file" formatter="json-formatter" relative-to="jboss.server.data.dir" path="audit-log.log"/>
+            </handlers>
+            <logger log-boot="true" log-read-only="false" enabled="false">
+                <handlers>
+                    <handler name="host-file"/>
+                </handlers>
+            </logger>
+            <server-logger log-boot="true" log-read-only="false" enabled="false">
+                <handlers>
+                    <handler name="server-file"/>
+                </handlers>
+            </server-logger>
+        </audit-log>
+        <management-interfaces>
+            <native-interface security-realm="ManagementRealm">
+                <socket interface="management" port="${jboss.management.native.port:9999}"/>
+            </native-interface>
+            <http-interface security-realm="ManagementRealm" http-upgrade-enabled="true">
+                <socket interface="management" port="${jboss.management.http.port:9990}"/>
+            </http-interface>
+        </management-interfaces>
+    </management>
+    <domain-controller>
+        <local/>
+    </domain-controller>
+    <interfaces>
+        <interface name="management">
+            <inet-address value="${jboss.bind.address.management:127.0.0.1}"/>
+        </interface>
+    </interfaces>
+    <jvms>
+        <jvm name="default">
+            <heap size="64m" max-size="256m"/>
+            <jvm-options>
+                <option value="-server"/>
+            </jvm-options>
+        </jvm>
+    </jvms>
+    <profile>
+        <subsystem xmlns="urn:jboss:domain:jmx:1.3">
+            <expose-resolved-model/>
+            <expose-expression-model/>
+            <remoting-connector/>
+        </subsystem>
+    </profile>
+</host>

--- a/testsuite/server-config-migration/src/test/resources/domain/keycloak-server.json
+++ b/testsuite/server-config-migration/src/test/resources/domain/keycloak-server.json
@@ -1,0 +1,79 @@
+{
+    "providers": [
+        "classpath:${jboss.home.dir}/providers/*"
+    ],
+
+    "admin": {
+        "realm": "master"
+    },
+
+    "eventsStore": {
+        "provider": "jpa",
+        "jpa": {
+            "exclude-events": [ "REFRESH_TOKEN" ]
+        }
+    },
+
+    "realm": {
+        "provider": "jpa"
+    },
+
+    "user": {
+        "provider": "jpa"
+    },
+
+    "userCache": {
+        "default" : {
+            "enabled": true
+        }
+    },
+
+    "userSessionPersister": {
+        "provider": "jpa"
+    },
+
+    "authorizationPersister": {
+        "provider": "jpa"
+    },
+
+    "timer": {
+        "provider": "basic"
+    },
+
+    "theme": {
+        "staticMaxAge": 2592000,
+        "cacheTemplates": true,
+        "cacheThemes": true,
+        "folder": {
+          "dir": "${jboss.home.dir}/themes"
+        }
+    },
+
+    "scheduled": {
+        "interval": 900
+    },
+
+    "connectionsHttpClient": {
+        "default": {}
+    },
+
+    "connectionsJpa": {
+        "default": {
+            "dataSource": "java:jboss/datasources/KeycloakDS",
+            "databaseSchema": "update"
+        }
+    },
+
+    "realmCache": {
+        "default" : {
+            "enabled": true
+        }
+    },
+
+    "connectionsInfinispan": {
+        "provider": "default",
+        "default": {
+            "cacheContainer" : "java:comp/env/infinispan/Keycloak"
+        }
+    }
+}

--- a/testsuite/server-config-migration/src/test/resources/standalone/keycloak-server.json
+++ b/testsuite/server-config-migration/src/test/resources/standalone/keycloak-server.json
@@ -1,0 +1,79 @@
+{
+    "providers": [
+        "classpath:${jboss.home.dir}/providers/*"
+    ],
+
+    "admin": {
+        "realm": "master"
+    },
+
+    "eventsStore": {
+        "provider": "jpa",
+        "jpa": {
+            "exclude-events": [ "REFRESH_TOKEN" ]
+        }
+    },
+
+    "realm": {
+        "provider": "jpa"
+    },
+
+    "user": {
+        "provider": "jpa"
+    },
+
+    "userCache": {
+        "default" : {
+            "enabled": true
+        }
+    },
+
+    "userSessionPersister": {
+        "provider": "jpa"
+    },
+
+    "authorizationPersister": {
+        "provider": "jpa"
+    },
+
+    "timer": {
+        "provider": "basic"
+    },
+
+    "theme": {
+        "staticMaxAge": 2592000,
+        "cacheTemplates": true,
+        "cacheThemes": true,
+        "folder": {
+          "dir": "${jboss.home.dir}/themes"
+        }
+    },
+
+    "scheduled": {
+        "interval": 900
+    },
+
+    "connectionsHttpClient": {
+        "default": {}
+    },
+
+    "connectionsJpa": {
+        "default": {
+            "dataSource": "java:jboss/datasources/KeycloakDS",
+            "databaseSchema": "update"
+        }
+    },
+
+    "realmCache": {
+        "default" : {
+            "enabled": true
+        }
+    },
+
+    "connectionsInfinispan": {
+        "provider": "default",
+        "default": {
+            "cacheContainer" : "java:comp/env/infinispan/Keycloak"
+        }
+    }
+}

--- a/testsuite/server-config-migration/src/test/resources/standalone/standalone-1.8.1.xml
+++ b/testsuite/server-config-migration/src/test/resources/standalone/standalone-1.8.1.xml
@@ -1,0 +1,392 @@
+<?xml version="1.0" ?>
+
+<server xmlns="urn:jboss:domain:4.0">
+    <extensions>
+        <extension module="org.jboss.as.clustering.infinispan"/>
+        <extension module="org.jboss.as.connector"/>
+        <extension module="org.jboss.as.ee"/>
+        <extension module="org.jboss.as.ejb3"/>
+        <extension module="org.jboss.as.jaxrs"/>
+        <extension module="org.jboss.as.jdr"/>
+        <extension module="org.jboss.as.jmx"/>
+        <extension module="org.jboss.as.jpa"/>
+        <extension module="org.jboss.as.jsf"/>
+        <extension module="org.jboss.as.logging"/>
+        <extension module="org.jboss.as.mail"/>
+        <extension module="org.jboss.as.naming"/>
+        <extension module="org.jboss.as.remoting"/>
+        <extension module="org.jboss.as.security"/>
+        <extension module="org.jboss.as.transactions"/>
+        <extension module="org.keycloak.keycloak-server-subsystem"/>
+        <extension module="org.wildfly.extension.bean-validation"/>
+        <extension module="org.wildfly.extension.io"/>
+        <extension module="org.wildfly.extension.request-controller"/>
+        <extension module="org.wildfly.extension.security.manager"/>
+        <extension module="org.wildfly.extension.undertow"/>
+    </extensions>
+    <management>
+        <security-realms>
+            <security-realm name="ManagementRealm">
+                <authentication>
+                    <local default-user="$local" skip-group-loading="true"/>
+                    <properties path="mgmt-users.properties" relative-to="jboss.server.config.dir"/>
+                </authentication>
+                <authorization map-groups-to-roles="false">
+                    <properties path="mgmt-groups.properties" relative-to="jboss.server.config.dir"/>
+                </authorization>
+            </security-realm>
+            <security-realm name="ApplicationRealm">
+                <authentication>
+                    <local default-user="$local" allowed-users="*" skip-group-loading="true"/>
+                    <properties path="application-users.properties" relative-to="jboss.server.config.dir"/>
+                </authentication>
+                <authorization>
+                    <properties path="application-roles.properties" relative-to="jboss.server.config.dir"/>
+                </authorization>
+            </security-realm>
+        </security-realms>
+        <audit-log>
+            <formatters>
+                <json-formatter name="json-formatter"/>
+            </formatters>
+            <handlers>
+                <file-handler name="file" formatter="json-formatter" relative-to="jboss.server.data.dir" path="audit-log.log"/>
+            </handlers>
+            <logger log-boot="true" log-read-only="false" enabled="false">
+                <handlers>
+                    <handler name="file"/>
+                </handlers>
+            </logger>
+        </audit-log>
+        <management-interfaces>
+            <http-interface security-realm="ManagementRealm" http-upgrade-enabled="true">
+                <socket-binding http="management-http"/>
+            </http-interface>
+        </management-interfaces>
+        <access-control provider="simple">
+            <role-mapping>
+                <role name="SuperUser">
+                    <include>
+                        <user name="$local"/>
+                    </include>
+                </role>
+            </role-mapping>
+        </access-control>
+    </management>
+    <profile>
+        <subsystem xmlns="urn:jboss:domain:logging:3.0">
+            <console-handler name="CONSOLE">
+                <level name="INFO"/>
+                <formatter>
+                    <named-formatter name="COLOR-PATTERN"/>
+                </formatter>
+            </console-handler>
+            <periodic-rotating-file-handler name="FILE" autoflush="true">
+                <formatter>
+                    <named-formatter name="PATTERN"/>
+                </formatter>
+                <file relative-to="jboss.server.log.dir" path="server.log"/>
+                <suffix value=".yyyy-MM-dd"/>
+                <append value="true"/>
+            </periodic-rotating-file-handler>
+            <logger category="com.arjuna">
+                <level name="WARN"/>
+            </logger>
+            <logger category="org.jboss.as.config">
+                <level name="DEBUG"/>
+            </logger>
+            <logger category="sun.rmi">
+                <level name="WARN"/>
+            </logger>
+            <root-logger>
+                <level name="INFO"/>
+                <handlers>
+                    <handler name="CONSOLE"/>
+                    <handler name="FILE"/>
+                </handlers>
+            </root-logger>
+            <formatter name="PATTERN">
+                <pattern-formatter pattern="%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n"/>
+            </formatter>
+            <formatter name="COLOR-PATTERN">
+                <pattern-formatter pattern="%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n"/>
+            </formatter>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:bean-validation:1.0"/>
+        <subsystem xmlns="urn:jboss:domain:datasources:4.0">
+            <datasources>
+                <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
+                    <connection-url>jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE</connection-url>
+                    <driver>h2</driver>
+                    <security>
+                        <user-name>sa</user-name>
+                        <password>sa</password>
+                    </security>
+                </datasource>
+                <datasource jndi-name="java:jboss/datasources/KeycloakDS" pool-name="KeycloakDS" enabled="true" use-java-context="true">
+                    <connection-url>jdbc:h2:${jboss.server.data.dir}/keycloak;AUTO_SERVER=TRUE</connection-url>
+                    <driver>h2</driver>
+                    <security>
+                        <user-name>sa</user-name>
+                        <password>sa</password>
+                    </security>
+                </datasource>
+                <drivers>
+                    <driver name="h2" module="com.h2database.h2">
+                        <xa-datasource-class>org.h2.jdbcx.JdbcDataSource</xa-datasource-class>
+                    </driver>
+                </drivers>
+            </datasources>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:ee:4.0">
+            <spec-descriptor-property-replacement>false</spec-descriptor-property-replacement>
+            <concurrent>
+                <context-services>
+                    <context-service name="default" jndi-name="java:jboss/ee/concurrency/context/default" use-transaction-setup-provider="true"/>
+                </context-services>
+                <managed-thread-factories>
+                    <managed-thread-factory name="default" jndi-name="java:jboss/ee/concurrency/factory/default" context-service="default"/>
+                </managed-thread-factories>
+                <managed-executor-services>
+                    <managed-executor-service name="default" jndi-name="java:jboss/ee/concurrency/executor/default" context-service="default" hung-task-threshold="60000" keepalive-time="5000"/>
+                </managed-executor-services>
+                <managed-scheduled-executor-services>
+                    <managed-scheduled-executor-service name="default" jndi-name="java:jboss/ee/concurrency/scheduler/default" context-service="default" hung-task-threshold="60000" keepalive-time="3000"/>
+                </managed-scheduled-executor-services>
+            </concurrent>
+            <default-bindings context-service="java:jboss/ee/concurrency/context/default" datasource="java:jboss/datasources/ExampleDS" managed-executor-service="java:jboss/ee/concurrency/executor/default" managed-scheduled-executor-service="java:jboss/ee/concurrency/scheduler/default" managed-thread-factory="java:jboss/ee/concurrency/factory/default"/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:ejb3:4.0">
+            <session-bean>
+                <stateless>
+                    <bean-instance-pool-ref pool-name="slsb-strict-max-pool"/>
+                </stateless>
+                <stateful default-access-timeout="5000" cache-ref="simple" passivation-disabled-cache-ref="simple"/>
+                <singleton default-access-timeout="5000"/>
+            </session-bean>
+            <pools>
+                <bean-instance-pools>
+                    <!-- Automatically configure pools. Alternatively, max-pool-size can be set to a specific value -->
+                    <strict-max-pool name="slsb-strict-max-pool" derive-size="from-worker-pools" instance-acquisition-timeout="5" instance-acquisition-timeout-unit="MINUTES"/>
+                    <strict-max-pool name="mdb-strict-max-pool" derive-size="from-cpu-count" instance-acquisition-timeout="5" instance-acquisition-timeout-unit="MINUTES"/>
+                </bean-instance-pools>
+            </pools>
+            <caches>
+                <cache name="simple"/>
+                <cache name="distributable" passivation-store-ref="infinispan" aliases="passivating clustered"/>
+            </caches>
+            <passivation-stores>
+                <passivation-store name="infinispan" cache-container="ejb" max-size="10000"/>
+            </passivation-stores>
+            <async thread-pool-name="default"/>
+            <timer-service thread-pool-name="default" default-data-store="default-file-store">
+                <data-stores>
+                    <file-data-store name="default-file-store" path="timer-service-data" relative-to="jboss.server.data.dir"/>
+                </data-stores>
+            </timer-service>
+            <remote connector-ref="http-remoting-connector" thread-pool-name="default"/>
+            <thread-pools>
+                <thread-pool name="default">
+                    <max-threads count="10"/>
+                    <keepalive-time time="100" unit="milliseconds"/>
+                </thread-pool>
+            </thread-pools>
+            <default-security-domain value="other"/>
+            <default-missing-method-permissions-deny-access value="true"/>
+            <log-system-exceptions value="true"/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:io:1.1">
+            <worker name="default"/>
+            <buffer-pool name="default"/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:infinispan:4.0">
+            <cache-container name="keycloak" jndi-name="infinispan/Keycloak">
+                <local-cache name="realms"/>
+                <local-cache name="users"/>
+                <local-cache name="sessions"/>
+                <local-cache name="offlineSessions"/>
+                <local-cache name="loginFailures"/>
+            </cache-container>
+            <cache-container name="server" default-cache="default" module="org.wildfly.clustering.server">
+                <local-cache name="default">
+                    <transaction mode="BATCH"/>
+                </local-cache>
+            </cache-container>
+            <cache-container name="web" default-cache="passivation" module="org.wildfly.clustering.web.infinispan">
+                <local-cache name="passivation">
+                    <locking isolation="REPEATABLE_READ"/>
+                    <transaction mode="BATCH"/>
+                    <file-store passivation="true" purge="false"/>
+                </local-cache>
+                <local-cache name="persistent">
+                    <locking isolation="REPEATABLE_READ"/>
+                    <transaction mode="BATCH"/>
+                    <file-store passivation="false" purge="false"/>
+                </local-cache>
+            </cache-container>
+            <cache-container name="ejb" aliases="sfsb" default-cache="passivation" module="org.wildfly.clustering.ejb.infinispan">
+                <local-cache name="passivation">
+                    <locking isolation="REPEATABLE_READ"/>
+                    <transaction mode="BATCH"/>
+                    <file-store passivation="true" purge="false"/>
+                </local-cache>
+                <local-cache name="persistent">
+                    <transaction mode="BATCH"/>
+                    <file-store passivation="false" purge="false"/>
+                </local-cache>
+            </cache-container>
+            <cache-container name="hibernate" default-cache="local-query" module="org.hibernate.infinispan">
+                <local-cache name="entity">
+                    <transaction mode="NON_XA"/>
+                    <eviction strategy="LRU" max-entries="10000"/>
+                    <expiration max-idle="100000"/>
+                </local-cache>
+                <local-cache name="immutable-entity">
+                    <transaction mode="NON_XA"/>
+                    <eviction strategy="LRU" max-entries="10000"/>
+                    <expiration max-idle="100000"/>
+                </local-cache>
+                <local-cache name="local-query">
+                    <eviction strategy="LRU" max-entries="10000"/>
+                    <expiration max-idle="100000"/>
+                </local-cache>
+                <local-cache name="timestamps"/>
+            </cache-container>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:jaxrs:1.0"/>
+        <subsystem xmlns="urn:jboss:domain:jca:4.0">
+            <archive-validation enabled="true" fail-on-error="true" fail-on-warn="false"/>
+            <bean-validation enabled="true"/>
+            <default-workmanager>
+                <short-running-threads>
+                    <core-threads count="50"/>
+                    <queue-length count="50"/>
+                    <max-threads count="50"/>
+                    <keepalive-time time="10" unit="seconds"/>
+                </short-running-threads>
+                <long-running-threads>
+                    <core-threads count="50"/>
+                    <queue-length count="50"/>
+                    <max-threads count="50"/>
+                    <keepalive-time time="10" unit="seconds"/>
+                </long-running-threads>
+            </default-workmanager>
+            <cached-connection-manager/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:jdr:1.0"/>
+        <subsystem xmlns="urn:jboss:domain:jmx:1.3">
+            <expose-resolved-model/>
+            <expose-expression-model/>
+            <remoting-connector/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:jpa:1.1">
+            <jpa default-datasource="" default-extended-persistence-inheritance="DEEP"/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:jsf:1.0"/>
+        <subsystem xmlns="urn:jboss:domain:mail:2.0">
+            <mail-session name="default" jndi-name="java:jboss/mail/Default">
+                <smtp-server outbound-socket-binding-ref="mail-smtp"/>
+            </mail-session>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:naming:2.0">
+            <remote-naming/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:remoting:3.0">
+            <endpoint/>
+            <http-connector name="http-remoting-connector" connector-ref="default" security-realm="ApplicationRealm"/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:request-controller:1.0"/>
+        <subsystem xmlns="urn:jboss:domain:security-manager:1.0">
+            <deployment-permissions>
+                <maximum-set>
+                    <permission class="java.security.AllPermission"/>
+                </maximum-set>
+            </deployment-permissions>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:security:1.2">
+            <security-domains>
+                <security-domain name="other" cache-type="default">
+                    <authentication>
+                        <login-module code="Remoting" flag="optional">
+                            <module-option name="password-stacking" value="useFirstPass"/>
+                        </login-module>
+                        <login-module code="RealmDirect" flag="required">
+                            <module-option name="password-stacking" value="useFirstPass"/>
+                        </login-module>
+                    </authentication>
+                </security-domain>
+                <security-domain name="jboss-web-policy" cache-type="default">
+                    <authorization>
+                        <policy-module code="Delegating" flag="required"/>
+                    </authorization>
+                </security-domain>
+                <security-domain name="jboss-ejb-policy" cache-type="default">
+                    <authorization>
+                        <policy-module code="Delegating" flag="required"/>
+                    </authorization>
+                </security-domain>
+                <security-domain name="jaspitest" cache-type="default">
+                    <authentication-jaspi>
+                        <login-module-stack name="dummy">
+                            <login-module code="Dummy" flag="optional"/>
+                        </login-module-stack>
+                        <auth-module code="Dummy"/>
+                    </authentication-jaspi>
+                </security-domain>
+            </security-domains>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:transactions:3.0">
+            <core-environment>
+                <process-id>
+                    <uuid/>
+                </process-id>
+            </core-environment>
+            <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:undertow:3.0">
+            <buffer-cache name="default"/>
+            <server name="default-server">
+                <http-listener name="default" socket-binding="http" redirect-socket="https"/>
+                <host name="default-host" alias="localhost">
+                    <location name="/" handler="welcome-content"/>
+                    <filter-ref name="server-header"/>
+                    <filter-ref name="x-powered-by-header"/>
+                </host>
+            </server>
+            <servlet-container name="default">
+                <jsp-config/>
+                <websockets/>
+            </servlet-container>
+            <handlers>
+                <file name="welcome-content" path="${jboss.home.dir}/welcome-content"/>
+            </handlers>
+            <filters>
+                <response-header name="server-header" header-name="Server" header-value="WildFly/10"/>
+                <response-header name="x-powered-by-header" header-name="X-Powered-By" header-value="Undertow/1"/>
+            </filters>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:keycloak-server:1.1">
+            <web-context>auth</web-context>
+        </subsystem>
+    </profile>
+    <interfaces>
+        <interface name="management">
+            <inet-address value="${jboss.bind.address.management:127.0.0.1}"/>
+        </interface>
+        <interface name="public">
+            <inet-address value="${jboss.bind.address:127.0.0.1}"/>
+        </interface>
+    </interfaces>
+    <socket-binding-group name="standard-sockets" default-interface="public" port-offset="${jboss.socket.binding.port-offset:0}">
+        <socket-binding name="management-http" interface="management" port="${jboss.management.http.port:9990}"/>
+        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9993}"/>
+        <socket-binding name="ajp" port="${jboss.ajp.port:8009}"/>
+        <socket-binding name="http" port="${jboss.http.port:8080}"/>
+        <socket-binding name="https" port="${jboss.https.port:8443}"/>
+        <socket-binding name="txn-recovery-environment" port="4712"/>
+        <socket-binding name="txn-status-manager" port="4713"/>
+        <outbound-socket-binding name="mail-smtp">
+            <remote-destination host="localhost" port="25"/>
+        </outbound-socket-binding>
+    </socket-binding-group>
+</server>

--- a/testsuite/server-config-migration/src/test/resources/standalone/standalone-ha-1.8.1.xml
+++ b/testsuite/server-config-migration/src/test/resources/standalone/standalone-ha-1.8.1.xml
@@ -1,0 +1,438 @@
+<?xml version="1.0" ?>
+
+<server xmlns="urn:jboss:domain:4.0">
+    <extensions>
+        <extension module="org.jboss.as.clustering.infinispan"/>
+        <extension module="org.jboss.as.clustering.jgroups"/>
+        <extension module="org.jboss.as.connector"/>
+        <extension module="org.jboss.as.ee"/>
+        <extension module="org.jboss.as.ejb3"/>
+        <extension module="org.jboss.as.jaxrs"/>
+        <extension module="org.jboss.as.jdr"/>
+        <extension module="org.jboss.as.jmx"/>
+        <extension module="org.jboss.as.jpa"/>
+        <extension module="org.jboss.as.jsf"/>
+        <extension module="org.jboss.as.logging"/>
+        <extension module="org.jboss.as.mail"/>
+        <extension module="org.jboss.as.modcluster"/>
+        <extension module="org.jboss.as.naming"/>
+        <extension module="org.jboss.as.remoting"/>
+        <extension module="org.jboss.as.security"/>
+        <extension module="org.jboss.as.transactions"/>
+        <extension module="org.keycloak.keycloak-server-subsystem"/>
+        <extension module="org.wildfly.extension.bean-validation"/>
+        <extension module="org.wildfly.extension.io"/>
+        <extension module="org.wildfly.extension.request-controller"/>
+        <extension module="org.wildfly.extension.security.manager"/>
+        <extension module="org.wildfly.extension.undertow"/>
+    </extensions>
+    <management>
+        <security-realms>
+            <security-realm name="ManagementRealm">
+                <authentication>
+                    <local default-user="$local" skip-group-loading="true"/>
+                    <properties path="mgmt-users.properties" relative-to="jboss.server.config.dir"/>
+                </authentication>
+                <authorization map-groups-to-roles="false">
+                    <properties path="mgmt-groups.properties" relative-to="jboss.server.config.dir"/>
+                </authorization>
+            </security-realm>
+            <security-realm name="ApplicationRealm">
+                <authentication>
+                    <local default-user="$local" allowed-users="*" skip-group-loading="true"/>
+                    <properties path="application-users.properties" relative-to="jboss.server.config.dir"/>
+                </authentication>
+                <authorization>
+                    <properties path="application-roles.properties" relative-to="jboss.server.config.dir"/>
+                </authorization>
+            </security-realm>
+        </security-realms>
+        <audit-log>
+            <formatters>
+                <json-formatter name="json-formatter"/>
+            </formatters>
+            <handlers>
+                <file-handler name="file" formatter="json-formatter" relative-to="jboss.server.data.dir" path="audit-log.log"/>
+            </handlers>
+            <logger log-boot="true" log-read-only="false" enabled="false">
+                <handlers>
+                    <handler name="file"/>
+                </handlers>
+            </logger>
+        </audit-log>
+        <management-interfaces>
+            <http-interface security-realm="ManagementRealm" http-upgrade-enabled="true">
+                <socket-binding http="management-http"/>
+            </http-interface>
+        </management-interfaces>
+        <access-control provider="simple">
+            <role-mapping>
+                <role name="SuperUser">
+                    <include>
+                        <user name="$local"/>
+                    </include>
+                </role>
+            </role-mapping>
+        </access-control>
+    </management>
+    <profile>
+        <subsystem xmlns="urn:jboss:domain:logging:3.0">
+            <console-handler name="CONSOLE">
+                <level name="INFO"/>
+                <formatter>
+                    <named-formatter name="COLOR-PATTERN"/>
+                </formatter>
+            </console-handler>
+            <periodic-rotating-file-handler name="FILE" autoflush="true">
+                <formatter>
+                    <named-formatter name="PATTERN"/>
+                </formatter>
+                <file relative-to="jboss.server.log.dir" path="server.log"/>
+                <suffix value=".yyyy-MM-dd"/>
+                <append value="true"/>
+            </periodic-rotating-file-handler>
+            <logger category="com.arjuna">
+                <level name="WARN"/>
+            </logger>
+            <logger category="org.jboss.as.config">
+                <level name="DEBUG"/>
+            </logger>
+            <logger category="sun.rmi">
+                <level name="WARN"/>
+            </logger>
+            <root-logger>
+                <level name="INFO"/>
+                <handlers>
+                    <handler name="CONSOLE"/>
+                    <handler name="FILE"/>
+                </handlers>
+            </root-logger>
+            <formatter name="PATTERN">
+                <pattern-formatter pattern="%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n"/>
+            </formatter>
+            <formatter name="COLOR-PATTERN">
+                <pattern-formatter pattern="%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n"/>
+            </formatter>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:bean-validation:1.0"/>
+        <subsystem xmlns="urn:jboss:domain:datasources:4.0">
+            <datasources>
+                <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
+                    <connection-url>jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE</connection-url>
+                    <driver>h2</driver>
+                    <security>
+                        <user-name>sa</user-name>
+                        <password>sa</password>
+                    </security>
+                </datasource>
+                <datasource jndi-name="java:jboss/datasources/KeycloakDS" pool-name="KeycloakDS" enabled="true" use-java-context="true">
+                    <connection-url>jdbc:h2:${jboss.server.data.dir}/keycloak;AUTO_SERVER=TRUE</connection-url>
+                    <driver>h2</driver>
+                    <security>
+                        <user-name>sa</user-name>
+                        <password>sa</password>
+                    </security>
+                </datasource>
+                <drivers>
+                    <driver name="h2" module="com.h2database.h2">
+                        <xa-datasource-class>org.h2.jdbcx.JdbcDataSource</xa-datasource-class>
+                    </driver>
+                </drivers>
+            </datasources>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:ee:4.0">
+            <spec-descriptor-property-replacement>false</spec-descriptor-property-replacement>
+            <concurrent>
+                <context-services>
+                    <context-service name="default" jndi-name="java:jboss/ee/concurrency/context/default" use-transaction-setup-provider="true"/>
+                </context-services>
+                <managed-thread-factories>
+                    <managed-thread-factory name="default" jndi-name="java:jboss/ee/concurrency/factory/default" context-service="default"/>
+                </managed-thread-factories>
+                <managed-executor-services>
+                    <managed-executor-service name="default" jndi-name="java:jboss/ee/concurrency/executor/default" context-service="default" hung-task-threshold="60000" keepalive-time="5000"/>
+                </managed-executor-services>
+                <managed-scheduled-executor-services>
+                    <managed-scheduled-executor-service name="default" jndi-name="java:jboss/ee/concurrency/scheduler/default" context-service="default" hung-task-threshold="60000" keepalive-time="3000"/>
+                </managed-scheduled-executor-services>
+            </concurrent>
+            <default-bindings context-service="java:jboss/ee/concurrency/context/default" datasource="java:jboss/datasources/ExampleDS" managed-executor-service="java:jboss/ee/concurrency/executor/default" managed-scheduled-executor-service="java:jboss/ee/concurrency/scheduler/default" managed-thread-factory="java:jboss/ee/concurrency/factory/default"/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:ejb3:4.0">
+            <session-bean>
+                <stateless>
+                    <bean-instance-pool-ref pool-name="slsb-strict-max-pool"/>
+                </stateless>
+                <stateful default-access-timeout="5000" cache-ref="distributable" passivation-disabled-cache-ref="simple"/>
+                <singleton default-access-timeout="5000"/>
+            </session-bean>
+            <pools>
+                <bean-instance-pools>
+                    <!-- Automatically configure pools. Alternatively, max-pool-size can be set to a specific value -->
+                    <strict-max-pool name="slsb-strict-max-pool" derive-size="from-worker-pools" instance-acquisition-timeout="5" instance-acquisition-timeout-unit="MINUTES"/>
+                    <strict-max-pool name="mdb-strict-max-pool" derive-size="from-cpu-count" instance-acquisition-timeout="5" instance-acquisition-timeout-unit="MINUTES"/>
+                </bean-instance-pools>
+            </pools>
+            <caches>
+                <cache name="simple"/>
+                <cache name="distributable" passivation-store-ref="infinispan" aliases="passivating clustered"/>
+            </caches>
+            <passivation-stores>
+                <passivation-store name="infinispan" cache-container="ejb" max-size="10000"/>
+            </passivation-stores>
+            <async thread-pool-name="default"/>
+            <timer-service thread-pool-name="default" default-data-store="default-file-store">
+                <data-stores>
+                    <file-data-store name="default-file-store" path="timer-service-data" relative-to="jboss.server.data.dir"/>
+                </data-stores>
+            </timer-service>
+            <remote connector-ref="http-remoting-connector" thread-pool-name="default"/>
+            <thread-pools>
+                <thread-pool name="default">
+                    <max-threads count="10"/>
+                    <keepalive-time time="100" unit="milliseconds"/>
+                </thread-pool>
+            </thread-pools>
+            <default-security-domain value="other"/>
+            <default-missing-method-permissions-deny-access value="true"/>
+            <log-system-exceptions value="true"/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:io:1.1">
+            <worker name="default"/>
+            <buffer-pool name="default"/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:infinispan:4.0">
+            <cache-container name="keycloak" jndi-name="infinispan/Keycloak">
+                <transport lock-timeout="60000"/>
+                <invalidation-cache name="realms" mode="SYNC"/>
+                <invalidation-cache name="users" mode="SYNC"/>
+                <distributed-cache name="sessions" mode="SYNC" owners="1"/>
+                <distributed-cache name="offlineSessions" mode="SYNC" owners="1"/>
+                <distributed-cache name="loginFailures" mode="SYNC" owners="1"/>
+            </cache-container>
+            <cache-container name="server" aliases="singleton cluster" default-cache="default" module="org.wildfly.clustering.server">
+                <transport lock-timeout="60000"/>
+                <replicated-cache name="default" mode="SYNC">
+                    <transaction mode="BATCH"/>
+                </replicated-cache>
+            </cache-container>
+            <cache-container name="web" default-cache="dist" module="org.wildfly.clustering.web.infinispan">
+                <transport lock-timeout="60000"/>
+                <distributed-cache name="dist" mode="ASYNC" l1-lifespan="0" owners="2">
+                    <locking isolation="REPEATABLE_READ"/>
+                    <transaction mode="BATCH"/>
+                    <file-store/>
+                </distributed-cache>
+            </cache-container>
+            <cache-container name="ejb" aliases="sfsb" default-cache="dist" module="org.wildfly.clustering.ejb.infinispan">
+                <transport lock-timeout="60000"/>
+                <distributed-cache name="dist" mode="ASYNC" l1-lifespan="0" owners="2">
+                    <locking isolation="REPEATABLE_READ"/>
+                    <transaction mode="BATCH"/>
+                    <file-store/>
+                </distributed-cache>
+            </cache-container>
+            <cache-container name="hibernate" default-cache="local-query" module="org.hibernate.infinispan">
+                <transport lock-timeout="60000"/>
+                <invalidation-cache name="entity" mode="SYNC">
+                    <transaction mode="NON_XA"/>
+                    <eviction strategy="LRU" max-entries="10000"/>
+                    <expiration max-idle="100000"/>
+                </invalidation-cache>
+                <local-cache name="local-query">
+                    <eviction strategy="LRU" max-entries="10000"/>
+                    <expiration max-idle="100000"/>
+                </local-cache>
+                <replicated-cache name="timestamps" mode="ASYNC"/>
+            </cache-container>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:jaxrs:1.0"/>
+        <subsystem xmlns="urn:jboss:domain:jca:4.0">
+            <archive-validation enabled="true" fail-on-error="true" fail-on-warn="false"/>
+            <bean-validation enabled="true"/>
+            <default-workmanager>
+                <short-running-threads>
+                    <core-threads count="50"/>
+                    <queue-length count="50"/>
+                    <max-threads count="50"/>
+                    <keepalive-time time="10" unit="seconds"/>
+                </short-running-threads>
+                <long-running-threads>
+                    <core-threads count="50"/>
+                    <queue-length count="50"/>
+                    <max-threads count="50"/>
+                    <keepalive-time time="10" unit="seconds"/>
+                </long-running-threads>
+            </default-workmanager>
+            <cached-connection-manager/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:jdr:1.0"/>
+        <subsystem xmlns="urn:jboss:domain:jgroups:4.0">
+            <channels default="ee">
+                <channel name="ee" stack="udp"/>
+            </channels>
+            <stacks>
+                <stack name="udp">
+                    <transport type="UDP" socket-binding="jgroups-udp"/>
+                    <protocol type="PING"/>
+                    <protocol type="MERGE3"/>
+                    <protocol type="FD_SOCK" socket-binding="jgroups-udp-fd"/>
+                    <protocol type="FD_ALL"/>
+                    <protocol type="VERIFY_SUSPECT"/>
+                    <protocol type="pbcast.NAKACK2"/>
+                    <protocol type="UNICAST3"/>
+                    <protocol type="pbcast.STABLE"/>
+                    <protocol type="pbcast.GMS"/>
+                    <protocol type="UFC"/>
+                    <protocol type="MFC"/>
+                    <protocol type="FRAG2"/>
+                </stack>
+                <stack name="tcp">
+                    <transport type="TCP" socket-binding="jgroups-tcp"/>
+                    <protocol type="MPING" socket-binding="jgroups-mping"/>
+                    <protocol type="MERGE3"/>
+                    <protocol type="FD_SOCK" socket-binding="jgroups-tcp-fd"/>
+                    <protocol type="FD"/>
+                    <protocol type="VERIFY_SUSPECT"/>
+                    <protocol type="pbcast.NAKACK2"/>
+                    <protocol type="UNICAST3"/>
+                    <protocol type="pbcast.STABLE"/>
+                    <protocol type="pbcast.GMS"/>
+                    <protocol type="MFC"/>
+                    <protocol type="FRAG2"/>
+                </stack>
+            </stacks>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:jmx:1.3">
+            <expose-resolved-model/>
+            <expose-expression-model/>
+            <remoting-connector/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:jpa:1.1">
+            <jpa default-datasource="" default-extended-persistence-inheritance="DEEP"/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:jsf:1.0"/>
+        <subsystem xmlns="urn:jboss:domain:mail:2.0">
+            <mail-session name="default" jndi-name="java:jboss/mail/Default">
+                <smtp-server outbound-socket-binding-ref="mail-smtp"/>
+            </mail-session>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:modcluster:2.0">
+            <mod-cluster-config advertise-socket="modcluster" connector="ajp">
+                <dynamic-load-provider>
+                    <load-metric type="cpu"/>
+                </dynamic-load-provider>
+            </mod-cluster-config>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:naming:2.0">
+            <remote-naming/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:remoting:3.0">
+            <endpoint/>
+            <http-connector name="http-remoting-connector" connector-ref="default" security-realm="ApplicationRealm"/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:request-controller:1.0"/>
+        <subsystem xmlns="urn:jboss:domain:security-manager:1.0">
+            <deployment-permissions>
+                <maximum-set>
+                    <permission class="java.security.AllPermission"/>
+                </maximum-set>
+            </deployment-permissions>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:security:1.2">
+            <security-domains>
+                <security-domain name="other" cache-type="default">
+                    <authentication>
+                        <login-module code="Remoting" flag="optional">
+                            <module-option name="password-stacking" value="useFirstPass"/>
+                        </login-module>
+                        <login-module code="RealmDirect" flag="required">
+                            <module-option name="password-stacking" value="useFirstPass"/>
+                        </login-module>
+                    </authentication>
+                </security-domain>
+                <security-domain name="jboss-web-policy" cache-type="default">
+                    <authorization>
+                        <policy-module code="Delegating" flag="required"/>
+                    </authorization>
+                </security-domain>
+                <security-domain name="jboss-ejb-policy" cache-type="default">
+                    <authorization>
+                        <policy-module code="Delegating" flag="required"/>
+                    </authorization>
+                </security-domain>
+                <security-domain name="jaspitest" cache-type="default">
+                    <authentication-jaspi>
+                        <login-module-stack name="dummy">
+                            <login-module code="Dummy" flag="optional"/>
+                        </login-module-stack>
+                        <auth-module code="Dummy"/>
+                    </authentication-jaspi>
+                </security-domain>
+            </security-domains>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:transactions:3.0">
+            <core-environment>
+                <process-id>
+                    <uuid/>
+                </process-id>
+            </core-environment>
+            <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:undertow:3.0">
+            <buffer-cache name="default"/>
+            <server name="default-server">
+                <ajp-listener name="ajp" socket-binding="ajp"/>
+                <http-listener name="default" socket-binding="http" redirect-socket="https"/>
+                <host name="default-host" alias="localhost">
+                    <location name="/" handler="welcome-content"/>
+                    <filter-ref name="server-header"/>
+                    <filter-ref name="x-powered-by-header"/>
+                </host>
+            </server>
+            <servlet-container name="default">
+                <jsp-config/>
+                <websockets/>
+            </servlet-container>
+            <handlers>
+                <file name="welcome-content" path="${jboss.home.dir}/welcome-content"/>
+            </handlers>
+            <filters>
+                <response-header name="server-header" header-name="Server" header-value="WildFly/10"/>
+                <response-header name="x-powered-by-header" header-name="X-Powered-By" header-value="Undertow/1"/>
+            </filters>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:keycloak-server:1.1">
+            <web-context>auth</web-context>
+        </subsystem>
+    </profile>
+    <interfaces>
+        <interface name="management">
+            <inet-address value="${jboss.bind.address.management:127.0.0.1}"/>
+        </interface>
+        <interface name="public">
+            <inet-address value="${jboss.bind.address:127.0.0.1}"/>
+        </interface>
+        <interface name="private">
+            <inet-address value="${jboss.bind.address.private:127.0.0.1}"/>
+        </interface>
+    </interfaces>
+    <socket-binding-group name="standard-sockets" default-interface="public" port-offset="${jboss.socket.binding.port-offset:0}">
+        <socket-binding name="management-http" interface="management" port="${jboss.management.http.port:9990}"/>
+        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9993}"/>
+        <socket-binding name="ajp" port="${jboss.ajp.port:8009}"/>
+        <socket-binding name="http" port="${jboss.http.port:8080}"/>
+        <socket-binding name="https" port="${jboss.https.port:8443}"/>
+        <socket-binding name="jgroups-mping" interface="private" port="0" multicast-address="${jboss.default.multicast.address:230.0.0.4}" multicast-port="45700"/>
+        <socket-binding name="jgroups-tcp" interface="private" port="7600"/>
+        <socket-binding name="jgroups-tcp-fd" interface="private" port="57600"/>
+        <socket-binding name="jgroups-udp" interface="private" port="55200" multicast-address="${jboss.default.multicast.address:230.0.0.4}" multicast-port="45688"/>
+        <socket-binding name="jgroups-udp-fd" interface="private" port="54200"/>
+        <socket-binding name="modcluster" port="0" multicast-address="224.0.1.105" multicast-port="23364"/>
+        <socket-binding name="txn-recovery-environment" port="4712"/>
+        <socket-binding name="txn-status-manager" port="4713"/>
+        <outbound-socket-binding name="mail-smtp">
+            <remote-destination host="localhost" port="25"/>
+        </outbound-socket-binding>
+    </socket-binding-group>
+</server>


### PR DESCRIPTION
I don't think we're ready to merge this yet.  It does work and the tests pass.  However, this creates a new module testsuite/server-config-migration.  That module depends on server-dist, which I think is not built when the tests run.  So I think this will fail when we build and test from scratch.