### PR TITLE
KEYCLOAK-4222 Remove slash from state parameter

### DIFF
--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/OAuthRequestAuthenticator.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/OAuthRequestAuthenticator.java
@@ -196,10 +196,8 @@ public class OAuthRequestAuthenticator {
         return sslRedirectPort;
     }
 
-    protected static final AtomicLong counter = new AtomicLong();
-
     protected String getStateCode() {
-        return counter.getAndIncrement() + "/" + AdapterUtils.generateId();
+        return AdapterUtils.generateId();
     }
 
     protected AuthChallenge loginRedirect() {


### PR DESCRIPTION
This was causing us lots of trouble. See https://issues.jboss.org/browse/KEYCLOAK-4222 for details. 