### PR TITLE
KEYCLOAK-4414 Allow to add user-agent header for out-bound http calls

### DIFF
--- a/services/src/main/java/org/keycloak/connections/httpclient/DefaultHttpClientFactory.java
+++ b/services/src/main/java/org/keycloak/connections/httpclient/DefaultHttpClientFactory.java
@@ -117,6 +117,7 @@ public class DefaultHttpClientFactory implements HttpClientFactory {
         if (httpClient == null) {
             synchronized(this) {
                 if (httpClient == null) {
+                    String userAgent = config.get("user-agent");
                     long socketTimeout = config.getLong("socket-timeout-millis", -1L);
                     long establishConnectionTimeout = config.getLong("establish-connection-timeout-millis", -1L);
                     int maxPooledPerRoute = config.getInt("max-pooled-per-route", 64);
@@ -143,6 +144,7 @@ public class DefaultHttpClientFactory implements HttpClientFactory {
                             .connectionPoolSize(connectionPoolSize)
                             .connectionTTL(connectionTTL, TimeUnit.MILLISECONDS)
                             .maxConnectionIdleTime(maxConnectionIdleTime, TimeUnit.MILLISECONDS)
+                            .userAgent(userAgent)
                             .disableCookies(disableCookies);
 
                     if (disableTrustManager) {

--- a/services/src/main/java/org/keycloak/connections/httpclient/DefaultHttpClientFactory.java
+++ b/services/src/main/java/org/keycloak/connections/httpclient/DefaultHttpClientFactory.java
@@ -44,52 +44,17 @@ import java.util.concurrent.TimeUnit;
 public class DefaultHttpClientFactory implements HttpClientFactory {
 
     private static final Logger logger = Logger.getLogger(DefaultHttpClientFactory.class);
+    public static final String DEFAULT_USER_AGENT = "Keycloak";
 
     private volatile CloseableHttpClient httpClient;
     private Config.Scope config;
 
     @Override
     public HttpClientProvider create(KeycloakSession session) {
+
         lazyInit(session);
 
-        return new HttpClientProvider() {
-            @Override
-            public HttpClient getHttpClient() {
-                return httpClient;
-            }
-
-            @Override
-            public void close() {
-
-            }
-
-            @Override
-            public int postText(String uri, String text) throws IOException {
-                HttpPost request = new HttpPost(uri);
-                request.setEntity(EntityBuilder.create().setText(text).setContentType(ContentType.TEXT_PLAIN).build());
-                HttpResponse response = httpClient.execute(request);
-                try {
-                    return response.getStatusLine().getStatusCode();
-                } finally {
-                    HttpEntity entity = response.getEntity();
-                    if (entity != null) {
-                        InputStream is = entity.getContent();
-                        if (is != null) is.close();
-                    }
-
-                }
-            }
-
-            @Override
-            public InputStream get(String uri) throws IOException {
-                HttpGet request = new HttpGet(uri);
-                HttpResponse response = httpClient.execute(request);
-                HttpEntity entity = response.getEntity();
-                if (entity == null) return null;
-                return entity.getContent();
-
-            }
-        };
+        return new DefaultHttpClientProvider();
     }
 
     @Override
@@ -98,8 +63,7 @@ public class DefaultHttpClientFactory implements HttpClientFactory {
             if (httpClient != null) {
                 httpClient.close();
             }
-        } catch (IOException e) {
-
+        } catch (IOException ignored) {
         }
     }
 
@@ -114,71 +78,122 @@ public class DefaultHttpClientFactory implements HttpClientFactory {
     }
 
     private void lazyInit(KeycloakSession session) {
-        if (httpClient == null) {
-            synchronized(this) {
-                if (httpClient == null) {
-                    String userAgent = config.get("user-agent");
-                    long socketTimeout = config.getLong("socket-timeout-millis", -1L);
-                    long establishConnectionTimeout = config.getLong("establish-connection-timeout-millis", -1L);
-                    int maxPooledPerRoute = config.getInt("max-pooled-per-route", 64);
-                    int connectionPoolSize = config.getInt("connection-pool-size", 128);
-                    long connectionTTL = config.getLong("connection-ttl-millis", -1L);
-                    long maxConnectionIdleTime = config.getLong("max-connection-idle-time-millis", 900000L);
-                    boolean disableCookies = config.getBoolean("disable-cookies", true);
-                    String clientKeystore = config.get("client-keystore");
-                    String clientKeystorePassword = config.get("client-keystore-password");
-                    String clientPrivateKeyPassword = config.get("client-key-password");
 
-                    TruststoreProvider truststoreProvider = session.getProvider(TruststoreProvider.class);
-                    boolean disableTrustManager = truststoreProvider == null || truststoreProvider.getTruststore() == null;
-                    if (disableTrustManager) {
-                        logger.warn("Truststore is disabled");
-                    }
-                    HttpClientBuilder.HostnameVerificationPolicy hostnamePolicy = disableTrustManager ? null
-                            : HttpClientBuilder.HostnameVerificationPolicy.valueOf(truststoreProvider.getPolicy().name());
+        if (httpClient != null) {
+            return;
+        }
 
-                    HttpClientBuilder builder = new HttpClientBuilder();
-                    builder.socketTimeout(socketTimeout, TimeUnit.MILLISECONDS)
-                            .establishConnectionTimeout(establishConnectionTimeout, TimeUnit.MILLISECONDS)
-                            .maxPooledPerRoute(maxPooledPerRoute)
-                            .connectionPoolSize(connectionPoolSize)
-                            .connectionTTL(connectionTTL, TimeUnit.MILLISECONDS)
-                            .maxConnectionIdleTime(maxConnectionIdleTime, TimeUnit.MILLISECONDS)
-                            .userAgent(userAgent)
-                            .disableCookies(disableCookies);
-
-                    if (disableTrustManager) {
-                        // TODO: is it ok to do away with disabling trust manager?
-                        //builder.disableTrustManager();
-                    } else {
-                        builder.hostnameVerification(hostnamePolicy);
-                        try {
-                            builder.trustStore(truststoreProvider.getTruststore());
-                        } catch (Exception e) {
-                            throw new RuntimeException("Failed to load truststore", e);
-                        }
-                    }
-
-                    if (clientKeystore != null) {
-                        clientKeystore = EnvUtil.replace(clientKeystore);
-                        try {
-                            KeyStore clientCertKeystore = KeystoreUtil.loadKeyStore(clientKeystore, clientKeystorePassword);
-                            builder.keyStore(clientCertKeystore, clientPrivateKeyPassword);
-                        } catch (Exception e) {
-                            throw new RuntimeException("Failed to load keystore", e);
-                        }
-                    }
-                    httpClient = builder.build();
-                }
+        synchronized(this) {
+            if (httpClient == null) {
+                httpClient = createHttpClient(session.getProvider(TruststoreProvider.class));
             }
         }
     }
 
+    /*
+     * visible for testing
+     */
+    CloseableHttpClient createHttpClient(TruststoreProvider truststoreProvider) {
+
+        String userAgent = config.get("user-agent", DEFAULT_USER_AGENT);
+        long socketTimeout = config.getLong("socket-timeout-millis", -1L);
+        long establishConnectionTimeout = config.getLong("establish-connection-timeout-millis", -1L);
+        int maxPooledPerRoute = config.getInt("max-pooled-per-route", 64);
+        int connectionPoolSize = config.getInt("connection-pool-size", 128);
+        long connectionTTL = config.getLong("connection-ttl-millis", -1L);
+        long maxConnectionIdleTime = config.getLong("max-connection-idle-time-millis", 900000L);
+        boolean disableCookies = config.getBoolean("disable-cookies", true);
+        String clientKeystore = config.get("client-keystore");
+        String clientKeystorePassword = config.get("client-keystore-password");
+        String clientPrivateKeyPassword = config.get("client-key-password");
+
+        boolean disableTrustManager = truststoreProvider == null || truststoreProvider.getTruststore() == null;
+        if (disableTrustManager) {
+            logger.warn("Truststore is disabled");
+        }
+        HttpClientBuilder.HostnameVerificationPolicy hostnamePolicy = disableTrustManager ? null
+                : HttpClientBuilder.HostnameVerificationPolicy.valueOf(truststoreProvider.getPolicy().name());
+
+        HttpClientBuilder builder = new HttpClientBuilder();
+        builder.socketTimeout(socketTimeout, TimeUnit.MILLISECONDS)
+                .establishConnectionTimeout(establishConnectionTimeout, TimeUnit.MILLISECONDS)
+                .maxPooledPerRoute(maxPooledPerRoute)
+                .connectionPoolSize(connectionPoolSize)
+                .connectionTTL(connectionTTL, TimeUnit.MILLISECONDS)
+                .maxConnectionIdleTime(maxConnectionIdleTime, TimeUnit.MILLISECONDS)
+                .userAgent(userAgent)
+                .disableCookies(disableCookies);
+
+        if (disableTrustManager) {
+            // TODO: is it ok to do away with disabling trust manager?
+            //builder.disableTrustManager();
+        } else {
+            builder.hostnameVerification(hostnamePolicy);
+            try {
+                builder.trustStore(truststoreProvider.getTruststore());
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to load truststore", e);
+            }
+        }
+
+        if (clientKeystore != null) {
+            clientKeystore = EnvUtil.replace(clientKeystore);
+            try {
+                KeyStore clientCertKeystore = KeystoreUtil.loadKeyStore(clientKeystore, clientKeystorePassword);
+                builder.keyStore(clientCertKeystore, clientPrivateKeyPassword);
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to load keystore", e);
+            }
+        }
+        return builder.build();
+    }
+
     @Override
     public void postInit(KeycloakSessionFactory factory) {
-
+        //noop
     }
 
 
+    private class DefaultHttpClientProvider implements HttpClientProvider {
 
+        @Override
+        public HttpClient getHttpClient() {
+            return httpClient;
+        }
+
+        @Override
+        public void close() {
+            //noop
+        }
+
+        @Override
+        public int postText(String uri, String text) throws IOException {
+            HttpPost request = new HttpPost(uri);
+            request.setEntity(EntityBuilder.create().setText(text).setContentType(ContentType.TEXT_PLAIN).build());
+            HttpResponse response = httpClient.execute(request);
+            try {
+                return response.getStatusLine().getStatusCode();
+            } finally {
+                HttpEntity entity = response.getEntity();
+                if (entity != null) {
+                    InputStream is = entity.getContent();
+                    if (is != null){
+                        is.close();
+                    }
+                }
+
+            }
+        }
+
+        @Override
+        public InputStream get(String uri) throws IOException {
+            HttpGet request = new HttpGet(uri);
+            HttpResponse response = httpClient.execute(request);
+            HttpEntity entity = response.getEntity();
+            if (entity == null){
+                return null;
+            }
+            return entity.getContent();
+        }
+    }
 }

--- a/services/src/main/java/org/keycloak/connections/httpclient/HttpClientBuilder.java
+++ b/services/src/main/java/org/keycloak/connections/httpclient/HttpClientBuilder.java
@@ -103,6 +103,7 @@ public class HttpClientBuilder {
     protected TimeUnit socketTimeoutUnits = TimeUnit.MILLISECONDS;
     protected long establishConnectionTimeout = -1;
     protected TimeUnit establishConnectionTimeoutUnits = TimeUnit.MILLISECONDS;
+    protected String userAgent;
     protected boolean disableCookies = false;
 
 
@@ -171,6 +172,17 @@ public class HttpClientBuilder {
      */
     public HttpClientBuilder disableCookies(boolean disable) {
         this.disableCookies = disable;
+        return this;
+    }
+
+
+    /**
+     * User agent string
+     * @param userAgent
+     * @return
+     */
+    public HttpClientBuilder userAgent(String userAgent) {
+        this.userAgent = userAgent;
         return this;
     }
 
@@ -282,6 +294,10 @@ public class HttpClientBuilder {
                     .setMaxConnTotal(connectionPoolSize)
                     .setMaxConnPerRoute(maxPooledPerRoute)
                     .setConnectionTimeToLive(connectionTTL, connectionTTLUnit);
+
+            if (userAgent != null) {
+                builder.setUserAgent(userAgent);
+            }
 
             if (maxConnectionIdleTime > 0) {
                 // Will start background cleaner thread

--- a/services/src/test/java/org/keycloak/connections/httpclient/DefaultHttpClientFactoryTest.java
+++ b/services/src/test/java/org/keycloak/connections/httpclient/DefaultHttpClientFactoryTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.connections.httpclient;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.net.httpserver.Headers;
+import com.sun.net.httpserver.HttpServer;
+import org.apache.commons.io.IOUtils;
+import org.apache.http.HttpHost;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.keycloak.Config;
+import org.keycloak.services.util.JsonConfigProvider;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.InetSocketAddress;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * Tests for {@link DefaultHttpClientFactory}
+ */
+public class DefaultHttpClientFactoryTest {
+
+  private static final ObjectMapper OM = new ObjectMapper();
+
+  private static final String USER_AGENT_CONFIG_PROPERTY = "user-agent";
+
+  private static final String USER_AGENT_HEADER = "User-agent";
+
+  private static final String ECHO_ENDPOINT = "/echo";
+
+  private HttpServer httpServer;
+
+  private HttpHost localhost;
+
+  private DefaultHttpClientFactory factory;
+
+  @Before
+  public void setup() throws Exception {
+
+    this.factory = new DefaultHttpClientFactory();
+    this.factory.init(createScopeFrom(Collections.emptyMap()));
+
+    this.httpServer = startEchoWebServerAtFreePort();
+    this.localhost = new HttpHost("localhost", httpServer.getAddress().getPort());
+  }
+
+  @After
+  public void destroy() {
+    httpServer.stop(0);
+  }
+
+  private Config.Scope createScopeFrom(Map<String, Object> config) throws IOException {
+    return new JsonConfigProvider(OM.readTree(OM.writeValueAsString(config)), new Properties()).scope();
+  }
+
+  @Test
+  public void httpClientShouldUseDefaultUserAgent() throws Exception {
+
+    try (CloseableHttpClient httpClient = factory.createHttpClient(null);
+         CloseableHttpResponse response = httpClient.execute(localhost, new HttpGet(ECHO_ENDPOINT))) {
+
+      EchoResponse echo = OM.readValue(response.getEntity().getContent(), EchoResponse.class);
+
+      Assert.assertEquals(DefaultHttpClientFactory.DEFAULT_USER_AGENT, echo.getHeaders().getFirst(USER_AGENT_HEADER));
+    }
+  }
+
+  @Test
+  public void httpClientShouldUseProvidedUserAgent() throws Exception {
+
+    String customUserAgent = "custom-user-agent";
+
+    this.factory.init(createScopeFrom(Collections.singletonMap(USER_AGENT_CONFIG_PROPERTY, customUserAgent)));
+
+    try (CloseableHttpClient httpClient = factory.createHttpClient(null);
+         CloseableHttpResponse response = httpClient.execute(localhost, new HttpGet("/echo"))
+    ) {
+
+      EchoResponse echo = OM.readValue(response.getEntity().getContent(), EchoResponse.class);
+
+      Assert.assertEquals(customUserAgent, echo.getHeaders().getFirst(USER_AGENT_HEADER));
+    }
+  }
+
+  private HttpServer startEchoWebServerAtFreePort() throws IOException {
+
+    HttpServer httpServer = HttpServer.create(new InetSocketAddress(0), 0);
+    httpServer.createContext(ECHO_ENDPOINT, exchange -> {
+
+      Map<String, Object> echoResponse = new HashMap<>();
+      echoResponse.put("headers", exchange.getRequestHeaders());
+      echoResponse.put("body", IOUtils.toString(exchange.getRequestBody(), "UTF-8"));
+
+      byte[] response = OM.writeValueAsString(echoResponse).getBytes();
+
+      exchange.sendResponseHeaders(HttpURLConnection.HTTP_OK, response.length);
+      exchange.getResponseBody().write(response);
+      exchange.close();
+
+    });
+    httpServer.start();
+
+    return httpServer;
+  }
+
+  private static class EchoResponse {
+
+    String body;
+
+    Headers headers;
+
+    public String getBody() {
+      return body;
+    }
+
+    public void setBody(String body) {
+      this.body = body;
+    }
+
+    public Headers getHeaders() {
+      return headers;
+    }
+
+    public void setHeaders(Headers headers) {
+      this.headers = headers;
+    }
+  }
+}


### PR DESCRIPTION
We now support the configuration of `user-agent` headers set for out-bound http
calls performed by the Keycloak server to ease monitoring.

By default the user agent that is generated by the Apache HTTP Client is used, which currently exposes the underlying Java version, e.g.:
```
User-Agent: Apache-HttpClient/4.5.2 (Java/1.8.0_144)
```

With this users can configure the user-agent header via the SPI configuration to something less telling.
like `Keycloak (acme SSO)` or even just `acme SSO`.

jboss-cli example:
```
/subsystem=keycloak-server/spi=connectionsHttpClient/provider=default:write-attribute(name=properties.user-agent,value="Keycloak (acme SSO)")
```
