### PR TITLE
[KEYCLOAK-9118] : ignores media type parameters when checking Content…

### DIFF
--- a/services/src/main/java/org/keycloak/broker/oidc/OIDCIdentityProvider.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/OIDCIdentityProvider.java
@@ -382,7 +382,7 @@ public class OIDCIdentityProvider extends AbstractOAuth2IdentityProvider<OIDCIde
                     String contentType = response.getFirstHeader(HttpHeaders.CONTENT_TYPE);
                     JsonNode userInfo;
 
-                    if (MediaType.APPLICATION_JSON.equals(contentType)) {
+                    if (MediaType.APPLICATION_JSON_TYPE.isCompatible(MediaType.valueOf(contentType))) {
                         userInfo = response.asJson();
                     } else if ("application/jwt".equals(contentType)) {
                         JWSInput jwsInput;


### PR DESCRIPTION
…-Type header.

The change here tries to keep the original check on Content-Type==application/json (or jwt and failing otherwise), but I don't know if it is really what you want. I don't see anything in the OIDC spec saying userinfo endpoint must have that content-type. 