### PR TITLE
KEYCLOAK-4743 Add support for HTTP Proxy in DefaultHttpClientFactory

### DIFF
--- a/services/src/main/java/org/keycloak/connections/httpclient/DefaultHttpClientFactory.java
+++ b/services/src/main/java/org/keycloak/connections/httpclient/DefaultHttpClientFactory.java
@@ -127,6 +127,7 @@ public class DefaultHttpClientFactory implements HttpClientFactory {
                     String clientKeystore = config.get("client-keystore");
                     String clientKeystorePassword = config.get("client-keystore-password");
                     String clientPrivateKeyPassword = config.get("client-key-password");
+                    String proxyUrl= config.get("proxy-url");
 
                     TruststoreProvider truststoreProvider = session.getProvider(TruststoreProvider.class);
                     boolean disableTrustManager = truststoreProvider == null || truststoreProvider.getTruststore() == null;
@@ -137,13 +138,15 @@ public class DefaultHttpClientFactory implements HttpClientFactory {
                             : HttpClientBuilder.HostnameVerificationPolicy.valueOf(truststoreProvider.getPolicy().name());
 
                     HttpClientBuilder builder = new HttpClientBuilder();
+
                     builder.socketTimeout(socketTimeout, TimeUnit.MILLISECONDS)
                             .establishConnectionTimeout(establishConnectionTimeout, TimeUnit.MILLISECONDS)
                             .maxPooledPerRoute(maxPooledPerRoute)
                             .connectionPoolSize(connectionPoolSize)
                             .connectionTTL(connectionTTL, TimeUnit.MILLISECONDS)
                             .maxConnectionIdleTime(maxConnectionIdleTime, TimeUnit.MILLISECONDS)
-                            .disableCookies(disableCookies);
+                            .disableCookies(disableCookies)
+                            .proxyUrl(proxyUrl);
 
                     if (disableTrustManager) {
                         // TODO: is it ok to do away with disabling trust manager?


### PR DESCRIPTION
We now support basic proxy configuration for out-bound calls
via the HttpClient provided by the HttpClientProvider.

To configure a proxy one needs to set the proxy-url property to the
"default" connectionsHttpClient in the standalone(-ha).xml file.
The `HttpClientBuilder` builder will derive the proxy configuration
from the provided proxy-url.
By default no proxy is configured.

The following jboss-cli command can be used to configure
the proxy-url.
```
/subsystem=keycloak-server/spi=connectionsHttpClient/provider=default:write-attribute(name=properties.proxy-url,value="http://www-proxy.tdlabs.local:3128")
```