### PR TITLE
KEYCLOAK-7984 Fix migration issue

### DIFF
--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-4.3.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-4.3.0.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  ~ * Copyright 2018 Red Hat, Inc. and/or its affiliates
+  ~ * and other contributors as indicated by the @author tags.
+  ~ *
+  ~ * Licensed under the Apache License, Version 2.0 (the "License");
+  ~ * you may not use this file except in compliance with the License.
+  ~ * You may obtain a copy of the License at
+  ~ *
+  ~ * http://www.apache.org/licenses/LICENSE-2.0
+  ~ *
+  ~ * Unless required by applicable law or agreed to in writing, software
+  ~ * distributed under the License is distributed on an "AS IS" BASIS,
+  ~ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ * See the License for the specific language governing permissions and
+  ~ * limitations under the License.
+  -->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet author="wadahiro@gmail.com" id="4.3.0-KEYCLOAK-7984">
+        <update tableName="REQUIRED_ACTION_PROVIDER">
+            <column name="PRIORITY" type="INT" valueNumeric="0"/>
+            <where>PRIORITY is NULL</where>
+        </update>
+    </changeSet>
+ 
+</databaseChangeLog>

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-master.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-master.xml
@@ -58,4 +58,5 @@
     <include file="META-INF/jpa-changelog-authz-4.0.0.Beta3.xml"/>
     <include file="META-INF/jpa-changelog-authz-4.2.0.Final.xml"/>
     <include file="META-INF/jpa-changelog-4.2.0.xml"/>
+    <include file="META-INF/jpa-changelog-4.3.0.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
This PR fixes RequiredActionProviderEntity priority migration issue.
Unfortunately, this kind of issue wasn't detected in current automatic tests because the migration tests were skipped.
It looks like it needs to add `-D=migrated.auth.server.version=<from version>` option when testing, right? However, when I run the test with `-D=migrated.auth.server.version=3.4.3.Final`, I can't pass the old test case, `AbstractMigrationTest.testMigratedMasterData:104`. Currently, the migration tests are not  maintained well...?

```
Results :

Failed tests:
  MigrationTest.migration3_4_3Test:79->AbstractMigrationTest.testMigratedData:89->AbstractMigrationTest.testMigratedMasterData:104 Expected: [admin, create-realm, master-test-realm-role, offline_access, uma_authorization], was: [admin, create-realm, offline_access, uma_authorization]: array lengths differed, expected.length=5 actual.length=4

Tests run: 5, Failures: 1, Errors: 0, Skipped: 4
```

So, I tested this PR manually unfortunately.