### PR TITLE
KEYCLOAK-7796 Expose RequestAuthenticator and BasicAuthRequestAuthenticator.getToken()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 .project
 .settings
 .classpath
+bin
+.factorypath
+
 
 # NetBeans #
 ############

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 .project
 .settings
 .classpath
-bin
+bin/
 .factorypath
 
 

--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/BasicAuthRequestAuthenticator.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/BasicAuthRequestAuthenticator.java
@@ -85,7 +85,7 @@ public class BasicAuthRequestAuthenticator extends BearerTokenRequestAuthenticat
         return authenticateToken(exchange, atr.getToken());
     } 
  
-    private AccessTokenResponse getToken(String username, String password) throws Exception {
+    protected AccessTokenResponse getToken(String username, String password) throws Exception {
     	AccessTokenResponse tokenResponse=null;
     	HttpClient client = deployment.getClient();
 

--- a/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/authentication/RequestAuthenticatorFactory.java
+++ b/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/authentication/RequestAuthenticatorFactory.java
@@ -1,0 +1,13 @@
+package org.keycloak.adapters.springsecurity.authentication;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.keycloak.adapters.AdapterTokenStore;
+import org.keycloak.adapters.KeycloakDeployment;
+import org.keycloak.adapters.RequestAuthenticator;
+import org.keycloak.adapters.spi.HttpFacade;
+
+public interface RequestAuthenticatorFactory {
+    RequestAuthenticator createRequestAuthenticator(HttpFacade facade, HttpServletRequest request, 
+            KeycloakDeployment deployment, AdapterTokenStore tokenStore, int sslRedirectPort);
+}

--- a/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/authentication/RequestAuthenticatorFactory.java
+++ b/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/authentication/RequestAuthenticatorFactory.java
@@ -7,7 +7,13 @@ import org.keycloak.adapters.KeycloakDeployment;
 import org.keycloak.adapters.RequestAuthenticator;
 import org.keycloak.adapters.spi.HttpFacade;
 
+/**
+ * Creates {@link RequestAuthenticator}s.
+ */
 public interface RequestAuthenticatorFactory {
+    /**
+     * Creates new {@link RequestAuthenticator} instances on a per-request basis.
+    */
     RequestAuthenticator createRequestAuthenticator(HttpFacade facade, HttpServletRequest request, 
             KeycloakDeployment deployment, AdapterTokenStore tokenStore, int sslRedirectPort);
 }

--- a/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/authentication/SpringSecurityRequestAuthenticatorFactor.java
+++ b/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/authentication/SpringSecurityRequestAuthenticatorFactor.java
@@ -1,0 +1,17 @@
+package org.keycloak.adapters.springsecurity.authentication;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.keycloak.adapters.AdapterTokenStore;
+import org.keycloak.adapters.KeycloakDeployment;
+import org.keycloak.adapters.RequestAuthenticator;
+import org.keycloak.adapters.spi.HttpFacade;
+
+public class SpringSecurityRequestAuthenticatorFactor implements RequestAuthenticatorFactory {
+    @Override
+    public RequestAuthenticator createRequestAuthenticator(HttpFacade facade,
+            HttpServletRequest request, KeycloakDeployment deployment, AdapterTokenStore tokenStore,
+            int sslRedirectPort) {
+        return new SpringSecurityRequestAuthenticator(facade, request, deployment, tokenStore, sslRedirectPort);
+    }
+}

--- a/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/authentication/SpringSecurityRequestAuthenticatorFactory.java
+++ b/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/authentication/SpringSecurityRequestAuthenticatorFactory.java
@@ -7,11 +7,11 @@ import org.keycloak.adapters.KeycloakDeployment;
 import org.keycloak.adapters.RequestAuthenticator;
 import org.keycloak.adapters.spi.HttpFacade;
 
-public class SpringSecurityRequestAuthenticatorFactor implements RequestAuthenticatorFactory {
+public class SpringSecurityRequestAuthenticatorFactory implements RequestAuthenticatorFactory {
+    
     @Override
     public RequestAuthenticator createRequestAuthenticator(HttpFacade facade,
-            HttpServletRequest request, KeycloakDeployment deployment, AdapterTokenStore tokenStore,
-            int sslRedirectPort) {
+            HttpServletRequest request, KeycloakDeployment deployment, AdapterTokenStore tokenStore, int sslRedirectPort) {
         return new SpringSecurityRequestAuthenticator(facade, request, deployment, tokenStore, sslRedirectPort);
     }
 }

--- a/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/filter/KeycloakAuthenticationProcessingFilter.java
+++ b/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/filter/KeycloakAuthenticationProcessingFilter.java
@@ -27,16 +27,15 @@ import javax.servlet.http.HttpServletResponse;
 import org.keycloak.OAuth2Constants;
 import org.keycloak.adapters.AdapterDeploymentContext;
 import org.keycloak.adapters.AdapterTokenStore;
-import org.keycloak.adapters.AuthenticatedActionsHandler;
 import org.keycloak.adapters.KeycloakDeployment;
-import org.keycloak.adapters.OIDCHttpFacade;
 import org.keycloak.adapters.RequestAuthenticator;
 import org.keycloak.adapters.spi.AuthChallenge;
 import org.keycloak.adapters.spi.AuthOutcome;
 import org.keycloak.adapters.spi.HttpFacade;
 import org.keycloak.adapters.springsecurity.KeycloakAuthenticationException;
 import org.keycloak.adapters.springsecurity.authentication.KeycloakAuthenticationFailureHandler;
-import org.keycloak.adapters.springsecurity.authentication.SpringSecurityRequestAuthenticator;
+import org.keycloak.adapters.springsecurity.authentication.RequestAuthenticatorFactory;
+import org.keycloak.adapters.springsecurity.authentication.SpringSecurityRequestAuthenticatorFactor;
 import org.keycloak.adapters.springsecurity.facade.SimpleHttpFacade;
 import org.keycloak.adapters.springsecurity.token.AdapterTokenStoreFactory;
 import org.keycloak.adapters.springsecurity.token.KeycloakAuthenticationToken;
@@ -85,6 +84,7 @@ public class KeycloakAuthenticationProcessingFilter extends AbstractAuthenticati
     private AdapterDeploymentContext adapterDeploymentContext;
     private AdapterTokenStoreFactory adapterTokenStoreFactory = new SpringSecurityAdapterTokenStoreFactory();
     private AuthenticationManager authenticationManager;
+    private RequestAuthenticatorFactory requestAuthenticatorFactory = new SpringSecurityRequestAuthenticatorFactor();
 
     /**
      * Creates a new Keycloak authentication processing filter with given {@link AuthenticationManager} and the
@@ -144,7 +144,7 @@ public class KeycloakAuthenticationProcessingFilter extends AbstractAuthenticati
 
         AdapterTokenStore tokenStore = adapterTokenStoreFactory.createAdapterTokenStore(deployment, request);
         RequestAuthenticator authenticator
-                = new SpringSecurityRequestAuthenticator(facade, request, deployment, tokenStore, -1);
+                = requestAuthenticatorFactory.createRequestAuthenticator(facade, request, deployment, tokenStore, -1);
 
         AuthOutcome result = authenticator.authenticate();
         log.debug("Auth outcome: {}", result);
@@ -250,5 +250,15 @@ public class KeycloakAuthenticationProcessingFilter extends AbstractAuthenticati
     @Override
     public final void setContinueChainBeforeSuccessfulAuthentication(boolean continueChainBeforeSuccessfulAuthentication) {
         throw new UnsupportedOperationException("This filter does not support explicitly setting a continue chain before success policy");
+    }
+
+    /**
+     * Sets the request authenticator factory to use when creating per-request authenticators.
+     *
+     * @param requestAuthenticatorFactory the <code>RequestAuthenticatorFactory</code> to use
+     */
+    public void setRequestAuthenticatorFactory(RequestAuthenticatorFactory requestAuthenticatorFactory) {
+        Assert.notNull(requestAuthenticatorFactory, "RequestAuthenticatorFactory cannot be null");
+        this.requestAuthenticatorFactory = requestAuthenticatorFactory;
     }
 }

--- a/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/filter/KeycloakAuthenticationProcessingFilter.java
+++ b/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/filter/KeycloakAuthenticationProcessingFilter.java
@@ -35,7 +35,7 @@ import org.keycloak.adapters.spi.HttpFacade;
 import org.keycloak.adapters.springsecurity.KeycloakAuthenticationException;
 import org.keycloak.adapters.springsecurity.authentication.KeycloakAuthenticationFailureHandler;
 import org.keycloak.adapters.springsecurity.authentication.RequestAuthenticatorFactory;
-import org.keycloak.adapters.springsecurity.authentication.SpringSecurityRequestAuthenticatorFactor;
+import org.keycloak.adapters.springsecurity.authentication.SpringSecurityRequestAuthenticatorFactory;
 import org.keycloak.adapters.springsecurity.facade.SimpleHttpFacade;
 import org.keycloak.adapters.springsecurity.token.AdapterTokenStoreFactory;
 import org.keycloak.adapters.springsecurity.token.KeycloakAuthenticationToken;
@@ -84,7 +84,7 @@ public class KeycloakAuthenticationProcessingFilter extends AbstractAuthenticati
     private AdapterDeploymentContext adapterDeploymentContext;
     private AdapterTokenStoreFactory adapterTokenStoreFactory = new SpringSecurityAdapterTokenStoreFactory();
     private AuthenticationManager authenticationManager;
-    private RequestAuthenticatorFactory requestAuthenticatorFactory = new SpringSecurityRequestAuthenticatorFactor();
+    private RequestAuthenticatorFactory requestAuthenticatorFactory = new SpringSecurityRequestAuthenticatorFactory();
 
     /**
      * Creates a new Keycloak authentication processing filter with given {@link AuthenticationManager} and the


### PR DESCRIPTION
Alternative way of exposing `RequestAuthenticator` within `KeycloakAuthenticationProcessingFilter`.

#5363 solves this with inheritance, this PR here uses composition

https://issues.jboss.org/browse/KEYCLOAK-7796 

I've also tacked on exposing of `BasicAuthRequestAuthenticator#getToken` to allow overriding. _That_ was the main reason why I went through the effort of exposing `RequestAuthenticator` in the first place...