### PR TITLE
Fix German translation

### DIFF
--- a/themes/src/main/resources-community/theme/base/account/messages/messages_de.properties
+++ b/themes/src/main/resources-community/theme/base/account/messages/messages_de.properties
@@ -94,7 +94,7 @@ revoke=Berechtigung widerrufen
 
 configureAuthenticators=Authenticatoren konfigurieren
 mobile=Mobile
-totpStep1=Installieren Sie <a href="https://freeotp.github.io/" target="_blank">FreeOTP</a> oder <a href="http://code.google.com/p/google-authenticator/" target="_blank">Google Authenticator</a> auf Ihrem Smartphone.
+totpStep1=Installieren Sie bitte diese Applikation auf Ihrem Smartphone
 totpStep2=\u00D6ffnen Sie die Applikation und scannen Sie den Barcode oder geben Sie den Code ein.
 totpStep3=Geben Sie den von der Applikation generierten One-time Code ein und klicken Sie auf Speichern.
 


### PR DESCRIPTION
I removed the OTP application link in German since the message is not escaped. Now the apps are listed and not needed in the step1 message.

See #5036 for french

I only have basic knowledge of German. I ask a colleague for correction.