### PR TITLE
[KEYCLOAK-8449] - Option to automatically map HTTP verbs to scopes when configuring the policy enforcer

### DIFF
--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/authorization/AbstractPolicyEnforcer.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/authorization/AbstractPolicyEnforcer.java
@@ -17,6 +17,7 @@
  */
 package org.keycloak.adapters.authorization;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -309,7 +310,15 @@ public abstract class AbstractPolicyEnforcer {
         MethodConfig methodConfig = new MethodConfig();
 
         methodConfig.setMethod(request.getMethod());
-        methodConfig.setScopes(pathConfig.getScopes());
+        List scopes = new ArrayList<>();
+
+        if (Boolean.TRUE.equals(getEnforcerConfig().getHttpMethodAsScope())) {
+            scopes.add(request.getMethod());
+        } else {
+            scopes.addAll(pathConfig.getScopes());
+        }
+
+        methodConfig.setScopes(scopes);
         methodConfig.setScopesEnforcementMode(PolicyEnforcerConfig.ScopeEnforcementMode.ANY);
 
         return methodConfig;

--- a/core/src/main/java/org/keycloak/representations/adapters/config/PolicyEnforcerConfig.java
+++ b/core/src/main/java/org/keycloak/representations/adapters/config/PolicyEnforcerConfig.java
@@ -61,6 +61,9 @@ public class PolicyEnforcerConfig {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private Map<String, Map<String, Object>> claimInformationPointConfig;
 
+    @JsonProperty("http-method-as-scope")
+    private Boolean httpMethodAsScope;
+
     public List<PathConfig> getPaths() {
         return this.paths;
     }
@@ -115,6 +118,14 @@ public class PolicyEnforcerConfig {
 
     public void setClaimInformationPointConfig(Map<String, Map<String, Object>> config) {
         this.claimInformationPointConfig = config;
+    }
+
+    public Boolean getHttpMethodAsScope() {
+        return httpMethodAsScope;
+    }
+
+    public void setHttpMethodAsScope(Boolean httpMethodAsScope) {
+        this.httpMethodAsScope = httpMethodAsScope;
     }
 
     public static class PathConfig {

--- a/testsuite/integration-arquillian/tests/base/src/test/resources/authorization-test/enforcer-match-http-verbs-scopes.json
+++ b/testsuite/integration-arquillian/tests/base/src/test/resources/authorization-test/enforcer-match-http-verbs-scopes.json
@@ -1,0 +1,13 @@
+{
+  "realm": "authz-test",
+  "auth-server-url": "http://localhost:8180/auth",
+  "ssl-required": "external",
+  "resource": "resource-server-test",
+  "credentials": {
+    "secret": "secret"
+  },
+  "bearer-only": true,
+  "policy-enforcer": {
+    "http-method-as-scope": true
+  }
+}


### PR DESCRIPTION
Documentation: https://github.com/keycloak/keycloak-documentation/pull/494