### PR TITLE
KEYCLOAK-9039: Update the locale cookie from ui_locales

### DIFF
--- a/services/src/main/java/org/keycloak/locale/DefaultLocaleSelectorProvider.java
+++ b/services/src/main/java/org/keycloak/locale/DefaultLocaleSelectorProvider.java
@@ -85,6 +85,7 @@ public class DefaultLocaleSelectorProvider implements LocaleSelectorProvider {
 
         final LocaleSelection uiLocalesQueryParamSelection = getUiLocalesQueryParamSelection(realm, uriInfo);
         if (uiLocalesQueryParamSelection != null) {
+            updateLocaleCookie(realm, uiLocalesQueryParamSelection.getLocaleString(), uriInfo);
             return uiLocalesQueryParamSelection.getLocale();
         }
 


### PR DESCRIPTION
Update the locale cookie when a locale is selected based upon the ui_locales query parameter.
Issue: https://issues.jboss.org/browse/KEYCLOAK-9039