### PR TITLE
Add impersonator to user session note

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/UserResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UserResource.java
@@ -293,6 +293,9 @@ public class UserResource {
              .detail(Details.IMPERSONATOR_REALM,authenticatedRealm.getName())
              .detail(Details.IMPERSONATOR, auth.adminAuth().getUser().getUsername()).success();
 
+        userSession.setNote("impersonated", Boolean.TRUE.toString());
+        userSession.setNote("impersonator", auth.getAuth().getUser().getId());
+
         return result;
     }
 


### PR DESCRIPTION
Allow attribute mappers to expose the impersonator to clients.