### PR TITLE
promise never resolved

### DIFF
--- a/adapters/oidc/js/src/main/resources/keycloak.js
+++ b/adapters/oidc/js/src/main/resources/keycloak.js
@@ -879,9 +879,8 @@
                 if (loginIframe.callbackList.length == 1) {
                     loginIframe.iframe.contentWindow.postMessage(msg, origin);
                 }
-            } else {
-                promise.setSuccess();
             }
+            promise.setSuccess();
 
             return promise.promise;
         }


### PR DESCRIPTION
Promise never resolved when the `loginIframe` object had an `iframe` and an `iframeOrigin` fields.