### PR TITLE
KEYCLOAK-8938 Explicitly pass internal flag for all createPromise calls

### DIFF
--- a/adapters/oidc/js/src/main/resources/keycloak.js
+++ b/adapters/oidc/js/src/main/resources/keycloak.js
@@ -1160,17 +1160,17 @@
                 return {
                     login: function(options) {
                         window.location.replace(kc.createLoginUrl(options));
-                        return createPromise().promise;
+                        return createPromise(true).promise;
                     },
 
                     logout: function(options) {
                         window.location.replace(kc.createLogoutUrl(options));
-                        return createPromise().promise;
+                        return createPromise(false).promise;
                     },
 
                     register: function(options) {
                         window.location.replace(kc.createRegisterUrl(options));
-                        return createPromise().promise;
+                        return createPromise(false).promise;
                     },
 
                     accountManagement : function() {


### PR DESCRIPTION
<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->

See https://issues.jboss.org/browse/KEYCLOAK-8938 for details.

Short version: using native promises will generate an error `TypeError: kc.login(...).success is not a function`

This PR explicitly declares the `internal` argument for all internal calls to `createPromise`. Since the error is generated by an [internal function](https://github.com/keycloak/keycloak/blob/91c4bfa81c2ff874eb07b5425139c26bafe4e8c5/adapters/oidc/js/src/main/resources/keycloak.js#L145) we can fix the error by using legacy promise in the "default" login adapter.