### PR TITLE
[KEYCLOAK-4828] Enable adding of default groups

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProvider.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProvider.java
@@ -262,14 +262,14 @@ public class LDAPStorageProvider implements UserStorageProvider,
 
         // Add the user to the default groups and add default required actions
         UserModel proxy = proxy(realm, user, ldapUser);
-        DefaultRoles.addDefaultRoles(realm, user);
-        
+        DefaultRoles.addDefaultRoles(realm, proxy);
+
         for (GroupModel g : realm.getDefaultGroups()) {
             proxy.joinGroup(g);
         }
         for (RequiredActionProviderModel r : realm.getRequiredActionProviders()) {
             if (r.isEnabled() && r.isDefaultAction()) {
-                user.addRequiredAction(r.getAlias());
+                proxy.addRequiredAction(r.getAlias());
             }
         }
 

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProvider.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProvider.java
@@ -38,20 +38,11 @@ import org.keycloak.credential.CredentialInputValidator;
 import org.keycloak.credential.CredentialModel;
 import org.keycloak.federation.kerberos.impl.KerberosUsernamePasswordAuthenticator;
 import org.keycloak.federation.kerberos.impl.SPNEGOAuthenticator;
-import org.keycloak.models.CredentialValidationOutput;
-import org.keycloak.models.GroupModel;
-import org.keycloak.models.KeycloakSession;
-import org.keycloak.models.LDAPConstants;
-import org.keycloak.models.ModelDuplicateException;
-import org.keycloak.models.ModelException;
+import org.keycloak.models.*;
+import org.keycloak.models.utils.DefaultRoles;
 import org.keycloak.models.utils.ReadOnlyUserModelDelegate;
 import org.keycloak.policy.PasswordPolicyManagerProvider;
 import org.keycloak.policy.PolicyError;
-import org.keycloak.models.RealmModel;
-import org.keycloak.models.RoleModel;
-import org.keycloak.models.UserCredentialModel;
-import org.keycloak.models.UserManager;
-import org.keycloak.models.UserModel;
 import org.keycloak.models.cache.UserCache;
 import org.keycloak.models.credential.PasswordUserCredentialModel;
 import org.keycloak.models.utils.KeycloakModelUtils;
@@ -269,7 +260,20 @@ public class LDAPStorageProvider implements UserStorageProvider,
         user.setSingleAttribute(LDAPConstants.LDAP_ID, ldapUser.getUuid());
         user.setSingleAttribute(LDAPConstants.LDAP_ENTRY_DN, ldapUser.getDn().toString());
 
-        return proxy(realm, user, ldapUser);
+        // Add the user to the default groups and add default required actions
+        UserModel proxy = proxy(realm, user, ldapUser);
+        DefaultRoles.addDefaultRoles(realm, user);
+        
+        for (GroupModel g : realm.getDefaultGroups()) {
+            proxy.joinGroup(g);
+        }
+        for (RequiredActionProviderModel r : realm.getRequiredActionProviders()) {
+            if (r.isEnabled() && r.isDefaultAction()) {
+                user.addRequiredAction(r.getAlias());
+            }
+        }
+
+        return proxy;
     }
 
     @Override

--- a/testsuite/integration-deprecated/src/test/java/org/keycloak/testsuite/federation/storage/ldap/LDAPRoleMappingsTest.java
+++ b/testsuite/integration-deprecated/src/test/java/org/keycloak/testsuite/federation/storage/ldap/LDAPRoleMappingsTest.java
@@ -528,4 +528,32 @@ public class LDAPRoleMappingsTest {
         }
     }
 
+    @Test
+    public void test06_newUserDefaultRolesImportModeTest() throws Exception {
+
+        // Check user group memberships
+        KeycloakSession session = keycloakRule.startSession();
+        try {
+            RealmModel appRealm = session.realms().getRealmByName("test");
+
+            // Set a default role on the realm
+            appRealm.addDefaultRole("realmRole1");
+
+            UserModel david = session.users().addUser(appRealm, "davidkeycloak");
+
+            RoleModel defaultRole = appRealm.getRole("realmRole1");
+            RoleModel realmRole2 = appRealm.getRole("realmRole2");
+
+            Assert.assertNotNull(defaultRole);
+            Assert.assertNotNull(realmRole2);
+
+            Set<RoleModel> davidRoles = david.getRealmRoleMappings();
+
+            Assert.assertTrue(davidRoles.contains(defaultRole));
+            Assert.assertFalse(davidRoles.contains(realmRole2));
+
+        } finally {
+            keycloakRule.stopSession(session, true);
+        }
+    }
 }


### PR DESCRIPTION
As reported in https://issues.jboss.org/browse/KEYCLOAK-4828 - users are not added to the default groups when the LDAP federation provider is in use. 