### PR TITLE
KEYCLOAK-10785 X.509 Authenticator - Update user identity source mappers

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/x509/AbstractX509ClientCertificateAuthenticatorFactory.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/x509/AbstractX509ClientCertificateAuthenticatorFactory.java
@@ -40,8 +40,6 @@ import static org.keycloak.authentication.authenticators.x509.AbstractX509Client
 import static org.keycloak.authentication.authenticators.x509.AbstractX509ClientCertificateAuthenticator.ENABLE_CRLDP;
 import static org.keycloak.authentication.authenticators.x509.AbstractX509ClientCertificateAuthenticator.ENABLE_OCSP;
 import static org.keycloak.authentication.authenticators.x509.AbstractX509ClientCertificateAuthenticator.MAPPING_SOURCE_CERT_ISSUERDN;
-import static org.keycloak.authentication.authenticators.x509.AbstractX509ClientCertificateAuthenticator.MAPPING_SOURCE_CERT_ISSUERDN_CN;
-import static org.keycloak.authentication.authenticators.x509.AbstractX509ClientCertificateAuthenticator.MAPPING_SOURCE_CERT_ISSUERDN_EMAIL;
 import static org.keycloak.authentication.authenticators.x509.AbstractX509ClientCertificateAuthenticator.MAPPING_SOURCE_CERT_SERIALNUMBER;
 import static org.keycloak.authentication.authenticators.x509.AbstractX509ClientCertificateAuthenticator.MAPPING_SOURCE_CERT_SUBJECTALTNAME_EMAIL;
 import static org.keycloak.authentication.authenticators.x509.AbstractX509ClientCertificateAuthenticator.MAPPING_SOURCE_CERT_SUBJECTALTNAME_OTHERNAME;
@@ -77,9 +75,9 @@ public abstract class AbstractX509ClientCertificateAuthenticatorFactory implemen
             MAPPING_SOURCE_CERT_SUBJECTALTNAME_OTHERNAME,
             MAPPING_SOURCE_CERT_SUBJECTDN_CN,
             MAPPING_SOURCE_CERT_ISSUERDN,
-            MAPPING_SOURCE_CERT_ISSUERDN_EMAIL,
-            MAPPING_SOURCE_CERT_ISSUERDN_CN,
             MAPPING_SOURCE_CERT_SERIALNUMBER,
+            MAPPING_SOURCE_CERT_SERIALNUMBER_ISSUERDN,
+            MAPPING_SOURCE_CERT_SHA256_THUMBPRINT,
             MAPPING_SOURCE_CERT_CERTIFICATE_PEM
     };
 
@@ -109,6 +107,14 @@ public abstract class AbstractX509ClientCertificateAuthenticatorFactory implemen
         canonicalDn.setDefaultValue(false);
         canonicalDn.setHelpText("Use the canonical format to determine the distinguished name. This option is relevant for authenticators using a distinguished name.");
 
+        ProviderConfigProperty serialnumberHex = new ProviderConfigProperty();
+        serialnumberHex.setType(BOOLEAN_TYPE);
+        serialnumberHex.setName(SERIALNUMBER_HEX);
+        serialnumberHex.setLabel("Enable Serial Number hexadecimal representation");
+        serialnumberHex.setDefaultValue(false);
+        serialnumberHex.setHelpText("Use the hex representation of the serial number. This option is relevant for authenticators using serial number.");
+
+        
         ProviderConfigProperty regExp = new ProviderConfigProperty();
         regExp.setType(STRING_TYPE);
         regExp.setName(REGULAR_EXPRESSION);
@@ -130,11 +136,12 @@ public abstract class AbstractX509ClientCertificateAuthenticatorFactory implemen
         userMapperList.setOptions(mapperTypes);
 
         ProviderConfigProperty attributeOrPropertyValue = new ProviderConfigProperty();
-        attributeOrPropertyValue.setType(STRING_TYPE);
+        attributeOrPropertyValue.setType(MULTIVALUED_STRING_TYPE);
         attributeOrPropertyValue.setName(CUSTOM_ATTRIBUTE_NAME);
         attributeOrPropertyValue.setDefaultValue(DEFAULT_ATTRIBUTE_NAME);
         attributeOrPropertyValue.setLabel("A name of user attribute");
-        attributeOrPropertyValue.setHelpText("A name of user attribute to map the extracted user identity to existing user. The name must be a valid, existing user attribute if User Mapping Method is set to Custom Attribute Mapper.");
+        attributeOrPropertyValue.setHelpText("A name of user attribute to map the extracted user identity to existing user. The name must be a valid, existing user attribute if User Mapping Method is set to Custom Attribute Mapper. " +
+                "Multiple values are relevant when attribute mapping is related to multiple values, e.g. 'Certificate Serial Number and IssuerDN'");
 
         ProviderConfigProperty crlCheckingEnabled = new ProviderConfigProperty();
         crlCheckingEnabled.setType(BOOLEAN_TYPE);
@@ -198,6 +205,7 @@ public abstract class AbstractX509ClientCertificateAuthenticatorFactory implemen
 
         configProperties = asList(mappingMethodList,
                 canonicalDn,
+                serialnumberHex,
                 regExp,
                 userMapperList,
                 attributeOrPropertyValue,

--- a/services/src/main/java/org/keycloak/authentication/authenticators/x509/UserIdentityExtractor.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/x509/UserIdentityExtractor.java
@@ -37,6 +37,7 @@ import java.security.cert.X509Certificate;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -222,7 +223,7 @@ public abstract class UserIdentityExtractor {
 
         @Override
         public Object extractUserIdentity(X509Certificate[] certs) {
-            String value = _f.apply(certs);
+            String value = Optional.ofNullable(_f.apply(certs)).orElseThrow(IllegalArgumentException::new);
 
             Pattern r = Pattern.compile(_pattern, Pattern.CASE_INSENSITIVE);
 

--- a/services/src/main/java/org/keycloak/authentication/authenticators/x509/X509AuthenticatorConfigModel.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/x509/X509AuthenticatorConfigModel.java
@@ -55,16 +55,16 @@ public class X509AuthenticatorConfigModel extends AuthenticatorConfigModel {
 
     public enum MappingSourceType {
         SERIALNUMBER(MAPPING_SOURCE_CERT_SERIALNUMBER),
-        ISSUERDN_CN(MAPPING_SOURCE_CERT_ISSUERDN_CN),
-        ISSUERDN_EMAIL(MAPPING_SOURCE_CERT_ISSUERDN_EMAIL),
         ISSUERDN(MAPPING_SOURCE_CERT_ISSUERDN),
         SUBJECTDN_CN(MAPPING_SOURCE_CERT_SUBJECTDN_CN),
         SUBJECTDN_EMAIL(MAPPING_SOURCE_CERT_SUBJECTDN_EMAIL),
         SUBJECTALTNAME_EMAIL(MAPPING_SOURCE_CERT_SUBJECTALTNAME_EMAIL),
         SUBJECTALTNAME_OTHERNAME(MAPPING_SOURCE_CERT_SUBJECTALTNAME_OTHERNAME),
         SUBJECTDN(MAPPING_SOURCE_CERT_SUBJECTDN),
+        SHA256_THUMBPRINT(MAPPING_SOURCE_CERT_SHA256_THUMBPRINT),
+        SERIALNUMBER_ISSUERDN(MAPPING_SOURCE_CERT_SERIALNUMBER_ISSUERDN),
         CERTIFICATE_PEM(MAPPING_SOURCE_CERT_CERTIFICATE_PEM);
-
+        
         private String name;
         MappingSourceType(String name) {
             this.name = name;
@@ -251,6 +251,15 @@ public class X509AuthenticatorConfigModel extends AuthenticatorConfigModel {
 
     public X509AuthenticatorConfigModel setCanonicalDnEnabled(boolean value) {
         getConfig().put(CANONICAL_DN, Boolean.toString(value));
+        return this;
+    }
+    
+    public boolean isSerialnumberHex() {
+        return Boolean.parseBoolean(getConfig().get(SERIALNUMBER_HEX));
+    }
+
+    public X509AuthenticatorConfigModel setSerialnumberHex(boolean value) {
+        getConfig().put(SERIALNUMBER_HEX, Boolean.toString(value));
         return this;
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/x509/AbstractX509AuthenticationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/x509/AbstractX509AuthenticationTest.java
@@ -76,7 +76,6 @@ import java.util.Map;
 import static org.keycloak.authentication.authenticators.x509.X509AuthenticatorConfigModel.IdentityMapperType.USERNAME_EMAIL;
 import static org.keycloak.authentication.authenticators.x509.X509AuthenticatorConfigModel.IdentityMapperType.USER_ATTRIBUTE;
 import static org.keycloak.authentication.authenticators.x509.X509AuthenticatorConfigModel.MappingSourceType.ISSUERDN;
-import static org.keycloak.authentication.authenticators.x509.X509AuthenticatorConfigModel.MappingSourceType.ISSUERDN_CN;
 import static org.keycloak.authentication.authenticators.x509.X509AuthenticatorConfigModel.MappingSourceType.SUBJECTALTNAME_EMAIL;
 import static org.keycloak.authentication.authenticators.x509.X509AuthenticatorConfigModel.MappingSourceType.SUBJECTALTNAME_OTHERNAME;
 import static org.keycloak.authentication.authenticators.x509.X509AuthenticatorConfigModel.MappingSourceType.SUBJECTDN;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/x509/X509BrowserLoginTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/x509/X509BrowserLoginTest.java
@@ -40,8 +40,8 @@ import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertEquals;
 import static org.keycloak.authentication.authenticators.x509.X509AuthenticatorConfigModel.IdentityMapperType.USERNAME_EMAIL;
 import static org.keycloak.authentication.authenticators.x509.X509AuthenticatorConfigModel.IdentityMapperType.USER_ATTRIBUTE;
-import static org.keycloak.authentication.authenticators.x509.X509AuthenticatorConfigModel.MappingSourceType.ISSUERDN_CN;
-import static org.keycloak.authentication.authenticators.x509.X509AuthenticatorConfigModel.MappingSourceType.ISSUERDN_EMAIL;
+import static org.keycloak.authentication.authenticators.x509.X509AuthenticatorConfigModel.MappingSourceType.SERIALNUMBER_ISSUERDN;
+import static org.keycloak.authentication.authenticators.x509.X509AuthenticatorConfigModel.MappingSourceType.SHA256_THUMBPRINT;
 import static org.keycloak.authentication.authenticators.x509.X509AuthenticatorConfigModel.MappingSourceType.SERIALNUMBER;
 import static org.keycloak.authentication.authenticators.x509.X509AuthenticatorConfigModel.MappingSourceType.SUBJECTDN;
 import static org.keycloak.authentication.authenticators.x509.X509AuthenticatorConfigModel.MappingSourceType.SUBJECTDN_EMAIL;
@@ -146,9 +146,34 @@ public class X509BrowserLoginTest extends AbstractX509AuthenticationTest {
     }
 
     @Test
-    public void loginAsUserFromCertIssuerCNMappedToUserAttribute() {
-        x509BrowserLogin(createLoginWithSpecifiedSourceTypeToCustomAttributeConfig(ISSUERDN_CN, "x509_issuer_identity"),
-                userId2, "keycloak", "Keycloak Intermediate CA");
+    public void loginAsUserFromCertSerialnumberAndIssuerDNMappedToUserAttribute() {
+        UserRepresentation user = testRealm().users().get(userId2).toRepresentation();
+        Assert.assertNotNull(user);
+
+        user.singleAttribute("x509_certificate_serialnumber", "4105");
+        user.singleAttribute("x509_issuer_dn", "EMAILADDRESS=contact@keycloak.org, CN=Keycloak Intermediate CA, OU=Keycloak, O=Red Hat, ST=MA, C=US");
+        this.updateUser(user);
+
+        events.clear();
+        
+        x509BrowserLogin(createLoginWithSpecifiedSourceTypeToCustomAttributeConfig(SERIALNUMBER_ISSUERDN, "x509_certificate_serialnumber##x509_issuer_dn"),
+                userId2, "keycloak", "4105##EMAILADDRESS=contact@keycloak.org, CN=Keycloak Intermediate CA, OU=Keycloak, O=Red Hat, ST=MA, C=US");
+    }
+    
+    @Test
+    public void loginAsUserFromHexCertSerialnumberAndIssuerDNMappedToUserAttribute() {
+        UserRepresentation user = testRealm().users().get(userId2).toRepresentation();
+        Assert.assertNotNull(user);
+
+        user.singleAttribute("x509_certificate_serialnumber", "1009");
+        user.singleAttribute("x509_issuer_dn", "EMAILADDRESS=contact@keycloak.org, CN=Keycloak Intermediate CA, OU=Keycloak, O=Red Hat, ST=MA, C=US");
+        this.updateUser(user);
+
+        events.clear();
+        
+        X509AuthenticatorConfigModel config = createLoginWithSpecifiedSourceTypeToCustomAttributeConfig(SERIALNUMBER_ISSUERDN, "x509_certificate_serialnumber##x509_issuer_dn");
+        config.setSerialnumberHex(true);
+        x509BrowserLogin(config, userId2, "keycloak", "1009##EMAILADDRESS=contact@keycloak.org, CN=Keycloak Intermediate CA, OU=Keycloak, O=Red Hat, ST=MA, C=US");
     }
 
     @Test
@@ -167,18 +192,18 @@ public class X509BrowserLoginTest extends AbstractX509AuthenticationTest {
 
 
     @Test
-    public void loginAsUserFromCertIssuerEmailMappedToUserAttribute() {
+    public void loginAsUserFromCertSHA256MappedToUserAttribute() {
 
         UserRepresentation user = testRealm().users().get(userId2).toRepresentation();
         Assert.assertNotNull(user);
 
-        user.singleAttribute("x509_issuer_identity", "contact@keycloak.org");
+        user.singleAttribute("x509_cert_sha256thumbprint", "71237a14c118a90cc8406f14d039ed3431c9065f68e535293ee919d4c33b5e15");
         this.updateUser(user);
 
         events.clear();
 
-        x509BrowserLogin(createLoginWithSpecifiedSourceTypeToCustomAttributeConfig(ISSUERDN_EMAIL, "x509_issuer_identity"),
-                userId2, "keycloak", "contact@keycloak.org");
+        x509BrowserLogin(createLoginWithSpecifiedSourceTypeToCustomAttributeConfig(SHA256_THUMBPRINT, "x509_cert_sha256thumbprint"),
+                userId2, "keycloak", "71237a14c118a90cc8406f14d039ed3431c9065f68e535293ee919d4c33b5e15");
     }
 
 
@@ -195,6 +220,22 @@ public class X509BrowserLoginTest extends AbstractX509AuthenticationTest {
 
         x509BrowserLogin(createLoginWithSpecifiedSourceTypeToCustomAttributeConfig(SERIALNUMBER, "x509_serial_number"),
                 userId2, "keycloak", "4105");
+    }
+    
+    @Test
+    public void loginAsUserFromHexCertSerialNumberMappedToUserAttribute() {
+
+        UserRepresentation user = testRealm().users().get(userId2).toRepresentation();
+        Assert.assertNotNull(user);
+
+        user.singleAttribute("x509_serial_number", "1009");
+        this.updateUser(user);
+
+        events.clear();
+
+        X509AuthenticatorConfigModel config = createLoginWithSpecifiedSourceTypeToCustomAttributeConfig(SERIALNUMBER, "x509_serial_number");
+        config.setSerialnumberHex(true);
+        x509BrowserLogin(config, userId2, "keycloak", "1009");
     }
 
 


### PR DESCRIPTION
Update user identity sources and the way how X.509 certificates are mapped to the user to:
1. Include "Serial number + Issuer DN" as described in RFC 5280
2. Include "Certificate's SHA256-Thumbprint"
3. Exclude "Issuer DN"
4. Exclude "Issuer Email"

Add an option to represent serial number in hexadecimal format.

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
