### PR TITLE
Fix formatting error in log message

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/InfinispanChangelogBasedTransaction.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/InfinispanChangelogBasedTransaction.java
@@ -235,7 +235,7 @@ public class InfinispanChangelogBasedTransaction<K, V extends SessionEntity> ext
                 task.runUpdate(session);
             } else {
                 if (logger.isTraceEnabled()) {
-                    logger.tracef("Replace SUCCESS for entity: %s . old version: %d, new version: %d", key, oldVersionEntity.getVersion(), newVersionEntity.getVersion());
+                    logger.tracef("Replace SUCCESS for entity: %s . old version: %s, new version: %s", key, oldVersionEntity.getVersion(), newVersionEntity.getVersion());
                 }
             }
         }


### PR DESCRIPTION
Fixes the formatting error
java.util.IllegalFormatConversionException: d != java.util.UUID

See: https://issues.jboss.org/browse/KEYCLOAK-10545
