### PR TITLE
KEYCLOAK-10022 Fixing few admin events not raised bug

### DIFF
--- a/services/src/main/java/org/keycloak/authorization/admin/PolicyResourceService.java
+++ b/services/src/main/java/org/keycloak/authorization/admin/PolicyResourceService.java
@@ -113,9 +113,7 @@ public class PolicyResourceService {
 
         policyStore.delete(policy.getId());
 
-        if (authorization.getRealm().isAdminEventsEnabled()) {
-            audit(toRepresentation(policy, authorization), OperationType.DELETE);
-        }
+        audit(toRepresentation(policy, authorization), OperationType.DELETE);
 
         return Response.noContent().build();
     }
@@ -257,8 +255,6 @@ public class PolicyResourceService {
     }
 
     private void audit(AbstractPolicyRepresentation policy, OperationType operation) {
-        if (authorization.getRealm().isAdminEventsEnabled()) {
-            adminEvent.operation(operation).resourcePath(authorization.getKeycloakSession().getContext().getUri()).representation(policy).success();
-        }
+        adminEvent.operation(operation).resourcePath(authorization.getKeycloakSession().getContext().getUri()).representation(policy).success();
     }
 }

--- a/services/src/main/java/org/keycloak/authorization/admin/PolicyService.java
+++ b/services/src/main/java/org/keycloak/authorization/admin/PolicyService.java
@@ -320,12 +320,10 @@ public class PolicyService {
     }
 
     private void audit(AbstractPolicyRepresentation resource, String id, OperationType operation, KeycloakSession session) {
-        if (authorization.getRealm().isAdminEventsEnabled()) {
-            if (id != null) {
-                adminEvent.operation(operation).resourcePath(session.getContext().getUri(), id).representation(resource).success();
-            } else {
-                adminEvent.operation(operation).resourcePath(session.getContext().getUri()).representation(resource).success();
-            }
+        if (id != null) {
+            adminEvent.operation(operation).resourcePath(session.getContext().getUri(), id).representation(resource).success();
+        } else {
+            adminEvent.operation(operation).resourcePath(session.getContext().getUri()).representation(resource).success();
         }
     }
 }

--- a/services/src/main/java/org/keycloak/authorization/admin/ResourceSetService.java
+++ b/services/src/main/java/org/keycloak/authorization/admin/ResourceSetService.java
@@ -166,9 +166,7 @@ public class ResourceSetService {
 
         storeFactory.getResourceStore().delete(id);
 
-        if (authorization.getRealm().isAdminEventsEnabled()) {
-            audit(toRepresentation(resource, resourceServer, authorization), OperationType.DELETE);
-        }
+        audit(toRepresentation(resource, resourceServer, authorization), OperationType.DELETE);
 
         return Response.noContent().build();
     }
@@ -471,12 +469,10 @@ public class ResourceSetService {
     }
 
     public void audit(ResourceRepresentation resource, String id, OperationType operation) {
-        if (authorization.getRealm().isAdminEventsEnabled()) {
-            if (id != null) {
-                adminEvent.operation(operation).resourcePath(session.getContext().getUri(), id).representation(resource).success();
-            } else {
-                adminEvent.operation(operation).resourcePath(session.getContext().getUri()).representation(resource).success();
-            }
+        if (id != null) {
+            adminEvent.operation(operation).resourcePath(session.getContext().getUri(), id).representation(resource).success();
+        } else {
+            adminEvent.operation(operation).resourcePath(session.getContext().getUri()).representation(resource).success();
         }
     }
 }

--- a/services/src/main/java/org/keycloak/authorization/admin/ScopeService.java
+++ b/services/src/main/java/org/keycloak/authorization/admin/ScopeService.java
@@ -143,9 +143,7 @@ public class ScopeService {
 
         storeFactory.getScopeStore().delete(id);
 
-        if (authorization.getRealm().isAdminEventsEnabled()) {
-            audit(toRepresentation(scope), OperationType.DELETE);
-        }
+        audit(toRepresentation(scope), OperationType.DELETE);
 
         return Response.noContent().build();
     }
@@ -266,12 +264,10 @@ public class ScopeService {
     }
 
     private void audit(ScopeRepresentation resource, String id, OperationType operation) {
-        if (authorization.getRealm().isAdminEventsEnabled()) {
-            if (id != null) {
-                adminEvent.operation(operation).resourcePath(session.getContext().getUri(), id).representation(resource).success();
-            } else {
-                adminEvent.operation(operation).resourcePath(session.getContext().getUri()).representation(resource).success();
-            }
+        if (id != null) {
+            adminEvent.operation(operation).resourcePath(session.getContext().getUri(), id).representation(resource).success();
+        } else {
+            adminEvent.operation(operation).resourcePath(session.getContext().getUri()).representation(resource).success();
         }
     }
 }


### PR DESCRIPTION
<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
Fixing the bug KEYCLOAK-10022. It was due to a wrong flag being
checked to decide whether the admin events has to be raised or not. 

For instance, in file PolicyResourceService.java at line number 260, the
flag "authorization.getRealm().isAdminEventsEnabled()" is being checked
before raising the admin event. Actually, this flag is used to identify
whether the admin events are to be saved or not saved and not to
identify whether admin events are to be raised or not raised. 

The fix is to remove the if condition that checks for this flag before
raising the admin events. The same fix applies in few other
files: PolicyService.java, ResourceSetService.java and
ScopeService.java.

