### PR TITLE
KEYCLOAK-4814 disable keycloak spring boot by configuration

### DIFF
--- a/adapters/oidc/spring-boot/src/main/java/org/keycloak/adapters/springboot/KeycloakAutoConfiguration.java
+++ b/adapters/oidc/spring-boot/src/main/java/org/keycloak/adapters/springboot/KeycloakAutoConfiguration.java
@@ -33,6 +33,7 @@ import org.keycloak.adapters.tomcat.KeycloakAuthenticatorValve;
 import org.keycloak.adapters.undertow.KeycloakServletExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.context.embedded.ConfigurableEmbeddedServletContainer;
 import org.springframework.boot.context.embedded.EmbeddedServletContainerCustomizer;
@@ -60,6 +61,7 @@ import java.util.Set;
 @Configuration
 @ConditionalOnWebApplication
 @EnableConfigurationProperties(KeycloakSpringBootProperties.class)
+@ConditionalOnProperty(value = "keycloak.enabled", matchIfMissing = true)
 public class KeycloakAutoConfiguration {
 
     private KeycloakSpringBootProperties keycloakProperties;

--- a/adapters/oidc/spring-boot/src/main/java/org/keycloak/adapters/springboot/KeycloakSpringBootProperties.java
+++ b/adapters/oidc/spring-boot/src/main/java/org/keycloak/adapters/springboot/KeycloakSpringBootProperties.java
@@ -34,6 +34,11 @@ public class KeycloakSpringBootProperties extends AdapterConfig {
     @JsonIgnore
     private Map config = new HashMap();
 
+    /**
+     * Allow enabling of Keycloak Spring Boot adapter by configuration.
+     */
+    private boolean enabled = true;
+
     public Map getConfig() {
         return config;
     }
@@ -42,6 +47,14 @@ public class KeycloakSpringBootProperties extends AdapterConfig {
      * To provide Java EE security constraints
      */
     private List<SecurityConstraint> securityConstraints = new ArrayList<SecurityConstraint>();
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
 
     /**
      * This matches security-constraint of the servlet spec


### PR DESCRIPTION
This completes JIRA https://issues.jboss.org/browse/KEYCLOAK-4814. A Test project is available here https://github.com/ahus1/slackspace-angular-spring-keycloak/tree/KEYCLOAK-4814. It assumes that you've installed the module locally before using `mvn -am -pl adapters\oidc\spring-boot install  -DskipTests=true`

I've performed the following tests manually: property set to true, property set to false, property not set. 

Only property set to false will lead to Keycloak not being initialized. Property set to true or not set at all will lead to Keycloak being initialized. 