### PR TITLE
KEYCLOAK-9019: Signature provider should use the provided RealmModel

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/crypto/SignatureProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/crypto/SignatureProvider.java
@@ -17,13 +17,14 @@
 package org.keycloak.crypto;
 
 import org.keycloak.common.VerificationException;
+import org.keycloak.models.RealmModel;
 import org.keycloak.provider.Provider;
 
 public interface SignatureProvider extends Provider {
 
-    SignatureSignerContext signer() throws SignatureException;
+    SignatureSignerContext signer(RealmModel realm) throws SignatureException;
 
-    SignatureVerifierContext verifier(String kid) throws VerificationException;
+    SignatureVerifierContext verifier(RealmModel realm, String kid) throws VerificationException;
 
     @Override
     default void close() {

--- a/services/src/main/java/org/keycloak/crypto/AsymmetricSignatureProvider.java
+++ b/services/src/main/java/org/keycloak/crypto/AsymmetricSignatureProvider.java
@@ -18,6 +18,7 @@ package org.keycloak.crypto;
 
 import org.keycloak.common.VerificationException;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
 
 public class AsymmetricSignatureProvider implements SignatureProvider {
 
@@ -30,13 +31,13 @@ public class AsymmetricSignatureProvider implements SignatureProvider {
     }
 
     @Override
-    public SignatureSignerContext signer() throws SignatureException {
-        return new ServerAsymmetricSignatureSignerContext(session, algorithm);
+    public SignatureSignerContext signer(RealmModel realm) throws SignatureException {
+        return new ServerAsymmetricSignatureSignerContext(session, realm, algorithm);
     }
 
     @Override
-    public SignatureVerifierContext verifier(String kid) throws VerificationException {
-        return new ServerAsymmetricSignatureVerifierContext(session, kid, algorithm);
+    public SignatureVerifierContext verifier(RealmModel realm, String kid) throws VerificationException {
+        return new ServerAsymmetricSignatureVerifierContext(session, realm, kid, algorithm);
     }
 
 }

--- a/services/src/main/java/org/keycloak/crypto/MacSecretSignatureProvider.java
+++ b/services/src/main/java/org/keycloak/crypto/MacSecretSignatureProvider.java
@@ -18,6 +18,7 @@ package org.keycloak.crypto;
 
 import org.keycloak.common.VerificationException;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
 
 public class MacSecretSignatureProvider implements SignatureProvider {
 
@@ -30,12 +31,12 @@ public class MacSecretSignatureProvider implements SignatureProvider {
     }
 
     @Override
-    public SignatureSignerContext signer() throws SignatureException {
+    public SignatureSignerContext signer(RealmModel realm) throws SignatureException {
         return new ServerMacSignatureSignerContext(session, algorithm);
     }
 
     @Override
-    public SignatureVerifierContext verifier(String kid) throws VerificationException {
+    public SignatureVerifierContext verifier(RealmModel realm, String kid) throws VerificationException {
         return new ServerMacSignatureVerifierContext(session, kid, algorithm);
     }
 

--- a/services/src/main/java/org/keycloak/crypto/ServerAsymmetricSignatureSignerContext.java
+++ b/services/src/main/java/org/keycloak/crypto/ServerAsymmetricSignatureSignerContext.java
@@ -17,15 +17,16 @@
 package org.keycloak.crypto;
 
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
 
 public class ServerAsymmetricSignatureSignerContext extends AsymmetricSignatureSignerContext {
 
-    public ServerAsymmetricSignatureSignerContext(KeycloakSession session, String algorithm) throws SignatureException {
-        super(getKey(session, algorithm));
+    public ServerAsymmetricSignatureSignerContext(KeycloakSession session, RealmModel realm, String algorithm) throws SignatureException {
+        super(getKey(session, realm, algorithm));
     }
 
-    private static KeyWrapper getKey(KeycloakSession session, String algorithm) {
-        KeyWrapper key = session.keys().getActiveKey(session.getContext().getRealm(), KeyUse.SIG, algorithm);
+    private static KeyWrapper getKey(KeycloakSession session, RealmModel realm, String algorithm) {
+        KeyWrapper key = session.keys().getActiveKey(realm, KeyUse.SIG, algorithm);
         if (key == null) {
             throw new SignatureException("Active key for " + algorithm + " not found");
         }

--- a/services/src/main/java/org/keycloak/crypto/ServerAsymmetricSignatureVerifierContext.java
+++ b/services/src/main/java/org/keycloak/crypto/ServerAsymmetricSignatureVerifierContext.java
@@ -18,15 +18,16 @@ package org.keycloak.crypto;
 
 import org.keycloak.common.VerificationException;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
 
 public class ServerAsymmetricSignatureVerifierContext extends AsymmetricSignatureVerifierContext {
 
-    public ServerAsymmetricSignatureVerifierContext(KeycloakSession session, String kid, String algorithm) throws VerificationException {
-        super(getKey(session, kid, algorithm));
+    public ServerAsymmetricSignatureVerifierContext(KeycloakSession session, RealmModel realm, String kid, String algorithm) throws VerificationException {
+        super(getKey(session, realm, kid, algorithm));
     }
 
-    private static KeyWrapper getKey(KeycloakSession session, String kid, String algorithm) throws VerificationException {
-        KeyWrapper key = session.keys().getKey(session.getContext().getRealm(), kid, KeyUse.SIG, algorithm);
+    private static KeyWrapper getKey(KeycloakSession session, RealmModel realm, String kid, String algorithm) throws VerificationException {
+        KeyWrapper key = session.keys().getKey(realm, kid, KeyUse.SIG, algorithm);
         if (key == null) {
             throw new VerificationException("Key not found");
         }

--- a/services/src/main/java/org/keycloak/jose/jws/DefaultTokenManager.java
+++ b/services/src/main/java/org/keycloak/jose/jws/DefaultTokenManager.java
@@ -47,7 +47,7 @@ public class DefaultTokenManager implements TokenManager {
         String signatureAlgorithm = signatureAlgorithm(token.getCategory());
 
         SignatureProvider signatureProvider = session.getProvider(SignatureProvider.class, signatureAlgorithm);
-        SignatureSignerContext signer = signatureProvider.signer();
+        SignatureSignerContext signer = signatureProvider.signer(session.getContext().getRealm());
 
         String encodedToken = new JWSBuilder().type("JWT").jsonContent(token).sign(signer);
         return encodedToken;
@@ -76,7 +76,7 @@ public class DefaultTokenManager implements TokenManager {
                 kid = session.keys().getActiveKey(session.getContext().getRealm(), KeyUse.SIG, signatureAlgorithm).getKid();
             }
 
-            boolean valid = signatureProvider.verifier(kid).verify(jws.getEncodedSignatureInput().getBytes("UTF-8"), jws.getSignature());
+            boolean valid = signatureProvider.verifier(session.getContext().getRealm(), kid).verify(jws.getEncodedSignatureInput().getBytes("UTF-8"), jws.getSignature());
             return valid ? jws.readJsonContent(clazz) : null;
         } catch (Exception e) {
             logger.debug("Failed to decode token", e);

--- a/services/src/main/java/org/keycloak/protocol/oidc/AccessTokenIntrospectionProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/AccessTokenIntrospectionProvider.java
@@ -76,7 +76,7 @@ public class AccessTokenIntrospectionProvider implements TokenIntrospectionProvi
             TokenVerifier<AccessToken> verifier = TokenVerifier.create(token, AccessToken.class)
                     .realmUrl(Urls.realmIssuer(session.getContext().getUri().getBaseUri(), realm.getName()));
 
-            SignatureVerifierContext verifierContext = session.getProvider(SignatureProvider.class, verifier.getHeader().getAlgorithm().name()).verifier(verifier.getHeader().getKeyId());
+            SignatureVerifierContext verifierContext = session.getProvider(SignatureProvider.class, verifier.getHeader().getAlgorithm().name()).verifier(realm, verifier.getHeader().getKeyId());
             verifier.verifierContext(verifierContext);
 
             accessToken = verifier.verify().getToken();

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/UserInfoEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/UserInfoEndpoint.java
@@ -135,7 +135,7 @@ public class UserInfoEndpoint {
             TokenVerifier<AccessToken> verifier = TokenVerifier.create(tokenString, AccessToken.class)
                     .realmUrl(Urls.realmIssuer(session.getContext().getUri().getBaseUri(), realm.getName()));
 
-            SignatureVerifierContext verifierContext = session.getProvider(SignatureProvider.class, verifier.getHeader().getAlgorithm().name()).verifier(verifier.getHeader().getKeyId());
+            SignatureVerifierContext verifierContext = session.getProvider(SignatureProvider.class, verifier.getHeader().getAlgorithm().name()).verifier(realm, verifier.getHeader().getKeyId());
             verifier.verifierContext(verifierContext);
 
             token = verifier.verify().getToken();
@@ -209,7 +209,7 @@ public class UserInfoEndpoint {
             String signatureAlgorithm = session.tokens().signatureAlgorithm(TokenCategory.USERINFO);
 
             SignatureProvider signatureProvider = session.getProvider(SignatureProvider.class, signatureAlgorithm);
-            SignatureSignerContext signer = signatureProvider.signer();
+            SignatureSignerContext signer = signatureProvider.signer(realm);
 
             String signedUserInfo = new JWSBuilder().type("JWT").jsonContent(claims).sign(signer);
 

--- a/services/src/main/java/org/keycloak/protocol/openshift/OpenShiftTokenReviewEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/openshift/OpenShiftTokenReviewEndpoint.java
@@ -95,7 +95,7 @@ public class OpenShiftTokenReviewEndpoint implements OIDCExtProvider, Environmen
             TokenVerifier<AccessToken> verifier = TokenVerifier.create(reviewRequest.getSpec().getToken(), AccessToken.class)
                     .realmUrl(Urls.realmIssuer(session.getContext().getUri().getBaseUri(), realm.getName()));
 
-            SignatureVerifierContext verifierContext = session.getProvider(SignatureProvider.class, verifier.getHeader().getAlgorithm().name()).verifier(verifier.getHeader().getKeyId());
+            SignatureVerifierContext verifierContext = session.getProvider(SignatureProvider.class, verifier.getHeader().getAlgorithm().name()).verifier(realm, verifier.getHeader().getKeyId());
             verifier.verifierContext(verifierContext);
 
             verifier.verify();

--- a/services/src/main/java/org/keycloak/services/clientregistration/ClientRegistrationTokenUtils.java
+++ b/services/src/main/java/org/keycloak/services/clientregistration/ClientRegistrationTokenUtils.java
@@ -46,7 +46,7 @@ public class ClientRegistrationTokenUtils {
 
     public static String updateTokenSignature(KeycloakSession session, ClientRegistrationAuth auth) {
         String algorithm = session.tokens().signatureAlgorithm(TokenCategory.INTERNAL);
-        SignatureSignerContext signer = session.getProvider(SignatureProvider.class, algorithm).signer();
+        SignatureSignerContext signer = session.getProvider(SignatureProvider.class, algorithm).signer(session.getContext().getRealm());
 
         if (signer.getKid().equals(auth.getKid())) {
             return auth.getToken();
@@ -96,7 +96,7 @@ public class ClientRegistrationTokenUtils {
             TokenVerifier<JsonWebToken> verifier = TokenVerifier.create(token, JsonWebToken.class)
                     .withChecks(new TokenVerifier.RealmUrlCheck(getIssuer(session, realm)), TokenVerifier.IS_ACTIVE);
 
-            SignatureVerifierContext verifierContext = session.getProvider(SignatureProvider.class, verifier.getHeader().getAlgorithm().name()).verifier(verifier.getHeader().getKeyId());
+            SignatureVerifierContext verifierContext = session.getProvider(SignatureProvider.class, verifier.getHeader().getAlgorithm().name()).verifier(realm, verifier.getHeader().getKeyId());
             verifier.verifierContext(verifierContext);
 
             kid = verifierContext.getKid();

--- a/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
@@ -175,7 +175,7 @@ public class AuthenticationManager {
             String kid = verifier.getHeader().getKeyId();
             String algorithm = verifier.getHeader().getAlgorithm().name();
 
-            SignatureVerifierContext signatureVerifier = session.getProvider(SignatureProvider.class, algorithm).verifier(kid);
+            SignatureVerifierContext signatureVerifier = session.getProvider(SignatureProvider.class, algorithm).verifier(realm, kid);
             verifier.verifierContext(signatureVerifier);
 
             AccessToken token = verifier.verify().getToken();
@@ -1150,7 +1150,7 @@ public class AuthenticationManager {
             String kid = verifier.getHeader().getKeyId();
             String algorithm = verifier.getHeader().getAlgorithm().name();
 
-            SignatureVerifierContext signatureVerifier = session.getProvider(SignatureProvider.class, algorithm).verifier(kid);
+            SignatureVerifierContext signatureVerifier = session.getProvider(SignatureProvider.class, algorithm).verifier(realm, kid);
             verifier.verifierContext(signatureVerifier);
 
             AccessToken token = verifier.verify().getToken();

--- a/services/src/main/java/org/keycloak/services/resources/LoginActionsService.java
+++ b/services/src/main/java/org/keycloak/services/resources/LoginActionsService.java
@@ -490,7 +490,7 @@ public class LoginActionsService {
             String kid = verifier.getHeader().getKeyId();
             String algorithm = verifier.getHeader().getAlgorithm().name();
 
-            SignatureVerifierContext signatureVerifier = session.getProvider(SignatureProvider.class, algorithm).verifier(kid);
+            SignatureVerifierContext signatureVerifier = session.getProvider(SignatureProvider.class, algorithm).verifier(realm, kid);
             verifier.verifierContext(signatureVerifier);
 
             verifier.verify();


### PR DESCRIPTION
We pass the RealmModel into the methods calling the SignatureProvider, but then we forgot that we did that and use the model in KeycloakSession Context.

This PR fixes that.