### PR TITLE
Use @Autowired HttpSessionManager instead of creating @Bean HttpSessionManager

### DIFF
--- a/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/config/KeycloakWebSecurityConfigurerAdapter.java
+++ b/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/config/KeycloakWebSecurityConfigurerAdapter.java
@@ -60,6 +60,8 @@ public abstract class KeycloakWebSecurityConfigurerAdapter extends WebSecurityCo
     private Resource keycloakConfigFileResource;
     @Autowired(required = false)
     private KeycloakConfigResolver keycloakConfigResolver;
+    @Autowired
+    HttpSessionManager httpSessionManager;
 
     @Bean
     protected AdapterDeploymentContext adapterDeploymentContext() throws Exception {
@@ -98,9 +100,8 @@ public abstract class KeycloakWebSecurityConfigurerAdapter extends WebSecurityCo
         return new KeycloakCsrfRequestMatcher();
     }
 
-    @Bean
     protected HttpSessionManager httpSessionManager() {
-        return new HttpSessionManager();
+        return httpSessionManager;
     }
 
     protected KeycloakLogoutHandler keycloakLogoutHandler() throws Exception {


### PR DESCRIPTION
The current implementation will cause following error:
A bean with that name has already been defined in URL [jar:file:~/.m2/repository/org/keycloak/keycloak-spring-security-adapter/4.8.3.Final/keycloak-spring-security-adapter-4.8.3.Final.jar!/org/keycloak/adapters/springsecurity/management/HttpSessionManager.class] and overriding is disabled.

Providing [spring.main.allow-bean-definition-overriding=true] in application.properties file is required to solve this error.

This patch can solve this problem without modifying application.properties file.