### PR TITLE
Adding a providerAttrs field to Permission

### DIFF
--- a/core/src/main/java/org/keycloak/representations/idm/authorization/Permission.java
+++ b/core/src/main/java/org/keycloak/representations/idm/authorization/Permission.java
@@ -19,7 +19,9 @@ package org.keycloak.representations.idm.authorization;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -35,15 +37,24 @@ public class Permission {
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Set<String> scopes;
-
+    
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @JsonProperty("provider_attrs")
+    private Map<String, String> providerAttrs;
+    
     public Permission() {
-        this(null, null, null);
+        this(null, null, null, null);
     }
 
     public Permission(final String resourceSetId, String resourceSetName, final Set<String> scopes) {
+    	this(resourceSetId, resourceSetName, scopes, new HashMap<String,String>(0));
+    }
+
+    public Permission(final String resourceSetId, String resourceSetName, final Set<String> scopes, final Map<String, String> providerAttrs) {
         this.resourceSetId = resourceSetId;
         this.resourceSetName = resourceSetName;
         this.scopes = scopes;
+        this.providerAttrs = providerAttrs;
     }
 
     public String getResourceSetId() {
@@ -75,4 +86,8 @@ public class Permission {
     public void setScopes(Set<String> scopes) {
         this.scopes = scopes;
     }
+
+	public Map<String, String> getProviderAttrs() {
+		return providerAttrs;
+	}
 }

--- a/examples/authz/hello-world/src/main/java/org/keycloak/authz/helloworld/AuthorizationClientExample.java
+++ b/examples/authz/hello-world/src/main/java/org/keycloak/authz/helloworld/AuthorizationClientExample.java
@@ -28,6 +28,7 @@ import org.keycloak.authorization.client.representation.TokenIntrospectionRespon
 import org.keycloak.authorization.client.resource.ProtectedResource;
 import org.keycloak.representations.idm.authorization.Permission;
 
+import java.util.Map.Entry;
 import java.util.Set;
 
 /**
@@ -77,6 +78,11 @@ public class AuthorizationClientExample {
 
         for (Permission granted : requestingPartyToken.getPermissions()) {
             System.out.println(granted);
+            if (granted.getProviderAttrs() != null) {
+	            for (Entry<String, String> e : granted.getProviderAttrs().entrySet()) {
+	            	System.out.println(e.getKey() + ": " + e.getValue());
+	            }
+            }
         }
 
     }

--- a/server-spi-private/src/main/java/org/keycloak/authorization/permission/ResourcePermission.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/permission/ResourcePermission.java
@@ -22,8 +22,9 @@ import org.keycloak.authorization.model.Resource;
 import org.keycloak.authorization.model.ResourceServer;
 import org.keycloak.authorization.model.Scope;
 
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Represents a permission for a given resource.
@@ -35,11 +36,17 @@ public class ResourcePermission {
     private final Resource resource;
     private final List<Scope> scopes;
     private ResourceServer resourceServer;
+    private final Map<String, String> providerAttrs;
 
     public ResourcePermission(Resource resource, List<Scope> scopes, ResourceServer resourceServer) {
+    	this(resource, scopes, resourceServer, new HashMap<String,String>(0));
+    }
+
+    public ResourcePermission(Resource resource, List<Scope> scopes, ResourceServer resourceServer, Map<String,String> providerAttrs) {
         this.resource = resource;
         this.scopes = scopes;
         this.resourceServer = resourceServer;
+        this.providerAttrs = providerAttrs;
     }
 
     /**
@@ -68,4 +75,16 @@ public class ResourcePermission {
     public ResourceServer getResourceServer() {
         return this.resourceServer;
     }
+
+    /**
+     * Returns the attributes provided by the policy provider
+     * for this permission 
+     * 
+     * @return attributes
+     */
+	public Map<String, String> getProviderAttrs() {
+		return providerAttrs;
+	}
+    
+    
 }

--- a/services/src/main/java/org/keycloak/authorization/util/Permissions.java
+++ b/services/src/main/java/org/keycloak/authorization/util/Permissions.java
@@ -222,6 +222,7 @@ public final class Permissions {
         List<Resource> resources = new ArrayList<>();
         Resource resource = permission.getResource();
         Set<String> scopes = permission.getScopes().stream().map(Scope::getName).collect(Collectors.toSet());
+        Map<String, String> providerAttrs = permission.getProviderAttrs();
 
         if (resource != null) {
             resources.add(resource);
@@ -241,7 +242,7 @@ public final class Permissions {
                 Permission evalPermission = permissions.get(allowedResource.getId());
 
                 if (evalPermission == null) {
-                    evalPermission = new Permission(resourceId, resourceName, scopes);
+                    evalPermission = new Permission(resourceId, resourceName, scopes, providerAttrs);
                     permissions.put(resourceId, evalPermission);
                 }
 
@@ -261,7 +262,7 @@ public final class Permissions {
                 }
             }
         } else {
-            Permission scopePermission = new Permission(null, null, scopes);
+            Permission scopePermission = new Permission(null, null, scopes, providerAttrs);
             permissions.put(scopePermission.toString(), scopePermission);
         }
     }


### PR DESCRIPTION
Adding a providerAttrs field to Permission, to allow policy provider, to amend tested policy.

In my use cases I have rules with a dynamic context to be checked by business application. Keycloak tells to this application: yes access is allowed if a supplementary condition is also true. A simple case is "this user does have the access and pay scopes for the invoice resource" if "invoice.amount < 10000". I use SpringEL expressions to check dynamic context.

This is the smallest PR I found to fit my needs (without having to rebase all the time). I have not included a policy provider using this field, nor patch existing ones. So testing without that is quite difficult and testsuite is quite hard to make it working well.

This field could be used for other purposes : include which provider has evaluated permission (so business application can trace this when allowing sensitive access), or some specific context (emergency access was active), a signed timestamp, an external reference to the policy version and documentation allowing access...