### PR TITLE
KEYCLOAK-8702:Fix Offline Sessions requires column

### DIFF
--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-3.2.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-3.2.0.xml
@@ -53,6 +53,9 @@
             <not>
                 <changeSetExecuted id="3.2.0-fixed" author="keycloak" changeLogFile="META-INF/jpa-changelog-3.2.0.xml"/>
             </not>
+            <not>
+                <changeSetExecuted id="3.2.0" author="keycloak" changeLogFile="META-INF/jpa-changelog-3.2.0.xml"/>
+            </not>
         </preConditions>
         
         <customChange class="org.keycloak.connections.jpa.updater.liquibase.custom.RemoveDuplicateOfflineSessions" />


### PR DESCRIPTION
Prevent RemoveDuplicateOfflineSessions from running when database has already dropped CLIENT_SESSION_ID from  OFFLINE_CLIENT_SESSION table. This change unblocks migrating from 3.2.0 to 4.4.0 and later.