### PR TITLE
KEYCLOAK-9868 Support for JWK endpoint x5t and x5t#S256 parameters

### DIFF
--- a/common/src/main/java/org/keycloak/common/util/PemUtils.java
+++ b/common/src/main/java/org/keycloak/common/util/PemUtils.java
@@ -24,6 +24,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.security.Key;
+import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.cert.Certificate;
@@ -157,4 +158,7 @@ public final class PemUtils {
         return pem.trim();
     }
 
+    public static String generateThumbprint(String[] certChain, String encoding) throws NoSuchAlgorithmException, IOException {
+        return Base64Url.encode(pemToDer(certChain[0]));
+    }
 }

--- a/core/src/main/java/org/keycloak/jose/jwk/RSAPublicJWK.java
+++ b/core/src/main/java/org/keycloak/jose/jwk/RSAPublicJWK.java
@@ -18,9 +18,9 @@
 package org.keycloak.jose.jwk;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.keycloak.common.util.Base64Url;
+import org.keycloak.common.util.PemUtils;
 
-import java.security.MessageDigest;
+import java.io.IOException;
 import java.security.NoSuchAlgorithmException;
 
 /**
@@ -71,10 +71,10 @@ public class RSAPublicJWK extends JWK {
         this.x509CertificateChain = x509CertificateChain;
         if (x509CertificateChain != null && x509CertificateChain.length > 0) {
             try {
-                sha1x509Thumbprint = encode(x509CertificateChain, "SHA-1");
-                sha256x509Thumbprint = encode(x509CertificateChain, "SHA-256");
-            } catch (NoSuchAlgorithmException e) {
-                e.printStackTrace();
+                sha1x509Thumbprint = PemUtils.generateThumbprint(x509CertificateChain, "SHA-1");
+                sha256x509Thumbprint = PemUtils.generateThumbprint(x509CertificateChain, "SHA-256");
+            } catch (NoSuchAlgorithmException | IOException e) {
+                throw new RuntimeException(e);
             }
         }
     }
@@ -89,16 +89,4 @@ public class RSAPublicJWK extends JWK {
         return sha256x509Thumbprint;
     }
 
-    private String encode(String[] certChain, String encoding) throws NoSuchAlgorithmException {
-        MessageDigest md = MessageDigest.getInstance(encoding);
-        return Base64Url.encode(md.digest(toConcatenatedString(x509CertificateChain).getBytes()));
-    }
-
-    private String toConcatenatedString(String[] arr) {
-        StringBuilder sb = new StringBuilder();
-        for (String str : arr) {
-            sb.append(str);
-        }
-        return sb.toString();
-    }
 }

--- a/core/src/test/java/org/keycloak/jose/jwk/JWKTest.java
+++ b/core/src/test/java/org/keycloak/jose/jwk/JWKTest.java
@@ -60,6 +60,10 @@ public class JWKTest {
         assertNotNull(((RSAPublicJWK) jwk).getPublicExponent());
         assertNotNull(((RSAPublicJWK) jwk).getX509CertificateChain());
         assertEquals(PemUtils.encodeCertificate(certificate), ((RSAPublicJWK) jwk).getX509CertificateChain()[0]);
+        assertNotNull(((RSAPublicJWK) jwk).getSha1x509Thumbprint());
+        assertEquals(PemUtils.generateThumbprint(((RSAPublicJWK) jwk).getX509CertificateChain(), "SHA-1"), ((RSAPublicJWK) jwk).getSha1x509Thumbprint());
+        assertNotNull(((RSAPublicJWK) jwk).getSha256x509Thumbprint());
+        assertEquals(PemUtils.generateThumbprint(((RSAPublicJWK) jwk).getX509CertificateChain(), "SHA-256"), ((RSAPublicJWK) jwk).getSha256x509Thumbprint());
 
         String jwkJson = JsonSerialization.writeValueAsString(jwk);
 


### PR DESCRIPTION
Adds the x5t and x5t#S256 JWK parameters to the response returned by the JWK set endpoint.