### PR TITLE
Added media rule for 'account' with small css tweak

### DIFF
--- a/themes/src/main/resources-community/theme/base/account/messages/messages_no.properties
+++ b/themes/src/main/resources-community/theme/base/account/messages/messages_no.properties
@@ -97,7 +97,7 @@ revoke=Opphev rettighet
 
 configureAuthenticators=Konfigurerte autentikatorer
 mobile=Mobiltelefon
-totpStep1=Installer <a href="https://freeotp.github.io/" target="_blank">FreeOTP</a> eller Google Authenticator p\u00E5 din enhet. Begge applikasjoner er tilgjengelige p\u00E5 <a href="https://play.google.com">Google Play</a> og Apple App Store.
+totpStep1=Installer ett av f\u00F8lgende programmer p\u00E5  mobilen din.
 totpStep2=\u00C5pne applikasjonen og skann strekkoden eller skriv inn koden.
 totpStep3=Skriv inn engangskoden gitt av applikasjonen og klikk Lagre for \u00E5 fullf\u00F8re.
 

--- a/themes/src/main/resources/theme/keycloak/account/resources/css/account.css
+++ b/themes/src/main/resources/theme/keycloak/account/resources/css/account.css
@@ -275,3 +275,26 @@ hr + .form-horizontal {
     padding: 10px;
     margin: 50px 0;
 }
+
+@media (max-width: 767px) {
+    .container {
+        padding: 0;
+    }
+
+    .content-area {
+        border-width: 1px;
+        padding: 0 16px;
+    }
+
+    .form-horizontal .control-label {
+        text-align: left;
+    }    
+
+    .control-label + .required {
+        top: 30px;
+        right: 8px;
+    }
+
+}
+
+


### PR DESCRIPTION
I added a media rule for 'account' with some css tweaks for better view on small devices.

summarized: removed padding and text-align left, small tweaks for better display

![before](https://user-images.githubusercontent.com/16241840/50678274-35c93780-0ffe-11e9-9cae-22ef894e5325.png)

This also fixed other display issues

![before1](https://user-images.githubusercontent.com/16241840/50678422-e3d4e180-0ffe-11e9-99f2-5d36095524e5.png)

