### PR TITLE
KEYCLOAK-10340: Create independent message bundle

### DIFF
--- a/themes/src/main/resources/theme/keycloak-preview/account/messages/messages_de.properties
+++ b/themes/src/main/resources/theme/keycloak-preview/account/messages/messages_de.properties
@@ -1,0 +1,169 @@
+doSave=Speichern
+doCancel=Abbrechen
+#doLogOutAllSessions=Alle Sitzungen abmelden
+#doRemove=Entfernen
+#doAdd=Hinzuf\u00fcgen
+doSignOut=Abmelden
+
+#editAccountHtmlTitle=Benutzerkonto bearbeiten
+#federatedIdentitiesHtmlTitle=F\u00f6derierte Identit\u00e4ten
+#accountLogHtmlTitle=Benutzerkonto Log
+changePasswordHtmlTitle=Passwort \u00c4ndern
+#sessionsHtmlTitle=Sitzungen
+accountManagementTitle=Keycloak Benutzerkontoverwaltung
+authenticatorTitle=Mehrfachauthentifizierung
+applicationsHtmlTitle=Applikationen
+
+#authenticatorCode=One-time Code
+email=E-Mail
+firstName=Vorname
+#givenName=Vorname
+#fullName=Voller Name
+lastName=Nachname
+#familyName=Nachname
+password=Passwort
+passwordConfirm=Passwort best\u00e4tigen
+passwordNew=Neues Passwort
+username=Benutzername
+#address=Adresse
+#street=Stra\u00dfe
+#region=Staat, Provinz, Region
+#postal_code=PLZ
+#locality=Stadt oder Ortschaft
+#country=Land
+#emailVerified=E-Mail verifiziert
+#gssDelegationCredential=GSS delegierte Berechtigung
+
+#role_admin=Admin
+#role_realm-admin=Realm Admin
+#role_create-realm=Realm erstellen
+#role_view-realm=Realm ansehen
+#role_view-users=Benutzer ansehen
+#role_view-applications=Applikationen ansehen
+#role_view-clients=Clients ansehen
+#role_view-events=Events ansehen
+#role_view-identity-providers=Identity Provider ansehen
+#role_manage-realm=Realm verwalten
+#role_manage-users=Benutzer verwalten
+#role_manage-applications=Applikationen verwalten
+#role_manage-identity-providers=Identity Provider verwalten
+#role_manage-clients=Clients verwalten
+#role_manage-events=Events verwalten
+#role_view-profile=Profile ansehen
+#role_manage-account=Profile verwalten
+#role_manage-account-links=Profil-Links verwalten
+#role_read-token=Token lesen
+#role_offline-access=Offline-Zugriff
+#role_uma_authorization=Berechtigungen einholen
+#client_account=Clientkonto
+client_security-admin-console=Security Adminkonsole
+#client_realm-management=Realm-Management
+#client_broker=Broker
+
+
+requiredFields=Erforderliche Felder
+#allFieldsRequired=Alle Felder sind erforderlich
+
+#backToApplication=&laquo; Zur\u00fcck zur Applikation
+backTo=Zur\u00fcck zu {0}
+
+#date=Datum
+#event=Ereignis
+#ip=IP
+#client=Client
+#clients=Clients
+#details=Details
+#started=Startdatum
+#lastAccess=Letzter Zugriff
+#expires=Ablaufdatum
+applications=Applikationen
+
+#account=Benutzerkonto
+#federatedIdentity=F\u00f6derierte Identit\u00e4t
+authenticator=Mehrfachauthentifizierung
+#sessions=Sitzungen
+#log=Log
+
+#application=Applikation
+#availablePermissions=verf\u00fcgbare Berechtigungen
+#grantedPermissions=gew\u00e4hrte Berechtigungen
+#grantedPersonalInfo=gew\u00e4hrte pers\u00f6nliche Informationen
+#additionalGrants=zus\u00e4tzliche Berechtigungen
+#action=Aktion
+#inResource=in
+#fullAccess=Vollzugriff
+#offlineToken=Offline-Token
+#revoke=Berechtigung widerrufen
+
+#configureAuthenticators=Mehrfachauthentifizierung konfigurieren
+#mobile=Mobil
+#totpStep1=Installieren Sie eine der folgenden Applikationen auf Ihrem Smartphone:
+#totpStep2=\u00d6ffnen Sie die Applikation und scannen Sie den Barcode.
+#totpStep3=Geben Sie den von der Applikation generierten One-time Code ein und klicken Sie auf Speichern.
+
+#totpManualStep2=\u00d6ffnen Sie die Applikation und geben Sie den folgenden Schl\u00fcssel ein.
+#totpManualStep3=Verwenden Sie die folgenden Konfigurationswerte, falls Sie diese f\u00fcr die Applikation anpassen k\u00f6nnen:
+#totpUnableToScan=Sie k\u00f6nnen den Barcode nicht scannen?
+#totpScanBarcode=Barcode scannen?
+
+#totp.totp=zeitbasiert (time-based)
+#totp.hotp=z\u00e4hlerbasiert (counter-based)
+
+#totpType=Typ
+#totpAlgorithm=Algorithmus
+#totpDigits=Ziffern
+#totpInterval=Intervall
+#totpCounter=Z\u00e4hler
+
+#missingUsernameMessage=Bitte geben Sie einen Benutzernamen ein.
+#missingFirstNameMessage=Bitte geben Sie einen Vornamen ein.
+#invalidEmailMessage=Ung\u00fcltige E-Mail Adresse.
+#missingLastNameMessage=Bitte geben Sie einen Nachnamen ein.
+#missingEmailMessage=Bitte geben Sie eine E-Mail Adresse ein.
+#missingPasswordMessage=Bitte geben Sie ein Passwort ein.
+#notMatchPasswordMessage=Die Passw\u00f6rter sind nicht identisch.
+
+#missingTotpMessage=Bitte geben Sie den One-time Code ein.
+#invalidPasswordExistingMessage=Das aktuelle Passwort is ung\u00fcltig.
+#invalidPasswordConfirmMessage=Die Passwortbest\u00e4tigung ist nicht identisch.
+#invalidTotpMessage=Ung\u00fcltiger One-time Code.
+
+#usernameExistsMessage=Der Benutzername existiert bereits.
+#emailExistsMessage=Die E-Mail-Adresse existiert bereits.
+
+#readOnlyUserMessage=Sie k\u00f6nnen Ihr Benutzerkonto nicht \u00e4ndern, da es schreibgesch\u00fctzt ist.
+#readOnlyUsernameMessage=Sie k\u00f6nnen Ihren Benutzernamen nicht \u00e4ndern, da er schreibgesch\u00fctzt ist.
+#readOnlyPasswordMessage=Sie k\u00f6nnen Ihr Passwort nicht \u00e4ndern, da es schreibgesch\u00fctzt ist.
+
+#successTotpMessage=Mehrfachauthentifizierung erfolgreich konfiguriert.
+#successTotpRemovedMessage=Mehrfachauthentifizierung erfolgreich entfernt.
+
+#successGrantRevokedMessage=Berechtigung erfolgreich widerrufen.
+
+accountUpdatedMessage=Ihr Benutzerkonto wurde aktualisiert.
+#accountPasswordUpdatedMessage=Ihr Passwort wurde aktualisiert.
+
+#missingIdentityProviderMessage=Identity Provider nicht angegeben.
+#invalidFederatedIdentityActionMessage=Ung\u00fcltige oder fehlende Aktion.
+#identityProviderNotFoundMessage=Angegebener Identity Provider nicht gefunden.
+#federatedIdentityLinkNotActiveMessage=Diese Identit\u00e4t ist nicht mehr aktiv.
+#federatedIdentityRemovingLastProviderMessage=Sie k\u00f6nnen den letzten Eintrag nicht entfernen, da Sie kein Passwort haben.
+#identityProviderRedirectErrorMessage=Fehler bei der Weiterleitung zum Identity Provider.
+#identityProviderRemovedMessage=Identity Provider erfolgreich entfernt.
+#identityProviderAlreadyLinkedMessage=Die f\u00f6derierte Identit\u00e4t von {0} ist bereits einem anderen Benutzer zugewiesen.
+#staleCodeAccountMessage=Diese Seite ist nicht mehr g\u00fcltig, bitte versuchen Sie es noch einmal.
+#consentDenied=Einverst\u00e4ndnis verweigert.
+
+#accountDisabledMessage=Ihr Benutzerkonto ist gesperrt, bitte kontaktieren Sie den Admin.
+
+#accountTemporarilyDisabledMessage=Ihr Benutzerkonto ist tempor\u00e4r gesperrt, bitte kontaktieren Sie den Admin oder versuchen Sie es sp\u00e4ter noch einmal.
+#invalidPasswordMinLengthMessage=Ung\u00fcltiges Passwort: Es muss mindestens {0} Zeichen lang sein.
+#invalidPasswordMinLowerCaseCharsMessage=Ung\u00fcltiges Passwort\: Es muss mindestens {0} Kleinbuchstaben beinhalten.
+#invalidPasswordMinDigitsMessage=Ung\u00fcltiges Passwort: Es muss mindestens {0} Zahl(en) beinhalten.
+#invalidPasswordMinUpperCaseCharsMessage=Ung\u00fcltiges Passwort: Es muss mindestens {0} Gro\u00dfbuchstaben beinhalten.
+#invalidPasswordMinSpecialCharsMessage=Ung\u00fcltiges Passwort: Es muss mindestens {0} Sonderzeichen beinhalten.
+#invalidPasswordNotUsernameMessage=Ung\u00fcltiges Passwort: Es darf nicht gleich sein wie der Benutzername.
+#invalidPasswordRegexPatternMessage=Ung\u00fcltiges Passwort: Es entspricht nicht dem Regex-Muster.
+#invalidPasswordHistoryMessage=Ung\u00fcltiges Passwort: Es darf nicht einem der letzten {0} Passw\u00f6rter entsprechen.
+#invalidPasswordBlacklistedMessage=Ung\u00fcltiges Passwort: Das Passwort steht auf der Blocklist (schwarzen Liste).
+#invalidPasswordGenericMessge=Ung\u00fcltiges Passwort: Das neue Passwort verletzt die Passwort-Richtlinien.

--- a/themes/src/main/resources/theme/keycloak-preview/account/messages/messages_en.properties
+++ b/themes/src/main/resources/theme/keycloak-preview/account/messages/messages_en.properties
@@ -1,0 +1,354 @@
+doSave=Save
+doCancel=Cancel
+#doLogOutAllSessions=Log out all sessions
+#doRemove=Remove
+#doAdd=Add
+doSignOut=Sign Out
+doLogIn=Log In
+#doLink=Link
+
+
+#editAccountHtmlTitle=Edit Account
+personalInfoHtmlTitle=Personal Info
+#federatedIdentitiesHtmlTitle=Federated Identities
+#accountLogHtmlTitle=Account Log
+changePasswordHtmlTitle=Change Password
+deviceActivityHtmlTitle=Device Activity
+#sessionsHtmlTitle=Sessions
+accountManagementTitle=Keycloak Account Management
+authenticatorTitle=Authenticator
+applicationsHtmlTitle=Applications
+linkedAccountsHtmlTitle=Linked Accounts
+
+accountManagementWelcomeMessage=Welcome to Keycloak Account Management
+personalInfoIntroMessage=Manage your basic information
+accountSecurityTitle=Account Security
+accountSecurityIntroMessage=Control your password and account access
+applicationsIntroMessage=Track and manage your app permission to access your account
+resourceIntroMessage=Share your resources among team members
+passwordLastUpdateMessage=Your password was updated at
+updatePasswordTitle=Update Password
+updatePasswordMessageTitle=Make sure you choose a strong password
+updatePasswordMessage=A strong password contains a mix of numbers, letters, and symbols. It is hard to guess, does not resemble a real word, and is only used for this account.
+#personalSubTitle=Your Personal Info
+personalSubMessage=Manage this basic information: your first name, last name and email
+
+#authenticatorCode=One-time code
+email=Email
+firstName=First name
+#givenName=Given name
+#fullName=Full name
+lastName=Last name
+#familyName=Family name
+password=Password
+currentPassword=Current Password
+passwordConfirm=Confirmation
+passwordNew=New Password
+username=Username
+#address=Address
+#street=Street
+#locality=City or Locality
+#region=State, Province, or Region
+#postal_code=Zip or Postal code
+#country=Country
+#emailVerified=Email verified
+#gssDelegationCredential=GSS Delegation Credential
+
+#profileScopeConsentText=User profile
+#emailScopeConsentText=Email address
+#addressScopeConsentText=Address
+#phoneScopeConsentText=Phone number
+#offlineAccessScopeConsentText=Offline Access
+#samlRoleListScopeConsentText=My Roles
+#rolesScopeConsentText=User roles
+
+#role_admin=Admin
+#role_realm-admin=Realm Admin
+#role_create-realm=Create realm
+#role_view-realm=View realm
+#role_view-users=View users
+#role_view-applications=View applications
+#role_view-clients=View clients
+#role_view-events=View events
+#role_view-identity-providers=View identity providers
+#role_manage-realm=Manage realm
+#role_manage-users=Manage users
+#role_manage-applications=Manage applications
+#role_manage-identity-providers=Manage identity providers
+#role_manage-clients=Manage clients
+#role_manage-events=Manage events
+#role_view-profile=View profile
+#role_manage-account=Manage account
+#role_manage-account-links=Manage account links
+#role_read-token=Read token
+#role_offline-access=Offline access
+#role_uma_authorization=Obtain permissions
+#client_account=Account
+client_security-admin-console=Security Admin Console
+#client_admin-cli=Admin CLI
+#client_realm-management=Realm Management
+#client_broker=Broker
+
+
+requiredFields=Required fields
+#allFieldsRequired=All fields required
+
+#backToApplication=&laquo; Back to application
+backTo=Back to {0}
+
+#date=Date
+#event=Event
+#ip=IP
+#client=Client
+#clients=Clients
+#details=Details
+#started=Started
+#lastAccess=Last Access
+#expires=Expires
+applications=Applications
+
+#account=Account
+#federatedIdentity=Federated Identity
+authenticator=Authenticator
+device-activity=Device Activity
+#sessions=Sessions
+#log=Log
+
+#application=Application
+#availableRoles=Available Roles
+#grantedPermissions=Granted Permissions
+#grantedPersonalInfo=Granted Personal Info
+#additionalGrants=Additional Grants
+#action=Action
+#inResource=in
+#fullAccess=Full Access
+#offlineToken=Offline Token
+#revoke=Revoke Grant
+
+#configureAuthenticators=Configured Authenticators
+#mobile=Mobile
+#totpStep1=Install one of the following applications on your mobile
+#totpStep2=Open the application and scan the barcode
+#totpStep3=Enter the one-time code provided by the application and click Save to finish the setup.
+
+#totpManualStep2=Open the application and enter the key
+#totpManualStep3=Use the following configuration values if the application allows setting them
+#totpUnableToScan=Unable to scan?
+#totpScanBarcode=Scan barcode?
+
+#totp.totp=Time-based
+#totp.hotp=Counter-based
+
+#totpType=Type
+#totpAlgorithm=Algorithm
+#totpDigits=Digits
+#totpInterval=Interval
+#totpCounter=Counter
+
+#missingUsernameMessage=Please specify username.
+#missingFirstNameMessage=Please specify first name.
+#invalidEmailMessage=Invalid email address.
+#missingLastNameMessage=Please specify last name.
+#missingEmailMessage=Please specify email.
+#missingPasswordMessage=Please specify password.
+#notMatchPasswordMessage=Passwords don''t match.
+#invalidUserMessage=Invalid user
+
+#missingTotpMessage=Please specify authenticator code.
+#invalidPasswordExistingMessage=Invalid existing password.
+#invalidPasswordConfirmMessage=Password confirmation doesn''t match.
+#invalidTotpMessage=Invalid authenticator code.
+
+#usernameExistsMessage=Username already exists.
+#emailExistsMessage=Email already exists.
+
+#readOnlyUserMessage=You can''t update your account as it is read-only.
+#readOnlyUsernameMessage=You can''t update your username as it is read-only.
+#readOnlyPasswordMessage=You can''t update your password as your account is read-only.
+
+#successTotpMessage=Mobile authenticator configured.
+#successTotpRemovedMessage=Mobile authenticator removed.
+
+#successGrantRevokedMessage=Grant revoked successfully.
+
+accountUpdatedMessage=Your account has been updated.
+#accountPasswordUpdatedMessage=Your password has been updated.
+
+#missingIdentityProviderMessage=Identity provider not specified.
+#invalidFederatedIdentityActionMessage=Invalid or missing action.
+#identityProviderNotFoundMessage=Specified identity provider not found.
+#federatedIdentityLinkNotActiveMessage=This identity is not active anymore.
+#federatedIdentityRemovingLastProviderMessage=You can''t remove last federated identity as you don''t have password.
+#identityProviderRedirectErrorMessage=Failed to redirect to identity provider.
+#identityProviderRemovedMessage=Identity provider removed successfully.
+#identityProviderAlreadyLinkedMessage=Federated identity returned by {0} is already linked to another user.
+#staleCodeAccountMessage=The page expired. Please try one more time.
+#consentDenied=Consent denied.
+
+#accountDisabledMessage=Account is disabled, contact admin.
+
+#accountTemporarilyDisabledMessage=Account is temporarily disabled, contact admin or try again later.
+#invalidPasswordMinLengthMessage=Invalid password: minimum length {0}.
+#invalidPasswordMinLowerCaseCharsMessage=Invalid password: must contain at least {0} lower case characters.
+#invalidPasswordMinDigitsMessage=Invalid password: must contain at least {0} numerical digits.
+#invalidPasswordMinUpperCaseCharsMessage=Invalid password: must contain at least {0} upper case characters.
+#invalidPasswordMinSpecialCharsMessage=Invalid password: must contain at least {0} special characters.
+#invalidPasswordNotUsernameMessage=Invalid password: must not be equal to the username.
+#invalidPasswordRegexPatternMessage=Invalid password: fails to match regex pattern(s).
+#invalidPasswordHistoryMessage=Invalid password: must not be equal to any of last {0} passwords.
+#invalidPasswordBlacklistedMessage=Invalid password: password is blacklisted.
+#invalidPasswordGenericMessage=Invalid password: new password doesn''t match password policies.
+
+# Authorization
+myResources=My Resources
+#myResourcesSub=My resources
+#doDeny=Deny
+#doRevoke=Revoke
+#doApprove=Approve
+#doRemoveSharing=Remove Sharing
+#doRemoveRequest=Remove Request
+#peopleAccessResource=People with access to this resource
+#resourceManagedPolicies=Permissions granting access to this resource
+#resourceNoPermissionsGrantingAccess=No permissions granting access to this resource
+#anyAction=Any action
+#description=Description
+#name=Name
+#scopes=Scopes
+#resource=Resource
+#user=User
+#peopleSharingThisResource=People sharing this resource
+#shareWithOthers=Share with others
+#needMyApproval=Need my approval
+#requestsWaitingApproval=Your requests waiting approval
+#icon=Icon
+#requestor=Requestor
+#owner=Owner
+#resourcesSharedWithMe=Resources shared with me
+#permissionRequestion=Permission Requestion
+#permission=Permission
+#shares=share(s)
+
+locale_ca=Catal\u00e0
+locale_de=Deutsch
+locale_en=English
+locale_es=Espa\u00f1ol
+locale_fr=Fran\u00e7ais
+locale_it=Italian
+locale_ja=\u65e5\u672c\u8a9e
+locale_nl=Nederlands
+locale_no=Norsk
+locale_lt=Lietuvi\u0173
+locale_pt-BR=Portugu\u00eas (Brasil)
+locale_ru=\u0420\u0443\u0441\u0441\u043a\u0438\u0439
+locale_sk=Sloven\u010dina
+locale_sv=Svenska
+locale_tr=Turkish
+locale_zh-CN=\u4e2d\u6587\u7b80\u4f53
+
+# Applications
+#applicaitonName=Name
+#applicationType=Application Type
+#applicationInUse=In-use app only
+#clearAllFilter=Clear all filters
+#activeFilters=Active filters
+#filterByName=Filter By Name ...
+#allApps=All applications
+#internalApps=Internal applications
+#thirdpartyApps=Third-Party applications
+#appResults=Results
+
+# Linked account
+#authorizedProvider=Authorized Provider
+#authorizedProviderMessage=Authorized Providers linked with your account
+#identityProvider=Identity Provider
+#identityProviderMessage=To link your account with identity providers you have configured
+#socialLogin=Social Login
+#userDefined=User Defined
+#removeAccess=Remove Access
+#removeAccessMessage=You will need to grant access again, if you want to use this app account.
+
+#Authenticator
+#authenticatorStatusMessage=Two-factor authentication is currently
+#authenticatorFinishSetUpTitle=Your Two-Factor Authentication
+#authenticatorFinishSetUpMessage=Each time you sign in to your Keycloak account, you will be asked to provide a two-factor authentication code.
+#authenticatorSubTitle=Set Up Two-Factor Authentication
+#authenticatorSubMessage=To enhance the security of your account, enable at least one of the available two-factor authentication methods.
+#authenticatorMobileTitle=Mobile Authenticator
+#authenticatorMobileMessage=Use mobile Authenticator to get Verification codes as the two-factor authentication.
+#authenticatorMobileFinishSetUpMessage=The authenticator has been bound to your phone.
+#authenticatorActionSetup=Set up
+#authenticatorSMSTitle=SMS Code
+#authenticatorSMSMessage=Keycloak will send the Verification code to your phone as the two-factor authentication.
+#authenticatorSMSFinishSetUpMessage=Text messages are sent to
+#authenticatorDefaultStatus=Default
+#authenticatorChangePhone=Change Phone Number
+#authenticatorBackupCodesTitle=Backup Codes
+#authenticatorBackupCodesMessage=Get your 8-digit backup codes
+#authenticatorBackupCodesFinishSetUpMessage=12 backup codes was generated at this time. Each one can be used once.
+
+#Authenticator - Mobile Authenticator setup
+#authenticatorMobileSetupTitle=Mobile Authenticator Setup
+#smscodeIntroMessage=Enter your phone number and a verification code will be sent to your phone.
+#mobileSetupStep1=Install an authenticator application on your phone. The applications listed here are supported.
+#mobileSetupStep2=Open the application and scan the barcode.
+#mobileSetupStep3=Enter the one-time code provided by the application and click Save to finish the setup.
+#scanBarCode=Want to scan the barcode?
+#enterBarCode=Enter the one-time code
+#doCopy=Copy
+#doFinish=Finish
+
+#Authenticator - SMS Code setup
+#authenticatorSMSCodeSetupTitle=SMS Code Setup
+#smscodeIntroMessage=Enter your phone number and a verification code will be sent to your phone.
+#chooseYourCountry=Choose your country
+#enterYourPhoneNumber=Enter your phone number
+#sendVerficationCode=Send Verification Code
+#enterYourVerficationCode=Enter your verification code
+
+#Authenticator - backup Code setup
+#authenticatorBackupCodesSetupTitle=Backup Codes Setup
+#backupcodesIntroMessage=If you lose access to your phone, you can still log into your account through backup codes. Keep them somewhere safe and accessible.
+#realmName=Realm
+#doDownload=Download
+#doPrint=Print
+#doCopy=Copy
+#backupCodesTips-1=Each backup code can be used once.
+#backupCodesTips-2=These codes were generated on
+#generateNewBackupCodes=Generate New Backup Codes
+#backupCodesTips-3=When you generate new backup codes, the current codes will not work anymore.
+#backtoAuthenticatorPage=Back to Authenticator Page
+
+
+#Resources
+#resources=Resources
+#myResources=My Resources
+#sharedwithMe=Shared with Me
+#share=Share
+#resource=Resource
+#application=Application
+#date=Date
+#sharedwith=Shared with
+#owner=Owner
+#accessPermissions=Access Permissions
+#permissionRequests=Permission Requests
+#approve=Approve
+#approveAll=Approve all
+#sharedwith=Shared with
+#people=people
+#perPage=per page
+#currentPage=Current Page
+#sharetheResource=Share the resource
+#user=User
+#group=Group
+#selectPermission=Select Permission
+#addPeople=Add people to share your resource with
+#addTeam=Add team to share your resource with
+#myPermissions=My Permissions
+#waitingforApproval=Waiting for approval
+#anyPermission=Any Permission
+
+# Openshift messages
+#openshift.scope.user_info=User information
+#openshift.scope.user_check-access=User access information
+#openshift.scope.user_full=Full Access
+#openshift.scope.list-projects=List projects

--- a/themes/src/main/resources/theme/keycloak-preview/account/theme.properties
+++ b/themes/src/main/resources/theme/keycloak-preview/account/theme.properties
@@ -1,4 +1,4 @@
-parent=base
+locales=de,en
 deprecatedMode=false
 scripts=WelcomePageScripts.js content.js
 developmentMode=true


### PR DESCRIPTION
This PR removes the dependency on the base message bundle for the new account console.

The main reason to do this is so that we are not making changes to "live" code that users rely on today.

Also, this will make it easier to clean up the bundle when we are done.  We can quickly identify the messages we are no longer using and get rid of them.

I only added English and German bundles so that we can continue to test changing locales.
