### PR TITLE
Fix: use base64Encode() method in deflateBase64Encode()

### DIFF
--- a/saml-core/src/main/java/org/keycloak/saml/processing/web/util/RedirectBindingUtil.java
+++ b/saml-core/src/main/java/org/keycloak/saml/processing/web/util/RedirectBindingUtil.java
@@ -139,7 +139,7 @@ public class RedirectBindingUtil {
      */
     public static String deflateBase64Encode(byte[] stringToEncode) throws IOException {
         byte[] deflatedMsg = DeflateUtil.encode(stringToEncode);
-        return Base64.encodeBytes(deflatedMsg);
+        return base64Encode(deflatedMsg);
     }
 
     /**


### PR DESCRIPTION
Hello,

We tried to update Keycloak from 3.1.0.Final to 3.2.0.Final and found a problem with SAML logout request Base64 encoding. The problem is related to the commit 5d88c2b8bef811fa5461c3875843c191c26cab27 (issue https://issues.jboss.org/browse/KEYCLOAK-4758).