### PR TITLE
KEYCLOAK-5131 ProviderFactory::postInit not called with hot deployment

### DIFF
--- a/services/src/main/java/org/keycloak/services/DefaultKeycloakSessionFactory.java
+++ b/services/src/main/java/org/keycloak/services/DefaultKeycloakSessionFactory.java
@@ -112,6 +112,7 @@ public class DefaultKeycloakSessionFactory implements KeycloakSessionFactory, Pr
     public void deploy(ProviderManager pm) {
         Map<Class<? extends Provider>, Map<String, ProviderFactory>> copy = getFactoriesCopy();
         Map<Class<? extends Provider>, Map<String, ProviderFactory>> newFactories = loadFactories(pm);
+        List<ProviderFactory> deployed = new LinkedList<>();
         List<ProviderFactory> undeployed = new LinkedList<>();
 
         for (Map.Entry<Class<? extends Provider>, Map<String, ProviderFactory>> entry : newFactories.entrySet()) {
@@ -120,6 +121,7 @@ public class DefaultKeycloakSessionFactory implements KeycloakSessionFactory, Pr
                 copy.put(entry.getKey(), entry.getValue());
             } else {
                 for (ProviderFactory f : entry.getValue().values()) {
+                    deployed.add(f);
                     ProviderFactory old = current.remove(f.getId());
                     if (old != null) undeployed.add(old);
                 }
@@ -130,6 +132,9 @@ public class DefaultKeycloakSessionFactory implements KeycloakSessionFactory, Pr
         factoriesMap = copy;
         for (ProviderFactory factory : undeployed) {
             factory.close();
+        }
+        for (ProviderFactory factory : deployed) {
+            factory.postInit(this);
         }
     }
 


### PR DESCRIPTION
The PR fixes the bug, however, the `ProviderFactory::postInit` invoked this way will have limitations, e.g. won't be able to access `java:comp` JNDI namespace; the other stuff like accessing the data model works well nevertheless. This is because the code is executed in WildFly's "MSC service thread", unlike application code that uses "ServerService Thread Pool".

If we are to get rid of this limitation, I think there exists an approach that will by the way fix [KEYCLOAK-5132](https://issues.jboss.org/browse/KEYCLOAK-5132) too. Let me know if this is topical, so we can discuss it further.