### PR TITLE
KEYCLOAK-7242: LDAPS not working with truststore SPI and connection timeout

### DIFF
--- a/services/src/main/java/org/keycloak/truststore/SSLSocketFactory.java
+++ b/services/src/main/java/org/keycloak/truststore/SSLSocketFactory.java
@@ -101,4 +101,10 @@ public class SSLSocketFactory extends javax.net.ssl.SSLSocketFactory {
     public Socket createSocket(InetAddress address, int port, InetAddress localAddress, int localPort) throws IOException {
         return sslsf.createSocket(address, port, localAddress, localPort);
     }
+
+    @Override
+    public Socket createSocket() throws IOException {
+        return sslsf.createSocket();
+    }
+
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/UserFederationLdapConnectionTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/UserFederationLdapConnectionTest.java
@@ -71,6 +71,9 @@ public class UserFederationLdapConnectionTest extends AbstractAdminTest {
 
         response = realm.testLDAPConnection(LDAPConnectionTestManager.TEST_AUTHENTICATION, "ldaps://localhost:10636", "uid=admin,ou=system", "secret", "true", null);
         assertStatus(response, 204);
+
+        response = realm.testLDAPConnection(LDAPConnectionTestManager.TEST_AUTHENTICATION, "ldaps://localhost:10636", "uid=admin,ou=system", "secret", "true", "10000");
+        assertStatus(response, 204);
     }
 
     private void assertStatus(Response response, int status) {


### PR DESCRIPTION
Fix for KEYCLOAK-7242. The root cause is that the `SSLSocketFactory` does not implement the `createSocket` method without arguments (called inside the [com.sun.jndi.ldap.Connection](https://github.com/bpupadhyaya/openjdk-8/blob/master/jdk/src/share/classes/com/sun/jndi/ldap/Connection.java#L303)).