### PR TITLE
[KEYCLOAK-8043] Allow prompt=none query parameter to be propagated to…

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/AuthenticationProcessor.java
+++ b/services/src/main/java/org/keycloak/authentication/AuthenticationProcessor.java
@@ -30,7 +30,6 @@ import org.keycloak.forms.login.LoginFormsProvider;
 import org.keycloak.models.AuthenticationExecutionModel;
 import org.keycloak.models.AuthenticationFlowModel;
 import org.keycloak.models.AuthenticatorConfigModel;
-import org.keycloak.models.AuthenticatedClientSessionModel;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.ClientSessionContext;
 import org.keycloak.models.Constants;
@@ -77,6 +76,7 @@ public class AuthenticationProcessor {
 
     public static final String BROKER_SESSION_ID = "broker.session.id";
     public static final String BROKER_USER_ID = "broker.user.id";
+    public static final String FORWARDED_PASSIVE_LOGIN = "forwarded.passive.login";
 
     protected static final Logger logger = Logger.getLogger(AuthenticationProcessor.class);
     protected RealmModel realm;

--- a/services/src/main/java/org/keycloak/broker/oidc/AbstractOAuth2IdentityProvider.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/AbstractOAuth2IdentityProvider.java
@@ -402,12 +402,12 @@ public abstract class AbstractOAuth2IdentityProvider<C extends OAuth2IdentityPro
                                      @QueryParam(AbstractOAuth2IdentityProvider.OAUTH2_PARAMETER_CODE) String authorizationCode,
                                      @QueryParam(OAuth2Constants.ERROR) String error) {
             if (error != null) {
-                //logger.error("Failed " + getConfig().getAlias() + " broker login: " + error);
+                logger.error(error + " for broker login " + getConfig().getProviderId());
                 if (error.equals(ACCESS_DENIED)) {
-                    logger.error(ACCESS_DENIED + " for broker login " + getConfig().getProviderId());
                     return callback.cancelled(state);
+                } else if (error.equals(OAuthErrorException.LOGIN_REQUIRED) || error.equals(OAuthErrorException.INTERACTION_REQUIRED)) {
+                    return callback.error(state, error);
                 } else {
-                    logger.error(error + " for broker login " + getConfig().getProviderId());
                     return callback.error(state, Messages.IDENTITY_PROVIDER_UNEXPECTED_ERROR);
                 }
             }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerPromptNoneRedirectTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerPromptNoneRedirectTest.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.testsuite.broker;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.testsuite.Assert;
+import org.keycloak.testsuite.arquillian.SuiteContext;
+import org.keycloak.testsuite.util.UserBuilder;
+
+import static org.keycloak.testsuite.admin.ApiUtil.createUserWithAdminClient;
+import static org.keycloak.testsuite.admin.ApiUtil.resetUserPassword;
+import static org.keycloak.testsuite.broker.BrokerRunOnServerUtil.configurePostBrokerLoginWithOTP;
+import static org.keycloak.testsuite.broker.BrokerTestConstants.CLIENT_ID;
+import static org.keycloak.testsuite.broker.BrokerTestConstants.USER_EMAIL;
+import static org.keycloak.testsuite.broker.BrokerTestTools.waitForPage;
+
+/**
+ * This class tests the propagation of the {@code prompt=none} request parameter to a default IDP (if one has been specified)
+ * if that IDP supports {@code prompt=none} redirects.
+ *
+ * @author <a href="mailto:sguilhen@redhat.com">Stefan Guilhen</a>
+ */
+public class KcOidcBrokerPromptNoneRedirectTest extends AbstractInitializedBaseBrokerTest {
+
+    @Override
+    protected BrokerConfiguration getBrokerConfiguration() {
+        return new KcOidcBrokerPromptNoneConfiguration();
+    }
+
+    /**
+     * Tests the successful forwarding of an auth request with {@code prompt=none} to a default identity provider.
+     *
+     * @throws Exception if an error occurs while running the test.
+     */
+    @Test
+    public void testSuccessfulRedirectToProviderWithPromptNone() throws Exception {
+        /* we need to disable profile update for the prompt=none propagation to work. */
+        updateExecutions(AbstractBrokerTest::disableUpdateProfileOnFirstLogin);
+
+        /* let's start by authenticating directly in the IDP so the test user is already authenticated there. */
+        authenticateDirectlyInIDP();
+
+        /* now send an auth request to the consumer realm including both the kc_idp_hint (to identify the default provider) and prompt=none.
+           The presence of the default provider should cause the request with prompt=none to be propagated to the idp instead of resulting
+           in a login required error because the user is not yet authenticated in the consumer realm. */
+        driver.navigate().to(getAccountUrl(bc.consumerRealmName()));
+        waitForPage(driver, "log in to", true);
+        String url = driver.getCurrentUrl() + "&kc_idp_hint=" + bc.getIDPAlias() + "&prompt=none";
+        driver.navigate().to(url);
+
+        /* no need to log in again, the idp should have been able to identify that the user is already logged in and the authenticated user should
+           have been established in the consumer realm. Lastly, user must be redirected to the account app as expected. */
+        waitForPage(driver, "keycloak account management", true);
+        Assert.assertTrue(driver.getCurrentUrl().contains("/auth/realms/" + bc.consumerRealmName() + "/account"));
+        accountUpdateProfilePage.assertCurrent();
+
+        /* let's try logging out from the consumer realm and then send an auth request with only prompt=none. The absence of a default idp
+           should result in a login required error because the user is not authenticated in the consumer realm and the request won't be propagated
+           all the way to the idp where the user is authenticated. */
+        logoutFromRealm(bc.consumerRealmName(), bc.getIDPAlias());
+        driver.navigate().to(getAccountUrl(bc.consumerRealmName()));
+        waitForPage(driver, "log in to", true);
+        url = driver.getCurrentUrl() + "&prompt=none";
+        driver.navigate().to(url);
+        Assert.assertTrue(driver.getCurrentUrl().contains(bc.consumerRealmName() + "/account/login-redirect?error=login_required"));
+    }
+
+    /**
+     * Tests that an auth request with {@code prompt=none} that is forwarded to the default IDP returns a {@code login_required}
+     * error message if the user is not currently authenticated in neither the initiating realm nor the IDP.
+     *
+     * @throws Exception if an error occurs while running the test.
+     */
+    @Test
+    public void testUnauthenticatedUserReturnsLoginRequired() throws Exception {
+        /* try sending an auth request to the consumer realm with prompt=none. As we have no user authenticated in both
+           the consumer realm and the IDP, the IDP should return an error=login_required to the broker and the broker must
+           in turn return the same error to the client. */
+        driver.navigate().to(getAccountUrl(bc.consumerRealmName()));
+        waitForPage(driver, "log in to", true);
+        String url = driver.getCurrentUrl() + "&prompt=none&kc_idp_hint=" + bc.getIDPAlias();
+        driver.navigate().to(url);
+        Assert.assertTrue(driver.getCurrentUrl().contains(bc.consumerRealmName() + "/account/login-redirect?error=login_required"));
+    }
+
+    /**
+     * Tests that an auth request with {@code prompt=none} that is forwarded to a default IDP returns a {@code interaction_required}
+     * error message if the user is required to update the imported profile as part of the first broker login flow. Per spec,
+     * when {@code prompt=none} is used the server must not display any authentication or consent user interface pages.
+     *
+     * @throws Exception if an error occurs while running the test.
+     */
+    @Test
+    public void testUpdateProfileReturnsInteractionRequired() throws Exception {
+        /* for this test we don't disable the update profile page - we are expecting an interaction_required error. */
+        updateExecutions(AbstractBrokerTest::enableUpdateProfileOnFirstLogin);
+        /* verify that the interaction_required error is returned with sending auth request to the consumer realm with prompt=none. */
+        checkAuthWithPromptNoneReturnsInteractionRequired();
+    }
+
+    /**
+     * Tests that an auth request with {@code prompt=none} that is forwarded to a default IDP returns a {@code interaction_required}
+     * error message if the user is required to update his password (which happens via a required action that might also
+     * be triggered by the first broker login flow). Per spec, when {@code prompt=none} is used the server must not display any
+     * authentication or consent user interface pages.
+     *
+     * @throws Exception if an error occurs while running the test.
+     */
+    @Test
+    public void testRequirePasswordUpdateReturnsInteractionRequired() throws Exception {
+        /* disable the update profile but add a required action to update password after registration */
+        updateExecutions(AbstractBrokerTest::disableUpdateProfileOnFirstLogin);
+        updateExecutions(AbstractBrokerTest::enableRequirePassword);
+        /* verify that the interaction_required error is returned with sending auth request to the consumer realm with prompt=none. */
+        checkAuthWithPromptNoneReturnsInteractionRequired();
+    }
+
+    /**
+     * Tests that an auth request with {@code prompt=none} that is forwarded to a default IDP returns a {@code interaction_required}
+     * error message if the user is prompted to link an existing account as part of the first broker login flow. Per spec,
+     * when {@code prompt=none} is used the server must not display any authentication or consent user interface pages.
+     *
+     * @throws Exception if an error occurs while running the test.
+     */
+    @Test
+    public void testLinkExistingAccountReturnsInteractionRequired() throws Exception {
+        updateExecutions(AbstractBrokerTest::disableUpdateProfileOnFirstLogin);
+        /* create user in the consumer realm with same e-mail as the user in the idp */
+        UserRepresentation newUser = UserBuilder.create().username("consumer").email(USER_EMAIL).enabled(true).build();
+        String userId = createUserWithAdminClient(adminClient.realm(bc.consumerRealmName()), newUser);
+        resetUserPassword(adminClient.realm(bc.consumerRealmName()).users().get(userId), "password", false);
+        /* verify that the interaction_required error is returned with sending auth request to the consumer realm with prompt=none. */
+        checkAuthWithPromptNoneReturnsInteractionRequired();
+    }
+
+    /**
+     * Tests that an auth request with {@code prompt=none} that is forwarded to a default IDP returns a {@code interaction_required}
+     * error message if the user is further required to login with an OTP as part of the post broker login flow. Per spec,
+     * when {@code prompt=none} is used the server must not display any authentication or consent user interface pages.
+     *
+     * @throws Exception if an error occurs while running the test.
+     */
+    @Test
+    public void testPostBrokerLoginWithOTPReturnsInteractionRequired() throws Exception {
+        updateExecutions(AbstractBrokerTest::disableUpdateProfileOnFirstLogin);
+        /* setup the post broker login flow with OTP. */
+        testingClient.server(bc.consumerRealmName()).run(configurePostBrokerLoginWithOTP(bc.getIDPAlias()));
+        /* verify that the interaction_required error is returned with sending auth request to the consumer realm with prompt=none. */
+        checkAuthWithPromptNoneReturnsInteractionRequired();
+    }
+
+    /**
+     * Tests that an auth request with {@code prompt=none} that is forwarded to a default IDP returns a {@code interaction_required}
+     * error message if the IDP requires consent as part of the authentication process. Per spec, when {@code prompt=none} is used
+     * the server must not display any authentication or consent user interface pages.
+     *
+     * @throws Exception if an error occurs while running the test.
+     */
+    @Test
+    public void testRequireConsentReturnsInteractionRequired() throws Exception {
+        RealmResource brokeredRealm = adminClient.realm(bc.providerRealmName());
+        List<ClientRepresentation> clients = brokeredRealm.clients().findByClientId(CLIENT_ID);
+        org.junit.Assert.assertEquals(1, clients.size());
+        ClientRepresentation brokerApp = clients.get(0);
+        brokerApp.setConsentRequired(true);
+        brokeredRealm.clients().get(brokerApp.getId()).update(brokerApp);
+        /* verify that the interaction_required error is returned with sending auth request to the consumer realm with prompt=none. */
+        checkAuthWithPromptNoneReturnsInteractionRequired();
+    }
+
+    /**
+     * Utility method that authenticates the broker user directly in the IDP to establish a session there. It then proceeds to
+     * send an auth request to the account app in the consumer realm with {@code prompt=none}, checking that the resulting page
+     * is an error page containing the {@code interaction_required} message.
+     */
+    protected void checkAuthWithPromptNoneReturnsInteractionRequired() {
+        /* start by authenticating directly in the IDP so the test user is already authenticated there. */
+        authenticateDirectlyInIDP();
+
+        /* send an auth request to the consumer realm with prompt=none and a default provider. */
+        driver.navigate().to(getAccountUrl(bc.consumerRealmName()));
+        waitForPage(driver, "log in to", true);
+        String url = driver.getCurrentUrl() + "&kc_idp_hint=" + bc.getIDPAlias() + "&prompt=none";
+        driver.navigate().to(url);
+        Assert.assertTrue(driver.getCurrentUrl().contains(bc.consumerRealmName() + "/account/login-redirect?error=interaction_required"));
+    }
+
+    /**
+     * Authenticates the broker user directly in the IDP to establish a valid authenticated session there.
+     */
+    protected void authenticateDirectlyInIDP() {
+        driver.navigate().to(getAccountUrl(bc.providerRealmName()));
+        waitForPage(driver, "log in to", true);
+        Assert.assertTrue("Driver should be on the provider realm page right now",
+                driver.getCurrentUrl().contains("/auth/realms/" + bc.providerRealmName() + "/"));
+        accountLoginPage.login(bc.getUserLogin(), bc.getUserPassword());
+
+        waitForPage(driver, "keycloak account management", true);
+        Assert.assertTrue(driver.getCurrentUrl().contains("/auth/realms/" + bc.providerRealmName() + "/account"));
+        accountUpdateProfilePage.assertCurrent();
+    }
+
+    private class KcOidcBrokerPromptNoneConfiguration extends KcOidcBrokerConfiguration {
+
+        /**
+         * Override the default configuration to unset the {@code prompt} parameter and specify that the IDP accepts forwarded
+         * auth requests with {@code prompt=none}.
+         */
+        protected void applyDefaultConfiguration(final SuiteContext suiteContext, final Map<String, String> config) {
+            super.applyDefaultConfiguration(suiteContext, config);
+            config.remove("prompt");
+            config.put("acceptsPromptNoneForwardFromClient", "true");
+        }
+    }
+
+}

--- a/themes/src/main/resources/theme/base/admin/messages/admin-messages_en.properties
+++ b/themes/src/main/resources/theme/base/admin/messages/admin-messages_en.properties
@@ -593,6 +593,8 @@ consent.option=consent
 login.option=login
 select-account.option=select_account
 prompt.tooltip=Specifies whether the Authorization Server prompts the End-User for reauthentication and consent.
+accepts-prompt-none-forward-from-client=Accepts prompt=none forward from client
+accepts-prompt-none-forward-from-client.tooltip=This is just used together with Identity Provider Authenticator or when kc_idp_hint points to this identity provider. In case that client sends a request with prompt=none and user is not yet authenticated, the error won't be directly returned to client, but the request with prompt=none will be forwarded to this identity provider.
 validate-signatures=Validate Signatures
 identity-provider.validate-signatures.tooltip=Enable/disable signature validation of external IDP signatures.
 identity-provider.use-jwks-url.tooltip=If the switch is on, then identity provider public keys will be downloaded from given JWKS URL. This allows great flexibility because new keys will be always re-downloaded again when identity provider generates new keypair. If the switch is off, then public key (or certificate) from the Keycloak DB is used, so when identity provider keypair changes, you always need to import new key to the Keycloak DB as well.

--- a/themes/src/main/resources/theme/base/admin/resources/partials/realm-identity-provider-oidc.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/realm-identity-provider-oidc.html
@@ -210,6 +210,13 @@
                 <kc-tooltip>{{:: 'prompt.tooltip' | translate}}</kc-tooltip>
             </div>
             <div class="form-group">
+                <label class="col-md-2 control-label" for="acceptsPromptNoneForwardFromClient">{{:: 'accepts-prompt-none-forward-from-client' | translate}}</label>
+                <div class="col-md-6">
+                    <input ng-model="identityProvider.config.acceptsPromptNoneForwardFromClient" id="acceptsPromptNoneForwardFromClient" onoffswitchvalue on-text="{{:: 'onText' | translate}}" off-text="{{:: 'offText' | translate}}" />
+                </div>
+                <kc-tooltip>{{:: 'accepts-prompt-none-forward-from-client.tooltip' | translate}}</kc-tooltip>
+            </div>
+            <div class="form-group">
                 <label class="col-md-2 control-label" for="validateSignature">{{:: 'validate-signatures' | translate}}</label>
                 <div class="col-md-6">
                     <input ng-model="identityProvider.config.validateSignature" id="validateSignature" onoffswitchvalue on-text="{{:: 'onText' | translate}}" off-text="{{:: 'offText' | translate}}" />

--- a/themes/src/main/resources/theme/base/admin/resources/partials/realm-identity-provider-social.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/realm-identity-provider-social.html
@@ -62,6 +62,13 @@
                 <kc-tooltip>{{:: 'identity-provider.enabled.tooltip' | translate}}</kc-tooltip>
             </div>
             <div class="form-group">
+                <label class="col-md-2 control-label" for="acceptsPromptNoneForwardFromClient">{{:: 'accepts-prompt-none-forward-from-client' | translate}}</label>
+                <div class="col-md-6">
+                    <input ng-model="identityProvider.config.acceptsPromptNoneForwardFromClient" id="acceptsPromptNoneForwardFromClient" onoffswitchvalue on-text="{{:: 'onText' | translate}}" off-text="{{:: 'offText' | translate}}" />
+                </div>
+                <kc-tooltip>{{:: 'accepts-prompt-none-forward-from-client.tooltip' | translate}}</kc-tooltip>
+            </div>
+            <div class="form-group">
                 <label class="col-md-2 control-label" for="disableUserInfo">{{:: 'disableUserInfo' | translate}}</label>
                 <div class="col-md-6">
                     <input ng-model="identityProvider.config.disableUserInfo" id="disableUserInfo" onoffswitchvalue on-text="{{:: 'onText' | translate}}" off-text="{{:: 'offText' | translate}}" />


### PR DESCRIPTION
… default IdP

Link to Jira: https://issues.jboss.org/browse/KEYCLOAK-8043
Link to Documentation PR: https://github.com/keycloak/keycloak-documentation/pull/642

Following the discussion in Jira and Stian's comments there I've introduced a "Support prompt=none - On/Off" configuration for the OIDC providers (defaults to Off). When enabled, it signals that the provider can handle redirects that have the prompt=none query parameter.

The redirect with prompt=none is only performed if the request can be automatically directed to a default identity provider that supports the param. This is either accomplished by the "kc_idp_hint" param or by setting up a default provider for the realm. If a default provider can't be found we can't assume a provider and the standard "login_required" error is returned in the response.

The scenario for this redirect is as follows: Realm A has a default IdP B and the user is already authenticated in B but not yet in A. When an auth request with prompt=none is sent to A (for instance, using the javascript adapter with the check-sso param), the authorization endpoint in A verifies that the user is not yet authenticated but instead of returning the "login_required" error right away it first checks if a default provider can be determined and if this provider supports prompt=none it redirects the request to the provider. The IdP then verifies the user is already authenticated and as a result the account is re-established in realm A without errors.

If the user hasn't authenticated in the default IdP, then the "login_required" error is returned as expected.