### PR TITLE
[KEYCLOAK-6657] Javascript Adapter - Logout promise on cordova does not resolve because of hidden=yes

### DIFF
--- a/adapters/oidc/js/src/main/resources/keycloak.js
+++ b/adapters/oidc/js/src/main/resources/keycloak.js
@@ -1239,14 +1239,17 @@
                             }
                         });
 
-                        ref.addEventListener('exit', function(event) {
+                        var handleExit = function (event) {
                             if (error) {
                                 promise.setError();
                             } else {
                                 kc.clearToken();
                                 promise.setSuccess();
                             }
-                        });
+                        };
+
+                        ref.addEventListener('exit', handleExit);
+                        ref.addEventListener('loadstop', handleExit);
 
                         return promise.promise;
                     },


### PR DESCRIPTION
## Problem

When signing out using the Javascript Adapter and Cordova, the promise is never resolved if the redirectUri does not start with `http://localhost`.

This is due to the in-app-browser option `hidden=yes` that does not show the browser (and then never explicitly close it). Therefore, the `exit` event is not triggered.

## Solution

If the in-app-browser is never shown (because of `hidden=yes`), the `exit` event is not triggered. However, an event `loadstop` is always triggered (see https://cordova.apache.org/docs/en/latest/reference/cordova-plugin-inappbrowser/#cordovainappbrowseropen ).

This `loadstop` event can be catched, exactly as the 'exit' one is catched. 

## Testing

Tested on Android 8 and IOS 10.
