### PR TITLE
use redirectUri for cordova as well if specified

### DIFF
--- a/adapters/oidc/js/src/main/resources/keycloak.js
+++ b/adapters/oidc/js/src/main/resources/keycloak.js
@@ -1051,7 +1051,7 @@
                     },
 
                     redirectUri: function(options) {
-                        return 'http://localhost';
+                        return (config && config.redirectUri) || 'http://localhost';
                     }
                 }
             }


### PR DESCRIPTION
While I don't know if this was the best way to do this, this is the way that worked for me.

The reason for this change: When developing a PWA or using WkWebView on iOS, it's probable that you'll be testing with a port, or in the case of the latter, your app will be running on localhost:8080. In these cases you need to be able to specify a redirectUri that will actually work.

JIRA issue: https://issues.jboss.org/browse/KEYCLOAK-5759