### PR TITLE
KEYCLOAK-7936 Prevent registration of the same node

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/ClientsManagementService.java
+++ b/services/src/main/java/org/keycloak/services/resources/ClientsManagementService.java
@@ -120,7 +120,12 @@ public class ClientsManagementService {
         event.client(client).detail(Details.NODE_HOST, nodeHost);
         logger.debugf("Registering cluster host '%s' for client '%s'", nodeHost, client.getClientId());
 
-        client.registerNode(nodeHost, Time.currentTime());
+        try {
+            client.registerNode(nodeHost, Time.currentTime());
+        } catch (RuntimeException e) {
+            event.error(e.getMessage());
+            throw e;
+        }
 
         event.success();
 


### PR DESCRIPTION
The root cause is that NodesRegistrationManagement.tryRegister can be
called from multiple threads on the same node, so it can require
registration of the same node multiple times. Hence once it turns to
tasks that invoke sendRegistrationEvent (called sequentially), the same
check has been added to that method to prevent multiple invocations on
server side, or invocation upon undeployment/termination.