### PR TITLE
KEYCLOAK-7480 Make fuse7 adapter's jetty94 conditional on the community profile

### DIFF
--- a/adapters/oidc/fuse7/pom.xml
+++ b/adapters/oidc/fuse7/pom.xml
@@ -38,8 +38,21 @@
 
     <modules>
         <module>camel-undertow</module>
-        <module>jetty94</module>
         <module>tomcat8</module>
         <module>undertow</module>
     </modules>
+
+    <profiles>
+        <profile>
+            <id>community</id>
+            <activation>
+                <property>
+                    <name>!product</name>
+                </property>
+            </activation>
+            <modules>
+                <module>jetty94</module>
+            </modules>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
In commit d70859ef keycloak-pax-web-jetty94 was added.

org.keycloak:keycloak-jetty94-adapter:jar is a dependency of this module, and
isn't produced outside of the community profile. So, the jetty94 module here
must be consistent with that.