### PR TITLE
KEYCLOAK-5841 Fix NPE in deletePermissionSetup in UserPermissions

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/permissions/UserPermissions.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/permissions/UserPermissions.java
@@ -195,7 +195,7 @@ class UserPermissions implements UserPermissionEvaluator, UserPermissionManageme
 
         }
         Resource usersResource = authz.getStoreFactory().getResourceStore().findByName(USERS_RESOURCE, server.getId());
-        if (usersResource == null) {
+        if (usersResource != null) {
             authz.getStoreFactory().getResourceStore().delete(usersResource.getId());
         }
     }


### PR DESCRIPTION
Previously a call to `UserPermissions#deletePermissionSetup`
always resulted in a NPE if the usersResource was null.

We now only try to delete the resourceStore information if
the given usersResource is not null.