### PR TITLE
KEYCLOAK-5506: Set empty config prop in custom fed provider fails in admin console

### DIFF
--- a/themes/src/main/resources/theme/base/admin/resources/js/controllers/users.js
+++ b/themes/src/main/resources/theme/base/admin/resources/js/controllers/users.js
@@ -775,6 +775,15 @@ module.controller('GenericUserStorageCtrl', function($scope, $location, Notifica
             if (!instance.config['priority']) {
                 instance.config['priority'] = ['0'];
             }
+            
+            if (providerFactory.properties) {
+                for (var i = 0; i < providerFactory.properties.length; i++) {
+                    var configProperty = providerFactory.properties[i];
+                    if (!instance.config[configProperty.name]) {
+                        instance.config[configProperty.name] = [''];
+                    }
+                }
+            }
 
         }
         if (providerFactory.metadata.synchronizable) {


### PR DESCRIPTION
This fixes the bug.

We don't have any admin console tests for custom federation providers.  I've created KEYCLOAK-5764 to address that.