### PR TITLE
KEYCLOAK-4612 Fix CachePolicy.MAX_LIFESPAN invalidation

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/UserCacheSession.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/UserCacheSession.java
@@ -302,6 +302,10 @@ public class UserCacheSession implements UserCache {
                     invalidate = true;
                 } else if (cached.getCacheTimestamp() < model.getCacheInvalidBefore()) {
                     invalidate = true;
+                } else if (policy == UserStorageProviderModel.CachePolicy.MAX_LIFESPAN) {
+                    if (cached.getCacheTimestamp() + model.getMaxLifespan() < Time.currentTimeMillis()) {
+                        invalidate = true;
+                    }
                 } else if (policy == UserStorageProviderModel.CachePolicy.EVICT_DAILY) {
                     long dailyTimeout = dailyTimeout(model.getEvictionHour(), model.getEvictionMinute());
                     dailyTimeout = dailyTimeout - (24 * 60 * 60 * 1000);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/storage/UserStorageTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/storage/UserStorageTest.java
@@ -447,7 +447,6 @@ public class UserStorageTest extends AbstractAuthTest {
     }
 
     @Test
-    @Ignore
     public void testMaxLifespan() {
         ApiUtil.findUserByUsername(testRealmResource(), "thor");
 


### PR DESCRIPTION
This adds explicit cache invalidation for UserModel objects that are around past their max lifespan. Previously Keycloak never checked this time even though there were already checks for the daily/weekly evictions. We would like to use the max lifespan eviction in RH-SSO 7.1 but that feature isn't reliable in 3.0.0.CR1 without this change.