### PR TITLE
KEYCLOAK-6942 Cut off background on the new login page

### DIFF
--- a/themes/src/main/resources-product/theme/rh-sso/login/resources/css/login-rhsso.css
+++ b/themes/src/main/resources-product/theme/rh-sso/login/resources/css/login-rhsso.css
@@ -1,6 +1,6 @@
 .login-pf body {
-    background-image: url(../node_modules/rcue/dist/img/bg-login.png);
-    background-size: auto;
+  background: url("../node_modules/rcue/dist/img/bg-login.png") no-repeat left top fixed;
+  background-size: auto;
 }
 
 @media (max-width: 767px) {
@@ -10,4 +10,9 @@
     .login-pf {
       background-color: white;
     }
+}
+@media (min-width: 767px) {
+  .login-pf {
+    background-attachment: fixed;
+  }
 }

--- a/themes/src/main/resources/theme/keycloak/login/resources/css/login.css
+++ b/themes/src/main/resources/theme/keycloak/login/resources/css/login.css
@@ -1,5 +1,5 @@
 .login-pf body {
-    background-image: url("../img/keycloak-bg.png");
+    background: url("../img/keycloak-bg.png") no-repeat center center fixed;
     background-size: cover;
 }
 


### PR DESCRIPTION
Fixed the bug: https://issues.jboss.org/browse/KEYCLOAK-6942
When the content is long enough and the page needs to be scrolled the background is cut off.

<img width="600" alt="screen shot 2018-03-22 at 6 27 52 pm" src="https://user-images.githubusercontent.com/701009/37765393-f6ab6e7e-2dfe-11e8-8e78-8217bafd7c75.png">

@vmuzikar Please help to check this bug.