### PR TITLE
Remove the deprecated from readString(InputStream, Charset)

### DIFF
--- a/common/src/main/java/org/keycloak/common/util/StreamUtil.java
+++ b/common/src/main/java/org/keycloak/common/util/StreamUtil.java
@@ -53,7 +53,6 @@ public final class StreamUtil {
      * @param charset Charset used to decode the input stream
      * @return String representation of the input stream contents decoded using given charset
      * @throws IOException
-     * @deprecated Use {@link #readString(java.io.InputStream, java.nio.charset.Charset)} variant.
      */
     public static String readString(InputStream in, Charset charset) throws IOException
     {


### PR DESCRIPTION
I believe it was copied from the previous overload.