### PR TITLE
Do not show empty page size selectors in events lists

### DIFF
--- a/themes/src/main/resources/theme/base/admin/resources/partials/realm-events-admin.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/realm-events-admin.html
@@ -17,11 +17,10 @@
             <tr>
                 <th class="kc-table-actions" colspan="5">
                     <div class="pull-right">
-                        <select data-ng-model="query.max" data-ng-click="update()" class="btn btn-default">
-                            <option>5</option>
-                            <option>10</option>
-                            <option>50</option>
-                            <option>100</option>
+                        <select data-ng-model="query.max"
+                                data-ng-click="update()"
+                                data-ng-options="itemCount for itemCount in [5,10,50,100]"
+                                class="btn btn-default">
                         </select>
                         <button class="btn btn-default" data-ng-click="filter = !filter">
                             <span class="glyphicon glyphicon-plus" data-ng-show="!filter"></span>

--- a/themes/src/main/resources/theme/base/admin/resources/partials/realm-events.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/realm-events.html
@@ -15,11 +15,10 @@
         <tr>
             <th class="kc-table-actions" colspan="4">
                 <div class="pull-right">
-                    <select data-ng-model="query.max" data-ng-click="update()" class="btn btn-default">
-                        <option>5</option>
-                        <option>10</option>
-                        <option>50</option>
-                        <option>100</option>
+                    <select data-ng-model="query.max"
+                            data-ng-click="update()"
+                            data-ng-options="itemCount for itemCount in [5,10,50,100]"
+                            class="btn btn-default">
                     </select>
                     <button class="btn btn-default" data-ng-click="filter = !filter">
                         <span class="glyphicon glyphicon-plus" data-ng-show="!filter"></span>


### PR DESCRIPTION
Very small change in the UI so that the events tables do not show an empty selector for the `query.max` selector