### PR TITLE
KEYCLOAK-3599 Revise Script based OIDC ProtocolMapper

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/AbstractOIDCProtocolMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/AbstractOIDCProtocolMapper.java
@@ -67,7 +67,7 @@ public abstract class AbstractOIDCProtocolMapper implements ProtocolMapper {
             return token;
         }
 
-        setClaim(token, mappingModel, userSession);
+        setClaim(token, mappingModel, userSession, session);
         return token;
     }
 
@@ -78,7 +78,7 @@ public abstract class AbstractOIDCProtocolMapper implements ProtocolMapper {
             return token;
         }
 
-        setClaim(token, mappingModel, userSession);
+        setClaim(token, mappingModel, userSession, session);
         return token;
     }
 
@@ -89,7 +89,7 @@ public abstract class AbstractOIDCProtocolMapper implements ProtocolMapper {
             return token;
         }
 
-        setClaim(token, mappingModel, userSession);
+        setClaim(token, mappingModel, userSession, session);
         return token;
     }
 
@@ -98,7 +98,22 @@ public abstract class AbstractOIDCProtocolMapper implements ProtocolMapper {
      * @param token
      * @param mappingModel
      * @param userSession
+     *
+     * @deprecated override {@link #setClaim(IDToken, ProtocolMapperModel, UserSessionModel, KeycloakSession)} instead.
      */
+    @Deprecated
     protected void setClaim(IDToken token, ProtocolMapperModel mappingModel, UserSessionModel userSession) {
+    }
+
+    /**
+     * Intended to be overridden in {@link ProtocolMapper} implementations to add claims to an token.
+     * @param token
+     * @param mappingModel
+     * @param userSession
+     * @param keycloakSession
+     */
+    protected void setClaim(IDToken token, ProtocolMapperModel mappingModel, UserSessionModel userSession, KeycloakSession keycloakSession) {
+        // we delegate to the old #setClaim(...) method for backwards compatibility
+        setClaim(token, mappingModel, userSession);
     }
 }


### PR DESCRIPTION
We now use the `ScriptingProvider` API instead of
using the `ScriptEngineManager` because dynamic
`ScriptEngineManager` lookups might fail in some
environments like JBoss EAP.

This mapper is now only available if the feature 
`Profile.Feature.SCRIPTS` is enabled.

Refactored `AbstractOIDCProtocolMapper` to provide
a new version of the `setClaim(..)` method which takes a
`KeycloakSession` as additional argument.
The old `setClaim(..)` method is marked as deprecated and
should be scheduled for removal in a later release.
To ensure backwards compatibility we call the old `setClaim(..)`
from the new `setClaim(..,keycloakSession)` method in order
to not break user implementations of OIDC ProtocolMappers.

The existing OIDC ProtocolMappers which override the old
`setClaim(..)` method should be updated to use the new version
`setClaim(..,keycloakSession)`.

This was necessary to be able to lookup a `ScriptingProvider`.