### PR TITLE
KEYCLOAK-9167 Using kcadm to update an identity-provider instance via…

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/IdentityProviderResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/IdentityProviderResource.java
@@ -172,6 +172,10 @@ public class IdentityProviderResource {
         String newProviderId = providerRep.getAlias();
         String oldProviderId = getProviderIdByInternalId(realm, internalId);
 
+        if (oldProviderId == null) {
+            lookUpProviderIdByAlias(realm, providerRep);
+        }
+
         IdentityProviderModel updated = RepresentationToModel.toModel(realm, providerRep);
 
         if (updated.getConfig() != null && ComponentRepresentation.SECRET_VALUE.equals(updated.getConfig().get("clientSecret"))) {
@@ -199,6 +203,18 @@ public class IdentityProviderResource {
         }
 
         return null;
+    }
+
+    // sets internalId to IdentityProvider based on alias
+    private static void lookUpProviderIdByAlias(RealmModel realm, IdentityProviderRepresentation providerRep) {
+        List<IdentityProviderModel> providerModels = realm.getIdentityProviders();
+        for (IdentityProviderModel providerModel : providerModels) {
+            if (providerModel.getAlias().equals(providerRep.getAlias())) {
+                providerRep.setInternalId(providerModel.getInternalId());
+                return;
+            }
+        }
+        throw new javax.ws.rs.NotFoundException();
     }
 
     private static void updateUsersAfterProviderAliasChange(List<UserModel> users, String oldProviderId, String newProviderId, RealmModel realm, KeycloakSession session) {

--- a/testsuite/integration-arquillian/tests/base/src/test/resources/cli/idp-keycloak-9167.json
+++ b/testsuite/integration-arquillian/tests/base/src/test/resources/cli/idp-keycloak-9167.json
@@ -1,0 +1,21 @@
+{
+  "alias" : "idpAlias",
+  "displayName" : "SAML_UPDATED",
+  "providerId" : "saml",
+  "enabled" : true,
+  "updateProfileFirstLoginMode" : "on",
+  "trustEmail" : false,
+  "storeToken" : false,
+  "addReadTokenRoleOnCreate" : false,
+  "authenticateByDefault" : false,
+  "linkOnly" : false,
+  "firstBrokerLoginFlowAlias" : "first broker login",
+  "config" : {
+    "nameIDPolicyFormat" : "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
+    "postBindingResponse" : "false",
+    "singleLogoutServiceUrl" : "http://saml.idp/saml",
+    "postBindingAuthnRequest" : "false",
+    "singleSignOnServiceUrl" : "http://saml.idp/saml",
+    "backchannelSupported" : "false"
+  }
+}


### PR DESCRIPTION
… a json file does not work without an "internalId" present in the json