### PR TITLE
[KEYCLOAK-7239] Fixed ConcurrentModificationException while importing groups from LDAP

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/membership/group/GroupTreeResolver.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/membership/group/GroupTreeResolver.java
@@ -21,6 +21,7 @@ import org.jboss.logging.Logger;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -109,13 +110,15 @@ public class GroupTreeResolver {
         }
 
         for (Group group : groups) {
-            for (String child : group.getChildrenNames()) {
+            Iterator<String> iterator = group.getChildrenNames().iterator();
+            while (iterator.hasNext()) {
+                String child = iterator.next();
                 List<String> list = result.get(child);
                 if (list != null) {
                     list.add(group.getGroupName());
-                } else if(ignoreMissingGroups){
+                } else if (ignoreMissingGroups) {
                     // Need to remove the missing group
-                    group.getChildrenNames().remove(child);
+                    iterator.remove();
                     logger.debug("Group '" + child + "' referenced as member of group '" + group.getGroupName() + "' doesn't exists. Ignoring.");
                 } else {
                     throw new GroupTreeResolveException("Group '" + child + "' referenced as member of group '" + group.getGroupName() + "' doesn't exists");

--- a/federation/ldap/src/test/java/org/keycloak/storage/ldap/idm/model/GroupTreeResolverTest.java
+++ b/federation/ldap/src/test/java/org/keycloak/storage/ldap/idm/model/GroupTreeResolverTest.java
@@ -110,7 +110,7 @@ public class GroupTreeResolverTest {
     @Test
     public void testGroupResolvingMissingGroup() throws GroupTreeResolver.GroupTreeResolveException {
         GroupTreeResolver.Group group1 = new GroupTreeResolver.Group("group1", "group2");
-        GroupTreeResolver.Group group2 = new GroupTreeResolver.Group("group2", "group3");
+        GroupTreeResolver.Group group2 = new GroupTreeResolver.Group("group2", "group3", "group5");
         GroupTreeResolver.Group group4 = new GroupTreeResolver.Group("group4");
         List<GroupTreeResolver.Group> groups = Arrays.asList(group1, group2, group4);
 


### PR DESCRIPTION
Fixed ConcurrentModificationException while importing groups from LDAP with "ignoreMissingGroups" checked.

Fixed test so that now it checks this use case.