### PR TITLE
Importing users from keycloak-add-user.json now allows users to join existing groups.

### DIFF
--- a/services/src/main/java/org/keycloak/services/ServicesLogger.java
+++ b/services/src/main/java/org/keycloak/services/ServicesLogger.java
@@ -81,6 +81,10 @@ public interface ServicesLogger extends BasicLogger {
     @Message(id=8, value="Failed to add user %s to realm %s: realm not found")
     void addUserFailedRealmNotFound(String user, String realm);
 
+    @LogMessage(level = WARN)
+    @Message(id=104, value="Failed to add user %s to group with path %s: group not found")
+    void addUserFailedGroupNotFound(String user, String group);
+
     @LogMessage(level = INFO)
     @Message(id=9, value="Added user '%s' to realm '%s'")
     void addUserSuccess(String user, String realm);

--- a/services/src/main/java/org/keycloak/services/resources/KeycloakApplication.java
+++ b/services/src/main/java/org/keycloak/services/resources/KeycloakApplication.java
@@ -33,6 +33,7 @@ import org.keycloak.models.KeycloakSessionTask;
 import org.keycloak.models.ModelDuplicateException;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
+import org.keycloak.models.GroupModel;
 import org.keycloak.models.dblock.DBLockManager;
 import org.keycloak.models.dblock.DBLockProvider;
 import org.keycloak.models.utils.KeycloakModelUtils;
@@ -443,6 +444,17 @@ public class KeycloakApplication extends Application {
                                 user.setEnabled(userRep.isEnabled());
                                 RepresentationToModel.createCredentials(userRep, session, realm, user, false);
                                 RepresentationToModel.createRoleMappings(userRep, user, realm);
+                                if (userRep.getGroups() != null) {
+                                    for (String path : userRep.getGroups()) {
+                                        GroupModel group = KeycloakModelUtils.findGroupByPath(realm, path);
+                                        if (group == null) {
+                                            ServicesLogger.LOGGER.addUserFailedGroupNotFound(user.getUsername(), path);
+                                        }
+                                        else {
+                                            user.joinGroup(group);
+                                        }
+                                    }
+                                }
                             }
 
                             session.getTransactionManager().commit();


### PR DESCRIPTION
_Expected behaviour:_
We bootstrap our Keycloak docker image by importing a custom realm then custom users. To import users into Keycloak at container start up, we put a keycloak-add-user.json file in the relevant configuration directory. In this json file, we describe users to be imported, including their roles and groups. 
Once Keycloak is started, we expect to see the given users with correct roles and groups mapping.

_Current behaviour:_
The users are correctly imported, as well as their roles, but the users are not mapped to the given groups.

This pull request allows the users group mappings to be imported as well. 
However, I can see that only User name, credentials and roles mapping were imported there. I guess other user information are not imported because of federation issues at this point of the Keycloak start up. Thus, is the implementation I propose to import group mappings OK? Otherwise, would it be possible to implement this feature in another way? Should the other user information be imported as well? Thanks in advance for your answer.