### PR TITLE
Return location for execution/flow creation

### DIFF
--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/AuthenticationManagementResource.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/AuthenticationManagementResource.java
@@ -113,6 +113,11 @@ public interface AuthenticationManagementResource {
     @Consumes(MediaType.APPLICATION_JSON)
     Response addExecution(AuthenticationExecutionRepresentation model);
 
+    @Path("/executions/{executionId}")
+	@GET
+    @Produces(MediaType.APPLICATION_JSON)
+    AuthenticationExecutionRepresentation getExecution(final @PathParam("executionId") String executionId);
+
     @Path("/executions/{executionId}/raise-priority")
     @POST
     void raisePriority(@PathParam("executionId") String execution);

--- a/services/src/main/java/org/keycloak/services/resources/admin/AuthenticationManagementResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/AuthenticationManagementResource.java
@@ -64,12 +64,14 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 
@@ -384,7 +386,8 @@ public class AuthenticationManagementResource {
         data.put("id", execution.getId());
         adminEvent.operation(OperationType.CREATE).resource(ResourceType.AUTH_EXECUTION_FLOW).resourcePath(uriInfo).representation(data).success();
 
-        return Response.status(Response.Status.CREATED).build();
+        String addExecutionPathSegment = UriBuilder.fromMethod(AuthenticationManagementResource.class, "addExecutionFlow").build(parentFlow.getAlias()).getPath();
+        return Response.created(uriInfo.getBaseUriBuilder().path(uriInfo.getPath().replace(addExecutionPathSegment, "")).path("flows").path(newFlow.getId()).build()).build();
     }
 
     private int getNextPriority(AuthenticationFlowModel parentFlow) {
@@ -402,7 +405,7 @@ public class AuthenticationManagementResource {
     @POST
     @NoCache
     @Consumes(MediaType.APPLICATION_JSON)
-    public void addExecution(@PathParam("flowAlias") String flowAlias, Map<String, String> data) {
+    public Response addExecutionToFlow(@PathParam("flowAlias") String flowAlias, Map<String, String> data) {
         auth.realm().requireManageRealm();
 
         AuthenticationFlowModel parentFlow = realm.getFlowByAlias(flowAlias);
@@ -438,6 +441,9 @@ public class AuthenticationManagementResource {
 
         data.put("id", execution.getId());
         adminEvent.operation(OperationType.CREATE).resource(ResourceType.AUTH_EXECUTION).resourcePath(uriInfo).representation(data).success();
+
+        String addExecutionPathSegment = UriBuilder.fromMethod(AuthenticationManagementResource.class, "addExecutionToFlow").build(parentFlow.getAlias()).getPath();
+        return Response.created(uriInfo.getBaseUriBuilder().path(uriInfo.getPath().replace(addExecutionPathSegment, "")).path("executions").path(execution.getId()).build()).build();
     }
 
     /**
@@ -560,6 +566,26 @@ public class AuthenticationManagementResource {
     }
 
     /**
+     * Get Single Execution
+     */
+    @Path("/executions/{executionId}")
+    @GET
+    @NoCache
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getExecution(final @PathParam("executionId") String executionId) {
+    	//http://localhost:8080/auth/admin/realms/master/authentication/executions/cf26211b-9e68-4788-b754-1afd02e59d7f
+        auth.realm().requireManageRealm();
+
+        final Optional<AuthenticationExecutionModel> model = Optional.ofNullable(realm.getAuthenticationExecutionById(executionId));
+        if (!model.isPresent()) {
+            logger.debugv("Could not find execution by Id: {}", executionId);
+            throw new NotFoundException("Illegal execution");
+        }
+
+        return Response.ok(model.get()).build();
+    }
+
+    /**
      * Add new authentication execution
      *
      * @param execution JSON model describing authentication execution
@@ -594,6 +620,7 @@ public class AuthenticationManagementResource {
         }
         return parentFlow;
     }
+
 
     /**
      * Raise execution's priority


### PR DESCRIPTION
This pull request does 3 things:

- Returns flow location header on creation
- Returns execution location header on creation
- Adds method whereby executions can be retrieved by ID