### PR TITLE
Update TestContainers to 1.4.2 to remove some hacks

### DIFF
--- a/testsuite/integration-arquillian/tests/base/pom.xml
+++ b/testsuite/integration-arquillian/tests/base/pom.xml
@@ -112,7 +112,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <version>1.2.1</version>
+            <version>1.4.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Hi! 

I spotted that you use TestContainers, and decided to help you to update to 1.4.2.

We released some great features like Docker Networks support (so that you don't have to do `withExtraHost` anymore 🎉  )