### PR TITLE
Force the mvn-golang plugin to use the maven proxy

### DIFF
--- a/testsuite/integration-arquillian/tests/base/pom.xml
+++ b/testsuite/integration-arquillian/tests/base/pom.xml
@@ -240,6 +240,7 @@
                 <extensions>true</extensions>
                 <configuration>
                     <goVersion>1.9.2</goVersion>
+                    <useMavenProxy>true</useMavenProxy>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
Without this patch, keycloak cannot be built if behind a proxy server because the mvn-golang plugin uses neither the maven-configured proxy nor the java proxy System Properties.  This simple change tells the plugin to use whatever proxy maven is configured to use.