### PR TITLE
KEYCLOAK-8460 Request Object Signature Verification Other Than RS256

### DIFF
--- a/core/src/main/java/org/keycloak/jose/jwk/ECPublicJWK.java
+++ b/core/src/main/java/org/keycloak/jose/jwk/ECPublicJWK.java
@@ -24,6 +24,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 public class ECPublicJWK extends JWK {
 
+    public static final String EC = "EC";
+
     public static final String CRV = "crv";
     public static final String X = "x";
     public static final String Y = "y";

--- a/core/src/main/java/org/keycloak/jose/jwk/JWKParser.java
+++ b/core/src/main/java/org/keycloak/jose/jwk/JWKParser.java
@@ -128,7 +128,7 @@ public class JWKParser {
     }
 
     public boolean isKeyTypeSupported(String keyType) {
-        return RSAPublicJWK.RSA.equals(keyType);
+        return (RSAPublicJWK.RSA.equals(keyType) || ECPublicJWK.EC.equals(keyType));
     }
 
 }

--- a/model/infinispan/src/test/java/org/keycloak/keys/infinispan/InfinispanKeyStorageProviderTest.java
+++ b/model/infinispan/src/test/java/org/keycloak/keys/infinispan/InfinispanKeyStorageProviderTest.java
@@ -17,7 +17,6 @@
 
 package org.keycloak.keys.infinispan;
 
-import java.security.PublicKey;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
@@ -39,6 +38,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.keycloak.common.util.Time;
 import org.keycloak.connections.infinispan.InfinispanConnectionProvider;
+import org.keycloak.crypto.KeyWrapper;
 import org.keycloak.keys.PublicKeyLoader;
 
 /**
@@ -144,7 +144,7 @@ public class InfinispanKeyStorageProviderTest {
         }
 
         @Override
-        public Map<String, PublicKey> loadKeys() throws Exception {
+        public Map<String, KeyWrapper> loadKeys() throws Exception {
             counters.putIfAbsent(modelKey, new AtomicInteger(0));
             AtomicInteger currentCounter = counters.get(modelKey);
 

--- a/server-spi-private/src/main/java/org/keycloak/crypto/ClientSignatureVerifierProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/crypto/ClientSignatureVerifierProvider.java
@@ -14,29 +14,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.keycloak.crypto;
 
 import org.keycloak.common.VerificationException;
-import org.keycloak.models.KeycloakSession;
+import org.keycloak.jose.jws.JWSInput;
+import org.keycloak.models.ClientModel;
+import org.keycloak.provider.Provider;
 
-public class MacSecretSignatureProvider implements SignatureProvider {
-
-    private final KeycloakSession session;
-    private final String algorithm;
-
-    public MacSecretSignatureProvider(KeycloakSession session, String algorithm) {
-        this.session = session;
-        this.algorithm = algorithm;
-    }
+public interface ClientSignatureVerifierProvider extends Provider {
+    SignatureVerifierContext verifier(ClientModel client, JWSInput input) throws VerificationException;
 
     @Override
-    public SignatureSignerContext signer() throws SignatureException {
-        return new ServerMacSignatureSignerContext(session, algorithm);
+    default void close() {
     }
-
-    @Override
-    public SignatureVerifierContext verifier(String kid) throws VerificationException {
-        return new ServerMacSignatureVerifierContext(session, kid, algorithm);
-    }
-
 }

--- a/server-spi-private/src/main/java/org/keycloak/crypto/ClientSignatureVerifierProviderFactory.java
+++ b/server-spi-private/src/main/java/org/keycloak/crypto/ClientSignatureVerifierProviderFactory.java
@@ -15,32 +15,24 @@
  * limitations under the License.
  */
 
-package org.keycloak.keys.infinispan;
+package org.keycloak.crypto;
 
-import java.io.Serializable;
-import java.util.Map;
+import org.keycloak.Config;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.provider.ProviderFactory;
 
-import org.keycloak.crypto.KeyWrapper;
+public interface ClientSignatureVerifierProviderFactory extends ProviderFactory<ClientSignatureVerifierProvider> {
 
-/**
- * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
- */
-public class PublicKeysEntry implements Serializable {
-
-    private final int lastRequestTime;
-
-    private final Map<String, KeyWrapper> currentKeys;
-
-    public PublicKeysEntry(int lastRequestTime, Map<String, KeyWrapper> currentKeys) {
-        this.lastRequestTime = lastRequestTime;
-        this.currentKeys = currentKeys;
+    @Override
+    default void init(Config.Scope config) {
     }
 
-    public int getLastRequestTime() {
-        return lastRequestTime;
+    @Override
+    default void postInit(KeycloakSessionFactory factory) {
     }
 
-    public Map<String, KeyWrapper> getCurrentKeys() {
-        return currentKeys;
+    @Override
+    default void close() {
     }
+
 }

--- a/server-spi-private/src/main/java/org/keycloak/crypto/ClientSignatureVerifierSpi.java
+++ b/server-spi-private/src/main/java/org/keycloak/crypto/ClientSignatureVerifierSpi.java
@@ -16,27 +16,29 @@
  */
 package org.keycloak.crypto;
 
-import org.keycloak.common.VerificationException;
-import org.keycloak.models.KeycloakSession;
+import org.keycloak.provider.Provider;
+import org.keycloak.provider.ProviderFactory;
+import org.keycloak.provider.Spi;
 
-public class MacSecretSignatureProvider implements SignatureProvider {
+public class ClientSignatureVerifierSpi implements Spi {
 
-    private final KeycloakSession session;
-    private final String algorithm;
-
-    public MacSecretSignatureProvider(KeycloakSession session, String algorithm) {
-        this.session = session;
-        this.algorithm = algorithm;
+    @Override
+    public boolean isInternal() {
+        return true;
     }
 
     @Override
-    public SignatureSignerContext signer() throws SignatureException {
-        return new ServerMacSignatureSignerContext(session, algorithm);
+    public String getName() {
+        return "clientSignature";
     }
 
     @Override
-    public SignatureVerifierContext verifier(String kid) throws VerificationException {
-        return new ServerMacSignatureVerifierContext(session, kid, algorithm);
+    public Class<? extends Provider> getProviderClass() {
+        return ClientSignatureVerifierProvider.class;
     }
 
+    @Override
+    public Class<? extends ProviderFactory> getProviderFactoryClass() {
+        return ClientSignatureVerifierProviderFactory.class;
+    }
 }

--- a/server-spi-private/src/main/java/org/keycloak/crypto/SignatureProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/crypto/SignatureProvider.java
@@ -17,6 +17,8 @@
 package org.keycloak.crypto;
 
 import org.keycloak.common.VerificationException;
+import org.keycloak.jose.jws.JWSInput;
+import org.keycloak.models.ClientModel;
 import org.keycloak.provider.Provider;
 
 public interface SignatureProvider extends Provider {
@@ -24,6 +26,9 @@ public interface SignatureProvider extends Provider {
     SignatureSignerContext signer() throws SignatureException;
 
     SignatureVerifierContext verifier(String kid) throws VerificationException;
+
+    // KEYCLOAK-8460 client signed signature verification
+    SignatureVerifierContext verifier(ClientModel client, JWSInput input) throws VerificationException;
 
     @Override
     default void close() {

--- a/server-spi-private/src/main/java/org/keycloak/crypto/SignatureProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/crypto/SignatureProvider.java
@@ -17,8 +17,6 @@
 package org.keycloak.crypto;
 
 import org.keycloak.common.VerificationException;
-import org.keycloak.jose.jws.JWSInput;
-import org.keycloak.models.ClientModel;
 import org.keycloak.provider.Provider;
 
 public interface SignatureProvider extends Provider {
@@ -26,9 +24,6 @@ public interface SignatureProvider extends Provider {
     SignatureSignerContext signer() throws SignatureException;
 
     SignatureVerifierContext verifier(String kid) throws VerificationException;
-
-    // KEYCLOAK-8460 client signed signature verification
-    SignatureVerifierContext verifier(ClientModel client, JWSInput input) throws VerificationException;
 
     @Override
     default void close() {

--- a/server-spi-private/src/main/java/org/keycloak/keys/PublicKeyLoader.java
+++ b/server-spi-private/src/main/java/org/keycloak/keys/PublicKeyLoader.java
@@ -17,14 +17,15 @@
 
 package org.keycloak.keys;
 
-import java.security.PublicKey;
 import java.util.Map;
+
+import org.keycloak.crypto.KeyWrapper;
 
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
  */
 public interface PublicKeyLoader {
 
-    Map<String, PublicKey> loadKeys() throws Exception;
+    Map<String, KeyWrapper> loadKeys() throws Exception;
 
 }

--- a/server-spi-private/src/main/java/org/keycloak/keys/PublicKeyStorageProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/keys/PublicKeyStorageProvider.java
@@ -17,8 +17,7 @@
 
 package org.keycloak.keys;
 
-import java.security.PublicKey;
-
+import org.keycloak.crypto.KeyWrapper;
 import org.keycloak.provider.Provider;
 
 /**
@@ -35,7 +34,7 @@ public interface PublicKeyStorageProvider extends Provider {
      * @param loader
      * @return
      */
-    PublicKey getPublicKey(String modelKey, String kid, PublicKeyLoader loader);
+	KeyWrapper getPublicKey(String modelKey, String kid, PublicKeyLoader loader);
 
     /**
      * Clears all the cached public keys, so they need to be loaded again

--- a/server-spi-private/src/main/resources/META-INF/services/org.keycloak.provider.Spi
+++ b/server-spi-private/src/main/resources/META-INF/services/org.keycloak.provider.Spi
@@ -72,3 +72,4 @@ org.keycloak.keys.PublicKeyStorageSpi
 org.keycloak.keys.KeySpi
 org.keycloak.storage.client.ClientStorageProviderSpi
 org.keycloak.crypto.SignatureSpi
+org.keycloak.crypto.ClientSignatureVerifierSpi

--- a/server-spi/src/main/java/org/keycloak/models/TokenManager.java
+++ b/server-spi/src/main/java/org/keycloak/models/TokenManager.java
@@ -41,4 +41,6 @@ public interface TokenManager {
 
     String signatureAlgorithm(TokenCategory category);
 
+    <T> T decodeClientJWT(String token, ClientModel client, Class<T> clazz);
+
 }

--- a/services/src/main/java/org/keycloak/crypto/AsymmetricClientSignatureVerifierProvider.java
+++ b/services/src/main/java/org/keycloak/crypto/AsymmetricClientSignatureVerifierProvider.java
@@ -17,26 +17,22 @@
 package org.keycloak.crypto;
 
 import org.keycloak.common.VerificationException;
+import org.keycloak.jose.jws.JWSInput;
+import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 
-public class MacSecretSignatureProvider implements SignatureProvider {
-
+public class AsymmetricClientSignatureVerifierProvider implements ClientSignatureVerifierProvider {
     private final KeycloakSession session;
     private final String algorithm;
 
-    public MacSecretSignatureProvider(KeycloakSession session, String algorithm) {
+    public AsymmetricClientSignatureVerifierProvider(KeycloakSession session, String algorithm) {
         this.session = session;
         this.algorithm = algorithm;
     }
 
     @Override
-    public SignatureSignerContext signer() throws SignatureException {
-        return new ServerMacSignatureSignerContext(session, algorithm);
-    }
-
-    @Override
-    public SignatureVerifierContext verifier(String kid) throws VerificationException {
-        return new ServerMacSignatureVerifierContext(session, kid, algorithm);
+    public SignatureVerifierContext verifier(ClientModel client, JWSInput input) throws VerificationException {
+        return new ClientAsymmetricSignatureVerifierContext(session, client, input);
     }
 
 }

--- a/services/src/main/java/org/keycloak/crypto/AsymmetricSignatureProvider.java
+++ b/services/src/main/java/org/keycloak/crypto/AsymmetricSignatureProvider.java
@@ -17,8 +17,6 @@
 package org.keycloak.crypto;
 
 import org.keycloak.common.VerificationException;
-import org.keycloak.jose.jws.JWSInput;
-import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 
 public class AsymmetricSignatureProvider implements SignatureProvider {
@@ -39,11 +37,6 @@ public class AsymmetricSignatureProvider implements SignatureProvider {
     @Override
     public SignatureVerifierContext verifier(String kid) throws VerificationException {
         return new ServerAsymmetricSignatureVerifierContext(session, kid, algorithm);
-    }
-
-    @Override
-    public SignatureVerifierContext verifier(ClientModel client, JWSInput input) throws VerificationException {
-        return new ClientAsymmetricSignatureVerifierContext(session, client, input);
     }
 
 }

--- a/services/src/main/java/org/keycloak/crypto/ClientAsymmetricSignatureVerifierContext.java
+++ b/services/src/main/java/org/keycloak/crypto/ClientAsymmetricSignatureVerifierContext.java
@@ -24,7 +24,6 @@ import org.keycloak.models.KeycloakSession;
 
 public class ClientAsymmetricSignatureVerifierContext extends AsymmetricSignatureVerifierContext {
 
-    // KEYCLOAK-8460 client signed signature verification
     public ClientAsymmetricSignatureVerifierContext(KeycloakSession session, ClientModel client, JWSInput input) throws VerificationException {
         super(getKey(session, client, input));
     }

--- a/services/src/main/java/org/keycloak/crypto/ES256ClientSignatureVerifierProviderFactory.java
+++ b/services/src/main/java/org/keycloak/crypto/ES256ClientSignatureVerifierProviderFactory.java
@@ -16,27 +16,20 @@
  */
 package org.keycloak.crypto;
 
-import org.keycloak.common.VerificationException;
 import org.keycloak.models.KeycloakSession;
 
-public class MacSecretSignatureProvider implements SignatureProvider {
+public class ES256ClientSignatureVerifierProviderFactory implements ClientSignatureVerifierProviderFactory {
 
-    private final KeycloakSession session;
-    private final String algorithm;
+    public static final String ID = Algorithm.ES256;
 
-    public MacSecretSignatureProvider(KeycloakSession session, String algorithm) {
-        this.session = session;
-        this.algorithm = algorithm;
+    @Override
+    public String getId() {
+        return ID;
     }
 
     @Override
-    public SignatureSignerContext signer() throws SignatureException {
-        return new ServerMacSignatureSignerContext(session, algorithm);
-    }
-
-    @Override
-    public SignatureVerifierContext verifier(String kid) throws VerificationException {
-        return new ServerMacSignatureVerifierContext(session, kid, algorithm);
+    public ClientSignatureVerifierProvider create(KeycloakSession session) {
+        return new AsymmetricClientSignatureVerifierProvider(session, Algorithm.ES256);
     }
 
 }

--- a/services/src/main/java/org/keycloak/crypto/ES384ClientSignatureVerifierProviderFactory.java
+++ b/services/src/main/java/org/keycloak/crypto/ES384ClientSignatureVerifierProviderFactory.java
@@ -16,27 +16,20 @@
  */
 package org.keycloak.crypto;
 
-import org.keycloak.common.VerificationException;
 import org.keycloak.models.KeycloakSession;
 
-public class MacSecretSignatureProvider implements SignatureProvider {
+public class ES384ClientSignatureVerifierProviderFactory implements ClientSignatureVerifierProviderFactory {
 
-    private final KeycloakSession session;
-    private final String algorithm;
+    public static final String ID = Algorithm.ES384;
 
-    public MacSecretSignatureProvider(KeycloakSession session, String algorithm) {
-        this.session = session;
-        this.algorithm = algorithm;
+    @Override
+    public String getId() {
+        return ID;
     }
 
     @Override
-    public SignatureSignerContext signer() throws SignatureException {
-        return new ServerMacSignatureSignerContext(session, algorithm);
-    }
-
-    @Override
-    public SignatureVerifierContext verifier(String kid) throws VerificationException {
-        return new ServerMacSignatureVerifierContext(session, kid, algorithm);
+    public ClientSignatureVerifierProvider create(KeycloakSession session) {
+        return new AsymmetricClientSignatureVerifierProvider(session, Algorithm.ES384);
     }
 
 }

--- a/services/src/main/java/org/keycloak/crypto/ES512ClientSignatureVerifierProviderFactory.java
+++ b/services/src/main/java/org/keycloak/crypto/ES512ClientSignatureVerifierProviderFactory.java
@@ -16,27 +16,20 @@
  */
 package org.keycloak.crypto;
 
-import org.keycloak.common.VerificationException;
 import org.keycloak.models.KeycloakSession;
 
-public class MacSecretSignatureProvider implements SignatureProvider {
+public class ES512ClientSignatureVerifierProviderFactory  implements ClientSignatureVerifierProviderFactory {
 
-    private final KeycloakSession session;
-    private final String algorithm;
+    public static final String ID = Algorithm.ES512;
 
-    public MacSecretSignatureProvider(KeycloakSession session, String algorithm) {
-        this.session = session;
-        this.algorithm = algorithm;
+    @Override
+    public String getId() {
+        return ID;
     }
 
     @Override
-    public SignatureSignerContext signer() throws SignatureException {
-        return new ServerMacSignatureSignerContext(session, algorithm);
-    }
-
-    @Override
-    public SignatureVerifierContext verifier(String kid) throws VerificationException {
-        return new ServerMacSignatureVerifierContext(session, kid, algorithm);
+    public ClientSignatureVerifierProvider create(KeycloakSession session) {
+        return new AsymmetricClientSignatureVerifierProvider(session, Algorithm.ES512);
     }
 
 }

--- a/services/src/main/java/org/keycloak/crypto/MacSecretSignatureProvider.java
+++ b/services/src/main/java/org/keycloak/crypto/MacSecretSignatureProvider.java
@@ -17,6 +17,8 @@
 package org.keycloak.crypto;
 
 import org.keycloak.common.VerificationException;
+import org.keycloak.jose.jws.JWSInput;
+import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 
 public class MacSecretSignatureProvider implements SignatureProvider {
@@ -37,6 +39,12 @@ public class MacSecretSignatureProvider implements SignatureProvider {
     @Override
     public SignatureVerifierContext verifier(String kid) throws VerificationException {
         return new ServerMacSignatureVerifierContext(session, kid, algorithm);
+    }
+
+    @Override
+    public SignatureVerifierContext verifier(ClientModel client, JWSInput input) throws VerificationException {
+        // HMAC is not supported for client signed signature verification
+        return null;
     }
 
 }

--- a/services/src/main/java/org/keycloak/crypto/RS256ClientSignatureVerifierProviderFactory.java
+++ b/services/src/main/java/org/keycloak/crypto/RS256ClientSignatureVerifierProviderFactory.java
@@ -16,27 +16,20 @@
  */
 package org.keycloak.crypto;
 
-import org.keycloak.common.VerificationException;
 import org.keycloak.models.KeycloakSession;
 
-public class MacSecretSignatureProvider implements SignatureProvider {
+public class RS256ClientSignatureVerifierProviderFactory implements ClientSignatureVerifierProviderFactory {
 
-    private final KeycloakSession session;
-    private final String algorithm;
+    public static final String ID = Algorithm.RS256;
 
-    public MacSecretSignatureProvider(KeycloakSession session, String algorithm) {
-        this.session = session;
-        this.algorithm = algorithm;
+    @Override
+    public String getId() {
+        return ID;
     }
 
     @Override
-    public SignatureSignerContext signer() throws SignatureException {
-        return new ServerMacSignatureSignerContext(session, algorithm);
-    }
-
-    @Override
-    public SignatureVerifierContext verifier(String kid) throws VerificationException {
-        return new ServerMacSignatureVerifierContext(session, kid, algorithm);
+    public ClientSignatureVerifierProvider create(KeycloakSession session) {
+        return new AsymmetricClientSignatureVerifierProvider(session, Algorithm.RS256);
     }
 
 }

--- a/services/src/main/java/org/keycloak/crypto/RS384ClientSignatureVerifierProviderFactory.java
+++ b/services/src/main/java/org/keycloak/crypto/RS384ClientSignatureVerifierProviderFactory.java
@@ -16,27 +16,20 @@
  */
 package org.keycloak.crypto;
 
-import org.keycloak.common.VerificationException;
 import org.keycloak.models.KeycloakSession;
 
-public class MacSecretSignatureProvider implements SignatureProvider {
+public class RS384ClientSignatureVerifierProviderFactory implements ClientSignatureVerifierProviderFactory {
 
-    private final KeycloakSession session;
-    private final String algorithm;
+    public static final String ID = Algorithm.RS384;
 
-    public MacSecretSignatureProvider(KeycloakSession session, String algorithm) {
-        this.session = session;
-        this.algorithm = algorithm;
+    @Override
+    public String getId() {
+        return ID;
     }
 
     @Override
-    public SignatureSignerContext signer() throws SignatureException {
-        return new ServerMacSignatureSignerContext(session, algorithm);
-    }
-
-    @Override
-    public SignatureVerifierContext verifier(String kid) throws VerificationException {
-        return new ServerMacSignatureVerifierContext(session, kid, algorithm);
+    public ClientSignatureVerifierProvider create(KeycloakSession session) {
+        return new AsymmetricClientSignatureVerifierProvider(session, Algorithm.RS384);
     }
 
 }

--- a/services/src/main/java/org/keycloak/crypto/RS512ClientSignatureVerifierProviderFactory.java
+++ b/services/src/main/java/org/keycloak/crypto/RS512ClientSignatureVerifierProviderFactory.java
@@ -16,27 +16,20 @@
  */
 package org.keycloak.crypto;
 
-import org.keycloak.common.VerificationException;
 import org.keycloak.models.KeycloakSession;
 
-public class MacSecretSignatureProvider implements SignatureProvider {
+public class RS512ClientSignatureVerifierProviderFactory implements ClientSignatureVerifierProviderFactory {
 
-    private final KeycloakSession session;
-    private final String algorithm;
+    public static final String ID = Algorithm.RS512;
 
-    public MacSecretSignatureProvider(KeycloakSession session, String algorithm) {
-        this.session = session;
-        this.algorithm = algorithm;
+    @Override
+    public String getId() {
+        return ID;
     }
 
     @Override
-    public SignatureSignerContext signer() throws SignatureException {
-        return new ServerMacSignatureSignerContext(session, algorithm);
-    }
-
-    @Override
-    public SignatureVerifierContext verifier(String kid) throws VerificationException {
-        return new ServerMacSignatureVerifierContext(session, kid, algorithm);
+    public ClientSignatureVerifierProvider create(KeycloakSession session) {
+        return new AsymmetricClientSignatureVerifierProvider(session, Algorithm.RS512);
     }
 
 }

--- a/services/src/main/java/org/keycloak/keys/loader/ClientPublicKeyLoader.java
+++ b/services/src/main/java/org/keycloak/keys/loader/ClientPublicKeyLoader.java
@@ -20,6 +20,10 @@ package org.keycloak.keys.loader;
 import org.jboss.logging.Logger;
 import org.keycloak.authentication.authenticators.client.JWTClientAuthenticator;
 import org.keycloak.common.util.KeyUtils;
+import org.keycloak.crypto.Algorithm;
+import org.keycloak.crypto.KeyType;
+import org.keycloak.crypto.KeyUse;
+import org.keycloak.crypto.KeyWrapper;
 import org.keycloak.jose.jwk.JSONWebKeySet;
 import org.keycloak.jose.jwk.JWK;
 import org.keycloak.keys.PublicKeyLoader;
@@ -56,21 +60,18 @@ public class ClientPublicKeyLoader implements PublicKeyLoader {
 
 
     @Override
-    public Map<String, PublicKey> loadKeys() throws Exception {
+    public Map<String, KeyWrapper> loadKeys() throws Exception {
         OIDCAdvancedConfigWrapper config = OIDCAdvancedConfigWrapper.fromClientModel(client);
         if (config.isUseJwksUrl()) {
             String jwksUrl = config.getJwksUrl();
             jwksUrl = ResolveRelative.resolveRelativeUri(session.getContext().getUri().getRequestUri(), client.getRootUrl(), jwksUrl);
             JSONWebKeySet jwks = JWKSHttpUtils.sendJwksRequest(session, jwksUrl);
-            return JWKSUtils.getKeysForUse(jwks, JWK.Use.SIG);
+            return JWKSUtils.getKeyWrappersForUse(jwks, JWK.Use.SIG);
         } else {
             try {
                 CertificateRepresentation certInfo = CertificateInfoHelper.getCertificateFromClient(client, JWTClientAuthenticator.ATTR_PREFIX);
-                PublicKey publicKey = getSignatureValidationKey(certInfo);
-
-                // Check if we have kid in DB, generate otherwise
-                String kid = certInfo.getKid() != null ? certInfo.getKid() : KeyUtils.createKeyId(publicKey);
-                return Collections.singletonMap(kid, publicKey);
+                KeyWrapper publicKey = getSignatureValidationKey(certInfo);
+                return Collections.singletonMap(publicKey.getKid(), publicKey);
             } catch (ModelException me) {
                 logger.warnf(me, "Unable to retrieve publicKey for verify signature of client '%s' . Error details: %s", client.getClientId(), me.getMessage());
                 return Collections.emptyMap();
@@ -79,7 +80,8 @@ public class ClientPublicKeyLoader implements PublicKeyLoader {
         }
     }
 
-    private static PublicKey getSignatureValidationKey(CertificateRepresentation certInfo) throws ModelException {
+    private static KeyWrapper getSignatureValidationKey(CertificateRepresentation certInfo) throws ModelException {
+        KeyWrapper keyWrapper = new KeyWrapper();
         String encodedCertificate = certInfo.getCertificate();
         String encodedPublicKey = certInfo.getPublicKey();
 
@@ -91,12 +93,25 @@ public class ClientPublicKeyLoader implements PublicKeyLoader {
             throw new ModelException("Client has both publicKey and certificate configured");
         }
 
+        keyWrapper.setAlgorithm(Algorithm.RS256);
+        keyWrapper.setType(KeyType.RSA);
+        keyWrapper.setUse(KeyUse.SIG);
+        String kid = null;
         if (encodedCertificate != null) {
             X509Certificate clientCert = KeycloakModelUtils.getCertificate(encodedCertificate);
-            return clientCert.getPublicKey();
+            // Check if we have kid in DB, generate otherwise
+            kid = certInfo.getKid() != null ? certInfo.getKid() : KeyUtils.createKeyId(clientCert.getPublicKey());
+            keyWrapper.setKid(kid);
+            keyWrapper.setVerifyKey(clientCert.getPublicKey());
+            keyWrapper.setCertificate(clientCert);
         } else {
-            return KeycloakModelUtils.getPublicKey(encodedPublicKey);
+            PublicKey publicKey = KeycloakModelUtils.getPublicKey(encodedPublicKey);
+            // Check if we have kid in DB, generate otherwise
+            kid = certInfo.getKid() != null ? certInfo.getKid() : KeyUtils.createKeyId(publicKey);
+            keyWrapper.setKid(kid);
+            keyWrapper.setVerifyKey(publicKey);
         }
+        return keyWrapper;
     }
 
 

--- a/services/src/main/java/org/keycloak/keys/loader/HardcodedPublicKeyLoader.java
+++ b/services/src/main/java/org/keycloak/keys/loader/HardcodedPublicKeyLoader.java
@@ -17,9 +17,12 @@
 package org.keycloak.keys.loader;
 
 import org.keycloak.common.util.PemUtils;
+import org.keycloak.crypto.Algorithm;
+import org.keycloak.crypto.KeyType;
+import org.keycloak.crypto.KeyUse;
+import org.keycloak.crypto.KeyWrapper;
 import org.keycloak.keys.PublicKeyLoader;
 
-import java.security.PublicKey;
 import java.util.Collections;
 import java.util.Map;
 
@@ -38,15 +41,20 @@ public class HardcodedPublicKeyLoader implements PublicKeyLoader {
     }
 
     @Override
-    public Map<String, PublicKey> loadKeys() throws Exception {
+    public Map<String, KeyWrapper> loadKeys() throws Exception {
         return Collections.unmodifiableMap(Collections.singletonMap(kid, getSavedPublicKey()));
     }
 
-    protected PublicKey getSavedPublicKey() {
+    protected KeyWrapper getSavedPublicKey() {
+        KeyWrapper keyWrapper = null;
         if (pem != null && ! pem.trim().equals("")) {
-            return PemUtils.decodePublicKey(pem);
-        } else {
-            return null;
+            keyWrapper = new KeyWrapper();
+            keyWrapper.setKid(kid);
+            keyWrapper.setType(KeyType.RSA);
+            keyWrapper.setAlgorithm(Algorithm.RS256);
+            keyWrapper.setUse(KeyUse.SIG);
+            keyWrapper.setVerifyKey(PemUtils.decodePublicKey(pem));
         }
+        return keyWrapper;
     }
 }

--- a/services/src/main/java/org/keycloak/keys/loader/OIDCIdentityProviderPublicKeyLoader.java
+++ b/services/src/main/java/org/keycloak/keys/loader/OIDCIdentityProviderPublicKeyLoader.java
@@ -21,6 +21,10 @@ import org.jboss.logging.Logger;
 import org.keycloak.broker.oidc.OIDCIdentityProviderConfig;
 import org.keycloak.common.util.KeyUtils;
 import org.keycloak.common.util.PemUtils;
+import org.keycloak.crypto.Algorithm;
+import org.keycloak.crypto.KeyType;
+import org.keycloak.crypto.KeyUse;
+import org.keycloak.crypto.KeyWrapper;
 import org.keycloak.jose.jwk.JSONWebKeySet;
 import org.keycloak.jose.jwk.JWK;
 import org.keycloak.keys.PublicKeyLoader;
@@ -48,23 +52,18 @@ public class OIDCIdentityProviderPublicKeyLoader implements PublicKeyLoader {
     }
 
     @Override
-    public Map<String, PublicKey> loadKeys() throws Exception {
+    public Map<String, KeyWrapper> loadKeys() throws Exception {
         if (config.isUseJwksUrl()) {
             String jwksUrl = config.getJwksUrl();
             JSONWebKeySet jwks = JWKSHttpUtils.sendJwksRequest(session, jwksUrl);
-            return JWKSUtils.getKeysForUse(jwks, JWK.Use.SIG);
+            return JWKSUtils.getKeyWrappersForUse(jwks, JWK.Use.SIG);
         } else {
             try {
-                PublicKey publicKey = getSavedPublicKey();
+            	KeyWrapper publicKey = getSavedPublicKey();
                 if (publicKey == null) {
                     return Collections.emptyMap();
                 }
-
-                String presetKeyId = config.getPublicKeySignatureVerifierKeyId();
-                String kid = (presetKeyId == null || presetKeyId.trim().isEmpty())
-                  ? KeyUtils.createKeyId(publicKey)
-                  : presetKeyId;
-                return Collections.singletonMap(kid, publicKey);
+                return Collections.singletonMap(publicKey.getKid(), publicKey);
             } catch (Exception e) {
                 logger.warnf(e, "Unable to retrieve publicKey for verify signature of identityProvider '%s' . Error details: %s", config.getAlias(), e.getMessage());
                 return Collections.emptyMap();
@@ -72,12 +71,23 @@ public class OIDCIdentityProviderPublicKeyLoader implements PublicKeyLoader {
         }
     }
 
-    protected PublicKey getSavedPublicKey() throws Exception {
+    protected KeyWrapper getSavedPublicKey() throws Exception {
+        KeyWrapper keyWrapper = null;
         if (config.getPublicKeySignatureVerifier() != null && !config.getPublicKeySignatureVerifier().trim().equals("")) {
-            return PemUtils.decodePublicKey(config.getPublicKeySignatureVerifier());
+            PublicKey publicKey = PemUtils.decodePublicKey(config.getPublicKeySignatureVerifier());
+            keyWrapper = new KeyWrapper();
+            String presetKeyId = config.getPublicKeySignatureVerifierKeyId();
+            String kid = (presetKeyId == null || presetKeyId.trim().isEmpty())
+              ? KeyUtils.createKeyId(publicKey)
+              : presetKeyId;
+            keyWrapper.setKid(kid);
+            keyWrapper.setType(KeyType.RSA);
+            keyWrapper.setAlgorithm(Algorithm.RS256);
+            keyWrapper.setUse(KeyUse.SIG);
+            keyWrapper.setVerifyKey(publicKey);
         } else {
             logger.warnf("No public key saved on identityProvider %s", config.getAlias());
-            return null;
         }
+        return keyWrapper;
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCWellKnownProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCWellKnownProvider.java
@@ -46,7 +46,8 @@ import java.util.List;
  */
 public class OIDCWellKnownProvider implements WellKnownProvider {
 
-    public static final List<String> DEFAULT_REQUEST_OBJECT_SIGNING_ALG_VALUES_SUPPORTED  = list(Algorithm.none.toString(), Algorithm.RS256.toString());
+    // KEYCLOAK-8460 Request Object Signature Verification Other Than RS256
+    public static final List<String> DEFAULT_REQUEST_OBJECT_SIGNING_ALG_VALUES_SUPPORTED  = list(Algorithm.none.toString(), Algorithm.RS256.toString(), Algorithm.RS384.toString(), Algorithm.RS512.toString(), Algorithm.ES256.toString(), Algorithm.ES384.toString(), Algorithm.ES512.toString());
 
     public static final List<String> DEFAULT_GRANT_TYPES_SUPPORTED = list(OAuth2Constants.AUTHORIZATION_CODE, OAuth2Constants.IMPLICIT, OAuth2Constants.REFRESH_TOKEN, OAuth2Constants.PASSWORD, OAuth2Constants.CLIENT_CREDENTIALS);
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCWellKnownProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCWellKnownProvider.java
@@ -20,6 +20,7 @@ package org.keycloak.protocol.oidc;
 import org.keycloak.OAuth2Constants;
 import org.keycloak.authentication.ClientAuthenticator;
 import org.keycloak.authentication.ClientAuthenticatorFactory;
+import org.keycloak.crypto.ClientSignatureVerifierProvider;
 import org.keycloak.crypto.SignatureProvider;
 import org.keycloak.jose.jws.Algorithm;
 import org.keycloak.models.ClientScopeModel;
@@ -45,9 +46,6 @@ import java.util.List;
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
  */
 public class OIDCWellKnownProvider implements WellKnownProvider {
-
-    // KEYCLOAK-8460 Request Object Signature Verification Other Than RS256
-    public static final List<String> DEFAULT_REQUEST_OBJECT_SIGNING_ALG_VALUES_SUPPORTED  = list(Algorithm.none.toString(), Algorithm.RS256.toString(), Algorithm.RS384.toString(), Algorithm.RS512.toString(), Algorithm.ES256.toString(), Algorithm.ES384.toString(), Algorithm.ES512.toString());
 
     public static final List<String> DEFAULT_GRANT_TYPES_SUPPORTED = list(OAuth2Constants.AUTHORIZATION_CODE, OAuth2Constants.IMPLICIT, OAuth2Constants.REFRESH_TOKEN, OAuth2Constants.PASSWORD, OAuth2Constants.CLIENT_CREDENTIALS);
 
@@ -93,7 +91,7 @@ public class OIDCWellKnownProvider implements WellKnownProvider {
 
         config.setIdTokenSigningAlgValuesSupported(getSupportedSigningAlgorithms(false));
         config.setUserInfoSigningAlgValuesSupported(getSupportedSigningAlgorithms(true));
-        config.setRequestObjectSigningAlgValuesSupported(DEFAULT_REQUEST_OBJECT_SIGNING_ALG_VALUES_SUPPORTED);
+        config.setRequestObjectSigningAlgValuesSupported(getSupportedClientSigningAlgorithms(true));
         config.setResponseTypesSupported(DEFAULT_RESPONSE_TYPES_SUPPORTED);
         config.setSubjectTypesSupported(DEFAULT_SUBJECT_TYPES_SUPPORTED);
         config.setResponseModesSupported(DEFAULT_RESPONSE_MODES_SUPPORTED);
@@ -164,4 +162,14 @@ public class OIDCWellKnownProvider implements WellKnownProvider {
         return result;
     }
 
+    private List<String> getSupportedClientSigningAlgorithms(boolean includeNone) {
+        List<String> result = new LinkedList<>();
+        for (ProviderFactory s : session.getKeycloakSessionFactory().getProviderFactories(ClientSignatureVerifierProvider.class)) {
+            result.add(s.getId());
+        }
+        if (includeNone) {
+            result.add("none");
+        }
+        return result;
+    }
 }

--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCWellKnownProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCWellKnownProvider.java
@@ -91,7 +91,7 @@ public class OIDCWellKnownProvider implements WellKnownProvider {
 
         config.setIdTokenSigningAlgValuesSupported(getSupportedSigningAlgorithms(false));
         config.setUserInfoSigningAlgValuesSupported(getSupportedSigningAlgorithms(true));
-        config.setRequestObjectSigningAlgValuesSupported(getSupportedClientSigningAlgorithms(false));
+        config.setRequestObjectSigningAlgValuesSupported(getSupportedClientSigningAlgorithms(true));
         config.setResponseTypesSupported(DEFAULT_RESPONSE_TYPES_SUPPORTED);
         config.setSubjectTypesSupported(DEFAULT_SUBJECT_TYPES_SUPPORTED);
         config.setResponseModesSupported(DEFAULT_RESPONSE_MODES_SUPPORTED);

--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCWellKnownProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCWellKnownProvider.java
@@ -91,7 +91,7 @@ public class OIDCWellKnownProvider implements WellKnownProvider {
 
         config.setIdTokenSigningAlgValuesSupported(getSupportedSigningAlgorithms(false));
         config.setUserInfoSigningAlgValuesSupported(getSupportedSigningAlgorithms(true));
-        config.setRequestObjectSigningAlgValuesSupported(getSupportedClientSigningAlgorithms(true));
+        config.setRequestObjectSigningAlgValuesSupported(getSupportedClientSigningAlgorithms(false));
         config.setResponseTypesSupported(DEFAULT_RESPONSE_TYPES_SUPPORTED);
         config.setSubjectTypesSupported(DEFAULT_SUBJECT_TYPES_SUPPORTED);
         config.setResponseModesSupported(DEFAULT_RESPONSE_MODES_SUPPORTED);

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/request/AuthzEndpointRequestObjectParser.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/request/AuthzEndpointRequestObjectParser.java
@@ -50,17 +50,18 @@ class AuthzEndpointRequestObjectParser extends AuthzEndpointRequestParser {
         if (headerAlgorithm == null) {
             throw new RuntimeException("Request object signed algorithm not specified");
         }
-        if (requestedSignatureAlgorithm != null && requestedSignatureAlgorithm != headerAlgorithm) {
-            throw new RuntimeException("Request object signed with different algorithm than client requested algorithm");
-        }
-
-        if (header.getAlgorithm() == Algorithm.none) {
-            this.requestParams = JsonSerialization.readValue(input.getContent(), JsonNode.class);
-        } else {
-            this.requestParams = session.tokens().decodeClientJWT(requestObject, client, JsonNode.class);
-            if (this.requestParams == null) {
-            	throw new RuntimeException("Failed to verify signature on 'request' object");
+        if (requestedSignatureAlgorithm != null) {
+            if (requestedSignatureAlgorithm == Algorithm.none) {
+                throw new RuntimeException("client setting of Request object without signature(none) no longer permitted");
             }
+            if (requestedSignatureAlgorithm != headerAlgorithm) {
+                throw new RuntimeException("Request object signed with different algorithm than client requested algorithm");
+            }
+        }
+        // requestedSignatureAlgorithm is null if 'any'
+        this.requestParams = session.tokens().decodeClientJWT(requestObject, client, JsonNode.class);
+        if (this.requestParams == null) {
+            throw new RuntimeException("Failed to verify signature on 'request' object");
         }
     }
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/request/AuthzEndpointRequestObjectParser.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/request/AuthzEndpointRequestObjectParser.java
@@ -17,16 +17,15 @@
 package org.keycloak.protocol.oidc.endpoints.request;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import java.security.PublicKey;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.keycloak.crypto.SignatureProvider;
+import org.keycloak.crypto.SignatureVerifierContext;
 import org.keycloak.jose.jws.Algorithm;
 import org.keycloak.jose.jws.JWSHeader;
 import org.keycloak.jose.jws.JWSInput;
-import org.keycloak.jose.jws.crypto.RSAProvider;
-import org.keycloak.keys.loader.PublicKeyStorageManager;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.protocol.oidc.OIDCAdvancedConfigWrapper;
@@ -42,31 +41,29 @@ class AuthzEndpointRequestObjectParser extends AuthzEndpointRequestParser {
     private final JsonNode requestParams;
 
     public AuthzEndpointRequestObjectParser(KeycloakSession session, String requestObject, ClientModel client) throws Exception {
+        // KEYCLOAK-8460 Request Object Signature Verification Other Than RS256
         JWSInput input = new JWSInput(requestObject);
         JWSHeader header = input.getHeader();
+        Algorithm headerAlgorithm = header.getAlgorithm();
 
         Algorithm requestedSignatureAlgorithm = OIDCAdvancedConfigWrapper.fromClientModel(client).getRequestObjectSignatureAlg();
 
-        if (requestedSignatureAlgorithm != null && requestedSignatureAlgorithm != header.getAlgorithm()) {
+        if (headerAlgorithm == null) {
+            throw new RuntimeException("Request object signed algorithm not specified");
+        }
+        if (requestedSignatureAlgorithm != null && requestedSignatureAlgorithm != headerAlgorithm) {
             throw new RuntimeException("Request object signed with different algorithm than client requested algorithm");
         }
 
         if (header.getAlgorithm() == Algorithm.none) {
             this.requestParams = JsonSerialization.readValue(input.getContent(), JsonNode.class);
-        } else if (header.getAlgorithm() == Algorithm.RS256) {
-            PublicKey clientPublicKey = PublicKeyStorageManager.getClientPublicKey(session, client, input);
-            if (clientPublicKey == null) {
-                throw new RuntimeException("Client public key not found");
-            }
-
-            boolean verified = RSAProvider.verify(input, clientPublicKey);
+        } else {
+            SignatureVerifierContext verifierContext = session.getProvider(SignatureProvider.class, headerAlgorithm.name()).verifier(client, input);
+            boolean verified = verifierContext.verify(input.getEncodedSignatureInput().getBytes("UTF-8"), input.getSignature());
             if (!verified) {
                 throw new RuntimeException("Failed to verify signature on 'request' object");
             }
-
             this.requestParams = JsonSerialization.readValue(input.getContent(), JsonNode.class);
-        } else {
-            throw new RuntimeException("Unsupported JWA algorithm used for signed request");
         }
     }
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/request/AuthzEndpointRequestObjectParser.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/request/AuthzEndpointRequestObjectParser.java
@@ -50,18 +50,17 @@ class AuthzEndpointRequestObjectParser extends AuthzEndpointRequestParser {
         if (headerAlgorithm == null) {
             throw new RuntimeException("Request object signed algorithm not specified");
         }
-        if (requestedSignatureAlgorithm != null) {
-            if (requestedSignatureAlgorithm == Algorithm.none) {
-                throw new RuntimeException("client setting of Request object without signature(none) no longer permitted");
-            }
-            if (requestedSignatureAlgorithm != headerAlgorithm) {
-                throw new RuntimeException("Request object signed with different algorithm than client requested algorithm");
-            }
+        if (requestedSignatureAlgorithm != null && requestedSignatureAlgorithm != headerAlgorithm) {
+            throw new RuntimeException("Request object signed with different algorithm than client requested algorithm");
         }
-        // requestedSignatureAlgorithm is null if 'any'
-        this.requestParams = session.tokens().decodeClientJWT(requestObject, client, JsonNode.class);
-        if (this.requestParams == null) {
-            throw new RuntimeException("Failed to verify signature on 'request' object");
+
+        if (header.getAlgorithm() == Algorithm.none) {
+            this.requestParams = JsonSerialization.readValue(input.getContent(), JsonNode.class);
+        } else {
+            this.requestParams = session.tokens().decodeClientJWT(requestObject, client, JsonNode.class);
+            if (this.requestParams == null) {
+            	throw new RuntimeException("Failed to verify signature on 'request' object");
+            }
         }
     }
 

--- a/services/src/main/resources/META-INF/services/org.keycloak.crypto.ClientSignatureVerifierProviderFactory
+++ b/services/src/main/resources/META-INF/services/org.keycloak.crypto.ClientSignatureVerifierProviderFactory
@@ -1,0 +1,6 @@
+org.keycloak.crypto.RS256ClientSignatureVerifierProviderFactory
+org.keycloak.crypto.RS384ClientSignatureVerifierProviderFactory
+org.keycloak.crypto.RS512ClientSignatureVerifierProviderFactory
+org.keycloak.crypto.ES256ClientSignatureVerifierProviderFactory
+org.keycloak.crypto.ES384ClientSignatureVerifierProviderFactory
+org.keycloak.crypto.ES512ClientSignatureVerifierProviderFactory

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/rest/TestApplicationResourceProviderFactory.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/rest/TestApplicationResourceProviderFactory.java
@@ -18,6 +18,8 @@
 package org.keycloak.testsuite.rest;
 
 import org.keycloak.Config.Scope;
+import org.keycloak.crypto.Algorithm;
+import org.keycloak.crypto.KeyType;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.representations.adapters.action.LogoutAction;
@@ -70,6 +72,8 @@ public class TestApplicationResourceProviderFactory implements RealmResourceProv
         private KeyPair signingKeyPair;
         private String oidcRequest;
         private List<String> sectorIdentifierRedirectUris;
+        private String signingKeyType = KeyType.RSA;
+        private String signingKeyAlgorithm = Algorithm.RS256;
 
         public KeyPair getSigningKeyPair() {
             return signingKeyPair;
@@ -93,6 +97,22 @@ public class TestApplicationResourceProviderFactory implements RealmResourceProv
 
         public void setSectorIdentifierRedirectUris(List<String> sectorIdentifierRedirectUris) {
             this.sectorIdentifierRedirectUris = sectorIdentifierRedirectUris;
+        }
+
+        public String getSigningKeyType() {
+            return signingKeyType;
+        }
+
+        public void setSigningKeyType(String signingKeyType) {
+            this.signingKeyType = signingKeyType;
+        }
+
+        public String getSigningKeyAlgorithm() {
+            return signingKeyAlgorithm;
+        }
+
+        public void setSigningKeyAlgorithm(String signingKeyAlgorithm) {
+            this.signingKeyAlgorithm = signingKeyAlgorithm;
         }
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/client/resources/TestOIDCEndpointsApplicationResource.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/client/resources/TestOIDCEndpointsApplicationResource.java
@@ -35,7 +35,7 @@ public interface TestOIDCEndpointsApplicationResource {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/generate-keys")
-    Map<String, String> generateKeys();
+    Map<String, String> generateKeys(@QueryParam("jwaAlgorithm") String jwaAlgorithm);
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/OIDCClientRegistrationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/OIDCClientRegistrationTest.java
@@ -207,17 +207,30 @@ public class OIDCClientRegistrationTest extends AbstractClientRegistrationTest {
     @Test
     public void testSignaturesRequired() throws Exception {
         OIDCClientRepresentation clientRep = createRep();
-        clientRep.setUserinfoSignedResponseAlg(Algorithm.RS256.toString());
-        clientRep.setRequestObjectSigningAlg(Algorithm.RS256.toString());
+        clientRep.setUserinfoSignedResponseAlg(Algorithm.ES256.toString());
+        clientRep.setRequestObjectSigningAlg(Algorithm.ES256.toString());
 
         OIDCClientRepresentation response = reg.oidc().create(clientRep);
-        Assert.assertEquals(Algorithm.RS256.toString(), response.getUserinfoSignedResponseAlg());
-        Assert.assertEquals(Algorithm.RS256.toString(), response.getRequestObjectSigningAlg());
+        Assert.assertEquals(Algorithm.ES256.toString(), response.getUserinfoSignedResponseAlg());
+        Assert.assertEquals(Algorithm.ES256.toString(), response.getRequestObjectSigningAlg());
         Assert.assertNotNull(response.getClientSecret());
 
         // Test Keycloak representation
         ClientRepresentation kcClient = getClient(response.getClientId());
         OIDCAdvancedConfigWrapper config = OIDCAdvancedConfigWrapper.fromClientRepresentation(kcClient);
+        Assert.assertEquals(config.getUserInfoSignedResponseAlg(), Algorithm.ES256);
+        Assert.assertEquals(config.getRequestObjectSignatureAlg(), Algorithm.ES256);
+
+        // update (ES256 to RS256)
+        clientRep.setUserinfoSignedResponseAlg(Algorithm.RS256.toString());
+        clientRep.setRequestObjectSigningAlg(Algorithm.RS256.toString());
+        response = reg.oidc().create(clientRep);
+        Assert.assertEquals(Algorithm.RS256.toString(), response.getUserinfoSignedResponseAlg());
+        Assert.assertEquals(Algorithm.RS256.toString(), response.getRequestObjectSigningAlg());
+
+        // keycloak representation
+        kcClient = getClient(response.getClientId());
+        config = OIDCAdvancedConfigWrapper.fromClientRepresentation(kcClient);
         Assert.assertEquals(config.getUserInfoSignedResponseAlg(), Algorithm.RS256);
         Assert.assertEquals(config.getRequestObjectSignatureAlg(), Algorithm.RS256);
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/OIDCJwksClientRegistrationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/OIDCJwksClientRegistrationTest.java
@@ -104,7 +104,7 @@ public class OIDCJwksClientRegistrationTest extends AbstractClientRegistrationTe
 
         // Generate keys for client
         TestOIDCEndpointsApplicationResource oidcClientEndpointsResource = testingClient.testApp().oidcClientEndpoints();
-        Map<String, String> generatedKeys = oidcClientEndpointsResource.generateKeys(null);
+        Map<String, String> generatedKeys = oidcClientEndpointsResource.generateKeys("RS256");
 
         JSONWebKeySet keySet = oidcClientEndpointsResource.getJwks();
         clientRep.setJwks(keySet);
@@ -129,7 +129,7 @@ public class OIDCJwksClientRegistrationTest extends AbstractClientRegistrationTe
 
         // Generate keys for client
         TestOIDCEndpointsApplicationResource oidcClientEndpointsResource = testingClient.testApp().oidcClientEndpoints();
-        Map<String, String> generatedKeys = oidcClientEndpointsResource.generateKeys(null);
+        Map<String, String> generatedKeys = oidcClientEndpointsResource.generateKeys("RS256");
 
         JSONWebKeySet keySet = oidcClientEndpointsResource.getJwks();
         clientRep.setJwks(keySet);
@@ -161,7 +161,7 @@ public class OIDCJwksClientRegistrationTest extends AbstractClientRegistrationTe
 
         // Generate keys for client
         TestOIDCEndpointsApplicationResource oidcClientEndpointsResource = testingClient.testApp().oidcClientEndpoints();
-        oidcClientEndpointsResource.generateKeys(null);
+        oidcClientEndpointsResource.generateKeys("RS256");
 
         JSONWebKeySet keySet = oidcClientEndpointsResource.getJwks();
 
@@ -248,7 +248,7 @@ public class OIDCJwksClientRegistrationTest extends AbstractClientRegistrationTe
 
         // Generate keys for client
         TestOIDCEndpointsApplicationResource oidcClientEndpointsResource = testingClient.testApp().oidcClientEndpoints();
-        Map<String, String> generatedKeys = oidcClientEndpointsResource.generateKeys(null);
+        Map<String, String> generatedKeys = oidcClientEndpointsResource.generateKeys("RS256");
 
         clientRep.setJwksUri(TestApplicationResourceUrls.clientJwksUri());
 
@@ -271,7 +271,7 @@ public class OIDCJwksClientRegistrationTest extends AbstractClientRegistrationTe
 
         // Generate keys for client
         TestOIDCEndpointsApplicationResource oidcClientEndpointsResource = testingClient.testApp().oidcClientEndpoints();
-        Map<String, String> generatedKeys = oidcClientEndpointsResource.generateKeys(null);
+        Map<String, String> generatedKeys = oidcClientEndpointsResource.generateKeys("RS256");
 
         clientRep.setJwksUri(TestApplicationResourceUrls.clientJwksUri());
 
@@ -285,7 +285,7 @@ public class OIDCJwksClientRegistrationTest extends AbstractClientRegistrationTe
         assertAuthenticateClientSuccess(generatedKeys, response, KEEP_GENERATED_KID);
 
         // Add new key to the jwks
-        Map<String, String> generatedKeys2 = oidcClientEndpointsResource.generateKeys(null);
+        Map<String, String> generatedKeys2 = oidcClientEndpointsResource.generateKeys("RS256");
 
         // Error should happen. KeyStorageProvider won't yet download new keys because of timeout
         assertAuthenticateClientError(generatedKeys2, response, KEEP_GENERATED_KID);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/OIDCJwksClientRegistrationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/OIDCJwksClientRegistrationTest.java
@@ -28,7 +28,6 @@ import java.util.Map;
 
 import javax.ws.rs.core.UriBuilder;
 
-import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -49,7 +48,6 @@ import org.keycloak.jose.jwk.JWK;
 import org.keycloak.jose.jwk.JWKBuilder;
 import org.keycloak.jose.jws.JWSBuilder;
 import org.keycloak.keys.PublicKeyStorageUtils;
-import org.keycloak.keys.loader.PublicKeyStorageManager;
 import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.protocol.oidc.OIDCLoginProtocolService;
@@ -106,7 +104,7 @@ public class OIDCJwksClientRegistrationTest extends AbstractClientRegistrationTe
 
         // Generate keys for client
         TestOIDCEndpointsApplicationResource oidcClientEndpointsResource = testingClient.testApp().oidcClientEndpoints();
-        Map<String, String> generatedKeys = oidcClientEndpointsResource.generateKeys();
+        Map<String, String> generatedKeys = oidcClientEndpointsResource.generateKeys(null);
 
         JSONWebKeySet keySet = oidcClientEndpointsResource.getJwks();
         clientRep.setJwks(keySet);
@@ -131,7 +129,7 @@ public class OIDCJwksClientRegistrationTest extends AbstractClientRegistrationTe
 
         // Generate keys for client
         TestOIDCEndpointsApplicationResource oidcClientEndpointsResource = testingClient.testApp().oidcClientEndpoints();
-        Map<String, String> generatedKeys = oidcClientEndpointsResource.generateKeys();
+        Map<String, String> generatedKeys = oidcClientEndpointsResource.generateKeys(null);
 
         JSONWebKeySet keySet = oidcClientEndpointsResource.getJwks();
         clientRep.setJwks(keySet);
@@ -163,7 +161,7 @@ public class OIDCJwksClientRegistrationTest extends AbstractClientRegistrationTe
 
         // Generate keys for client
         TestOIDCEndpointsApplicationResource oidcClientEndpointsResource = testingClient.testApp().oidcClientEndpoints();
-        oidcClientEndpointsResource.generateKeys();
+        oidcClientEndpointsResource.generateKeys(null);
 
         JSONWebKeySet keySet = oidcClientEndpointsResource.getJwks();
 
@@ -250,7 +248,7 @@ public class OIDCJwksClientRegistrationTest extends AbstractClientRegistrationTe
 
         // Generate keys for client
         TestOIDCEndpointsApplicationResource oidcClientEndpointsResource = testingClient.testApp().oidcClientEndpoints();
-        Map<String, String> generatedKeys = oidcClientEndpointsResource.generateKeys();
+        Map<String, String> generatedKeys = oidcClientEndpointsResource.generateKeys(null);
 
         clientRep.setJwksUri(TestApplicationResourceUrls.clientJwksUri());
 
@@ -273,7 +271,7 @@ public class OIDCJwksClientRegistrationTest extends AbstractClientRegistrationTe
 
         // Generate keys for client
         TestOIDCEndpointsApplicationResource oidcClientEndpointsResource = testingClient.testApp().oidcClientEndpoints();
-        Map<String, String> generatedKeys = oidcClientEndpointsResource.generateKeys();
+        Map<String, String> generatedKeys = oidcClientEndpointsResource.generateKeys(null);
 
         clientRep.setJwksUri(TestApplicationResourceUrls.clientJwksUri());
 
@@ -287,7 +285,7 @@ public class OIDCJwksClientRegistrationTest extends AbstractClientRegistrationTe
         assertAuthenticateClientSuccess(generatedKeys, response, KEEP_GENERATED_KID);
 
         // Add new key to the jwks
-        Map<String, String> generatedKeys2 = oidcClientEndpointsResource.generateKeys();
+        Map<String, String> generatedKeys2 = oidcClientEndpointsResource.generateKeys(null);
 
         // Error should happen. KeyStorageProvider won't yet download new keys because of timeout
         assertAuthenticateClientError(generatedKeys2, response, KEEP_GENERATED_KID);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/OIDCAdvancedRequestParamsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/OIDCAdvancedRequestParamsTest.java
@@ -37,6 +37,7 @@ import org.keycloak.models.AuthenticatedClientSessionModel;
 import org.keycloak.models.Constants;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserSessionModel;
+import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.protocol.oidc.OIDCAdvancedConfigWrapper;
 import org.keycloak.protocol.oidc.OIDCConfigAttributes;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
@@ -65,6 +66,7 @@ import org.keycloak.testsuite.util.OAuthClient;
 import org.keycloak.util.JsonSerialization;
 
 import java.io.IOException;
+import java.security.PrivateKey;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -463,51 +465,57 @@ public class OIDCAdvancedRequestParamsTest extends AbstractTestRealmKeycloakTest
         Assert.assertEquals("mystate2", response.getState());
         assertTrue(appPage.isCurrent());
     }
-    
+
     @Test
     public void requestObjectNotRequiredProvidedInRequestParam() throws Exception {
-        oauth.stateParamHardcoded("mystate2");
-        // Set request object not required for client
-        ClientResource clientResource = ApiUtil.findClientByClientId(adminClient.realm("test"), "test-app");
-        ClientRepresentation clientRep = clientResource.toRepresentation();
-        OIDCAdvancedConfigWrapper.fromClientRepresentation(clientRep).setRequestObjectRequired(null);
-        clientResource.update(clientRep);
-        
-        // Set up a request object
-        TestOIDCEndpointsApplicationResource oidcClientEndpointsResource = testingClient.testApp().oidcClientEndpoints();
-        oidcClientEndpointsResource.setOIDCRequest("test", "test-app", oauth.getRedirectUri(), "10", Algorithm.none.toString());
-        
-        // Send request object in "request" param
-        oauth.request(oidcClientEndpointsResource.getOIDCRequest());
-        // Assert that the request is accepted
-        OAuthClient.AuthorizationEndpointResponse response1 = oauth.doLogin("test-user@localhost", "password");
-        Assert.assertNotNull(response1.getCode());
-        Assert.assertEquals("mystate2", response1.getState());
-        assertTrue(appPage.isCurrent());
+        ClientResource clientResource = null;
+        ClientRepresentation clientRep = null;
+        try {
+            oauth.stateParamHardcoded("mystate2");
+            clientResource = ApiUtil.findClientByClientId(adminClient.realm("test"), "test-app");
+            clientRep = clientResource.toRepresentation();
+            // Set request object not required for client
+            prepareClientRepresentation(Algorithm.RS256, null, clientResource, clientRep);
+            // prepare OIDC Endpoint Application Resource
+            TestOIDCEndpointsApplicationResource oidcClientEndpointsResource = prepareOIDCEndpointsApplicationResource(Algorithm.RS256);
+            // Send request object in "request" param
+            oauth.request(oidcClientEndpointsResource.getOIDCRequest());
+            // Assert that the request is accepted
+            OAuthClient.AuthorizationEndpointResponse response1 = oauth.doLogin("test-user@localhost", "password");
+            Assert.assertNotNull(response1.getCode());
+            Assert.assertEquals("mystate2", response1.getState());
+            assertTrue(appPage.isCurrent());
+        } finally {
+            // revert client settings
+            revertClientRepresentation(clientResource, clientRep);
+        }
     }
-    
+
     @Test
     public void requestObjectNotRequiredProvidedInRequestUriParam() throws Exception {
-        oauth.stateParamHardcoded("mystate2");
-        // Set request object not required for client
-        ClientResource clientResource = ApiUtil.findClientByClientId(adminClient.realm("test"), "test-app");
-        ClientRepresentation clientRep = clientResource.toRepresentation();
-        OIDCAdvancedConfigWrapper.fromClientRepresentation(clientRep).setRequestObjectRequired(null);
-        clientResource.update(clientRep);
-        
-        // Set up a request object
-        TestOIDCEndpointsApplicationResource oidcClientEndpointsResource = testingClient.testApp().oidcClientEndpoints();
-        oidcClientEndpointsResource.setOIDCRequest("test", "test-app", oauth.getRedirectUri(), "10", Algorithm.none.toString());
-        
-        // Send request object reference in "request_uri" param
-        oauth.requestUri(TestApplicationResourceUrls.clientRequestUri());
-        // Assert that the request is accepted
-        OAuthClient.AuthorizationEndpointResponse response2 = oauth.doLogin("test-user@localhost", "password");
-        Assert.assertNotNull(response2.getCode());
-        Assert.assertEquals("mystate2", response2.getState());
-        assertTrue(appPage.isCurrent());
+        ClientResource clientResource = null;
+        ClientRepresentation clientRep = null;
+        try {
+            oauth.stateParamHardcoded("mystate2");
+            clientResource = ApiUtil.findClientByClientId(adminClient.realm("test"), "test-app");
+            clientRep = clientResource.toRepresentation();
+            // Set request object not required for client
+            prepareClientRepresentation(Algorithm.ES256, null, clientResource, clientRep);
+            // prepare OIDC Endpoint Application Resource
+            TestOIDCEndpointsApplicationResource oidcClientEndpointsResource = prepareOIDCEndpointsApplicationResource(Algorithm.ES256);
+            // Send request object reference in "request_uri" param
+            oauth.requestUri(TestApplicationResourceUrls.clientRequestUri());
+            // Assert that the request is accepted
+            OAuthClient.AuthorizationEndpointResponse response2 = oauth.doLogin("test-user@localhost", "password");
+            Assert.assertNotNull(response2.getCode());
+            Assert.assertEquals("mystate2", response2.getState());
+            assertTrue(appPage.isCurrent());
+        } finally {
+            // revert client settings
+            revertClientRepresentation(clientResource, clientRep);
+        }
     }
-    
+
     @Test
     public void requestObjectRequiredNotProvided() throws Exception {
         oauth.stateParamHardcoded("mystate2");
@@ -527,57 +535,55 @@ public class OIDCAdvancedRequestParamsTest extends AbstractTestRealmKeycloakTest
         OIDCAdvancedConfigWrapper.fromClientRepresentation(clientRep).setRequestObjectRequired(null);
         clientResource.update(clientRep);
     }
-    
+
     @Test
     public void requestObjectRequiredProvidedInRequestParam() throws Exception {
-        oauth.stateParamHardcoded("mystate2");
-        // Set request object not required for client
-        ClientResource clientResource = ApiUtil.findClientByClientId(adminClient.realm("test"), "test-app");
-        ClientRepresentation clientRep = clientResource.toRepresentation();
-        OIDCAdvancedConfigWrapper.fromClientRepresentation(clientRep).setRequestObjectRequired(OIDCConfigAttributes.REQUEST_OBJECT_REQUIRED_REQUEST_OR_REQUEST_URI);
-        clientResource.update(clientRep);
-        
-        // Set up a request object
-        TestOIDCEndpointsApplicationResource oidcClientEndpointsResource = testingClient.testApp().oidcClientEndpoints();
-        oidcClientEndpointsResource.setOIDCRequest("test", "test-app", oauth.getRedirectUri(), "10", Algorithm.none.toString());
-        
-        // Send request object in "request" param
-        oauth.request(oidcClientEndpointsResource.getOIDCRequest());
-        // Assert that the request is accepted
-        OAuthClient.AuthorizationEndpointResponse response1 = oauth.doLogin("test-user@localhost", "password");
-        Assert.assertNotNull(response1.getCode());
-        Assert.assertEquals("mystate2", response1.getState());
-        assertTrue(appPage.isCurrent());
-        
-        // Revert requiring request object for client
-        OIDCAdvancedConfigWrapper.fromClientRepresentation(clientRep).setRequestObjectRequired(null);
-        clientResource.update(clientRep);
+        ClientResource clientResource = null;
+        ClientRepresentation clientRep = null;
+        try {
+            oauth.stateParamHardcoded("mystate2");
+            clientResource = ApiUtil.findClientByClientId(adminClient.realm("test"), "test-app");
+            clientRep = clientResource.toRepresentation();
+            // Set request object required for client
+            prepareClientRepresentation(Algorithm.RS256, OIDCConfigAttributes.REQUEST_OBJECT_REQUIRED_REQUEST_OR_REQUEST_URI, clientResource, clientRep);
+            // prepare OIDC Endpoint Application Resource
+            TestOIDCEndpointsApplicationResource oidcClientEndpointsResource = prepareOIDCEndpointsApplicationResource(Algorithm.RS256);
+            // Send request object in "request" param
+            oauth.request(oidcClientEndpointsResource.getOIDCRequest());
+            // Assert that the request is accepted
+            OAuthClient.AuthorizationEndpointResponse response1 = oauth.doLogin("test-user@localhost", "password");
+            Assert.assertNotNull(response1.getCode());
+            Assert.assertEquals("mystate2", response1.getState());
+            assertTrue(appPage.isCurrent());
+        } finally {
+            // revert client settings
+            revertClientRepresentation(clientResource, clientRep);
+        }
     }
-    
+
     @Test
     public void requestObjectRequiredProvidedInRequestUriParam() throws Exception {
-        oauth.stateParamHardcoded("mystate2");
-        // Set request object not required for client
-        ClientResource clientResource = ApiUtil.findClientByClientId(adminClient.realm("test"), "test-app");
-        ClientRepresentation clientRep = clientResource.toRepresentation();
-        OIDCAdvancedConfigWrapper.fromClientRepresentation(clientRep).setRequestObjectRequired(OIDCConfigAttributes.REQUEST_OBJECT_REQUIRED_REQUEST_OR_REQUEST_URI);
-        clientResource.update(clientRep);
-        
-        // Set up a request object
-        TestOIDCEndpointsApplicationResource oidcClientEndpointsResource = testingClient.testApp().oidcClientEndpoints();
-        oidcClientEndpointsResource.setOIDCRequest("test", "test-app", oauth.getRedirectUri(), "10", Algorithm.none.toString());
-        
-        // Send request object reference in "request_uri" param
-        oauth.requestUri(TestApplicationResourceUrls.clientRequestUri());
-        // Assert that the request is accepted
-        OAuthClient.AuthorizationEndpointResponse response2 = oauth.doLogin("test-user@localhost", "password");
-        Assert.assertNotNull(response2.getCode());
-        Assert.assertEquals("mystate2", response2.getState());
-        assertTrue(appPage.isCurrent());
-        
-        // Revert requiring request object for client
-        OIDCAdvancedConfigWrapper.fromClientRepresentation(clientRep).setRequestObjectRequired(null);
-        clientResource.update(clientRep);
+        ClientResource clientResource = null;
+        ClientRepresentation clientRep = null;
+        try {
+            oauth.stateParamHardcoded("mystate2");
+            clientResource = ApiUtil.findClientByClientId(adminClient.realm("test"), "test-app");
+            clientRep = clientResource.toRepresentation();
+            // Set request object required for client
+            prepareClientRepresentation(Algorithm.ES256, OIDCConfigAttributes.REQUEST_OBJECT_REQUIRED_REQUEST_OR_REQUEST_URI, clientResource, clientRep);
+            // prepare OIDC Endpoint Application Resource
+            prepareOIDCEndpointsApplicationResource(Algorithm.ES256);
+            // Send request object reference in "request_uri" param
+            oauth.requestUri(TestApplicationResourceUrls.clientRequestUri());
+            // Assert that the request is accepted
+            OAuthClient.AuthorizationEndpointResponse response2 = oauth.doLogin("test-user@localhost", "password");
+            Assert.assertNotNull(response2.getCode());
+            Assert.assertEquals("mystate2", response2.getState());
+            assertTrue(appPage.isCurrent());
+        } finally {
+            // revert client settings
+            revertClientRepresentation(clientResource, clientRep);
+        }
     }
     
     @Test
@@ -602,55 +608,53 @@ public class OIDCAdvancedRequestParamsTest extends AbstractTestRealmKeycloakTest
     
     @Test
     public void requestObjectRequiredAsRequestParamProvidedInRequestParam() throws Exception {
-        oauth.stateParamHardcoded("mystate2");
-        // Set request object not required for client
-        ClientResource clientResource = ApiUtil.findClientByClientId(adminClient.realm("test"), "test-app");
-        ClientRepresentation clientRep = clientResource.toRepresentation();
-        OIDCAdvancedConfigWrapper.fromClientRepresentation(clientRep).setRequestObjectRequired(OIDCConfigAttributes.REQUEST_OBJECT_REQUIRED_REQUEST);
-        clientResource.update(clientRep);
-        
-        // Set up a request object
-        TestOIDCEndpointsApplicationResource oidcClientEndpointsResource = testingClient.testApp().oidcClientEndpoints();
-        oidcClientEndpointsResource.setOIDCRequest("test", "test-app", oauth.getRedirectUri(), "10", Algorithm.none.toString());
-        
-        // Send request object in "request" param
-        oauth.request(oidcClientEndpointsResource.getOIDCRequest());
-        // Assert that the request is accepted
-        OAuthClient.AuthorizationEndpointResponse response1 = oauth.doLogin("test-user@localhost", "password");
-        Assert.assertNotNull(response1.getCode());
-        Assert.assertEquals("mystate2", response1.getState());
-        assertTrue(appPage.isCurrent());
-        
-        // Revert requiring request object for client
-        OIDCAdvancedConfigWrapper.fromClientRepresentation(clientRep).setRequestObjectRequired(null);
-        clientResource.update(clientRep);
+        ClientResource clientResource = null;
+        ClientRepresentation clientRep = null;
+        try {
+            oauth.stateParamHardcoded("mystate2");
+            clientResource = ApiUtil.findClientByClientId(adminClient.realm("test"), "test-app");
+            clientRep = clientResource.toRepresentation();
+            // Set request object required as request parameter for client
+            prepareClientRepresentation(Algorithm.RS256, OIDCConfigAttributes.REQUEST_OBJECT_REQUIRED_REQUEST, clientResource, clientRep);
+            // prepare OIDC Endpoint Application Resource
+            TestOIDCEndpointsApplicationResource oidcClientEndpointsResource = prepareOIDCEndpointsApplicationResource(Algorithm.RS256);
+            // Send request object in "request" param
+            oauth.request(oidcClientEndpointsResource.getOIDCRequest());
+            // Assert that the request is accepted
+            OAuthClient.AuthorizationEndpointResponse response1 = oauth.doLogin("test-user@localhost", "password");
+            Assert.assertNotNull(response1.getCode());
+            Assert.assertEquals("mystate2", response1.getState());
+            assertTrue(appPage.isCurrent());
+        } finally {
+            // revert client settings
+            revertClientRepresentation(clientResource, clientRep);
+        }
     }
-    
+
     @Test
     public void requestObjectRequiredAsRequestParamProvidedInRequestUriParam() throws Exception {
-        oauth.stateParamHardcoded("mystate2");
-        // Set request object not required for client
-        ClientResource clientResource = ApiUtil.findClientByClientId(adminClient.realm("test"), "test-app");
-        ClientRepresentation clientRep = clientResource.toRepresentation();
-        OIDCAdvancedConfigWrapper.fromClientRepresentation(clientRep).setRequestObjectRequired(OIDCConfigAttributes.REQUEST_OBJECT_REQUIRED_REQUEST);
-        clientResource.update(clientRep);
-        
-        // Set up a request object
-        TestOIDCEndpointsApplicationResource oidcClientEndpointsResource = testingClient.testApp().oidcClientEndpoints();
-        oidcClientEndpointsResource.setOIDCRequest("test", "test-app", oauth.getRedirectUri(), "10", Algorithm.none.toString());
-        
-        // Send request object reference in "request_uri" param
-        oauth.requestUri(TestApplicationResourceUrls.clientRequestUri());
-        // Assert that the request is accepted
-        oauth.openLoginForm();
-        Assert.assertTrue(errorPage.isCurrent());
-        assertEquals("Invalid Request", errorPage.getError());
-        
-        // Revert requiring request object for client
-        OIDCAdvancedConfigWrapper.fromClientRepresentation(clientRep).setRequestObjectRequired(null);
-        clientResource.update(clientRep);
+        ClientResource clientResource = null;
+        ClientRepresentation clientRep = null;
+        try {
+            oauth.stateParamHardcoded("mystate2");
+            clientResource = ApiUtil.findClientByClientId(adminClient.realm("test"), "test-app");
+            clientRep = clientResource.toRepresentation();
+            // Set request object required as request parameter for client
+            prepareClientRepresentation(Algorithm.ES256, OIDCConfigAttributes.REQUEST_OBJECT_REQUIRED_REQUEST, clientResource, clientRep);
+            // prepare OIDC Endpoint Application Resource
+            prepareOIDCEndpointsApplicationResource(Algorithm.ES256);
+            // Send request object reference in "request_uri" param
+            oauth.requestUri(TestApplicationResourceUrls.clientRequestUri());
+            // Assert that the request is accepted
+            oauth.openLoginForm();
+            Assert.assertTrue(errorPage.isCurrent());
+            assertEquals("Invalid Request", errorPage.getError());
+        } finally {
+            // revert client settings
+            revertClientRepresentation(clientResource, clientRep);
+        }
     }
-    
+
     @Test
     public void requestObjectRequiredAsRequestUriParamNotProvided() throws Exception {
         oauth.stateParamHardcoded("mystate2");
@@ -670,63 +674,60 @@ public class OIDCAdvancedRequestParamsTest extends AbstractTestRealmKeycloakTest
         OIDCAdvancedConfigWrapper.fromClientRepresentation(clientRep).setRequestObjectRequired(null);
         clientResource.update(clientRep);
     }
-    
+
     @Test
     public void requestObjectRequiredAsRequestUriParamProvidedInRequestParam() throws Exception {
-        oauth.stateParamHardcoded("mystate2");
-        // Set request object not required for client
-        ClientResource clientResource = ApiUtil.findClientByClientId(adminClient.realm("test"), "test-app");
-        ClientRepresentation clientRep = clientResource.toRepresentation();
-        OIDCAdvancedConfigWrapper.fromClientRepresentation(clientRep).setRequestObjectRequired(OIDCConfigAttributes.REQUEST_OBJECT_REQUIRED_REQUEST_URI);
-        clientResource.update(clientRep);
-        
-        // Set up a request object
-        TestOIDCEndpointsApplicationResource oidcClientEndpointsResource = testingClient.testApp().oidcClientEndpoints();
-        oidcClientEndpointsResource.setOIDCRequest("test", "test-app", oauth.getRedirectUri(), "10", Algorithm.none.toString());
-        
-        // Send request object in "request" param
-        oauth.request(oidcClientEndpointsResource.getOIDCRequest());
-        // Assert that the request is not accepted
-        oauth.openLoginForm();
-        Assert.assertTrue(errorPage.isCurrent());
-        assertEquals("Invalid Request", errorPage.getError());
-        
-        // Revert requiring request object for client
-        OIDCAdvancedConfigWrapper.fromClientRepresentation(clientRep).setRequestObjectRequired(null);
-        clientResource.update(clientRep);
+        ClientResource clientResource = null;
+        ClientRepresentation clientRep = null;
+        try {
+            oauth.stateParamHardcoded("mystate2");
+            clientResource = ApiUtil.findClientByClientId(adminClient.realm("test"), "test-app");
+            clientRep = clientResource.toRepresentation();
+            // Set request object required as request uri parameter for client
+            prepareClientRepresentation(Algorithm.RS256, OIDCConfigAttributes.REQUEST_OBJECT_REQUIRED_REQUEST_URI, clientResource, clientRep);
+            // prepare OIDC Endpoint Application Resource
+            TestOIDCEndpointsApplicationResource oidcClientEndpointsResource = prepareOIDCEndpointsApplicationResource(Algorithm.RS256);
+            // Send request object in "request" param
+            oauth.request(oidcClientEndpointsResource.getOIDCRequest());
+            // Assert that the request is not accepted
+            oauth.openLoginForm();
+            Assert.assertTrue(errorPage.isCurrent());
+            assertEquals("Invalid Request", errorPage.getError());
+        } finally {
+            // revert client settings
+            revertClientRepresentation(clientResource, clientRep);
+        }
     }
-    
+
     @Test
     public void requestObjectRequiredAsRequestUriParamProvidedInRequestUriParam() throws Exception {
-        oauth.stateParamHardcoded("mystate2");
-        // Set request object not required for client
-        ClientResource clientResource = ApiUtil.findClientByClientId(adminClient.realm("test"), "test-app");
-        ClientRepresentation clientRep = clientResource.toRepresentation();
-        OIDCAdvancedConfigWrapper.fromClientRepresentation(clientRep).setRequestObjectRequired(OIDCConfigAttributes.REQUEST_OBJECT_REQUIRED_REQUEST_URI);
-        clientResource.update(clientRep);
-        
-        // Set up a request object
-        TestOIDCEndpointsApplicationResource oidcClientEndpointsResource = testingClient.testApp().oidcClientEndpoints();
-        oidcClientEndpointsResource.setOIDCRequest("test", "test-app", oauth.getRedirectUri(), "10", Algorithm.none.toString());
-        
-        // Send request object reference in "request_uri" param
-        oauth.requestUri(TestApplicationResourceUrls.clientRequestUri());
-        // Assert that the request is accepted
-        OAuthClient.AuthorizationEndpointResponse response1 = oauth.doLogin("test-user@localhost", "password");
-        Assert.assertNotNull(response1.getCode());
-        Assert.assertEquals("mystate2", response1.getState());
-        assertTrue(appPage.isCurrent());
-        
-        // Revert requiring request object for client
-        OIDCAdvancedConfigWrapper.fromClientRepresentation(clientRep).setRequestObjectRequired(null);
-        clientResource.update(clientRep);
+        ClientResource clientResource = null;
+        ClientRepresentation clientRep = null;
+        try {
+            oauth.stateParamHardcoded("mystate2");
+            clientResource = ApiUtil.findClientByClientId(adminClient.realm("test"), "test-app");
+            clientRep = clientResource.toRepresentation();
+            // Set request object required as request uri parameter for client
+            prepareClientRepresentation(Algorithm.ES256, OIDCConfigAttributes.REQUEST_OBJECT_REQUIRED_REQUEST_URI, clientResource, clientRep);
+            // prepare OIDC Endpoint Application Resource
+            prepareOIDCEndpointsApplicationResource(Algorithm.ES256);
+            // Send request object reference in "request_uri" param
+            oauth.requestUri(TestApplicationResourceUrls.clientRequestUri());
+            // Assert that the request is accepted
+            OAuthClient.AuthorizationEndpointResponse response1 = oauth.doLogin("test-user@localhost", "password");
+            Assert.assertNotNull(response1.getCode());
+            Assert.assertEquals("mystate2", response1.getState());
+            assertTrue(appPage.isCurrent());
+        } finally {
+            // revert client settings
+            revertClientRepresentation(clientResource, clientRep);
+        }
     }
 
     @Test
     public void requestParamUnsigned() throws Exception {
         oauth.stateParamHardcoded("mystate2");
 
-        String validRedirectUri = oauth.getRedirectUri();
         TestOIDCEndpointsApplicationResource oidcClientEndpointsResource = testingClient.testApp().oidcClientEndpoints();
 
         // Send request object with invalid redirect uri.
@@ -736,25 +737,13 @@ public class OIDCAdvancedRequestParamsTest extends AbstractTestRealmKeycloakTest
         oauth.request(requestStr);
         oauth.openLoginForm();
         Assert.assertTrue(errorPage.isCurrent());
-        assertEquals("Invalid parameter: redirect_uri", errorPage.getError());
-
-        // Assert the value from request object has bigger priority then from the query parameter.
-        oauth.redirectUri("http://invalid");
-        oidcClientEndpointsResource.setOIDCRequest("test", "test-app", validRedirectUri, "10", Algorithm.none.toString());
-        requestStr = oidcClientEndpointsResource.getOIDCRequest();
-
-        oauth.request(requestStr);
-        OAuthClient.AuthorizationEndpointResponse response = oauth.doLogin("test-user@localhost", "password");
-        Assert.assertNotNull(response.getCode());
-        Assert.assertEquals("mystate2", response.getState());
-        assertTrue(appPage.isCurrent());
+        assertEquals("Invalid Request", errorPage.getError());
     }
 
     @Test
     public void requestUriParamUnsigned() throws Exception {
         oauth.stateParamHardcoded("mystate1");
 
-        String validRedirectUri = oauth.getRedirectUri();
         TestOIDCEndpointsApplicationResource oidcClientEndpointsResource = testingClient.testApp().oidcClientEndpoints();
 
         // Send request object with invalid redirect uri.
@@ -763,16 +752,7 @@ public class OIDCAdvancedRequestParamsTest extends AbstractTestRealmKeycloakTest
         oauth.requestUri(TestApplicationResourceUrls.clientRequestUri());
         oauth.openLoginForm();
         Assert.assertTrue(errorPage.isCurrent());
-        assertEquals("Invalid parameter: redirect_uri", errorPage.getError());
-
-        // Assert the value from request object has bigger priority then from the query parameter.
-        oauth.redirectUri("http://invalid");
-        oidcClientEndpointsResource.setOIDCRequest("test", "test-app", validRedirectUri, "10", Algorithm.none.toString());
-
-        OAuthClient.AuthorizationEndpointResponse response = oauth.doLogin("test-user@localhost", "password");
-        Assert.assertNotNull(response.getCode());
-        Assert.assertEquals("mystate1", response.getState());
-        assertTrue(appPage.isCurrent());
+        assertEquals("Invalid Request", errorPage.getError());
     }
 
     @Test
@@ -831,35 +811,29 @@ public class OIDCAdvancedRequestParamsTest extends AbstractTestRealmKeycloakTest
         ClientRepresentation clientRep = null;
         try {
             oauth.stateParamHardcoded("mystate3");
-
             String validRedirectUri = oauth.getRedirectUri();
-            TestOIDCEndpointsApplicationResource oidcClientEndpointsResource = testingClient.testApp().oidcClientEndpoints();
 
-            // Set required signature for request_uri
             clientResource = ApiUtil.findClientByClientId(adminClient.realm("test"), "test-app");
             clientRep = clientResource.toRepresentation();
-            OIDCAdvancedConfigWrapper.fromClientRepresentation(clientRep).setRequestObjectSignatureAlg(expectedAlgorithm);
-            clientResource.update(clientRep);
+            // Set request object required as request uri parameter for client
+            prepareClientRepresentation(expectedAlgorithm, OIDCConfigAttributes.REQUEST_OBJECT_REQUIRED_REQUEST_URI, clientResource, clientRep);
 
+            TestOIDCEndpointsApplicationResource oidcClientEndpointsResource = testingClient.testApp().oidcClientEndpoints();
             // generate and register client keypair
-            if (Algorithm.none != actualAlgorithm) oidcClientEndpointsResource.generateKeys(actualAlgorithm.name());
-
+            if (actualAlgorithm == Algorithm.none) {
+                // register RS256 key intentionally to test no signed Request Object case
+                oidcClientEndpointsResource.generateKeys(Algorithm.RS256.name());
+            } else {
+                oidcClientEndpointsResource.generateKeys(actualAlgorithm.name());
+            }
             // register request object
             oidcClientEndpointsResource.setOIDCRequest("test", "test-app", validRedirectUri, "10", actualAlgorithm.name());
-
-            // use and set jwks_url
-            clientResource = ApiUtil.findClientByClientId(adminClient.realm("test"), "test-app");
-            clientRep = clientResource.toRepresentation();
-            OIDCAdvancedConfigWrapper.fromClientRepresentation(clientRep).setUseJwksUrl(true);
-            String jwksUrl = TestApplicationResourceUrls.clientJwksUri();
-            OIDCAdvancedConfigWrapper.fromClientRepresentation(clientRep).setJwksUrl(jwksUrl);
-            clientResource.update(clientRep);
 
             // set time offset, so that new keys are downloaded
             setTimeOffset(20);
 
             oauth.requestUri(TestApplicationResourceUrls.clientRequestUri());
-            if (expectedAlgorithm == null || expectedAlgorithm == actualAlgorithm) {
+            if ((expectedAlgorithm == null && actualAlgorithm != Algorithm.none) || expectedAlgorithm == actualAlgorithm) {
                 // Check signed request_uri will pass
                 OAuthClient.AuthorizationEndpointResponse response = oauth.doLogin("test-user@localhost", "password");
                 Assert.assertNotNull(response.getCode());
@@ -873,12 +847,8 @@ public class OIDCAdvancedRequestParamsTest extends AbstractTestRealmKeycloakTest
             }
 
         } finally {
-            // Revert requiring signature for client
-            OIDCAdvancedConfigWrapper.fromClientRepresentation(clientRep).setRequestObjectSignatureAlg(null);
-            // Revert jwks_url settings
-            OIDCAdvancedConfigWrapper.fromClientRepresentation(clientRep).setUseJwksUrl(false);
-            OIDCAdvancedConfigWrapper.fromClientRepresentation(clientRep).setJwksUrl(null);
-            clientResource.update(clientRep);
+            // revert client settings
+            revertClientRepresentation(clientResource, clientRep);
         }
     }
 
@@ -886,18 +856,6 @@ public class OIDCAdvancedRequestParamsTest extends AbstractTestRealmKeycloakTest
     public void requestUriParamSignedExpectedES256ActualRS256() throws Exception {
         // will fail
         requestUriParamSignedIn(Algorithm.ES256, Algorithm.RS256);
-    }
-
-    @Test
-    public void requestUriParamSignedExpectedNoneActualES256() throws Exception {
-        // will fail
-        requestUriParamSignedIn(Algorithm.none, Algorithm.ES256);
-    }
-
-    @Test
-    public void requestUriParamSignedExpectedNoneActualNone() throws Exception {
-        // will success
-        requestUriParamSignedIn(Algorithm.none, Algorithm.none);
     }
 
     @Test
@@ -937,6 +895,13 @@ public class OIDCAdvancedRequestParamsTest extends AbstractTestRealmKeycloakTest
         requestUriParamSignedIn(null, Algorithm.ES256);
     }
 
+    @Test
+    public void requestUriParamSignedExpectedAnyActualNone() throws Exception {
+        // Algorithm is null if 'any'
+        // will fail
+        requestUriParamSignedIn(null, Algorithm.none);
+    }
+    
     // LOGIN_HINT
 
     @Test
@@ -988,41 +953,95 @@ public class OIDCAdvancedRequestParamsTest extends AbstractTestRealmKeycloakTest
     
     @Test
     public void processClaimsRequestParam() throws Exception {
-        Map<String, Object> claims = ImmutableMap.of(
-                "id_token", ImmutableMap.of(
-                        "test_claim", ImmutableMap.of(
-                                "essential", true)));
-        
-        String claimsJson = JsonSerialization.writeValueAsString(claims);
+        ClientResource clientResource = null;
+        ClientRepresentation clientRep = null;
+        try {
+            // Set request object not required for client
+            clientResource = ApiUtil.findClientByClientId(adminClient.realm("test"), "test-app");
+            clientRep = clientResource.toRepresentation();
 
-        Map<String, Object> oidcRequest = new HashMap<>();
-        oidcRequest.put(OIDCLoginProtocol.CLIENT_ID_PARAM, "test-app");
-        oidcRequest.put(OIDCLoginProtocol.RESPONSE_TYPE_PARAM, OAuth2Constants.CODE);
-        oidcRequest.put(OIDCLoginProtocol.REDIRECT_URI_PARAM, oauth.getRedirectUri());
-        oidcRequest.put(OIDCLoginProtocol.CLAIMS_PARAM, claims);
+            // Set request object required as request parameter for client
+            prepareClientRepresentation(Algorithm.RS256, OIDCConfigAttributes.REQUEST_OBJECT_REQUIRED_REQUEST, clientResource, clientRep);
 
-        String request = new JWSBuilder().jsonContent(oidcRequest).none();
-        
-        driver.navigate().to(oauth.getLoginFormUrl() + "&" + OIDCLoginProtocol.REQUEST_PARAM + "=" + request);
-        
-        // need to login so session id can be read from event
-        loginPage.assertCurrent();
-        loginPage.login("test-user@localhost", "password");
-        Assert.assertEquals(AppPage.RequestType.AUTH_RESPONSE, appPage.getRequestType());
+            // Set up a request object
+            TestOIDCEndpointsApplicationResource oidcClientEndpointsResource = testingClient.testApp().oidcClientEndpoints();
 
-        EventRepresentation loginEvent = events.expectLogin().detail(Details.USERNAME, "test-user@localhost").assertEvent();
-        String sessionId = loginEvent.getSessionId();
-        String clientId = loginEvent.getClientId();
-        
-        testingClient.server("test").run(session -> {
-            RealmModel realmModel = session.getContext().getRealm();
-            String clientUuid = realmModel.getClientByClientId(clientId).getId();
-            UserSessionModel userSession = session.sessions().getUserSession(realmModel, sessionId);
-            AuthenticatedClientSessionModel clientSession = userSession.getAuthenticatedClientSessionByClient(clientUuid);
-            
-            String claimsInSession = clientSession.getNote(OIDCLoginProtocol.CLAIMS_PARAM);
-            assertEquals(claimsJson, claimsInSession);
-        });
+            // generate and register client keypair
+            Map<String, String> generatedKeys = oidcClientEndpointsResource.generateKeys(Algorithm.RS256.name());
+            String privateKeyPem = generatedKeys.get(TestingOIDCEndpointsApplicationResource.PRIVATE_KEY);
+            PrivateKey privateKey = KeycloakModelUtils.getPrivateKey(privateKeyPem);
+
+            Map<String, Object> claims = ImmutableMap.of(
+                    "id_token", ImmutableMap.of(
+                            "test_claim", ImmutableMap.of(
+                                    "essential", true)));
+
+            String claimsJson = JsonSerialization.writeValueAsString(claims);
+
+            Map<String, Object> oidcRequest = new HashMap<>();
+            oidcRequest.put(OIDCLoginProtocol.CLIENT_ID_PARAM, "test-app");
+            oidcRequest.put(OIDCLoginProtocol.RESPONSE_TYPE_PARAM, OAuth2Constants.CODE);
+            oidcRequest.put(OIDCLoginProtocol.REDIRECT_URI_PARAM, oauth.getRedirectUri());
+            oidcRequest.put(OIDCLoginProtocol.CLAIMS_PARAM, claims);
+
+            String request = new JWSBuilder().jsonContent(oidcRequest).rsa256(privateKey);
+
+            driver.navigate().to(oauth.getLoginFormUrl() + "&" + OIDCLoginProtocol.REQUEST_PARAM + "=" + request);
+
+            // need to login so session id can be read from event
+            loginPage.assertCurrent();
+            loginPage.login("test-user@localhost", "password");
+            Assert.assertEquals(AppPage.RequestType.AUTH_RESPONSE, appPage.getRequestType());
+
+            EventRepresentation loginEvent = events.expectLogin().detail(Details.USERNAME, "test-user@localhost").assertEvent();
+            String sessionId = loginEvent.getSessionId();
+            String clientId = loginEvent.getClientId();
+
+            testingClient.server("test").run(session -> {
+                RealmModel realmModel = session.getContext().getRealm();
+                String clientUuid = realmModel.getClientByClientId(clientId).getId();
+                UserSessionModel userSession = session.sessions().getUserSession(realmModel, sessionId);
+                AuthenticatedClientSessionModel clientSession = userSession.getAuthenticatedClientSessionByClient(clientUuid);
+
+                String claimsInSession = clientSession.getNote(OIDCLoginProtocol.CLAIMS_PARAM);
+                assertEquals(claimsJson, claimsInSession);
+            });
+        } finally {
+            // revert client settings
+            revertClientRepresentation(clientResource, clientRep);
+        }
     }
 
+    private void prepareClientRepresentation(Algorithm signatureAlg, String requestObjectRequired, ClientResource clientResource, ClientRepresentation clientRep) {
+        OIDCAdvancedConfigWrapper.fromClientRepresentation(clientRep).setRequestObjectRequired(requestObjectRequired);
+        // use and set jwks_url
+        OIDCAdvancedConfigWrapper.fromClientRepresentation(clientRep).setUseJwksUrl(true);
+        String jwksUrl = TestApplicationResourceUrls.clientJwksUri();
+        OIDCAdvancedConfigWrapper.fromClientRepresentation(clientRep).setJwksUrl(jwksUrl);
+        // Set required signature
+        OIDCAdvancedConfigWrapper.fromClientRepresentation(clientRep).setRequestObjectSignatureAlg(signatureAlg);
+        // update client settings
+        clientResource.update(clientRep);
+    }
+
+    private TestOIDCEndpointsApplicationResource prepareOIDCEndpointsApplicationResource(Algorithm signatureAlg) {
+        // Set up a request object
+        TestOIDCEndpointsApplicationResource oidcClientEndpointsResource = testingClient.testApp().oidcClientEndpoints();
+        // generate and register client keypair
+        oidcClientEndpointsResource.generateKeys(signatureAlg.name());
+        // register request object
+        oidcClientEndpointsResource.setOIDCRequest("test", "test-app", oauth.getRedirectUri(), "10", signatureAlg.name());
+        return oidcClientEndpointsResource;
+    }
+
+    private void revertClientRepresentation(ClientResource clientResource, ClientRepresentation clientRep) {
+        // Revert requiring request object for client
+        OIDCAdvancedConfigWrapper.fromClientRepresentation(clientRep).setRequestObjectRequired(null);
+        // Revert requiring signature for client
+        OIDCAdvancedConfigWrapper.fromClientRepresentation(clientRep).setRequestObjectSignatureAlg(null);
+        // Revert jwks_url settings
+        OIDCAdvancedConfigWrapper.fromClientRepresentation(clientRep).setUseJwksUrl(false);
+        OIDCAdvancedConfigWrapper.fromClientRepresentation(clientRep).setJwksUrl(null);
+        clientResource.update(clientRep);
+    }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/OIDCWellKnownProviderTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/OIDCWellKnownProviderTest.java
@@ -126,7 +126,7 @@ public class OIDCWellKnownProviderTest extends AbstractKeycloakTest {
             Assert.assertNames(oidcConfig.getSubjectTypesSupported(), "pairwise", "public");
             Assert.assertNames(oidcConfig.getIdTokenSigningAlgValuesSupported(), Algorithm.RS256, Algorithm.RS384, Algorithm.RS512, Algorithm.ES256, Algorithm.ES384, Algorithm.ES512, Algorithm.HS256, Algorithm.HS384, Algorithm.HS512);
             Assert.assertNames(oidcConfig.getUserInfoSigningAlgValuesSupported(), "none", Algorithm.RS256, Algorithm.RS384, Algorithm.RS512, Algorithm.ES256, Algorithm.ES384, Algorithm.ES512, Algorithm.HS256, Algorithm.HS384, Algorithm.HS512);
-            Assert.assertNames(oidcConfig.getRequestObjectSigningAlgValuesSupported(), "none", Algorithm.RS256);
+            Assert.assertNames(oidcConfig.getRequestObjectSigningAlgValuesSupported(), "none", Algorithm.RS256, Algorithm.RS384, Algorithm.RS512, Algorithm.ES256, Algorithm.ES384, Algorithm.ES512);
 
             // Client authentication
             Assert.assertNames(oidcConfig.getTokenEndpointAuthMethodsSupported(), "client_secret_basic", "client_secret_post", "private_key_jwt", "client_secret_jwt");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/OIDCWellKnownProviderTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/OIDCWellKnownProviderTest.java
@@ -96,7 +96,6 @@ public class OIDCWellKnownProviderTest extends AbstractKeycloakTest {
         oauth.clientId("test-app");
     }
 
-
     @Test
     public void testDiscovery() {
         Client client = ClientBuilder.newClient();
@@ -126,7 +125,7 @@ public class OIDCWellKnownProviderTest extends AbstractKeycloakTest {
             Assert.assertNames(oidcConfig.getSubjectTypesSupported(), "pairwise", "public");
             Assert.assertNames(oidcConfig.getIdTokenSigningAlgValuesSupported(), Algorithm.RS256, Algorithm.RS384, Algorithm.RS512, Algorithm.ES256, Algorithm.ES384, Algorithm.ES512, Algorithm.HS256, Algorithm.HS384, Algorithm.HS512);
             Assert.assertNames(oidcConfig.getUserInfoSigningAlgValuesSupported(), "none", Algorithm.RS256, Algorithm.RS384, Algorithm.RS512, Algorithm.ES256, Algorithm.ES384, Algorithm.ES512, Algorithm.HS256, Algorithm.HS384, Algorithm.HS512);
-            Assert.assertNames(oidcConfig.getRequestObjectSigningAlgValuesSupported(), Algorithm.RS256, Algorithm.RS384, Algorithm.RS512, Algorithm.ES256, Algorithm.ES384, Algorithm.ES512);
+            Assert.assertNames(oidcConfig.getRequestObjectSigningAlgValuesSupported(), "none", Algorithm.RS256, Algorithm.RS384, Algorithm.RS512, Algorithm.ES256, Algorithm.ES384, Algorithm.ES512);
 
             // Client authentication
             Assert.assertNames(oidcConfig.getTokenEndpointAuthMethodsSupported(), "client_secret_basic", "client_secret_post", "private_key_jwt", "client_secret_jwt");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/OIDCWellKnownProviderTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/OIDCWellKnownProviderTest.java
@@ -126,7 +126,7 @@ public class OIDCWellKnownProviderTest extends AbstractKeycloakTest {
             Assert.assertNames(oidcConfig.getSubjectTypesSupported(), "pairwise", "public");
             Assert.assertNames(oidcConfig.getIdTokenSigningAlgValuesSupported(), Algorithm.RS256, Algorithm.RS384, Algorithm.RS512, Algorithm.ES256, Algorithm.ES384, Algorithm.ES512, Algorithm.HS256, Algorithm.HS384, Algorithm.HS512);
             Assert.assertNames(oidcConfig.getUserInfoSigningAlgValuesSupported(), "none", Algorithm.RS256, Algorithm.RS384, Algorithm.RS512, Algorithm.ES256, Algorithm.ES384, Algorithm.ES512, Algorithm.HS256, Algorithm.HS384, Algorithm.HS512);
-            Assert.assertNames(oidcConfig.getRequestObjectSigningAlgValuesSupported(), "none", Algorithm.RS256, Algorithm.RS384, Algorithm.RS512, Algorithm.ES256, Algorithm.ES384, Algorithm.ES512);
+            Assert.assertNames(oidcConfig.getRequestObjectSigningAlgValuesSupported(), Algorithm.RS256, Algorithm.RS384, Algorithm.RS512, Algorithm.ES256, Algorithm.ES384, Algorithm.ES512);
 
             // Client authentication
             Assert.assertNames(oidcConfig.getTokenEndpointAuthMethodsSupported(), "client_secret_basic", "client_secret_post", "private_key_jwt", "client_secret_jwt");

--- a/themes/src/main/resources/theme/base/admin/resources/js/controllers/clients.js
+++ b/themes/src/main/resources/theme/base/admin/resources/js/controllers/clients.js
@@ -929,10 +929,16 @@ module.controller('ClientDetailCtrl', function($scope, realm, client, flows, $ro
         {name: "INCLUSIVE_WITH_COMMENTS", value: "http://www.w3.org/TR/2001/REC-xml-c14n-20010315#WithComments"}
     ];
 
+    // KEYCLOAK-8460 Request Object Signature Verification Other Than RS256
     $scope.requestObjectSignatureAlgorithms = [
         "any",
         "none",
-        "RS256"
+        "RS256",
+        "RS384",
+        "RS512",
+        "ES256",
+        "ES384",
+        "ES512"
     ];
     
     $scope.requestObjectRequiredOptions = [

--- a/themes/src/main/resources/theme/base/admin/resources/js/controllers/clients.js
+++ b/themes/src/main/resources/theme/base/admin/resources/js/controllers/clients.js
@@ -929,18 +929,6 @@ module.controller('ClientDetailCtrl', function($scope, realm, client, flows, $ro
         {name: "INCLUSIVE_WITH_COMMENTS", value: "http://www.w3.org/TR/2001/REC-xml-c14n-20010315#WithComments"}
     ];
 
-    // KEYCLOAK-8460 Request Object Signature Verification Other Than RS256
-    $scope.requestObjectSignatureAlgorithms = [
-        "any",
-        "none",
-        "RS256",
-        "RS384",
-        "RS512",
-        "ES256",
-        "ES384",
-        "ES512"
-    ];
-    
     $scope.requestObjectRequiredOptions = [
         "not required",
         "request or request_uri",

--- a/themes/src/main/resources/theme/base/admin/resources/partials/client-detail.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/client-detail.html
@@ -438,8 +438,10 @@
                     <div>
                         <select class="form-control" id="requestObjectSignatureAlg"
                                 ng-change="changeRequestObjectSignatureAlg()"
-                                ng-model="requestObjectSignatureAlg"
-                                ng-options="sig for sig in requestObjectSignatureAlgorithms">
+                                ng-model="requestObjectSignatureAlg">
+                            <option value="any">any</option>
+                            <option value="none">none</option>
+                            <option ng-repeat="provider in serverInfo.listProviderIds('clientSignature')" value="{{provider}}">{{provider}}</option>
                         </select>
                     </div>
                 </div>

--- a/themes/src/main/resources/theme/base/admin/resources/partials/client-detail.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/client-detail.html
@@ -440,6 +440,7 @@
                                 ng-change="changeRequestObjectSignatureAlg()"
                                 ng-model="requestObjectSignatureAlg">
                             <option value="any">any</option>
+                            <option value="none">none</option>
                             <option ng-repeat="provider in serverInfo.listProviderIds('clientSignature')" value="{{provider}}">{{provider}}</option>
                         </select>
                     </div>

--- a/themes/src/main/resources/theme/base/admin/resources/partials/client-detail.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/client-detail.html
@@ -440,7 +440,6 @@
                                 ng-change="changeRequestObjectSignatureAlg()"
                                 ng-model="requestObjectSignatureAlg">
                             <option value="any">any</option>
-                            <option value="none">none</option>
                             <option ng-repeat="provider in serverInfo.listProviderIds('clientSignature')" value="{{provider}}">{{provider}}</option>
                         </select>
                     </div>


### PR DESCRIPTION
This PR is for supporting client signed signature verification in RS256, RS384, RS512, ES256, ES384, ES512 by using refactored token verification mechanism.

The case where the client signs JWT is Request Object.

The JIRA ticket is the following.
https://issues.jboss.org/browse/KEYCLOAK-8460
