### PR TITLE
Check query string to be empty

### DIFF
--- a/adapters/spi/servlet-adapter-spi/src/main/java/org/keycloak/adapters/servlet/ServletHttpFacade.java
+++ b/adapters/spi/servlet-adapter-spi/src/main/java/org/keycloak/adapters/servlet/ServletHttpFacade.java
@@ -59,8 +59,9 @@ public class ServletHttpFacade implements HttpFacade {
         @Override
         public String getURI() {
             StringBuffer buf = request.getRequestURL();
-            if (request.getQueryString() != null) {
-                buf.append('?').append(request.getQueryString());
+            String queryString = request.getQueryString();
+            if (queryString != null && !queryString.isEmpty()) {
+                buf.append('?').append(queryString);
             }
             return buf.toString();
         }


### PR DESCRIPTION
otherwise an query without query parameter will add a question mark to the url. I had this problem with jenkins 1.532 integration, where the requested url can be http://localhost:8080/favicon.ico?. In this case I will always get a invalid redirect uri error. I could fix this problem by changing it like that. 