### PR TITLE
KEYCLOAK-5571 Changes to support emailVerified boolean mapper with LD…

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/model/LDAPObject.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/model/LDAPObject.java
@@ -102,6 +102,16 @@ public class LDAPObject {
         setAttribute(attributeName, asSet);
     }
 
+    public void setSingleBooleanAttribute(String attributeName, Boolean attributeValue) {
+        Set<String> asSet = new LinkedHashSet<>();
+	if (attributeValue == true) {
+            asSet.add("TRUE");
+	} else {
+            asSet.add("FALSE");
+	}
+        setAttribute(attributeName, asSet);
+    }
+
     public void setAttribute(String attributeName, Set<String> attributeValue) {
         attributes.put(attributeName, attributeValue);
         lowerCasedAttributes.put(attributeName.toLowerCase(), attributeValue);

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPIdentityStore.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPIdentityStore.java
@@ -426,7 +426,14 @@ public class LDAPIdentityStore implements IdentityStore {
                         if (val instanceof byte[]) { // byte[]
                             String attrVal = Base64.encodeBytes((byte[]) val);
                             attrValues.add(attrVal);
-                        } else { // String
+                        } if (val instanceof Boolean) { //Boolean
+			    Boolean attrVal = (Boolean)val;
+		    	    if (attrVal == true) {
+		        	attrValues.add("TRUE");
+	    	   	    } else {
+                            	attrValues.add("FALSE");
+			    }
+			}else { // String
                             String attrVal = val.toString().trim();
                             attrValues.add(attrVal);
                         }

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/UserAttributeLDAPStorageMapper.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/UserAttributeLDAPStorageMapper.java
@@ -134,7 +134,7 @@ public class UserAttributeLDAPStorageMapper extends AbstractLDAPStorageMapper {
 
             if (Boolean.class.equals(userModelProperty.getJavaClass()) || boolean.class.equals(userModelProperty.getJavaClass())) {
 		attrValue = false;
-		if (attrValue == "true" || attrValue == "TRUE") {
+		if (attrValue.equals("true") || attrValue.equals("TRUE")) {
 		    attrValue = true;
 		}
 	    }

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/UserAttributeLDAPStorageMapper.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/UserAttributeLDAPStorageMapper.java
@@ -132,6 +132,12 @@ public class UserAttributeLDAPStorageMapper extends AbstractLDAPStorageMapper {
             // we have java property on UserModel. Assuming we support just properties of simple types
             Object attrValue = userModelProperty.getValue(localUser);
 
+            if (Boolean.class.equals(userModelProperty.getJavaClass()) || boolean.class.equals(userModelProperty.getJavaClass())) {
+		attrValue = false;
+		if (attrValue == "true" || attrValue == "TRUE") {
+		    attrValue = true;
+		}
+	    }
             if (attrValue == null) {
                 if (isMandatoryInLdap) {
                     ldapUser.setSingleAttribute(ldapAttrName, LDAPConstants.EMPTY_ATTRIBUTE_VALUE);
@@ -139,7 +145,11 @@ public class UserAttributeLDAPStorageMapper extends AbstractLDAPStorageMapper {
                     ldapUser.setAttribute(ldapAttrName, new LinkedHashSet<String>());
                 }
             } else {
-                ldapUser.setSingleAttribute(ldapAttrName, attrValue.toString());
+            	if (Boolean.class.equals(userModelProperty.getJavaClass()) || boolean.class.equals(userModelProperty.getJavaClass())) {
+              	    ldapUser.setSingleBooleanAttribute(ldapAttrName, (Boolean)attrValue);
+		} else {
+              	    ldapUser.setSingleAttribute(ldapAttrName, attrValue.toString());
+		}
             }
         } else {
 
@@ -259,6 +269,12 @@ public class UserAttributeLDAPStorageMapper extends AbstractLDAPStorageMapper {
                     super.setFirstName(firstName);
                 }
 
+                @Override
+                public void setEmailVerified(boolean verified) {
+                    setLDAPAttribute(UserModel.EMAIL_VERIFIED, verified);
+                    super.setEmailVerified(verified);
+                }
+
                 protected boolean setLDAPAttribute(String modelAttrName, Object value) {
                     if (modelAttrName.equalsIgnoreCase(userModelAttrName)) {
                         if (UserAttributeLDAPStorageMapper.logger.isTraceEnabled()) {
@@ -275,6 +291,8 @@ public class UserAttributeLDAPStorageMapper extends AbstractLDAPStorageMapper {
                             }
                         } else if (value instanceof String) {
                             ldapUser.setSingleAttribute(ldapAttrName, (String) value);
+                        } else if (value instanceof Boolean) {
+              	    	    ldapUser.setSingleBooleanAttribute(ldapAttrName, (Boolean)value);
                         } else {
                             List<String> asList = (List<String>) value;
                             if (asList.isEmpty() && isMandatoryInLdap) {

--- a/server-spi/src/main/java/org/keycloak/models/UserModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/UserModel.java
@@ -34,6 +34,7 @@ public interface UserModel extends RoleMapperModel {
     String LAST_NAME = "lastName";
     String FIRST_NAME = "firstName";
     String EMAIL = "email";
+    String EMAIL_VERIFIED = "emailVerified";
     String LOCALE = "locale";
     String INCLUDE_SERVICE_ACCOUNT = "keycloak.session.realm.users.query.include_service_account";
     String GROUPS = "keycloak.session.realm.users.query.groups";


### PR DESCRIPTION
KEYCLOAK-5571 Changes to support emailVerified boolean mapper with LDAP user federation.

LDAP Boolean attributes accept "TRUE" or "FALSE" (https://tools.ietf.org/html/rfc4517#page-7). 
java Boolean to LDAP Boolean mapping done in case mapper is of LDAP Boolean type.
