### PR TITLE
KEYCLOAK-5831 JS adapter should redirect using window.location.replace to avoid cluttering history

### DIFF
--- a/adapters/oidc/js/src/main/resources/keycloak.js
+++ b/adapters/oidc/js/src/main/resources/keycloak.js
@@ -1149,17 +1149,17 @@
             if (!type || type == 'default') {
                 return {
                     login: function(options) {
-                        window.location.href = kc.createLoginUrl(options);
+                        window.location.replace(kc.createLoginUrl(options));
                         return createPromise().promise;
                     },
 
                     logout: function(options) {
-                        window.location.href = kc.createLogoutUrl(options);
+                        window.location.replace(kc.createLogoutUrl(options));
                         return createPromise().promise;
                     },
 
                     register: function(options) {
-                        window.location.href = kc.createRegisterUrl(options);
+                        window.location.replace(kc.createRegisterUrl(options));
                         return createPromise().promise;
                     },
 


### PR DESCRIPTION
The Keycloak JS adapter Should not create a new browser history entry, when it is redirecting the user.