### PR TITLE
OIDC Financial API Read Only Profile : scope MUST be returned in the response from Token Endpoint

### DIFF
--- a/core/src/main/java/org/keycloak/representations/AccessTokenResponse.java
+++ b/core/src/main/java/org/keycloak/representations/AccessTokenResponse.java
@@ -57,7 +57,17 @@ public class AccessTokenResponse {
 
     protected Map<String, Object> otherClaims = new HashMap<String, Object>();
 
+    // OIDC Financial API Read Only Profile : scope MUST be returned in the response from Token Endpoint
+    @JsonProperty("scope")
+    protected String scope;
 
+    public String getScope() {
+        return scope;
+    }
+
+    public void setScope(String scope) {
+        this.scope = scope;
+    }
 
     public String getToken() {
         return token;

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/OAuthClient.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/OAuthClient.java
@@ -949,6 +949,8 @@ public class OAuthClient {
         private int expiresIn;
         private int refreshExpiresIn;
         private String refreshToken;
+        // OIDC Financial API Read Only Profile : scope MUST be returned in the response from Token Endpoint
+        private String scope;
 
         private String error;
         private String errorDescription;
@@ -969,6 +971,11 @@ public class OAuthClient {
                     tokenType = (String) responseJson.get("token_type");
                     expiresIn = (Integer) responseJson.get("expires_in");
                     refreshExpiresIn = (Integer) responseJson.get("refresh_expires_in");
+
+                    // OIDC Financial API Read Only Profile : scope MUST be returned in the response from Token Endpoint
+                    if (responseJson.containsKey(OAuth2Constants.SCOPE)) {
+                        scope = (String) responseJson.get(OAuth2Constants.SCOPE);
+                    }
 
                     if (responseJson.containsKey(OAuth2Constants.REFRESH_TOKEN)) {
                         refreshToken = (String) responseJson.get(OAuth2Constants.REFRESH_TOKEN);
@@ -1016,6 +1023,11 @@ public class OAuthClient {
 
         public String getTokenType() {
             return tokenType;
+        }
+
+        // OIDC Financial API Read Only Profile : scope MUST be returned in the response from Token Endpoint
+        public String getScope() {
+            return scope;
         }
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OAuthScopeInTokenResponseTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OAuthScopeInTokenResponseTest.java
@@ -1,0 +1,208 @@
+package org.keycloak.testsuite.oauth;
+
+import static org.junit.Assert.assertEquals;
+import static org.keycloak.testsuite.admin.AbstractAdminTest.loadJson;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.keycloak.OAuth2Constants;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.testsuite.AbstractKeycloakTest;
+import org.keycloak.testsuite.util.OAuthClient;
+
+//OIDC Financial API Read Only Profile : scope MUST be returned in the response from Token Endpoint
+public class OAuthScopeInTokenResponseTest extends AbstractKeycloakTest {
+
+    @Override
+    public void beforeAbstractKeycloakTest() throws Exception {
+        super.beforeAbstractKeycloakTest();
+    }
+
+    @Override
+    public void addTestRealms(List<RealmRepresentation> testRealms) {
+        RealmRepresentation realm = loadJson(getClass().getResourceAsStream("/testrealm.json"), RealmRepresentation.class);
+        testRealms.add(realm);
+    }
+
+    @Test
+    public void specifyNoScopeTest() throws Exception {
+        String loginUser = "john-doh@localhost";
+        String loginPassword = "password";
+        String clientSecret = "password";
+        
+    	String expectedScope = "";
+    	
+        oauth.doLogin(loginUser, loginPassword);
+
+        String code = oauth.getCurrentQuery().get(OAuth2Constants.CODE);
+        
+        expectSuccessfulResponseFromTokenEndpoint(code, expectedScope, clientSecret);
+    }
+    
+    @Test
+    public void specifySingleScopeAsRealmRoleTest() throws Exception {
+        String loginUser = "john-doh@localhost";
+        String loginPassword = "password";
+        String clientSecret = "password";
+        
+    	String requestedScope = "user";
+    	String expectedScope = requestedScope;
+    	
+    	oauth.scope(requestedScope);
+        oauth.doLogin(loginUser, loginPassword);
+
+        String code = oauth.getCurrentQuery().get(OAuth2Constants.CODE);
+        
+        expectSuccessfulResponseFromTokenEndpoint(code, expectedScope, clientSecret);
+    }
+    
+    @Test
+    public void specifyMultipleScopeAsRealmRoleTest() throws Exception {
+        String loginUser = "rich.roles@redhat.com";
+        String loginPassword = "password";
+        String clientSecret = "password";
+        
+    	String requestedScope = "user realm-composite-role";
+    	String expectedScope = requestedScope;
+    	
+    	oauth.scope(requestedScope);
+        oauth.doLogin(loginUser, loginPassword);
+
+        String code = oauth.getCurrentQuery().get(OAuth2Constants.CODE);
+        
+        expectSuccessfulResponseFromTokenEndpoint(code, expectedScope, clientSecret);
+    }
+
+    @Test
+    public void specifyNotAssignedScopeAsRealmRoleTest() throws Exception {
+        String loginUser = "john-doh@localhost";
+        String loginPassword = "password";
+        String clientSecret = "password";
+        
+    	String requestedScope = "user realm-composite-role";
+    	String expectedScope = "user";
+    	
+    	oauth.scope(requestedScope);
+        oauth.doLogin(loginUser, loginPassword);
+
+        String code = oauth.getCurrentQuery().get(OAuth2Constants.CODE);
+        
+        expectSuccessfulResponseFromTokenEndpoint(code, expectedScope, clientSecret);
+    }
+
+    @Test
+    public void specifySingleScopeAsClientRoleTest() throws Exception {
+        String loginUser = "john-doh@localhost";
+        String loginPassword = "password";
+        String clientSecret = "password";
+        
+    	String requestedScope = "test-app/customer-user";
+    	String expectedScope = requestedScope;
+    	
+    	oauth.scope(requestedScope);
+        oauth.doLogin(loginUser, loginPassword);
+
+        String code = oauth.getCurrentQuery().get(OAuth2Constants.CODE);
+        
+        expectSuccessfulResponseFromTokenEndpoint(code, expectedScope, clientSecret);
+    }
+
+    @Test
+    public void specifyMultipleScopeAsClientRoleTest() throws Exception {
+        String loginUser = "rich.roles@redhat.com";
+        String loginPassword = "password";
+        String clientSecret = "password";
+        
+    	String requestedScope = "test-app-scope/test-app-disallowed-by-scope test-app-scope/test-app-allowed-by-scope";
+    	String expectedScope = requestedScope;
+    	
+    	oauth.scope(requestedScope);
+        oauth.doLogin(loginUser, loginPassword);
+
+        String code = oauth.getCurrentQuery().get(OAuth2Constants.CODE);
+        
+        expectSuccessfulResponseFromTokenEndpoint(code, expectedScope, clientSecret);
+    }
+
+    @Test
+    public void specifyNotAssignedScopeAsClientRoleTest() throws Exception {
+        String loginUser = "rich.roles@redhat.com";
+        String loginPassword = "password";
+        String clientSecret = "password";
+        
+    	String requestedScope = "test-app-scope/test-app-unspecified-by-scope test-app-scope/test-app-allowed-by-scope";
+    	String expectedScope = "test-app-scope/test-app-allowed-by-scope";
+    	
+    	oauth.scope(requestedScope);
+        oauth.doLogin(loginUser, loginPassword);
+
+        String code = oauth.getCurrentQuery().get(OAuth2Constants.CODE);
+        
+        expectSuccessfulResponseFromTokenEndpoint(code, expectedScope, clientSecret);
+    }
+
+    @Test
+    public void specifyMultipleScopeAsRealmAndClientRoleTest() throws Exception {
+        String loginUser = "rich.roles@redhat.com";
+        String loginPassword = "password";
+        String clientSecret = "password";
+        
+    	String requestedScope = "test-app-scope/test-app-disallowed-by-scope admin test-app/customer-user test-app-scope/test-app-allowed-by-scope";
+    	String expectedScope = requestedScope;
+    	
+    	oauth.scope(requestedScope);
+        oauth.doLogin(loginUser, loginPassword);
+
+        String code = oauth.getCurrentQuery().get(OAuth2Constants.CODE);
+        
+        expectSuccessfulResponseFromTokenEndpoint(code, expectedScope, clientSecret);
+    }
+
+    @Test
+    public void specifyNotAssignedScopeAsRealmAndClientRoleTest() throws Exception {
+        String loginUser = "john-doh@localhost";
+        String loginPassword = "password";
+        String clientSecret = "password";
+        
+    	String requestedScope = "test-app/customer-user test-app-scope/test-app-disallowed-by-scope admin test-app/customer-user user test-app-scope/test-app-allowed-by-scope";
+    	String expectedScope = "user test-app/customer-user";
+    	
+    	oauth.scope(requestedScope);
+        oauth.doLogin(loginUser, loginPassword);
+
+        String code = oauth.getCurrentQuery().get(OAuth2Constants.CODE);
+        
+        expectSuccessfulResponseFromTokenEndpoint(code, expectedScope, clientSecret);
+    }
+ 
+    @Test
+    public void specifyDuplicatedScopeAsRealmAndClientRoleTest() throws Exception {
+        String loginUser = "john-doh@localhost";
+        String loginPassword = "password";
+        String clientSecret = "password";
+        
+    	String requestedScope = "test-app/customer-user user user test-app/customer-user";
+    	String expectedScope = "user test-app/customer-user";
+    	
+    	oauth.scope(requestedScope);
+        oauth.doLogin(loginUser, loginPassword);
+
+        String code = oauth.getCurrentQuery().get(OAuth2Constants.CODE);
+        
+        expectSuccessfulResponseFromTokenEndpoint(code, expectedScope, clientSecret);
+    }
+    
+    private void expectSuccessfulResponseFromTokenEndpoint(String code, String expectedScope, String clientSecret) throws Exception {
+    	OAuthClient.AccessTokenResponse response = oauth.doAccessTokenRequest(code, clientSecret);
+        assertEquals(200, response.getStatusCode());
+        log.info("expectedScopes = " + expectedScope);
+        log.info("receivedScopes = " + response.getScope());
+    	Collection<String> expectedScopes = Arrays.asList(expectedScope.split(" "));
+    	Collection<String> receivedScopes = Arrays.asList(response.getScope().split(" "));
+    	Assert.assertTrue(expectedScopes.containsAll(receivedScopes) && receivedScopes.containsAll(expectedScopes));
+    }
+}


### PR DESCRIPTION
I've investigated into keycloak to find out whether it completely conforms to Financial API Read Only Profile Requirements for Authorization Server and found that it does not satisfy only one point.

Therefore, I've implemented this point, namely always including OAuth scope in the response from Token Endpoint.

Financial API is API's security requirement for API services in financial sector.
It is specified by OpenID Foundation.
http://openid.net/wg/fapi/

Financial API Read Only Profile Requirements for Authorization Server is the following.
http://openid.net/specs/openid-financial-api-part-1.html#authorization-server
* shall return the list of allowed scopes with the issued access token;
is met by this PR

Hope this PR is reviewed and merged.