### PR TITLE
[KEYCLOAK-9451] - Policy evaluation fails when not evaluated against a particual resource

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/authorization/policy/evaluation/DecisionPermissionCollector.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/policy/evaluation/DecisionPermissionCollector.java
@@ -78,7 +78,7 @@ public class DecisionPermissionCollector extends AbstractDecisionCollector {
                                 grantedScopes.add(scope);
                                 // we need to grant any scope granted by a permission in case it is not explicitly
                                 // associated with the resource. For instance, resources inheriting scopes from parent resources.
-                                if (!resource.getScopes().contains(scope)) {
+                                if (resource != null && !resource.getScopes().contains(scope)) {
                                     deniedScopes.remove(scope);
                                 }
                             }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/authorization/AbstractAuthorizationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/authorization/AbstractAuthorizationTest.java
@@ -107,13 +107,13 @@ public abstract class AbstractAuthorizationTest extends AbstractClientTest {
 
         ResourceScopesResource resources = getClientResource().authorization().scopes();
 
-        Response response = resources.create(newScope);
+        try (Response response = resources.create(newScope)) {
+            assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatus());
 
-        assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatus());
+            ScopeRepresentation stored = response.readEntity(ScopeRepresentation.class);
 
-        ScopeRepresentation stored = response.readEntity(ScopeRepresentation.class);
-
-        return resources.scope(stored.getId());
+            return resources.scope(stored.getId());
+        }
     }
 
     private RealmBuilder createTestRealm() {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/authorization/AggregatePolicyManagementTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/authorization/AggregatePolicyManagementTest.java
@@ -86,27 +86,30 @@ public class AggregatePolicyManagementTest extends AbstractPolicyManagementTest 
         representation.addPolicy("Only Marta Policy");
 
         AggregatePoliciesResource policies = authorization.policies().aggregate();
-        Response response = policies.create(representation);
-        AggregatePolicyRepresentation created = response.readEntity(AggregatePolicyRepresentation.class);
 
-        policies.findById(created.getId()).remove();
+        try (Response response = policies.create(representation)) {
+            AggregatePolicyRepresentation created = response.readEntity(AggregatePolicyRepresentation.class);
 
-        AggregatePolicyResource removed = policies.findById(created.getId());
+            policies.findById(created.getId()).remove();
 
-        try {
-            removed.toRepresentation();
-            fail("Policy not removed");
-        } catch (NotFoundException ignore) {
+            AggregatePolicyResource removed = policies.findById(created.getId());
 
+            try {
+                removed.toRepresentation();
+                fail("Policy not removed");
+            } catch (NotFoundException ignore) {
+
+            }
         }
     }
 
     private void assertCreated(AuthorizationResource authorization, AggregatePolicyRepresentation representation) {
         AggregatePoliciesResource permissions = authorization.policies().aggregate();
-        Response response = permissions.create(representation);
-        AggregatePolicyRepresentation created = response.readEntity(AggregatePolicyRepresentation.class);
-        AggregatePolicyResource permission = permissions.findById(created.getId());
-        assertRepresentation(representation, permission);
+        try (Response response = permissions.create(representation)) {
+            AggregatePolicyRepresentation created = response.readEntity(AggregatePolicyRepresentation.class);
+            AggregatePolicyResource permission = permissions.findById(created.getId());
+            assertRepresentation(representation, permission);
+        }
     }
 
     private void assertRepresentation(AggregatePolicyRepresentation representation, AggregatePolicyResource policy) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/authorization/ClientPolicyManagementTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/authorization/ClientPolicyManagementTest.java
@@ -115,19 +115,20 @@ public class ClientPolicyManagementTest extends AbstractPolicyManagementTest {
         representation.addClient("Client A");
 
         ClientPoliciesResource policies = authorization.policies().client();
-        Response response = policies.create(representation);
-        ClientPolicyRepresentation created = response.readEntity(ClientPolicyRepresentation.class);
-        response.close();
 
-        policies.findById(created.getId()).remove();
+        try (Response response = policies.create(representation)) {
+            ClientPolicyRepresentation created = response.readEntity(ClientPolicyRepresentation.class);
 
-        ClientPolicyResource removed = policies.findById(created.getId());
+            policies.findById(created.getId()).remove();
 
-        try {
-            removed.toRepresentation();
-            fail("Permission not removed");
-        } catch (NotFoundException ignore) {
+            ClientPolicyResource removed = policies.findById(created.getId());
 
+            try {
+                removed.toRepresentation();
+                fail("Permission not removed");
+            } catch (NotFoundException ignore) {
+
+            }
         }
     }
 
@@ -185,28 +186,30 @@ public class ClientPolicyManagementTest extends AbstractPolicyManagementTest {
         representation.addClient("Client A");
 
         ClientPoliciesResource policies = authorization.policies().client();
-        Response response = policies.create(representation);
-        ClientPolicyRepresentation created = response.readEntity(ClientPolicyRepresentation.class);
-        response.close();
 
-        PolicyResource policy = authorization.policies().policy(created.getId());
-        PolicyRepresentation genericConfig = policy.toRepresentation();
+        try (Response response = policies.create(representation)) {
+            ClientPolicyRepresentation created = response.readEntity(ClientPolicyRepresentation.class);
 
-        assertNotNull(genericConfig.getConfig());
-        assertNotNull(genericConfig.getConfig().get("clients"));
+            PolicyResource policy = authorization.policies().policy(created.getId());
+            PolicyRepresentation genericConfig = policy.toRepresentation();
 
-        ClientRepresentation user = getRealm().clients().findByClientId("Client A").get(0);
+            assertNotNull(genericConfig.getConfig());
+            assertNotNull(genericConfig.getConfig().get("clients"));
 
-        assertTrue(genericConfig.getConfig().get("clients").contains(user.getId()));
+            ClientRepresentation user = getRealm().clients().findByClientId("Client A").get(0);
+
+            assertTrue(genericConfig.getConfig().get("clients").contains(user.getId()));
+        }
     }
 
     private void assertCreated(AuthorizationResource authorization, ClientPolicyRepresentation representation) {
         ClientPoliciesResource permissions = authorization.policies().client();
-        Response response = permissions.create(representation);
-        ClientPolicyRepresentation created = response.readEntity(ClientPolicyRepresentation.class);
-        response.close();
-        ClientPolicyResource permission = permissions.findById(created.getId());
-        assertRepresentation(representation, permission);
+
+        try (Response response = permissions.create(representation)) {
+            ClientPolicyRepresentation created = response.readEntity(ClientPolicyRepresentation.class);
+            ClientPolicyResource permission = permissions.findById(created.getId());
+            assertRepresentation(representation, permission);
+        }
     }
 
     private void assertRepresentation(ClientPolicyRepresentation representation, ClientPolicyResource permission) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/authorization/GenericPolicyManagementTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/authorization/GenericPolicyManagementTest.java
@@ -189,13 +189,14 @@ public class GenericPolicyManagementTest extends AbstractAuthorizationTest {
         newPolicy.setConfig(config);
 
         PoliciesResource policies = getClientResource().authorization().policies();
-        Response response = policies.create(newPolicy);
 
-        assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatus());
+        try (Response response = policies.create(newPolicy)) {
+            assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatus());
 
-        PolicyRepresentation stored = response.readEntity(PolicyRepresentation.class);
+            PolicyRepresentation stored = response.readEntity(PolicyRepresentation.class);
 
-        return policies.policy(stored.getId());
+            return policies.policy(stored.getId());
+        }
     }
 
     private ResourceResource createResource(String name) {
@@ -205,13 +206,13 @@ public class GenericPolicyManagementTest extends AbstractAuthorizationTest {
 
         ResourcesResource resources = getClientResource().authorization().resources();
 
-        Response response = resources.create(newResource);
+        try (Response response = resources.create(newResource)) {
+            assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatus());
 
-        assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatus());
+            ResourceRepresentation stored = response.readEntity(ResourceRepresentation.class);
 
-        ResourceRepresentation stored = response.readEntity(ResourceRepresentation.class);
-
-        return resources.resource(stored.getId());
+            return resources.resource(stored.getId());
+        }
     }
 
     private ResourceScopeResource createScope(String name) {
@@ -221,13 +222,14 @@ public class GenericPolicyManagementTest extends AbstractAuthorizationTest {
 
         ResourceScopesResource scopes = getClientResource().authorization().scopes();
 
-        Response response = scopes.create(newScope);
+        try (Response response = scopes.create(newScope)) {
 
-        assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatus());
+            assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatus());
 
-        ScopeRepresentation stored = response.readEntity(ScopeRepresentation.class);
+            ScopeRepresentation stored = response.readEntity(ScopeRepresentation.class);
 
-        return scopes.scope(stored.getId());
+            return scopes.scope(stored.getId());
+        }
     }
 
     private String buildConfigOption(String... values) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/authorization/GroupPolicyManagementTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/authorization/GroupPolicyManagementTest.java
@@ -145,18 +145,20 @@ public class GroupPolicyManagementTest extends AbstractPolicyManagementTest {
         representation.addGroupPath("Group F");
 
         GroupPoliciesResource policies = authorization.policies().group();
-        Response response = policies.create(representation);
-        GroupPolicyRepresentation created = response.readEntity(GroupPolicyRepresentation.class);
 
-        policies.findById(created.getId()).remove();
+        try (Response response = policies.create(representation)) {
+            GroupPolicyRepresentation created = response.readEntity(GroupPolicyRepresentation.class);
 
-        GroupPolicyResource removed = policies.findById(created.getId());
+            policies.findById(created.getId()).remove();
 
-        try {
-            removed.toRepresentation();
-            fail("Permission not removed");
-        } catch (NotFoundException ignore) {
+            GroupPolicyResource removed = policies.findById(created.getId());
 
+            try {
+                removed.toRepresentation();
+                fail("Permission not removed");
+            } catch (NotFoundException ignore) {
+
+            }
         }
     }
 
@@ -183,18 +185,20 @@ public class GroupPolicyManagementTest extends AbstractPolicyManagementTest {
         representation.addGroupPath("/Group A");
 
         GroupPoliciesResource policies = authorization.policies().group();
-        Response response = policies.create(representation);
-        GroupPolicyRepresentation created = response.readEntity(GroupPolicyRepresentation.class);
 
-        PolicyResource policy = authorization.policies().policy(created.getId());
-        PolicyRepresentation genericConfig = policy.toRepresentation();
+        try (Response response = policies.create(representation)) {
+            GroupPolicyRepresentation created = response.readEntity(GroupPolicyRepresentation.class);
 
-        assertNotNull(genericConfig.getConfig());
-        assertNotNull(genericConfig.getConfig().get("groups"));
+            PolicyResource policy = authorization.policies().policy(created.getId());
+            PolicyRepresentation genericConfig = policy.toRepresentation();
 
-        GroupRepresentation group = getRealm().groups().groups().stream().filter(groupRepresentation -> groupRepresentation.getName().equals("Group A")).findFirst().get();
+            assertNotNull(genericConfig.getConfig());
+            assertNotNull(genericConfig.getConfig().get("groups"));
 
-        assertTrue(genericConfig.getConfig().get("groups").contains(group.getId()));
+            GroupRepresentation group = getRealm().groups().groups().stream().filter(groupRepresentation -> groupRepresentation.getName().equals("Group A")).findFirst().get();
+
+            assertTrue(genericConfig.getConfig().get("groups").contains(group.getId()));
+        }
     }
 
     private void assertCreated(AuthorizationResource authorization, GroupPolicyRepresentation representation) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/authorization/JSPolicyManagementTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/authorization/JSPolicyManagementTest.java
@@ -86,27 +86,30 @@ public class JSPolicyManagementTest extends AbstractPolicyManagementTest {
         representation.setCode("$evaluation.grant()");
 
         JSPoliciesResource policies = authorization.policies().js();
-        Response response = policies.create(representation);
-        JSPolicyRepresentation created = response.readEntity(JSPolicyRepresentation.class);
+        try (Response response = policies.create(representation)) {
+            JSPolicyRepresentation created = response.readEntity(JSPolicyRepresentation.class);
 
-        policies.findById(created.getId()).remove();
+            policies.findById(created.getId()).remove();
 
-        JSPolicyResource removed = policies.findById(created.getId());
+            JSPolicyResource removed = policies.findById(created.getId());
 
-        try {
-            removed.toRepresentation();
-            fail("Permission not removed");
-        } catch (NotFoundException ignore) {
+            try {
+                removed.toRepresentation();
+                fail("Permission not removed");
+            } catch (NotFoundException ignore) {
 
+            }
         }
     }
 
     private void assertCreated(AuthorizationResource authorization, JSPolicyRepresentation representation) {
         JSPoliciesResource permissions = authorization.policies().js();
-        Response response = permissions.create(representation);
-        JSPolicyRepresentation created = response.readEntity(JSPolicyRepresentation.class);
-        JSPolicyResource permission = permissions.findById(created.getId());
-        assertRepresentation(representation, permission);
+
+        try (Response response = permissions.create(representation)) {
+            JSPolicyRepresentation created = response.readEntity(JSPolicyRepresentation.class);
+            JSPolicyResource permission = permissions.findById(created.getId());
+            assertRepresentation(representation, permission);
+        }
     }
 
     private void assertRepresentation(JSPolicyRepresentation representation, JSPolicyResource permission) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/authorization/PolicyEnforcerClaimsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/authorization/PolicyEnforcerClaimsTest.java
@@ -333,7 +333,7 @@ public class PolicyEnforcerClaimsTest extends AbstractKeycloakTest {
 
             policy.setCode(code.toString());
 
-            clientResource.authorization().policies().js().create(policy);
+            clientResource.authorization().policies().js().create(policy).close();
 
             createResource(clientResource, "Bank Account", "/api/bank/account/{id}/withdrawal", "withdrawal");
 
@@ -343,7 +343,7 @@ public class PolicyEnforcerClaimsTest extends AbstractKeycloakTest {
             permission.addScope("withdrawal");
             permission.addPolicy(policy.getName());
 
-            clientResource.authorization().permissions().scope().create(permission);
+            clientResource.authorization().permissions().scope().create(permission).close();
         }
     }
 
@@ -362,11 +362,12 @@ public class PolicyEnforcerClaimsTest extends AbstractKeycloakTest {
         representation.setUri(uri);
         representation.setScopes(Arrays.asList(scopes).stream().map(ScopeRepresentation::new).collect(Collectors.toSet()));
 
-        javax.ws.rs.core.Response response = clientResource.authorization().resources().create(representation);
+        try (javax.ws.rs.core.Response response = clientResource.authorization().resources().create(representation)) {
 
-        representation.setId(response.readEntity(ResourceRepresentation.class).getId());
+            representation.setId(response.readEntity(ResourceRepresentation.class).getId());
 
-        return representation;
+            return representation;
+        }
     }
 
     private ClientResource getClientResource(String name) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/authorization/ResourceManagementTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/authorization/ResourceManagementTest.java
@@ -250,17 +250,18 @@ public class ResourceManagementTest extends AbstractAuthorizationTest {
     protected ResourceRepresentation doCreateResource(ResourceRepresentation newResource) {
         ResourcesResource resources = getClientResource().authorization().resources();
 
-        Response response = resources.create(newResource);
+        try (Response response = resources.create(newResource)) {
 
-        int status = response.getStatus();
+            int status = response.getStatus();
 
-        if (status != Response.Status.CREATED.getStatusCode()) {
-            throw new RuntimeException(new HttpResponseException("Error", status, "", null));
+            if (status != Response.Status.CREATED.getStatusCode()) {
+                throw new RuntimeException(new HttpResponseException("Error", status, "", null));
+            }
+
+            ResourceRepresentation stored = response.readEntity(ResourceRepresentation.class);
+
+            return resources.resource(stored.getId()).toRepresentation();
         }
-
-        ResourceRepresentation stored = response.readEntity(ResourceRepresentation.class);
-
-        return resources.resource(stored.getId()).toRepresentation();
     }
 
     protected ResourceRepresentation doUpdateResource(ResourceRepresentation resource) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/authorization/ResourcePermissionManagementTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/authorization/ResourcePermissionManagementTest.java
@@ -114,18 +114,20 @@ public class ResourcePermissionManagementTest extends AbstractPolicyManagementTe
         representation.addPolicy("Only Marta Policy");
 
         ResourcePermissionsResource permissions = authorization.permissions().resource();
-        Response response = permissions.create(representation);
-        ResourcePermissionRepresentation created = response.readEntity(ResourcePermissionRepresentation.class);
 
-        permissions.findById(created.getId()).remove();
+        try (Response response = permissions.create(representation)) {
+            ResourcePermissionRepresentation created = response.readEntity(ResourcePermissionRepresentation.class);
 
-        ResourcePermissionResource removed = permissions.findById(created.getId());
+            permissions.findById(created.getId()).remove();
 
-        try {
-            removed.toRepresentation();
-            fail("Permission not removed");
-        } catch (NotFoundException ignore) {
+            ResourcePermissionResource removed = permissions.findById(created.getId());
 
+            try {
+                removed.toRepresentation();
+                fail("Permission not removed");
+            } catch (NotFoundException ignore) {
+
+            }
         }
     }
 
@@ -140,23 +142,24 @@ public class ResourcePermissionManagementTest extends AbstractPolicyManagementTe
 
         ResourcePermissionsResource permissions = authorization.permissions().resource();
 
-        permissions.create(permission1);
+        permissions.create(permission1).close();
 
         ResourcePermissionRepresentation permission2 = new ResourcePermissionRepresentation();
 
         permission2.setName(permission1.getName());
 
-        Response response = permissions.create(permission2);
-
-        assertEquals(Response.Status.CONFLICT.getStatusCode(), response.getStatus());
+        try (Response response = permissions.create(permission2)) {
+            assertEquals(Response.Status.CONFLICT.getStatusCode(), response.getStatus());
+        }
     }
 
     private void assertCreated(AuthorizationResource authorization, ResourcePermissionRepresentation representation) {
         ResourcePermissionsResource permissions = authorization.permissions().resource();
-        Response response = permissions.create(representation);
-        ResourcePermissionRepresentation created = response.readEntity(ResourcePermissionRepresentation.class);
-        ResourcePermissionResource permission = permissions.findById(created.getId());
-        assertRepresentation(representation, permission);
+        try (Response response = permissions.create(representation)) {
+            ResourcePermissionRepresentation created = response.readEntity(ResourcePermissionRepresentation.class);
+            ResourcePermissionResource permission = permissions.findById(created.getId());
+            assertRepresentation(representation, permission);
+        }
     }
 
     private void assertRepresentation(ResourcePermissionRepresentation representation, ResourcePermissionResource permission) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/authorization/RolePolicyManagementTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/authorization/RolePolicyManagementTest.java
@@ -147,18 +147,20 @@ public class RolePolicyManagementTest extends AbstractPolicyManagementTest {
         representation.addRole("Role A", false);
 
         RolePoliciesResource policies = authorization.policies().role();
-        Response response = policies.create(representation);
-        RolePolicyRepresentation created = response.readEntity(RolePolicyRepresentation.class);
 
-        policies.findById(created.getId()).remove();
+        try (Response response = policies.create(representation)) {
+            RolePolicyRepresentation created = response.readEntity(RolePolicyRepresentation.class);
 
-        RolePolicyResource removed = policies.findById(created.getId());
+            policies.findById(created.getId()).remove();
 
-        try {
-            removed.toRepresentation();
-            fail("Permission not removed");
-        } catch (NotFoundException ignore) {
+            RolePolicyResource removed = policies.findById(created.getId());
 
+            try {
+                removed.toRepresentation();
+                fail("Permission not removed");
+            } catch (NotFoundException ignore) {
+
+            }
         }
     }
 
@@ -171,26 +173,30 @@ public class RolePolicyManagementTest extends AbstractPolicyManagementTest {
         representation.addRole("Role A", false);
 
         RolePoliciesResource policies = authorization.policies().role();
-        Response response = policies.create(representation);
-        RolePolicyRepresentation created = response.readEntity(RolePolicyRepresentation.class);
 
-        PolicyResource policy = authorization.policies().policy(created.getId());
-        PolicyRepresentation genericConfig = policy.toRepresentation();
+        try (Response response = policies.create(representation)) {
+            RolePolicyRepresentation created = response.readEntity(RolePolicyRepresentation.class);
 
-        assertNotNull(genericConfig.getConfig());
-        assertNotNull(genericConfig.getConfig().get("roles"));
+            PolicyResource policy = authorization.policies().policy(created.getId());
+            PolicyRepresentation genericConfig = policy.toRepresentation();
 
-        RoleRepresentation role = getRealm().roles().get("Role A").toRepresentation();
+            assertNotNull(genericConfig.getConfig());
+            assertNotNull(genericConfig.getConfig().get("roles"));
 
-        assertTrue(genericConfig.getConfig().get("roles").contains(role.getId()));
+            RoleRepresentation role = getRealm().roles().get("Role A").toRepresentation();
+
+            assertTrue(genericConfig.getConfig().get("roles").contains(role.getId()));
+        }
     }
 
     private void assertCreated(AuthorizationResource authorization, RolePolicyRepresentation representation) {
         RolePoliciesResource permissions = authorization.policies().role();
-        Response response = permissions.create(representation);
-        RolePolicyRepresentation created = response.readEntity(RolePolicyRepresentation.class);
-        RolePolicyResource permission = permissions.findById(created.getId());
-        assertRepresentation(representation, permission);
+
+        try (Response response = permissions.create(representation)) {
+            RolePolicyRepresentation created = response.readEntity(RolePolicyRepresentation.class);
+            RolePolicyResource permission = permissions.findById(created.getId());
+            assertRepresentation(representation, permission);
+        }
     }
 
     private void assertRepresentation(RolePolicyRepresentation representation, RolePolicyResource permission) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/authorization/RulesPolicyManagementTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/authorization/RulesPolicyManagementTest.java
@@ -77,18 +77,20 @@ public class RulesPolicyManagementTest extends AbstractPolicyManagementTest {
         RulePolicyRepresentation representation = createDefaultRepresentation("Delete Rule Policy");
 
         RulePoliciesResource policies = authorization.policies().rule();
-        Response response = policies.create(representation);
-        RulePolicyRepresentation created = response.readEntity(RulePolicyRepresentation.class);
 
-        policies.findById(created.getId()).remove();
+        try (Response response = policies.create(representation)) {
+            RulePolicyRepresentation created = response.readEntity(RulePolicyRepresentation.class);
 
-        RulePolicyResource removed = policies.findById(created.getId());
+            policies.findById(created.getId()).remove();
 
-        try {
-            removed.toRepresentation();
-            fail("Policy not removed");
-        } catch (NotFoundException ignore) {
+            RulePolicyResource removed = policies.findById(created.getId());
 
+            try {
+                removed.toRepresentation();
+                fail("Policy not removed");
+            } catch (NotFoundException ignore) {
+
+            }
         }
     }
 
@@ -112,10 +114,12 @@ public class RulesPolicyManagementTest extends AbstractPolicyManagementTest {
 
     private void assertCreated(AuthorizationResource authorization, RulePolicyRepresentation representation) {
         RulePoliciesResource permissions = authorization.policies().rule();
-        Response response = permissions.create(representation);
-        RulePolicyRepresentation created = response.readEntity(RulePolicyRepresentation.class);
-        RulePolicyResource permission = permissions.findById(created.getId());
-        assertRepresentation(representation, permission);
+
+        try (Response response = permissions.create(representation)) {
+            RulePolicyRepresentation created = response.readEntity(RulePolicyRepresentation.class);
+            RulePolicyResource permission = permissions.findById(created.getId());
+            assertRepresentation(representation, permission);
+        }
     }
 
     private void assertRepresentation(RulePolicyRepresentation expected, RulePolicyResource policy) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/authorization/ScopePermissionManagementTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/authorization/ScopePermissionManagementTest.java
@@ -134,23 +134,25 @@ public class ScopePermissionManagementTest extends AbstractPolicyManagementTest 
 
         ScopePermissionsResource permissions = authorization.permissions().scope();
 
-        permissions.create(permission1);
+        permissions.create(permission1).close();
 
         ScopePermissionRepresentation permission2 = new ScopePermissionRepresentation();
 
         permission2.setName(permission1.getName());
 
-        Response response = permissions.create(permission2);
-
-        assertEquals(Response.Status.CONFLICT.getStatusCode(), response.getStatus());
+        try (Response response = permissions.create(permission2)) {
+            assertEquals(Response.Status.CONFLICT.getStatusCode(), response.getStatus());
+        }
     }
 
     private void assertCreated(AuthorizationResource authorization, ScopePermissionRepresentation representation) {
         ScopePermissionsResource permissions = authorization.permissions().scope();
-        Response response = permissions.create(representation);
-        ScopePermissionRepresentation created = response.readEntity(ScopePermissionRepresentation.class);
-        ScopePermissionResource permission = permissions.findById(created.getId());
-        assertRepresentation(representation, permission);
+
+        try (Response response = permissions.create(representation)) {
+            ScopePermissionRepresentation created = response.readEntity(ScopePermissionRepresentation.class);
+            ScopePermissionResource permission = permissions.findById(created.getId());
+            assertRepresentation(representation, permission);
+        }
     }
 
     private void assertRepresentation(ScopePermissionRepresentation representation, ScopePermissionResource permission) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/authorization/TimePolicyManagementTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/authorization/TimePolicyManagementTest.java
@@ -101,18 +101,20 @@ public class TimePolicyManagementTest extends AbstractPolicyManagementTest {
         AuthorizationResource authorization = getClient().authorization();
         TimePolicyRepresentation representation = createRepresentation("Test Delete Policy");
         TimePoliciesResource policies = authorization.policies().time();
-        Response response = policies.create(representation);
-        TimePolicyRepresentation created = response.readEntity(TimePolicyRepresentation.class);
 
-        policies.findById(created.getId()).remove();
+        try (Response response = policies.create(representation)) {
+            TimePolicyRepresentation created = response.readEntity(TimePolicyRepresentation.class);
 
-        TimePolicyResource removed = policies.findById(created.getId());
+            policies.findById(created.getId()).remove();
 
-        try {
-            removed.toRepresentation();
-            fail("Permission not removed");
-        } catch (NotFoundException ignore) {
+            TimePolicyResource removed = policies.findById(created.getId());
 
+            try {
+                removed.toRepresentation();
+                fail("Permission not removed");
+            } catch (NotFoundException ignore) {
+
+            }
         }
     }
 
@@ -140,10 +142,12 @@ public class TimePolicyManagementTest extends AbstractPolicyManagementTest {
 
     private void assertCreated(AuthorizationResource authorization, TimePolicyRepresentation representation) {
         TimePoliciesResource permissions = authorization.policies().time();
-        Response response = permissions.create(representation);
-        TimePolicyRepresentation created = response.readEntity(TimePolicyRepresentation.class);
-        TimePolicyResource permission = permissions.findById(created.getId());
-        assertRepresentation(representation, permission);
+
+        try (Response response = permissions.create(representation)) {
+            TimePolicyRepresentation created = response.readEntity(TimePolicyRepresentation.class);
+            TimePolicyResource permission = permissions.findById(created.getId());
+            assertRepresentation(representation, permission);
+        }
     }
 
     private void assertRepresentation(TimePolicyRepresentation representation, TimePolicyResource permission) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/authorization/UserPolicyManagementTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/authorization/UserPolicyManagementTest.java
@@ -118,18 +118,20 @@ public class UserPolicyManagementTest extends AbstractPolicyManagementTest {
         representation.addUser("User A");
 
         UserPoliciesResource policies = authorization.policies().user();
-        Response response = policies.create(representation);
-        UserPolicyRepresentation created = response.readEntity(UserPolicyRepresentation.class);
 
-        policies.findById(created.getId()).remove();
+        try (Response response = policies.create(representation)) {
+            UserPolicyRepresentation created = response.readEntity(UserPolicyRepresentation.class);
 
-        UserPolicyResource removed = policies.findById(created.getId());
+            policies.findById(created.getId()).remove();
 
-        try {
-            removed.toRepresentation();
-            fail("Permission not removed");
-        } catch (NotFoundException ignore) {
+            UserPolicyResource removed = policies.findById(created.getId());
 
+            try {
+                removed.toRepresentation();
+                fail("Permission not removed");
+            } catch (NotFoundException ignore) {
+
+            }
         }
     }
 
@@ -186,18 +188,20 @@ public class UserPolicyManagementTest extends AbstractPolicyManagementTest {
         representation.addUser("User A");
 
         UserPoliciesResource policies = authorization.policies().user();
-        Response response = policies.create(representation);
-        UserPolicyRepresentation created = response.readEntity(UserPolicyRepresentation.class);
 
-        PolicyResource policy = authorization.policies().policy(created.getId());
-        PolicyRepresentation genericConfig = policy.toRepresentation();
+        try (Response response = policies.create(representation)) {
+            UserPolicyRepresentation created = response.readEntity(UserPolicyRepresentation.class);
 
-        assertNotNull(genericConfig.getConfig());
-        assertNotNull(genericConfig.getConfig().get("users"));
+            PolicyResource policy = authorization.policies().policy(created.getId());
+            PolicyRepresentation genericConfig = policy.toRepresentation();
 
-        UserRepresentation user = getRealm().users().search("User A").get(0);
+            assertNotNull(genericConfig.getConfig());
+            assertNotNull(genericConfig.getConfig().get("users"));
 
-        assertTrue(genericConfig.getConfig().get("users").contains(user.getId()));
+            UserRepresentation user = getRealm().users().search("User A").get(0);
+
+            assertTrue(genericConfig.getConfig().get("users").contains(user.getId()));
+        }
     }
 
     @Test
@@ -219,33 +223,35 @@ public class UserPolicyManagementTest extends AbstractPolicyManagementTest {
 
         policy.setConfig(config);
 
-        Response response = authorization.policies().create(policy);
-        assertEquals(Response.Status.INTERNAL_SERVER_ERROR, response.getStatusInfo());
-        response.close();
+        try (Response response = authorization.policies().create(policy)) {
+            assertEquals(Response.Status.INTERNAL_SERVER_ERROR, response.getStatusInfo());
+        }
 
         config.put("users", "");
 
         policy.setConfig(config);
 
-        response = authorization.policies().create(policy);
-        assertEquals(Response.Status.INTERNAL_SERVER_ERROR, response.getStatusInfo());
-        response.close();
+        try (Response response = authorization.policies().create(policy)) {
+            assertEquals(Response.Status.INTERNAL_SERVER_ERROR, response.getStatusInfo());
+        }
 
         config.clear();
 
         policy.setConfig(config);
 
-        response = authorization.policies().create(policy);
-        assertEquals(Response.Status.INTERNAL_SERVER_ERROR, response.getStatusInfo());
-        response.close();
+        try (Response response = authorization.policies().create(policy)) {
+            assertEquals(Response.Status.INTERNAL_SERVER_ERROR, response.getStatusInfo());
+        }
     }
 
     private void assertCreated(AuthorizationResource authorization, UserPolicyRepresentation representation) {
         UserPoliciesResource permissions = authorization.policies().user();
-        Response response = permissions.create(representation);
-        UserPolicyRepresentation created = response.readEntity(UserPolicyRepresentation.class);
-        UserPolicyResource permission = permissions.findById(created.getId());
-        assertRepresentation(representation, permission);
+
+        try (Response response = permissions.create(representation)) {
+            UserPolicyRepresentation created = response.readEntity(UserPolicyRepresentation.class);
+            UserPolicyResource permission = permissions.findById(created.getId());
+            assertRepresentation(representation, permission);
+        }
     }
 
     private void assertRepresentation(UserPolicyRepresentation representation, UserPolicyResource permission) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/AuthorizationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/AuthorizationTest.java
@@ -183,9 +183,9 @@ public class AuthorizationTest extends AbstractAuthzTest {
         permission.addResource(resource.getId());
         permission.addPolicy(policies);
 
-        Response response = getClient().authorization().permissions().resource().create(permission);
-
-        assertEquals(201, response.getStatus());
+        try (Response response = getClient().authorization().permissions().resource().create(permission)) {
+            assertEquals(201, response.getStatus());
+        }
     }
 
     @NotNull

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/ConflictingScopePermissionTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/ConflictingScopePermissionTest.java
@@ -274,7 +274,7 @@ public class ConflictingScopePermissionTest extends AbstractAuthzTest {
 
         representation.setConfig(config);
 
-        client.authorization().policies().create(representation);
+        client.authorization().policies().create(representation).close();
     }
 
     private void createResourcePermission(String name, String resourceName, List<String> policies, ClientResource client) throws IOException {
@@ -284,7 +284,7 @@ public class ConflictingScopePermissionTest extends AbstractAuthzTest {
         representation.addResource(resourceName);
         representation.addPolicy(policies.toArray(new String[policies.size()]));
 
-        client.authorization().permissions().resource().create(representation);
+        client.authorization().permissions().resource().create(representation).close();
     }
 
     private void createScopePermission(String name, String resourceName, List<String> scopes, List<String> policies, ClientResource client) throws IOException {
@@ -300,7 +300,7 @@ public class ConflictingScopePermissionTest extends AbstractAuthzTest {
         representation.addScope(scopes.toArray(new String[scopes.size()]));
         representation.addPolicy(policies.toArray(new String[policies.size()]));
 
-        authorization.permissions().scope().create(representation);
+        authorization.permissions().scope().create(representation).close();
     }
 
     private AuthzClient getAuthzClient() {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/GroupNamePolicyTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/GroupNamePolicyTest.java
@@ -28,8 +28,6 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import javax.ws.rs.core.Response;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.keycloak.admin.client.resource.AuthorizationResource;
@@ -38,7 +36,6 @@ import org.keycloak.admin.client.resource.ClientsResource;
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.authorization.client.AuthorizationDeniedException;
 import org.keycloak.authorization.client.AuthzClient;
-import org.keycloak.authorization.client.Configuration;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.protocol.oidc.mappers.GroupMembershipMapper;
 import org.keycloak.protocol.oidc.mappers.OIDCAttributeMapperHelper;
@@ -52,14 +49,12 @@ import org.keycloak.representations.idm.authorization.GroupPolicyRepresentation;
 import org.keycloak.representations.idm.authorization.PermissionRequest;
 import org.keycloak.representations.idm.authorization.ResourcePermissionRepresentation;
 import org.keycloak.representations.idm.authorization.ResourceRepresentation;
-import org.keycloak.testsuite.util.AdminClientUtil;
 import org.keycloak.testsuite.util.ClientBuilder;
 import org.keycloak.testsuite.util.GroupBuilder;
 import org.keycloak.testsuite.util.RealmBuilder;
 import org.keycloak.testsuite.util.RoleBuilder;
 import org.keycloak.testsuite.util.RolesBuilder;
 import org.keycloak.testsuite.util.UserBuilder;
-import org.keycloak.util.JsonSerialization;
 
 /**
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
@@ -197,8 +192,7 @@ public class GroupNamePolicyTest extends AbstractAuthzTest {
         policy.setGroupsClaim("groups");
         policy.addGroupPath(groupPath, extendChildren);
 
-        Response response = getClient().authorization().policies().group().create(policy);
-        response.close();
+        getClient().authorization().policies().group().create(policy).close();
     }
 
     private void createResourcePermission(String name, String resource, String... policies) {
@@ -208,16 +202,14 @@ public class GroupNamePolicyTest extends AbstractAuthzTest {
         permission.addResource(resource);
         permission.addPolicy(policies);
 
-        Response response = getClient().authorization().permissions().resource().create(permission);
-        response.close();
+        getClient().authorization().permissions().resource().create(permission).close();
     }
 
     private void createResource(String name) {
         AuthorizationResource authorization = getClient().authorization();
         ResourceRepresentation resource = new ResourceRepresentation(name);
 
-        Response response = authorization.resources().create(resource);
-        response.close();
+        authorization.resources().create(resource).close();
     }
 
     private RealmResource getRealm() {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/GroupPathPolicyTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/GroupPathPolicyTest.java
@@ -28,8 +28,6 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import javax.ws.rs.core.Response;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.keycloak.admin.client.resource.AuthorizationResource;
@@ -181,8 +179,7 @@ public class GroupPathPolicyTest extends AbstractAuthzTest {
         policy.setGroupsClaim("groups");
         policy.addGroupPath(groupPath, extendChildren);
 
-        Response response = getClient().authorization().policies().group().create(policy);
-        response.close();
+        getClient().authorization().policies().group().create(policy).close();
     }
 
     private void createResourcePermission(String name, String resource, String... policies) {
@@ -192,16 +189,14 @@ public class GroupPathPolicyTest extends AbstractAuthzTest {
         permission.addResource(resource);
         permission.addPolicy(policies);
 
-        Response response = getClient().authorization().permissions().resource().create(permission);
-        response.close();
+        getClient().authorization().permissions().resource().create(permission).close();
     }
 
     private void createResource(String name) {
         AuthorizationResource authorization = getClient().authorization();
         ResourceRepresentation resource = new ResourceRepresentation(name);
 
-        Response response = authorization.resources().create(resource);
-        response.close();
+        authorization.resources().create(resource).close();
     }
 
     private RealmResource getRealm() {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/PermissionClaimTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/PermissionClaimTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -247,7 +248,9 @@ public class PermissionClaimTest extends AbstractAuthzTest {
         updatePermission.addScope("update");
         updatePermission.addPolicy(claimCPolicy.getName());
 
-        updatePermission = authorization.permissions().scope().create(updatePermission).readEntity(ScopePermissionRepresentation.class);
+        try (Response response = authorization.permissions().scope().create(updatePermission)) {
+            updatePermission = response.readEntity(ScopePermissionRepresentation.class);
+        }
 
         AuthzClient authzClient = getAuthzClient();
         AuthorizationRequest request = new AuthorizationRequest();
@@ -320,7 +323,9 @@ public class PermissionClaimTest extends AbstractAuthzTest {
         updatePermission.addResource(resourceA.getName());
         updatePermission.addPolicy(claimCPolicy.getName());
 
-        updatePermission = authorization.permissions().resource().create(updatePermission).readEntity(ResourcePermissionRepresentation.class);
+        try (Response response = authorization.permissions().resource().create(updatePermission)) {
+            updatePermission = response.readEntity(ResourcePermissionRepresentation.class);
+        }
 
         AuthzClient authzClient = getAuthzClient();
         AuthorizationResponse response = authzClient.authorization("marta", "password").authorize();
@@ -357,7 +362,9 @@ public class PermissionClaimTest extends AbstractAuthzTest {
         resourceInstance.setType(resourceA.getType());
         resourceInstance.setOwner("marta");
 
-        resourceInstance = authorization.resources().create(resourceInstance).readEntity(ResourceRepresentation.class);
+        try (Response response1 = authorization.resources().create(resourceInstance)) {
+            resourceInstance = response1.readEntity(ResourceRepresentation.class);
+        }
 
         AuthorizationRequest request = new AuthorizationRequest();
 
@@ -377,7 +384,9 @@ public class PermissionClaimTest extends AbstractAuthzTest {
         resourceInstancePermission.addResource(resourceInstance.getId());
         resourceInstancePermission.addPolicy(claimCPolicy.getName());
 
-        resourceInstancePermission = authorization.permissions().resource().create(resourceInstancePermission).readEntity(ResourcePermissionRepresentation.class);
+        try (Response response1 = authorization.permissions().resource().create(resourceInstancePermission)) {
+            resourceInstancePermission = response1.readEntity(ResourcePermissionRepresentation.class);
+        }
 
         response = authzClient.authorization("marta", "password").authorize(request);
         assertNotNull(response.getToken());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/RolePolicyTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/RolePolicyTest.java
@@ -23,8 +23,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.ws.rs.core.Response;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.keycloak.admin.client.resource.AuthorizationResource;
@@ -33,7 +31,6 @@ import org.keycloak.admin.client.resource.ClientsResource;
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.authorization.client.AuthorizationDeniedException;
 import org.keycloak.authorization.client.AuthzClient;
-import org.keycloak.authorization.client.Configuration;
 import org.keycloak.representations.idm.GroupRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.RoleRepresentation;
@@ -51,7 +48,6 @@ import org.keycloak.testsuite.util.RealmBuilder;
 import org.keycloak.testsuite.util.RoleBuilder;
 import org.keycloak.testsuite.util.RolesBuilder;
 import org.keycloak.testsuite.util.UserBuilder;
-import org.keycloak.util.JsonSerialization;
 
 /**
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
@@ -179,8 +175,7 @@ public class RolePolicyTest extends AbstractAuthzTest {
             policy.addRole(role);
         }
 
-        Response response = getClient().authorization().policies().role().create(policy);
-        response.close();
+        getClient().authorization().policies().role().create(policy).close();
     }
 
     private void createResourcePermission(String name, String resource, String... policies) {
@@ -190,16 +185,14 @@ public class RolePolicyTest extends AbstractAuthzTest {
         permission.addResource(resource);
         permission.addPolicy(policies);
 
-        Response response = getClient().authorization().permissions().resource().create(permission);
-        response.close();
+        getClient().authorization().permissions().resource().create(permission).close();
     }
 
     private void createResource(String name) {
         AuthorizationResource authorization = getClient().authorization();
         ResourceRepresentation resource = new ResourceRepresentation(name);
 
-        Response response = authorization.resources().create(resource);
-        response.close();
+        authorization.resources().create(resource).close();
     }
 
     private RealmResource getRealm() {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/UmaDiscoveryDocumentTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/UmaDiscoveryDocumentTest.java
@@ -56,22 +56,24 @@ public class UmaDiscoveryDocumentTest extends AbstractKeycloakTest {
         URI oidcDiscoveryUri = RealmsResource.wellKnownProviderUrl(builder).build("test", UmaWellKnownProviderFactory.PROVIDER_ID);
         WebTarget oidcDiscoveryTarget = client.target(oidcDiscoveryUri);
 
-        Response response = oidcDiscoveryTarget.request().get();
+        try (Response response = oidcDiscoveryTarget.request().get()) {
+            assertEquals("no-cache, must-revalidate, no-transform, no-store", response.getHeaders().getFirst("Cache-Control"));
 
-        assertEquals("no-cache, must-revalidate, no-transform, no-store", response.getHeaders().getFirst("Cache-Control"));
 
-        UmaConfiguration configuration = response.readEntity(UmaConfiguration.class);
+            UmaConfiguration configuration = response.readEntity(UmaConfiguration.class);
 
-        assertEquals(configuration.getAuthorizationEndpoint(), OIDCLoginProtocolService.authUrl(UriBuilder.fromUri(OAuthClient.AUTH_SERVER_ROOT)).build("test").toString());
-        assertEquals(configuration.getTokenEndpoint(), oauth.getAccessTokenUrl());
-        assertEquals(configuration.getJwksUri(), oauth.getCertsUrl("test"));
-        assertEquals(configuration.getTokenIntrospectionEndpoint(), oauth.getTokenIntrospectionUrl());
 
-        String registrationUri = UriBuilder
-                .fromUri(OAuthClient.AUTH_SERVER_ROOT)
-                .path(RealmsResource.class).path(RealmsResource.class, "getRealmResource").build(realmsResouce().realm("test").toRepresentation().getRealm()).toString();
+            assertEquals(configuration.getAuthorizationEndpoint(), OIDCLoginProtocolService.authUrl(UriBuilder.fromUri(OAuthClient.AUTH_SERVER_ROOT)).build("test").toString());
+            assertEquals(configuration.getTokenEndpoint(), oauth.getAccessTokenUrl());
+            assertEquals(configuration.getJwksUri(), oauth.getCertsUrl("test"));
+            assertEquals(configuration.getTokenIntrospectionEndpoint(), oauth.getTokenIntrospectionUrl());
 
-        assertEquals(registrationUri + "/authz/protection/permission", configuration.getPermissionEndpoint().toString());
-        assertEquals(registrationUri + "/authz/protection/resource_set", configuration.getResourceRegistrationEndpoint().toString());
+            String registrationUri = UriBuilder
+                    .fromUri(OAuthClient.AUTH_SERVER_ROOT)
+                    .path(RealmsResource.class).path(RealmsResource.class, "getRealmResource").build(realmsResouce().realm("test").toRepresentation().getRealm()).toString();
+
+            assertEquals(registrationUri + "/authz/protection/permission", configuration.getPermissionEndpoint().toString());
+            assertEquals(registrationUri + "/authz/protection/resource_set", configuration.getResourceRegistrationEndpoint().toString());
+        }
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/UmaGrantTypeTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/UmaGrantTypeTest.java
@@ -79,8 +79,7 @@ public class UmaGrantTypeTest extends AbstractResourceServerTest {
         policy.setName("Default Policy");
         policy.setCode("$evaluation.grant();");
 
-        Response response = authorization.policies().js().create(policy);
-        response.close();
+        authorization.policies().js().create(policy).close();
 
         ResourcePermissionRepresentation permission = new ResourcePermissionRepresentation();
         resourceA = addResource("Resource A", "ScopeA", "ScopeB", "ScopeC");
@@ -89,16 +88,14 @@ public class UmaGrantTypeTest extends AbstractResourceServerTest {
         permission.addResource(resourceA.getName());
         permission.addPolicy(policy.getName());
 
-        response = authorization.permissions().resource().create(permission);
-        response.close();
+        authorization.permissions().resource().create(permission).close();
 
         policy = new JSPolicyRepresentation();
 
         policy.setName("Deny Policy");
         policy.setCode("$evaluation.deny();");
 
-        response = authorization.policies().js().create(policy);
-        response.close();
+        authorization.policies().js().create(policy).close();
     }
 
     @Test

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/UmaPermissionTicketPushedClaimsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/UmaPermissionTicketPushedClaimsTest.java
@@ -64,7 +64,7 @@ public class UmaPermissionTicketPushedClaimsTest extends AbstractResourceServerT
 
         AuthorizationResource authorization = getClient(getRealm()).authorization();
 
-        authorization.policies().js().create(policy);
+        authorization.policies().js().create(policy).close();
 
         ScopePermissionRepresentation representation = new ScopePermissionRepresentation();
 
@@ -72,7 +72,7 @@ public class UmaPermissionTicketPushedClaimsTest extends AbstractResourceServerT
         representation.addScope("withdraw");
         representation.addPolicy(policy.getName());
 
-        authorization.permissions().scope().create(representation);
+        authorization.permissions().scope().create(representation).close();
 
         AuthzClient authzClient = getAuthzClient();
         PermissionRequest permissionRequest = new PermissionRequest(resource.getId());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/UserManagedAccessTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/UserManagedAccessTest.java
@@ -62,8 +62,7 @@ public class UserManagedAccessTest extends AbstractResourceServerTest {
         policy.setName("Only Owner Policy");
         policy.setCode("if ($evaluation.getContext().getIdentity().getId() == $evaluation.getPermission().getResource().getOwner()) {$evaluation.grant();}");
 
-        Response response = authorization.policies().js().create(policy);
-        response.close();
+        authorization.policies().js().create(policy).close();
     }
 
     @Test


### PR DESCRIPTION
In addition to a new test added to cover the issue I'm fixing, most of the changes I did to test suite are related with closing jaxrs responses.