### PR TITLE
[master]: fix type for checkLoginIframeInterval

### DIFF
--- a/adapters/oidc/js/src/main/resources/keycloak.d.ts
+++ b/adapters/oidc/js/src/main/resources/keycloak.d.ts
@@ -78,7 +78,7 @@ declare namespace Keycloak {
 		 * Set the interval to check login state (in seconds).
 		 * @default 5
 		 */
-		checkLoginIframeInterval?: boolean;
+		checkLoginIframeInterval?: number;
 
 		/**
 		 * Set the OpenID Connect response mode to send to Keycloak upon login.


### PR DESCRIPTION
It appears that type for checkLoginIframeInterval is not correct.
It should be interval in seconds but the type is boolean.