### PR TITLE
KEYCLOAK-10070 Fix typo in account/message_de.properties

### DIFF
--- a/themes/src/main/resources-community/theme/base/account/messages/messages_de.properties
+++ b/themes/src/main/resources-community/theme/base/account/messages/messages_de.properties
@@ -124,7 +124,7 @@ missingPasswordMessage=Bitte geben Sie ein Passwort ein.
 notMatchPasswordMessage=Die Passw\u00F6rter sind nicht identisch.
 
 missingTotpMessage=Bitte geben Sie den One-time Code ein.
-invalidPasswordExistingMessage=Das aktuelle Passwort is ung\u00FCltig.
+invalidPasswordExistingMessage=Das aktuelle Passwort ist ung\u00FCltig.
 invalidPasswordConfirmMessage=Die Passwortbest\u00E4tigung ist nicht identisch.
 invalidTotpMessage=Ung\u00FCltiger One-time Code.
 


### PR DESCRIPTION
Fixed typo in account/message_de.properties.

Jira issue here: https://issues.jboss.org/browse/KEYCLOAK-10070
