### PR TITLE
KEYCLOAK-5842 Fix NPE in admin-cli ParseUtil.mergeAttributes

### DIFF
--- a/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/admin/cli/util/ParseUtil.java
+++ b/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/admin/cli/util/ParseUtil.java
@@ -98,7 +98,7 @@ public class ParseUtil {
                 }
                 content = JsonSerialization.writeValueAsString(result);
             } else {
-                throw new RuntimeException("Setting attributes is not supported for type: " + result.getClass().getName());
+                throw new RuntimeException("Failed to merge attributes");
             }
         } catch (IOException e) {
             throw new RuntimeException("Failed to merge set attributes with configuration from file", e);


### PR DESCRIPTION
Previously a null result would yield a NPE instead of
a proper exception.

See:
https://lgtm.com/projects/g/keycloak/keycloak/snapshot/73c82d296e70e09343f6f55eeea56a085075b289/files/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/admin/cli/util/ParseUtil.java?sort=name&dir=ASC&mode=heatmap&excluded=false#xc67023c37ffaadfd:1