### PR TITLE
[KEYCLOAK-9772] Permissions are duplicated

### DIFF
--- a/services/src/main/java/org/keycloak/authorization/util/Permissions.java
+++ b/services/src/main/java/org/keycloak/authorization/util/Permissions.java
@@ -44,7 +44,6 @@ import org.keycloak.representations.idm.authorization.AuthorizationRequest.Metad
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
  */
 public final class Permissions {
-
     public static ResourcePermission permission(ResourceServer server, Resource resource, Scope scope) {
        return new ResourcePermission(resource, new ArrayList<>(Arrays.asList(scope)), server);
     }
@@ -80,12 +79,15 @@ public final class Permissions {
             }
         });
 
-        // obtain all resources where owner is the current user
-        resourceStore.findByOwner(identity.getId(), resourceServer.getId(), resource -> {
-            if (limit.decrementAndGet() >= 0) {
-                permissions.add(createResourcePermissions(resource, authorization, request));
-            }
-        });
+        // resource server isn't current user
+        if (resourceServer.getId() != identity.getId()) {
+            // obtain all resources where owner is the current user
+            resourceStore.findByOwner(identity.getId(), resourceServer.getId(), resource -> {
+                if (limit.decrementAndGet() >= 0) {
+                    permissions.add(createResourcePermissions(resource, authorization, request));
+                }
+            });
+        }
 
         // obtain all resources granted to the user via permission tickets (uma)
         List<PermissionTicket> tickets = storeFactory.getPermissionTicketStore().findGranted(identity.getId(), resourceServer.getId());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/AuthzClientCredentialsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/AuthzClientCredentialsTest.java
@@ -165,7 +165,6 @@ public class AuthzClientCredentialsTest extends AbstractAuthzTest {
 
         protection.resource().findByName("Default Resource");
         userSessions = clients.get(clientRepresentation.getId()).getUserSessions(null, null);
-
         assertEquals(1, userSessions.size());
 
         Thread.sleep(2000);
@@ -175,6 +174,23 @@ public class AuthzClientCredentialsTest extends AbstractAuthzTest {
         userSessions = clients.get(clientRepresentation.getId()).getUserSessions(null, null);
 
         assertEquals(1, userSessions.size());
+    }
+
+    @Test
+    public void testPermissionWhenResourceServerIsCurrentUser() throws Exception {
+        ClientsResource clients = getAdminClient().realm("authz-test-session").clients();
+        ClientRepresentation clientRepresentation = clients.findByClientId("resource-server-test").get(0);
+        List<UserSessionRepresentation> userSessions = clients.get(clientRepresentation.getId()).getUserSessions(-1, -1);
+
+        assertEquals(0, userSessions.size());
+
+        AuthzClient authzClient = getAuthzClient("default-session-keycloak.json");
+        org.keycloak.authorization.client.resource.AuthorizationResource authorization = authzClient.authorization(authzClient.obtainAccessToken().getToken());
+        AuthorizationResponse response = authorization.authorize();
+        AccessToken accessToken = toAccessToken(response.getToken());
+
+        assertEquals(1, accessToken.getAuthorization().getPermissions().size());
+        assertEquals("Default Resource", accessToken.getAuthorization().getPermissions().iterator().next().getResourceName());
     }
 
     @Test


### PR DESCRIPTION
- when resource server is current user

[KEYCLOAK-9772](https://issues.jboss.org/browse/KEYCLOAK-9772)
