### PR TITLE
Fixes KEYCLOAK-7637 UI background color issue

### DIFF
--- a/themes/src/main/resources/theme/keycloak-preview/account/resources/app/vertical-nav/vertical-nav.component.html
+++ b/themes/src/main/resources/theme/keycloak-preview/account/resources/app/vertical-nav/vertical-nav.component.html
@@ -1,4 +1,4 @@
-<div id="verticalNavLayout" class="layout-pf layout-pf-fixed faux-layout" style="background-color: white;">
+<div id="verticalNavLayout" class="layout-pf layout-pf-fixed faux-layout">
     <pfng-vertical-navigation
         #pfVerticalNav
         [brandSrc]="resourceUrl + '/app/assets/img/keycloak-logo-min.png'"
@@ -37,8 +37,7 @@
 
 
     <div #contentContainer
-        class="container-fluid container-cards-pf container-pf-nav-pf-vertical example-page-container"
-        style="background-color: white;">
+        class="container-fluid container-cards-pf container-pf-nav-pf-vertical example-page-container">
         <div class="row">
             <div class="col-sm-12">
                 <router-outlet></router-outlet>

--- a/themes/src/main/resources/theme/keycloak-preview/account/resources/styles.css
+++ b/themes/src/main/resources/theme/keycloak-preview/account/resources/styles.css
@@ -9,6 +9,9 @@ body {
 .cards-pf {
   background: #f5f5f5;
 }
+.card-pf {
+  margin: 0 0 20px;
+}
 .card-pf .row-cards-pf:first-child {
   padding-top: 0px;
 }
@@ -54,7 +57,10 @@ p.description {
   background: #ffffff;
   margin-bottom: 10px;
 }
-
+.row {
+  margin-left: -20px;
+  margin-right: -20px;
+}
 
 /*Responsive Design*/
 @media (max-width: 767px) {


### PR DESCRIPTION
This PR is aim to fix the ui background color issue.
JIRA task: https://issues.jboss.org/browse/KEYCLOAK-7637

Before Screenshot:
<img width="1165" alt="screen shot 2018-06-15 at 3 03 54 pm" src="https://user-images.githubusercontent.com/701009/41456761-0b5af8ba-70b4-11e8-884c-9f6f6a0a8271.png">


After Screenshot:
<img width="1155" alt="screen shot 2018-06-15 at 3 11 42 pm" src="https://user-images.githubusercontent.com/701009/41456770-11a76762-70b4-11e8-96ee-a654b50cd18f.png">

@ssilvert Could you help to review this PR, please?