### PR TITLE
KEYCLOAK-6759 Create the databases for import during perf tests

### DIFF
--- a/testsuite/performance/README.datasets.md
+++ b/testsuite/performance/README.datasets.md
@@ -1,0 +1,46 @@
+# Keycloak Performance Testsuite - Generating datasets
+
+
+## Generating a set of datasets for multiple realms
+
+The first dataset is small and is created quickly. Building of each subsequent dataset continues on top
+of the previous dataset.
+
+Datasets are created with a specific released server version (rather than a snapshot) in order to be
+usable with later releases - newer server version should be able to migrate schema from any previous release.
+
+We use 10 concurrent threads, which is enough to saturate a 
+dual core machine. For quad-core you can try to double the number of workers.
+
+```
+cd testsuite/performance
+
+mvn clean install -Dserver.version=4.0.0.Beta1
+
+mvn verify -Pteardown
+mvn verify -Pprovision
+mvn verify -Pgenerate-data -Ddataset=10r100u1c -DnumOfWorkers=10
+mvn verify -Pexport-dump -Ddataset=10r100u1c
+
+mvn verify -Pgenerate-data -Ddataset=20r100u1c -DstartAtRealmIdx=10 -DnumOfWorkers=10
+mvn verify -Pexport-dump -Ddataset=20r100u1c
+
+mvn verify -Pgenerate-data -Ddataset=50r100u1c -DstartAtRealmIdx=20 -DnumOfWorkers=10
+mvn verify -Pexport-dump -Ddataset=50r100u1c
+
+mvn verify -Pgenerate-data -Ddataset=200r100u1c -DstartAtRealmIdx=50 -DnumOfWorkers=10
+mvn verify -Pexport-dump -Ddataset=200r100u1c
+
+mvn verify -Pgenerate-data -Ddataset=500r100u1c -DstartAtRealmIdx=200 -DnumOfWorkers=10
+mvn verify -Pexport-dump -Ddataset=500r100u1c
+```
+
+If the dataset dump file is not available locally but it's known that the dataset for specific version exists on the server
+it can be retrieved by specifying a proper server version again. For example:
+```
+mvn verify -Pteardown
+mvn clean install
+mvn verify -Pprovision
+mvn verify -Pimport-dump -Ddataset=20r100u1c -Dserver.version=4.0.0.Beta1
+
+```

--- a/testsuite/performance/tests/docker-compose.sh
+++ b/testsuite/performance/tests/docker-compose.sh
@@ -399,7 +399,7 @@ case "$OPERATION" in
                 fi
                 echo "Importing $DATASET.sql.gz"
                 set -o pipefail
-                if ! zcat $DATASET.sql.gz | docker exec -i $DB_CONTAINER /usr/bin/mysql -u root --password=root keycloak ; then
+                if ! gunzip -c $DATASET.sql.gz | docker exec -i $DB_CONTAINER /usr/bin/mysql -u root --password=root keycloak ; then
                     echo Import failed.
                     exit 1
                 fi

--- a/testsuite/performance/tests/parameters/datasets/10r100u1c.properties
+++ b/testsuite/performance/tests/parameters/datasets/10r100u1c.properties
@@ -1,0 +1,8 @@
+numOfRealms=10
+usersPerRealm=100
+clientsPerRealm=1
+realmRoles=100
+realmRolesPerUser=50
+clientRolesPerUser=0
+clientRolesPerClient=0
+hashIterations=27500

--- a/testsuite/performance/tests/parameters/datasets/200r100u1c.properties
+++ b/testsuite/performance/tests/parameters/datasets/200r100u1c.properties
@@ -1,0 +1,8 @@
+numOfRealms=200
+usersPerRealm=100
+clientsPerRealm=1
+realmRoles=100
+realmRolesPerUser=50
+clientRolesPerUser=0
+clientRolesPerClient=0
+hashIterations=27500

--- a/testsuite/performance/tests/parameters/datasets/20r100u1c.properties
+++ b/testsuite/performance/tests/parameters/datasets/20r100u1c.properties
@@ -1,0 +1,8 @@
+numOfRealms=20
+usersPerRealm=100
+clientsPerRealm=1
+realmRoles=100
+realmRolesPerUser=50
+clientRolesPerUser=0
+clientRolesPerClient=0
+hashIterations=27500

--- a/testsuite/performance/tests/parameters/datasets/500r100u1c.properties
+++ b/testsuite/performance/tests/parameters/datasets/500r100u1c.properties
@@ -1,0 +1,8 @@
+numOfRealms=500
+usersPerRealm=100
+clientsPerRealm=1
+realmRoles=100
+realmRolesPerUser=50
+clientRolesPerUser=0
+clientRolesPerClient=0
+hashIterations=27500

--- a/testsuite/performance/tests/parameters/datasets/50r100u1c.properties
+++ b/testsuite/performance/tests/parameters/datasets/50r100u1c.properties
@@ -1,0 +1,8 @@
+numOfRealms=50
+usersPerRealm=100
+clientsPerRealm=1
+realmRoles=100
+realmRolesPerUser=50
+clientRolesPerUser=0
+clientRolesPerClient=0
+hashIterations=27500

--- a/testsuite/performance/tests/pom.xml
+++ b/testsuite/performance/tests/pom.xml
@@ -185,6 +185,7 @@
                             <goal>read-project-properties</goal>
                         </goals>
                         <configuration>
+                            <quiet>true</quiet>
                             <files>
                                 <file>${provisioning.properties.file}</file>
                                 <file>${dataset.properties.file}</file>
@@ -456,6 +457,12 @@
         
         <profile>
             <id>generate-data</id>
+            <properties>
+                <startAtRealmIdx>0</startAtRealmIdx>
+                <ignoreConflicts>false</ignoreConflicts>
+                <skipRealmRoles>false</skipRealmRoles>
+                <skipClientRoles>false</skipClientRoles>
+            </properties>
             <build>
                 <plugins>
                     <plugin>
@@ -504,6 +511,10 @@
                                         <argument>-DauthUser=${keycloak.admin.user}</argument>
                                         <argument>-DauthPassword=${keycloak.admin.password}</argument>
                                         <argument>-DnumOfWorkers=${numOfWorkers}</argument>
+                                        <argument>-DstartAtRealmIdx=${startAtRealmIdx}</argument>
+                                        <argument>-DignoreConflicts=${ignoreConflicts}</argument>
+                                        <argument>-DskipRealmRoles=${skipRealmRoles}</argument>
+                                        <argument>-DskipClientRoles=${skipClientRoles}</argument>
                                         <argument>org.keycloak.performance.RealmsConfigurationLoader</argument>
                                         <argument>benchmark-realms.json</argument>
                                     </arguments>

--- a/testsuite/performance/tests/src/main/java/org/keycloak/performance/TestConfig.java
+++ b/testsuite/performance/tests/src/main/java/org/keycloak/performance/TestConfig.java
@@ -34,6 +34,11 @@ public class TestConfig {
     // Settings used by RealmsConfigurationLoader only - when loading data into Keycloak
     //
     public static final int numOfWorkers = Integer.getInteger("numOfWorkers", 1);
+    public static final int startAtRealmIdx = Integer.getInteger("startAtRealmIdx", 0);
+    public static final int startAtUserIdx = 0; // doesn't work properly, will be removed later //Integer.getInteger("startAtUserIdx", 0);
+    public static final boolean ignoreConflicts = "true".equals(System.getProperty("ignoreConflicts", "false"));
+    public static final boolean skipRealmRoles = "true".equals(System.getProperty("skipRealmRoles", "false"));
+    public static final boolean skipClientRoles = "true".equals(System.getProperty("skipClientRoles", "false"));
 
     //
     // Settings used by RealmConfigurationLoader to connect to Admin REST API

--- a/testsuite/performance/tests/src/main/resources/logback.xml
+++ b/testsuite/performance/tests/src/main/resources/logback.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
+        <resetJUL>true</resetJUL>
+    </contextListener>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%-5level] %logger{15} - %msg%n%rEx</pattern>
+        </encoder>
+        <immediateFlush>false</immediateFlush>
+    </appender>
+
+    <!-- Uncomment for logging ALL HTTP request and responses -->
+    <!-- 	<logger name="io.gatling.http" level="TRACE" /> -->
+    <!-- Uncomment for logging ONLY FAILED HTTP request and responses -->
+    <!-- 	<logger name="io.gatling.http" level="DEBUG" /> -->
+
+    <root level="WARN">
+        <appender-ref ref="CONSOLE" />
+    </root>
+
+</configuration>


### PR DESCRIPTION
- Marko's original PR with additional fixes related to handling HTTP 409 Conflict during data import
- It allows for incremental building of datasets on top of each other. This is useful for many-realms/many-users testing. For example we can first create 10k users dataset and export DB dump, then 50k, 100k, etc., while building on top of the data from the previous steps.
