### PR TITLE
KEYCLOAK-5751 Login/logout performance test scenario failing

### DIFF
--- a/testsuite/performance/tests/src/test/scala/keycloak/DefaultSimulation.scala
+++ b/testsuite/performance/tests/src/test/scala/keycloak/DefaultSimulation.scala
@@ -81,7 +81,7 @@ class DefaultSimulation extends Simulation {
       .queryParam("client_id", "${clientId}")
       .queryParam("state", "${state}")
       .queryParam("redirect_uri", "${appUrl}")
-      .check(status.is(200), regex("action=\"([^\"]*)\"").saveAs("login-form-uri")))
+      .check(status.is(200), regex("action=\"([^\"]*)\"").find.transform(_.replaceAll("&amp;", "&")).saveAs("login-form-uri")))
     .exitHereIfFailed
     .pause(TestConfig.userThinkTime, Normal(TestConfig.userThinkTime * 0.2))
 
@@ -92,7 +92,7 @@ class DefaultSimulation extends Simulation {
         .formParam("username", "${username}")
         .formParam("password", _ => Util.randomString(10))
         .formParam("login", "Log in")
-        .check(status.is(200), regex("action=\"([^\"]*)\"").saveAs("login-form-uri")))
+        .check(status.is(200), regex("action=\"([^\"]*)\"").find.transform(_.replaceAll("&amp;", "&")).saveAs("login-form-uri")))
         .exitHereIfFailed
         .pause(TestConfig.userThinkTime, Normal(TestConfig.userThinkTime * 0.2))
     }

--- a/testsuite/performance/tests/src/test/scala/keycloak/SimulationsHelper.scala
+++ b/testsuite/performance/tests/src/test/scala/keycloak/SimulationsHelper.scala
@@ -64,7 +64,7 @@ object SimulationsHelper {
         .exec(http("JS Adapter Auth - Login Form Redirect")
           .get("/auth/realms/master/protocol/openid-connect/auth?client_id=security-admin-console&redirect_uri=${keycloakServerUrlEncoded}%2Fadmin%2Fmaster%2Fconsole%2F&state=${state}&nonce=${nonce}&response_mode=fragment&response_type=code&scope=openid")
           .headers(UI_HEADERS)
-          .check(status.is(200), regex("action=\"([^\"]*)\"").saveAs("login-form-uri")))
+          .check(status.is(200), regex("action=\"([^\"]*)\"").find.transform(_.replaceAll("&amp;", "&")).saveAs("login-form-uri")))
         .exitHereIfFailed
         .thinkPause()
         // Successful login


### PR DESCRIPTION
Added "\&amp; to &" rewrite for login form URI in the perf tests.