### PR TITLE
[KEYCLOAK-7695] Restore token_type and expires_in for implicit flow

### DIFF
--- a/adapters/oidc/js/src/main/resources/keycloak.js
+++ b/adapters/oidc/js/src/main/resources/keycloak.js
@@ -907,7 +907,7 @@
                     supportedParams = ['code', 'state', 'session_state'];
                     break;
                 case 'implicit':
-                    supportedParams = ['access_token', 'id_token', 'state', 'session_state'];
+                    supportedParams = ['access_token', 'token_type', 'id_token', 'state', 'session_state', 'expires_in'];
                     break;
                 case 'hybrid':
                     supportedParams = ['access_token', 'id_token', 'code', 'state', 'session_state'];

--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocol.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocol.java
@@ -235,6 +235,10 @@ public class OIDCLoginProtocol implements LoginProtocol {
 
             if (responseType.hasResponseType(OIDCResponseType.TOKEN)) {
                 redirectUri.addParam(OAuth2Constants.ACCESS_TOKEN, res.getToken());
+                if (responseType.isImplicitFlow()) {
+                    redirectUri.addParam("token_type", res.getTokenType());
+                    redirectUri.addParam("expires_in", String.valueOf(res.getExpiresIn()));
+                }
             }
         }
 


### PR DESCRIPTION
As [`KEYCLOAK-6585`](https://issues.jboss.org/browse/KEYCLOAK-6585) concerns only hybrid flow, this commit restores the old behavior for implicit flow.

This commit partially reverts #5041 (`061049e41a6b0e6fb45c75f05748023ad7ab7d92`).