### PR TITLE
[KEYCLOAK-5180] Add title attribute for keycloak-session-iframe to suppress accessibility errors

### DIFF
--- a/adapters/oidc/js/src/main/resources/keycloak.js
+++ b/adapters/oidc/js/src/main/resources/keycloak.js
@@ -843,6 +843,7 @@
             }
 
             iframe.setAttribute('src', src );
+            iframe.setAttribute('title', 'keycloak' );
             iframe.style.display = 'none';
             document.body.appendChild(iframe);
 


### PR DESCRIPTION
Hi guys, 

I actually create an app to improve accessibility, and my last error is the iframe title for keycloak.

Thanks a lot for merging :)