### PR TITLE
KEYCLOAK-2886 Turn off clustered tests from IDE

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/AuthServerTestEnricher.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/AuthServerTestEnricher.java
@@ -70,28 +70,28 @@ public class AuthServerTestEnricher {
     private Event<StopContainer> stopContainerEvent;
 
     public static final String AUTH_SERVER_CONTAINER_DEFAULT = "auth-server-undertow";
-    private static final String AUTH_SERVER_CONTAINER_PROPERTY = "auth.server.container";
+    public static final String AUTH_SERVER_CONTAINER_PROPERTY = "auth.server.container";
     public static final String AUTH_SERVER_CONTAINER = System.getProperty(AUTH_SERVER_CONTAINER_PROPERTY, AUTH_SERVER_CONTAINER_DEFAULT);
 
-    private static final String AUTH_SERVER_BACKEND_DEFAULT = AUTH_SERVER_CONTAINER + "-backend";
-    private static final String AUTH_SERVER_BACKEND_PROPERTY = "auth.server.backend";
+    public static final String AUTH_SERVER_BACKEND_DEFAULT = AUTH_SERVER_CONTAINER + "-backend";
+    public static final String AUTH_SERVER_BACKEND_PROPERTY = "auth.server.backend";
     public static final String AUTH_SERVER_BACKEND = System.getProperty(AUTH_SERVER_BACKEND_PROPERTY, AUTH_SERVER_BACKEND_DEFAULT);
 
-    private static final String AUTH_SERVER_BALANCER_DEFAULT = "auth-server-balancer";
-    private static final String AUTH_SERVER_BALANCER_PROPERTY = "auth.server.balancer";
+    public static final String AUTH_SERVER_BALANCER_DEFAULT = "auth-server-balancer";
+    public static final String AUTH_SERVER_BALANCER_PROPERTY = "auth.server.balancer";
     public static final String AUTH_SERVER_BALANCER = System.getProperty(AUTH_SERVER_BALANCER_PROPERTY, AUTH_SERVER_BALANCER_DEFAULT);
 
-    private static final String AUTH_SERVER_CLUSTER_PROPERTY = "auth.server.cluster";
+    public static final String AUTH_SERVER_CLUSTER_PROPERTY = "auth.server.cluster";
     public static final boolean AUTH_SERVER_CLUSTER = Boolean.parseBoolean(System.getProperty(AUTH_SERVER_CLUSTER_PROPERTY, "false"));
-    private static final String AUTH_SERVER_CROSS_DC_PROPERTY = "auth.server.crossdc";
+    public static final String AUTH_SERVER_CROSS_DC_PROPERTY = "auth.server.crossdc";
     public static final boolean AUTH_SERVER_CROSS_DC = Boolean.parseBoolean(System.getProperty(AUTH_SERVER_CROSS_DC_PROPERTY, "false"));
 
-    private static final Boolean START_MIGRATION_CONTAINER = "auto".equals(System.getProperty("migration.mode")) || 
+    public static final Boolean START_MIGRATION_CONTAINER = "auto".equals(System.getProperty("migration.mode")) ||
             "manual".equals(System.getProperty("migration.mode"));
 
     // In manual mode are all containers despite loadbalancers started in mode "manual" and nothing is managed through "suite".
     // Useful for tests, which require restart servers etc.
-    private static final String MANUAL_MODE = "manual.mode";
+    public static final String MANUAL_MODE = "manual.mode";
 
     @Inject
     @SuiteScoped

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/ContainerAssume.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/ContainerAssume.java
@@ -32,6 +32,12 @@ public class ContainerAssume {
                 AuthServerTestEnricher.AUTH_SERVER_CONTAINER.equals(AuthServerTestEnricher.AUTH_SERVER_CONTAINER_DEFAULT));
     }
 
+    public static void assumeClusteredContainer() {
+        Assume.assumeTrue(
+              String.format("Ignoring test since %s is set to false",
+                    AuthServerTestEnricher.AUTH_SERVER_CLUSTER_PROPERTY), AuthServerTestEnricher.AUTH_SERVER_CLUSTER);
+    }
+
     public static void assumeNotAppServerUndertow() {
         log.warn("TODO: Not stable on app-server-undertow. "
                 + "It throws: KC-SERVICES0057: Logout for client '${CLIENT_NAME}' failed\n" 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/cluster/AbstractClusterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/cluster/AbstractClusterTest.java
@@ -3,12 +3,14 @@ package org.keycloak.testsuite.cluster;
 import org.jboss.arquillian.container.test.api.ContainerController;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.models.Constants;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.testsuite.AbstractKeycloakTest;
 import org.keycloak.testsuite.arquillian.ContainerInfo;
 import org.keycloak.testsuite.client.KeycloakTestingClient;
+import org.keycloak.testsuite.util.ContainerAssume;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -151,6 +153,11 @@ public abstract class AbstractClusterTest extends AbstractKeycloakTest {
         }
 
         return testingClient;
+    }
+
+    @BeforeClass
+    public static void enabled() {
+        ContainerAssume.assumeClusteredContainer();
     }
 
     @Before

--- a/testsuite/integration-arquillian/tests/pom.xml
+++ b/testsuite/integration-arquillian/tests/pom.xml
@@ -891,9 +891,6 @@
                             </execution>
                         </executions>
                     </plugin>
-                    <plugin>
-                        <artifactId>maven-antrun-plugin</artifactId>
-                    </plugin>
                 </plugins>
                 <pluginManagement>
                     <plugins>
@@ -963,9 +960,6 @@
                                 </configuration>
                             </execution>
                         </executions>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-antrun-plugin</artifactId>
                     </plugin>
                 </plugins>
                 <pluginManagement>
@@ -1082,9 +1076,6 @@
                                 </configuration>
                             </execution>
                         </executions>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-antrun-plugin</artifactId>
                     </plugin>
                 </plugins>
                 <pluginManagement>
@@ -1712,6 +1703,9 @@
                     </plugin>
                     <plugin>
                         <artifactId>maven-dependency-plugin</artifactId>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-antrun-plugin</artifactId>
                     </plugin>
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
https://issues.jboss.org/browse/KEYCLOAK-2886

I followed the suggestion from @stianst and the manual entry for caching tests. In order to run them we need to:
- Assume, the `auth.server.cluster` is set to `true`. Essentially, this means that we're running with `auth-server-cluster` profile.
- Use Wildfly or EAP. For this I used the same approach as for the adapters - `@AppServerContainer` annotation.

There are also two additional parts of this PR - one replaced the `adapter` word used in the tests (because now we also use it in clustering tests). The second part moves `maven-antrun-plugin` to the `common-test-dependencies` profile. This allows to run `mvn install -Pauth-server-cluster,auth-server-wildfly,distribution -DskipTests` on the project root (previously it failed with ant error).