### PR TITLE
KEYCLOAK-7361 Add `!community` profile to prod-arguments.json

### DIFF
--- a/prod-arguments.json
+++ b/prod-arguments.json
@@ -1,6 +1,6 @@
 {
   "mvn": {
-    "profiles": ["product", "jboss-release"],
+    "profiles": ["product", "!community", "jboss-release"],
     "properties": {
         "skipTests": "true"
     }


### PR DESCRIPTION
This causes the community profile to be disabled in the product build.

The product profile is active already, but unfortunately maven doesn't allow
chained profile activation, so there's no way to automatically disable the
community profile when the product profile is active.

An alternative solution would have been to add `-Dproduct` to the properties
list, but then it wouldn't be clear what was trying to be done with the extra
argument.

I've checked with `git grep -B3 '!product'`, and the only profiles that use the
`!product` property activation condition are the community profiles.