### PR TITLE
[KEYCLOAK-8621] The Keycloak JS adapter should not mutate browser history state

### DIFF
--- a/adapters/oidc/js/src/main/resources/keycloak.js
+++ b/adapters/oidc/js/src/main/resources/keycloak.js
@@ -180,7 +180,7 @@
                 var callback = parseCallback(window.location.href);
 
                 if (callback) {
-                    window.history.replaceState({}, null, callback.newUrl);
+                    window.history.replaceState(window.history.state, null, callback.newUrl);
                 }
 
                 if (callback && callback.valid) {


### PR DESCRIPTION
Current adapter is mutating the browser history state. This side effect may cause browser navigation issue. Because navigating pages could be depended on browser history state.

[Reference](https://github.com/zeit/next.js/blob/master/errors/popstate-state-empty.md) could be an example.

There is no reason to mutate browser history. Even if it should depend on browser history, it should provide an interface to protect state.
