### PR TITLE
KEYCLOAK-10020 Add ability to request ticket permissions by name

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/authorization/PermissionTicketAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/authorization/PermissionTicketAdapter.java
@@ -42,9 +42,9 @@ public class PermissionTicketAdapter implements PermissionTicket, CachedModel<Pe
     @Override
     public PermissionTicket getDelegateForUpdate() {
         if (updated == null) {
-            cacheSession.registerPermissionTicketInvalidation(cached.getId(), cached.getOwner(), cached.getRequester(), cached.getResourceId(), cached.getScopeId(), cached.getResourceServerId());
             updated = cacheSession.getPermissionTicketStoreDelegate().findById(cached.getId(), cached.getResourceServerId());
             if (updated == null) throw new IllegalStateException("Not found in database");
+            cacheSession.registerPermissionTicketInvalidation(cached.getId(), cached.getOwner(), cached.getRequester(), cached.getResourceId(), updated.getResource().getName(), cached.getScopeId(), cached.getResourceServerId());
         }
         return updated;
     }
@@ -114,7 +114,7 @@ public class PermissionTicketAdapter implements PermissionTicket, CachedModel<Pe
     @Override
     public void setGrantedTimestamp(Long millis) {
         getDelegateForUpdate();
-        cacheSession.registerPermissionTicketInvalidation(cached.getId(), cached.getOwner(), cached.getRequester(), cached.getResourceId(), cached.getScopeId(), cached.getResourceServerId());
+        cacheSession.registerPermissionTicketInvalidation(cached.getId(), cached.getOwner(), cached.getRequester(), cached.getResourceId(), updated.getResource().getName(), cached.getScopeId(), cached.getResourceServerId());
         updated.setGrantedTimestamp(millis);
     }
 
@@ -132,7 +132,7 @@ public class PermissionTicketAdapter implements PermissionTicket, CachedModel<Pe
     @Override
     public void setPolicy(Policy policy) {
         getDelegateForUpdate();
-        cacheSession.registerPermissionTicketInvalidation(cached.getId(), cached.getOwner(), cached.getRequester(), cached.getResourceId(), cached.getScopeId(), cached.getResourceServerId());
+        cacheSession.registerPermissionTicketInvalidation(cached.getId(), cached.getOwner(), cached.getRequester(), cached.getResourceId(), updated.getResource().getName(), cached.getScopeId(), cached.getResourceServerId());
         updated.setPolicy(policy);
     }
 

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/authorization/ResourceAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/authorization/ResourceAdapter.java
@@ -115,7 +115,7 @@ public class ResourceAdapter implements Resource, CachedModel<Resource> {
     @Override
     public void setDisplayName(String name) {
         getDelegateForUpdate();
-        cacheSession.registerResourceInvalidation(cached.getId(), name, cached.getType(), cached.getUris(modelSupplier), cached.getScopesIds(modelSupplier), cached.getResourceServerId(), cached.getOwner());
+        cacheSession.registerResourceInvalidation(cached.getId(), cached.getName(), cached.getType(), cached.getUris(modelSupplier), cached.getScopesIds(modelSupplier), cached.getResourceServerId(), cached.getOwner());
         updated.setDisplayName(name);
     }
 

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/authorization/StoreFactoryCacheManager.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/authorization/StoreFactoryCacheManager.java
@@ -83,6 +83,7 @@ public class StoreFactoryCacheManager extends CacheManager {
         invalidations.add(StoreFactoryCacheSession.getResourceByOwnerCacheKey(owner, serverId));
         invalidations.add(StoreFactoryCacheSession.getResourceByOwnerCacheKey(owner, null));
         invalidations.add(StoreFactoryCacheSession.getPermissionTicketByResource(id, serverId));
+        addInvalidations(InResourcePredicate.create().resource(name), invalidations);
 
         if (type != null) {
             invalidations.add(StoreFactoryCacheSession.getResourceByTypeCacheKey(type, serverId));
@@ -137,11 +138,12 @@ public class StoreFactoryCacheManager extends CacheManager {
         }
     }
 
-    public void permissionTicketUpdated(String id, String owner, String requester, String resource, String scope, String serverId, Set<String> invalidations) {
+    public void permissionTicketUpdated(String id, String owner, String requester, String resource, String resourceName, String scope, String serverId, Set<String> invalidations) {
         invalidations.add(id);
         invalidations.add(StoreFactoryCacheSession.getPermissionTicketByOwner(owner, serverId));
         invalidations.add(StoreFactoryCacheSession.getPermissionTicketByResource(resource, serverId));
         invalidations.add(StoreFactoryCacheSession.getPermissionTicketByGranted(requester, serverId));
+        invalidations.add(StoreFactoryCacheSession.getPermissionTicketByResourceNameAndGranted(resourceName, requester, serverId));
         if (scope != null) {
             invalidations.add(StoreFactoryCacheSession.getPermissionTicketByScope(scope, serverId));
         }
@@ -151,8 +153,8 @@ public class StoreFactoryCacheManager extends CacheManager {
         policyUpdated(id, name, resources, resourceTypes, scopes, serverId, invalidations);
     }
 
-    public void permissionTicketRemoval(String id, String owner, String requester, String resource, String scope, String serverId, Set<String> invalidations) {
-        permissionTicketUpdated(id, owner, requester, resource, scope, serverId, invalidations);
+    public void permissionTicketRemoval(String id, String owner, String requester, String resource, String resourceName, String scope, String serverId, Set<String> invalidations) {
+        permissionTicketUpdated(id, owner, requester, resource, resourceName, scope, serverId, invalidations);
     }
 
 }

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/authorization/StoreFactoryCacheSession.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/authorization/StoreFactoryCacheSession.java
@@ -295,12 +295,12 @@ public class StoreFactoryCacheSession implements CachedStoreFactoryProvider {
         invalidationEvents.add(PolicyUpdatedEvent.create(id, name, resources, resourceTypes, scopes, serverId));
     }
 
-    public void registerPermissionTicketInvalidation(String id, String owner, String requester, String resource,  String scope,  String serverId) {
-        cache.permissionTicketUpdated(id, owner, requester, resource, scope, serverId, invalidations);
+    public void registerPermissionTicketInvalidation(String id, String owner, String requester, String resource, String resourceName, String scope, String serverId) {
+        cache.permissionTicketUpdated(id, owner, requester, resource, resourceName, scope, serverId, invalidations);
         PermissionTicketAdapter adapter = managedPermissionTickets.get(id);
         if (adapter != null) adapter.invalidateFlag();
 
-        invalidationEvents.add(PermissionTicketUpdatedEvent.create(id, owner, requester, resource, scope, serverId));
+        invalidationEvents.add(PermissionTicketUpdatedEvent.create(id, owner, requester, resource, resourceName, scope, serverId));
     }
 
     private Set<String> getResourceTypes(Set<String> resources, String serverId) {
@@ -398,6 +398,10 @@ public class StoreFactoryCacheSession implements CachedStoreFactoryProvider {
 
     public static String getPermissionTicketByGranted(String userId, String serverId) {
         return "permission.ticket.granted." + userId + "." + serverId;
+    }
+
+    public static String getPermissionTicketByResourceNameAndGranted(String resourceName, String userId, String serverId) {
+        return "permission.ticket.granted." + resourceName + "." + userId + "." + serverId;
     }
 
     public static String getPermissionTicketByOwner(String owner, String serverId) {
@@ -993,7 +997,7 @@ public class StoreFactoryCacheSession implements CachedStoreFactoryProvider {
         @Override
         public PermissionTicket create(String resourceId, String scopeId, String requester, ResourceServer resourceServer) {
             PermissionTicket created = getPermissionTicketStoreDelegate().create(resourceId, scopeId, requester, resourceServer);
-            registerPermissionTicketInvalidation(created.getId(), created.getOwner(), created.getRequester(), created.getResource().getId(), scopeId, created.getResourceServer().getId());
+            registerPermissionTicketInvalidation(created.getId(), created.getOwner(), created.getRequester(), created.getResource().getId(), created.getResource().getName(), scopeId, created.getResourceServer().getId());
             return created;
         }
 
@@ -1008,8 +1012,8 @@ public class StoreFactoryCacheSession implements CachedStoreFactoryProvider {
             if (permission.getScope() != null) {
                 scopeId = permission.getScope().getId();
             }
-            invalidationEvents.add(PermissionTicketRemovedEvent.create(id, permission.getOwner(), permission.getRequester(), permission.getResource().getId(), scopeId, permission.getResourceServer().getId()));
-            cache.permissionTicketRemoval(id, permission.getOwner(), permission.getRequester(), permission.getResource().getId(), scopeId, permission.getResourceServer().getId(), invalidations);
+            invalidationEvents.add(PermissionTicketRemovedEvent.create(id, permission.getOwner(), permission.getRequester(), permission.getResource().getId(), permission.getResource().getName(), scopeId, permission.getResourceServer().getId()));
+            cache.permissionTicketRemoval(id, permission.getOwner(), permission.getRequester(), permission.getResource().getId(), permission.getResource().getName(),scopeId, permission.getResourceServer().getId(), invalidations);
             getPermissionTicketStoreDelegate().delete(id);
             UserManagedPermissionUtil.removePolicy(permission, StoreFactoryCacheSession.this);
 
@@ -1073,6 +1077,13 @@ public class StoreFactoryCacheSession implements CachedStoreFactoryProvider {
             String cacheKey = getPermissionTicketByGranted(userId, resourceServerId);
             return cacheQuery(cacheKey, PermissionTicketListQuery.class, () -> getPermissionTicketStoreDelegate().findGranted(userId, resourceServerId),
                     (revision, permissions) -> new PermissionTicketListQuery(revision, cacheKey, permissions.stream().map(permission -> permission.getId()).collect(Collectors.toSet()), resourceServerId), resourceServerId);
+        }
+
+        @Override
+        public List<PermissionTicket> findGranted(String resourceName, String userId, String resourceServerId) {
+            String cacheKey = getPermissionTicketByResourceNameAndGranted(resourceName, userId, resourceServerId);
+            return cacheQuery(cacheKey, PermissionTicketListQuery.class, () -> getPermissionTicketStoreDelegate().findGranted(resourceName, userId, resourceServerId),
+                    (revision, permissions) -> new PermissionTicketResourceListQuery(revision, cacheKey, resourceName, permissions.stream().map(permission -> permission.getId()).collect(Collectors.toSet()), resourceServerId), resourceServerId);
         }
 
         @Override

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/authorization/events/PermissionTicketRemovedEvent.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/authorization/events/PermissionTicketRemovedEvent.java
@@ -33,13 +33,15 @@ public class PermissionTicketRemovedEvent extends InvalidationEvent implements A
     private String scope;
     private String serverId;
     private String requester;
+    private String resourceName;
 
-    public static PermissionTicketRemovedEvent create(String id, String owner, String requester, String resource, String scope, String serverId) {
+    public static PermissionTicketRemovedEvent create(String id, String owner, String requester, String resource, String resourceName, String scope, String serverId) {
         PermissionTicketRemovedEvent event = new PermissionTicketRemovedEvent();
         event.id = id;
         event.owner = owner;
         event.requester = requester;
         event.resource = resource;
+        event.resourceName = resourceName;
         event.scope = scope;
         event.serverId = serverId;
         return event;
@@ -57,6 +59,6 @@ public class PermissionTicketRemovedEvent extends InvalidationEvent implements A
 
     @Override
     public void addInvalidations(StoreFactoryCacheManager cache, Set<String> invalidations) {
-        cache.permissionTicketRemoval(id, owner, requester, resource, scope, serverId, invalidations);
+        cache.permissionTicketRemoval(id, owner, requester, resource, resourceName, scope, serverId, invalidations);
     }
 }

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/authorization/events/PermissionTicketUpdatedEvent.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/authorization/events/PermissionTicketUpdatedEvent.java
@@ -33,13 +33,15 @@ public class PermissionTicketUpdatedEvent extends InvalidationEvent implements A
     private String scope;
     private String serverId;
     private String requester;
+    private String resourceName;
 
-    public static PermissionTicketUpdatedEvent create(String id, String owner, String requester, String resource, String scope, String serverId) {
+    public static PermissionTicketUpdatedEvent create(String id, String owner, String requester, String resource, String resourceName, String scope, String serverId) {
         PermissionTicketUpdatedEvent event = new PermissionTicketUpdatedEvent();
         event.id = id;
         event.owner = owner;
         event.requester = requester;
         event.resource = resource;
+        event.resourceName = resourceName;
         event.scope = scope;
         event.serverId = serverId;
         return event;
@@ -57,6 +59,6 @@ public class PermissionTicketUpdatedEvent extends InvalidationEvent implements A
 
     @Override
     public void addInvalidations(StoreFactoryCacheManager cache, Set<String> invalidations) {
-        cache.permissionTicketUpdated(id, owner, requester, resource, scope, serverId, invalidations);
+        cache.permissionTicketUpdated(id, owner, requester, resource, resourceName, scope, serverId, invalidations);
     }
 }

--- a/model/jpa/src/main/java/org/keycloak/authorization/jpa/store/JPAPermissionTicketStore.java
+++ b/model/jpa/src/main/java/org/keycloak/authorization/jpa/store/JPAPermissionTicketStore.java
@@ -192,6 +192,8 @@ public class JPAPermissionTicketStore implements PermissionTicketStore {
                 }
             } else if (PermissionTicket.RESOURCE.equals(name)) {
                 predicates.add(root.join("resource").get("id").in(value));
+            } else if (PermissionTicket.RESOURCE_NAME.equals(name)) {
+                predicates.add(root.join("resource").get("name").in(value));
             } else if (PermissionTicket.OWNER.equals(name)) {
                 predicates.add(builder.equal(root.get("owner"), value));
             } else if (PermissionTicket.REQUESTER.equals(name)) {
@@ -243,6 +245,17 @@ public class JPAPermissionTicketStore implements PermissionTicketStore {
     public List<PermissionTicket> findGranted(String userId, String resourceServerId) {
         HashMap<String, String> filters = new HashMap<>();
 
+        filters.put(PermissionTicket.GRANTED, Boolean.TRUE.toString());
+        filters.put(PermissionTicket.REQUESTER, userId);
+
+        return find(filters, resourceServerId, -1, -1);
+    }
+
+    @Override
+    public List<PermissionTicket> findGranted(String resourceName, String userId, String resourceServerId) {
+        HashMap<String, String> filters = new HashMap<>();
+
+        filters.put(PermissionTicket.RESOURCE_NAME, resourceName);
         filters.put(PermissionTicket.GRANTED, Boolean.TRUE.toString());
         filters.put(PermissionTicket.REQUESTER, userId);
 

--- a/server-spi-private/src/main/java/org/keycloak/authorization/model/PermissionTicket.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/model/PermissionTicket.java
@@ -23,6 +23,7 @@ public interface PermissionTicket {
 
     String ID = "id";
     String RESOURCE = "resource.id";
+    String RESOURCE_NAME = "resource.name";
     String SCOPE = "scope.id";
     String SCOPE_IS_NULL = "scope_is_null";
     String OWNER = "owner";

--- a/server-spi-private/src/main/java/org/keycloak/authorization/store/PermissionTicketStore.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/store/PermissionTicketStore.java
@@ -99,4 +99,14 @@ public interface PermissionTicketStore {
      * @return a list of permissions granted for a particular user
      */
     List<PermissionTicket> findGranted(String userId, String resourceServerId);
+
+    /**
+     * Returns a list of {@link PermissionTicket} with name equal to {@code resourceName} granted to the given {@code userId}.
+     *
+     * @param resourceName the name of a resource
+     * @param userId the user id
+     * @param resourceServerId the resource server id
+     * @return a list of permissions granted for a particular user
+     */
+    List<PermissionTicket> findGranted(String resourceName, String userId, String resourceServerId);
 }

--- a/services/src/main/java/org/keycloak/authorization/authorization/AuthorizationTokenService.java
+++ b/services/src/main/java/org/keycloak/authorization/authorization/AuthorizationTokenService.java
@@ -47,6 +47,7 @@ import org.keycloak.authorization.common.KeycloakIdentity;
 import org.keycloak.authorization.model.Resource;
 import org.keycloak.authorization.model.ResourceServer;
 import org.keycloak.authorization.model.Scope;
+import org.keycloak.authorization.model.PermissionTicket;
 import org.keycloak.authorization.permission.ResourcePermission;
 import org.keycloak.authorization.policy.evaluation.EvaluationContext;
 import org.keycloak.authorization.policy.evaluation.PermissionTicketAwareDecisionResultCollector;
@@ -419,6 +420,11 @@ public class AuthorizationTokenService {
                     }
 
                     if (!identity.isResourceServer()) {
+                        List<PermissionTicket> tickets = storeFactory.getPermissionTicketStore().findGranted(resourceName, identity.getId(), resourceServer.getId());
+                        for (PermissionTicket permissionTicket : tickets) {
+                            requestedResources.add(permissionTicket.getResource());
+                        }
+
                         Resource serverResource = resourceStore.findByName(resourceName, resourceServer.getId());
 
                         if (serverResource != null) {


### PR DESCRIPTION
<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
[KEYCLOAK-10020: Unable to get RPT by the name of a resource being shared via UMA](https://issues.jboss.org/browse/KEYCLOAK-10020)

This PR adds ability to request by name permissions for shared resources

Example of a request that wouldn't work otherwise (if another user has shared resource with the requester)
```
    curl "$PROTOCOL://$HOST:$PORT/auth/realms/$REALM/protocol/openid-connect/token" \
    -H "Authorization: Bearer $ACCESS_TOKEN" \
    --data "grant_type=urn:ietf:params:oauth:grant-type:uma-ticket&permission=$RESOURCE_NAME&audience=$RESOURCE_CLIENT_ID"
```