### PR TITLE
Allow to use custom adapter

### DIFF
--- a/adapters/oidc/js/src/main/resources/keycloak.d.ts
+++ b/adapters/oidc/js/src/main/resources/keycloak.d.ts
@@ -29,7 +29,7 @@ export = Keycloak;
 declare function Keycloak(config?: string|{}): Keycloak.KeycloakInstance;
 
 declare namespace Keycloak {
-	type KeycloakAdapterName = 'cordova'|'default';
+	type KeycloakAdapterName = 'cordova'|'default' | any;
 	type KeycloakOnLoad = 'login-required'|'check-sso';
 	type KeycloakResponseMode = 'query'|'fragment';
 	type KeycloakResponseType = 'code'|'id_token token'|'code id_token token';
@@ -42,7 +42,7 @@ declare namespace Keycloak {
 		useNonce?: boolean;
 
 		/**
-		 * @private Undocumented.
+		 * Allows to use different adapter (default/cordova or custom adapter)
 		 */
 		adapter?: KeycloakAdapterName;
 		

--- a/adapters/oidc/js/src/main/resources/keycloak.d.ts
+++ b/adapters/oidc/js/src/main/resources/keycloak.d.ts
@@ -42,7 +42,11 @@ declare namespace Keycloak {
 		useNonce?: boolean;
 
 		/**
-		 * Allows to use different adapter (default/cordova or custom adapter)
+		 * Allows to use different adapter:
+		 * 
+		 * - {string} default - using browser api for redirects
+		 * - {string} cordova - using cordova plugins 
+		 * - {function} - allows to provide custom function as adapter.
 		 */
 		adapter?: KeycloakAdapterName;
 		

--- a/adapters/oidc/js/src/main/resources/keycloak.js
+++ b/adapters/oidc/js/src/main/resources/keycloak.js
@@ -51,6 +51,8 @@
                 adapter = loadAdapter('cordova');
             } else if (initOptions && initOptions.adapter === 'default') {
                 adapter = loadAdapter();
+            } else if (initOptions && typeof initOptions.adapter === "object") {
+                adapter = initOptions.adapter;
             } else {
                 if (window.Cordova || window.cordova) {
                     adapter = loadAdapter('cordova');


### PR DESCRIPTION
## Motivation

Allow to provide custom implementation for adapters.
Adapters are using opinionated implementation which not always work well in some environment like cordova/web. Additionally api is not consistent sometimes is returning promise sometimes not. This will also allow to do major improvements in api without breaking compatibility. Change is relatively small for the moment, but I'm happy to apply any improvements.

## Additional work

Options to improve this:

- Export current adapters to separate class or even file so they are more structured and reused when needed.
- Provide typescript definitions for adapters.

## Notes

Mailing list link: http://lists.jboss.org/pipermail/keycloak-dev/2018-March/010474.html
Jira issue: https://issues.jboss.org/browse/KEYCLOAK-6798