### PR TITLE
KEYCLOAK-10660 Fix internal server error when re-logging in from my resources page

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/account/AccountFormService.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountFormService.java
@@ -704,13 +704,13 @@ public class AccountFormService extends AbstractSecuredLocalService {
     @Path("resource")
     @GET
     public Response resourcesPage(@QueryParam("resource_id") String resourceId) {
-        return forwardToPage("resources", AccountPages.RESOURCES);
+        return forwardToPage("resource", AccountPages.RESOURCES);
     }
 
     @Path("resource/{resource_id}")
     @GET
     public Response resourceDetailPage(@PathParam("resource_id") String resourceId) {
-        return forwardToPage("resource-detail", AccountPages.RESOURCE_DETAIL);
+        return forwardToPage("resource", AccountPages.RESOURCE_DETAIL);
     }
 
     @Path("resource/{resource_id}/grant")
@@ -815,10 +815,10 @@ public class AccountFormService extends AbstractSecuredLocalService {
         }
 
         if (isRevoke || isRevokePolicy || isRevokePolicyAll) {
-            return forwardToPage("resource-detail", AccountPages.RESOURCE_DETAIL);
+            return forwardToPage("resource", AccountPages.RESOURCE_DETAIL);
         }
 
-        return forwardToPage("resources", AccountPages.RESOURCES);
+        return forwardToPage("resource", AccountPages.RESOURCES);
     }
 
     @Path("resource/{resource_id}/share")
@@ -894,7 +894,7 @@ public class AccountFormService extends AbstractSecuredLocalService {
             }
         }
 
-        return forwardToPage("resource-detail", AccountPages.RESOURCE_DETAIL);
+        return forwardToPage("resource", AccountPages.RESOURCE_DETAIL);
     }
 
     @Path("resource")


### PR DESCRIPTION
Please refer to [this ticket](https://issues.jboss.org/projects/KEYCLOAK/issues/KEYCLOAK-10660).

If a user logs out from the following _UMA My Resources_ page:
- ttp://localhost:8080/auth/realms/demo/account/**resource**?referrer=security-admin-console

then the user is redirected to the login page:

- ttp://localhost:8080/auth/realms/demo/account/login-redirect?path=**resources**&referrer=security-admin-console&state=0%2F6f16a667-014e-48a1-91a9-3f170d46433f...

After logging out, if the user logs into _UMA My Resources_ page again, the user is redirected to the URL:

- ttp://localhost:8080/auth/realms/demo/account/**resources**?referrer=security-admin-console

but the URL does not exist and HTTP 400 (bad request) error occurs. So the redirect path (in other words, the arrgument of the following line of `AccountFormService.java`) should be changed from **resources** to **resource**. 

```java
return forwardToPage("resources", AccountPages.RESOURCES);
```

The first parameter of `AccountFormService.forwardToPage()` is used as redirect path after re-login as follows:

```
login-redirect?path=resource
```

therefore, the arrgument must be an existing path. The following line should also be changed to **resource**. 

```java
return forwardToPage("resource-detail", AccountPages.RESOURCE_DETAIL);
```