### PR TITLE
Fix log message in AbstractClientCertificateFromHttpHeadersLookupFactory

### DIFF
--- a/services/src/main/java/org/keycloak/services/x509/AbstractClientCertificateFromHttpHeadersLookupFactory.java
+++ b/services/src/main/java/org/keycloak/services/x509/AbstractClientCertificateFromHttpHeadersLookupFactory.java
@@ -44,20 +44,20 @@ public abstract class AbstractClientCertificateFromHttpHeadersLookupFactory impl
     public void init(Config.Scope config) {
         if (config != null) {
             certificateChainLength = config.getInt(CERTIFICATE_CHAIN_LENGTH, 1);
-            logger.tracev("{0}: '{1}'", CERTIFICATE_CHAIN_LENGTH, certificateChainLength);
+            logger.tracev("{0}: ''{1}''", CERTIFICATE_CHAIN_LENGTH, certificateChainLength);
 
             sslClientCertHttpHeader = config.get(HTTP_HEADER_CLIENT_CERT, "");
-            logger.tracev("{0}:   '{1}'", HTTP_HEADER_CLIENT_CERT, sslClientCertHttpHeader);
+            logger.tracev("{0}:   ''{1}''", HTTP_HEADER_CLIENT_CERT, sslClientCertHttpHeader);
 
             sslChainHttpHeaderPrefix = config.get(HTTP_HEADER_CERT_CHAIN_PREFIX, null);
             if (sslChainHttpHeaderPrefix != null) {
-                logger.tracev("{0}:  '{1}'", HTTP_HEADER_CERT_CHAIN_PREFIX, sslChainHttpHeaderPrefix);
+                logger.tracev("{0}:  ''{1}''", HTTP_HEADER_CERT_CHAIN_PREFIX, sslChainHttpHeaderPrefix);
             } else {
                 logger.tracev("{0} was not configured", HTTP_HEADER_CERT_CHAIN_PREFIX);
             }
         }
         else {
-            logger.tracev("No configuration for '{0}' reverse proxy was found", this.getId());
+            logger.tracev("No configuration for ''{0}'' reverse proxy was found", this.getId());
             sslClientCertHttpHeader = "";
             sslChainHttpHeaderPrefix = "";
             certificateChainLength = 0;


### PR DESCRIPTION
Single quotes need to be represented by double single quotes throughout a String.
See: https://docs.oracle.com/javase/7/docs/api/java/text/MessageFormat.html

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
