### PR TITLE
KEYCLOAK-6073 - Support different URLs for front and back channel requests in adapters

### DIFF
--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/BasicAuthRequestAuthenticator.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/BasicAuthRequestAuthenticator.java
@@ -89,9 +89,7 @@ public class BasicAuthRequestAuthenticator extends BearerTokenRequestAuthenticat
     	AccessTokenResponse tokenResponse=null;
     	HttpClient client = deployment.getClient();
 
-        HttpPost post = new HttpPost(
-                KeycloakUriBuilder.fromUri(deployment.getAuthServerBaseUrl())
-                .path(ServiceUrlConstants.TOKEN_PATH).build(deployment.getRealm()));
+        HttpPost post = new HttpPost(deployment.getTokenUrl());
         java.util.List <NameValuePair> formparams = new java.util.ArrayList <NameValuePair>();
         formparams.add(new BasicNameValuePair(OAuth2Constants.GRANT_TYPE, OAuth2Constants.PASSWORD));
         formparams.add(new BasicNameValuePair("username", username));

--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/KeycloakDeploymentBuilder.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/KeycloakDeploymentBuilder.java
@@ -139,6 +139,8 @@ public class KeycloakDeploymentBuilder {
             throw new RuntimeException("You must specify auth-server-url");
         }
         deployment.setAuthServerBaseUrl(adapterConfig);
+        deployment.setAuthServerBackChannelBaseUrl(adapterConfig);
+
         if (adapterConfig.getTurnOffChangeSessionIdOnLogin() != null) {
             deployment.setTurnOffChangeSessionIdOnLogin(adapterConfig.getTurnOffChangeSessionIdOnLogin());
         }

--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/authorization/PolicyEnforcer.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/authorization/PolicyEnforcer.java
@@ -62,7 +62,7 @@ public class PolicyEnforcer {
     public PolicyEnforcer(KeycloakDeployment deployment, AdapterConfig adapterConfig) {
         this.deployment = deployment;
         this.enforcerConfig = adapterConfig.getPolicyEnforcerConfig();
-        Configuration configuration = new Configuration(adapterConfig.getAuthServerUrl(), adapterConfig.getRealm(), adapterConfig.getResource(), adapterConfig.getCredentials(), deployment.getClient());
+        Configuration configuration = new Configuration(adapterConfig.getAuthServerUrl(), adapterConfig.getAuthServerBackChannelUrl(), adapterConfig.getRealm(), adapterConfig.getResource(), adapterConfig.getCredentials(), deployment.getClient());
         this.authzClient = AuthzClient.create(configuration, new ClientAuthenticator() {
             @Override
             public void configureClientCredentials(Map<String, List<String>> requestParams, Map<String, String> requestHeaders) {

--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/jaas/DirectAccessGrantsLoginModule.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/jaas/DirectAccessGrantsLoginModule.java
@@ -85,9 +85,7 @@ public class DirectAccessGrantsLoginModule extends AbstractKeycloakLoginModule {
     }
 
     protected Auth directGrantAuth(String username, String password) throws IOException, VerificationException {
-        String authServerBaseUrl = deployment.getAuthServerBaseUrl();
-        URI directGrantUri = KeycloakUriBuilder.fromUri(authServerBaseUrl).path(ServiceUrlConstants.TOKEN_PATH).build(deployment.getRealm());
-        HttpPost post = new HttpPost(directGrantUri);
+        HttpPost post = new HttpPost(deployment.getTokenUrl());
 
         List<NameValuePair> formparams = new ArrayList<NameValuePair>();
         formparams.add(new BasicNameValuePair(OAuth2Constants.GRANT_TYPE, OAuth2Constants.PASSWORD));

--- a/adapters/oidc/adapter-core/src/test/java/org/keycloak/adapters/AdapterDeploymentContextTest.java
+++ b/adapters/oidc/adapter-core/src/test/java/org/keycloak/adapters/AdapterDeploymentContextTest.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.adapters;
+
+import org.junit.Test;
+import org.keycloak.adapters.spi.AuthenticationError;
+import org.keycloak.adapters.spi.HttpFacade;
+import org.keycloak.adapters.spi.LogoutError;
+import org.keycloak.representations.adapters.config.AdapterConfig;
+
+import javax.security.cert.X509Certificate;
+import java.io.InputStream;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class AdapterDeploymentContextTest {
+
+    @Test
+    public void resolveUrls_ShouldResolveAllUrlsToRelativeFrontChannel_WhenRelativeFrontChannelUrlAndNoBackChannelUrlIsGiven() {
+        AdapterConfig relativeAuthServeUrlConfig = createRelativeAuthServerConfig();
+
+        KeycloakDeployment deployment = createDeployment();
+        deployment.setAuthServerBaseUrl(relativeAuthServeUrlConfig);
+
+        AdapterDeploymentContext deploymentContext = new AdapterDeploymentContext(deployment);
+        String requestUri = "https://test.app";
+        KeycloakDeployment resolvedDeployment = deploymentContext.resolveUrls(deployment, createFakeRequest(requestUri));
+
+        String frontChannelUrl = requestUri + "/auth";
+        assertEquals(frontChannelUrl, resolvedDeployment.getAuthServerBaseUrl());
+        assertNull(resolvedDeployment.getAuthServerBackChannelBaseUrl());
+
+        assertFrontChannelUrls(resolvedDeployment, frontChannelUrl);
+        assertBackChannelUrls(resolvedDeployment, frontChannelUrl);
+    }
+
+    @Test
+    public void resolveUrls_ShouldResolveBackChannelUrlsToBackChannel_WhenRelativeFrontChannelUrlAndBackChannelUrlIsGiven() {
+        String backChannelUrl = "https://test.backchannel/auth";
+
+        AdapterConfig relativeAuthServeUrlConfig = createRelativeAuthServerConfig();
+        relativeAuthServeUrlConfig.setAuthServerBackChannelUrl(backChannelUrl);
+
+        KeycloakDeployment deployment = createDeployment();
+        deployment.setAuthServerBaseUrl(relativeAuthServeUrlConfig);
+        deployment.setAuthServerBackChannelBaseUrl(relativeAuthServeUrlConfig);
+
+        AdapterDeploymentContext deploymentContext = new AdapterDeploymentContext(deployment);
+        String requestUri = "https://test.app";
+        KeycloakDeployment resolvedDeployment = deploymentContext.resolveUrls(deployment, createFakeRequest(requestUri));
+
+        String frontChannelUrl = requestUri + "/auth";
+        assertEquals(frontChannelUrl, resolvedDeployment.getAuthServerBaseUrl());
+        assertEquals(backChannelUrl, resolvedDeployment.getAuthServerBackChannelBaseUrl());
+
+        assertFrontChannelUrls(resolvedDeployment, frontChannelUrl);
+        assertBackChannelUrls(resolvedDeployment, backChannelUrl);
+    }
+
+    private void assertFrontChannelUrls(KeycloakDeployment deployment, String url) {
+        assertEquals(url + "/realms/test", deployment.getRealmInfoUrl());
+        assertEquals(url + "/realms/test/protocol/openid-connect/auth", deployment.getAuthUrl().build().toString());
+        assertEquals(url + "/realms/test/account", deployment.getAccountUrl());
+    }
+
+    private void assertBackChannelUrls(KeycloakDeployment deployment, String url) {
+        assertEquals(url + "/realms/test/protocol/openid-connect/token", deployment.getTokenUrl());
+        assertEquals(url + "/realms/test/protocol/openid-connect/logout", deployment.getLogoutUrl().build().toString());
+        assertEquals(url + "/realms/test/protocol/openid-connect/certs", deployment.getJwksUrl());
+        assertEquals(url + "/realms/test/clients-managements/register-node", deployment.getRegisterNodeUrl());
+        assertEquals(url + "/realms/test/clients-managements/unregister-node", deployment.getUnregisterNodeUrl());
+    }
+
+    private AdapterConfig createRelativeAuthServerConfig() {
+        AdapterConfig relativeAuthServeUrlConfig = new AdapterConfig();
+        relativeAuthServeUrlConfig.setAuthServerUrl("/auth");
+        return relativeAuthServeUrlConfig;
+    }
+
+    private KeycloakDeployment createDeployment() {
+        KeycloakDeployment deployment = new KeycloakDeployment();
+        deployment.setRealm("test");
+        return deployment;
+    }
+
+    private HttpFacade createFakeRequest(final String uri) {
+        return new HttpFacade() {
+            @Override
+            public Request getRequest() {
+                return new Request() {
+                    @Override
+                    public String getMethod() {
+                        return null;
+                    }
+
+                    @Override
+                    public String getURI() {
+                        return uri;
+                    }
+
+                    @Override
+                    public String getRelativePath() {
+                        return null;
+                    }
+
+                    @Override
+                    public boolean isSecure() {
+                        return false;
+                    }
+
+                    @Override
+                    public String getFirstParam(String param) {
+                        return null;
+                    }
+
+                    @Override
+                    public String getQueryParamValue(String param) {
+                        return null;
+                    }
+
+                    @Override
+                    public Cookie getCookie(String cookieName) {
+                        return null;
+                    }
+
+                    @Override
+                    public String getHeader(String name) {
+                        return null;
+                    }
+
+                    @Override
+                    public List<String> getHeaders(String name) {
+                        return null;
+                    }
+
+                    @Override
+                    public InputStream getInputStream() {
+                        return null;
+                    }
+
+                    @Override
+                    public InputStream getInputStream(boolean buffered) {
+                        return null;
+                    }
+
+                    @Override
+                    public String getRemoteAddr() {
+                        return null;
+                    }
+
+                    @Override
+                    public void setError(AuthenticationError error) {
+
+                    }
+
+                    @Override
+                    public void setError(LogoutError error) {
+
+                    }
+                };
+            }
+
+            @Override
+            public Response getResponse() {
+                return null;
+            }
+
+            @Override
+            public X509Certificate[] getCertificateChain() {
+                return new X509Certificate[0];
+            }
+        };
+    }
+}

--- a/adapters/oidc/adapter-core/src/test/java/org/keycloak/adapters/KeycloakDeploymentTest.java
+++ b/adapters/oidc/adapter-core/src/test/java/org/keycloak/adapters/KeycloakDeploymentTest.java
@@ -22,6 +22,7 @@ import org.keycloak.representations.adapters.config.AdapterConfig;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNull;
 
 /**
  * @author <a href="mailto:brad.culley@spartasystems.com">Brad Culley</a>
@@ -63,6 +64,15 @@ public class KeycloakDeploymentTest {
         keycloakDeployment.setAuthServerBaseUrl(config);
 
         assertEquals("https://localhost/auth", keycloakDeployment.getAuthServerBaseUrl());
+
+
+        config.setAuthServerBackChannelUrl("http://backchannel:80/auth");
+        keycloakDeployment.setAuthServerBackChannelBaseUrl(config);
+        assertEquals("http://backchannel/auth", keycloakDeployment.getAuthServerBackChannelBaseUrl());
+
+        config.setAuthServerBackChannelUrl("https://backchannel:443/auth");
+        keycloakDeployment.setAuthServerBackChannelBaseUrl(config);
+        assertEquals("https://backchannel/auth", keycloakDeployment.getAuthServerBackChannelBaseUrl());
     }
 
 }

--- a/adapters/oidc/adapter-core/src/test/resources/keycloak-backchannel-url.json
+++ b/adapters/oidc/adapter-core/src/test/resources/keycloak-backchannel-url.json
@@ -1,0 +1,6 @@
+{
+    "realm": "test",
+    "resource": "test-resource",
+    "auth-server-url": "https://test.frontchannel:8443/auth",
+    "auth-server-backchannel-url": "https://test.backchannel:8443/auth"
+}

--- a/adapters/oidc/adapter-core/src/test/resources/keycloak-frontchannel-url-only.json
+++ b/adapters/oidc/adapter-core/src/test/resources/keycloak-frontchannel-url-only.json
@@ -1,0 +1,5 @@
+{
+    "realm": "test",
+    "resource": "test-resource",
+    "auth-server-url": "https://test.frontchannel:8443/auth"
+}

--- a/authz/client/pom.xml
+++ b/authz/client/pom.xml
@@ -70,6 +70,12 @@
             <artifactId>jackson-annotations</artifactId>
             <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/authz/client/src/main/java/org/keycloak/authorization/client/Configuration.java
+++ b/authz/client/src/main/java/org/keycloak/authorization/client/Configuration.java
@@ -45,14 +45,16 @@ public class Configuration extends AdapterConfig {
      * Creates a new instance.
      *
      * @param authServerUrl the server's URL. E.g.: http://{server}:{port}/auth.(not {@code null})
+     * @param authServerBackChannelUrl the server's backchannel URL. E.g.: http://{server}:{port}/auth.(not {@code null})
      * @param realm the realm name (not {@code null})
      * @param clientId the client id (not {@code null})
      * @param clientCredentials a map with the client credentials (not {@code null})
      * @param httpClient the {@link HttpClient} instance that should be used when sending requests to the server, or {@code null} if a default instance should be created
      */
-    public Configuration(String authServerUrl, String realm, String clientId, Map<String, Object> clientCredentials, HttpClient httpClient) {
+    public Configuration(String authServerUrl, String authServerBackChannelUrl, String realm, String clientId, Map<String, Object> clientCredentials, HttpClient httpClient) {
         this.authServerUrl = authServerUrl;
         setAuthServerUrl(authServerUrl);
+        setAuthServerBackChannelUrl(authServerBackChannelUrl);
         setRealm(realm);
         setResource(clientId);
         setCredentials(clientCredentials);

--- a/authz/client/src/main/java/org/keycloak/authorization/client/ServerBackChannelUrlConfiguration.java
+++ b/authz/client/src/main/java/org/keycloak/authorization/client/ServerBackChannelUrlConfiguration.java
@@ -1,0 +1,212 @@
+/*
+ *  Copyright 2019 Red Hat, Inc. and/or its affiliates
+ *  and other contributors as indicated by the @author tags.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package org.keycloak.authorization.client;
+
+import org.keycloak.authorization.client.representation.ServerConfiguration;
+import org.keycloak.common.util.KeycloakUriBuilder;
+import org.keycloak.constants.ServiceUrlConstants;
+
+import java.util.List;
+
+class ServerBackChannelUrlConfiguration extends ServerConfiguration {
+
+    private static final String TOKEN_INTROSPECTION_PATH = "/realms/{realm-name}/protocol/openid-connect/token/introspect";
+    private static final String USER_INFO_PATH = "/realms/{realm-name}/protocol/openid-connect/userinfo";
+
+    private static final String REGISTRATION_PATH = "/realms/{realm-name}/clients-registrations/openid-connect";
+    private static final String RESOURCE_REGISTRATION_PATH = "/realms/{realm-name}/authz/protection/resource_set";
+    private static final String PERMISSION_PATH = "/realms/{realm-name}/authz/protection/permission";
+    private static final String POLICY_PATH = "/realms/{realm-name}/authz/protection/uma-policy";
+
+    private final ServerConfiguration delegate;
+
+
+    private String tokenUrl;
+
+    private String tokenIntrospectionUrl;
+
+    private String userInfoUrl;
+
+    private String logoutUrl;
+
+    private String jwksUrl;
+
+    private String registrationUrl;
+
+    private String resourceRegistrationUrl;
+
+    private String permissionUrl;
+
+    private String policyUrl;
+
+
+    ServerBackChannelUrlConfiguration(ServerConfiguration delegate, String authServerUrl, String realm) {
+        this.delegate = delegate;
+        resolveBackChannelUrls(authServerUrl, realm);
+    }
+
+
+    private void resolveBackChannelUrls(String backChannelUrl, String realm) {
+        KeycloakUriBuilder builder = KeycloakUriBuilder.fromUri(backChannelUrl);
+        tokenUrl = builder.clone().path(ServiceUrlConstants.TOKEN_PATH).build(realm).toString();
+        tokenIntrospectionUrl = builder.clone().path(TOKEN_INTROSPECTION_PATH).build(realm).toString();
+        userInfoUrl = builder.clone().path(USER_INFO_PATH).build(realm).toString();
+        logoutUrl = builder.clone().path(ServiceUrlConstants.TOKEN_SERVICE_LOGOUT_PATH).build(realm).toString();
+        jwksUrl = builder.clone().path(ServiceUrlConstants.JWKS_URL).build(realm).toString();
+        registrationUrl = builder.clone().path(REGISTRATION_PATH).build(realm).toString();
+        resourceRegistrationUrl = builder.clone().path(RESOURCE_REGISTRATION_PATH).build(realm).toString();
+        permissionUrl = builder.clone().path(PERMISSION_PATH).build(realm).toString();
+        policyUrl = builder.clone().path(POLICY_PATH).build(realm).toString();
+    }
+
+    @Override
+    public String getTokenEndpoint() {
+        return tokenUrl;
+    }
+
+    @Override
+    public String getTokenIntrospectionEndpoint() {
+        return tokenIntrospectionUrl;
+    }
+
+    @Override
+    public String getUserinfoEndpoint() {
+        return userInfoUrl;
+    }
+
+    @Override
+    public String getLogoutEndpoint() {
+        return logoutUrl;
+    }
+
+    @Override
+    public String getJwksUri() {
+        return jwksUrl;
+    }
+
+    @Override
+    public String getRegistrationEndpoint() {
+        return registrationUrl;
+    }
+
+    @Override
+    public String getResourceRegistrationEndpoint() {
+        return resourceRegistrationUrl;
+    }
+
+    @Override
+    public String getPermissionEndpoint() {
+        return permissionUrl;
+    }
+
+    @Override
+    public String getPolicyEndpoint() {
+        return policyUrl;
+    }
+
+
+    @Override
+    public String getIssuer() {
+        return delegate.getIssuer();
+    }
+
+    @Override
+    public String getAuthorizationEndpoint() {
+        return delegate.getAuthorizationEndpoint();
+    }
+
+    @Override
+    public String getCheckSessionIframe() {
+        return delegate.getCheckSessionIframe();
+    }
+
+    @Override
+    public List<String> getGrantTypesSupported() {
+        return delegate.getGrantTypesSupported();
+    }
+
+    @Override
+    public List<String> getResponseTypesSupported() {
+        return delegate.getResponseTypesSupported();
+    }
+
+    @Override
+    public List<String> getSubjectTypesSupported() {
+        return delegate.getSubjectTypesSupported();
+    }
+
+    @Override
+    public List<String> getIdTokenSigningAlgValuesSupported() {
+        return delegate.getIdTokenSigningAlgValuesSupported();
+    }
+
+    @Override
+    public List<String> getUserInfoSigningAlgValuesSupported() {
+        return delegate.getUserInfoSigningAlgValuesSupported();
+    }
+
+    @Override
+    public List<String> getRequestObjectSigningAlgValuesSupported() {
+        return delegate.getRequestObjectSigningAlgValuesSupported();
+    }
+
+    @Override
+    public List<String> getResponseModesSupported() {
+        return delegate.getResponseModesSupported();
+    }
+
+    @Override
+    public List<String> getTokenEndpointAuthMethodsSupported() {
+        return delegate.getTokenEndpointAuthMethodsSupported();
+    }
+
+    @Override
+    public List<String> getTokenEndpointAuthSigningAlgValuesSupported() {
+        return delegate.getTokenEndpointAuthSigningAlgValuesSupported();
+    }
+
+    @Override
+    public List<String> getClaimsSupported() {
+        return delegate.getClaimsSupported();
+    }
+
+    @Override
+    public List<String> getClaimTypesSupported() {
+        return delegate.getClaimTypesSupported();
+    }
+
+    @Override
+    public Boolean getClaimsParameterSupported() {
+        return delegate.getClaimsParameterSupported();
+    }
+
+    @Override
+    public List<String> getScopesSupported() {
+        return delegate.getScopesSupported();
+    }
+
+    @Override
+    public Boolean getRequestParameterSupported() {
+        return delegate.getRequestParameterSupported();
+    }
+
+    @Override
+    public Boolean getRequestUriParameterSupported() {
+        return delegate.getRequestUriParameterSupported();
+    }
+}

--- a/authz/client/src/test/java/org/keycloak/authorization/client/ServerBackChannelUrlConfigurationTest.java
+++ b/authz/client/src/test/java/org/keycloak/authorization/client/ServerBackChannelUrlConfigurationTest.java
@@ -1,0 +1,28 @@
+package org.keycloak.authorization.client;
+
+import org.junit.Test;
+import org.keycloak.authorization.client.representation.ServerConfiguration;
+
+import static org.junit.Assert.assertEquals;
+
+public class ServerBackChannelUrlConfigurationTest {
+
+    @Test
+    public void init_ShouldResolveAllUrlsBasedOnGivenUrlAndRealm() {
+        ServerConfiguration delegate = new ServerConfiguration();
+        String url = "https://test.app/auth";
+        String realm = "test";
+
+        ServerBackChannelUrlConfiguration config = new ServerBackChannelUrlConfiguration(delegate, url, realm);
+
+        assertEquals(url + "/realms/test/protocol/openid-connect/token", config.getTokenEndpoint());
+        assertEquals(url + "/realms/test/protocol/openid-connect/token/introspect", config.getTokenIntrospectionEndpoint());
+        assertEquals(url + "/realms/test/protocol/openid-connect/userinfo", config.getUserinfoEndpoint());
+        assertEquals(url + "/realms/test/protocol/openid-connect/logout", config.getLogoutEndpoint());
+        assertEquals(url + "/realms/test/protocol/openid-connect/certs", config.getJwksUri());
+        assertEquals(url + "/realms/test/clients-registrations/openid-connect", config.getRegistrationEndpoint());
+        assertEquals(url + "/realms/test/authz/protection/resource_set", config.getResourceRegistrationEndpoint());
+        assertEquals(url + "/realms/test/authz/protection/permission", config.getPermissionEndpoint());
+        assertEquals(url + "/realms/test/authz/protection/uma-policy", config.getPolicyEndpoint());
+    }
+}

--- a/core/src/main/java/org/keycloak/representations/adapters/config/AdapterConfig.java
+++ b/core/src/main/java/org/keycloak/representations/adapters/config/AdapterConfig.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * @author <a href="mailto:john.ament@spartasystems.com">John D. Ament</a>
  * @version $Revision: 1 $
  */
-@JsonPropertyOrder({"realm", "realm-public-key", "auth-server-url", "ssl-required",
+@JsonPropertyOrder({"realm", "realm-public-key", "auth-server-url", "auth-server-backchannel-url", "ssl-required",
         "resource", "public-client", "credentials",
         "use-resource-role-mappings",
         "enable-cors", "cors-max-age", "cors-allowed-methods", "cors-exposed-headers",

--- a/core/src/main/java/org/keycloak/representations/adapters/config/BaseAdapterConfig.java
+++ b/core/src/main/java/org/keycloak/representations/adapters/config/BaseAdapterConfig.java
@@ -29,7 +29,7 @@ import java.util.TreeMap;
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
  */
-@JsonPropertyOrder({"realm", "realm-public-key", "auth-server-url", "ssl-required",
+@JsonPropertyOrder({"realm", "realm-public-key", "auth-server-url", "auth-server-backchannel-url", "ssl-required",
         "resource", "public-client", "credentials",
         "use-resource-role-mappings",
         "enable-cors", "cors-max-age", "cors-allowed-methods", "cors-exposed-headers",

--- a/core/src/main/java/org/keycloak/representations/adapters/config/BaseRealmConfig.java
+++ b/core/src/main/java/org/keycloak/representations/adapters/config/BaseRealmConfig.java
@@ -26,7 +26,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
  */
-@JsonPropertyOrder({"realm", "realm-public-key", "auth-server-url", "ssl-required"})
+@JsonPropertyOrder({"realm", "realm-public-key", "auth-server-url", "auth-server-backchannel-url", "ssl-required"})
 public class BaseRealmConfig {
     @JsonProperty("realm")
     protected String realm;
@@ -34,6 +34,8 @@ public class BaseRealmConfig {
     protected String realmKey;
     @JsonProperty("auth-server-url")
     protected String authServerUrl;
+    @JsonProperty("auth-server-backchannel-url")
+    protected String authServerBackChannelUrl;
     @JsonProperty("ssl-required")
     protected String sslRequired;
     @JsonProperty("confidential-port")
@@ -69,6 +71,14 @@ public class BaseRealmConfig {
 
     public void setAuthServerUrl(String authServerUrl) {
         this.authServerUrl = authServerUrl;
+    }
+
+    public String getAuthServerBackChannelUrl() {
+        return authServerBackChannelUrl;
+    }
+
+    public void setAuthServerBackChannelUrl(String authServerBackChannelUrl) {
+        this.authServerBackChannelUrl = authServerBackChannelUrl;
     }
 
     public int getConfidentialPort() {

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/adapter/page/AbstractShowTokensPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/adapter/page/AbstractShowTokensPage.java
@@ -32,7 +32,9 @@ import java.io.IOException;
  */
 public abstract class AbstractShowTokensPage extends AbstractPageWithInjectedUrl {
 
-    @FindBy(id = "accessToken")
+    public static final String ACCESS_TOKEN_ID = "accessToken";
+
+    @FindBy(id = ACCESS_TOKEN_ID)
     private WebElement accessToken;
 
     @FindBy(id = "refreshToken")

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/adapter/page/SessionPortal.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/adapter/page/SessionPortal.java
@@ -40,4 +40,7 @@ public class SessionPortal extends AbstractPageWithInjectedUrl {
         return url;
     }
 
+    public String logoutURL() {
+        return  url + "logout";
+    }
 }

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/adapter/page/TokenMinTTLPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/adapter/page/TokenMinTTLPage.java
@@ -37,4 +37,8 @@ public class TokenMinTTLPage extends AbstractShowTokensPage {
     public URL getInjectedUrl() {
         return url;
     }
+
+    public String getUnsecuredUrl() {
+        return url + "unsecured";
+    }
 }

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/AppServerTestEnricher.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/AppServerTestEnricher.java
@@ -296,6 +296,10 @@ public class AppServerTestEnricher {
         return CURRENT_APP_SERVER.startsWith("tomcat");
     }
 
+    public static boolean isJettyAppServer() {
+        return CURRENT_APP_SERVER.startsWith("jetty");
+    }
+
     public static boolean isEAP6AppServer() {
         return CURRENT_APP_SERVER.equals("eap6");
     }

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/AuthServerTestEnricher.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/AuthServerTestEnricher.java
@@ -469,7 +469,7 @@ public class AuthServerTestEnricher {
         }
     }
 
-    private static OnlineManagementClient getManagementClient(ContainerInfo containerInfo) {
+    public static OnlineManagementClient getManagementClient(ContainerInfo containerInfo) {
         try {
             return ManagementClient.online(OnlineOptions
                     .standalone()

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/AuthServerConfigurationUtil.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/AuthServerConfigurationUtil.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.testsuite.util;
+
+import org.jboss.arquillian.container.test.api.ContainerController;
+import org.keycloak.testsuite.arquillian.AuthServerTestEnricher;
+import org.keycloak.testsuite.arquillian.SuiteContext;
+import org.wildfly.extras.creaper.core.online.OnlineManagementClient;
+import org.wildfly.extras.creaper.core.online.operations.admin.Administration;
+
+public class AuthServerConfigurationUtil {
+
+    private final SuiteContext suiteContext;
+    private final ContainerController controller;
+
+    public AuthServerConfigurationUtil(SuiteContext suiteContext, ContainerController controller) {
+        this.suiteContext = suiteContext;
+        this.controller = controller;
+    }
+
+    public void configureFixedHostname(String hostname, int httpPort, int httpsPort, boolean alwaysHttps) throws Exception {
+        if (suiteContext.getAuthServerInfo().isUndertow()) {
+            configureUndertow("fixed", hostname, httpPort, httpsPort, alwaysHttps);
+        } else if (suiteContext.getAuthServerInfo().isJBossBased()) {
+            configureWildFly("fixed", hostname, httpPort, httpsPort, alwaysHttps);
+        } else {
+            throw new RuntimeException("Don't know how to config");
+        }
+    }
+
+    public void clearFixedHostname() throws Exception {
+        if (suiteContext.getAuthServerInfo().isUndertow()) {
+            configureUndertow("request", "localhost", -1, -1, false);
+        } else if (suiteContext.getAuthServerInfo().isJBossBased()) {
+            configureWildFly("request", "localhost", -1, -1, false);
+        } else {
+            throw new RuntimeException("Don't know how to config");
+        }
+    }
+
+    public void configureUndertow(String provider, String hostname, int httpPort, int httpsPort, boolean alwaysHttps) {
+        controller.stop(suiteContext.getAuthServerInfo().getQualifier());
+
+        System.setProperty("keycloak.hostname.provider", provider);
+        System.setProperty("keycloak.hostname.fixed.hostname", hostname);
+        System.setProperty("keycloak.hostname.fixed.httpPort", String.valueOf(httpPort));
+        System.setProperty("keycloak.hostname.fixed.httpsPort", String.valueOf(httpsPort));
+        System.setProperty("keycloak.hostname.fixed.alwaysHttps", String.valueOf(alwaysHttps));
+
+        controller.start(suiteContext.getAuthServerInfo().getQualifier());
+    }
+
+    public void configureWildFly(String provider, String hostname, int httpPort, int httpsPort, boolean alwaysHttps) throws Exception {
+        OnlineManagementClient client = AuthServerTestEnricher.getManagementClient(suiteContext.getAuthServerInfo());
+        Administration administration = new Administration(client);
+
+        client.execute("/subsystem=keycloak-server/spi=hostname:write-attribute(name=default-provider,value=" + provider + ")");
+        client.execute("/subsystem=keycloak-server/spi=hostname/provider=fixed:write-attribute(name=properties.hostname,value=" + hostname + ")");
+        client.execute("/subsystem=keycloak-server/spi=hostname/provider=fixed:write-attribute(name=properties.httpPort,value=" + httpPort + ")");
+        client.execute("/subsystem=keycloak-server/spi=hostname/provider=fixed:write-attribute(name=properties.httpsPort,value=" + httpsPort + ")");
+        client.execute("/subsystem=keycloak-server/spi=hostname/provider=fixed:write-attribute(name=properties.alwaysHttps,value=" + alwaysHttps + ")");
+
+        administration.reloadIfRequired();
+
+        client.close();
+    }
+}

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/ResourcesRestServiceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/ResourcesRestServiceTest.java
@@ -619,6 +619,7 @@ public class ResourcesRestServiceTest extends AbstractRestServiceTest {
 
         return AuthzClient
                 .create(new Configuration(suiteContext.getAuthServerInfo().getContextRoot().toString() + "/auth",
+                        suiteContext.getAuthServerInfo().getContextRoot().toString() + "/auth",
                         testRealm().toRepresentation().getRealm(), client.getClientId(),
                         credentials, httpClient));
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/BackChannelServletAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/BackChannelServletAdapterTest.java
@@ -1,0 +1,374 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.testsuite.adapter.servlet;
+
+import org.jboss.arquillian.container.test.api.ContainerController;
+import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.graphene.page.Page;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Element;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Test;
+import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.testsuite.adapter.AbstractServletsAdapterTest;
+import org.keycloak.testsuite.adapter.filter.AdapterActionsFilter;
+import org.keycloak.testsuite.adapter.page.BasicAuth;
+import org.keycloak.testsuite.adapter.page.SessionPortal;
+import org.keycloak.testsuite.adapter.page.TokenMinTTLPage;
+import org.keycloak.testsuite.arquillian.AppServerTestEnricher;
+import org.keycloak.testsuite.arquillian.annotation.AppServerContainer;
+import org.keycloak.testsuite.util.AuthServerConfigurationUtil;
+import org.keycloak.testsuite.utils.arquillian.ContainerConstants;
+import org.keycloak.util.BasicAuthHelper;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.core.Form;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.net.URI;
+
+import static javax.ws.rs.core.Response.Status.FOUND;
+import static javax.ws.rs.core.Response.Status.OK;
+import static org.junit.Assert.*;
+
+@AppServerContainer(ContainerConstants.APP_SERVER_UNDERTOW)
+@AppServerContainer(ContainerConstants.APP_SERVER_WILDFLY)
+@AppServerContainer(ContainerConstants.APP_SERVER_EAP)
+@AppServerContainer(ContainerConstants.APP_SERVER_EAP6)
+@AppServerContainer(ContainerConstants.APP_SERVER_EAP71)
+@AppServerContainer(ContainerConstants.APP_SERVER_TOMCAT7)
+@AppServerContainer(ContainerConstants.APP_SERVER_TOMCAT8)
+@AppServerContainer(ContainerConstants.APP_SERVER_TOMCAT9)
+@AppServerContainer(ContainerConstants.APP_SERVER_JETTY92)
+@AppServerContainer(ContainerConstants.APP_SERVER_JETTY93)
+@AppServerContainer(ContainerConstants.APP_SERVER_JETTY94)
+public class BackChannelServletAdapterTest extends AbstractServletsAdapterTest {
+
+    // NOTE: This test use an invalid frontchannel url, to verify that the adapter use it's (valid) backchannel url
+    private static final String AUTH_SERVER_HOST_PROPERTY = "auth.server.host";
+    private static final String INVALID_FRONTCHANNEL_HOST = "keycloak.invalid";
+
+    private static String hostBackup;
+    static {
+        hostBackup = System.getProperty(AUTH_SERVER_HOST_PROPERTY, "localhost");
+        System.setProperty(AUTH_SERVER_HOST_PROPERTY, INVALID_FRONTCHANNEL_HOST);
+    }
+
+    @ArquillianResource
+    private ContainerController controller;
+
+    @ArquillianResource
+    private Deployer deployer;
+
+    @Page
+    private SessionPortal sessionPortalPage;
+
+    @Page
+    private TokenMinTTLPage tokenMinTTLPage;
+
+    @Page
+    private BasicAuth basicAuthPage;
+
+
+    @Deployment(name = SessionPortal.DEPLOYMENT_NAME)
+    protected static WebArchive sessionPortalServlet() {
+        return servletDeployment(SessionPortal.DEPLOYMENT_NAME, "keycloak-backchannel.json", SessionServlet.class);
+    }
+
+    @Deployment(name = TokenMinTTLPage.DEPLOYMENT_NAME)
+    protected static WebArchive tokenMinTTLPage() {
+        return servletDeployment(TokenMinTTLPage.DEPLOYMENT_NAME, "keycloak-backchannel.json", AdapterActionsFilter.class, AbstractShowTokensServlet.class, TokenMinTTLServlet.class, ErrorServlet.class);
+    }
+
+    @Deployment(name = BasicAuth.DEPLOYMENT_NAME, managed = false)
+    protected static WebArchive basicAuthServlet() {
+        return servletDeployment(BasicAuth.DEPLOYMENT_NAME, "keycloak-backchannel.json", BasicAuthServlet.class);
+    }
+
+    @AfterClass
+    public static void resetAuthServerHost() {
+        System.setProperty(AUTH_SERVER_HOST_PROPERTY, hostBackup);
+    }
+
+    @Before
+    public void configureAuthServer() throws Exception {
+        configureFixedHostname();
+    }
+
+    @After
+    public void revertAuthServerConfiguration() throws Exception {
+        clearFixedHostname();
+    }
+
+    @Test
+    public void standardFlowLoginAndBackChannelLogout() {
+        Client client = ClientBuilder.newClient();
+        try {
+            // login
+            FakeStandardFlow standardFlow = new FakeStandardFlow(client, sessionPortalPage.toString());
+            ApplicationLoginResponse loginResponse = standardFlow.login("bburke@redhat.com", "password");
+
+            assertEquals(OK, loginResponse.getStatusInfo());
+            assertEquals(sessionPortalPage.toString(), loginResponse.getUrl());
+            assertTrue(loginResponse.getPageSource().contains("Counter=1"));
+
+            // logout
+            String logoutUrl = sessionPortalPage.logoutURL();
+            try (Response logoutRedirect = client.target(logoutUrl).request().get()) {
+                assertEquals(OK, logoutRedirect.getStatusInfo());
+                assertTrue(logoutRedirect.readEntity(String.class).isEmpty());
+            }
+
+            try (Response authServerRedirect = client.target(sessionPortalPage.toString()).request().get()) {
+                String authServerRedirectUrl = authServerRedirect.getHeaderString("Location");
+                String invalidAuthServerUrl = getInvalidAuthServerUrl();
+
+                assertEquals(FOUND, authServerRedirect.getStatusInfo());
+                assertTrue(authServerRedirectUrl.startsWith(invalidAuthServerUrl));
+            }
+        } finally {
+            client.close();
+        }
+    }
+
+    @Test
+    public void tokenRefresh() {
+        RealmRepresentation realm = getDemoRealm().toRepresentation();
+        int originalTokenLifespan = realm.getAccessTokenLifespan();
+        realm.setAccessTokenLifespan(10);
+        getDemoRealm().update(realm);
+
+        Client client = ClientBuilder.newClient();
+        try {
+            FakeStandardFlow standardFlow = new FakeStandardFlow(client, tokenMinTTLPage.toString());
+            ApplicationLoginResponse loginResponse = standardFlow.login("bburke@redhat.com", "password");
+
+            assertEquals(OK, loginResponse.getStatusInfo());
+            String initialToken = extractAccessToken(loginResponse.getPageSource(), TokenMinTTLPage.ACCESS_TOKEN_ID);
+            assertNotNull(initialToken);
+
+            setAdapterAndServerTimeOffset(12, tokenMinTTLPage.getUnsecuredUrl());
+
+            try (Response applicationRefresh = client.target(tokenMinTTLPage.toString()).request().get()) {
+                String pageSource = applicationRefresh.readEntity(String.class);
+                String refreshedToken = extractAccessToken(pageSource, TokenMinTTLPage.ACCESS_TOKEN_ID);
+
+                assertNotNull(refreshedToken);
+                assertNotEquals(initialToken, refreshedToken);
+            }
+        } finally {
+            realm.setAccessTokenLifespan(originalTokenLifespan);
+            getDemoRealm().update(realm);
+            setAdapterAndServerTimeOffset(0, tokenMinTTLPage.getUnsecuredUrl());
+            client.close();
+        }
+    }
+
+    @Test
+    public void basicAuthAndClientRegistration() {
+        String clientId = "basic-auth-service";
+
+        try {
+            assertNull(getClient(clientId).getRegisteredNodes());
+            deployer.deploy(BasicAuth.DEPLOYMENT_NAME);
+
+            Client client = ClientBuilder.newClient();
+            try {
+                String value = "hello";
+                URI uri = basicAuthPage.setTemplateValues(value).buildUri();
+                String authHeader = BasicAuthHelper.createHeader("mposolda", "password");
+
+                Invocation.Builder request = client.target(uri).request().header("Authorization", authHeader);
+                try (Response response = request.get()) {
+                    // basic auth
+                    assertEquals(OK, response.getStatusInfo());
+                    assertEquals(value, response.readEntity(String.class));
+
+                    // client registration
+                    assertEquals(1, getClient(clientId).getRegisteredNodes().size());
+                }
+            } finally {
+                client.close();
+            }
+        } finally {
+            deployer.undeploy(BasicAuth.DEPLOYMENT_NAME);
+
+            // it looks like the arquillian undeployment does not trigger client-unregistration on all appservers.
+            // https://www.keycloak.org/docs/latest/securing_apps/index.html#_registration_app_nodes
+            if(appServerTriggersNodeUnregistration()) {
+                // client unregistration
+                assertNull(getClient(clientId).getRegisteredNodes());
+            }
+        }
+    }
+
+    private boolean appServerTriggersNodeUnregistration() {
+        return !testContext.getAppServerInfo().isJBossBased() && !AppServerTestEnricher.isJettyAppServer();
+    }
+
+    private String getInvalidAuthServerUrl() {
+        String validRealmLoginPage = testRealmPage.toString();
+        String validAuthServerHost = testRealmPage.getInjectedUrl().getHost();
+        return validRealmLoginPage.replace(validAuthServerHost, INVALID_FRONTCHANNEL_HOST);
+    }
+
+    private String extractAccessToken(String html, String id) {
+        return Jsoup.parse(html).getElementById(id).text();
+    }
+
+
+    private RealmResource getDemoRealm() {
+        return adminClient.realm("demo");
+    }
+
+    private ClientRepresentation getClient(String clientId) {
+        return getDemoRealm().clients().findByClientId(clientId).get(0);
+    }
+
+    private void configureFixedHostname() throws Exception {
+        AuthServerConfigurationUtil authServerConfiguration = new AuthServerConfigurationUtil(suiteContext, controller);
+        authServerConfiguration.configureFixedHostname(INVALID_FRONTCHANNEL_HOST, -1, -1, false);
+
+        reconnectAdminClient();
+    }
+
+    private void clearFixedHostname() throws Exception {
+        AuthServerConfigurationUtil authServerConfiguration = new AuthServerConfigurationUtil(suiteContext, controller);
+        authServerConfiguration.clearFixedHostname();
+
+        reconnectAdminClient();
+    }
+
+    /**
+     * Do a standard flow login by replacing a invalid frontchannel host with a valid one.
+     */
+    private class FakeStandardFlow {
+        private final Client client;
+        private final String applicationUrl;
+
+        FakeStandardFlow(Client client, String applicationUrl) {
+            this.client = client;
+            this.applicationUrl = applicationUrl;
+        }
+
+        ApplicationLoginResponse login(String username, String password) {
+            String keycloakLoginFormRedirect = accessApplicationLoggedOut(applicationUrl);
+            String keycloakLoginFormActionUrl = loadLoginFormAndGetActionUrl(keycloakLoginFormRedirect);
+            String applicationCodeToTokenRedirect = submitLoginForm(keycloakLoginFormActionUrl, username, password);
+            String applicationRedirect = applicationCodeToTokenExchange(applicationCodeToTokenRedirect);
+
+            return accessApplicationLoggedIn(applicationRedirect);
+        }
+
+        private String accessApplicationLoggedOut(String applicationUrl) {
+            try (Response applicationRedirect = client.target(applicationUrl).request().get()) {
+                assertEquals("access application before login failed", FOUND, applicationRedirect.getStatusInfo());
+
+                String applicationRedirectUrl = getLocationHeader(applicationRedirect);
+                return replaceInvalidFrontChannelHost(applicationRedirectUrl);
+            }
+        }
+
+        private String loadLoginFormAndGetActionUrl(String keycloakLoginFormUrl) {
+            try (Response loginForm = client.target(keycloakLoginFormUrl).request().get()) {
+                assertEquals("loading login form failed", OK, loginForm.getStatusInfo());
+
+                String loginPageSource = loginForm.readEntity(String.class);
+                String loginFormActionUrl = extractLoginFormActionUrl(loginPageSource);
+                return replaceInvalidFrontChannelHost(loginFormActionUrl);
+            }
+        }
+
+        private String submitLoginForm(String loginFormActionUrl, String username, String password) {
+            Form form = new Form();
+            form.param("username", username);
+            form.param("password", password);
+
+            Invocation.Builder loginFormRequest = client.target(loginFormActionUrl).request(MediaType.APPLICATION_FORM_URLENCODED);
+            try (Response loginRedirect = loginFormRequest.post(Entity.form(form))) {
+                assertEquals("submit login form failed", FOUND, loginRedirect.getStatusInfo());
+
+                return getLocationHeader(loginRedirect);
+            }
+        }
+
+        private String applicationCodeToTokenExchange(String applicationRedirect) {
+            try (Response codeToTokenResponse = client.target(applicationRedirect).request().get()) {
+                assertEquals("code-to-token exchange failed", FOUND, codeToTokenResponse.getStatusInfo());
+
+                return getLocationHeader(codeToTokenResponse);
+            }
+        }
+
+        private ApplicationLoginResponse accessApplicationLoggedIn(String applicationRedirect) {
+            try (Response applicationResponse = client.target(applicationRedirect).request().get()) {
+                assertEquals("access application after login failed", OK, applicationResponse.getStatusInfo());
+
+                String applicationPageSource = applicationResponse.readEntity(String.class);
+                return new ApplicationLoginResponse(applicationRedirect, applicationResponse.getStatusInfo(), applicationPageSource);
+            }
+        }
+
+        private String extractLoginFormActionUrl(String loginPageSource) {
+            Element loginForm = Jsoup.parse(loginPageSource).getElementById("kc-form-login");
+            return loginForm.attr("action");
+        }
+
+        private String replaceInvalidFrontChannelHost(String frontChannelUrl) {
+            String validFrontChannelHost = authServerContextRootPage.getInjectedUrl().getHost();
+            return frontChannelUrl.replace(INVALID_FRONTCHANNEL_HOST, validFrontChannelHost);
+        }
+
+        private String getLocationHeader(Response redirect) {
+            return redirect.getHeaderString("Location");
+        }
+    }
+
+    private static class ApplicationLoginResponse {
+        private final String url;
+        private final Response.StatusType status;
+        private final String pageSource;
+
+        ApplicationLoginResponse(String url, Response.StatusType status, String pageSource) {
+            this.url = url;
+            this.status = status;
+            this.pageSource = pageSource;
+        }
+
+        String getUrl() {
+            return url;
+        }
+
+        Response.StatusType getStatusInfo() {
+            return status;
+        }
+
+        String getPageSource() {
+            return pageSource;
+        }
+    }
+}

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/AuthzClientBackChannelTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/AuthzClientBackChannelTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.testsuite.authz;
+
+import org.junit.Test;
+import org.keycloak.authorization.client.AuthzClient;
+import org.keycloak.authorization.client.representation.TokenIntrospectionResponse;
+import org.keycloak.authorization.client.resource.PermissionResource;
+import org.keycloak.authorization.client.resource.PolicyResource;
+import org.keycloak.authorization.client.resource.ProtectedResource;
+import org.keycloak.authorization.client.resource.ProtectionResource;
+import org.keycloak.representations.AccessTokenResponse;
+import org.keycloak.representations.idm.authorization.PermissionTicketRepresentation;
+import org.keycloak.representations.idm.authorization.ResourceRepresentation;
+import org.keycloak.representations.idm.authorization.UmaPermissionRepresentation;
+
+import java.io.IOException;
+import java.util.List;
+
+import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class AuthzClientBackChannelTest extends AbstractResourceServerTest {
+
+    @Override
+    protected AuthzClient getAuthzClient() {
+        try {
+            return AuthzClient.create(httpsAwareConfigurationStream(getClass().getResourceAsStream("/authorization-test/keycloak-backchannel.json")));
+        } catch (IOException cause) {
+            throw new RuntimeException("Failed to create authz client", cause);
+        }
+    }
+
+    @Test
+    public void tokenIntrospectionEndpoint() {
+        AuthzClient client = getAuthzClient();
+        ProtectionResource protection = client.protection();
+        AccessTokenResponse tokenResponse = client.obtainAccessToken();
+
+        TokenIntrospectionResponse response = protection.introspectRequestingPartyToken(tokenResponse.getToken());
+
+        assertNotNull(response);
+    }
+
+    @Test
+    public void resourceRegistrationEndpoint() {
+        AuthzClient client = getAuthzClient();
+        ProtectedResource protectionResource = client.protection().resource();
+
+        String[] protectedResources = protectionResource.findAll();
+
+        assertEquals(0, protectedResources.length);
+    }
+
+    @Test
+    public void permissionEndpoint() {
+        AuthzClient client = getAuthzClient();
+        PermissionResource permissionResource = client.protection().permission();
+        List<PermissionTicketRepresentation> tickets = permissionResource.findByScope("not-existent");
+
+        assertTrue(tickets.isEmpty());
+    }
+
+    @Test
+    public void policyEndpoint() throws Exception {
+        ResourceRepresentation resource = addResource("resource-backchannel");
+
+        AuthzClient client = getAuthzClient();
+        PolicyResource policyResource = client.protection().policy(resource.getId());
+
+        List<UmaPermissionRepresentation> permissions = policyResource.find("not-existent", null, null, null);
+
+        assertTrue(permissions.isEmpty());
+    }
+
+}

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/AuthzClientCredentialsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/AuthzClientCredentialsTest.java
@@ -252,7 +252,7 @@ public class AuthzClientCredentialsTest extends AbstractAuthzTest {
     private AuthzClient getAuthzClient(String adapterConfig) {
         KeycloakDeployment deployment = KeycloakDeploymentBuilder.build(getConfigurationStream(adapterConfig));
 
-        return AuthzClient.create(new Configuration(deployment.getAuthServerBaseUrl(), deployment.getRealm(), deployment.getResourceName(), deployment.getResourceCredentials(), deployment.getClient()), new ClientAuthenticator() {
+        return AuthzClient.create(new Configuration(deployment.getAuthServerBaseUrl(), deployment.getAuthServerBaseUrl(), deployment.getRealm(), deployment.getResourceName(), deployment.getResourceCredentials(), deployment.getClient()), new ClientAuthenticator() {
             @Override
             public void configureClientCredentials(Map<String, List<String>> requestParams, Map<String, String> requestHeaders) {
                 Map<String, String> formparams = new HashMap<>();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/EntitlementAPITest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/EntitlementAPITest.java
@@ -2016,7 +2016,7 @@ public class EntitlementAPITest extends AbstractAuthzTest {
             HttpClient client = HttpClients.custom()
                     .setConnectionManager(connectionManager)
                     .build();
-            authzClient = AuthzClient.create(new Configuration(configuration.getAuthServerUrl(), configuration.getRealm(), configuration.getResource(), configuration.getCredentials(), client));
+            authzClient = AuthzClient.create(new Configuration(configuration.getAuthServerUrl(),configuration.getAuthServerBackChannelUrl(), configuration.getRealm(), configuration.getResource(), configuration.getCredentials(), client));
         }
 
         return authzClient;

--- a/testsuite/integration-arquillian/tests/base/src/test/resources/adapter-test/basic-auth/WEB-INF/keycloak-backchannel.json
+++ b/testsuite/integration-arquillian/tests/base/src/test/resources/adapter-test/basic-auth/WEB-INF/keycloak-backchannel.json
@@ -1,0 +1,12 @@
+{
+  "realm" : "demo",
+  "resource" : "basic-auth-service",
+  "auth-server-url": "https://keycloak.invalid:8543/auth/",
+  "auth-server-backchannel-url": "https://localhost:8543/auth/",
+  "ssl-required" : "external",
+  "enable-basic-auth" : "true",
+  "register-node-at-startup": true,
+  "credentials": {
+    "secret": "password"
+  }
+}

--- a/testsuite/integration-arquillian/tests/base/src/test/resources/adapter-test/session-portal/WEB-INF/keycloak-backchannel.json
+++ b/testsuite/integration-arquillian/tests/base/src/test/resources/adapter-test/session-portal/WEB-INF/keycloak-backchannel.json
@@ -1,0 +1,10 @@
+{
+  "realm" : "demo",
+  "resource" : "session-portal",
+  "auth-server-url" : "https://keycloak.invalid:8543/auth/",
+  "auth-server-backchannel-url": "https://localhost:8543/auth/",
+  "ssl-required" : "external",
+  "credentials" : {
+      "secret": "password"
+   }
+}

--- a/testsuite/integration-arquillian/tests/base/src/test/resources/adapter-test/token-min-ttl/WEB-INF/keycloak-backchannel.json
+++ b/testsuite/integration-arquillian/tests/base/src/test/resources/adapter-test/token-min-ttl/WEB-INF/keycloak-backchannel.json
@@ -1,0 +1,10 @@
+{
+  "realm": "demo",
+  "resource": "token-min-ttl",
+  "auth-server-url" : "https://keycloak.invalid:8543/auth/",
+  "auth-server-backchannel-url": "https://localhost:8543/auth/",
+  "ssl-required" : "external",
+  "credentials": {
+    "secret": "password"
+  }
+}

--- a/testsuite/integration-arquillian/tests/base/src/test/resources/authorization-test/keycloak-backchannel.json
+++ b/testsuite/integration-arquillian/tests/base/src/test/resources/authorization-test/keycloak-backchannel.json
@@ -1,0 +1,9 @@
+{
+    "realm": "authz-test",
+    "auth-server-url" : "https://keycloak.invalid:8543/auth/",
+    "auth-server-backchannel-url" : "http://localhost:8180/auth",
+    "resource" : "resource-server-test",
+    "credentials": {
+        "secret": "secret"
+    }
+}

--- a/testsuite/integration-arquillian/tests/pom.xml
+++ b/testsuite/integration-arquillian/tests/pom.xml
@@ -56,6 +56,7 @@
         <auth.server.config.dir>${auth.server.home}</auth.server.config.dir>
 
         <auth.server.host>localhost</auth.server.host>
+        <auth.server.backchannel.host>localhost</auth.server.backchannel.host>
         <auth.server.browserHost/> <!-- if set, this host will be used by the browser instead of auth.server.host -->
         <auth.server.port.offset>100</auth.server.port.offset>
         <auth.server.http.port>8180</auth.server.http.port>
@@ -421,6 +422,7 @@
                             <auth.server.java.home>${auth.server.java.home}</auth.server.java.home>
 
                             <auth.server.host>${auth.server.host}</auth.server.host>
+                            <auth.server.backchannel.host>${auth.server.backchannel.host}</auth.server.backchannel.host>
                             <auth.server.browserHost>${auth.server.browserHost}</auth.server.browserHost>
                             <auth.server.port.offset>${auth.server.port.offset}</auth.server.port.offset>
                             <auth.server.http.port>${auth.server.http.port}</auth.server.http.port>

--- a/testsuite/integration-arquillian/util/src/main/java/org/keycloak/testsuite/utils/arquillian/DeploymentArchiveProcessorUtils.java
+++ b/testsuite/integration-arquillian/util/src/main/java/org/keycloak/testsuite/utils/arquillian/DeploymentArchiveProcessorUtils.java
@@ -195,6 +195,9 @@ public class DeploymentArchiveProcessorUtils {
                     .getAsset().openStream(), AdapterConfig.class);
 
             adapterConfig.setAuthServerUrl(getAuthServerUrl());
+            if(adapterConfig.getAuthServerBackChannelUrl() != null) {
+                adapterConfig.setAuthServerBackChannelUrl(getAuthServerBackChannelUrl());
+            }
 
             if (APP_SERVER_SSL_REQUIRED) {
                 adapterConfig.setSslRequired("all");
@@ -252,8 +255,16 @@ public class DeploymentArchiveProcessorUtils {
     }
 
     private static String getAuthServerUrl() {
+        return getAuthServerUrl("auth.server.host");
+    }
+
+    private static String getAuthServerBackChannelUrl() {
+        return getAuthServerUrl("auth.server.backchannel.host");
+    }
+
+    private static String getAuthServerUrl(String authServerHostProperty) {
         String scheme = AUTH_SERVER_SSL_REQUIRED ? "https" : "http";
-        String host = System.getProperty("auth.server.host", "localhost");
+        String host = System.getProperty(authServerHostProperty, "localhost");
         String port = AUTH_SERVER_SSL_REQUIRED ? System.getProperty("auth.server.https.port", "8443") :
                 System.getProperty("auth.server.http.port", "8180");
 


### PR DESCRIPTION
[KEYCLOAK-6073](https://issues.jboss.org/browse/KEYCLOAK-6073)

[Documentation](https://github.com/keycloak/keycloak-documentation/pull/683)

**Description**
If `auth-server-backchannel-url` is configured the current implementation always resolve backchannel urls during KeycloakDeployment creation (they should never change).

**Absolute `auth-server-url` case**
* During the creation of the KeycloakDeployment frontchannel and backchannel urls are resolved.

**Relative `auth-server-url` case**
* During the creation of the KeycloakDeployment only backchannel urls are resolved. Frontchannel urls will be resolved for each request (AdapterDeploymentContext).

The PR currently contains two commits (implementation, integration tests), maybe this might be helpful during the review. If you prefer a single commit for the review, just let me know and i will squash it.
