### PR TITLE
KEYCLOAK-4640: LDAP memberships are being replaced instead of being added or deleted

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/IdentityStore.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/IdentityStore.java
@@ -65,6 +65,22 @@ public interface IdentityStore {
      */
     void remove(LDAPObject ldapObject);
 
+    /**
+     * Adds a member to a group.
+     * @param groupDn The DN of the group object
+     * @param memberAttrName The member attribute name
+     * @param value The value (it can be uid or dn depending the group type)
+     */
+    public void addMemberToGroup(String groupDn, String memberAttrName, String value);
+
+    /**
+     * Removes a member from a group.
+     * @param groupDn The DN of the group object
+     * @param memberAttrName The member attribute name
+     * @param value The value (it can be uid or dn depending the group type)
+     */
+    public void removeMemberFromGroup(String groupDn, String memberAttrName, String value);
+
     // Identity query
 
     List<LDAPObject> fetchQueryResults(LDAPQuery LDAPQuery);

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPOperationManager.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPOperationManager.java
@@ -528,50 +528,52 @@ public class LDAPOperationManager {
         }
     }
 
-    public void modifyAttributes(final String dn, final ModificationItem[] mods, LDAPOperationDecorator decorator) {
-        try {
-            if (logger.isTraceEnabled()) {
-                logger.tracef("Modifying attributes for entry [%s]: [", dn);
+    public void modifyAttributesNaming(final String dn, final ModificationItem[] mods, LDAPOperationDecorator decorator) throws NamingException {
+        if (logger.isTraceEnabled()) {
+            logger.tracef("Modifying attributes for entry [%s]: [", dn);
 
-                for (ModificationItem item : mods) {
-                    Object values;
+            for (ModificationItem item : mods) {
+                Object values;
 
-                    if (item.getAttribute().size() > 0) {
-                        values = item.getAttribute().get();
-                    } else {
-                        values = "No values";
-                    }
-
-                    String attrName = item.getAttribute().getID().toUpperCase();
-                    if (attrName.contains("PASSWORD") || attrName.contains("UNICODEPWD")) {
-                        values = "********************";
-                    }
-
-                    logger.tracef("  Op [%s]: %s = %s", item.getModificationOp(), item.getAttribute().getID(), values);
+                if (item.getAttribute().size() > 0) {
+                    values = item.getAttribute().get();
+                } else {
+                    values = "No values";
                 }
 
-                logger.tracef("]");
+                String attrName = item.getAttribute().getID().toUpperCase();
+                if (attrName.contains("PASSWORD") || attrName.contains("UNICODEPWD")) {
+                    values = "********************";
+                }
+
+                logger.tracef("  Op [%s]: %s = %s", item.getModificationOp(), item.getAttribute().getID(), values);
             }
 
-            execute(new LdapOperation<Void>() {
+            logger.tracef("]");
+        }
 
-                @Override
-                public Void execute(LdapContext context) throws NamingException {
-                    context.modifyAttributes(new LdapName(dn), mods);
-                    return null;
-                }
+        execute(new LdapOperation<Void>() {
 
+            @Override
+            public Void execute(LdapContext context) throws NamingException {
+                context.modifyAttributes(new LdapName(dn), mods);
+                return null;
+            }
 
-                @Override
-                public String toString() {
-                    return new StringBuilder("LdapOperation: modify\n")
-                            .append(" dn: ").append(dn).append("\n")
-                            .append(" modificationsSize: ").append(mods.length)
-                            .toString();
-                }
+            @Override
+            public String toString() {
+                return new StringBuilder("LdapOperation: modify\n")
+                        .append(" dn: ").append(dn).append("\n")
+                        .append(" modificationsSize: ").append(mods.length)
+                        .toString();
+            }
 
+        }, null, decorator);
+    }
 
-            }, null, decorator);
+    public void modifyAttributes(final String dn, final ModificationItem[] mods, LDAPOperationDecorator decorator) {
+        try {
+            modifyAttributesNaming(dn, mods, decorator);
         } catch (NamingException e) {
             throw new ModelException("Could not modify attribute for DN [" + dn + "]", e);
         }

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/membership/MembershipType.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/membership/MembershipType.java
@@ -50,12 +50,12 @@ public enum MembershipType {
         @Override
         public Set<LDAPDn> getLDAPSubgroups(GroupLDAPStorageMapper groupMapper, LDAPObject ldapGroup) {
             CommonLDAPGroupMapperConfig config = groupMapper.getConfig();
-            return getLDAPMembersWithParent(ldapGroup, config.getMembershipLdapAttribute(), LDAPDn.fromString(config.getLDAPGroupsDn()));
+            return getLDAPMembersWithParent(groupMapper.getLdapProvider(), ldapGroup, config.getMembershipLdapAttribute(), LDAPDn.fromString(config.getLDAPGroupsDn()));
         }
 
         // Get just those members of specified group, which are descendants of "requiredParentDn"
-        protected Set<LDAPDn> getLDAPMembersWithParent(LDAPObject ldapGroup, String membershipLdapAttribute, LDAPDn requiredParentDn) {
-            Set<String> allMemberships = LDAPUtils.getExistingMemberships(membershipLdapAttribute, ldapGroup);
+        protected Set<LDAPDn> getLDAPMembersWithParent(LDAPStorageProvider ldapProvider, LDAPObject ldapGroup, String membershipLdapAttribute, LDAPDn requiredParentDn) {
+            Set<String> allMemberships = LDAPUtils.getExistingMemberships(ldapProvider, membershipLdapAttribute, ldapGroup);
 
             // Filter and keep just descendants of requiredParentDn
             Set<LDAPDn> result = new HashSet<>();
@@ -74,7 +74,7 @@ public enum MembershipType {
             CommonLDAPGroupMapperConfig config = groupMapper.getConfig();
 
             LDAPDn usersDn = LDAPDn.fromString(ldapProvider.getLdapIdentityStore().getConfig().getUsersDn());
-            Set<LDAPDn> userDns = getLDAPMembersWithParent(ldapGroup, config.getMembershipLdapAttribute(), usersDn);
+            Set<LDAPDn> userDns = getLDAPMembersWithParent(ldapProvider, ldapGroup, config.getMembershipLdapAttribute(), usersDn);
 
             if (userDns == null) {
                 return Collections.emptyList();
@@ -139,7 +139,7 @@ public enum MembershipType {
             LDAPConfig ldapConfig = ldapProvider.getLdapIdentityStore().getConfig();
 
             String memberAttrName = groupMapper.getConfig().getMembershipLdapAttribute();
-            Set<String> memberUids = LDAPUtils.getExistingMemberships(memberAttrName, ldapGroup);
+            Set<String> memberUids = LDAPUtils.getExistingMemberships(ldapProvider, memberAttrName, ldapGroup);
 
             if (memberUids == null || memberUids.size() <= firstResult) {
                 return Collections.emptyList();

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/membership/role/RoleLDAPStorageMapper.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/membership/role/RoleLDAPStorageMapper.java
@@ -261,7 +261,7 @@ public class RoleLDAPStorageMapper extends AbstractLDAPStorageMapper implements 
 
         String membershipUserAttrName = getMembershipUserLdapAttribute();
 
-        LDAPUtils.addMember(ldapProvider, config.getMembershipTypeLdapAttribute(), config.getMembershipLdapAttribute(), membershipUserAttrName, ldapRole, ldapUser, true);
+        LDAPUtils.addMember(ldapProvider, config.getMembershipTypeLdapAttribute(), config.getMembershipLdapAttribute(), membershipUserAttrName, ldapRole, ldapUser);
     }
 
     public void deleteRoleMappingInLDAP(LDAPObject ldapUser, LDAPObject ldapRole) {

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/rest/resource/TestLDAPResource.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/rest/resource/TestLDAPResource.java
@@ -142,17 +142,17 @@ public class TestLDAPResource {
         LDAPObject defaultGroup15 = LDAPTestUtils.createLDAPGroup(session, realm, ldapModel, "defaultGroup15", descriptionAttrName, "Default Group15 - description");
         LDAPObject teamSubChild20262027 = LDAPTestUtils.createLDAPGroup(session, realm, ldapModel, "Team SubChild 2026/2027", descriptionAttrName, "A sub child group with slashes in the name");
 
-        LDAPUtils.addMember(ldapFedProvider, MembershipType.DN, LDAPConstants.MEMBER, "not-used", group1, group11, false);
-        LDAPUtils.addMember(ldapFedProvider, MembershipType.DN, LDAPConstants.MEMBER, "not-used", group1, group12, true);
+        LDAPUtils.addMember(ldapFedProvider, MembershipType.DN, LDAPConstants.MEMBER, "not-used", group1, group11);
+        LDAPUtils.addMember(ldapFedProvider, MembershipType.DN, LDAPConstants.MEMBER, "not-used", group1, group12);
 
-        LDAPUtils.addMember(ldapFedProvider, MembershipType.DN, LDAPConstants.MEMBER, "not-used", defaultGroup1, defaultGroup11, false);
-        LDAPUtils.addMember(ldapFedProvider, MembershipType.DN, LDAPConstants.MEMBER, "not-used", defaultGroup1, defaultGroup12, true);
-        LDAPUtils.addMember(ldapFedProvider, MembershipType.DN, LDAPConstants.MEMBER, "not-used", defaultGroup1, teamChild20182019, true);
-        LDAPUtils.addMember(ldapFedProvider, MembershipType.DN, LDAPConstants.MEMBER, "not-used", teamChild20182019, teamSubChild20202021, true);
-        LDAPUtils.addMember(ldapFedProvider, MembershipType.DN, LDAPConstants.MEMBER, "not-used", defaultGroup13, teamSubChild20222023, true);
-        LDAPUtils.addMember(ldapFedProvider, MembershipType.DN, LDAPConstants.MEMBER, "not-used", teamSubChild20222023, defaultGroup14, true);
-        LDAPUtils.addMember(ldapFedProvider, MembershipType.DN, LDAPConstants.MEMBER, "not-used", teamRoot20242025, defaultGroup15, true);
-        LDAPUtils.addMember(ldapFedProvider, MembershipType.DN, LDAPConstants.MEMBER, "not-used", defaultGroup15, teamSubChild20262027, true);
+        LDAPUtils.addMember(ldapFedProvider, MembershipType.DN, LDAPConstants.MEMBER, "not-used", defaultGroup1, defaultGroup11);
+        LDAPUtils.addMember(ldapFedProvider, MembershipType.DN, LDAPConstants.MEMBER, "not-used", defaultGroup1, defaultGroup12);
+        LDAPUtils.addMember(ldapFedProvider, MembershipType.DN, LDAPConstants.MEMBER, "not-used", defaultGroup1, teamChild20182019);
+        LDAPUtils.addMember(ldapFedProvider, MembershipType.DN, LDAPConstants.MEMBER, "not-used", teamChild20182019, teamSubChild20202021);
+        LDAPUtils.addMember(ldapFedProvider, MembershipType.DN, LDAPConstants.MEMBER, "not-used", defaultGroup13, teamSubChild20222023);
+        LDAPUtils.addMember(ldapFedProvider, MembershipType.DN, LDAPConstants.MEMBER, "not-used", teamSubChild20222023, defaultGroup14);
+        LDAPUtils.addMember(ldapFedProvider, MembershipType.DN, LDAPConstants.MEMBER, "not-used", teamRoot20242025, defaultGroup15);
+        LDAPUtils.addMember(ldapFedProvider, MembershipType.DN, LDAPConstants.MEMBER, "not-used", defaultGroup15, teamSubChild20262027);
 
         // Sync LDAP groups to Keycloak DB
         ComponentModel mapperModel = LDAPTestUtils.getSubcomponentByName(realm, ldapModel, "groupsMapper");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPGroupMapperSyncTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPGroupMapperSyncTest.java
@@ -99,8 +99,8 @@ public class LDAPGroupMapperSyncTest extends AbstractLDAPTest {
             LDAPObject group11 = LDAPTestUtils.createLDAPGroup(session, appRealm, ctx.getLdapModel(), "group11");
             LDAPObject group12 = LDAPTestUtils.createLDAPGroup(session, appRealm, ctx.getLdapModel(), "group12", descriptionAttrName, "group12 - description");
 
-            LDAPUtils.addMember(ctx.getLdapProvider(), MembershipType.DN, LDAPConstants.MEMBER, "not-used", group1, group11, false);
-            LDAPUtils.addMember(ctx.getLdapProvider(), MembershipType.DN, LDAPConstants.MEMBER, "not-used", group1, group12, true);
+            LDAPUtils.addMember(ctx.getLdapProvider(), MembershipType.DN, LDAPConstants.MEMBER, "not-used", group1, group11);
+            LDAPUtils.addMember(ctx.getLdapProvider(), MembershipType.DN, LDAPConstants.MEMBER, "not-used", group1, group12);
 
         });
     }
@@ -135,7 +135,7 @@ public class LDAPGroupMapperSyncTest extends AbstractLDAPTest {
             // Add recursive group mapping to LDAP. Check that sync with preserve group inheritance will fail
             LDAPObject group1 = groupMapper.loadLDAPGroupByName("group1");
             LDAPObject group12 = groupMapper.loadLDAPGroupByName("group12");
-            LDAPUtils.addMember(ldapProvider, MembershipType.DN, LDAPConstants.MEMBER, "not-used", group12, group1, true);
+            LDAPUtils.addMember(ldapProvider, MembershipType.DN, LDAPConstants.MEMBER, "not-used", group12, group1);
 
             try {
                 new GroupLDAPStorageMapperFactory().create(session, mapperModel).syncDataFromFederationProviderToKeycloak(realm);
@@ -298,7 +298,7 @@ public class LDAPGroupMapperSyncTest extends AbstractLDAPTest {
             GroupMapperConfig groupMapperConfig = new GroupMapperConfig(mapperModel);
             LDAPObject ldapGroup = groupMapper.loadLDAPGroupByName("group11");
             LDAPUtils.addMember(ldapProvider, groupMapperConfig.getMembershipTypeLdapAttribute(), groupMapperConfig.getMembershipLdapAttribute(),
-                    groupMapperConfig.getMembershipUserLdapAttribute(ldapProvider.getLdapIdentityStore().getConfig()), ldapGroup, johnLdap, true);
+                    groupMapperConfig.getMembershipUserLdapAttribute(ldapProvider.getLdapIdentityStore().getConfig()), ldapGroup, johnLdap);
 
             // Assert groups not yet imported to Keycloak DB
             Assert.assertNull(KeycloakModelUtils.findGroupByPath(realm, "/group1"));

--- a/util/embedded-ldap/src/main/java/org/keycloak/util/ldap/RangedAttributeInterceptor.java
+++ b/util/embedded-ldap/src/main/java/org/keycloak/util/ldap/RangedAttributeInterceptor.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.util.ldap;
+
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import org.apache.directory.api.ldap.model.cursor.ClosureMonitor;
+import org.apache.directory.api.ldap.model.cursor.CursorException;
+import org.apache.directory.api.ldap.model.entry.Attribute;
+import org.apache.directory.api.ldap.model.entry.Entry;
+import org.apache.directory.api.ldap.model.entry.Value;
+import org.apache.directory.api.ldap.model.exception.LdapException;
+import org.apache.directory.api.ldap.model.schema.AttributeType;
+import org.apache.directory.api.ldap.model.schema.AttributeTypeOptions;
+import org.apache.directory.server.core.api.filtering.EntryFilter;
+import org.apache.directory.server.core.api.filtering.EntryFilteringCursor;
+import org.apache.directory.server.core.api.interceptor.BaseInterceptor;
+import org.apache.directory.server.core.api.interceptor.context.SearchOperationContext;
+
+/**
+ * <p>Ranged interceptor to emulate the behavior of AD. AD has a limit in
+ * the number of attributes that return (15000 by default in MaxValRange). 
+ * See this MS link for AD limits:</p>
+ *
+ * https://support.microsoft.com/en-us/help/315071/how-to-view-and-set-ldap-policy-in-active-directory-by-using-ntdsutil
+ *
+ * <p>And this other link to know how range attribute search works:</p>
+ *
+ * https://docs.microsoft.com/en-us/previous-versions/windows/desktop/ldap/searching-using-range-retrieval
+ *
+ * @author rmartinc
+ */
+public class RangedAttributeInterceptor extends BaseInterceptor {
+
+    private class RangedEntryFilteringCursor implements EntryFilteringCursor {
+
+        private final EntryFilteringCursor c;
+        private final String name;
+        private final Integer min;
+        private final Integer max;
+
+        public RangedEntryFilteringCursor(EntryFilteringCursor c, String name, Integer min, Integer max) {
+            this.c = c;
+            this.name = name;
+            this.min = min;
+            this.max = max;
+            AttributeType type = new AttributeType(name);
+        }
+
+        private Entry prepareEntry(Entry e) {
+            Attribute attr = e.get(name);
+            if (attr != null) {
+                int start = (min != null)? min : 0;
+                start = (start < attr.size())? start : attr.size() - 1;
+                int end = (max != null && max < attr.size() - 1)? max : attr.size() - 1;
+                if (start != 0 || end != attr.size() - 1) {
+                    // some values should be stripped out
+                    Iterator<Value<?>> it = attr.iterator();
+                    Set<Value<?>> valuesToRemove = new HashSet<>(end - start + 1);
+                    for (int i = 0; i < attr.size(); i++) {
+                        Value<?> v = it.next();
+                        if (i < start || i > end) {
+                            valuesToRemove.add(v);
+                        }
+                    }
+                    attr.setUpId(attr.getUpId() + ";range=" + start + "-" + ((end == attr.size() - 1)? "*" : end));
+                    attr.remove(valuesToRemove.toArray(new Value<?>[0]));
+                } else if (min != null) {
+                    // range explicitly requested although no value stripped
+                    attr.setUpId(attr.getUpId() + ";range=0-*");
+                }
+            }
+            return e;
+        }
+
+        @Override
+        public boolean addEntryFilter(EntryFilter ef) {
+            return c.addEntryFilter(ef);
+        }
+
+        @Override
+        public List<EntryFilter> getEntryFilters() {
+            return c.getEntryFilters();
+        }
+
+        @Override
+        public SearchOperationContext getOperationContext() {
+            return c.getOperationContext();
+        }
+
+        @Override
+        public boolean available() {
+            return c.available();
+        }
+
+        @Override
+        public void before(Entry e) throws LdapException, CursorException {
+            c.before(e);
+        }
+
+        @Override
+        public void after(Entry e) throws LdapException, CursorException {
+            c.after(e);
+        }
+
+        @Override
+        public void beforeFirst() throws LdapException, CursorException {
+            c.beforeFirst();
+        }
+
+        @Override
+        public void afterLast() throws LdapException, CursorException {
+            c.afterLast();
+        }
+
+        @Override
+        public boolean first() throws LdapException, CursorException {
+            return c.first();
+        }
+
+        @Override
+        public boolean isFirst() {
+            return c.isFirst();
+        }
+
+        @Override
+        public boolean isBeforeFirst() {
+            return c.isBeforeFirst();
+        }
+
+        @Override
+        public boolean last() throws LdapException, CursorException {
+            return c.last();
+        }
+
+        @Override
+        public boolean isLast() {
+            return c.isLast();
+        }
+
+        @Override
+        public boolean isAfterLast() {
+            return c.isAfterLast();
+        }
+
+        @Override
+        public boolean isClosed() {
+            return c.isClosed();
+        }
+
+        @Override
+        public boolean previous() throws LdapException, CursorException {
+            return c.previous();
+        }
+
+        @Override
+        public boolean next() throws LdapException, CursorException {
+            return c.next();
+        }
+
+        @Override
+        public Entry get() throws CursorException {
+            return prepareEntry(c.get());
+        }
+
+        @Override
+        public void close() {
+            c.close();
+        }
+
+        @Override
+        public void close(Exception excptn) {
+            c.close(excptn);
+        }
+
+        @Override
+        public void setClosureMonitor(ClosureMonitor cm) {
+            c.setClosureMonitor(cm);
+        }
+
+        @Override
+        public String toString(String string) {
+            return c.toString(string);
+        }
+
+        @Override
+        public Iterator<Entry> iterator() {
+            return c.iterator();
+        }
+    }
+
+    private final String name;
+    private final int max;
+
+    public RangedAttributeInterceptor(String name, int max) {
+        this.name = name;
+        this.max = max - 1;
+    }
+
+    @Override
+    public EntryFilteringCursor search(SearchOperationContext sc) throws LdapException {
+        Set<AttributeTypeOptions> attrs = sc.getReturningAttributes();
+        Integer lmin = null, lmax = max;
+        if (attrs != null) {
+            for (AttributeTypeOptions attr : attrs) {
+                if (attr.getAttributeType().getName().equalsIgnoreCase(name)) {
+                    if (attr.getOptions() != null) {
+                        for (String option : attr.getOptions()) {
+                            if (option.startsWith("range=")) {
+                                String[] ranges = option.substring(6).split("-");
+                                if (ranges.length == 2) {
+                                    try {
+                                        lmin = Integer.parseInt(ranges[0]);
+                                        if (lmin < 0) {
+                                            lmin = 0;
+                                        }
+                                        if ("*".equals(ranges[1])) {
+                                            lmax = lmin + max;
+                                        } else {
+                                            lmax = Integer.parseInt(ranges[1]);
+                                            if (lmax < lmin) {
+                                                lmax = lmin;
+                                            } else if (lmax > lmin + max) {
+                                                lmax = lmin + max;
+                                            }
+                                        }
+                                    } catch (NumberFormatException e) {
+                                        lmin = null;
+                                        lmax = max;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    break;
+                }
+            }
+        }
+        return new RangedEntryFilteringCursor(super.next(sc), name, lmin, lmax);
+    }
+}


### PR DESCRIPTION
Tentative fix for KEYCLOAK-4640 (also includes some changes for covering range attribute retrieval: KEYCLOAK-8525). I suppose we are going to need some cycles for this, but we have to start with something.
