### PR TITLE
KEYCLOAK-4524

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/models/jpa/RealmAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/RealmAdapter.java
@@ -1191,7 +1191,7 @@ public class RealmAdapter implements RealmModel, JpaModel<RealmEntity> {
 
     @Override
     public IdentityProviderMapperModel addIdentityProviderMapper(IdentityProviderMapperModel model) {
-        if (getIdentityProviderMapperByName(model.getIdentityProviderAlias(), model.getIdentityProviderMapper()) != null) {
+        if (getIdentityProviderMapperByName(model.getIdentityProviderAlias(), model.getName()) != null) {
             throw new RuntimeException("identity provider mapper name must be unique per identity provider");
         }
         String id = KeycloakModelUtils.generateId();

--- a/services/src/main/java/org/keycloak/services/resources/admin/IdentityProviderResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/IdentityProviderResource.java
@@ -319,7 +319,11 @@ public class IdentityProviderResource {
         }
 
         IdentityProviderMapperModel model = RepresentationToModel.toModel(mapper);
-        model = realm.addIdentityProviderMapper(model);
+        try {
+            model = realm.addIdentityProviderMapper(model);
+        } catch (Exception e) {
+            return ErrorResponse.error("Failed to add mapper '" + model.getName() + "' to identity provider [" + identityProviderModel.getProviderId() + "].", Response.Status.BAD_REQUEST);
+        }
 
         adminEvent.operation(OperationType.CREATE).resource(ResourceType.IDENTITY_PROVIDER_MAPPER).resourcePath(uriInfo, model.getId())
             .representation(mapper).success();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/IdentityProviderTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/IdentityProviderTest.java
@@ -424,6 +424,11 @@ public class IdentityProviderTest extends AbstractAdminTest {
         Assert.assertNotNull("mapper.config exists", mapper.getConfig());
         Assert.assertEquals("config retained", "offline_access", mapper.getConfig().get("role"));
 
+        // add duplicate mapper
+        Response error = provider.addMapper(mapper);
+        Assert.assertEquals("mapper unique name", 400, error.getStatus());
+        error.close();
+
         // update mapper
         mapper.getConfig().put("role", "master-realm.manage-realm");
         provider.update(id, mapper);


### PR DESCRIPTION
Bug: Possible to add identity provider mappers with same name into single identity provider

Changes:
- Unique names enforced
- Added test