### PR TITLE
KEYCLOAK-7742,KEYCLOAK-6332 Switch Admin Console UI tests to GeckoDriver

### DIFF
--- a/testsuite/integration-arquillian/HOW-TO-RUN.md
+++ b/testsuite/integration-arquillian/HOW-TO-RUN.md
@@ -413,17 +413,11 @@ To run individual social provider test only you can use option like `-Dtest=Soci
 You can use many different real-world browsers to run the integration tests.
 Although technically they can be run with almost every test in the testsuite, they can fail with some of them as the tests often require specific optimizations for given browser. Therefore, only some of the test modules have support to be run with specific browsers.
 
-#### Mozilla Firefox with legacy driver
-* **Supported test modules:** `console`
-* **Supported version:** [52 ESR](https://www.mozilla.org/en-US/firefox/organizations/) (Extended Support Release)
-* **Driver download required:** no
-* **Run with:** `-Dbrowser=firefox -DfirefoxLegacyDriver=true`; optionally you can specify `-Dfirefox_binary=path/to/firefox/binary`
-
-#### Mozilla Firefox with GeckoDriver
-* **Supported test modules:** `base-ui`
-* **Supported version:** as latest as possible (Firefox has better support for Marionette with each version released)
+#### Mozilla Firefox
+* **Supported test modules:** `console`, `base-ui`
+* **Supported version:** latest stable
 * **Driver download required:** [GeckoDriver](https://github.com/mozilla/geckodriver/releases)
-* **Run with:** `-Dbrowser=firefox -DfirefoxLegacyDriver=false -Dwebdriver.gecko.driver=path/to/geckodriver`
+* **Run with:** `-Dbrowser=firefox -Dwebdriver.gecko.driver=path/to/geckodriver`; optionally you can specify `-Dfirefox_binary=path/to/firefox/binary`
 
 #### Google Chrome
 * **Supported test modules:** `console`, `base-ui`
@@ -442,6 +436,12 @@ Although technically they can be run with almost every test in the testsuite, th
 * **Supported version:** latest stable
 * **Driver download required:** no (the driver is bundled with macOS)
 * **Run with:** `-Dbrowser=safari`
+
+#### [DEPRECATED] Mozilla Firefox with legacy driver
+* **Supported test modules:** `console`
+* **Supported version:** [52 ESR](http://ftp.mozilla.org/pub/firefox/releases/52.9.0esr/) ([Extended Support Release](https://www.mozilla.org/en-US/firefox/organizations/))
+* **Driver download required:** no
+* **Run with:** `-Dbrowser=firefox -DfirefoxLegacyDriver=true -Dfirefox_binary=path/to/firefox-52-esr/binary`
 
 #### Automatic driver downloads
 You can rely on automatic driver downloads which is provided by [Arquillian Drone](http://arquillian.org/arquillian-extension-drone/#_automatic_download). To do so just omit the `-Dwebdriver.{browser}.driver` CLI argument when running the tests.

--- a/testsuite/integration-arquillian/pom.xml
+++ b/testsuite/integration-arquillian/pom.xml
@@ -57,7 +57,7 @@
         <arquillian-core.version>1.2.1.Final</arquillian-core.version>
         <!--the version of shrinkwrap_resolver should align with the version in arquillian-bom-->
         <shrinkwrap-resolver.version>2.2.6</shrinkwrap-resolver.version>
-        <selenium.version>3.13.0</selenium.version>
+        <selenium.version>3.14.0</selenium.version>
         <arquillian-drone.version>2.5.1</arquillian-drone.version>
         <arquillian-graphene.version>2.3.2</arquillian-graphene.version>
         <arquillian-wildfly-container.version>2.1.0.Final</arquillian-wildfly-container.version>
@@ -81,13 +81,78 @@
 
     <dependencyManagement>
         <dependencies>
+
+            <!-- Selenium Server -->
             <dependency>
-                <groupId>org.jboss.arquillian.selenium</groupId>
-                <artifactId>selenium-bom</artifactId>
+                <groupId>org.seleniumhq.selenium</groupId>
+                <artifactId>selenium-server</artifactId>
                 <version>${selenium.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
             </dependency>
+
+            <!-- Selenium dependencies -->
+            <dependency>
+                <groupId>org.seleniumhq.selenium</groupId>
+                <artifactId>selenium-api</artifactId>
+                <version>${selenium.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.seleniumhq.selenium</groupId>
+                <artifactId>selenium-java</artifactId>
+                <version>${selenium.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.seleniumhq.selenium</groupId>
+                <artifactId>selenium-support</artifactId>
+                <version>${selenium.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.seleniumhq.selenium</groupId>
+                <artifactId>selenium-leg-rc</artifactId>
+                <version>${selenium.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.seleniumhq.selenium</groupId>
+                <artifactId>lift</artifactId>
+                <version>${selenium.version}</version>
+            </dependency>
+
+            <!-- Drivers -->
+            <dependency>
+                <groupId>org.seleniumhq.selenium</groupId>
+                <artifactId>selenium-chrome-driver</artifactId>
+                <version>${selenium.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.seleniumhq.selenium</groupId>
+                <artifactId>selenium-firefox-driver</artifactId>
+                <version>${selenium.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.seleniumhq.selenium</groupId>
+                <artifactId>selenium-ie-driver</artifactId>
+                <version>${selenium.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.seleniumhq.selenium</groupId>
+                <artifactId>selenium-edge-driver</artifactId>
+                <version>${selenium.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.seleniumhq.selenium</groupId>
+                <artifactId>selenium-safari-driver</artifactId>
+                <version>${selenium.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.seleniumhq.selenium</groupId>
+                <artifactId>selenium-remote-driver</artifactId>
+                <version>${selenium.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.seleniumhq.selenium</groupId>
+                <artifactId>selenium-opera-driver</artifactId>
+                <version>${selenium.version}</version>
+            </dependency>
+
             <dependency>
                 <groupId>org.jboss.arquillian</groupId>
                 <artifactId>arquillian-bom</artifactId>

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/auth/page/login/LoginBase.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/auth/page/login/LoginBase.java
@@ -40,7 +40,7 @@ public abstract class LoginBase extends AuthRealm {
     @FindBy(id = "kc-header-wrapper")
     protected WebElement header;
 
-    @FindBy(id = "kc-locale-dropdown")
+    @FindBy(id = "kc-locale")
     private LocaleDropdown localeDropdown;
 
     protected String keycloakThemeCssName;

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/console/page/fragment/LocaleDropdown.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/console/page/fragment/LocaleDropdown.java
@@ -1,12 +1,14 @@
 package org.keycloak.testsuite.console.page.fragment;
 
+import io.appium.java_client.android.AndroidDriver;
 import io.appium.java_client.ios.IOSDriver;
+import org.jboss.arquillian.drone.api.annotation.Drone;
 import org.jboss.arquillian.graphene.fragment.Root;
-import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.logging.Logger;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.firefox.FirefoxDriver;
+import org.openqa.selenium.ie.InternetExplorerDriver;
 import org.openqa.selenium.interactions.Actions;
 import org.openqa.selenium.support.FindBy;
 
@@ -14,12 +16,13 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.keycloak.testsuite.util.UIUtils.clickLink;
 import static org.keycloak.testsuite.util.UIUtils.getTextFromElement;
-import static org.keycloak.testsuite.util.WaitUtils.pause;
 
 /**
  * @author Vaclav Muzikar <vmuzikar@redhat.com>
  */
 public class LocaleDropdown {
+    protected Logger log = Logger.getLogger(this.getClass());
+
     @Root
     private WebElement root;
 
@@ -29,7 +32,7 @@ public class LocaleDropdown {
     @FindBy(id = "kc-current-locale-link")
     private WebElement currentLocaleLink;
 
-    @ArquillianResource
+    @Drone
     private WebDriver driver;
 
     public String getSelected() {
@@ -38,16 +41,17 @@ public class LocaleDropdown {
 
     public void selectByText(String text) {
         // open the menu
-        if (driver instanceof FirefoxDriver) { // GeckoDriver hack
-            Actions actions = new Actions(driver);
-            actions.moveToElement(root).perform();
-            pause(500);
-        }
-        else if (driver instanceof IOSDriver) { // TODO: Fix this! It's a very, very, ... very nasty hack for Safari on iOS - see KEYCLOAK-7947
+        if (driver instanceof IOSDriver) { // TODO: Fix this! It's a very, very, ... very nasty hack for Safari on iOS - see KEYCLOAK-7947
             ((IOSDriver) driver).executeScript("arguments[0].setAttribute('style', 'display: block')", dropDownMenu);
         }
+        else if (driver instanceof AndroidDriver || driver instanceof InternetExplorerDriver) { // Android needs to tap (no cursor)
+                                                                                                // and IE has some bug so needs to click as well (instead of moving cursor)
+            currentLocaleLink.click();
+        }
         else {
-            root.click();
+            Actions actions = new Actions(driver);
+            log.info("Moving mouse cursor to the localization menu");
+            actions.moveToElement(currentLocaleLink).perform();
         }
 
         // click desired locale

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/console/page/fragment/Menu.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/console/page/fragment/Menu.java
@@ -22,6 +22,7 @@ import org.openqa.selenium.support.FindBy;
 
 import java.util.List;
 
+import static org.keycloak.testsuite.util.UIUtils.clickLink;
 import static org.keycloak.testsuite.util.WaitUtils.waitUntilElement;
 
 /**
@@ -73,7 +74,7 @@ public class Menu {
         }
         for (WebElement item : menuList.get(menuOrder).findElements(By.cssSelector(MENU_LOCATOR + " a"))) {
             if (item.getText().contains(linkText)) {
-                item.click();
+                clickLink(item);
                 return;
             }
         }

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/page/LoginPasswordUpdatePage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/page/LoginPasswordUpdatePage.java
@@ -25,6 +25,8 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 
+import static org.keycloak.testsuite.util.UIUtils.getTextFromElement;
+
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
  */
@@ -65,7 +67,7 @@ public class LoginPasswordUpdatePage {
     }
 
     public String getError() {
-        return loginErrorMessage != null ? loginErrorMessage.getText() : null;
+        return loginErrorMessage != null ? getTextFromElement(loginErrorMessage) : null;
     }
 
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/AccountFormServiceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/AccountFormServiceTest.java
@@ -56,6 +56,7 @@ import org.keycloak.testsuite.pages.RegisterPage;
 import org.keycloak.testsuite.util.IdentityProviderBuilder;
 import org.keycloak.testsuite.util.OAuthClient;
 import org.keycloak.testsuite.util.RealmBuilder;
+import org.keycloak.testsuite.util.UIUtils;
 import org.keycloak.testsuite.util.UserBuilder;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
@@ -834,7 +835,7 @@ public class AccountFormServiceTest extends AbstractTestRealmKeycloakTest {
         assertFalse(pageSource.contains("Unable to scan?"));
         assertTrue(pageSource.contains("Scan barcode?"));
 
-        assertTrue(driver.findElement(By.id("kc-totp-secret-key")).getText().matches("[\\w]{4}( [\\w]{4}){7}"));
+        assertTrue(UIUtils.getTextFromElement(driver.findElement(By.id("kc-totp-secret-key"))).matches("[\\w]{4}( [\\w]{4}){7}"));
 
         assertEquals("Type: Time-based", driver.findElement(By.id("kc-totp-type")).getText());
         assertEquals("Algorithm: SHA1", driver.findElement(By.id("kc-totp-algorithm")).getText());

--- a/testsuite/integration-arquillian/tests/other/base-ui/pom.xml
+++ b/testsuite/integration-arquillian/tests/other/base-ui/pom.xml
@@ -31,7 +31,6 @@
 
     <properties>
         <droneInstantiationTimeoutInSeconds>600</droneInstantiationTimeoutInSeconds>
-        <firefoxLegacyDriver>false</firefoxLegacyDriver> <!-- using the new GeckoDriver -->
         <keycloak.theme.dir>${auth.server.home}/themes</keycloak.theme.dir>
     </properties>
 

--- a/testsuite/integration-arquillian/tests/other/console/pom.xml
+++ b/testsuite/integration-arquillian/tests/other/console/pom.xml
@@ -33,7 +33,7 @@
 
     <properties>
         <keycloak.theme.dir>${auth.server.home}/themes</keycloak.theme.dir>
-        <supportedBrowsers>firefox|chrome|internetExplorer</supportedBrowsers>
+        <supportedBrowsers>firefox|chrome|internetExplorer|safari</supportedBrowsers>
     </properties>
 
     <build>

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/authentication/Authentication.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/authentication/Authentication.java
@@ -4,6 +4,7 @@ import org.keycloak.testsuite.console.page.AdminConsoleRealm;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 
+import static org.keycloak.testsuite.util.UIUtils.getTextFromElement;
 import static org.keycloak.testsuite.util.WaitUtils.*;
 
 /**
@@ -26,12 +27,12 @@ public class Authentication extends AdminConsoleRealm {
     
     public String getSuccessMessage() {
         waitUntilElement(success).is().present();
-        return success.getText();
+        return getTextFromElement(success);
     }
     
     public String getErrorMessage() {
         waitUntilElement(error).is().present();
-        return error.getText();
+        return getTextFromElement(error);
     }
     
     public void closeNotification() {

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/authentication/flows/Flows.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/authentication/flows/Flows.java
@@ -8,6 +8,7 @@ import org.openqa.selenium.support.ui.Select;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static org.keycloak.testsuite.util.UIUtils.getTextFromElement;
 import static org.keycloak.testsuite.util.UIUtils.performOperationWithPageReload;
 
 /**
@@ -67,7 +68,7 @@ public class Flows extends Authentication {
     }
 
     public String getFlowSelectValue() {
-        return flowSelect.getFirstSelectedOption().getText();
+        return getTextFromElement(flowSelect.getFirstSelectedOption());
     }
 
     public List<String> getFlowAllValues() {

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/authentication/flows/FlowsTable.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/authentication/flows/FlowsTable.java
@@ -29,6 +29,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.keycloak.testsuite.util.UIUtils.getTextFromElement;
 import static org.keycloak.testsuite.util.WaitUtils.waitUntilElement;
 
 /**
@@ -115,7 +116,7 @@ public class FlowsTable {
             List<WebElement> requirementsOptions = alias.findElements(By.xpath(".//../parent::*//input[@type='radio']"));
             for (WebElement requirement : requirementsOptions) {
                 if (requirement.isSelected()) {
-                    flows.put(alias.getText(), requirement.getAttribute("value"));
+                    flows.put(getTextFromElement(alias), requirement.getAttribute("value"));
                 }
             }
         }

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/clients/Clients.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/clients/Clients.java
@@ -26,6 +26,7 @@ import org.openqa.selenium.support.FindBy;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.keycloak.testsuite.util.UIUtils.getTextFromElement;
 import static org.openqa.selenium.By.linkText;
 import static org.openqa.selenium.By.tagName;
 
@@ -110,9 +111,9 @@ public class Clients extends AdminConsoleRealm {
             if (row.isDisplayed()) {
                 client = new ClientRepresentation();
                 List<WebElement> tds = row.findElements(tagName("td"));
-                client.setClientId(tds.get(0).getText());
+                client.setClientId(getTextFromElement(tds.get(0)));
                 List<String> redirectUris = new ArrayList<>();
-                redirectUris.add(tds.get(2).getText()); // FIXME there can be more than 1 redirect uri
+                redirectUris.add(getTextFromElement(tds.get(2))); // FIXME there can be more than 1 redirect uri
                 client.setRedirectUris(redirectUris);
             }
             return client;

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/clients/CreateClientForm.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/clients/CreateClientForm.java
@@ -8,6 +8,7 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.ui.Select;
 
+import static org.keycloak.testsuite.util.UIUtils.getTextFromElement;
 import static org.keycloak.testsuite.util.UIUtils.getTextInputValue;
 import static org.keycloak.testsuite.util.WaitUtils.*;
 
@@ -40,7 +41,7 @@ public class CreateClientForm extends Form {
 
     public String getProtocol() {
         waitUntilElement(protocolSelect.getFirstSelectedOption()).is().present();
-        return protocolSelect.getFirstSelectedOption().getText();
+        return getTextFromElement(protocolSelect.getFirstSelectedOption());
     }
 
     public void setProtocol(String protocol) {

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/clients/authorization/permission/PermissionsTable.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/clients/authorization/permission/PermissionsTable.java
@@ -16,6 +16,7 @@
  */
 package org.keycloak.testsuite.console.page.clients.authorization.permission;
 
+import static org.keycloak.testsuite.util.UIUtils.getTextFromElement;
 import static org.openqa.selenium.By.tagName;
 
 import java.util.ArrayList;
@@ -65,11 +66,11 @@ public class PermissionsTable extends DataTable {
     public PolicyRepresentation toRepresentation(WebElement row) {
         PolicyRepresentation representation = null;
         List<WebElement> tds = row.findElements(tagName("td"));
-        if (!(tds.isEmpty() || tds.get(1).getText().isEmpty())) {
+        if (!(tds.isEmpty() || getTextFromElement(tds.get(1)).isEmpty())) {
             representation = new PolicyRepresentation();
-            representation.setName(tds.get(1).getText());
-            representation.setDescription(tds.get(2).getText());
-            representation.setType(tds.get(3).getText());
+            representation.setName(getTextFromElement(tds.get(1)));
+            representation.setDescription(getTextFromElement(tds.get(2)));
+            representation.setType(getTextFromElement(tds.get(3)));
         }
         return representation;
     }

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/clients/authorization/permission/ResourcePermissionForm.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/clients/authorization/permission/ResourcePermissionForm.java
@@ -135,7 +135,7 @@ public class ResourcePermissionForm extends Form {
 
         representation.setName(UIUtils.getTextInputValue(name));
         representation.setDescription(UIUtils.getTextInputValue(description));
-        representation.setDecisionStrategy(DecisionStrategy.valueOf(decisionStrategy.getFirstSelectedOption().getText().toUpperCase()));
+        representation.setDecisionStrategy(DecisionStrategy.valueOf(UIUtils.getTextFromElement(decisionStrategy.getFirstSelectedOption()).toUpperCase()));
         representation.setPolicies(policySelect.getSelected());
         String inputValue = UIUtils.getTextInputValue(resourceType);
 

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/clients/authorization/permission/ScopePermissionForm.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/clients/authorization/permission/ScopePermissionForm.java
@@ -144,7 +144,7 @@ public class ScopePermissionForm extends Form {
 
         representation.setName(UIUtils.getTextInputValue(name));
         representation.setDescription(UIUtils.getTextInputValue(description));
-        representation.setDecisionStrategy(DecisionStrategy.valueOf(decisionStrategy.getFirstSelectedOption().getText().toUpperCase()));
+        representation.setDecisionStrategy(DecisionStrategy.valueOf(UIUtils.getTextFromElement(decisionStrategy.getFirstSelectedOption()).toUpperCase()));
         representation.setPolicies(policySelect.getSelected());
         representation.setResources(resourceSelect.getSelected());
         representation.setScopes(scopeSelect.getSelected());

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/clients/authorization/policy/AggregatePolicyForm.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/clients/authorization/policy/AggregatePolicyForm.java
@@ -131,7 +131,7 @@ public class AggregatePolicyForm extends Form {
 
         representation.setName(UIUtils.getTextInputValue(name));
         representation.setDescription(UIUtils.getTextInputValue(description));
-        representation.setLogic(Logic.valueOf(logic.getFirstSelectedOption().getText().toUpperCase()));
+        representation.setLogic(Logic.valueOf(UIUtils.getTextFromElement(logic.getFirstSelectedOption()).toUpperCase()));
         representation.setPolicies(policySelect.getSelected());
 
         return representation;

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/clients/authorization/policy/ClientPolicyForm.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/clients/authorization/policy/ClientPolicyForm.java
@@ -16,6 +16,7 @@
  */
 package org.keycloak.testsuite.console.page.clients.authorization.policy;
 
+import static org.keycloak.testsuite.util.UIUtils.getTextFromElement;
 import static org.openqa.selenium.By.tagName;
 
 import java.util.List;
@@ -79,7 +80,7 @@ public class ClientPolicyForm extends Form {
 
         representation.setName(UIUtils.getTextInputValue(name));
         representation.setDescription(UIUtils.getTextInputValue(description));
-        representation.setLogic(Logic.valueOf(logic.getFirstSelectedOption().getText().toUpperCase()));
+        representation.setLogic(Logic.valueOf(UIUtils.getTextFromElement(logic.getFirstSelectedOption()).toUpperCase()));
         representation.setClients(clientsInput.getSelected());
 
         return representation;
@@ -99,8 +100,8 @@ public class ClientPolicyForm extends Form {
             return (webElement, name) -> {
                 List<WebElement> tds = webElement.findElements(tagName("td"));
 
-                if (!tds.get(0).getText().isEmpty()) {
-                    if (tds.get(0).getText().equals(name)) {
+                if (!UIUtils.getTextFromElement(tds.get(0)).isEmpty()) {
+                    if (UIUtils.getTextFromElement(tds.get(0)).equals(name)) {
                         tds.get(1).findElement(By.tagName("button")).click();
                         return true;
                     }
@@ -112,7 +113,7 @@ public class ClientPolicyForm extends Form {
 
         @Override
         protected Function<WebElement, String> representation() {
-            return webElement -> webElement.findElements(tagName("td")).get(0).getText();
+            return webElement -> getTextFromElement(webElement.findElements(tagName("td")).get(0));
         }
     }
 }

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/clients/authorization/policy/GroupPolicyForm.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/clients/authorization/policy/GroupPolicyForm.java
@@ -32,6 +32,7 @@ import org.openqa.selenium.support.ui.Select;
 import java.util.HashSet;
 import java.util.List;
 
+import static org.keycloak.testsuite.util.UIUtils.getTextFromElement;
 import static org.keycloak.testsuite.util.WaitUtils.waitUntilElement;
 import static org.openqa.selenium.By.tagName;
 
@@ -96,7 +97,7 @@ public class GroupPolicyForm extends Form {
             driver.findElements(By.xpath("(//table[@id='selected-groups'])/tbody/tr")).stream()
                     .filter(webElement -> webElement.findElements(tagName("td")).size() > 1)
                     .map(webElement -> webElement.findElements(tagName("td")))
-                    .filter(tds -> tds.get(0).getText().equals(definition.getPath()))
+                    .filter(tds -> UIUtils.getTextFromElement(tds.get(0)).equals(definition.getPath()))
                     .forEach(tds -> {
                         if (!tds.get(1).findElement(By.tagName("input")).isSelected()) {
                             if (definition.isExtendChildren()) {
@@ -120,7 +121,7 @@ public class GroupPolicyForm extends Form {
             List<WebElement> tds = webElement.findElements(tagName("td"));
 
             if (tds.size() > 1) {
-                if (tds.get(0).getText().equals(path)) {
+                if (UIUtils.getTextFromElement(tds.get(0)).equals(path)) {
                     tds.get(2).findElement(By.tagName("button")).click();
                     return;
                 }
@@ -142,14 +143,14 @@ public class GroupPolicyForm extends Form {
         String groupsClaimValue = UIUtils.getTextInputValue(groupsClaim);
 
         representation.setGroupsClaim(groupsClaim == null || "".equals(groupsClaimValue.trim()) ? null : groupsClaimValue);
-        representation.setLogic(Logic.valueOf(logic.getFirstSelectedOption().getText().toUpperCase()));
+        representation.setLogic(Logic.valueOf(UIUtils.getTextFromElement(logic.getFirstSelectedOption()).toUpperCase()));
         representation.setGroups(new HashSet<>());
 
         driver.findElements(By.xpath("(//table[@id='selected-groups'])/tbody/tr")).stream()
                 .filter(webElement -> webElement.findElements(tagName("td")).size() > 1)
                 .forEach(webElement -> {
                     List<WebElement> tds = webElement.findElements(tagName("td"));
-                    representation.addGroupPath(tds.get(0).getText(), tds.get(1).findElement(By.tagName("input")).isSelected());
+                    representation.addGroupPath(getTextFromElement(tds.get(0)), tds.get(1).findElement(tagName("input")).isSelected());
                 });
 
         return representation;

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/clients/authorization/policy/JSPolicyForm.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/clients/authorization/policy/JSPolicyForm.java
@@ -70,7 +70,7 @@ public class JSPolicyForm extends Form {
 
         representation.setName(UIUtils.getTextInputValue(name));
         representation.setDescription(UIUtils.getTextInputValue(description));
-        representation.setLogic(Logic.valueOf(logic.getFirstSelectedOption().getText().toUpperCase()));
+        representation.setLogic(Logic.valueOf(UIUtils.getTextFromElement(logic.getFirstSelectedOption()).toUpperCase()));
 
         JavascriptExecutor scriptExecutor = (JavascriptExecutor) driver;
 

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/clients/authorization/policy/PoliciesTable.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/clients/authorization/policy/PoliciesTable.java
@@ -16,6 +16,7 @@
  */
 package org.keycloak.testsuite.console.page.clients.authorization.policy;
 
+import static org.keycloak.testsuite.util.UIUtils.getTextFromElement;
 import static org.openqa.selenium.By.tagName;
 
 import java.util.ArrayList;
@@ -65,11 +66,11 @@ public class PoliciesTable extends DataTable {
     public PolicyRepresentation toRepresentation(WebElement row) {
         PolicyRepresentation representation = null;
         List<WebElement> tds = row.findElements(tagName("td"));
-        if (!(tds.isEmpty() || tds.get(1).getText().isEmpty())) {
+        if (!(tds.isEmpty() || getTextFromElement(tds.get(1)).isEmpty())) {
             representation = new PolicyRepresentation();
-            representation.setName(tds.get(1).getText());
-            representation.setDescription(tds.get(2).getText());
-            representation.setType(tds.get(3).getText());
+            representation.setName(getTextFromElement(tds.get(1)));
+            representation.setDescription(getTextFromElement(tds.get(2)));
+            representation.setType(getTextFromElement(tds.get(3)));
         }
         return representation;
     }

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/clients/authorization/policy/PolicySelect.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/clients/authorization/policy/PolicySelect.java
@@ -16,6 +16,7 @@
  */
 package org.keycloak.testsuite.console.page.clients.authorization.policy;
 
+import static org.keycloak.testsuite.util.UIUtils.getTextFromElement;
 import static org.openqa.selenium.By.tagName;
 
 import java.util.List;
@@ -41,8 +42,8 @@ public class PolicySelect extends MultipleStringSelect2 {
         return (webElement, name) -> {
             List<WebElement> tds = webElement.findElements(tagName("td"));
 
-            if (!tds.get(0).getText().isEmpty()) {
-                if (tds.get(0).getText().equals(name)) {
+            if (!getTextFromElement(tds.get(0)).isEmpty()) {
+                if (getTextFromElement(tds.get(0)).equals(name)) {
                     tds.get(3).click();
                     return true;
                 }
@@ -54,6 +55,6 @@ public class PolicySelect extends MultipleStringSelect2 {
 
     @Override
     protected Function<WebElement, String> representation() {
-        return webElement -> webElement.findElements(tagName("td")).get(0).getText();
+        return webElement -> getTextFromElement(webElement.findElements(tagName("td")).get(0));
     }
 }

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/clients/authorization/policy/RolePolicyForm.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/clients/authorization/policy/RolePolicyForm.java
@@ -16,6 +16,7 @@
  */
 package org.keycloak.testsuite.console.page.clients.authorization.policy;
 
+import static org.keycloak.testsuite.util.UIUtils.getTextFromElement;
 import static org.openqa.selenium.By.tagName;
 
 import java.util.Iterator;
@@ -127,7 +128,7 @@ public class RolePolicyForm extends Form {
 
         representation.setName(UIUtils.getTextInputValue(name));
         representation.setDescription(UIUtils.getTextInputValue(description));
-        representation.setLogic(Logic.valueOf(logic.getFirstSelectedOption().getText().toUpperCase()));
+        representation.setLogic(Logic.valueOf(UIUtils.getTextFromElement(logic.getFirstSelectedOption()).toUpperCase()));
 
         Set<RolePolicyRepresentation.RoleDefinition> roles = realmRoleSelect.getSelected();
 
@@ -162,7 +163,7 @@ public class RolePolicyForm extends Form {
                 RolePolicyRepresentation.RoleDefinition selectedRole = new RolePolicyRepresentation.RoleDefinition();
                 boolean clientRole = tds.size() == 4;
 
-                selectedRole.setId(clientRole ? tds.get(1).getText() + "/" + tds.get(0).getText() : tds.get(0).getText());
+                selectedRole.setId(clientRole ? getTextFromElement(tds.get(1)) + "/" + getTextFromElement(tds.get(0)) : getTextFromElement(tds.get(0)));
                 selectedRole.setRequired(tds.get(clientRole ? 2 : 1).findElement(By.tagName("input")).isSelected());
 
                 return selectedRole;
@@ -178,8 +179,8 @@ public class RolePolicyForm extends Form {
                 boolean clientRole = role.getId().indexOf("/") != -1;
                 WebElement roleName = tds.get(0);
 
-                if (!roleName.getText().isEmpty()) {
-                    if (roleName.getText().equals(getRoleId(role, clientRole))) {
+                if (!UIUtils.getTextFromElement(roleName).isEmpty()) {
+                    if (UIUtils.getTextFromElement(roleName).equals(getRoleId(role, clientRole))) {
                         WebElement required = tds.get(clientRole ? 2 : 1).findElement(By.tagName("input"));
 
                         if (required.isSelected() && role.isRequired()) {
@@ -201,8 +202,8 @@ public class RolePolicyForm extends Form {
                 List<WebElement> tds = webElement.findElements(tagName("td"));
                 boolean clientRole = tds.size() == 4;
 
-                if (!tds.get(0).getText().isEmpty()) {
-                    if (tds.get(0).getText().equals(getRoleId(roleDefinition, clientRole))) {
+                if (!UIUtils.getTextFromElement(tds.get(0)).isEmpty()) {
+                    if (UIUtils.getTextFromElement(tds.get(0)).equals(getRoleId(roleDefinition, clientRole))) {
                         tds.get(clientRole ? 3 : 2).findElement(By.tagName("button")).click();
                         return true;
                     }

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/clients/authorization/policy/RulePolicyForm.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/clients/authorization/policy/RulePolicyForm.java
@@ -30,6 +30,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.jboss.arquillian.graphene.Graphene.waitGui;
 import static org.keycloak.testsuite.util.UIUtils.clickLink;
+import static org.keycloak.testsuite.util.UIUtils.getTextFromElement;
 import static org.openqa.selenium.By.id;
 
 /**
@@ -110,14 +111,14 @@ public class RulePolicyForm extends Form {
 
         representation.setName(UIUtils.getTextInputValue(name));
         representation.setDescription(UIUtils.getTextInputValue(description));
-        representation.setLogic(Logic.valueOf(logic.getFirstSelectedOption().getText().toUpperCase()));
+        representation.setLogic(Logic.valueOf(UIUtils.getTextFromElement(logic.getFirstSelectedOption()).toUpperCase()));
         representation.setArtifactGroupId(UIUtils.getTextInputValue(artifactGroupId));
         representation.setArtifactId(UIUtils.getTextInputValue(artifactId));
         representation.setArtifactVersion(UIUtils.getTextInputValue(artifactVersion));
-        representation.setModuleName(moduleName.getFirstSelectedOption().getText());
-        representation.setSessionName(sessionName.getFirstSelectedOption().getText());
+        representation.setModuleName(getTextFromElement(moduleName.getFirstSelectedOption()));
+        representation.setSessionName(getTextFromElement(sessionName.getFirstSelectedOption()));
         representation.setScannerPeriod(UIUtils.getTextInputValue(scannerPeriod));
-        representation.setScannerPeriodUnit(scannerPeriodUnit.getFirstSelectedOption().getText());
+        representation.setScannerPeriodUnit(getTextFromElement(scannerPeriodUnit.getFirstSelectedOption()));
 
         return representation;
     }

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/clients/authorization/policy/TimePolicyForm.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/clients/authorization/policy/TimePolicyForm.java
@@ -114,7 +114,7 @@ public class TimePolicyForm extends Form {
 
         representation.setName(UIUtils.getTextInputValue(name));
         representation.setDescription(UIUtils.getTextInputValue(description));
-        representation.setLogic(Logic.valueOf(logic.getFirstSelectedOption().getText().toUpperCase()));
+        representation.setLogic(Logic.valueOf(UIUtils.getTextFromElement(logic.getFirstSelectedOption()).toUpperCase()));
         representation.setDayMonth(UIUtils.getTextInputValue(dayMonth));
         representation.setDayMonthEnd(UIUtils.getTextInputValue(dayMonthEnd));
         representation.setMonth(UIUtils.getTextInputValue(month));

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/clients/authorization/policy/UserPolicyForm.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/clients/authorization/policy/UserPolicyForm.java
@@ -16,6 +16,7 @@
  */
 package org.keycloak.testsuite.console.page.clients.authorization.policy;
 
+import static org.keycloak.testsuite.util.UIUtils.getTextFromElement;
 import static org.openqa.selenium.By.tagName;
 
 import java.util.List;
@@ -79,7 +80,7 @@ public class UserPolicyForm extends Form {
 
         representation.setName(UIUtils.getTextInputValue(name));
         representation.setDescription(UIUtils.getTextInputValue(description));
-        representation.setLogic(Logic.valueOf(logic.getFirstSelectedOption().getText().toUpperCase()));
+        representation.setLogic(Logic.valueOf(UIUtils.getTextFromElement(logic.getFirstSelectedOption()).toUpperCase()));
         representation.setUsers(usersInput.getSelected());
 
         return representation;
@@ -99,8 +100,8 @@ public class UserPolicyForm extends Form {
             return (webElement, name) -> {
                 List<WebElement> tds = webElement.findElements(tagName("td"));
 
-                if (!tds.get(0).getText().isEmpty()) {
-                    if (tds.get(0).getText().equals(name)) {
+                if (!UIUtils.getTextFromElement(tds.get(0)).isEmpty()) {
+                    if (UIUtils.getTextFromElement(tds.get(0)).equals(name)) {
                         tds.get(1).findElement(By.tagName("button")).click();
                         return true;
                     }
@@ -112,7 +113,7 @@ public class UserPolicyForm extends Form {
 
         @Override
         protected Function<WebElement, String> representation() {
-            return webElement -> webElement.findElements(tagName("td")).get(0).getText();
+            return webElement -> getTextFromElement(webElement.findElements(tagName("td")).get(0));
         }
     }
 }

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/clients/authorization/resource/ResourceForm.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/clients/authorization/resource/ResourceForm.java
@@ -16,23 +16,26 @@
  */
 package org.keycloak.testsuite.console.page.clients.authorization.resource;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
 import org.jboss.arquillian.graphene.fragment.Root;
 import org.keycloak.representations.idm.authorization.ResourceRepresentation;
 import org.keycloak.representations.idm.authorization.ScopeRepresentation;
 import org.keycloak.testsuite.console.page.fragment.ModalDialog;
 import org.keycloak.testsuite.page.Form;
 import org.keycloak.testsuite.util.UIUtils;
-import org.keycloak.testsuite.util.WaitUtils;
 import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.keycloak.testsuite.util.UIUtils.getTextFromElement;
+import static org.keycloak.testsuite.util.WaitUtils.pause;
+import static org.openqa.selenium.By.tagName;
 
 /**
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
@@ -156,13 +159,9 @@ public class ResourceForm extends Form {
 
         public void select(String name) {
             UIUtils.setTextInputValue(search, name);
-            try {
-                Thread.sleep(1000);
-            } catch (InterruptedException e) {
-                e.printStackTrace();
-            }
+            pause(1000);
             for (WebElement result : result) {
-                if (result.getText().equalsIgnoreCase(name)) {
+                if (result.isDisplayed() && UIUtils.getTextFromElement(result).equalsIgnoreCase(name)) {
                     result.click();
                     return;
                 }
@@ -173,7 +172,7 @@ public class ResourceForm extends Form {
             HashSet<ScopeRepresentation> values = new HashSet<>();
 
             for (WebElement selected : selection) {
-                values.add(new ScopeRepresentation(selected.findElements(By.tagName("div")).get(0).getText()));
+                values.add(new ScopeRepresentation(getTextFromElement(selected.findElements(tagName("div")).get(0))));
             }
 
             return values;
@@ -181,11 +180,11 @@ public class ResourceForm extends Form {
 
         public void unSelect(String name, WebDriver driver) {
             for (WebElement selected : selection) {
-                if (name.equals(selected.findElements(By.tagName("div")).get(0).getText())) {
+                if (name.equals(getTextFromElement(selected.findElements(tagName("div")).get(0)))) {
                     WebElement element = selected.findElement(By.xpath("//a[contains(@class,'select2-search-choice-close')]"));
                     JavascriptExecutor executor = (JavascriptExecutor) driver;
                     executor.executeScript("arguments[0].click();", element);
-                    WaitUtils.pause(1000);
+                    pause(1000);
                     return;
                 }
             }

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/clients/authorization/resource/ResourcesTable.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/clients/authorization/resource/ResourcesTable.java
@@ -16,6 +16,7 @@
  */
 package org.keycloak.testsuite.console.page.clients.authorization.resource;
 
+import static org.keycloak.testsuite.util.UIUtils.getTextFromElement;
 import static org.openqa.selenium.By.tagName;
 
 import java.util.ArrayList;
@@ -67,13 +68,13 @@ public class ResourcesTable extends DataTable {
         ResourceRepresentation representation = null;
         List<WebElement> tds = row.findElements(tagName("td"));
         try {
-            if (!(tds.isEmpty() || tds.get(1).getText().isEmpty())) {
+            if (!(tds.isEmpty() || getTextFromElement(tds.get(1)).isEmpty())) {
                 representation = new ResourceRepresentation();
-                representation.setName(tds.get(1).getText());
-                representation.setType(tds.get(2).getText());
-                representation.setUri(tds.get(3).getText());
+                representation.setName(getTextFromElement(tds.get(1)));
+                representation.setType(getTextFromElement(tds.get(2)));
+                representation.setUri(getTextFromElement(tds.get(3)));
                 ResourceOwnerRepresentation owner = new ResourceOwnerRepresentation();
-                owner.setName(tds.get(4).getText());
+                owner.setName(getTextFromElement(tds.get(4)));
                 representation.setOwner(owner);
             }
         } catch (IndexOutOfBoundsException cause) {

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/clients/authorization/scope/ScopesTable.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/clients/authorization/scope/ScopesTable.java
@@ -16,6 +16,7 @@
  */
 package org.keycloak.testsuite.console.page.clients.authorization.scope;
 
+import static org.keycloak.testsuite.util.UIUtils.getTextFromElement;
 import static org.openqa.selenium.By.tagName;
 
 import java.util.ArrayList;
@@ -65,9 +66,9 @@ public class ScopesTable extends DataTable {
     public ScopeRepresentation toRepresentation(WebElement row) {
         ScopeRepresentation representation = null;
         List<WebElement> tds = row.findElements(tagName("td"));
-        if (!(tds.isEmpty() || tds.get(1).getText().isEmpty())) {
+        if (!(tds.isEmpty() || getTextFromElement(tds.get(1)).isEmpty())) {
             representation = new ScopeRepresentation();
-            representation.setName(tds.get(1).getText());
+            representation.setName(getTextFromElement(tds.get(1)));
         }
         return representation;
     }

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/clients/clientscopes/ClientScopesEvaluateForm.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/clients/clientscopes/ClientScopesEvaluateForm.java
@@ -30,6 +30,9 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.ui.Select;
 
+import static org.keycloak.testsuite.util.UIUtils.getTextFromElement;
+import static org.openqa.selenium.By.xpath;
+
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
  */
@@ -133,7 +136,7 @@ public class ClientScopesEvaluateForm extends Form {
 
         Set<String> names = rows.stream().map((WebElement row) -> {
 
-            return row.findElement(By.xpath("td[1]")).getText();
+            return getTextFromElement(row.findElement(xpath("td[1]")));
 
         }).collect(Collectors.toSet());
 
@@ -150,7 +153,7 @@ public class ClientScopesEvaluateForm extends Form {
     }
 
     public String getAccessToken() {
-        return accessTokenTextArea.getText();
+        return getTextFromElement(accessTokenTextArea);
     }
 
 

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/clients/clientscopes/ClientScopesSetupForm.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/clients/clientscopes/ClientScopesSetupForm.java
@@ -26,6 +26,7 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.ui.Select;
 
+import static org.keycloak.testsuite.util.UIUtils.getTextFromElement;
 import static org.keycloak.testsuite.util.WaitUtils.waitUntilElement;
 
 /**
@@ -92,7 +93,7 @@ public class ClientScopesSetupForm extends Form {
     static Set<String> getSelectValues(Select select) {
         Set<String> roles = new HashSet<>();
         for (WebElement option : select.getOptions()) {
-            roles.add(option.getText());
+            roles.add(getTextFromElement(option));
         }
         return roles;
     }

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/clients/credentials/SAMLClientCredentialsForm.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/clients/credentials/SAMLClientCredentialsForm.java
@@ -13,6 +13,7 @@ import static org.keycloak.services.resources.admin.ClientAttributeCertificateRe
 import static org.keycloak.common.util.KeystoreUtil.KeystoreFormat.JKS;
 import static org.keycloak.common.util.KeystoreUtil.KeystoreFormat.PKCS12;
 import static org.keycloak.testsuite.util.UIUtils.clickLink;
+import static org.keycloak.testsuite.util.UIUtils.getTextFromElement;
 import static org.keycloak.testsuite.util.UIUtils.sendKeysToInvisibleElement;
 
 /**
@@ -67,7 +68,7 @@ public class SAMLClientCredentialsForm extends Form {
     }
 
     public String getSuccessMessage() {
-        return success.getText();
+        return getTextFromElement(success);
     }
 
     private void uploadFile(String file) {

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/clients/installation/ClientInstallationForm.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/clients/installation/ClientInstallationForm.java
@@ -27,6 +27,8 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.ui.Select;
 
+import static org.keycloak.testsuite.util.UIUtils.getTextFromElement;
+
 /**
  *
  * @author <a href="mailto:vramik@redhat.com">Vlastislav Ramik</a>
@@ -45,6 +47,6 @@ public class ClientInstallationForm extends Form {
     }
     
     public String getTextareaContent() {
-        return textarea.getText();
+        return getTextFromElement(textarea);
     }
 }

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/clients/mappers/ClientMappers.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/clients/mappers/ClientMappers.java
@@ -10,6 +10,8 @@ import org.openqa.selenium.support.FindBy;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.keycloak.testsuite.util.UIUtils.getTextFromElement;
+
 /**
  *
  * @author tkyjovsk
@@ -96,9 +98,9 @@ public class ClientMappers extends Client {
             List<WebElement> cols = row.findElements(By.tagName("td"));
 
 
-            mappingsRepresentation.setName(cols.get(0).getText());
+            mappingsRepresentation.setName(getTextFromElement(cols.get(0)));
             //mappingsRepresentation.setProtocol(cols.get(1).getText());
-            mappingsRepresentation.setProtocolMapper(cols.get(2).getText());
+            mappingsRepresentation.setProtocolMapper(getTextFromElement(cols.get(2)));
 
             return mappingsRepresentation;
         }

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/clients/mappers/CreateClientMappersForm.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/clients/mappers/CreateClientMappersForm.java
@@ -10,6 +10,8 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.ui.Select;
 
+import static org.keycloak.testsuite.util.UIUtils.getTextFromElement;
+
 
 /**
  * @author Vaclav Muzikar <vmuzikar@redhat.com>
@@ -217,7 +219,7 @@ public class CreateClientMappersForm extends Form {
     }
 
     public String getClaimJSONType() {
-        return claimJSONTypeInput.getFirstSelectedOption().getText();
+        return getTextFromElement(claimJSONTypeInput.getFirstSelectedOption());
     }
 
     public void setClaimJSONType(String value) {

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/federation/LdapUserProviderForm.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/federation/LdapUserProviderForm.java
@@ -12,6 +12,8 @@ import org.openqa.selenium.support.ui.Select;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.keycloak.testsuite.util.UIUtils.clickLink;
+import static org.keycloak.testsuite.util.UIUtils.getTextFromElement;
 import static org.keycloak.testsuite.util.WaitUtils.waitUntilElement;
 
 /**
@@ -227,7 +229,7 @@ public class LdapUserProviderForm extends Form {
         List<String> vendorsString = new ArrayList<>();
 
         for (WebElement vendorElement : vendorsElements) {
-            String text = vendorElement.getText();
+            String text = getTextFromElement(vendorElement);
             if (text.equals("")) {continue;}
             vendorsString.add(text);
         }
@@ -314,15 +316,15 @@ public class LdapUserProviderForm extends Form {
     }
 
     public void testConnection() {
-        testConnectionButton.click();
+        clickLink(testConnectionButton);
     }
 
     public void testAuthentication() {
-        testAuthenticationButton.click();
+        clickLink(testAuthenticationButton);
     }
 
     public void synchronizeAllUsers() {
         waitUntilElement(synchronizeAllUsersButton).is().present();
-        synchronizeAllUsersButton.click();
+        clickLink(synchronizeAllUsersButton);
     }
 }

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/idp/IdentityProviderSettings.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/idp/IdentityProviderSettings.java
@@ -28,6 +28,7 @@ import org.openqa.selenium.support.ui.Select;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.keycloak.testsuite.util.UIUtils.getTextFromElement;
 import static org.openqa.selenium.By.tagName;
 
 /**
@@ -83,10 +84,10 @@ public class IdentityProviderSettings extends AdminConsoleRealm {
         for (WebElement rowElement : providersTable.findElements(tagName("tr"))) {
             Provider provider = new Provider();
             List<WebElement> tds = rowElement.findElements(tagName("td"));
-            if (!(tds.isEmpty() || tds.get(0).getText().isEmpty())) {
-                provider.providerName = SocialProvider.valueOf(tds.get(0).getText());
-                provider.key = tds.get(1).getText();
-                provider.secret = tds.get(2).getText();
+            if (!(tds.isEmpty() || getTextFromElement(tds.get(0)).isEmpty())) {
+                provider.providerName = SocialProvider.valueOf(getTextFromElement(tds.get(0)));
+                provider.key = getTextFromElement(tds.get(1));
+                provider.secret = getTextFromElement(tds.get(2));
                 rows.add(provider);
             }
         }

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/realm/ThemeSettings.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/realm/ThemeSettings.java
@@ -21,6 +21,8 @@ import org.keycloak.testsuite.console.page.fragment.OnOffSwitch;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.ui.Select;
 
+import static org.keycloak.testsuite.util.UIUtils.clickLink;
+
 /**
  *
  * @author Filip Kiss
@@ -72,7 +74,7 @@ public class ThemeSettings extends RealmSettings {
     }
 
     public void saveTheme() {
-        primaryButton.click();
+        clickLink(primaryButton);
     }
 
 }

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/realm/TokenSettings.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/realm/TokenSettings.java
@@ -28,6 +28,8 @@ import java.util.concurrent.TimeUnit;
 
 import static java.lang.String.valueOf;
 import static org.apache.commons.lang3.text.WordUtils.capitalize;
+import static org.keycloak.testsuite.util.UIUtils.clickLink;
+import static org.keycloak.testsuite.util.UIUtils.scrollElementIntoView;
 import static org.keycloak.testsuite.util.WaitUtils.pause;
 
 /**
@@ -97,12 +99,13 @@ public class TokenSettings extends RealmSettings {
             selectOperation(tokenType);
 
             return actionTokenAttributeTime.getAttribute("value").equals(Integer.toString(timeout)) &&
-                    actionTokenAttributeUnit.getFirstSelectedOption().getText().equals(capitalize(unit.name().toLowerCase()));
+                    UIUtils.getTextFromElement(actionTokenAttributeUnit.getFirstSelectedOption()).equals(capitalize(unit.name().toLowerCase()));
         }
 
         public void resetActionToken(String tokenType) {
             selectOperation(tokenType);
-            resetButton.click();
+            scrollElementIntoView(resetButton);
+            clickLink(resetButton);
         }
 
         public void selectOperation(String tokenType) {

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/roles/RoleCompositeRoles.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/roles/RoleCompositeRoles.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.keycloak.testsuite.util.UIUtils.getTextFromElement;
 import static org.keycloak.testsuite.util.WaitUtils.waitUntilElement;
 
 /**
@@ -116,7 +117,7 @@ public class RoleCompositeRoles extends Form {
     public static Set<String> getSelectValues(Select select) {
         Set<String> roles = new HashSet<>();
         for (WebElement option : select.getOptions()) {
-            roles.add(option.getText());
+            roles.add(getTextFromElement(option));
         }
         return roles;
     }

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/roles/RolesTable.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/roles/RolesTable.java
@@ -7,6 +7,7 @@ import org.openqa.selenium.WebElement;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.keycloak.testsuite.util.UIUtils.getTextFromElement;
 import static org.openqa.selenium.By.tagName;
 
 /**
@@ -74,11 +75,11 @@ public class RolesTable extends DataTable {
     public RoleRepresentation getRoleFromRow(WebElement row) {
         RoleRepresentation role = null;
         List<WebElement> tds = row.findElements(tagName("td"));
-        if (!(tds.isEmpty() || tds.get(0).getText().isEmpty())) {
+        if (!(tds.isEmpty() || getTextFromElement(tds.get(0)).isEmpty())) {
             role = new RoleRepresentation();
-            role.setName(tds.get(0).getText());
-            role.setComposite(Boolean.valueOf(tds.get(1).getText()));
-            role.setDescription(tds.get(2).getText());
+            role.setName(getTextFromElement(tds.get(0)));
+            role.setComposite(Boolean.valueOf(getTextFromElement(tds.get(1))));
+            role.setDescription(getTextFromElement(tds.get(2)));
         }
         return role;
     }

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/roles/UsersInRole.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/roles/UsersInRole.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import static org.keycloak.testsuite.util.UIUtils.getTextFromElement;
 import static org.openqa.selenium.By.tagName;
 import static org.openqa.selenium.By.xpath;
 
@@ -54,12 +55,12 @@ public class UsersInRole extends Role {
         public UserRepresentation getUserFromTableRow(WebElement row) {
             UserRepresentation user = null;
             List<WebElement> tds = row.findElements(tagName("td"));
-            if (tds.size() == 5 && !tds.get(0).getText().isEmpty()) {
+            if (tds.size() == 5 && !getTextFromElement(tds.get(0)).isEmpty()) {
                 user = new UserRepresentation();
-                user.setUsername(tds.get(0).getText());
-                user.setLastName(tds.get(1).getText());
-                user.setFirstName(tds.get(2).getText());
-                user.setEmail(tds.get(3).getText());
+                user.setUsername(getTextFromElement(tds.get(0)));
+                user.setLastName(getTextFromElement(tds.get(1)));
+                user.setFirstName(getTextFromElement(tds.get(2)));
+                user.setEmail(getTextFromElement(tds.get(3)));
             }
             return user;
         }

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/users/UserAttributesForm.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/users/UserAttributesForm.java
@@ -1,14 +1,15 @@
 package org.keycloak.testsuite.console.page.users;
 
 import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.testsuite.console.page.fragment.MultipleStringSelect2;
 import org.keycloak.testsuite.console.page.fragment.OnOffSwitch;
 import org.keycloak.testsuite.page.Form;
 import org.keycloak.testsuite.util.UIUtils;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
-import org.openqa.selenium.support.ui.Select;
 
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 
 import static org.keycloak.testsuite.util.WaitUtils.waitUntilElement;
 
@@ -40,17 +41,8 @@ public class UserAttributesForm extends Form {
     @FindBy(xpath = ".//div[@class='onoffswitch' and ./input[@id='emailVerified']]")
     private OnOffSwitch emailVerifiedSwitch;
 
-    @FindBy(xpath = ".//div[./label[contains(text(), 'Required User Actions')]]//input")
-    private WebElement requiredUserActionsInput;
-
-    @FindBy(id = "reqActions")
-    private Select requiredUserActionsSelect;
-
-    @FindBy(className = "select2-result-label")
-    private WebElement requiredUserActionsConfirm;
-
-    @FindBy(className = "select2-search-choice-close")
-    private List<WebElement> removeRequiredActionsList;
+    @FindBy(id = "s2id_reqActions")
+    private MultipleStringSelect2 requiredUserActionsSelect;
 
     @FindBy(xpath = "//button[@data-ng-click='unlockUser()']")
     private WebElement unlockUserButton;
@@ -112,19 +104,11 @@ public class UserAttributesForm extends Form {
     }
 
     public void addRequiredAction(String requiredAction) {
-        requiredUserActionsInput.click();
-        requiredUserActionsSelect.selectByVisibleText(requiredAction);
+        requiredUserActionsSelect.select(requiredAction);
     }
 
-    public void setRequiredActions(List<String> requiredActions) {
-        for (WebElement e : removeRequiredActionsList) {
-            e.click();
-        }
-        if (requiredActions != null && !requiredActions.isEmpty()) {
-            for (String action : requiredActions) {
-                addRequiredAction(action);
-            }
-        }
+    public void setRequiredActions(Set<String> requiredActions) {
+        requiredUserActionsSelect.update(requiredActions);
     }
 
     public void setValues(UserRepresentation user) {
@@ -135,7 +119,7 @@ public class UserAttributesForm extends Form {
         setLastName(user.getLastName());
         if (user.isEnabled() != null) setEnabled(user.isEnabled());
         if (user.isEmailVerified() != null) setEmailVerified(user.isEmailVerified());
-        setRequiredActions(user.getRequiredActions());
+        if (user.getRequiredActions() != null) setRequiredActions(new HashSet<>(user.getRequiredActions()));
     }
 
     // TODO Contact Information section

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/users/UserRoleMappingsForm.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/users/UserRoleMappingsForm.java
@@ -10,6 +10,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.keycloak.testsuite.util.UIUtils.getTextFromElement;
+
 /**
  * Created by fkiss.
  */
@@ -35,8 +37,8 @@ public class UserRoleMappingsForm extends RoleCompositeRoles {
             roleNames.add(role.getName());
         }
         for (WebElement role : select.getOptions()) {
-            roleNames.contains(role.getText());
-            roleNames.remove(role.getText());
+            roleNames.contains(getTextFromElement(role));
+            roleNames.remove(getTextFromElement(role));
         }
         log.info(Arrays.toString(roles));
         log.info(roleNames);

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/users/Users.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/users/Users.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.keycloak.testsuite.util.UIUtils.clickLink;
+import static org.keycloak.testsuite.util.UIUtils.getTextFromElement;
 import static org.openqa.selenium.By.tagName;
 
 /**
@@ -111,12 +112,12 @@ public class Users extends AdminConsoleRealm {
         public UserRepresentation getUserFromTableRow(WebElement row) {
             UserRepresentation user = null;
             List<WebElement> tds = row.findElements(tagName("td"));
-            if (!(tds.isEmpty() || tds.get(0).getText().isEmpty())) {
+            if (!(tds.isEmpty() || getTextFromElement(tds.get(0)).isEmpty())) {
                 user = new UserRepresentation();
-                user.setUsername(tds.get(0).getText());
-                user.setLastName(tds.get(1).getText());
-                user.setFirstName(tds.get(2).getText());
-                user.setEmail(tds.get(3).getText());
+                user.setUsername(getTextFromElement(tds.get(0)));
+                user.setLastName(getTextFromElement(tds.get(1)));
+                user.setFirstName(getTextFromElement(tds.get(2)));
+                user.setEmail(getTextFromElement(tds.get(3)));
             }
             return user;
         }

--- a/testsuite/integration-arquillian/tests/other/console/src/test/java/org/keycloak/testsuite/console/AbstractConsoleTest.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/test/java/org/keycloak/testsuite/console/AbstractConsoleTest.java
@@ -28,9 +28,9 @@ import org.keycloak.testsuite.console.page.AdminConsoleRealm.ConfigureMenu;
 import org.keycloak.testsuite.console.page.AdminConsoleRealm.ManageMenu;
 import org.keycloak.testsuite.console.page.fragment.ModalDialog;
 import org.keycloak.testsuite.page.PatternFlyClosableAlert;
+import org.openqa.selenium.safari.SafariDriver;
 import org.openqa.selenium.support.FindBy;
 
-import static org.junit.Assert.assertTrue;
 import static org.keycloak.testsuite.auth.page.AuthRealm.TEST;
 import static org.keycloak.testsuite.util.URLAssert.assertCurrentUrlStartsWith;
 import static org.keycloak.testsuite.util.URLAssert.assertCurrentUrlStartsWithLoginUrlOf;
@@ -67,6 +67,13 @@ public abstract class AbstractConsoleTest extends AbstractAuthTest {
 
     @Before
     public void beforeConsoleTest() {
+        // Safari driver seemingly doesn't comply with WebDriver specs.
+        // driver.manage().deleteAllCookies() seems to delete all cookies regardless the path, i.e. when we delete cookies
+        // in the 'test' realm, they're deleted in 'master' as well resulting in admin user to be logged out.
+        if (driver instanceof SafariDriver) {
+            testContext.setAdminLoggedIn(false);
+        }
+
         createTestUserWithAdminClient();
         if (!testContext.isAdminLoggedIn()) {
             loginToMasterRealmAdminConsoleAs(adminUser);

--- a/testsuite/integration-arquillian/tests/other/console/src/test/java/org/keycloak/testsuite/console/authentication/RequiredActionsTest.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/test/java/org/keycloak/testsuite/console/authentication/RequiredActionsTest.java
@@ -27,6 +27,7 @@ import org.keycloak.testsuite.auth.page.login.TermsAndConditions;
 import org.keycloak.testsuite.console.AbstractConsoleTest;
 import org.keycloak.testsuite.console.page.authentication.RequiredActions;
 import org.keycloak.testsuite.console.page.realm.LoginSettings;
+import org.keycloak.testsuite.util.UIUtils;
 import org.openqa.selenium.By;
 
 import static org.keycloak.representations.idm.CredentialRepresentation.PASSWORD;
@@ -54,6 +55,7 @@ public class RequiredActionsTest extends AbstractConsoleTest {
     public void setDefaultPageUriParameters() {
         super.setDefaultPageUriParameters();
         testRealmRegistrationPage.setAuthRealm("test");
+        termsAndConditionsPage.setAuthRealm("test");
     }
 
     @Before
@@ -133,7 +135,7 @@ public class RequiredActionsTest extends AbstractConsoleTest {
 
         registerTestUser();
 
-        Assert.assertTrue(driver.findElement(By.id("kc-page-title")).getText().equals("Mobile Authenticator Setup"));
+        Assert.assertTrue(UIUtils.getTextFromElement(driver.findElement(By.id("kc-page-title"))).equals("Mobile Authenticator Setup"));
     }
 
     private void allowTestRealmUserRegistration() {

--- a/testsuite/integration-arquillian/tests/other/console/src/test/java/org/keycloak/testsuite/console/authentication/actions/TermsAndConditionsTest.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/test/java/org/keycloak/testsuite/console/authentication/actions/TermsAndConditionsTest.java
@@ -24,11 +24,11 @@ import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.representations.idm.CredentialRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.testsuite.auth.page.login.LoginError;
 import org.keycloak.testsuite.auth.page.login.Registration;
 import org.keycloak.testsuite.auth.page.login.TermsAndConditions;
 import org.keycloak.testsuite.console.AbstractConsoleTest;
 import org.keycloak.testsuite.console.page.authentication.RequiredActions;
-import org.keycloak.testsuite.pages.ErrorPage;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -63,7 +63,7 @@ public class TermsAndConditionsTest extends AbstractConsoleTest {
     private Registration registrationPage;
 
     @Page
-    protected ErrorPage errorPage;
+    protected LoginError errorPage;
     
     @Override
     public void beforeConsoleTest() {
@@ -75,6 +75,7 @@ public class TermsAndConditionsTest extends AbstractConsoleTest {
         super.setDefaultPageUriParameters();
         testRealmPage.setAuthRealm(REALM);
         testRealmAdminConsolePage.setAdminRealm(REALM);
+        termsAndConditionsPage.setAuthRealm(testRealmPage);
     }
     
     @Override
@@ -188,10 +189,10 @@ public class TermsAndConditionsTest extends AbstractConsoleTest {
 
         // check an error page after declining the terms
         errorPage.assertCurrent();
-        assertEquals("No access", errorPage.getError());
+        assertEquals("No access", errorPage.getErrorMessage());
 
         // follow the link "back to application"
-        errorPage.clickBackToApplication();
+        errorPage.backToApplication();
 
         // login again and accept the terms for now
         loginPage.form().login(FLANDERS, FLANDERS_PASS);

--- a/testsuite/integration-arquillian/tests/other/console/src/test/java/org/keycloak/testsuite/console/realm/InternationalizationTest.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/test/java/org/keycloak/testsuite/console/realm/InternationalizationTest.java
@@ -13,6 +13,7 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 
 import static org.junit.Assert.*;
+import static org.keycloak.testsuite.util.UIUtils.getTextFromElement;
 import static org.keycloak.testsuite.util.URLAssert.*;
 
 /**
@@ -107,6 +108,6 @@ public class InternationalizationTest extends AbstractRealmTest {
     }
 
     private void assertLocale(WebElement element, String expected) {
-        assertEquals(expected, element.getText());
+        assertEquals(expected, getTextFromElement(element));
     }
 }

--- a/testsuite/integration-arquillian/tests/other/console/src/test/java/org/keycloak/testsuite/console/realm/SecurityDefensesTest.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/test/java/org/keycloak/testsuite/console/realm/SecurityDefensesTest.java
@@ -31,6 +31,7 @@ import static org.junit.Assert.*;
 import static org.keycloak.representations.idm.CredentialRepresentation.PASSWORD;
 import static org.keycloak.testsuite.admin.Users.setPasswordFor;
 import static org.keycloak.testsuite.auth.page.AuthRealm.TEST;
+import static org.keycloak.testsuite.util.UIUtils.getTextFromElement;
 import static org.keycloak.testsuite.util.URLAssert.assertCurrentUrlStartsWith;
 import static org.keycloak.testsuite.util.WaitUtils.*;
 
@@ -85,7 +86,7 @@ public class SecurityDefensesTest extends AbstractRealmTest {
         bruteForceDetectionPage.form().save();
         assertAlertSuccess();
 
-        tryToLogin(secondsToWait * (ATTEMPTS_BAD_PWD + ATTEMPTS_GOOD_PWD) / maxLoginFailures);
+        tryToLogin(secondsToWait * (ATTEMPTS_BAD_PWD / maxLoginFailures));
     }
 
     @Test
@@ -109,7 +110,7 @@ public class SecurityDefensesTest extends AbstractRealmTest {
 
         bruteForceDetectionPage.form().setProtectionEnabled(true);
         bruteForceDetectionPage.form().setMaxLoginFailures("1");
-        bruteForceDetectionPage.form().setWaitIncrementSelect(BruteForceDetection.TimeSelectValues.SECONDS);
+        bruteForceDetectionPage.form().setWaitIncrementSelect(BruteForceDetection.TimeSelectValues.MINUTES);
         bruteForceDetectionPage.form().setWaitIncrementInput("10");
         bruteForceDetectionPage.form().setMaxWaitSelect(BruteForceDetection.TimeSelectValues.SECONDS);
         bruteForceDetectionPage.form().setMaxWaitInput(String.valueOf(secondsToWait));
@@ -119,12 +120,13 @@ public class SecurityDefensesTest extends AbstractRealmTest {
     }
 
     @Test
-    public void failureResetTime() throws InterruptedException {
-        final short failureResetTime = 3;
-        final short waitIncrement = 5;
+    public void failureResetTime() {
+        final short failureResetTime = 10;
+        final short waitIncrement = 30;
+        final short maxFailures = 2;
 
         bruteForceDetectionPage.form().setProtectionEnabled(true);
-        bruteForceDetectionPage.form().setMaxLoginFailures("1");
+        bruteForceDetectionPage.form().setMaxLoginFailures(String.valueOf(maxFailures));
         bruteForceDetectionPage.form().setWaitIncrementSelect(BruteForceDetection.TimeSelectValues.SECONDS);
         bruteForceDetectionPage.form().setWaitIncrementInput(String.valueOf(waitIncrement));
         bruteForceDetectionPage.form().setFailureResetTimeSelect(BruteForceDetection.TimeSelectValues.SECONDS);
@@ -132,13 +134,10 @@ public class SecurityDefensesTest extends AbstractRealmTest {
         bruteForceDetectionPage.form().save();
         assertAlertSuccess();
 
-        tryToLogin(failureResetTime, false);
-
-        testRealmLoginPage.form().login(testUser);
-        assertFeedbackText(ACC_DISABLED_MSG);
-
-        Thread.sleep(waitIncrement * 1000);
-
+        testRealmAccountPage.navigateTo();
+        testRealmLoginPage.form().login(testUser.getUsername(), PASSWORD + "-mismatch");
+        pause(failureResetTime * 1000);
+        testRealmLoginPage.form().login(testUser.getUsername(), PASSWORD + "-mismatch");
         testRealmLoginPage.form().login(testUser);
         assertCurrentUrlStartsWith(testRealmAccountPage);
     }
@@ -175,7 +174,7 @@ public class SecurityDefensesTest extends AbstractRealmTest {
 
     private void assertFeedbackText(String text) {
         waitUntilElement(feedbackTextElement).is().present();
-        assertEquals(text, feedbackTextElement.getText());
+        assertEquals(text, getTextFromElement(feedbackTextElement));
     }
 
     private void tryToLogin(int wait) throws InterruptedException {

--- a/testsuite/integration-arquillian/tests/other/console/src/test/java/org/keycloak/testsuite/console/themes/TermsAndConditionsThemeTest.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/test/java/org/keycloak/testsuite/console/themes/TermsAndConditionsThemeTest.java
@@ -46,6 +46,7 @@ public class TermsAndConditionsThemeTest extends AbstractConsoleTest {
         super.setDefaultPageUriParameters();
         testRealmPage.setAuthRealm(REALM);
         testRealmAdminConsolePage.setAdminRealm(REALM);
+        termsAndConditionsPage.setAuthRealm(testRealmPage);
     }
     
     @Override

--- a/testsuite/integration-arquillian/tests/other/console/src/test/java/org/keycloak/testsuite/console/users/RequiredUserActionsTest.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/test/java/org/keycloak/testsuite/console/users/RequiredUserActionsTest.java
@@ -60,6 +60,7 @@ public class RequiredUserActionsTest extends AbstractUserTest {
         testRealmAccountPage.setAuthRealm(TEST);
         testRealmUpdateAccountPage.setAuthRealm(TEST);
         testRealmUpdatePasswordPage.setAuthRealm(TEST);
+        termsAndConditionsPage.setAuthRealm(TEST);
     }
 
     @Before

--- a/testsuite/integration-arquillian/tests/pom.xml
+++ b/testsuite/integration-arquillian/tests/pom.xml
@@ -151,7 +151,7 @@
         <js.chromeArguments>--headless</js.chromeArguments>
         <htmlUnitBrowserVersion>chrome</htmlUnitBrowserVersion>
         <firefox_binary/> <!-- the path is set automatically based on the OS -->
-        <firefoxLegacyDriver>true</firefoxLegacyDriver>
+        <firefoxLegacyDriver>false</firefoxLegacyDriver>
         <chromeBinary/>
         <chromeArguments/>
 


### PR DESCRIPTION
Maintenance PR for Admin Console UI tests with following changes:
- Fixes existing broken tests ([KEYCLOAK-7742](https://issues.jboss.org/browse/KEYCLOAK-7742))
- Switches Firefox driver to the new GeckoDriver (that's required for all FF versions now) + includes necessary optimizations for this new driver ([KEYCLOAK-6332](https://issues.jboss.org/browse/KEYCLOAK-6332))
- Removes dependency on Arquillian's `selenium-bom` and replaces it with direct Selenium dependencies. This way we don't need to wait for Arquillian to update their BOM and we can use new versions of WebDriver straight away.
- Also includes some preliminary optimizations for Safari (as a result of reevaluating the possibility of running the tests with this browser) - still we're not quite there yet (many tests failing) as Safari still doesn't comply with many WebDriver specs.