### PR TITLE
KEYCLOAK-8483 Remove application from the aud claim of accessToken and refreshToken

### DIFF
--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/rotation/AdapterTokenVerifier.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/rotation/AdapterTokenVerifier.java
@@ -74,8 +74,9 @@ public class AdapterTokenVerifier {
             IDToken idToken = TokenVerifier.create(idTokenString, IDToken.class).getToken();
             TokenVerifier<IDToken> idTokenVerifier = TokenVerifier.createWithoutSignature(idToken);
 
-            // Always verify audience on IDToken
+            // Always verify audience and azp on IDToken
             idTokenVerifier.audience(deployment.getResourceName());
+            idTokenVerifier.issuedFor(deployment.getResourceName());
 
             idTokenVerifier.verify();
             return new VerifiedTokens(accessToken, idToken);

--- a/core/src/main/java/org/keycloak/TokenVerifier.java
+++ b/core/src/main/java/org/keycloak/TokenVerifier.java
@@ -153,15 +153,36 @@ public class TokenVerifier<T extends JsonWebToken> {
                 throw new VerificationException("No audience in the token");
             }
 
-            for (String aud : audience) {
-                if (expectedAudience.equals(aud)) {
-                    return true;
-                }
+            if (t.hasAudience(expectedAudience)) {
+                return true;
             }
 
             throw new VerificationException("Expected audience not available in the token");
         }
     };
+
+
+    public static class IssuedForCheck implements Predicate<JsonWebToken> {
+
+        private final String expectedIssuedFor;
+
+        public IssuedForCheck(String expectedIssuedFor) {
+            this.expectedIssuedFor = expectedIssuedFor;
+        }
+
+        @Override
+        public boolean test(JsonWebToken jsonWebToken) throws VerificationException {
+            if (expectedIssuedFor == null) {
+                throw new VerificationException("Missing expectedIssuedFor");
+            }
+
+            if (expectedIssuedFor.equals(jsonWebToken.getIssuedFor())) {
+                return true;
+            }
+
+            throw new VerificationException("Expected issuedFor doesn't match");
+        }
+    }
 
 
     private String tokenString;
@@ -350,6 +371,16 @@ public class TokenVerifier<T extends JsonWebToken> {
      */
     public TokenVerifier<T> audience(String expectedAudience) {
         return this.replaceCheck(AudienceCheck.class, true, new AudienceCheck(expectedAudience));
+    }
+
+    /**
+     * Add check for verifying that token issuedFor (azp claim) is the expected value
+     *
+     * @param expectedIssuedFor issuedFor, which needs to be in the target token. Can't be null
+     * @return This token verifier
+     */
+    public TokenVerifier<T> issuedFor(String expectedIssuedFor) {
+        return this.replaceCheck(IssuedForCheck.class, true, new IssuedForCheck(expectedIssuedFor));
     }
 
     public TokenVerifier<T> parse() throws VerificationException {

--- a/core/src/main/java/org/keycloak/representations/RefreshToken.java
+++ b/core/src/main/java/org/keycloak/representations/RefreshToken.java
@@ -46,7 +46,7 @@ public class RefreshToken extends AccessToken {
         this.issuedFor = token.issuedFor;
         this.sessionState = token.sessionState;
         this.nonce = token.nonce;
-        this.audience = token.audience;
+        this.audience = new String[] { token.issuer };
         this.scope = token.scope;
         if (token.realmAccess != null) {
             realmAccess = token.realmAccess.clone();

--- a/services/src/main/java/org/keycloak/authorization/admin/PolicyEvaluationService.java
+++ b/services/src/main/java/org/keycloak/authorization/admin/PolicyEvaluationService.java
@@ -258,10 +258,13 @@ public class PolicyEvaluationService {
 
         }
 
-        AccessToken.Access realmAccess = accessToken.getRealmAccess();
+        if (representation.getRoleIds() != null && !representation.getRoleIds().isEmpty()) {
+            if (accessToken.getRealmAccess() == null) {
+                accessToken.setRealmAccess(new AccessToken.Access());
+            }
+            AccessToken.Access realmAccess = accessToken.getRealmAccess();
 
-        if (representation.getRoleIds() != null) {
-            representation.getRoleIds().forEach(roleName -> realmAccess.addRole(roleName));
+            representation.getRoleIds().forEach(realmAccess::addRole);
         }
 
         return new CloseableKeycloakIdentity(accessToken, keycloakSession, userSession);

--- a/services/src/main/java/org/keycloak/broker/oidc/KeycloakOIDCIdentityProvider.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/KeycloakOIDCIdentityProvider.java
@@ -64,7 +64,8 @@ public class KeycloakOIDCIdentityProvider extends OIDCIdentityProvider {
 
     @Override
     protected void processAccessTokenResponse(BrokeredIdentityContext context, AccessTokenResponse response) {
-        JsonWebToken access = validateToken(response.getToken());
+        // Don't verify audience on accessToken as it may not be there. It was verified on IDToken already
+        JsonWebToken access = validateToken(response.getToken(), true);
         context.getContextData().put(VALIDATED_ACCESS_TOKEN, access);
     }
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
@@ -640,7 +640,6 @@ public class TokenManager {
         token.id(KeycloakModelUtils.generateId());
         token.type(TokenUtil.TOKEN_TYPE_BEARER);
         token.subject(user.getId());
-        token.audience(client.getClientId());
         token.issuedNow();
         token.issuedFor(client.getClientId());
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
@@ -854,6 +854,10 @@ public class TokenEndpoint {
                 .generateAccessToken();
         responseBuilder.getAccessToken().issuedFor(client.getClientId());
 
+        if (audience != null) {
+            responseBuilder.getAccessToken().addAudience(audience);
+        }
+
         if (requestedTokenType.equals(OAuth2Constants.REFRESH_TOKEN_TYPE)) {
             responseBuilder.generateRefreshToken();
             responseBuilder.getRefreshToken().issuedFor(client.getClientId());

--- a/services/src/main/java/org/keycloak/services/resources/IdentityBrokerService.java
+++ b/services/src/main/java/org/keycloak/services/resources/IdentityBrokerService.java
@@ -439,11 +439,14 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
 
             if (authResult != null) {
                 AccessToken token = authResult.getToken();
-                String[] audience = token.getAudience();
-                ClientModel clientModel = this.realmModel.getClientByClientId(audience[0]);
+                String issuedFor = token.getIssuedFor();
+                ClientModel clientModel = this.realmModel.getClientByClientId(issuedFor);
 
                 if (clientModel == null) {
                     return badRequest("Invalid client.");
+                }
+                if (!clientModel.isEnabled()) {
+                    return badRequest("Client is disabled");
                 }
 
                 session.getContext().setClient(clientModel);

--- a/services/src/main/java/org/keycloak/services/resources/admin/permissions/MgmtPermissions.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/permissions/MgmtPermissions.java
@@ -96,8 +96,8 @@ class MgmtPermissions implements AdminPermissionEvaluator, AdminPermissionManage
     }
 
     private void initIdentity(KeycloakSession session, AdminAuth auth) {
-        if (auth.getToken().hasAudience(Constants.ADMIN_CLI_CLIENT_ID)
-                || auth.getToken().hasAudience(Constants.ADMIN_CONSOLE_CLIENT_ID)) {
+        if (Constants.ADMIN_CLI_CLIENT_ID.equals(auth.getToken().getIssuedFor())
+                || Constants.ADMIN_CONSOLE_CLIENT_ID.equals(auth.getToken().getIssuedFor())) {
             this.identity = new UserModelIdentity(auth.getRealm(), auth.getUser());
 
         } else {

--- a/testsuite/integration-arquillian/test-apps/servlets/src/main/java/org/keycloak/testsuite/adapter/servlet/ClientInitiatedAccountLinkServlet.java
+++ b/testsuite/integration-arquillian/test-apps/servlets/src/main/java/org/keycloak/testsuite/adapter/servlet/ClientInitiatedAccountLinkServlet.java
@@ -47,7 +47,7 @@ public class ClientInitiatedAccountLinkServlet extends HttpServlet {
             String realm = request.getParameter("realm");
             KeycloakSecurityContext session = (KeycloakSecurityContext) request.getAttribute(KeycloakSecurityContext.class.getName());
             AccessToken token = session.getToken();
-            String clientId = token.getAudience()[0];
+            String clientId = token.getIssuedFor();
             String nonce = UUID.randomUUID().toString();
             MessageDigest md = null;
             try {

--- a/testsuite/integration-arquillian/test-apps/servlets/src/main/java/org/keycloak/testsuite/adapter/servlet/LinkAndExchangeServlet.java
+++ b/testsuite/integration-arquillian/test-apps/servlets/src/main/java/org/keycloak/testsuite/adapter/servlet/LinkAndExchangeServlet.java
@@ -126,7 +126,7 @@ public class LinkAndExchangeServlet extends HttpServlet {
             AccessToken token = session.getToken();
             String tokenString = session.getTokenString();
 
-            String clientId = token.getAudience()[0];
+            String clientId = token.getIssuedFor();
             String linkUrl = null;
             try {
                 AccessTokenResponse response = doTokenExchange(realm, tokenString, provider,  clientId, "password");
@@ -176,7 +176,7 @@ public class LinkAndExchangeServlet extends HttpServlet {
                 String realm = request.getParameter("realm");
                 KeycloakSecurityContext session = (KeycloakSecurityContext) request.getAttribute(KeycloakSecurityContext.class.getName());
                 AccessToken token = session.getToken();
-                String clientId = token.getAudience()[0];
+                String clientId = token.getIssuedFor();
                 String tokenString = session.getTokenString();
                 AccessTokenResponse response = doTokenExchange(realm, tokenString, provider,  clientId, "password");
                 error = (String)response.getOtherClaims().get("error");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/OIDCJwksClientRegistrationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/OIDCJwksClientRegistrationTest.java
@@ -307,7 +307,7 @@ public class OIDCJwksClientRegistrationTest extends AbstractClientRegistrationTe
         OAuthClient.AccessTokenResponse accessTokenResponse = doClientCredentialsGrantRequest(signedJwt);
         Assert.assertEquals(200, accessTokenResponse.getStatusCode());
         AccessToken accessToken = oauth.verifyToken(accessTokenResponse.getAccessToken());
-        Assert.assertEquals(response.getClientId(), accessToken.getAudience()[0]);
+        Assert.assertEquals(response.getClientId(), accessToken.getIssuedFor());
     }
 
     private void assertAuthenticateClientError(Map<String, String> generatedKeys, OIDCClientRepresentation response, String kid) throws Exception {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/OIDCPairwiseClientRegistrationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/OIDCPairwiseClientRegistrationTest.java
@@ -397,9 +397,6 @@ public class OIDCPairwiseClientRegistrationTest extends AbstractClientRegistrati
         // its iat Claim MUST represent the time that the new ID Token is issued
         Assert.assertEquals(refreshedIdToken.getIssuedAt(), refreshedRefreshToken.getIssuedAt());
 
-        // its aud Claim Value MUST be the same as in the ID Token issued when the original authentication occurred
-        Assert.assertArrayEquals(idToken.getAudience(), refreshedRefreshToken.getAudience());
-
         // if the ID Token contains an auth_time Claim, its value MUST represent the time of the original authentication
         // - not the time that the new ID token is issued
         Assert.assertEquals(idToken.getAuthTime(), refreshedIdToken.getAuthTime());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/AccessTokenTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/AccessTokenTest.java
@@ -143,6 +143,16 @@ public class AccessTokenTest extends AbstractKeycloakTest {
                 .password("password");
         realm.getUsers().add(user.build());
 
+        realm.getClients().stream().filter(clientRepresentation -> {
+
+            return "test-app".equals(clientRepresentation.getClientId());
+
+        }).forEach(clientRepresentation -> {
+
+            clientRepresentation.setFullScopeAllowed(false);
+
+        });
+
         testRealms.add(realm);
 
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ClientTokenExchangeTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ClientTokenExchangeTest.java
@@ -301,7 +301,7 @@ public class ClientTokenExchangeTest extends AbstractKeycloakTest {
             TokenVerifier<AccessToken> verifier = TokenVerifier.create(exchangedTokenString, AccessToken.class);
             AccessToken exchangedToken = verifier.parse().getToken();
             Assert.assertEquals("client-exchanger", exchangedToken.getIssuedFor());
-            Assert.assertEquals("client-exchanger", exchangedToken.getAudience()[0]);
+            Assert.assertNull(exchangedToken.getAudience());
             Assert.assertEquals(exchangedToken.getPreferredUsername(), "impersonated-user");
             Assert.assertNull(exchangedToken.getRealmAccess());
         }
@@ -409,7 +409,7 @@ public class ClientTokenExchangeTest extends AbstractKeycloakTest {
             TokenVerifier<AccessToken> verifier = TokenVerifier.create(exchangedTokenString, AccessToken.class);
             AccessToken exchangedToken = verifier.parse().getToken();
             Assert.assertEquals("direct-exchanger", exchangedToken.getIssuedFor());
-            Assert.assertEquals("direct-exchanger", exchangedToken.getAudience()[0]);
+            Assert.assertNull(exchangedToken.getAudience());
             Assert.assertEquals(exchangedToken.getPreferredUsername(), "impersonated-user");
             Assert.assertNull(exchangedToken.getRealmAccess());
         }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/RefreshTokenTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/RefreshTokenTest.java
@@ -179,6 +179,10 @@ public class RefreshTokenTest extends AbstractKeycloakTest {
         Assert.assertThat(refreshedToken.getExpiration() - token.getExpiration(), allOf(greaterThanOrEqualTo(1), lessThanOrEqualTo(10)));
         Assert.assertThat(refreshedRefreshToken.getExpiration() - refreshToken.getExpiration(), allOf(greaterThanOrEqualTo(1), lessThanOrEqualTo(10)));
 
+        // "test-app" should not be an audience in the refresh token
+        assertEquals("test-app", refreshedRefreshToken.getIssuedFor());
+        Assert.assertFalse(refreshedRefreshToken.hasAudience("test-app"));
+
         Assert.assertNotEquals(token.getId(), refreshedToken.getId());
         Assert.assertNotEquals(refreshToken.getId(), refreshedRefreshToken.getId());
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/AudienceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/AudienceTest.java
@@ -19,6 +19,7 @@ package org.keycloak.testsuite.oidc;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 
 import javax.ws.rs.core.Response;
 
@@ -136,8 +137,8 @@ public class AudienceTest extends AbstractOIDCScopeTest {
                 .user(userId)
                 .assertEvent();
         Tokens tokens = sendTokenRequest(loginEvent, userId,"openid profile email audience-scope", "test-app");
-        // TODO: Frontend client itself should not be in the audiences of access token. Will be fixed in the future
-        assertAudiences(tokens.accessToken, "test-app", "service-client");
+
+        assertAudiences(tokens.accessToken, "service-client");
         assertAudiences(tokens.idToken, "test-app");
 
         // Revert
@@ -168,8 +169,8 @@ public class AudienceTest extends AbstractOIDCScopeTest {
                 .user(userId)
                 .assertEvent();
         Tokens tokens = sendTokenRequest(loginEvent, userId,"openid profile email audience-scope", "test-app");
-        // TODO: Frontend client itself should not be in the audiences of access token. Will be fixed in the future
-        assertAudiences(tokens.accessToken, "test-app", "http://host/service/ctx1", "http://host/service/ctx2");
+
+        assertAudiences(tokens.accessToken, "http://host/service/ctx1", "http://host/service/ctx2");
         assertAudiences(tokens.idToken, "test-app", "http://host/service/ctx2");
 
         // Revert
@@ -192,7 +193,7 @@ public class AudienceTest extends AbstractOIDCScopeTest {
                 .user(userId)
                 .assertEvent();
         Tokens tokens = sendTokenRequest(loginEvent, userId,"openid profile email", "test-app");
-        assertAudiences(tokens.accessToken, "test-app");
+        assertAudiences(tokens.accessToken);
         assertAudiences(tokens.idToken, "test-app");
         Assert.assertFalse(tokens.accessToken.getResourceAccess().containsKey("service-client"));
 
@@ -215,7 +216,7 @@ public class AudienceTest extends AbstractOIDCScopeTest {
                 .user(userId)
                 .assertEvent();
         tokens = sendTokenRequest(loginEvent, userId,"openid profile email service-client", "test-app");
-        assertAudiences(tokens.accessToken, "test-app", "service-client");
+        assertAudiences(tokens.accessToken, "service-client");
         assertAudiences(tokens.idToken, "test-app");
         Assert.assertTrue(tokens.accessToken.getResourceAccess().containsKey("service-client"));
         Assert.assertNames(tokens.accessToken.getResourceAccess().get("service-client").getRoles(), "role1");
@@ -228,7 +229,7 @@ public class AudienceTest extends AbstractOIDCScopeTest {
 
 
     private void assertAudiences(JsonWebToken token, String... expectedAudience) {
-        Collection<String> audiences = Arrays.asList(token.getAudience());
+        Collection<String> audiences = token.getAudience() == null ? Collections.emptyList() : Arrays.asList(token.getAudience());
         Collection<String> expectedAudiences = Arrays.asList(expectedAudience);
         Assert.assertTrue("Not matched. expectedAudiences: " + expectedAudiences + ", audiences: " + audiences,
                 expectedAudiences.containsAll(audiences) && audiences.containsAll(expectedAudiences));


### PR DESCRIPTION
This PR:

- Always remove application from the "aud" of refreshToken. In the refreshToken, the "aud" is realmUrl now (same like for example clientRegistration initial access tokens etc)

- In case of accessToken, aud is added just in case that is is included by AudienceResolveProtocolMapper. Which happens if application itself has clientRoles and target user is member of some of the roles.

I did not change the audience related behaviour for any authorization tokens/responses (AuthorizationTokenService.createAuthorizationResponse , AbstractPermissionsService.createPermissionTicket, PolicyEvaluationService). I don't know all the possible side-effects of this. @pedroigor WDYT? Can be the app itself removed from the "aud" in those tokens? If yes, would you prefer to do it as part of this or rather the separate follow-up PR?

I did not change anything with regards to "azp" for now. See my comment: https://issues.jboss.org/browse/KEYCLOAK-8482?focusedCommentId=13650730&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-13650730