### PR TITLE
KEYCLOAK-2486: Update SimpleHTTP to use Apache HTTP Client

### DIFF
--- a/services/src/main/java/org/keycloak/broker/oidc/AbstractOAuth2IdentityProvider.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/AbstractOAuth2IdentityProvider.java
@@ -34,7 +34,6 @@ import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.services.ErrorPage;
 import org.keycloak.services.messages.Messages;
-import org.keycloak.truststore.JSSETruststoreConfigurator;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.QueryParam;
@@ -250,15 +249,12 @@ public abstract class AbstractOAuth2IdentityProvider<C extends OAuth2IdentityPro
         }
 
         public SimpleHttp generateTokenRequest(String authorizationCode) {
-            JSSETruststoreConfigurator configurator = new JSSETruststoreConfigurator(session);
-            return SimpleHttp.doPost(getConfig().getTokenUrl())
+            return SimpleHttp.doPost(getConfig().getTokenUrl(), session)
                     .param(OAUTH2_PARAMETER_CODE, authorizationCode)
                     .param(OAUTH2_PARAMETER_CLIENT_ID, getConfig().getClientId())
                     .param(OAUTH2_PARAMETER_CLIENT_SECRET, getConfig().getClientSecret())
                     .param(OAUTH2_PARAMETER_REDIRECT_URI, uriInfo.getAbsolutePath().toString())
-                    .param(OAUTH2_PARAMETER_GRANT_TYPE, OAUTH2_GRANT_TYPE_AUTHORIZATION_CODE)
-                    .sslFactory(configurator.getSSLSocketFactory())
-                    .hostnameVerifier(configurator.getHostnameVerifier());
+                    .param(OAUTH2_PARAMETER_GRANT_TYPE, OAUTH2_GRANT_TYPE_AUTHORIZATION_CODE);
         }
     }
 }

--- a/services/src/main/java/org/keycloak/broker/oidc/util/JsonSimpleHttp.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/util/JsonSimpleHttp.java
@@ -20,6 +20,7 @@ package org.keycloak.broker.oidc.util;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.keycloak.broker.provider.util.SimpleHttp;
+import org.keycloak.models.KeycloakSession;
 
 import java.io.IOException;
 
@@ -28,16 +29,16 @@ import java.io.IOException;
  * @version $Revision: 1 $
  */
 public class JsonSimpleHttp extends SimpleHttp {
-    public JsonSimpleHttp(String url, String method) {
-        super(url, method);
+    public JsonSimpleHttp(String url, String method, KeycloakSession session) {
+        super(url, method, session);
     }
 
-    public static JsonSimpleHttp doGet(String url) {
-        return new JsonSimpleHttp(url, "GET");
+    public static JsonSimpleHttp doGet(String url, KeycloakSession session) {
+        return new JsonSimpleHttp(url, "GET", session);
     }
 
-    public static JsonSimpleHttp doPost(String url) {
-        return new JsonSimpleHttp(url, "POST");
+    public static JsonSimpleHttp doPost(String url, KeycloakSession session) {
+        return new JsonSimpleHttp(url, "POST", session);
     }
 
     private static ObjectMapper mapper = new ObjectMapper();

--- a/services/src/main/java/org/keycloak/broker/saml/SAMLIdentityProvider.java
+++ b/services/src/main/java/org/keycloak/broker/saml/SAMLIdentityProvider.java
@@ -159,7 +159,7 @@ public class SAMLIdentityProvider extends AbstractIdentityProvider<SAMLIdentityP
         SAML2LogoutRequestBuilder logoutBuilder = buildLogoutRequest(userSession, uriInfo, realm, singleLogoutServiceUrl);
         JaxrsSAML2BindingBuilder binding = buildLogoutBinding(session, userSession, realm);
         try {
-            int status = SimpleHttp.doPost(singleLogoutServiceUrl)
+            int status = SimpleHttp.doPost(singleLogoutServiceUrl, session)
                     .param(GeneralConstants.SAML_REQUEST_KEY, binding.postBinding(logoutBuilder.buildDocument()).encoded())
                     .param(GeneralConstants.RELAY_STATE, userSession.getId()).asStatus();
             boolean success = status >=200 && status < 400;

--- a/services/src/main/java/org/keycloak/social/facebook/FacebookIdentityProvider.java
+++ b/services/src/main/java/org/keycloak/social/facebook/FacebookIdentityProvider.java
@@ -47,7 +47,7 @@ public class FacebookIdentityProvider extends AbstractOAuth2IdentityProvider imp
 
 	protected BrokeredIdentityContext doGetFederatedIdentity(String accessToken) {
 		try {
-			JsonNode profile = JsonSimpleHttp.asJson(SimpleHttp.doGet(PROFILE_URL).header("Authorization", "Bearer " + accessToken));
+			JsonNode profile = JsonSimpleHttp.asJson(SimpleHttp.doGet(PROFILE_URL, session).header("Authorization", "Bearer " + accessToken));
 
 			String id = getJsonProperty(profile, "id");
 

--- a/services/src/main/java/org/keycloak/social/github/GitHubIdentityProvider.java
+++ b/services/src/main/java/org/keycloak/social/github/GitHubIdentityProvider.java
@@ -48,7 +48,7 @@ public class GitHubIdentityProvider extends AbstractOAuth2IdentityProvider imple
 	@Override
 	protected BrokeredIdentityContext doGetFederatedIdentity(String accessToken) {
 		try {
-			JsonNode profile = JsonSimpleHttp.asJson(SimpleHttp.doGet(PROFILE_URL).header("Authorization", "Bearer " + accessToken));
+			JsonNode profile = JsonSimpleHttp.asJson(SimpleHttp.doGet(PROFILE_URL, session).header("Authorization", "Bearer " + accessToken));
 
 			BrokeredIdentityContext user = new BrokeredIdentityContext(getJsonProperty(profile, "id"));
 

--- a/services/src/main/java/org/keycloak/social/linkedin/LinkedInIdentityProvider.java
+++ b/services/src/main/java/org/keycloak/social/linkedin/LinkedInIdentityProvider.java
@@ -57,7 +57,7 @@ public class LinkedInIdentityProvider extends AbstractOAuth2IdentityProvider imp
 	protected BrokeredIdentityContext doGetFederatedIdentity(String accessToken) {
 		log.debug("doGetFederatedIdentity()");
 		try {
-			JsonNode profile = JsonSimpleHttp.asJson(SimpleHttp.doGet(PROFILE_URL).header("Authorization", "Bearer " + accessToken));
+			JsonNode profile = JsonSimpleHttp.asJson(SimpleHttp.doGet(PROFILE_URL, session).header("Authorization", "Bearer " + accessToken));
 
 			BrokeredIdentityContext user = new BrokeredIdentityContext(getJsonProperty(profile, "id"));
 

--- a/services/src/main/java/org/keycloak/social/microsoft/MicrosoftIdentityProvider.java
+++ b/services/src/main/java/org/keycloak/social/microsoft/MicrosoftIdentityProvider.java
@@ -62,7 +62,7 @@ public class MicrosoftIdentityProvider extends AbstractOAuth2IdentityProvider im
             if (log.isDebugEnabled()) {
                 log.debug("Microsoft Live user profile request to: " + URL);
             }
-            JsonNode profile = JsonSimpleHttp.asJson(SimpleHttp.doGet(URL));
+            JsonNode profile = JsonSimpleHttp.asJson(SimpleHttp.doGet(URL, session));
 
             String id = getJsonProperty(profile, "id");
 

--- a/services/src/main/java/org/keycloak/social/stackoverflow/StackoverflowIdentityProvider.java
+++ b/services/src/main/java/org/keycloak/social/stackoverflow/StackoverflowIdentityProvider.java
@@ -63,7 +63,7 @@ public class StackoverflowIdentityProvider extends AbstractOAuth2IdentityProvide
 			if (log.isDebugEnabled()) {
 				log.debug("StackOverflow profile request to: " + URL);
 			}
-			JsonNode profile = JsonSimpleHttp.asJson(SimpleHttp.doGet(URL)).get("items").get(0);
+			JsonNode profile = JsonSimpleHttp.asJson(SimpleHttp.doGet(URL, session)).get("items").get(0);
 
 			BrokeredIdentityContext user = new BrokeredIdentityContext(getJsonProperty(profile, "user_id"));
 


### PR DESCRIPTION
In addition to that I cleaned up some methods in `SimpleHttp` because the `TrustStore` is already configured in the **DefaultHttpClientFactory** (no need for the `setupTruststoreIfApplicable` method anymore).

`SimpleHttp` needs the current session in the constructor to retrieve the `DefaultHttpClient`.