### PR TITLE
KEYCLOAK-5837 Remove duplicate check in SAML11AuthenticationQueryType

### DIFF
--- a/saml-core/src/main/java/org/keycloak/saml/processing/core/saml/v1/writers/SAML11RequestWriter.java
+++ b/saml-core/src/main/java/org/keycloak/saml/processing/core/saml/v1/writers/SAML11RequestWriter.java
@@ -86,9 +86,6 @@ public class SAML11RequestWriter extends BaseSAML11Writer {
         } else if (query instanceof SAML11AttributeQueryType) {
             SAML11AttributeQueryType attQuery = (SAML11AttributeQueryType) query;
             write(attQuery);
-        } else if (query instanceof SAML11AuthenticationQueryType) {
-            SAML11AuthenticationQueryType attQuery = (SAML11AuthenticationQueryType) query;
-            write(attQuery);
         } else if (query instanceof SAML11AuthorizationDecisionQueryType) {
             SAML11AuthorizationDecisionQueryType attQuery = (SAML11AuthorizationDecisionQueryType) query;
             write(attQuery);


### PR DESCRIPTION
The same check is applied in line 83.