### PR TITLE
Disable KeycloakAutoConfiguration with properties

### DIFF
--- a/adapters/oidc/spring-boot/src/main/java/org/keycloak/adapters/springboot/KeycloakAutoConfiguration.java
+++ b/adapters/oidc/spring-boot/src/main/java/org/keycloak/adapters/springboot/KeycloakAutoConfiguration.java
@@ -33,6 +33,7 @@ import org.keycloak.adapters.tomcat.KeycloakAuthenticatorValve;
 import org.keycloak.adapters.undertow.KeycloakServletExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.context.embedded.ConfigurableEmbeddedServletContainer;
 import org.springframework.boot.context.embedded.EmbeddedServletContainerCustomizer;
@@ -59,6 +60,7 @@ import java.util.Set;
  */
 @Configuration
 @ConditionalOnWebApplication
+@ConditionalOnProperty(prefix = "keycloak", name = "disabled", havingValue = "false", matchIfMissing = true)
 @EnableConfigurationProperties(KeycloakSpringBootProperties.class)
 public class KeycloakAutoConfiguration {
 

--- a/adapters/oidc/spring-boot/src/main/java/org/keycloak/adapters/springboot/KeycloakSpringBootProperties.java
+++ b/adapters/oidc/spring-boot/src/main/java/org/keycloak/adapters/springboot/KeycloakSpringBootProperties.java
@@ -34,6 +34,11 @@ public class KeycloakSpringBootProperties extends AdapterConfig {
     @JsonIgnore
     private Map config = new HashMap();
 
+    /**
+     * Disable Keycloak auto configuration. See {@link KeycloakAutoConfiguration}
+     */
+    private boolean disabled = false;
+
     public Map getConfig() {
         return config;
     }
@@ -145,5 +150,13 @@ public class KeycloakSpringBootProperties extends AdapterConfig {
 
     public void setSecurityConstraints(List<SecurityConstraint> securityConstraints) {
         this.securityConstraints = securityConstraints;
+    }
+
+    public boolean isDisabled() {
+        return disabled;
+    }
+
+    public void setDisabled(boolean disabled) {
+        this.disabled = disabled;
     }
 }


### PR DESCRIPTION
Disable `KeycloakAutoConfiguration` of `keycloak-spring-boot-adapter` at runtime base on a property (`keycloak.disabled=true`). 

The configuration will be **enabled** if the property is set to `false` or is missing (i.e. active by default).

The main purpose is to load an alternative Security configuration without having to work with AutoConfiguration exclusions that can be hard to manage. 

Indeed, `@ConditionalOnWebApplication` on `KeycloakAutoConfiguration` have precedence and seems hard to exclude whatever the AutoConfiguration exclusions. Maybe someone can point to a working alternative?

Thanks!