### PR TITLE
[KEYCLOAK-9646] Increase import range for javax.servlet API to cover …

### DIFF
--- a/adapters/oidc/fuse7/undertow/pom.xml
+++ b/adapters/oidc/fuse7/undertow/pom.xml
@@ -42,7 +42,7 @@
             org.keycloak.*;version="${project.version}",
             org.keycloak.adapters.osgi.*;version="${project.version}",
             org.ops4j.pax.web.*;version="[7.1,9)",
-            javax.servlet.*;version="[2.5,4)";resolution:=optional,
+            javax.servlet.*;version="[2.5,5)";resolution:=optional,
             org.apache.cxf.transport.http;resolution:=optional;version="[3,4)",
             org.apache.cxf.transport.http_undertow;resolution:=optional;version="[3,4)",
             org.apache.cxf.transport.servlet;resolution:=optional;version="[3,4)",

--- a/adapters/oidc/osgi-adapter/pom.xml
+++ b/adapters/oidc/osgi-adapter/pom.xml
@@ -40,7 +40,7 @@
         </keycloak.osgi.export>
         <keycloak.osgi.import>
             org.ops4j.pax.web.*;version="[3.0,8)",
-            javax.servlet.*;version="[2.5,4)";resolution:=optional,
+            javax.servlet.*;version="[2.5,5)";resolution:=optional,
             org.eclipse.jetty.*;version="[8.1,10)";resolution:=optional,
             org.keycloak.*;version="${project.version}",
             org.apache.cxf.transport.http;resolution:=optional;version="[3,4)",

--- a/adapters/oidc/servlet-filter/pom.xml
+++ b/adapters/oidc/servlet-filter/pom.xml
@@ -38,7 +38,7 @@
             org.keycloak.adapters.servlet.*
         </keycloak.osgi.export>
         <keycloak.osgi.import>
-            javax.servlet.*;version="[2.5,4)";resolution:=optional,
+            javax.servlet.*;version="[2.5,5)";resolution:=optional,
             org.keycloak.*;version="${project.version}",
             *;resolution:=optional
         </keycloak.osgi.import>

--- a/adapters/oidc/undertow/pom.xml
+++ b/adapters/oidc/undertow/pom.xml
@@ -39,6 +39,7 @@
         </keycloak.osgi.export>
         <keycloak.osgi.import>
             io.undertow.*;version="[1.4,3)",
+            javax.servlet.*;version="[3.1,5)";resolution:=optional,
             *;resolution:=optional
         </keycloak.osgi.import>
     </properties>

--- a/testsuite/integration-arquillian/HOW-TO-RUN.md
+++ b/testsuite/integration-arquillian/HOW-TO-RUN.md
@@ -154,8 +154,8 @@ Assumed you downloaded `jboss-fuse-karaf-6.3.0.redhat-229.zip`
 
 ### JBoss Fuse 7.X
 
-1) Download JBoss Fuse 7 to your filesystem. It can be downloaded from http://origin-repository.jboss.org/nexus/content/groups/m2-proxy/org/jboss/fuse/fuse-karaf 
-Assumed you downloaded `fuse-karaf-7.0.0.fuse-000202.zip`
+1) Download JBoss Fuse 7 to your filesystem. It can be downloaded from http://origin-repository.jboss.org/nexus/content/groups/m2-proxy/org/jboss/fuse/fuse-karaf  (Fuse 7.1 or higher is required)
+Assumed you downloaded `fuse-karaf-7.1.0.fuse-710029.zip`
 
 2) Install to your local maven repository and change the properties according to your env (This step can be likely avoided if you somehow configure your local maven settings to point directly to Fuse repo):
 
@@ -163,9 +163,9 @@ Assumed you downloaded `fuse-karaf-7.0.0.fuse-000202.zip`
     mvn install:install-file \
       -DgroupId=org.jboss.fuse \
       -DartifactId=fuse-karaf \
-      -Dversion=7.0.0.fuse-000202 \
+      -Dversion=7.1.0.fuse-710029 \
       -Dpackaging=zip \
-      -Dfile=/mydownloads/fuse-karaf-7.0.0.fuse-000202.zip
+      -Dfile=/mydownloads/fuse-karaf-7.1.0.fuse-710029.zip
 
 
 3) Prepare Fuse and run the tests (change props according to your environment, versions etc):
@@ -175,7 +175,7 @@ Assumed you downloaded `fuse-karaf-7.0.0.fuse-000202.zip`
     mvn -f testsuite/integration-arquillian/servers/pom.xml \
       clean install \
       -Papp-server-fuse7x \
-      -Dfuse7x.version=7.0.0.fuse-000202 \
+      -Dfuse7x.version=7.1.0.fuse-710029 \
       -Dapp.server.karaf.update.config=true \
       -Dmaven.local.settings=$HOME/.m2/settings.xml \
       -Drepositories=,http://REPO-SERVER/brewroot/repos/sso-7.1-build/latest/maven/ \

--- a/testsuite/integration-arquillian/test-apps/fuse/camel-fuse7-undertow/pom.xml
+++ b/testsuite/integration-arquillian/test-apps/fuse/camel-fuse7-undertow/pom.xml
@@ -35,8 +35,8 @@
         <keycloak.osgi.export>
         </keycloak.osgi.export>
         <keycloak.osgi.import>
-            javax.servlet;version="[3,4)",
-            javax.servlet.http;version="[3,4)",
+            javax.servlet;version="[3,5)",
+            javax.servlet.http;version="[3,5)",
             javax.net.ssl,
             org.apache.camel.*,
             io.undertow.*;version="[1.4,3)",

--- a/testsuite/integration-arquillian/test-apps/fuse/camel/pom.xml
+++ b/testsuite/integration-arquillian/test-apps/fuse/camel/pom.xml
@@ -36,8 +36,8 @@
         <keycloak.osgi.export>
         </keycloak.osgi.export>
         <keycloak.osgi.import>
-            javax.servlet;version="[3,4)",
-            javax.servlet.http;version="[3,4)",
+            javax.servlet;version="[3,5)",
+            javax.servlet.http;version="[3,5)",
             org.apache.camel.*,
             org.apache.camel;version="[2.13,3)",
             org.eclipse.jetty.security;version="[8,10)",

--- a/testsuite/integration-arquillian/test-apps/fuse/customer-app-fuse/pom.xml
+++ b/testsuite/integration-arquillian/test-apps/fuse/customer-app-fuse/pom.xml
@@ -45,7 +45,7 @@
             org.apache.http.impl.cookie.*;version=${apache.httpcomponents.version},
             org.apache.http.impl.execchain.*;version=${apache.httpcomponents.version},
             org.apache.http.*;version=${apache.httpcomponents.httpcore.version},
-            javax.servlet.*;version="[2.5,4)",
+            javax.servlet.*;version="[2.5,5)",
             org.keycloak.adapters.authentication;version="${project.version}";resolution:=optional,
             org.keycloak.adapters.jetty;version="${project.version}";resolution:=optional,
             org.keycloak.adapters;version="${project.version}",

--- a/testsuite/integration-arquillian/test-apps/fuse/external-config/pom.xml
+++ b/testsuite/integration-arquillian/test-apps/fuse/external-config/pom.xml
@@ -46,7 +46,7 @@
             org.apache.http.impl.cookie.*;version=${apache.httpcomponents.version},
             org.apache.http.impl.execchain.*;version=${apache.httpcomponents.version},
             org.apache.http.*;version=${apache.httpcomponents.httpcore.version},
-            javax.servlet.*;version="[2.5,4)",
+            javax.servlet.*;version="[3.1,5)",
             org.keycloak.adapters.jetty;version="${project.version}";resolution:=optional,
             org.keycloak.adapters;version="${project.version}",
             org.keycloak.constants;version="${project.version}",

--- a/testsuite/integration-arquillian/test-apps/fuse/product-app-fuse7-undertow/pom.xml
+++ b/testsuite/integration-arquillian/test-apps/fuse/product-app-fuse7-undertow/pom.xml
@@ -43,6 +43,7 @@
             org.apache.cxf.*;version="[2.7,3.3)",
             org.keycloak.*;version="${project.version}",
             org.keycloak.adapters.authentication;version="${project.version}";resolution:=optional,
+            javax.servlet.*;version="[3.1,5)",
             *;resolution:=optional
         </keycloak.osgi.import>
         <keycloak.osgi.private>


### PR DESCRIPTION
…EAP 7.2, servlet-api 4.0

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
