### PR TITLE
[KEYCLOAK-10710] Make social providers compatible with UsernameTemplateMappers

### DIFF
--- a/services/src/main/java/org/keycloak/broker/oidc/mappers/UsernameTemplateMapper.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/mappers/UsernameTemplateMapper.java
@@ -26,6 +26,18 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.social.bitbucket.BitbucketIdentityProviderFactory;
+import org.keycloak.social.facebook.FacebookIdentityProviderFactory;
+import org.keycloak.social.github.GitHubIdentityProviderFactory;
+import org.keycloak.social.gitlab.GitLabIdentityProviderFactory;
+import org.keycloak.social.google.GoogleIdentityProviderFactory;
+import org.keycloak.social.instagram.InstagramIdentityProviderFactory;
+import org.keycloak.social.linkedin.LinkedInIdentityProviderFactory;
+import org.keycloak.social.microsoft.MicrosoftIdentityProviderFactory;
+import org.keycloak.social.openshift.OpenshiftV3IdentityProviderFactory;
+import org.keycloak.social.paypal.PayPalIdentityProviderFactory;
+import org.keycloak.social.stackoverflow.StackoverflowIdentityProviderFactory;
+import org.keycloak.social.twitter.TwitterIdentityProviderFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -38,7 +50,22 @@ import java.util.regex.Pattern;
  */
 public class UsernameTemplateMapper extends AbstractClaimMapper {
 
-    public static final String[] COMPATIBLE_PROVIDERS = {KeycloakOIDCIdentityProviderFactory.PROVIDER_ID, OIDCIdentityProviderFactory.PROVIDER_ID};
+    public static final String[] COMPATIBLE_PROVIDERS = {
+            KeycloakOIDCIdentityProviderFactory.PROVIDER_ID,
+            OIDCIdentityProviderFactory.PROVIDER_ID,
+            BitbucketIdentityProviderFactory.PROVIDER_ID,
+            FacebookIdentityProviderFactory.PROVIDER_ID,
+            GitHubIdentityProviderFactory.PROVIDER_ID,
+            GitLabIdentityProviderFactory.PROVIDER_ID,
+            GoogleIdentityProviderFactory.PROVIDER_ID,
+            InstagramIdentityProviderFactory.PROVIDER_ID,
+            LinkedInIdentityProviderFactory.PROVIDER_ID,
+            MicrosoftIdentityProviderFactory.PROVIDER_ID,
+            OpenshiftV3IdentityProviderFactory.PROVIDER_ID,
+            PayPalIdentityProviderFactory.PROVIDER_ID,
+            StackoverflowIdentityProviderFactory.PROVIDER_ID,
+            TwitterIdentityProviderFactory.PROVIDER_ID
+    };
 
     private static final List<ProviderConfigProperty> configProperties = new ArrayList<ProviderConfigProperty>();
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/IdentityProviderTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/IdentityProviderTest.java
@@ -249,37 +249,37 @@ public class IdentityProviderTest extends AbstractAdminTest {
         create(createRep("google", "google"));
         provider = realm.identityProviders().get("google");
         mapperTypes = provider.getMapperTypes();
-        assertMapperTypes(mapperTypes, "google-user-attribute-mapper");
+        assertMapperTypes(mapperTypes, "google-user-attribute-mapper", "oidc-username-idp-mapper");
 
         create(createRep("facebook", "facebook"));
         provider = realm.identityProviders().get("facebook");
         mapperTypes = provider.getMapperTypes();
-        assertMapperTypes(mapperTypes, "facebook-user-attribute-mapper");
+        assertMapperTypes(mapperTypes, "facebook-user-attribute-mapper", "oidc-username-idp-mapper");
 
         create(createRep("github", "github"));
         provider = realm.identityProviders().get("github");
         mapperTypes = provider.getMapperTypes();
-        assertMapperTypes(mapperTypes, "github-user-attribute-mapper");
+        assertMapperTypes(mapperTypes, "github-user-attribute-mapper", "oidc-username-idp-mapper");
 
         create(createRep("twitter", "twitter"));
         provider = realm.identityProviders().get("twitter");
         mapperTypes = provider.getMapperTypes();
-        assertMapperTypes(mapperTypes);
+        assertMapperTypes(mapperTypes, "oidc-username-idp-mapper");
 
         create(createRep("linkedin", "linkedin"));
         provider = realm.identityProviders().get("linkedin");
         mapperTypes = provider.getMapperTypes();
-        assertMapperTypes(mapperTypes, "linkedin-user-attribute-mapper");
+        assertMapperTypes(mapperTypes, "linkedin-user-attribute-mapper", "oidc-username-idp-mapper");
 
         create(createRep("microsoft", "microsoft"));
         provider = realm.identityProviders().get("microsoft");
         mapperTypes = provider.getMapperTypes();
-        assertMapperTypes(mapperTypes, "microsoft-user-attribute-mapper");
+        assertMapperTypes(mapperTypes, "microsoft-user-attribute-mapper", "oidc-username-idp-mapper");
 
         create(createRep("stackoverflow", "stackoverflow"));
         provider = realm.identityProviders().get("stackoverflow");
         mapperTypes = provider.getMapperTypes();
-        assertMapperTypes(mapperTypes, "stackoverflow-user-attribute-mapper");
+        assertMapperTypes(mapperTypes, "stackoverflow-user-attribute-mapper", "oidc-username-idp-mapper");
 
         create(createRep("keycloak-oidc", "keycloak-oidc"));
         provider = realm.identityProviders().get("keycloak-oidc");


### PR DESCRIPTION
Hi,
I'm proposing a change for the issue described in: https://issues.jboss.org/browse/KEYCLOAK-10710

The mapper functionality is identical in social providers and generic OIDC providers, so they can be set as compatible.

I configured and tested this mapper for Facebook, GitHub, Google and LinkedIn, including some specific claims in the template (e.g. `${CLAIM.id}@linkedin` for LinkedIn, `${CLAIM.sub}@google` for Google).