### PR TITLE
KEYCLOAK-10712 get groups full representation endpoint

### DIFF
--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/GroupsResource.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/GroupsResource.java
@@ -69,6 +69,22 @@ public interface GroupsResource {
                                      @QueryParam("max") Integer max);
 
     /**
+     * Get groups by pagination params.
+     * @param search max number of occurrences
+     * @param first index of the first element
+     * @param max max number of occurrences
+     * @param fullRepresentation if true, return groups with their attributes
+     * @return A list containing the slice of all groups.
+     */
+    @GET
+    @NoCache
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    List<GroupRepresentation> groups(@QueryParam("search") String search,
+                                     @QueryParam("first") Integer first,
+                                     @QueryParam("max") Integer max,
+                                     @QueryParam("full") @DefaultValue("false") boolean fullRepresentation);
+    /**
      * Counts all groups.
      * @return A map containing key "count" with number of groups as value.
      */

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
@@ -95,12 +95,12 @@ public class ModelToRepresentation {
         return rep;
     }
 
-    public static List<GroupRepresentation> searchForGroupByName(RealmModel realm, String search, Integer first, Integer max) {
+    public static List<GroupRepresentation> searchForGroupByName(RealmModel realm, boolean full, String search, Integer first, Integer max) {
         List<GroupRepresentation> result = new LinkedList<>();
         List<GroupModel> groups = realm.searchForGroupByName(search, first, max);
         if (Objects.isNull(groups)) return result;
         for (GroupModel group : groups) {
-            GroupRepresentation rep = toGroupHierarchy(group, false);
+            GroupRepresentation rep = toGroupHierarchy(group, full);
             result.add(rep);
         }
         return result;

--- a/services/src/main/java/org/keycloak/services/resources/admin/GroupsResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/GroupsResource.java
@@ -74,17 +74,18 @@ public class GroupsResource {
     @Produces(MediaType.APPLICATION_JSON)
     public List<GroupRepresentation> getGroups(@QueryParam("search") String search,
                                                @QueryParam("first") Integer firstResult,
-                                               @QueryParam("max") Integer maxResults) {
+                                               @QueryParam("max") Integer maxResults,
+                                               @QueryParam("full") @DefaultValue("false") boolean fullRepresentation) {
         auth.groups().requireList();
 
         List<GroupRepresentation> results;
 
         if (Objects.nonNull(search)) {
-            results = ModelToRepresentation.searchForGroupByName(realm, search.trim(), firstResult, maxResults);
+            results = ModelToRepresentation.searchForGroupByName(realm, fullRepresentation, search.trim(), firstResult, maxResults);
         } else if(Objects.nonNull(firstResult) && Objects.nonNull(maxResults)) {
-            results = ModelToRepresentation.toGroupHierarchy(realm, false, firstResult, maxResults);
+            results = ModelToRepresentation.toGroupHierarchy(realm, fullRepresentation, firstResult, maxResults);
         } else {
-            results = ModelToRepresentation.toGroupHierarchy(realm, false);
+            results = ModelToRepresentation.toGroupHierarchy(realm, fullRepresentation);
         }
 
         return results;
@@ -140,7 +141,7 @@ public class GroupsResource {
     public Response addTopLevelGroup(GroupRepresentation rep) {
         auth.groups().requireManage();
 
-        List<GroupRepresentation> search = ModelToRepresentation.searchForGroupByName(realm, rep.getName(), 0, 1);
+        List<GroupRepresentation> search = ModelToRepresentation.searchForGroupByName(realm, false, rep.getName(), 0, 1);
         if (search != null && !search.isEmpty() && Objects.equals(search.get(0).getName(), rep.getName())) {
             return ErrorResponse.exists("Top level group named '" + rep.getName() + "' already exists.");
         }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/group/GroupTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/group/GroupTest.java
@@ -52,9 +52,12 @@ import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import javax.ws.rs.ClientErrorException;
 import javax.ws.rs.core.Response.Status;
@@ -670,6 +673,44 @@ public class GroupTest extends AbstractGroupTest {
             assertEquals(110, group.members(0, 1000).size());
             assertEquals(110, group.members(-1, -2).size());
         }
+    }
+    
+    @Test
+    public void getGroupsWithFullRepresentation() {
+        RealmResource realm = adminClient.realms().realm("test");
+        GroupsResource groupsResource = adminClient.realms().realm("test").groups();
+        
+        GroupRepresentation group = new GroupRepresentation();
+        group.setName("groupWithAttribute");
+        
+        Map<String, List<String>> attributes = new HashMap<String, List<String>>();
+        attributes.put("attribute1", Arrays.asList("attribute1","attribute2"));
+		group.setAttributes(attributes);
+        group = createGroup(realm, group);
+        
+        List<GroupRepresentation> groups = groupsResource.groups("groupWithAttribute", 0, 20, true);
+        
+        assertFalse(groups.isEmpty());
+        assertTrue(groups.get(0).getAttributes().containsKey("attribute1"));
+    }
+    
+    @Test
+    public void getGroupsWithBriefRepresentation() {
+        RealmResource realm = adminClient.realms().realm("test");
+        GroupsResource groupsResource = adminClient.realms().realm("test").groups();
+        
+        GroupRepresentation group = new GroupRepresentation();
+        group.setName("groupWithAttribute");
+        
+        Map<String, List<String>> attributes = new HashMap<String, List<String>>();
+        attributes.put("attribute1", Arrays.asList("attribute1","attribute2"));
+		group.setAttributes(attributes);
+        group = createGroup(realm, group);
+        
+        List<GroupRepresentation> groups = groupsResource.groups("groupWithAttribute", 0, 20);
+        
+        assertFalse(groups.isEmpty());
+        assertNull(groups.get(0).getAttributes());
     }
 
     @Test


### PR DESCRIPTION
JIRA

https://issues.jboss.org/browse/KEYCLOAK-10712

The get groups endpoint is not coherent with the documentation and the others endpoint. He don't return a full representation of a group ( in my case I need the attributes ). So I added an optional query parameters ( still false by default ) to have the ability to fetch theses extra info missing.
