### PR TITLE
KEYCLOAK-9538: Allow usage of AuthzClient#createRefreshableAccessTokenSupplier

### DIFF
--- a/authz/client/src/main/java/org/keycloak/authorization/client/AuthzClient.java
+++ b/authz/client/src/main/java/org/keycloak/authorization/client/AuthzClient.java
@@ -211,6 +211,24 @@ public class AuthzClient {
     }
 
     /**
+     * Obtains an access token callable (transparently handling refreshes) using the client credentials.
+     *
+     * @return an {@link TokenCallable}
+     */
+    public TokenCallable obtainAccessTokenCallable() {
+        return createPatSupplier();
+    }
+
+    /**
+     * Obtains an access token callable (transparently handling refreshes) using the resource owner credentials.
+     *
+     * @return an {@link TokenCallable}
+     */
+    public TokenCallable obtainAccessTokenCallable(String userName, String password) {
+        return createPatSupplier(userName, password);
+    }
+
+    /**
      * Returns the configuration obtained from the server at the UMA Discovery Endpoint.
      *
      * @return the {@link ServerConfiguration}
@@ -267,7 +285,7 @@ public class AuthzClient {
         return createPatSupplier(null, null);
     }
 
-    public TokenCallable createRefreshableAccessTokenSupplier(final String userName, final String password) {
+    private TokenCallable createRefreshableAccessTokenSupplier(final String userName, final String password) {
         return new TokenCallable(userName, password, http, configuration, serverConfiguration);
     }
 }

--- a/authz/client/src/main/java/org/keycloak/authorization/client/AuthzClient.java
+++ b/authz/client/src/main/java/org/keycloak/authorization/client/AuthzClient.java
@@ -267,7 +267,7 @@ public class AuthzClient {
         return createPatSupplier(null, null);
     }
 
-    private TokenCallable createRefreshableAccessTokenSupplier(final String userName, final String password) {
+    public TokenCallable createRefreshableAccessTokenSupplier(final String userName, final String password) {
         return new TokenCallable(userName, password, http, configuration, serverConfiguration);
     }
 }


### PR DESCRIPTION
In my applications I often need to have a way to just obtain an access token and refresh it if needed.

The public method `org.keycloak.authorization.client.AuthzClient#obtainAccessToken()` is enough for the first, but there is no way to easily refresh it. (Or am I just blind?)

The TokenCallable class is already a perfect implementation of this - only that there is no way to obtain an instance of this without configuring it yourself:

```kotlin
val tokenCallable = TokenCallable(Http(authzClient.configuration, ClientAuthenticator { requestParams, requestHeaders ->
    val secret = authzClient.configuration.credentials.get("secret") as String?
            ?: throw RuntimeException("Client secret not provided.")

    requestHeaders["Authorization"] = BasicAuthHelper.createHeader(authzClient.configuration.resource, secret)
}), authzClient.configuration, authzClient.serverConfiguration)
```
