### PR TITLE
KEYCLOAK-6573 No auto escaping 'totpStep1' message variable

### DIFF
--- a/themes/src/main/resources/theme/base/account/totp.ftl
+++ b/themes/src/main/resources/theme/base/account/totp.ftl
@@ -30,7 +30,7 @@
 
 <ol>
     <li>
-        <p>${msg("totpStep1")}</p>
+        <p>${msg("totpStep1")?no_esc}</p>
 
         <ul>
             <#list totp.policy.supportedApplications as app>


### PR DESCRIPTION
Added auto-escaping in 'totpStep1' message variable