### PR TITLE
[KEYCLOAK-9371] Fix UserSessionPredicate logic to use the correct rem…

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanUserSessionProvider.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanUserSessionProvider.java
@@ -529,7 +529,7 @@ public class InfinispanUserSessionProvider implements UserSessionProvider {
         localClientSessionCacheStoreIgnore
                 .entrySet()
                 .stream()
-                .filter(AuthenticatedClientSessionPredicate.create(realm.getId()).expired(expired))
+                .filter(AuthenticatedClientSessionPredicate.create(realm.getId()).expired(Math.min(expired, expiredRememberMe)))
                 .map(Mappers.clientSessionEntity())
                 .forEach(new Consumer<AuthenticatedClientSessionEntity>() {
 

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/stream/UserSessionPredicate.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/stream/UserSessionPredicate.java
@@ -133,7 +133,7 @@ public class UserSessionPredicate implements Predicate<Map.Entry<String, Session
         }
 
         if (entity.isRememberMe()) {
-            if (expiredRememberMe != null && expiredRefreshRememberMe != null && entity.getStarted() > expiredRefreshRememberMe && entity.getLastSessionRefresh() > expiredRefreshRememberMe) {
+            if (expiredRememberMe != null && expiredRefreshRememberMe != null && entity.getStarted() > expiredRememberMe && entity.getLastSessionRefresh() > expiredRefreshRememberMe) {
                 return false;
             }
         }


### PR DESCRIPTION
- Fixed bug in UserSessionPredicate that wasn't considering the right timeout value when checking for expired sessions.
- Fixed issue in InfinispanUserSessionProvider so that it now considers the remember-me timeouts when checking client sessions for expiration
- Enhanced the UserSessionProviderTest to include a test for the removal of sessions when remember-me is in use. Also made changes to the testRemoveUserSessionsByExpired to make it more comprehensive.