### PR TITLE
Fixed typo in Dutch translations

### DIFF
--- a/themes/src/main/resources-community/theme/base/login/messages/messages_nl.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_nl.properties
@@ -1,5 +1,5 @@
 doLogIn=Inloggen
-doRegister=Registeer
+doRegister=Registreer
 doCancel=Annuleer
 doSubmit=Verzenden
 doYes=Ja
@@ -14,7 +14,7 @@ kerberosNotConfigured=Kerberos is niet geconfigureerd
 kerberosNotConfiguredTitle=Kerberos is niet geconfigureerd
 bypassKerberosDetail=U bent niet ingelogd via Kerberos of uw browser kan niet met Kerberos inloggen. Klik op 'doorgaan' om via een andere manier in te loggen
 kerberosNotSetUp=Kerberos is onjuist geconfigureerd. U kunt niet inloggen.
-registerWithTitle=Registeer met {0}
+registerWithTitle=Registreer met {0}
 registerWithTitleHtml={0}
 loginTitle=Inloggen bij {0}
 loginTitleHtml={0}


### PR DESCRIPTION
The Dutch word "Registreer" is misspelled in the translations.