### PR TITLE
KEYCLOAK-6615 Remove offline session from database on offline token logout

### DIFF
--- a/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
@@ -211,7 +211,7 @@ public class AuthenticationManager {
         userSession.setState(UserSessionModel.State.LOGGED_OUT);
 
         if (offlineSession) {
-            session.sessions().removeOfflineUserSession(realm, userSession);
+            new UserSessionManager(session).revokeOfflineUserSession(userSession);
         } else {
             session.sessions().removeUserSession(realm, userSession);
         }


### PR DESCRIPTION
Offline token session logout was leaving the token in the database. If keycloak was restarted the token became valid again. 