### PR TITLE
KEYCLOAK-5840 Remove unused config map in AddUser command

### DIFF
--- a/wildfly/adduser/src/main/java/org/keycloak/wildfly/adduser/AddUser.java
+++ b/wildfly/adduser/src/main/java/org/keycloak/wildfly/adduser/AddUser.java
@@ -32,7 +32,6 @@ import org.keycloak.common.util.Base64;
 import org.keycloak.credential.CredentialModel;
 import org.keycloak.credential.hash.PasswordHashProvider;
 import org.keycloak.credential.hash.PasswordHashProviderFactory;
-import org.keycloak.credential.hash.Pbkdf2PasswordHashProviderFactory;
 import org.keycloak.models.PasswordPolicy;
 import org.keycloak.representations.idm.CredentialRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
@@ -47,7 +46,6 @@ import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 import java.util.ServiceLoader;
 
 /**
@@ -157,11 +155,6 @@ public class AddUser {
         user.setEnabled(true);
         user.setUsername(userName);
         user.setCredentials(new LinkedList<CredentialRepresentation>());
-
-        Map<String, Object> config = new HashMap<>();
-        if (iterations > 0) {
-            config.put("hashIterations", iterations);
-        }
 
         PasswordHashProviderFactory hashProviderFactory = getHashProviderFactory(DEFAULT_HASH_ALGORITH);
         PasswordHashProvider hashProvider = hashProviderFactory.create(null);


### PR DESCRIPTION
The only value put into this config map is the password hash iterations count.
The map itself is never used.
But `iterations` is used directly with the hashProvider.

See:
https://lgtm.com/projects/g/keycloak/keycloak/snapshot/73c82d296e70e09343f6f55eeea56a085075b289/files/wildfly/adduser/src/main/java/org/keycloak/wildfly/adduser/AddUser.java?sort=name&dir=ASC&mode=heatmap&excluded=false#x490b537b199a8415:1