### PR TITLE
[KEYCLOAK-9353] - Final field failing to be set when running quarkus in native mode

### DIFF
--- a/core/src/main/java/org/keycloak/representations/idm/authorization/Permission.java
+++ b/core/src/main/java/org/keycloak/representations/idm/authorization/Permission.java
@@ -41,7 +41,7 @@ public class Permission {
     private Set<String> scopes;
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private final Map<String, Set<String>> claims;
+    private Map<String, Set<String>> claims;
 
     public Permission() {
         this(null, null, null, null);


### PR DESCRIPTION
After adding more tests to quarkus extension I found failures when testing a specific scenario where CIP is being used to push arbitrary claims to the Keycloak Server.

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
