### PR TITLE
[KEYCLOAK-7985] fix the table name error,  from RESOURCE_URI to RESOURCE_URIS

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/connections/jpa/updater/liquibase/custom/AuthzResourceUseMoreURIs.java
+++ b/model/jpa/src/main/java/org/keycloak/connections/jpa/updater/liquibase/custom/AuthzResourceUseMoreURIs.java
@@ -23,7 +23,7 @@ public class AuthzResourceUseMoreURIs extends CustomKeycloakTask {
                         String resourceId = resultSet.getString(1);
                         String resourceUri = resultSet.getString(2);
 
-                        InsertStatement insertComponent = new InsertStatement(null, null, database.correctObjectName("RESOURCE_URI", Table.class))
+                        InsertStatement insertComponent = new InsertStatement(null, null, database.correctObjectName("RESOURCE_URIS", Table.class))
                                 .addColumnValue("RESOURCE_ID", resourceId)
                                 .addColumnValue("VALUE", resourceUri);
 
@@ -36,7 +36,7 @@ public class AuthzResourceUseMoreURIs extends CustomKeycloakTask {
                 statement.close();
             }
 
-            confirmationMessage.append("Moved " + statements.size() + " records from RESOURCE_SERVER_RESOURCE to RESOURCE_URI table");
+            confirmationMessage.append("Moved " + statements.size() + " records from RESOURCE_SERVER_RESOURCE to RESOURCE_URIS table");
         } catch (Exception e) {
             throw new CustomChangeException(getTaskId() + ": Exception when updating data from previous version", e);
         }


### PR DESCRIPTION
Signed-off-by: alva.huang <alva@izhiju.cn>

###  Database table names do not match
The file ：
"./model/jpa/src/main/java/org/keycloak/connections/jpa/updater/liquibase/custom/AuthzResourceUseMoreURIs.java " 
database table names do not match with
file：“./model/jpa/src/main/resources/META-INF/jpa-changelog-authz-4.2.0.Final.xml"

### Table name ‘RESOURCE_URI’ not match ‘RESOURCE_URIS’

./model/jpa/src/main/java/org/keycloak/connections/jpa/updater/liquibase/custom/AuthzResourceUseMoreURIs.java:
```
public class AuthzResourceUseMoreURIs extends CustomKeycloakTask {
    @Override
    protected void generateStatementsImpl() throws CustomChangeException {
        try {
            PreparedStatement statement = jdbcConnection.prepareStatement("select ID,URI from " + getTableName("RESOURCE_SERVER_RESOURCE"));

            try {
                ResultSet resultSet = statement.executeQuery();
                try {
                    while (resultSet.next()) {
                        String resourceId = resultSet.getString(1);
                        String resourceUri = resultSet.getString(2);

                        InsertStatement insertComponent = new InsertStatement(null, null, database.correctObjectName("RESOURCE_URI", Table.class))
                                .addColumnValue("RESOURCE_ID", resourceId)
                                .addColumnValue("VALUE", resourceUri);

                        statements.add(insertComponent);
                    }
                } finally {
                    resultSet.close();
                }
            } finally {
                statement.close();
            }

            confirmationMessage.append("Moved " + statements.size() + " records from RESOURCE_SERVER_RESOURCE to RESOURCE_URI table");
        } catch (Exception e) {
            throw new CustomChangeException(getTaskId() + ": Exception when updating data from previous version", e);
        }
    }

    @Override
    protected String getTaskId() {
        return "Update 4.2.0.Final";
    }
}

```
./model/jpa/src/main/resources/META-INF/jpa-changelog-authz-4.2.0.Final.xml  :
```

<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.2.xsd">
    <changeSet author="mhajas@redhat.com" id="authz-4.2.0.Final">
        <createTable tableName="RESOURCE_URIS">
            <column name="RESOURCE_ID" type="VARCHAR(36)">
                <constraints nullable="false"/>
            </column>
            <column name="VALUE" type="VARCHAR(255)">
                <constraints nullable="false"/>
            </column>
        </createTable>

        <addForeignKeyConstraint baseColumnNames="RESOURCE_ID" baseTableName="RESOURCE_URIS" constraintName="FK_RESOURCE_SERVER_URIS" referencedColumnNames="ID" referencedTableName="RESOURCE_SERVER_RESOURCE"/>

        <customChange class="org.keycloak.connections.jpa.updater.liquibase.custom.AuthzResourceUseMoreURIs"/>

        <dropColumn columnName="URI" tableName="RESOURCE_SERVER_RESOURCE"/>
    </changeSet>
</databaseChangeLog>

```