### PR TITLE
KEYCLOAK-8378 Drop dependencyOverride for infinispan-core in prod-arguments.json

### DIFF
--- a/prod-arguments.json
+++ b/prod-arguments.json
@@ -19,7 +19,6 @@
       "dependencyExclusion.org.drools:drools-bom@*": "6.5.0.Final-redhat-19",
       "dependencyExclusion.org.jboss:jboss-parent@*": "19.0.0.redhat-2",
       "dependencyExclusion.org.jboss.web:jbossweb@*": "$EAP6SUPPORTED_ORG_JBOSS_WEB_JBOSSWEB",
-      "dependencyOverride.org.infinispan:infinispan-core@*": "8.2.9.Final-redhat-1",
       "dependencyOverride.com.google.guava:guava@org.keycloak.testsuite:integration-arquillian": ""
     }
   }


### PR DESCRIPTION
This will allow automated BOMREST alignment for the version configured in the
root keycloak POM, when built as the product.