### PR TITLE
[KEYCLOAK-8342]   Add core-management subsystem to standalone and standalone-ha

### DIFF
--- a/distribution/feature-packs/server-feature-pack/src/main/resources/configuration/standalone/subsystems-ha.xml
+++ b/distribution/feature-packs/server-feature-pack/src/main/resources/configuration/standalone/subsystems-ha.xml
@@ -21,6 +21,7 @@
     <subsystems>
         <subsystem>logging.xml</subsystem>
         <subsystem>bean-validation.xml</subsystem>
+        <subsystem>core-management.xml</subsystem>
         <subsystem supplement="default">keycloak-datasources.xml</subsystem>
         <subsystem>deployment-scanner.xml</subsystem>
         <subsystem>ee.xml</subsystem>

--- a/distribution/feature-packs/server-feature-pack/src/main/resources/configuration/standalone/subsystems.xml
+++ b/distribution/feature-packs/server-feature-pack/src/main/resources/configuration/standalone/subsystems.xml
@@ -21,6 +21,7 @@
    <subsystems>
        <subsystem>logging.xml</subsystem>
        <subsystem>bean-validation.xml</subsystem>
+       <subsystem>core-management.xml</subsystem>
        <subsystem supplement="default">keycloak-datasources.xml</subsystem>
        <subsystem>deployment-scanner.xml</subsystem>
        <subsystem>ee.xml</subsystem>

--- a/distribution/feature-packs/server-feature-pack/src/main/resources/content/bin/migrate-standalone-ha.cli
+++ b/distribution/feature-packs/server-feature-pack/src/main/resources/content/bin/migrate-standalone-ha.cli
@@ -527,4 +527,19 @@ if (outcome == success) of /subsystem=keycloak-server/spi=connectionsInfinispan/
   echo
 end-if
 
+# Migrate from 4.4.0 to 4.5.0
+if (outcome == failed) of /subsystem=core-management/:read-resource
+    try
+        echo Trying to add core-management extension
+        /extension=org.wildfly.extension.core-management/:add
+        echo
+    catch
+        echo Wasn't able to add core-management extension, it should be already added by migrate-domain-standalone.cli
+        echo
+    end-try
+    echo Adding subsystem core-management
+    /subsystem=core-management/:add
+    echo
+end-if
+
 echo *** End Migration ***

--- a/distribution/feature-packs/server-feature-pack/src/main/resources/content/bin/migrate-standalone.cli
+++ b/distribution/feature-packs/server-feature-pack/src/main/resources/content/bin/migrate-standalone.cli
@@ -434,4 +434,19 @@ if (outcome == success) of /subsystem=keycloak-server/spi=connectionsInfinispan/
   echo
 end-if
 
+# Migrate from 4.4.0 to 4.5.0
+if (outcome == failed) of /subsystem=core-management/:read-resource
+    try
+        echo Trying to add core-management extension
+        /extension=org.wildfly.extension.core-management/:add
+        echo
+    catch
+        echo Wasn't able to add core-management extension, it should be already added by migrate-domain-standalone.cli
+        echo
+    end-try
+    echo Adding subsystem core-management
+    /subsystem=core-management/:add
+    echo
+end-if
+
 echo *** End Migration ***


### PR DESCRIPTION
In standalone mode, Wildfly management console "Runtime" tab does not work with the following error.

```
Internal error
--
Details:
Unable to load required resources for column 'standalone-server-column':
"WFLYCTL0030: No resource definition is registered for address [
(\"subsystem\" => \"core-management\"),
(\"service\" => \"configuration-changes\")
]"
```
To fix this error,  `org.wildfly.extension.core-management` extension and `core-managemnt` subsystem are needed in standalone.xml and standalone-ha.xml. 

 And also fixed the migration script, `migrate-standalone.cli` and `migrate-standalone-ha.cli`.