### PR TITLE
KEYCLOAK-10026: Add missing TypeScript definition for init options

### DIFF
--- a/adapters/oidc/js/src/main/resources/keycloak.d.ts
+++ b/adapters/oidc/js/src/main/resources/keycloak.d.ts
@@ -34,6 +34,7 @@ declare namespace Keycloak {
 	type KeycloakResponseMode = 'query'|'fragment';
 	type KeycloakResponseType = 'code'|'id_token token'|'code id_token token';
 	type KeycloakFlow = 'standard'|'implicit'|'hybrid';
+	type KeycloakPromiseType = 'native'
 
 	interface KeycloakInitOptions {
 		/**
@@ -109,6 +110,13 @@ declare namespace Keycloak {
 		 * @default standard
 		 */
 		flow?: KeycloakFlow;
+
+		/**
+		 * Set the promise type. If set to `'native'` all methods returning a promise
+		 * will return a native JavaScript promise. If not set will return
+		 * Keycloak specific promise objects.
+		 */
+		promiseType?: KeycloakPromiseType;
 	}
 
 	interface KeycloakLoginOptions {


### PR DESCRIPTION
Adds missing TypeScript definition for init option `promiseType`

https://issues.jboss.org/browse/KEYCLOAK-10026