### PR TITLE
Fixes to allow longer timeouts in DB tests

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/javascript/JavascriptTestExecutor.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/javascript/JavascriptTestExecutor.java
@@ -2,6 +2,7 @@ package org.keycloak.testsuite.util.javascript;
 
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.testsuite.auth.page.login.OIDCLogin;
+import org.keycloak.testsuite.util.WaitUtils;
 import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
@@ -29,7 +30,7 @@ public class JavascriptTestExecutor {
 
     protected JavascriptTestExecutor(WebDriver driver, OIDCLogin loginPage) {
         this.jsDriver = driver;
-        driver.manage().timeouts().setScriptTimeout(10, TimeUnit.SECONDS);
+        driver.manage().timeouts().setScriptTimeout(WaitUtils.PAGELOAD_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
         jsExecutor = (JavascriptExecutor) driver;
         events = driver.findElement(By.id("events"));
         output = driver.findElement(By.id("output"));

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/ComponentsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/ComponentsTest.java
@@ -67,9 +67,9 @@ public class ComponentsTest extends AbstractAdminTest {
         }
 
         try {
-            assertTrue("Did not create all components in time", this.remainingDeleteSubmissions.await(30, TimeUnit.SECONDS));
+            assertTrue("Did not create all components in time", this.remainingDeleteSubmissions.await(100, TimeUnit.SECONDS));
             s.shutdown();
-            assertTrue("Did not finish before timeout", s.awaitTermination(30, TimeUnit.SECONDS));
+            assertTrue("Did not finish before timeout", s.awaitTermination(100, TimeUnit.SECONDS));
         } finally {
             s.shutdownNow();
         }

--- a/testsuite/integration-arquillian/tests/base/src/test/resources/arquillian.xml
+++ b/testsuite/integration-arquillian/tests/base/src/test/resources/arquillian.xml
@@ -122,6 +122,7 @@
             <!-- This is required for domain mode -->
             <property name="allowConnectingToRunningServer">true</property>
             <property name="jbossArguments">
+                -Djboss.as.management.blocking.timeout=${auth.server.jboss.startup.timeout}
                 -Djboss.socket.binding.port-offset=${auth.server.port.offset}
                 -Djboss.bind.address=0.0.0.0 
                 -Dauth.server.http.port=${auth.server.http.port}
@@ -155,6 +156,7 @@
                 <property name="jbossHome">${auth.server.backend1.home}</property>
                 <property name="serverConfig">standalone-ha.xml</property>
                 <property name="jbossArguments">
+                    -Djboss.as.management.blocking.timeout=${auth.server.jboss.startup.timeout}
                     -Djboss.socket.binding.port-offset=${auth.server.backend1.port.offset}
                     -Djboss.node.name=node1
                     ${adapter.test.props}
@@ -181,6 +183,7 @@
                 <property name="jbossHome">${auth.server.backend2.home}</property>
                 <property name="serverConfig">standalone-ha.xml</property>
                 <property name="jbossArguments">
+                    -Djboss.as.management.blocking.timeout=${auth.server.jboss.startup.timeout}
                     -Djboss.socket.binding.port-offset=${auth.server.backend2.port.offset} 
                     -Djboss.node.name=node2
                     ${adapter.test.props}
@@ -265,6 +268,7 @@
                 <property name="jbossHome">${cache.server.home}</property>
                 <property name="serverConfig">clustered-1.xml</property>
                 <property name="jbossArguments">
+                    -Djboss.as.management.blocking.timeout=${auth.server.jboss.startup.timeout}
                     -Djboss.socket.binding.port-offset=${cache.server.1.port.offset}
                     -Djboss.default.multicast.address=234.56.78.99
                     -Djboss.node.name=cache-server-dc-1
@@ -295,6 +299,7 @@
                 <property name="cleanServerBaseDir">${cache.server.home}/standalone-dc-2</property>
                 <property name="serverConfig">clustered-2.xml</property>
                 <property name="jbossArguments">
+                    -Djboss.as.management.blocking.timeout=${auth.server.jboss.startup.timeout}
                     -Djboss.socket.binding.port-offset=${cache.server.2.port.offset}
                     -Djboss.default.multicast.address=234.56.78.100
                     -Djboss.node.name=cache-server-dc-2
@@ -438,6 +443,7 @@
                 <property name="jbossHome">${auth.server.crossdc01.home}</property>
                 <property name="serverConfig">standalone-ha.xml</property>
                 <property name="jbossArguments">
+                    -Djboss.as.management.blocking.timeout=${auth.server.jboss.startup.timeout}
                     -Djboss.socket.binding.port-offset=${auth.server.crossdc01.port.offset}
                     -Djboss.default.multicast.address=234.56.78.1
                     -Dremote.cache.port=12232
@@ -469,6 +475,7 @@
                 <property name="jbossHome">${auth.server.crossdc02.home}</property>
                 <property name="serverConfig">standalone-ha.xml</property>
                 <property name="jbossArguments">
+                    -Djboss.as.management.blocking.timeout=${auth.server.jboss.startup.timeout}
                     -Djboss.socket.binding.port-offset=${auth.server.crossdc02.port.offset}
                     -Djboss.default.multicast.address=234.56.78.1
                     -Dremote.cache.port=12232
@@ -501,6 +508,7 @@
                 <property name="jbossHome">${auth.server.crossdc11.home}</property>
                 <property name="serverConfig">standalone-ha.xml</property>
                 <property name="jbossArguments">
+                    -Djboss.as.management.blocking.timeout=${auth.server.jboss.startup.timeout}
                     -Djboss.socket.binding.port-offset=${auth.server.crossdc11.port.offset}
                     -Djboss.default.multicast.address=234.56.78.2
                     -Dremote.cache.port=13232
@@ -532,6 +540,7 @@
                 <property name="jbossHome">${auth.server.crossdc12.home}</property>
                 <property name="serverConfig">standalone-ha.xml</property>
                 <property name="jbossArguments">
+                    -Djboss.as.management.blocking.timeout=${auth.server.jboss.startup.timeout}
                     -Djboss.socket.binding.port-offset=${auth.server.crossdc12.port.offset}
                     -Djboss.default.multicast.address=234.56.78.2
                     -Dremote.cache.port=13232
@@ -578,6 +587,7 @@
             <property name="adapterImplClass">org.jboss.as.arquillian.container.managed.ManagedDeployableContainer</property>
             <property name="jbossHome">${keycloak.migration.home}</property>
             <property name="javaVmArguments">
+                -Djboss.as.management.blocking.timeout=${auth.server.jboss.startup.timeout}
                 -Djboss.socket.binding.port-offset=${auth.server.port.offset}
                 ${migration.import.props.previous}
                 ${auth.server.memory.settings}


### PR DESCRIPTION
In some case when the connection from Keycloak to DB is slow (EG. Keycloak testing pipeline), some tests can fail due the various timeouts. What was seen so far is either:
- timeout when starting server ( KEYCLOAK-10793 )
- timeout when sending WebDriver or WebDriver JS requests ( KEYCLOAK-10753 )
- timeout for the time limit of the test itself ( KEYCLOAK-10813 ).

Sorry to have 3 JIRAs in single PR. I wanted to run pipeline for single time to verify all 3 fixes. But there is separate commit for each change. What is here is:
- KEYCLOAK-10793: Possibility to increase server startup timeout. The property "startupTimeoutInSeconds" of arquillian ManagedDeployableContainer is just arquillian-internal, but doesn't propagate the timeout to underlying Wildfly server, which has also timeout of 300 seconds by default. So adding "jboss.as.management.blocking.timeout" was done to have ability to increase timeout, which WF/EAP server will be aware as well. Now when running test with property "auth.server.jboss.startup.timeout", it is propagated to both WF and arquillian.

- KEYCLOAK-10753: Possibility to have JS request timeout sent by WebDriver configurable by "pageload.timeout" property instead of have hardcoded value 10 seconds. The "pageload.timeout" property is already used for non-JS WebDriver requests.

- KEYCLOAK-10813: Possibility to increase timeout of ComponentsTest. This is the only commit, which doesn't require change in the pipeline. For the 2 other, there will be also keycloak-pipeline PR needed.


