### PR TITLE
Clarify verifyEmail failure when client disabled

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
@@ -871,7 +871,7 @@ public class UsersResource {
         ClientModel client = realm.getClientByClientId(clientId);
         if (client == null || !client.isEnabled()) {
             throw new WebApplicationException(
-                ErrorResponse.error(clientId + " not enabled", Response.Status.BAD_REQUEST));
+                ErrorResponse.error("The \"" + clientId + "\" client is not enabled.", Response.Status.BAD_REQUEST));
         }
 
         String redirect;


### PR DESCRIPTION
I was really confused by the error message "account not enabled". I immediately presumed it referred to a user account, not the client named "account".