### PR TITLE
KEYCLOAK-10393 Fix permission ticket pagination in Authz Client

### DIFF
--- a/authz/client/src/main/java/org/keycloak/authorization/client/resource/PermissionResource.java
+++ b/authz/client/src/main/java/org/keycloak/authorization/client/resource/PermissionResource.java
@@ -213,8 +213,8 @@ public class PermissionResource {
                         .param("requester", requester)
                         .param("granted", granted == null ? null : granted.toString())
                         .param("returnNames", returnNames == null ? null : returnNames.toString())
-                        .param("firstResult", firstResult == null ? null : firstResult.toString())
-                        .param("maxResult", maxResult == null ? null : maxResult.toString())
+                        .param("first", firstResult == null ? null : firstResult.toString())
+                        .param("max", maxResult == null ? null : maxResult.toString())
                         .response().json(new TypeReference<List<PermissionTicketRepresentation>>(){}).execute();
             }
         };

--- a/model/jpa/src/main/java/org/keycloak/authorization/jpa/store/JPAPermissionTicketStore.java
+++ b/model/jpa/src/main/java/org/keycloak/authorization/jpa/store/JPAPermissionTicketStore.java
@@ -215,7 +215,7 @@ public class JPAPermissionTicketStore implements PermissionTicketStore {
             }
         });
 
-        querybuilder.where(predicates.toArray(new Predicate[predicates.size()])).orderBy(builder.asc(root.get("resource").get("id")));
+        querybuilder.where(predicates.toArray(new Predicate[predicates.size()])).orderBy(builder.asc(root.get("id")));
 
         Query query = entityManager.createQuery(querybuilder);
 


### PR DESCRIPTION
Please refer to [KEYCLOAK-10393](https://issues.jboss.org/projects/KEYCLOAK/issues/KEYCLOAK-10393) for details on this pull request.

If you agree to this change, it would be fabulous to get this ported back to the 4.x code base too.