### PR TITLE
KEYCLOAK-10784 i18n support for UMA resource pages

### DIFF
--- a/themes/src/main/resources-community/theme/base/account/messages/messages_ja.properties
+++ b/themes/src/main/resources-community/theme/base/account/messages/messages_ja.properties
@@ -227,6 +227,12 @@ resourcesSharedWithMe=共有しているリソース
 permissionRequestion=パーミッションリクエスト
 permission=パーミッション
 shares=共有(複数)
+notBeingShared=このリソースは共有されていません。
+notHaveAnyResource=リソースがありません。
+noResourcesSharedWithYou=共有しているリソースはありません
+havePermissionRequestsWaitingForApproval=承認待ちの{0}個のパーミッションリクエストがあります。
+clickHereForDetails=詳細はこちらをクリックしてください。
+resourceIsNotBeingShared=リソースは共有されていません。
 
 locale_ca=Catal\u00e0
 locale_de=Deutsch

--- a/themes/src/main/resources/theme/base/account/messages/messages_en.properties
+++ b/themes/src/main/resources/theme/base/account/messages/messages_en.properties
@@ -227,6 +227,12 @@ resourcesSharedWithMe=Resources shared with me
 permissionRequestion=Permission Requestion
 permission=Permission
 shares=share(s)
+notBeingShared=This resource is not being shared.
+notHaveAnyResource=You don't have any resource
+noResourcesSharedWithYou=There are no resources shared with you
+havePermissionRequestsWaitingForApproval=You have {0} permission request(s) waiting for approval.
+clickHereForDetails=Click here for details.
+resourceIsNotBeingShared=The resource is not being shared
 
 locale_ca=Catal\u00e0
 locale_de=Deutsch

--- a/themes/src/main/resources/theme/base/account/resource-detail.ftl
+++ b/themes/src/main/resources/theme/base/account/resource-detail.ftl
@@ -87,7 +87,7 @@
     <div class="row">
         <div class="col-md-10">
             <h2>
-                <a href="${url.resourceUrl}">My Resources</a> <i class="fa fa-angle-right"></i> <#if authorization.resource.displayName??>${authorization.resource.displayName}<#else>${authorization.resource.name}</#if>
+                <a href="${url.resourceUrl}">${msg("myResources")}</a> <i class="fa fa-angle-right"></i> <#if authorization.resource.displayName??>${authorization.resource.displayName}<#else>${authorization.resource.name}</#if>
             </h2>
         </div>
     </div>
@@ -157,7 +157,7 @@
                             </#list>
                         <#else>
                             <tr>
-                                <td colspan="4">The resource is not being shared</td>
+                                <td colspan="4">${msg("resourceIsNotBeingShared")}</td>
                             </tr>
                         </#if>
                     </tbody>

--- a/themes/src/main/resources/theme/base/account/resources.ftl
+++ b/themes/src/main/resources/theme/base/account/resources.ftl
@@ -208,14 +208,14 @@
                                 <#if resource.shares?size != 0>
                                     <a href="${url.getResourceDetailUrl(resource.id)}">${resource.shares?size} <i class="fa fa-users"></i></a>
                                 <#else>
-                                    This resource is not being shared.
+                                    ${msg("notBeingShared")}
                                 </#if>
                             </td>
                         </tr>
                     </#list>
                 <#else>
                     <tr>
-                        <td colspan="4">You don't have any resource</td>
+                        <td colspan="4">${msg("notHaveAnyResource")}</td>
                     </tr>
                 </#if>
                 </tbody>
@@ -291,7 +291,7 @@
                             </#list>
                         <#else>
                             <tr>
-                                <td colspan="6">There are no resources shared with you</td>
+                                <td colspan="6">${msg("noResourcesSharedWithYou")}</td>
                             </tr>
                         </#if>
                     </tbody>
@@ -316,11 +316,8 @@
         </div>
         <div class="row">
             <div class="col-md-12">
-                <#if authorization.resourcesWaitingOthersApproval?size != 0>
-                    <i class="pficon pficon-info"></i> You have ${authorization.resourcesWaitingOthersApproval?size} permission request(s) <a href="#" onclick="document.getElementById('waitingApproval').style.display=''">waiting</a> for approval.
-                <#else>
-                    You have no permission requests waiting for approval.
-                </#if>
+                <i class="pficon pficon-info"></i> ${msg("havePermissionRequestsWaitingForApproval",authorization.resourcesWaitingOthersApproval?size)}
+                <a href="#" onclick="document.getElementById('waitingApproval').style.display=''">${msg("clickHereForDetails")}</a>
                 <div class="row">
                     <div class="col-md-12"></div>
                 </div>


### PR DESCRIPTION
Please refer to: [KEYCLOAK-10784](https://issues.jboss.org/browse/KEYCLOAK-10784)

Images after I fixed:
(in Japanese)
![AfterFixInJapanese1](https://user-images.githubusercontent.com/1562861/60782573-334cc380-a182-11e9-8093-b2ad0cae753c.png)
![AfterFixInJapanese2](https://user-images.githubusercontent.com/1562861/60791462-ae23d780-a19e-11e9-9c93-224bd7a41eeb.png)
![AfterFixInJapanese3](https://user-images.githubusercontent.com/1562861/60782575-33e55a00-a182-11e9-914a-f830963bec84.png)

(in English)
![AfterFixInEnglish1](https://user-images.githubusercontent.com/1562861/60782576-33e55a00-a182-11e9-92cd-c9573ce2aa42.png)
![AfterFixInEnglish2](https://user-images.githubusercontent.com/1562861/60791461-ad8b4100-a19e-11e9-90d0-a3f596db4e53.png)
![AfterFixInEnglish3](https://user-images.githubusercontent.com/1562861/60782572-334cc380-a182-11e9-8273-267aa973d43d.png)



