### PR TITLE
configurable request timeout

### DIFF
--- a/proxy/proxy-server/src/main/java/org/keycloak/proxy/ProxyConfig.java
+++ b/proxy/proxy-server/src/main/java/org/keycloak/proxy/ProxyConfig.java
@@ -56,6 +56,9 @@ public class ProxyConfig {
     protected Boolean directBuffers;
     @JsonProperty("target-url")
     protected String targetUrl;
+    /** Defaults to 30 seconds */
+    @JsonProperty("target-request-timeout")
+    protected Integer targetRequestTimeout = 30000;
     @JsonProperty("send-access-token")
     protected boolean sendAccessToken;
     @JsonProperty("applications")
@@ -157,6 +160,14 @@ public class ProxyConfig {
 
     public void setTargetUrl(String targetUrl) {
         this.targetUrl = targetUrl;
+    }
+
+    public Integer getTargetRequestTimeout() {
+        return targetRequestTimeout;
+    }
+
+    public void setTargetRequestTimeout(Integer targetRequestTimeout) {
+        this.targetRequestTimeout = targetRequestTimeout;
     }
 
     public List<Application> getApplications() {

--- a/proxy/proxy-server/src/main/java/org/keycloak/proxy/ProxyServerBuilder.java
+++ b/proxy/proxy-server/src/main/java/org/keycloak/proxy/ProxyServerBuilder.java
@@ -97,14 +97,14 @@ public class ProxyServerBuilder {
 
     protected Map<String, String> headerNameConfig;
 
-    public ProxyServerBuilder target(String uri) {
+    public ProxyServerBuilder target(ProxyConfig config) {
         SimpleProxyClientProvider provider = null;
         try {
-            provider = new SimpleProxyClientProvider(new URI(uri));
+            provider = new SimpleProxyClientProvider(new URI(config.getTargetUrl()));
         } catch (URISyntaxException e) {
             throw new RuntimeException(e);
         }
-        final HttpHandler handler = new ProxyHandler(provider, 30000, ResponseCodeHandler.HANDLE_404);
+        final HttpHandler handler = new ProxyHandler(provider, config.getTargetRequestTimeout(), ResponseCodeHandler.HANDLE_404);
         proxyHandler = new HttpHandler() {
             @Override
             public void handleRequest(HttpServerExchange exchange) throws Exception {
@@ -385,7 +385,7 @@ public class ProxyServerBuilder {
             log.error("Must set Target URL");
             return null;
         }
-        builder.target(config.getTargetUrl());
+        builder.target(config);
         if (config.getApplications() == null || config.getApplications().size() == 0) {
             log.error("No applications defined");
             return null;


### PR DESCRIPTION
In the current keycloak proxy server, the request timeout is hard-coded to 30 seconds. 
We want to secure a download server with the keycloak proxy, where this request timeout is too short. 
So I introduced another config option, which provides the possibility to configure the request timeout as needed. If no configuration is set, the current default value (30 seconds) is preserved. 