### PR TITLE
[KEYCLOAK-6808] fix for the WildflyConsoleProtectionTest

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/AppServerWelcomePage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/AppServerWelcomePage.java
@@ -34,7 +34,7 @@ public class AppServerWelcomePage extends AppServerContextRoot {
     @Page
     protected OIDCLogin loginPage;
 
-    @FindBy(xpath = "//a[text() = 'Access Control']")
+    @FindBy(xpath = "//span[text() = 'Access Control']")
     private WebElement accessControlLink;
 
     @FindBy(xpath = "//a[text() = 'Manage user profile']")

--- a/testsuite/integration-arquillian/tests/other/adapters/jboss/wildfly/src/test/java/org/keycloak/testsuite/adapter/example/hal/WildflyConsoleProtectionTest.java
+++ b/testsuite/integration-arquillian/tests/other/adapters/jboss/wildfly/src/test/java/org/keycloak/testsuite/adapter/example/hal/WildflyConsoleProtectionTest.java
@@ -93,8 +93,7 @@ public class WildflyConsoleProtectionTest extends AbstractAdapterTest {
         }
     }
 
-    @Test
-    public void testLogin() throws InterruptedException {
+    private void testLogin() throws InterruptedException {
         appServerWelcomePage.navigateToConsole();
         appServerWelcomePage.login("admin", "admin");
         WaitUtils.pause(2000);
@@ -103,9 +102,7 @@ public class WildflyConsoleProtectionTest extends AbstractAdapterTest {
 
     @Test
     public void testUserCanAccessAccountService() throws InterruptedException {
-        appServerWelcomePage.navigateToConsole();
-        appServerWelcomePage.login("admin", "admin");
-        WaitUtils.pause(2000);
+        testLogin();
         appServerWelcomePage.navigateToAccessControl();
         appServerWelcomePage.navigateManageProfile();
         assertTrue(accountUpdateProfilePage.isCurrent());


### PR DESCRIPTION
Access Control is not an 'a' tag, but rather 'span'
Also two tests do not behave correctly with a same
Before annotated initialization, so reduce number
of tests to one, which calls the other one