### PR TITLE
Add test covering KEYCLOAK-3964 using a method in my previous uncommited pull

### DIFF
--- a/testsuite/integration/src/test/java/org/keycloak/testsuite/federation/storage/ldap/LDAPProvidersIntegrationTest.java
+++ b/testsuite/integration/src/test/java/org/keycloak/testsuite/federation/storage/ldap/LDAPProvidersIntegrationTest.java
@@ -432,7 +432,7 @@ public class LDAPProvidersIntegrationTest {
         loginPage.open();
         loginPage.clickRegister();
         registerPage.assertCurrent();
-
+        
         // check existing username
         registerPage.register("firstName", "lastName", "email@mail.cz", "existing", "Password1", "Password1");
         registerPage.assertCurrent();
@@ -443,7 +443,42 @@ public class LDAPProvidersIntegrationTest {
         registerPage.assertCurrent();
         Assert.assertEquals("Email already exists.", registerPage.getError());
     }
+  
+    
+   
+    //
+    // KEYCLOAK-4533
+    //
+    @Test
+    public void testLDAPUserDeletionImport() {
+       
+    	KeycloakSession session = keycloakRule.startSession();
+        RealmModel appRealm = new RealmManager(session).getRealmByName("test");
+        LDAPStorageProvider ldapProvider = LDAPTestUtils.getLdapProvider(session, ldapModel);        	
+      	//UserModel user = session.users().getUserByUsername("maryjane", appRealm);
+      	LDAPConfig config = ldapProvider.getLdapIdentityStore().getConfig();      
+      	
+     // Create the user in LDAP and register him
 
+       LDAPObject mary = LDAPTestUtils.addLDAPUser(ldapProvider, appRealm, "maryjane", "mary", "yram", "mj@testing.redhat.cz", null, "12398");
+       LDAPTestUtils.updateLDAPPassword(ldapProvider, mary, "Password1");
+        
+        try {
+        	
+        	// Log in and out of the user
+         	loginSuccessAndLogout("maryjane", "Password1");  
+           
+         	// Delete LDAP User
+        	LDAPTestUtils.removeLDAPUserByUsername(ldapProvider, appRealm, config, "maryjane");
+   
+        	// Make sure the deletion took place. 
+        	List<UserModel> deletedUsers = session.users().searchForUser("mary yram", appRealm);
+            Assert.assertTrue(deletedUsers.isEmpty());
+                  
+        } finally {
+            keycloakRule.stopSession(session, false);
+        }
+    }
     @Test
     public void registerUserLdapSuccess() {
         loginPage.open();

--- a/testsuite/integration/src/test/java/org/keycloak/testsuite/federation/storage/ldap/LDAPProvidersIntegrationTest.java
+++ b/testsuite/integration/src/test/java/org/keycloak/testsuite/federation/storage/ldap/LDAPProvidersIntegrationTest.java
@@ -455,8 +455,10 @@ public class LDAPProvidersIntegrationTest {
     	KeycloakSession session = keycloakRule.startSession();
         RealmModel appRealm = new RealmManager(session).getRealmByName("test");
         LDAPStorageProvider ldapProvider = LDAPTestUtils.getLdapProvider(session, ldapModel);        	
-      	//UserModel user = session.users().getUserByUsername("maryjane", appRealm);
       	LDAPConfig config = ldapProvider.getLdapIdentityStore().getConfig();      
+      
+      	// Make sure mary is gone
+      	LDAPTestUtils.removeLDAPUserByUsername(ldapProvider, appRealm, config, "maryjane");
       	
      // Create the user in LDAP and register him
 

--- a/testsuite/integration/src/test/java/org/keycloak/testsuite/federation/storage/ldap/LDAPTestUtils.java
+++ b/testsuite/integration/src/test/java/org/keycloak/testsuite/federation/storage/ldap/LDAPTestUtils.java
@@ -32,6 +32,7 @@ import org.keycloak.representations.idm.CredentialRepresentation;
 import org.keycloak.representations.idm.SynchronizationResultRepresentation;
 import org.keycloak.storage.UserStorageProvider;
 import org.keycloak.storage.ldap.LDAPStorageProvider;
+import org.keycloak.storage.ldap.LDAPConfig;
 import org.keycloak.storage.ldap.LDAPUtils;
 import org.keycloak.storage.ldap.idm.model.LDAPObject;
 import org.keycloak.storage.ldap.idm.query.internal.LDAPQuery;
@@ -263,7 +264,20 @@ public class LDAPTestUtils {
             ldapStore.remove(ldapUser);
         }
     }
-
+    
+    public static void removeLDAPUserByUsername(LDAPStorageProvider ldapProvider, RealmModel realm, LDAPConfig config, String username) {
+        LDAPIdentityStore ldapStore = ldapProvider.getLdapIdentityStore();
+        LDAPQuery ldapQuery = LDAPUtils.createQueryForUserSearch(ldapProvider, realm);
+        List<LDAPObject> allUsers = ldapQuery.getResultList();
+        
+        // This is ugly, we are iterating over the entire set of ldap users and deleting the one where the username matches.  TODO: Find a better way!
+        for (LDAPObject ldapUser : allUsers) {
+            if (username.equals(LDAPUtils.getUsername(ldapUser, config))) {
+            	ldapStore.remove(ldapUser);
+            }
+        }
+    }
+    
     public static void removeAllLDAPRoles(KeycloakSession session, RealmModel appRealm, ComponentModel ldapModel, String mapperName) {
         ComponentModel mapperModel = getSubcomponentByName(appRealm, ldapModel, mapperName);
         LDAPStorageProvider ldapProvider = LDAPTestUtils.getLdapProvider(session, ldapModel);

--- a/testsuite/integration/src/test/java/org/keycloak/testsuite/federation/storage/ldap/noimport/LDAPProvidersIntegrationNoImportTest.java
+++ b/testsuite/integration/src/test/java/org/keycloak/testsuite/federation/storage/ldap/noimport/LDAPProvidersIntegrationNoImportTest.java
@@ -362,6 +362,46 @@ public class LDAPProvidersIntegrationNoImportTest {
     }
 
     @Test
+    public void testLDAPUserDeletionImport() {
+       
+    	KeycloakSession session = keycloakRule.startSession();
+        RealmModel appRealm = new RealmManager(session).getRealmByName("test");
+        LDAPStorageProvider ldapProvider = LDAPTestUtils.getLdapProvider(session, ldapModel);        	
+      	LDAPConfig config = ldapProvider.getLdapIdentityStore().getConfig();      
+      
+      	// Make sure mary is gone
+      	LDAPTestUtils.removeLDAPUserByUsername(ldapProvider, appRealm, config, "maryjane");
+      	
+     // Create the user in LDAP and register him
+
+       LDAPObject mary = LDAPTestUtils.addLDAPUser(ldapProvider, appRealm, "maryjane", "mary", "yram", "mj@testing.redhat.cz", null, "12398");
+       LDAPTestUtils.updateLDAPPassword(ldapProvider, mary, "Password1");
+        
+        try {
+        	
+        	// Log in and out of the user
+         	loginSuccessAndLogout("maryjane", "Password1");  
+           
+         	// Delete LDAP User
+        	LDAPTestUtils.removeLDAPUserByUsername(ldapProvider, appRealm, config, "maryjane");
+   
+        	// Make sure the deletion took place. 
+        	List<UserModel> deletedUsers = session.users().searchForUser("mary yram", appRealm);
+            Assert.assertTrue(deletedUsers.isEmpty());
+                  
+        } finally {
+            keycloakRule.stopSession(session, false);
+        }
+    }
+    
+    
+    
+    
+    
+    
+    
+    
+    @Test
     public void registerExistingLdapUser() {
         loginPage.open();
         loginPage.clickRegister();

--- a/testsuite/integration/src/test/java/org/keycloak/testsuite/federation/storage/ldap/noimport/LDAPProvidersIntegrationNoImportTest.java
+++ b/testsuite/integration/src/test/java/org/keycloak/testsuite/federation/storage/ldap/noimport/LDAPProvidersIntegrationNoImportTest.java
@@ -376,8 +376,9 @@ public class LDAPProvidersIntegrationNoImportTest {
       	// Make sure mary is gone
       	LDAPTestUtils.removeLDAPUserByUsername(ldapProvider, appRealm, config, "maryjane");
       	
-     // Create the user in LDAP and register him
-
+     
+      // Create the user in LDAP and register him
+      //
        LDAPObject mary = LDAPTestUtils.addLDAPUser(ldapProvider, appRealm, "maryjane", "mary", "yram", "mj@testing.redhat.cz", null, "12398");
        LDAPTestUtils.updateLDAPPassword(ldapProvider, mary, "Password1");
         

--- a/testsuite/integration/src/test/java/org/keycloak/testsuite/federation/storage/ldap/noimport/LDAPProvidersIntegrationNoImportTest.java
+++ b/testsuite/integration/src/test/java/org/keycloak/testsuite/federation/storage/ldap/noimport/LDAPProvidersIntegrationNoImportTest.java
@@ -361,8 +361,12 @@ public class LDAPProvidersIntegrationNoImportTest {
         Assert.assertEquals("Your password has been updated.", profilePage.getSuccess());
     }
 
+    //
+    //  KEYCLOAK-3964
+    //
+    // Adding a user to LDAP and Logging In as him - Verifying he is not added locally both times
     @Test
-    public void testLDAPUserDeletionImport() {
+    public void testLDAPUserImportOnCreationOrLogin() {
        
     	KeycloakSession session = keycloakRule.startSession();
         RealmModel appRealm = new RealmManager(session).getRealmByName("test");


### PR DESCRIPTION


It turns out the test for noImport is pretty close to what I had to do for my original test.  So I modified it and moved it over.   The other two files are from the earlier pull request that is still waiting for commit. 

