### PR TITLE
KEYCLOAK-9068: IDP-initiated-flow is not working with REDIRECT binding

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/IdentityBrokerService.java
+++ b/services/src/main/java/org/keycloak/services/resources/IdentityBrokerService.java
@@ -1052,6 +1052,10 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
         SamlService samlService = (SamlService) factory.createProtocolEndpoint(realmModel, event);
         ResteasyProviderFactory.getInstance().injectProperties(samlService);
         AuthenticationSessionModel authSession = samlService.getOrCreateLoginSessionForIdpInitiatedSso(session, realmModel, oClient.get(), null);
+        if (authSession == null) {
+            event.error(Errors.INVALID_REDIRECT_URI);
+            return ParsedCodeContext.response(redirectToErrorPage(Response.Status.BAD_REQUEST, Messages.INVALID_REDIRECT_URI));
+        }
 
         return ParsedCodeContext.clientSessionCode(new ClientSessionCode<>(session, this.realmModel, authSession));
     }

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/updaters/ClientAttributeUpdater.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/updaters/ClientAttributeUpdater.java
@@ -102,4 +102,8 @@ public class ClientAttributeUpdater extends ServerResourceUpdater<ClientAttribut
         return new RoleScopeUpdater(resource.getScopeMappings().clientLevel(clientUUID));
     }
 
+    public ClientAttributeUpdater setAdminUrl(String adminUrl) {
+        rep.setAdminUrl(adminUrl);
+        return this;
+    }
 }


### PR DESCRIPTION
Patch for KEYCLOAK-9068.

The SAML binding-type is POST if `Assertion Consumer Service Redirect Binding URL` or general `Master SAML Processing URL` is configured. It is only REDIRECT is `Assertion Consumer Service Redirect Binding URL` is configured and the other two are not set (empty).

Previously it was half done and it always defaulted to POST no matter the configuration.