### PR TITLE
fix: html tag should have a lang attribute

### DIFF
--- a/themes/src/main/resources/theme/base/admin/index.ftl
+++ b/themes/src/main/resources/theme/base/admin/index.ftl
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title></title>
 


### PR DESCRIPTION
All HTML pages should have a global lang attribute (on the html tag for example). This value is used by screen readers (JAWs, VoiceOver, ... ) in order to get the right voice with the right accent. 
This is something we check when doing A11Y (accessibility) audits. 