### PR TITLE
NPE fix for HttpMethod

### DIFF
--- a/authz/client/src/main/java/org/keycloak/authorization/client/util/HttpMethod.java
+++ b/authz/client/src/main/java/org/keycloak/authorization/client/util/HttpMethod.java
@@ -100,7 +100,7 @@ public class HttpMethod<R> {
         } catch (HttpResponseException e) {
             throw e;
         } catch (Exception e) {
-            throw new RuntimeException("Error executing http method [" + builder + "]. Response : " + new String(bytes), e);
+            throw new RuntimeException("Error executing http method [" + builder + "]. Response : " + String.valueOf(bytes), e);
         }
     }
 


### PR DESCRIPTION
In case of PKI validation exception HttpMethod throws NPE, because `bytes` value is null and real cause of error becomes hidden.