### PR TITLE
Handle setupCheckLoginIframe promise

### DIFF
--- a/adapters/oidc/js/src/main/resources/keycloak.js
+++ b/adapters/oidc/js/src/main/resources/keycloak.js
@@ -163,7 +163,7 @@
                         window.history.replaceState({}, null, callback.newUrl);
                         processCallback(callback, initPromise);
                     }).error(function (e) {
-                        throw 'Could not initialize iframe';
+                        initPromise.setError();
                     });
                 } else if (initOptions) {
                     if (initOptions.token && initOptions.refreshToken) {

--- a/adapters/oidc/js/src/main/resources/keycloak.js
+++ b/adapters/oidc/js/src/main/resources/keycloak.js
@@ -159,10 +159,12 @@
                 var callback = parseCallback(window.location.href);
 
                 if (callback) {
-                    setupCheckLoginIframe();
-                    window.history.replaceState({}, null, callback.newUrl);
-                    processCallback(callback, initPromise);
-                    return;
+                    return setupCheckLoginIframe().success(function() {
+                        window.history.replaceState({}, null, callback.newUrl);
+                        processCallback(callback, initPromise);
+                    }).error(function (e) {
+                        throw 'Could not initialize iframe';
+                    });
                 } else if (initOptions) {
                     if (initOptions.token && initOptions.refreshToken) {
                         setToken(initOptions.token, initOptions.refreshToken, initOptions.idToken);


### PR DESCRIPTION
The processInit function should return a promise for setupCheckLoginIframe and should only call processCallback if that setupCheckLoginIframe is successful.  

I've seen in instances where a user's network was very slow that failing to return a promise here caused problems where the authentication failed.  I don't have more specifics at the moment than returning the promise here and ensuring it was successful fixed some edge cases we saw on super slow networks on the client side.