### PR TITLE
KEYCLOAK-10807 Fix incorrect RS link on my resources page

### DIFF
--- a/services/src/main/java/org/keycloak/forms/account/freemarker/model/AuthorizationBean.java
+++ b/services/src/main/java/org/keycloak/forms/account/freemarker/model/AuthorizationBean.java
@@ -42,6 +42,7 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.utils.ModelToRepresentation;
 import org.keycloak.representations.idm.authorization.ScopeRepresentation;
+import org.keycloak.services.util.ResolveRelative;
 
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
@@ -379,6 +380,10 @@ public class AuthorizationBean {
             }
 
             return redirectUris.iterator().next();
+        }
+
+        public String getBaseUri() {
+            return ResolveRelative.resolveRelativeUri(null, clientModel.getRootUrl(), clientModel.getBaseUrl());
         }
     }
 

--- a/services/src/main/java/org/keycloak/services/util/ResolveRelative.java
+++ b/services/src/main/java/org/keycloak/services/util/ResolveRelative.java
@@ -29,13 +29,15 @@ public class ResolveRelative {
         if (url == null || !url.startsWith("/")) return url;
         if (rootUrl != null) {
             return rootUrl + url;
-        } else {
+        } else if (requestUri != null) {
             UriBuilder builder = UriBuilder.fromPath(url).host(requestUri.getHost());
             builder.scheme(requestUri.getScheme());
             if (requestUri.getPort() != -1) {
                 builder.port(requestUri.getPort());
             }
             return builder.build().toString();
+        } else {
+            return null;
         }
     }
 }

--- a/themes/src/main/resources/theme/base/account/resources.ftl
+++ b/themes/src/main/resources/theme/base/account/resources.ftl
@@ -202,7 +202,7 @@
                                 </a>
                             </td>
                             <td>
-                                <a href="${resource.resourceServer.redirectUri}">${resource.resourceServer.name}</a>
+                                <a href="${resource.resourceServer.baseUri}">${resource.resourceServer.name}</a>
                             </td>
                             <td>
                                 <#if resource.shares?size != 0>
@@ -259,7 +259,7 @@
                                         <#if resource.owner.email??>${resource.owner.email}<#else>${resource.owner.username}</#if>
                                     </td>
                                     <td>
-                                        <a href="${resource.resourceServer.redirectUri}">${resource.resourceServer.name}</a>
+                                        <a href="${resource.resourceServer.baseUri}">${resource.resourceServer.name}</a>
                                     </td>
                                     <td>
                                         <#if resource.permissions?size != 0>


### PR DESCRIPTION
Currently, UMA resource server link on the _My Resource_ page is chosen from one of the _Valid Redirect URIs_.

![RSLink](https://user-images.githubusercontent.com/1562861/61015150-67fc8d00-a3c5-11e9-8ec2-9c89579cf23d.png)

For example, if an UMA resource server is setup as follows:

![settings](https://user-images.githubusercontent.com/1562861/60936371-cfec9e00-a307-11e9-9931-57c178bb558d.png)

then the UMA resource server link on the _My Resource_ page is:

![result](https://user-images.githubusercontent.com/1562861/60936368-cebb7100-a307-11e9-97f3-c6ee277a6ca8.png)

HTML code of this link is:

`<a href="/authz-uma-api/*">authz-uma-api</a>`

If clicking the link, then HTTP 404 error occurs. So the link should be changed to (_Root URL_ +) _Base URL_.

----

Could you do me a favor?
I would like to remove all of the attached image files on [KEYCLOAK-10665](https://issues.jboss.org/browse/KEYCLOAK-10665) and [KEYCLOAK-10807](https://issues.jboss.org/browse/KEYCLOAK-10807). I uploaded unsuitable image files which can confuse you by mistake but I cannot remove them.