### PR TITLE
KEYCLOAK-7718 DemoFilterServletAdapterTest not configured correctly

### DIFF
--- a/testsuite/integration-arquillian/servers/app-server/jboss/common/add-secured-deployments.bat
+++ b/testsuite/integration-arquillian/servers/app-server/jboss/common/add-secured-deployments.bat
@@ -1,0 +1,35 @@
+set NOPAUSE=true
+
+start "JBoss Server" /b cmd /c %JBOSS_HOME%\bin\standalone.bat -Djboss.server.config.dir=%JBOSS_HOME%\standalone-secured-deployments\configuration
+
+set ERROR=0
+set TIMEOUT=10
+set I=0
+
+ping 127.0.0.1 -n 3 > nul
+
+
+:wait_for_jboss
+call %JBOSS_HOME%\bin\jboss-cli.bat -c --command=":read-attribute(name=server-state)" | findstr "running"
+if %ERRORLEVEL% equ 0 goto add_secured_deployments
+ping 127.0.0.1 -n 1 > nul
+set /a I=%I%+1
+if %I% gtr %TIMEOUT% (
+    set ERROR=1
+    goto shutdown_jboss
+)
+goto wait_for_jboss
+
+
+:add_secured_deployments
+call %JBOSS_HOME%\bin\jboss-cli.bat -c --file="%CLI_PATH%\add-secured-deployments.cli"
+set ERROR=%ERRORLEVEL%
+echo Error code: "%ERROR%"
+if %ERROR% neq 0 (
+    goto shutdown_jboss
+)
+
+:shutdown_jboss
+echo Shutting down with error code: "%ERROR%"
+call %JBOSS_HOME%\bin\jboss-cli.bat -c --command=":shutdown"
+exit /b %ERROR%

--- a/testsuite/integration-arquillian/servers/app-server/jboss/common/add-secured-deployments.sh
+++ b/testsuite/integration-arquillian/servers/app-server/jboss/common/add-secured-deployments.sh
@@ -8,7 +8,7 @@ fi
 
 cd $JBOSS_HOME/bin
 
-./standalone.sh &
+./standalone.sh -Djboss.server.config.dir=$JBOSS_HOME/standalone-secured-deployments/configuration &
 sleep 3
 
 TIMEOUT=10
@@ -20,19 +20,11 @@ RESULT=0
 until [ $T -gt $TIMEOUT ]
 do
     if ./jboss-cli.sh -c --command=":read-attribute(name=server-state)" | grep -q "running" ; then
-        echo "Server is running. Installing adapter."
+        echo "Server is running. Adding secured deployments"
 
-        ./jboss-cli.sh -c --file="adapter-install.cli"
+        ./jboss-cli.sh -c --file="$CLI_PATH/add-secured-deployments.cli"
         RESULT=$?
-        echo "Return code of adapter-install:"${RESULT}
-
-        if [ "$SAML_SUPPORTED" = true ] && [ ${RESULT} -eq 0 ]; then
-            ./jboss-cli.sh -c --file="adapter-install-saml.cli"
-            RESULT=$?
-            echo "Return code of saml adapter-install:"$RESULT
-        fi
-
-        ./jboss-cli.sh -c --file="$CLI_PATH/add-adapter-log-level.cli"
+        echo "Return code:"${RESULT}
 
         ./jboss-cli.sh -c --command=":shutdown"
         rm -rf $JBOSS_HOME/standalone/data

--- a/testsuite/integration-arquillian/servers/app-server/jboss/common/install-adapters-online.bat
+++ b/testsuite/integration-arquillian/servers/app-server/jboss/common/install-adapters-online.bat
@@ -39,7 +39,6 @@ if "%SAML_SUPPORTED%" == "true" (
 )
 
 call %JBOSS_HOME%\bin\jboss-cli.bat -c --file="%CLI_PATH%\add-adapter-log-level.cli"
-call %JBOSS_HOME%\bin\jboss-cli.bat -c --file="%CLI_PATH%\add-secured-deployments.cli"
 
 :shutdown_jboss
 echo Shutting down with error code: "%ERROR%"

--- a/testsuite/integration-arquillian/servers/app-server/jboss/eap/src/main/java/org/keycloak/testsuite/arquillian/eap/container/EAPAppServerProvider.java
+++ b/testsuite/integration-arquillian/servers/app-server/jboss/eap/src/main/java/org/keycloak/testsuite/arquillian/eap/container/EAPAppServerProvider.java
@@ -85,6 +85,7 @@ public class EAPAppServerProvider implements AppServerContainerProvider {
         createChild("jbossHome", appServerHome);
         createChild("javaHome", appServerJavaHome);
         createChild("jbossArguments", 
+                "-Djboss.server.base.dir=" + appServerHome + "/standalone-test " +
                 "-Djboss.socket.binding.port-offset=" + appServerPortOffset + " " +
                 System.getProperty("adapter.test.props", " ") +
                 System.getProperty("kie.maven.settings", " ")

--- a/testsuite/integration-arquillian/servers/app-server/jboss/eap6/pom.xml
+++ b/testsuite/integration-arquillian/servers/app-server/jboss/eap6/pom.xml
@@ -118,6 +118,22 @@
                             </environmentVariables>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>add-secured-deployments-eap6</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>${common.resources}/add-secured-deployments.${script.suffix}</executable>
+                            <workingDirectory>${app.server.jboss.home}/bin</workingDirectory>
+                            <environmentVariables>
+                                <JAVA_HOME>${app.server.java.home}</JAVA_HOME>
+                                <JBOSS_HOME>${app.server.jboss.home}</JBOSS_HOME>
+                                <CLI_PATH>${common.resources}/cli/eap6/</CLI_PATH>
+                            </environmentVariables>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>

--- a/testsuite/integration-arquillian/servers/app-server/jboss/eap6/src/main/java/org/keycloak/testsuite/arquillian/eap/container/EAP6AppServerProvider.java
+++ b/testsuite/integration-arquillian/servers/app-server/jboss/eap6/src/main/java/org/keycloak/testsuite/arquillian/eap/container/EAP6AppServerProvider.java
@@ -85,6 +85,7 @@ public class EAP6AppServerProvider implements AppServerContainerProvider {
         createChild("jbossHome", appServerHome);
         createChild("javaHome", appServerJavaHome);
         createChild("jbossArguments", 
+                "-Djboss.server.base.dir=" + appServerHome + "/standalone-test " +
                 "-Djboss.socket.binding.port-offset=" + appServerPortOffset + " " +
                 System.getProperty("adapter.test.props", " ") +
                 System.getProperty("kie.maven.settings", " ")

--- a/testsuite/integration-arquillian/servers/app-server/jboss/pom.xml
+++ b/testsuite/integration-arquillian/servers/app-server/jboss/pom.xml
@@ -205,6 +205,21 @@
                                 </configuration>
                             </execution>
                             <execution>
+                                <id>copy-configs-secured-deployments</id>
+                                <phase>generate-test-sources</phase>
+                                <goals>
+                                    <goal>copy-resources</goal>
+                                </goals>
+                                <configuration>
+                                    <outputDirectory>${app.server.jboss.home}/standalone-secured-deployments</outputDirectory>
+                                    <resources>
+                                        <resource>
+                                            <directory>${app.server.jboss.home}/standalone</directory>
+                                        </resource>
+                                    </resources>
+                                </configuration>
+                            </execution>
+                            <execution>
                                 <id>copy-configs-crossdc</id>
                                 <phase>generate-test-sources</phase>
                                 <goals>
@@ -393,7 +408,7 @@
                             </execution>
                             <execution>
                                 <id>add-secured-deployments</id>
-                                <phase>process-resources</phase>
+                                <phase>generate-test-sources</phase>
                                 <goals>
                                     <goal>exec</goal>
                                 </goals>
@@ -403,6 +418,7 @@
                                     <executable>./jboss-cli.sh</executable>
                                     <arguments>
                                         <argument>--file=${common.resources}/cli/add-secured-deployments.cli</argument>
+                                        <argument>-Djboss.server.config.dir=${app.server.jboss.home}/standalone-secured-deployments/configuration</argument>
                                     </arguments>
                                 </configuration>
                             </execution>

--- a/testsuite/integration-arquillian/servers/app-server/jboss/wildfly/src/main/java/org/keycloak/testsuite/arquillian/wildfly/container/WildflyAppServerProvider.java
+++ b/testsuite/integration-arquillian/servers/app-server/jboss/wildfly/src/main/java/org/keycloak/testsuite/arquillian/wildfly/container/WildflyAppServerProvider.java
@@ -85,6 +85,7 @@ public class WildflyAppServerProvider implements AppServerContainerProvider {
         createChild("jbossHome", appServerHome);
         createChild("javaHome", appServerJavaHome);
         createChild("jbossArguments", 
+                "-Djboss.server.base.dir=" + appServerHome + "/standalone-test " +
                 "-Djboss.socket.binding.port-offset=" + appServerPortOffset + " " +
                 System.getProperty("adapter.test.props", " ") +
                 System.getProperty("kie.maven.settings", " ")

--- a/testsuite/integration-arquillian/servers/app-server/jboss/wildfly10/src/main/java/org/keycloak/testsuite/arquillian/wildfly/container/Wildfly10AppServerProvider.java
+++ b/testsuite/integration-arquillian/servers/app-server/jboss/wildfly10/src/main/java/org/keycloak/testsuite/arquillian/wildfly/container/Wildfly10AppServerProvider.java
@@ -85,6 +85,7 @@ public class Wildfly10AppServerProvider implements AppServerContainerProvider {
         createChild("jbossHome", appServerHome);
         createChild("javaHome", appServerJavaHome);
         createChild("jbossArguments", 
+                "-Djboss.server.base.dir=" + appServerHome + "/standalone-test " +
                 "-Djboss.socket.binding.port-offset=" + appServerPortOffset + " " +
                 System.getProperty("adapter.test.props", " ") +
                 System.getProperty("kie.maven.settings", " ")

--- a/testsuite/integration-arquillian/servers/app-server/jboss/wildfly9/src/main/java/org/keycloak/testsuite/arquillian/wildfly/container/Wildfly9AppServerProvider.java
+++ b/testsuite/integration-arquillian/servers/app-server/jboss/wildfly9/src/main/java/org/keycloak/testsuite/arquillian/wildfly/container/Wildfly9AppServerProvider.java
@@ -85,6 +85,7 @@ public class Wildfly9AppServerProvider implements AppServerContainerProvider {
         createChild("jbossHome", appServerHome);
         createChild("javaHome", appServerJavaHome);
         createChild("jbossArguments", 
+                "-Djboss.server.base.dir=" + appServerHome + "/standalone-test " +
                 "-Djboss.socket.binding.port-offset=" + appServerPortOffset + " " +
                 System.getProperty("adapter.test.props", " ") +
                 System.getProperty("kie.maven.settings", " ")

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/AppServerTestEnricher.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/AppServerTestEnricher.java
@@ -17,6 +17,8 @@
 
 package org.keycloak.testsuite.arquillian;
 
+import java.io.File;
+import org.apache.commons.io.FileUtils;
 import org.jboss.arquillian.container.test.api.ContainerController;
 import org.jboss.arquillian.core.api.Instance;
 import org.jboss.arquillian.core.api.annotation.Inject;
@@ -25,6 +27,7 @@ import org.jboss.arquillian.test.spi.event.suite.BeforeClass;
 import org.jboss.logging.Logger;
 import org.keycloak.testsuite.arquillian.annotation.AppServerContainer;
 import org.keycloak.testsuite.arquillian.annotation.AppServerContainers;
+import org.keycloak.testsuite.arquillian.containers.SelfManagedAppContainerLifecycle;
 import org.wildfly.extras.creaper.core.ManagementClient;
 import org.wildfly.extras.creaper.core.online.ManagementProtocol;
 import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
@@ -33,6 +36,8 @@ import org.wildfly.extras.creaper.core.online.OnlineOptions;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -46,7 +51,7 @@ import static org.keycloak.testsuite.arquillian.AuthServerTestEnricher.getAuthSe
  */
 public class AppServerTestEnricher {
 
-    protected final Logger log = Logger.getLogger(this.getClass());
+    private static final Logger log = Logger.getLogger(AppServerTestEnricher.class);
 
     public static final String CURRENT_APP_SERVER = System.getProperty("app.server", "undertow");
 
@@ -160,13 +165,40 @@ public class AppServerTestEnricher {
     }
 
     public void startAppServer(@Observes(precedence = -1) BeforeClass event) throws MalformedURLException, InterruptedException, IOException {
+        // if testClass implements SelfManagedAppContainerLifecycle we skip starting container and let the test to manage the lifecycle itself
+        if (SelfManagedAppContainerLifecycle.class.isAssignableFrom(event.getTestClass().getJavaClass())) {
+            log.debug("Skipping starting App server. Server should be started by testClass.");
+            return;
+        }
         if (testContext.isAdapterContainerEnabled() && !testContext.isRelativeAdapterTest()) {
+            if (isJBossBased()) {
+                prepareServerDir("standalone");
+            }
             ContainerController controller = containerConrollerInstance.get();
             if (!controller.isStarted(testContext.getAppServerInfo().getQualifier())) {
                 log.info("Starting app server: " + testContext.getAppServerInfo().getQualifier());
                 controller.start(testContext.getAppServerInfo().getQualifier());
             }
         }
+    }
+
+    /**
+     * Workaround for WFARQ-44. It cannot be used 'cleanServerBaseDir' property.
+     * 
+     * It copies deployments and configuration into $JBOSS_HOME/standalone-test from where 
+     * the container is started for the test
+     * 
+     * @param baseDir string representing folder name, relative to app.server.home, from which the copy is made
+     * @throws IOException 
+     */
+    public static void prepareServerDir(String baseDir) throws IOException {
+        log.debug("Creating cleanServerBaseDir from: " + baseDir);
+        Path path = Paths.get(System.getProperty("app.server.home"), "standalone-test");
+        File targetSubdirFile = path.toFile();
+        FileUtils.deleteDirectory(targetSubdirFile);
+        FileUtils.forceMkdir(targetSubdirFile);
+        FileUtils.copyDirectory(Paths.get(System.getProperty("app.server.home"), baseDir, "deployments").toFile(), new File(targetSubdirFile, "deployments"));
+        FileUtils.copyDirectory(Paths.get(System.getProperty("app.server.home"), baseDir, "configuration").toFile(), new File(targetSubdirFile, "configuration"));
     }
 
     /**
@@ -230,4 +262,7 @@ public class AppServerTestEnricher {
         return CURRENT_APP_SERVER.contains("karaf") || CURRENT_APP_SERVER.contains("fuse");
     }
 
+    private boolean isJBossBased() {
+        return testContext.getAppServerInfo().isJBossBased();
+    }
 }

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/containers/SelfManagedAppContainerLifecycle.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/containers/SelfManagedAppContainerLifecycle.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.testsuite.arquillian.containers;
+
+/**
+ *
+ * @author vramik
+ */
+public interface SelfManagedAppContainerLifecycle {
+    
+    void startServer();
+    void stopServer();
+}

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/AbstractAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/AbstractAdapterTest.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.testsuite.adapter;
 
+import java.io.File;
 import org.apache.commons.io.IOUtils;
 import org.jboss.arquillian.graphene.page.Page;
 import org.jboss.shrinkwrap.api.Archive;
@@ -43,10 +44,14 @@ import org.wildfly.extras.creaper.core.online.operations.admin.Administration;
 
 import java.io.IOException;
 import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
+import org.apache.commons.io.FileUtils;
+import org.junit.Before;
 
 /**
  * <code>@AppServerContainer</code> is needed for stopping recursion in 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/DemoServletsAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/DemoServletsAdapterTest.java
@@ -997,7 +997,7 @@ public class DemoServletsAdapterTest extends AbstractServletsAdapterTest {
 
         String appServer = System.getProperty("app.server");
         if (appServer != null && (appServer.equals("wildfly") || appServer.equals("eap6") || appServer.equals("eap"))) {
-            serverLogPath = System.getProperty("app.server.home") + "/standalone/log/server.log";
+            serverLogPath = System.getProperty("app.server.home") + "/standalone-test/log/server.log";
         }
 
         String appServerUrl;


### PR DESCRIPTION
@pedroigor can you pls check if this resolves the issue? 

The idea behind is that for all tests we specify `-Djboss.server.base.dir=" + appServerHome + "/standalone-test"` when container is started. 

For `SecuredDeploymentsAdapterTest.java` it's used "[standalone-secured-deployments](https://github.com/vramik/keycloak/commit/baaf783c1ce2397736badb92db03401679fbbc44#diff-9e9d78ea4d2ab9ecf14039c17ee3f2d7R214)" as template, otherwise by default "standalone" is used. 

"standalone-secured-deployments" contains `<secure-deployment ...`
"standalone" doesn't.