### PR TITLE
KEYCLOAK-7362 Disable mvn-golang-wrapper in the product build

### DIFF
--- a/testsuite/integration-arquillian/tests/base/pom.xml
+++ b/testsuite/integration-arquillian/tests/base/pom.xml
@@ -277,6 +277,26 @@
 
     <profiles>
         <profile>
+            <id>product</id>
+            <activation>
+                <property>
+                    <name>product</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.igormaznitsa</groupId>
+                        <artifactId>mvn-golang-wrapper</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
             <id>auth-servers-crossdc-undertow</id>
             <properties>
                 <skip.clean.second.cache>false</skip.clean.second.cache>


### PR DESCRIPTION
com.igormaznitsa:mvn-golang-wrapper is a new plugin used by the testsuite. It
depends on arbitrary internet resources, including github and
storage.googleapis.com. This isn't permissible in a product build, and so PNC
blocks it.

As a short-term solution, I've added a product profile the sets the skip
parameter to true for this plugin. Other approaches, like changing the phase of
the get goals, didn't work.