### PR TITLE
KEYCLOAK-6309 Fix tests

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/DeploymentArchiveProcessor.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/DeploymentArchiveProcessor.java
@@ -160,9 +160,8 @@ public class DeploymentArchiveProcessor implements ApplicationArchiveProcessor {
 
                 archive.add(new StringAsset(IOUtil.documentToString(doc)), adapterConfigPath);
 
-                if (APP_SERVER_SSL_REQUIRED) {
-                    ((WebArchive) archive).addAsResource(new File(DeploymentArchiveProcessor.class.getResource("/keystore/keycloak.truststore").getFile()));
-                }
+                ((WebArchive) archive).addAsResource(new File(DeploymentArchiveProcessor.class.getResource("/keystore/keycloak.truststore").getFile()));
+
                 // For running SAML tests it is necessary to have few dependencies on app-server side.
                 // Few of them are not in adapter zip so we need to add them manually here
             } else { // OIDC adapter config


### PR DESCRIPTION
Add trustore to war even if ssl is not enabled because HttpClient is configured with truststore