### PR TITLE
KEYCLOAK-8318 Workaround Elytron's double encoding of the query parameters

### DIFF
--- a/adapters/oidc/wildfly-elytron/src/main/java/org/keycloak/adapters/elytron/ElytronHttpFacade.java
+++ b/adapters/oidc/wildfly-elytron/src/main/java/org/keycloak/adapters/elytron/ElytronHttpFacade.java
@@ -19,7 +19,6 @@
 package org.keycloak.adapters.elytron;
 
 import io.undertow.server.handlers.CookieImpl;
-import org.bouncycastle.asn1.cmp.Challenge;
 import org.keycloak.KeycloakSecurityContext;
 import org.keycloak.adapters.AdapterDeploymentContext;
 import org.keycloak.adapters.AdapterTokenStore;
@@ -31,10 +30,8 @@ import org.keycloak.adapters.spi.AuthenticationError;
 import org.keycloak.adapters.spi.LogoutError;
 import org.keycloak.enums.TokenStore;
 import org.wildfly.security.auth.server.SecurityIdentity;
-import org.wildfly.security.http.HttpAuthenticationException;
 import org.wildfly.security.http.HttpScope;
 import org.wildfly.security.http.HttpServerCookie;
-import org.wildfly.security.http.HttpServerMechanismsResponder;
 import org.wildfly.security.http.HttpServerRequest;
 import org.wildfly.security.http.HttpServerResponse;
 import org.wildfly.security.http.Scope;
@@ -201,9 +198,13 @@ class ElytronHttpFacade implements OIDCHttpFacade {
                 if (query != null) {
                     String[] parameters = query.split("&");
                     for (String parameter : parameters) {
-                        String[] keyValue = parameter.split("=");
+                        String[] keyValue = parameter.split("=", 2);
                         if (keyValue[0].equals(param)) {
-                            return keyValue[1];
+                            try {
+                                return URLDecoder.decode(keyValue[1], "UTF-8");
+                            } catch (IOException e) {
+                                throw new RuntimeException("Failed to decode request URI", e);
+                            }
                         }
                     }
                 }

--- a/adapters/saml/wildfly-elytron/src/main/java/org/keycloak/adapters/saml/elytron/ElytronHttpFacade.java
+++ b/adapters/saml/wildfly-elytron/src/main/java/org/keycloak/adapters/saml/elytron/ElytronHttpFacade.java
@@ -186,9 +186,13 @@ class ElytronHttpFacade implements HttpFacade {
                 if (query != null) {
                     String[] parameters = query.split("&");
                     for (String parameter : parameters) {
-                        String[] keyValue = parameter.split("=");
+                        String[] keyValue = parameter.split("=", 2);
                         if (keyValue[0].equals(param)) {
-                            return keyValue[1];
+                            try {
+                                return URLDecoder.decode(keyValue[1], "UTF-8");
+                            } catch (IOException e) {
+                                throw new RuntimeException("Failed to decode request URI", e);
+                            }
                         }
                     }
                 }

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/auth/page/login/LoginForm.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/auth/page/login/LoginForm.java
@@ -145,6 +145,10 @@ public class LoginForm extends Form {
         return accountFields.getUsernameLabel();
     }
 
+    public String getUsername() {
+        return accountFields.getUsername();
+    }
+
     public String getPasswordLabel() {
         return passwordFields.getPasswordLabel();
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/DemoServletsAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/DemoServletsAdapterTest.java
@@ -1409,4 +1409,12 @@ public class DemoServletsAdapterTest extends AbstractServletsAdapterTest {
                 .clearDetails()
                 .assertEvent(); 
     }
+
+    @Test
+    public void testLoginHintFromClientRequest() {
+        driver.navigate().to(customerPortal + "?login_hint=blah%3d");
+        waitForPageToLoad();
+        assertCurrentUrlStartsWithLoginUrlOf(testRealmPage);
+        assertThat(testRealmLoginPage.form().getUsername(), is("blah="));
+    }
 }


### PR DESCRIPTION
Both SAML and OIDC `ElytronHttpFacade` classes obtain query parametrs using elytron's `ElytronHttpExchange.getRequestURI()`. The [`getRequestURI`](https://github.com/wildfly-security/elytron-web/blob/1.x/undertow/src/main/java/org/wildfly/elytron/web/undertow/server/ElytronHttpExchange.java#L187) method performs double encoding of the query string since [`query` obtained from `httpServerExchange`](https://github.com/wildfly-security/elytron-web/blob/1.6.0.CR1/undertow/src/main/java/org/wildfly/elytron/web/undertow/server/ElytronHttpExchange.java#L187) is ["not decoded in any way"](https://github.com/undertow-io/undertow/blob/2.0.22.Final/core/src/main/java/io/undertow/server/HttpServerExchange.java#L440) but [every character that is not a legal URI character (including `%`) is encoded again](https://docs.oracle.com/javase/8/docs/api/java/net/URI.html#URI-java.lang.String-java.lang.String-java.lang.String-java.lang.String-java.lang.String-) when [instantiating the resulting URI](https://github.com/wildfly-security/elytron-web/blob/1.6.0.CR1/undertow/src/main/java/org/wildfly/elytron/web/undertow/server/ElytronHttpExchange.java#L203). This needs to be accounted for in Elytron adapters.