### PR TITLE
Managing user in UI - input for user's password should have type="password"

### DIFF
--- a/themes/src/main/resources/theme/base/admin/resources/partials/user-credentials.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/user-credentials.html
@@ -12,14 +12,14 @@
             <div class="form-group">
                     <label class="col-md-2 control-label" for="newPas">{{:: 'new-password' | translate}} <span class="required" data-ng-show="create">*</span></label>
                     <div class="col-md-6">
-                        <input class="form-control" kc-password type="text" id="newPas" name="newPas" data-ng-model="password" required>
+                        <input class="form-control" kc-password type="password" id="newPas" name="newPas" data-ng-model="password" required>
                     </div>
                 </div>
 
                 <div class="form-group">
                     <label class="col-md-2 control-label" for="confirmPas">{{:: 'password-confirmation' | translate}} <span class="required" data-ng-show="create">*</span></label>
                     <div class="col-md-6">
-                        <input class="form-control" kc-password id="confirmPas" name="confirmPas" data-ng-model="confirmPassword" required>
+                        <input class="form-control" kc-password type="password" id="confirmPas" name="confirmPas" data-ng-model="confirmPassword" required>
                     </div>
                 </div>
 


### PR DESCRIPTION
In Keycloak's administration section "Manage" -> "Users" -> <specific user> -> Tab "Credentials" inputs for password were of type "text" which has side effects in some browsers (like remembering already inserted strings) which results in security issues.

![screenshot](https://image.ibb.co/cZ7Twc/screen.jpg)

