### PR TITLE
Javascript Adapter - Remove default zoom capability from Cordova InAppBrowser

### DIFF
--- a/adapters/oidc/js/src/main/resources/keycloak.js
+++ b/adapters/oidc/js/src/main/resources/keycloak.js
@@ -40,6 +40,12 @@
             }
         }
 
+        var addDefaultInAppOptionsTo = function (options) {
+            var optionsWithDefaultValues = (options || "");
+            optionsWithDefaultValues += (optionsWithDefaultValues.length > 0 ? "," : "") + "zoom=no"; // Android only
+            return optionsWithDefaultValues;
+        };
+
         var useNonce = true;
         
         kc.init = function (initOptions) {
@@ -1097,7 +1103,7 @@
                 var cordovaOpenWindowWrapper = function(loginUrl, target, options) {
                     if (window.cordova && window.cordova.InAppBrowser) {
                         // Use inappbrowser for IOS and Android if available
-                        return window.cordova.InAppBrowser.open(loginUrl, target, options);
+                        return window.cordova.InAppBrowser.open(loginUrl, target, addDefaultInAppOptionsTo(options));
                     } else {
                         return window.open(loginUrl, target, options);
                     }


### PR DESCRIPTION
When running `keycloak-js` on an Android device, the InAppBrowser plugin from Cordova adds (by default) a "zoom" feature (_in_ and _out_) in the InAppBrowser window.

This PR aims at disabling this zoom capability, which is useless in the context of an authentication page.