### PR TITLE
KEYCLOAK-4761 Support for Java adapter backward compatibility testing

### DIFF
--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/Keycloak.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/Keycloak.java
@@ -20,6 +20,7 @@ package org.keycloak.admin.client;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
+import org.jboss.resteasy.plugins.providers.jackson.ResteasyJackson2Provider;
 import org.keycloak.admin.client.resource.BearerAuthFilter;
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.admin.client.resource.RealmsResource;
@@ -31,7 +32,6 @@ import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLSession;
 
 import java.net.URI;
-import java.security.KeyStore;
 
 import static org.keycloak.OAuth2Constants.PASSWORD;
 
@@ -66,12 +66,20 @@ public class Keycloak {
     }
 
     public static Keycloak getInstance(String serverUrl, String realm, String username, String password, String clientId, String clientSecret, SSLContext sslContext) {
-        ResteasyClient client = new ResteasyClientBuilder()
+        return getInstance(serverUrl, realm, username, password, clientId, clientSecret, sslContext, null);
+    }
+
+    public static Keycloak getInstance(String serverUrl, String realm, String username, String password, String clientId, String clientSecret, SSLContext sslContext, ResteasyJackson2Provider customJacksonProvider) {
+        ResteasyClientBuilder clientBuilder = new ResteasyClientBuilder()
                 .sslContext(sslContext)
                 .hostnameVerification(ResteasyClientBuilder.HostnameVerificationPolicy.WILDCARD)
-                .connectionPoolSize(10).build();
+                .connectionPoolSize(10);
 
-        return new Keycloak(serverUrl, realm, username, password, clientId, clientSecret, PASSWORD, client, null);
+        if (customJacksonProvider != null) {
+            clientBuilder.register(customJacksonProvider);
+        }
+
+        return new Keycloak(serverUrl, realm, username, password, clientId, clientSecret, PASSWORD, clientBuilder.build(), null);
     }
 
     private static ResteasyClientBuilder newResteasyClientBuilder() {

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/SuiteContext.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/SuiteContext.java
@@ -45,6 +45,12 @@ public final class SuiteContext {
     private boolean adminPasswordUpdated;
     private final Map<String, String> smtpServer = new HashMap<>();
 
+    /**
+     * True if the testsuite is running in the adapter backward compatibility testing mode,
+     * i.e. if the tests are running against newer auth server
+     */
+    private static final boolean adapterCompatTesting = Boolean.parseBoolean(System.getProperty("testsuite.adapter.compat.testing"));
+
     public SuiteContext(Set<ContainerInfo> arquillianContainers) {
         this.container = arquillianContainers;
         this.adminPasswordUpdated = false;
@@ -101,6 +107,10 @@ public final class SuiteContext {
         return container;
     }
 
+    public boolean isAdapterCompatTesting() {
+        return adapterCompatTesting;
+    }
+
     @Override
     public String toString() {
         String containers = "Auth server: " + (isAuthServerCluster() ? "\nFrontend: " : "")
@@ -110,6 +120,9 @@ public final class SuiteContext {
         }
         if (isAuthServerMigrationEnabled()) {
             containers += "Migrated from: " + System.getProperty("migrated.auth.server.version") + "\n";
+        }
+        if (isAdapterCompatTesting()) {
+            containers += "Adapter backward compatibility testing mode!\n";
         }
         return "SUITE CONTEXT:\n"
                 + containers;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/AbstractKeycloakTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/AbstractKeycloakTest.java
@@ -135,7 +135,7 @@ public abstract class AbstractKeycloakTest {
     public void beforeAbstractKeycloakTest() throws Exception {
         adminClient = testContext.getAdminClient();
         if (adminClient == null) {
-            adminClient = AdminClientUtil.createAdminClient();
+            adminClient = AdminClientUtil.createAdminClient(suiteContext.isAdapterCompatTesting());
             testContext.setAdminClient(adminClient);
         }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/AbstractDemoServletsAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/AbstractDemoServletsAdapterTest.java
@@ -469,8 +469,10 @@ public abstract class AbstractDemoServletsAdapterTest extends AbstractServletsAd
         assertNotNull(version2);
         assertNotNull(version2.getVersion());
         assertNotNull(version2.getBuildTime());
-        assertEquals(version.getVersion(), version2.getVersion());
-        assertEquals(version.getBuildTime(), version2.getBuildTime());
+        if (!suiteContext.isAdapterCompatTesting()) {
+            assertEquals(version.getVersion(), version2.getVersion());
+            assertEquals(version.getBuildTime(), version2.getBuildTime());
+        }
         client.close();
     }
 


### PR DESCRIPTION
Aside from the testsuite changes, I've also added a method to the admin client which accepts custom Jackson provider.
Custom Jackson is necessary to be able to globally ignore unknown JSON properties which typically occurs during testing against a newer auth server. This is, however, only used with the special testing mode for adapter backward compatibility tests.