### PR TITLE
java admin ClientResource.update() returns 409

### DIFF
--- a/services/src/main/java/org/keycloak/authorization/admin/AuthorizationService.java
+++ b/services/src/main/java/org/keycloak/authorization/admin/AuthorizationService.java
@@ -57,12 +57,15 @@ public class AuthorizationService {
     }
 
     public void enable(boolean newClient) {
-        this.resourceServer = resourceServer().create(newClient);
+		if (!isEnabled()) {
+			this.resourceServer = resourceServer().create(newClient);
+		}
     }
 
     public void disable() {
         if (isEnabled()) {
             resourceServer().delete();
+            this.resourceServer = null;
         }
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/ClientTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/ClientTest.java
@@ -227,14 +227,14 @@ public class ClientTest extends AbstractAdminTest {
     public void updateClientWithAuthzServices() throws Exception {
       // create a new client
       ClientRepresentation client = new ClientRepresentation();
-      client.setClientId("my-app");
+      client.setClientId("my-app-oldname");
       client.setPublicClient(false);
       client.setBearerOnly(false);
       client.setStandardFlowEnabled(true);
       client.setImplicitFlowEnabled(false);
       client.setDirectAccessGrantsEnabled(true);
       client.setServiceAccountsEnabled(true);
-      client.setAuthorizationServicesEnabled(true); // TRIGGER!
+      client.setAuthorizationServicesEnabled(true);
       client.setRedirectUris(Collections.singletonList("/"));
       assertEquals(201, realm.clients().create(client).getStatus());
 
@@ -253,7 +253,7 @@ public class ClientTest extends AbstractAdminTest {
       // attempt to update the client
       ClientRepresentation newClient = storedClient;
       newClient.setClientId("my-app-newname");
-      realm.clients().get(newClient.getId()).update(newClient); // HTTP 409 here!
+      realm.clients().get(newClient.getId()).update(newClient);
       ClientRepresentation newStoredClient =
           realm.clients().get(newClient.getId()).toRepresentation();
       assertClient(newClient, newStoredClient);


### PR DESCRIPTION
[KEYCLOAK-8620]
If `AuthorizationService.enable(boolean)` is called multiple times, then it should not re-create the resource server when it already exists. Attempting to create when it already exists would cause a conflict with the existing resources.