### PR TITLE
KEYCLOAK-2962 Autodetect bearer-only clients

### DIFF
--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/KeycloakDeployment.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/KeycloakDeployment.java
@@ -57,6 +57,7 @@ public class KeycloakDeployment {
 
     protected String resourceName;
     protected boolean bearerOnly;
+    protected boolean autodetectBearerOnly;
     protected boolean enableBasicAuth;
     protected boolean publicClient;
     protected Map<String, Object> resourceCredentials = new HashMap<>();
@@ -199,6 +200,14 @@ public class KeycloakDeployment {
 
     public void setBearerOnly(boolean bearerOnly) {
         this.bearerOnly = bearerOnly;
+    }
+
+    public boolean isAutodetectBearerOnly() {
+        return autodetectBearerOnly;
+    }
+
+    public void setAutodetectBearerOnly(boolean autodetectBearerOnly) {
+        this.autodetectBearerOnly = autodetectBearerOnly;
     }
 
     public boolean isEnableBasicAuth() {

--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/KeycloakDeploymentBuilder.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/KeycloakDeploymentBuilder.java
@@ -99,6 +99,7 @@ public class KeycloakDeploymentBuilder {
         }
 
         deployment.setBearerOnly(adapterConfig.isBearerOnly());
+        deployment.setAutodetectBearerOnly(adapterConfig.isAutodetectBearerOnly());
         deployment.setEnableBasicAuth(adapterConfig.isEnableBasicAuth());
         deployment.setAlwaysRefreshToken(adapterConfig.isAlwaysRefreshToken());
         deployment.setRegisterNodeAtStartup(adapterConfig.isRegisterNodeAtStartup());

--- a/core/src/main/java/org/keycloak/representations/adapters/config/AdapterConfig.java
+++ b/core/src/main/java/org/keycloak/representations/adapters/config/AdapterConfig.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
         "resource", "public-client", "credentials",
         "use-resource-role-mappings",
         "enable-cors", "cors-max-age", "cors-allowed-methods",
-        "expose-token", "bearer-only",
+        "expose-token", "bearer-only", "autodetect-bearer-only",
         "connection-pool-size",
         "allow-any-hostname", "disable-trust-manager", "truststore", "truststore-password",
         "client-keystore", "client-keystore-password", "client-key-password",

--- a/core/src/main/java/org/keycloak/representations/adapters/config/BaseAdapterConfig.java
+++ b/core/src/main/java/org/keycloak/representations/adapters/config/BaseAdapterConfig.java
@@ -33,7 +33,7 @@ import java.util.Map;
         "resource", "public-client", "credentials",
         "use-resource-role-mappings",
         "enable-cors", "cors-max-age", "cors-allowed-methods",
-        "expose-token", "bearer-only", "enable-basic-auth"})
+        "expose-token", "bearer-only", "autodetect-bearer-only", "enable-basic-auth"})
 public class BaseAdapterConfig extends BaseRealmConfig {
     @JsonProperty("resource")
     protected String resource;
@@ -51,6 +51,8 @@ public class BaseAdapterConfig extends BaseRealmConfig {
     protected boolean exposeToken;
     @JsonProperty("bearer-only")
     protected boolean bearerOnly;
+    @JsonProperty("autodetect-bearer-only")
+    protected boolean autodetectBearerOnly;
     @JsonProperty("enable-basic-auth")
     protected boolean enableBasicAuth;
     @JsonProperty("public-client")
@@ -121,6 +123,14 @@ public class BaseAdapterConfig extends BaseRealmConfig {
 
     public void setBearerOnly(boolean bearerOnly) {
         this.bearerOnly = bearerOnly;
+    }
+
+    public boolean isAutodetectBearerOnly() {
+        return autodetectBearerOnly;
+    }
+
+    public void setAutodetectBearerOnly(boolean autodetectBearerOnly) {
+        this.autodetectBearerOnly = autodetectBearerOnly;
     }
 
     public boolean isEnableBasicAuth() {

--- a/testsuite/integration/src/test/java/org/keycloak/testsuite/adapter/AdapterTest.java
+++ b/testsuite/integration/src/test/java/org/keycloak/testsuite/adapter/AdapterTest.java
@@ -72,6 +72,12 @@ public class AdapterTest {
                     .name("product-portal").contextPath("/product-portal")
                     .servletClass(ProductServlet.class).adapterConfigPath(url.getPath())
                     .role("user").deployApplication();
+           
+            url = getClass().getResource("/adapter-test/product-autodetect-bearer-only-keycloak.json");
+            createApplicationDeployment()
+                    .name("product-portal-autodetect-bearer-only").contextPath("/product-portal-autodetect-bearer-only")
+                    .servletClass(ProductServlet.class).adapterConfigPath(url.getPath())
+                    .role("user").deployApplication();
 
             // Test that replacing system properties works for adapters
             System.setProperty("app.server.base.url", "http://localhost:8081");
@@ -147,6 +153,11 @@ public class AdapterTest {
     @Test
     public void testNullBearerTokenCustomErrorPage() throws Exception {
         testStrategy.testNullBearerTokenCustomErrorPage();
+    }
+
+    @Test
+    public void testAutodetectBearerOnly() throws Exception {
+        testStrategy.testAutodetectBearerOnly();
     }
 
     @Test

--- a/testsuite/integration/src/test/resources/adapter-test/product-autodetect-bearer-only-keycloak.json
+++ b/testsuite/integration/src/test/resources/adapter-test/product-autodetect-bearer-only-keycloak.json
@@ -1,0 +1,11 @@
+{
+  "realm" : "demo",
+  "resource" : "product-portal",
+  "realm-public-key" : "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCrVrCuTtArbgaZzL1hvh0xtL5mc7o0NqPVnYXkLvgcwiC3BjLGw1tGEGoJaXDuSaRllobm53JBhjx33UNv+5z/UMG4kytBWxheNVKnL6GgqlNabMaFfPLPCF8kAgKnsi79NMo+n6KnSY8YeUmec/p2vjO2NjsSAVcWEQMVhJ31LwIDAQAB",
+  "auth-server-url" : "http://localhost:8081/auth",
+  "ssl-required" : "external",
+  "credentials" : {
+      "secret": "password"
+   },
+   "autodetect-bearer-only" : true
+}


### PR DESCRIPTION
This adds an `autodetect-bearer-only` config option to the adapter config for OIDC clients. If set to `true`, requests that do not accept an HTML response according to their `Accept` header or requests having an `X-Requested-With: XMLHttpRequest` header will be treated as bearer-only and not forwarded to the `OAuthRequestAuthenticator` in case of a missing bearer token or missing basic auth. That is, they won't be redirected but receive a 401.

Background: We have lots of legacy applications serving both a web application and SOAP or REST services. This use case is too common to require a custom `KeycloakConfigResolver`.

@stianst: Looking at some older PR for this you requested the values of the `Accept` headers to be configurable. This was my initial intention, too. But looking at typical applications, they either send a proper `Accept` header accepting only JSON responses, the default one from the browser that accepts anything or a broken one. As such, I don't see any real benefit in making this configurable. Eventually, all that counts is whether the client supports an HTML response, as this is what the login page is.
What might make sense instead is to look at the degree of preference for the `text/html` media type in the `Accept` header and make the threshold configurable. For instance, an Accept header sent by Primefaces looks like this: `application/xml, text/xml, */*; q=0.01`. From this we can read that the application can't do much with anything other than XML. But I'd leave that for a separate PR as the few frameworks that send a proper `Accept` header like this already send the `X-Requested-With` header. Most of them are just broken in this aspect. Take Angular as an example. It puts the requested media type at the first position, e.g. `application/json, text/plain, */*`, but this actually only tells the precedence, not the preference. We can't tell from this wether the application can handle HTML responses or not.