### PR TITLE
Add property replacement into realm import process

### DIFF
--- a/services/src/main/java/org/keycloak/exportimport/dir/DirImportProvider.java
+++ b/services/src/main/java/org/keycloak/exportimport/dir/DirImportProvider.java
@@ -131,7 +131,7 @@ public class DirImportProvider implements ImportProvider {
 
         // Import realm first
         FileInputStream is = new FileInputStream(realmFile);
-        final RealmRepresentation realmRep = JsonSerialization.readValue(is, RealmRepresentation.class);
+        final RealmRepresentation realmRep = JsonSerialization.readValue(is, RealmRepresentation.class, true);
         final AtomicBoolean realmImported = new AtomicBoolean();
 
         KeycloakModelUtils.runJobInTransaction(factory, new ExportImportSessionTask() {


### PR DESCRIPTION
I'm using export and import feature to transfer configuration between the different stages. But the configuration contains stage dependent values, like LDAP URIs. I changed the import mechanism to activate sysprops replacing within realm config by switching to another signature of the JsonSerialization.readValue(..) and this works fine. Would be nice to have this feature upstream.

Fabian