### PR TITLE
Attaching impersonator details to UserSession notes

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/models/ImpersonationSessionNote.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/ImpersonationSessionNote.java
@@ -1,0 +1,23 @@
+package org.keycloak.models;
+
+/**
+ * Session note metadata for impersonation details stored in user session notes.
+ */
+public enum ImpersonationSessionNote implements UserSessionNoteDescriptor {
+    IMPERSONATOR_ID("Impersonator User ID"),
+    IMPERSONATOR_USERNAME("Impersonator Username");
+
+    final String displayName;
+
+    ImpersonationSessionNote(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public String getTokenClaim() {
+        return this.toString().toLowerCase().replace('_', '.');
+    }
+}

--- a/server-spi-private/src/main/java/org/keycloak/models/UserSessionNoteDescriptor.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/UserSessionNoteDescriptor.java
@@ -1,0 +1,16 @@
+package org.keycloak.models;
+
+/**
+ * Describes a user session note for simple and generic {@link ProtocolMapperModel} creation.
+ */
+public interface UserSessionNoteDescriptor {
+    /**
+     * @return A human-readable name for the session note. This should tell the end user what the session note contains
+     */
+    String getDisplayName();
+
+    /**
+     * @return Token claim name/path to store the user session note value in.
+     */
+    String getTokenClaim();
+}

--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocolFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocolFactory.java
@@ -50,6 +50,9 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import static org.keycloak.models.ImpersonationSessionNote.IMPERSONATOR_ID;
+import static org.keycloak.models.ImpersonationSessionNote.IMPERSONATOR_USERNAME;
+
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
@@ -173,6 +176,9 @@ public class OIDCLoginProtocolFactory extends AbstractLoginProtocolFactory {
 
         model = AllowedWebOriginsProtocolMapper.createClaimMapper(ALLOWED_WEB_ORIGINS);
         builtins.put(ALLOWED_WEB_ORIGINS, model);
+
+        builtins.put(IMPERSONATOR_ID.getDisplayName(), UserSessionNoteMapper.createUserSessionNoteMapper(IMPERSONATOR_ID));
+        builtins.put(IMPERSONATOR_USERNAME.getDisplayName(), UserSessionNoteMapper.createUserSessionNoteMapper(IMPERSONATOR_USERNAME));
     }
 
     private static void createUserAttributeMapper(String name, String attrName, String claimName, String type) {

--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/UserSessionNoteMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/UserSessionNoteMapper.java
@@ -19,6 +19,7 @@ package org.keycloak.protocol.oidc.mappers;
 
 import org.keycloak.models.ProtocolMapperModel;
 import org.keycloak.models.UserSessionModel;
+import org.keycloak.models.UserSessionNoteDescriptor;
 import org.keycloak.protocol.ProtocolMapperUtils;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.provider.ProviderConfigProperty;
@@ -101,4 +102,20 @@ public class UserSessionNoteMapper extends AbstractOIDCProtocolMapper implements
         mapper.setConfig(config);
         return mapper;
     }
+
+    /**
+     * For session notes defined using a {@link UserSessionNoteDescriptor} enum
+     *
+     * @param userSessionNoteDescriptor User session note descriptor for which to create a protocol mapper model.
+     */
+    public static ProtocolMapperModel createUserSessionNoteMapper(UserSessionNoteDescriptor userSessionNoteDescriptor) {
+        return UserSessionNoteMapper.createClaimMapper(
+                userSessionNoteDescriptor.getDisplayName(),
+                userSessionNoteDescriptor.toString(),
+                userSessionNoteDescriptor.getTokenClaim(),
+                "String",
+                true, true
+        );
+    }
+
 }


### PR DESCRIPTION
I found PR's #4813 and #3788 were rejected because of their implementation and no follow up, so I've taken a stab at essentially the same as #4813 but more detailed for our needs.

I'd be happy to populate these in `UserSessionModel` fields that are [persisted if required](https://github.com/keycloak/keycloak/blob/master/misc/UpdatingDatabaseSchema.md), but I'd need a little guidance on how to go about it.

EDIT: ~I've added a small test for the impersonating username and ID in `ClientTokenExchangeTest`, but this seems a little out of place and is missing tests to cover the remote IdP user details. Any suggestions here would be greatly appreciated!~ (dropped those tests)

Apologies for not following the [hacking guide](https://github.com/keycloak/keycloak/blob/master/misc/HackingOnKeycloak.md). I'd like to get us off our fork and back onto mainline keycloak, so if I can get some sort of merge / feature add underway (if at all possible) that'd be a step in the right direction :)