### PR TITLE
Change the way native promise is returned to end user API

### DIFF
--- a/adapters/oidc/js/src/main/resources/keycloak.d.ts
+++ b/adapters/oidc/js/src/main/resources/keycloak.d.ts
@@ -197,10 +197,10 @@ declare namespace Keycloak {
 	}
 
 	interface KeycloakAdapter {
-		login(options?: KeycloakLoginOptions): KeycloakPromise<void, void>;
-		logout(options?: any): KeycloakPromise<void, void>;
-		register(options?: KeycloakLoginOptions): KeycloakPromise<void, void>;
-		accountManagement(): KeycloakPromise<void, void>;
+		login(options?: KeycloakLoginOptions): KeycloakPromise<void, void> | Promise<void>;
+		logout(options?: any): KeycloakPromise<void, void> | Promise<void>;
+		register(options?: KeycloakLoginOptions): KeycloakPromise<void, void> | Promise<void>;
+		accountManagement(): KeycloakPromise<void, void> | Promise<void>;
 		redirectUri(options: { redirectUri: string; }, encodeHash: boolean): string;
 	}
 
@@ -405,32 +405,32 @@ declare namespace Keycloak {
 		 * @param initOptions Initialization options.
 		 * @returns A promise to set functions to be invoked on success or error.
 		 */
-		init(initOptions: KeycloakInitOptions): KeycloakPromise<boolean, KeycloakError>;
+		init(initOptions: KeycloakInitOptions): KeycloakPromise<boolean, KeycloakError> | Promise<boolean>;
 
 		/**
 		 * Redirects to login form.
 		 * @param options Login options.
 		 */
-		login(options?: KeycloakLoginOptions): KeycloakPromise<void, void>;
+		login(options?: KeycloakLoginOptions): KeycloakPromise<void, void> | Promise<void>;
 
 		/**
 		 * Redirects to logout.
 		 * @param options Logout options.
 		 * @param options.redirectUri Specifies the uri to redirect to after logout.
 		 */
-		logout(options?: any): KeycloakPromise<void, void>;
+		logout(options?: any): KeycloakPromise<void, void> | Promise<void>;
 
 		/**
 		 * Redirects to registration form.
 		 * @param options Supports same options as Keycloak#login but `action` is
 		 *                set to `'register'`.
 		 */
-		register(options?: any): KeycloakPromise<void, void>;
+		register(options?: any): KeycloakPromise<void, void> | Promise<void>;
 
 		/**
 		 * Redirects to the Account Management Console.
 		 */
-		accountManagement(): KeycloakPromise<void, void>;
+		accountManagement(): KeycloakPromise<void, void> | Promise<void>;
 
 		/**
 		 * Returns the URL to login form.
@@ -482,7 +482,7 @@ declare namespace Keycloak {
 		 *   alert('Failed to refresh the token, or the session has expired');
 		 * });
 		 */
-		updateToken(minValidity: number): KeycloakPromise<boolean, boolean>;
+		updateToken(minValidity: number): KeycloakPromise<boolean, boolean> | Promise<boolean>;
 
 		/**
 		 * Clears authentication state, including tokens. This can be useful if
@@ -509,11 +509,11 @@ declare namespace Keycloak {
 		 * Loads the user's profile.
 		 * @returns A promise to set functions to be invoked on success or error.
 		 */
-		loadUserProfile(): KeycloakPromise<KeycloakProfile, void>;
+		loadUserProfile(): KeycloakPromise<KeycloakProfile, void> | Promise<KeycloakProfile>;
 
 		/**
 		 * @private Undocumented.
 		 */
-		loadUserInfo(): KeycloakPromise<{}, void>;
+		loadUserInfo(): KeycloakPromise<{}, void> | Promise<any>;
 	}
 }

--- a/adapters/oidc/js/src/main/resources/keycloak.js
+++ b/adapters/oidc/js/src/main/resources/keycloak.js
@@ -74,9 +74,11 @@
                 }
 
                 if (initOptions.promiseType === 'native') {
-                    kc.useNativePromise = typeof Promise === "function";
+                   kc.useNativePromise = true;
+                }  if (initOptions.promiseType === 'legacy') {
+                    kc.useNativePromise = true;
                 } else {
-                    kc.useNativePromise = false;
+                   kc.useNativePromise = typeof Promise === "function";
                 }
 
                 if (initOptions.onLoad === 'login-required') {

--- a/adapters/oidc/js/src/main/resources/keycloak.js
+++ b/adapters/oidc/js/src/main/resources/keycloak.js
@@ -76,7 +76,7 @@
                 if (initOptions.promiseType === 'native') {
                    kc.useNativePromise = true;
                 }  if (initOptions.promiseType === 'legacy') {
-                    kc.useNativePromise = true;
+                    kc.useNativePromise = false;
                 } else {
                    kc.useNativePromise = typeof Promise === "function";
                 }


### PR DESCRIPTION
## Motivation 

In previous versions of the keycloak js library was always returning native promise.
With current release to return native promise users need to explicitly add to config: `useNativePromise`which is breaking many clients. 

I could not find any release notes or docs that will point that this flag is needed.
In this PR we propose that:

- users can explicitly state what promise they need
- by default api will use promises as before, but only when Promises are available (and this is fairly standard)
- Keycloak TypeScript types will support both cases (currently only Keycloak ones are supported)

Additional problem here is that typescript types are fixed to keycloak legacy promise so it is not possible to use them with regular promise. Example: https://github.com/aerogear/apollo-voyager-ionic-example/blob/master/src/app/services/auth.service.ts#L38