### PR TITLE
KEYCLOAK-6009 Fix incorrect String.format usage

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/x509/CertificateValidator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/x509/CertificateValidator.java
@@ -300,7 +300,7 @@ public class CertificateValidator {
                         logger.debugf("Loading CRL from %s", f.getAbsolutePath());
 
                         if (!f.canRead()) {
-                            throw new IOException(String.format("Unable to read CRL from \"%path\"", f.getAbsolutePath()));
+                            throw new IOException(String.format("Unable to read CRL from \"%s\"", f.getAbsolutePath()));
                         }
                         X509CRL crl = loadFromStream(cf, new FileInputStream(f.getAbsolutePath()));
                         return Collections.singleton(crl);

--- a/services/src/main/java/org/keycloak/services/x509/AbstractClientCertificateFromHttpHeadersLookup.java
+++ b/services/src/main/java/org/keycloak/services/x509/AbstractClientCertificateFromHttpHeadersLookup.java
@@ -124,7 +124,7 @@ public abstract class AbstractClientCertificateFromHttpHeadersLookup implements 
             // Get the certificate of the client certificate chain
             for (int i = 0; i < certificateChainLength; i++) {
                 try {
-                    String s = String.format("{0}_{1}", sslCertChainHttpHeaderPrefix, i);
+                    String s = String.format("%s_%s", sslCertChainHttpHeaderPrefix, i);
                     cert = getCertificateFromHttpHeader(httpRequest, s);
                     if (cert != null) {
                         chain.add(cert);


### PR DESCRIPTION
I found incorrect `String.format` usage and fixed it.