### PR TITLE
feature: add additional GET parameters support

### DIFF
--- a/adapters/oidc/js/src/main/resources/keycloak.d.ts
+++ b/adapters/oidc/js/src/main/resources/keycloak.d.ts
@@ -317,6 +317,11 @@ declare namespace Keycloak {
 		timeSkew?: number;
 
 		/**
+		 * Set the additional GET parameters.
+		 */
+		urlParams?: { [index: string]: string }
+
+		/**
 		 * @private Undocumented.
 		 */
 		loginRequired?: boolean;

--- a/adapters/oidc/js/src/main/resources/keycloak.js
+++ b/adapters/oidc/js/src/main/resources/keycloak.js
@@ -41,6 +41,7 @@
         }
 
         var useNonce = true;
+        var urlParams = '';
         
         kc.init = function (initOptions) {
             kc.authenticated = false;
@@ -71,6 +72,10 @@
 
                 if (initOptions.checkLoginIframeInterval) {
                     loginIframe.interval = initOptions.checkLoginIframeInterval;
+                }
+
+                if (typeof initOptions.urlParams !== 'undefined') {
+                    urlParams = generateParams(initOptions.urlParams);
                 }
 
                 if (initOptions.promiseType === 'native') {
@@ -313,6 +318,8 @@
                 url += '&kc_locale=' + encodeURIComponent(options.kcLocale);
             }
 
+            url += urlParams;
+
             return url;
         }
 
@@ -346,7 +353,8 @@
                 url = realm
                 + '/account'
                 + '?referrer=' + encodeURIComponent(kc.clientId)
-                + '&referrer_uri=' + encodeURIComponent(adapter.redirectUri(options));
+                + '&referrer_uri=' + encodeURIComponent(adapter.redirectUri(options))
+                + urlParams;
             }
             return url;
         }
@@ -535,6 +543,16 @@
                     kc.login();
                 }
             }
+        }
+
+        function generateParams(params) {
+            var str = '';
+            for (var param in params) {
+                if (params.hasOwnProperty(param)) {
+                    str += '&' + param + '=' + encodeURIComponent(params[param]);
+                }
+            }
+            return str;
         }
 
         function getRealmUrl() {


### PR DESCRIPTION
My keycloak server support more then one theme via include css file with colors, but i can't receive the theme name in the url, i searched.
In my case i should pass the theme name like _http://realm...&theme=sometheme_.

I tried resolve this problem without changes, but unsuccessfully. Can't use one predefined theme because themes switch dynamically.