### PR TITLE
Include additional styles that are now in latest version.

### DIFF
--- a/examples/themes/src/main/resources/theme/logo-example/admin/theme.properties
+++ b/examples/themes/src/main/resources/theme/logo-example/admin/theme.properties
@@ -17,4 +17,4 @@
 
 parent=keycloak
 import=common/keycloak
-styles=lib/patternfly/css/patternfly.css node_modules/select2/select2.css css/styles.css css/logo.css
+styles=lib/patternfly/css/patternfly.css node_modules/select2/select2.css css/styles.css lib/angular/treeview/css/angular.treeview.css node_modules/text-security/dist/text-security.css css/logo.css


### PR DESCRIPTION
This is necessary for the example to function properly.  For example: without the other styles, the passwords are not hidden when updating user credentials.  Ideally, all the styles would be automatically inherited from keycloak but they don't appear to be.

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
