### PR TITLE
KEYCLOAK-9348 UserStorageConsentTest fails with some databases

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/storage/UserStorageTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/storage/UserStorageTest.java
@@ -752,6 +752,8 @@ public class UserStorageTest extends AbstractAuthTest {
 
             Assert.assertEquals(1, UserMapStorage.allocations.get());
             Assert.assertEquals(0, UserMapStorage.closings.get());
+
+            session.users().removeUser(realm,session.users().getUserByUsername("memuser",realm));
         });
 
         testingClient.server().run(session -> {


### PR DESCRIPTION
JIRA: [KEYCLOAK-9348](https://issues.jboss.org/browse/KEYCLOAK-9348)