### PR TITLE
Fix typo

### DIFF
--- a/distribution/feature-packs/server-feature-pack/src/main/resources/configuration/domain/template.xml
+++ b/distribution/feature-packs/server-feature-pack/src/main/resources/configuration/domain/template.xml
@@ -83,7 +83,7 @@
         <socket-binding-group name="ha-sockets" default-interface="public">
             <?SOCKET-BINDINGS?>
         </socket-binding-group>
-        <!-- load-balancer-sockets should be removed in production systems and replaced with a better softare or hardare based one -->
+        <!-- load-balancer-sockets should be removed in production systems and replaced with a better software or hardware based one -->
         <socket-binding-group name="load-balancer-sockets" default-interface="public">
             <!-- Needed for server groups using the 'load-balancer' profile  -->
             <?SOCKET-BINDINGS?>
@@ -98,7 +98,7 @@
             <socket-binding-group ref="ha-sockets"/>
         </server-group>
 
-        <!-- load-balancer-group should be removed in production systems and replaced with a better softare or hardare based one -->
+        <!-- load-balancer-group should be removed in production systems and replaced with a better software or hardware based one -->
         <server-group name="load-balancer-group" profile="load-balancer">
             <jvm name="default">
                 <heap size="64m" max-size="512m"/>

--- a/distribution/feature-packs/server-feature-pack/src/main/resources/configuration/host/host-master.xml
+++ b/distribution/feature-packs/server-feature-pack/src/main/resources/configuration/host/host-master.xml
@@ -111,7 +111,7 @@
     </jvms>
 
     <servers>
-        <!-- load-balancer should be removed in production systems and replaced with a better softare or hardare based one -->
+        <!-- load-balancer should be removed in production systems and replaced with a better software or hardware based one -->
         <server name="load-balancer" group="load-balancer-group">
         </server>
         <server name="server-one" group="auth-server-group" auto-start="true">

--- a/distribution/feature-packs/server-feature-pack/src/main/resources/configuration/host/host.xml
+++ b/distribution/feature-packs/server-feature-pack/src/main/resources/configuration/host/host.xml
@@ -114,7 +114,7 @@
     </jvms>
 
     <servers>
-        <!-- load-balancer should be removed in production systems and replaced with a better softare or hardare based one -->
+        <!-- load-balancer should be removed in production systems and replaced with a better software or hardware based one -->
         <server name="load-balancer" group="load-balancer-group">
         </server>
         <server name="server-one" group="auth-server-group" auto-start="true">

--- a/testsuite/integration-arquillian/tests/other/server-config-migration/src/test/resources/domain/domain-1.9.8.Final-redhat-1.xml
+++ b/testsuite/integration-arquillian/tests/other/server-config-migration/src/test/resources/domain/domain-1.9.8.Final-redhat-1.xml
@@ -865,7 +865,7 @@
                 <remote-destination host="localhost" port="25"/>
             </outbound-socket-binding>
         </socket-binding-group>
-        <!-- load-balancer-sockets should be removed in production systems and replaced with a better softare or hardare based one -->
+        <!-- load-balancer-sockets should be removed in production systems and replaced with a better software or hardware based one -->
         <socket-binding-group name="load-balancer-sockets" default-interface="public">
             <socket-binding name="ajp" port="${jboss.ajp.port:8009}"/>
             <socket-binding name="http" port="${jboss.http.port:8080}"/>
@@ -879,7 +879,7 @@
         </socket-binding-group>
     </socket-binding-groups>
     <server-groups>
-        <!-- load-balancer-group should be removed in production systems and replaced with a better softare or hardare based one -->
+        <!-- load-balancer-group should be removed in production systems and replaced with a better software or hardware based one -->
         <server-group name="load-balancer-group" profile="load-balancer">
             <jvm name="default">
                 <heap size="64m" max-size="512m"/>

--- a/testsuite/integration-arquillian/tests/other/server-config-migration/src/test/resources/domain/domain-2.5.5.Final-redhat-1.xml
+++ b/testsuite/integration-arquillian/tests/other/server-config-migration/src/test/resources/domain/domain-2.5.5.Final-redhat-1.xml
@@ -1021,7 +1021,7 @@
                 <remote-destination host="localhost" port="25"/>
             </outbound-socket-binding>
         </socket-binding-group>
-        <!-- load-balancer-sockets should be removed in production systems and replaced with a better softare or hardare based one -->
+        <!-- load-balancer-sockets should be removed in production systems and replaced with a better software or hardware based one -->
         <socket-binding-group name="load-balancer-sockets" default-interface="public">
             <socket-binding name="ajp" port="${jboss.ajp.port:8009}"/>
             <socket-binding name="http" port="${jboss.http.port:8080}"/>
@@ -1035,7 +1035,7 @@
         </socket-binding-group>
     </socket-binding-groups>
     <server-groups>
-        <!-- load-balancer-group should be removed in production systems and replaced with a better softare or hardare based one -->
+        <!-- load-balancer-group should be removed in production systems and replaced with a better software or hardware based one -->
         <server-group name="load-balancer-group" profile="load-balancer">
             <jvm name="default">
                 <heap size="64m" max-size="512m"/>

--- a/testsuite/integration-arquillian/tests/other/server-config-migration/src/test/resources/domain/domain-3.4.3.Final-redhat-2.xml
+++ b/testsuite/integration-arquillian/tests/other/server-config-migration/src/test/resources/domain/domain-3.4.3.Final-redhat-2.xml
@@ -1096,7 +1096,7 @@
                 <remote-destination host="localhost" port="25"/>
             </outbound-socket-binding>
         </socket-binding-group>
-        <!-- load-balancer-sockets should be removed in production systems and replaced with a better softare or hardare based one -->
+        <!-- load-balancer-sockets should be removed in production systems and replaced with a better software or hardware based one -->
         <socket-binding-group name="load-balancer-sockets" default-interface="public">
             <!-- Needed for server groups using the 'load-balancer' profile  -->
             <socket-binding name="http" port="${jboss.http.port:8080}"/>
@@ -1112,7 +1112,7 @@
             </jvm>
             <socket-binding-group ref="ha-sockets"/>
         </server-group>
-        <!-- load-balancer-group should be removed in production systems and replaced with a better softare or hardare based one -->
+        <!-- load-balancer-group should be removed in production systems and replaced with a better software or hardware based one -->
         <server-group name="load-balancer-group" profile="load-balancer">
             <jvm name="default">
                 <heap size="64m" max-size="512m"/>

--- a/testsuite/integration-arquillian/tests/other/server-config-migration/src/test/resources/domain/domain-4.8.3.Final-redhat-00001.xml
+++ b/testsuite/integration-arquillian/tests/other/server-config-migration/src/test/resources/domain/domain-4.8.3.Final-redhat-00001.xml
@@ -1108,7 +1108,7 @@
                 <remote-destination host="localhost" port="25"/>
             </outbound-socket-binding>
         </socket-binding-group>
-        <!-- load-balancer-sockets should be removed in production systems and replaced with a better softare or hardare based one -->
+        <!-- load-balancer-sockets should be removed in production systems and replaced with a better software or hardware based one -->
         <socket-binding-group name="load-balancer-sockets" default-interface="public">
             <!-- Needed for server groups using the 'load-balancer' profile  -->
             <socket-binding name="http" port="${jboss.http.port:8080}"/>
@@ -1124,7 +1124,7 @@
             </jvm>
             <socket-binding-group ref="ha-sockets"/>
         </server-group>
-        <!-- load-balancer-group should be removed in production systems and replaced with a better softare or hardare based one -->
+        <!-- load-balancer-group should be removed in production systems and replaced with a better software or hardware based one -->
         <server-group name="load-balancer-group" profile="load-balancer">
             <jvm name="default">
                 <heap size="64m" max-size="512m"/>

--- a/testsuite/integration-arquillian/tests/other/server-config-migration/src/test/resources/domain/host-master-2.5.5.Final-redhat-1.xml
+++ b/testsuite/integration-arquillian/tests/other/server-config-migration/src/test/resources/domain/host-master-2.5.5.Final-redhat-1.xml
@@ -73,7 +73,7 @@
         </jvm>
     </jvms>
     <servers>
-        <!-- load-balancer should be removed in production systems and replaced with a better softare or hardare based one -->
+        <!-- load-balancer should be removed in production systems and replaced with a better software or hardware based one -->
         <server name="load-balancer" group="load-balancer-group"/>
         <server name="server-one" group="auth-server-group" auto-start="true">
             <!--

--- a/testsuite/integration-arquillian/tests/other/server-config-migration/src/test/resources/domain/host-master-3.4.3.Final-redhat-2.xml
+++ b/testsuite/integration-arquillian/tests/other/server-config-migration/src/test/resources/domain/host-master-3.4.3.Final-redhat-2.xml
@@ -83,7 +83,7 @@
         </jvm>
     </jvms>
     <servers>
-        <!-- load-balancer should be removed in production systems and replaced with a better softare or hardare based one -->
+        <!-- load-balancer should be removed in production systems and replaced with a better software or hardware based one -->
         <server name="load-balancer" group="load-balancer-group"/>
         <server name="server-one" group="auth-server-group" auto-start="true">
             <!--

--- a/testsuite/integration-arquillian/tests/other/server-config-migration/src/test/resources/domain/host-master-4.8.3.Final-redhat-00001.xml
+++ b/testsuite/integration-arquillian/tests/other/server-config-migration/src/test/resources/domain/host-master-4.8.3.Final-redhat-00001.xml
@@ -83,7 +83,7 @@
         </jvm>
     </jvms>
     <servers>
-        <!-- load-balancer should be removed in production systems and replaced with a better softare or hardare based one -->
+        <!-- load-balancer should be removed in production systems and replaced with a better software or hardware based one -->
         <server name="load-balancer" group="load-balancer-group"/>
         <server name="server-one" group="auth-server-group" auto-start="true">
             <!--


### PR DESCRIPTION
While working on a domain setup for keycloak I noticed a typo in the default master configuration. I found this same typo in nine other files and fixed them all.
