### PR TITLE
KEYCLOAK-4593 Flush and clear when fetching multiple realms

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
@@ -116,7 +116,8 @@ public class JpaRealmProvider implements RealmProvider {
         for (String id : entities) {
             RealmModel realm = session.realms().getRealm(id);
             if (realm != null) realms.add(realm);
-
+            em.flush();
+            em.clear();
         }
         return realms;
     }


### PR DESCRIPTION
Fixes a performance hit with a large number of realms (200+) when called from various points.

For example when called during startup when timers are started for syncing users if this is configured for a realm ( i.e when fetching all realms which have a custom UserStorageProvider )
