### PR TITLE
[KEYCLOAK-6655] Javascript Adapter - Allow users to provide cordova-specific options to login and register

### DIFF
--- a/adapters/oidc/js/src/main/resources/keycloak.js
+++ b/adapters/oidc/js/src/main/resources/keycloak.js
@@ -1180,7 +1180,7 @@
 
                 var shallowCloneCordovaOptions = function (userOptions) {
                     if (userOptions && userOptions.cordovaOptions) {
-                        return Object.keys(userOptions.cordovaOptions).reduce((options, optionName) => {
+                        return Object.keys(userOptions.cordovaOptions).reduce(function (options, optionName) {
                             options[optionName] = userOptions.cordovaOptions[optionName];
                             return options;
                         }, {});
@@ -1190,7 +1190,7 @@
                 };
 
                 var formatCordovaOptions = function (cordovaOptions) {
-                    return Object.keys(cordovaOptions).reduce((options, optionName) => {
+                    return Object.keys(cordovaOptions).reduce(function (options, optionName) {
                         options.push(optionName+"="+cordovaOptions[optionName]);
                         return options;
                     }, []).join(",");

--- a/adapters/oidc/js/src/main/resources/keycloak.js
+++ b/adapters/oidc/js/src/main/resources/keycloak.js
@@ -1198,8 +1198,10 @@
 
                 var createCordovaOptions = function (userOptions) {
                     var cordovaOptions = shallowCloneCordovaOptions(userOptions);
-                    cordovaOptions.location = "no";
-                    cordovaOptions.hidden = userOptions && userOptions.prompt == "none" ? "yes" : "no";
+                    cordovaOptions.location = 'no';
+                    if (userOptions && userOptions.prompt == 'none') {
+                        cordovaOptions.hidden = 'yes';
+                    }                    
                     return formatCordovaOptions(cordovaOptions);
                 };
 

--- a/adapters/oidc/js/src/main/resources/keycloak.js
+++ b/adapters/oidc/js/src/main/resources/keycloak.js
@@ -1177,17 +1177,39 @@
                         return window.open(loginUrl, target, options);
                     }
                 };
+
+                var shallowCloneCordovaOptions = function (userOptions) {
+                    if (userOptions && userOptions.cordovaOptions) {
+                        return Object.keys(userOptions.cordovaOptions).reduce((options, optionName) => {
+                            options[optionName] = userOptions.cordovaOptions[optionName];
+                            return options;
+                        }, {});
+                    } else {
+                        return {};
+                    }
+                };
+
+                var formatCordovaOptions = function (cordovaOptions) {
+                    return Object.keys(cordovaOptions).reduce((options, optionName) => {
+                        options.push(optionName+"="+cordovaOptions[optionName]);
+                        return options;
+                    }, []).join(",");
+                };
+
+                var createCordovaOptions = function (userOptions) {
+                    var cordovaOptions = shallowCloneCordovaOptions(userOptions);
+                    cordovaOptions.location = "no";
+                    cordovaOptions.hidden = userOptions && userOptions.prompt == "none" ? "yes" : "no";
+                    return formatCordovaOptions(cordovaOptions);
+                };
+
                 return {
                     login: function(options) {
                         var promise = createPromise();
 
-                        var o = 'location=no';
-                        if (options && options.prompt == 'none') {
-                            o += ',hidden=yes';
-                        }
-
+                        var cordovaOptions = createCordovaOptions(options);
                         var loginUrl = kc.createLoginUrl(options);
-                        var ref = cordovaOpenWindowWrapper(loginUrl, '_blank', o);
+                        var ref = cordovaOpenWindowWrapper(loginUrl, '_blank', cordovaOptions);
                         var completed = false;
 
                         ref.addEventListener('loadstart', function(event) {
@@ -1218,7 +1240,7 @@
 
                     logout: function(options) {
                         var promise = createPromise();
-
+                        
                         var logoutUrl = kc.createLogoutUrl(options);
                         var ref = cordovaOpenWindowWrapper(logoutUrl, '_blank', 'location=no,hidden=yes');
 
@@ -1253,7 +1275,8 @@
 
                     register : function() {
                         var registerUrl = kc.createRegisterUrl();
-                        var ref = cordovaOpenWindowWrapper(registerUrl, '_blank', 'location=no');
+                        var cordovaOptions = createCordovaOptions(options);
+                        var ref = cordovaOpenWindowWrapper(registerUrl, '_blank', cordovaOptions);
                         ref.addEventListener('loadstart', function(event) {
                             if (event.url.indexOf('http://localhost') == 0) {
                                 ref.close();


### PR DESCRIPTION
In `keycloak-js` (version 3.4.3), `login` and `register` functions do not allow to pass cordova-specific options to the in-app-browser.

This PR proposes an additional `cordovaOptions` key (to the `options` parameter).
`cordovaOptions` is an object where is key/value is passed to the in-app-browser.

For example, this parameter disables the in-app-browser's zoom capability on Android:
```
var options = {
  cordovaOptions: {
     zoom= "no"
  }
}
```

`hidden` and `location` options are not affected by this new parameter.

Available options are defined at https://cordova.apache.org/docs/en/latest/reference/cordova-plugin-inappbrowser/ 
