### PR TITLE
[KEYCLOAK-3837] jetty version can be passed as argument for springboot tests

### DIFF
--- a/testsuite/integration-arquillian/test-apps/spring-boot-adapter/pom.xml
+++ b/testsuite/integration-arquillian/test-apps/spring-boot-adapter/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.5.3.RELEASE</version>
+		<version>1.5.9.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 
@@ -26,6 +26,9 @@
         <keycloak.version>3.3.0.CR1-SNAPSHOT</keycloak.version>
 
 	    <repo.url />
+
+		<jetty.version />
+		<jetty.adapter.version />
 	</properties>
 
 	<dependencies>
@@ -73,26 +76,16 @@
 		<profile>
 			<id>spring-boot-adapter-jetty</id>
 			<dependencies>
-				<dependency>
-					<groupId>org.springframework.boot</groupId>
-					<artifactId>spring-boot-starter-web</artifactId>
-					<exclusions>
-						<exclusion>
-							<groupId>org.springframework.boot</groupId>
-							<artifactId>spring-boot-starter-tomcat</artifactId>
-						</exclusion>
-					</exclusions>
-				</dependency>
-				<dependency>
-					<groupId>org.springframework.boot</groupId>
-					<artifactId>spring-boot-starter-jetty</artifactId>
-				</dependency>
-
-				<dependency>
-					<groupId>org.keycloak</groupId>
-					<artifactId>keycloak-jetty94-adapter</artifactId>
-					<version>${keycloak.version}</version>
-				</dependency>
+                <dependency>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-web</artifactId>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>org.springframework.boot</groupId>
+                            <artifactId>spring-boot-starter-tomcat</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
 			</dependencies>
 		</profile>
 
@@ -137,6 +130,85 @@
 				</repository>
 			</repositories>
 		</profile>
+
+		<profile>
+			<id>jetty-version-81</id>
+			<activation>
+				<property>
+					<name>jetty.adapter.version</name>
+					<value>81</value>
+				</property>
+			</activation>
+			<properties>
+				<jetty.version>8.1.22.v20160922</jetty.version>
+			</properties>
+			<dependencies>
+                <dependency>
+                    <groupId>org.keycloak</groupId>
+                    <artifactId>keycloak-jetty81-adapter</artifactId>
+                    <version>${keycloak.version}</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-jetty</artifactId>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>org.eclipse.jetty.websocket</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+			</dependencies>
+		</profile>
+
+		<profile>
+			<id>jetty-version-92</id>
+			<activation>
+				<property>
+					<name>jetty.adapter.version</name>
+					<value>92</value>
+				</property>
+			</activation>
+			<properties>
+				<jetty.version>9.2.23.v20171218</jetty.version>
+			</properties>
+			<dependencies>
+				<dependency>
+					<groupId>org.keycloak</groupId>
+					<artifactId>keycloak-jetty92-adapter</artifactId>
+					<version>${keycloak.version}</version>
+				</dependency>
+                <dependency>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-jetty</artifactId>
+                </dependency>
+			</dependencies>
+		</profile>
+
+		<profile>
+			<id>jetty-version-93</id>
+			<activation>
+				<property>
+					<name>jetty.adapter.version</name>
+					<value>93</value>
+				</property>
+			</activation>
+			<properties>
+				<jetty.version>9.3.22.v20171030</jetty.version>
+			</properties>
+            <dependencies>
+				<dependency>
+					<groupId>org.keycloak</groupId>
+					<artifactId>keycloak-jetty93-adapter</artifactId>
+					<version>${keycloak.version}</version>
+				</dependency>
+                <dependency>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-jetty</artifactId>
+                </dependency>
+			</dependencies>
+		</profile>
+
 	</profiles>
 
 

--- a/testsuite/integration-arquillian/tests/other/springboot-tests/pom.xml
+++ b/testsuite/integration-arquillian/tests/other/springboot-tests/pom.xml
@@ -18,6 +18,8 @@
 
         <repo.argument />
         <maven.settings.file />
+
+        <jetty.adapter.version />
     </properties>
 
     <dependencies>
@@ -74,6 +76,7 @@
                                         <argument>-Dkeycloak.version=${project.version}</argument>
                                         <argument>-Pspring-boot-adapter-${adapter.container}</argument>
                                         <argument>-Dmaven.repo.local=${settings.localRepository}</argument>
+                                        <argument>-Djetty.adapter.version=${jetty.adapter.version}</argument>
                                         <argument>${repo.argument}</argument>
                                     </arguments>
                                 </configuration>
@@ -125,6 +128,7 @@
                                         <argument>-Dkeycloak.version=${project.version}</argument>
                                         <argument>-Pspring-boot-adapter-${adapter.container}</argument>
                                         <argument>-Dmaven.repo.local=${settings.localRepository}</argument>
+                                        <argument>-Djetty.adapter.version=${jetty.adapter.version}</argument>
                                     </arguments>
                                 </configuration>
                             </execution>


### PR DESCRIPTION
title is pretty self-explanatory.
added maven property which allows to specify jetty version for use in spring boot app.