### PR TITLE
KEYCLOAK-2339 Add impersonation claim to identity token

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/models/ImpersonationConstants.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/ImpersonationConstants.java
@@ -26,6 +26,7 @@ import org.keycloak.models.utils.KeycloakModelUtils;
  */
 public class ImpersonationConstants {
     public static String IMPERSONATION_ROLE = "impersonation";
+    public static String IMPERSONATION_CLAIM = "impersonation";
 
 
     public static void setupMasterRealmRole(RealmProvider model, RealmModel realm) {

--- a/services/src/main/java/org/keycloak/services/managers/AppAuthManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/AppAuthManager.java
@@ -36,7 +36,7 @@ public class AppAuthManager extends AuthenticationManager {
         AuthResult authResult = super.authenticateIdentityCookie(session, realm);
         if (authResult == null) return null;
         // refresh the cookies!
-        createLoginCookie(session, realm, authResult.getUser(), authResult.getSession(), session.getContext().getUri(), session.getContext().getConnection());
+        createLoginCookie(session, realm, authResult.getUser(), authResult.getSession(), session.getContext().getUri(), session.getContext().getConnection(), null);
         if (authResult.getSession().isRememberMe()) createRememberMeCookie(realm, authResult.getUser().getUsername(), session.getContext().getUri(), session.getContext().getConnection());
         return authResult;
     }

--- a/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
@@ -344,7 +344,7 @@ public class UsersResource {
         EventBuilder event = new EventBuilder(realm, session, clientConnection);
 
         UserSessionModel userSession = session.sessions().createUserSession(realm, user, user.getUsername(), clientConnection.getRemoteAddr(), "impersonate", false, null, null);
-        AuthenticationManager.createLoginCookie(session, realm, userSession.getUser(), userSession, uriInfo, clientConnection);
+        AuthenticationManager.createLoginCookie(session, realm, userSession.getUser(), userSession, uriInfo, clientConnection, auth);
         URI redirect = AccountService.accountServiceApplicationPage(uriInfo).build(realm.getName());
         Map<String, Object> result = new HashMap<>();
         result.put("sameRealm", sameRealm);


### PR DESCRIPTION
We now include an impersonation claim in the identity token
issued for an impersonated user which hints at the impersonator.
We include a claim "impersonator" containing a nested structure
containing information about original username, sub (userId)
as well as the original realmName of the impersonator.

An example for a token with impersonator claim can be found here:
https://gist.github.com/thomasdarimont/e92204febc634049f660fee8548870b5