### PR TITLE
[KEYCLOAK-8452] Return the definition of the 'keycloak' cache-container

### DIFF
--- a/distribution/server-overlay/src/main/cli/keycloak-install-base.cli
+++ b/distribution/server-overlay/src/main/cli/keycloak-install-base.cli
@@ -1,5 +1,6 @@
 embed-server --server-config=standalone.xml
 /subsystem=datasources/data-source=KeycloakDS/:add(connection-url="jdbc:h2:${jboss.server.data.dir}/keycloak;AUTO_SERVER=TRUE",enabled=true,driver-name=h2,jndi-name=java:jboss/datasources/KeycloakDS,password=sa,user-name=sa,use-java-context=true)
+/subsystem=infinispan/cache-container=keycloak:add()
 /subsystem=infinispan/cache-container=keycloak/local-cache=realms:add()
 /subsystem=infinispan/cache-container=keycloak/local-cache=realms/memory=object:add(size=10000)
 /subsystem=infinispan/cache-container=keycloak/local-cache=users:add()

--- a/distribution/server-overlay/src/main/cli/keycloak-install-ha-base.cli
+++ b/distribution/server-overlay/src/main/cli/keycloak-install-ha-base.cli
@@ -1,5 +1,6 @@
 embed-server --server-config=standalone-ha.xml
 /subsystem=datasources/data-source=KeycloakDS/:add(connection-url="jdbc:h2:${jboss.server.data.dir}/keycloak;AUTO_SERVER=TRUE",enabled=true,driver-name=h2,jndi-name=java:jboss/datasources/KeycloakDS,password=sa,user-name=sa,use-java-context=true)
+/subsystem=infinispan/cache-container=keycloak:add()
 /subsystem=infinispan/cache-container=keycloak/transport=TRANSPORT:add(lock-timeout=60000)
 /subsystem=infinispan/cache-container=keycloak/local-cache=realms:add()
 /subsystem=infinispan/cache-container=keycloak/local-cache=realms/memory=object:add(size=10000)


### PR DESCRIPTION
into the `infinispan` subsystem for the Keycloak server overlay scripts

Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

Fixes: https://issues.jboss.org/browse/KEYCLOAK-8452