### PR TITLE
KEYCLOAK-6676: TokenEndpoint: Fix NPE if the redirect_uri parameter is missing in code flow

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
@@ -308,7 +308,7 @@ public class TokenEndpoint {
         String redirectUriParam = formParams.getFirst(OAuth2Constants.REDIRECT_URI);
 
         // KEYCLOAK-4478 Backwards compatibility with the adapters earlier than KC 3.4.2
-        if (redirectUriParam.contains("session_state=")) {
+        if (redirectUriParam != null && redirectUriParam.contains("session_state=")) {
             redirectUriParam = KeycloakUriBuilder.fromUri(redirectUriParam)
                     .replaceQueryParam(OAuth2Constants.SESSION_STATE, null)
                     .build().toString();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OAuthRedirectUriTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OAuthRedirectUriTest.java
@@ -346,6 +346,21 @@ public class OAuthRedirectUriTest extends AbstractKeycloakTest {
         checkRedirectUri("http://localhost/myapp2", false);
     }
 
+    @Test
+    public void okThenNull() throws IOException {
+        oauth.clientId("test-wildcard");
+        oauth.redirectUri("http://localhost:8280/foo");
+        oauth.doLogin("test-user@localhost", "password");
+
+        String code = oauth.getCurrentQuery().get(OAuth2Constants.CODE);
+        Assert.assertNotNull(code);
+        oauth.redirectUri(null);
+
+        OAuthClient.AccessTokenResponse tokenResponse = oauth.doAccessTokenRequest(code, "password");
+
+        Assert.assertEquals("Expected 400, but got something else", 400, tokenResponse.getStatusCode());
+    }
+
     private void checkRedirectUri(String redirectUri, boolean expectValid) throws IOException {
         checkRedirectUri(redirectUri, expectValid, false);
     }


### PR DESCRIPTION
This is my first contribution here, not really sure if this should be reported as an issue first.
