### PR TITLE
[KEYCLOAK-7608] Adding NPE guards to FolderThemeProvider

### DIFF
--- a/services/src/main/java/org/keycloak/theme/FolderThemeProvider.java
+++ b/services/src/main/java/org/keycloak/theme/FolderThemeProvider.java
@@ -42,33 +42,38 @@ public class FolderThemeProvider implements ThemeProvider {
 
     @Override
     public Theme getTheme(String name, Theme.Type type) throws IOException {
-        File themeDir = getThemeDir(name, type);
-        return themeDir.isDirectory() ? new FolderTheme(themeDir, name, type) : null;
+        if (themesDir != null) {
+            File themeDir = getThemeDir(name, type);
+            return themeDir.isDirectory() ? new FolderTheme(themeDir, name, type) : null;
+        } else {
+            return null;
+        } 
     }
 
     @Override
     public Set<String> nameSet(Theme.Type type) {
-        final String typeName = type.name().toLowerCase();
-        File[] themeDirs = themesDir.listFiles(new FileFilter() {
-            @Override
-            public boolean accept(File pathname) {
-                return pathname.isDirectory() && new File(pathname, typeName).isDirectory();
+        if (themesDir != null) {
+            final String typeName = type.name().toLowerCase();
+            File[] themeDirs = themesDir.listFiles(new FileFilter() {
+                @Override
+                public boolean accept(File pathname) {
+                    return pathname.isDirectory() && new File(pathname, typeName).isDirectory();
+                }
+            });
+            if (themeDirs != null) {
+                Set<String> names = new HashSet<String>();
+                for (File themeDir : themeDirs) {
+                    names.add(themeDir.getName());
+                }
+                return names;
             }
-        });
-        if (themeDirs != null) {
-            Set<String> names = new HashSet<String>();
-            for (File themeDir : themeDirs) {
-                names.add(themeDir.getName());
-            }
-            return names;
-        } else {
-            return Collections.emptySet();
         }
+        return Collections.emptySet();
     }
 
     @Override
     public boolean hasTheme(String name, Theme.Type type) {
-        return getThemeDir(name, type).isDirectory();
+        return themesDir != null ? getThemeDir(name, type).isDirectory() : false;
     }
 
     @Override


### PR DESCRIPTION
I thought of updating FolderThemeProviderFactory to return a null provider instead when no 'dir' is set but it would require adding quite a few NPE checks in other places so I was not sure how safe that option was, hence decided to do a few local NPE checks instead though I've no problems with trying that option if preferred.

FYI, NPE only starts showing up with the themes loaded from the classpath when one logs in into the administration console, this is why I did not spot it initially when experimenting with loading the themes from the classpath, only did a quick check that a customized Welcome page can be loaded... 