### PR TITLE
KEYCLOAK-7965 Redundant div end tag in base theme login.ftl

### DIFF
--- a/themes/src/main/resources/theme/base/login/login.ftl
+++ b/themes/src/main/resources/theme/base/login/login.ftl
@@ -47,7 +47,6 @@
                   <div id="kc-form-buttons" class="${properties.kcFormGroupClass!}">
                     <input tabindex="4" class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}" name="login" id="kc-login" type="submit" value="${msg("doLogIn")}"/>
                   </div>
-                </div>
             </form>
         </#if>
         <#if realm.password && social.providers??>


### PR DESCRIPTION
Remove a redundant div end tag from base theme `login.ftl`

JIRA ticket:
https://issues.jboss.org/browse/KEYCLOAK-7965