### PR TITLE
[KEYCLOAK-5522] Fix JAAS login module for Fuse 7 / Karaf 4

### DIFF
--- a/adapters/oidc/osgi-adapter/pom.xml
+++ b/adapters/oidc/osgi-adapter/pom.xml
@@ -36,7 +36,7 @@
             org.keycloak.adapters.osgi.*
         </keycloak.osgi.export>
         <keycloak.osgi.import>
-            org.ops4j.pax.web.*;version="[3.0,5)",
+            org.ops4j.pax.web.*;version="[3.0,7)",
             javax.servlet.*;version="[2.5,4)";resolution:=optional,
             org.eclipse.jetty.*;version="[8.1,10)";resolution:=optional,
             org.keycloak.*;version="${project.version}",

--- a/distribution/adapters/fuse-adapter-zip/pom.xml
+++ b/distribution/adapters/fuse-adapter-zip/pom.xml
@@ -124,6 +124,10 @@
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-jetty92-adapter</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-jetty93-adapter</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/distribution/adapters/osgi/features/src/main/resources/features.xml
+++ b/distribution/adapters/osgi/features/src/main/resources/features.xml
@@ -40,26 +40,53 @@
     <feature name="keycloak-osgi-adapter" version="${project.version}" resolver="(obr)">
         <details>The keycloak adapter core stuff</details>
         <feature>keycloak-adapter-core</feature>
-        <feature version="[2.3,4)">http-whiteboard</feature>
+        <feature>http-whiteboard</feature>
         <bundle>mvn:org.keycloak/keycloak-osgi-adapter/${project.version}</bundle>
     </feature>
 
-    <feature name="keycloak-jetty8-adapter" version="${project.version}" resolver="(obr)">
-        <details>The keycloak Jetty8 adapter</details>
+    <feature name="keycloak-jetty81-adapter" version="${project.version}" resolver="(obr)">
+        <details>The keycloak Jetty8.1 adapter</details>
         <feature>keycloak-adapter-core</feature>
-        <feature version="[8,9)">jetty</feature>
+        <feature version="[8.1,8.2)">jetty</feature>
         <bundle>mvn:org.keycloak/keycloak-jetty-adapter-spi/${project.version}</bundle>
         <bundle>mvn:org.keycloak/keycloak-jetty-core/${project.version}</bundle>
         <bundle>mvn:org.keycloak/keycloak-jetty81-adapter/${project.version}</bundle>
     </feature>
 
-    <feature name="keycloak-jetty9-adapter" version="${project.version}" resolver="(obr)">
-        <details>The keycloak Jetty9 adapter</details>
+    <feature name="keycloak-jetty91-adapter" version="${project.version}" resolver="(obr)">
+        <details>The keycloak Jetty9.1 adapter</details>
         <feature>keycloak-adapter-core</feature>
-        <feature version="[9,10)">jetty</feature>
+        <feature version="[9.1,9.2)">jetty</feature>
+        <bundle>mvn:org.keycloak/keycloak-jetty-adapter-spi/${project.version}</bundle>
+        <bundle>mvn:org.keycloak/keycloak-jetty-core/${project.version}</bundle>
+        <bundle>mvn:org.keycloak/keycloak-jetty91-adapter/${project.version}</bundle>
+    </feature>
+
+    <feature name="keycloak-jetty92-adapter" version="${project.version}" resolver="(obr)">
+        <details>The keycloak Jetty9.2 adapter</details>
+        <feature>keycloak-adapter-core</feature>
+        <feature version="[9.2,9.3)">jetty</feature>
         <bundle>mvn:org.keycloak/keycloak-jetty-adapter-spi/${project.version}</bundle>
         <bundle>mvn:org.keycloak/keycloak-jetty-core/${project.version}</bundle>
         <bundle>mvn:org.keycloak/keycloak-jetty92-adapter/${project.version}</bundle>
+    </feature>
+
+    <feature name="keycloak-jetty93adapter" version="${project.version}" resolver="(obr)">
+        <details>The keycloak Jetty9.3 adapter</details>
+        <feature>keycloak-adapter-core</feature>
+        <feature version="[9.3,9.4)">jetty</feature>
+        <bundle>mvn:org.keycloak/keycloak-jetty-adapter-spi/${project.version}</bundle>
+        <bundle>mvn:org.keycloak/keycloak-jetty-core/${project.version}</bundle>
+        <bundle>mvn:org.keycloak/keycloak-jetty93-adapter/${project.version}</bundle>
+    </feature>
+
+    <feature name="keycloak-jetty94-adapter" version="${project.version}" resolver="(obr)">
+        <details>The keycloak Jetty9.4 adapter</details>
+        <feature>keycloak-adapter-core</feature>
+        <feature version="[9.4,9.5)">jetty</feature>
+        <bundle>mvn:org.keycloak/keycloak-jetty-adapter-spi/${project.version}</bundle>
+        <bundle>mvn:org.keycloak/keycloak-jetty-core/${project.version}</bundle>
+        <bundle>mvn:org.keycloak/keycloak-jetty94-adapter/${project.version}</bundle>
     </feature>
 
     <feature name="keycloak-jaas" version="${project.version}" resolver="(obr)">


### PR DESCRIPTION
This only handles the JAAS login module support in Fuse 7 / Karaf 4.