### PR TITLE
KEYCLOAK-10849 KeycloakRole equals only with itself

### DIFF
--- a/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/account/KeycloakRole.java
+++ b/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/account/KeycloakRole.java
@@ -51,13 +51,13 @@ public class KeycloakRole implements GrantedAuthority {
         if (this == o) {
             return true;
         }
-        if (!(o instanceof KeycloakRole)) {
+        if (!(o instanceof GrantedAuthority)) {
             return false;
         }
 
-        KeycloakRole that = (KeycloakRole) o;
+        GrantedAuthority that = (GrantedAuthority) o;
 
-        if (!role.equals(that.role)) {
+        if (!role.equals(that.getAuthority())) {
             return false;
         }
 


### PR DESCRIPTION
I use Keycloak Spring Adapter (KSA) to secure existing application. Today I realized that some functions didn't work anymore because of security checking like this:
```
GrantedAuthority adminRole = new MySpecialGrantedAuthority( "superadmin" );
for ( GrantedAuthority role : userRoles ) {
        if ( role.equals( adminRole ) ) {
          return true;
        }
      }
```
In this example, when I use KSA authorization fails.
I believe, that more preferable in `KeycloakRole` use this implementation of `equals` method.

Previous discussion:
https://github.com/keycloak/keycloak/pull/6113
