### PR TITLE
[KEYCLOAK-8649] add javadoc tags for correct swagger-doclet results

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/AdminRoot.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/AdminRoot.java
@@ -196,6 +196,7 @@ public class AdminRoot {
      *
      * @param headers
      * @return
+     * @returnType org.keycloak.services.resources.admin.RealmsAdminResource
      */
     @Path("realms")
     public Object getRealmsAdmin(@Context final HttpHeaders headers) {
@@ -218,6 +219,7 @@ public class AdminRoot {
     /**
      * General information about the server
      *
+     * @returnType org.keycloak.services.resources.admin.info.ServerInfoAdminResource
      * @param headers
      * @return
      */

--- a/services/src/main/java/org/keycloak/services/resources/admin/info/ServerInfoAdminResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/info/ServerInfoAdminResource.java
@@ -71,6 +71,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
+ * @resource Server Info
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
  */
 public class ServerInfoAdminResource {


### PR DESCRIPTION
The Swagger definition (`service.json` & co, [blog post](http://blog.keycloak.org/2015/09/having-fun-with-rest-api-documentation.html)) generated by `swagger-doclet` has invalid resource paths, e.g. `/{realm}/clients` instead of the proper `/admin/realms/{realm}/clients`. These issues also affect official published REST API docs generated by asciidoc (https://www.keycloak.org/docs-api/4.3/rest-api/index.html).

This pull request adds the missing javadoc tags to allow swagger-doclet to properly recognize sub-resource paths.

Unfortunately, a bug in swagger-doclet needs to be [patched](https://github.com/conorroche/swagger-doclet/pull/18), see final results on my fork's GitHub Pages: 
- [Swagger UI](https://illes.github.io/keycloak/apidocs/),
- [Asciidoc](https://illes.github.io/keycloak/apidocs/asciidoc.html).

To reproduce:
```bash
git clone https://github.com/illes/keycloak -b gh-pages
cd services
mvn package -P jboss-release
# see target/apidocs-rest/
```

The resulting [`service.json`](https://illes.github.io/keycloak/apidocs/service.json) was successfully used for generating a working client API.

Related effort using `swagger-jaxrs` instead of `swagger-doclet`: [KEYCLOAK-4474](https://issues.jboss.org/browse/KEYCLOAK-4474) / #5198 (imho a far better long-term solution: OAS 2.0 instead of 1.2, and not using the unmaintained `swagger-doclet`)

