### PR TITLE
KEYCLOAK-10665 Fix incorrect client link on my resources page

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/account/AccountFormService.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountFormService.java
@@ -971,7 +971,7 @@ public class AccountFormService extends AbstractSecuredLocalService {
             if (referrerUri != null) {
                 referrerUri = RedirectUtils.verifyRedirectUri(session.getContext().getUri(), referrerUri, realm, referrerClient);
             } else {
-                referrerUri = ResolveRelative.resolveRelativeUri(session.getContext().getUri().getRequestUri(), client.getRootUrl(), referrerClient.getBaseUrl());
+                referrerUri = ResolveRelative.resolveRelativeUri(session.getContext().getUri().getRequestUri(), referrerClient.getRootUrl(), referrerClient.getBaseUrl());
             }
 
             if (referrerUri != null) {
@@ -982,9 +982,8 @@ public class AccountFormService extends AbstractSecuredLocalService {
                 return new String[]{referrerName, referrerUri};
             }
         } else if (referrerUri != null) {
-            referrerClient = realm.getClientByClientId(referrer);
             if (client != null) {
-                referrerUri = RedirectUtils.verifyRedirectUri(session.getContext().getUri(), referrerUri, realm, referrerClient);
+                referrerUri = RedirectUtils.verifyRedirectUri(session.getContext().getUri(), referrerUri, realm, client);
 
                 if (referrerUri != null) {
                     return new String[]{referrer, referrerUri};


### PR DESCRIPTION
Currently, Back to UMA client application link on top right of the _My Resource_ page can become host (Keyclaok server) URL if the application uses relative path for _Base URL_.

![headerLink](https://user-images.githubusercontent.com/1562861/61015682-9b401b80-a3c7-11e9-8df1-45e3d8da8278.png)

For example, if an UMA client is setup as follows:

![settings](https://user-images.githubusercontent.com/1562861/60939193-c1a37f80-a311-11e9-9eea-0bf5abccf22f.png)

then the UMA client link on the My Resource page is:

![beforeLogout](https://user-images.githubusercontent.com/1562861/60939392-6cb43900-a312-11e9-9ebe-8337a6996930.png)

However, after re-logging in, the link is changed to:

![afterLogout](https://user-images.githubusercontent.com/1562861/60939391-6cb43900-a312-11e9-9046-8dfaf673b74f.png)

_AccountFormService.getReferrer()_ seems to be broken and should be fixed.
