### PR TITLE
[KEYCLOAK-9353] - Avoids initialization of the policy enforcer during deployment

### DIFF
--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/AdapterDeploymentContext.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/AdapterDeploymentContext.java
@@ -33,6 +33,7 @@ import org.keycloak.representations.adapters.config.AdapterConfig;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Map;
+import java.util.concurrent.Callable;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -469,7 +470,7 @@ public class AdapterDeploymentContext {
         }
 
         @Override
-        public void setPolicyEnforcer(PolicyEnforcer policyEnforcer) {
+        public void setPolicyEnforcer(Callable<PolicyEnforcer> policyEnforcer) {
             delegate.setPolicyEnforcer(policyEnforcer);
         }
 

--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/KeycloakDeployment.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/KeycloakDeployment.java
@@ -89,7 +89,7 @@ public class KeycloakDeployment {
     protected int tokenMinimumTimeToLive;
     protected int minTimeBetweenJwksRequests;
     protected int publicKeyCacheTtl;
-    private PolicyEnforcer policyEnforcer;
+    protected Callable<PolicyEnforcer> policyEnforcer;
 
     // https://tools.ietf.org/html/rfc7636
     protected boolean pkce = false;
@@ -464,12 +464,19 @@ public class KeycloakDeployment {
         this.publicKeyCacheTtl = publicKeyCacheTtl;
     }
 
-    public void setPolicyEnforcer(PolicyEnforcer policyEnforcer) {
+    public void setPolicyEnforcer(Callable<PolicyEnforcer> policyEnforcer) {
         this.policyEnforcer = policyEnforcer;
     }
 
     public PolicyEnforcer getPolicyEnforcer() {
-        return policyEnforcer;
+        if (policyEnforcer == null) {
+            return null;
+        }
+        try {
+            return policyEnforcer.call();
+        } catch (Exception cause) {
+            throw new RuntimeException("Failed to obtain policy enforcer", cause);
+        }
     }
 
     // https://tools.ietf.org/html/rfc7636


### PR DESCRIPTION
This change is basically deferring the policy enforcer initialization instead of doing during deployment.