### PR TITLE
KEYCLOAK-7635 Matrix param support for x509 Authenticator

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/client/X509ClientAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/client/X509ClientAuthenticator.java
@@ -67,6 +67,15 @@ public class X509ClientAuthenticator extends AbstractClientAuthenticator {
             }
 
             if (client_id == null) {
+                client_id = context.getHttpRequest().getUri().getPathSegments().stream()
+                      .flatMap(segment -> segment.getMatrixParameters().entrySet().stream())
+                      .filter(matixParamMapEntry -> "client_id".equals(matixParamMapEntry.getKey()))
+                      .map(clientIdEntry -> clientIdEntry.getValue().get(0))
+                      .findFirst()
+                      .orElse(null);
+            }
+
+            if (client_id == null) {
                 Response challengeResponse = ClientAuthUtil.errorResponse(Response.Status.BAD_REQUEST.getStatusCode(), "invalid_client", "Missing client_id parameter");
                 context.challenge(challengeResponse);
                 return;


### PR DESCRIPTION
https://issues.jboss.org/browse/KEYCLOAK-7635

It seems OpenShift overrides query params, so here I propose to use `client_id` in matrix params.