### PR TITLE
Token validation endpoint rejects tokens with pairwise sub id

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
@@ -189,13 +189,6 @@ public class TokenManager {
             return false;
         }
 
-        UserModel user = session.users().getUserById(token.getSubject(), realm);
-        if (user == null) {
-            return false;
-        }
-        if (!user.isEnabled()) {
-            return false;
-        }
 
         ClientModel client = realm.getClientByClientId(token.getIssuedFor());
         if (client == null || !client.isEnabled()) {
@@ -203,13 +196,21 @@ public class TokenManager {
         }
 
         UserSessionModel userSession =  session.sessions().getUserSession(realm, token.getSessionState());
+
+        UserModel user = userSession.getUser();
+        if (user == null) {
+            return false;
+        }
+        if (!user.isEnabled()) {
+            return false;
+        }
+
         if (AuthenticationManager.isSessionValid(realm, userSession)) {
             AuthenticatedClientSessionModel clientSession = userSession.getAuthenticatedClientSessions().get(client.getId());
             if (clientSession != null) {
                 return true;
             }
         }
-
 
         userSession = session.sessions().getOfflineUserSession(realm, token.getSessionState());
         if (AuthenticationManager.isOfflineSessionValid(realm, userSession)) {


### PR DESCRIPTION
When a pairwise sub is used, token introspection fails
due to an attempt to retrieve user by id
As the user session is required to be active for the validation to succeed,
the active user session is used instead

Resolves: ID-796