### PR TITLE
KEYCLOAK-5381 Implementation of method LDAPsearchForUSerByAttribute

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProvider.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProvider.java
@@ -17,6 +17,17 @@
 
 package org.keycloak.storage.ldap;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.naming.AuthenticationException;
+
 import org.jboss.logging.Logger;
 import org.keycloak.common.constants.KerberosConstants;
 import org.keycloak.component.ComponentModel;
@@ -33,14 +44,15 @@ import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.LDAPConstants;
 import org.keycloak.models.ModelDuplicateException;
 import org.keycloak.models.ModelException;
-import org.keycloak.models.utils.ReadOnlyUserModelDelegate;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.RoleModel;
 import org.keycloak.models.UserCredentialModel;
-import org.keycloak.models.UserModel;
 import org.keycloak.models.UserManager;
+import org.keycloak.models.UserModel;
 import org.keycloak.models.cache.UserCache;
 import org.keycloak.models.credential.PasswordUserCredentialModel;
+import org.keycloak.models.utils.KeycloakModelUtils;
+import org.keycloak.models.utils.ReadOnlyUserModelDelegate;
 import org.keycloak.storage.ReadOnlyException;
 import org.keycloak.storage.StorageId;
 import org.keycloak.storage.UserStorageProvider;
@@ -61,16 +73,6 @@ import org.keycloak.storage.user.ImportedUserValidation;
 import org.keycloak.storage.user.UserLookupProvider;
 import org.keycloak.storage.user.UserQueryProvider;
 import org.keycloak.storage.user.UserRegistrationProvider;
-
-import javax.naming.AuthenticationException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
@@ -216,7 +218,30 @@ public class LDAPStorageProvider implements UserStorageProvider,
 
     @Override
     public List<UserModel> searchForUserByUserAttribute(String attrName, String attrValue, RealmModel realm) {
-        return Collections.EMPTY_LIST;
+    	 LDAPQuery ldapQuery = LDAPUtils.createQueryForUserSearch(this, realm);
+         LDAPQueryConditionsBuilder conditionsBuilder = new LDAPQueryConditionsBuilder();
+
+         Condition attrCondition = conditionsBuilder.equal(attrName, attrValue, EscapeStrategy.DEFAULT);
+         ldapQuery.addWhereCondition(attrCondition);
+
+         List<LDAPObject> ldapObjects = ldapQuery.getResultList();
+         
+         if (ldapObjects == null || ldapObjects.isEmpty()) {
+        	 return Collections.emptyList();
+         }
+         
+         List<UserModel> searchResults =new LinkedList<UserModel>();
+         
+         for (LDAPObject ldapUser : ldapObjects) {
+             String ldapUsername = LDAPUtils.getUsername(ldapUser, this.ldapIdentityStore.getConfig());
+             if (session.userLocalStorage().getUserByUsername(ldapUsername, realm) == null) {
+                 UserModel imported = importUserFromLDAP(session, realm, ldapUser);
+                 searchResults.add(imported);
+             }
+         }
+
+         return searchResults;
+         
     }
 
     public boolean synchronizeRegistrations() {


### PR DESCRIPTION
LDAPStorageProvider.searchForUserByUserAttribute is not implemented, it just returns an empty list without executing the search. This merge request implements it and add tests for this implementation.