### PR TITLE
KEYCLOAK-10783 Fix internal server error when logging out after sharing my resource

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/account/AccountFormService.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountFormService.java
@@ -714,6 +714,12 @@ public class AccountFormService extends AbstractSecuredLocalService {
     }
 
     @Path("resource/{resource_id}/grant")
+    @GET
+    public Response resourceDetailPageAfterGrant(@PathParam("resource_id") String resourceId) {
+        return resourceDetailPage(resourceId);
+    }
+
+    @Path("resource/{resource_id}/grant")
     @POST
     public Response grantPermission(@PathParam("resource_id") String resourceId, @FormParam("action") String action, @FormParam("permission_id") String[] permissionId, @FormParam("requester") String requester) {
         AuthorizationProvider authorization = session.getProvider(AuthorizationProvider.class);
@@ -819,6 +825,12 @@ public class AccountFormService extends AbstractSecuredLocalService {
         }
 
         return forwardToPage("resource", AccountPages.RESOURCES);
+    }
+
+    @Path("resource/{resource_id}/share")
+    @GET
+    public Response resourceDetailPageAfterShare(@PathParam("resource_id") String resourceId) {
+        return resourceDetailPage(resourceId);
     }
 
     @Path("resource/{resource_id}/share")


### PR DESCRIPTION
Please refer to: [KEYCLOAK-10783](https://issues.jboss.org/browse/KEYCLOAK-10783)

After clicking the Share button on the My Resource page, the URL is as follows:
https://sso.example.com/auth/realms/demo-authz/account/resource/8fe3eed3-2d9d-4718-885d-dbdbb1df7cec/share?referrer=authz-uma-client&referrer_uri=https%3A%2F%2Fuma.example.com%2Fauthz-uma-client%2F

And then if clicking the Sign Out link, the user is redirected to the value of the _redirect_uri_ parameter and finally the internal server error page is shown (due to HTTP 405 error):

GET https://sso.example.com/auth/realms/demo-authz/protocol/openid-connect/logout?referrer=authz-uma-client&referrer_uri=https://uma.example.com/authz-uma-client/&redirect_uri=https://sso.example.com/auth/realms/demo-authz/account/resource/8fe3eed3-2d9d-4718-885d-dbdbb1df7cec/share?referrer=authz-uma-client&referrer_uri=https://uma.example.com/authz-uma-client/

-> HTTP 302 Found

GET https://sso.example.com/auth/realms/demo-authz/account/resource/8fe3eed3-2d9d-4718-885d-dbdbb1df7cec/share?referrer=authz-uma-client&referrer_uri=https://uma.example.com/authz-uma-client/

-> HTTP 405 Method Not Allowed

So _AccountFormService_ should handle GET requests to _/resource/{resource_id}/share_. The same is true of _/resource/{resource_id}/grant_.