### PR TITLE
KEYCLOAK-8817 skip EntitlementAPITest.testOfflineRequestingPartyToken…

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/EntitlementAPITest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/EntitlementAPITest.java
@@ -77,6 +77,7 @@ import org.keycloak.representations.idm.authorization.ResourceRepresentation;
 import org.keycloak.representations.idm.authorization.ScopePermissionRepresentation;
 import org.keycloak.representations.idm.authorization.UserPolicyRepresentation;
 import org.keycloak.testsuite.util.ClientBuilder;
+import org.keycloak.testsuite.util.ContainerAssume;
 import org.keycloak.testsuite.util.OAuthClient;
 import org.keycloak.testsuite.util.RealmBuilder;
 import org.keycloak.testsuite.util.RoleBuilder;
@@ -1169,6 +1170,8 @@ public class EntitlementAPITest extends AbstractAuthzTest {
 
     @Test
     public void testOfflineRequestingPartyToken() throws Exception {
+        ContainerAssume.assumeNotAuthServerUndertow();
+
         ClientResource client = getClient(getRealm(), RESOURCE_SERVER_TEST);
         AuthorizationResource authorization = client.authorization();
 


### PR DESCRIPTION
… for auth-server-undertow

The actual fix will be part of https://issues.jboss.org/browse/KEYCLOAK-7723