### PR TITLE
KEYCLOAK-6658 Access fine grain permissions via the java admin client

### DIFF
--- a/core/src/main/java/org/keycloak/representations/idm/ManagementPermissionRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/idm/ManagementPermissionRepresentation.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018 Bosch Software Innovations GmbH
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+/**
+ * @author <a href="mailto:leon.graser@bosch-si.com">Leon Graser</a>
+ */
+public class ManagementPermissionRepresentation {
+
+    private final boolean enabled;
+
+    public ManagementPermissionRepresentation(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+}

--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/ClientResource.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/ClientResource.java
@@ -24,6 +24,8 @@ import org.keycloak.representations.idm.ClientScopeRepresentation;
 import org.keycloak.representations.idm.CredentialRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.representations.idm.UserSessionRepresentation;
+import org.keycloak.representations.idm.ManagementPermissionReference;
+import org.keycloak.representations.idm.ManagementPermissionRepresentation;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -42,6 +44,30 @@ import java.util.Map;
  * @author rodrigo.sasaki@icarros.com.br
  */
 public interface ClientResource {
+
+    /**
+     * Enables or disables the fine grain permissions feature.
+     * Returns the updated status of the server in the
+     * {@link ManagementPermissionReference}.
+     *
+     * @param status status request to apply
+     * @return permission reference indicating the updated status
+     */
+    @PUT
+    @Path("/management/permissions")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    ManagementPermissionReference setPermissions(ManagementPermissionRepresentation status);
+
+    /**
+     * Returns indicator if the fine grain permissions are enabled or not.
+     *
+     * @return current representation of the permissions feature
+     */
+    @GET
+    @Path("/management/permissions")
+    @Produces(MediaType.APPLICATION_JSON)
+    ManagementPermissionReference getPermissions();
 
     @Path("protocol-mappers")
     public ProtocolMappersResource getProtocolMappers();

--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/GroupResource.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/GroupResource.java
@@ -19,6 +19,8 @@ package org.keycloak.admin.client.resource;
 
 import org.jboss.resteasy.annotations.cache.NoCache;
 import org.keycloak.representations.idm.GroupRepresentation;
+import org.keycloak.representations.idm.ManagementPermissionReference;
+import org.keycloak.representations.idm.ManagementPermissionRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 
 import javax.ws.rs.Consumes;
@@ -38,6 +40,30 @@ import java.util.List;
  * @version $Revision: 1 $
  */
 public interface GroupResource {
+
+    /**
+     * Enables or disables the fine grain permissions feature.
+     * Returns the updated status of the server in the
+     * {@link ManagementPermissionReference}.
+     *
+     * @param status status request to apply
+     * @return permission reference indicating the updated status
+     */
+    @PUT
+    @Path("/management/permissions")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    ManagementPermissionReference setPermissions(ManagementPermissionRepresentation status);
+
+    /**
+     * Returns indicator if the fine grain permissions are enabled or not.
+     *
+     * @return current representation of the permissions feature
+     */
+    @GET
+    @Path("/management/permissions")
+    @Produces(MediaType.APPLICATION_JSON)
+    ManagementPermissionReference getPermissions();
 
     /**
      * Does not expand hierarchy.  Subgroups will not be set.

--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/RoleResource.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/RoleResource.java
@@ -17,6 +17,8 @@
 
 package org.keycloak.admin.client.resource;
 
+import org.keycloak.representations.idm.ManagementPermissionReference;
+import org.keycloak.representations.idm.ManagementPermissionRepresentation;
 import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 
@@ -37,6 +39,30 @@ import java.util.Set;
  * @author rodrigo.sasaki@icarros.com.br
  */
 public interface RoleResource {
+
+    /**
+     * Enables or disables the fine grain permissions feature.
+     * Returns the updated status of the server in the
+     * {@link ManagementPermissionReference}.
+     *
+     * @param status status request to apply
+     * @return permission reference indicating the updated status
+     */
+    @PUT
+    @Path("/management/permissions")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    ManagementPermissionReference setPermissions(ManagementPermissionRepresentation status);
+
+    /**
+     * Returns indicator if the fine grain permissions are enabled or not.
+     *
+     * @return current representation of the permissions feature
+     */
+    @GET
+    @Path("/management/permissions")
+    @Produces(MediaType.APPLICATION_JSON)
+    ManagementPermissionReference getPermissions();
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/ManagementPermissionsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/ManagementPermissionsTest.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2018 Bosch Software Innovations GmbH
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.testsuite.admin;
+
+import org.junit.Test;
+import org.keycloak.admin.client.resource.ClientResource;
+import org.keycloak.admin.client.resource.GroupResource;
+import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.admin.client.resource.RoleResource;
+import org.keycloak.representations.idm.*;
+import org.keycloak.testsuite.AbstractTestRealmKeycloakTest;
+
+import javax.ws.rs.core.Response;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author <a href="mailto:leon.graser@bosch-si.com">Leon Graser</a>
+ */
+public class ManagementPermissionsTest extends AbstractTestRealmKeycloakTest {
+
+    @Override
+    public void configureTestRealm(RealmRepresentation testRealm) {
+
+    }
+
+    @Test
+    public void updateGroupPermissions() {
+        RealmResource realmResource = adminClient.realms().realm("test");
+        GroupRepresentation group = new GroupRepresentation();
+        group.setName("perm-group-test");
+        Response response = realmResource.groups().add(group);
+        String id = ApiUtil.getCreatedId(response);
+        GroupResource groupResource = realmResource.groups().group(id);
+
+        ManagementPermissionReference result = groupResource.setPermissions(new ManagementPermissionRepresentation(true));
+        assertNotNull(result);
+        assertTrue(result.isEnabled());
+        result = groupResource.getPermissions();
+        assertNotNull(result);
+        assertTrue(result.isEnabled());
+
+        result = groupResource.setPermissions(new ManagementPermissionRepresentation(false));
+        assertNotNull(result);
+        assertFalse(result.isEnabled());
+        result = groupResource.getPermissions();
+        assertNotNull(result);
+        assertFalse(result.isEnabled());
+
+        result = groupResource.setPermissions(new ManagementPermissionRepresentation(true));
+        assertNotNull(result);
+        assertTrue(result.isEnabled());
+        result = groupResource.getPermissions();
+        assertNotNull(result);
+        assertTrue(result.isEnabled());
+
+        result = groupResource.setPermissions(new ManagementPermissionRepresentation(true));
+        assertNotNull(result);
+        assertTrue(result.isEnabled());
+        result = groupResource.getPermissions();
+        assertNotNull(result);
+        assertTrue(result.isEnabled());
+
+        result = groupResource.setPermissions(new ManagementPermissionRepresentation(false));
+        assertNotNull(result);
+        assertFalse(result.isEnabled());
+        result = groupResource.getPermissions();
+        assertNotNull(result);
+        assertFalse(result.isEnabled());
+
+        result = groupResource.setPermissions(new ManagementPermissionRepresentation(false));
+        assertNotNull(result);
+        assertFalse(result.isEnabled());
+        result = groupResource.getPermissions();
+        assertNotNull(result);
+        assertFalse(result.isEnabled());
+    }
+
+    @Test
+    public void updateClientPermissions() {
+        RealmResource realmResource = adminClient.realms().realm("test");
+        ClientRepresentation clientRepresentation = new ClientRepresentation();
+        clientRepresentation.setName("perm-client-test");
+        Response response = realmResource.clients().create(clientRepresentation);
+        String id = ApiUtil.getCreatedId(response);
+        ClientResource clientResource = realmResource.clients().get(id);
+
+        ManagementPermissionReference result = clientResource.setPermissions(new ManagementPermissionRepresentation(true));
+        assertNotNull(result);
+        assertTrue(result.isEnabled());
+        result = clientResource.getPermissions();
+        assertNotNull(result);
+        assertTrue(result.isEnabled());
+
+        result = clientResource.setPermissions(new ManagementPermissionRepresentation(false));
+        assertNotNull(result);
+        assertFalse(result.isEnabled());
+        result = clientResource.getPermissions();
+        assertNotNull(result);
+        assertFalse(result.isEnabled());
+
+        result = clientResource.setPermissions(new ManagementPermissionRepresentation(true));
+        assertNotNull(result);
+        assertTrue(result.isEnabled());
+        result = clientResource.getPermissions();
+        assertNotNull(result);
+        assertTrue(result.isEnabled());
+
+        result = clientResource.setPermissions(new ManagementPermissionRepresentation(true));
+        assertNotNull(result);
+        assertTrue(result.isEnabled());
+        result = clientResource.getPermissions();
+        assertNotNull(result);
+        assertTrue(result.isEnabled());
+
+        result = clientResource.setPermissions(new ManagementPermissionRepresentation(false));
+        assertNotNull(result);
+        assertFalse(result.isEnabled());
+        result = clientResource.getPermissions();
+        assertNotNull(result);
+        assertFalse(result.isEnabled());
+
+        result = clientResource.setPermissions(new ManagementPermissionRepresentation(false));
+        assertNotNull(result);
+        assertFalse(result.isEnabled());
+        result = clientResource.getPermissions();
+        assertNotNull(result);
+        assertFalse(result.isEnabled());
+    }
+
+    @Test
+    public void updateRealmRolePermissions() {
+        RealmResource realmResource = adminClient.realms().realm("test");
+        RoleRepresentation roleRepresentation = new RoleRepresentation();
+        roleRepresentation.setName("perm-role-test");
+        realmResource.roles().create(roleRepresentation);
+        RoleResource roleResource = realmResource.roles().get("perm-role-test");
+
+        ManagementPermissionReference result = roleResource.setPermissions(new ManagementPermissionRepresentation(true));
+        assertNotNull(result);
+        assertTrue(result.isEnabled());
+        result = roleResource.getPermissions();
+        assertNotNull(result);
+        assertTrue(result.isEnabled());
+
+        result = roleResource.setPermissions(new ManagementPermissionRepresentation(false));
+        assertNotNull(result);
+        assertFalse(result.isEnabled());
+        result = roleResource.getPermissions();
+        assertNotNull(result);
+        assertFalse(result.isEnabled());
+
+        result = roleResource.setPermissions(new ManagementPermissionRepresentation(true));
+        assertNotNull(result);
+        assertTrue(result.isEnabled());
+        result = roleResource.getPermissions();
+        assertNotNull(result);
+        assertTrue(result.isEnabled());
+
+        result = roleResource.setPermissions(new ManagementPermissionRepresentation(true));
+        assertNotNull(result);
+        assertTrue(result.isEnabled());
+        result = roleResource.getPermissions();
+        assertNotNull(result);
+        assertTrue(result.isEnabled());
+
+        result = roleResource.setPermissions(new ManagementPermissionRepresentation(false));
+        assertNotNull(result);
+        assertFalse(result.isEnabled());
+        result = roleResource.getPermissions();
+        assertNotNull(result);
+        assertFalse(result.isEnabled());
+
+        result = roleResource.setPermissions(new ManagementPermissionRepresentation(false));
+        assertNotNull(result);
+        assertFalse(result.isEnabled());
+        result = roleResource.getPermissions();
+        assertNotNull(result);
+        assertFalse(result.isEnabled());
+    }
+
+    @Test
+    public void updateClientRolePermissions() {
+        RealmResource realmResource = adminClient.realms().realm("test");
+        ClientRepresentation clientRepresentation = new ClientRepresentation();
+        clientRepresentation.setName("perm-client-test");
+        Response response = realmResource.clients().create(clientRepresentation);
+        String id = ApiUtil.getCreatedId(response);
+        ClientResource clientResource = realmResource.clients().get(id);
+        RoleRepresentation roleRepresentation = new RoleRepresentation();
+        roleRepresentation.setName("perm-client-role-test");
+        clientResource.roles().create(roleRepresentation);
+        RoleResource roleResource = clientResource.roles().get("perm-client-role-test");
+
+        ManagementPermissionReference result = roleResource.setPermissions(new ManagementPermissionRepresentation(true));
+        assertNotNull(result);
+        assertTrue(result.isEnabled());
+        result = roleResource.getPermissions();
+        assertNotNull(result);
+        assertTrue(result.isEnabled());
+
+        result = roleResource.setPermissions(new ManagementPermissionRepresentation(false));
+        assertNotNull(result);
+        assertFalse(result.isEnabled());
+        result = roleResource.getPermissions();
+        assertNotNull(result);
+        assertFalse(result.isEnabled());
+
+        result = roleResource.setPermissions(new ManagementPermissionRepresentation(true));
+        assertNotNull(result);
+        assertTrue(result.isEnabled());
+        result = roleResource.getPermissions();
+        assertNotNull(result);
+        assertTrue(result.isEnabled());
+
+        result = roleResource.setPermissions(new ManagementPermissionRepresentation(true));
+        assertNotNull(result);
+        assertTrue(result.isEnabled());
+        result = roleResource.getPermissions();
+        assertNotNull(result);
+        assertTrue(result.isEnabled());
+
+        result = roleResource.setPermissions(new ManagementPermissionRepresentation(false));
+        assertNotNull(result);
+        assertFalse(result.isEnabled());
+        result = roleResource.getPermissions();
+        assertNotNull(result);
+        assertFalse(result.isEnabled());
+
+        result = roleResource.setPermissions(new ManagementPermissionRepresentation(false));
+        assertNotNull(result);
+        assertFalse(result.isEnabled());
+        result = roleResource.getPermissions();
+        assertNotNull(result);
+        assertFalse(result.isEnabled());
+    }
+}


### PR DESCRIPTION
Includes a getter to retreive the current status of the fine grain permission feature as well as a setter to enable/disable the permissions.

Discussed in Jira Ticket 6658