### PR TITLE
Verify message comes from loginIframe

### DIFF
--- a/adapters/oidc/js/src/main/resources/keycloak.js
+++ b/adapters/oidc/js/src/main/resources/keycloak.js
@@ -832,9 +832,10 @@
             document.body.appendChild(iframe);
 
             var messageCallback = function(event) {
-                if (event.origin !== loginIframe.iframeOrigin) {
+                if ((event.origin !== loginIframe.iframeOrigin) || (loginIframe.iframe.contentWindow !== event.source)) {
                     return;
                 }
+                
 
                 if (event.data != "unchanged") {
                     kc.clearToken();


### PR DESCRIPTION
In the current implementation a message coming from any window on the same origin may cause the refresh token to be cleared.
In my case, messages generated by a chrome extension were causing the application to logout unexpectedly. With additional condition only messages coming from the login iFrame will be processed. Another suggestion would be changing the condition `event.data != "unchanged"` to something more specific.