### PR TITLE
KEYCLOAK-6709 Fix OpenShift IdP doesn't fetch user's full name

### DIFF
--- a/services/src/main/java/org/keycloak/social/openshift/OpenshiftV3IdentityProvider.java
+++ b/services/src/main/java/org/keycloak/social/openshift/OpenshiftV3IdentityProvider.java
@@ -47,7 +47,7 @@ public class OpenshiftV3IdentityProvider extends AbstractOAuth2IdentityProvider<
     protected BrokeredIdentityContext doGetFederatedIdentity(String accessToken) {
         try {
             final JsonNode profile = fetchProfile(accessToken);
-            final BrokeredIdentityContext user = extractUserContext(profile.get("metadata"));
+            final BrokeredIdentityContext user = extractUserContext(profile);
             AbstractJsonUserAttributeMapper.storeUserProfileForMapper(user, profile, getConfig().getAlias());
             return user;
         } catch (Exception e) {
@@ -55,10 +55,12 @@ public class OpenshiftV3IdentityProvider extends AbstractOAuth2IdentityProvider<
         }
     }
 
-    private BrokeredIdentityContext extractUserContext(JsonNode metadata) {
+    private BrokeredIdentityContext extractUserContext(JsonNode profile) {
+        JsonNode metadata = profile.get("metadata");
+
         final BrokeredIdentityContext user = new BrokeredIdentityContext(getJsonProperty(metadata, "uid"));
         user.setUsername(getJsonProperty(metadata, "name"));
-        user.setName(getJsonProperty(metadata, "fullName"));
+        user.setName(getJsonProperty(profile, "fullName"));
         user.setIdpConfig(getConfig());
         user.setIdp(this);
         return user;

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/social/OpenShiftLoginPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/social/OpenShiftLoginPage.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite.pages.social;
+
+import org.openqa.selenium.Keys;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+/**
+ * @author Vaclav Muzikar <vmuzikar@redhat.com>
+ */
+public class OpenShiftLoginPage extends AbstractSocialLoginPage {
+    @FindBy(name = "username")
+    private WebElement usernameInput;
+
+    @FindBy(name = "password")
+    private WebElement passwordInput;
+
+    @Override
+    public void login(String user, String password) {
+        usernameInput.sendKeys(user);
+        passwordInput.sendKeys(password);
+        passwordInput.sendKeys(Keys.RETURN);
+    }
+}


### PR DESCRIPTION
This PR also contains the related fixes to the OpenShift Social Login test so it'd check the user's full name.