### PR TITLE
KEYCLOAK-9077 Adds support for SAML SessionNotOnOrAfter attribute in response xml serialization

### DIFF
--- a/saml-core/src/main/java/org/keycloak/saml/processing/core/parsers/saml/assertion/SAMLAssertionQNames.java
+++ b/saml-core/src/main/java/org/keycloak/saml/processing/core/parsers/saml/assertion/SAMLAssertionQNames.java
@@ -79,6 +79,7 @@ public enum SAMLAssertionQNames implements HasQName {
     ATTR_NOT_ON_OR_AFTER(null, "NotOnOrAfter"),
     ATTR_RECIPIENT(null, "Recipient"),
     ATTR_SESSION_INDEX(null, "SessionIndex"),
+    ATTR_SESSION_NOT_ON_OR_AFTER(null, "SessionNotOnOrAfter"),
     ATTR_SP_PROVIDED_ID(null, "SPProvidedID"),
     ATTR_SP_NAME_QUALIFIER(null, "SPNameQualifier"),
     ATTR_VERSION(null, "Version"),

--- a/saml-core/src/main/java/org/keycloak/saml/processing/core/parsers/saml/assertion/SAMLAuthnStatementParser.java
+++ b/saml-core/src/main/java/org/keycloak/saml/processing/core/parsers/saml/assertion/SAMLAuthnStatementParser.java
@@ -48,7 +48,7 @@ public class SAMLAuthnStatementParser extends AbstractStaxSamlAssertionParser<Au
         AuthnStatementType res = new AuthnStatementType(authnInstant);
 
         res.setSessionIndex(StaxParserUtil.getAttributeValue(element, SAMLAssertionQNames.ATTR_SESSION_INDEX));
-        res.setSessionNotOnOrAfter(StaxParserUtil.getXmlTimeAttributeValue(element, SAMLAssertionQNames.ATTR_NOT_ON_OR_AFTER));
+        res.setSessionNotOnOrAfter(StaxParserUtil.getXmlTimeAttributeValue(element, SAMLAssertionQNames.ATTR_SESSION_NOT_ON_OR_AFTER));
         return res;
     }
 

--- a/saml-core/src/main/java/org/keycloak/saml/processing/core/saml/v2/writers/SAMLAssertionWriter.java
+++ b/saml-core/src/main/java/org/keycloak/saml/processing/core/saml/v2/writers/SAMLAssertionWriter.java
@@ -38,6 +38,7 @@ import org.keycloak.dom.saml.v2.assertion.URIType;
 import org.keycloak.saml.common.constants.JBossSAMLConstants;
 import org.keycloak.saml.common.exceptions.ProcessingException;
 import org.keycloak.saml.common.util.StaxUtil;
+import org.keycloak.saml.processing.core.parsers.saml.assertion.SAMLAssertionQNames;
 import org.w3c.dom.Element;
 
 import javax.xml.datatype.XMLGregorianCalendar;
@@ -219,6 +220,11 @@ public class SAMLAssertionWriter extends BaseWriter {
 
         if (sessionIndex != null) {
             StaxUtil.writeAttribute(writer, JBossSAMLConstants.SESSION_INDEX.get(), sessionIndex);
+        }
+
+        XMLGregorianCalendar sessionNotOnOrAfter = authnStatement.getSessionNotOnOrAfter();
+        if (sessionNotOnOrAfter != null) {
+            StaxUtil.writeAttribute(writer, SAMLAssertionQNames.ATTR_SESSION_NOT_ON_OR_AFTER.getQName(), sessionNotOnOrAfter.toString());
         }
 
         AuthnContextType authnContext = authnStatement.getAuthnContext();

--- a/saml-core/src/test/java/org/keycloak/saml/processing/core/saml/v2/writers/SAMLAssertionWriterTest.java
+++ b/saml-core/src/test/java/org/keycloak/saml/processing/core/saml/v2/writers/SAMLAssertionWriterTest.java
@@ -1,0 +1,37 @@
+package org.keycloak.saml.processing.core.saml.v2.writers;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.keycloak.dom.saml.v2.assertion.AuthnStatementType;
+import org.keycloak.saml.common.constants.GeneralConstants;
+import org.keycloak.saml.common.exceptions.ProcessingException;
+import org.keycloak.saml.common.util.StaxUtil;
+import org.keycloak.saml.processing.core.saml.v2.util.XMLTimeUtil;
+
+import javax.xml.datatype.XMLGregorianCalendar;
+import java.io.ByteArrayOutputStream;
+
+public class SAMLAssertionWriterTest {
+    @Test
+    public void testAuthnStatementSessionNotOnOrAfterExists() throws ProcessingException {
+        long sessionLengthInSeconds = 3600;
+
+        XMLGregorianCalendar issueInstant = XMLTimeUtil.getIssueInstant();
+        XMLGregorianCalendar sessionExpirationDate = XMLTimeUtil.add(issueInstant, sessionLengthInSeconds);
+
+        AuthnStatementType authnStatementType = new AuthnStatementType(issueInstant);
+
+        authnStatementType.setSessionIndex("9b3cf799-225b-424a-8e5e-ee3c38e06ded::24b2f572-163c-43ad-8011-de6cd3803f76");
+        authnStatementType.setSessionNotOnOrAfter(sessionExpirationDate);
+
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        SAMLAssertionWriter samlAssertionWriter = new SAMLAssertionWriter(StaxUtil.getXMLStreamWriter(byteArrayOutputStream));
+
+        samlAssertionWriter.write(authnStatementType, true);
+
+        String serializedAssertion = new String(byteArrayOutputStream.toByteArray(), GeneralConstants.SAML_CHARSET);
+        String expectedXMLAttribute = "SessionNotOnOrAfter=\"" + sessionExpirationDate.toString() + "\"";
+
+        Assert.assertTrue(serializedAssertion.contains(expectedXMLAttribute));
+    }
+}

--- a/saml-core/src/test/resources/org/keycloak/saml/processing/core/parsers/saml/saml20-assertion-example.xml
+++ b/saml-core/src/test/resources/org/keycloak/saml/processing/core/parsers/saml/saml20-assertion-example.xml
@@ -70,7 +70,7 @@
         </saml:AudienceRestriction>
     </saml:Conditions>
 
-    <saml:AuthnStatement AuthnInstant="2009-06-17T18:45:10.738Z" NotOnOrAfter="2009-06-17T18:55:10.738Z">
+    <saml:AuthnStatement AuthnInstant="2009-06-17T18:45:10.738Z" SessionNotOnOrAfter="2009-06-17T18:55:10.738Z">
         <saml:AuthnContext>
             <saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:unspecified
             </saml:AuthnContextClassRef>


### PR DESCRIPTION
Loosely based on #3250

JIRA: https://issues.jboss.org/browse/KEYCLOAK-9077

For context, I'm working on integrating some software with my Keycloak deployment via SAML.  I want to be able to control the client session length using `SessionNotOnOrAfter` in order to force that client to re-authenticate with Keycloak every hour or so.  I noticed that there is a setter on `AuthnStatementType` for this attribute, so I wrote a custom `SAMLLoginResponseMapper` to use this setter.  Once I was finished, I realized that this getter is never invoked when serializing the XML response, so all I am changing here is invoking that getter during the serialization process and adding that attribute if it exists.

Even after this change, there is still no "official" way to set this attribute without using a custom mapper like I did.  I am willing to look into adding this, perhaps as a setting for SAML clients, but I felt like that was out of scope for this PR.