### PR TITLE
Fixes KEYCLOAK-6838 Update RH-SSO logo style

### DIFF
--- a/themes/src/main/resources-product/theme/rh-sso/login/resources/css/login-rhsso.css
+++ b/themes/src/main/resources-product/theme/rh-sso/login/resources/css/login-rhsso.css
@@ -16,3 +16,7 @@
     background-attachment: fixed;
   }
 }
+#kc-header-wrapper sup {
+  font-size: 35%;
+  top: -1.4em;
+}


### PR DESCRIPTION
Fixes KEYCLOAK-6838 Update RH-SSO logo style
https://issues.jboss.org/browse/KEYCLOAK-6838

css tweak about the logo style.

<img width="1124" alt="screen shot 2018-04-12 at 2 56 37 pm" src="https://user-images.githubusercontent.com/701009/38661167-8522c332-3e62-11e8-8d8f-7a646d6324fd.png">
