### PR TITLE
Renames realmKey to realmPublicKey for consistency

### DIFF
--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/KeycloakDeploymentBuilder.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/KeycloakDeploymentBuilder.java
@@ -58,7 +58,7 @@ public class KeycloakDeploymentBuilder {
         if (resource == null) throw new RuntimeException("Must set 'resource' in config");
         deployment.setResourceName(resource);
 
-        String realmKeyPem = adapterConfig.getRealmKey();
+        String realmKeyPem = adapterConfig.getRealmPublicKey();
         if (realmKeyPem != null) {
             PublicKey realmKey;
             try {

--- a/core/src/main/java/org/keycloak/representations/adapters/config/BaseRealmConfig.java
+++ b/core/src/main/java/org/keycloak/representations/adapters/config/BaseRealmConfig.java
@@ -31,7 +31,7 @@ public class BaseRealmConfig {
     @JsonProperty("realm")
     protected String realm;
     @JsonProperty("realm-public-key")
-    protected String realmKey;
+    protected String realmPublicKey;
     @JsonProperty("auth-server-url")
     protected String authServerUrl;
     @JsonProperty("ssl-required")
@@ -53,12 +53,12 @@ public class BaseRealmConfig {
         this.realm = realm;
     }
 
-    public String getRealmKey() {
-        return realmKey;
+    public String getRealmPublicKey() {
+        return realmPublicKey;
     }
 
-    public void setRealmKey(String realmKey) {
-        this.realmKey = realmKey;
+    public void setRealmPublicKey(String realmPublicKey) {
+        this.realmPublicKey = realmPublicKey;
     }
 
     public String getAuthServerUrl() {


### PR DESCRIPTION
### Problem:

When using installation JSON as a property source for spring-boot application with spring-boot-adapter, it reads properties based on field names and ignores `@JsonProperty` annotations. That means then if we generate installation JSON with `realm-public-key` property it won't fit into `realmKey` field and will cause an error.

### Solution:

Renaming `realmKey` field to `realmPublicKey` will match field name defined in `@JsonProperty` annotation for this field which means that installation JSON will be able to be used as a property source for spring applications using keycloak.