### PR TITLE
KEYCLOAK-10734 Let the check-sso feature do the check in hidden iframe

### DIFF
--- a/adapters/oidc/js/src/main/resources/keycloak.d.ts
+++ b/adapters/oidc/js/src/main/resources/keycloak.d.ts
@@ -107,6 +107,13 @@ declare namespace Keycloak {
 		redirectUri?: string;
 
 		/**
+		 * Specifies an uri to redirect to after silent check-sso.
+		 * Silent check-sso will only happen, when this redirect uri is given and
+		 * the specified uri is available whithin the application.
+		 */
+		silentCheckSsoRedirectUri?: string;
+
+		/**
 		 * Set the OpenID Connect flow.
 		 * @default standard
 		 */

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/rest/resource/TestJavascriptResource.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/rest/resource/TestJavascriptResource.java
@@ -31,6 +31,13 @@ public class TestJavascriptResource {
     }
 
     @GET
+    @Path("/silent-check-sso.html")
+    @Produces(MediaType.TEXT_HTML)
+    public String getJavascriptTestingEnvironmentSilentCheckSso() throws IOException {
+        return resourceToString("/javascript/silent-check-sso.html");
+    }
+
+    @GET
     @Path("/keycloak.json")
     @Produces(MediaType.APPLICATION_JSON)
     public String getKeycloakJSON() throws IOException {

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/resources/javascript/silent-check-sso.html
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/resources/javascript/silent-check-sso.html
@@ -1,0 +1,1 @@
+<html><body><script>parent.postMessage(location.href, location.origin)</script></body></html>

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/javascript/JSObjectBuilder.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/javascript/JSObjectBuilder.java
@@ -78,6 +78,10 @@ public class JSObjectBuilder {
         return this;
     }
 
+    private boolean skipQuotes(Object o) {
+        return (o instanceof Integer || o instanceof Boolean);
+    }
+
     public String build() {
         StringBuilder argument = new StringBuilder("{");
         String comma = "";
@@ -86,11 +90,11 @@ public class JSObjectBuilder {
                     .append(option.getKey())
                     .append(" : ");
 
-            if (!(option.getValue() instanceof Integer)) argument.append("\"");
+            if (!skipQuotes(option.getValue())) argument.append("\"");
 
             argument.append(option.getValue());
 
-            if (!(option.getValue() instanceof Integer)) argument.append("\"");
+            if (!skipQuotes(option.getValue())) argument.append("\"");
             comma = ",";
         }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/javascript/JavascriptAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/javascript/JavascriptAdapterTest.java
@@ -47,6 +47,7 @@ import static org.hamcrest.collection.IsMapContaining.hasEntry;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.keycloak.testsuite.util.URLAssert.assertCurrentUrlDoesntStartWith;
 import static org.keycloak.testsuite.util.URLAssert.assertCurrentUrlStartsWith;
 import static org.keycloak.testsuite.util.WaitUtils.waitForPageToLoad;
@@ -151,6 +152,58 @@ public class JavascriptAdapterTest extends AbstractJavascriptTest {
                 .init(pkceS256, this::assertSuccessfullyLoggedIn)
                 .logout(this::assertOnTestAppUrl)
                 .init(pkceS256, this::assertInitNotAuth);
+    }
+
+    @Test
+    public void testSilentCheckSso() {
+        JSObjectBuilder checkSSO = defaultArguments().checkSSOOnLoad();
+        testExecutor.init(checkSSO, this::assertInitNotAuth)
+                .login(this::assertOnLoginPage)
+                .loginForm(testUser, this::assertOnTestAppUrl)
+                .init(checkSSO, this::assertSuccessfullyLoggedIn)
+                .refresh()
+                .init(checkSSO
+                        .add("silentCheckSsoRedirectUri", authServerContextRootPage + JAVASCRIPT_URL + "/silent-check-sso.html")
+                        , this::assertSuccessfullyLoggedIn);
+    }
+
+    @Test
+    public void testSilentCheckSsoLoginWithLoginIframeDisabled() {
+        JSObjectBuilder checkSSO = defaultArguments().checkSSOOnLoad();
+        testExecutor.init(checkSSO, this::assertInitNotAuth)
+                .login(this::assertOnLoginPage)
+                .loginForm(testUser, this::assertOnTestAppUrl)
+                .init(checkSSO, this::assertSuccessfullyLoggedIn)
+                .refresh()
+                .init(checkSSO
+                        .add("checkLoginIframe", false)
+                        .add("silentCheckSsoRedirectUri", authServerContextRootPage + JAVASCRIPT_URL + "/silent-check-sso.html")
+                        , this::assertSuccessfullyLoggedIn);
+    }
+
+    @Test
+    public void testSilentCheckSsoWithoutRedirectUri() {
+        JSObjectBuilder checkSSO = defaultArguments().checkSSOOnLoad();
+        try {
+            testExecutor.init(checkSSO, this::assertInitNotAuth)
+                    .login(this::assertOnLoginPage)
+                    .loginForm(testUser, this::assertOnTestAppUrl)
+                    .init(checkSSO, this::assertSuccessfullyLoggedIn)
+                    .refresh()
+                    .init(checkSSO);
+            fail();
+        } catch (WebDriverException e) {
+            // should happen
+        }
+    }
+
+    @Test
+    public void testSilentCheckSsoNotAuthenticated() {
+        JSObjectBuilder checkSSO = defaultArguments().checkSSOOnLoad();
+        testExecutor.init(checkSSO
+                .add("checkLoginIframe", false)
+                .add("silentCheckSsoRedirectUri", authServerContextRootPage + JAVASCRIPT_URL + "/silent-check-sso.html")
+                , this::assertInitNotAuth);
     }
 
     @Test


### PR DESCRIPTION
This is yet a _work-in-progress_ PR for https://issues.jboss.org/browse/KEYCLOAK-10734, based on the discussions in https://github.com/keycloak/keycloak/pull/5932

Still no tests and still no documentation.

Similar to the originating PR, it's necessary to specifiy a `silentCheckSsoRedirectUri` at the KC.init() method and providing a valid endpoint at the specified uri within the application of course (e.g. like documented here: https://github.com/keycloak/keycloak-documentation/pull/600/files#diff-e17f71a40a51038c46666bac2e71268dR160).

I'd like to discuss, if this yields into the right direction (@stianst ?)