### PR TITLE
[KEYCLOAK-5067] Allow refreshable context to have an optional adapter token store

### DIFF
--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/RefreshableKeycloakSecurityContext.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/RefreshableKeycloakSecurityContext.java
@@ -155,7 +155,9 @@ public class RefreshableKeycloakSecurityContext extends KeycloakSecurityContext 
             this.refreshToken = response.getRefreshToken();
         }
         this.tokenString = tokenString;
-        tokenStore.refreshCallback(this);
+        if (tokenStore != null) {
+            tokenStore.refreshCallback(this);
+        }
         return true;
     }
 


### PR DESCRIPTION
It seems to me the adapter token store can be optional hence the null check