### PR TITLE
KEYCLOAK-9571: Fix Redundant Calls to /group and /count in Web UI

### DIFF
--- a/themes/src/main/resources/theme/base/admin/resources/js/controllers/groups.js
+++ b/themes/src/main/resources/theme/base/admin/resources/js/controllers/groups.js
@@ -17,6 +17,7 @@ module.controller('GroupListCtrl', function($scope, $route, $q, realm, Groups, G
 
     var refreshGroups = function (search) {
         console.log('refreshGroups');
+        $scope.currentPageInput = $scope.currentPage;
 
         var first = ($scope.currentPage * $scope.pageSize) - $scope.pageSize;
         console.log('first:' + first);
@@ -73,20 +74,26 @@ module.controller('GroupListCtrl', function($scope, $route, $q, realm, Groups, G
     refreshGroups();
 
     $scope.$watch('currentPage', function(newValue, oldValue) {
-        if(newValue !== oldValue) {
+        if(parseInt(newValue, 10) !== oldValue) {
             refreshGroups($scope.searchCriteria);
         }
     });
 
     $scope.clearSearch = function() {
         $scope.searchCriteria = '';
-        $scope.currentPage = 1;
-        refreshGroups();
+        if (parseInt($scope.currentPage, 10) === 1) {
+            refreshGroups();
+        } else {
+            $scope.currentPage = 1;
+        }
     };
 
     $scope.searchGroup = function() {
-        $scope.currentPage = 1;
-        refreshGroups($scope.searchCriteria);
+        if (parseInt($scope.currentPage, 10) === 1) {
+            refreshGroups($scope.searchCriteria);
+        } else {
+            $scope.currentPage = 1;
+        }
     };
 
     $scope.edit = function(selected) {
@@ -475,6 +482,7 @@ module.controller('DefaultGroupsCtrl', function($scope, $q, realm, Groups, Group
 
     var refreshAvailableGroups = function (search) {
         var first = ($scope.currentPage * $scope.pageSize) - $scope.pageSize;
+        $scope.currentPageInput = $scope.currentPage;
         var queryParams = {
             realm : realm.realm,
             first : first,
@@ -520,20 +528,26 @@ module.controller('DefaultGroupsCtrl', function($scope, $q, realm, Groups, Group
     refreshAvailableGroups();
 
     $scope.$watch('currentPage', function(newValue, oldValue) {
-        if(newValue !== oldValue) {
+        if(parseInt(newValue, 10) !== parseInt(oldValue, 10)) {
             refreshAvailableGroups($scope.searchCriteria);
         }
     });
 
     $scope.clearSearch = function() {
         $scope.searchCriteria = '';
-        $scope.currentPage = 1;
-        refreshAvailableGroups();
+        if (parseInt($scope.currentPage, 10) === 1) {
+            refreshAvailableGroups();
+        } else {
+            $scope.currentPage = 1;
+        }
     };
 
     $scope.searchGroup = function() {
-        $scope.currentPage = 1;
-        refreshAvailableGroups($scope.searchCriteria);
+        if (parseInt($scope.currentPage, 10) === 1) {
+            refreshAvailableGroups($scope.searchCriteria);
+        } else {
+            $scope.currentPage = 1;
+        }
     };
 
     refreshDefaultGroups();

--- a/themes/src/main/resources/theme/base/admin/resources/js/controllers/users.js
+++ b/themes/src/main/resources/theme/base/admin/resources/js/controllers/users.js
@@ -975,6 +975,7 @@ module.controller('UserGroupMembershipCtrl', function($scope, $q, realm, user, U
     };
 
     var refreshUserGroupMembership = function (search) {
+        $scope.currentMembershipPageInput = $scope.currentMembershipPage;
         var first = ($scope.currentMembershipPage * $scope.pageSize) - $scope.pageSize;
         var queryParams = {
             realm : realm.realm,
@@ -1021,12 +1022,16 @@ module.controller('UserGroupMembershipCtrl', function($scope, $q, realm, user, U
             } else {
                 $scope.numberOfMembershipPages = 1;
             }
+            if (parseInt($scope.currentMembershipPage, 10) > $scope.numberOfMembershipPages) {
+                $scope.currentMembershipPage = $scope.numberOfMembershipPages;
+            }
         }, function (failed) {
             Notifications.error(failed);
         });
     };
 
     var refreshAvailableGroups = function (search) {
+        $scope.currentPageInput = $scope.currentPage;
         var first = ($scope.currentPage * $scope.pageSize) - $scope.pageSize;
         var queryParams = {
             realm : realm.realm,
@@ -1077,14 +1082,19 @@ module.controller('UserGroupMembershipCtrl', function($scope, $q, realm, user, U
 
     $scope.clearSearchMembership = function() {
         $scope.searchCriteriaMembership = '';
-        $scope.currentMembershipPage = 1;
-        $scope.currentMembershipPageInput = 1;
-        refreshUserGroupMembership();
+        if (parseInt($scope.currentMembershipPage, 10) === 1) {
+            refreshUserGroupMembership();
+        } else {
+            $scope.currentMembershipPage = 1;
+        }
     };
 
     $scope.searchGroupMembership = function() {
-        $scope.currentMembershipPage = 1;
-        refreshUserGroupMembership($scope.searchCriteriaMembership);
+        if (parseInt($scope.currentMembershipPage, 10) === 1) {
+            refreshUserGroupMembership($scope.searchCriteriaMembership);
+        } else {
+            $scope.currentMembershipPage = 1;
+        }
     };
 
     refreshAvailableGroups();
@@ -1092,30 +1102,32 @@ module.controller('UserGroupMembershipCtrl', function($scope, $q, realm, user, U
     refreshCompleteUserGroupMembership();
 
     $scope.$watch('currentPage', function(newValue, oldValue) {
-        if(newValue !== oldValue) {
-            refreshAvailableGroups($scope.searchCriteria)
-            .then(function(){
-                refreshUserGroupMembership($scope.searchCriteriaMembership);
-            });
+        if(parseInt(newValue, 10) !== parseInt(oldValue, 10)) {
+            refreshAvailableGroups($scope.searchCriteria);
         }
     });
 
     $scope.$watch('currentMembershipPage', function(newValue, oldValue) {
-        if(newValue !== oldValue) {
+        if(parseInt(newValue, 10) !== parseInt(oldValue, 10)) {
             refreshUserGroupMembership($scope.searchCriteriaMembership);
         }
     });
 
     $scope.clearSearch = function() {
         $scope.searchCriteria = '';
-        $scope.currentPage = 1;
-        $scope.currentPageInput = 1;
-        refreshAvailableGroups();
+        if (parseInt($scope.currentPage, 10) === 1) {
+            refreshAvailableGroups();
+        } else {
+            $scope.currentPage = 1;
+        }
     };
 
     $scope.searchGroup = function() {
-        $scope.currentPage = 1;
-        refreshAvailableGroups($scope.searchCriteria);
+        if (parseInt($scope.currentPage, 10) === 1) {
+            refreshAvailableGroups($scope.searchCriteria);
+        } else {
+            $scope.currentPage = 1;
+        }
     };
 
     $scope.joinGroup = function() {
@@ -1129,7 +1141,7 @@ module.controller('UserGroupMembershipCtrl', function($scope, $q, realm, user, U
         }
         UserGroupMapping.update({realm: realm.realm, userId: user.id, groupId: $scope.tree.currentNode.id}, function() {
             $scope.allGroupMemberships.push($scope.tree.currentNode);
-            refreshUserGroupMembership();
+            refreshUserGroupMembership($scope.searchCriteriaMembership);
             Notifications.success('Added group membership');
         });
 
@@ -1142,8 +1154,7 @@ module.controller('UserGroupMembershipCtrl', function($scope, $q, realm, user, U
         }
         UserGroupMapping.remove({realm: realm.realm, userId: user.id, groupId: $scope.membershipTree.currentNode.id}, function () {
             removeGroupMember($scope.allGroupMemberships, $scope.membershipTree.currentNode);
-            refreshAvailableGroups();
-            refreshUserGroupMembership();
+            refreshUserGroupMembership($scope.searchCriteriaMembership);
             Notifications.success('Removed group membership');
         });
 


### PR DESCRIPTION
This PR is related to https://issues.jboss.org/browse/KEYCLOAK-9571.
The groups page and the user group membership page on the Keycloak Admin Web UI are calling the /groups and /count endpoint more often than required.