### PR TITLE
fix: add promiseType to KeycloakInitOptions

### DIFF
--- a/adapters/oidc/js/src/main/resources/keycloak.d.ts
+++ b/adapters/oidc/js/src/main/resources/keycloak.d.ts
@@ -34,6 +34,7 @@ declare namespace Keycloak {
 	type KeycloakResponseMode = 'query'|'fragment';
 	type KeycloakResponseType = 'code'|'id_token token'|'code id_token token';
 	type KeycloakFlow = 'standard'|'implicit'|'hybrid';
+	type KeycloakPromiseType = 'native' | undefined;
 
 	interface KeycloakInitOptions {
 		/**
@@ -116,7 +117,7 @@ declare namespace Keycloak {
 		 * Set to 'native' to use native ES6 Promises instead of the legacy Promises
 		 * which use .success() and .error() callbacks.
 		 */
-		promiseType: string;
+		promiseType: KeycloakPromiseType;
 	}
 
 	interface KeycloakLoginOptions {

--- a/adapters/oidc/js/src/main/resources/keycloak.d.ts
+++ b/adapters/oidc/js/src/main/resources/keycloak.d.ts
@@ -109,6 +109,14 @@ declare namespace Keycloak {
 		 * @default standard
 		 */
 		flow?: KeycloakFlow;
+		
+		/**
+		 *
+		 * Set the type of Promises to be returned for all Promise based actions
+		 * Set to 'native' to use native ES6 Promises instead of the legacy Promises
+		 * which use .success() and .error() callbacks.
+		 */
+		promiseType: string;
 	}
 
 	interface KeycloakLoginOptions {


### PR DESCRIPTION
While using the latest `keycloak-js@4.8.3` module with TypeScript I noticed there is a new option called `promiseType` which is not included in the type definitions for `KeycloakInitOptions.` This PR simply adds the type and hopefully a good enough description. Thanks!