### PR TITLE
KEYCLOAK-5019 Replace trap inputs, to avoid the browser keeping dummy values.

### DIFF
--- a/themes/src/main/resources/theme/base/account/password.ftl
+++ b/themes/src/main/resources/theme/base/account/password.ftl
@@ -11,9 +11,6 @@
     </div>
 
     <form action="${url.passwordUrl}" class="form-horizontal" method="post">
-        <input type="text" readonly value="this is not a login form" style="display: none;">
-        <input type="password" readonly value="this is not a login form" style="display: none;">
-
         <#if password.passwordSet>
             <div class="form-group">
                 <div class="col-sm-2 col-md-2">
@@ -21,7 +18,7 @@
                 </div>
 
                 <div class="col-sm-10 col-md-10">
-                    <input type="password" class="form-control" id="password" name="password" autofocus autocomplete="off">
+                    <input type="password" class="form-control" id="password" name="password" autofocus />
                 </div>
             </div>
         </#if>
@@ -34,7 +31,7 @@
             </div>
 
             <div class="col-sm-10 col-md-10">
-                <input type="password" class="form-control" id="password-new" name="password-new" autocomplete="off">
+                <input type="password" class="form-control" id="password-new" name="password-new" autocomplete="new-password" />
             </div>
         </div>
 
@@ -44,7 +41,7 @@
             </div>
 
             <div class="col-sm-10 col-md-10">
-                <input type="password" class="form-control" id="password-confirm" name="password-confirm" autocomplete="off">
+                <input type="password" class="form-control" id="password-confirm" name="password-confirm" autocomplete="new-password" />
             </div>
         </div>
 

--- a/themes/src/main/resources/theme/base/admin/resources/partials/authenticator-config.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/authenticator-config.html
@@ -16,9 +16,6 @@
     </h1>
 
     <form class="form-horizontal" name="realmForm" novalidate kc-read-only="!access.manageRealm">
-        <input type="text" readonly value="this is not a login form" style="display: none;">
-        <input type="password" readonly value="this is not a login form" style="display: none;">
-
         <fieldset>
             <div class="form-group clearfix" data-ng-show="!create">
                 <label class="col-md-2 control-label" for="configId">{{:: 'id' | translate}} </label>

--- a/themes/src/main/resources/theme/base/admin/resources/partials/client-credentials-jwt-key-export.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/client-credentials-jwt-key-export.html
@@ -10,9 +10,6 @@
     <h1>{{:: 'generate-private-key' | translate}}</h1>
 
     <form class="form-horizontal" name="keyForm" novalidate kc-read-only="!client.access.configure">
-        <input type="text" readonly value="this is not a login form" style="display: none;">
-        <input type="password" readonly value="this is not a login form" style="display: none;">
-
         <fieldset class="form-group col-sm-10">
             <div class="form-group">
                 <label class="col-md-2 control-label" for="downloadKeyFormat">{{:: 'archive-format' | translate}}</label>
@@ -36,14 +33,14 @@
             <div class="form-group">
                 <label class="col-md-2 control-label" for="keyPassword">{{:: 'key-password' | translate}}</label>
                 <div class="col-md-6">
-                    <input class="form-control" type="password" id="keyPassword" name="keyPassword" data-ng-model="jks.keyPassword" autofocus required>
+                    <input class="form-control" type="password" id="keyPassword" name="keyPassword" data-ng-model="jks.keyPassword" autofocus required autocomplete="off" readonly onfocus="this.removeAttribute('readonly');" />
                 </div>
                 <kc-tooltip>{{:: 'key-password.tooltip' | translate}}</kc-tooltip>
             </div>
             <div class="form-group">
                 <label class="col-md-2 control-label" for="storePassword">{{:: 'store-password' | translate}}</label>
                 <div class="col-md-6">
-                    <input class="form-control" type="password" id="storePassword" name="storePassword" data-ng-model="jks.storePassword" autofocus required>
+                    <input class="form-control" type="password" id="storePassword" name="storePassword" data-ng-model="jks.storePassword" autofocus required autocomplete="off" readonly onfocus="this.removeAttribute('readonly');" />
                 </div>
                 <kc-tooltip>{{:: 'store-password.tooltip' | translate}}</kc-tooltip>
             </div>

--- a/themes/src/main/resources/theme/base/admin/resources/partials/client-credentials-jwt-key-import.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/client-credentials-jwt-key-import.html
@@ -10,9 +10,6 @@
     <h1>{{:: 'import-client-certificate' | translate}}</h1>
 
     <form class="form-horizontal" name="keyForm" novalidate kc-read-only="!client.access.configure">
-        <input type="text" readonly value="this is not a login form" style="display: none;">
-        <input type="password" readonly value="this is not a login form" style="display: none;">
-
         <fieldset>
             <div class="form-group">
                 <label class="col-md-2 control-label" for="uploadKeyFormat">{{:: 'archive-format' | translate}}</label>
@@ -36,7 +33,7 @@
             <div class="form-group" data-ng-hide="hideKeystoreSettings()">
                 <label class="col-md-2 control-label" for="uploadStorePassword">{{:: 'store-password' | translate}}</label>
                 <div class="col-md-6">
-                    <input class="form-control" type="password" id="uploadStorePassword" name="uploadStorePassword" data-ng-model="uploadStorePassword" autofocus required>
+                    <input class="form-control" type="password" id="uploadStorePassword" name="uploadStorePassword" data-ng-model="uploadStorePassword" autofocus required autocomplete="off" readonly onfocus="this.removeAttribute('readonly');" />
                 </div>
                 <kc-tooltip>{{:: 'store-password.tooltip' | translate}}</kc-tooltip>
             </div>

--- a/themes/src/main/resources/theme/base/admin/resources/partials/client-keys.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/client-keys.html
@@ -8,9 +8,6 @@
     <kc-tabs-client></kc-tabs-client>
 
     <form class="form-horizontal" name="keyForm" novalidate kc-read-only="!client.access.configure">
-        <input type="text" readonly value="this is not a login form" style="display: none;">
-        <input type="password" readonly value="this is not a login form" style="display: none;">
-
         <fieldset>
             <legend collapsed><span class="text">{{:: 'import-keys-and-cert' | translate}}</span> <kc-tooltip>{{:: 'import-keys-and-cert.tooltip' | translate}}</kc-tooltip></legend>
             <div class="form-group">
@@ -35,14 +32,14 @@
             <div class="form-group">
                 <label class="col-md-2 control-label" for="keyPassword">{{:: 'key-password' | translate}}</label>
                 <div class="col-md-6">
-                    <input class="form-control" type="password" id="uploadKeyPassword" name="uploadKeyPassword" data-ng-model="uploadKeyPassword" autofocus required>
+                    <input class="form-control" type="password" id="uploadKeyPassword" name="uploadKeyPassword" data-ng-model="uploadKeyPassword" autofocus required autocomplete="off" readonly onfocus="this.removeAttribute('readonly');" />
                 </div>
                 <kc-tooltip>{{:: 'key-password.tooltip' | translate}}</kc-tooltip>
             </div>
             <div class="form-group">
                 <label class="col-md-2 control-label" for="uploadStorePassword">{{:: 'store-password' | translate}}</label>
                 <div class="col-md-6">
-                    <input class="form-control" type="password" id="uploadStorePassword" name="uploadStorePassword" data-ng-model="uploadStorePassword" autofocus required>
+                    <input class="form-control" type="password" id="uploadStorePassword" name="uploadStorePassword" data-ng-model="uploadStorePassword" autofocus required autocomplete="off" readonly onfocus="this.removeAttribute('readonly');" />
                 </div>
                 <kc-tooltip>{{:: 'store-password.tooltip' | translate}}</kc-tooltip>
             </div>
@@ -87,7 +84,7 @@
             <div class="form-group">
                 <label class="col-md-2 control-label" for="keyPassword">Key Password</label>
                 <div class="col-md-6">
-                    <input class="form-control" type="password" id="keyPassword" name="keyPassword" data-ng-model="jks.keyPassword" autofocus required>
+                    <input class="form-control" type="password" id="keyPassword" name="keyPassword" data-ng-model="jks.keyPassword" autofocus required autocomplete="off" readonly onfocus="this.removeAttribute('readonly');" />
                 </div>
                 <kc-tooltip>Password to access the private key in the archive</kc-tooltip>
             </div>
@@ -101,7 +98,7 @@
             <div class="form-group">
                 <label class="col-md-2 control-label" for="storePassword">Store Password</label>
                 <div class="col-md-6">
-                    <input class="form-control" type="password" id="storePassword" name="storePassword" data-ng-model="jks.storePassword" autofocus required>
+                    <input class="form-control" type="password" id="storePassword" name="storePassword" data-ng-model="jks.storePassword" autofocus required autocomplete="off" readonly onfocus="this.removeAttribute('readonly');" />
                 </div>
                 <kc-tooltip>Password to access the archive itself</kc-tooltip>
            </div>

--- a/themes/src/main/resources/theme/base/admin/resources/partials/client-saml-key-export.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/client-saml-key-export.html
@@ -10,9 +10,6 @@
     <h1>{{:: 'export-saml-key' | translate}} {{client.clientId|capitalize}}</h1>
 
     <form class="form-horizontal" name="keyForm" novalidate kc-read-only="!client.access.configure">
-        <input type="text" readonly value="this is not a login form" style="display: none;">
-        <input type="password" readonly value="this is not a login form" style="display: none;">
-
         <fieldset class="form-group col-sm-10">
             <div class="form-group">
                 <label class="col-md-2 control-label" for="downloadKeyFormat">{{:: 'archive-format' | translate}}</label>
@@ -36,7 +33,7 @@
             <div class="form-group" data-ng-hide="!keyInfo.privateKey">
                 <label class="col-md-2 control-label" for="keyPassword">{{:: 'key-password' | translate}}</label>
                 <div class="col-md-6">
-                    <input class="form-control" type="password" id="keyPassword" name="keyPassword" data-ng-model="jks.keyPassword" autofocus required>
+                    <input class="form-control" type="password" id="keyPassword" name="keyPassword" data-ng-model="jks.keyPassword" autofocus required autocomplete="off" readonly onfocus="this.removeAttribute('readonly');" />
                 </div>
                 <kc-tooltip>{{:: 'key-password.tooltip' | translate}}</kc-tooltip>
             </div>
@@ -50,7 +47,7 @@
             <div class="form-group">
                 <label class="col-md-2 control-label" for="storePassword">{{:: 'store-password' | translate}}</label>
                 <div class="col-md-6">
-                    <input class="form-control" type="password" id="storePassword" name="storePassword" data-ng-model="jks.storePassword" autofocus required>
+                    <input class="form-control" type="password" id="storePassword" name="storePassword" data-ng-model="jks.storePassword" autofocus required autocomplete="off" readonly onfocus="this.removeAttribute('readonly');" />
                 </div>
                 <kc-tooltip>{{:: 'store-password.tooltip' | translate}}</kc-tooltip>
            </div>

--- a/themes/src/main/resources/theme/base/admin/resources/partials/client-saml-key-import.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/client-saml-key-import.html
@@ -10,9 +10,6 @@
     <h1>{{:: 'import-saml-key' | translate}} {{client.clientId|capitalize}}</h1>
 
     <form class="form-horizontal" name="keyForm" novalidate kc-read-only="!client.access.configure">
-        <input type="text" readonly value="this is not a login form" style="display: none;">
-        <input type="password" readonly value="this is not a login form" style="display: none;">
-
         <fieldset>
             <div class="form-group">
                 <label class="col-md-2 control-label" for="uploadKeyFormat">{{:: 'archive-format' | translate}}</label>
@@ -36,7 +33,7 @@
             <div class="form-group" data-ng-hide="hideKeystoreSettings()">
                 <label class="col-md-2 control-label" for="uploadStorePassword">{{:: 'store-password' | translate}}</label>
                 <div class="col-md-6">
-                    <input class="form-control" type="password" id="uploadStorePassword" name="uploadStorePassword" data-ng-model="uploadStorePassword" autofocus required>
+                    <input class="form-control" type="password" id="uploadStorePassword" name="uploadStorePassword" data-ng-model="uploadStorePassword" autofocus required autocomplete="off" readonly onfocus="this.removeAttribute('readonly');" />
                 </div>
                 <kc-tooltip>{{:: 'store-password.tooltip' | translate}}</kc-tooltip>
             </div>

--- a/themes/src/main/resources/theme/base/admin/resources/partials/realm-identity-provider-oidc.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/realm-identity-provider-oidc.html
@@ -9,9 +9,6 @@
     <kc-tabs-identity-provider></kc-tabs-identity-provider>
 
     <form class="form-horizontal" name="realmForm" novalidate kc-read-only="!access.manageIdentityProviders">
-        <input type="text" readonly value="this is not a login form" style="display: none;">
-        <input type="password" readonly value="this is not a login form" style="display: none;">
-
         <fieldset>
             <div class="form-group clearfix">
                 <label class="col-md-2 control-label" for="redirectUri">{{:: 'redirect-uri' | translate}}</label>
@@ -172,7 +169,7 @@
             <div class="form-group clearfix">
                 <label class="col-md-2 control-label" for="clientSecret"><span class="required">*</span> {{:: 'client-secret' | translate}}</label>
                 <div class="col-md-6">
-                    <input class="form-control" id="clientSecret" type="password" ng-model="identityProvider.config.clientSecret" required>
+                    <input class="form-control" id="clientSecret" type="password" ng-model="identityProvider.config.clientSecret" required autocomplete="off" readonly onfocus="this.removeAttribute('readonly');" />
                 </div>
                 <kc-tooltip>{{:: 'client-secret.tooltip' | translate}}</kc-tooltip>
             </div>

--- a/themes/src/main/resources/theme/base/admin/resources/partials/realm-identity-provider-openshift-v3.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/realm-identity-provider-openshift-v3.html
@@ -8,11 +8,6 @@
     <kc-tabs-identity-provider></kc-tabs-identity-provider>
 
     <form class="form-horizontal" name="realmForm" novalidate kc-read-only="!access.manageIdentityProviders">
-        <input type="text" readonly value="this is not a login form" style="display: none;">
-        <input type="password" readonly value="this is not a login form" style="display: none;">
-        
-        
-
         <fieldset>
             <div class="form-group clearfix">
                 <label class="col-md-2 control-label" for="redirectUri">{{:: 'redirect-uri' | translate}}</label>
@@ -47,7 +42,7 @@
             <div class="form-group clearfix">
                 <label class="col-md-2 control-label" for="clientSecret"><span class="required">*</span> {{:: 'client-secret' | translate}}</label>
                 <div class="col-md-6">
-                    <input class="form-control" id="clientSecret" type="password" ng-model="identityProvider.config.clientSecret" required>
+                    <input class="form-control" id="clientSecret" type="password" ng-model="identityProvider.config.clientSecret" required autocomplete="off" readonly onfocus="this.removeAttribute('readonly');" />
                 </div>
                 <kc-tooltip>{{:: 'social.client-secret.tooltip' | translate}}</kc-tooltip>
             </div>

--- a/themes/src/main/resources/theme/base/admin/resources/partials/realm-identity-provider-social.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/realm-identity-provider-social.html
@@ -8,9 +8,6 @@
     <kc-tabs-identity-provider></kc-tabs-identity-provider>
 
     <form class="form-horizontal" name="realmForm" novalidate kc-read-only="!access.manageIdentityProviders">
-        <input type="text" readonly value="this is not a login form" style="display: none;">
-        <input type="password" readonly value="this is not a login form" style="display: none;">
-
         <fieldset>
             <div class="form-group clearfix">
                 <label class="col-md-2 control-label" for="redirectUri">{{:: 'redirect-uri' | translate}}</label>
@@ -31,7 +28,7 @@
             <div class="form-group clearfix">
                 <label class="col-md-2 control-label" for="clientSecret"><span class="required">*</span> {{:: 'client-secret' | translate}}</label>
                 <div class="col-md-6">
-                    <input class="form-control" id="clientSecret" type="password" ng-model="identityProvider.config.clientSecret" required>
+                    <input class="form-control" id="clientSecret" type="password" ng-model="identityProvider.config.clientSecret" required autocomplete="off" readonly onfocus="this.removeAttribute('readonly');" />
                 </div>
                 <kc-tooltip>{{:: 'social.client-secret.tooltip' | translate}}</kc-tooltip>
             </div>

--- a/themes/src/main/resources/theme/base/admin/resources/partials/realm-smtp.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/realm-smtp.html
@@ -2,9 +2,6 @@
     <kc-tabs-realm></kc-tabs-realm>
 
     <form class="form-horizontal" name="realmForm" novalidate kc-read-only="!access.manageRealm">
-        <input type="text" readonly value="this is not a login form" style="display: none;">
-        <input type="password" readonly value="this is not a login form" style="display: none;">
-
         <div class="form-group clearfix">
             <label class="col-md-2 control-label" for="smtpHost"><span class="required">*</span> {{:: 'host' | translate}}</label>
             <div class="col-md-6">
@@ -81,7 +78,7 @@
         <div class="form-group clearfix" data-ng-show="realm.smtpServer.auth">
             <label class="col-md-2 control-label" for="smtpPassword"><span class="required">*</span> {{:: 'password' | translate}}</label>
             <div class="col-md-6">
-                <input class="form-control" id="smtpPassword" type="password" ng-model="realm.smtpServer.password" placeholder="{{:: 'login-password' | translate}}" ng-disabled="!realm.smtpServer.auth" ng-required="realm.smtpServer.auth">
+                <input class="form-control" id="smtpPassword" type="password" ng-model="realm.smtpServer.password" placeholder="{{:: 'login-password' | translate}}" ng-disabled="!realm.smtpServer.auth" ng-required="realm.smtpServer.auth" autocomplete="off" readonly onfocus="this.removeAttribute('readonly');" />
             </div>
         </div>
 

--- a/themes/src/main/resources/theme/base/admin/resources/partials/user-credentials.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/user-credentials.html
@@ -7,22 +7,19 @@
     <kc-tabs-user></kc-tabs-user>
 
     <form class="form-horizontal" name="userForm" novalidate>
-        <input type="text" readonly value="this is not a login form" style="display: none;">
-        <input type="password" readonly value="this is not a login form" style="display: none;">
-
         <fieldset class="border-top">
             <legend><span class="text">{{:: 'manage-user-password' | translate}}</span></legend>
             <div class="form-group">
                     <label class="col-md-2 control-label" for="password">{{:: 'new-password' | translate}} <span class="required" data-ng-show="create">*</span></label>
                     <div class="col-md-6">
-                        <input class="form-control" type="password" id="password" name="password" data-ng-model="password" required>
+                        <input class="form-control" type="password" id="password" name="password" data-ng-model="password" required autocomplete="off" readonly onfocus="this.removeAttribute('readonly');" />
                     </div>
                 </div>
 
                 <div class="form-group">
                     <label class="col-md-2 control-label" for="confirmPassword">{{:: 'password-confirmation' | translate}} <span class="required" data-ng-show="create">*</span></label>
                     <div class="col-md-6">
-                        <input class="form-control" type="password" id="confirmPassword" name="confirmPassword" data-ng-model="confirmPassword" required>
+                        <input class="form-control" type="password" id="confirmPassword" name="confirmPassword" data-ng-model="confirmPassword" required autocomplete="off" readonly onfocus="this.removeAttribute('readonly');" />
                     </div>
                 </div>
 

--- a/themes/src/main/resources/theme/base/admin/resources/partials/user-storage-ldap.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/user-storage-ldap.html
@@ -8,9 +8,6 @@
     <kc-tabs-ldap></kc-tabs-ldap>
 
     <form class="form-horizontal" name="realmForm" novalidate kc-read-only="!access.manageRealm">
-        <input type="text" readonly value="this is not a login form" style="display: none;">
-        <input type="password" readonly value="this is not a login form" style="display: none;">
-
         <fieldset>
             <legend><span class="text">{{:: 'required-settings' | translate}}</span></legend>
             <div class="form-group clearfix" data-ng-show="!create">
@@ -146,7 +143,7 @@
             <div class="form-group clearfix" data-ng-hide="instance.config['authType'][0] == 'none'">
                 <label class="col-md-2 control-label" for="ldapBindCredential"><span class="required">*</span> {{:: 'bind-credential' | translate}}</label>
                 <div class="col-md-6">
-                    <input class="form-control" id="ldapBindCredential" type="password" ng-model="instance.config['bindCredential'][0]" placeholder="{{:: 'ldap-bind-credentials' | translate}}" data-ng-required="instance.config['authType'][0] != 'none'">
+                    <input class="form-control" id="ldapBindCredential" type="password" ng-model="instance.config['bindCredential'][0]" placeholder="{{:: 'ldap-bind-credentials' | translate}}" data-ng-required="instance.config['authType'][0] != 'none'" autocomplete="off" readonly onfocus="this.removeAttribute('readonly');" />
                 </div>
                 <kc-tooltip>{{:: 'ldap.bind-credential.tooltip' | translate}}</kc-tooltip>
                 <div class="col-sm-4" data-ng-show="access.manageRealm">

--- a/themes/src/main/resources/theme/base/login/login-update-password.ftl
+++ b/themes/src/main/resources/theme/base/login/login-update-password.ftl
@@ -6,15 +6,12 @@
         ${msg("updatePasswordTitle")}
     <#elseif section = "form">
         <form id="kc-passwd-update-form" class="${properties.kcFormClass!}" action="${url.loginAction}" method="post">
-            <input type="text" readonly value="this is not a login form" style="display: none;">
-            <input type="password" readonly value="this is not a login form" style="display: none;">
-
             <div class="${properties.kcFormGroupClass!}">
                 <div class="${properties.kcLabelWrapperClass!}">
                     <label for="password-new" class="${properties.kcLabelClass!}">${msg("passwordNew")}</label>
                 </div>
                 <div class="${properties.kcInputWrapperClass!}">
-                    <input type="password" id="password-new" name="password-new" class="${properties.kcInputClass!}" autofocus autocomplete="off" />
+                    <input type="password" id="password-new" name="password-new" class="${properties.kcInputClass!}" autofocus autocomplete="new-password" />
                 </div>
             </div>
 
@@ -23,7 +20,7 @@
                     <label for="password-confirm" class="${properties.kcLabelClass!}">${msg("passwordConfirm")}</label>
                 </div>
                 <div class="${properties.kcInputWrapperClass!}">
-                    <input type="password" id="password-confirm" name="password-confirm" class="${properties.kcInputClass!}" autocomplete="off" />
+                    <input type="password" id="password-confirm" name="password-confirm" class="${properties.kcInputClass!}" autocomplete="new-password" />
                 </div>
             </div>
 

--- a/themes/src/main/resources/theme/base/login/register.ftl
+++ b/themes/src/main/resources/theme/base/login/register.ftl
@@ -6,9 +6,6 @@
         ${msg("registerWithTitleHtml",(realm.displayNameHtml!''))?no_esc}
     <#elseif section = "form">
         <form id="kc-register-form" class="${properties.kcFormClass!}" action="${url.registrationAction}" method="post">
-          <input type="text" readonly value="this is not a login form" style="display: none;">
-          <input type="password" readonly value="this is not a login form" style="display: none;">
-
           <#if !realm.registrationEmailAsUsername>
             <div class="${properties.kcFormGroupClass!} ${messagesPerField.printIfExists('username',properties.kcFormGroupErrorClass!)}">
                 <div class="${properties.kcLabelWrapperClass!}">
@@ -52,7 +49,7 @@
                     <label for="password" class="${properties.kcLabelClass!}">${msg("password")}</label>
                 </div>
                 <div class="${properties.kcInputWrapperClass!}">
-                    <input type="password" id="password" class="${properties.kcInputClass!}" name="password" />
+                    <input type="password" id="password" class="${properties.kcInputClass!}" name="password" autocomplete="new-password" />
                 </div>
             </div>
 
@@ -61,7 +58,7 @@
                     <label for="password-confirm" class="${properties.kcLabelClass!}">${msg("passwordConfirm")}</label>
                 </div>
                 <div class="${properties.kcInputWrapperClass!}">
-                    <input type="password" id="password-confirm" class="${properties.kcInputClass!}" name="password-confirm" />
+                    <input type="password" id="password-confirm" class="${properties.kcInputClass!}" name="password-confirm" autocomplete="new-password" />
                 </div>
             </div>
             </#if>


### PR DESCRIPTION
A JavaScript alternative is used on admin page. Non-JS "new-password"
autocomplete mode used on account and login pages (which doesn't seem to work
well enough to use on the admin pages).