### PR TITLE
KEYCLOAK-7014: Correctly handle null-values in UserAttributes

### DIFF
--- a/core/src/main/java/org/keycloak/json/StringListMapDeserializer.java
+++ b/core/src/main/java/org/keycloak/json/StringListMapDeserializer.java
@@ -41,17 +41,27 @@ public class StringListMapDeserializer extends JsonDeserializer<Object> {
             Map.Entry<String, JsonNode> e = itr.next();
             List<String> values = new LinkedList<>();
             if (!e.getValue().isArray()) {
-                values.add(e.getValue().asText());
+                if(e.getValue().isNull()) {
+                    values.add(null);
+                } else {
+                    values.add(e.getValue().asText());
+                }
             } else {
                 ArrayNode a = (ArrayNode) e.getValue();
                 Iterator<JsonNode> vitr = a.elements();
                 while (vitr.hasNext()) {
-                    values.add(vitr.next().asText());
+                    JsonNode node = vitr.next();
+                    if(node.isNull()) {
+                        values.add(null);
+                    } else {
+                        values.add(node.asText());
+                    }
                 }
             }
             map.put(e.getKey(), values);
         }
         return map;
     }
+
 
 }

--- a/core/src/test/java/org/keycloak/json/StringListMapDeserializerTest.java
+++ b/core/src/test/java/org/keycloak/json/StringListMapDeserializerTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.json;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * @author <a href="mailto:urs.honegger@starmind.com">Urs Honegger</a>
+ */
+public class StringListMapDeserializerTest {
+
+    private ObjectMapper mapper;
+
+    @Before
+    public void setUp() {
+        mapper = new ObjectMapper();
+    }
+
+    @After
+    public void tearDown() {
+        mapper = null;
+    }
+
+    @Test
+    public void nonNullValue() throws IOException {
+        Map<String, List<String>> attributes = deserialize("\"foo\": \"bar\"");
+        assertTrue(attributes.containsKey("foo"));
+        List<String> foo = attributes.get("foo");
+        assertEquals(1, foo.size());
+        assertEquals("bar", foo.get(0));
+
+    }
+
+    @Test
+    public void nonNullValueArray() throws IOException {
+        Map<String, List<String>> attributes = deserialize("\"foo\": [ \"bar\", \"baz\" ]");
+        assertTrue(attributes.containsKey("foo"));
+        List<String> foo = attributes.get("foo");
+        assertEquals(2, foo.size());
+        assertEquals("baz", foo.get(1));
+    }
+
+    @Test
+    public void nullValue() throws IOException {
+        // null values must deserialize to null
+        Map<String, List<String>> attributes = deserialize("\"foo\": null");
+        assertTrue(attributes.containsKey("foo"));
+        List<String> foo = attributes.get("foo");
+        assertEquals(1, foo.size());
+        assertNull(foo.get(0));
+    }
+
+    @Test
+    public void nullValueArray() throws IOException {
+        // null values must deserialize to null
+        Map<String, List<String>> attributes = deserialize("\"foo\": [ null, \"something\", null ]");
+        assertTrue(attributes.containsKey("foo"));
+        List<String> foo = attributes.get("foo");
+        assertEquals(3, foo.size());
+        assertEquals("something", foo.get(1));
+        assertNull(foo.get(2));
+    }
+
+    private Map<String, List<String>> deserialize(String attributeKeyValueString) throws IOException {
+        TestObject testObject = mapper.readValue("{ \"attributes\": {" + attributeKeyValueString + " } }", TestObject.class);
+
+        return testObject.getAttributes();
+    }
+
+    private static class TestObject {
+
+        @JsonDeserialize(using = StringListMapDeserializer.class)
+        private final Map<String, List<String>> attributes = null;
+
+        public Map<String, List<String>> getAttributes() {
+            return attributes;
+        }
+    }
+
+}

--- a/model/jpa/pom.xml
+++ b/model/jpa/pom.xml
@@ -33,6 +33,7 @@
     <properties>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
+        <mockito.version>1.9.5</mockito.version>
     </properties>
 
     <dependencies>
@@ -109,6 +110,12 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/UserAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/UserAdapter.java
@@ -36,12 +36,8 @@ import org.keycloak.models.utils.RoleUtils;
 import javax.persistence.EntityManager;
 import javax.persistence.Query;
 import javax.persistence.TypedQuery;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -107,7 +103,7 @@ public class UserAdapter implements UserModel, JpaModel<UserEntity> {
         List<UserAttributeEntity> toRemove = new ArrayList<>();
         for (UserAttributeEntity attr : user.getAttributes()) {
             if (attr.getName().equals(name)) {
-                if (firstExistingAttrId == null) {
+                if (firstExistingAttrId == null && value != null) {
                     attr.setValue(value);
                     firstExistingAttrId = attr.getId();
                 } else {
@@ -127,8 +123,9 @@ public class UserAdapter implements UserModel, JpaModel<UserEntity> {
             // Remove attribute from local entity
             user.getAttributes().removeAll(toRemove);
         } else {
-
-            persistAttributeValue(name, value);
+            if(value != null) {
+                persistAttributeValue(name, value);
+            }
         }
     }
 
@@ -137,8 +134,9 @@ public class UserAdapter implements UserModel, JpaModel<UserEntity> {
         // Remove all existing
         removeAttribute(name);
 
-        // Put all new
-        for (String value : values) {
+        List<String> nonNullValues = values.stream().filter(Objects::nonNull).collect(Collectors.toList());
+        // Put all new nonNull values
+        for (String value : nonNullValues) {
             persistAttributeValue(name, value);
         }
     }

--- a/model/jpa/src/test/java/org/keycloak/models/jpa/UserAdapterTest.java
+++ b/model/jpa/src/test/java/org/keycloak/models/jpa/UserAdapterTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.models.jpa;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.keycloak.models.jpa.entities.UserAttributeEntity;
+import org.keycloak.models.jpa.entities.UserEntity;
+
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.anyString;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+
+/**
+ * @author <a href="mailto:urs.honegger@starmind.com">Urs Honegger</a>
+ */
+public class UserAdapterTest {
+
+    UserAdapter userAdapter = null;
+
+    @Before
+    public void setUp() {
+        EntityManager mockedEm = mock(EntityManager.class);
+        doNothing().when(mockedEm).persist(anyObject());
+        doReturn(mock(Query.class)).when(mockedEm).createNamedQuery(anyString());
+
+        UserAttributeEntity firstValue = new UserAttributeEntity();
+        firstValue.setId("v1");
+        firstValue.setName("foo");
+        firstValue.setValue("aValue");
+
+        UserAttributeEntity secondValue = new UserAttributeEntity();
+        secondValue.setId("v2");
+        secondValue.setName("foo");
+        secondValue.setValue("anotherValue");
+
+        ArrayList<UserAttributeEntity> attributes = new ArrayList<>();
+        attributes.add(firstValue);
+        attributes.add(secondValue);
+
+        UserEntity user = new UserEntity();
+        user.setAttributes(attributes);
+
+        userAdapter = new UserAdapter(null, null, mockedEm, user);
+    }
+
+    @After
+    public void tearDown() {
+        userAdapter = null;
+    }
+
+    @Test
+    public void setSingleNonNullAttribute() {
+        userAdapter.setSingleAttribute("foo", "bar");
+        Map<String, List<String>> attributes = userAdapter.getAttributes();
+        assertTrue(attributes.containsKey("foo"));
+        List<String> foo = attributes.get("foo");
+        assertEquals(1, foo.size());
+        assertEquals("bar", foo.get(0));
+    }
+
+    @Test
+    public void setNonNullAttributes() {
+        userAdapter.setAttribute("foo", Arrays.asList("bar", "baz"));
+        Map<String, List<String>> attributes = userAdapter.getAttributes();
+        assertTrue(attributes.containsKey("foo"));
+        List<String> foo = attributes.get("foo");
+        assertEquals(2, foo.size());
+        assertEquals("baz", foo.get(1));
+    }
+
+    @Test
+    public void setSingleNullAttribute() {
+        userAdapter.setSingleAttribute("foo", null);
+        Map<String, List<String>> attributes = userAdapter.getAttributes();
+        assertFalse(attributes.containsKey("foo"));
+    }
+
+    @Test
+    public void setNullAttributes() {
+        userAdapter.setAttribute("foo", Arrays.asList(null, null));
+        Map<String, List<String>> attributes = userAdapter.getAttributes();
+        assertFalse(attributes.containsKey("foo"));
+    }
+
+    @Test
+    public void setAttributesWithValuesAndNull() {
+        userAdapter.setAttribute("foo", Arrays.asList(null, "bar", "baz", "aValue", null));
+        Map<String, List<String>> attributes = userAdapter.getAttributes();
+        assertTrue(attributes.containsKey("foo"));
+        List<String> foo = attributes.get("foo");
+        assertEquals(3, foo.size());
+        assertEquals(Arrays.asList("bar", "baz", "aValue"), foo);
+    }
+}


### PR DESCRIPTION
* null values are deserialized correctly via API (in UserRepresentation)
* jpa UserAdapter only stores non-null attributes (so no empty values
  appear in User Attributes tab of the Admin Console. Otherwise a press
  to 'Save'-Button would convert those null values to "")