### PR TITLE
[KEYCLOAK-9634] Keycloak Testhelper uses wrong url

### DIFF
--- a/misc/keycloak-test-helper/src/main/java/org/keycloak/test/FluentTestsHelper.java
+++ b/misc/keycloak-test-helper/src/main/java/org/keycloak/test/FluentTestsHelper.java
@@ -151,7 +151,7 @@ public class FluentTestsHelper {
      * @return <code>this</code>
      */
     public FluentTestsHelper init() {
-        keycloak = getKeycloakInstance(DEFAULT_KEYCLOAK_URL, adminRealm, adminUserName, adminPassword, adminClient);
+        keycloak = getKeycloakInstance(keycloakBaseUrl, adminRealm, adminUserName, adminPassword, adminClient);
         accessToken = generateInitialAccessToken();
         isInitialized = true;
         return this;


### PR DESCRIPTION
This is a small typo that is blocking me.

Thanks in advance