### PR TITLE
Fix null protocols for default clients

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/migration/migrators/MigrateTo3_0_0.java
+++ b/server-spi-private/src/main/java/org/keycloak/migration/migrators/MigrateTo3_0_0.java
@@ -20,13 +20,18 @@ package org.keycloak.migration.migrators;
 
 import org.keycloak.migration.ModelVersion;
 import org.keycloak.models.ClientModel;
+import org.keycloak.models.Constants;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.RoleModel;
+import org.keycloak.representations.oidc.OIDCClientRepresentation;
+
+import java.util.Objects;
 
 import static org.keycloak.models.AccountRoles.MANAGE_ACCOUNT;
 import static org.keycloak.models.AccountRoles.MANAGE_ACCOUNT_LINKS;
 import static org.keycloak.models.Constants.ACCOUNT_MANAGEMENT_CLIENT_ID;
+import static org.keycloak.models.Constants.defaultClients;
 
 /**
  * @author <a href="mailto:bburke@redhat.com">Bill Burke</a>
@@ -38,6 +43,12 @@ public class MigrateTo3_0_0 implements Migration {
     @Override
     public void migrate(KeycloakSession session) {
         for (RealmModel realm : session.realms().getRealms()) {
+
+            realm.getClients().stream()
+                    .filter(clientModel -> defaultClients.contains(clientModel.getId()))
+                    .filter(clientModel -> Objects.nonNull(clientModel.getProtocol()))
+                    .forEach(clientModel -> clientModel.setProtocol("openid-connect"));
+
             ClientModel client = realm.getClientByClientId(ACCOUNT_MANAGEMENT_CLIENT_ID);
             if (client == null) continue;
             RoleModel linkRole = client.getRole(MANAGE_ACCOUNT_LINKS);

--- a/server-spi-private/src/main/java/org/keycloak/migration/migrators/MigrateTo3_0_0.java
+++ b/server-spi-private/src/main/java/org/keycloak/migration/migrators/MigrateTo3_0_0.java
@@ -46,7 +46,7 @@ public class MigrateTo3_0_0 implements Migration {
 
             realm.getClients().stream()
                     .filter(clientModel -> defaultClients.contains(clientModel.getId()))
-                    .filter(clientModel -> Objects.nonNull(clientModel.getProtocol()))
+                    .filter(clientModel -> Objects.isNull(clientModel.getProtocol()))
                     .forEach(clientModel -> clientModel.setProtocol("openid-connect"));
 
             ClientModel client = realm.getClientByClientId(ACCOUNT_MANAGEMENT_CLIENT_ID);

--- a/server-spi-private/src/main/java/org/keycloak/models/Constants.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/Constants.java
@@ -19,6 +19,9 @@ package org.keycloak.models;
 
 import org.keycloak.OAuth2Constants;
 
+import java.util.Arrays;
+import java.util.Collection;
+
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
@@ -30,6 +33,8 @@ public interface Constants {
     String ACCOUNT_MANAGEMENT_CLIENT_ID = "account";
     String BROKER_SERVICE_CLIENT_ID = "broker";
     String REALM_MANAGEMENT_CLIENT_ID = "realm-management";
+
+    Collection<String> defaultClients = Arrays.asList(ACCOUNT_MANAGEMENT_CLIENT_ID, ADMIN_CLI_CLIENT_ID, BROKER_SERVICE_CLIENT_ID, REALM_MANAGEMENT_CLIENT_ID, ADMIN_CONSOLE_CLIENT_ID);
 
     String INSTALLED_APP_URN = "urn:ietf:wg:oauth:2.0:oob";
     String INSTALLED_APP_URL = "http://localhost";

--- a/services/src/main/java/org/keycloak/services/managers/RealmManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/RealmManager.java
@@ -148,6 +148,7 @@ public class RealmManager {
         adminConsole.setPublicClient(true);
         adminConsole.addRedirectUri(baseUrl + "/*");
         adminConsole.setFullScopeAllowed(false);
+        adminConsole.setProtocol(OIDCLoginProtocol.LOGIN_PROTOCOL);
 
         RoleModel adminRole;
         if (realm.getName().equals(Config.getAdminRealm())) {
@@ -182,6 +183,7 @@ public class RealmManager {
             adminCli.setFullScopeAllowed(false);
             adminCli.setStandardFlowEnabled(false);
             adminCli.setDirectAccessGrantsEnabled(true);
+            adminCli.setProtocol(OIDCLoginProtocol.LOGIN_PROTOCOL);
 
             RoleModel adminRole;
             if (realm.getName().equals(Config.getAdminRealm())) {
@@ -348,6 +350,7 @@ public class RealmManager {
         adminRole.setScopeParamRequired(false);
         realmAdminClient.setBearerOnly(true);
         realmAdminClient.setFullScopeAllowed(false);
+        realmAdminClient.setProtocol(OIDCLoginProtocol.LOGIN_PROTOCOL);
 
         for (String r : AdminRoles.ALL_REALM_ROLES) {
             addAndSetAdminRole(r, realmAdminClient, adminRole);
@@ -389,6 +392,7 @@ public class RealmManager {
             String redirectUri = base + "/*";
             client.addRedirectUri(redirectUri);
             client.setBaseUrl(base);
+            client.setProtocol(OIDCLoginProtocol.LOGIN_PROTOCOL);
 
             for (String role : AccountRoles.ALL) {
                 client.addDefaultRole(role);
@@ -415,6 +419,7 @@ public class RealmManager {
             client.setEnabled(true);
             client.setName("${client_" + Constants.BROKER_SERVICE_CLIENT_ID + "}");
             client.setFullScopeAllowed(false);
+            client.setProtocol(OIDCLoginProtocol.LOGIN_PROTOCOL);
 
             for (String role : Constants.BROKER_SERVICE_ROLES) {
                 RoleModel roleModel = client.addRole(role);


### PR DESCRIPTION
All default clients created when a realm is initialized have a null protocol.  Specify OIDC.