### PR TITLE
KEYCLOAK-5499: Spring Security adapter doesn't work with access_token URL parameter.

### DIFF
--- a/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/authentication/KeycloakAuthenticationProvider.java
+++ b/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/authentication/KeycloakAuthenticationProvider.java
@@ -50,7 +50,7 @@ public class KeycloakAuthenticationProvider implements AuthenticationProvider {
         for (String role : token.getAccount().getRoles()) {
             grantedAuthorities.add(new KeycloakRole(role));
         }
-        return new KeycloakAuthenticationToken(token.getAccount(), mapAuthorities(grantedAuthorities));
+        return new KeycloakAuthenticationToken(token.getAccount(), token.isInteractive(), mapAuthorities(grantedAuthorities));
     }
 
     private Collection<? extends GrantedAuthority> mapAuthorities(

--- a/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/authentication/SpringSecurityRequestAuthenticator.java
+++ b/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/authentication/SpringSecurityRequestAuthenticator.java
@@ -94,7 +94,7 @@ public class SpringSecurityRequestAuthenticator extends RequestAuthenticator {
 
         logger.debug("Completing bearer authentication. Bearer roles: {} ",roles);
 
-        SecurityContextHolder.getContext().setAuthentication(new KeycloakAuthenticationToken(account));
+        SecurityContextHolder.getContext().setAuthentication(new KeycloakAuthenticationToken(account, false));
         request.setAttribute(KeycloakSecurityContext.class.getName(), securityContext);
     }
 

--- a/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/filter/QueryParamPresenceRequestMatcher.java
+++ b/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/filter/QueryParamPresenceRequestMatcher.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.adapters.springsecurity.filter;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.springframework.security.web.util.matcher.RequestMatcher;
+
+/**
+ * Spring RequestMatcher that checks for the presence of a query parameter.
+ *
+ * @author <a href="mailto:glavoie@gmail.com">Gabriel Lavoie</a>
+ */
+public class QueryParamPresenceRequestMatcher implements RequestMatcher {
+    private String param;
+
+    public QueryParamPresenceRequestMatcher(String param) {
+        this.param = param;
+    }
+
+    @Override
+    public boolean matches(HttpServletRequest httpServletRequest) {
+        return param != null && httpServletRequest.getParameter(param) != null;
+    }
+}

--- a/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/token/KeycloakAuthenticationToken.java
+++ b/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/token/KeycloakAuthenticationToken.java
@@ -38,24 +38,27 @@ import java.util.Collection;
 public class KeycloakAuthenticationToken extends AbstractAuthenticationToken implements Authentication {
 
     private Principal principal;
+    private boolean interactive;
 
     /**
      * Creates a new, unauthenticated Keycloak security token for the given account.
      */
-    public KeycloakAuthenticationToken(KeycloakAccount account) {
+    public KeycloakAuthenticationToken(KeycloakAccount account, boolean interactive) {
         super(null);
         Assert.notNull(account, "KeycloakAccount cannot be null");
         Assert.notNull(account.getPrincipal(), "KeycloakAccount.getPrincipal() cannot be null");
         this.principal = account.getPrincipal();
         this.setDetails(account);
+        this.interactive = interactive;
     }
 
-    public KeycloakAuthenticationToken(KeycloakAccount account, Collection<? extends GrantedAuthority> authorities) {
+    public KeycloakAuthenticationToken(KeycloakAccount account, boolean interactive, Collection<? extends GrantedAuthority> authorities) {
         super(authorities);
         Assert.notNull(account, "KeycloakAccount cannot be null");
         Assert.notNull(account.getPrincipal(), "KeycloakAccount.getPrincipal() cannot be null");
         this.principal = account.getPrincipal();
         this.setDetails(account);
+        this.interactive = interactive;
         setAuthenticated(true);
     }
 
@@ -71,5 +74,9 @@ public class KeycloakAuthenticationToken extends AbstractAuthenticationToken imp
 
     public OidcKeycloakAccount getAccount() {
         return (OidcKeycloakAccount) this.getDetails();
+    }
+
+    public boolean isInteractive() {
+        return interactive;
     }
 }

--- a/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/token/SpringSecurityTokenStore.java
+++ b/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/token/SpringSecurityTokenStore.java
@@ -105,7 +105,7 @@ public class SpringSecurityTokenStore implements AdapterTokenStore {
         }
 
         logger.debug("Saving account info {}", account);
-        SecurityContextHolder.getContext().setAuthentication(new KeycloakAuthenticationToken(account));
+        SecurityContextHolder.getContext().setAuthentication(new KeycloakAuthenticationToken(account, true));
     }
 
     @Override

--- a/adapters/oidc/spring-security/src/test/java/org/keycloak/adapters/springsecurity/authentication/KeycloakAuthenticationProviderTest.java
+++ b/adapters/oidc/spring-security/src/test/java/org/keycloak/adapters/springsecurity/authentication/KeycloakAuthenticationProviderTest.java
@@ -44,6 +44,7 @@ import static org.mockito.Mockito.mock;
 public class KeycloakAuthenticationProviderTest {
     private KeycloakAuthenticationProvider provider = new KeycloakAuthenticationProvider();
     private KeycloakAuthenticationToken token;
+    private KeycloakAuthenticationToken interactiveToken;
     private Set<String> roles = Sets.newSet("user", "admin");
 
     @Before
@@ -52,18 +53,18 @@ public class KeycloakAuthenticationProviderTest {
         RefreshableKeycloakSecurityContext securityContext = mock(RefreshableKeycloakSecurityContext.class);
         KeycloakAccount account = new SimpleKeycloakAccount(principal, roles, securityContext);
 
-        token = new KeycloakAuthenticationToken(account);
+        token = new KeycloakAuthenticationToken(account, false);
+        interactiveToken = new KeycloakAuthenticationToken(account, true);
     }
 
     @Test
     public void testAuthenticate() throws Exception {
-        Authentication result = provider.authenticate(token);
-        assertNotNull(result);
-        assertEquals(roles, AuthorityUtils.authorityListToSet(result.getAuthorities()));
-        assertTrue(result.isAuthenticated());
-        assertNotNull(result.getPrincipal());
-        assertNotNull(result.getCredentials());
-        assertNotNull(result.getDetails());
+        assertAuthenticationResult(provider.authenticate(token));
+    }
+
+    @Test
+    public void testAuthenticateInteractive() throws Exception {
+        assertAuthenticationResult(provider.authenticate(interactiveToken));
     }
 
     @Test
@@ -82,5 +83,14 @@ public class KeycloakAuthenticationProviderTest {
         Authentication result = provider.authenticate(token);
         assertEquals(Sets.newSet("ROLE_USER", "ROLE_ADMIN"),
             AuthorityUtils.authorityListToSet(result.getAuthorities()));
+    }
+
+    private void assertAuthenticationResult(Authentication result) {
+        assertNotNull(result);
+        assertEquals(roles, AuthorityUtils.authorityListToSet(result.getAuthorities()));
+        assertTrue(result.isAuthenticated());
+        assertNotNull(result.getPrincipal());
+        assertNotNull(result.getCredentials());
+        assertNotNull(result.getDetails());
     }
 }

--- a/adapters/oidc/spring-security/src/test/java/org/keycloak/adapters/springsecurity/facade/SimpleHttpFacadeTest.java
+++ b/adapters/oidc/spring-security/src/test/java/org/keycloak/adapters/springsecurity/facade/SimpleHttpFacadeTest.java
@@ -28,7 +28,7 @@ public class SimpleHttpFacadeTest {
         Principal principal = mock(Principal.class);
         RefreshableKeycloakSecurityContext keycloakSecurityContext = mock(RefreshableKeycloakSecurityContext.class);
         KeycloakAccount account = new SimpleKeycloakAccount(principal, roles, keycloakSecurityContext);
-        KeycloakAuthenticationToken token = new KeycloakAuthenticationToken(account);
+        KeycloakAuthenticationToken token = new KeycloakAuthenticationToken(account, false);
         springSecurityContext.setAuthentication(token);
     }
 

--- a/adapters/oidc/spring-security/src/test/java/org/keycloak/adapters/springsecurity/filter/KeycloakAuthenticationProcessingFilterTest.java
+++ b/adapters/oidc/spring-security/src/test/java/org/keycloak/adapters/springsecurity/filter/KeycloakAuthenticationProcessingFilterTest.java
@@ -53,7 +53,6 @@ import java.util.UUID;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -125,34 +124,6 @@ public class KeycloakAuthenticationProcessingFilterTest {
     }
 
     @Test
-    public void testIsBearerTokenRequest() throws Exception {
-        assertFalse(filter.isBearerTokenRequest(request));
-        this.setBearerAuthHeader(request);
-        assertTrue(filter.isBearerTokenRequest(request));
-    }
-
-    @Test
-    public void testIsBearerTokenRequestCaseInsensitive() throws Exception {
-        assertFalse(filter.isBearerTokenRequest(request));
-        this.setAuthorizationHeader(request, "bearer");
-        assertTrue(filter.isBearerTokenRequest(request));
-    }
-
-    @Test
-    public void testIsBasicAuthRequest() throws Exception {
-        assertFalse(filter.isBasicAuthRequest(request));
-        this.setBasicAuthHeader(request);
-        assertTrue(filter.isBasicAuthRequest(request));
-    }
-
-    @Test
-    public void testIsBasicAuthRequestCaseInsensitive() throws Exception {
-        assertFalse(filter.isBasicAuthRequest(request));
-        this.setAuthorizationHeader(request, "basic");
-        assertTrue(filter.isBasicAuthRequest(request));
-    }
-
-    @Test
     public void testAttemptAuthenticationExpectRedirect() throws Exception {
         when(keycloakDeployment.getAuthUrl()).thenReturn(KeycloakUriBuilder.fromUri("http://localhost:8080/auth"));
         when(keycloakDeployment.getResourceName()).thenReturn("resource-name");
@@ -180,7 +151,7 @@ public class KeycloakAuthenticationProcessingFilterTest {
 
     @Test
     public void testSuccessfulAuthenticationInteractive() throws Exception {
-        Authentication authentication = new KeycloakAuthenticationToken(keycloakAccount, authorities);
+        Authentication authentication = new KeycloakAuthenticationToken(keycloakAccount, true, authorities);
         filter.successfulAuthentication(request, response, chain, authentication);
 
         verify(successHandler).onAuthenticationSuccess(eq(request), eq(response), eq(authentication));
@@ -189,7 +160,7 @@ public class KeycloakAuthenticationProcessingFilterTest {
 
     @Test
     public void testSuccessfulAuthenticationBearer() throws Exception {
-        Authentication authentication = new KeycloakAuthenticationToken(keycloakAccount, authorities);
+        Authentication authentication = new KeycloakAuthenticationToken(keycloakAccount, false, authorities);
         this.setBearerAuthHeader(request);
         filter.successfulAuthentication(request, response, chain, authentication);
 
@@ -200,7 +171,7 @@ public class KeycloakAuthenticationProcessingFilterTest {
 
     @Test
     public void testSuccessfulAuthenticationBasicAuth() throws Exception {
-        Authentication authentication = new KeycloakAuthenticationToken(keycloakAccount, authorities);
+        Authentication authentication = new KeycloakAuthenticationToken(keycloakAccount, false, authorities);
         this.setBasicAuthHeader(request);
         filter.successfulAuthentication(request, response, chain, authentication);
 

--- a/adapters/oidc/spring-security/src/test/java/org/keycloak/adapters/springsecurity/filter/QueryParamPresenceRequestMatcherTest.java
+++ b/adapters/oidc/spring-security/src/test/java/org/keycloak/adapters/springsecurity/filter/QueryParamPresenceRequestMatcherTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.adapters.springsecurity.filter;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+public class QueryParamPresenceRequestMatcherTest {
+    private static final String ROOT_CONTEXT_PATH = "";
+
+    private static final String VALID_PARAMETER = "access_token";
+
+    private QueryParamPresenceRequestMatcher matcher = new QueryParamPresenceRequestMatcher(VALID_PARAMETER);
+
+    private MockHttpServletRequest request;
+
+    @Before
+    public void setUp() throws Exception {
+        request = new MockHttpServletRequest();
+    }
+
+    @Test
+    public void testDoesNotMatchWithoutQueryParameter() throws Exception {
+        prepareRequest(HttpMethod.GET, ROOT_CONTEXT_PATH, "some/random/uri", Collections.EMPTY_MAP);
+        assertFalse(matcher.matches(request));
+    }
+
+    @Test
+    public void testMatchesWithValidParameter() throws Exception {
+        prepareRequest(HttpMethod.GET, ROOT_CONTEXT_PATH, "some/random/uri", Collections.singletonMap(VALID_PARAMETER, (Object) "123"));
+        assertTrue(matcher.matches(request));
+    }
+
+    @Test
+    public void testDoesNotMatchWithInvalidParameter() throws Exception {
+        prepareRequest(HttpMethod.GET, ROOT_CONTEXT_PATH, "some/random/uri", Collections.singletonMap("some_parameter", (Object) "123"));
+        assertFalse(matcher.matches(request));
+    }
+
+    private void prepareRequest(HttpMethod method, String contextPath, String uri, Map<String, Object> params) {
+        request.setMethod(method.name());
+        request.setContextPath(contextPath);
+        request.setRequestURI(contextPath + "/" + uri);
+        request.setParameters(params);
+    }
+}


### PR DESCRIPTION
… detection to identify interactive and non-interactive authentications.

- access_token URL parameter wasn't interpreted correctly as a non-interactive authentication.