### PR TITLE
KEYCLOAK-4978 Add endpoint to get groups by role

### DIFF
--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/RoleResource.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/RoleResource.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.admin.client.resource;
 
+import org.keycloak.representations.idm.GroupRepresentation;
 import org.keycloak.representations.idm.ManagementPermissionReference;
 import org.keycloak.representations.idm.ManagementPermissionRepresentation;
 import org.keycloak.representations.idm.RoleRepresentation;
@@ -126,5 +127,31 @@ public interface RoleResource {
     @Produces(MediaType.APPLICATION_JSON)
     Set<UserRepresentation> getRoleUserMembers(@QueryParam("first") Integer firstResult,
                                                @QueryParam("max") Integer maxResults);
+    
+    /**
+     * Get role groups
+     * <p/>
+     * Returns groups that have the given role
+     *
+     * @return a list of groups with the given role
+     */
+    @GET
+    @Path("groups")
+    @Produces(MediaType.APPLICATION_JSON)
+    Set<GroupRepresentation> getRoleGroupMembers();
 
+    /**
+     * Get role groups
+     * <p/>
+     * Returns groups that have the given role, paginated according to the query parameters
+     *
+     * @param firstResult Pagination offset
+     * @param maxResults  Pagination size
+     * @return a list of groups with the given role
+     */
+    @GET
+    @Path("groups")
+    @Produces(MediaType.APPLICATION_JSON)
+    Set<GroupRepresentation> getRoleGroupMembers(@QueryParam("first") Integer firstResult,
+                                               @QueryParam("max") Integer maxResults);
 }

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmCacheSession.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmCacheSession.java
@@ -878,6 +878,11 @@ public class RealmCacheSession implements CacheRealmProvider {
     public Long getGroupsCountByNameContaining(RealmModel realm, String search) {
         return getRealmDelegate().getGroupsCountByNameContaining(realm, search);
     }
+    
+    @Override
+    public List<GroupModel> getGroupsByRole(RealmModel realm, RoleModel role, int firstResult, int maxResults) {
+    	return getRealmDelegate().getGroupsByRole(realm, role, firstResult, maxResults);
+    }
 
     @Override
     public List<GroupModel> getTopLevelGroups(RealmModel realm) {

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
@@ -385,6 +385,25 @@ public class JpaRealmProvider implements RealmProvider {
     public Long getGroupsCountByNameContaining(RealmModel realm, String search) {
         return (long) searchForGroupByName(realm, search, null, null).size();
     }
+    
+    @Override
+    public List<GroupModel> getGroupsByRole(RealmModel realm, RoleModel role, int firstResult, int maxResults) {
+        TypedQuery<GroupEntity> query = em.createNamedQuery("groupsInRole", GroupEntity.class);
+        query.setParameter("roleId", role.getId());
+        if (firstResult != -1) {
+            query.setFirstResult(firstResult);
+        }
+        if (maxResults != -1) {
+            query.setMaxResults(maxResults);
+        }
+        List<GroupEntity> results = query.getResultList();
+
+        return results.stream()
+        		.map(g -> new GroupAdapter(realm, em, g))
+                .sorted(Comparator.comparing(GroupModel::getName))
+                .collect(Collectors.collectingAndThen(
+                        Collectors.toList(), Collections::unmodifiableList));
+    }
 
     @Override
     public List<GroupModel> getTopLevelGroups(RealmModel realm) {

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/GroupRoleMappingEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/GroupRoleMappingEntity.java
@@ -34,6 +34,7 @@ import java.io.Serializable;
  * @version $Revision: 1 $
  */
 @NamedQueries({
+    @NamedQuery(name="groupsInRole", query="select g from GroupRoleMappingEntity m, GroupEntity g where m.roleId=:roleId and g.id=m.group"),
         @NamedQuery(name="groupHasRole", query="select m from GroupRoleMappingEntity m where m.group = :group and m.roleId = :roleId"),
         @NamedQuery(name="groupRoleMappings", query="select m from GroupRoleMappingEntity m where m.group = :group"),
         @NamedQuery(name="groupRoleMappingIds", query="select m.roleId from GroupRoleMappingEntity m where m.group = :group"),

--- a/server-spi/src/main/java/org/keycloak/models/RealmProvider.java
+++ b/server-spi/src/main/java/org/keycloak/models/RealmProvider.java
@@ -43,6 +43,8 @@ public interface RealmProvider extends Provider, ClientProvider {
     Long getGroupsCount(RealmModel realm, Boolean onlyTopGroups);
 
     Long getGroupsCountByNameContaining(RealmModel realm, String search);
+    
+    List<GroupModel> getGroupsByRole(RealmModel realm, RoleModel role, int firstResult, int maxResults);
 
     List<GroupModel> getTopLevelGroups(RealmModel realm);
 


### PR DESCRIPTION
JIRA 

https://issues.jboss.org/browse/KEYCLOAK-4978

This old ticket was about add en endpoint to get groups by assigned role.

There is already an ( undocumented ) REST API to fetch users by role which is : 

`/auth/admin/realms/{realm-name}/roles/{role-name}/users`

So I created a very similar endpoint 

`/auth/admin/realms/{realm-name}/roles/{role-name}/groups`

It also works well with client role ( it's what we need )

`/auth/admin/realms/{realm-name}/clients/{client-uuid}/roles/{role-name}/groups`

The `GroupRepresentation toRepresentation(GroupModel group, boolean full)` function offered the possibility to return the full group object or just basic representation ( group id, name, path )

By default the new endpoint just return basic group representation but we can choose to return full representation using `/roles/{role-name}/groups?full=true`



