### PR TITLE
KEYCLOAK-9983 - Fix the P3P header corruption in Japanese or Turkish

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/LoginStatusIframeEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/LoginStatusIframeEndpoint.java
@@ -62,7 +62,7 @@ public class LoginStatusIframeEndpoint {
 
         InputStream resource = getClass().getClassLoader().getResourceAsStream("login-status-iframe.html");
         if (resource != null) {
-            P3PHelper.addP3PHeader(session);
+            P3PHelper.addP3PHeader();
             return Response.ok(resource).cacheControl(cacheControl).build();
         } else {
             return Response.status(Response.Status.NOT_FOUND).build();

--- a/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
@@ -623,7 +623,7 @@ public class AuthenticationManager {
         // Max age should be set to the max lifespan of the session as it's used to invalidate old-sessions on re-login
         int sessionCookieMaxAge = session.isRememberMe() && realm.getSsoSessionMaxLifespanRememberMe() > 0 ? realm.getSsoSessionMaxLifespanRememberMe() : realm.getSsoSessionMaxLifespan();
         CookieHelper.addCookie(KEYCLOAK_SESSION_COOKIE, sessionCookieValue, cookiePath, null, null, sessionCookieMaxAge, secureOnly, false);
-        P3PHelper.addP3PHeader(keycloakSession);
+        P3PHelper.addP3PHeader();
     }
 
     public static void createRememberMeCookie(RealmModel realm, String username, UriInfo uriInfo, ClientConnection connection) {

--- a/services/src/main/java/org/keycloak/services/util/P3PHelper.java
+++ b/services/src/main/java/org/keycloak/services/util/P3PHelper.java
@@ -17,15 +17,8 @@
 
 package org.keycloak.services.util;
 
-import org.jboss.logging.Logger;
 import org.jboss.resteasy.spi.HttpResponse;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
-import org.keycloak.models.KeycloakSession;
-import org.keycloak.services.validation.Validation;
-import org.keycloak.theme.Theme;
-
-import java.io.IOException;
-import java.util.Locale;
 
 /**
  * IE requires P3P header to allow loading cookies from iframes when domain differs from main page (see KEYCLOAK-2828 for more details)
@@ -34,23 +27,9 @@ import java.util.Locale;
  */
 public class P3PHelper {
 
-    private static final Logger logger = Logger.getLogger(P3PHelper.class);
-
-    public static void addP3PHeader(KeycloakSession session) {
-        try {
-            Theme theme = session.theme().getTheme(Theme.Type.LOGIN);
-
-            Locale locale = session.getContext().resolveLocale(null);
-            String p3pValue = theme.getMessages(locale).getProperty("p3pPolicy");
-
-            if (!Validation.isBlank(p3pValue)) {
-                HttpResponse response = ResteasyProviderFactory.getContextData(HttpResponse.class);
-                response.getOutputHeaders().putSingle("P3P", p3pValue);
-            }
-        } catch (IOException e) {
-            logger.error("Failed to set P3P header", e);
-            return;
-        }
+    public static void addP3PHeader() {
+        HttpResponse response = ResteasyProviderFactory.getContextData(HttpResponse.class);
+        response.getOutputHeaders().putSingle("P3P", "CP=\"This is not a P3P policy!\"");
     }
 
 }

--- a/themes/src/main/resources-community/theme/base/login/messages/messages_de.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_de.properties
@@ -255,8 +255,6 @@ requiredAction.UPDATE_PASSWORD=Passwort aktualisieren
 requiredAction.UPDATE_PROFILE=Profil aktualisieren
 requiredAction.VERIFY_EMAIL=E-Mail Adresse verifizieren
 
-p3pPolicy=CP="Das ist keine P3P Policy!"
-
 doX509Login=Sie werden angemeldet als\:
 clientCertificate=X509 Client Zertifikat\:
 noCertificate=[Kein Zertifikat]

--- a/themes/src/main/resources-community/theme/base/login/messages/messages_fr.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_fr.properties
@@ -266,8 +266,6 @@ requiredAction.UPDATE_PASSWORD=Mettre \u00e0 jour votre mot de passe
 requiredAction.UPDATE_PROFILE=Mettre \u00e0 jour votre profil
 requiredAction.VERIFY_EMAIL=Valider votre adresse email
 
-p3pPolicy=CP="Ce n''est pas une P3P policy!"
-
 
 doX509Login=Vous allez \u00eatre connect\u00e9 en tant que\:
 clientCertificate=X509 certificat client\:

--- a/themes/src/main/resources-community/theme/base/login/messages/messages_it.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_it.properties
@@ -212,5 +212,3 @@ clientNotFoundMessage=Client non trovato.
 clientDisabledMessage=Client disabilitato.
 invalidParameterMessage=Parametro non valido\: {0}
 alreadyLoggedIn=Sei gi\u00e0 connesso.
-
-p3pPolicy=CP="Questa non \u00e8 una P3P policy!"

--- a/themes/src/main/resources-community/theme/base/login/messages/messages_ja.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_ja.properties
@@ -291,8 +291,6 @@ requiredAction.UPDATE_PASSWORD=パスワードの更新
 requiredAction.UPDATE_PROFILE=プロフィールの更新
 requiredAction.VERIFY_EMAIL=Eメールの確認
 
-p3pPolicy=CP="これはP3Pポリシーではありません！"
-
 doX509Login=次のユーザーとしてログインします\:
 clientCertificate=X509クライアント証明書\:
 noCertificate=[証明書なし]

--- a/themes/src/main/resources-community/theme/base/login/messages/messages_lt.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_lt.properties
@@ -215,5 +215,3 @@ clientNotFoundMessage=Nenurodytas klientas.
 clientDisabledMessage=Kliento galiojimas išjungtas.
 invalidParameterMessage=Neteisingas parametras\: {0}
 alreadyLoggedIn=Jūs jau esate prisijungę.
-
-p3pPolicy=CP="Nurodyta reiksme nera P3P taisykle!"

--- a/themes/src/main/resources-community/theme/base/login/messages/messages_nl.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_nl.properties
@@ -274,8 +274,6 @@ requiredAction.UPDATE_PASSWORD=Update wachtwoord
 requiredAction.UPDATE_PROFILE=Update profiel
 requiredAction.VERIFY_EMAIL=Verifieer e-mail
 
-p3pPolicy=CP="This is not a P3P policy!"
-
 doX509Login=U wordt ingelogd als\:
 clientCertificate=X509 client certificate\:
 noCertificate=[No Certificate]

--- a/themes/src/main/resources-community/theme/base/login/messages/messages_no.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_no.properties
@@ -227,5 +227,3 @@ clientNotFoundMessage=Klient ikke funnet.
 clientDisabledMessage=Klient deaktivert.
 invalidParameterMessage=Ugyldig parameter\: {0}
 alreadyLoggedIn=Du er allerede innlogget.
-
-p3pPolicy=CP="Dette er ikke en P3P policy!"

--- a/themes/src/main/resources-community/theme/base/login/messages/messages_pl.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_pl.properties
@@ -292,8 +292,6 @@ requiredAction.UPDATE_PASSWORD=Zaktualizuj hasło
 requiredAction.UPDATE_PROFILE=Zaktualizuj profil
 requiredAction.VERIFY_EMAIL=Zweryfikuj adres e-mail
 
-p3pPolicy=CP \= "To nie jest polityka P3P\!"
-
 doX509Login=Użytkownik będzie zalogowany jako\:
 clientCertificate=X509 certyfikat klienta\:
 noCertificate=[brak certyfikatu]

--- a/themes/src/main/resources-community/theme/base/login/messages/messages_ru.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_ru.properties
@@ -216,5 +216,3 @@ clientNotFoundMessage=Клиент не найден.
 clientDisabledMessage=Клиент отключен.
 invalidParameterMessage=Неверный параметр\: {0}
 alreadyLoggedIn=Вы уже вошли.
-
-p3pPolicy=CP="Это не политика P3P!"

--- a/themes/src/main/resources-community/theme/base/login/messages/messages_sk.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_sk.properties
@@ -254,8 +254,6 @@ requiredAction.UPDATE_PASSWORD=Aktualizovať heslo
 requiredAction.UPDATE_PROFILE=Aktualizovať profil
 requiredAction.VERIFY_EMAIL=Overiť e-mail
 
-p3pPolicy=CP="Toto nie je plán (policy) P3P!"
-
 doX509Login=Budete prihlásení ako\:
 clientCertificate=certifikát klienta X509\:
 noCertificate=[Bez certifikátu]

--- a/themes/src/main/resources-community/theme/base/login/messages/messages_sv.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_sv.properties
@@ -212,5 +212,3 @@ clientNotFoundMessage=Klienten hittades ej.
 clientDisabledMessage=Klienten är inaktiverad.
 invalidParameterMessage=Ogiltig parameter\: {0}
 alreadyLoggedIn=Du är redan inloggad.
-
-p3pPolicy=CP="Det här är ingen P3P policy!"

--- a/themes/src/main/resources-community/theme/base/login/messages/messages_tr.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_tr.properties
@@ -294,8 +294,6 @@ requiredAction.UPDATE_PASSWORD=\u015Eifre g\u00FCncelle
 requiredAction.UPDATE_PROFILE=Profili G\u00FCncelle
 requiredAction.VERIFY_EMAIL=E-mail''i do\u011Frula
 
-p3pPolicy=CP="Bu bir P3P politikas\u0131 de\u011Fil!"
-
 doX509Login=Olarak giri\u015F yapacaks\u0131n\u0131z\:
 clientCertificate=X509 istemci sertifikas\u0131\:
 noCertificate=[Sertifika Yok]

--- a/themes/src/main/resources-community/theme/base/login/messages/messages_zh_CN.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_zh_CN.properties
@@ -230,5 +230,3 @@ clientNotFoundMessage=客户端未找到
 clientDisabledMessage=客户端已禁用
 invalidParameterMessage=无效的参数 \: {0}
 alreadyLoggedIn=您已经登录
-
-p3pPolicy="This is not a P3P policy!"

--- a/themes/src/main/resources/theme/base/login/messages/messages_en.properties
+++ b/themes/src/main/resources/theme/base/login/messages/messages_en.properties
@@ -292,8 +292,6 @@ requiredAction.UPDATE_PASSWORD=Update Password
 requiredAction.UPDATE_PROFILE=Update Profile
 requiredAction.VERIFY_EMAIL=Verify Email
 
-p3pPolicy=CP="This is not a P3P policy!"
-
 doX509Login=You will be logged in as\:
 clientCertificate=X509 client certificate\:
 noCertificate=[No Certificate]


### PR DESCRIPTION
_P3P_ header does not need to be translated because the reader of the header is usually browser. [KEYCLOAK-9983 ](https://issues.jboss.org/browse/KEYCLOAK-9983)can greatly influence Japanese Keycloak users. So I would like to fix ASAP.