### PR TITLE
KEYCLOAK-10033 ServletAuthzCacheLifespanAdapterTest stabilized

### DIFF
--- a/services/src/main/java/org/keycloak/connections/httpclient/DefaultHttpClientFactory.java
+++ b/services/src/main/java/org/keycloak/connections/httpclient/DefaultHttpClientFactory.java
@@ -140,6 +140,7 @@ public class DefaultHttpClientFactory implements HttpClientFactory {
                     long connectionTTL = config.getLong("connection-ttl-millis", -1L);
                     long maxConnectionIdleTime = config.getLong("max-connection-idle-time-millis", 900000L);
                     boolean disableCookies = config.getBoolean("disable-cookies", true);
+                    boolean retryUnfinishedRequests = config.getBoolean("retry-unfinished-requests", false);
                     String clientKeystore = config.get("client-keystore");
                     String clientKeystorePassword = config.get("client-keystore-password");
                     String clientPrivateKeyPassword = config.get("client-key-password");
@@ -154,6 +155,8 @@ public class DefaultHttpClientFactory implements HttpClientFactory {
                             : HttpClientBuilder.HostnameVerificationPolicy.valueOf(truststoreProvider.getPolicy().name());
 
                     HttpClientBuilder builder = new HttpClientBuilder();
+
+                    builder.retryUnfinishedRequests(retryUnfinishedRequests);
 
                     builder.socketTimeout(socketTimeout, TimeUnit.MILLISECONDS)
                             .establishConnectionTimeout(establishConnectionTimeout, TimeUnit.MILLISECONDS)

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/example/authorization/AbstractBaseServletAuthzAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/example/authorization/AbstractBaseServletAuthzAdapterTest.java
@@ -124,6 +124,7 @@ public abstract class AbstractBaseServletAuthzAdapterTest extends AbstractExampl
 
             this.loginPage.form().login(username, password);
         } catch (Exception cause) {
+            log.warnf("Login failed, currentURL:%s\nPage source\n%s", driver.getCurrentUrl(), driver.getPageSource());
             throw new RuntimeException("Login failed", cause);
         }
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/resources/META-INF/keycloak-server.json
+++ b/testsuite/integration-arquillian/tests/base/src/test/resources/META-INF/keycloak-server.json
@@ -91,7 +91,9 @@
     },
 
     "connectionsHttpClient": {
-        "default": {}
+        "default": {
+            "retry-unfinished-requests": true
+        }
     },
 
 


### PR DESCRIPTION
https://issues.jboss.org/browse/KEYCLOAK-10033

When analysing the logs, I noticed that the APP Server stopped responding. On one side the Auth Server got the `NoHttpResponseException` when calling the logout url, and on the other hand, the HTMLUnit wasn't able to find the username field in the login page.

My theory is that the logout wasn't successful and therefore, the HTML Unit wasn't able to log in. The fix makes sure it gets some response from the App Server. If the response is empty - it retries. 