### PR TITLE
fix some typos

### DIFF
--- a/examples/providers/authenticator/src/main/java/org/keycloak/examples/authenticator/SecretQuestionAuthenticator.java
+++ b/examples/providers/authenticator/src/main/java/org/keycloak/examples/authenticator/SecretQuestionAuthenticator.java
@@ -47,7 +47,7 @@ public class SecretQuestionAuthenticator implements Authenticator {
         Cookie cookie = context.getHttpRequest().getHttpHeaders().getCookies().get("SECRET_QUESTION_ANSWERED");
         boolean result = cookie != null;
         if (result) {
-            System.out.println("Bypassing secret question because cookie as set");
+            System.out.println("Bypassing secret question because cookie is set");
         }
         return result;
     }

--- a/examples/providers/user-storage-jpa/pom.xml
+++ b/examples/providers/user-storage-jpa/pom.xml
@@ -23,7 +23,7 @@
         <version>3.4.0.CR1-SNAPSHOT</version>
     </parent>
 
-    <name>User Storage JPA Provider Exapmle</name>
+    <name>User Storage JPA Provider Example</name>
     <description/>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
This change fixes a typo in the user-storage-jpa-example