### PR TITLE
KEYCLOAK-9243 fix running tests in travis

### DIFF
--- a/travis-run-tests.sh
+++ b/travis-run-tests.sh
@@ -65,7 +65,7 @@ if [ $1 == "unit" ]; then
 fi
 
 if [ $1 == "server-group1" ]; then
-    run-server-tests org.keycloak.testsuite.adm.**.*Test,org.keycloak.testsuite.add.**.*Test
+    run-server-tests org.keycloak.testsuite.adm*.**.*Test,org.keycloak.testsuite.add*.**.*Test
 fi
 
 if [ $1 == "server-group2" ]; then


### PR DESCRIPTION
We're not testing admin package and adduser package since Nov 9 2018 in travis, this PR fixes it.