### PR TITLE
KEYCLOAK-6055 Include X.509 certificate data in audit logs

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/events/Details.java
+++ b/server-spi-private/src/main/java/org/keycloak/events/Details.java
@@ -70,4 +70,7 @@ public interface Details {
 
     String EXISTING_USER = "previous_user";
 
+    String X509_CERTIFICATE_SERIAL_NUMBER = "x509_cert_serial_number";
+    String X509_CERTIFICATE_SUBJECT_DISTINGUISHED_NAME = "x509_cert_subject_distinguished_name";
+    String X509_CERTIFICATE_ISSUER_DISTINGUISHED_NAME = "x509_cert_issuer_distinguished_name";
 }

--- a/services/src/main/java/org/keycloak/authentication/authenticators/x509/ValidateX509CertificateUsername.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/x509/ValidateX509CertificateUsername.java
@@ -53,6 +53,9 @@ public class ValidateX509CertificateUsername extends AbstractX509ClientCertifica
             return;
         }
 
+        saveX509CertificateAuditDataToAuthSession(context, certs[0]);
+        recordX509CertificateAuditDataViaContextEvent(context);
+
         X509AuthenticatorConfigModel config = null;
         if (context.getAuthenticatorConfig() != null && context.getAuthenticatorConfig().getConfig() != null) {
             config = new X509AuthenticatorConfigModel(context.getAuthenticatorConfig());

--- a/services/src/main/java/org/keycloak/authentication/authenticators/x509/X509ClientCertificateAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/x509/X509ClientCertificateAuthenticator.java
@@ -66,6 +66,9 @@ public class X509ClientCertificateAuthenticator extends AbstractX509ClientCertif
                 return;
             }
 
+            saveX509CertificateAuditDataToAuthSession(context, certs[0]);
+            recordX509CertificateAuditDataViaContextEvent(context);
+
             X509AuthenticatorConfigModel config = null;
             if (context.getAuthenticatorConfig() != null && context.getAuthenticatorConfig().getConfig() != null) {
                 config = new X509AuthenticatorConfigModel(context.getAuthenticatorConfig());
@@ -261,6 +264,7 @@ public class X509ClientCertificateAuthenticator extends AbstractX509ClientCertif
             return;
         }
         if (context.getUser() != null) {
+            recordX509CertificateAuditDataViaContextEvent(context);
             context.success();
             return;
         }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/x509/AbstractX509AuthenticationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/x509/AbstractX509AuthenticationTest.java
@@ -18,6 +18,8 @@
 
 package org.keycloak.testsuite.x509;
 
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.Matchers;
 import org.jboss.arquillian.graphene.page.Page;
 import org.jboss.logging.Logger;
 import org.junit.AfterClass;
@@ -524,10 +526,20 @@ public abstract class AbstractX509AuthenticationTest extends AbstractTestRealmKe
         Assert.assertEquals(AppPage.RequestType.AUTH_RESPONSE, appPage.getRequestType());
         Assert.assertNotNull(oauth.getCurrentQuery().get(OAuth2Constants.CODE));
 
-        events.expectLogin()
+        AssertEvents.ExpectedEvent expectedEvent = events.expectLogin()
                 .user(userId)
                 .detail(Details.USERNAME, attemptedUsername)
-                .removeDetail(Details.REDIRECT_URI)
+                .removeDetail(Details.REDIRECT_URI);
+
+        addX509CertificateDetails(expectedEvent)
                 .assertEvent();
+    }
+
+
+    protected AssertEvents.ExpectedEvent addX509CertificateDetails(AssertEvents.ExpectedEvent expectedEvent) {
+        return expectedEvent
+                .detail(Details.X509_CERTIFICATE_SERIAL_NUMBER, Matchers.not(Matchers.isEmptyOrNullString()))
+                .detail(Details.X509_CERTIFICATE_SUBJECT_DISTINGUISHED_NAME, Matchers.startsWith("EMAILADDRESS=test-user@localhost"))
+                .detail(Details.X509_CERTIFICATE_ISSUER_DISTINGUISHED_NAME, Matchers.startsWith("EMAILADDRESS=contact@keycloak.org"));
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/x509/X509DirectGrantTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/x509/X509DirectGrantTest.java
@@ -31,6 +31,7 @@ import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.RefreshToken;
 import org.keycloak.representations.idm.AuthenticatorConfigRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.testsuite.AssertEvents;
 import org.keycloak.testsuite.util.ContainerAssume;
 import org.keycloak.testsuite.util.OAuthClient;
 import org.keycloak.testsuite.util.PhantomJSBrowser;
@@ -173,14 +174,16 @@ public class X509DirectGrantTest extends AbstractX509AuthenticationTest {
 
         assertEquals(401, response.getStatusCode());
 
-        events.expectLogin()
+        AssertEvents.ExpectedEvent expectedEvent = events.expectLogin()
                 .user((String) null)
                 .session((String) null)
                 .error("invalid_user_credentials")
                 .client("resource-owner")
                 .removeDetail(Details.CODE_ID)
                 .removeDetail(Details.CONSENT)
-                .removeDetail(Details.REDIRECT_URI)
+                .removeDetail(Details.REDIRECT_URI);
+
+        addX509CertificateDetails(expectedEvent)
                 .assertEvent();
     }
 
@@ -308,7 +311,7 @@ public class X509DirectGrantTest extends AbstractX509AuthenticationTest {
         AccessToken accessToken = oauth.verifyToken(response.getAccessToken());
         RefreshToken refreshToken = oauth.parseRefreshToken(response.getRefreshToken());
 
-        events.expectLogin()
+        AssertEvents.ExpectedEvent expectedEvent = events.expectLogin()
                 .client(clientId)
                 .user(userId)
                 .session(accessToken.getSessionState())
@@ -318,7 +321,9 @@ public class X509DirectGrantTest extends AbstractX509AuthenticationTest {
                 .detail(Details.USERNAME, login)
                 .removeDetail(Details.CODE_ID)
                 .removeDetail(Details.REDIRECT_URI)
-                .removeDetail(Details.CONSENT)
+                .removeDetail(Details.CONSENT);
+
+        addX509CertificateDetails(expectedEvent)
                 .assertEvent();
     }
 


### PR DESCRIPTION
Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>
Co-authored-by: mposolda <mposolda@gmail.com>

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
