### PR TITLE
KEYCLOAK-5857 Supports PBKDF2 hashes with different key size

### DIFF
--- a/server-spi-private/pom.xml
+++ b/server-spi-private/pom.xml
@@ -86,6 +86,11 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
    </dependencies>
     <build>
         <plugins>


### PR DESCRIPTION
The original use case is to support imported credentials with a different key size without
implementing a totally new PasswordHashProvider