### PR TITLE
Support for MySQL 8.

### DIFF
--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-1.0.0.Final-db2.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-1.0.0.Final-db2.xml
@@ -171,8 +171,8 @@
                 <constraints nullable="false"/>
             </column>
             <column name="PASSWORD_POLICY" type="VARCHAR(255)"/>
-            <column name="PRIVATE_KEY" type="VARCHAR(2048)"/>
-            <column name="PUBLIC_KEY" type="VARCHAR(2048)"/>
+            <column name="PRIVATE_KEY" type="TEXT(2048)"/>
+            <column name="PUBLIC_KEY" type="TEXT(2048)"/>
             <column name="REGISTRATION_ALLOWED" type="BOOLEAN" defaultValueBoolean="false">
                 <constraints nullable="false"/>
             </column>

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-1.0.0.Final.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-1.0.0.Final.xml
@@ -163,8 +163,8 @@
                 <constraints nullable="false"/>
             </column>
             <column name="PASSWORD_POLICY" type="VARCHAR(255)"/>
-            <column name="PRIVATE_KEY" type="VARCHAR(2048)"/>
-            <column name="PUBLIC_KEY" type="VARCHAR(2048)"/>
+            <column name="PRIVATE_KEY" type="TEXT(2048)"/>
+            <column name="PUBLIC_KEY" type="TEXT(2048)"/>
             <column name="REGISTRATION_ALLOWED" type="BOOLEAN" defaultValueBoolean="false">
                 <constraints nullable="false"/>
             </column>

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-1.1.0.Beta1.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-1.1.0.Beta1.xml
@@ -26,7 +26,7 @@
             <column name="CLIENT_ID" type="VARCHAR(36)">
                 <constraints nullable="false"/>
             </column>
-            <column name="VALUE" type="VARCHAR(2048)"/>
+            <column name="VALUE" type="TEXT(2048)"/>
             <column name="NAME" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
@@ -59,7 +59,7 @@
             <column name="REALM_ID" type="VARCHAR(255)"/>
         </addColumn>
         <addColumn tableName="REALM">
-            <column name="CERTIFICATE" type="VARCHAR(2048)"/>
+            <column name="CERTIFICATE" type="TEXT(2048)"/>
             <column name="CODE_SECRET" type="VARCHAR(255)"/>
         </addColumn>
         <addColumn tableName="CLIENT">

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-1.2.0.Beta1-db2.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-1.2.0.Beta1-db2.xml
@@ -127,7 +127,7 @@
             <column name="NAME" type="VARCHAR(255)">
                 <constraints nullable="false" />
             </column>
-            <column name="VALUE" type="VARCHAR(2048)" />
+            <column name="VALUE" type="TEXT(2048)" />
         </createTable>
         <addColumn tableName="CLIENT">
             <column name="FRONTCHANNEL_LOGOUT" type="BOOLEAN" defaultValueBoolean="false">

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-1.2.0.Beta1.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-1.2.0.Beta1.xml
@@ -124,7 +124,7 @@
             <column name="NAME" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="VALUE" type="VARCHAR(2048)"/>
+            <column name="VALUE" type="TEXT(2048)"/>
         </createTable>
         <addColumn tableName="CLIENT">
             <column name="FRONTCHANNEL_LOGOUT" type="BOOLEAN" defaultValueBoolean="false">

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-1.4.0-db2.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-1.4.0-db2.xml
@@ -127,7 +127,7 @@
             <column name="NAME" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="VALUE" type="VARCHAR(2048)"/>
+            <column name="VALUE" type="TEXT(2048)"/>
             <column name="CLIENT_SESSION" type="VARCHAR(36)">
                 <constraints nullable="false"/>
             </column>

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-1.4.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-1.4.0.xml
@@ -125,7 +125,7 @@
             <column name="NAME" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="VALUE" type="VARCHAR(2048)"/>
+            <column name="VALUE" type="TEXT(2048)"/>
             <column name="CLIENT_SESSION" type="VARCHAR(36)">
                 <constraints nullable="false"/>
             </column>

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-1.8.0-db2.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-1.8.0-db2.xml
@@ -71,7 +71,7 @@
             <column name="TEMPLATE_ID" type="VARCHAR(36)">
                 <constraints nullable="false"/>
             </column>
-            <column name="VALUE" type="VARCHAR(2048)"/>
+            <column name="VALUE" type="TEXT(2048)"/>
             <column name="NAME" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-1.8.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-1.8.0.xml
@@ -69,7 +69,7 @@
             <column name="TEMPLATE_ID" type="VARCHAR(36)">
                 <constraints nullable="false"/>
             </column>
-            <column name="VALUE" type="VARCHAR(2048)"/>
+            <column name="VALUE" type="TEXT(2048)"/>
             <column name="NAME" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-1.9.1-db2.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-1.9.1-db2.xml
@@ -23,8 +23,8 @@
         </preConditions>
 
         <!-- Can't increase publicKey on DB2 due the DB2 SQL Error: SQLCODE=-670, SQLSTATE=54010, SQLERRMC=16293;USERSPACE1, DRIVER=4.19.26 . Need to find better solution -->
-        <modifyDataType tableName="REALM" columnName="PRIVATE_KEY" newDataType="VARCHAR(4000)"/>
-        <!--<modifyDataType tableName="REALM" columnName="PUBLIC_KEY" newDataType="VARCHAR(4000)"/>-->
-        <modifyDataType tableName="REALM" columnName="CERTIFICATE" newDataType="VARCHAR(4000)"/>
+        <modifyDataType tableName="REALM" columnName="PRIVATE_KEY" newDataType="TEXT(4000)"/>
+        <!--<modifyDataType tableName="REALM" columnName="PUBLIC_KEY" newDataType="TEXT(4000)"/>-->
+        <modifyDataType tableName="REALM" columnName="CERTIFICATE" newDataType="TEXT(4000)"/>
     </changeSet>
 </databaseChangeLog>

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-1.9.1.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-1.9.1.xml
@@ -24,8 +24,8 @@
             </not>
         </preConditions>
 
-        <modifyDataType tableName="REALM" columnName="PRIVATE_KEY" newDataType="VARCHAR(4000)"/>
-        <modifyDataType tableName="REALM" columnName="PUBLIC_KEY" newDataType="VARCHAR(4000)"/>
-        <modifyDataType tableName="REALM" columnName="CERTIFICATE" newDataType="VARCHAR(4000)"/>
+        <modifyDataType tableName="REALM" columnName="PRIVATE_KEY" newDataType="TEXT(4000)"/>
+        <modifyDataType tableName="REALM" columnName="PUBLIC_KEY" newDataType="TEXT(4000)"/>
+        <modifyDataType tableName="REALM" columnName="CERTIFICATE" newDataType="TEXT(4000)"/>
     </changeSet>
 </databaseChangeLog>

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-2.1.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-2.1.0.xml
@@ -159,7 +159,7 @@
             <column name="NAME" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="VALUE" type="VARCHAR(4000)"/>
+            <column name="VALUE" type="TEXT(4000)"/>
         </createTable>
         <createTable tableName="COMPONENT">
             <column name="ID" type="VARCHAR(36)">

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-2.2.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-2.2.0.xml
@@ -34,7 +34,7 @@
             <column name="NAME" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="VALUE" type="VARCHAR(4000)"/>
+            <column name="VALUE" type="TEXT(4000)"/>
         </createTable>
 
         <createTable tableName="FED_CREDENTIAL_ATTRIBUTE">
@@ -47,9 +47,9 @@
             <column name="NAME" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="VALUE" type="VARCHAR(4000)"/>
+            <column name="VALUE" type="TEXT(4000)"/>
         </createTable>
-        <modifyDataType tableName="CREDENTIAL" columnName="VALUE" newDataType="VARCHAR(4000)"/>
+        <modifyDataType tableName="CREDENTIAL" columnName="VALUE" newDataType="TEXT(4000)"/>
 
         <addForeignKeyConstraint baseColumnNames="CREDENTIAL_ID" baseTableName="FED_CREDENTIAL_ATTRIBUTE" constraintName="FK_FED_CRED_ATTR" referencedColumnNames="ID" referencedTableName="FED_USER_CREDENTIAL"/>
         <addForeignKeyConstraint baseColumnNames="CREDENTIAL_ID" baseTableName="CREDENTIAL_ATTRIBUTE" constraintName="FK_CRED_ATTR" referencedColumnNames="ID" referencedTableName="CREDENTIAL"/>

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-2.5.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-2.5.0.xml
@@ -91,7 +91,7 @@
         <modifyDataType tableName="USER_ATTRIBUTE" columnName="VALUE" newDataType="NVARCHAR(255)"/>
         <modifyDataType tableName="GROUP_ATTRIBUTE" columnName="VALUE" newDataType="NVARCHAR(255)"/>
         <modifyDataType tableName="REALM_ATTRIBUTE" columnName="VALUE" newDataType="NVARCHAR(255)"/>
-        <modifyDataType tableName="COMPONENT_CONFIG" columnName="VALUE" newDataType="NVARCHAR(4000)"/>
+        <modifyDataType tableName="COMPONENT_CONFIG" columnName="VALUE" newDataType="NTEXT(4000)"/>
 
         <dropUniqueConstraint constraintName="UK_J3RWUVD56ONTGSUHOGM184WW2-2" tableName="KEYCLOAK_ROLE"/>
         <modifyDataType tableName="KEYCLOAK_ROLE" columnName="NAME" newDataType="NVARCHAR(255)"/>

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-3.4.1.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-3.4.1.xml
@@ -19,7 +19,7 @@
 
     <changeSet author="psilva@redhat.com" id="3.4.1">
         <!-- KEYCLOAK-4231, changing length to same value used by COMPONENT_CONFIG.VALUE -->
-        <modifyDataType tableName="CLIENT_ATTRIBUTES" columnName="VALUE" newDataType="VARCHAR(4000)"/>
+        <modifyDataType tableName="CLIENT_ATTRIBUTES" columnName="VALUE" newDataType="TEXT(4000)"/>
     </changeSet>
 
 </databaseChangeLog>

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
 
         <jetty9.version>9.1.0.v20131115</jetty9.version>
         <liquibase.version>3.4.1</liquibase.version>
-        <mysql.version>5.1.29</mysql.version>
+        <mysql.version>5.1.46</mysql.version>
         <osgi.version>4.2.0</osgi.version>
         <pax.web.version>4.2.4</pax.web.version>
         <postgresql.version>9.3-1100-jdbc41</postgresql.version>


### PR DESCRIPTION
Changes big VARCHAR variables to use TEXT to avoid Row Size limits in MySQL
Upgrades to latest 5.x jdbc driver

I also sent an email to the keycloak dev list to discuss this. https://lists.jboss.org/pipermail/keycloak-dev/2018-May/010815.html