### PR TITLE
create JS source maps

### DIFF
--- a/adapters/oidc/js/pom.xml
+++ b/adapters/oidc/js/pom.xml
@@ -38,6 +38,11 @@
             <plugin>
                 <groupId>com.samaxes.maven</groupId>
                 <artifactId>minify-maven-plugin</artifactId>
+                <configuration>
+                    <jsEngine>CLOSURE</jsEngine>
+                    <closureLanguageIn>ECMASCRIPT5</closureLanguageIn>
+                    <closureCreateSourceMap>true</closureCreateSourceMap>
+                </configuration>
                 <executions>
                     <execution>
                         <id>min-js</id>

--- a/adapters/oidc/js/src/main/resources/keycloak.js
+++ b/adapters/oidc/js/src/main/resources/keycloak.js
@@ -221,7 +221,7 @@
             var callbackState = {
                 state: state,
                 nonce: nonce,
-                redirectUri: encodeURIComponent(redirectUri),
+                redirectUri: encodeURIComponent(redirectUri)
             }
 
             if (options && options.prompt) {

--- a/distribution/adapters/js-adapter-zip/assembly.xml
+++ b/distribution/adapters/js-adapter-zip/assembly.xml
@@ -30,6 +30,7 @@
             <outputDirectory></outputDirectory>
             <includes>
                 <include>**/*.js</include>
+                <include>**/*.map</include>
                 <include>**/*.d.ts</include>
                 <include>**/*.html</include>
             </includes>

--- a/distribution/adapters/js-adapter-zip/pom.xml
+++ b/distribution/adapters/js-adapter-zip/pom.xml
@@ -50,7 +50,7 @@
                                     <groupId>org.keycloak</groupId>
                                     <artifactId>keycloak-js-adapter</artifactId>
                                     <outputDirectory>${project.build.directory}/unpacked/js-adapter</outputDirectory>
-                                    <includes>*.js,*.d.ts</includes>                                 
+                                    <includes>*.js,*.map,*.d.ts</includes>
                                 </artifactItem>
                             </artifactItems>
                             <excludes>**/welcome-content/*</excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
         <jboss.as.plugin.version>7.5.Final</jboss.as.plugin.version>
         <jmeter.plugin.version>1.9.0</jmeter.plugin.version>
         <jmeter.analysis.plugin.version>1.0.4</jmeter.analysis.plugin.version>
-        <minify.plugin.version>1.7.2</minify.plugin.version>
+        <minify.plugin.version>1.7.6</minify.plugin.version>
         <osgi.bundle.plugin.version>2.3.7</osgi.bundle.plugin.version>
         <wildfly.plugin.version>1.1.0.Final</wildfly.plugin.version>
         <nexus.staging.plugin.version>1.6.5</nexus.staging.plugin.version>


### PR DESCRIPTION
updated minify plugin to 1.7.6
switch minify plugin to use CLOSURE compiler
enable [source map](https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k) generation
include source maps in distribution files