### PR TITLE
When switching to PLAIN in PKCE look for both allowed values (FIXED)

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
@@ -455,12 +455,19 @@ public class TokenEndpoint {
         try {
             // https://tools.ietf.org/html/rfc7636#section-4.2
             // plain or S256
-            if (codeChallengeMethod != null && codeChallengeMethod.equals(OAuth2Constants.PKCE_METHOD_S256)) {
-                logger.debugf("PKCE codeChallengeMethod = %s", codeChallengeMethod);
-                codeVerifierEncoded = generateS256CodeChallenge(codeVerifier);
-            } else {
-                logger.debug("PKCE codeChallengeMethod is plain");
-                codeVerifierEncoded = codeVerifier;
+            if(codeChallengeMethod != null) {
+                if(codeChallengeMethod.equals(OAuth2Constants.PKCE_METHOD_S256))) {
+                    logger.debugf("PKCE codeChallengeMethod = %s", codeChallengeMethod);
+                    codeVerifierEncoded = generateS256CodeChallenge(codeVerifier);
+                }
+                else if(codeChallengeMethod.equals(OAuth2Constants.PKCE_METHOD_PLAIN) {
+                    logger.debug("PKCE codeChallengeMethod is plain");
+                    codeVerifierEncoded = codeVerifier;
+                }
+                else {
+                    logger.warn("PKCE codeChallengeMethod neither S256 nor PLAIN : using PLAIN (missing code_challenge_method in headers ?)");
+                    codeVerifierEncoded = codeVerifier;
+                }
             }
         } catch (Exception nae) {
             logger.infof("PKCE code verification failed, not supported algorithm specified");

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
@@ -456,16 +456,16 @@ public class TokenEndpoint {
             // https://tools.ietf.org/html/rfc7636#section-4.2
             // plain or S256
             if(codeChallengeMethod != null) {
-                if(codeChallengeMethod.equals(OAuth2Constants.PKCE_METHOD_S256))) {
+                if(codeChallengeMethod.equals(OAuth2Constants.PKCE_METHOD_S256)) {
                     logger.debugf("PKCE codeChallengeMethod = %s", codeChallengeMethod);
                     codeVerifierEncoded = generateS256CodeChallenge(codeVerifier);
                 }
-                else if(codeChallengeMethod.equals(OAuth2Constants.PKCE_METHOD_PLAIN) {
+                else if(codeChallengeMethod.equals(OAuth2Constants.PKCE_METHOD_PLAIN)) {
                     logger.debug("PKCE codeChallengeMethod is plain");
                     codeVerifierEncoded = codeVerifier;
                 }
                 else {
-                    logger.warn("PKCE codeChallengeMethod neither S256 nor PLAIN : using PLAIN (missing code_challenge_method in headers ?)");
+                    logger.warn("PKCE codeChallengeMethod is neither S256 nor PLAIN : using PLAIN (missing code_challenge_method in headers ?)");
                     codeVerifierEncoded = codeVerifier;
                 }
             }


### PR DESCRIPTION
Instead of checking for S256 in code_challenge_method and switching to PLAIN if S256 was not found, check for S256 then PLAIN and report to console as WARNING when none of the allowed values has been found. This helps detecting client programmer errors when they don't set the code_challenge_method properly, think they are using S256 and get PKCE errors because Keycloak switched to PLAIN and only report this when DEBUG level is set (which we usually do not do in production of very busy servers).

Note : finding this is very annoying on production. On production servers, we are usually running INFO level for log4j. Switching to DEBUG on busy servers within a cluster is a big NO-NO so I had to replicate the problem on test servers, to find out the client programmer made a mistake ans was using neither S256 nor PLAIN and Keycloak switches to PLAIN when it's not S256 and I would have prefered a report to console that the method used was not within the two known and authorized values :/

This pull request replaces the previous one, stupid me not checking the module did compile and some parenthesis were misplaced.