### PR TITLE
[KEYCLOAK-4231] - Unable to import PEM certificate > 2048

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/ClientEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/ClientEntity.java
@@ -115,7 +115,7 @@ public class ClientEntity {
 
     @ElementCollection
     @MapKeyColumn(name="NAME")
-    @Column(name="VALUE", length = 2048)
+    @Column(name="VALUE", length = 4000)
     @CollectionTable(name="CLIENT_ATTRIBUTES", joinColumns={ @JoinColumn(name="CLIENT_ID") })
     protected Map<String, String> attributes = new HashMap<String, String>();
 

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-3.4.1.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-3.4.1.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  ~ * Copyright 2017 Red Hat, Inc. and/or its affiliates
+  ~ * and other contributors as indicated by the @author tags.
+  ~ *
+  ~ * Licensed under the Apache License, Version 2.0 (the "License");
+  ~ * you may not use this file except in compliance with the License.
+  ~ * You may obtain a copy of the License at
+  ~ *
+  ~ * http://www.apache.org/licenses/LICENSE-2.0
+  ~ *
+  ~ * Unless required by applicable law or agreed to in writing, software
+  ~ * distributed under the License is distributed on an "AS IS" BASIS,
+  ~ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ * See the License for the specific language governing permissions and
+  ~ * limitations under the License.
+  -->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet author="psilva@redhat.com" id="3.4.1">
+        <!-- KEYCLOAK-4231, changing length to same value used by COMPONENT_CONFIG.VALUE -->
+        <modifyDataType tableName="CLIENT_ATTRIBUTES" columnName="VALUE" newDataType="VARCHAR(4000)"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-master.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-master.xml
@@ -51,4 +51,5 @@
     <include file="META-INF/jpa-changelog-3.3.0.xml"/>
     <include file="META-INF/jpa-changelog-authz-3.4.0.CR1.xml"/>
     <include file="META-INF/jpa-changelog-3.4.0.xml"/>
+    <include file="META-INF/jpa-changelog-3.4.1.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
This change is basically changing ```CLIENT_ATTRIBUTES.VALUE``` column size to the same value used by ```COMPONENT_CONFIG.VALUE```.