### PR TITLE
KEYCLOAK-7454 Set product.rhsso.version to 7.3-CD1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <product.rhsso.version>7.2.2.GA</product.rhsso.version>
+        <product.rhsso.version>7.3-CD1</product.rhsso.version>
 
         <product.build-time>${timestamp}</product.build-time>
 


### PR DESCRIPTION
This version format may change in the future, but this was the comprimise
agreed on for the purposes of the current tech-preview product build.

This product version string is only used in the UI, logs, etc. So we don't have
to make it OSGI compliant, or anything else that it being used programmatically
would imply.