### PR TITLE
[KEYCLOAK-8348] - Containerize database tests

### DIFF
--- a/misc/DatabaseTesting.md
+++ b/misc/DatabaseTesting.md
@@ -51,5 +51,24 @@ Run tests:
     
 Stop MySQl:
 
-    docker rm -f mariadb    
+    docker rm -f mariadb
 
+Using built-in profiles to run database tests using docker containers
+-------
+
+The project provides specific profiles to run database tests using containers. The supported databases and their respective profiles are:
+
+* `db-mysql`
+* `db-postgres`
+* `db-mariadb`
+
+As an example, to run tests using a MySQL docker container:
+
+    mvn -f testsuite/integration-arquillian clean verify -Pdb-mysql,jpa
+
+If you want to run tests using a pre-configured Keycloak distribution (instead of Undertow):
+
+    mvn -f testsuite/integration-arquillian clean verify -Pdb-mysql,jpa,auth-server-wildfly
+    
+Note that you must always activate the `jpa` profile.
+    

--- a/model/jpa/src/main/java/org/keycloak/connections/jpa/DefaultJpaConnectionProviderFactory.java
+++ b/model/jpa/src/main/java/org/keycloak/connections/jpa/DefaultJpaConnectionProviderFactory.java
@@ -22,6 +22,7 @@ import org.hibernate.engine.transaction.jta.platform.internal.AbstractJtaPlatfor
 import org.jboss.logging.Logger;
 import org.keycloak.Config;
 import org.keycloak.ServerStartupError;
+import org.keycloak.common.util.StringPropertyReplacer;
 import org.keycloak.connections.jpa.updater.JpaUpdaterProvider;
 import org.keycloak.connections.jpa.util.JpaUtils;
 import org.keycloak.models.KeycloakSession;
@@ -375,7 +376,7 @@ public class DefaultJpaConnectionProviderFactory implements JpaConnectionProvide
                 return dataSource.getConnection();
             } else {
                 Class.forName(config.get("driver"));
-                return DriverManager.getConnection(config.get("url"), config.get("user"), config.get("password"));
+                return DriverManager.getConnection(StringPropertyReplacer.replaceProperties(config.get("url"), System.getProperties()), config.get("user"), config.get("password"));
             }
         } catch (Exception e) {
             throw new RuntimeException("Failed to connect to database", e);

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
         <osgi.version>4.2.0</osgi.version>
         <pax.web.version>7.1.0</pax.web.version>
         <postgresql.version>9.3-1100-jdbc41</postgresql.version>
-        <mariadb.version>1.3.7</mariadb.version>
+        <mariadb.version>2.2.4</mariadb.version>
         <servlet.api.30.version>1.0.2.Final</servlet.api.30.version>
         <servlet.api.40.version>1.0.0.Final</servlet.api.40.version>
         <twitter4j.version>4.0.4</twitter4j.version>
@@ -141,6 +141,7 @@
         <wildfly.plugin.version>1.1.0.Final</wildfly.plugin.version>
         <nexus.staging.plugin.version>1.6.5</nexus.staging.plugin.version>
         <frontend.plugin.version>1.5</frontend.plugin.version>
+        <docker.maven.plugin.version>0.28.0</docker.maven.plugin.version>
 
         <!-- Surefire Settings -->
         <surefire.memory.settings>-Xms512m -Xmx2048m -XX:MetaspaceSize=96m -XX:MaxMetaspaceSize=256m</surefire.memory.settings>

--- a/testsuite/integration-arquillian/pom.xml
+++ b/testsuite/integration-arquillian/pom.xml
@@ -72,6 +72,9 @@
         <migration.70.version>1.9.8.Final</migration.70.version>
         <migration.71.version>2.5.5.Final</migration.71.version>
         <migration.72.version>3.4.3.Final</migration.72.version>
+
+        <!-- By default, skip docker-maven-plugin when running base tests-->
+        <docker.database.skip>true</docker.database.skip>
     </properties>
 
     <dependencyManagement>
@@ -319,6 +322,54 @@
                     </plugins>
                 </pluginManagement>
             </build>
+        </profile>
+        <profile>
+            <id>db-mysql</id>
+            <properties>
+                <keycloak.connectionsJpa.driver>com.mysql.jdbc.Driver</keycloak.connectionsJpa.driver>
+                <keycloak.connectionsJpa.database>keycloak</keycloak.connectionsJpa.database>
+                <keycloak.connectionsJpa.user>keycloak</keycloak.connectionsJpa.user>
+                <keycloak.connectionsJpa.password>keycloak</keycloak.connectionsJpa.password>
+                <keycloak.connectionsJpa.url>jdbc:mysql://${auth.server.db.host}/${keycloak.connectionsJpa.database}</keycloak.connectionsJpa.url>
+                <jdbc.mvn.groupId>mysql</jdbc.mvn.groupId>
+                <jdbc.mvn.artifactId>mysql-connector-java</jdbc.mvn.artifactId>
+                <jdbc.mvn.version>${mysql.version}</jdbc.mvn.version>
+                <docker.database.image>mysql:5.7.25</docker.database.image>
+                <docker.database.port>3306</docker.database.port>
+                <docker.database.skip>false</docker.database.skip>
+            </properties>
+        </profile>
+        <profile>
+            <id>db-postgres</id>
+            <properties>
+                <keycloak.connectionsJpa.driver>org.postgresql.Driver</keycloak.connectionsJpa.driver>
+                <keycloak.connectionsJpa.database>keycloak</keycloak.connectionsJpa.database>
+                <keycloak.connectionsJpa.user>keycloak</keycloak.connectionsJpa.user>
+                <keycloak.connectionsJpa.password>keycloak</keycloak.connectionsJpa.password>
+                <keycloak.connectionsJpa.url>jdbc:postgresql://${auth.server.db.host}/${keycloak.connectionsJpa.database}</keycloak.connectionsJpa.url>
+                <jdbc.mvn.groupId>org.postgresql</jdbc.mvn.groupId>
+                <jdbc.mvn.artifactId>postgresql</jdbc.mvn.artifactId>
+                <jdbc.mvn.version>${postgresql.version}</jdbc.mvn.version>
+                <docker.database.image>postgres:9.6.11</docker.database.image>
+                <docker.database.port>5432</docker.database.port>
+                <docker.database.skip>false</docker.database.skip>
+            </properties>
+        </profile>
+        <profile>
+            <id>db-mariadb</id>
+            <properties>
+                <keycloak.connectionsJpa.driver>org.mariadb.jdbc.Driver</keycloak.connectionsJpa.driver>
+                <keycloak.connectionsJpa.database>keycloak</keycloak.connectionsJpa.database>
+                <keycloak.connectionsJpa.user>keycloak</keycloak.connectionsJpa.user>
+                <keycloak.connectionsJpa.password>keycloak</keycloak.connectionsJpa.password>
+                <keycloak.connectionsJpa.url>jdbc:mariadb://${auth.server.db.host}/${keycloak.connectionsJpa.database}</keycloak.connectionsJpa.url>
+                <jdbc.mvn.groupId>org.mariadb.jdbc</jdbc.mvn.groupId>
+                <jdbc.mvn.artifactId>mariadb-java-client</jdbc.mvn.artifactId>
+                <jdbc.mvn.version>${mariadb.version}</jdbc.mvn.version>
+                <docker.database.image>mariadb:10.2.21</docker.database.image>
+                <docker.database.port>3306</docker.database.port>
+                <docker.database.skip>false</docker.database.skip>
+            </properties>
         </profile>
     </profiles>
 

--- a/testsuite/integration-arquillian/tests/base/pom.xml
+++ b/testsuite/integration-arquillian/tests/base/pom.xml
@@ -193,10 +193,16 @@
                     </excludes>
                     <systemPropertyVariables>
                         <com.mchange.v2.c3p0.VMID>testsuiteVmId</com.mchange.v2.c3p0.VMID>
+                        <auth.server.db.host>${docker.container.testdb.ip}</auth.server.db.host>
+                        <keycloak.connectionsJpa.driver>${keycloak.connectionsJpa.driver}</keycloak.connectionsJpa.driver>
+                        <keycloak.connectionsJpa.url>${keycloak.connectionsJpa.url}</keycloak.connectionsJpa.url>
+                        <keycloak.connectionsJpa.database>${keycloak.connectionsJpa.database}</keycloak.connectionsJpa.database>
+                        <keycloak.connectionsJpa.user>${keycloak.connectionsJpa.user}</keycloak.connectionsJpa.user>
+                        <keycloak.connectionsJpa.password>${keycloak.connectionsJpa.password}</keycloak.connectionsJpa.password>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
-        
+
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
                 <executions>
@@ -301,6 +307,64 @@
                             <goPath>${project.build.directory}/gopath</goPath>
                             <tag>0.5</tag>
                         </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <version>${docker.maven.plugin.version}</version>
+                <configuration>
+                    <skip>${docker.database.skip}</skip>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>start-db-container</id>
+                        <phase>process-test-classes</phase>
+                        <goals>
+                            <goal>start</goal>
+                        </goals>
+                        <configuration>
+                            <showLogs>true</showLogs>
+                            <images>
+                                <image>
+                                    <alias>testdb</alias>
+                                    <name>${docker.database.image}</name>
+                                    <run>
+                                        <ports>
+                                            <port>${docker.database.port}</port>
+                                        </ports>
+                                        <env>
+                                            <!-- MYSQL and MariaDB -->
+                                            <MYSQL_DATABASE>${keycloak.connectionsJpa.database}</MYSQL_DATABASE>
+                                            <MYSQL_USER>${keycloak.connectionsJpa.user}</MYSQL_USER>
+                                            <MYSQL_PASSWORD>${keycloak.connectionsJpa.password}</MYSQL_PASSWORD>
+                                            <MYSQL_RANDOM_ROOT_PASSWORD>true</MYSQL_RANDOM_ROOT_PASSWORD>
+
+                                            <!-- PostgreSQL -->
+                                            <POSTGRES_DB>${keycloak.connectionsJpa.database}</POSTGRES_DB>
+                                            <POSTGRES_USER>${keycloak.connectionsJpa.user}</POSTGRES_USER>
+                                            <POSTGRES_PASSWORD>${keycloak.connectionsJpa.password}</POSTGRES_PASSWORD>
+                                        </env>
+                                        <wait>
+                                            <tcp>
+                                                <ports>
+                                                    <port>${docker.database.port}</port>
+                                                </ports>
+                                            </tcp>
+                                            <time>120000</time>
+                                        </wait>
+                                    </run>
+                                </image>
+                            </images>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>stop-db-container</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>stop</goal>
+                        </goals>
                     </execution>
                 </executions>
             </plugin>

--- a/testsuite/integration-arquillian/tests/base/src/test/resources/arquillian.xml
+++ b/testsuite/integration-arquillian/tests/base/src/test/resources/arquillian.xml
@@ -127,6 +127,7 @@
                 ${kie.maven.settings}
                 -Dauth.server.truststore=${auth.server.truststore}
                 -Dauth.server.truststore.password=${auth.server.truststore.password}
+                -Dauth.server.db.host=${auth.server.db.host}
             </property>
             <property name="javaVmArguments">
                 ${auth.server.jboss.jvm.debug.args}
@@ -154,6 +155,7 @@
                     ${auth.server.profile}
                     -Dauth.server.truststore=${auth.server.truststore}
                     -Dauth.server.truststore.password=${auth.server.truststore.password}
+                    -Dauth.server.db.host=${auth.server.db.host}
                 </property>
                 <property name="javaVmArguments">
                     ${auth.server.memory.settings}
@@ -179,6 +181,7 @@
                     ${auth.server.profile}
                     -Dauth.server.truststore=${auth.server.truststore}
                     -Dauth.server.truststore.password=${auth.server.truststore.password}
+                    -Dauth.server.db.host=${auth.server.db.host}
                 </property>
                 <property name="javaVmArguments">
                     ${auth.server.memory.settings}
@@ -258,6 +261,7 @@
                     ${auth.server.profile}
                     -Dauth.server.truststore=${auth.server.truststore}
                     -Dauth.server.truststore.password=${auth.server.truststore.password}
+                    -Dauth.server.db.host=${auth.server.db.host}
                 </property>
                 <property name="javaVmArguments">
                     ${auth.server.memory.settings}
@@ -287,6 +291,7 @@
                     ${auth.server.profile}
                     -Dauth.server.truststore=${auth.server.truststore}
                     -Dauth.server.truststore.password=${auth.server.truststore.password}
+                    -Dauth.server.db.host=${auth.server.db.host}
                 </property>
                 <property name="javaVmArguments">
                     ${auth.server.memory.settings}
@@ -423,6 +428,7 @@
                     -Dauth.server.truststore.password=${auth.server.truststore.password}
                     -Dkeycloak.connectionsInfinispan.default.remoteStoreSecurityEnabled=${keycloak.connectionsInfinispan.default.remoteStoreSecurityEnabled}
                     -Dkeycloak.connectionsInfinispan.hotrodProtocolVersion=${keycloak.connectionsInfinispan.hotrodProtocolVersion}
+                    -Dauth.server.db.host=${auth.server.db.host}
                 </property>
                 <property name="javaVmArguments">
                     ${auth.server.memory.settings}
@@ -452,6 +458,7 @@
                     -Dauth.server.truststore.password=${auth.server.truststore.password}
                     -Dkeycloak.connectionsInfinispan.default.remoteStoreSecurityEnabled=${keycloak.connectionsInfinispan.default.remoteStoreSecurityEnabled}
                     -Dkeycloak.connectionsInfinispan.hotrodProtocolVersion=${keycloak.connectionsInfinispan.hotrodProtocolVersion}
+                    -Dauth.server.db.host=${auth.server.db.host}
                 </property>
                 <property name="javaVmArguments">
                     ${auth.server.memory.settings}
@@ -482,6 +489,7 @@
                     -Dauth.server.truststore.password=${auth.server.truststore.password}
                     -Dkeycloak.connectionsInfinispan.default.remoteStoreSecurityEnabled=${keycloak.connectionsInfinispan.default.remoteStoreSecurityEnabled}
                     -Dkeycloak.connectionsInfinispan.hotrodProtocolVersion=${keycloak.connectionsInfinispan.hotrodProtocolVersion}
+                    -Dauth.server.db.host=${auth.server.db.host}
                 </property>
                 <property name="javaVmArguments">
                     ${auth.server.memory.settings}
@@ -511,6 +519,7 @@
                     -Dauth.server.truststore.password=${auth.server.truststore.password}
                     -Dkeycloak.connectionsInfinispan.default.remoteStoreSecurityEnabled=${keycloak.connectionsInfinispan.default.remoteStoreSecurityEnabled}
                     -Dkeycloak.connectionsInfinispan.hotrodProtocolVersion=${keycloak.connectionsInfinispan.hotrodProtocolVersion}
+                    -Dauth.server.db.host=${auth.server.db.host}
                 </property>
                 <property name="javaVmArguments">
                     ${auth.server.memory.settings}
@@ -551,6 +560,7 @@
                 ${auth.server.memory.settings}
                 -Dauth.server.truststore=${auth.server.truststore}
                 -Dauth.server.truststore.password=${auth.server.truststore.password}
+                -Dauth.server.db.host=${auth.server.db.host}
             </property>
             <property name="managementPort">${auth.server.management.port}</property>
             <property name="startupTimeoutInSeconds">${auth.server.jboss.startup.timeout}</property>


### PR DESCRIPTION
The intent of this PR is run database tests using docker containers. Right now you can run tests using `mvn clean verify -Pmysql,jpa,auth-server-wildfly` or `mvn clean verify -Ppostgres,jpa,auth-server-wildfly`.

I'm finishing some last tests and how this works with CI. As well try to simplify the mvn comand to a single profile such as `-Pmysql|postgres`.