### PR TITLE
KEYCLOAK-10033 Prevent connections going stale

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/resources/META-INF/keycloak-server.json
+++ b/testsuite/integration-arquillian/tests/base/src/test/resources/META-INF/keycloak-server.json
@@ -91,7 +91,9 @@
     },
 
     "connectionsHttpClient": {
-        "default": {}
+        "default": {
+            "max-connection-idle-time-millis": 1000
+        }
     },
 
 


### PR DESCRIPTION
https://issues.jboss.org/browse/KEYCLOAK-10033 

This PR contains a different approach for solving `NoHttpResponseException` (it is based on https://stackoverflow.com/questions/10558791/apache-httpclient-interim-error-nohttpresponseexception)

This may possibly replace https://github.com/keycloak/keycloak/pull/6142 (if it solves the problem).