### PR TITLE
[KEYCLOAK-5066] Admin API: validate-password

### DIFF
--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/UserResource.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/UserResource.java
@@ -92,6 +92,10 @@ public interface UserResource {
     @Path("reset-password")
     public void resetPassword(CredentialRepresentation credentialRepresentation);
 
+    @GET
+    @Path("validate-password")
+    public void validatePassword(CredentialRepresentation credentialRepresentation);
+
     /**
      * Use executeActionsEmail and pass in the UPDATE_PASSWORD required action
      *


### PR DESCRIPTION
Via an admin/user support portal @ our side, we provide the functionality of updating user's data.
This includes the user's keycloak password.

For the sake of atomicity, all update steps first goes through a series of validations for all modified data before actually committing the changes

At the moment, there is no way to pre-update do a validity check of the updated password against keycloak's current password policy(ies) 

Therefor I propose to have a validate-password endpoint in the Admin API.

As there is already a reset-password endpoint I personally feel this is acceptable.
