### PR TITLE
KEYCLOAK-8783 only checked admin roles when roles are specified in imported realm

### DIFF
--- a/services/src/main/java/org/keycloak/services/managers/RealmManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/RealmManager.java
@@ -531,9 +531,11 @@ public class RealmManager {
             setupMasterAdminManagement(realm);
         }
 
-        // Assert all admin roles are available once import took place. This is needed due to import from previous version where JSON file may not contain all admin roles
-        checkMasterAdminManagementRoles(realm);
-        checkRealmAdminManagementRoles(realm);
+        if (rep.getRoles() != null) {
+        	// Assert all admin roles are available once import took place. This is needed due to import from previous version where JSON file may not contain all admin roles
+        	checkMasterAdminManagementRoles(realm);
+        	checkRealmAdminManagementRoles(realm);
+        }
 
         // Could happen when migrating from older version and I have exported JSON file, which contains "realm-management" client but not "impersonation" client
         // I need to postpone impersonation because it needs "realm-management" client and its roles set

--- a/services/src/main/java/org/keycloak/services/managers/RealmManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/RealmManager.java
@@ -531,7 +531,7 @@ public class RealmManager {
             setupMasterAdminManagement(realm);
         }
 
-        if (rep.getRoles() != null) {
+        if (rep.getRoles() != null || hasRealmAdminManagementClient(rep)) {
         	// Assert all admin roles are available once import took place. This is needed due to import from previous version where JSON file may not contain all admin roles
         	checkMasterAdminManagementRoles(realm);
         	checkRealmAdminManagementRoles(realm);


### PR DESCRIPTION
only checked master and realm admin roles when roles are specified in imported realm to speed up realm creation