### PR TITLE
KEYCLOAK-4515 Make it possible to clean-up other DB types than mysql or postgres

### DIFF
--- a/testsuite/integration-arquillian/servers/auth-server/jboss/common/datasource.xsl
+++ b/testsuite/integration-arquillian/servers/auth-server/jboss/common/datasource.xsl
@@ -74,7 +74,7 @@
     
     <xsl:variable name="newDriverDefinition">
         <xsl:if test="$driver != 'h2'">
-            <driver name="{$driver}" module="com.{$driver}" />
+            <driver name="{$driver}" module="test.jdbc.{$driver}" />
         </xsl:if>
     </xsl:variable>
     

--- a/testsuite/integration-arquillian/servers/auth-server/jboss/eap/src/main/resources/xslt/module.xsl
+++ b/testsuite/integration-arquillian/servers/auth-server/jboss/eap/src/main/resources/xslt/module.xsl
@@ -27,7 +27,7 @@
     <xsl:param name="version" select="''"/>
     
     <xsl:variable name="newModuleDefinition">
-        <module xmlns="urn:jboss:module:1.1" name="com.{$database}">
+        <module xmlns="urn:jboss:module:1.1" name="test.jdbc.{$database}">
             <resources>
                 <resource-root path="{$database}-{$version}.jar"/>
             </resources>

--- a/testsuite/integration-arquillian/servers/auth-server/jboss/pom.xml
+++ b/testsuite/integration-arquillian/servers/auth-server/jboss/pom.xml
@@ -403,7 +403,7 @@
         <profile>
             <id>jpa</id>
             <properties>
-                <jdbc.mvn.driver.deployment.dir>${auth.server.home}/modules/system/layers/base/com/${jdbc.mvn.artifactId}/main</jdbc.mvn.driver.deployment.dir>
+                <jdbc.mvn.driver.deployment.dir>${auth.server.home}/modules/system/layers/base/test/jdbc/${jdbc.mvn.artifactId}/main</jdbc.mvn.driver.deployment.dir>
                 <skip.h2.tcp>true</skip.h2.tcp>
             </properties>
             <build>

--- a/testsuite/integration-arquillian/servers/auth-server/jboss/wildfly/src/main/resources/xslt/module.xsl
+++ b/testsuite/integration-arquillian/servers/auth-server/jboss/wildfly/src/main/resources/xslt/module.xsl
@@ -28,7 +28,7 @@
     <xsl:param name="version" select="''"/>
     
     <xsl:variable name="newModuleDefinition">
-        <module xmlns="urn:jboss:module:1.3" name="com.{$database}">
+        <module xmlns="urn:jboss:module:1.3" name="test.jdbc.{$database}">
             <resources>
                 <resource-root path="{$database}-{$version}.jar"/>
             </resources>

--- a/testsuite/integration-arquillian/tests/pom.xml
+++ b/testsuite/integration-arquillian/tests/pom.xml
@@ -487,6 +487,46 @@
                 </pluginManagement>
             </build>
         </profile>
+        
+        <profile>
+            <id>jdbc-driver-dependency</id>
+            <activation>
+                <property>
+                    <name>jdbc.mvn.artifactId</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>${jdbc.mvn.groupId}</groupId>
+                    <artifactId>${jdbc.mvn.artifactId}</artifactId>
+                    <version>${jdbc.mvn.version}</version>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-enforcer-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>enforce</goal>
+                                </goals>
+                                <configuration>
+                                    <rules>
+                                        <requireProperty>
+                                            <property>jdbc.mvn.groupId</property>
+                                        </requireProperty>
+                                        <requireProperty>
+                                            <property>jdbc.mvn.version</property>
+                                        </requireProperty>
+                                    </rules>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
 
         <!-- Profiles for migration tests-->
         
@@ -890,10 +930,10 @@
 
                 <!-- CLI -->
                 <!--
-                   - This dependency must come after org.bouncycastle dependencies since it contains BC classes,
-                   - and MAC signature check on classes would fail otherwise with:
-                   - 'java.lang.SecurityException: JCE cannot authenticate the provider BC'
-                 -->
+                  - This dependency must come after org.bouncycastle dependencies since it contains BC classes,
+                  - and MAC signature check on classes would fail otherwise with:
+                  - 'java.lang.SecurityException: JCE cannot authenticate the provider BC'
+                -->
                 <dependency>
                     <groupId>org.keycloak</groupId>
                     <artifactId>keycloak-client-cli-dist</artifactId>


### PR DESCRIPTION
- added profile `jdbc-driver-depencency` to arquillian testsuite
- changed jdbc module path from layers/base/com/${db} to layers/base/test/jdbc/${db}