### PR TITLE
Fix Authenticator Page HTML

### DIFF
--- a/themes/src/main/resources/theme/base/account/totp.ftl
+++ b/themes/src/main/resources/theme/base/account/totp.ftl
@@ -5,7 +5,7 @@
 <h2>${msg("authenticatorTitle")}</h2>
 
 <table class="table table-bordered table-striped">
-    <thead
+    <thead>
         <tr>
             <th colspan="2">${msg("configureAuthenticators")}</th>
             </tr>
@@ -30,7 +30,7 @@
 
 <ol>
     <li>
-        <p>${msg("totpStep1")}</p>
+        <p>${msg("totpStep1")?no_esc}</p>
 
         <ul>
             <#list totp.policy.supportedApplications as app>


### PR DESCRIPTION
Closes `<thead>` and disables escaping for the `totpStep1` message as it includes HTML links.