### PR TITLE
NPE fix for missing/null attributes

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/models/utils/KeycloakModelUtils.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/KeycloakModelUtils.java
@@ -372,7 +372,7 @@ public final class KeycloakModelUtils {
 
     public static List<String> resolveAttribute(UserModel user, String name) {
         List<String> values = user.getAttribute(name);
-        if (!values.isEmpty()) return values;
+        if (values != null && !values.isEmpty()) return values;
         for (GroupModel group : user.getGroups()) {
             values = resolveAttribute(group, name);
             if (values != null) return values;


### PR DESCRIPTION
Small fix for NPE when there are mapped attributes optional for some users (using federated storage).