### PR TITLE
[KEYCLOAK-10745] Update KeycloakTokenParsed definition.

### DIFF
--- a/adapters/oidc/js/src/main/resources/keycloak.d.ts
+++ b/adapters/oidc/js/src/main/resources/keycloak.d.ts
@@ -238,8 +238,8 @@ declare namespace Keycloak {
 		nonce?: string;
 		sub?: string;
 		session_state?: string;
-		realm_access?: { roles: string[] };
-		resource_access?: string[];
+		realm_access?: KeycloakRoles;
+		resource_access?: KeycloakResourceAccess;
 	}
 
 	interface KeycloakResourceAccess {


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/KEYCLOAK-10745

To match KeycloakInstance's realm_access and resources_access.

Currently, they are:
```'typescript'
realm_access?: { roles: string[] };
resource_access?: string[];
```

Their KeycloakInstance counterpart are using:
```'typescript'
realmAccess?: KeycloakRoles;
resourceAccess?: KeycloakResourceAccess;
```

realm_access still cast correctly by resource_access is outright wrong type.