### PR TITLE
KEYCLOAK-5023 database migration fails if mysql schema name has hyphen

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/connections/jpa/updater/liquibase/custom/AddRealmCodeSecret.java
+++ b/model/jpa/src/main/java/org/keycloak/connections/jpa/updater/liquibase/custom/AddRealmCodeSecret.java
@@ -27,6 +27,7 @@ import liquibase.resource.ResourceAccessor;
 import liquibase.snapshot.SnapshotGeneratorFactory;
 import liquibase.statement.SqlStatement;
 import liquibase.statement.core.UpdateStatement;
+import liquibase.structure.core.Schema;
 import liquibase.structure.core.Table;
 import org.keycloak.connections.jpa.updater.liquibase.LiquibaseJpaUpdaterProvider;
 import org.keycloak.models.utils.KeycloakModelUtils;
@@ -52,8 +53,10 @@ public class AddRealmCodeSecret implements CustomSqlChange {
             ArrayList<SqlStatement> statements = new ArrayList<SqlStatement>();
 
             String correctedTableName = database.correctObjectName("REALM", Table.class);
+            String correctedSchemaName = database.escapeObjectName(database.getDefaultSchemaName(), Schema.class);
+
             if (SnapshotGeneratorFactory.getInstance().has(new Table().setName(correctedTableName), database)) {
-                ResultSet resultSet = connection.createStatement().executeQuery("SELECT ID FROM " + LiquibaseJpaUpdaterProvider.getTable(correctedTableName, database.getDefaultSchemaName()) + " WHERE CODE_SECRET IS NULL");
+                ResultSet resultSet = connection.createStatement().executeQuery("SELECT ID FROM " + LiquibaseJpaUpdaterProvider.getTable(correctedTableName, correctedSchemaName) + " WHERE CODE_SECRET IS NULL");
                 while (resultSet.next()) {
                     String id = resultSet.getString(1);
 

--- a/model/jpa/src/main/java/org/keycloak/connections/jpa/updater/liquibase/custom/CustomKeycloakTask.java
+++ b/model/jpa/src/main/java/org/keycloak/connections/jpa/updater/liquibase/custom/CustomKeycloakTask.java
@@ -26,6 +26,7 @@ import liquibase.exception.ValidationErrors;
 import liquibase.resource.ResourceAccessor;
 import liquibase.snapshot.SnapshotGeneratorFactory;
 import liquibase.statement.SqlStatement;
+import liquibase.structure.core.Schema;
 import liquibase.structure.core.Table;
 import org.jboss.logging.Logger;
 import org.keycloak.connections.jpa.updater.liquibase.LiquibaseJpaUpdaterProvider;
@@ -129,6 +130,7 @@ public abstract class CustomKeycloakTask implements CustomSqlChange {
 
     // get Table name for sql selects
     protected String getTableName(String tableName) {
-       return LiquibaseJpaUpdaterProvider.getTable(tableName, database.getDefaultSchemaName());
+        String correctedSchemaName = database.escapeObjectName(database.getDefaultSchemaName(), Schema.class);
+        return LiquibaseJpaUpdaterProvider.getTable(tableName, correctedSchemaName);
     }
 }


### PR DESCRIPTION
@mposolda @vramik I've run test-keycloak-jpa-migration-manual, test-keycloak-jpa-migration-auto-import, test-keycloak-jpa and results look good to me. Also tested locally on mysql with "tmp-tmp" schema and the fix helped. 