### PR TITLE
[KEYCLOAK-6656] Javascript Adapter - Reject 'login' promise when users close their cordova in-app-browser on purpose

### DIFF
--- a/adapters/oidc/js/src/main/resources/keycloak.js
+++ b/adapters/oidc/js/src/main/resources/keycloak.js
@@ -1189,12 +1189,18 @@
                         var loginUrl = kc.createLoginUrl(options);
                         var ref = cordovaOpenWindowWrapper(loginUrl, '_blank', o);
                         var completed = false;
+                        
+                        var closed = false;
+                        var closeBrowser = function() {
+                            closed = true;
+                            ref.close();
+                        };
 
                         ref.addEventListener('loadstart', function(event) {
                             if (event.url.indexOf('http://localhost') == 0) {
                                 var callback = parseCallback(event.url);
                                 processCallback(callback, promise);
-                                ref.close();
+                                closeBrowser();
                                 completed = true;
                             }
                         });
@@ -1204,12 +1210,20 @@
                                 if (event.url.indexOf('http://localhost') == 0) {
                                     var callback = parseCallback(event.url);
                                     processCallback(callback, promise);
-                                    ref.close();
+                                    closeBrowser();
                                     completed = true;
                                 } else {
                                     promise.setError();
-                                    ref.close();
+                                    closeBrowser();
                                 }
+                            }
+                        });
+
+                        ref.addEventListener('exit', function(event) {
+                            if (!closed) {
+                                promise.setError({
+                                    reason: "closed_by_user"
+                                });
                             }
                         });
 


### PR DESCRIPTION
### Current behaviour

When users close the cordova in-app-browser using backbutton (Android) or the "Done" button (IOS), the `login` function does not resolve its promise.

Therefore, based on this promise's status, there is no way to know whether the in-app-browser is still alive or not.

### Proposed solution

When users close their in-app-browser, `keycloak-js` listens to the cordova `exit` event to reject the promise with an explicit reason `{ reason: "closed_by_user" }`.

### Testing

This implementation has been tested on IOS 10 and Android 8.

 