### PR TITLE
KEYCLOAK-4975 Use authenticationSession binding name in ScriptBasedAuthenticator

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/ScriptBasedAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/ScriptBasedAuthenticator.java
@@ -47,7 +47,7 @@ import java.util.Map;
  * <li>{@code realm} the {@link RealmModel}</li>
  * <li>{@code user} the current {@link UserModel}</li>
  * <li>{@code session} the active {@link KeycloakSession}</li>
- * <li>{@code clientSession} the current {@link org.keycloak.sessions.AuthenticationSessionModel}</li>
+ * <li>{@code authenticationSession} the current {@link org.keycloak.sessions.AuthenticationSessionModel}</li>
  * <li>{@code httpRequest} the current {@link org.jboss.resteasy.spi.HttpRequest}</li>
  * <li>{@code LOG} a {@link org.jboss.logging.Logger} scoped to {@link ScriptBasedAuthenticator}/li>
  * </ol>
@@ -160,7 +160,7 @@ public class ScriptBasedAuthenticator implements Authenticator {
             bindings.put("user", context.getUser());
             bindings.put("session", context.getSession());
             bindings.put("httpRequest", context.getHttpRequest());
-            bindings.put("clientSession", context.getAuthenticationSession());
+            bindings.put("authenticationSession", context.getAuthenticationSession());
             bindings.put("LOG", LOGGER);
         });
     }

--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/ScriptBasedAuthenticatorFactory.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/ScriptBasedAuthenticatorFactory.java
@@ -146,7 +146,7 @@ public class ScriptBasedAuthenticatorFactory implements AuthenticatorFactory, En
         }
         script.setDefaultValue(scriptTemplate);
         script.setHelpText("The script used to authenticate. Scripts must at least define a function with the name 'authenticate(context)' that accepts a context (AuthenticationFlowContext) parameter.\n" +
-                "This authenticator exposes the following additional variables: 'script', 'realm', 'user', 'session', 'httpRequest', 'LOG'");
+                "This authenticator exposes the following additional variables: 'script', 'realm', 'user', 'session', 'authenticationSession', 'httpRequest', 'LOG'");
 
         return asList(name, description, script);
     }

--- a/services/src/main/resources/scripts/authenticator-template.js
+++ b/services/src/main/resources/scripts/authenticator-template.js
@@ -15,7 +15,7 @@ AuthenticationFlowError = Java.type("org.keycloak.authentication.AuthenticationF
  * session - current KeycloakSession {@see org.keycloak.models.KeycloakSession}
  * httpRequest - current HttpRequest {@see org.jboss.resteasy.spi.HttpRequest}
  * script - current script {@see org.keycloak.models.ScriptModel}
- * clientSession - current client session {@see org.keycloak.models.ClientSessionModel}
+ * authenticationSession - current client session {@see org.keycloak.sessions.AuthenticationSessionModel}
  * LOG - current logger {@see org.jboss.logging.Logger}
  *
  * You one can extract current http request headers via:

--- a/testsuite/integration-arquillian/tests/base/src/test/resources/scripts/client-session-test.js
+++ b/testsuite/integration-arquillian/tests/base/src/test/resources/scripts/client-session-test.js
@@ -2,17 +2,17 @@ AuthenticationFlowError = Java.type("org.keycloak.authentication.AuthenticationF
 
 function authenticate(context) {
 
-    if (clientSession.getRealm().getName() != "${realm}") {
+    if (authenticationSession.getRealm().getName() != "${realm}") {
         context.failure(AuthenticationFlowError.INVALID_CLIENT_SESSION);
         return;
     }
 
-    if (clientSession.getClient().getClientId() != "${clientId}") {
+    if (authenticationSession.getClient().getClientId() != "${clientId}") {
         context.failure(AuthenticationFlowError.UNKNOWN_CLIENT);
         return;
     }
 
-    if (clientSession.getProtocol() != "${authMethod}") {
+    if (authenticationSession.getProtocol() != "${authMethod}") {
         context.failure(AuthenticationFlowError.INVALID_CLIENT_SESSION);
         return;
     }


### PR DESCRIPTION
We now use authenticationSession instead of clientSession to reflect
the renaming of ClientSessionModel to AuthenticationSessionModel.

Note that this is a breaking change which needs to be mentioned in
the upgrade notes!