### PR TITLE
KEYCLOAK-6299 Upstream keycloak-javadocs-pom into the product profile of keycloak-api-docs-dist

### DIFF
--- a/distribution/api-docs-dist/assembly.xml
+++ b/distribution/api-docs-dist/assembly.xml
@@ -39,6 +39,7 @@
         <file>
             <source>src/index.html</source>
             <outputDirectory></outputDirectory>
+            <filtered>true</filtered>
         </file>
     </files>
 

--- a/distribution/api-docs-dist/pom.xml
+++ b/distribution/api-docs-dist/pom.xml
@@ -29,13 +29,9 @@
     <name>Keycloak Docs Distribution</name>
     <description/>
 
-    <dependencies>
-        <dependency>
-            <groupId>org.keycloak</groupId>
-            <artifactId>keycloak-dependencies-server-all</artifactId>
-            <type>pom</type>
-        </dependency>
-    </dependencies>
+    <properties>
+        <javadoc.branding>${product.name.full} ${product.version}</javadoc.branding>
+    </properties>
 
     <build>
         <finalName>keycloak-api-docs-${project.version}</finalName>
@@ -45,12 +41,9 @@
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
                     <minmemory>128m</minmemory>
-                    <maxmemory>1024m</maxmemory>
-                    <dependencySourceIncludes>
-                        <dependencySourceInclude>org.keycloak:*</dependencySourceInclude>
-                    </dependencySourceIncludes>
+                    <maxmemory>2400m</maxmemory>
+                    <encoding>UTF-8</encoding>
                     <includeDependencySources>true</includeDependencySources>
-                    <includeTransitiveDependencySources>true</includeTransitiveDependencySources>
                 </configuration>
                 <executions>
                     <execution>
@@ -75,12 +68,6 @@
                             <descriptors>
                                 <descriptor>assembly.xml</descriptor>
                             </descriptors>
-                            <outputDirectory>
-                                target
-                            </outputDirectory>
-                            <workDirectory>
-                                target/assembly/work
-                            </workDirectory>
                             <appendAssemblyId>false</appendAssemblyId>
                         </configuration>
                     </execution>
@@ -88,7 +75,6 @@
             </plugin>
         </plugins>
     </build>
-
 
     <profiles>
         <profile>
@@ -98,14 +84,106 @@
                     <name>!product</name>
                 </property>
             </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.keycloak</groupId>
+                    <artifactId>keycloak-dependencies-server-all</artifactId>
+                    <type>pom</type>
+                </dependency>
+            </dependencies>
             <build>
                 <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>aggregate-javadoc</id>
+                                <configuration>
+                                    <includeTransitiveDependencySources>true</includeTransitiveDependencySources>
+                                    <dependencySourceIncludes>
+                                        <dependencySourceInclude>org.keycloak:*</dependencySourceInclude>
+                                    </dependencySourceIncludes>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-deploy-plugin</artifactId>
                         <configuration>
                             <skip>true</skip>
                         </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>product</id>
+            <activation>
+                <property>
+                    <name>product</name>
+                </property>
+            </activation>
+            <!-- Make sure to keep this list in sync with <dependencySourceIncludes> -->
+            <dependencies>
+                <dependency>
+                    <groupId>org.keycloak</groupId>
+                    <artifactId>keycloak-server-spi</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.keycloak</groupId>
+                    <artifactId>keycloak-common</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.keycloak</groupId>
+                    <artifactId>keycloak-core</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.keycloak</groupId>
+                    <artifactId>keycloak-saml-core-public</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.keycloak</groupId>
+                    <artifactId>keycloak-adapter-spi</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.keycloak</groupId>
+                    <artifactId>keycloak-adapter-core</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.keycloak</groupId>
+                    <artifactId>keycloak-saml-adapter-api-public</artifactId>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>aggregate-javadoc</id>
+                                <configuration>
+                                    <windowtitle>${javadoc.branding} public API</windowtitle>
+                                    <doctitle>${javadoc.branding} public API</doctitle>
+                                    <header>${javadoc.branding}</header>
+                                    <footer>${javadoc.branding}</footer>
+                                    <includeTransitiveDependencySources>false</includeTransitiveDependencySources>
+                                    <!-- Make sure to keep this list in sync with <dependencies> -->
+                                    <dependencySourceIncludes>
+                                        <include>org.keycloak:keycloak-server-spi</include>
+                                        <include>org.keycloak:keycloak-common</include>
+                                        <include>org.keycloak:keycloak-core</include>
+                                        <include>org.keycloak:keycloak-saml-core-public</include>
+                                        <include>org.keycloak:keycloak-adapter-spi</include>
+                                        <include>org.keycloak:keycloak-adapter-core</include>
+                                        <include>org.keycloak:keycloak-saml-adapter-api-public</include>
+                                    </dependencySourceIncludes>
+                                </configuration>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>

--- a/distribution/api-docs-dist/src/index.html
+++ b/distribution/api-docs-dist/src/index.html
@@ -24,7 +24,7 @@
 </head>
 
 <body>
-<h1>Keyloak API Documentation</h1>
+<h1>${product.name.full} API Documentation</h1>
 <table>
     <tr>
         <td>Admin REST API</td>


### PR DESCRIPTION
A product profile has been added to keycloak-api-docs-dist, to replace the
downstream product javadocs POM. I've merged in any misc. changes from that
pom, but I've kept the upstream zip layout:

```
index.html
rest-api/index.html
javadocs/index.html
javadocs/index-all.html
javadocs/*
```

instead of the current product deliverable layout of:

```
META-INF/*
index.html
index-all.html
*
```

The community layout includes the rest-api that's distributed as a separate
product deliverable in 7.2.0. I've kept this layout for better artifact
consistency, but it could easily be changed to keep the product artifacts
consistent for the next product minor version.