### PR TITLE
KEYCLOAK-3108: Make the credentials map case insensitive

### DIFF
--- a/core/src/main/java/org/keycloak/representations/adapters/config/BaseAdapterConfig.java
+++ b/core/src/main/java/org/keycloak/representations/adapters/config/BaseAdapterConfig.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.TreeMap;
 
 /**
  * Common Adapter configuration
@@ -58,7 +59,7 @@ public class BaseAdapterConfig extends BaseRealmConfig {
     @JsonProperty("public-client")
     protected boolean publicClient;
     @JsonProperty("credentials")
-    protected Map<String, Object> credentials = new HashMap<>();
+    protected Map<String, Object> credentials = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 
 
     public boolean isUseResourceRoleMappings() {


### PR DESCRIPTION
With the Spring Boot you can override keycloak properties by passing them as environment properties in this form : KEYCLOAK_CREDENTIALS_SECRET but this will create 2 keys in the Map : `secret` and `SECRET`. 
This fix use a TreeMap which case insensitivity instead of a hashMap. 