### PR TITLE
[KEYCLOAK-7531] Javascript Adapter - Typescript definition of login.cordovaOptions

### DIFF
--- a/adapters/oidc/js/src/main/resources/keycloak.d.ts
+++ b/adapters/oidc/js/src/main/resources/keycloak.d.ts
@@ -161,6 +161,14 @@ declare namespace Keycloak {
                  * the user's profile to a new preferred locale.
 		 */
 		kcLocale?: string;
+
+		/**
+		 * Specifies arguments that are passed to the Cordova in-app-browser (if applicable).
+		 * Options 'hidden' and 'location' are not affected by these arguments.
+		 * All available options are defined at https://cordova.apache.org/docs/en/latest/reference/cordova-plugin-inappbrowser/.
+		 * Example of use: { zoom: "no", hardwareback: "yes" }
+		 */
+		cordovaOptions?: { [optionName: string]: string };
 	}
 
 	type KeycloakPromiseCallback<T> = (result: T) => void;


### PR DESCRIPTION
This [PR](https://github.com/keycloak/keycloak/pull/4998) added a new `cordovaOptions` to the `login` function.

However, its typescript definition was missing.