### PR TITLE
KEYCLOAK-7821 Spring-Boot -- Enable tomcat-specific features: `*` (all roles), `**` (authenticated users)

### DIFF
--- a/adapters/oidc/spring-boot-adapter-core/src/main/java/org/keycloak/adapters/springboot/KeycloakBaseSpringBootConfiguration.java
+++ b/adapters/oidc/spring-boot-adapter-core/src/main/java/org/keycloak/adapters/springboot/KeycloakBaseSpringBootConfiguration.java
@@ -223,9 +223,12 @@ public class KeycloakBaseSpringBootConfiguration {
 
             for (KeycloakSpringBootProperties.SecurityConstraint constraint : keycloakProperties.getSecurityConstraints()) {
                 SecurityConstraint tomcatConstraint = new SecurityConstraint();
-
                 for (String authRole : constraint.getAuthRoles()) {
                     tomcatConstraint.addAuthRole(authRole);
+                    if(authRole.equals("*") || authRole.equals("**")) {
+                        // For some reasons embed tomcat don't set the auth constraint on true when wildcard is used
+                        tomcatConstraint.setAuthConstraint(true);
+                    }
                 }
 
                 for (KeycloakSpringBootProperties.SecurityCollection collection : constraint.getSecurityCollections()) {


### PR DESCRIPTION
This lets you specify a security constraint that demand a user to have ANY role (*) or to be AUTHENTICATED (**). This feature is Tomcat-specific. Examples:

    keycloak.securityConstraints[0].authRoles[0]=**
    keycloak.securityConstraints[0].securityCollections[0].name=authenticated user resources
    keycloak.securityConstraints[0].securityCollections[0].patterns=/authenticated/*

    keycloak.securityConstraints[1].authRoles[0]=*
    keycloak.securityConstraints[1].securityCollections[0].name=any role resources
    keycloak.securityConstraints[1].securityCollections[0].patterns=/anyRole/*
