### PR TITLE
KEYCLOAK-7733 Change product version format

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <product.rhsso.version>7.3-CD2</product.rhsso.version>
+        <product.rhsso.version>7.3.0.CD02</product.rhsso.version>
 
         <product.build-time>${timestamp}</product.build-time>
 


### PR DESCRIPTION
Brew rejecting a container version of 7.3-CD2 due to the dash has triggered a
redesign of the product version number. New format:

7.3.0.CD02

This is OSGI compatible, and if there's a need in the future to use this
product version for a maven artifact, then it would look like this in the maven
artifact version:

7.3.0.CD02-redhat-1

There are numerous flaws with this format, but it's all we have to work with
given OSGI.