### PR TITLE
[KEYCLOAK-4869] Integration tests for app-html5 are failing after upgrade to 3.1.0.Final

### DIFF
--- a/misc/keycloak-test-helper/pom.xml
+++ b/misc/keycloak-test-helper/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
     <parent>
@@ -12,26 +13,32 @@
     <name>keycloak-test-helper</name>
     <description>Helper library to test application using Keycloak.</description>
     <packaging>jar</packaging>
+    <properties>
+        <resteasy.client.version>3.0.7.Final</resteasy.client.version>
+    </properties>
     <dependencies>
-             <dependency>
-                <groupId>org.keycloak</groupId>
-                <artifactId>keycloak-client-registration-api</artifactId>
-                <version>3.2.0.CR1-SNAPSHOT</version>
-            </dependency>
-            <dependency>
-                <groupId>org.keycloak</groupId>
-                <artifactId>keycloak-admin-client</artifactId>
-                <version>3.2.0.CR1-SNAPSHOT</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.resteasy</groupId>
-                <artifactId>resteasy-client</artifactId>
-                <version>3.0.7.Final</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.resteasy</groupId>
-                <artifactId>resteasy-jackson2-provider</artifactId>
-                <version>3.0.7.Final</version>
-            </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-client-registration-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-admin-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-client</artifactId>
+            <version>3.0.7.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-jackson2-provider</artifactId>
+            <version>3.0.7.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-java</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/misc/keycloak-test-helper/src/main/java/org/keycloak/test/page/IndexPage.java
+++ b/misc/keycloak-test-helper/src/main/java/org/keycloak/test/page/IndexPage.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.test.page;
+
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+/**
+ * @author <a href="mailto:bruno@abstractj.org">Bruno Oliveira</a>
+ */
+public class IndexPage {
+
+    public static final String UNAUTHORIZED = "401 Unauthorized";
+
+    @FindBy(name = "loginBtn")
+    private WebElement loginButton;
+
+    @FindBy(name = "logoutBtn")
+    private WebElement logoutButton;
+
+    @FindBy(name = "adminBtn")
+    private WebElement adminButton;
+
+    @FindBy(name = "publicBtn")
+    private WebElement publicButton;
+
+    @FindBy(name = "securedBtn")
+    private WebElement securedBtn;
+
+    public void clickLogin() {
+        loginButton.click();
+    }
+
+    public void clickLogout() {
+        logoutButton.click();
+    }
+
+    public void clickAdmin() {
+        adminButton.click();
+    }
+
+    public void clickPublic() {
+        publicButton.click();
+    }
+
+    public void clickSecured() {
+        securedBtn.click();
+    }
+}

--- a/misc/keycloak-test-helper/src/main/java/org/keycloak/test/page/LoginPage.java
+++ b/misc/keycloak-test-helper/src/main/java/org/keycloak/test/page/LoginPage.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.test.page;
+
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+/**
+ * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
+ */
+public class LoginPage {
+
+    @FindBy(id = "username")
+    private WebElement usernameInput;
+
+    @FindBy(id = "password")
+    private WebElement passwordInput;
+
+    @FindBy(id = "totp")
+    private WebElement totp;
+
+    @FindBy(id = "rememberMe")
+    private WebElement rememberMe;
+
+    @FindBy(name = "login")
+    private WebElement submitButton;
+
+    @FindBy(name = "cancel")
+    private WebElement cancelButton;
+
+    @FindBy(linkText = "Register")
+    private WebElement registerLink;
+
+    @FindBy(linkText = "Forgot Password?")
+    private WebElement resetPasswordLink;
+
+    @FindBy(linkText = "Username")
+    private WebElement recoverUsernameLink;
+
+    @FindBy(className = "alert-error")
+    private WebElement loginErrorMessage;
+
+    @FindBy(className = "alert-warning")
+    private WebElement loginWarningMessage;
+
+    @FindBy(className = "alert-success")
+    private WebElement loginSuccessMessage;
+
+
+    @FindBy(className = "alert-info")
+    private WebElement loginInfoMessage;
+
+    @FindBy(className = "instruction")
+    private WebElement instruction;
+
+
+    @FindBy(id = "kc-current-locale-link")
+    private WebElement languageText;
+
+    @FindBy(id = "kc-locale-dropdown")
+    private WebElement localeDropdown;
+
+    public void login(String username, String password) {
+        usernameInput.clear();
+        usernameInput.sendKeys(username);
+
+        passwordInput.clear();
+        passwordInput.sendKeys(password);
+
+        submitButton.click();
+    }
+}

--- a/misc/keycloak-test-helper/src/main/java/org/keycloak/test/page/ProfilePage.java
+++ b/misc/keycloak-test-helper/src/main/java/org/keycloak/test/page/ProfilePage.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.test.page;
+
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+/**
+ * @author <a href="mailto:bruno@abstractj.org">Bruno Oliveira</a>
+ */
+public class ProfilePage {
+
+    @FindBy(name = "profileBtn")
+    private WebElement profileButton;
+
+    @FindBy(name = "tokenBtn")
+    private WebElement tokenButton;
+
+    @FindBy(name = "logoutBtn")
+    private WebElement logoutButton;
+
+    @FindBy(name = "accountBtn")
+    private WebElement accountButton;
+
+    @FindBy(id = "token-content")
+    private WebElement tokenContent;
+
+    @FindBy(id = "username")
+    private WebElement username;
+
+    public String getUsername() {
+        return username.getText();
+    }
+
+    public void clickProfile() {
+        profileButton.click();
+    }
+
+    public void clickToken() {
+        tokenButton.click();
+    }
+
+    public void clickLogout() {
+        logoutButton.click();
+    }
+
+    public void clickAccount() {
+        accountButton.click();
+    }
+
+    public String getTokenContent() throws Exception {
+        return tokenContent.getText();
+    }
+
+}
+


### PR DESCRIPTION
This is a refactor to adds common classes for Selenium used by the quickstarts. The codebase has too much duplicates today because every project need this.

@sebastienblanc mind to review?