### PR TITLE
Add Chinese translation for email verification page

### DIFF
--- a/themes/src/main/resources-community/theme/base/login/messages/messages_zh_CN.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_zh_CN.properties
@@ -123,6 +123,9 @@ invalidEmailMessage=无效的电子邮件地址
 accountDisabledMessage=账户被禁用，请联系管理员。
 accountTemporarilyDisabledMessage=账户被暂时禁用，请稍后再试或联系管理员。
 expiredCodeMessage=登录超时，请重新登陆。
+expiredActionMessage=操作已过期，请登陆
+expiredActionTokenNoSessionMessage=操作已过期
+expiredActionTokenSessionExistsMessage=操作已过期，请重试
 
 missingFirstNameMessage=请输入名
 missingLastNameMessage=请输入姓
@@ -150,6 +153,7 @@ confirmLinkIdpContinue=添加到已知账户
 configureTotpMessage=您需要设置验证码模块来激活您的账户
 updateProfileMessage=您需要更新您的简介来激活您的账户
 updatePasswordMessage=您需要更新您的密码来激活您的账户
+resetPasswordMessage=请更改密码
 verifyEmailMessage=您需要验证您的电子邮箱来激活您的账户
 linkIdpMessage=您需要验证您的电子邮箱来连接到账户{0}.
 
@@ -208,6 +212,7 @@ realmSupportsNoCredentialsMessage=域不支持特定类型密码
 identityProviderNotUniqueMessage=域支持通过多个身份提供者登录，不知道应用哪一种方式登录
 emailVerifiedMessage=您的电子邮箱已经验证。
 staleEmailVerificationLink=您点击的链接已无效。可能您已经验证过您的电子邮箱?
+confirmExecutionOfActions=请执行以下操作
 
 locale_ca=Català
 locale_de=Deutsch
@@ -230,5 +235,11 @@ clientNotFoundMessage=客户端未找到
 clientDisabledMessage=客户端已禁用
 invalidParameterMessage=无效的参数 \: {0}
 alreadyLoggedIn=您已经登录
+
+requiredAction.terms_and_conditions=一般条款
+requiredAction.UPDATE_PASSWORD=更新密码
+requiredAction.UPDATE_PROFILE=更新您的信息
+requiredAction.VERIFY_EMAIL=验证邮件
+proceedWithAction=&raquo; 请点击这里以继续
 
 p3pPolicy="This is not a P3P policy!"


### PR DESCRIPTION
These translations were provided by our customer and are approved for publishing.

This change includes the following constants:

```
expiredActionMessage=Action expired. Please continue with login now.
expiredActionTokenNoSessionMessage=Action expired.
expiredActionTokenSessionExistsMessage=Action expired. Please start again.
resetPasswordMessage=You need to change your password.
confirmExecutionOfActions=Perform the following action(s)
requiredAction.terms_and_conditions=Terms and Conditions
requiredAction.UPDATE_PASSWORD=Update Password
requiredAction.UPDATE_PROFILE=Update Profile
requiredAction.VERIFY_EMAIL=Verify Email
proceedWithAction=Click here to proceed
```
The most important change is that during email verification process a localized Chinese screen is shown to the user instead of using the English fallback:

![image](https://user-images.githubusercontent.com/1732128/49457892-00a5ab80-f7ec-11e8-9886-daee4dfdedec.png)

There still is a noticeable disparity between the core English and community translations, e.g. CN (red) vs EN (green):

```diff
diff --git a/cn.keys b/en.keys
index a0e4a28..a682a76 100644
--- a/cn.keys
+++ b/en.keys
@@ -5,6 +5,7 @@ doSubmit
 doYes
 doNo
 doContinue
+doIgnore
 doAccept
 doDecline
 doForgotPassword
@@ -14,8 +15,7 @@ kerberosNotConfigured
 kerberosNotConfiguredTitle
 bypassKerberosDetail
 kerberosNotSetUp
-registerWithTitle
-registerWithTitleHtml
+registerTitle
 loginTitle
 loginTitleHtml
 impersonateTitle
@@ -34,9 +34,14 @@ emailForgotTitle
 updatePasswordTitle
 codeSuccessTitle
 codeErrorTitle
+displayUnsupported
+browserRequired
+browserContinue
+browserContinuePrompt
+browserContinueAnswer
 termsTitle
-termsTitleHtml
 termsText
+termsPlainText
 recaptchaFailed
 recaptchaNotConfigured
 consentDenied
@@ -63,10 +68,29 @@ postal_code
 country
 emailVerified
 gssDelegationCredential
+profileScopeConsentText
+emailScopeConsentText
+addressScopeConsentText
+phoneScopeConsentText
+offlineAccessScopeConsentText
+samlRoleListScopeConsentText
+rolesScopeConsentText
+loginTotpIntro
 loginTotpStep1
 loginTotpStep2
 loginTotpStep3
+loginTotpManualStep2
+loginTotpManualStep3
+loginTotpUnableToScan
+loginTotpScanBarcode
 loginTotpOneTime
+loginTotpType
+loginTotpAlgorithm
+loginTotpDigits
+loginTotpInterval
+loginTotpCounter
+loginTotp.totp
+loginTotp.hotp
 oauthGrantRequest
 inResource
 emailVerifyInstruction1
@@ -76,9 +100,14 @@ emailLinkIdpTitle
 emailLinkIdp1
 emailLinkIdp2
 emailLinkIdp3
+emailLinkIdp4
+emailLinkIdp5
 backToLogin
 emailInstruction
 copyCodeInstruction
+pageExpiredTitle
+pageExpiredMsg1
+pageExpiredMsg2
 personalInfo
 role_admin
 role_realm-admin
@@ -98,6 +127,7 @@ role_manage-clients
 role_manage-events
 role_view-profile
 role_manage-account
+role_manage-account-links
 role_read-token
 role_offline-access
 client_account
@@ -110,6 +140,9 @@ invalidEmailMessage
 accountDisabledMessage
 accountTemporarilyDisabledMessage
 expiredCodeMessage
+expiredActionMessage
+expiredActionTokenNoSessionMessage
+expiredActionTokenSessionExistsMessage
 missingFirstNameMessage
 missingLastNameMessage
 missingEmailMessage
@@ -118,6 +151,7 @@ missingPasswordMessage
 missingTotpMessage
 notMatchPasswordMessage
 invalidPasswordExistingMessage
+invalidPasswordBlacklistedMessage
 invalidPasswordConfirmMessage
 invalidTotpMessage
 usernameExistsMessage
@@ -131,12 +165,17 @@ confirmLinkIdpContinue
 configureTotpMessage
 updateProfileMessage
 updatePasswordMessage
+resetPasswordMessage
 verifyEmailMessage
 linkIdpMessage
 emailSentMessage
 emailSendErrorMessage
 accountUpdatedMessage
 accountPasswordUpdatedMessage
+delegationCompleteHeader
+delegationCompleteMessage
+delegationFailedHeader
+delegationFailedMessage
 noAccessMessage
 invalidPasswordMinLengthMessage
 invalidPasswordMinDigitsMessage
@@ -146,6 +185,7 @@ invalidPasswordMinSpecialCharsMessage
 invalidPasswordNotUsernameMessage
 invalidPasswordRegexPatternMessage
 invalidPasswordHistoryMessage
+invalidPasswordGenericMessage
 failedToProcessResponseMessage
 httpsRequiredMessage
 realmNotEnabledMessage
@@ -183,6 +223,10 @@ realmSupportsNoCredentialsMessage
 identityProviderNotUniqueMessage
 emailVerifiedMessage
 staleEmailVerificationLink
+identityProviderAlreadyLinkedMessage
+confirmAccountLinking
+confirmEmailAddressVerification
+confirmExecutionOfActions
 locale_ca
 locale_de
 locale_en
@@ -192,15 +236,41 @@ locale_it
 locale_ja
 locale_nl
 locale_no
+locale_pl
 locale_pt_BR
 locale_pt-BR
 locale_ru
 locale_lt
 locale_zh-CN
+locale_sk
+locale_sv
 backToApplication
 missingParameterMessage
 clientNotFoundMessage
 clientDisabledMessage
 invalidParameterMessage
 alreadyLoggedIn
+differentUserAuthenticated
+brokerLinkingSessionExpired
+proceedWithAction
+requiredAction.CONFIGURE_TOTP
+requiredAction.terms_and_conditions
+requiredAction.UPDATE_PASSWORD
+requiredAction.UPDATE_PROFILE
+requiredAction.VERIFY_EMAIL
 p3pPolicy
+doX509Login
+clientCertificate
+noCertificate
+pageNotFound
+internalServerError
+console-username
+console-password
+console-otp
+console-new-password
+console-confirm-password
+console-update-password
+console-verify-email
+console-email-code
+console-accept-terms
+console-accept
```

The diff was created with:

```bash
egrep -v "^\s*($|#)" messages_en.properties | awk -F'=' '{print $1}' > en.keys
egrep -v "^\s*($|#)" messages_zh_CN.properties | awk -F'=' '{print $1}' > cn.keys
git diff --no-index cn.keys en.keys >> cn-to-en.diff
```