### PR TITLE
in addition to KEYCLOAK-6065 no automplete

### DIFF
--- a/themes/src/main/resources/theme/base/admin/resources/js/app.js
+++ b/themes/src/main/resources/theme/base/admin/resources/js/app.js
@@ -2964,6 +2964,7 @@ module.directive('kcPassword', function ($compile, Notifications) {
         link: function ($scope, elem, attr, ctrl) {
             elem.addClass("password-conceal");
             elem.attr("type","text");
+            elem.attr("autocomplete", "off");
         }
     }
 });


### PR DESCRIPTION
Dear keycloak team,

in addition to not trigger password managers (see KEYCLOAK-6065) the directive kcPassword (password-conceal) should also disable auto completion from browsers.
When using Firefox (Quantum 58.0), the autocompletion is triggered, e.g. when trying to export SAML key for SAML clients (see screenshot)
<img width="571" alt="autocomplete_export_pwd" src="https://user-images.githubusercontent.com/629385/36255706-6395925a-1250-11e8-9a24-e65841dd3442.png">
<img width="568" alt="autocomplete_export_pwd_2" src="https://user-images.githubusercontent.com/629385/36255715-6a24656a-1250-11e8-9d6a-eabf10cb66b2.png">

This could easily be avoided by adding autocomplete attribute to kcPassword fields.
<img width="927" alt="screen shot 2018-02-15 at 13 07 25" src="https://user-images.githubusercontent.com/629385/36255957-446313e8-1251-11e8-9251-2cd9890decde.png">

This pull requests changes the implementation of kcPassword directive....

