### PR TITLE
KEYCLOAK-9923 - add-user-keycloak detect if Java uses modules (JDK 9+)

### DIFF
--- a/distribution/feature-packs/server-feature-pack/src/main/resources/content/bin/add-user-keycloak.bat
+++ b/distribution/feature-packs/server-feature-pack/src/main/resources/content/bin/add-user-keycloak.bat
@@ -46,6 +46,12 @@ if "x%JAVA_HOME%" == "x" (
   set "JAVA=%JAVA_HOME%\bin\java"
 )
 
+rem set default modular jvm parameters
+setlocal EnableDelayedExpansion
+call "!DIRNAME!common.bat" :setDefaultModularJvmOptions "!JAVA_OPTS!"
+set "JAVA_OPTS=!JAVA_OPTS! !DEFAULT_MODULAR_JVM_OPTIONS!"
+setlocal DisableDelayedExpansion
+
 rem Find jboss-modules.jar, or we can't continue
 if exist "%JBOSS_HOME%\jboss-modules.jar" (
     set "RUNJAR=%JBOSS_HOME%\jboss-modules.jar"

--- a/distribution/feature-packs/server-feature-pack/src/main/resources/content/bin/add-user-keycloak.sh
+++ b/distribution/feature-packs/server-feature-pack/src/main/resources/content/bin/add-user-keycloak.sh
@@ -7,6 +7,9 @@
 #
 
 DIRNAME=`dirname "$0"`
+GREP="grep"
+
+ . "$DIRNAME/common.sh"
 
 # OS specific support (must be 'true' or 'false').
 cygwin=false;
@@ -46,6 +49,10 @@ if [ "x$JAVA" = "x" ]; then
         JAVA="java"
     fi
 fi
+
+# Set default modular JVM options
+setDefaultModularJvmOptions $JAVA_OPTS
+JAVA_OPTS="$JAVA_OPTS $DEFAULT_MODULAR_JVM_OPTIONS"
 
 if [ "x$JBOSS_MODULEPATH" = "x" ]; then
     JBOSS_MODULEPATH="$JBOSS_HOME/modules"


### PR DESCRIPTION
add-user-keycloak scripts don't work on Java 9+ due to new module system.   

The fix simply copies what Wildfly add-user scripts do to handle this: https://github.com/wildfly/wildfly-core/pull/3488/

Keycloak Issue: https://issues.jboss.org/browse/KEYCLOAK-9923
