### PR TITLE
KEYCLOAK-10747 Explicit Proof Key for Code Exchange Activation Settings

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCAdvancedConfigWrapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCAdvancedConfigWrapper.java
@@ -118,6 +118,14 @@ public class OIDCAdvancedConfigWrapper {
         setAttribute(OIDCConfigAttributes.USE_MTLS_HOK_TOKEN, val);
     }
 
+    public String getPkceCodeChallengeMethod() {
+        return getAttribute(OIDCConfigAttributes.PKCE_CODE_CHALLENGE_METHOD);
+    }
+
+    public void setPkceCodeChallengeMethod(String codeChallengeMethodName) {
+        setAttribute(OIDCConfigAttributes.PKCE_CODE_CHALLENGE_METHOD, codeChallengeMethodName);
+    }
+
     public String getIdTokenSignedResponseAlg() {
         return getAttribute(OIDCConfigAttributes.ID_TOKEN_SIGNED_RESPONSE_ALG);
     }

--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCConfigAttributes.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCConfigAttributes.java
@@ -41,6 +41,8 @@ public final class OIDCConfigAttributes {
 
     public static final String ACCESS_TOKEN_LIFESPAN = "access.token.lifespan";
 
+    public static final String PKCE_CODE_CHALLENGE_METHOD = "pkce.code.challenge.method";
+
     private OIDCConfigAttributes() {
     }
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
@@ -364,47 +364,13 @@ public class TokenEndpoint {
         if (authUsername == null) {
             authUsername = "unknown";
         }
-        if (codeChallenge != null && codeVerifier == null) {
-            logger.warnf("PKCE code verifier not specified, authUserId = %s, authUsername = %s", authUserId, authUsername);
-            event.error(Errors.CODE_VERIFIER_MISSING);
-            throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_GRANT, "PKCE code verifier not specified", Response.Status.BAD_REQUEST);
+
+        if (codeChallengeMethod != null && !codeChallengeMethod.isEmpty()) {
+            checkParamsForPkceEnforcedClient(codeVerifier, codeChallenge, codeChallengeMethod, authUserId, authUsername);
+        } else {
+            // PKCE Activation is OFF, execute the codes implemented in KEYCLOAK-2604
+            checkParamsForPkceNotEnforcedClient(codeVerifier, codeChallenge, codeChallengeMethod, authUserId, authUsername);
         }
-
-        if (codeChallenge != null) {
-            // based on whether code_challenge has been stored at corresponding authorization code request previously
-            // decide whether this client(RP) supports PKCE
-            if (!isValidPkceCodeVerifier(codeVerifier)) {
-                logger.infof("PKCE invalid code verifier");
-                event.error(Errors.INVALID_CODE_VERIFIER);
-                throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_GRANT, "PKCE invalid code verifier", Response.Status.BAD_REQUEST);
-            }
-
-            logger.debugf("PKCE supporting Client, codeVerifier = %s", codeVerifier);
-            String codeVerifierEncoded = codeVerifier;
-            try {
-                // https://tools.ietf.org/html/rfc7636#section-4.2
-                // plain or S256
-                if (codeChallengeMethod != null && codeChallengeMethod.equals(OAuth2Constants.PKCE_METHOD_S256)) {
-                    logger.debugf("PKCE codeChallengeMethod = %s", codeChallengeMethod);
-                    codeVerifierEncoded = generateS256CodeChallenge(codeVerifier);
-                } else {
-                    logger.debug("PKCE codeChallengeMethod is plain");
-                    codeVerifierEncoded = codeVerifier;
-                }
-            } catch (Exception nae) {
-                logger.infof("PKCE code verification failed, not supported algorithm specified");
-                event.error(Errors.PKCE_VERIFICATION_FAILED);
-                throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_GRANT, "PKCE code verification failed, not supported algorithm specified", Response.Status.BAD_REQUEST);
-            }
-            if (!codeChallenge.equals(codeVerifierEncoded)) {
-                logger.warnf("PKCE verification failed. authUserId = %s, authUsername = %s", authUserId, authUsername);
-                event.error(Errors.PKCE_VERIFICATION_FAILED);
-                throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_GRANT, "PKCE verification failed", Response.Status.BAD_REQUEST);
-            } else {
-                logger.debugf("PKCE verification success. codeVerifierEncoded = %s, codeChallenge = %s", codeVerifierEncoded, codeChallenge);
-            }
-        }
-
 
         updateClientSession(clientSession);
         updateUserSessionFromClientAuth(userSession);
@@ -451,6 +417,63 @@ public class TokenEndpoint {
         event.success();
 
         return cors.builder(Response.ok(res).type(MediaType.APPLICATION_JSON_TYPE)).build();
+    }
+
+    private void checkParamsForPkceEnforcedClient(String codeVerifier, String codeChallenge, String codeChallengeMethod, String authUserId, String authUsername) {
+        // check whether code verifier is specified
+        if (codeVerifier == null) {
+            logger.warnf("PKCE code verifier not specified, authUserId = %s, authUsername = %s", authUserId, authUsername);
+            event.error(Errors.CODE_VERIFIER_MISSING);
+            throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_GRANT, "PKCE code verifier not specified", Response.Status.BAD_REQUEST); 
+        }
+        verifyCodeVerifier(codeVerifier, codeChallenge, codeChallengeMethod, authUserId, authUsername);
+    }
+
+    private void checkParamsForPkceNotEnforcedClient(String codeVerifier, String codeChallenge, String codeChallengeMethod, String authUserId, String authUsername) {
+        if (codeChallenge != null && codeVerifier == null) {
+            logger.warnf("PKCE code verifier not specified, authUserId = %s, authUsername = %s", authUserId, authUsername);
+            event.error(Errors.CODE_VERIFIER_MISSING);
+            throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_GRANT, "PKCE code verifier not specified", Response.Status.BAD_REQUEST);
+        }
+
+        if (codeChallenge != null) {
+            verifyCodeVerifier(codeVerifier, codeChallenge, codeChallengeMethod, authUserId, authUsername);
+        }
+    }
+
+    private void verifyCodeVerifier(String codeVerifier, String codeChallenge, String codeChallengeMethod, String authUserId, String authUsername) {
+        // check whether code verifier is formatted along with the PKCE specification
+
+        if (!isValidPkceCodeVerifier(codeVerifier)) {
+            logger.infof("PKCE invalid code verifier");
+            event.error(Errors.INVALID_CODE_VERIFIER);
+            throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_GRANT, "PKCE invalid code verifier", Response.Status.BAD_REQUEST);
+        }
+
+        logger.debugf("PKCE supporting Client, codeVerifier = %s", codeVerifier);
+        String codeVerifierEncoded = codeVerifier;
+        try {
+            // https://tools.ietf.org/html/rfc7636#section-4.2
+            // plain or S256
+            if (codeChallengeMethod != null && codeChallengeMethod.equals(OAuth2Constants.PKCE_METHOD_S256)) {
+                logger.debugf("PKCE codeChallengeMethod = %s", codeChallengeMethod);
+                codeVerifierEncoded = generateS256CodeChallenge(codeVerifier);
+            } else {
+                logger.debug("PKCE codeChallengeMethod is plain");
+                codeVerifierEncoded = codeVerifier;
+            }
+        } catch (Exception nae) {
+            logger.infof("PKCE code verification failed, not supported algorithm specified");
+            event.error(Errors.PKCE_VERIFICATION_FAILED);
+            throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_GRANT, "PKCE code verification failed, not supported algorithm specified", Response.Status.BAD_REQUEST);
+        }
+        if (!codeChallenge.equals(codeVerifierEncoded)) {
+            logger.warnf("PKCE verification failed. authUserId = %s, authUsername = %s", authUserId, authUsername);
+            event.error(Errors.PKCE_VERIFICATION_FAILED);
+            throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_GRANT, "PKCE verification failed", Response.Status.BAD_REQUEST);
+        } else {
+            logger.debugf("PKCE verification success. codeVerifierEncoded = %s, codeChallenge = %s", codeVerifierEncoded, codeChallenge);
+        }
     }
 
     public Response refreshTokenGrant() {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OAuthProofKeyForCodeExchangeTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OAuthProofKeyForCodeExchangeTest.java
@@ -6,18 +6,22 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.keycloak.OAuth2Constants;
 import org.keycloak.OAuthErrorException;
+import org.keycloak.admin.client.resource.ClientResource;
 import org.keycloak.common.util.Base64Url;
 import org.keycloak.events.Details;
 import org.keycloak.events.Errors;
 import org.keycloak.jose.jws.JWSHeader;
 import org.keycloak.jose.jws.JWSInput;
 import org.keycloak.models.utils.KeycloakModelUtils;
+import org.keycloak.protocol.oidc.OIDCAdvancedConfigWrapper;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.RefreshToken;
+import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.EventRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.testsuite.AbstractKeycloakTest;
 import org.keycloak.testsuite.AssertEvents;
+import org.keycloak.testsuite.admin.ApiUtil;
 import org.keycloak.testsuite.util.ClientManager;
 import org.keycloak.testsuite.util.OAuthClient;
 import org.keycloak.testsuite.util.UserBuilder;
@@ -492,5 +496,193 @@ public class OAuthProofKeyForCodeExchangeTest extends AbstractKeycloakTest {
         Assert.assertNotEquals(event.getDetails().get(Details.REFRESH_TOKEN_ID), refreshEvent.getDetails().get(Details.UPDATED_REFRESH_TOKEN_ID));
 
         setTimeOffset(0);
+    }
+
+    // KEYCLOAK-10747 Explicit Proof Key for Code Exchange Activation Settings
+
+    private void setPkceActivationSettings(String clientId, String codeChallengeMethodName) {
+        ClientResource clientResource = ApiUtil.findClientByClientId(adminClient.realm("test"), clientId);
+        ClientRepresentation clientRep = clientResource.toRepresentation();
+        OIDCAdvancedConfigWrapper.fromClientRepresentation(clientRep).setPkceCodeChallengeMethod(codeChallengeMethodName);
+        clientResource.update(clientRep);
+    }
+
+    @Test
+    public void accessTokenRequestValidS256CodeChallengeMethodPkceEnforced() throws Exception {
+        try {
+            setPkceActivationSettings("test-app", OAuth2Constants.PKCE_METHOD_S256);
+            String codeVerifier = "1a345A7890123456r8901c3456789012b45K7890l23"; // 43
+            String codeChallenge = generateS256CodeChallenge(codeVerifier);
+            oauth.codeChallenge(codeChallenge);
+            oauth.codeChallengeMethod(OAuth2Constants.PKCE_METHOD_S256);
+
+            oauth.doLogin("test-user@localhost", "password");
+
+            EventRepresentation loginEvent = events.expectLogin().assertEvent();
+
+            String sessionId = loginEvent.getSessionId();
+            String codeId = loginEvent.getDetails().get(Details.CODE_ID);
+
+            String code = oauth.getCurrentQuery().get(OAuth2Constants.CODE);
+
+            oauth.codeVerifier(codeVerifier);
+
+            expectSuccessfulResponseFromTokenEndpoint(codeId, sessionId, code);
+        } finally {
+            setPkceActivationSettings("test-app", null);
+        }
+    }
+
+    @Test
+    public void accessTokenRequestValidPlainCodeChallengeMethodPkceEnforced() throws Exception {
+        try {
+            setPkceActivationSettings("test-app", OAuth2Constants.PKCE_METHOD_PLAIN);
+            String codeVerifier = "12E45r78901d3456789G12y45G78901234B67v901u3"; // 43
+            String codeChallenge = codeVerifier;
+            oauth.codeChallenge(codeChallenge);
+            oauth.codeChallengeMethod(OAuth2Constants.PKCE_METHOD_PLAIN);
+
+            oauth.doLogin("test-user@localhost", "password");
+
+            EventRepresentation loginEvent = events.expectLogin().assertEvent();
+
+            String sessionId = loginEvent.getSessionId();
+            String codeId = loginEvent.getDetails().get(Details.CODE_ID);
+
+            String code = oauth.getCurrentQuery().get(OAuth2Constants.CODE);
+
+            oauth.codeVerifier(codeVerifier);
+
+            expectSuccessfulResponseFromTokenEndpoint(codeId, sessionId, code);
+        } finally {
+            setPkceActivationSettings("test-app", null);
+        }
+    }
+ 
+    @Test
+    public void accessTokenRequestCodeChallengeMethodMismatchPkceEnforced() throws Exception {
+        try {
+            setPkceActivationSettings("test-app", OAuth2Constants.PKCE_METHOD_S256);
+            String codeVerifier = "12345678e01234567890g2345678h012a4567j90123"; // 43
+            String codeChallenge = generateS256CodeChallenge(codeVerifier);
+            oauth.codeChallenge(codeChallenge);
+            oauth.codeChallengeMethod(OAuth2Constants.PKCE_METHOD_PLAIN);
+
+            UriBuilder b = UriBuilder.fromUri(oauth.getLoginFormUrl());
+
+            driver.navigate().to(b.build().toURL());
+
+            OAuthClient.AuthorizationEndpointResponse errorResponse = new OAuthClient.AuthorizationEndpointResponse(oauth);
+
+            Assert.assertTrue(errorResponse.isRedirected());
+            Assert.assertEquals(errorResponse.getError(), OAuthErrorException.INVALID_REQUEST);
+            Assert.assertEquals(errorResponse.getErrorDescription(), "Invalid parameter: code challenge method is not configured one");
+
+            events.expectLogin().error(Errors.INVALID_REQUEST).user((String) null).session((String) null).clearDetails().assertEvent();
+        } finally {
+            setPkceActivationSettings("test-app", null);
+        }
+    }
+
+    @Test
+    public void accessTokenRequestCodeChallengeMethodMissingPkceEnforced() throws Exception {
+        try {
+            setPkceActivationSettings("test-app", OAuth2Constants.PKCE_METHOD_S256);
+            String codeVerifier = "1234567890123456789012345678901234567890123"; // 43
+            String codeChallenge = generateS256CodeChallenge(codeVerifier);
+            oauth.codeChallenge(codeChallenge);
+
+            UriBuilder b = UriBuilder.fromUri(oauth.getLoginFormUrl());
+
+            driver.navigate().to(b.build().toURL());
+
+            OAuthClient.AuthorizationEndpointResponse errorResponse = new OAuthClient.AuthorizationEndpointResponse(oauth);
+
+            Assert.assertTrue(errorResponse.isRedirected());
+            Assert.assertEquals(errorResponse.getError(), OAuthErrorException.INVALID_REQUEST);
+            Assert.assertEquals(errorResponse.getErrorDescription(), "Missing parameter: code_challenge_method");
+
+            events.expectLogin().error(Errors.INVALID_REQUEST).user((String) null).session((String) null).clearDetails().assertEvent();
+
+        } finally {
+            setPkceActivationSettings("test-app", null);
+        }
+    }
+
+    @Test
+    public void accessTokenRequestCodeChallengeMissingPkceEnforced() throws Exception {
+        try {
+            setPkceActivationSettings("test-app", OAuth2Constants.PKCE_METHOD_S256);
+            oauth.codeChallengeMethod(OAuth2Constants.PKCE_METHOD_S256);
+
+            UriBuilder b = UriBuilder.fromUri(oauth.getLoginFormUrl());
+
+            driver.navigate().to(b.build().toURL());
+
+            OAuthClient.AuthorizationEndpointResponse errorResponse = new OAuthClient.AuthorizationEndpointResponse(oauth);
+
+            Assert.assertTrue(errorResponse.isRedirected());
+            Assert.assertEquals(errorResponse.getError(), OAuthErrorException.INVALID_REQUEST);
+            Assert.assertEquals(errorResponse.getErrorDescription(), "Missing parameter: code_challenge");
+
+            events.expectLogin().error(Errors.INVALID_REQUEST).user((String) null).session((String) null).clearDetails().assertEvent();
+
+        } finally {
+            setPkceActivationSettings("test-app", null);
+        }
+    }
+
+    @Test
+    public void accessTokenRequestInvalidCodeChallengePkceEnforced() throws Exception {
+        try {
+            setPkceActivationSettings("test-app", OAuth2Constants.PKCE_METHOD_S256);
+            oauth.codeChallenge("invalid");
+            oauth.codeChallengeMethod(OAuth2Constants.PKCE_METHOD_S256);
+
+            UriBuilder b = UriBuilder.fromUri(oauth.getLoginFormUrl());
+
+            driver.navigate().to(b.build().toURL());
+
+            OAuthClient.AuthorizationEndpointResponse errorResponse = new OAuthClient.AuthorizationEndpointResponse(oauth);
+
+            Assert.assertTrue(errorResponse.isRedirected());
+            Assert.assertEquals(errorResponse.getError(), OAuthErrorException.INVALID_REQUEST);
+            Assert.assertEquals(errorResponse.getErrorDescription(), "Invalid parameter: code_challenge");
+
+            events.expectLogin().error(Errors.INVALID_REQUEST).user((String) null).session((String) null).clearDetails().assertEvent();
+
+        } finally {
+            setPkceActivationSettings("test-app", null);
+        }
+    }
+
+    @Test
+    public void accessTokenRequestWithoutCodeVerifierPkceEnforced() throws Exception {
+        try {
+            setPkceActivationSettings("test-app", OAuth2Constants.PKCE_METHOD_S256);
+            String codeVerifier = "1234567890123456789012345678901234567890123";
+            String codeChallenge = generateS256CodeChallenge(codeVerifier);
+            oauth.codeChallenge(codeChallenge);
+            oauth.codeChallengeMethod(OAuth2Constants.PKCE_METHOD_S256);
+
+            oauth.doLogin("test-user@localhost", "password");
+
+            EventRepresentation loginEvent = events.expectLogin().assertEvent();
+
+            String sessionId = loginEvent.getSessionId();
+            String codeId = loginEvent.getDetails().get(Details.CODE_ID);
+
+            String code = oauth.getCurrentQuery().get(OAuth2Constants.CODE);
+
+            OAuthClient.AccessTokenResponse response = oauth.doAccessTokenRequest(code, "password");
+
+            assertEquals(400, response.getStatusCode());
+            assertEquals(OAuthErrorException.INVALID_GRANT, response.getError());
+            assertEquals("PKCE code verifier not specified", response.getErrorDescription());
+
+            events.expectCodeToToken(codeId, sessionId).error(Errors.CODE_VERIFIER_MISSING).clearDetails().assertEvent();
+        } finally {
+            setPkceActivationSettings("test-app", null);
+        }
     }
 }

--- a/themes/src/main/resources/theme/base/admin/messages/admin-messages_en.properties
+++ b/themes/src/main/resources/theme/base/admin/messages/admin-messages_en.properties
@@ -1551,3 +1551,6 @@ tls-client-certificate-bound-access-tokens=OAuth 2.0 Mutual TLS Certificate Boun
 tls-client-certificate-bound-access-tokens.tooltip=This enables support for OAuth 2.0 Mutual TLS Certificate Bound Access Tokens, which means that keycloak bind an access token and a refresh token with a X.509 certificate of a token requesting client exchanged in mutual TLS between keycloak's Token Endpoint and this client. These tokens can be treated as Holder-of-Key tokens instead of bearer tokens.
 subjectdn=Subject DN
 subjectdn-tooltip=A regular expression for validating Subject DN in the Client Certificate. Use "(.*?)(?:$)" to match all kind of expressions.
+
+pkce-code-challenge-method=Proof Key for Code Exchange Code Challenge Method
+pkce-code-challenge-method.tooltip=Choose which code challenge method for PKCE is used. If not specified, keycloak does not applies PKCE to a client unless the client send an authorization request with appropriate code challenge and code exchange method.

--- a/themes/src/main/resources/theme/base/admin/resources/js/controllers/clients.js
+++ b/themes/src/main/resources/theme/base/admin/resources/js/controllers/clients.js
@@ -966,6 +966,12 @@ module.controller('ClientDetailCtrl', function($scope, realm, client, flows, $ro
         "request_uri only"
     ];
 
+    $scope.changePkceCodeChallengeMethodOptions = [
+        "S256",
+        "plain",
+        ""
+    ];
+
     $scope.realm = realm;
     $scope.samlAuthnStatement = false;
     $scope.samlOneTimeUseCondition = false;
@@ -1130,6 +1136,9 @@ module.controller('ClientDetailCtrl', function($scope, realm, client, flows, $ro
         var attrVal3 = $scope.client.attributes['request.object.required'];
         $scope.requestObjectRequired = attrVal3==null ? 'not required' : attrVal3;
 
+        var attrVal4 = $scope.client.attributes['pkce.code.challenge.method'];
+        $scope.pkceCodeChallengeMethod = attrVal4==null ? 'none' : attrVal4;
+
         if ($scope.client.attributes["exclude.session.state.from.auth.response"]) {
             if ($scope.client.attributes["exclude.session.state.from.auth.response"] == "true") {
                 $scope.excludeSessionStateFromAuthResponse = true;
@@ -1254,13 +1263,17 @@ module.controller('ClientDetailCtrl', function($scope, realm, client, flows, $ro
             $scope.clientEdit.attributes['request.object.signature.alg'] = $scope.requestObjectSignatureAlg;
         }
     };
-    
+
     $scope.changeRequestObjectRequired = function() {
         if ($scope.requestObjectRequired === 'not required') {
             $scope.clientEdit.attributes['request.object.required'] = null;
         } else {
             $scope.clientEdit.attributes['request.object.required'] = $scope.requestObjectRequired;
         }
+    };
+
+    $scope.changePkceCodeChallengeMethod = function() {
+        $scope.clientEdit.attributes['pkce.code.challenge.method'] = $scope.pkceCodeChallengeMethod;
     };
 
     $scope.$watch(function() {

--- a/themes/src/main/resources/theme/base/admin/resources/partials/client-detail.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/client-detail.html
@@ -500,6 +500,20 @@
                 </div>
                 <kc-tooltip>{{:: 'tls-client-certificate-bound-access-tokens.tooltip' | translate}}</kc-tooltip>
             </div>
+
+            <div class="form-group clearfix block" data-ng-show="protocol == 'openid-connect'">
+                <label class="col-md-2 control-label" for="changePkceCodeChallengeMethod">{{:: 'pkce-code-challenge-method' | translate}}</label>
+                <div class="col-sm-6">
+                    <div>
+                        <select class="form-control" id="pkceCodeChallengeMethod"
+                                ng-change="changePkceCodeChallengeMethod()"
+                                ng-model="pkceCodeChallengeMethod"
+                                ng-options="method for method in changePkceCodeChallengeMethodOptions">
+                        </select>
+                    </div>
+                </div>
+                <kc-tooltip>{{:: 'pkce-code-challenge-method.tooltip' | translate}}</kc-tooltip>
+            </div>
         </fieldset>
 
         <fieldset>


### PR DESCRIPTION
As mentioned in [Financial-grade API - Part 1: Read-Only API Security Profile](https://github.com/keycloak/keycloak-community/blob/master/specifications/fapi-notes.md), keycloak can not refuse client's authorization request without PKCE's parameters. This pull request resolves this issue.

[scope]
per client

[UI]
set as Cilent's Advanced Settings

* Activation
 Implemented as switch : ON / OFF
 If OFF, do as usual considering backward compatibility.
 If ON, keycloak refuses client that does not obey PKCE.
 Default setting is OFF.

* Code Challenge Method
 Implemented as pulldown menu : S256 / plain
 This pulldown menu appears when Activation Switch is ON.

[Admin REST API]
set as Attribuite (avoid DB schema change)

* Activation
  key is "pkce.activation"

* Code Challenge Method
  key is "pkce.code.challenge.method"

[Dynamic Client Registration]
not supported because no standard claim was found. please see [OAuth Dynamic Client Registration Metadata](https://www.iana.org/assignments/oauth-parameters/oauth-parameters.xml#client-metadata).

[Logic]

* Authorization Endpoint
 If Activation is off, execute codes implemented as KEYCLOA-2604 considering backward compartibility.
 IF Activation is on, keycloak rejects the authorization request from the client without sendint PKCE's parameter properly.

* Token Endpoint
  If Activation is off, execute codes implemented as KEYCLOA-2604 considering backward compartibility.
 IF Activation is on, keycloak rejects the token request from the client without sendint PKCE's parameter properly.



I've created the JIRA ticket as follow.
https://issues.jboss.org/browse/KEYCLOAK-10747
Kindly you comfirm it.

Hope this pull request is reviewed and merged.

Also, I'm willing to prepare its documentation. I'will send its pull request onto keycloak-document if this pull request is merged.
