### PR TITLE
KEYCLOAK-5329 async support for tomcat7 and tomcat8

### DIFF
--- a/adapters/oidc/as7-eap6/as7-adapter/src/main/java/org/keycloak/adapters/jbossweb/AuthenticatedActionsValve.java
+++ b/adapters/oidc/as7-eap6/as7-adapter/src/main/java/org/keycloak/adapters/jbossweb/AuthenticatedActionsValve.java
@@ -1,0 +1,13 @@
+package org.keycloak.adapters.jbossweb;
+
+import org.apache.catalina.Container;
+import org.apache.catalina.Valve;
+import org.keycloak.adapters.AdapterDeploymentContext;
+import org.keycloak.adapters.tomcat.AbstractAuthenticatedActionsValve;
+
+public class AuthenticatedActionsValve extends AbstractAuthenticatedActionsValve {
+
+    public AuthenticatedActionsValve(AdapterDeploymentContext deploymentContext, Valve next, Container container) {
+        super(deploymentContext, next, container);
+    }
+}

--- a/adapters/oidc/as7-eap6/as7-adapter/src/main/java/org/keycloak/adapters/jbossweb/KeycloakAuthenticatorValve.java
+++ b/adapters/oidc/as7-eap6/as7-adapter/src/main/java/org/keycloak/adapters/jbossweb/KeycloakAuthenticatorValve.java
@@ -17,11 +17,15 @@
 
 package org.keycloak.adapters.jbossweb;
 
+import org.apache.catalina.Container;
 import org.apache.catalina.LifecycleException;
+import org.apache.catalina.Valve;
 import org.apache.catalina.connector.Request;
 import org.apache.catalina.connector.Response;
 import org.apache.catalina.core.StandardContext;
 import org.apache.catalina.deploy.LoginConfig;
+import org.keycloak.adapters.AdapterDeploymentContext;
+import org.keycloak.adapters.tomcat.AbstractAuthenticatedActionsValve;
 import org.keycloak.adapters.tomcat.AbstractKeycloakAuthenticatorValve;
 import org.keycloak.adapters.tomcat.GenericPrincipalFactory;
 
@@ -56,7 +60,6 @@ public class KeycloakAuthenticatorValve extends AbstractKeycloakAuthenticatorVal
         super.start();
     }
 
-
     public void logout(Request request) {
         logoutInternal(request);
     }
@@ -64,5 +67,10 @@ public class KeycloakAuthenticatorValve extends AbstractKeycloakAuthenticatorVal
     @Override
     protected GenericPrincipalFactory createPrincipalFactory() {
         return new JBossWebPrincipalFactory();
+    }
+
+    @Override
+    protected AbstractAuthenticatedActionsValve createAuthenticatedActionsValve(AdapterDeploymentContext deploymentContext, Valve next, Container container) {
+        return new AuthenticatedActionsValve(deploymentContext, next, container);
     }
 }

--- a/adapters/oidc/tomcat/tomcat-core/src/main/java/org/keycloak/adapters/tomcat/AbstractAuthenticatedActionsValve.java
+++ b/adapters/oidc/tomcat/tomcat-core/src/main/java/org/keycloak/adapters/tomcat/AbstractAuthenticatedActionsValve.java
@@ -31,7 +31,7 @@ import javax.servlet.ServletException;
 import java.io.IOException;
 
 /**
- * Pre-installed actions that must be authenticated
+ * Abstract base for pre-installed actions that must be authenticated
  * <p/>
  * Actions include:
  * <p/>
@@ -41,17 +41,16 @@ import java.io.IOException;
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
  */
-public class AuthenticatedActionsValve extends ValveBase {
-    private static final Logger log = Logger.getLogger(AuthenticatedActionsValve.class);
+public abstract class AbstractAuthenticatedActionsValve extends ValveBase {
+    private static final Logger log = Logger.getLogger(AbstractAuthenticatedActionsValve.class);
     protected AdapterDeploymentContext deploymentContext;
 
-    public AuthenticatedActionsValve(AdapterDeploymentContext deploymentContext, Valve next, Container container) {
+    public AbstractAuthenticatedActionsValve(AdapterDeploymentContext deploymentContext, Valve next, Container container) {
         this.deploymentContext = deploymentContext;
         if (next == null) throw new RuntimeException("Next valve is null!!!");
         setNext(next);
         setContainer(container);
     }
-
 
     @Override
     public void invoke(Request request, Response response) throws IOException, ServletException {

--- a/adapters/oidc/tomcat/tomcat-core/src/main/java/org/keycloak/adapters/tomcat/AbstractKeycloakAuthenticatorValve.java
+++ b/adapters/oidc/tomcat/tomcat-core/src/main/java/org/keycloak/adapters/tomcat/AbstractKeycloakAuthenticatorValve.java
@@ -17,11 +17,7 @@
 
 package org.keycloak.adapters.tomcat;
 
-import org.apache.catalina.Context;
-import org.apache.catalina.Lifecycle;
-import org.apache.catalina.LifecycleEvent;
-import org.apache.catalina.LifecycleListener;
-import org.apache.catalina.Manager;
+import org.apache.catalina.*;
 import org.apache.catalina.authenticator.FormAuthenticator;
 import org.apache.catalina.connector.Request;
 import org.apache.catalina.connector.Response;
@@ -136,7 +132,7 @@ public abstract class AbstractKeycloakAuthenticatorValve extends FormAuthenticat
         }
 
         context.getServletContext().setAttribute(AdapterDeploymentContext.class.getName(), deploymentContext);
-        AuthenticatedActionsValve actions = new AuthenticatedActionsValve(deploymentContext, getNext(), getContainer());
+        AbstractAuthenticatedActionsValve actions = createAuthenticatedActionsValve(deploymentContext, getNext(), getContainer());
         setNext(actions);
 
         nodesRegistrationManagement = new NodesRegistrationManagement();
@@ -189,6 +185,7 @@ public abstract class AbstractKeycloakAuthenticatorValve extends FormAuthenticat
 
     protected abstract GenericPrincipalFactory createPrincipalFactory();
     protected abstract boolean forwardToErrorPageInternal(Request request, HttpServletResponse response, Object loginConfig) throws IOException;
+    protected abstract AbstractAuthenticatedActionsValve createAuthenticatedActionsValve(AdapterDeploymentContext deploymentContext, Valve next, Container container);
 
     protected boolean authenticateInternal(Request request, HttpServletResponse response, Object loginConfig) throws IOException {
         CatalinaHttpFacade facade = new OIDCCatalinaHttpFacade(request, response);

--- a/adapters/oidc/tomcat/tomcat6/src/main/java/org/keycloak/adapters/tomcat/AuthenticatedActionsValve.java
+++ b/adapters/oidc/tomcat/tomcat6/src/main/java/org/keycloak/adapters/tomcat/AuthenticatedActionsValve.java
@@ -1,0 +1,12 @@
+package org.keycloak.adapters.tomcat;
+
+import org.apache.catalina.Container;
+import org.apache.catalina.Valve;
+import org.keycloak.adapters.AdapterDeploymentContext;
+
+public class AuthenticatedActionsValve extends AbstractAuthenticatedActionsValve {
+
+    public AuthenticatedActionsValve(AdapterDeploymentContext deploymentContext, Valve next, Container container) {
+        super(deploymentContext, next, container);
+    }
+}

--- a/adapters/oidc/tomcat/tomcat6/src/main/java/org/keycloak/adapters/tomcat/KeycloakAuthenticatorValve.java
+++ b/adapters/oidc/tomcat/tomcat6/src/main/java/org/keycloak/adapters/tomcat/KeycloakAuthenticatorValve.java
@@ -17,12 +17,15 @@
 
 package org.keycloak.adapters.tomcat;
 
+import org.apache.catalina.Container;
 import org.apache.catalina.LifecycleException;
+import org.apache.catalina.Valve;
 import org.apache.catalina.connector.Request;
 import org.apache.catalina.connector.Response;
 import org.apache.catalina.core.StandardContext;
 import org.apache.catalina.deploy.LoginConfig;
 import org.apache.catalina.realm.GenericPrincipal;
+import org.keycloak.adapters.AdapterDeploymentContext;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletResponse;
@@ -51,6 +54,10 @@ public class KeycloakAuthenticatorValve extends AbstractKeycloakAuthenticatorVal
         return true;
     }
 
+    @Override
+    protected AbstractAuthenticatedActionsValve createAuthenticatedActionsValve(AdapterDeploymentContext deploymentContext, Valve next, Container container) {
+        return new AuthenticatedActionsValve(deploymentContext, next, container);
+    }
 
     @Override
     public void start() throws LifecycleException {

--- a/adapters/oidc/tomcat/tomcat7/src/main/java/org/keycloak/adapters/tomcat/AuthenticatedActionsValve.java
+++ b/adapters/oidc/tomcat/tomcat7/src/main/java/org/keycloak/adapters/tomcat/AuthenticatedActionsValve.java
@@ -1,0 +1,17 @@
+package org.keycloak.adapters.tomcat;
+
+import org.apache.catalina.Container;
+import org.apache.catalina.Valve;
+import org.keycloak.adapters.AdapterDeploymentContext;
+
+public class AuthenticatedActionsValve extends AbstractAuthenticatedActionsValve {
+
+    public AuthenticatedActionsValve(AdapterDeploymentContext deploymentContext, Valve next, Container container) {
+        super(deploymentContext, next, container);
+    }
+
+    @Override
+    public boolean isAsyncSupported() {
+        return true;
+    }
+}

--- a/adapters/oidc/tomcat/tomcat7/src/main/java/org/keycloak/adapters/tomcat/KeycloakAuthenticatorValve.java
+++ b/adapters/oidc/tomcat/tomcat7/src/main/java/org/keycloak/adapters/tomcat/KeycloakAuthenticatorValve.java
@@ -17,11 +17,14 @@
 
 package org.keycloak.adapters.tomcat;
 
+import org.apache.catalina.Container;
+import org.apache.catalina.Valve;
 import org.apache.catalina.connector.Request;
 import org.apache.catalina.connector.Response;
 import org.apache.catalina.core.StandardContext;
 import org.apache.catalina.deploy.LoginConfig;
 import org.apache.catalina.realm.GenericPrincipal;
+import org.keycloak.adapters.AdapterDeploymentContext;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletResponse;
@@ -67,6 +70,11 @@ public class KeycloakAuthenticatorValve extends AbstractKeycloakAuthenticatorVal
                 return new GenericPrincipal(userPrincipal.getName(), null, roles, userPrincipal, null);
             }
         };
+    }
+
+    @Override
+    protected AbstractAuthenticatedActionsValve createAuthenticatedActionsValve(AdapterDeploymentContext deploymentContext, Valve next, Container container) {
+        return new AuthenticatedActionsValve(deploymentContext, next, container);
     }
 
 }

--- a/adapters/oidc/tomcat/tomcat8/src/main/java/org/keycloak/adapters/tomcat/AuthenticatedActionsValve.java
+++ b/adapters/oidc/tomcat/tomcat8/src/main/java/org/keycloak/adapters/tomcat/AuthenticatedActionsValve.java
@@ -1,0 +1,17 @@
+package org.keycloak.adapters.tomcat;
+
+import org.apache.catalina.Container;
+import org.apache.catalina.Valve;
+import org.keycloak.adapters.AdapterDeploymentContext;
+
+public class AuthenticatedActionsValve extends AbstractAuthenticatedActionsValve {
+
+    public AuthenticatedActionsValve(AdapterDeploymentContext deploymentContext, Valve next, Container container) {
+        super(deploymentContext, next, container);
+    }
+
+    @Override
+    public boolean isAsyncSupported() {
+        return true;
+    }
+}

--- a/adapters/oidc/tomcat/tomcat8/src/main/java/org/keycloak/adapters/tomcat/KeycloakAuthenticatorValve.java
+++ b/adapters/oidc/tomcat/tomcat8/src/main/java/org/keycloak/adapters/tomcat/KeycloakAuthenticatorValve.java
@@ -17,11 +17,14 @@
 
 package org.keycloak.adapters.tomcat;
 
+import org.apache.catalina.Container;
+import org.apache.catalina.Valve;
 import org.apache.catalina.authenticator.FormAuthenticator;
 import org.apache.catalina.connector.Request;
 import org.apache.catalina.core.StandardContext;
 import org.apache.catalina.realm.GenericPrincipal;
 import org.apache.tomcat.util.descriptor.web.LoginConfig;
+import org.keycloak.adapters.AdapterDeploymentContext;
 import org.keycloak.adapters.AdapterTokenStore;
 import org.keycloak.adapters.KeycloakDeployment;
 import org.keycloak.adapters.spi.HttpFacade;
@@ -101,5 +104,10 @@ public class KeycloakAuthenticatorValve extends AbstractKeycloakAuthenticatorVal
     @Override
     protected AdapterTokenStore getTokenStore(Request request, HttpFacade facade, KeycloakDeployment resolvedDeployment) {
         return super.getTokenStore(request, facade, resolvedDeployment);
+    }
+
+    @Override
+    protected AbstractAuthenticatedActionsValve createAuthenticatedActionsValve(AdapterDeploymentContext deploymentContext, Valve next, Container container) {
+        return new AuthenticatedActionsValve(deploymentContext, next, container);
     }
 }


### PR DESCRIPTION
abstracted AuthenticatedActionsValve to allow async support for Tomcat7 and Tomcat8 adapter.
issue: https://issues.jboss.org/browse/KEYCLOAK-5329

