### PR TITLE
Easy Spring security annotation

### DIFF
--- a/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/KeycloakConfiguration.java
+++ b/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/KeycloakConfiguration.java
@@ -1,0 +1,24 @@
+package org.keycloak.adapters.springsecurity;
+
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Add this annotation to a class that extends {@code KeycloakWebSecurityConfigurerAdapter} to provide
+ * a keycloak based Spring security configuration.
+ *
+ */
+@Retention(value = RUNTIME)
+@Target(value = { TYPE })
+@Configuration
+@ComponentScan(basePackageClasses = KeycloakSecurityComponents.class)
+@EnableWebSecurity
+public @interface KeycloakConfiguration {
+}

--- a/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/KeycloakConfiguration.java
+++ b/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/KeycloakConfiguration.java
@@ -13,6 +13,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 /**
  * Add this annotation to a class that extends {@code KeycloakWebSecurityConfigurerAdapter} to provide
  * a keycloak based Spring security configuration.
+ *
  * @author Hendrik Ebbers
  */
 @Retention(value = RUNTIME)

--- a/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/KeycloakConfiguration.java
+++ b/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/KeycloakConfiguration.java
@@ -13,7 +13,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 /**
  * Add this annotation to a class that extends {@code KeycloakWebSecurityConfigurerAdapter} to provide
  * a keycloak based Spring security configuration.
- *
+ * @author Hendrik Ebbers
  */
 @Retention(value = RUNTIME)
 @Target(value = { TYPE })


### PR DESCRIPTION
Added an annotation that can be used to define a Spring security config & imports keycloak.

Example:
```
@KeycloakConfiguration
class SecurityConfig extends KeycloakWebSecurityConfigurerAdapter
{
   //...
}
```