### PR TITLE
KEYCLOAK-5753 fixed NPE thrown when using custom RequestMatcher

### DIFF
--- a/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/authentication/KeycloakAuthenticationEntryPoint.java
+++ b/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/authentication/KeycloakAuthenticationEntryPoint.java
@@ -17,7 +17,16 @@
 
 package org.keycloak.adapters.springsecurity.authentication;
 
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 import org.apache.http.HttpHeaders;
+import org.keycloak.adapters.AdapterDeploymentContext;
+import org.keycloak.adapters.spi.HttpFacade;
+import org.keycloak.adapters.springsecurity.facade.SimpleHttpFacade;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -25,17 +34,6 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.util.Assert;
-
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import org.keycloak.adapters.AdapterDeploymentContext;
-import org.keycloak.adapters.spi.HttpFacade;
-import org.keycloak.adapters.springsecurity.config.KeycloakWebSecurityConfigurerAdapter;
-import org.keycloak.adapters.springsecurity.facade.SimpleHttpFacade;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
 /**
  * Provides a Keycloak {@link AuthenticationEntryPoint authentication entry point}. Uses a
@@ -62,15 +60,14 @@ public class KeycloakAuthenticationEntryPoint implements AuthenticationEntryPoin
     private final RequestMatcher apiRequestMatcher;
     private String loginUri = DEFAULT_LOGIN_URI;
     private String realm = DEFAULT_REALM;
- 
+
     private AdapterDeploymentContext adapterDeploymentContext;
 
     /**
      * Creates a new Keycloak authentication entry point.
      */
     public KeycloakAuthenticationEntryPoint(AdapterDeploymentContext adapterDeploymentContext) {
-        this(DEFAULT_API_REQUEST_MATCHER);
-        this.adapterDeploymentContext = adapterDeploymentContext;
+        this(adapterDeploymentContext, DEFAULT_API_REQUEST_MATCHER);
     }
 
     /**
@@ -80,14 +77,15 @@ public class KeycloakAuthenticationEntryPoint implements AuthenticationEntryPoin
      * @param apiRequestMatcher the <code>RequestMatcher</code> to use to determine
      * if the current request is an API request or a browser request (required)
      */
-    public KeycloakAuthenticationEntryPoint(RequestMatcher apiRequestMatcher) {
+    public KeycloakAuthenticationEntryPoint(AdapterDeploymentContext adapterDeploymentContext, RequestMatcher apiRequestMatcher) {
         Assert.notNull(apiRequestMatcher, "apiRequestMatcher required");
+        Assert.notNull(adapterDeploymentContext, "adapterDeploymentContext required");
+        this.adapterDeploymentContext = adapterDeploymentContext;
         this.apiRequestMatcher = apiRequestMatcher;
     }
 
     @Override
-    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException
-    {
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
         HttpFacade facade = new SimpleHttpFacade(request, response);
         if (apiRequestMatcher.matches(request) || adapterDeploymentContext.resolveDeployment(facade).isBearerOnly()) {
             commenceUnauthorizedResponse(request, response);

--- a/adapters/oidc/spring-security/src/test/java/org/keycloak/adapters/springsecurity/authentication/KeycloakAuthenticationEntryPointTest.java
+++ b/adapters/oidc/spring-security/src/test/java/org/keycloak/adapters/springsecurity/authentication/KeycloakAuthenticationEntryPointTest.java
@@ -17,25 +17,27 @@
 
 package org.keycloak.adapters.springsecurity.authentication;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import org.apache.http.HttpHeaders;
 import org.junit.Before;
 import org.junit.Test;
-import org.springframework.http.HttpStatus;
-import org.springframework.mock.web.MockHttpServletRequest;
-import org.springframework.mock.web.MockHttpServletResponse;
 
-import static junit.framework.TestCase.assertNull;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import org.keycloak.adapters.AdapterDeploymentContext;
 import org.keycloak.adapters.KeycloakDeployment;
 import org.keycloak.adapters.spi.HttpFacade;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
 import org.mockito.Mock;
-import static org.mockito.Mockito.when;
 import org.mockito.MockitoAnnotations;
 import org.springframework.context.ApplicationContext;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.web.util.matcher.RequestMatcher;
 
 /**
  * Keycloak authentication entry point tests.
@@ -47,12 +49,15 @@ public class KeycloakAuthenticationEntryPointTest {
     private MockHttpServletResponse response;
     @Mock
     private ApplicationContext applicationContext;
-   
+
     @Mock
     private AdapterDeploymentContext adapterDeploymentContext;
-    
+
     @Mock
     private KeycloakDeployment keycloakDeployment;
+
+    @Mock
+    private RequestMatcher requestMatcher;
 
     @Before
     public void setUp() throws Exception {
@@ -99,6 +104,14 @@ public class KeycloakAuthenticationEntryPointTest {
         authenticationEntryPoint.commence(request, response, null);
         assertEquals(HttpStatus.FOUND.value(), response.getStatus());
         assertEquals(logoutUri, response.getHeader("Location"));
+    }
+
+    @Test
+    public void testCommenceWithCustomRequestMatcher() throws Exception {
+        new KeycloakAuthenticationEntryPoint(adapterDeploymentContext, requestMatcher)
+            .commence(request, response, null);
+
+        verify(requestMatcher).matches(request);
     }
 
     private void configureBrowserRequest() {


### PR DESCRIPTION
This pull request fixes [KEYCLOAK-5753](https://issues.jboss.org/browse/KEYCLOAK-5753) by providing a two-args constructor.