### PR TITLE
Fix NullPointerException for preflightCors method

### DIFF
--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/PreAuthActionsHandler.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/PreAuthActionsHandler.java
@@ -105,7 +105,7 @@ public class PreAuthActionsHandler {
     public boolean preflightCors() {
         // don't need to resolve deployment on cors requests.  Just need to know local cors config.
         KeycloakDeployment deployment = deploymentContext.resolveDeployment(facade);
-        if (!deployment.isCors()) return false;
+        if (deployment == null || !deployment.isCors()) return false;
         log.debugv("checkCorsPreflight {0}", facade.getRequest().getURI());
         if (!facade.getRequest().getMethod().equalsIgnoreCase("OPTIONS")) {
             return false;


### PR DESCRIPTION
The deployment-resolver could return `null` at some point, so the `preflightCors` method must be able to process a non existing deployment.