### PR TITLE
KEYCLOAK-8830 Stabilize ExportImportTest

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/model/ClientModelTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/model/ClientModelTest.java
@@ -68,6 +68,11 @@ public class ClientModelTest extends AbstractKeycloakTest {
     }
 
     @Override
+    protected boolean isImportAfterEachMethod() {
+        return true;
+    }
+
+    @Override
     public void addTestRealms(List<RealmRepresentation> testRealms) {
         RealmRepresentation realm = new RealmRepresentation();
         realm.setRealm(realmName);
@@ -301,6 +306,7 @@ public class ClientModelTest extends AbstractKeycloakTest {
 
             currentSession.realms().removeClient(client.getId(), realm);
             currentSession.realms().removeClient(copyClient.getId(), realm);
+            currentSession.realms().removeRealm(realm.getId());
         });
     }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/KEYCLOAK-8830

The explanation of the implementation has been added to the ticket. See [this comment](https://issues.jboss.org/browse/KEYCLOAK-8830).

Making the long story short, the `ClientModelTest` was causing multiple failures, because it didn't clean up properly. Since we don't restart AuthServer between the tests, this got exported. And, so the `copy` realm (created by the `ClientModelTests#json`) wasn't properly formed, it failed in various of places during export or import.