### PR TITLE
KEYCLOAK-6828 Drop jcenter repository from services/pom.xml

### DIFF
--- a/services/pom.xml
+++ b/services/pom.xml
@@ -205,27 +205,6 @@
         <profile>
             <id>jboss-release</id>
 
-            <repositories>
-                <repository>
-                    <snapshots>
-                        <enabled>false</enabled>
-                    </snapshots>
-                    <id>central</id>
-                    <name>bintray</name>
-                    <url>https://jcenter.bintray.com</url>
-                </repository>
-            </repositories>
-            <pluginRepositories>
-                <pluginRepository>
-                    <snapshots>
-                        <enabled>false</enabled>
-                    </snapshots>
-                    <id>central</id>
-                    <name>bintray</name>
-                    <url>https://jcenter.bintray.com</url>
-                </pluginRepository>
-            </pluginRepositories>
-
             <build>
                 <plugins>
                     <plugin>
@@ -288,6 +267,28 @@
                         <groupId>io.github.swagger2markup</groupId>
                         <artifactId>swagger2markup-maven-plugin</artifactId>
                         <version>1.1.0</version>
+
+                        <!-- Replace the dependencies that aren't in Maven Central -->
+                        <dependencies>
+                            <dependency>
+                                <groupId>ca.szc.thirdparty.nl.jworks.markdown_to_asciidoc</groupId>
+                                <artifactId>markdown_to_asciidoc</artifactId>
+                                <!-- Keep in sync with markup-document-builder's dependency -->
+                                <version>1.0</version>
+                            </dependency>
+                            <dependency>
+                                <groupId>io.github.swagger2markup</groupId>
+                                <artifactId>swagger2markup</artifactId>
+                                <!-- Keep in sync with swagger2markup-maven-plugin's dependency -->
+                                <version>1.1.0</version>
+                                <exclusions>
+                                    <exclusion>
+                                        <groupId>nl.jworks.markdown_to_asciidoc</groupId>
+                                        <artifactId>markdown_to_asciidoc</artifactId>
+                                    </exclusion>
+                                </exclusions>
+                            </dependency>
+                        </dependencies>
 
                         <executions>
                             <execution>


### PR DESCRIPTION
swagger2markup-maven-plugin depends transitively on markdown_to_asciidoc, which
is inexplicably not in Central. This causes issues during productisation, as
it's reasonably assumed that all third party artifacts will be in Central.

Stian has already asked the community project to get their artifacts in Central
( bodiam/markdown-to-asciidoc#26 ), and they haven't done anything in almost a
year. So, I've added the artifacts under my own namespace, and changed the pom
to use those instead. The artifacts are unchanged from the ones on jcenter,
except the pom was expanded slightly to meet the minimum requirements of
Central.

I'm making this change now, as I hit the problem when trying to set up
continuous productization builds from master.