### PR TITLE
Add Deny All Authenticator

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/FailureAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/FailureAuthenticator.java
@@ -1,0 +1,44 @@
+package org.keycloak.authentication.authenticators;
+
+import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.authentication.AuthenticationFlowError;
+import org.keycloak.authentication.Authenticator;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+
+/**
+ * Authenticator that results in failure every time.  Useful for disallowing entire flow types for realms
+ */
+public class FailureAuthenticator implements Authenticator {
+
+	@Override
+	public void authenticate(final AuthenticationFlowContext context) {
+		context.failure(AuthenticationFlowError.INVALID_CREDENTIALS);
+	}
+
+	@Override
+	public void action(final AuthenticationFlowContext context) {
+		throw new RuntimeException("Unreachable!");
+	}
+
+	@Override
+	public boolean requiresUser() {
+		return false;
+	}
+
+	@Override
+	public boolean configuredFor(final KeycloakSession session, final RealmModel realm, final UserModel user) {
+		return true;
+	}
+
+	@Override
+	public void setRequiredActions(final KeycloakSession session, final RealmModel realm, final UserModel user) {
+		// no-op
+	}
+
+	@Override
+	public void close() {
+		// no-op
+	}
+}

--- a/services/src/main/java/org/keycloak/authentication/authenticators/FailureAuthenticatorFactory.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/FailureAuthenticatorFactory.java
@@ -1,0 +1,85 @@
+package org.keycloak.authentication.authenticators;
+
+import org.keycloak.Config;
+import org.keycloak.authentication.Authenticator;
+import org.keycloak.authentication.AuthenticatorFactory;
+import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.models.UserCredentialModel;
+import org.keycloak.provider.ProviderConfigProperty;
+
+import java.util.Collections;
+import java.util.List;
+
+public class FailureAuthenticatorFactory implements AuthenticatorFactory {
+
+	public static final String PROVIDER_ID = "always-fail";
+	public static final Authenticator SINGLETON = new FailureAuthenticator();
+
+	@Override
+	public String getDisplayType() {
+		return "Deny All";
+	}
+
+	@Override
+	public String getReferenceCategory() {
+		return UserCredentialModel.PASSWORD;
+	}
+
+	@Override
+	public boolean isConfigurable() {
+		return false;
+	}
+
+	public static final AuthenticationExecutionModel.Requirement[] REQUIREMENT_CHOICES = {
+			AuthenticationExecutionModel.Requirement.REQUIRED,
+			AuthenticationExecutionModel.Requirement.DISABLED
+	};
+
+	@Override
+	public AuthenticationExecutionModel.Requirement[] getRequirementChoices() {
+		return REQUIREMENT_CHOICES;
+	}
+
+
+	@Override
+	public boolean isUserSetupAllowed() {
+		return false;
+	}
+
+	@Override
+	public String getHelpText() {
+		return "Authenticator returns failure every time.  Only use this if you want to disable auth entirely for the given flow.";
+	}
+
+	@Override
+	public List<ProviderConfigProperty> getConfigProperties() {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public Authenticator create(final KeycloakSession session) {
+		return SINGLETON;
+	}
+
+	@Override
+	public void init(final Config.Scope config) {
+		// no-op
+	}
+
+	@Override
+	public void postInit(final KeycloakSessionFactory factory) {
+		// no-op
+	}
+
+	@Override
+	public void close() {
+		// no-op
+	}
+
+	@Override
+	public String getId() {
+		return PROVIDER_ID;
+	}
+}

--- a/services/src/main/resources/META-INF/services/org.keycloak.authentication.AuthenticatorFactory
+++ b/services/src/main/resources/META-INF/services/org.keycloak.authentication.AuthenticatorFactory
@@ -39,3 +39,4 @@ org.keycloak.authentication.authenticators.x509.X509ClientCertificateAuthenticat
 org.keycloak.authentication.authenticators.x509.ValidateX509CertificateUsernameFactory
 org.keycloak.protocol.docker.DockerAuthenticatorFactory
 org.keycloak.authentication.authenticators.console.ConsoleUsernamePasswordAuthenticatorFactory
+org.keycloak.authentication.authenticators.FailureAuthenticatorFactory

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/authentication/ProvidersTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/authentication/ProvidersTest.java
@@ -134,6 +134,7 @@ public class ProvidersTest extends AbstractAuthenticationTest {
 
     private List<Map<String, Object>> expectedAuthProviders() {
         ArrayList<Map<String, Object>> result = new ArrayList<>();
+        addProviderInfo(result, "always-fail", "Deny All", "Authenticator returns failure every time.  Only use this if you want to disable auth entirely for the given flow.");
         addProviderInfo(result, "auth-conditional-otp-form", "Conditional OTP Form",
                 "Validates a OTP on a separate OTP form. Only shown if required based on the configured conditions.");
         addProviderInfo(result, "auth-cookie", "Cookie", "Validates the SSO cookie set by the auth server.");


### PR DESCRIPTION
We have a need to shutdown some (unused) flows entirely.  As such, this authenicator is just a way to cause immediate failure when an auth flow is attempted.