### PR TITLE
KEYCLOAK-7844: Space in the realm name causes infinite browser redirects

### DIFF
--- a/core/src/main/java/org/keycloak/KeycloakSecurityContext.java
+++ b/core/src/main/java/org/keycloak/KeycloakSecurityContext.java
@@ -26,6 +26,9 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Available in secured requests under HttpServlerRequest.getAttribute()
@@ -75,7 +78,14 @@ public class KeycloakSecurityContext implements Serializable {
 
     public String getRealm() {
         // Assumption that issuer contains realm name
-        return token.getIssuer().substring(token.getIssuer().lastIndexOf('/') + 1);
+        String realmName = token.getIssuer().substring(token.getIssuer().lastIndexOf('/') + 1);
+
+        //trying to URL decode the name since it's derived from URL. See https://issues.jboss.org/browse/KEYCLOAK-7844
+        try {
+            return URLDecoder.decode(realmName, StandardCharsets.UTF_8.name());
+        } catch (UnsupportedEncodingException e) {
+            return realmName; //if the decoding fails for some reason, return the value
+        }
     }
 
     // SERIALIZATION

--- a/core/src/test/java/org/keycloak/SkeletonKeyTokenTest.java
+++ b/core/src/test/java/org/keycloak/SkeletonKeyTokenTest.java
@@ -114,14 +114,14 @@ public class SkeletonKeyTokenTest {
         Assert.assertTrue(token.getResourceAccess("foo").isUserInRole("admin"));
         Assert.assertTrue(token.getResourceAccess("bar").isUserInRole("user"));
         Assert.assertEquals("joe@email.cz", idToken.getEmail());
-        Assert.assertEquals("acme", ctx.getRealm());
+        Assert.assertEquals("Realm <name>", ctx.getRealm());
         ois.close();
     }
 
     private AccessToken createSimpleToken() {
         AccessToken token = new AccessToken();
         token.id("111");
-        token.issuer("http://localhost:8080/auth/acme");
+        token.issuer("http://localhost:8080/auth/Realm%20%3Cname%3E");
         token.addAccess("foo").addRole("admin");
         token.addAccess("bar").addRole("user");
         return token;


### PR DESCRIPTION
URL decoding the Realm name, which is derived from the ticket issuer.
This is required for a realm name, which has non URL compliant symbols,
such as white spaces.