### PR TITLE
Unable to override KeycloakConfigResolver (multi-tenant)

### DIFF
--- a/adapters/oidc/spring-boot/src/main/java/org/keycloak/adapters/springboot/KeycloakAutoConfiguration.java
+++ b/adapters/oidc/spring-boot/src/main/java/org/keycloak/adapters/springboot/KeycloakAutoConfiguration.java
@@ -176,7 +176,6 @@ public class KeycloakAutoConfiguration {
         public void customize(Server server) {
 
             KeycloakJettyAuthenticator keycloakJettyAuthenticator = new KeycloakJettyAuthenticator();
-            keycloakJettyAuthenticator.setConfigResolver(new KeycloakSpringBootConfigResolver());
 
             /* see org.eclipse.jetty.webapp.StandardDescriptorProcessor#visitSecurityConstraint for an example
                on how to map servlet spec to Constraints */

--- a/adapters/oidc/spring-boot/src/main/java/org/keycloak/adapters/springboot/KeycloakAutoConfiguration.java
+++ b/adapters/oidc/spring-boot/src/main/java/org/keycloak/adapters/springboot/KeycloakAutoConfiguration.java
@@ -196,7 +196,7 @@ public class KeycloakAutoConfiguration {
                     jettyConstraint.setName(securityCollectionDefinition.getName());
 
                     // according to the servlet spec each security-constraint has at least one URL pattern
-                    for(String pattern : securityCollectionDefinition.getPatterns()) {
+                    for (String pattern : securityCollectionDefinition.getPatterns()) {
 
                         /* the following code is asymmetric as Jetty's ConstraintMapping accepts only one allowed HTTP method,
                            but multiple omitted methods. Therefore we add one ConstraintMapping for each allowed
@@ -205,7 +205,7 @@ public class KeycloakAutoConfiguration {
 
                         if (securityCollectionDefinition.getMethods().size() > 0) {
                             // according to the servlet spec we have either methods ...
-                            for(String method : securityCollectionDefinition.getMethods()) {
+                            for (String method : securityCollectionDefinition.getMethods()) {
                                 ConstraintMapping jettyConstraintMapping = new ConstraintMapping();
                                 jettyConstraintMappings.add(jettyConstraintMapping);
 
@@ -213,7 +213,7 @@ public class KeycloakAutoConfiguration {
                                 jettyConstraintMapping.setPathSpec(pattern);
                                 jettyConstraintMapping.setMethod(method);
                             }
-                        } else if (securityCollectionDefinition.getOmittedMethods().size() > 0){
+                        } else if (securityCollectionDefinition.getOmittedMethods().size() > 0) {
                             // ... omitted methods ...
                             ConstraintMapping jettyConstraintMapping = new ConstraintMapping();
                             jettyConstraintMappings.add(jettyConstraintMapping);
@@ -238,7 +238,7 @@ public class KeycloakAutoConfiguration {
 
             WebAppContext webAppContext = server.getBean(WebAppContext.class);
             //if not found as registered bean let's try the handler
-            if(webAppContext==null){
+            if (webAppContext == null) {
                 webAppContext = (WebAppContext) server.getHandler();
             }
 


### PR DESCRIPTION
Hello,

It seems that it is not possible to use a custom `KeycloakConfigResolver` as stated in the following documentation: [keycloak multi-tenancy](https://keycloak.gitbooks.io/documentation/securing_apps/topics/oidc/java/multi-tenancy.html)

The purposes are: 
- Secure the application with `keycloak-spring-security-adapter`
- Use a **custom KeycloakConfigResolver** to set up a multi-tenant Spring Boot application
- Based on Jetty with `keycloak-jetty94-adapter`
- Version 3.1.0.Final

It does not work even when overriding the `KeycloakConfigResolver` bean as shown in 
spring-security-adapter [Using Spring Boot Configuration](https://keycloak.gitbooks.io/documentation/securing_apps/topics/oidc/java/spring-security-adapter.html):
```
By Default, the Spring Security Adapter looks for a keycloak.json configuration file. You can make sure it looks at the configuration provided by the Spring Boot Adapter by adding this bean :
@Bean
public KeycloakConfigResolver KeycloakConfigResolver() {
    return new KeycloakSpringBootConfigResolver();
}
```

The trouble is that another `KeycloakConfigResolver` (i.e. `KeycloakSpringBootConfigResolver`) is defined in `KeycloakJettyServerCustomizer`:

```
KeycloakJettyAuthenticator keycloakJettyAuthenticator = new KeycloakJettyAuthenticator();
keycloakJettyAuthenticator.setConfigResolver(new KeycloakSpringBootConfigResolver());
```

Therefore, 2 `KeycloakConfigResolver` instances are registered:
- One in `KeycloakJettyServerCustomizer` with its local instance (`keycloak-spring-boot-adapter`)
- One declared as a Spring bean that I want to customize (`keycloak-spring-security-adapter`)
- And there is also the `keycloak.config.resolver` context param that seems (therefore) unused

This PR removes the `keycloakJettyAuthenticator.setConfigResolver(new KeycloakSpringBootConfigResolver()) `in `KeycloakJettyServerCustomizer`

And I am registering a bean like this:

```
@Bean
public KeycloakConfigResolver KeycloakConfigResolver() {
    return new CustomMultiTenantConfigResolver();
}
```
in `KeycloakWebSecurityConfigurerAdapter`.

It then works fine but there is no longer a `KeycloakConfigResolver` for `KeycloakJettyServerCustomizer` and I do not know is this could lead to regression on uncovered use case.
In fact, I am not sure why this `KeycloakSpringBootConfigResolver` is required in `AbstractKeycloakJettyAuthenticator`. 
Can anyone explain the difference with the one in `KeycloakWebSecurityConfigurerAdapter`? 

Thanks!

