### PR TITLE
KEYCLOAK-10875 Adding quotes around the path to the JAR in case %DIRNAME% contains spaces

### DIFF
--- a/integration/client-cli/admin-cli/src/main/bin/kcadm.bat
+++ b/integration/client-cli/admin-cli/src/main/bin/kcadm.bat
@@ -5,4 +5,4 @@ if "%OS%" == "Windows_NT" (
 ) else (
   set DIRNAME=.\
 )
-java %KC_OPTS% -cp %DIRNAME%\client\keycloak-admin-cli-${project.version}.jar org.keycloak.client.admin.cli.KcAdmMain %*
+java %KC_OPTS% -cp "%DIRNAME%\client\keycloak-admin-cli-${project.version}.jar" org.keycloak.client.admin.cli.KcAdmMain %*


### PR DESCRIPTION
Adding quotes around path to JAR to handle the scenario where Keycloak is installed to C:\Program Files\Keycloak