### PR TITLE
KEYCLOAK-5791 Allow multi-valued ScriptBasedOIDCProtocolMapper

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/ScriptBasedOIDCProtocolMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/ScriptBasedOIDCProtocolMapper.java
@@ -25,6 +25,7 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.ScriptModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.UserSessionModel;
+import org.keycloak.protocol.ProtocolMapperUtils;
 import org.keycloak.provider.ProviderConfigProperty;
 import org.keycloak.provider.ProviderConfigurationBuilder;
 import org.keycloak.representations.IDToken;
@@ -73,6 +74,13 @@ public class ScriptBasedOIDCProtocolMapper extends AbstractOIDCProtocolMapper im
         " * keycloakSession - the current userSession\n" + //
         " */\n\n\n//insert your code here..." //
       )
+      .add()
+      .property()
+      .name(ProtocolMapperUtils.MULTIVALUED)
+      .label(ProtocolMapperUtils.MULTIVALUED_LABEL)
+      .helpText(ProtocolMapperUtils.MULTIVALUED_HELP_TEXT)
+      .type(ProviderConfigProperty.BOOLEAN_TYPE)
+      .defaultValue(false)
       .add()
       .build();
 
@@ -135,15 +143,20 @@ public class ScriptBasedOIDCProtocolMapper extends AbstractOIDCProtocolMapper im
     OIDCAttributeMapperHelper.mapClaim(token, mappingModel, claimValue);
   }
 
-  public static ProtocolMapperModel createClaimMapper(String name,
+  public static ProtocolMapperModel create(String name,
                                                       String userAttribute,
                                                       String tokenClaimName, String claimType,
                                                       boolean consentRequired, String consentText,
-                                                      boolean accessToken, boolean idToken) {
-    return OIDCAttributeMapperHelper.createClaimMapper(name, userAttribute,
+                                                      boolean accessToken, boolean idToken, String script, boolean multiValued) {
+    ProtocolMapperModel mapper = OIDCAttributeMapperHelper.createClaimMapper(name, userAttribute,
       tokenClaimName, claimType,
       consentRequired, consentText,
       accessToken, idToken,
       PROVIDER_ID);
+
+    mapper.getConfig().put(SCRIPT, script);
+    mapper.getConfig().put(ProtocolMapperUtils.MULTIVALUED, String.valueOf(multiValued));
+
+    return mapper;
   }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OIDCProtocolMappersTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OIDCProtocolMappersTest.java
@@ -147,7 +147,8 @@ public class OIDCProtocolMappersTest extends AbstractKeycloakTest {
             app.getProtocolMappers().createMapper(createHardcodedRole("hard-realm", "hardcoded")).close();
             app.getProtocolMappers().createMapper(createHardcodedRole("hard-app", "app.hardcoded")).close();
             app.getProtocolMappers().createMapper(createRoleNameMapper("rename-app-role", "test-app.customer-user", "realm-user")).close();
-            app.getProtocolMappers().createMapper(createScriptMapper("test-script-mapper","computed-via-script", "computed-via-script", "String", true, true, "'hello_' + user.username")).close();
+            app.getProtocolMappers().createMapper(createScriptMapper("test-script-mapper1","computed-via-script", "computed-via-script", "String", true, true, "'hello_' + user.username", false)).close();
+            app.getProtocolMappers().createMapper(createScriptMapper("test-script-mapper2","multiValued-via-script", "multiValued-via-script", "String", true, true, "new java.util.ArrayList(['A','B'])", true)).close();
         }
 
         {
@@ -202,6 +203,7 @@ public class OIDCProtocolMappersTest extends AbstractKeycloakTest {
             assertTrue(accessToken.getResourceAccess("app").getRoles().contains("hardcoded"));
 
             assertEquals("hello_test-user@localhost", accessToken.getOtherClaims().get("computed-via-script"));
+            assertEquals(Arrays.asList("A","B"), accessToken.getOtherClaims().get("multiValued-via-script"));
             oauth.openLogout();
         }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/util/ProtocolMapperUtil.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/util/ProtocolMapperUtil.java
@@ -1,7 +1,6 @@
 package org.keycloak.testsuite.util;
 
 import org.keycloak.admin.client.resource.ProtocolMappersResource;
-import org.keycloak.models.ProtocolMapperModel;
 import org.keycloak.models.utils.ModelToRepresentation;
 import org.keycloak.protocol.oidc.mappers.AddressMapper;
 import org.keycloak.protocol.oidc.mappers.HardcodedClaim;
@@ -157,12 +156,12 @@ public class ProtocolMapperUtil {
                                                                   String claimType,
                                                                   boolean accessToken,
                                                                   boolean idToken,
-                                                                  String script) {
+                                                                  String script,
+                                                                  boolean multiValued) {
 
-        ProtocolMapperModel mapper = ScriptBasedOIDCProtocolMapper.createClaimMapper(name, userAttribute, tokenClaimName, claimType, false, null, accessToken, idToken);
-        mapper.getConfig().put("script", script);
-
-        return ModelToRepresentation.toRepresentation(mapper);
+        return ModelToRepresentation.toRepresentation(
+          ScriptBasedOIDCProtocolMapper.create(name, userAttribute, tokenClaimName, claimType, false, null, accessToken, idToken, script, multiValued)
+        );
     }
 
 }


### PR DESCRIPTION
We now support multi-valued attribute values for the
`ScriptBasedOIDCProtocolMapper`.
Previously the `ScriptBasedOIDCProtocolMapper` only supported
single valued output. If a script returned a list of
output values then only the first value was emitted to the token.

By default multi-valued is set to `false` / `off`.