### PR TITLE
[KEYCLOAK-8265] Document default test suite credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ To start Keycloak during development first build as specified above, then run:
 
     mvn -f testsuite/utils/pom.xml exec:java -Pkeycloak-server 
 
+When running testsuite, by default an account with username `admin` and password `admin` will be created within the master realm at start.
 
 To start Keycloak from the server distribution first build the distribution it as specified above, then run:
 

--- a/misc/Testsuite.md
+++ b/misc/Testsuite.md
@@ -42,6 +42,16 @@ and https port, optionally setting the truststore.
         -Djavax.net.ssl.keyStorePassword=CHANGEME \
         -Dkeycloak.port.https=8443
 
+### Default admin account
+
+The default admin within the master realm are created with credentials:
+* Username: `admin`
+* Password: `admin`
+
+The Keycloak test suite server will automatically create the new master realm user when the following conditions are met
+* Property `keycloak.createAdminUser` is set to `true` (defaults to `true` if not present)
+* There is no existing user within the master realm
+
 ### Live edit of html and styles
 
 The Keycloak test server can load resources directly from the filesystem instead of the classpath. This allows editing html, styles and updating images without restarting the server. To make the server use resources from the filesystem start with:

--- a/testsuite/utils/src/main/java/org/keycloak/testsuite/KeycloakServer.java
+++ b/testsuite/utils/src/main/java/org/keycloak/testsuite/KeycloakServer.java
@@ -359,6 +359,7 @@ public class KeycloakServer {
                 session.getTransactionManager().begin();
                 if (new ApplianceBootstrap(session).isNoMasterUser()) {
                     new ApplianceBootstrap(session).createMasterRealmUser("admin", "admin");
+                    log.info("Created master user with credentials admin:admin");
                 }
                 session.getTransactionManager().commit();
             } finally {


### PR DESCRIPTION
`[KEYCLOAK-8265](https://issues.jboss.org/projects/KEYCLOAK/issues/KEYCLOAK-8265)`