### PR TITLE
FIX CVE-2018-1000632 caused by transitively dependent dom4j 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,8 +62,8 @@
         <github.relaxng.version>2011.1</github.relaxng.version>
         <h2.version>1.4.193</h2.version>
         <javax.persistence.version>2.2</javax.persistence.version>
-        <hibernate.core.version>5.3.6.Final</hibernate.core.version>
-        <hibernate.c3p0.version>5.3.6.Final</hibernate.c3p0.version>
+        <hibernate.core.version>5.3.7.Final</hibernate.core.version>
+        <hibernate.c3p0.version>5.3.7.Final</hibernate.c3p0.version>
         <infinispan.version>9.3.1.Final</infinispan.version>
         <jackson.version>2.9.5</jackson.version>
         <javax.mail.version>1.6.1</javax.mail.version>


### PR DESCRIPTION
Fixes https://nvd.nist.gov/vuln/detail/CVE-2018-1000632 caused by dom4j transitive dependency (through hibernate-core).

Discussion in Hibernate Jira: https://hibernate.atlassian.net/browse/HHH-12964