### PR TITLE
KEYCLOAK-4278 Testsuite failures with -Pauth-server-wildfly

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/TrustStoreEmailTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/TrustStoreEmailTest.java
@@ -18,6 +18,7 @@ package org.keycloak.testsuite.account;
 
 import org.jboss.arquillian.graphene.page.Page;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
@@ -28,8 +29,9 @@ import org.keycloak.testsuite.auth.page.account.AccountManagement;
 import org.keycloak.testsuite.auth.page.login.OIDCLogin;
 import org.keycloak.testsuite.auth.page.login.VerifyEmail;
 import org.keycloak.testsuite.util.MailServerConfiguration;
-import org.keycloak.testsuite.util.RealmRepUtil;
 import org.keycloak.testsuite.util.SslMailServer;
+
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 import static org.keycloak.testsuite.util.MailAssert.assertEmailAndGetUrl;
@@ -77,6 +79,10 @@ public class TrustStoreEmailTest extends AbstractTestRealmKeycloakTest {
         SslMailServer.stop();
     }
 
+    @Before
+    public void increaseRequestTimeout() {
+        driver.manage().timeouts().pageLoadTimeout(30, TimeUnit.SECONDS);
+    }
 
     @Test
     public void verifyEmailWithSslEnabled() {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/RequiredActionEmailVerificationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/RequiredActionEmailVerificationTest.java
@@ -47,6 +47,7 @@ import javax.mail.Multipart;
 import javax.mail.internet.MimeMessage;
 import java.io.IOException;
 import java.util.Collections;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -96,6 +97,11 @@ public class RequiredActionEmailVerificationTest extends AbstractTestRealmKeyclo
                 .username("test-user@localhost")
                 .email("test-user@localhost").build();
         ApiUtil.createUserAndResetPasswordWithAdminClient(testRealm(), user, "password");
+    }
+
+    @Before
+    public void increaseRequestTimeout() {
+        driver.manage().timeouts().pageLoadTimeout(30, TimeUnit.SECONDS);
     }
 
     @Test

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractBrokerTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractBrokerTest.java
@@ -174,6 +174,7 @@ public abstract class AbstractBrokerTest extends AbstractBaseBrokerTest {
             resetUserPassword(adminClient.realm(bc.consumerRealmName()).users().get(userId), "password", false);
         
             //test
+            driver.manage().timeouts().pageLoadTimeout(30, TimeUnit.SECONDS);
             driver.navigate().to(getAccountUrl(bc.consumerRealmName()));
 
             log.debug("Clicking social " + bc.getIDPAlias());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/ResetPasswordTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/ResetPasswordTest.java
@@ -48,6 +48,7 @@ import javax.mail.internet.MimeMessage;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.assertEquals;
@@ -103,6 +104,11 @@ public class ResetPasswordTest extends AbstractTestRealmKeycloakTest {
 
     @Rule
     public AssertEvents events = new AssertEvents(this);
+
+    @Before
+    public void increaseRequestTimeout() {
+        driver.manage().timeouts().pageLoadTimeout(30, TimeUnit.SECONDS);
+    }
 
     @Test
     public void resetPasswordLink() throws IOException, MessagingException {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/i18n/EmailTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/i18n/EmailTest.java
@@ -18,6 +18,7 @@ package org.keycloak.testsuite.i18n;
 
 import org.jboss.arquillian.graphene.page.Page;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.keycloak.models.UserModel;
@@ -30,6 +31,7 @@ import org.keycloak.testsuite.util.GreenMailRule;
 import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 import org.keycloak.testsuite.ProfileAssume;
@@ -53,6 +55,11 @@ public class EmailTest extends AbstractI18NTest {
         UserRepresentation user = findUser("login-test");
         user.singleAttribute(UserModel.LOCALE, locale);
         ApiUtil.findUserByUsernameId(testRealm(), "login-test").update(user);
+    }
+
+    @Before
+    public void increaseRequestTimeout() {
+        driver.manage().timeouts().pageLoadTimeout(30, TimeUnit.SECONDS);
     }
 
     @Test


### PR DESCRIPTION
- Fixed timeouts in tests involving sending of emails
- Excluded one test requiring auth-server-undertow from executing as part of auth-server-wildfly