### PR TITLE
KEYCLOAK-5183 Support for AssertionConsumerServiceUrl in Saml Adapter subsystem

### DIFF
--- a/adapters/saml/as7-eap6/subsystem/src/main/java/org/keycloak/subsystem/saml/as7/Constants.java
+++ b/adapters/saml/as7-eap6/subsystem/src/main/java/org/keycloak/subsystem/saml/as7/Constants.java
@@ -16,7 +16,6 @@
  */
 package org.keycloak.subsystem.saml.as7;
 
-
 /**
  * @author <a href="mailto:mstrukel@redhat.com">Marko Strukelj</a>
  */
@@ -46,6 +45,8 @@ public class Constants {
         static final String SIGN_REQUEST = "signRequest";
         static final String VALIDATE_RESPONSE_SIGNATURE = "validateResponseSignature";
         static final String VALIDATE_ASSERTION_SIGNATURE = "validateAssertionSignature";
+        static final String ASSERTION_CONSUMER_SERVICE_URL = "assertionConsumerServiceUrl";
+
         static final String REQUEST_BINDING = "requestBinding";
         static final String BINDING_URL = "bindingUrl";
         static final String VALIDATE_REQUEST_SIGNATURE = "validateRequestSignature";
@@ -68,7 +69,6 @@ public class Constants {
         static final String FILE = "file";
         static final String SIGNATURES_REQUIRED = "signaturesRequired";
     }
-
 
     static class XML {
         static final String SECURE_DEPLOYMENT = "secure-deployment";
@@ -122,5 +122,6 @@ public class Constants {
         static final String ALIAS = "alias";
         static final String FILE = "file";
         static final String SIGNATURES_REQUIRED = "signaturesRequired";
+        static final String ASSERTION_CONSUMER_SERVICE_URL = "assertionConsumerServiceUrl";
     }
 }

--- a/adapters/saml/as7-eap6/subsystem/src/main/java/org/keycloak/subsystem/saml/as7/SingleSignOnDefinition.java
+++ b/adapters/saml/as7-eap6/subsystem/src/main/java/org/keycloak/subsystem/saml/as7/SingleSignOnDefinition.java
@@ -56,8 +56,13 @@ abstract class SingleSignOnDefinition {
             new SimpleAttributeDefinitionBuilder(Constants.Model.BINDING_URL, ModelType.STRING, true)
                     .setXmlName(Constants.XML.BINDING_URL)
                     .build();
+    
+    static final SimpleAttributeDefinition ASSERTION_CONSUMER_SERVICE_URL =
+            new SimpleAttributeDefinitionBuilder(Constants.Model.ASSERTION_CONSUMER_SERVICE_URL, ModelType.STRING, true)
+                    .setXmlName(Constants.XML.ASSERTION_CONSUMER_SERVICE_URL)
+                    .build();
 
-    static final SimpleAttributeDefinition[] ATTRIBUTES = {SIGN_REQUEST, VALIDATE_RESPONSE_SIGNATURE, VALIDATE_ASSERTION_SIGNATURE, REQUEST_BINDING, RESPONSE_BINDING, BINDING_URL};
+    static final SimpleAttributeDefinition[] ATTRIBUTES = {SIGN_REQUEST, VALIDATE_RESPONSE_SIGNATURE, VALIDATE_ASSERTION_SIGNATURE, REQUEST_BINDING, RESPONSE_BINDING, BINDING_URL, ASSERTION_CONSUMER_SERVICE_URL};
 
     static final HashMap<String, SimpleAttributeDefinition> ATTRIBUTE_MAP = new HashMap<>();
 

--- a/adapters/saml/as7-eap6/subsystem/src/main/resources/org/keycloak/subsystem/saml/as7/LocalDescriptions.properties
+++ b/adapters/saml/as7-eap6/subsystem/src/main/resources/org/keycloak/subsystem/saml/as7/LocalDescriptions.properties
@@ -71,6 +71,7 @@ keycloak-saml.IDP.SingleSignOnService.validateAssertionSignature=Validate an SSO
 keycloak-saml.IDP.SingleSignOnService.requestBinding=HTTP method to use for requests
 keycloak-saml.IDP.SingleSignOnService.responseBinding=HTTP method to use for responses
 keycloak-saml.IDP.SingleSignOnService.bindingUrl=SSO endpoint URL
+keycloak-saml.IDP.SingleSignOnService.assertionConsumerServiceUrl=Endpoint of Assertion Consumer Service at SP
 keycloak-saml.IDP.SingleLogoutService=Single logout configuration
 keycloak-saml.IDP.SingleLogoutService.validateRequestSignature=Validate a SingleLogoutService request signature
 keycloak-saml.IDP.SingleLogoutService.validateResponseSignature=Validate a SingleLogoutService response signature

--- a/adapters/saml/as7-eap6/subsystem/src/main/resources/schema/wildfly-keycloak-saml_1_1.xsd
+++ b/adapters/saml/as7-eap6/subsystem/src/main/resources/schema/wildfly-keycloak-saml_1_1.xsd
@@ -152,6 +152,11 @@
                 <xs:documentation>SSO endpoint URL</xs:documentation>
             </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="assertionConsumerServiceUrl" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>Endpoint of Assertion Consumer Service at SP</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:complexType>
     <xs:complexType name="single-logout-type">
         <xs:attribute name="validateRequestSignature" type="xs:boolean" use="optional">

--- a/adapters/saml/as7-eap6/subsystem/src/test/resources/org/keycloak/subsystem/saml/as7/keycloak-saml-1.1.xml
+++ b/adapters/saml/as7-eap6/subsystem/src/test/resources/org/keycloak/subsystem/saml/as7/keycloak-saml-1.1.xml
@@ -44,7 +44,8 @@
                                      validateResponseSignature="true"
                                      validateAssertionSignature="true"
                                      requestBinding="POST"
-                                     bindingUrl="http://localhost:8080/auth/realms/saml-demo/protocol/saml"/>
+                                     bindingUrl="http://localhost:8080/auth/realms/saml-demo/protocol/saml"
+                                     assertionConsumerServiceUrl="acsUrl"/>
                 <SingleLogoutService
                         validateRequestSignature="true"
                         validateResponseSignature="true"

--- a/adapters/saml/wildfly/wildfly-subsystem/src/main/java/org/keycloak/subsystem/adapter/saml/extension/Constants.java
+++ b/adapters/saml/wildfly/wildfly-subsystem/src/main/java/org/keycloak/subsystem/adapter/saml/extension/Constants.java
@@ -46,6 +46,9 @@ public class Constants {
         static final String SIGN_REQUEST = "signRequest";
         static final String VALIDATE_RESPONSE_SIGNATURE = "validateResponseSignature";
         static final String VALIDATE_ASSERTION_SIGNATURE = "validateAssertionSignature";
+        static final String ASSERTION_CONSUMER_SERVICE_URL = "assertionConsumerServiceUrl";
+		
+
         static final String REQUEST_BINDING = "requestBinding";
         static final String BINDING_URL = "bindingUrl";
         static final String VALIDATE_REQUEST_SIGNATURE = "validateRequestSignature";
@@ -122,5 +125,8 @@ public class Constants {
         static final String ALIAS = "alias";
         static final String FILE = "file";
         static final String SIGNATURES_REQUIRED = "signaturesRequired";
+        static final String ASSERTION_CONSUMER_SERVICE_URL = "assertionConsumerServiceUrl";
     }
 }
+
+

--- a/adapters/saml/wildfly/wildfly-subsystem/src/main/java/org/keycloak/subsystem/adapter/saml/extension/SingleSignOnDefinition.java
+++ b/adapters/saml/wildfly/wildfly-subsystem/src/main/java/org/keycloak/subsystem/adapter/saml/extension/SingleSignOnDefinition.java
@@ -57,7 +57,12 @@ abstract class SingleSignOnDefinition {
                     .setXmlName(Constants.XML.BINDING_URL)
                     .build();
 
-    static final SimpleAttributeDefinition[] ATTRIBUTES = {SIGN_REQUEST, VALIDATE_RESPONSE_SIGNATURE, VALIDATE_ASSERTION_SIGNATURE, REQUEST_BINDING, RESPONSE_BINDING, BINDING_URL};
+    static final SimpleAttributeDefinition ASSERTION_CONSUMER_SERVICE_URL =
+            new SimpleAttributeDefinitionBuilder(Constants.Model.ASSERTION_CONSUMER_SERVICE_URL, ModelType.STRING, true)
+                    .setXmlName(Constants.XML.ASSERTION_CONSUMER_SERVICE_URL)
+                    .build();
+
+    static final SimpleAttributeDefinition[] ATTRIBUTES = {SIGN_REQUEST, VALIDATE_RESPONSE_SIGNATURE, VALIDATE_ASSERTION_SIGNATURE, REQUEST_BINDING, RESPONSE_BINDING, BINDING_URL, ASSERTION_CONSUMER_SERVICE_URL};
 
     static final HashMap<String, SimpleAttributeDefinition> ATTRIBUTE_MAP = new HashMap<>();
 

--- a/adapters/saml/wildfly/wildfly-subsystem/src/main/resources/org/keycloak/subsystem/adapter/saml/extension/LocalDescriptions.properties
+++ b/adapters/saml/wildfly/wildfly-subsystem/src/main/resources/org/keycloak/subsystem/adapter/saml/extension/LocalDescriptions.properties
@@ -71,6 +71,7 @@ keycloak-saml.IDP.SingleSignOnService.validateAssertionSignature=Validate an SSO
 keycloak-saml.IDP.SingleSignOnService.requestBinding=HTTP method to use for requests
 keycloak-saml.IDP.SingleSignOnService.responseBinding=HTTP method to use for responses
 keycloak-saml.IDP.SingleSignOnService.bindingUrl=SSO endpoint URL
+keycloak-saml.IDP.SingleSignOnService.assertionConsumerServiceUrl=Endpoint of Assertion Consumer Service at SP
 keycloak-saml.IDP.SingleLogoutService=Single logout configuration
 keycloak-saml.IDP.SingleLogoutService.validateRequestSignature=Validate a SingleLogoutService request signature
 keycloak-saml.IDP.SingleLogoutService.validateResponseSignature=Validate a SingleLogoutService response signature

--- a/adapters/saml/wildfly/wildfly-subsystem/src/main/resources/schema/wildfly-keycloak-saml_1_1.xsd
+++ b/adapters/saml/wildfly/wildfly-subsystem/src/main/resources/schema/wildfly-keycloak-saml_1_1.xsd
@@ -152,6 +152,11 @@
                 <xs:documentation>SSO endpoint URL</xs:documentation>
             </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="assertionConsumerServiceUrl" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>Endpoint of Assertion Consumer Service at SP</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:complexType>
     <xs:complexType name="single-logout-type">
         <xs:attribute name="validateRequestSignature" type="xs:boolean" use="optional">

--- a/adapters/saml/wildfly/wildfly-subsystem/src/test/resources/org/keycloak/subsystem/adapter/saml/extension/keycloak-saml-1.1.xml
+++ b/adapters/saml/wildfly/wildfly-subsystem/src/test/resources/org/keycloak/subsystem/adapter/saml/extension/keycloak-saml-1.1.xml
@@ -47,7 +47,8 @@
                                      validateAssertionSignature="true"
                                      requestBinding="POST"
                                      responseBinding="POST"
-                                     bindingUrl="http://localhost:8080/auth/realms/saml-demo/protocol/saml"/>
+                                     bindingUrl="http://localhost:8080/auth/realms/saml-demo/protocol/saml"
+                                     assertionConsumerServiceUrl="acsUrl"/>
                 <SingleLogoutService
                         validateRequestSignature="true"
                         validateResponseSignature="true"


### PR DESCRIPTION
Enhanced version of #4315 which replaces that PR.

Not increasing schema version since this is only a new attribute addition. Formally that would be more correct but would require much wider set of changes and the only drawback of the current approach is that if 1) user would revert to earliear adapter version and 2) they would set `assertionConsumerServiceUrl` attribute in `SingleSignOnService` element - which is highly unlikely scenario.