### PR TITLE
Fix three lgtm.com alerts: two possible NPEs, one possible int overflow

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserCredentialStore.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserCredentialStore.java
@@ -119,7 +119,7 @@ public class JpaUserCredentialStore implements UserCredentialStore {
         entity.setUser(userRef);
         em.persist(entity);
         MultivaluedHashMap<String, String> config = cred.getConfig();
-        if (config != null || !config.isEmpty()) {
+        if (config != null && !config.isEmpty()) {
 
             for (String key : config.keySet()) {
                 List<String> values = config.getList(key);

--- a/saml-core/src/main/java/org/keycloak/saml/processing/core/saml/v2/util/XMLTimeUtil.java
+++ b/saml-core/src/main/java/org/keycloak/saml/processing/core/saml/v2/util/XMLTimeUtil.java
@@ -130,7 +130,7 @@ public class XMLTimeUtil {
      * @return
      */
     public static long inMilis(int valueInMins) {
-        return valueInMins * 60 * 1000;
+        return (long) valueInMins * 60 * 1000;
     }
 
     /**

--- a/services/src/main/java/org/keycloak/services/resources/admin/RealmAdminResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RealmAdminResource.java
@@ -541,7 +541,7 @@ public class RealmAdminResource {
             query.client(client);
         }
 
-        if (types != null & !types.isEmpty()) {
+        if (types != null && !types.isEmpty()) {
             EventType[] t = new EventType[types.size()];
             for (int i = 0; i < t.length; i++) {
                 t[i] = EventType.valueOf(types.get(i));


### PR DESCRIPTION
This PR addresses three (of a total of 97) alerts reported by lgtm.com (@lgtmhq):

```JpaUserCredentialStore.java```: if ```config``` is null, the second operand to the ```||``` will yield a NPE. Likely a logical-AND was intended here. 
Details: https://lgtm.com/projects/g/keycloak/keycloak/snapshot/dist-7900299-1490802114895/files/model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserCredentialStore.java#V122

```XMLTimeUtil.java```: the multiplication of integer values potentially overflows prior to being cast to the ```long``` result type. This happens if valueInMins > 71582 (for 32-bit integers).
Details: https://lgtm.com/projects/g/keycloak/keycloak/snapshot/dist-7900299-1490802114895/files/saml-core/src/main/java/org/keycloak/saml/processing/core/saml/v2/util/XMLTimeUtil.java#V133

```RealmAdminResource.java```: the bitwise-AND operator '&' works almost identical to the logical-AND operator '&&', with the exception that the former always evaluates both operands, whereas the latter applies short-circuit logic. Because a bitwise-AND is used here, this will result in a NPE on the second operand if ```types``` is null.
Details: https://lgtm.com/projects/g/keycloak/keycloak/snapshot/dist-7900299-1490802114895/files/services/src/main/java/org/keycloak/services/resources/admin/RealmAdminResource.java#V543

There's a large number of alerts on lgtm.com (https://lgtm.com/projects/g/keycloak/keycloak/alerts/) - most of which appear to be well worth fixing, but require more knowledge of the keycloak code base.

Let me know if there's anything else I can do to help!