### PR TITLE
Providing a custom error when the sessionId has changed

### DIFF
--- a/adapters/oidc/js/src/main/resources/keycloak.js
+++ b/adapters/oidc/js/src/main/resources/keycloak.js
@@ -481,8 +481,8 @@
                 var iframePromise = checkLoginIframe();
                 iframePromise.success(function() {
                     exec();
-                }).error(function() {
-                    promise.setError();
+                }).error(function(e) {
+                    promise.setError(e);
                 });
             } else {
                 exec();
@@ -1089,7 +1089,7 @@
                     if (event.data == 'unchanged') {
                         promise.setSuccess();
                     } else {
-                        promise.setError();
+                        promise.setError(new Error('Cookie sessionId and keycloak sessionId do not match.  Please logout and log back in.'));
                     }
                 }
             };


### PR DESCRIPTION
In the login-status-iframe.html here is this bit of code:

```
var c = cookie.split('/');
if (sessionState === c[2]) {
  callback('unchanged');
} else {
  callback('changed');
}
```

 if the keycloak sessionState variable (keycloak.clientId) doesn't match the cookie value then the 'changed' logic is hit.  When this happens `promise.setError()` is executed.  However as it stands there is no way of knowing what really happened.

To allow the client side to be a bit more robust and handle this situation, then that setError should pass an error describing the problem, which then can be caught on the client side impl.

A concrete example of when this can happen is the following:

- Have a webapp logged in an open in two tabs.
- Logout on one tab
- On the other tab attempt to log back in
- This error will occur on login

This error happens when logging back in with specifically not clearing cookies or localStorage first.  If one is actually logged out, but attempts, in the current tab, without clearing existing cookies/storage, to log back in, then the old token information is still in the cookie.  When re-authing, the first hit to updateToken will result in that 'changed' logic even though authentication was successful.

The avoid this, one just needs to properly re-login (logout first and or clear cookies/storage).  Otherwise, without doing this, there is no way of knowing what really happened.  Hence this PR with the enhanced error.