### PR TITLE
KEYCLOAK-7316 IsPassive is not a mandatory field

### DIFF
--- a/saml-core/src/test/java/org/keycloak/saml/processing/core/parsers/saml/SAMLParserTest.java
+++ b/saml-core/src/test/java/org/keycloak/saml/processing/core/parsers/saml/SAMLParserTest.java
@@ -96,12 +96,13 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-
+import static org.junit.Assert.assertFalse;
 /**
  * Test class for SAML parser.
  *
@@ -678,6 +679,28 @@ public class SAMLParserTest {
         assertThat(req.getRequestedAuthnContext(), notNullValue());
         assertThat(req.getRequestedAuthnContext().getAuthnContextClassRef(), hasItem(is("urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport")));
         assertThat(req.getRequestedAuthnContext().getAuthnContextDeclRef(), hasItem(is("urn:kc:SAML:2.0:ac:ref:demo:decl")));
+    }
+
+    @Test //https://issues.jboss.org/browse/KEYCLOAK-7316
+    public void testAuthnRequestOptionalIsPassive() throws Exception {
+        AuthnRequestType req = assertParsed("KEYCLOAK-7316-noAtrributes.xml", AuthnRequestType.class);
+
+        assertThat("Not null!", req.isIsPassive(), nullValue());
+        assertThat("Not null!", req.isForceAuthn(), nullValue());
+
+        req = assertParsed("KEYCLOAK-7316-withTrueAttributes.xml", AuthnRequestType.class);
+
+        assertThat(req.isIsPassive(), notNullValue());
+        assertTrue("Wrong value!", req.isIsPassive().booleanValue());
+        assertThat(req.isForceAuthn(), notNullValue());
+        assertTrue("Wrong value!", req.isForceAuthn().booleanValue());
+
+        req = assertParsed("KEYCLOAK-7316-withFalseAttributes.xml", AuthnRequestType.class);
+
+        assertThat(req.isIsPassive(), notNullValue());
+        assertFalse("Wrong value!", req.isIsPassive().booleanValue());
+        assertThat(req.isForceAuthn(), notNullValue());
+        assertFalse("Wrong value!", req.isForceAuthn().booleanValue());
     }
 
     @Test

--- a/saml-core/src/test/resources/org/keycloak/saml/processing/core/parsers/saml/KEYCLOAK-7316-noAtrributes.xml
+++ b/saml-core/src/test/resources/org/keycloak/saml/processing/core/parsers/saml/KEYCLOAK-7316-noAtrributes.xml
@@ -1,0 +1,14 @@
+<samlp:AuthnRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+                    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+                    ID="_c327a0622c69920a4bdefa8a2fd98847b67cf18473"
+                    Version="2.0"
+                    IssueInstant="2017-11-16T07:09:05Z"
+                    Destination="https://idp.example.com/auth/realms/MYIDP/protocol/saml"
+                    AssertionConsumerServiceURL="https://iif.example.com/idp/module.php/saml/sp/saml2-acs.php/default-sp"
+                    ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+                    >
+    <saml:Issuer>https://iif.example.com/idp/module.php/saml/sp/metadata.php/default-sp</saml:Issuer>
+    <samlp:Scoping>
+        <samlp:RequesterID>https://some.domain/sp</samlp:RequesterID>
+    </samlp:Scoping>
+</samlp:AuthnRequest>

--- a/saml-core/src/test/resources/org/keycloak/saml/processing/core/parsers/saml/KEYCLOAK-7316-withFalseAttributes.xml
+++ b/saml-core/src/test/resources/org/keycloak/saml/processing/core/parsers/saml/KEYCLOAK-7316-withFalseAttributes.xml
@@ -1,0 +1,16 @@
+<samlp:AuthnRequest ForceAuthn="false"
+                    IsPassive="false"
+                    xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+                    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+                    ID="_c327a0622c69920a4bdefa8a2fd98847b67cf18473"
+                    Version="2.0"
+                    IssueInstant="2017-11-16T07:09:05Z"
+                    Destination="https://idp.example.com/auth/realms/MYIDP/protocol/saml"
+                    AssertionConsumerServiceURL="https://iif.example.com/idp/module.php/saml/sp/saml2-acs.php/default-sp"
+                    ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+                    >
+    <saml:Issuer>https://iif.example.com/idp/module.php/saml/sp/metadata.php/default-sp</saml:Issuer>
+    <samlp:Scoping>
+        <samlp:RequesterID>https://some.domain/sp</samlp:RequesterID>
+    </samlp:Scoping>
+</samlp:AuthnRequest>

--- a/saml-core/src/test/resources/org/keycloak/saml/processing/core/parsers/saml/KEYCLOAK-7316-withTrueAttributes.xml
+++ b/saml-core/src/test/resources/org/keycloak/saml/processing/core/parsers/saml/KEYCLOAK-7316-withTrueAttributes.xml
@@ -1,0 +1,16 @@
+<samlp:AuthnRequest IsPassive="true"
+                    xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+                    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+                    ID="_c327a0622c69920a4bdefa8a2fd98847b67cf18473"
+                    Version="2.0"
+                    IssueInstant="2017-11-16T07:09:05Z"
+                    Destination="https://idp.example.com/auth/realms/MYIDP/protocol/saml"
+                    AssertionConsumerServiceURL="https://iif.example.com/idp/module.php/saml/sp/saml2-acs.php/default-sp"
+                    ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+                    ForceAuthn="true"
+                    >
+    <saml:Issuer>https://iif.example.com/idp/module.php/saml/sp/metadata.php/default-sp</saml:Issuer>
+    <samlp:Scoping>
+        <samlp:RequesterID>https://some.domain/sp</samlp:RequesterID>
+    </samlp:Scoping>
+</samlp:AuthnRequest>

--- a/services/src/main/java/org/keycloak/protocol/saml/SamlService.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/SamlService.java
@@ -338,8 +338,10 @@ public class SamlService extends AuthorizationEndpointBase {
 
                 }
             }
-
-            return newBrowserAuthentication(authSession, requestAbstractType.isIsPassive(), redirectToAuthentication);
+            //If unset we fall back to default "false"
+            final boolean isPassive = (null == requestAbstractType.isIsPassive() ?
+                    false : requestAbstractType.isIsPassive().booleanValue());
+            return newBrowserAuthentication(authSession, isPassive, redirectToAuthentication);
         }
 
         protected String getBindingType(AuthnRequestType requestAbstractType) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/AuthnRequestTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/AuthnRequestTest.java
@@ -33,7 +33,6 @@ public class AuthnRequestTest extends AbstractSamlTest {
 
     // KEYCLOAK-7316
     @Test
-    @Ignore
     public void testIsPassiveNotSet() throws Exception {
         String res = new SamlClientBuilder()
           .authnRequest(getAuthServerSamlEndpoint(REALM_NAME), SAML_CLIENT_ID_SALES_POST, SAML_ASSERTION_CONSUMER_URL_SALES_POST, Binding.POST)
@@ -44,6 +43,22 @@ public class AuthnRequestTest extends AbstractSamlTest {
             .build()
 
           .executeAndTransform(resp -> EntityUtils.toString(resp.getEntity()));
+
+        assertThat(res, containsString("login"));
+    }
+
+    // KEYCLOAK-7316
+    @Test
+    public void testIsForceAuthNotSet() throws Exception {
+        String res = new SamlClientBuilder()
+                .authnRequest(getAuthServerSamlEndpoint(REALM_NAME), SAML_CLIENT_ID_SALES_POST, SAML_ASSERTION_CONSUMER_URL_SALES_POST, Binding.POST)
+                .transformObject(so -> {
+                    so.setForceAuthn(null);
+                    return so;
+                })
+                .build()
+
+                .executeAndTransform(resp -> EntityUtils.toString(resp.getEntity()));
 
         assertThat(res, containsString("login"));
     }


### PR DESCRIPTION
https://issues.jboss.org/browse/KEYCLOAK-7316
IsPassive is not a mandatory field.
Some SAML plugins is not capable of setting this attribute to its default value and a NPE is created. This fix does not allow null valued isPassive in AuthnRequest but rather falls back to default FALSE.