### PR TITLE
KEYCLOAK-10097 Fix register method in javascript adatper for cordova

### DIFF
--- a/adapters/oidc/js/src/main/resources/keycloak.js
+++ b/adapters/oidc/js/src/main/resources/keycloak.js
@@ -1324,15 +1324,19 @@
                         return promise.promise;
                     },
 
-                    register : function() {
+                    register : function(options) {
+                        var promise = createPromise(false);
                         var registerUrl = kc.createRegisterUrl();
                         var cordovaOptions = createCordovaOptions(options);
                         var ref = cordovaOpenWindowWrapper(registerUrl, '_blank', cordovaOptions);
                         ref.addEventListener('loadstart', function(event) {
                             if (event.url.indexOf('http://localhost') == 0) {
                                 ref.close();
+                                var oauth = parseCallback(event.url);
+                                processCallback(oauth, promise);
                             }
                         });
+                        return promise.promise;
                     },
 
                     accountManagement : function() {


### PR DESCRIPTION
Follow-up of https://github.com/keycloak/keycloak/pull/6007

[KEYCLOAK-10097](https://issues.jboss.org/browse/KEYCLOAK-10097)
In the javascript adapter, the cordova "register" method implementation was broken and inconsistent with its other implementations. These changes fix this issue:

Added the missing parameter "options" to the method
The method now returns a promise that parses and processes the callback from the register process