### PR TITLE
KEYCLOAK-8813 Avoid Need for allow-bean-definition-overriding in boot 2.1

### DIFF
--- a/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/KeycloakConfiguration.java
+++ b/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/KeycloakConfiguration.java
@@ -3,10 +3,10 @@ package org.keycloak.adapters.springsecurity;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-
+import org.keycloak.adapters.springsecurity.management.HttpSessionManager;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
-
+import org.springframework.context.annotation.FilterType;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
@@ -19,7 +19,8 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Retention(value = RUNTIME)
 @Target(value = { TYPE })
 @Configuration
-@ComponentScan(basePackageClasses = KeycloakSecurityComponents.class)
+@ComponentScan(basePackageClasses = KeycloakSecurityComponents.class, excludeFilters={
+  @ComponentScan.Filter(type=FilterType.ASSIGNABLE_TYPE, value=HttpSessionManager.class)})
 @EnableWebSecurity
 public @interface KeycloakConfiguration {
 }

--- a/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/config/KeycloakWebSecurityConfigurerAdapter.java
+++ b/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/config/KeycloakWebSecurityConfigurerAdapter.java
@@ -99,6 +99,7 @@ public abstract class KeycloakWebSecurityConfigurerAdapter extends WebSecurityCo
     }
 
     @Bean
+    @ConditionalOnMissingBean(HttpSessionManager.class)
     protected HttpSessionManager httpSessionManager() {
         return new HttpSessionManager();
     }

--- a/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/config/KeycloakWebSecurityConfigurerAdapter.java
+++ b/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/config/KeycloakWebSecurityConfigurerAdapter.java
@@ -99,7 +99,6 @@ public abstract class KeycloakWebSecurityConfigurerAdapter extends WebSecurityCo
     }
 
     @Bean
-    @ConditionalOnMissingBean(HttpSessionManager.class)
     protected HttpSessionManager httpSessionManager() {
         return new HttpSessionManager();
     }


### PR DESCRIPTION
Issue at https://issues.jboss.org/browse/KEYCLOAK-8813

Linked activiti issue https://github.com/Activiti/Activiti/issues/2201