### PR TITLE
KEYCLOAK-9172 Implement vk.com Identity Provider

### DIFF
--- a/services/src/main/java/org/keycloak/social/vkontakte/VKontakteIdentityProvider.java
+++ b/services/src/main/java/org/keycloak/social/vkontakte/VKontakteIdentityProvider.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.social.vkontakte;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.keycloak.broker.oidc.AbstractOAuth2IdentityProvider;
+import org.keycloak.broker.oidc.mappers.AbstractJsonUserAttributeMapper;
+import org.keycloak.broker.provider.BrokeredIdentityContext;
+import org.keycloak.broker.provider.IdentityBrokerException;
+import org.keycloak.broker.provider.util.SimpleHttp;
+import org.keycloak.broker.social.SocialIdentityProvider;
+import org.keycloak.events.EventBuilder;
+import org.keycloak.models.KeycloakSession;
+
+import java.io.IOException;
+
+/**
+ * @author Wladislaw Mitzel <mitzel@tawadi.de>
+ */
+public class VKontakteIdentityProvider extends AbstractOAuth2IdentityProvider<VKontakteIdentityProviderConfig>
+        implements SocialIdentityProvider<VKontakteIdentityProviderConfig> {
+
+    public static final String API_VERSION = "5.92";
+    public static final String API_VERSION_PARAM = "?v=" + API_VERSION;
+
+    public VKontakteIdentityProvider(KeycloakSession session, VKontakteIdentityProviderConfig config) {
+        super(session, config);
+        config.setAuthorizationUrl("https://oauth.vk.com/authorize" + API_VERSION_PARAM);
+        config.setTokenUrl("https://oauth.vk.com/access_token" + API_VERSION_PARAM);
+        config.setUserInfoUrl("https://api.vk.com/method/users.get" + API_VERSION_PARAM);
+    }
+
+    @Override
+    protected String getDefaultScopes() {
+        return "email offline";
+    }
+
+    @Override
+    protected boolean supportsExternalExchange() {
+        return true;
+    }
+
+    @Override
+    protected String getProfileEndpointForValidation(EventBuilder event) {
+        return getConfig().getUserInfoUrl();
+    }
+
+    @Override
+    protected BrokeredIdentityContext extractIdentityFromProfile(EventBuilder event, JsonNode profile) {
+        JsonNode node = profile.get("response").get(0);
+        BrokeredIdentityContext user = new BrokeredIdentityContext(getJsonProperty(node, "id"));
+
+        user.setUsername(getJsonProperty(node, "screen_name"));
+        user.setFirstName(getJsonProperty(node, "first_name"));
+        user.setLastName(getJsonProperty(node, "last_name"));
+        user.setIdpConfig(getConfig());
+        user.setIdp(this);
+
+        AbstractJsonUserAttributeMapper.storeUserProfileForMapper(user, node, getConfig().getAlias());
+        return user;
+    }
+
+    @Override
+    protected BrokeredIdentityContext doGetFederatedIdentity(String accessToken) {
+        try {
+            JsonNode profile = SimpleHttp.doGet(getConfig().getUserInfoUrl(), session)
+                    .param("v", API_VERSION)
+                    .param("fields", "screen_name")
+                    .param("access_token", accessToken)
+                    .asJson();
+
+            return extractIdentityFromProfile(null, profile);
+        } catch (Exception e) {
+            throw new IdentityBrokerException("Could not obtain user profile from paypal.", e);
+        }
+    }
+
+    @Override
+    protected SimpleHttp buildUserInfoRequest(String subjectToken, String userInfoUrl) {
+        return SimpleHttp.doGet(userInfoUrl, session)
+                .param("v", API_VERSION)
+                .param("fields", "screen_name")
+                .param("access_token", subjectToken);
+    }
+
+    @Override
+    public BrokeredIdentityContext getFederatedIdentity(String response) {
+        String accessToken = extractTokenFromResponse(response, getAccessTokenResponseParameter());
+
+        if (accessToken == null) {
+            throw new IdentityBrokerException("No access token available in OAuth server response: " + response);
+        }
+
+        BrokeredIdentityContext context = doGetFederatedIdentity(accessToken);
+        JsonNode node = null;
+        try {
+            node = mapper.readTree(response);
+            context.setEmail(getJsonProperty(node, "email"));
+        } catch (IOException e) {
+            throw new IdentityBrokerException("Could not get user_id or  e-mail address from response: " + response);
+        }
+        context.getContextData().put(FEDERATED_ACCESS_TOKEN, accessToken);
+        return context;
+    }
+}

--- a/services/src/main/java/org/keycloak/social/vkontakte/VKontakteIdentityProviderConfig.java
+++ b/services/src/main/java/org/keycloak/social/vkontakte/VKontakteIdentityProviderConfig.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.social.vkontakte;
+
+import org.keycloak.broker.oidc.OAuth2IdentityProviderConfig;
+import org.keycloak.models.IdentityProviderModel;
+
+/**
+ * @author Wladislaw Mitzel <mitzel@tawadi.de>
+ */
+public class VKontakteIdentityProviderConfig extends OAuth2IdentityProviderConfig {
+
+    public VKontakteIdentityProviderConfig(IdentityProviderModel model) {
+        super(model);
+    }
+
+}

--- a/services/src/main/java/org/keycloak/social/vkontakte/VKontakteIdentityProviderFactory.java
+++ b/services/src/main/java/org/keycloak/social/vkontakte/VKontakteIdentityProviderFactory.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.social.vkontakte;
+
+import org.keycloak.broker.provider.AbstractIdentityProviderFactory;
+import org.keycloak.broker.social.SocialIdentityProviderFactory;
+import org.keycloak.models.IdentityProviderModel;
+import org.keycloak.models.KeycloakSession;
+
+/**
+ * @author Wladislaw Mitzel <mitzel@tawadi.de>
+ */
+public class VKontakteIdentityProviderFactory extends AbstractIdentityProviderFactory<VKontakteIdentityProvider>
+        implements SocialIdentityProviderFactory<VKontakteIdentityProvider> {
+
+    public static final String PROVIDER_ID = "vkontakte";
+    private static final String PROVIDER_NAME = "VKontakte";
+
+    public String getName() {
+        return PROVIDER_NAME;
+    }
+
+    public VKontakteIdentityProvider create(KeycloakSession keycloakSession, IdentityProviderModel identityProviderModel) {
+        return new VKontakteIdentityProvider(keycloakSession, new VKontakteIdentityProviderConfig(identityProviderModel));
+    }
+
+    public String getId() {
+        return PROVIDER_ID;
+    }
+}

--- a/services/src/main/java/org/keycloak/social/vkontakte/VKontakteUserAttributeMapper.java
+++ b/services/src/main/java/org/keycloak/social/vkontakte/VKontakteUserAttributeMapper.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.social.vkontakte;
+
+import org.keycloak.broker.oidc.mappers.AbstractJsonUserAttributeMapper;
+
+/**
+ * @author Wladislaw Mitzel <mitzel@tawadi.de>
+ */
+public class VKontakteUserAttributeMapper extends AbstractJsonUserAttributeMapper {
+
+    private static final String MAPPER_ID = "vkontakte-user-attribute-mapper";
+    private static final String[] PROVIDER = { VKontakteIdentityProviderFactory.PROVIDER_ID };
+
+    public String[] getCompatibleProviders() {
+        return PROVIDER;
+    }
+
+    public String getId() {
+        return MAPPER_ID;
+    }
+
+}

--- a/services/src/main/resources/META-INF/services/org.keycloak.broker.provider.IdentityProviderMapper
+++ b/services/src/main/resources/META-INF/services/org.keycloak.broker.provider.IdentityProviderMapper
@@ -33,3 +33,4 @@ org.keycloak.social.linkedin.LinkedInUserAttributeMapper
 org.keycloak.social.stackoverflow.StackoverflowUserAttributeMapper
 org.keycloak.social.microsoft.MicrosoftUserAttributeMapper
 org.keycloak.social.instagram.InstagramUserAttributeMapper
+org.keycloak.social.vkontakte.VKontakteUserAttributeMapper

--- a/services/src/main/resources/META-INF/services/org.keycloak.broker.social.SocialIdentityProviderFactory
+++ b/services/src/main/resources/META-INF/services/org.keycloak.broker.social.SocialIdentityProviderFactory
@@ -27,3 +27,4 @@ org.keycloak.social.openshift.OpenshiftV3IdentityProviderFactory
 org.keycloak.social.gitlab.GitLabIdentityProviderFactory
 org.keycloak.social.bitbucket.BitbucketIdentityProviderFactory
 org.keycloak.social.instagram.InstagramIdentityProviderFactory
+org.keycloak.social.vkontakte.VKontakteIdentityProviderFactory

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/social/VKontakteLoginPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/social/VKontakteLoginPage.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2018 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite.pages.social;
+
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+import static org.keycloak.testsuite.util.UIUtils.clickLink;
+
+/**
+ * @author Wladislaw Mitzel <wmitzel@tawadi.de>
+ */
+public class VKontakteLoginPage extends AbstractSocialLoginPage {
+
+    @FindBy(name = "email")
+    private WebElement usernameInput;
+
+    @FindBy(name = "pass")
+    private WebElement passwordInput;
+
+    @FindBy(id = "install_allow")
+    private WebElement loginButton;
+
+    @FindBy(xpath = "//button[text()='Allow']")
+    private WebElement authorizeButton;
+
+    @Override
+    public void login(String user, String password) {
+        //normal login
+        try {
+            usernameInput.clear();
+            usernameInput.sendKeys(user);
+            passwordInput.sendKeys(password);
+            clickLink(loginButton);
+        } catch (NoSuchElementException e) {
+            // already logged in
+        }
+        //scope confirmation
+        try {
+            authorizeButton.click();
+        } catch (NoSuchElementException e) {
+            // might not be necessary
+        }
+    }
+}

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/SocialLoginTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/SocialLoginTest.java
@@ -33,16 +33,17 @@ import org.keycloak.testsuite.pages.LoginPage;
 import org.keycloak.testsuite.pages.social.AbstractSocialLoginPage;
 import org.keycloak.testsuite.pages.social.BitbucketLoginPage;
 import org.keycloak.testsuite.pages.social.FacebookLoginPage;
-import org.keycloak.testsuite.pages.social.InstagramLoginPage;
 import org.keycloak.testsuite.pages.social.GitHubLoginPage;
 import org.keycloak.testsuite.pages.social.GitLabLoginPage;
 import org.keycloak.testsuite.pages.social.GoogleLoginPage;
+import org.keycloak.testsuite.pages.social.InstagramLoginPage;
 import org.keycloak.testsuite.pages.social.LinkedInLoginPage;
 import org.keycloak.testsuite.pages.social.MicrosoftLoginPage;
 import org.keycloak.testsuite.pages.social.OpenShiftLoginPage;
 import org.keycloak.testsuite.pages.social.PayPalLoginPage;
 import org.keycloak.testsuite.pages.social.StackOverflowLoginPage;
 import org.keycloak.testsuite.pages.social.TwitterLoginPage;
+import org.keycloak.testsuite.pages.social.VKontakteLoginPage;
 import org.keycloak.testsuite.runonserver.RunOnServerDeployment;
 import org.keycloak.testsuite.util.IdentityProviderBuilder;
 import org.keycloak.testsuite.util.OAuthClient;
@@ -69,19 +70,20 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 import static org.keycloak.testsuite.broker.SocialLoginTest.Provider.BITBUCKET;
 import static org.keycloak.testsuite.broker.SocialLoginTest.Provider.FACEBOOK;
-import static org.keycloak.testsuite.broker.SocialLoginTest.Provider.INSTAGRAM;
 import static org.keycloak.testsuite.broker.SocialLoginTest.Provider.GITHUB;
 import static org.keycloak.testsuite.broker.SocialLoginTest.Provider.GITHUB_PRIVATE_EMAIL;
 import static org.keycloak.testsuite.broker.SocialLoginTest.Provider.GITLAB;
 import static org.keycloak.testsuite.broker.SocialLoginTest.Provider.GOOGLE;
 import static org.keycloak.testsuite.broker.SocialLoginTest.Provider.GOOGLE_HOSTED_DOMAIN;
 import static org.keycloak.testsuite.broker.SocialLoginTest.Provider.GOOGLE_NON_MATCHING_HOSTED_DOMAIN;
+import static org.keycloak.testsuite.broker.SocialLoginTest.Provider.INSTAGRAM;
 import static org.keycloak.testsuite.broker.SocialLoginTest.Provider.LINKEDIN;
 import static org.keycloak.testsuite.broker.SocialLoginTest.Provider.MICROSOFT;
 import static org.keycloak.testsuite.broker.SocialLoginTest.Provider.OPENSHIFT;
 import static org.keycloak.testsuite.broker.SocialLoginTest.Provider.PAYPAL;
 import static org.keycloak.testsuite.broker.SocialLoginTest.Provider.STACKOVERFLOW;
 import static org.keycloak.testsuite.broker.SocialLoginTest.Provider.TWITTER;
+import static org.keycloak.testsuite.broker.SocialLoginTest.Provider.VKONTAKTE;
 
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
@@ -116,7 +118,8 @@ public class SocialLoginTest extends AbstractKeycloakTest {
         OPENSHIFT("openshift-v3", OpenShiftLoginPage.class),
         GITLAB("gitlab", GitLabLoginPage.class),
         BITBUCKET("bitbucket", BitbucketLoginPage.class),
-        INSTAGRAM("instagram", InstagramLoginPage.class);
+        INSTAGRAM("instagram", InstagramLoginPage.class),
+        VKONTAKTE("vkontakte", VKontakteLoginPage.class);
 
         private String id;
         private Class<? extends AbstractSocialLoginPage> pageObjectClazz;
@@ -350,6 +353,13 @@ public class SocialLoginTest extends AbstractKeycloakTest {
         setTestProvider(STACKOVERFLOW);
         performLogin();
         assertUpdateProfile(false, false, true);
+        assertAccount();
+    }
+
+    @Test
+    public void vkontakteLogin() throws InterruptedException {
+        setTestProvider(VKONTAKTE);
+        performLogin();
         assertAccount();
     }
 

--- a/testsuite/integration-deprecated/src/test/java/org/keycloak/testsuite/broker/AbstractIdentityProviderModelTest.java
+++ b/testsuite/integration-deprecated/src/test/java/org/keycloak/testsuite/broker/AbstractIdentityProviderModelTest.java
@@ -26,6 +26,7 @@ import org.keycloak.social.google.GoogleIdentityProviderFactory;
 import org.keycloak.social.linkedin.LinkedInIdentityProviderFactory;
 import org.keycloak.social.stackoverflow.StackoverflowIdentityProviderFactory;
 import org.keycloak.social.twitter.TwitterIdentityProviderFactory;
+import org.keycloak.social.vkontakte.VKontakteIdentityProviderFactory;
 import org.keycloak.testsuite.model.AbstractModelTest;
 
 import java.util.Collections;
@@ -52,6 +53,7 @@ public abstract class AbstractIdentityProviderModelTest extends AbstractModelTes
         this.expectedProviders.add(TwitterIdentityProviderFactory.PROVIDER_ID);
         this.expectedProviders.add(LinkedInIdentityProviderFactory.PROVIDER_ID);
         this.expectedProviders.add(StackoverflowIdentityProviderFactory.PROVIDER_ID);
+        this.expectedProviders.add(VKontakteIdentityProviderFactory.PROVIDER_ID);
 
         this.expectedProviders = Collections.unmodifiableSet(this.expectedProviders);
     }

--- a/testsuite/integration-deprecated/src/test/java/org/keycloak/testsuite/broker/ImportIdentityProviderTest.java
+++ b/testsuite/integration-deprecated/src/test/java/org/keycloak/testsuite/broker/ImportIdentityProviderTest.java
@@ -48,6 +48,9 @@ import org.keycloak.social.stackoverflow.StackoverflowIdentityProvider;
 import org.keycloak.social.stackoverflow.StackoverflowIdentityProviderFactory;
 import org.keycloak.social.twitter.TwitterIdentityProvider;
 import org.keycloak.social.twitter.TwitterIdentityProviderFactory;
+import org.keycloak.social.vkontakte.VKontakteIdentityProvider;
+import org.keycloak.social.vkontakte.VKontakteIdentityProviderConfig;
+import org.keycloak.social.vkontakte.VKontakteIdentityProviderFactory;
 
 import java.io.IOException;
 import java.util.HashSet;
@@ -156,6 +159,8 @@ public class ImportIdentityProviderTest extends AbstractIdentityProviderModelTes
                     assertStackoverflowIdentityProviderConfig(identityProvider);
                 } else if (OpenshiftV3IdentityProviderFactory.PROVIDER_ID.equals(providerId)) {
                     assertOpenshiftIdentityProviderConfig(identityProvider);
+                } else if (VKontakteIdentityProviderFactory.PROVIDER_ID.equals(providerId)) {
+                    assertVkontakteIdentityProviderConfig(identityProvider);
                 } else {
                     continue;
                 }
@@ -324,6 +329,20 @@ public class ImportIdentityProviderTest extends AbstractIdentityProviderModelTes
         assertEquals(false, config.isAuthenticateByDefault());
         assertEquals(true, config.isStoreToken());
         assertEquals(OpenshiftV3IdentityProvider.BASE_URL, config.getBaseUrl());
+        assertEquals("clientId", config.getClientId());
+        assertEquals("clientSecret", config.getClientSecret());
+    }
+
+    private void assertVkontakteIdentityProviderConfig(IdentityProviderModel identityProvider) {
+        VKontakteIdentityProvider vKontakteIdentityProvider = new VKontakteIdentityProviderFactory().create(session, identityProvider);
+        VKontakteIdentityProviderConfig config = vKontakteIdentityProvider.getConfig();
+
+        assertEquals("model-vkontakte", config.getAlias());
+        assertEquals(VKontakteIdentityProviderFactory.PROVIDER_ID, config.getProviderId());
+        assertEquals(true, config.isEnabled());
+        assertEquals(false, config.isTrustEmail());
+        assertEquals(false, config.isAuthenticateByDefault());
+        assertEquals(false, config.isStoreToken());
         assertEquals("clientId", config.getClientId());
         assertEquals("clientSecret", config.getClientSecret());
     }

--- a/testsuite/integration-deprecated/src/test/resources/broker-test/test-realm-with-broker.json
+++ b/testsuite/integration-deprecated/src/test/resources/broker-test/test-realm-with-broker.json
@@ -252,6 +252,21 @@
                 "backchannelSupported": "true",
                 "hideOnLoginPage": true
             }
+        },
+        {
+            "alias" : "model-vkontakte",
+            "providerId" : "vkontakte",
+            "enabled": true,
+            "storeToken": false,
+            "postBrokerLoginFlowAlias" : "browser",
+            "config": {
+                "sandbox": false,
+                "authorizationUrl": "authorizationUrl",
+                "tokenUrl": "tokenUrl",
+                "userInfoUrl": "userInfoUrl",
+                "clientId": "clientId",
+                "clientSecret": "clientSecret"
+            }
         }
     ],
     "identityProviderMappers": [

--- a/themes/src/main/resources/theme/base/admin/resources/partials/realm-identity-provider-vkontakte-ext.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/realm-identity-provider-vkontakte-ext.html
@@ -1,0 +1,3 @@
+<div class="form-group">
+
+</div>

--- a/themes/src/main/resources/theme/base/admin/resources/partials/realm-identity-provider-vkontakte.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/realm-identity-provider-vkontakte.html
@@ -1,0 +1,1 @@
+<div data-ng-include data-src="resourceUrl + '/partials/realm-identity-provider-social.html'"></div>


### PR DESCRIPTION
This PR adds [vk.com](https://vk.com) as an Identity Provider. VK has over 500m users and is ranked 18 (as of October 2018) in Alexa's global Top 500 sites according to [Wikipedia](https://en.wikipedia.org/wiki/VK_(service)).

I've had a look at how the other identity providers are implemented and tried to follow them as close as possible.
* There is no extra configuration required. As far as I know, there is no "sandbox" environment which could be configured for integration tests.
* I've added an automated Selenium test in `SocialLoginTest`
* I've opened a separate PR which describes the required set up https://github.com/keycloak/keycloak-documentation/pull/551