### PR TITLE
use org.hibernate.jpa.HibernatePersistenceProvider

### DIFF
--- a/testsuite/integration-arquillian/test-apps/photoz/photoz-restful-api/src/main/resources/META-INF/persistence.xml
+++ b/testsuite/integration-arquillian/test-apps/photoz/photoz-restful-api/src/main/resources/META-INF/persistence.xml
@@ -5,7 +5,7 @@
         http://java.sun.com/xml/ns/persistence
         http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd">
 	<persistence-unit name="primary" transaction-type="RESOURCE_LOCAL">
-		<provider>org.hibernate.ejb.HibernatePersistence</provider>
+		<provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
 
 		<class>org.keycloak.example.photoz.entity.Album</class>
 		<class>org.keycloak.example.photoz.entity.Photo</class>


### PR DESCRIPTION
org.hibernate.jpa.HibernatePersistenceProvider should work in Hibernate ORM 4.3+.  You can no longer use org.hibernate.ejb.HibernatePersistence in Hibernate 5.3 (was removed in an earlier ORM 5.x release).