### PR TITLE
KEYCLOAK-9438: Typescript support for both native and legacy promises

### DIFF
--- a/adapters/oidc/js/src/main/resources/keycloak.d.ts
+++ b/adapters/oidc/js/src/main/resources/keycloak.d.ts
@@ -26,7 +26,7 @@ export = Keycloak;
  * Creates a new Keycloak client instance.
  * @param config Path to a JSON config file or a plain config object.
  */
-declare function Keycloak(config?: string|{}): Keycloak.KeycloakInstance;
+declare function Keycloak<TPromise extends Keycloak.PromiseType = undefined>(config?: string|{}): Keycloak.KeycloakInstance<TPromise>;
 
 declare namespace Keycloak {
 	type KeycloakAdapterName = 'cordova' | 'cordova-native' |'default' | any;
@@ -245,10 +245,18 @@ declare namespace Keycloak {
 	// export interface KeycloakUserInfo {}
 
 	/**
+	 * Conditional CompatPromise type in order to support
+	 * both legacy promises and native promises as return types.
+	 */
+	type PromiseType = KeycloakPromiseType | undefined;
+	type CompatPromise<TPromiseType extends PromiseType, TSuccess, TError> = 
+		TPromiseType extends KeycloakPromiseType ? Promise<TSuccess> : KeycloakPromise<TSuccess, TError>;
+
+	/**
 	 * A client for the Keycloak authentication server.
 	 * @see {@link https://keycloak.gitbooks.io/securing-client-applications-guide/content/topics/oidc/javascript-adapter.html|Keycloak JS adapter documentation}
 	 */
-	interface KeycloakInstance {
+	interface KeycloakInstance<TPromise extends PromiseType = undefined> {
 		/**
 		 * Is true if the user is authenticated, false otherwise.
 		 */
@@ -413,32 +421,32 @@ declare namespace Keycloak {
 		 * @param initOptions Initialization options.
 		 * @returns A promise to set functions to be invoked on success or error.
 		 */
-		init(initOptions: KeycloakInitOptions): KeycloakPromise<boolean, KeycloakError>;
+		init(initOptions: KeycloakInitOptions): CompatPromise<TPromise, boolean, KeycloakError>;
 
 		/**
 		 * Redirects to login form.
 		 * @param options Login options.
 		 */
-		login(options?: KeycloakLoginOptions): KeycloakPromise<void, void>;
+		login(options?: KeycloakLoginOptions): CompatPromise<TPromise, void, void>;
 
 		/**
 		 * Redirects to logout.
 		 * @param options Logout options.
 		 * @param options.redirectUri Specifies the uri to redirect to after logout.
 		 */
-		logout(options?: any): KeycloakPromise<void, void>;
+		logout(options?: any): CompatPromise<TPromise, void, void>;
 
 		/**
 		 * Redirects to registration form.
 		 * @param options Supports same options as Keycloak#login but `action` is
 		 *                set to `'register'`.
 		 */
-		register(options?: any): KeycloakPromise<void, void>;
+		register(options?: any): CompatPromise<TPromise, void, void>;
 
 		/**
 		 * Redirects to the Account Management Console.
 		 */
-		accountManagement(): KeycloakPromise<void, void>;
+		accountManagement(): CompatPromise<TPromise, void, void>;
 
 		/**
 		 * Returns the URL to login form.
@@ -490,7 +498,7 @@ declare namespace Keycloak {
 		 *   alert('Failed to refresh the token, or the session has expired');
 		 * });
 		 */
-		updateToken(minValidity: number): KeycloakPromise<boolean, boolean>;
+		updateToken(minValidity: number): CompatPromise<TPromise, boolean, boolean>;
 
 		/**
 		 * Clears authentication state, including tokens. This can be useful if
@@ -517,11 +525,11 @@ declare namespace Keycloak {
 		 * Loads the user's profile.
 		 * @returns A promise to set functions to be invoked on success or error.
 		 */
-		loadUserProfile(): KeycloakPromise<KeycloakProfile, void>;
+		loadUserProfile(): CompatPromise<TPromise, KeycloakProfile, void>;
 
 		/**
 		 * @private Undocumented.
 		 */
-		loadUserInfo(): KeycloakPromise<{}, void>;
+		loadUserInfo(): CompatPromise<TPromise, {}, void>;
 	}
 }


### PR DESCRIPTION
This PR will add a conditional type so that native promise types can be set as return type from the function of `KeycloakInstance`.

This PR is backwards compatible because by default the legacy promises are used.

To specify that you want native promise types as return types you can now do this:

```typescript
import Keycloak from "keycloak-js";

const keycloak = Keycloak<Keycloak.KeycloakPromiseType>("/keycloak.json");
keycloak
  .init({ onLoad: "login-required", promiseType: "native" })
   .then(authenticated => {
    this.setState({ keycloak: keycloak, authenticated: authenticated });
  });
```

Notice the generic parameter in `Keycloak<Keycloak.KeycloakPromiseType>`, this is what will trigger the native promise types to be used as return types. To use the legacy promise type just use `Keycloak` without any generic params as usual. 