### PR TITLE
[KEYCLOAK-9080] Keycloak dosen't work with Spring Boot 2.1.X and Jetty Embedded Server

### DIFF
--- a/adapters/oidc/spring-boot-container-bundle/pom.xml
+++ b/adapters/oidc/spring-boot-container-bundle/pom.xml
@@ -44,6 +44,7 @@
                                     <include>org.keycloak:keycloak-tomcat8-adapter</include>
                                     <include>org.keycloak:keycloak-undertow-adapter</include>
                                     <include>org.keycloak:keycloak-jetty93-adapter</include>
+                                    <include>org.keycloak:keycloak-jetty94-adapter</include>
                                     <include>org.keycloak:keycloak-tomcat-core-adapter</include>
                                     <include>org.keycloak:keycloak-tomcat-adapter-spi</include>
                                     <include>org.keycloak:keycloak-undertow-adapter</include>

--- a/adapters/oidc/spring-boot-container-bundle/pom.xml
+++ b/adapters/oidc/spring-boot-container-bundle/pom.xml
@@ -25,6 +25,11 @@
             <artifactId>keycloak-jetty93-adapter</artifactId>
             <scope>compile</scope>
         </dependency>
+         <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-jetty94-adapter</artifactId>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>


### PR DESCRIPTION
Add Jetty 9.4 Adapter inclusion for Spring Boot.
This solve issue with spring boot 2.X integration.