### PR TITLE
KEYCLOAK-4725

### DIFF
--- a/adapters/oidc/js/src/main/resources/keycloak.js
+++ b/adapters/oidc/js/src/main/resources/keycloak.js
@@ -922,7 +922,7 @@
                             var redirectUri = location.href;
                             if (location.hash && encodeHash) {
                                 redirectUri = redirectUri.substring(0, location.href.indexOf('#'));
-                                redirectUri += (redirectUri.indexOf('?') == -1 ? '?' : '&') + 'redirect_fragment=' + encodeURIComponent(location.hash.substring(1));
+                                redirectUri += (redirectUri.indexOf('?') == -1 ? '?' : '&') + 'redirect_fragment=' + location.hash.substring(1);
                             }
                             return redirectUri;
                         }


### PR DESCRIPTION
removing encoding because it is done twice

issue: https://issues.jboss.org/browse/KEYCLOAK-4725

