### PR TITLE
SLF4J for keycloak-adapter-core module

### DIFF
--- a/adapters/oidc/adapter-core/pom.xml
+++ b/adapters/oidc/adapter-core/pom.xml
@@ -50,9 +50,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>${slf4j.version}</version>
+            <groupId>org.jboss.slf4j</groupId>
+            <artifactId>slf4j-jboss-logging</artifactId>
+            <version>1.1.0.Final</version>
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>

--- a/adapters/oidc/adapter-core/pom.xml
+++ b/adapters/oidc/adapter-core/pom.xml
@@ -50,10 +50,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging</artifactId>
-            <version>${jboss.logging.version}</version>
-            <scope>provided</scope>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>

--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/AdapterDeploymentContext.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/AdapterDeploymentContext.java
@@ -39,7 +39,7 @@ import java.util.Map;
  * @version $Revision: 1 $
  */
 public class AdapterDeploymentContext {
-    private static final Logger log = Logger.getLogger(AdapterDeploymentContext.class);
+    private static final Logger LOG = Logger.getLogger(AdapterDeploymentContext.class);
     protected KeycloakDeployment deployment;
     protected KeycloakConfigResolver configResolver;
 
@@ -491,7 +491,7 @@ public class AdapterDeploymentContext {
         if (deployment.getSslRequired().isRequired(facade.getRequest().getRemoteAddr())) {
             scheme = "https";
             if (!request.getScheme().equals(scheme) && request.getPort() != -1) {
-                log.error("request scheme: " + request.getScheme() + " ssl required");
+                LOG.error("request scheme: " + request.getScheme() + " ssl required");
                 throw new RuntimeException("Can't resolve relative url from adapter config.");
             }
         }

--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/AdapterDeploymentContext.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/AdapterDeploymentContext.java
@@ -19,7 +19,6 @@ package org.keycloak.adapters;
 
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
-import org.jboss.logging.Logger;
 import org.keycloak.adapters.authentication.ClientCredentialsProvider;
 import org.keycloak.adapters.authorization.PolicyEnforcer;
 import org.keycloak.adapters.rotation.PublicKeyLocator;
@@ -29,6 +28,8 @@ import org.keycloak.common.enums.SslRequired;
 import org.keycloak.common.util.KeycloakUriBuilder;
 import org.keycloak.enums.TokenStore;
 import org.keycloak.representations.adapters.config.AdapterConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.URI;
@@ -39,7 +40,7 @@ import java.util.Map;
  * @version $Revision: 1 $
  */
 public class AdapterDeploymentContext {
-    private static final Logger LOG = Logger.getLogger(AdapterDeploymentContext.class);
+    private static final Logger LOG = LoggerFactory.getLogger(AdapterDeploymentContext.class);
     protected KeycloakDeployment deployment;
     protected KeycloakConfigResolver configResolver;
 

--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/AdapterUtils.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/AdapterUtils.java
@@ -30,7 +30,7 @@ import java.util.UUID;
  */
 public class AdapterUtils {
 
-    private static Logger log = Logger.getLogger(AdapterUtils.class);
+    private static final Logger LOG = Logger.getLogger(AdapterUtils.class);
 
     public static String generateId() {
         return UUID.randomUUID().toString();
@@ -40,23 +40,23 @@ public class AdapterUtils {
         Set<String> roles = null;
         AccessToken accessToken = session.getToken();
         if (session.getDeployment().isUseResourceRoleMappings()) {
-            if (log.isTraceEnabled()) {
-                log.trace("useResourceRoleMappings");
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("useResourceRoleMappings");
             }
             AccessToken.Access access = accessToken.getResourceAccess(session.getDeployment().getResourceName());
             if (access != null) roles = access.getRoles();
         } else {
-            if (log.isTraceEnabled()) {
-                log.trace("use realm role mappings");
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("use realm role mappings");
             }
             AccessToken.Access access = accessToken.getRealmAccess();
             if (access != null) roles = access.getRoles();
         }
         if (roles == null) roles = Collections.emptySet();
-        if (log.isTraceEnabled()) {
-            log.trace("Setting roles: ");
+        if (LOG.isTraceEnabled()) {
+            LOG.trace("Setting roles: ");
             for (String role : roles) {
-                log.trace("   role: " + role);
+                LOG.trace("   role: " + role);
             }
         }
         return roles;

--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/AdapterUtils.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/AdapterUtils.java
@@ -17,9 +17,10 @@
 
 package org.keycloak.adapters;
 
-import org.jboss.logging.Logger;
 import org.keycloak.KeycloakPrincipal;
 import org.keycloak.representations.AccessToken;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
 import java.util.Set;
@@ -30,7 +31,7 @@ import java.util.UUID;
  */
 public class AdapterUtils {
 
-    private static final Logger LOG = Logger.getLogger(AdapterUtils.class);
+    private static final Logger LOG = LoggerFactory.getLogger(AdapterUtils.class);
 
     public static String generateId() {
         return UUID.randomUUID().toString();

--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/AuthenticatedActionsHandler.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/AuthenticatedActionsHandler.java
@@ -40,7 +40,7 @@ import java.util.Set;
  * @version $Revision: 1 $
  */
 public class AuthenticatedActionsHandler {
-    private static final Logger log = Logger.getLogger(AuthenticatedActionsHandler.class);
+    private static final Logger LOG = Logger.getLogger(AuthenticatedActionsHandler.class);
     protected KeycloakDeployment deployment;
     protected OIDCHttpFacade facade;
 
@@ -50,7 +50,7 @@ public class AuthenticatedActionsHandler {
     }
 
     public boolean handledRequest() {
-        log.debugv("AuthenticatedActionsValve.invoke {0}", facade.getRequest().getURI());
+        LOG.debugv("AuthenticatedActionsValve.invoke {0}", facade.getRequest().getURI());
         if (corsRequest()) return true;
         String requestUri = facade.getRequest().getURI();
         if (requestUri.endsWith(AdapterConstants.K_QUERY_BEARER_TOKEN)) {
@@ -64,7 +64,7 @@ public class AuthenticatedActionsHandler {
     }
 
     protected void queryBearerToken()  {
-        log.debugv("queryBearerToken {0}",facade.getRequest().getURI());
+        LOG.debugv("queryBearerToken {0}",facade.getRequest().getURI());
         if (abortTokenResponse()) return;
         facade.getResponse().setStatus(200);
         facade.getResponse().setHeader("Content-Type", "text/plain");
@@ -78,7 +78,7 @@ public class AuthenticatedActionsHandler {
 
     protected boolean abortTokenResponse() {
         if (facade.getSecurityContext() == null) {
-            log.debugv("Not logged in, sending back 401: {0}",facade.getRequest().getURI());
+            LOG.debugv("Not logged in, sending back 401: {0}",facade.getRequest().getURI());
             facade.getResponse().sendError(401);
             facade.getResponse().end();
             return true;
@@ -103,25 +103,25 @@ public class AuthenticatedActionsHandler {
         String origin = facade.getRequest().getHeader(CorsHeaders.ORIGIN);
         String exposeHeaders = deployment.getCorsExposedHeaders();
         String requestOrigin = UriUtils.getOrigin(facade.getRequest().getURI());
-        log.debugv("Origin: {0} uri: {1}", origin, facade.getRequest().getURI());
+        LOG.debugv("Origin: {0} uri: {1}", origin, facade.getRequest().getURI());
         if (securityContext != null && origin != null && !origin.equals(requestOrigin)) {
             AccessToken token = securityContext.getToken();
             Set<String> allowedOrigins = token.getAllowedOrigins();
-            if (log.isDebugEnabled()) {
-                for (String a : allowedOrigins) log.debug("   " + a);
+            if (LOG.isDebugEnabled()) {
+                for (String a : allowedOrigins) LOG.debug("   " + a);
             }
             if (allowedOrigins == null || (!allowedOrigins.contains("*") && !allowedOrigins.contains(origin))) {
                 if (allowedOrigins == null) {
-                    log.debugv("allowedOrigins was null in token");
+                    LOG.debugv("allowedOrigins was null in token");
                 } else {
-                    log.debugv("allowedOrigins did not contain origin");
+                    LOG.debugv("allowedOrigins did not contain origin");
 
                 }
                 facade.getResponse().sendError(403);
                 facade.getResponse().end();
                 return true;
             }
-            log.debugv("returning origin: {0}", origin);
+            LOG.debugv("returning origin: {0}", origin);
             facade.getResponse().setStatus(200);
             facade.getResponse().setHeader(CorsHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, origin);
             facade.getResponse().setHeader(CorsHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS, "true");
@@ -129,7 +129,7 @@ public class AuthenticatedActionsHandler {
                 facade.getResponse().setHeader(CorsHeaders.ACCESS_CONTROL_EXPOSE_HEADERS, exposeHeaders);
             }
         } else {
-            log.debugv("cors validation not needed as we're not a secure session or origin header was null: {0}", facade.getRequest().getURI());
+            LOG.debugv("cors validation not needed as we're not a secure session or origin header was null: {0}", facade.getRequest().getURI());
         }
         return false;
     }
@@ -138,7 +138,7 @@ public class AuthenticatedActionsHandler {
         PolicyEnforcer policyEnforcer = this.deployment.getPolicyEnforcer();
 
         if (policyEnforcer == null) {
-            log.debugv("Policy enforcement is disabled.");
+            LOG.debugv("Policy enforcement is disabled.");
             return true;
         }
         try {

--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/BasicAuthRequestAuthenticator.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/BasicAuthRequestAuthenticator.java
@@ -25,7 +25,6 @@ import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
-import org.jboss.logging.Logger;
 import org.keycloak.OAuth2Constants;
 import org.keycloak.adapters.authentication.ClientCredentialsProviderUtils;
 import org.keycloak.adapters.spi.AuthOutcome;
@@ -35,6 +34,8 @@ import org.keycloak.common.util.KeycloakUriBuilder;
 import org.keycloak.constants.ServiceUrlConstants;
 import org.keycloak.representations.AccessTokenResponse;
 import org.keycloak.util.JsonSerialization;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
@@ -42,7 +43,7 @@ import java.util.List;
  * Basic auth request authenticator.
  */
 public class BasicAuthRequestAuthenticator extends BearerTokenRequestAuthenticator {
-    private final static Logger LOG = Logger.getLogger(BasicAuthRequestAuthenticator.class);
+    private final static Logger LOG = LoggerFactory.getLogger(BasicAuthRequestAuthenticator.class);
     
     public BasicAuthRequestAuthenticator(KeycloakDeployment deployment) {
     	super(deployment);

--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/BasicAuthRequestAuthenticator.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/BasicAuthRequestAuthenticator.java
@@ -42,7 +42,7 @@ import java.util.List;
  * Basic auth request authenticator.
  */
 public class BasicAuthRequestAuthenticator extends BearerTokenRequestAuthenticator {
-    protected Logger log = Logger.getLogger(BasicAuthRequestAuthenticator.class);
+    private final static Logger LOG = Logger.getLogger(BasicAuthRequestAuthenticator.class);
     
     public BasicAuthRequestAuthenticator(KeycloakDeployment deployment) {
     	super(deployment);
@@ -77,7 +77,7 @@ public class BasicAuthRequestAuthenticator extends BearerTokenRequestAuthenticat
             atr = getToken(user, pw);
             tokenString = atr.getToken();
         } catch (Exception e) {
-            log.debug("Failed to obtain token", e);
+            LOG.debug("Failed to obtain token", e);
             challenge = challengeResponse(exchange, OIDCAuthenticationError.Reason.INVALID_TOKEN, "no_token", e.getMessage());
             return AuthOutcome.FAILED;
         }

--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/BearerTokenRequestAuthenticator.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/BearerTokenRequestAuthenticator.java
@@ -17,7 +17,6 @@
 
 package org.keycloak.adapters;
 
-import org.jboss.logging.Logger;
 import org.keycloak.adapters.rotation.AdapterRSATokenVerifier;
 import org.keycloak.adapters.spi.AuthChallenge;
 import org.keycloak.adapters.spi.AuthOutcome;
@@ -26,6 +25,8 @@ import org.keycloak.common.VerificationException;
 import org.keycloak.jose.jws.JWSInput;
 import org.keycloak.jose.jws.JWSInputException;
 import org.keycloak.representations.AccessToken;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.security.cert.X509Certificate;
 import java.util.List;
@@ -34,7 +35,7 @@ import java.util.List;
  * @version $Revision: 1 $
  */
 public class BearerTokenRequestAuthenticator {
-    private final static Logger LOG = Logger.getLogger(BearerTokenRequestAuthenticator.class);
+    private final static Logger LOG = LoggerFactory.getLogger(BearerTokenRequestAuthenticator.class);
     protected String tokenString;
     protected AccessToken token;
     protected String surrogate;
@@ -90,9 +91,9 @@ public class BearerTokenRequestAuthenticator {
             try {
                 JWSInput jwsInput = new JWSInput(tokenString);
                 String wireString = jwsInput.getWireString();
-                LOG.tracef("\taccess_token: %s", wireString.substring(0, wireString.lastIndexOf(".")) + ".signature");
+                LOG.trace("\taccess_token: {}", wireString.substring(0, wireString.lastIndexOf(".")) + ".signature");
             } catch (JWSInputException e) {
-                LOG.errorf(e, "Failed to parse access_token: %s", tokenString);
+                LOG.error("Failed to parse access_token: " + tokenString, e);
             }
         }
         try {

--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/BearerTokenRequestAuthenticator.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/BearerTokenRequestAuthenticator.java
@@ -34,7 +34,7 @@ import java.util.List;
  * @version $Revision: 1 $
  */
 public class BearerTokenRequestAuthenticator {
-    protected Logger log = Logger.getLogger(BearerTokenRequestAuthenticator.class);
+    private final static Logger LOG = Logger.getLogger(BearerTokenRequestAuthenticator.class);
     protected String tokenString;
     protected AccessToken token;
     protected String surrogate;
@@ -85,25 +85,25 @@ public class BearerTokenRequestAuthenticator {
     }
     
     protected AuthOutcome authenticateToken(HttpFacade exchange, String tokenString) {
-        log.debug("Verifying access_token");
-        if (log.isTraceEnabled()) {
+        LOG.debug("Verifying access_token");
+        if (LOG.isTraceEnabled()) {
             try {
                 JWSInput jwsInput = new JWSInput(tokenString);
                 String wireString = jwsInput.getWireString();
-                log.tracef("\taccess_token: %s", wireString.substring(0, wireString.lastIndexOf(".")) + ".signature");
+                LOG.tracef("\taccess_token: %s", wireString.substring(0, wireString.lastIndexOf(".")) + ".signature");
             } catch (JWSInputException e) {
-                log.errorf(e, "Failed to parse access_token: %s", tokenString);
+                LOG.errorf(e, "Failed to parse access_token: %s", tokenString);
             }
         }
         try {
             token = AdapterRSATokenVerifier.verifyToken(tokenString, deployment);
         } catch (VerificationException e) {
-            log.error("Failed to verify token", e);
+            LOG.error("Failed to verify token", e);
             challenge = challengeResponse(exchange, OIDCAuthenticationError.Reason.INVALID_TOKEN, "invalid_token", e.getMessage());
             return AuthOutcome.FAILED;
         }
         if (token.getIssuedAt() < deployment.getNotBefore()) {
-            log.error("Stale token");
+            LOG.error("Stale token");
             challenge = challengeResponse(exchange,  OIDCAuthenticationError.Reason.STALE_TOKEN, "invalid_token", "Stale token");
             return AuthOutcome.FAILED;
         }
@@ -116,7 +116,7 @@ public class BearerTokenRequestAuthenticator {
         surrogate = null;
         if (verifyCaller) {
             if (token.getTrustedCertificates() == null || token.getTrustedCertificates().size() == 0) {
-                log.warn("No trusted certificates in token");
+                LOG.warn("No trusted certificates in token");
                 challenge = clientCertChallenge();
                 return AuthOutcome.FAILED;
             }
@@ -130,13 +130,13 @@ public class BearerTokenRequestAuthenticator {
 
             }
             if (chain == null || chain.length == 0) {
-                log.warn("No certificates provided by undertow to verify the caller");
+                LOG.warn("No certificates provided by undertow to verify the caller");
                 challenge = clientCertChallenge();
                 return AuthOutcome.FAILED;
             }
             surrogate = chain[0].getSubjectDN().getName();
         }
-        log.debug("successful authorized");
+        LOG.debug("successful authorized");
         return AuthOutcome.AUTHENTICATED;
     }
 

--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/CookieTokenStore.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/CookieTokenStore.java
@@ -17,7 +17,6 @@
 
 package org.keycloak.adapters;
 
-import org.jboss.logging.Logger;
 import org.keycloak.KeycloakPrincipal;
 import org.keycloak.adapters.rotation.AdapterRSATokenVerifier;
 import org.keycloak.adapters.spi.HttpFacade;
@@ -28,17 +27,19 @@ import org.keycloak.jose.jws.JWSInput;
 import org.keycloak.jose.jws.JWSInputException;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.IDToken;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
  */
 public class CookieTokenStore {
 
-    private static final Logger LOG = Logger.getLogger(CookieTokenStore.class);
+    private static final Logger LOG = LoggerFactory.getLogger(CookieTokenStore.class);
     private static final String DELIM = "___";
 
     public static void setTokenCookie(KeycloakDeployment deployment, HttpFacade facade, RefreshableKeycloakSecurityContext session) {
-        LOG.debugf("Set new %s cookie now", AdapterConstants.KEYCLOAK_ADAPTER_STATE_COOKIE);
+        LOG.debug("Set new {} cookie now", AdapterConstants.KEYCLOAK_ADAPTER_STATE_COOKIE);
         String accessToken = session.getTokenString();
         String idToken = session.getIdTokenString();
         String refreshToken = session.getRefreshToken();
@@ -61,7 +62,7 @@ public class CookieTokenStore {
 
         String[] tokens = cookieVal.split(DELIM);
         if (tokens.length != 3) {
-            LOG.warnf("Invalid format of %s cookie. Count of tokens: %s, expected 3", AdapterConstants.KEYCLOAK_ADAPTER_STATE_COOKIE, tokens.length);
+            LOG.warn("Invalid format of {} cookie. Count of tokens: {}, expected 3", AdapterConstants.KEYCLOAK_ADAPTER_STATE_COOKIE, tokens.length);
             return null;
         }
 

--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/CookieTokenStore.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/CookieTokenStore.java
@@ -34,11 +34,11 @@ import org.keycloak.representations.IDToken;
  */
 public class CookieTokenStore {
 
-    private static final Logger log = Logger.getLogger(CookieTokenStore.class);
+    private static final Logger LOG = Logger.getLogger(CookieTokenStore.class);
     private static final String DELIM = "___";
 
     public static void setTokenCookie(KeycloakDeployment deployment, HttpFacade facade, RefreshableKeycloakSecurityContext session) {
-        log.debugf("Set new %s cookie now", AdapterConstants.KEYCLOAK_ADAPTER_STATE_COOKIE);
+        LOG.debugf("Set new %s cookie now", AdapterConstants.KEYCLOAK_ADAPTER_STATE_COOKIE);
         String accessToken = session.getTokenString();
         String idToken = session.getIdTokenString();
         String refreshToken = session.getRefreshToken();
@@ -53,7 +53,7 @@ public class CookieTokenStore {
     public static KeycloakPrincipal<RefreshableKeycloakSecurityContext> getPrincipalFromCookie(KeycloakDeployment deployment, HttpFacade facade, AdapterTokenStore tokenStore) {
         OIDCHttpFacade.Cookie cookie = facade.getRequest().getCookie(AdapterConstants.KEYCLOAK_ADAPTER_STATE_COOKIE);
         if (cookie == null) {
-            log.debug("Not found adapter state cookie in current request");
+            LOG.debug("Not found adapter state cookie in current request");
             return null;
         }
 
@@ -61,7 +61,7 @@ public class CookieTokenStore {
 
         String[] tokens = cookieVal.split(DELIM);
         if (tokens.length != 3) {
-            log.warnf("Invalid format of %s cookie. Count of tokens: %s, expected 3", AdapterConstants.KEYCLOAK_ADAPTER_STATE_COOKIE, tokens.length);
+            LOG.warnf("Invalid format of %s cookie. Count of tokens: %s, expected 3", AdapterConstants.KEYCLOAK_ADAPTER_STATE_COOKIE, tokens.length);
             return null;
         }
 
@@ -84,11 +84,11 @@ public class CookieTokenStore {
                 idToken = null;
             }
 
-            log.debug("Token Verification succeeded!");
+            LOG.debug("Token Verification succeeded!");
             RefreshableKeycloakSecurityContext secContext = new RefreshableKeycloakSecurityContext(deployment, tokenStore, accessTokenString, accessToken, idTokenString, idToken, refreshTokenString);
             return new KeycloakPrincipal<RefreshableKeycloakSecurityContext>(AdapterUtils.getPrincipalName(deployment, accessToken), secContext);
         } catch (VerificationException ve) {
-            log.warn("Failed verify token", ve);
+            LOG.warn("Failed verify token", ve);
             return null;
         }
     }

--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/KeycloakDeployment.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/KeycloakDeployment.java
@@ -18,7 +18,6 @@
 package org.keycloak.adapters;
 
 import org.apache.http.client.HttpClient;
-import org.jboss.logging.Logger;
 import org.keycloak.adapters.authentication.ClientCredentialsProvider;
 import org.keycloak.adapters.authorization.PolicyEnforcer;
 import org.keycloak.adapters.rotation.PublicKeyLocator;
@@ -28,6 +27,8 @@ import org.keycloak.common.util.KeycloakUriBuilder;
 import org.keycloak.constants.ServiceUrlConstants;
 import org.keycloak.enums.TokenStore;
 import org.keycloak.representations.adapters.config.AdapterConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.net.URI;
 import java.util.HashMap;
@@ -41,7 +42,7 @@ import java.util.Map;
  */
 public class KeycloakDeployment {
 
-    private static final Logger log = Logger.getLogger(KeycloakDeployment.class);
+    private static final Logger LOG = LoggerFactory.getLogger(KeycloakDeployment.class);
 
     protected RelativeUrlsUsed relativeUrls;
     protected String realm;
@@ -150,8 +151,8 @@ public class KeycloakDeployment {
      * @param authUrlBuilder absolute URI
      */
     protected void resolveUrls(KeycloakUriBuilder authUrlBuilder) {
-        if (log.isDebugEnabled()) {
-            log.debug("resolveUrls");
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("resolveUrls");
         }
 
         authServerBaseUrl = authUrlBuilder.build().toString();

--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/KeycloakDeploymentBuilder.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/KeycloakDeploymentBuilder.java
@@ -19,7 +19,6 @@ package org.keycloak.adapters;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.jboss.logging.Logger;
 import org.keycloak.adapters.authentication.ClientCredentialsProviderUtils;
 import org.keycloak.adapters.authorization.PolicyEnforcer;
 import org.keycloak.adapters.rotation.HardcodedPublicKeyLocator;
@@ -30,6 +29,8 @@ import org.keycloak.enums.TokenStore;
 import org.keycloak.representations.adapters.config.AdapterConfig;
 import org.keycloak.representations.adapters.config.PolicyEnforcerConfig;
 import org.keycloak.util.SystemPropertiesJsonParserFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -43,7 +44,7 @@ import java.security.PublicKey;
  */
 public class KeycloakDeploymentBuilder {
 
-    private static final Logger log = Logger.getLogger(KeycloakDeploymentBuilder.class);
+    private static final Logger LOG = LoggerFactory.getLogger(KeycloakDeploymentBuilder.class);
 
     protected KeycloakDeployment deployment = new KeycloakDeployment();
 
@@ -143,7 +144,7 @@ public class KeycloakDeploymentBuilder {
             deployment.setPolicyEnforcer(new PolicyEnforcer(deployment, adapterConfig));
         }
 
-        log.debug("Use authServerUrl: " + deployment.getAuthServerBaseUrl() + ", tokenUrl: " + deployment.getTokenUrl() + ", relativeUrls: " + deployment.getRelativeUrls());
+        LOG.debug("Use authServerUrl: " + deployment.getAuthServerBaseUrl() + ", tokenUrl: " + deployment.getTokenUrl() + ", relativeUrls: " + deployment.getRelativeUrls());
         return deployment;
     }
 

--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/NodesRegistrationManagement.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/NodesRegistrationManagement.java
@@ -17,9 +17,10 @@
 
 package org.keycloak.adapters;
 
-import org.jboss.logging.Logger;
 import org.keycloak.common.util.HostUtils;
 import org.keycloak.common.util.Time;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -33,7 +34,7 @@ import java.util.concurrent.Executors;
  */
 public class NodesRegistrationManagement {
 
-    private static final Logger log = Logger.getLogger(NodesRegistrationManagement.class);
+    private static final Logger LOG = LoggerFactory.getLogger(NodesRegistrationManagement.class);
 
     private final Map<String, NodeRegistrationContext> nodeRegistrations = new ConcurrentHashMap<String, NodeRegistrationContext>();
     private final Executor executor = Executors.newSingleThreadExecutor();
@@ -79,42 +80,42 @@ public class NodesRegistrationManagement {
     }
 
     protected void sendRegistrationEvent(KeycloakDeployment deployment) {
-        log.debug("Sending registration event right now");
+        LOG.debug("Sending registration event right now");
 
         String host = HostUtils.getHostName();
         try {
             ServerRequest.invokeRegisterNode(deployment, host);
             NodeRegistrationContext regContext = new NodeRegistrationContext(Time.currentTime(), deployment);
             nodeRegistrations.put(deployment.getRegisterNodeUrl(), regContext);
-            log.debugf("Node '%s' successfully registered in Keycloak", host);
+            LOG.debug("Node '{}' successfully registered in Keycloak", host);
         } catch (ServerRequest.HttpFailure failure) {
-            log.error("failed to register node to keycloak");
-            log.error("status from server: " + failure.getStatus());
+            LOG.error("failed to register node to keycloak");
+            LOG.error("status from server: " + failure.getStatus());
             if (failure.getError() != null) {
-                log.error("   " + failure.getError());
+                LOG.error("   " + failure.getError());
             }
         } catch (IOException e) {
-            log.error("failed to register node to keycloak", e);
+            LOG.error("failed to register node to keycloak", e);
         }
     }
 
     protected boolean sendUnregistrationEvent(KeycloakDeployment deployment) {
-        log.debug("Sending Unregistration event right now");
+        LOG.debug("Sending Unregistration event right now");
 
         String host = HostUtils.getHostName();
         try {
             ServerRequest.invokeUnregisterNode(deployment, host);
-            log.debugf("Node '%s' successfully unregistered from Keycloak", host);
+            LOG.debug("Node '{}' successfully unregistered from Keycloak", host);
             return true;
         } catch (ServerRequest.HttpFailure failure) {
-            log.error("failed to unregister node from keycloak");
-            log.error("status from server: " + failure.getStatus());
+            LOG.error("failed to unregister node from keycloak");
+            LOG.error("status from server: " + failure.getStatus());
             if (failure.getError() != null) {
-                log.error("   " + failure.getError());
+                LOG.error("   " + failure.getError());
             }
             return false;
         } catch (IOException e) {
-            log.error("failed to unregister node from keycloak", e);
+            LOG.error("failed to unregister node from keycloak", e);
             return false;
         }
     }

--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/OAuthRequestAuthenticator.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/OAuthRequestAuthenticator.java
@@ -17,7 +17,6 @@
 
 package org.keycloak.adapters;
 
-import org.jboss.logging.Logger;
 import org.keycloak.OAuth2Constants;
 import org.keycloak.adapters.rotation.AdapterRSATokenVerifier;
 import org.keycloak.adapters.spi.AdapterSessionStore;
@@ -35,12 +34,13 @@ import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.AccessTokenResponse;
 import org.keycloak.representations.IDToken;
 import org.keycloak.util.TokenUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Map;
-import java.util.logging.Level;
 
 
 /**
@@ -48,7 +48,7 @@ import java.util.logging.Level;
  * @version $Revision: 1 $
  */
 public class OAuthRequestAuthenticator {
-    private static final Logger log = Logger.getLogger(OAuthRequestAuthenticator.class);
+    private static final Logger LOG = LoggerFactory.getLogger(OAuthRequestAuthenticator.class);
     protected KeycloakDeployment deployment;
     protected RequestAuthenticator reqAuthenticator;
     protected int sslRedirectPort;
@@ -142,7 +142,7 @@ public class OAuthRequestAuthenticator {
 
     protected String getRedirectUri(String state) {
         String url = getRequestUrl();
-        log.debugf("callback uri: %s", url);
+        LOG.debug("callback uri: {}", url);
       
         if (!facade.getRequest().isSecure() && deployment.getSslRequired().isRequired(facade.getRequest().getRemoteAddr())) {
             int port = sslRedirectPort();
@@ -225,7 +225,7 @@ public class OAuthRequestAuthenticator {
             @Override
             public boolean challenge(HttpFacade exchange) {
                 tokenStore.saveRequest();
-                log.debug("Sending redirect to login page: " + redirect);
+                LOG.debug("Sending redirect to login page: " + redirect);
                 exchange.getResponse().setStatus(302);
                 exchange.getResponse().setCookie(deployment.getStateCookieName(), state, /* need to set path? */ null, null, -1, deployment.getSslRequired().isRequired(facade.getRequest().getRemoteAddr()), true);
                 exchange.getResponse().setHeader("Location", redirect);
@@ -238,23 +238,23 @@ public class OAuthRequestAuthenticator {
         OIDCHttpFacade.Cookie stateCookie = getCookie(deployment.getStateCookieName());
 
         if (stateCookie == null) {
-            log.warn("No state cookie");
+            LOG.warn("No state cookie");
             return challenge(400, OIDCAuthenticationError.Reason.INVALID_STATE_COOKIE, null);
         }
         // reset the cookie
-        log.debug("** reseting application state cookie");
+        LOG.debug("** reseting application state cookie");
         facade.getResponse().resetCookie(deployment.getStateCookieName(), stateCookie.getPath());
         String stateCookieValue = getCookieValue(deployment.getStateCookieName());
 
         String state = getQueryParamValue(OAuth2Constants.STATE);
         if (state == null) {
-            log.warn("state parameter was null");
+            LOG.warn("state parameter was null");
             return challenge(400, OIDCAuthenticationError.Reason.INVALID_STATE_COOKIE, null);
         }
         if (!state.equals(stateCookieValue)) {
-            log.warn("state parameter invalid");
-            log.warn("cookie: " + stateCookieValue);
-            log.warn("queryParam: " + state);
+            LOG.warn("state parameter invalid");
+            LOG.warn("cookie: " + stateCookieValue);
+            LOG.warn("queryParam: " + state);
             return challenge(400, OIDCAuthenticationError.Reason.INVALID_STATE_COOKIE, null);
         }
         return null;
@@ -264,20 +264,20 @@ public class OAuthRequestAuthenticator {
     public AuthOutcome authenticate() {
         String code = getCode();
         if (code == null) {
-            log.debug("there was no code");
+            LOG.debug("there was no code");
             String error = getError();
             if (error != null) {
                 // todo how do we send a response?
-                log.warn("There was an error: " + error);
+                LOG.warn("There was an error: " + error);
                 challenge = challenge(400, OIDCAuthenticationError.Reason.OAUTH_ERROR, error);
                 return AuthOutcome.FAILED;
             } else {
-                log.debug("redirecting to auth server");
+                LOG.debug("redirecting to auth server");
                 challenge = loginRedirect();
                 return AuthOutcome.NOT_ATTEMPTED;
             }
         } else {
-            log.debug("there was a code, resolving");
+            LOG.debug("there was a code, resolving");
             challenge = resolveCode(code);
             if (challenge != null) {
                 return AuthOutcome.FAILED;
@@ -319,11 +319,11 @@ public class OAuthRequestAuthenticator {
     protected AuthChallenge resolveCode(String code) {
         // abort if not HTTPS
         if (!isRequestSecure() && deployment.getSslRequired().isRequired(facade.getRequest().getRemoteAddr())) {
-            log.error("Adapter requires SSL. Request: " + facade.getRequest().getURI());
+            LOG.error("Adapter requires SSL. Request: " + facade.getRequest().getURI());
             return challenge(403, OIDCAuthenticationError.Reason.SSL_REQUIRED, null);
         }
 
-        log.debug("checking state cookie for after code");
+        LOG.debug("checking state cookie for after code");
         AuthChallenge challenge = checkStateCookie();
         if (challenge != null) return challenge;
 
@@ -335,15 +335,15 @@ public class OAuthRequestAuthenticator {
             String httpSessionId = deployment.getTokenStore() == TokenStore.SESSION ? reqAuthenticator.changeHttpSessionId(true) : null;
             tokenResponse = ServerRequest.invokeAccessCodeToToken(deployment, code, rewrittenRedirectUri(strippedOauthParametersRequestUri), httpSessionId);
         } catch (ServerRequest.HttpFailure failure) {
-            log.error("failed to turn code into token");
-            log.error("status from server: " + failure.getStatus());
+            LOG.error("failed to turn code into token");
+            LOG.error("status from server: " + failure.getStatus());
             if (failure.getError() != null) {
-                log.error("   " + failure.getError());
+                LOG.error("   " + failure.getError());
             }
             return challenge(403, OIDCAuthenticationError.Reason.CODE_TO_TOKEN_FAILURE, null);
 
         } catch (IOException e) {
-            log.error("failed to turn code into token", e);
+            LOG.error("failed to turn code into token", e);
             return challenge(403, OIDCAuthenticationError.Reason.CODE_TO_TOKEN_FAILURE, null);
         }
 
@@ -351,8 +351,8 @@ public class OAuthRequestAuthenticator {
         refreshToken = tokenResponse.getRefreshToken();
         idTokenString = tokenResponse.getIdToken();
 
-        log.debug("Verifying tokens");
-        if (log.isTraceEnabled()) {
+        LOG.debug("Verifying tokens");
+        if (LOG.isTraceEnabled()) {
             logToken("\taccess_token", tokenString);
             logToken("\tid_token", idTokenString);
             logToken("\trefresh_token", refreshToken);
@@ -368,19 +368,19 @@ public class OAuthRequestAuthenticator {
                     throw new VerificationException();
                 }
             }
-            log.debug("Token Verification succeeded!");
+            LOG.debug("Token Verification succeeded!");
         } catch (VerificationException e) {
-            log.error("failed verification of token: " + e.getMessage());
+            LOG.error("failed verification of token: " + e.getMessage());
             return challenge(403, OIDCAuthenticationError.Reason.INVALID_TOKEN, null);
         }
         if (tokenResponse.getNotBeforePolicy() > deployment.getNotBefore()) {
             deployment.updateNotBefore(tokenResponse.getNotBeforePolicy());
         }
         if (token.getIssuedAt() < deployment.getNotBefore()) {
-            log.error("Stale token");
+            LOG.error("Stale token");
             return challenge(403, OIDCAuthenticationError.Reason.STALE_TOKEN, null);
         }
-        log.debug("successful authenticated");
+        LOG.debug("successful authenticated");
         return null;
     }
 
@@ -406,7 +406,7 @@ public class OAuthRequestAuthenticator {
                 redirectUriBuilder.append(url.getPath().replaceFirst(rule.getKey(), rule.getValue()));
                 return redirectUriBuilder.toString();
             } catch (MalformedURLException ex) {
-                log.error("Not a valid request url");
+                LOG.error("Not a valid request url");
                 throw new RuntimeException(ex);
             }
             }
@@ -417,9 +417,9 @@ public class OAuthRequestAuthenticator {
         try {
             JWSInput jwsInput = new JWSInput(token);
             String wireString = jwsInput.getWireString();
-            log.tracef("\t%s: %s", name, wireString.substring(0, wireString.lastIndexOf(".")) + ".signature");
+            LOG.trace("\t{}: {}", name, wireString.substring(0, wireString.lastIndexOf(".")) + ".signature");
         } catch (JWSInputException e) {
-            log.errorf(e, "Failed to parse %s: %s", name, token);
+            LOG.error("Failed to parse " + name + ": " + token, e);
         }
     }
 }

--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/QueryParamterTokenRequestAuthenticator.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/QueryParamterTokenRequestAuthenticator.java
@@ -16,7 +16,6 @@
  */
 package org.keycloak.adapters;
 
-import org.jboss.logging.Logger;
 import org.keycloak.adapters.spi.AuthOutcome;
 import org.keycloak.adapters.spi.HttpFacade;
 
@@ -28,7 +27,6 @@ import org.keycloak.adapters.spi.HttpFacade;
  */
 public class QueryParamterTokenRequestAuthenticator extends BearerTokenRequestAuthenticator {
     public static final String ACCESS_TOKEN = "access_token";
-    protected Logger log = Logger.getLogger(QueryParamterTokenRequestAuthenticator.class);
 
     public QueryParamterTokenRequestAuthenticator(KeycloakDeployment deployment) {
         super(deployment);

--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/ServerRequest.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/ServerRequest.java
@@ -32,8 +32,8 @@ import org.keycloak.common.util.StreamUtil;
 import org.keycloak.constants.AdapterConstants;
 import org.keycloak.representations.AccessTokenResponse;
 import org.keycloak.util.JsonSerialization;
-
-import org.jboss.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -48,7 +48,7 @@ import java.util.List;
  */
 public class ServerRequest {
 
-	private static Logger logger = Logger.getLogger(ServerRequest.class);
+	private final static Logger LOG = LoggerFactory.getLogger(ServerRequest.class);
 
     public static class HttpFailure extends Exception {
         private int status;
@@ -153,10 +153,10 @@ public class ServerRequest {
         }
         // https://tools.ietf.org/html/rfc7636#section-4
         if (codeVerifier != null) {
-            logger.debugf("add to POST parameters of Token Request, codeVerifier = %s", codeVerifier);
+            LOG.debug("add to POST parameters of Token Request, codeVerifier = {}", codeVerifier);
             formparams.add(new BasicNameValuePair(OAuth2Constants.CODE_VERIFIER, codeVerifier));
         } else {
-            logger.debug("add to POST parameters of Token Request without codeVerifier");
+            LOG.debug("add to POST parameters of Token Request without codeVerifier");
         }
 
         HttpPost post = new HttpPost(deployment.getTokenUrl());

--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/SniSSLSocketFactory.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/SniSSLSocketFactory.java
@@ -23,6 +23,8 @@ import org.apache.http.conn.ssl.SSLSocketFactory;
 import org.apache.http.conn.ssl.TrustStrategy;
 import org.apache.http.conn.ssl.X509HostnameVerifier;
 import org.apache.http.protocol.HttpContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocket;
@@ -38,15 +40,13 @@ import java.security.NoSuchAlgorithmException;
 import java.security.PrivilegedExceptionAction;
 import java.security.SecureRandom;
 import java.security.UnrecoverableKeyException;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * @author <a href="mailto:mstrukel@redhat.com">Marko Strukelj</a>
  */
 public class SniSSLSocketFactory extends SSLSocketFactory {
 
-    private static Logger log = Logger.getLogger(SniSSLSocketFactory.class.getName());
+    private final static Logger LOG = LoggerFactory.getLogger(SniSSLSocketFactory.class);
 
     public SniSSLSocketFactory(String algorithm, KeyStore keystore, String keyPassword, KeyStore truststore, SecureRandom random, HostNameResolver nameResolver) throws NoSuchAlgorithmException, KeyManagementException, KeyStoreException, UnrecoverableKeyException {
         super(algorithm, keystore, keyPassword, truststore, random, nameResolver);
@@ -124,9 +124,9 @@ public class SniSSLSocketFactory extends SSLSocketFactory {
                 });
 
                 setHostMethod.invoke(socket, hostname);
-                log.finest("Applied SNI to socket for: " + hostname);
+                LOG.trace("Applied SNI to socket for: " + hostname);
             } catch (Exception e) {
-                log.log(Level.WARNING, "Failed to apply SNI to SSLSocket", e);
+                LOG.warn("Failed to apply SNI to SSLSocket", e);
             }
         }
         return socket;

--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/authentication/ClientCredentialsProviderUtils.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/authentication/ClientCredentialsProviderUtils.java
@@ -20,8 +20,9 @@ package org.keycloak.adapters.authentication;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.message.BasicNameValuePair;
-import org.jboss.logging.Logger;
 import org.keycloak.adapters.KeycloakDeployment;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Iterator;
@@ -35,7 +36,7 @@ import java.util.ServiceLoader;
  */
 public class ClientCredentialsProviderUtils {
 
-    private static Logger logger = Logger.getLogger(ClientCredentialsProviderUtils.class);
+    private static Logger LOG = LoggerFactory.getLogger(ClientCredentialsProviderUtils.class);
 
     public static ClientCredentialsProvider bootstrapClientAuthenticator(KeycloakDeployment deployment) {
         String clientId = deployment.getResourceName();
@@ -56,7 +57,7 @@ public class ClientCredentialsProviderUtils {
             }
         }
 
-        logger.debugf("Using provider '%s' for authentication of client '%s'", authenticatorId, clientId);
+        LOG.debug("Using provider '{}' for authentication of client '{}'", authenticatorId, clientId);
 
         Map<String, ClientCredentialsProvider> authenticators = new HashMap<>();
         loadAuthenticators(authenticators, ClientCredentialsProviderUtils.class.getClassLoader());
@@ -78,11 +79,11 @@ public class ClientCredentialsProviderUtils {
         while (iterator.hasNext()) {
             try {
                 ClientCredentialsProvider authenticator = iterator.next();
-                logger.debugf("Loaded clientCredentialsProvider %s", authenticator.getId());
+                LOG.debug("Loaded clientCredentialsProvider {}", authenticator.getId());
                 authenticators.put(authenticator.getId(), authenticator);
             } catch (ServiceConfigurationError e) {
-                if (logger.isDebugEnabled()) {
-                    logger.debug("Failed to load clientCredentialsProvider with classloader: " + classLoader, e);
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Failed to load clientCredentialsProvider with classloader: " + classLoader, e);
                 }
             }
         }

--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/authentication/ClientIdAndSecretCredentialsProvider.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/authentication/ClientIdAndSecretCredentialsProvider.java
@@ -17,11 +17,12 @@
 
 package org.keycloak.adapters.authentication;
 
-import org.jboss.logging.Logger;
 import org.keycloak.OAuth2Constants;
 import org.keycloak.adapters.KeycloakDeployment;
 import org.keycloak.representations.idm.CredentialRepresentation;
 import org.keycloak.util.BasicAuthHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 
@@ -32,7 +33,7 @@ import java.util.Map;
  */
 public class ClientIdAndSecretCredentialsProvider implements ClientCredentialsProvider {
 
-    private static Logger logger = Logger.getLogger(ClientIdAndSecretCredentialsProvider.class);
+    private static Logger LOG = LoggerFactory.getLogger(ClientIdAndSecretCredentialsProvider.class);
 
     public static final String PROVIDER_ID = CredentialRepresentation.SECRET;
 
@@ -57,7 +58,7 @@ public class ClientIdAndSecretCredentialsProvider implements ClientCredentialsPr
                 String authorization = BasicAuthHelper.createHeader(clientId, clientSecret);
                 requestHeaders.put("Authorization", authorization);
             } else {
-                logger.warnf("Client '%s' doesn't have secret available", clientId);
+                LOG.warn("Client '{}' doesn't have secret available", clientId);
             }
         } else {
             formParams.put(OAuth2Constants.CLIENT_ID, clientId);

--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/authentication/JWTClientCredentialsProvider.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/authentication/JWTClientCredentialsProvider.java
@@ -17,23 +17,18 @@
 
 package org.keycloak.adapters.authentication;
 
-import java.security.KeyPair;
-import java.security.PublicKey;
-import java.util.Map;
-
 import org.keycloak.OAuth2Constants;
 import org.keycloak.adapters.AdapterUtils;
 import org.keycloak.adapters.KeycloakDeployment;
+import org.keycloak.common.util.KeystoreUtil;
+import org.keycloak.common.util.Time;
 import org.keycloak.jose.jwk.JWK;
 import org.keycloak.jose.jwk.JWKBuilder;
 import org.keycloak.jose.jws.JWSBuilder;
 import org.keycloak.representations.JsonWebToken;
-import org.keycloak.common.util.KeystoreUtil;
-import org.keycloak.common.util.Time;
-import org.keycloak.jose.jws.JWSBuilder;
-import org.keycloak.representations.JsonWebToken;
 
-import java.security.PrivateKey;
+import java.security.KeyPair;
+import java.security.PublicKey;
 import java.util.Map;
 
 /**

--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/authentication/JWTClientSecretCredentialsProvider.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/authentication/JWTClientSecretCredentialsProvider.java
@@ -1,19 +1,16 @@
 package org.keycloak.adapters.authentication;
 
-import java.io.UnsupportedEncodingException;
-import java.util.Map;
-
-import javax.crypto.SecretKey;
-import javax.crypto.spec.SecretKeySpec;
-
-import org.jboss.logging.Logger;
 import org.keycloak.OAuth2Constants;
 import org.keycloak.adapters.AdapterUtils;
 import org.keycloak.adapters.KeycloakDeployment;
 import org.keycloak.common.util.Time;
 import org.keycloak.jose.jws.JWSBuilder;
-import org.keycloak.jose.jws.JWSInput;
 import org.keycloak.representations.JsonWebToken;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.io.UnsupportedEncodingException;
+import java.util.Map;
 
 /**
  * Client authentication based on JWT signed by client secret instead of private key .
@@ -23,8 +20,6 @@ import org.keycloak.representations.JsonWebToken;
  */
 public class JWTClientSecretCredentialsProvider implements ClientCredentialsProvider {
     
-	private static final Logger logger = Logger.getLogger(JWTClientSecretCredentialsProvider.class);
-	
     public static final String PROVIDER_ID = "secret-jwt";
     
     private SecretKey clientSecret;

--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/authorization/AbstractPolicyEnforcer.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/authorization/AbstractPolicyEnforcer.java
@@ -17,12 +17,6 @@
  */
 package org.keycloak.adapters.authorization;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import org.jboss.logging.Logger;
 import org.keycloak.AuthorizationContext;
 import org.keycloak.KeycloakSecurityContext;
 import org.keycloak.adapters.OIDCHttpFacade;
@@ -35,13 +29,20 @@ import org.keycloak.representations.adapters.config.PolicyEnforcerConfig.Enforce
 import org.keycloak.representations.adapters.config.PolicyEnforcerConfig.MethodConfig;
 import org.keycloak.representations.adapters.config.PolicyEnforcerConfig.PathConfig;
 import org.keycloak.representations.idm.authorization.Permission;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
  */
 public abstract class AbstractPolicyEnforcer {
 
-    private static Logger LOGGER = Logger.getLogger(AbstractPolicyEnforcer.class);
+    private static Logger LOG = LoggerFactory.getLogger(AbstractPolicyEnforcer.class);
     private final PolicyEnforcerConfig enforcerConfig;
     private final PolicyEnforcer policyEnforcer;
 
@@ -79,14 +80,14 @@ public abstract class AbstractPolicyEnforcer {
         AccessToken accessToken = securityContext.getToken();
 
         if (accessToken != null) {
-            LOGGER.debugf("Checking permissions for path [%s] with config [%s].", request.getURI(), pathConfig);
+            LOG.debug("Checking permissions for path [{}] with config [{}].", request.getURI(), pathConfig);
 
             if (pathConfig == null) {
                 if (EnforcementMode.PERMISSIVE.equals(enforcementMode)) {
                     return createAuthorizationContext(accessToken, null);
                 }
 
-                LOGGER.debugf("Could not find a configuration for path [%s]", path);
+                LOG.debug("Could not find a configuration for path [{}]", path);
 
                 if (isDefaultAccessDeniedUri(request, enforcerConfig)) {
                     return createAuthorizationContext(accessToken, null);
@@ -111,10 +112,10 @@ public abstract class AbstractPolicyEnforcer {
                 }
             }
 
-            LOGGER.debugf("Sending challenge to the client. Path [%s]", pathConfig);
+            LOG.debug("Sending challenge to the client. Path [{}]", pathConfig);
 
             if (!challenge(pathConfig, methodConfig, httpFacade)) {
-                LOGGER.debugf("Challenge not sent, sending default forbidden response. Path [%s]", pathConfig);
+                LOG.debug("Challenge not sent, sending default forbidden response. Path [{}]", pathConfig);
                 handleAccessDenied(httpFacade);
             }
         }
@@ -151,7 +152,7 @@ public abstract class AbstractPolicyEnforcer {
                     }
 
                     if (hasResourceScopePermission(methodConfig, permission)) {
-                        LOGGER.debugf("Authorization GRANTED for path [%s]. Permissions [%s].", actualPathConfig, permissions);
+                        LOG.debug("Authorization GRANTED for path [{}]. Permissions [{}].", actualPathConfig, permissions);
                         if (request.getMethod().equalsIgnoreCase("DELETE") && actualPathConfig.isInstance()) {
                             this.paths.remove(actualPathConfig);
                         }
@@ -170,7 +171,7 @@ public abstract class AbstractPolicyEnforcer {
             return true;
         }
 
-        LOGGER.debugf("Authorization FAILED for path [%s]. Not enough permissions [%s].", actualPathConfig, permissions);
+        LOG.debug("Authorization FAILED for path [{}]. Not enough permissions [{}].", actualPathConfig, permissions);
 
         return false;
     }

--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/authorization/BearerTokenPolicyEnforcer.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/authorization/BearerTokenPolicyEnforcer.java
@@ -17,9 +17,6 @@
  */
 package org.keycloak.adapters.authorization;
 
-import java.util.HashSet;
-
-import org.jboss.logging.Logger;
 import org.keycloak.adapters.OIDCHttpFacade;
 import org.keycloak.adapters.spi.HttpFacade;
 import org.keycloak.authorization.client.AuthzClient;
@@ -28,13 +25,17 @@ import org.keycloak.authorization.client.resource.ProtectionResource;
 import org.keycloak.representations.adapters.config.PolicyEnforcerConfig;
 import org.keycloak.representations.adapters.config.PolicyEnforcerConfig.PathConfig;
 import org.keycloak.representations.idm.authorization.PermissionRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashSet;
 
 /**
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
  */
 public class BearerTokenPolicyEnforcer extends AbstractPolicyEnforcer {
 
-    private static Logger LOGGER = Logger.getLogger(BearerTokenPolicyEnforcer.class);
+    private static Logger LOG = LoggerFactory.getLogger(BearerTokenPolicyEnforcer.class);
 
     public BearerTokenPolicyEnforcer(PolicyEnforcer enforcer) {
         super(enforcer);
@@ -61,8 +62,8 @@ public class BearerTokenPolicyEnforcer extends AbstractPolicyEnforcer {
         }
 
         response.setHeader("WWW-Authenticate", wwwAuthenticate.toString());
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Sending UMA challenge");
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Sending UMA challenge");
         }
         return true;
     }

--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/authorization/KeycloakAdapterPolicyEnforcer.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/authorization/KeycloakAdapterPolicyEnforcer.java
@@ -17,10 +17,6 @@
  */
 package org.keycloak.adapters.authorization;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-
-import org.jboss.logging.Logger;
 import org.keycloak.KeycloakSecurityContext;
 import org.keycloak.adapters.KeycloakDeployment;
 import org.keycloak.adapters.OIDCHttpFacade;
@@ -36,13 +32,18 @@ import org.keycloak.representations.idm.authorization.AuthorizationResponse;
 import org.keycloak.representations.idm.authorization.Permission;
 import org.keycloak.representations.idm.authorization.PermissionRequest;
 import org.keycloak.representations.idm.authorization.PermissionResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.HashSet;
 
 /**
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
  */
 public class KeycloakAdapterPolicyEnforcer extends AbstractPolicyEnforcer {
 
-    private static Logger LOGGER = Logger.getLogger(KeycloakAdapterPolicyEnforcer.class);
+    private static Logger LOG = LoggerFactory.getLogger(KeycloakAdapterPolicyEnforcer.class);
 
     public KeycloakAdapterPolicyEnforcer(PolicyEnforcer policyEnforcer) {
         super(policyEnforcer);
@@ -134,7 +135,7 @@ public class KeycloakAdapterPolicyEnforcer extends AbstractPolicyEnforcer {
                 authzRequest.setRpt(accessTokenString);
             }
 
-            LOGGER.debug("Obtaining authorization for authenticated user.");
+            LOG.debug("Obtaining authorization for authenticated user.");
             AuthorizationResponse authzResponse = authzClient.authorization(accessTokenString).authorize(authzRequest);
 
             if (authzResponse != null) {
@@ -143,7 +144,7 @@ public class KeycloakAdapterPolicyEnforcer extends AbstractPolicyEnforcer {
 
             return null;
         } catch (AuthorizationDeniedException e) {
-            LOGGER.debug("Authorization denied", e);
+            LOG.debug("Authorization denied", e);
             return null;
         } catch (Exception e) {
             throw new RuntimeException("Unexpected error during authorization request.", e);

--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/jaas/AbstractKeycloakLoginModule.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/jaas/AbstractKeycloakLoginModule.java
@@ -17,7 +17,6 @@
 
 package org.keycloak.adapters.jaas;
 
-import org.jboss.logging.Logger;
 import org.keycloak.KeycloakPrincipal;
 import org.keycloak.adapters.AdapterUtils;
 import org.keycloak.adapters.KeycloakDeployment;
@@ -28,6 +27,7 @@ import org.keycloak.common.VerificationException;
 import org.keycloak.common.util.FindFile;
 import org.keycloak.common.util.reflections.Reflections;
 import org.keycloak.representations.AccessToken;
+import org.slf4j.Logger;
 
 import javax.security.auth.Subject;
 import javax.security.auth.callback.Callback;
@@ -37,7 +37,6 @@ import javax.security.auth.callback.PasswordCallback;
 import javax.security.auth.callback.UnsupportedCallbackException;
 import javax.security.auth.login.LoginException;
 import javax.security.auth.spi.LoginModule;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Constructor;

--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/jaas/BearerTokenLoginModule.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/jaas/BearerTokenLoginModule.java
@@ -17,8 +17,9 @@
 
 package org.keycloak.adapters.jaas;
 
-import org.jboss.logging.Logger;
 import org.keycloak.common.VerificationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Login module, which allows to authenticate Keycloak access token in environments, which rely on JAAS
@@ -29,7 +30,7 @@ import org.keycloak.common.VerificationException;
  */
 public class BearerTokenLoginModule extends AbstractKeycloakLoginModule {
 
-    private static final Logger log = Logger.getLogger(BearerTokenLoginModule.class);
+    private static final Logger LOG = LoggerFactory.getLogger(BearerTokenLoginModule.class);
 
     @Override
     protected Auth doAuth(String username, String password) throws VerificationException {
@@ -39,7 +40,7 @@ public class BearerTokenLoginModule extends AbstractKeycloakLoginModule {
 
     @Override
     protected Logger getLogger() {
-        return log;
+        return LOG;
     }
 
 }

--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/jaas/DirectAccessGrantsLoginModule.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/jaas/DirectAccessGrantsLoginModule.java
@@ -24,7 +24,6 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.message.BasicNameValuePair;
-import org.jboss.logging.Logger;
 import org.keycloak.OAuth2Constants;
 import org.keycloak.adapters.authentication.ClientCredentialsProviderUtils;
 import org.keycloak.common.VerificationException;
@@ -33,6 +32,8 @@ import org.keycloak.constants.ServiceUrlConstants;
 import org.keycloak.representations.AccessTokenResponse;
 import org.keycloak.representations.idm.OAuth2ErrorRepresentation;
 import org.keycloak.util.JsonSerialization;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.security.auth.Subject;
 import javax.security.auth.callback.CallbackHandler;
@@ -54,7 +55,7 @@ import java.util.Map;
  */
 public class DirectAccessGrantsLoginModule extends AbstractKeycloakLoginModule {
 
-    private static final Logger log = Logger.getLogger(DirectAccessGrantsLoginModule.class);
+    private static final Logger LOG = LoggerFactory.getLogger(DirectAccessGrantsLoginModule.class);
 
     private String refreshToken;
 
@@ -76,7 +77,7 @@ public class DirectAccessGrantsLoginModule extends AbstractKeycloakLoginModule {
 
     @Override
     protected Logger getLogger() {
-        return log;
+        return LOG;
     }
 
     protected Auth directGrantAuth(String username, String password) throws IOException, VerificationException {
@@ -107,7 +108,7 @@ public class DirectAccessGrantsLoginModule extends AbstractKeycloakLoginModule {
                         .append(", Error description: " + errorRep.getErrorDescription());
             }
             String error = errorBuilder.toString();
-            log.warn(error);
+            LOG.warn(error);
             throw new IOException(error);
         }
 
@@ -171,10 +172,10 @@ public class DirectAccessGrantsLoginModule extends AbstractKeycloakLoginModule {
                     }
 
                     // Should do something better than warn if logout failed? Perhaps update of refresh tokens on existing subject might be supported too...
-                    log.warn(errorBuilder.toString());
+                    LOG.warn(errorBuilder.toString());
                 }
             } catch (IOException ioe) {
-                log.warn(ioe);
+                LOG.warn("Warning", ioe);
             }
         }
 

--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/rotation/AdapterRSATokenVerifier.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/rotation/AdapterRSATokenVerifier.java
@@ -17,12 +17,12 @@
 
 package org.keycloak.adapters.rotation;
 
-import org.jboss.logging.Logger;
 import org.keycloak.RSATokenVerifier;
 import org.keycloak.adapters.KeycloakDeployment;
 import org.keycloak.common.VerificationException;
-import org.keycloak.jose.jws.JWSInput;
 import org.keycloak.representations.AccessToken;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.security.PublicKey;
 
@@ -31,7 +31,7 @@ import java.security.PublicKey;
  */
 public class AdapterRSATokenVerifier {
 
-    private static final Logger log = Logger.getLogger(AdapterRSATokenVerifier.class);
+    private static final Logger LOG = LoggerFactory.getLogger(AdapterRSATokenVerifier.class);
 
     public static AccessToken verifyToken(String tokenString, KeycloakDeployment deployment) throws VerificationException {
         return verifyToken(tokenString, deployment, true, true);
@@ -43,7 +43,7 @@ public class AdapterRSATokenVerifier {
 
         PublicKey publicKey = pkLocator.getPublicKey(kid, deployment);
         if (publicKey == null) {
-            log.errorf("Didn't find publicKey for kid: %s", kid);
+            LOG.error("Didn't find publicKey for kid: {}", kid);
             throw new VerificationException("Didn't find publicKey for specified kid");
         }
 

--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/rotation/JWKPublicKeyLocator.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/rotation/JWKPublicKeyLocator.java
@@ -18,7 +18,6 @@
 package org.keycloak.adapters.rotation;
 
 import org.apache.http.client.methods.HttpGet;
-import org.jboss.logging.Logger;
 import org.keycloak.adapters.HttpAdapterUtils;
 import org.keycloak.adapters.HttpClientAdapterException;
 import org.keycloak.adapters.KeycloakDeployment;
@@ -26,6 +25,8 @@ import org.keycloak.common.util.Time;
 import org.keycloak.jose.jwk.JSONWebKeySet;
 import org.keycloak.jose.jwk.JWK;
 import org.keycloak.util.JWKSUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.security.PublicKey;
 import java.util.Map;
@@ -38,7 +39,7 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class JWKPublicKeyLocator implements PublicKeyLocator {
 
-    private static final Logger log = Logger.getLogger(JWKPublicKeyLocator.class);
+    private static final Logger LOG = LoggerFactory.getLogger(JWKPublicKeyLocator.class);
 
     private Map<String, PublicKey> currentKeys = new ConcurrentHashMap<>();
 
@@ -63,7 +64,7 @@ public class JWKPublicKeyLocator implements PublicKeyLocator {
                 sendRequest(deployment);
                 lastRequestTime = currentTime;
             } else {
-                log.debug("Won't send request to realm jwks url. Last request time was " + lastRequestTime);
+                LOG.debug("Won't send request to realm jwks url. Last request time was " + lastRequestTime);
             }
 
             return lookupCachedKey(publicKeyCacheTtl, currentTime, kid);
@@ -90,8 +91,8 @@ public class JWKPublicKeyLocator implements PublicKeyLocator {
 
 
     private void sendRequest(KeycloakDeployment deployment) {
-        if (log.isTraceEnabled()) {
-            log.trace("Going to send request to retrieve new set of realm public keys for client " + deployment.getResourceName());
+        if (LOG.isTraceEnabled()) {
+            LOG.trace("Going to send request to retrieve new set of realm public keys for client " + deployment.getResourceName());
         }
 
         HttpGet getMethod = new HttpGet(deployment.getJwksUrl());
@@ -100,8 +101,8 @@ public class JWKPublicKeyLocator implements PublicKeyLocator {
 
             Map<String, PublicKey> publicKeys = JWKSUtils.getKeysForUse(jwks, JWK.Use.SIG);
 
-            if (log.isDebugEnabled()) {
-                log.debug("Realm public keys successfully retrieved for client " +  deployment.getResourceName() + ". New kids: " + publicKeys.keySet().toString());
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Realm public keys successfully retrieved for client " +  deployment.getResourceName() + ". New kids: " + publicKeys.keySet().toString());
             }
 
             // Update current keys
@@ -109,7 +110,7 @@ public class JWKPublicKeyLocator implements PublicKeyLocator {
             currentKeys.putAll(publicKeys);
 
         } catch (HttpClientAdapterException e) {
-            log.error("Error when sending request to retrieve realm keys", e);
+            LOG.error("Error when sending request to retrieve realm keys", e);
         }
     }
 }


### PR DESCRIPTION
As described in KEYCLOAK-6063 (https://issues.jboss.org/browse/KEYCLOAK-6063) the logging of keycloak and in special for the adapters is not well defined. In the code you can find several different patterns how logging is used. Based on this it is very hard to configure logging for keycloak.

I would love to refactor the code of all adapters to use SLF4J as logger facade and the same pattern for logging in all sources.

This PR does it for the `keycloak-adapter-core` module to give an overview what I want to do. Once this PR is merged I will do the same refactoring for all other modules.