### PR TITLE
KEYCLOAK-9056 Change wrong params passed to /groups endpoint

### DIFF
--- a/themes/src/main/resources/theme/base/admin/resources/js/controllers/groups.js
+++ b/themes/src/main/resources/theme/base/admin/resources/js/controllers/groups.js
@@ -469,12 +469,12 @@ module.controller('DefaultGroupsCtrl', function($scope, $q, realm, Groups, Group
     var refreshAvailableGroups = function (search) {
         var first = ($scope.currentPage * $scope.pageSize) - $scope.pageSize;
         var queryParams = {
-            realm : realm.id,
+            realm : realm.realm,
             first : first,
             max : $scope.pageSize
         };
         var countParams = {
-            realm : realm.id,
+            realm : realm.realm,
             top : 'true'
         };
 

--- a/themes/src/main/resources/theme/base/admin/resources/js/controllers/users.js
+++ b/themes/src/main/resources/theme/base/admin/resources/js/controllers/users.js
@@ -1026,13 +1026,13 @@ module.controller('UserGroupMembershipCtrl', function($scope, $q, realm, user, U
     var refreshAvailableGroups = function (search) {
         var first = ($scope.currentPage * $scope.pageSize) - $scope.pageSize;
         var queryParams = {
-            realm : realm.id,
+            realm : realm.realm,
             first : first,
             max : $scope.pageSize
         };
 
         var countParams = {
-            realm : realm.id,
+            realm : realm.realm,
             top : 'true'
         };
 


### PR DESCRIPTION
 Change wrong params passed to /groups endpoint in groups and user panel

JIRA https://issues.jboss.org/projects/KEYCLOAK/issues/KEYCLOAK-9056?filter=allopenissues

`/groups` endpoint works with realm name and not id, but since 4.7 the UI in the panels Groups/Default Groups and Users/Groups is broken because a commit was made to add pagination on groups, but the author passed `realm.id` instead of `realm.realm` to the endpoint

https://github.com/keycloak/keycloak/commit/85f11873c3e49f69de8224657ad7edabb2646ff8#diff-671bef09ec6beef6124c534ecbb890fe

Hopefully in most case the realm name equals the realm id ( when create through the UI ) but it's not the case when we create realm through api or if we rename it.

I also tested to create thirty groups and pagination is still working fine. join/quit group for a user works too.
