### PR TITLE
KEYCLOAK-4509 Support IDP Initiated to OIDC RP

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/saml/JaxrsSAML2BindingBuilder.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/JaxrsSAML2BindingBuilder.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.protocol.saml;
 
+import org.keycloak.common.util.KeycloakUriBuilder;
 import org.keycloak.saml.BaseSAML2BindingBuilder;
 import org.keycloak.saml.common.exceptions.ConfigurationException;
 import org.keycloak.saml.common.exceptions.ProcessingException;
@@ -77,6 +78,30 @@ public class JaxrsSAML2BindingBuilder extends BaseSAML2BindingBuilder<JaxrsSAML2
                     .header("Cache-Control", "no-cache, no-store").build();
         }
 
+    }
+
+    /**
+     * Used for redirecting to SP/RP for Idp-Initiated SSO involving non SAML target SPs (i.e. OIDC RP).
+     */
+    public static class PlainRedirectBindingBuilder extends BaseRedirectBindingBuilder {
+        public PlainRedirectBindingBuilder(JaxrsSAML2BindingBuilder builder, Document document) throws ProcessingException {
+            super(builder, document);
+        }
+        @Override
+        public URI responseURI(String actionUrl) throws ConfigurationException, ProcessingException, IOException {
+            return KeycloakUriBuilder.fromUri(actionUrl).build();
+        }
+
+        public Response response(String redirect) throws ProcessingException, ConfigurationException, IOException {
+            URI uri = responseURI(redirect);
+            return Response.status(302).location(uri)
+                    .header("Pragma", "no-cache")
+                    .header("Cache-Control", "no-cache, no-store").build();
+        }
+    }
+
+    public PlainRedirectBindingBuilder plainRedirectBinding(Document document) throws ProcessingException  {
+        return new PlainRedirectBindingBuilder(this, document);
     }
 
     public RedirectBindingBuilder redirectBinding(Document document) throws ProcessingException  {

--- a/services/src/main/java/org/keycloak/protocol/saml/SamlProtocol.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/SamlProtocol.java
@@ -98,6 +98,7 @@ public class SamlProtocol implements LoginProtocol {
     public static final String SAML_SINGLE_LOGOUT_SERVICE_URL_POST_ATTRIBUTE = "saml_single_logout_service_url_post";
     public static final String SAML_SINGLE_LOGOUT_SERVICE_URL_REDIRECT_ATTRIBUTE = "saml_single_logout_service_url_redirect";
     public static final String LOGIN_PROTOCOL = "saml";
+    public static final String SAML_IDP_INITIATED_PLAIN_REDIRECT = "saml_binding_plain_redirect";
     public static final String SAML_BINDING = "saml_binding";
     public static final String SAML_IDP_INITIATED_LOGIN = "saml_idp_initiated_login";
     public static final String SAML_POST_BINDING = "post";
@@ -467,7 +468,9 @@ public class SamlProtocol implements LoginProtocol {
     }
 
     protected Response buildAuthenticatedResponse(AuthenticatedClientSessionModel clientSession, String redirectUri, Document samlDocument, JaxrsSAML2BindingBuilder bindingBuilder) throws ConfigurationException, ProcessingException, IOException {
-        if (isPostBinding(clientSession)) {
+        if (redirectUri != null && clientSession.getNotes().get(SamlProtocol.SAML_IDP_INITIATED_PLAIN_REDIRECT) != null) {
+            return bindingBuilder.plainRedirectBinding(samlDocument).response(redirectUri);
+        } else if (isPostBinding(clientSession)) {
             return bindingBuilder.postBinding(samlDocument).response(redirectUri);
         } else {
             return bindingBuilder.redirectBinding(samlDocument).response(redirectUri);

--- a/themes/src/main/resources/theme/base/admin/messages/admin-messages_en.properties
+++ b/themes/src/main/resources/theme/base/admin/messages/admin-messages_en.properties
@@ -321,6 +321,8 @@ oidc-compatibility-modes=OpenID Connect Compatibility Modes
 oidc-compatibility-modes.tooltip=Expand this section to configure settings for backwards compatibility with older OpenID Connect / OAuth2 adapters. It is useful especially if your client uses older version of Keycloak / RH-SSO adapter.
 exclude-session-state-from-auth-response=Exclude Session State From Authentication Response
 exclude-session-state-from-auth-response.tooltip=If this is on, the parameter 'session_state' will not be included in OpenID Connect Authentication Response. It is useful if your client uses older OIDC / OAuth2 adapter, which does not support 'session_state' parameter.
+idp-initiated-default-url=IDP Initiated Target URL
+idp-initiated-default-url.tooltip=Keycloak will redirect to this URL for IDP-initiated authentication. 
 
 # client import
 import-client=Import Client

--- a/themes/src/main/resources/theme/base/admin/resources/partials/client-detail.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/client-detail.html
@@ -399,6 +399,20 @@
                 </div>
                 <kc-tooltip>{{:: 'request-object-signature-alg.tooltip' | translate}}</kc-tooltip>
             </div>
+            <div class="form-group clearfix block" data-ng-show="protocol == 'openid-connect'">
+                <label class="col-md-2 control-label" for="requestObjectSignatureAlg">{{:: 'idp-sso-url-ref' | translate}}</label>
+                <div class="col-sm-6">
+                    <input ng-model="clientEdit.attributes.saml_idp_initiated_sso_url_name" class="form-control" type="text" name="idpSsoUrlRef" id="idpSsoUrlRef" />
+                </div>
+                <kc-tooltip>{{:: 'idp-sso-url-ref.tooltip' | translate}}</kc-tooltip>
+            </div>
+            <div class="form-group clearfix block" data-ng-show="protocol == 'openid-connect'">
+                <label class="col-md-2 control-label" for="requestObjectSignatureAlg">{{:: 'idp-initiated-default-url' | translate}}</label>
+                <div class="col-sm-6">
+                    <input ng-model="clientEdit.attributes.saml_assertion_consumer_url_redirect" class="form-control" type="text" name="idpInitiatedDefaultUrl" id="idpInitiatedDefaultUrl" />
+                </div>
+                <kc-tooltip>{{:: 'idp-initiated-default-url.tooltip' | translate}}</kc-tooltip>
+            </div>
         </fieldset>
 
         <fieldset data-ng-show="protocol == 'openid-connect'">


### PR DESCRIPTION
*Mostly as a proof of concept, I'll add unit tests if the general idea is ok. I feel code can be improved, but I'm a bit too young on KC to know the good areas to extend*

KC supports only SAML Clients for IDP Initiated login.

This commit adds IDP Initiated login to OIDC Clients.

To use this feature, the admin needs:

 * in Client conf
 ** IDP Initiated SSO URL Name=<client-alias>
 ** IDP Initiated Target URL=<target-url-of-client>
 * in the external IDP configuration, set keycloak
   redirectURL=http://<keycloak>/auth/realms/<realm>/broker/<idp-name>/endpoint/clients/<client-alias>

The whole behaviour will be :

* the user is authenticated in external IDP.
* external IDP dashboard page list all available Client.
* user clicks on a Client.
* external IDP redirects to KC (using SAML).
* KC validates the authentication.
* KC redirects to the OIDC RP (IDP Initiated Target URL).
* OIDC RP initiates a OIDC authentication flow, and redirects to KC
* KC creates automatically a session and redirects back to OIDC RP.