### PR TITLE
KEYCLOAK-7014: Correctly handle null-values in UserAttributes

### DIFF
--- a/core/src/main/java/org/keycloak/json/StringListMapDeserializer.java
+++ b/core/src/main/java/org/keycloak/json/StringListMapDeserializer.java
@@ -41,17 +41,27 @@ public class StringListMapDeserializer extends JsonDeserializer<Object> {
             Map.Entry<String, JsonNode> e = itr.next();
             List<String> values = new LinkedList<>();
             if (!e.getValue().isArray()) {
-                values.add(e.getValue().asText());
+                if(e.getValue().isNull()) {
+                    values.add(null);
+                } else {
+                    values.add(e.getValue().asText());
+                }
             } else {
                 ArrayNode a = (ArrayNode) e.getValue();
                 Iterator<JsonNode> vitr = a.elements();
                 while (vitr.hasNext()) {
-                    values.add(vitr.next().asText());
+                    JsonNode node = vitr.next();
+                    if(node.isNull()) {
+                        values.add(null);
+                    } else {
+                        values.add(node.asText());
+                    }
                 }
             }
             map.put(e.getKey(), values);
         }
         return map;
     }
+
 
 }

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/UserAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/UserAdapter.java
@@ -107,7 +107,7 @@ public class UserAdapter implements UserModel, JpaModel<UserEntity> {
         List<UserAttributeEntity> toRemove = new ArrayList<>();
         for (UserAttributeEntity attr : user.getAttributes()) {
             if (attr.getName().equals(name)) {
-                if (firstExistingAttrId == null) {
+                if (firstExistingAttrId == null && value != null) {
                     attr.setValue(value);
                     firstExistingAttrId = attr.getId();
                 } else {
@@ -127,8 +127,9 @@ public class UserAdapter implements UserModel, JpaModel<UserEntity> {
             // Remove attribute from local entity
             user.getAttributes().removeAll(toRemove);
         } else {
-
-            persistAttributeValue(name, value);
+            if(value != null) {
+                persistAttributeValue(name, value);
+            }
         }
     }
 
@@ -137,8 +138,9 @@ public class UserAdapter implements UserModel, JpaModel<UserEntity> {
         // Remove all existing
         removeAttribute(name);
 
-        // Put all new
-        for (String value : values) {
+        List<String> nonNullValues = values.stream().filter(Objects::nonNull).collect(Collectors.toList());
+        // Put all new nonNull values
+        for (String value : nonNullValues) {
             persistAttributeValue(name, value);
         }
     }


### PR DESCRIPTION
* null values are deserialized correctly via API (in UserRepresentation)
* jpa UserAdapter only stores non-null attributes (so no empty values
  appear in User Attributes tab of the Admin Console. Otherwise a press
  to 'Save'-Button would convert those null values to "")