### PR TITLE
Fix test failures on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+dist: precise
 
 cache:
   cache: false


### PR DESCRIPTION
After Travis switched from [Ubuntu Precise to Trusty](https://blog.travis-ci.com/2017-04-17-precise-EOL), the server-group1 testsuite run started consistently failing for variety of reasons. Set the distribution explicitly. Investigation of actual cause postponed. Confirmed that it is not any of the latest commits that would cause these issues.