### PR TITLE
KEYCLOAK-7024: Fix logout dropdown

### DIFF
--- a/themes/src/main/resources/theme/keycloak-preview/account/index.ftl
+++ b/themes/src/main/resources/theme/keycloak-preview/account/index.ftl
@@ -59,6 +59,7 @@
         <link href="${resourceUrl}/node_modules/patternfly/dist/css/patternfly-additions.min.css" rel="stylesheet"
               media="screen, print">
 
+        <script src="${resourceUrl}/node_modules/jquery/dist/jquery.min.js"></script>
         <script src="${resourceUrl}/node_modules/bootstrap/dist/js/bootstrap.min.js"></script>
         <script src="${resourceUrl}/node_modules/patternfly/dist/js/patternfly.min.js"></script>
         <script src="${authUrl}/js/keycloak.js"></script>
@@ -133,6 +134,7 @@
 <!--Top Nav -->
         
 <!-- Home Page --->
+    
     <div class="cards-pf" id="welcomeScreen">
         <div><h1 class="text-center">Welcome to Keycloak Account Management</h1></div>
         <div class="container-fluid container-cards-pf">
@@ -201,6 +203,13 @@
             </div>
         </div>
     </div>
+        
+        <script>
+            var winHash = window.location.hash;
+            if (winHash.startsWith('#/') && !winHash.startsWith('#/&state')) {
+                document.getElementById("welcomeScreen").style.visibility='hidden';
+            }
+        </script>
 
         <app-root></app-root>
     </body>

--- a/themes/src/main/resources/theme/keycloak-preview/account/resources/app/top-nav/top-nav.component.html
+++ b/themes/src/main/resources/theme/keycloak-preview/account/resources/app/top-nav/top-nav.component.html
@@ -21,13 +21,12 @@
             <li *ngIf="referrer.exists()">
                 <a class="nav-item-iconic" href="{{referrer.getUri()}}"><span class="pficon-arrow"></span> {{'backTo' | translate:referrer.getName()}}</a>
             </li>
-            <li class="dropdown" (click)="logout()">
+            <li class="dropdown" >
                 <a class="dropdown-toggle nav-item-iconic" id="dropdownMenu2" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
                     <span title="Username" class="fa pficon-user"></span>
                     <span class="caret"></span>
                 </a>
                 <ul class="dropdown-menu" aria-labelledby="dropdownMenu2">
-                    <li><a href="#">Preferences</a></li>
                     <li><a href="#" (click)="logout()">{{'doSignOut' | translate}}</a></li>
                 </ul>
             </li>

--- a/themes/src/main/resources/theme/keycloak-preview/account/resources/app/top-nav/top-nav.component.ts
+++ b/themes/src/main/resources/theme/keycloak-preview/account/resources/app/top-nav/top-nav.component.ts
@@ -21,6 +21,7 @@ import {ResponsivenessService} from "../responsiveness-service/responsiveness.se
 import {Referrer} from "../page/referrer";
 
 declare const resourceUrl: string;
+declare const baseUrl: string;
 declare const referrer: string;
 declare const referrer_uri: string;
 
@@ -48,7 +49,7 @@ export class TopNavComponent implements OnInit {
     }
 
     private logout() {
-        this.keycloakService.logout();
+        this.keycloakService.logout(baseUrl);
     }
 
 }


### PR DESCRIPTION
"Person" icon in upper righthand corner is currently hacked to logout. Fix this so that it uses a dropdown.

For now, we will add jquery back in so that dropdown works via PatternFly/Bootstrap. If necessary for performance we can go back and implement by hand so that jquery isn't required.

Also, tweak login/logout so that it is more performant (or at least appears that way).
