### PR TITLE
[KEYCLOAK-7493] - NullPointerException in FilterSessionStore when restoring request

### DIFF
--- a/adapters/spi/servlet-adapter-spi/src/main/java/org/keycloak/adapters/servlet/FilterSessionStore.java
+++ b/adapters/spi/servlet-adapter-spi/src/main/java/org/keycloak/adapters/servlet/FilterSessionStore.java
@@ -111,8 +111,7 @@ public class FilterSessionStore implements AdapterSessionStore {
                     if (body == null) return new MultivaluedHashMap<String, String>();
 
                     String contentType = getContentType();
-                    contentType = contentType.toLowerCase();
-                    if (contentType.startsWith("application/x-www-form-urlencoded")) {
+                    if (contentType != null && contentType.toLowerCase().startsWith("application/x-www-form-urlencoded")) {
                         ByteArrayInputStream is = new ByteArrayInputStream(body);
                         try {
                             parameters = parseForm(is);


### PR DESCRIPTION
Hi,

I came across the following problem in FilterSessionStore:

The problem occurs when a POST request is restored after a successfull login.

If during that request the getParams() Method is called on the HttpServletRequestWrapper we get a NullPointerException if the restored "content-type" header is null.

This commit adds a null-check to avoid this problem.

Cheers
Samuel