### PR TITLE
KEYCLOAK-5446 Clarify request URI mismatch error message in SAML adapter.

### DIFF
--- a/adapters/saml/core/src/main/java/org/keycloak/adapters/saml/profile/AbstractSamlAuthenticationHandler.java
+++ b/adapters/saml/core/src/main/java/org/keycloak/adapters/saml/profile/AbstractSamlAuthenticationHandler.java
@@ -187,7 +187,7 @@ public abstract class AbstractSamlAuthenticationHandler implements SamlAuthentic
         final StatusResponseType statusResponse = (StatusResponseType) holder.getSamlObject();
         // validate destination
         if (!requestUri.equals(statusResponse.getDestination())) {
-            log.error("Request URI does not match SAML request destination");
+            log.error("Request URI '" + requestUri + "' does not match SAML request destination '" + statusResponse.getDestination() + "'");
             return AuthOutcome.FAILED;
         }
 


### PR DESCRIPTION
Show expected URI and received URI in error message. Also makes the logging behavior of 'handleSamlResponse' the same as 'handleSamlRequest' since that method already shows the expected and received URI.

This is primarily useful when troubleshooting issues that arise from using the adapter in an application behind a reverse proxy.