### PR TITLE
KEYCLOAK-4342: return correct web context

### DIFF
--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/CookieTokenStore.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/CookieTokenStore.java
@@ -102,6 +102,6 @@ public class CookieTokenStore {
         String uri = facade.getRequest().getURI();
         String path = KeycloakUriBuilder.fromUri(uri).getPath();
         int index = path.indexOf("/", 1);
-        return index == -1 ? path : path.substring(0, index);
+        return index == -1 ? path.substring(0, 1) : path.substring(0, index);
     }
 }


### PR DESCRIPTION
When no webcontext was specified (i.e by default for a Spring Boot or Wildfly Swarm App) then the cookie store was not returning the correct root web context. This should fix it.
@patriot1burke @mposolda Could you review this ? 