### PR TITLE
Update OAuthRequestAuthenticator.java

### DIFF
--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/OAuthRequestAuthenticator.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/OAuthRequestAuthenticator.java
@@ -331,7 +331,7 @@ public class OAuthRequestAuthenticator {
         } catch (ServerRequest.HttpFailure failure) {
             log.error("failed to turn code into token");
             log.error("status from server: " + failure.getStatus());
-            if (failure.getStatus() == 400 && failure.getError() != null) {
+            if (failure.getError() != null) {
                 log.error("   " + failure.getError());
             }
             return challenge(403, OIDCAuthenticationError.Reason.CODE_TO_TOKEN_FAILURE, null);


### PR DESCRIPTION
Removed a check for a 400 error, I was seeing a 403 error, and it wasn't until I rewrote the code to be like what is in line 334 I did not see enough meaningful information to figure out I had a /etc/hosts issue.  I had an entry on my local machine, but the remote tomcat instance needed it also to enable all the redirects to work.  Kind of a wonky issue.  Alternatively do we even need the check for null in this?