### PR TITLE
KEYCLOAK-8991 Keycloak Installed Application: provide OSGi meta data - alternative patch 2

### DIFF
--- a/adapters/oidc/installed/pom.xml
+++ b/adapters/oidc/installed/pom.xml
@@ -80,9 +80,8 @@
             <artifactId>jboss-logging</artifactId>
         </dependency>
         <dependency>
-            <!-- KEYCLOAK-8991 : Favor Jersey over Resteasy to support OSGi-based Keycloak clients -->
-            <groupId>org.glassfish.jersey.core</groupId>
-            <artifactId>jersey-client</artifactId>
+            <groupId>org.jboss.spec.javax.ws.rs</groupId>
+            <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
         </dependency>
     </dependencies>
 

--- a/adapters/oidc/installed/pom.xml
+++ b/adapters/oidc/installed/pom.xml
@@ -64,14 +64,23 @@
             <artifactId>jboss-logging</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-client</artifactId>
+            <!-- KEYCLOAK-8991 : Favor Jersey over Resteasy to support OSGi clients -->
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-client</artifactId>
+            <version>2.28</version>
         </dependency>
         <dependency>
-            <groupId>org.jboss.spec.javax.ws.rs</groupId>
-            <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
+            <groupId>org.glassfish.jersey.media</groupId>
+            <artifactId>jersey-media-json-jackson</artifactId>
+            <version>2.28</version>
+            <scope>runtime</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.glassfish.jersey.media</groupId>
+            <artifactId>jersey-media-multipart</artifactId>
+            <version>2.28</version>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/adapters/oidc/installed/pom.xml
+++ b/adapters/oidc/installed/pom.xml
@@ -67,18 +67,15 @@
             <!-- KEYCLOAK-8991 : Favor Jersey over Resteasy to support OSGi clients -->
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-client</artifactId>
-            <version>2.28</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-json-jackson</artifactId>
-            <version>2.28</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-multipart</artifactId>
-            <version>2.28</version>
             <scope>runtime</scope>
         </dependency>
     </dependencies>

--- a/adapters/oidc/installed/pom.xml
+++ b/adapters/oidc/installed/pom.xml
@@ -27,8 +27,14 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>keycloak-installed-adapter</artifactId>
+    <packaging>bundle</packaging>
     <name>Keycloak Installed Application</name>
     <description/>
+
+    <properties>
+        <!-- compile issues with v2.3.7 -->
+        <osgi.bundle.plugin.version>4.1.0</osgi.bundle.plugin.version>
+    </properties>
 
     <dependencies>
         <dependency>
@@ -44,12 +50,22 @@
             <artifactId>keycloak-adapter-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-authz-client</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk15on</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
+            <artifactId>httpclient-osgi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore-osgi</artifactId>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -64,20 +80,19 @@
             <artifactId>jboss-logging</artifactId>
         </dependency>
         <dependency>
-            <!-- KEYCLOAK-8991 : Favor Jersey over Resteasy to support OSGi clients -->
+            <!-- KEYCLOAK-8991 : Favor Jersey over Resteasy to support OSGi-based Keycloak clients -->
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-client</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.media</groupId>
-            <artifactId>jersey-media-json-jackson</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.media</groupId>
-            <artifactId>jersey-media-multipart</artifactId>
-            <scope>runtime</scope>
-        </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/adapters/oidc/installed/src/main/java/org/keycloak/adapters/installed/KcinitDriver.java
+++ b/adapters/oidc/installed/src/main/java/org/keycloak/adapters/installed/KcinitDriver.java
@@ -629,6 +629,7 @@ public class KcinitDriver {
     }
 
     public Client getHttpClient() {
+        // KEYCLOAK-8991 : no Resteasy dependency (does not provide OSGi meta data) to support OSGi-based Keycloak clients
         TrustManager[] trustAllCerts = new TrustManager[]{
                 new X509TrustManager() {
                     @Override

--- a/adapters/oidc/installed/src/main/java/org/keycloak/adapters/installed/KeycloakInstalled.java
+++ b/adapters/oidc/installed/src/main/java/org/keycloak/adapters/installed/KeycloakInstalled.java
@@ -501,6 +501,7 @@ public class KeycloakInstalled {
     }
 
     protected Client createRestClient() {
+        // KEYCLOAK-8991 : no Resteasy dependency (does not provide OSGi meta data) to support OSGi-based Keycloak clients
         TrustManager[] trustAllCerts = new TrustManager[]{
                 new X509TrustManager() {
                     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,6 @@
         <jboss-transaction-api_1.2_spec>1.1.1.Final</jboss-transaction-api_1.2_spec>
         <jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec.version>1.0.1.Final</jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec.version>
         <jboss.spec.javax.servlet.jsp.jboss-jsp-api_2.3_spec.version>1.0.3.Final</jboss.spec.javax.servlet.jsp.jboss-jsp-api_2.3_spec.version>
-        <jersey.version>2.28</jersey.version>
         <log4j.version>1.2.17</log4j.version>
         <resteasy.version>3.6.1.Final</resteasy.version>
         <resteasy.undertow.version>3.6.1.Final</resteasy.undertow.version>
@@ -777,13 +776,6 @@
                 <groupId>org.aesh</groupId>
                 <artifactId>aesh-readline</artifactId>
                 <version>${aesh.readline.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.glassfish.jersey</groupId>
-                <artifactId>jersey-bom</artifactId>
-                <version>${jersey.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
             </dependency>
 
             <!-- keycloak -->

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,7 @@
         <jboss-transaction-api_1.2_spec>1.1.1.Final</jboss-transaction-api_1.2_spec>
         <jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec.version>1.0.1.Final</jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec.version>
         <jboss.spec.javax.servlet.jsp.jboss-jsp-api_2.3_spec.version>1.0.3.Final</jboss.spec.javax.servlet.jsp.jboss-jsp-api_2.3_spec.version>
+        <jersey.version>2.28</jersey.version>
         <log4j.version>1.2.17</log4j.version>
         <resteasy.version>3.6.1.Final</resteasy.version>
         <resteasy.undertow.version>3.6.1.Final</resteasy.undertow.version>
@@ -766,6 +767,13 @@
                 <groupId>org.aesh</groupId>
                 <artifactId>aesh-readline</artifactId>
                 <version>${aesh.readline.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.jersey</groupId>
+                <artifactId>jersey-bom</artifactId>
+                <version>${jersey.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
 
             <!-- keycloak -->

--- a/pom.xml
+++ b/pom.xml
@@ -599,7 +599,17 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpclient-osgi</artifactId>
+                <version>${apache.httpcomponents.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpcore</artifactId>
+                <version>${apache.httpcomponents.httpcore.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpcore-osgi</artifactId>
                 <version>${apache.httpcomponents.httpcore.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
KEYCLOAK-8991 Keycloak Installed Application: provide OSGi meta data
keycloak-installed-adapter:
- replace Resteasy with plain JAX-RS to support OSGi-based Keycloak clients
- generate OSGi meta data
- dependencies with OSGi meta data