### PR TITLE
KEYCLOAK-7702: Admin API: Delete offline session by id

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/RealmAdminResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RealmAdminResource.java
@@ -588,10 +588,17 @@ public class RealmAdminResource {
         auth.users().requireManage();
 
         UserSessionModel userSession = session.sessions().getUserSession(realm, sessionId);
-        if (userSession == null) throw new NotFoundException("Sesssion not found");
-        AuthenticationManager.backchannelLogout(session, realm, userSession, uriInfo, connection, headers, true);
-        adminEvent.operation(OperationType.DELETE).resource(ResourceType.USER_SESSION).resourcePath(uriInfo).success();
+        UserSessionModel offlineSession = session.sessions().getOfflineUserSession(realm, sessionId);
+        if (userSession == null && offlineSession == null) {
+            throw new NotFoundException("Session not found");
+        }
+        if (offlineSession != null) {
+            AuthenticationManager.backchannelLogout(session, realm, offlineSession, uriInfo, connection, headers, true, true);
+        } else if (userSession != null) {
+            AuthenticationManager.backchannelLogout(session, realm, userSession, uriInfo, connection, headers, true, false);
+        }
 
+        adminEvent.operation(OperationType.DELETE).resource(ResourceType.USER_SESSION).resourcePath(uriInfo).success();
     }
 
     /**


### PR DESCRIPTION
In the admin api, when given a session id, it is only deleted if there still exists a corresponding user session by this id.
This commit also considers offline session when deleting a session by id.