### PR TITLE
Remove bug with login redirect on IOS

### DIFF
--- a/adapters/oidc/js/src/main/resources/keycloak.js
+++ b/adapters/oidc/js/src/main/resources/keycloak.js
@@ -50,7 +50,7 @@
             } else if (initOptions && initOptions.adapter === 'default') {
                 adapter = loadAdapter();
             } else {
-                if (window.Cordova) {
+                if (window.Cordova || window.cordova) {
                     adapter = loadAdapter('cordova');
                 } else {
                     adapter = loadAdapter();
@@ -948,7 +948,14 @@
 
             if (type == 'cordova') {
                 loginIframe.enable = false;
-
+                function cordovaOpenWindowWrapper(loginUrl, target, options) {
+                    if (window.cordova && window.cordova.InAppBrowser) {
+                        // Use inappbrowser for IOS and Android if available
+                        return window.cordova.InAppBrowser.open(loginUrl, target, options);
+                    } else {
+                        return window.open(loginUrl, target, options);
+                    }
+                };
                 return {
                     login: function(options) {
                         var promise = createPromise();
@@ -959,8 +966,7 @@
                         }
 
                         var loginUrl = kc.createLoginUrl(options);
-                        var ref = window.open(loginUrl, '_blank', o);
-
+                        var ref = cordovaOpenWindowWrapper(loginUrl, '_blank', o);
                         var completed = false;
 
                         ref.addEventListener('loadstart', function(event) {
@@ -993,7 +999,7 @@
                         var promise = createPromise();
 
                         var logoutUrl = kc.createLogoutUrl(options);
-                        var ref = window.open(logoutUrl, '_blank', 'location=no,hidden=yes');
+                        var ref = cordovaOpenWindowWrapper(logoutUrl, '_blank', 'location=no,hidden=yes');
 
                         var error;
 
@@ -1026,7 +1032,7 @@
 
                     register : function() {
                         var registerUrl = kc.createRegisterUrl();
-                        var ref = window.open(registerUrl, '_blank', 'location=no');
+                        var ref = cordovaOpenWindowWrapper(registerUrl, '_blank', 'location=no');
                         ref.addEventListener('loadstart', function(event) {
                             if (event.url.indexOf('http://localhost') == 0) {
                                 ref.close();
@@ -1036,7 +1042,7 @@
 
                     accountManagement : function() {
                         var accountUrl = kc.createAccountUrl();
-                        var ref = window.open(accountUrl, '_blank', 'location=no');
+                        var ref = cordovaOpenWindowWrapper(accountUrl, '_blank', 'location=no');
                         ref.addEventListener('loadstart', function(event) {
                             if (event.url.indexOf('http://localhost') == 0) {
                                 ref.close();

--- a/adapters/oidc/js/src/main/resources/keycloak.js
+++ b/adapters/oidc/js/src/main/resources/keycloak.js
@@ -948,7 +948,7 @@
 
             if (type == 'cordova') {
                 loginIframe.enable = false;
-                function cordovaOpenWindowWrapper(loginUrl, target, options) {
+                var cordovaOpenWindowWrapper = function(loginUrl, target, options) {
                     if (window.cordova && window.cordova.InAppBrowser) {
                         // Use inappbrowser for IOS and Android if available
                         return window.cordova.InAppBrowser.open(loginUrl, target, options);


### PR DESCRIPTION
I noticed that in order for adapter to work on the mobile devices (IOS in particular) users need to swap window.open implementation with inAppBrowser one. 

## Reason
window.open will never work in safari. Using default adapter also do not work on IOS. 
Android seems to be working fine with the both adapters.

On ios (starting from 9) window.open will return undefined and keycloak library will fail silently. 
Users can fix that by replacing handler in the application code as follows: 

```javascript
      var initConfig = {};
      initConfig.adapter = "cordova";
      document.addEventListener("deviceready", function onDeviceReady() {
        window.open = cordova.InAppBrowser.open;
        keycloak.init(initConfig).success(...);
      }, false);
```

To provide better user experience it's best for cordova adapter to use inappbrowser once it's available. This will resolve issues out of the box without creating wrapper. 
inAppBrowser plugin needs to be also documented as required when working on IOS (it's fairly common plugin used by most of the apps)

Change tested on IOS 9 and IOS 10. 

## Fixes issue

https://issues.jboss.org/browse/KEYCLOAK-5646