### PR TITLE
KEYCLOAK-6041 - Update changes on sssd.conf file to make script idempotent

### DIFF
--- a/distribution/feature-packs/server-feature-pack/src/main/resources/content/bin/federation-sssd-setup.sh
+++ b/distribution/feature-packs/server-feature-pack/src/main/resources/content/bin/federation-sssd-setup.sh
@@ -5,10 +5,25 @@ SSSD_FILE="/etc/sssd/sssd.conf"
 
 if [ -f "$SSSD_FILE" ];
 then
-  sed -i '/ldap_tls_cacert/a ldap_user_extra_attrs = mail:mail, sn:sn, givenname:givenname, telephoneNumber:telephoneNumber' $SSSD_FILE
-  sed -i 's/nss, sudo, pam/nss, sudo, pam, ifp/' $SSSD_FILE
-  sed -i '/\[ifp\]/a allowed_uids = root\nuser_attributes = +mail, +telephoneNumber, +givenname, +sn' $SSSD_FILE
+
+  if ! grep -q ^ldap_user_extra_attrs $SSSD_FILE; then 
+    sed -i '/ldap_tls_cacert/a ldap_user_extra_attrs = mail:mail, sn:sn, givenname:givenname, telephoneNumber:telephoneNumber' $SSSD_FILE
+  fi
+
+  if ! grep -q ^services.*ifp.* /etc/sssd/sssd.conf; then
+    sed -i '/^services/ s/$/, ifp/' $SSSD_FILE
+  fi
+
+  if ! grep -q ^allowed_uids $SSSD_FILE; then 
+    sed -i '/\[ifp\]/a allowed_uids = root' $SSSD_FILE
+  fi
+
+  if ! grep -q ^user_attributes $SSSD_FILE; then 
+    sed -i '/allowed_uids/a user_attributes = +mail, +telephoneNumber, +givenname, +sn' $SSSD_FILE
+  fi
+
   systemctl restart sssd
+
 else
   echo "Please make sure you have $SSSD_FILE into your system! Aborting."
   exit 1
@@ -27,5 +42,3 @@ else
   echo "$PAM_FILE already exists. Skipping it..."
   exit 0
 fi
-
-


### PR DESCRIPTION
When executing script more than one time, consecutive lines are added to the sssd.conf file, and sssd fails to start