### PR TITLE
[KEYCLOAK-7804] - Option to return resource body & tests

### DIFF
--- a/authz/client/src/main/java/org/keycloak/authorization/client/resource/ProtectedResource.java
+++ b/authz/client/src/main/java/org/keycloak/authorization/client/resource/ProtectedResource.java
@@ -17,14 +17,14 @@
  */
 package org.keycloak.authorization.client.resource;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Callable;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import org.keycloak.authorization.client.Configuration;
 import org.keycloak.authorization.client.representation.ServerConfiguration;
 import org.keycloak.authorization.client.util.Http;
+import org.keycloak.authorization.client.util.HttpMethod;
 import org.keycloak.authorization.client.util.Throwables;
 import org.keycloak.authorization.client.util.TokenCallable;
 import org.keycloak.representations.idm.authorization.ResourceRepresentation;
@@ -128,13 +128,13 @@ public class ProtectedResource {
      * @return a {@link ResourceRepresentation}
      */
     public ResourceRepresentation findByName(String name) {
-        String[] representations = find(null, name, null, configuration.getResource(), null, null, false, null, null);
+        List<ResourceRepresentation> representations = find(null, name, null, configuration.getResource(), null, null, false, true, null, null);
 
-        if (representations.length == 0) {
+        if (representations.isEmpty()) {
             return null;
         }
 
-        return findById(representations[0]);
+        return representations.get(0);
     }
 
     /**
@@ -145,13 +145,13 @@ public class ProtectedResource {
      * @return a {@link ResourceRepresentation}
      */
     public ResourceRepresentation findByName(String name, String ownerId) {
-        String[] representations = find(null, name, null, ownerId, null, null, false, null, null);
+        List<ResourceRepresentation> representations = find(null, name, null, ownerId, null, null, false, true,null, null);
 
-        if (representations.length == 0) {
+        if (representations.isEmpty()) {
             return null;
         }
 
-        return findById(representations[0]);
+        return representations.get(0);
     }
 
     /**
@@ -172,19 +172,7 @@ public class ProtectedResource {
         Callable<String[]> callable = new Callable<String[]>() {
             @Override
             public String[] call() throws Exception {
-                return http.<String[]>get(serverConfiguration.getResourceRegistrationEndpoint())
-                        .authorizationBearer(pat.call())
-                        .param("_id", id)
-                        .param("name", name)
-                        .param("uri", uri)
-                        .param("owner", owner)
-                        .param("type", type)
-                        .param("scope", scope)
-                        .param("matchingUri", Boolean.valueOf(matchingUri).toString())
-                        .param("deep", Boolean.FALSE.toString())
-                        .param("first", firstResult != null ? firstResult.toString() : null)
-                        .param("max", maxResult != null ? maxResult.toString() : null)
-                        .response().json(String[].class).execute();
+                return (String[]) createFindRequest(id, name, uri, owner, type, scope, matchingUri, false, firstResult, maxResult).response().json(String[].class).execute();
             }
         };
         try {
@@ -192,6 +180,40 @@ public class ProtectedResource {
         } catch (Exception cause) {
             return Throwables.retryAndWrapExceptionIfNecessary(callable, pat, "Could not find resource", cause);
         }
+    }
+
+    /**
+     * Query the server for any resource with the matching arguments.
+     *
+     * @param id the resource id
+     * @param name the resource name
+     * @param uri the resource uri
+     * @param owner the resource owner
+     * @param type the resource type
+     * @param scope the resource scope
+     * @param matchingUri the resource uri. Use this parameter to lookup a resource that best match the given uri
+     * @param deep if the result should be a list of resource representations with details about the resource. If false, only ids are returned
+     * @param firstResult the position of the first resource to retrieve
+     * @param maxResult the maximum number of resources to retrieve
+     * @return a list of resource representations or an array of strings representing resource ids, depending on the generic type
+     */
+    public <R> R find(final String id, final String name, final String uri, final String owner, final String type, final String scope, final boolean matchingUri, final boolean deep, final Integer firstResult, final Integer maxResult) {
+        if (deep) {
+            Callable<List<ResourceRepresentation>> callable = new Callable<List<ResourceRepresentation>>() {
+                @Override
+                public List<ResourceRepresentation> call() {
+                    return (List<ResourceRepresentation>) createFindRequest(id, name, uri, owner, type, scope, matchingUri, deep, firstResult, maxResult).response().json(new TypeReference<List<ResourceRepresentation>>() {
+                    }).execute();
+                }
+            };
+            try {
+                return (R) callable.call();
+            } catch (Exception cause) {
+                return (R) Throwables.retryAndWrapExceptionIfNecessary(callable, pat, "Could not find resource", cause);
+            }
+        }
+
+        return (R) find(id, name, uri, owner, type, scope, matchingUri, firstResult, maxResult);
     }
 
     /**
@@ -235,19 +257,7 @@ public class ProtectedResource {
      * @param uri the resource uri
      */
     public List<ResourceRepresentation> findByUri(String uri) {
-        String[] ids = find(null, null, uri, null, null, null, false, null, null);
-
-        if (ids.length == 0) {
-            return Collections.emptyList();
-        }
-
-        List<ResourceRepresentation> representations = new ArrayList<>();
-
-        for (String id : ids) {
-            representations.add(findById(id));
-        }
-
-        return representations;
+        return find(null, null, uri, null, null, null, false, true, null, null);
     }
 
     /**
@@ -258,18 +268,21 @@ public class ProtectedResource {
      * @return a list of resources
      */
     public List<ResourceRepresentation> findByMatchingUri(String uri) {
-        String[] ids = find(null, null, uri, null, null, null, true, null, null);
+        return find(null, null, uri, null, null, null, true, true,null, null);
+    }
 
-        if (ids.length == 0) {
-            return Collections.emptyList();
-        }
-
-        List<ResourceRepresentation> representations = new ArrayList<>();
-
-        for (String id : ids) {
-            representations.add(findById(id));
-        }
-
-        return representations;
+    private HttpMethod createFindRequest(String id, String name, String uri, String owner, String type, String scope, boolean matchingUri, boolean deep, Integer firstResult, Integer maxResult) {
+        return http.get(serverConfiguration.getResourceRegistrationEndpoint())
+                .authorizationBearer(pat.call())
+                .param("_id", id)
+                .param("name", name)
+                .param("uri", uri)
+                .param("owner", owner)
+                .param("type", type)
+                .param("scope", scope)
+                .param("matchingUri", Boolean.valueOf(matchingUri).toString())
+                .param("deep", Boolean.toString(deep))
+                .param("first", firstResult != null ? firstResult.toString() : null)
+                .param("max", maxResult != null ? maxResult.toString() : null);
     }
 }

--- a/services/src/main/java/org/keycloak/authorization/protection/resource/ResourceService.java
+++ b/services/src/main/java/org/keycloak/authorization/protection/resource/ResourceService.java
@@ -128,7 +128,12 @@ public class ResourceService {
                          @QueryParam("deep") Boolean deep,
                          @QueryParam("first") Integer firstResult,
                          @QueryParam("max") Integer maxResult) {
-        return resourceManager.find(id, name, uri, owner, type, scope, matchingUri, deep, firstResult, maxResult, (BiFunction<Resource, Boolean, String>) (resource, deep1) -> resource.getId());
+
+        if(deep != null && deep) {
+            return resourceManager.find(id, name, uri, owner, type, scope, matchingUri, deep, firstResult, maxResult);
+        } else {
+            return resourceManager.find(id, name, uri, owner, type, scope, matchingUri, deep, firstResult, maxResult, (BiFunction<Resource, Boolean, String>) (resource, deep1) -> resource.getId());
+        }
     }
 
     private void checkResourceServerSettings() {


### PR DESCRIPTION
When querying /resource_set API endpoint: If the query parameter "deep" is set to True, the body of the resources will be returned (instead of just resource ids).