### PR TITLE
Common interface for parsed tokens in typescript declaration file

### DIFF
--- a/adapters/oidc/js/src/main/resources/keycloak.d.ts
+++ b/adapters/oidc/js/src/main/resources/keycloak.d.ts
@@ -216,6 +216,16 @@ declare namespace Keycloak {
 		createdTimestamp?: number;
 	}
 
+	interface KeycloakTokenParsed {
+		exp?: number;
+		iat?: number;
+		nonce?: string;
+		sub?: string;
+		session_state?: string;
+		realm_access?: { roles: string[] };
+		resource_access?: string[];
+	}
+
 	// export interface KeycloakUserInfo {}
 
 	/**
@@ -269,15 +279,7 @@ declare namespace Keycloak {
 		/**
 		 * The parsed token as a JavaScript object.
 		 */
-		tokenParsed?: {
-			exp?: number;
-			iat?: number;
-			nonce?: string;
-			sub?: string;
-			session_state?: string;
-			realm_access?: { roles: string[] };
-			resource_access?: string[];
-		};
+		tokenParsed?: KeycloakTokenParsed;
 
 		/**
 		 * The base64 encoded refresh token that can be used to retrieve a new token.
@@ -287,7 +289,7 @@ declare namespace Keycloak {
 		/**
 		 * The parsed refresh token as a JavaScript object.
 		 */
-		refreshTokenParsed?: { nonce?: string };
+		refreshTokenParsed?: KeycloakTokenParsed;
 
 		/**
 		 * The base64 encoded ID token.
@@ -297,7 +299,7 @@ declare namespace Keycloak {
 		/**
 		 * The parsed id token as a JavaScript object.
 		 */
-		idTokenParsed?: { nonce?: string };
+		idTokenParsed?: KeycloakTokenParsed;
 
 		/**
 		 * The estimated time difference between the browser time and the Keycloak


### PR DESCRIPTION
We use some fields from the refreshTokenParsed and the typescript definition did not include those fields. I made a common interface that all of the parsed tokens can use.