### PR TITLE
KEYCLOAK-7015: Not allowing two users to have empty string emails addrs.

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/UserResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UserResource.java
@@ -195,6 +195,7 @@ public class UserResource {
             user.setUsername(rep.getUsername());
         }
         if (rep.getEmail() != null) user.setEmail(rep.getEmail());
+        if (rep.getEmail() == "") user.setEmail(null);
         if (rep.getFirstName() != null) user.setFirstName(rep.getFirstName());
         if (rep.getLastName() != null) user.setLastName(rep.getLastName());
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/UserTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/UserTest.java
@@ -324,6 +324,13 @@ public class UserTest extends AbstractAdminTest {
         assertAdminEvents.assertEmpty();
 
     }
+    
+    // KEYCLOAK-7015
+    @Test
+    public void createTwoUsersWithEmptyStringEmails() {
+        createUser("user1", "");
+        createUser("user2", "");
+    }
 
     @Test
     public void createUserWithFederationLink() {
@@ -1212,7 +1219,7 @@ public class UserTest extends AbstractAdminTest {
             switchEditUsernameAllowedOn(false);
         }
     }
-
+    
     @Test
     public void resetUserPassword() {
         String userId = createUser("user1", "user1@localhost");


### PR DESCRIPTION
Problem manifests itself if you try to change two email addresses to empty.  Admin console needs to send an empty string, which was getting saved in the database.  On second user you would get a constraint violation.

Same problem if you use admin REST API to create two users with empty string emails.