### PR TITLE
[KEYCLOAK-8185] add clear method to exportimport resource

### DIFF
--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/rest/resource/TestingExportImportResource.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/rest/resource/TestingExportImportResource.java
@@ -147,4 +147,16 @@ public class TestingExportImportResource {
         String absolutePath = new File(System.getProperty("project.build.directory", "target")).getAbsolutePath();
         return absolutePath;
     }
+
+    @GET
+    @Path("/clear")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response clear() {
+        System.clearProperty(REALM_NAME);
+        System.clearProperty(PROVIDER);
+        System.clearProperty(ACTION);
+        System.clearProperty(FILE);
+
+        return Response.ok().build();
+    }
 }

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/client/resources/TestingExportImportResource.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/client/resources/TestingExportImportResource.java
@@ -96,4 +96,9 @@ public interface TestingExportImportResource {
     @Produces(MediaType.APPLICATION_JSON)
     public String getExportImportTestDirectory();
 
+    @GET
+    @Path("/clear")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response clear();
+
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/BrokerLinkAndTokenExchangeTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/BrokerLinkAndTokenExchangeTest.java
@@ -492,7 +492,6 @@ public class BrokerLinkAndTokenExchangeTest extends AbstractServletsAdapterTest 
         testExternalExchange();
         testingClient.testing().exportImport().setProvider(SingleFileExportProviderFactory.PROVIDER_ID);
         String targetFilePath = testingClient.testing().exportImport().getExportImportTestDirectory() + File.separator + "singleFile-full.json";
-        //System.out.println("TARGET PATH: " + targetFilePath);
         testingClient.testing().exportImport().setFile(targetFilePath);
         testingClient.testing().exportImport().setAction(ExportImportConfig.ACTION_EXPORT);
         testingClient.testing().exportImport().setRealmName(CHILD_IDP);
@@ -502,12 +501,10 @@ public class BrokerLinkAndTokenExchangeTest extends AbstractServletsAdapterTest 
         testingClient.testing().exportImport().setAction(ExportImportConfig.ACTION_IMPORT);
 
         testingClient.testing().exportImport().runImport();
-        //System.out.println("************* AFTER IMPORT");
+
+        testingClient.testing().exportImport().clear();
+
         testExternalExchange();
-        //Thread.sleep(1000000000l);
-
-
-
     }
 
 


### PR DESCRIPTION
BrokerLinkAndTokenExhcnageTest configures syste properties for keycloak to import a realm from file.
Then FixedHostnameTest restarts keycloak, which still has said system properties and imports a child realm from file.
After that RealmTest fails on trying to enumerate the realms and finding one more than expected.

Cleaning system properties after use in BrokerLinkAndTokenExhcnageTest fixes the issue.