### PR TITLE
Update token every time

### DIFF
--- a/examples/demo-template/angular-product-app/src/main/webapp/js/app.js
+++ b/examples/demo-template/angular-product-app/src/main/webapp/js/app.js
@@ -61,16 +61,14 @@ module.factory('authInterceptor', function($q, Auth) {
     return {
         request: function (config) {
             var deferred = $q.defer();
-            if (Auth.authz.token) {
-                Auth.authz.updateToken(5).success(function() {
-                    config.headers = config.headers || {};
-                    config.headers.Authorization = 'Bearer ' + Auth.authz.token;
+            Auth.authz.updateToken(5).success(function() {
+                config.headers = config.headers || {};
+                config.headers.Authorization = 'Bearer ' + Auth.authz.token;
 
-                    deferred.resolve(config);
-                }).error(function() {
-                        deferred.reject('Failed to refresh token');
-                    });
-            }
+                deferred.resolve(config);
+            }).error(function() {
+                    deferred.reject('Failed to refresh token');
+            });
             return deferred.promise;
         }
     };


### PR DESCRIPTION
Update angular example to fix bug when token is not available.
When token is undefined all application requests will hang because promise is not resolved.

Alternative here will be to have if and resolve config without changes.