### PR TITLE
KEYCLOAK-9119: Look up root auth session by tab ID

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanAuthenticationSessionProvider.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanAuthenticationSessionProvider.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.models.sessions.infinispan;
 
+import org.infinispan.container.entries.CacheEntry;
 import org.keycloak.cluster.ClusterProvider;
 import java.util.Iterator;
 import java.util.Map;
@@ -29,6 +30,7 @@ import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.cache.infinispan.events.AuthenticationSessionAuthNoteUpdateEvent;
+import org.keycloak.models.sessions.infinispan.entities.AuthenticationSessionEntity;
 import org.keycloak.models.sessions.infinispan.entities.RootAuthenticationSessionEntity;
 import org.keycloak.models.sessions.infinispan.events.RealmRemovedSessionEvent;
 import org.keycloak.models.sessions.infinispan.events.SessionEventsSenderTransaction;
@@ -183,6 +185,17 @@ public class InfinispanAuthenticationSessionProvider implements AuthenticationSe
     public RootAuthenticationSessionModel getRootAuthenticationSession(RealmModel realm, String authenticationSessionId) {
         RootAuthenticationSessionEntity entity = getRootAuthenticationSessionEntity(authenticationSessionId);
         return wrap(realm, entity);
+    }
+
+    @Override
+    public RootAuthenticationSessionModel getRootAuthenticationSessionForTabId(RealmModel realm, String tabId) {
+        for (RootAuthenticationSessionEntity entity : cache.values()) {
+            if (entity.getAuthenticationSessions().containsKey(tabId)) {
+                return wrap(realm, entity);
+            }
+        }
+
+        return null;
     }
 
 

--- a/server-spi/src/main/java/org/keycloak/sessions/AuthenticationSessionProvider.java
+++ b/server-spi/src/main/java/org/keycloak/sessions/AuthenticationSessionProvider.java
@@ -38,6 +38,8 @@ public interface AuthenticationSessionProvider extends Provider {
 
     RootAuthenticationSessionModel getRootAuthenticationSession(RealmModel realm, String authenticationSessionId);
 
+    RootAuthenticationSessionModel getRootAuthenticationSessionForTabId(RealmModel realm, String tabId);
+
     void removeRootAuthenticationSession(RealmModel realm, RootAuthenticationSessionModel authenticationSession);
 
     void removeExpired(RealmModel realm);

--- a/services/src/main/java/org/keycloak/services/managers/AuthenticationSessionManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/AuthenticationSessionManager.java
@@ -224,13 +224,11 @@ public class AuthenticationSessionManager {
     public AuthenticationSessionModel getAuthenticationSessionByIdAndClient(RealmModel realm, String authSessionId, ClientModel client, String tabId) {
         final AuthenticationSessionProvider sessions = session.authenticationSessions();
         RootAuthenticationSessionModel rootAuthSession = sessions.getRootAuthenticationSession(realm, authSessionId);
-        if (rootAuthSession == null) {
-            return null;
-        }
-
-        final AuthenticationSessionModel authenticationSession = rootAuthSession.getAuthenticationSession(client, tabId);
-        if (authenticationSession != null) {
-            return authenticationSession;
+        if (rootAuthSession != null) {
+            final AuthenticationSessionModel authenticationSession = rootAuthSession.getAuthenticationSession(client, tabId);
+            if (authenticationSession != null) {
+                return authenticationSession;
+            }
         }
 
         final RootAuthenticationSessionModel rootSession = sessions.getRootAuthenticationSessionForTabId(realm, tabId);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/RequiredActionEmailVerificationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/RequiredActionEmailVerificationTest.java
@@ -817,14 +817,9 @@ public class RequiredActionEmailVerificationTest extends AbstractTestRealmKeyclo
 
                 driver2.navigate().to(verificationUrl.trim());
 
-                // Browser 2: Confirm email belongs to the user
-                final WebElement proceedLink = driver2.findElement(By.linkText("» Click here to proceed"));
-                assertThat(proceedLink, Matchers.notNullValue());
-                proceedLink.click();
-
-                // Browser 2: Expect confirmation
-                assertThat(driver2.getPageSource(), Matchers.containsString("kc-info-message"));
-                assertThat(driver2.getPageSource(), Matchers.containsString("Your email address has been verified."));
+                // admin console should be shown in the second browser due to redirect
+                assertThat(driver2.getPageSource(), Matchers.containsString("admin-console"));
+                assertThat(driver2.getPageSource(), Matchers.containsString("Keycloak Account Management"));
 
                 // Browser 1: Expect land back to account after refresh
                 driver.navigate().refresh();
@@ -936,22 +931,9 @@ public class RequiredActionEmailVerificationTest extends AbstractTestRealmKeyclo
         // confirm in the second browser
         driver2.navigate().to(verificationUrl);
 
-        // follow the link
-        final WebElement proceedLink = driver2.findElement(By.linkText("» Click here to proceed"));
-        assertThat(proceedLink, Matchers.notNullValue());
-        proceedLink.click();
-
-        // confirmation in the second browser
-        assertThat(driver2.getPageSource(), Matchers.containsString("kc-info-message"));
-        assertThat(driver2.getPageSource(), Matchers.containsString("Your email address has been verified."));
-
-        final WebElement backToApplicationLink = driver2.findElement(By.linkText("« Back to Application"));
-        assertThat(backToApplicationLink, Matchers.notNullValue());
-        backToApplicationLink.click();
-
-        // login page should be shown in the second browser
-        assertThat(driver2.getPageSource(), Matchers.containsString("kc-login"));
-        assertThat(driver2.getPageSource(), Matchers.containsString("Log In"));
+        // admin console should be shown in the second browser due to redirect
+        assertThat(driver2.getPageSource(), Matchers.containsString("admin-console"));
+        assertThat(driver2.getPageSource(), Matchers.containsString("Keycloak Account Management"));
 
         // email should be verified and required actions empty
         UserRepresentation user = testRealm().users().get(testUserId).toRepresentation();


### PR DESCRIPTION
If the current root auth session does not contain an auth session
matching the provided tab ID, then examine all the root auth sessions,
looking for the matching auth session.

If it still can't be found, return null and continue with existing
behaviour.