### PR TITLE
KEYCLOAK-5838 Fix comparison in SAMLSloRequestParser and SAMLSloResponseParser

### DIFF
--- a/saml-core/src/main/java/org/keycloak/saml/processing/core/parsers/saml/SAMLSloRequestParser.java
+++ b/saml-core/src/main/java/org/keycloak/saml/processing/core/parsers/saml/SAMLSloRequestParser.java
@@ -86,7 +86,8 @@ public class SAMLSloRequestParser extends SAMLRequestAbstractParser implements P
      * @see {@link ParserNamespaceSupport#supports(QName)}
      */
     public boolean supports(QName qname) {
-        return PROTOCOL_NSURI.get().equals(qname.getNamespaceURI()) && JBossSAMLConstants.LOGOUT_REQUEST.equals(qname.getLocalPart());
+        return PROTOCOL_NSURI.get().equals(qname.getNamespaceURI())
+          && JBossSAMLConstants.LOGOUT_REQUEST.get().equals(qname.getLocalPart());
     }
 
     /**

--- a/saml-core/src/main/java/org/keycloak/saml/processing/core/parsers/saml/SAMLSloResponseParser.java
+++ b/saml-core/src/main/java/org/keycloak/saml/processing/core/parsers/saml/SAMLSloResponseParser.java
@@ -75,6 +75,6 @@ public class SAMLSloResponseParser extends SAMLStatusResponseTypeParser implemen
      */
     public boolean supports(QName qname) {
         return JBossSAMLURIConstants.PROTOCOL_NSURI.get().equals(qname.getNamespaceURI())
-                && LOGOUT_RESPONSE.equals(qname.getLocalPart());
+                && LOGOUT_RESPONSE.get().equals(qname.getLocalPart());
     }
 }


### PR DESCRIPTION
The previous comparison was broken (always returned false)
since it compared the enum value with a string.
Calling `.get()` on the enum value to compare the string this the
given local-part fixes the comparison.

See:
https://lgtm.com/projects/g/keycloak/keycloak/snapshot/73c82d296e70e09343f6f55eeea56a085075b289/files/saml-core/src/main/java/org/keycloak/saml/processing/core/parsers/saml/SAMLSloRequestParser.java?sort=name&dir=ASC&mode=heatmap&excluded=false#xe3bb353ac67565ed:1
https://lgtm.com/projects/g/keycloak/keycloak/snapshot/73c82d296e70e09343f6f55eeea56a085075b289/files/saml-core/src/main/java/org/keycloak/saml/processing/core/parsers/saml/SAMLSloResponseParser.java?sort=name&dir=ASC&mode=heatmap&excluded=false#xdd5c8cb1952defd:1