### PR TITLE
KEYCLOAK-4216 Improve debuggability of mod_auth_mellon containers

### DIFF
--- a/testsuite/integration-arquillian/tests/other/mod_auth_mellon/README.md
+++ b/testsuite/integration-arquillian/tests/other/mod_auth_mellon/README.md
@@ -2,8 +2,9 @@
 
 ## Docker images
 
-Each docker image contains apache + mod_auth_mellon and two html files unprotected (/) and protected (/auth).
- 
+Each docker image contains apache + mod_auth_mellon, ssh daemon and two html files unprotected (/) and protected (/auth).
+SSH in each docker uses root user with password 'a' (without quotes).
+
 ## Build docker images
 
 docker build -t apache-mellon docker/
@@ -11,8 +12,8 @@ docker build -t apache-mellon2 docker2/
 
 ## Run docker image
 
-docker run -d -p 8380:80 apache-mellon
-docker run -d -p 8480:80 apache-mellon2
+docker run -d -p 8380:80 -p 8322:22 apache-mellon
+docker run -d -p 8480:80 -p 8322:22 apache-mellon2
 
 ## Run tests
 

--- a/testsuite/integration-arquillian/tests/other/mod_auth_mellon/docker/Dockerfile
+++ b/testsuite/integration-arquillian/tests/other/mod_auth_mellon/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu
 
-RUN apt-get update && apt-get install -y apache2 && apt-get install -y libapache2-mod-auth-mellon
+RUN apt-get update && apt-get install -y apache2 openssh-server mc && apt-get install -y libapache2-mod-auth-mellon
 
 RUN mkdir /etc/apache2/mellon
 
@@ -14,4 +14,12 @@ RUN mkdir /var/www/html/auth
 
 COPY www/auth/* /var/www/html/auth/
 
-CMD /usr/sbin/apache2ctl -D FOREGROUND
+RUN echo 'root:a' | chpasswd
+
+RUN mkdir /var/run/sshd
+
+RUN sed -ri 's/^PermitRootLogin\s+.*/PermitRootLogin yes/' /etc/ssh/sshd_config
+
+RUN sed -ri 's/UsePAM yes/#UsePAM yes/g' /etc/ssh/sshd_config
+
+CMD bash -c '(/usr/sbin/sshd -D & ) ; /usr/sbin/apache2ctl -D FOREGROUND'

--- a/testsuite/integration-arquillian/tests/other/mod_auth_mellon/docker2/Dockerfile
+++ b/testsuite/integration-arquillian/tests/other/mod_auth_mellon/docker2/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu
 
-RUN apt-get update && apt-get install -y apache2 && apt-get install -y libapache2-mod-auth-mellon
+RUN apt-get update && apt-get install -y apache2 openssh-server mc && apt-get install -y libapache2-mod-auth-mellon
 
 RUN mkdir /etc/apache2/mellon
 
@@ -14,4 +14,12 @@ RUN mkdir /var/www/html/auth2
 
 COPY www/auth2/* /var/www/html/auth2/
 
-CMD /usr/sbin/apache2ctl -D FOREGROUND
+RUN echo 'root:a' | chpasswd
+
+RUN mkdir /var/run/sshd
+
+RUN sed -ri 's/^PermitRootLogin\s+.*/PermitRootLogin yes/' /etc/ssh/sshd_config
+
+RUN sed -ri 's/UsePAM yes/#UsePAM yes/g' /etc/ssh/sshd_config
+
+CMD bash -c '(/usr/sbin/sshd -D & ) ; /usr/sbin/apache2ctl -D FOREGROUND'


### PR DESCRIPTION
Introduce ssh and midnight commander into docker images so that it
is possible to easily view logs and change settings when debugging
with these docker images.