### PR TITLE
[KEYCLOAK-10384] Add equals and hashCode to KeycloakUndertowAccount, ...

### DIFF
--- a/adapters/oidc/undertow/src/main/java/org/keycloak/adapters/undertow/KeycloakUndertowAccount.java
+++ b/adapters/oidc/undertow/src/main/java/org/keycloak/adapters/undertow/KeycloakUndertowAccount.java
@@ -89,6 +89,26 @@ public class KeycloakUndertowAccount implements Account, Serializable, OidcKeycl
         return true;
     }
 
+    @Override
+    public boolean equals(Object other) {
+        if (this == other)
+            return true;
 
+        if (!(other instanceof KeycloakUndertowAccount))
+            return false;
 
+        KeycloakUndertowAccount otherAccount = (KeycloakUndertowAccount) other;
+
+        return (this.principal != null ? this.principal.equals(otherAccount.principal) : otherAccount.principal == null) &&
+                (this.accountRoles != null ? this.accountRoles.equals(otherAccount.accountRoles) : otherAccount.accountRoles == null);
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + (this.principal == null ? 0 : this.principal.hashCode());
+        result = prime * result + (this.accountRoles == null ? 0 : this.accountRoles.hashCode());
+        return result;
+    }
 }

--- a/adapters/saml/core-public/src/main/java/org/keycloak/adapters/saml/SamlPrincipal.java
+++ b/adapters/saml/core-public/src/main/java/org/keycloak/adapters/saml/SamlPrincipal.java
@@ -191,4 +191,32 @@ public class SamlPrincipal implements Serializable, Principal {
 
     }
 
+    @Override
+    public boolean equals(Object other) {
+        if (this == other)
+            return true;
+
+        if (!(other instanceof SamlPrincipal))
+            return false;
+
+        SamlPrincipal otherPrincipal = (SamlPrincipal) other;
+
+        return (this.name != null ? this.name.equals(otherPrincipal.name) : otherPrincipal.name == null) &&
+                (this.samlSubject != null ? this.samlSubject.equals(otherPrincipal.samlSubject) : otherPrincipal.samlSubject == null) &&
+                (this.nameIDFormat != null ? this.nameIDFormat.equals(otherPrincipal.nameIDFormat) : otherPrincipal.nameIDFormat == null) &&
+                (this.attributes != null ? this.attributes.equals(otherPrincipal.attributes) : otherPrincipal.attributes == null) &&
+                (this.friendlyAttributes != null ? this.friendlyAttributes.equals(otherPrincipal.friendlyAttributes) : otherPrincipal.friendlyAttributes == null);
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + (this.name == null ? 0 : this.name.hashCode());
+        result = prime * result + (this.samlSubject == null ? 0 : this.samlSubject.hashCode());
+        result = prime * result + (this.nameIDFormat == null ? 0 : this.nameIDFormat.hashCode());
+        result = prime * result + (this.attributes == null ? 0 : this.attributes.hashCode());
+        result = prime * result + (this.friendlyAttributes == null ? 0 : this.friendlyAttributes.hashCode());
+        return result;
+    }
 }

--- a/adapters/saml/core/src/main/java/org/keycloak/adapters/saml/SamlSession.java
+++ b/adapters/saml/core/src/main/java/org/keycloak/adapters/saml/SamlSession.java
@@ -51,4 +51,29 @@ public class SamlSession implements Serializable, KeycloakAccount {
     public String getSessionIndex() {
         return sessionIndex;
     }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other)
+            return true;
+
+        if (!(other instanceof SamlSession))
+            return false;
+
+        SamlSession otherSession = (SamlSession) other;
+
+        return (this.principal != null ? this.principal.equals(otherSession.principal) : otherSession.principal == null) &&
+                (this.roles != null ? this.roles.equals(otherSession.roles) : otherSession.roles == null) &&
+                (this.sessionIndex != null ? this.sessionIndex.equals(otherSession.sessionIndex) : otherSession.sessionIndex == null);
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + (this.principal == null ? 0 : this.principal.hashCode());
+        result = prime * result + (this.roles == null ? 0 : this.roles.hashCode());
+        result = prime * result + (this.sessionIndex == null ? 0 : this.sessionIndex.hashCode());
+        return result;
+    }
 }


### PR DESCRIPTION
SamlPrincipal and SamlSession to avoid cache misses in the PicketBox JAAS authentication manager

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
