### PR TITLE
KEYCLOAK-8673 Disable maven-plugin-plugin helpmojo

### DIFF
--- a/distribution/maven-plugins/pom.xml
+++ b/distribution/maven-plugins/pom.xml
@@ -90,12 +90,6 @@
                                 <goal>descriptor</goal>
                             </goals>
                         </execution>
-                        <execution>
-                            <id>generate-help</id>
-                            <goals>
-                                <goal>helpmojo</goal>
-                            </goals>
-                        </execution>
                     </executions>
                 </plugin>
             </plugins>


### PR DESCRIPTION
It's suddenly started breaking the build, not obvious why. Disabling it is the
easiest solution. It's not required for these plugins that are only needed to
serve the keycloak build itself.