### PR TITLE
KEYCLOAK-10752 keep identity cookie if login completes without error

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocolService.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocolService.java
@@ -254,9 +254,9 @@ public class OIDCLoginProtocolService {
     @GET
     @Path("delegated")
     public Response kcinitBrowserLoginComplete(@QueryParam("error") boolean error) {
-        AuthenticationManager.expireIdentityCookie(realm, session.getContext().getUri(), clientConnection);
-        AuthenticationManager.expireRememberMeCookie(realm, session.getContext().getUri(), clientConnection);
         if (error) {
+        	AuthenticationManager.expireIdentityCookie(realm, session.getContext().getUri(), clientConnection);
+        	AuthenticationManager.expireRememberMeCookie(realm, session.getContext().getUri(), clientConnection);
             LoginFormsProvider forms = session.getProvider(LoginFormsProvider.class);
             return forms
                     .setAttribute("messageHeader", forms.getMessage(Messages.DELEGATION_FAILED_HEADER))


### PR DESCRIPTION
See https://issues.jboss.org/browse/KEYCLOAK-10752