### PR TITLE
KEYCLOAK-4505 Expose current clientSession binding to ScriptBasedAuthenticator

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/ScriptBasedAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/ScriptBasedAuthenticator.java
@@ -47,6 +47,7 @@ import java.util.Map;
  * <li>{@code realm} the {@link RealmModel}</li>
  * <li>{@code user} the current {@link UserModel}</li>
  * <li>{@code session} the active {@link KeycloakSession}</li>
+ * <li>{@code clientSession} the current {@link org.keycloak.models.ClientSessionModel}</li>
  * <li>{@code httpRequest} the current {@link org.jboss.resteasy.spi.HttpRequest}</li>
  * <li>{@code LOG} a {@link org.jboss.logging.Logger} scoped to {@link ScriptBasedAuthenticator}/li>
  * </ol>
@@ -159,6 +160,7 @@ public class ScriptBasedAuthenticator implements Authenticator {
             bindings.put("user", context.getUser());
             bindings.put("session", context.getSession());
             bindings.put("httpRequest", context.getHttpRequest());
+            bindings.put("clientSession", context.getClientSession());
             bindings.put("LOG", LOGGER);
         });
     }

--- a/services/src/main/resources/scripts/authenticator-template.js
+++ b/services/src/main/resources/scripts/authenticator-template.js
@@ -15,6 +15,7 @@ AuthenticationFlowError = Java.type("org.keycloak.authentication.AuthenticationF
  * session - current KeycloakSession {@see org.keycloak.models.KeycloakSession}
  * httpRequest - current HttpRequest {@see org.jboss.resteasy.spi.HttpRequest}
  * script - current script {@see org.keycloak.models.ScriptModel}
+ * clientSession - current client session {@see org.keycloak.models.ClientSessionModel}
  * LOG - current logger {@see org.jboss.logging.Logger}
  *
  * You one can extract current http request headers via:


### PR DESCRIPTION
Previously the ScriptBasedAuthenticator did not expose the current
clientSession from the AuthenticationFlowContext.
In order to implement client specific authentications with javascript
one needs information about the current client.

Information about the current client session is now exposed via the "clientSession" 
variable in the scripting context.

This can also be back-ported to 2.5.x.