### PR TITLE
Bad locale listbox placement

### DIFF
--- a/themes/src/main/resources/theme/keycloak/login/resources/css/login.css
+++ b/themes/src/main/resources/theme/keycloak/login/resources/css/login.css
@@ -274,7 +274,7 @@ ol#kc-totp-settings li:first-of-type {
     #kc-locale {
         position: relative;
         width: 200px;
-        left: -230px;
+        left: 230px;
         text-align: right;
         z-index: 9999;
     }


### PR DESCRIPTION
When display is higher than 768px, the locale listbox (for internationalization) is getting out of the screen.
Tested without minus sign and listbox is back on the screen.

I didn't check if there is also this kind of problem in other parts of theme (I only worked on login)