### PR TITLE
[DO NOT MERGE] KEYCLOAK-10150 surefire.memory.settings is ignored when running tests…

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/AuthServerTestEnricher.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/AuthServerTestEnricher.java
@@ -41,6 +41,7 @@ import org.keycloak.testsuite.arquillian.annotation.UncaughtServerErrorExpected;
 import org.keycloak.testsuite.client.KeycloakTestingClient;
 import org.keycloak.testsuite.util.LogChecker;
 import org.keycloak.testsuite.util.OAuthClient;
+import org.keycloak.testsuite.util.SystemInfoHelper;
 import org.wildfly.extras.creaper.commands.undertow.AddUndertowListener;
 import org.wildfly.extras.creaper.commands.undertow.RemoveUndertowListener;
 import org.wildfly.extras.creaper.commands.undertow.SslVerifyClient;
@@ -289,6 +290,7 @@ public class AuthServerTestEnricher {
         suiteContextProducer.set(suiteContext);
         CrossDCTestEnricher.initializeSuiteContext(suiteContext);
         log.info("\n\n" + suiteContext);
+        log.info("\n\n" + SystemInfoHelper.getSystemInfo());
     }
 
     private ContainerInfo updateWithAuthServerInfo(ContainerInfo authServerInfo) {

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/SystemInfoHelper.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/SystemInfoHelper.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite.util;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryPoolMXBean;
+
+
+/**
+ * Provides some data about CPU and Memory of the java process used for the testsuite
+ *
+ * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
+ */
+public class SystemInfoHelper {
+
+    public static String getSystemInfo() {
+        Runtime runtime = Runtime.getRuntime();
+
+        StringBuilder s = new StringBuilder("SYSTEM INFO: ");
+        s.append("\nProcessors: " + runtime.availableProcessors());
+        s.append("\nTotal memory (Xms): " + toMB(runtime.totalMemory()));
+        s.append("\nMax memory (Xmx): " + toMB(runtime.maxMemory()));
+
+        for (MemoryPoolMXBean memoryMXBean : ManagementFactory.getMemoryPoolMXBeans()) {
+            if ("Metaspace".equalsIgnoreCase(memoryMXBean.getName())) {
+                s.append("\nMetaspace Max: " + toMB(memoryMXBean.getUsage().getMax()));
+            }
+        }
+
+        return s.toString();
+    }
+
+
+    private static String toMB(long bytes) {
+        return bytes / 1024 / 1024 + " MB";
+    }
+
+}


### PR DESCRIPTION
Just test what are the Xms,Xmx values with default surefire settings