### PR TITLE
KEYCLOAK-8529 Fix most of adapter tests on EAP6

### DIFF
--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/BearerTokenRequestAuthenticator.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/BearerTokenRequestAuthenticator.java
@@ -74,9 +74,8 @@ public class BearerTokenRequestAuthenticator {
             if (split == null || split.length != 2) continue;
             if (split[0].equalsIgnoreCase("Bearer")) {
                 tokenString = split[1];
-                if (log.isDebugEnabled()) {
-                    log.debugf("Found [%s] values in authorization header, selecting the first value for Bearer.", authHeaders.size());
-                }
+
+                log.debugf("Found [%d] values in authorization header, selecting the first value for Bearer.", (Integer) authHeaders.size());
                 break;
             };
         }

--- a/distribution/adapters/as7-eap6-adapter/as7-modules/src/main/resources/modules/org/keycloak/keycloak-authz-client/main/module.xml
+++ b/distribution/adapters/as7-eap6-adapter/as7-modules/src/main/resources/modules/org/keycloak/keycloak-authz-client/main/module.xml
@@ -37,6 +37,7 @@
         <module name="com.fasterxml.jackson.core.jackson-annotations"/>
         <module name="com.fasterxml.jackson.core.jackson-databind"/>
         <module name="com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider"/>
+        <module name="org.jboss.logging"/>
     </dependencies>
 
 </module>

--- a/distribution/adapters/wf8-adapter/wf8-modules/src/main/resources/modules/org/keycloak/keycloak-authz-client/main/module.xml
+++ b/distribution/adapters/wf8-adapter/wf8-modules/src/main/resources/modules/org/keycloak/keycloak-authz-client/main/module.xml
@@ -36,6 +36,7 @@
         <module name="com.fasterxml.jackson.core.jackson-annotations"/>
         <module name="com.fasterxml.jackson.core.jackson-databind"/>
         <module name="com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider"/>
+        <module name="org.jboss.logging"/>
     </dependencies>
 
 </module>

--- a/testsuite/integration-arquillian/HOW-TO-RUN.md
+++ b/testsuite/integration-arquillian/HOW-TO-RUN.md
@@ -194,7 +194,7 @@ Assumed you downloaded `fuse-karaf-7.0.0.fuse-000202.zip`
     mvn install:install-file \
       -DgroupId=org.jboss.as \
       -DartifactId=jboss-as-dist \
-      -Dversion=7.5.0.Final-redhat-21 \
+      -Dversion=7.5.21.Final-redhat-1 \
       -Dpackaging=zip \
       -Dfile=/mydownloads/jboss-eap-6.4.0.zip
 
@@ -207,9 +207,9 @@ Assumed you downloaded `fuse-karaf-7.0.0.fuse-000202.zip`
     mvn install:install-file \
       -DgroupId=com.redhat.fuse.eap \
       -DartifactId=fuse-eap-installer \
-      -Dversion=6.3.0.redhat-220 \
+      -Dversion=6.3.0.redhat-347 \
       -Dpackaging=jar \
-      -Dfile=/fuse-eap-installer-6.3.0.redhat-220.jar
+      -Dfile=/fuse-eap-installer-6.3.0.redhat-347.jar
 
 
 5) Prepare EAP6 with Hawtio and run the test
@@ -219,15 +219,16 @@ Assumed you downloaded `fuse-karaf-7.0.0.fuse-000202.zip`
     mvn -f testsuite/integration-arquillian/servers \
       clean install \
       -Pauth-server-wildfly \
-      -Papp-server-eap6-fuse \
-      -Dapp.server.jboss.version=7.5.0.Final-redhat-21 \
-      -Dfuse.installer.version=6.3.0.redhat-220
+      -Papp-server-eap6 \
+      -Dapp.server.jboss.version=7.5.21.Final-redhat-1 \
+      -Dfuse63.version=6.3.0.redhat-347
  
     # Run the test
-    mvn -f testsuite/integration-arquillian/tests/other/adapters/jboss/eap6-fuse/pom.xml \
+    mvn -f testsuite/integration-arquillian/tests/base/pom.xml \
       clean install \
       -Pauth-server-wildfly \
-      -Papp-server-eap6-fuse  
+      -Papp-server-eap6 \
+      -Dtest=EAP6Fuse6HawtioAdapterTest
  
 
 ## Migration test

--- a/testsuite/integration-arquillian/servers/pom.xml
+++ b/testsuite/integration-arquillian/servers/pom.xml
@@ -33,7 +33,7 @@
         <script.suffix>sh</script.suffix>
         
         <!--app container versions-->
-        <eap6.version>7.5.20.Final-redhat-1</eap6.version>
+        <eap6.version>7.5.21.Final-redhat-1</eap6.version>
         <eap71.version>7.1.4.GA-redhat-1</eap71.version>
         <jboss.as.version>7.1.1.Final</jboss.as.version>
         <tomcat7.version>7.0.68</tomcat7.version>

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/DemoServletsAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/DemoServletsAdapterTest.java
@@ -1058,7 +1058,7 @@ public class DemoServletsAdapterTest extends AbstractServletsAdapterTest {
     public void testWithoutKeycloakConf() {
         customerPortalNoConf.navigateTo();
         String pageSource = driver.getPageSource();
-        assertThat(pageSource, anyOf(containsString("Forbidden"), containsString("HTTP Status 401")));
+        assertThat(pageSource, anyOf(containsString("Forbidden"), containsString("forbidden"), containsString("HTTP Status 401")));
     }
     
     // KEYCLOAK-3509

--- a/testsuite/integration-arquillian/tests/base/src/test/resources/adapter-test/customer-db-audience-required/WEB-INF/web.xml
+++ b/testsuite/integration-arquillian/tests/base/src/test/resources/adapter-test/customer-db-audience-required/WEB-INF/web.xml
@@ -21,7 +21,7 @@
          xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
          version="3.0">
 
-    <module-name>customer-db</module-name>
+    <module-name>customer-db-audience-required</module-name>
 
 
     <filter>


### PR DESCRIPTION
This updates EAP 6.4 to latest build ( 7.5.21.Final-redhat-1 ) and fixes most of the adapter tests with EAP6. The tests, which are still failing with app-server-eap6 even after applying this PR are:

- SAMLAdapterClusterTest (not sure if it's correct that test was executed when I used just -Papp-server-eap6 and not cluster)
- EAP6Fuse6HawtioAdapterTest - created https://issues.jboss.org/browse/KEYCLOAK-8553
- PhotozExampleLazyLoadPathsAdapterTest, PhotozExampleNoLazyLoadPathsAdapterTest, ServletPolicyEnforcerTest - AFAIK @mhajas is working on some refactoring of those tests, so I didn't want to spend more time on fixing them