### PR TITLE
KEYCLOAK-2343 Add support for exact user search

### DIFF
--- a/examples/providers/user-storage-jpa/src/main/java/org/keycloak/examples/storage/user/EjbExampleUserStorageProvider.java
+++ b/examples/providers/user-storage-jpa/src/main/java/org/keycloak/examples/storage/user/EjbExampleUserStorageProvider.java
@@ -259,14 +259,18 @@ public class EjbExampleUserStorageProvider implements UserStorageProvider,
     }
 
     @Override
-    public List<UserModel> searchForUser(String search, RealmModel realm) {
-        return searchForUser(search, realm, -1, -1);
+    public List<UserModel> searchForUser(String search, RealmModel realm, boolean exact) {
+        return searchForUser(search, realm, -1, -1, exact);
     }
 
     @Override
-    public List<UserModel> searchForUser(String search, RealmModel realm, int firstResult, int maxResults) {
+    public List<UserModel> searchForUser(String search, RealmModel realm, int firstResult, int maxResults, boolean exact) {
         TypedQuery<UserEntity> query = em.createNamedQuery("searchForUser", UserEntity.class);
-        query.setParameter("search", "%" + search.toLowerCase() + "%");
+        if (exact) {
+            query.setParameter("search", search.toLowerCase());
+        } else {
+            query.setParameter("search", "%" + search.toLowerCase() + "%");
+        }
         if (firstResult != -1) {
             query.setFirstResult(firstResult);
         }
@@ -280,12 +284,12 @@ public class EjbExampleUserStorageProvider implements UserStorageProvider,
     }
 
     @Override
-    public List<UserModel> searchForUser(Map<String, String> params, RealmModel realm) {
+    public List<UserModel> searchForUser(Map<String, String> params, RealmModel realm, boolean exact) {
         return Collections.EMPTY_LIST;
     }
 
     @Override
-    public List<UserModel> searchForUser(Map<String, String> params, RealmModel realm, int firstResult, int maxResults) {
+    public List<UserModel> searchForUser(Map<String, String> params, RealmModel realm, int firstResult, int maxResults, boolean exact) {
         return Collections.EMPTY_LIST;
     }
 

--- a/examples/providers/user-storage-simple/src/main/java/org/keycloak/examples/userstorage/writeable/PropertyFileUserStorageProvider.java
+++ b/examples/providers/user-storage-simple/src/main/java/org/keycloak/examples/userstorage/writeable/PropertyFileUserStorageProvider.java
@@ -147,18 +147,27 @@ public class PropertyFileUserStorageProvider implements
     // UserQueryProvider method implementations
 
     @Override
-    public List<UserModel> searchForUser(String search, RealmModel realm) {
-        return searchForUser(search, realm, 0, Integer.MAX_VALUE);
+    public List<UserModel> searchForUser(String search, RealmModel realm, boolean exact) {
+        return searchForUser(search, realm, 0, Integer.MAX_VALUE, exact);
     }
 
     @Override
-    public List<UserModel> searchForUser(String search, RealmModel realm, int firstResult, int maxResults) {
+    public List<UserModel> searchForUser(String search, RealmModel realm, int firstResult, int maxResults, boolean exact) {
         List<UserModel> users = new LinkedList<>();
         int i = 0;
         for (Object obj : properties.keySet()) {
             String username = (String)obj;
-            if (!username.contains(search)) continue;
-            if (i++ < firstResult) continue;
+
+            if(exact && !username.equals(search)){
+                continue;
+            }
+
+            if (!exact && !username.contains(search)){
+                continue;
+            }
+            if (i++ < firstResult){
+                continue;
+            }
             UserModel user = getUserByUsername(username, realm);
             users.add(user);
             if (users.size() >= maxResults) break;
@@ -167,16 +176,16 @@ public class PropertyFileUserStorageProvider implements
     }
 
     @Override
-    public List<UserModel> searchForUser(Map<String, String> params, RealmModel realm) {
-        return searchForUser(params, realm, 0, Integer.MAX_VALUE);
+    public List<UserModel> searchForUser(Map<String, String> params, RealmModel realm, boolean exact) {
+        return searchForUser(params, realm, 0, Integer.MAX_VALUE, exact);
     }
 
     @Override
-    public List<UserModel> searchForUser(Map<String, String> params, RealmModel realm, int firstResult, int maxResults) {
+    public List<UserModel> searchForUser(Map<String, String> params, RealmModel realm, int firstResult, int maxResults, boolean exact) {
         // only support searching by username
         String usernameSearchString = params.get("username");
         if (usernameSearchString == null) return Collections.EMPTY_LIST;
-        return searchForUser(usernameSearchString, realm, firstResult, maxResults);
+        return searchForUser(usernameSearchString, realm, firstResult, maxResults, exact);
     }
 
     @Override

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProvider.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProvider.java
@@ -244,12 +244,12 @@ public class LDAPStorageProvider implements UserStorageProvider,
     }
 
     @Override
-    public List<UserModel> searchForUser(String search, RealmModel realm) {
-        return searchForUser(search, realm, 0, Integer.MAX_VALUE - 1);
+    public List<UserModel> searchForUser(String search, RealmModel realm, boolean exact) {
+        return searchForUser(search, realm, 0, Integer.MAX_VALUE - 1, exact);
     }
 
     @Override
-    public List<UserModel> searchForUser(String search, RealmModel realm, int firstResult, int maxResults) {
+    public List<UserModel> searchForUser(String search, RealmModel realm, int firstResult, int maxResults, boolean exact) {
         Map<String, String> attributes = new HashMap<String, String>();
         int spaceIndex = search.lastIndexOf(' ');
         if (spaceIndex > -1) {
@@ -264,19 +264,19 @@ public class LDAPStorageProvider implements UserStorageProvider,
             attributes.put(UserModel.LAST_NAME, search.trim());
             attributes.put(UserModel.USERNAME, search.trim().toLowerCase());
         }
-        return searchForUser(attributes, realm, firstResult, maxResults);
+        return searchForUser(attributes, realm, firstResult, maxResults, exact);
     }
 
     @Override
-    public List<UserModel> searchForUser(Map<String, String> params, RealmModel realm) {
-        return searchForUser(params, realm, 0, Integer.MAX_VALUE - 1);
+    public List<UserModel> searchForUser(Map<String, String> params, RealmModel realm, boolean exact) {
+        return searchForUser(params, realm, 0, Integer.MAX_VALUE - 1, exact);
     }
 
     @Override
-    public List<UserModel> searchForUser(Map<String, String> params, RealmModel realm, int firstResult, int maxResults) {
+    public List<UserModel> searchForUser(Map<String, String> params, RealmModel realm, int firstResult, int maxResults, boolean exact) {
         List<UserModel> searchResults =new LinkedList<UserModel>();
 
-        List<LDAPObject> ldapUsers = searchLDAP(realm, params, maxResults + firstResult);
+        List<LDAPObject> ldapUsers = searchLDAP(realm, params, maxResults + firstResult, exact);
         int counter = 0;
         for (LDAPObject ldapUser : ldapUsers) {
             if (counter++ < firstResult) continue;
@@ -326,7 +326,9 @@ public class LDAPStorageProvider implements UserStorageProvider,
         return result;
     }
 
-    protected List<LDAPObject> searchLDAP(RealmModel realm, Map<String, String> attributes, int maxResults) {
+    protected List<LDAPObject> searchLDAP(RealmModel realm, Map<String, String> attributes, int maxResults, boolean exact) {
+
+        //TODO handle exact vs. !exact LDAP searches, currently only exact searches are supported
 
         List<LDAPObject> results = new ArrayList<LDAPObject>();
         if (attributes.containsKey(UserModel.USERNAME)) {

--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/UsersResource.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/UsersResource.java
@@ -33,20 +33,27 @@ import java.util.List;
 
 public interface UsersResource {
 
+    //TODO change langauge level to Java 8 and use default message to bridge API
+    // or accept breaking existing clients...
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     List<UserRepresentation> search(@QueryParam("username") String username,
-                                           @QueryParam("firstName") String firstName,
-                                           @QueryParam("lastName") String lastName,
-                                             @QueryParam("email") String email,
-                                             @QueryParam("first") Integer firstResult,
-                                             @QueryParam("max") Integer maxResults);
+                                    @QueryParam("firstName") String firstName,
+                                    @QueryParam("lastName") String lastName,
+                                    @QueryParam("email") String email,
+                                    @QueryParam("first") Integer firstResult,
+                                    @QueryParam("max") Integer maxResults,
+                                    @QueryParam("exact") Boolean exact
+                                    );
 
+    //TODO change langauge level to Java 8 and use default message to bridge API
+    // or accept breaking existing clients...
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     List<UserRepresentation> search(@QueryParam("search") String search,
-                                           @QueryParam("first") Integer firstResult,
-                                           @QueryParam("max") Integer maxResults);
+                                    @QueryParam("first") Integer firstResult,
+                                    @QueryParam("max") Integer maxResults,
+                                    @QueryParam("exact") Boolean exact);
 
     @POST
     @Consumes(MediaType.APPLICATION_JSON)

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/UserCacheSession.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/UserCacheSession.java
@@ -596,23 +596,23 @@ public class UserCacheSession implements UserCache {
     }
 
     @Override
-    public List<UserModel> searchForUser(String search, RealmModel realm) {
-        return getDelegate().searchForUser(search, realm);
+    public List<UserModel> searchForUser(String search, RealmModel realm, boolean exact) {
+        return getDelegate().searchForUser(search, realm, exact);
     }
 
     @Override
-    public List<UserModel> searchForUser(String search, RealmModel realm, int firstResult, int maxResults) {
-        return getDelegate().searchForUser(search, realm, firstResult, maxResults);
+    public List<UserModel> searchForUser(String search, RealmModel realm, int firstResult, int maxResults, boolean exact) {
+        return getDelegate().searchForUser(search, realm, firstResult, maxResults, exact);
     }
 
     @Override
-    public List<UserModel> searchForUser(Map<String, String> attributes, RealmModel realm) {
-        return getDelegate().searchForUser(attributes, realm);
+    public List<UserModel> searchForUser(Map<String, String> attributes, RealmModel realm, boolean exact) {
+        return getDelegate().searchForUser(attributes, realm, exact);
     }
 
     @Override
-    public List<UserModel> searchForUser(Map<String, String> attributes, RealmModel realm, int firstResult, int maxResults) {
-        return getDelegate().searchForUser(attributes, realm, firstResult, maxResults);
+    public List<UserModel> searchForUser(Map<String, String> attributes, RealmModel realm, int firstResult, int maxResults, boolean exact) {
+        return getDelegate().searchForUser(attributes, realm, firstResult, maxResults, exact);
     }
 
     @Override

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserProvider.java
@@ -583,15 +583,19 @@ public class JpaUserProvider implements UserProvider, UserCredentialStore {
     }
 
     @Override
-    public List<UserModel> searchForUser(String search, RealmModel realm) {
-        return searchForUser(search, realm, -1, -1);
+    public List<UserModel> searchForUser(String search, RealmModel realm, boolean exact) {
+        return searchForUser(search, realm, -1, -1, exact);
     }
 
     @Override
-    public List<UserModel> searchForUser(String search, RealmModel realm, int firstResult, int maxResults) {
+    public List<UserModel> searchForUser(String search, RealmModel realm, int firstResult, int maxResults, boolean exact) {
         TypedQuery<UserEntity> query = em.createNamedQuery("searchForUser", UserEntity.class);
         query.setParameter("realmId", realm.getId());
-        query.setParameter("search", "%" + search.toLowerCase() + "%");
+        if(exact){
+            query.setParameter("search", search.toLowerCase());
+        } else {
+            query.setParameter("search", "%" + search.toLowerCase() + "%");
+        }
         if (firstResult != -1) {
             query.setFirstResult(firstResult);
         }
@@ -605,12 +609,12 @@ public class JpaUserProvider implements UserProvider, UserCredentialStore {
     }
 
     @Override
-    public List<UserModel> searchForUser(Map<String, String> attributes, RealmModel realm) {
-        return searchForUser(attributes, realm, -1, -1);
+    public List<UserModel> searchForUser(Map<String, String> attributes, RealmModel realm, boolean exact) {
+        return searchForUser(attributes, realm, -1, -1, exact);
     }
 
     @Override
-    public List<UserModel> searchForUser(Map<String, String> attributes, RealmModel realm, int firstResult, int maxResults) {
+    public List<UserModel> searchForUser(Map<String, String> attributes, RealmModel realm, int firstResult, int maxResults, boolean exact) {
         StringBuilder builder = new StringBuilder("select u from UserEntity u where u.realmId = :realmId");
         for (Map.Entry<String, String> entry : attributes.entrySet()) {
             String attribute = null;
@@ -628,9 +632,19 @@ public class JpaUserProvider implements UserProvider, UserCredentialStore {
                 attribute = "lower(u.email)";
                 parameterName = JpaUserProvider.EMAIL;
             }
-            if (attribute == null) continue;
+            if (attribute == null){
+                continue;
+            }
             builder.append(" and ");
-            builder.append(attribute).append(" like :").append(parameterName);
+
+            builder.append(attribute);
+
+            if (exact) {
+                builder.append(" = ");
+            } else {
+                builder.append(" like ");
+            }
+            builder.append(':').append(parameterName);
         }
         builder.append(" order by u.username");
         String q = builder.toString();
@@ -647,8 +661,11 @@ public class JpaUserProvider implements UserProvider, UserCredentialStore {
             } else if (entry.getKey().equalsIgnoreCase(UserModel.EMAIL)) {
                 parameterName = JpaUserProvider.EMAIL;
             }
-            if (parameterName == null) continue;
-            query.setParameter(parameterName, "%" + entry.getValue().toLowerCase() + "%");
+            if (parameterName == null){
+                continue;
+            }
+            String parameterValue = exact ? entry.getValue().toLowerCase() : "%" + entry.getValue().toLowerCase() + "%";
+            query.setParameter(parameterName, parameterValue);
         }
         if (firstResult != -1) {
             query.setFirstResult(firstResult);

--- a/model/mongo/src/main/java/org/keycloak/models/mongo/keycloak/adapters/MongoUserProvider.java
+++ b/model/mongo/src/main/java/org/keycloak/models/mongo/keycloak/adapters/MongoUserProvider.java
@@ -52,6 +52,7 @@ import org.keycloak.models.utils.UserModelDelegate;
 import org.keycloak.storage.UserStorageProvider;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -210,13 +211,13 @@ public class MongoUserProvider implements UserProvider, UserCredentialStore {
     }
 
     @Override
-    public List<UserModel> searchForUser(String search, RealmModel realm) {
-        return searchForUser(search, realm, -1, -1);
+    public List<UserModel> searchForUser(String search, RealmModel realm, boolean exact) {
+        return searchForUser(search, realm, -1, -1, exact);
     }
 
     @Override
     public List<UserModel>
-    searchForUser(String search, RealmModel realm, int firstResult, int maxResults) {
+    searchForUser(String search, RealmModel realm, int firstResult, int maxResults, boolean exact) {
         search = search.trim();
         Pattern caseInsensitivePattern = Pattern.compile("(?i:" + search + ")");
 
@@ -227,29 +228,56 @@ public class MongoUserProvider implements UserProvider, UserCredentialStore {
         if (spaceInd != -1) {
             String firstName = search.substring(0, spaceInd);
             String lastName = search.substring(spaceInd + 1);
-            Pattern firstNamePattern = Pattern.compile("(?i:" + firstName + "$)");
-            Pattern lastNamePattern = Pattern.compile("(?i:^" + lastName + ")");
-            nameBuilder = new QueryBuilder().and(
-                    new QueryBuilder().put("firstName").regex(firstNamePattern).get(),
-                    new QueryBuilder().put("lastName").regex(lastNamePattern).get()
+
+            if(exact){
+                nameBuilder = new QueryBuilder().and(
+                  new QueryBuilder().put("firstName").is(firstName).get(),
+                  new QueryBuilder().put("lastName").is(lastName).get()
+                );
+            } else {
+
+                Pattern firstNamePattern = Pattern.compile("(?i:" + firstName + "$)");
+                Pattern lastNamePattern = Pattern.compile("(?i:^" + lastName + ")");
+                nameBuilder = new QueryBuilder().and(
+                  new QueryBuilder().put("firstName").regex(firstNamePattern).get(),
+                  new QueryBuilder().put("lastName").regex(lastNamePattern).get()
+                );
+            }
+        } else {
+
+            if (exact){
+                nameBuilder = new QueryBuilder().or(
+                  new QueryBuilder().put("firstName").is(search).get(),
+                  new QueryBuilder().put("lastName").is(search).get()
+                );
+            } else {
+                // Case when we have search without spaces like "foo". The firstName OR lastName could be "foo" (everything case-insensitive)
+                nameBuilder = new QueryBuilder().or(
+                  new QueryBuilder().put("firstName").regex(caseInsensitivePattern).get(),
+                  new QueryBuilder().put("lastName").regex(caseInsensitivePattern).get()
+                );
+            }
+        }
+
+        QueryBuilder userQueryPart = new QueryBuilder();
+        if (exact) {
+            userQueryPart.or(
+              new QueryBuilder().put("username").is(search).get(),
+              new QueryBuilder().put("email").is(search).get(),
+              nameBuilder.get()
             );
         } else {
-            // Case when we have search without spaces like "foo". The firstName OR lastName could be "foo" (everything case-insensitive)
-            nameBuilder = new QueryBuilder().or(
-                    new QueryBuilder().put("firstName").regex(caseInsensitivePattern).get(),
-                    new QueryBuilder().put("lastName").regex(caseInsensitivePattern).get()
+            userQueryPart.or(
+              new QueryBuilder().put("username").regex(caseInsensitivePattern).get(),
+              new QueryBuilder().put("email").regex(caseInsensitivePattern).get(),
+              nameBuilder.get()
             );
         }
 
         QueryBuilder builder = new QueryBuilder().and(
                 new QueryBuilder().and("realmId").is(realm.getId()).get(),
                 new QueryBuilder().and("serviceAccountClientLink").is(null).get(),
-                new QueryBuilder().or(
-                        new QueryBuilder().put("username").regex(caseInsensitivePattern).get(),
-                        new QueryBuilder().put("email").regex(caseInsensitivePattern).get(),
-                        nameBuilder.get()
-
-                ).get()
+                userQueryPart.get()
         );
 
         DBObject sort = new BasicDBObject("username", 1);
@@ -259,28 +287,25 @@ public class MongoUserProvider implements UserProvider, UserCredentialStore {
     }
 
     @Override
-    public List<UserModel> searchForUser(Map<String, String> attributes, RealmModel realm) {
-        return searchForUser(attributes, realm, -1, -1);
+    public List<UserModel> searchForUser(Map<String, String> attributes, RealmModel realm, boolean exact) {
+        return searchForUser(attributes, realm, -1, -1, exact);
     }
 
     @Override
-    public List<UserModel> searchForUser(Map<String, String> attributes, RealmModel realm, int firstResult, int maxResults) {
+    public List<UserModel> searchForUser(Map<String, String> attributes, RealmModel realm, int firstResult, int maxResults, boolean exact) {
         QueryBuilder queryBuilder = new QueryBuilder()
                 .and("realmId").is(realm.getId());
 
-        for (Map.Entry<String, String> entry : attributes.entrySet()) {
-            if (entry.getKey().equalsIgnoreCase(UserModel.USERNAME)) {
-                queryBuilder.and(UserModel.USERNAME).regex(Pattern.compile(".*" + entry.getValue() + ".*", Pattern.CASE_INSENSITIVE));
-            } else if (entry.getKey().equalsIgnoreCase(UserModel.FIRST_NAME)) {
-                queryBuilder.and(UserModel.FIRST_NAME).regex(Pattern.compile(".*" + entry.getValue() + ".*", Pattern.CASE_INSENSITIVE));
+        List<String> attributeNames = Arrays.asList(UserModel.USERNAME, UserModel.FIRST_NAME, UserModel.LAST_NAME, UserModel.EMAIL);
 
-            } else if (entry.getKey().equalsIgnoreCase(UserModel.LAST_NAME)) {
-                queryBuilder.and(UserModel.LAST_NAME).regex(Pattern.compile(".*" + entry.getValue() + ".*", Pattern.CASE_INSENSITIVE));
-
-            } else if (entry.getKey().equalsIgnoreCase(UserModel.EMAIL)) {
-                queryBuilder.and(UserModel.EMAIL).regex(Pattern.compile(".*" + entry.getValue() + ".*", Pattern.CASE_INSENSITIVE));
+        attributes.entrySet().stream().filter(attrEntry -> attributeNames.contains(attrEntry.getKey())).forEach(attrEntry -> {
+            queryBuilder.and(attrEntry.getKey());
+            if (exact){
+                queryBuilder.is(attrEntry.getValue());
+            } else {
+                queryBuilder.regex(Pattern.compile(".*" + attrEntry.getValue() + ".*", Pattern.CASE_INSENSITIVE));
             }
-        }
+        });
 
         DBObject sort = new BasicDBObject("username", 1);
 

--- a/server-spi-private/src/main/java/org/keycloak/models/LDAPConstants.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/LDAPConstants.java
@@ -100,6 +100,7 @@ public class LDAPConstants {
     public static final String MSDS_USER_PASSWORD_EXPIRED = "msDS-UserPasswordExpired"; // read-only
 
     public static final String COMMA = ",";
+    public static final String STAR = "*";
     public static final String EQUAL = "=";
     public static final String EMPTY_ATTRIBUTE_VALUE = " ";
     public static final String EMPTY_MEMBER_ATTRIBUTE_VALUE = "cn=empty-membership-placeholder";

--- a/server-spi/src/main/java/org/keycloak/storage/user/UserQueryProvider.java
+++ b/server-spi/src/main/java/org/keycloak/storage/user/UserQueryProvider.java
@@ -49,7 +49,11 @@ public interface UserQueryProvider {
      * @param realm
      * @return
      */
-    List<UserModel> searchForUser(String search, RealmModel realm);
+    default List<UserModel> searchForUser(String search, RealmModel realm){
+        return searchForUser(search, realm, false);
+    }
+
+    List<UserModel> searchForUser(String search, RealmModel realm, boolean exact);
 
     /**
      * Search for users with username, email or first + last name that is like search string.
@@ -64,7 +68,11 @@ public interface UserQueryProvider {
      * @param maxResults
      * @return
      */
-    List<UserModel> searchForUser(String search, RealmModel realm, int firstResult, int maxResults);
+    default List<UserModel> searchForUser(String search, RealmModel realm, int firstResult, int maxResults){
+        return searchForUser(search, realm, firstResult, maxResults, false);
+    }
+
+    List<UserModel> searchForUser(String search, RealmModel realm, int firstResult, int maxResults, boolean exact);
 
     /**
      * Search for user by parameter.  Valid parameters are:
@@ -82,7 +90,11 @@ public interface UserQueryProvider {
      * @param realm
      * @return
      */
-    List<UserModel> searchForUser(Map<String, String> params, RealmModel realm);
+    default List<UserModel> searchForUser(Map<String, String> params, RealmModel realm){
+        return searchForUser(params, realm);
+    }
+
+    List<UserModel> searchForUser(Map<String, String> params, RealmModel realm, boolean exact);
 
     /**
      * Search for user by parameter.  Valid parameters are:
@@ -101,7 +113,11 @@ public interface UserQueryProvider {
      * @param maxResults
      * @return
      */
-    List<UserModel> searchForUser(Map<String, String> params, RealmModel realm, int firstResult, int maxResults);
+    default List<UserModel> searchForUser(Map<String, String> params, RealmModel realm, int firstResult, int maxResults){
+        return searchForUser(params, realm, firstResult, maxResults);
+    }
+
+    List<UserModel> searchForUser(Map<String, String> params, RealmModel realm, int firstResult, int maxResults, boolean exact);
 
     /**
      * Get users that belong to a specific group.  Implementations do not have to search in UserFederatedStorageProvider

--- a/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
@@ -664,16 +664,18 @@ public class UsersResource {
                                              @QueryParam("email") String email,
                                              @QueryParam("username") String username,
                                              @QueryParam("first") Integer firstResult,
-                                             @QueryParam("max") Integer maxResults) {
+                                             @QueryParam("max") Integer maxResults,
+                                             @QueryParam("exact") Boolean exact) {
         auth.requireView();
 
         firstResult = firstResult != null ? firstResult : -1;
         maxResults = maxResults != null ? maxResults : Constants.DEFAULT_MAX_RESULTS;
+        exact = exact != null ? exact : false;
 
         List<UserRepresentation> results = new ArrayList<UserRepresentation>();
         List<UserModel> userModels;
         if (search != null) {
-            userModels = session.users().searchForUser(search.trim(), realm, firstResult, maxResults);
+            userModels = session.users().searchForUser(search.trim(), realm, firstResult, maxResults, exact);
         } else if (last != null || first != null || email != null || username != null) {
             Map<String, String> attributes = new HashMap<String, String>();
             if (last != null) {
@@ -688,7 +690,7 @@ public class UsersResource {
             if (username != null) {
                 attributes.put(UserModel.USERNAME, username);
             }
-            userModels = session.users().searchForUser(attributes, realm, firstResult, maxResults);
+            userModels = session.users().searchForUser(attributes, realm, firstResult, maxResults, exact);
         } else {
             userModels = session.users().getUsers(realm, firstResult, maxResults, false);
         }

--- a/services/src/main/java/org/keycloak/storage/UserStorageManager.java
+++ b/services/src/main/java/org/keycloak/storage/UserStorageManager.java
@@ -438,15 +438,15 @@ public class UserStorageManager implements UserProvider, OnUserCache {
     }
 
     @Override
-    public List<UserModel> searchForUser(String search, RealmModel realm) {
-        return searchForUser(search, realm, 0, Integer.MAX_VALUE - 1);
+    public List<UserModel> searchForUser(String search, RealmModel realm, boolean exact) {
+        return searchForUser(search, realm, 0, Integer.MAX_VALUE - 1, exact);
     }
 
     @Override
-    public List<UserModel> searchForUser(String search, RealmModel realm, int firstResult, int maxResults) {
+    public List<UserModel> searchForUser(String search, RealmModel realm, int firstResult, int maxResults, boolean exact) {
         List<UserModel> results = query((provider, first, max) -> {
             if (provider instanceof UserQueryProvider) {
-                return ((UserQueryProvider)provider).searchForUser(search, realm, first, max);
+                return ((UserQueryProvider)provider).searchForUser(search, realm, first, max, exact);
 
             }
             return Collections.EMPTY_LIST;
@@ -456,16 +456,16 @@ public class UserStorageManager implements UserProvider, OnUserCache {
     }
 
     @Override
-    public List<UserModel> searchForUser(Map<String, String> attributes, RealmModel realm) {
-        List<UserModel> results = searchForUser(attributes, realm, 0, Integer.MAX_VALUE - 1);
+    public List<UserModel> searchForUser(Map<String, String> attributes, RealmModel realm, boolean exact) {
+        List<UserModel> results = searchForUser(attributes, realm, 0, Integer.MAX_VALUE - 1, exact);
         return importValidation(realm, results);
     }
 
     @Override
-    public List<UserModel> searchForUser(Map<String, String> attributes, RealmModel realm, int firstResult, int maxResults) {
+    public List<UserModel> searchForUser(Map<String, String> attributes, RealmModel realm, int firstResult, int maxResults, boolean exact) {
         List<UserModel> results = query((provider, first, max) -> {
             if (provider instanceof UserQueryProvider) {
-                return ((UserQueryProvider)provider).searchForUser(attributes, realm, first, max);
+                return ((UserQueryProvider)provider).searchForUser(attributes, realm, first, max, exact);
 
             }
             return Collections.EMPTY_LIST;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/AssertEvents.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/AssertEvents.java
@@ -386,7 +386,7 @@ public class AssertEvents implements TestRule {
     }
 
     private UserRepresentation getUser(String username) {
-        List<UserRepresentation> users = context.adminClient.realm(DEFAULT_REALM).users().search(username, null, null, null, 0, 1);
+        List<UserRepresentation> users = context.adminClient.realm(DEFAULT_REALM).users().search(username, null, null, null, 0, 1, false);
         return users.isEmpty() ? null : users.get(0);
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/TestRealmKeycloakTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/TestRealmKeycloakTest.java
@@ -45,7 +45,7 @@ public abstract class TestRealmKeycloakTest extends AbstractKeycloakTest {
     }
 
     protected UserRepresentation findUser(String userNameOrEmail) {
-        List<UserRepresentation> repList = testRealm().users().search(userNameOrEmail, -1, -1);
+        List<UserRepresentation> repList = testRealm().users().search(userNameOrEmail, -1, -1, false);
         if (repList.size() != 1) throw new IllegalStateException("User search expected one result. Found " + repList.size() + " users.");
         return repList.get(0);
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/ActionUtil.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/ActionUtil.java
@@ -41,7 +41,7 @@ public class ActionUtil {
     }
 
     public static UserRepresentation findUserWithAdminClient(Keycloak adminClient, String username) {
-        return adminClient.realm("test").users().search(username, null, null, null, 0, 1).get(0);
+        return adminClient.realm("test").users().search(username, null, null, null, 0, 1, false).get(0);
     }
 
     public static void addRequiredActionForUser(RealmRepresentation testRealm, String userName, String action) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/example/AbstractJSConsoleExampleAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/example/AbstractJSConsoleExampleAdapterTest.java
@@ -423,7 +423,7 @@ public abstract class AbstractJSConsoleExampleAdapterTest extends AbstractExampl
 
         UsersResource userResource = testRealmResource().users();
 
-        List<UserRepresentation> users = userResource.search("mhajas", 0, 1);
+        List<UserRepresentation> users = userResource.search("mhajas", 0, 1, false);
         assertEquals("There should be created user mhajas", 1, users.size());
         waitUntilElement(jsConsoleTestAppPage.getOutputElement()).text()
                 .contains("location: " + authServerContextRootPage.toString() + "/auth/admin/realms/" + EXAMPLE + "/users/" + users.get(0).getId());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/example/authorization/AbstractPhotozExampleAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/example/authorization/AbstractPhotozExampleAdapterTest.java
@@ -350,7 +350,7 @@ public abstract class AbstractPhotozExampleAdapterTest extends AbstractExampleAd
             assertFalse(this.clientPage.wasDenied());
 
             UsersResource usersResource = realmsResouce().realm(REALM_NAME).users();
-            List<UserRepresentation> users = usersResource.search("alice", null, null, null, null, null);
+            List<UserRepresentation> users = usersResource.search("alice", null, null, null, null, null, false);
 
             assertFalse(users.isEmpty());
 
@@ -389,7 +389,7 @@ public abstract class AbstractPhotozExampleAdapterTest extends AbstractExampleAd
             assertFalse(this.clientPage.wasDenied());
 
             UsersResource usersResource = realmsResouce().realm(REALM_NAME).users();
-            List<UserRepresentation> users = usersResource.search("alice", null, null, null, null, null);
+            List<UserRepresentation> users = usersResource.search("alice", null, null, null, null, null, false);
 
             assertFalse(users.isEmpty());
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/example/authorization/AbstractServletAuthzAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/example/authorization/AbstractServletAuthzAdapterTest.java
@@ -213,7 +213,7 @@ public abstract class AbstractServletAuthzAdapterTest extends AbstractExampleAda
             onlyAlicePolicy.setType("user");
             HashMap<String, String> config = new HashMap<>();
             UsersResource usersResource = realmsResouce().realm(REALM_NAME).users();
-            List<UserRepresentation> users = usersResource.search("alice", null, null, null, null, null);
+            List<UserRepresentation> users = usersResource.search("alice", null, null, null, null, null, false);
 
             assertFalse(users.isEmpty());
 
@@ -250,7 +250,7 @@ public abstract class AbstractServletAuthzAdapterTest extends AbstractExampleAda
 
             RealmResource realmResource = realmsResouce().realm(REALM_NAME);
             UsersResource usersResource = realmResource.users();
-            List<UserRepresentation> users = usersResource.search("jdoe", null, null, null, null, null);
+            List<UserRepresentation> users = usersResource.search("jdoe", null, null, null, null, null, false);
 
             assertFalse(users.isEmpty());
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/AbstractSessionServletAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/AbstractSessionServletAdapterTest.java
@@ -159,7 +159,7 @@ public abstract class AbstractSessionServletAdapterTest extends AbstractServlets
         loginAndCheckSession(driver, testRealmLoginPage);
 
         // logout mposolda with admin client
-        UserRepresentation mposolda = testRealmResource().users().search("mposolda", null, null, null, null, null).get(0);
+        UserRepresentation mposolda = testRealmResource().users().search("mposolda", null, null, null, null, null, false).get(0);
         testRealmResource().users().get(mposolda.getId()).logout();
         
         // bburke should be still logged with original httpSession in our browser window

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/ApiUtil.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/ApiUtil.java
@@ -118,7 +118,7 @@ public class ApiUtil {
 
     public static UserRepresentation findUserByUsername(RealmResource realm, String username) {
         UserRepresentation user = null;
-        List<UserRepresentation> ur = realm.users().search(username, null, null);
+        List<UserRepresentation> ur = realm.users().search(username, null, null, false);
         if (ur.size() == 1) {
             user = ur.get(0);
         }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/ConsentsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/ConsentsTest.java
@@ -251,7 +251,7 @@ public class ConsentsTest extends AbstractKeycloakTest {
         UsersResource consumerUsers = adminClient.realm(consumerRealmName()).users();
         Assert.assertTrue("There must be at least one user", consumerUsers.count() > 0);
 
-        List<UserRepresentation> users = consumerUsers.search("", 0, 5);
+        List<UserRepresentation> users = consumerUsers.search("", 0, 5, false);
 
         UserRepresentation foundUser = null;
         for (UserRepresentation user : users) {
@@ -266,7 +266,7 @@ public class ConsentsTest extends AbstractKeycloakTest {
 
         // get user with the same username from provider realm
         RealmResource providerRealm = adminClient.realm(providerRealmName());
-        users = providerRealm.users().search(null, foundUser.getFirstName(), foundUser.getLastName(), null, 0, 1);
+        users = providerRealm.users().search(null, foundUser.getFirstName(), foundUser.getLastName(), null, 0, 1, false);
         Assert.assertEquals("Same user should be in provider realm", 1, users.size());
 
         String userId = users.get(0).getId();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/PermissionsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/PermissionsTest.java
@@ -160,7 +160,7 @@ public class PermissionsTest extends AbstractKeycloakTest {
 
     @Override
     public void afterAbstractKeycloakTest() {
-        for (UserRepresentation u : adminClient.realm("master").users().search("permissions-test-master-", 0, 100)) {
+        for (UserRepresentation u : adminClient.realm("master").users().search("permissions-test-master-", 0, 100, false)) {
             adminClient.realm("master").users().get(u.getId()).remove();
         }
 
@@ -1280,7 +1280,7 @@ public class PermissionsTest extends AbstractKeycloakTest {
         }, Resource.USER, true);
         invoke(new Invocation() {
             public void invoke(RealmResource realm) {
-                realm.users().search("foo", 0, 1);
+                realm.users().search("foo", 0, 1, false);
             }
         }, Resource.USER, false);
         invoke(new Invocation() {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/UserTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/UserTest.java
@@ -237,10 +237,10 @@ public class UserTest extends AbstractAdminTest {
     public void searchByEmail() {
         createUsers();
 
-        List<UserRepresentation> users = realm.users().search(null, null, null, "user1@localhost", null, null);
+        List<UserRepresentation> users = realm.users().search(null, null, null, "user1@localhost", null, null, false);
         assertEquals(1, users.size());
 
-        users = realm.users().search(null, null, null, "@localhost", null, null);
+        users = realm.users().search(null, null, null, "@localhost", null, null, false);
         assertEquals(9, users.size());
     }
 
@@ -248,10 +248,10 @@ public class UserTest extends AbstractAdminTest {
     public void searchByUsername() {
         createUsers();
 
-        List<UserRepresentation> users = realm.users().search("username1", null, null, null, null, null);
+        List<UserRepresentation> users = realm.users().search("username1", null, null, null, null, null, false);
         assertEquals(1, users.size());
 
-        users = realm.users().search("user", null, null, null, null, null);
+        users = realm.users().search("user", null, null, null, null, null, false);
         assertEquals(9, users.size());
     }
 
@@ -259,13 +259,13 @@ public class UserTest extends AbstractAdminTest {
     public void search() {
         createUsers();
 
-        List<UserRepresentation> users = realm.users().search("username1", null, null);
+        List<UserRepresentation> users = realm.users().search("username1", null, null, false);
         assertEquals(1, users.size());
 
-        users = realm.users().search("first1", null, null);
+        users = realm.users().search("first1", null, null, false);
         assertEquals(1, users.size());
 
-        users = realm.users().search("last", null, null);
+        users = realm.users().search("last", null, null, false);
         assertEquals(9, users.size());
     }
 
@@ -298,21 +298,21 @@ public class UserTest extends AbstractAdminTest {
     public void searchPaginated() {
         createUsers();
 
-        List<UserRepresentation> users = realm.users().search("username", 0, 1);
+        List<UserRepresentation> users = realm.users().search("username", 0, 1, false);
         assertEquals(1, users.size());
         assertEquals("username1", users.get(0).getUsername());
 
-        users = realm.users().search("username", 5, 2);
+        users = realm.users().search("username", 5, 2, false);
         assertEquals(2, users.size());
         assertEquals("username6", users.get(0).getUsername());
         assertEquals("username7", users.get(1).getUsername());
 
-        users = realm.users().search("username", 7, 20);
+        users = realm.users().search("username", 7, 20, false);
         assertEquals(2, users.size());
         assertEquals("username8", users.get(0).getUsername());
         assertEquals("username9", users.get(1).getUsername());
 
-        users = realm.users().search("username", 0, 20);
+        users = realm.users().search("username", 0, 20, false);
         assertEquals(9, users.size());
     }
 
@@ -922,9 +922,9 @@ public class UserTest extends AbstractAdminTest {
             users.create(UserBuilder.create().username("test-" + i).build()).close();
         }
 
-        assertEquals(100, users.search("test", null, null).size());
-        assertEquals(105, users.search("test", 0, 105).size());
-        assertEquals(111, users.search("test", 0, 1000).size());
+        assertEquals(100, users.search("test", null, null, false).size());
+        assertEquals(105, users.search("test", 0, 105, false).size());
+        assertEquals(111, users.search("test", 0, 1000, false).size());
     }
 
     private void switchEditUsernameAllowedOn() {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/UserTotpTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/UserTotpTest.java
@@ -85,7 +85,7 @@ public class UserTotpTest extends TestRealmKeycloakTest {
 
         Assert.assertTrue(driver.getPageSource().contains("pficon-delete"));
 
-        List<UserRepresentation> users = adminClient.realms().realm("test").users().search("test-user@localhost", null, null, null, 0, 1);
+        List<UserRepresentation> users = adminClient.realms().realm("test").users().search("test-user@localhost", null, null, null, 0, 1, false);
         String userId = users.get(0).getId();
         testingClient.testing().clearAdminEventQueue();
         adminClient.realms().realm("test").users().get(userId).removeTotp();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/AbstractClientTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/AbstractClientTest.java
@@ -72,7 +72,7 @@ public abstract class AbstractClientTest extends AbstractAuthTest {
     // returns UserRepresentation retrieved from server, with all fields, including id
     protected UserRepresentation getFullUserRep(String userName) {
         // the search returns all users who has userName contained in their username.
-        List<UserRepresentation> results = testRealmResource().users().search(userName, null, null, null, null, null);
+        List<UserRepresentation> results = testRealmResource().users().search(userName, null, null, null, null, null, false);
         UserRepresentation result = null;
         for (UserRepresentation user : results) {
             if (userName.equals(user.getUsername())) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/group/GroupMappersTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/group/GroupMappersTest.java
@@ -108,7 +108,7 @@ public class GroupMappersTest extends AbstractGroupTest {
     public void testGroupMappers() throws Exception {
         RealmResource realm = adminClient.realms().realm("test");
         {
-            UserRepresentation user = realm.users().search("topGroupUser", -1, -1).get(0);
+            UserRepresentation user = realm.users().search("topGroupUser", -1, -1, false).get(0);
 
             AccessToken token = login(user.getUsername(), "test-app", "password", user.getId());
             Assert.assertTrue(token.getRealmAccess().getRoles().contains("user"));
@@ -119,7 +119,7 @@ public class GroupMappersTest extends AbstractGroupTest {
             Assert.assertEquals("true", token.getOtherClaims().get("topAttribute"));
         }
         {
-            UserRepresentation user = realm.users().search("level2GroupUser", -1, -1).get(0);
+            UserRepresentation user = realm.users().search("level2GroupUser", -1, -1, false).get(0);
 
             AccessToken token = login(user.getUsername(), "test-app", "password", user.getId());
             Assert.assertTrue(token.getRealmAccess().getRoles().contains("user"));

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/group/GroupTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/group/GroupTest.java
@@ -241,7 +241,7 @@ public class GroupTest extends AbstractGroupTest {
         assertEquals(1, level3Group.getRealmRoles().size());
         assertTrue(level3Group.getRealmRoles().contains("level3Role"));
 
-        UserRepresentation user = realm.users().search("direct-login", -1, -1).get(0);
+        UserRepresentation user = realm.users().search("direct-login", -1, -1, false).get(0);
         realm.users().get(user.getId()).joinGroup(level3Group.getId());
         assertAdminEvents.assertEvent("test", OperationType.CREATE, AdminEventPaths.userGroupPath(user.getId(), level3Group.getId()), ResourceType.GROUP_MEMBERSHIP);
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/partialimport/PartialImportTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/partialimport/PartialImportTest.java
@@ -114,7 +114,7 @@ public class PartialImportTest extends AbstractAuthTest {
 
     @Before
     public void removeUsers() {
-        List<UserRepresentation> toRemove = testRealmResource().users().search(USER_PREFIX, 0, NUM_ENTITIES);
+        List<UserRepresentation> toRemove = testRealmResource().users().search(USER_PREFIX, 0, NUM_ENTITIES, false);
         for (UserRepresentation user : toRemove) {
             testRealmResource().users().get(user.getId()).remove();
         }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractBrokerTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractBrokerTest.java
@@ -104,7 +104,7 @@ public abstract class AbstractBrokerTest extends AbstractBaseBrokerTest {
         int userCount = consumerUsers.count();
         Assert.assertTrue("There must be at least one user", userCount > 0);
 
-        List<UserRepresentation> users = consumerUsers.search("", 0, userCount);
+        List<UserRepresentation> users = consumerUsers.search("", 0, userCount, false);
 
         boolean isUserFound = false;
         for (UserRepresentation user : users) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractUserAttributeMapperTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractUserAttributeMapperTest.java
@@ -100,7 +100,7 @@ public abstract class AbstractUserAttributeMapperTest extends AbstractBaseBroker
         int userCount = consumerUsers.count();
         assertThat("There must be at least one user", userCount, greaterThan(0));
 
-        List<UserRepresentation> users = consumerUsers.search("", 0, userCount);
+        List<UserRepresentation> users = consumerUsers.search("", 0, userCount, false);
 
         for (UserRepresentation user : users) {
             if (user.getUsername().equals(userName) && user.getEmail().equals(email)) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcSamlIdPInitiatedSsoTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcSamlIdPInitiatedSsoTest.java
@@ -109,7 +109,7 @@ public class KcSamlIdPInitiatedSsoTest extends AbstractKeycloakTest {
         int userCount = consumerUsers.count();
         Assert.assertTrue("There must be at least one user", userCount > 0);
 
-        List<UserRepresentation> users = consumerUsers.search("", 0, userCount);
+        List<UserRepresentation> users = consumerUsers.search("", 0, userCount, false);
 
         boolean isUserFound = users.stream().anyMatch(user -> user.getUsername().equals("mytest") && user.getEmail().equals("test@localhost"));
         Assert.assertTrue("There must be user " + "mytest" + " in realm " + REALM_CONS_NAME, isUserFound);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/OIDCPairwiseClientRegistrationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/OIDCPairwiseClientRegistrationTest.java
@@ -305,7 +305,7 @@ public class OIDCPairwiseClientRegistrationTest extends AbstractClientRegistrati
         String tokenUserId = accessToken.getSubject();
 
         // Assert public client has same subject like userId
-        UserRepresentation user = realmsResouce().realm("test").users().search("test-user", 0, 1).get(0);
+        UserRepresentation user = realmsResouce().realm("test").users().search("test-user", 0, 1, false).get(0);
         Assert.assertEquals(user.getId(), tokenUserId);
 
         // Create pairwise client

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/exportimport/ExportImportUtil.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/exportimport/ExportImportUtil.java
@@ -454,7 +454,7 @@ public class ExportImportUtil {
 
     // Workaround for KEYCLOAK-3104.  For this realm, search() only works if username is null.
     private static UserRepresentation findByUsername(RealmResource realmRsc, String username) {
-        for (UserRepresentation user : realmRsc.users().search(null, 0, Integer.MAX_VALUE)) {
+        for (UserRepresentation user : realmRsc.users().search(null, 0, Integer.MAX_VALUE, false)) {
             if (user.getUsername().equalsIgnoreCase(username)) return user;
         }
         return null;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/exportimport/LegacyImportTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/exportimport/LegacyImportTest.java
@@ -41,6 +41,8 @@ import java.util.Set;
 import static org.junit.Assert.assertNotNull;
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.exportimport.Strategy;
+import org.keycloak.representations.idm.UserRepresentation;
+
 import static org.keycloak.testsuite.Assert.assertNames;
 import static org.keycloak.testsuite.migration.MigrationTest.MIGRATION;
 
@@ -99,12 +101,14 @@ public class LegacyImportTest extends AbstractExportImportTest {
             assertNames(imported.clients().findAll(), "account", "admin-cli", "broker", "migration-test-client", "realm-management", "security-admin-console");
             String id = imported.clients().findByClientId("migration-test-client").get(0).getId();
             assertNames(imported.clients().get(id).roles().list(), "migration-test-client-role");
-            assertNames(imported.users().search("", 0, 5), "migration-test-user");
+            assertNames(imported.users().search("", 0, 5, false), "migration-test-user");
             assertNames(imported.groups().groups(), "migration-test-group");
         } finally {
             removeRealm(MIGRATION);
         }
     }
+
+
 
     //KEYCLOAK-1982
     @Test

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/BruteForceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/BruteForceTest.java
@@ -286,7 +286,7 @@ public class BruteForceTest extends TestRealmKeycloakTest {
 
     @Test
     public void testEmail() throws Exception {
-        String userId = adminClient.realm("test").users().search("user2", null, null, null, 0, 1).get(0).getId();
+        String userId = adminClient.realm("test").users().search("user2", null, null, null, 0, 1, false).get(0).getId();
 
         loginSuccess("user2@localhost");
         loginInvalidPassword("user2@localhost");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/migration/MigrationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/migration/MigrationTest.java
@@ -94,7 +94,7 @@ public class MigrationTest extends AbstractKeycloakTest {
                 "master-realm", "master-test-client", "Migration-realm");
         String id = masterRealm.clients().findByClientId("master-test-client").get(0).getId();
         assertNames(masterRealm.clients().get(id).roles().list(), "master-test-client-role");
-        assertNames(masterRealm.users().search("", 0, 5), "admin", "master-test-user");
+        assertNames(masterRealm.users().search("", 0, 5, false), "admin", "master-test-user");
         assertNames(masterRealm.groups().groups(), "master-test-group");
         
         //migrationRealm
@@ -102,7 +102,7 @@ public class MigrationTest extends AbstractKeycloakTest {
         assertNames(migrationRealm.clients().findAll(), "account", "admin-cli", "broker", "migration-test-client", "realm-management", "security-admin-console");
         String id2 = migrationRealm.clients().findByClientId("migration-test-client").get(0).getId();
         assertNames(migrationRealm.clients().get(id2).roles().list(), "migration-test-client-role");
-        assertNames(migrationRealm.users().search("", 0, 5), "migration-test-user");
+        assertNames(migrationRealm.users().search("", 0, 5, false), "migration-test-user");
         assertNames(migrationRealm.groups().groups(), "migration-test-group");
     }
     

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/AccessTokenTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/AccessTokenTest.java
@@ -705,7 +705,7 @@ public class AccessTokenTest extends AbstractKeycloakTest {
         realmRole2 = realm.roles().get("realm-test-role2").toRepresentation();
 
 
-        List<UserRepresentation> users = realm.users().search("test-user@localhost", -1, -1);
+        List<UserRepresentation> users = realm.users().search("test-user@localhost", -1, -1, false);
         assertEquals(1, users.size());
         UserRepresentation user = users.get(0);
 

--- a/testsuite/integration-arquillian/tests/other/sssd/src/test/java/org/keycloak/testsuite/sssd/SSSDTest.java
+++ b/testsuite/integration-arquillian/tests/other/sssd/src/test/java/org/keycloak/testsuite/sssd/SSSDTest.java
@@ -165,7 +165,7 @@ public class SSSDTest extends AbstractKeycloakTest {
     private void testUserGroups() {
         log.debug("Testing user groups");
 
-        List<UserRepresentation> users = adminClient.realm(REALM_NAME).users().search(USERNAME, 0, 1);
+        List<UserRepresentation> users = adminClient.realm(REALM_NAME).users().search(USERNAME, 0, 1, false);
 
         Assert.assertTrue("There must be at least one user", users.size() > 0);
         Assert.assertEquals("Exactly our test user", USERNAME, users.get(0).getUsername());

--- a/testsuite/integration/src/test/java/org/keycloak/testsuite/ApiUtil.java
+++ b/testsuite/integration/src/test/java/org/keycloak/testsuite/ApiUtil.java
@@ -117,7 +117,7 @@ public class ApiUtil {
 
     public static UserRepresentation findUserByUsername(RealmResource realm, String username) {
         UserRepresentation user = null;
-        List<UserRepresentation> ur = realm.users().search(username, null, null);
+        List<UserRepresentation> ur = realm.users().search(username, null, null, false);
         if (ur.size() == 1) {
             user = ur.get(0);
         }

--- a/testsuite/integration/src/test/java/org/keycloak/testsuite/adapter/AdapterTestStrategy.java
+++ b/testsuite/integration/src/test/java/org/keycloak/testsuite/adapter/AdapterTestStrategy.java
@@ -721,7 +721,7 @@ public class AdapterTestStrategy extends ExternalResource {
 
         // logout mposolda with admin client
         Keycloak keycloakAdmin = Keycloak.getInstance(AUTH_SERVER_URL, "master", "admin", "admin", Constants.ADMIN_CLI_CLIENT_ID);
-        UserRepresentation mposolda = keycloakAdmin.realm("demo").users().search("mposolda", null, null, null, null, null).get(0);
+        UserRepresentation mposolda = keycloakAdmin.realm("demo").users().search("mposolda", null, null, null, null, null, false).get(0);
         keycloakAdmin.realm("demo").users().get(mposolda.getId()).logout();
 
         // bburke should be still logged with original httpSession in our browser window

--- a/testsuite/integration/src/test/java/org/keycloak/testsuite/adduser/AddUserTest.java
+++ b/testsuite/integration/src/test/java/org/keycloak/testsuite/adduser/AddUserTest.java
@@ -104,7 +104,7 @@ public class AddUserTest {
 
             RealmResource realm = keycloak.realm("master");
 
-            List<UserRepresentation> users = realm.users().search("addusertest-admin", null, null, null, null, null);
+            List<UserRepresentation> users = realm.users().search("addusertest-admin", null, null, null, null, null, false);
             assertEquals(1, users.size());
 
             UserRepresentation created = users.get(0);

--- a/testsuite/integration/src/test/java/org/keycloak/testsuite/broker/OIDCKeycloakServerBrokerWithConsentTest.java
+++ b/testsuite/integration/src/test/java/org/keycloak/testsuite/broker/OIDCKeycloakServerBrokerWithConsentTest.java
@@ -212,7 +212,7 @@ public class OIDCKeycloakServerBrokerWithConsentTest extends AbstractIdentityPro
 
         // Revoke consent
         RealmResource brokeredRealm = keycloak2.realm("realm-with-oidc-identity-provider");
-        List<UserRepresentation> users = brokeredRealm.users().search("test-user", 0, 1);
+        List<UserRepresentation> users = brokeredRealm.users().search("test-user", 0, 1, false);
         brokeredRealm.users().get(users.get(0).getId()).revokeConsent("broker-app");
     }
 

--- a/testsuite/integration/src/test/java/org/keycloak/testsuite/federation/storage/UserPropertyFileStorage.java
+++ b/testsuite/integration/src/test/java/org/keycloak/testsuite/federation/storage/UserPropertyFileStorage.java
@@ -153,7 +153,7 @@ public class UserPropertyFileStorage implements UserLookupProvider, UserStorageP
     }
 
     @Override
-    public List<UserModel> searchForUser(Map<String, String> attributes, RealmModel realm) {
+    public List<UserModel> searchForUser(Map<String, String> attributes, RealmModel realm, boolean exact) {
         return Collections.EMPTY_LIST;
     }
 
@@ -172,29 +172,36 @@ public class UserPropertyFileStorage implements UserLookupProvider, UserStorageP
     }
 
     @Override
-    public List<UserModel> searchForUser(String search, RealmModel realm, int firstResult, int maxResults) {
+    public List<UserModel> searchForUser(String search, RealmModel realm, int firstResult, int maxResults, boolean exact) {
         if (maxResults == 0) return Collections.EMPTY_LIST;
         List<UserModel> users = new LinkedList<>();
         int count = 0;
         for (Object un : userPasswords.keySet()) {
             String username = (String)un;
-            if (username.contains(search)) {
-                if (count++ < firstResult) {
-                    continue;
-                }
-                users.add(createUser(realm, username));
-                if (users.size() + 1 > maxResults) break;
+
+            if(exact && !username.equals(search)){
+                continue;
             }
+
+            if(!exact && !username.contains(search)){
+                continue;
+            }
+
+            if (count++ < firstResult) {
+                continue;
+            }
+            users.add(createUser(realm, username));
+            if (users.size() + 1 > maxResults) break;
         }
         return users;
     }
 
     @Override
-    public List<UserModel> searchForUser(Map<String, String> attributes, RealmModel realm, int firstResult, int maxResults) {
+    public List<UserModel> searchForUser(Map<String, String> attributes, RealmModel realm, int firstResult, int maxResults, boolean exact) {
         if (attributes.size() != 1) return Collections.EMPTY_LIST;
         String username = attributes.get(UserModel.USERNAME);
         if (username == null) return Collections.EMPTY_LIST;
-        return searchForUser(username, realm, firstResult, maxResults);
+        return searchForUser(username, realm, firstResult, maxResults, exact);
     }
 
     @Override
@@ -208,7 +215,7 @@ public class UserPropertyFileStorage implements UserLookupProvider, UserStorageP
     }
 
     @Override
-    public List<UserModel> searchForUser(String search, RealmModel realm) {
+    public List<UserModel> searchForUser(String search, RealmModel realm, boolean exact) {
         return getUsers(realm, 0, Integer.MAX_VALUE - 1);
     }
 

--- a/testsuite/integration/src/test/java/org/keycloak/testsuite/federation/storage/ldap/LDAPBinaryAttributesTest.java
+++ b/testsuite/integration/src/test/java/org/keycloak/testsuite/federation/storage/ldap/LDAPBinaryAttributesTest.java
@@ -281,7 +281,7 @@ public class LDAPBinaryAttributesTest {
 
 
     private UserRepresentation getUserAndAssertPhoto(String username, boolean isPhotoExpected) {
-        List<UserRepresentation> johns = adminClient.realm("test").users().search(username, 0, 10);
+        List<UserRepresentation> johns = adminClient.realm("test").users().search(username, 0, 10, false);
         Assert.assertEquals(1, johns.size());
         UserRepresentation john = johns.get(0);
         Assert.assertEquals(username, john.getUsername());

--- a/testsuite/integration/src/test/java/org/keycloak/testsuite/federation/storage/ldap/LDAPSpecialCharsTest.java
+++ b/testsuite/integration/src/test/java/org/keycloak/testsuite/federation/storage/ldap/LDAPSpecialCharsTest.java
@@ -123,7 +123,7 @@ public class LDAPSpecialCharsTest {
 
     @Test
     public void test01_userSearch() {
-        List<UserRepresentation> users = adminClient.realm("test").users().search("j*", 0, 10);
+        List<UserRepresentation> users = adminClient.realm("test").users().search("j*", 0, 10, false);
         Assert.assertEquals(3, users.size());
 
         List<String> usernames = users.stream().map((UserRepresentation user) -> {

--- a/themes/src/main/resources/theme/base/admin/resources/partials/user-list.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/user-list.html
@@ -13,9 +13,10 @@
                             <div class="input-group-addon">
                                     <i class="fa fa-search" id="userSearch" data-ng-click="firstPage()"></i>
                             </div>
+                            <input name="queryExact" id="queryExact"  ng-model="query.exact" onoffswitch on-text="{{:: 'exact' | translate}}" off-text="{{:: 'fuzzy' | translate}}"/>
                         </div>
                     </div>
-                    <button id="viewAllUsers" class="btn btn-default" ng-click="query.search = null; firstPage()">{{:: 'view-all-users' | translate}}</button>
+                    <button id="viewAllUsers" class="btn btn-default" ng-click="query.search = null; query.exact = false; firstPage()">{{:: 'view-all-users' | translate}}</button>
 
                     <div class="pull-right" data-ng-show="access.manageUsers">
                         <button data-ng-click="unlockUsers()" class="btn btn-default">{{:: 'unlock-users' | translate}}</button>


### PR DESCRIPTION
This PoC adds support for using exact matching for
user search operations. Users can use a (currently ugly) checkbox
to mark a search as exact (if checked) or inexact (if unchecked, default).
Previously only inexact (wildcard) search was supported for the
JPA and MongoDB based search.

On the server-side UsersResource I used Java 8 default methods to provide some bridging
for clients that are using the old API.
Note that I couldn't use that approach on the admin-client side
UsersResource since the admin-client module is not (yet?) using Java 8.

Note that the LDAP search only supports exact searches.

Automatic tests are missing but a manual test showed that
everything works as expected. Will add tests if this approach
gets a "GO".