### PR TITLE
KEYCLOAK-5352 Basic Auth fails if password contains a ':'

### DIFF
--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/BasicAuthRequestAuthenticator.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/BasicAuthRequestAuthenticator.java
@@ -71,11 +71,11 @@ public class BasicAuthRequestAuthenticator extends BearerTokenRequestAuthenticat
         AccessTokenResponse atr=null;        
         try {
             String userpw=new String(Base64.decode(tokenString));
+            log.debug("Username and password string for basic auth is: " + userpw);
             int seperatorIndex = userpw.indexOf(":");
             String user = userpw.substring(0, seperatorIndex);
             String pw = userpw.substring(seperatorIndex + 1);
-            log.debug("user: " + user);
-            log.debug("pw: " + pw);
+            log.debug("Username for token  is: " + user + ", password is: " + pw);
             atr = getToken(user, pw);
             tokenString = atr.getToken();
         } catch (Exception e) {

--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/BasicAuthRequestAuthenticator.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/BasicAuthRequestAuthenticator.java
@@ -71,9 +71,12 @@ public class BasicAuthRequestAuthenticator extends BearerTokenRequestAuthenticat
         AccessTokenResponse atr=null;        
         try {
             String userpw=new String(Base64.decode(tokenString));
-            String[] parts=userpw.split(":");
-            
-            atr = getToken(parts[0], parts[1]);
+            int seperatorIndex = userpw.indexOf(":");
+            String user = userpw.substring(0, seperatorIndex);
+            String pw = userpw.substring(seperatorIndex + 1);
+            log.debug("user: " + user);
+            log.debug("pw: " + pw);
+            atr = getToken(user, pw);
             tokenString = atr.getToken();
         } catch (Exception e) {
             log.debug("Failed to obtain token", e);
@@ -82,8 +85,8 @@ public class BasicAuthRequestAuthenticator extends BearerTokenRequestAuthenticat
         }
 
         return authenticateToken(exchange, atr.getToken());
-    }
-    
+    } 
+ 
     private AccessTokenResponse getToken(String username, String password) throws Exception {
     	AccessTokenResponse tokenResponse=null;
     	HttpClient client = deployment.getClient();

--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/BasicAuthRequestAuthenticator.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/BasicAuthRequestAuthenticator.java
@@ -71,11 +71,9 @@ public class BasicAuthRequestAuthenticator extends BearerTokenRequestAuthenticat
         AccessTokenResponse atr=null;        
         try {
             String userpw=new String(Base64.decode(tokenString));
-            log.debug("Username and password string for basic auth is: " + userpw);
             int seperatorIndex = userpw.indexOf(":");
             String user = userpw.substring(0, seperatorIndex);
             String pw = userpw.substring(seperatorIndex + 1);
-            log.debug("Username for token  is: " + user + ", password is: " + pw);
             atr = getToken(user, pw);
             tokenString = atr.getToken();
         } catch (Exception e) {

--- a/core/src/main/java/org/keycloak/util/BasicAuthHelper.java
+++ b/core/src/main/java/org/keycloak/util/BasicAuthHelper.java
@@ -54,8 +54,10 @@ public class BasicAuthHelper
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
-        String[] split = val.split(":");
-        if (split.length != 2) return null;
-        return split;
+        int seperatorIndex = val.indexOf(":");
+        if(seperatorIndex == -1) return null;
+        String user = val.substring(0, seperatorIndex);
+        String pw = val.substring(seperatorIndex + 1);
+        return new String[]{user,pw};
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/saml/profile/ecp/authenticator/HttpBasicAuthenticator.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/profile/ecp/authenticator/HttpBasicAuthenticator.java
@@ -98,12 +98,12 @@ public class HttpBasicAuthenticator implements Authenticator {
 
         try {
             String val = new String(Base64.decode(credentials));
+            log.debug("Username and password string is: " + val);
             int seperatorIndex = val.indexOf(":");
-            if(seperatorIndex == -1) return null;
+            if(seperatorIndex == -1) return new String[]{val};
             String user = val.substring(0, seperatorIndex);
             String pw = val.substring(seperatorIndex + 1);
-            log.debug("user: " + user);
-            log.debug("pw: " + pw);
+            log.debug("Resolved username is: " + user + ", password is: " + pw);
             return new String[]{user,pw};
         } catch (final IOException e) {
             throw new RuntimeException("Failed to parse credentials.", e);

--- a/services/src/main/java/org/keycloak/protocol/saml/profile/ecp/authenticator/HttpBasicAuthenticator.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/profile/ecp/authenticator/HttpBasicAuthenticator.java
@@ -11,6 +11,8 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserCredentialModel;
 import org.keycloak.models.UserModel;
 
+import org.jboss.logging.Logger;
+
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
@@ -20,6 +22,7 @@ public class HttpBasicAuthenticator implements Authenticator {
 
     private static final String BASIC = "Basic";
     private static final String BASIC_PREFIX = BASIC + " ";
+    private Logger log = Logger.getLogger(HttpBasicAuthenticator.class);
 
     @Override
     public void authenticate(final AuthenticationFlowContext context) {
@@ -94,7 +97,14 @@ public class HttpBasicAuthenticator implements Authenticator {
         }
 
         try {
-            return new String(Base64.decode(credentials)).split(":");
+            String val = new String(Base64.decode(credentials));
+            int seperatorIndex = val.indexOf(":");
+            if(seperatorIndex == -1) return null;
+            String user = val.substring(0, seperatorIndex);
+            String pw = val.substring(seperatorIndex + 1);
+            log.debug("user: " + user);
+            log.debug("pw: " + pw);
+            return new String[]{user,pw};
         } catch (final IOException e) {
             throw new RuntimeException("Failed to parse credentials.", e);
         }

--- a/services/src/main/java/org/keycloak/protocol/saml/profile/ecp/authenticator/HttpBasicAuthenticator.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/profile/ecp/authenticator/HttpBasicAuthenticator.java
@@ -11,8 +11,6 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserCredentialModel;
 import org.keycloak.models.UserModel;
 
-import org.jboss.logging.Logger;
-
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
@@ -22,7 +20,6 @@ public class HttpBasicAuthenticator implements Authenticator {
 
     private static final String BASIC = "Basic";
     private static final String BASIC_PREFIX = BASIC + " ";
-    private Logger log = Logger.getLogger(HttpBasicAuthenticator.class);
 
     @Override
     public void authenticate(final AuthenticationFlowContext context) {
@@ -98,12 +95,10 @@ public class HttpBasicAuthenticator implements Authenticator {
 
         try {
             String val = new String(Base64.decode(credentials));
-            log.debug("Username and password string is: " + val);
             int seperatorIndex = val.indexOf(":");
             if(seperatorIndex == -1) return new String[]{val};
             String user = val.substring(0, seperatorIndex);
             String pw = val.substring(seperatorIndex + 1);
-            log.debug("Resolved username is: " + user + ", password is: " + pw);
             return new String[]{user,pw};
         } catch (final IOException e) {
             throw new RuntimeException("Failed to parse credentials.", e);


### PR DESCRIPTION
Modified 3 source files:
./adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/BasicAuthRequestAuthenticator.java
./core/src/main/java/org/keycloak/util/BasicAuthHelper.java
./services/src/main/java/org/keycloak/protocol/saml/profile/ecp/authenticator/HttpBasicAuthenticator.java