### PR TITLE
KEYCLOAK-5665 - elytron propagate security domain to ejb

### DIFF
--- a/distribution/adapters/shared-cli/adapter-elytron-install.cli
+++ b/distribution/adapters/shared-cli/adapter-elytron-install.cli
@@ -55,3 +55,9 @@ if (outcome != success) of /subsystem=undertow/application-security-domain=other
 else
     echo Undertow already configured with Keycloak
 end-if
+
+if (outcome != success) of /subsystem=ejb3/application-security-domain=other:read-resource
+    /subsystem=ejb3/application-security-domain=other:add(security-domain=KeycloakDomain)
+else
+    echo EJB already configured with Keycloak
+end-if


### PR DESCRIPTION
Automatically propagate security domain to EJBs when using Elytron Wildfly client adapter.

See: https://issues.jboss.org/browse/KEYCLOAK-5665
