### PR TITLE
KEYCLOAK-8080 Audit the realm event configuration change.

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/RealmAdminResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RealmAdminResource.java
@@ -680,6 +680,11 @@ public class RealmAdminResource {
 
         logger.debug("updating realm events config: " + realm.getName());
         new RealmManager(session).updateRealmEventsConfig(rep, realm);
+        adminEvent.operation(OperationType.UPDATE).resource(ResourceType.REALM).realm(realm)
+                .resourcePath(session.getContext().getUri()).representation(rep)
+                // refresh the builder to consider old and new config
+                .refreshRealmEventsConfig(session)
+                .success();
     }
 
     /**


### PR DESCRIPTION
Fix for KEYCLOAK-8080: Update Realm Events Config doesn't create an admin event.

Small change to generate an audit event when the updateRealmEventsConfig is executed. In order to always audit the event there are two special things:

* The listeners are added (old and new listeners are taken into account), this way all the listeners receive the modification (even when the listener is removed).
* The admin event storing is considered when ON->ON, ON->OFF or OFF->ON, in all the three situations the event is stored (to store the disablement).

I considered to the same for the details (always add the details even when ON->OFF) but I finally decided to not do it. Please comment if you think it is interesting too.