### PR TITLE
KEYCLOAK-6795 Silent refresh of tokens for implicit flow

### DIFF
--- a/adapters/oidc/js/src/main/resources/keycloak.d.ts
+++ b/adapters/oidc/js/src/main/resources/keycloak.d.ts
@@ -105,6 +105,14 @@ declare namespace Keycloak {
 		redirectUri?: string;
 
 		/**
+		 * Specifies an uri to redirect to after silent refresh of access token.
+		 * This is only used/supported for implicit flow.
+		 * Silent refresh will only happen, when this redirect uri is given and
+		 * the specified uri is available whithin the application.
+		 */
+		silentRefreshRedirectUri?: string;
+
+		/**
 		 * Set the OpenID Connect flow.
 		 * @default standard
 		 */

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/rest/resource/TestJavascriptResource.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/rest/resource/TestJavascriptResource.java
@@ -31,6 +31,13 @@ public class TestJavascriptResource {
     }
 
     @GET
+    @Path("/silent-refresh.html")
+    @Produces(MediaType.TEXT_HTML)
+    public String getJavascriptTestingEnvironmentSilentRefresh() throws IOException {
+        return resourceToString("/javascript/silent-refresh.html");
+    }
+
+    @GET
     @Path("/keycloak.json")
     @Produces(MediaType.APPLICATION_JSON)
     public String getKeycloakJSON() throws IOException {

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/resources/javascript/silent-refresh.html
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/resources/javascript/silent-refresh.html
@@ -1,0 +1,4 @@
+<html>
+<head><script src="js/keycloak.js"></script></head>
+<body onload="Keycloak.silentlyRefreshPage()"></body>
+</html>

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/javascript/JavascriptAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/javascript/JavascriptAdapterTest.java
@@ -271,6 +271,15 @@ public class JavascriptAdapterTest extends AbstractJavascriptTest {
     }
 
     @Test
+    public void implicitFlowUpdateTokenTest() {
+        setImplicitFlowForClient();
+        testExecutor.logInAndInit(defaultArguments().implicitFlow()
+                        .add("silentRefreshRedirectUri", authServerContextRootPage + JAVASCRIPT_URL + "/silent-refresh.html"),
+                testUser, this::assertSuccessfullyLoggedIn)
+            .refreshToken(-1, assertEventsContains("Auth Refresh Success"));
+    }
+
+    @Test
     public void implicitFlowOnTokenExpireTest() {
         RealmRepresentation realm = adminClient.realms().realm(REALM_NAME).toRepresentation();
         Integer storeAccesTokenLifespan = realm.getAccessTokenLifespanForImplicitFlow();


### PR DESCRIPTION
JavaScript adapter update to allow silent token refresh when using implicit flow.
It's implemented like mentioned in text and links in KEYCLOAK-6795.

There's a new init parameter for the JavaScript adapter: `silentRefreshRedirectUri`.

PR for docs update is here: https://github.com/keycloak/keycloak-documentation/pull/600