### PR TITLE
[KEYCLOAK-6814] check if HMAC exists during session restart

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/RestartLoginCookie.java
+++ b/services/src/main/java/org/keycloak/protocol/RestartLoginCookie.java
@@ -154,6 +154,10 @@ public class RestartLoginCookie {
         String encodedCookie = cook.getValue();
         JWSInput input = new JWSInput(encodedCookie);
         SecretKey secretKey = session.keys().getHmacSecretKey(realm, input.getHeader().getKeyId());
+        if (secretKey == null) {
+            logger.debug("Failed to retrieve HMAC secret key for session restart");
+            return null;
+        }
         if (!HMACProvider.verify(input, secretKey)) {
             logger.debug("Failed to verify encoded RestartLoginCookie");
             return null;


### PR DESCRIPTION
It's still in question, whether we need to show something more suitable than "We're sorry" in this situation (session restart and HMAC key missing), but this way at least there's no NPE and error's logged in debug output.