### PR TITLE
SAML adapter won't start under WF12

### DIFF
--- a/distribution/saml-adapters/wildfly-adapter/wildfly-modules/src/main/resources/modules/org/keycloak/keycloak-saml-wildfly-adapter/main/module.xml
+++ b/distribution/saml-adapters/wildfly-adapter/wildfly-modules/src/main/resources/modules/org/keycloak/keycloak-saml-wildfly-adapter/main/module.xml
@@ -44,7 +44,7 @@
         <module name="org.apache.httpcomponents"/>
         <module name="org.infinispan"/>
         <module name="org.infinispan.commons"/>
-        <module name="org.infinispan.cachestore.remote"/>
+        <module name="org.infinispan.persistence.remote"/>
         <module name="org.infinispan.client.hotrod"/>
     </dependencies>
 

--- a/distribution/saml-adapters/wildfly-adapter/wildfly-modules/src/main/resources/modules/org/keycloak/keycloak-saml-wildfly-elytron-adapter/main/module.xml
+++ b/distribution/saml-adapters/wildfly-adapter/wildfly-modules/src/main/resources/modules/org/keycloak/keycloak-saml-wildfly-elytron-adapter/main/module.xml
@@ -44,7 +44,7 @@
         <module name="org.apache.httpcomponents"/>
         <module name="org.infinispan"/>
         <module name="org.infinispan.commons"/>
-        <module name="org.infinispan.cachestore.remote"/>
+        <module name="org.infinispan.persistence.remote"/>
         <module name="org.infinispan.client.hotrod"/>
         <module name="org.wildfly.security.elytron"/>
     </dependencies>

--- a/distribution/saml-adapters/wildfly-adapter/wildfly-modules/src/main/resources/modules/org/keycloak/keycloak-saml-wildfly-subsystem/main/module.xml
+++ b/distribution/saml-adapters/wildfly-adapter/wildfly-modules/src/main/resources/modules/org/keycloak/keycloak-saml-wildfly-subsystem/main/module.xml
@@ -40,7 +40,7 @@
         <module name="org.jboss.as.web-common"/>
         <module name="org.jboss.metadata"/>
         <module name="org.apache.httpcomponents"/>
-        <module name="org.infinispan.cachestore.remote"/>
+        <module name="org.infinispan.persistence.remote"/>
         <module name="org.keycloak.keycloak-saml-wildfly-elytron-adapter"/>
     </dependencies>
 </module>


### PR DESCRIPTION
Wildfly 12 renamed the module tree of the Infinispan modules. Specifically, they rename "cachestore" to "persistence". Still, the keycloak adapters refer to the former naming.

I created quick fix for being able to start the SAML adapter even under Wildfly 12.