### PR TITLE
KEYCLOAK-4368 Enable htmlUnit for adapter tests (not examples though)

### DIFF
--- a/testsuite/integration-arquillian/test-apps/servlets/src/main/java/org/keycloak/testsuite/adapter/servlet/SendUsernameServlet.java
+++ b/testsuite/integration-arquillian/test-apps/servlets/src/main/java/org/keycloak/testsuite/adapter/servlet/SendUsernameServlet.java
@@ -65,7 +65,7 @@ public class SendUsernameServlet {
             return Response.status(Response.Status.FORBIDDEN).entity("Forbidden").build();
         }
 
-        return Response.ok(getOutput()).header(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_PLAIN_TYPE + ";charset=UTF-8").build();
+        return Response.ok(getOutput()).header(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_HTML_TYPE + ";charset=UTF-8").build();
     }
 
     @POST

--- a/testsuite/integration-arquillian/tests/base/pom.xml
+++ b/testsuite/integration-arquillian/tests/base/pom.xml
@@ -62,6 +62,11 @@
             <version>1.10</version>
         </dependency>
         <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.5</version>
+        </dependency>
+        <dependency>
             <groupId>org.keycloak.testsuite</groupId>
             <artifactId>integration-arquillian-testsuite-providers</artifactId>
             <version>${project.version}</version>

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/example/AbstractJSConsoleExampleAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/example/AbstractJSConsoleExampleAdapterTest.java
@@ -43,8 +43,8 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.*;
 import static org.keycloak.testsuite.auth.page.AuthRealm.EXAMPLE;
 import static org.keycloak.testsuite.util.IOUtil.loadRealm;
 import static org.keycloak.testsuite.util.URLAssert.assertCurrentUrlDoesntStartWith;
@@ -479,7 +479,7 @@ public abstract class AbstractJSConsoleExampleAdapterTest extends AbstractExampl
 
     private void assertResponseError(String errorDescription) {
         jsConsoleTestAppPage.showErrorResponse();
-        assertTrue(jsConsoleTestAppPage.getOutputElement().getText().contains(errorDescription));
+        assertThat(jsConsoleTestAppPage.getOutputElement().getText(), containsString(errorDescription));
     }
 
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/AbstractDemoServletsAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/AbstractDemoServletsAdapterTest.java
@@ -50,7 +50,7 @@ import org.keycloak.testsuite.auth.page.account.Applications;
 import org.keycloak.testsuite.auth.page.login.OAuthGrant;
 import org.keycloak.testsuite.console.page.events.Config;
 import org.keycloak.testsuite.console.page.events.LoginEvents;
-import org.keycloak.testsuite.util.URLUtils;
+import org.keycloak.testsuite.util.*;
 import org.keycloak.util.BasicAuthHelper;
 
 import org.openqa.selenium.By;
@@ -74,16 +74,13 @@ import java.util.regex.Pattern;
 
 import static org.junit.Assert.*;
 
-import org.keycloak.testsuite.util.Matchers;
-
 import javax.ws.rs.core.Response.Status;
 
 import static org.hamcrest.Matchers.*;
 import static org.keycloak.testsuite.auth.page.AuthRealm.DEMO;
 import static org.keycloak.testsuite.util.URLAssert.assertCurrentUrlEquals;
 import static org.keycloak.testsuite.util.URLAssert.assertCurrentUrlStartsWithLoginUrlOf;
-import static org.keycloak.testsuite.util.WaitUtils.pause;
-import static org.keycloak.testsuite.util.WaitUtils.waitUntilElement;
+import static org.keycloak.testsuite.util.WaitUtils.*;
 
 /**
  *
@@ -199,7 +196,9 @@ public abstract class AbstractDemoServletsAdapterTest extends AbstractServletsAd
         assertCurrentUrlStartsWithLoginUrlOf(testRealmPage);
         testRealmLoginPage.form().login("bburke@redhat.com", "password");
         assertCurrentUrlEquals(driver, inputPortal + "/secured/post");
-        waitUntilElement(By.xpath("//body")).text().contains("parameter=hello");
+        waitForPageToLoad(driver);
+        String pageSource = driver.getPageSource();
+        assertThat(pageSource, containsString("parameter=hello"));
 
         String logoutUri = OIDCLoginProtocolService.logoutUrl(authServerPage.createUriBuilder())
                 .queryParam(OAuth2Constants.REDIRECT_URI, customerPortal.toString())
@@ -621,8 +620,10 @@ public abstract class AbstractDemoServletsAdapterTest extends AbstractServletsAd
 
         oAuthGrantPage.accept();
 
-        waitUntilElement(By.xpath("//body")).text().contains("Bill Burke");
-        waitUntilElement(By.xpath("//body")).text().contains("Stian Thorgersen");
+        String pageSource = driver.getPageSource();
+        waitForPageToLoad(driver);
+        assertThat(pageSource, containsString("Bill Burke"));
+        assertThat(pageSource, containsString("Stian Thorgersen"));
 
         String userId = ApiUtil.findUserByUsername(testRealmResource(), "bburke@redhat.com").getId();
 
@@ -673,8 +674,10 @@ public abstract class AbstractDemoServletsAdapterTest extends AbstractServletsAd
 
         testRealmLoginPage.form().login("bburke@redhat.com", "password");
 
-        waitUntilElement(By.xpath("//body")).text().contains("Bill Burke");
-        waitUntilElement(By.xpath("//body")).text().contains("Stian Thorgersen");
+        waitForPageToLoad(driver);
+        String pageSource = driver.getPageSource();
+        assertThat(pageSource, containsString("Bill Burke"));
+        assertThat(pageSource, containsString("Stian Thorgersen"));
 
         String userId = ApiUtil.findUserByUsername(testRealmResource(), "bburke@redhat.com").getId();
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/AbstractSAMLServletsAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/AbstractSAMLServletsAdapterTest.java
@@ -84,9 +84,7 @@ import org.keycloak.testsuite.admin.ApiUtil;
 import org.keycloak.testsuite.auth.page.login.Login;
 import org.keycloak.testsuite.auth.page.login.SAMLIDPInitiatedLogin;
 import org.keycloak.testsuite.page.AbstractPage;
-import org.keycloak.testsuite.util.IOUtil;
-import org.keycloak.testsuite.util.SamlClient;
-import org.keycloak.testsuite.util.UserBuilder;
+import org.keycloak.testsuite.util.*;
 
 import org.openqa.selenium.By;
 import org.w3c.dom.Document;
@@ -133,7 +131,7 @@ import static org.keycloak.testsuite.util.Matchers.statusCodeIsHC;
 import static org.keycloak.testsuite.util.SamlClient.idpInitiatedLogin;
 import static org.keycloak.testsuite.util.SamlClient.login;
 import static org.keycloak.testsuite.util.URLAssert.assertCurrentUrlStartsWith;
-import static org.keycloak.testsuite.util.WaitUtils.waitUntilElement;
+import static org.keycloak.testsuite.util.WaitUtils.*;
 
 /**
  * @author mhajas
@@ -384,7 +382,7 @@ public abstract class AbstractSAMLServletsAdapterTest extends AbstractServletsAd
 
     private void checkLoggedOut(AbstractPage page, Login loginPage) {
         page.navigateTo();
-        waitUntilElement(By.xpath("//body")).is().present();
+        waitForPageToLoad(driver);
         assertCurrentUrlStartsWith(loginPage);
     }
 
@@ -862,8 +860,10 @@ public abstract class AbstractSAMLServletsAdapterTest extends AbstractServletsAd
         assertCurrentUrlStartsWith(testRealmSAMLPostLoginPage);
         testRealmSAMLPostLoginPage.form().login("bburke", "password");
         assertCurrentUrlStartsWith(employeeServletPage);
-        waitUntilElement(By.xpath("//body")).text().contains("Relay state: " + SamlSPFacade.RELAY_STATE);
-        waitUntilElement(By.xpath("//body")).text().not().contains("SAML response: null");
+        waitForPageToLoad(driver);
+        String pageSource = driver.getPageSource();
+        assertThat(pageSource, containsString("Relay state: " + SamlSPFacade.RELAY_STATE));
+        assertThat(pageSource, not(containsString("SAML response: null")));
     }
 
     @Test


### PR DESCRIPTION
Adapter tests for examples seem not to be compatible with htmlUnit - tracked as https://issues.jboss.org/browse/KEYCLOAK-4508