### PR TITLE
[KEYCLOAK-5379] MigrationTest fails for migration to 3.3.0

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/migration/MigrationModelManager.java
+++ b/server-spi-private/src/main/java/org/keycloak/migration/MigrationModelManager.java
@@ -35,8 +35,8 @@ import org.keycloak.migration.migrators.MigrateTo2_5_0;
 import org.keycloak.migration.migrators.MigrateTo3_0_0;
 import org.keycloak.migration.migrators.MigrateTo3_1_0;
 import org.keycloak.migration.migrators.MigrateTo3_2_0;
-import org.keycloak.migration.migrators.MigrateTo3_3_0;
 import org.keycloak.migration.migrators.MigrateTo3_4_0;
+import org.keycloak.migration.migrators.MigrateTo3_4_1;
 import org.keycloak.migration.migrators.Migration;
 import org.keycloak.models.KeycloakSession;
 
@@ -65,8 +65,8 @@ public class MigrationModelManager {
             new MigrateTo3_0_0(),
             new MigrateTo3_1_0(),
             new MigrateTo3_2_0(),
-            new MigrateTo3_3_0(),
-            new MigrateTo3_4_0()
+            new MigrateTo3_4_0(),
+            new MigrateTo3_4_1()
     };
 
     public static void migrate(KeycloakSession session) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/migration/MigrationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/migration/MigrationTest.java
@@ -116,7 +116,7 @@ public class MigrationTest extends AbstractKeycloakTest {
     public void migration2_5_5Test() {
         testMigratedData();
         testMigrationTo3_0_0();
-        testMigrationTo3_3_0();
+        testMigrationTo3_4_1();
     }
     @Test
     @Migration(versionFrom = "1.9.8.Final")
@@ -130,8 +130,8 @@ public class MigrationTest extends AbstractKeycloakTest {
         testMigrationTo2_5_1();
         testMigrationTo3_0_0();
         testMigrationTo3_2_0();
-        testMigrationTo3_3_0();
         testMigrationTo3_4_0();
+        testMigrationTo3_4_1();
     }
     @Test
     @Migration(versionFrom = "2.2.1.Final")
@@ -209,21 +209,21 @@ public class MigrationTest extends AbstractKeycloakTest {
         testDockerAuthenticationFlow(masterRealm, migrationRealm);
     }
 
-    private void testMigrationTo3_3_0() {
-        Map<String, String> securityHeaders = masterRealm.toRepresentation().getBrowserSecurityHeaders();
-        if (securityHeaders != null) {
-            assertEquals("frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
-                    securityHeaders.get("contentSecurityPolicy"));
-        } else {
-            fail("Browser security headers not found");
-        }
-    }
-
     private void testMigrationTo3_4_0() {
         Map<String, String> securityHeaders = masterRealm.toRepresentation().getBrowserSecurityHeaders();
         if (securityHeaders != null) {
             assertEquals("max-age=31536000; includeSubDomains",
                     securityHeaders.get("strictTransportSecurity"));
+        } else {
+            fail("Browser security headers not found");
+        }
+    }
+
+    private void testMigrationTo3_4_1() {
+        Map<String, String> securityHeaders = masterRealm.toRepresentation().getBrowserSecurityHeaders();
+        if (securityHeaders != null) {
+            assertEquals("frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+                    securityHeaders.get("contentSecurityPolicy"));
         } else {
             fail("Browser security headers not found");
         }


### PR DESCRIPTION
This PR fixes the migration for contentSecurityPolicy. The reason why MigrateTo3_3_0 was removed, it's because it has no practical effect and it's useless. It was replaced by MigrateTo3_4_1 instead.