### PR TITLE
[KEYCLOAK-7416] - Device info - Part 1

### DIFF
--- a/common/src/main/java/org/keycloak/common/ClientConnection.java
+++ b/common/src/main/java/org/keycloak/common/ClientConnection.java
@@ -31,4 +31,6 @@ public interface ClientConnection {
 
     String getLocalAddr();
     int getLocalPort();
+
+    DeviceInfo getDeviceInfo();
 }

--- a/common/src/main/java/org/keycloak/common/DeviceInfo.java
+++ b/common/src/main/java/org/keycloak/common/DeviceInfo.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.common;
+
+public class DeviceInfo {
+
+    public static final String NOTE = "DEVICE_INFO";
+
+    private String ip;
+    private String device;
+    private String browser;
+    private String browserVersion;
+    private String os;
+    private String osVersion;
+    private String userAgent;
+
+    public DeviceInfo() {
+        this(null, null, null, null, null, null, null);
+    }
+
+    public DeviceInfo(String device, String browser, String browserVersion, String os, String osVersion, String ip, String userAgent) {
+        this.device = device;
+        this.browser = browser;
+        this.browserVersion = browserVersion;
+        this.os = os;
+        this.osVersion = osVersion;
+        this.ip = ip;
+        this.userAgent = userAgent;
+    }
+
+    public String getDevice() {
+        return device;
+    }
+
+    public String getBrowser() {
+        return browser;
+    }
+
+    public String getBrowserVersion() {
+        return browserVersion;
+    }
+
+    public String getOs() {
+        return os;
+    }
+
+    public String getOsVersion() {
+        return osVersion;
+    }
+
+    public String getIp() {
+        return ip;
+    }
+
+    public String getUserAgent() {
+        return userAgent;
+    }
+}

--- a/core/src/main/java/org/keycloak/representations/account/SessionRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/account/SessionRepresentation.java
@@ -2,6 +2,8 @@ package org.keycloak.representations.account;
 
 import java.util.List;
 
+import org.keycloak.common.DeviceInfo;
+
 /**
  * Created by st on 29/03/17.
  */
@@ -13,6 +15,7 @@ public class SessionRepresentation {
     private int lastAccess;
     private int expires;
     private List<ClientRepresentation> clients;
+    private DeviceInfo deviceInfo;
 
     public String getId() {
         return id;
@@ -60,5 +63,13 @@ public class SessionRepresentation {
 
     public void setClients(List<ClientRepresentation> clients) {
         this.clients = clients;
+    }
+
+    public void setDeviceInfo(DeviceInfo deviceInfo) {
+        this.deviceInfo = deviceInfo;
+    }
+
+    public DeviceInfo getDeviceInfo() {
+        return deviceInfo;
     }
 }

--- a/distribution/feature-packs/server-feature-pack/pom.xml
+++ b/distribution/feature-packs/server-feature-pack/pom.xml
@@ -53,6 +53,16 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>com.github.ua-parser</groupId>
+            <artifactId>uap-java</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>com.google.zxing</groupId>
             <artifactId>core</artifactId>
             <exclusions>

--- a/distribution/feature-packs/server-feature-pack/src/main/resources/modules/system/layers/keycloak/com/github/ua-parser/main/module.xml
+++ b/distribution/feature-packs/server-feature-pack/src/main/resources/modules/system/layers/keycloak/com/github/ua-parser/main/module.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2016 Red Hat, Inc. and/or its affiliates
+  ~ and other contributors as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<module xmlns="urn:jboss:module:1.3" name="com.github.ua-parser">
+    <resources>
+        <artifact name="${com.github.ua-parser:uap-java}"/>
+    </resources>
+    <dependencies>
+        <module name="org.yaml.snakeyaml"/>
+    </dependencies>
+</module>

--- a/distribution/feature-packs/server-feature-pack/src/main/resources/modules/system/layers/keycloak/org/keycloak/keycloak-services/main/module.xml
+++ b/distribution/feature-packs/server-feature-pack/src/main/resources/modules/system/layers/keycloak/org/keycloak/keycloak-services/main/module.xml
@@ -61,6 +61,7 @@
         <module name="com.fasterxml.jackson.core.jackson-annotations"/>
         <module name="com.fasterxml.jackson.core.jackson-databind"/>
         <module name="com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider"/>
+        <module name="com.github.ua-parser"/>
         <module name="com.google.zxing.core"/>
         <module name="com.google.zxing.javase"/>
         <module name="org.jboss.logging"/>

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/UserSessionAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/UserSessionAdapter.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.models.sessions.infinispan;
 
+import org.keycloak.common.DeviceInfo;
 import org.keycloak.models.AuthenticatedClientSessionModel;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
@@ -32,7 +33,9 @@ import org.keycloak.models.sessions.infinispan.changes.sessions.CrossDCLastSessi
 import org.keycloak.models.sessions.infinispan.entities.AuthenticatedClientSessionEntity;
 import org.keycloak.models.sessions.infinispan.entities.AuthenticatedClientSessionStore;
 import org.keycloak.models.sessions.infinispan.entities.UserSessionEntity;
+import org.keycloak.util.JsonSerialization;
 
+import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -325,6 +328,32 @@ public class UserSessionAdapter implements UserSessionModel {
         };
 
         update(task);
+    }
+
+    @Override
+    public void setDeviceInfo(DeviceInfo deviceInfo) {
+        if (deviceInfo != null) {
+            try {
+                setNote(DeviceInfo.NOTE, JsonSerialization.writeValueAsString(deviceInfo));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+    
+    @Override
+    public DeviceInfo getDeviceInfo() {
+        String deviceInfo = getNote(DeviceInfo.NOTE);
+        
+        if (deviceInfo == null) {
+            return null;
+        }
+        
+        try {
+            return JsonSerialization.readValue(deviceInfo, DeviceInfo.class);
+        } catch (Exception cause) {
+            throw new RuntimeException(cause);
+        }
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,7 @@
         <xmlsec.version>2.1.3</xmlsec.version>
         <glassfish.json.version>1.1.2</glassfish.json.version>
         <wildfly.common.version>1.5.1.Final</wildfly.common.version>
+        <ua-parser.version>1.4.3</ua-parser.version>        
         <picketbox.version>5.0.3.Final</picketbox.version>
         <google.guava.version>25.0-jre</google.guava.version>
 
@@ -270,6 +271,11 @@
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bcpkix-jdk15on</artifactId>
                 <version>${bouncycastle.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.github.ua-parser</groupId>
+                <artifactId>uap-java</artifactId>
+                <version>${ua-parser.version}</version>
             </dependency>
             <dependency>
                 <groupId>javax.mail</groupId>

--- a/server-spi-private/src/main/java/org/keycloak/models/session/PersistentUserSessionAdapter.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/session/PersistentUserSessionAdapter.java
@@ -18,6 +18,7 @@
 package org.keycloak.models.session;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.keycloak.common.DeviceInfo;
 import org.keycloak.models.AuthenticatedClientSessionModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.ModelException;
@@ -241,6 +242,32 @@ public class PersistentUserSessionAdapter implements OfflineUserSessionModel {
     @Override
     public void restartSession(RealmModel realm, UserModel user, String loginUsername, String ipAddress, String authMethod, boolean rememberMe, String brokerSessionId, String brokerUserId) {
         throw new IllegalStateException("Not supported");
+    }
+
+    @Override
+    public void setDeviceInfo(DeviceInfo deviceInfo) {
+        if (deviceInfo != null) {
+            try {
+                setNote(DeviceInfo.NOTE, JsonSerialization.writeValueAsString(deviceInfo));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    @Override
+    public DeviceInfo getDeviceInfo() {
+        String deviceInfo = getNote(DeviceInfo.NOTE);
+
+        if (deviceInfo == null) {
+            return null;
+        }
+
+        try {
+            return JsonSerialization.readValue(deviceInfo, DeviceInfo.class);
+        } catch (Exception cause) {
+            throw new RuntimeException(cause);
+        }
     }
 
     @Override

--- a/server-spi/src/main/java/org/keycloak/models/UserSessionModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/UserSessionModel.java
@@ -20,6 +20,8 @@ package org.keycloak.models;
 import java.util.Collection;
 import java.util.Map;
 
+import org.keycloak.common.DeviceInfo;
+
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
  */
@@ -84,6 +86,10 @@ public interface UserSessionModel {
 
     // Will completely restart whole state of user session. It will just keep same ID.
     void restartSession(RealmModel realm, UserModel user, String loginUsername, String ipAddress, String authMethod, boolean rememberMe, String brokerSessionId, String brokerUserId);
+
+    void setDeviceInfo(DeviceInfo deviceInfo);
+
+    DeviceInfo getDeviceInfo();
 
     public static enum State {
         LOGGED_IN,

--- a/server-spi/src/main/java/org/keycloak/models/UserSessionProvider.java
+++ b/server-spi/src/main/java/org/keycloak/models/UserSessionProvider.java
@@ -18,6 +18,7 @@
 package org.keycloak.models;
 
 import org.keycloak.provider.Provider;
+import org.keycloak.sessions.RootAuthenticationSessionModel;
 
 import java.util.Collection;
 import java.util.List;
@@ -35,6 +36,7 @@ public interface UserSessionProvider extends Provider {
     AuthenticatedClientSessionModel getClientSession(UserSessionModel userSession, ClientModel client, UUID clientSessionId, boolean offline);
 
     UserSessionModel createUserSession(RealmModel realm, UserModel user, String loginUsername, String ipAddress, String authMethod, boolean rememberMe, String brokerSessionId, String brokerUserId);
+    UserSessionModel createUserSession(RootAuthenticationSessionModel parentSession, RealmModel realm, UserModel user, String loginUsername, String ipAddress, String authMethod, boolean rememberMe, String brokerSessionId, String brokerUserId);
     UserSessionModel createUserSession(String id, RealmModel realm, UserModel user, String loginUsername, String ipAddress, String authMethod, boolean rememberMe, String brokerSessionId, String brokerUserId);
     UserSessionModel getUserSession(RealmModel realm, String id);
     List<UserSessionModel> getUserSessions(RealmModel realm, UserModel user);

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -186,6 +186,10 @@
             <groupId>com.openshift</groupId>
             <artifactId>openshift-restclient-java</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.github.ua-parser</groupId>
+            <artifactId>uap-java</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/services/src/main/java/org/keycloak/authentication/AuthenticationProcessor.java
+++ b/services/src/main/java/org/keycloak/authentication/AuthenticationProcessor.java
@@ -940,7 +940,7 @@ public class AuthenticationProcessor {
 
             userSession = session.sessions().getUserSession(realm, authSession.getParentSession().getId());
             if (userSession == null) {
-                userSession = session.sessions().createUserSession(authSession.getParentSession().getId(), realm, authSession.getAuthenticatedUser(), username, connection.getRemoteAddr(), authSession.getProtocol()
+                userSession = session.sessions().createUserSession(authSession.getParentSession(), realm, authSession.getAuthenticatedUser(), username, connection.getRemoteAddr(), authSession.getProtocol()
                         , remember, brokerSessionId, brokerUserId);
             } else if (userSession.getUser() == null || !AuthenticationManager.isSessionValid(realm, userSession)) {
                 userSession.restartSession(realm, authSession.getAuthenticatedUser(), username, connection.getRemoteAddr(), authSession.getProtocol()

--- a/services/src/main/java/org/keycloak/authorization/admin/PolicyEvaluationService.java
+++ b/services/src/main/java/org/keycloak/authorization/admin/PolicyEvaluationService.java
@@ -256,7 +256,7 @@ public class PolicyEvaluationService {
                             .createAuthenticationSession(clientModel);
                     authSession.setProtocol(OIDCLoginProtocol.LOGIN_PROTOCOL);
                     authSession.setAuthenticatedUser(userModel);
-                    userSession = keycloakSession.sessions().createUserSession(authSession.getParentSession().getId(), realm, userModel, userModel.getUsername(), "127.0.0.1", "passwd", false, null, null);
+                    userSession = keycloakSession.sessions().createUserSession(authSession.getParentSession(), realm, userModel, userModel.getUsername(), "127.0.0.1", "passwd", false, null, null);
 
                     AuthenticationManager.setClientScopesInSession(authSession);
                     ClientSessionContext clientSessionCtx = TokenManager.attachAuthenticationSession(keycloakSession, userSession, authSession);

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
@@ -655,7 +655,7 @@ public class TokenEndpoint {
         authSession.setClientNote(OIDCLoginProtocol.ISSUER, Urls.realmIssuer(session.getContext().getUri().getBaseUri(), realm.getName()));
         authSession.setClientNote(OIDCLoginProtocol.SCOPE_PARAM, scope);
 
-        UserSessionModel userSession = session.sessions().createUserSession(authSession.getParentSession().getId(), realm, clientUser, clientUsername,
+        UserSessionModel userSession = session.sessions().createUserSession(authSession.getParentSession(), realm, clientUser, clientUsername,
                 clientConnection.getRemoteAddr(), ServiceAccountConstants.CLIENT_AUTH, false, null, null);
         event.session(userSession);
 

--- a/services/src/main/java/org/keycloak/services/resources/account/AccountRestService.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountRestService.java
@@ -28,13 +28,9 @@ import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
-import org.keycloak.models.UserSessionModel;
-import org.keycloak.representations.account.ClientRepresentation;
-import org.keycloak.representations.account.SessionRepresentation;
 import org.keycloak.representations.account.UserRepresentation;
 import org.keycloak.services.ErrorResponse;
 import org.keycloak.services.managers.Auth;
-import org.keycloak.services.managers.AuthenticationManager;
 import org.keycloak.services.messages.Messages;
 import org.keycloak.services.resources.Cors;
 import org.keycloak.services.resources.account.resources.ResourcesService;
@@ -45,7 +41,6 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import org.keycloak.common.Profile;
@@ -203,84 +198,10 @@ public class AccountRestService {
      * @return
      */
     @Path("/sessions")
-    @GET
-    @Produces(MediaType.APPLICATION_JSON)
-    @NoCache
-    public Response sessions() {
+    public SessionRestService sessions() {
         checkAccountApiEnabled();
         auth.requireOneOf(AccountRoles.MANAGE_ACCOUNT, AccountRoles.VIEW_PROFILE);
-        
-        List<SessionRepresentation> reps = new LinkedList<>();
-
-        List<UserSessionModel> sessions = session.sessions().getUserSessions(realm, user);
-        for (UserSessionModel s : sessions) {
-            SessionRepresentation rep = new SessionRepresentation();
-            rep.setId(s.getId());
-            rep.setIpAddress(s.getIpAddress());
-            rep.setStarted(s.getStarted());
-            rep.setLastAccess(s.getLastSessionRefresh());
-            rep.setExpires(s.getStarted() + realm.getSsoSessionMaxLifespan());
-            rep.setClients(new LinkedList());
-
-            for (String clientUUID : s.getAuthenticatedClientSessions().keySet()) {
-                ClientModel client = realm.getClientById(clientUUID);
-                ClientRepresentation clientRep = new ClientRepresentation();
-                clientRep.setClientId(client.getClientId());
-                clientRep.setClientName(client.getName());
-                rep.getClients().add(clientRep);
-            }
-
-            reps.add(rep);
-        }
-
-        return Cors.add(request, Response.ok(reps)).auth().allowedOrigins(auth.getToken()).build();
-    }
-
-    /**
-     * Remove sessions
-     *
-     * @param removeCurrent remove current session (default is false)
-     * @return
-     */
-    @Path("/sessions")
-    @DELETE
-    @Produces(MediaType.APPLICATION_JSON)
-    @NoCache
-    public Response sessionsLogout(@QueryParam("current") boolean removeCurrent) {
-        checkAccountApiEnabled();
-        auth.require(AccountRoles.MANAGE_ACCOUNT);
-        
-        UserSessionModel userSession = auth.getSession();
-
-        List<UserSessionModel> userSessions = session.sessions().getUserSessions(realm, user);
-        for (UserSessionModel s : userSessions) {
-            if (removeCurrent || !s.getId().equals(userSession.getId())) {
-                AuthenticationManager.backchannelLogout(session, s, true);
-            }
-        }
-
-        return Cors.add(request, Response.ok()).auth().allowedOrigins(auth.getToken()).build();
-    }
-
-    /**
-     * Remove a specific session
-     *
-     * @param id a specific session to remove
-     * @return
-     */
-    @Path("/session")
-    @DELETE
-    @Produces(MediaType.APPLICATION_JSON)
-    @NoCache
-    public Response sessionLogout(@QueryParam("id") String id) {
-        checkAccountApiEnabled();
-        auth.require(AccountRoles.MANAGE_ACCOUNT);
-        
-        UserSessionModel userSession = session.sessions().getUserSession(realm, id);
-        if (userSession != null && userSession.getUser().equals(user)) {
-            AuthenticationManager.backchannelLogout(session, userSession, true);
-        }
-        return Cors.add(request, Response.ok()).auth().allowedOrigins(auth.getToken()).build();
+        return new SessionRestService(session, auth, request);
     }
 
     @Path("/credentials")

--- a/services/src/main/java/org/keycloak/services/resources/account/SessionRestService.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/SessionRestService.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.services.resources.account;
+
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.jboss.resteasy.annotations.cache.NoCache;
+import org.jboss.resteasy.spi.HttpRequest;
+import org.keycloak.common.DeviceInfo;
+import org.keycloak.models.AccountRoles;
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.UserSessionModel;
+import org.keycloak.representations.account.ClientRepresentation;
+import org.keycloak.representations.account.SessionRepresentation;
+import org.keycloak.services.managers.Auth;
+import org.keycloak.services.managers.AuthenticationManager;
+import org.keycloak.services.resources.Cors;
+
+/**
+ * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
+ */
+public class SessionRestService {
+
+    private HttpRequest request;
+    private final KeycloakSession session;
+    private final Auth auth;
+    private final RealmModel realm;
+    private final UserModel user;
+
+    public SessionRestService(KeycloakSession session, Auth auth, HttpRequest request) {
+        this.session = session;
+        this.auth = auth;
+        this.realm = auth.getRealm();
+        this.user = auth.getUser();
+        this.request = request;
+    }
+    
+    /**
+     * Get session information.
+     *
+     * @return
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @NoCache
+    public Response sessions() {
+        List<SessionRepresentation> reps = new LinkedList<>();
+        List<UserSessionModel> sessions = session.sessions().getUserSessions(realm, user);
+
+        for (UserSessionModel s : sessions) {
+            SessionRepresentation rep = new SessionRepresentation();
+            rep.setId(s.getId());
+            rep.setIpAddress(s.getIpAddress());
+            rep.setStarted(s.getStarted());
+            rep.setLastAccess(s.getLastSessionRefresh());
+            rep.setExpires(s.getStarted() + realm.getSsoSessionMaxLifespan());
+            rep.setDeviceInfo(s.getDeviceInfo());
+            rep.setClients(new LinkedList());
+
+            for (String clientUUID : s.getAuthenticatedClientSessions().keySet()) {
+                ClientModel client = realm.getClientById(clientUUID);
+                ClientRepresentation clientRep = new ClientRepresentation();
+                clientRep.setClientId(client.getClientId());
+                clientRep.setClientName(client.getName());
+                rep.getClients().add(clientRep);
+            }
+
+            reps.add(rep);
+        }
+
+        return Cors.add(request, Response.ok(reps)).auth().allowedOrigins(auth.getToken()).build();
+    }
+
+    /**
+     * Remove sessions
+     *
+     * @param removeCurrent remove current session (default is false)
+     * @return
+     */
+    @DELETE
+    @Produces(MediaType.APPLICATION_JSON)
+    @NoCache
+    public Response logout(@QueryParam("current") boolean removeCurrent) {
+        auth.require(AccountRoles.MANAGE_ACCOUNT);
+        UserSessionModel userSession = auth.getSession();
+
+        List<UserSessionModel> userSessions = session.sessions().getUserSessions(realm, user);
+        for (UserSessionModel s : userSessions) {
+            if (removeCurrent || !s.getId().equals(userSession.getId())) {
+                AuthenticationManager.backchannelLogout(session, s, true);
+            }
+        }
+
+        return Cors.add(request, Response.ok()).auth().allowedOrigins(auth.getToken()).build();
+    }
+
+    /**
+     * Remove a specific session
+     *
+     * @param id a specific session to remove
+     * @return
+     */
+    @Path("/{id}")
+    @DELETE
+    @Produces(MediaType.APPLICATION_JSON)
+    @NoCache
+    public Response logout(@PathParam("id") String id) {
+        auth.require(AccountRoles.MANAGE_ACCOUNT);
+        UserSessionModel userSession = session.sessions().getUserSession(realm, id);
+        if (userSession != null && userSession.getUser().equals(user)) {
+            AuthenticationManager.backchannelLogout(session, userSession, true);
+        }
+        return Cors.add(request, Response.ok()).auth().allowedOrigins(auth.getToken()).build();
+    }
+}

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientScopeEvaluateResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientScopeEvaluateResource.java
@@ -194,7 +194,7 @@ public class ClientScopeEvaluateResource {
             authSession.setClientNote(OIDCLoginProtocol.ISSUER, Urls.realmIssuer(uriInfo.getBaseUri(), realm.getName()));
             authSession.setClientNote(OIDCLoginProtocol.SCOPE_PARAM, scopeParam);
 
-            userSession = session.sessions().createUserSession(authSession.getParentSession().getId(), realm, user, user.getUsername(),
+            userSession = session.sessions().createUserSession(authSession.getParentSession(), realm, user, user.getUsername(),
                     clientConnection.getRemoteAddr(), "example-auth", false, null, null);
 
             AuthenticationManager.setClientScopesInSession(authSession);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/AccountRestServiceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/AccountRestServiceTest.java
@@ -192,21 +192,6 @@ public class AccountRestServiceTest extends AbstractRestServiceTest {
         TokenUtil noaccessToken = new TokenUtil("no-account-access", "password");
         TokenUtil viewToken = new TokenUtil("view-account-access", "password");
         
-        // Read sessions with no access
-        assertEquals(403, SimpleHttp.doGet(getAccountUrl("sessions"), httpClient).header("Accept", "application/json").auth(noaccessToken.getToken()).asStatus());
-        
-        // Delete all sessions with no access
-        assertEquals(403, SimpleHttp.doDelete(getAccountUrl("sessions"), httpClient).header("Accept", "application/json").auth(noaccessToken.getToken()).asStatus());
-        
-        // Delete all sessions with read only
-        assertEquals(403, SimpleHttp.doDelete(getAccountUrl("sessions"), httpClient).header("Accept", "application/json").auth(viewToken.getToken()).asStatus());
-        
-        // Delete single session with no access
-        assertEquals(403, SimpleHttp.doDelete(getAccountUrl("session?id=bogusId"), httpClient).header("Accept", "application/json").auth(noaccessToken.getToken()).asStatus());
-        
-        // Delete single session with read only
-        assertEquals(403, SimpleHttp.doDelete(getAccountUrl("session?id=bogusId"), httpClient).header("Accept", "application/json").auth(viewToken.getToken()).asStatus());
-        
         // Read password details with no access
         assertEquals(403, SimpleHttp.doGet(getAccountUrl("credentials/password"), httpClient).header("Accept", "application/json").auth(noaccessToken.getToken()).asStatus());
         
@@ -226,15 +211,6 @@ public class AccountRestServiceTest extends AbstractRestServiceTest {
         TokenUtil viewToken = new TokenUtil("view-account-access", "password");
         status = SimpleHttp.doGet(getAccountUrl(null), httpClient).header("Accept", "application/json").auth(viewToken.getToken()).asStatus();
         assertEquals(200, status);
-    }
-
-    @Test
-    public void testGetSessions() throws IOException {
-        assumeFeatureEnabled(ACCOUNT_API);
-        
-        List<SessionRepresentation> sessions = SimpleHttp.doGet(getAccountUrl("sessions"), httpClient).auth(tokenUtil.getToken()).asJson(new TypeReference<List<SessionRepresentation>>() {});
-
-        assertEquals(1, sessions.size());
     }
 
     @Test
@@ -309,28 +285,6 @@ public class AccountRestServiceTest extends AbstractRestServiceTest {
         int status = SimpleHttp.doDelete(getAccountUrl("sessions?current=false"), httpClient).acceptJson().auth(viewToken.getToken()).asStatus();
         assertEquals(200, status);
         sessions = SimpleHttp.doGet(getAccountUrl("sessions"), httpClient).auth(viewToken.getToken()).asJson(new TypeReference<List<SessionRepresentation>>() {});
-        assertEquals(1, sessions.size());
-    }
-
-    @Test
-    public void testDeleteSession() throws IOException {
-        assumeFeatureEnabled(ACCOUNT_API);
-        
-        TokenUtil viewToken = new TokenUtil("view-account-access", "password");
-        String sessionId = oauth.doLogin("view-account-access", "password").getSessionState();
-        List<SessionRepresentation> sessions = SimpleHttp.doGet(getAccountUrl("sessions"), httpClient).auth(viewToken.getToken()).asJson(new TypeReference<List<SessionRepresentation>>() {});
-        assertEquals(2, sessions.size());
-
-        // With `ViewToken` you can only read
-        int status = SimpleHttp.doDelete(getAccountUrl("session?id=" + sessionId), httpClient).acceptJson().auth(viewToken.getToken()).asStatus();
-        assertEquals(403, status);
-        sessions = SimpleHttp.doGet(getAccountUrl("sessions"), httpClient).auth(viewToken.getToken()).asJson(new TypeReference<List<SessionRepresentation>>() {});
-        assertEquals(2, sessions.size());
-
-        // Here you can delete the session
-        status = SimpleHttp.doDelete(getAccountUrl("session?id=" + sessionId), httpClient).acceptJson().auth(tokenUtil.getToken()).asStatus();
-        assertEquals(200, status);
-        sessions = SimpleHttp.doGet(getAccountUrl("sessions"), httpClient).auth(tokenUtil.getToken()).asJson(new TypeReference<List<SessionRepresentation>>() {});
         assertEquals(1, sessions.size());
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/SessionRestServiceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/SessionRestServiceTest.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.testsuite.account;
+
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.isOneOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.keycloak.common.Profile.Feature.ACCOUNT_API;
+import static org.keycloak.testsuite.ProfileAssume.assumeFeatureEnabled;
+
+import java.io.IOException;
+import java.util.List;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import org.apache.http.client.methods.HttpPost;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.keycloak.OAuth2Constants;
+import org.keycloak.broker.provider.util.SimpleHttp;
+import org.keycloak.common.DeviceInfo;
+import org.keycloak.representations.account.ClientRepresentation;
+import org.keycloak.representations.account.SessionRepresentation;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.testsuite.util.ClientBuilder;
+import org.keycloak.testsuite.util.OAuthClient;
+import org.keycloak.testsuite.util.TokenUtil;
+
+/**
+ * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
+ */
+public class SessionRestServiceTest extends AbstractRestServiceTest {
+
+    private static void customUserAgent(HttpPost httpPost) {
+        httpPost.addHeader("User-Agent",
+                "Mozilla/5.0 (iPhone; CPU iPhone OS 5_1_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9B206 Safari/7534.48.3");
+    }
+
+    @Override
+    public void configureTestRealm(RealmRepresentation testRealm) {
+        super.configureTestRealm(testRealm);
+
+        testRealm.getClients().add(ClientBuilder.create()
+                .clientId("public-client-0")
+                .name("Public Client 0")
+                .baseUrl("http://client0.example.com")
+                .redirectUris(OAuthClient.APP_ROOT + "/auth")
+                .publicClient().build());
+
+        testRealm.getClients().add(ClientBuilder.create()
+                .clientId("mobile-client-0")
+                .name("Mobile Client 0")
+                .secret("secret")
+                .directAccessGrants().build());
+    }
+    
+    @Test
+    public void testProfilePreviewPermissions() throws IOException {
+        assumeFeatureEnabled(ACCOUNT_API);
+        
+        TokenUtil noaccessToken = new TokenUtil("no-account-access", "password");
+        TokenUtil viewToken = new TokenUtil("view-account-access", "password");
+        
+        // Read sessions with no access
+        assertEquals(403, SimpleHttp.doGet(getAccountUrl("sessions"), httpClient).header("Accept", "application/json").auth(noaccessToken.getToken()).asStatus());
+        
+        // Delete all sessions with no access
+        assertEquals(403, SimpleHttp.doDelete(getAccountUrl("sessions"), httpClient).header("Accept", "application/json").auth(noaccessToken.getToken()).asStatus());
+        
+        // Delete all sessions with read only
+        assertEquals(403, SimpleHttp.doDelete(getAccountUrl("sessions"), httpClient).header("Accept", "application/json").auth(viewToken.getToken()).asStatus());
+        
+        // Delete single session with no access
+        assertEquals(403, SimpleHttp.doDelete(getAccountUrl("sessions/bogusId"), httpClient).header("Accept", "application/json").auth(noaccessToken.getToken()).asStatus());
+        
+        // Delete single session with read only
+        assertEquals(403, SimpleHttp.doDelete(getAccountUrl("sessions/bogusId"), httpClient).header("Accept", "application/json").auth(viewToken.getToken()).asStatus());
+    }
+
+    @Test
+    public void testGetSessions() throws Exception {
+        assumeFeatureEnabled(ACCOUNT_API);
+
+        oauth.clientId("public-client-0");
+        oauth.redirectUri(OAuthClient.APP_ROOT + "/auth");
+        oauth.doLogin("test-user@localhost", "password");
+
+        String code = oauth.getCurrentQuery().get(OAuth2Constants.CODE);
+        OAuthClient.AccessTokenResponse response = oauth.doAccessTokenRequest(code, "password");
+
+        assertEquals(200, response.getStatusCode());
+        
+        oauth.clientId("mobile-client-0");
+        response = oauth
+                .doBeforeGrantAccessTokenRequest("secret", "test-user@localhost", "password", SessionRestServiceTest::customUserAgent);
+
+        assertEquals(200, response.getStatusCode());
+        
+        List<SessionRepresentation> sessions = SimpleHttp.doGet(getAccountUrl("sessions"), httpClient).auth(tokenUtil.getToken()).asJson(new TypeReference<List<SessionRepresentation>>() {});
+
+        assertEquals(3, sessions.size());
+
+        for (SessionRepresentation session : sessions) {
+            assertNotNull(session.getId());
+            assertThat(session.getStarted(), Matchers.greaterThan(0));
+            assertThat(session.getLastAccess(), Matchers.greaterThan(0));
+            assertThat(session.getExpires(), Matchers.greaterThan(0));
+            assertEquals(1, session.getClients().size());
+            assertThat(session.getClients(), hasItems(hasProperty("clientId", isOneOf("direct-grant", "public-client-0", "mobile-client-0"))));
+
+            ClientRepresentation client = session.getClients().get(0);
+
+            DeviceInfo deviceInfo = session.getDeviceInfo();
+            
+            if ("direct-grant".equalsIgnoreCase(client.getClientId())) {
+                assertNull(deviceInfo);
+            } else if ("public-client-0".equalsIgnoreCase(client.getClientId())) {
+                assertNotNull(deviceInfo);
+                assertNotNull(deviceInfo.getIp());
+                assertEquals("Other", deviceInfo.getDevice());
+                assertEquals("Chrome", deviceInfo.getBrowser());
+                assertEquals("58.0.3029", deviceInfo.getBrowserVersion());
+                assertEquals("Windows", deviceInfo.getOs());
+                assertEquals("7", deviceInfo.getOsVersion());
+            } else if ("mobile-client-0".equalsIgnoreCase(client.getClientId())) {
+                assertNotNull(deviceInfo);
+                assertNotNull(deviceInfo.getIp());
+                assertEquals("iPhone", deviceInfo.getDevice());
+                assertEquals("Mobile Safari", deviceInfo.getBrowser());
+                assertEquals("5.1", deviceInfo.getBrowserVersion());
+                assertEquals("iOS", deviceInfo.getOs());
+                assertEquals("5.1.1", deviceInfo.getOsVersion());
+            }
+        }
+    }
+
+    @Test
+    public void testDeleteSession() throws IOException {
+        assumeFeatureEnabled(ACCOUNT_API);
+        
+        TokenUtil viewToken = new TokenUtil("view-account-access", "password");
+        String sessionId = oauth.doLogin("view-account-access", "password").getSessionState();
+        List<SessionRepresentation> sessions = SimpleHttp.doGet(getAccountUrl("sessions"), httpClient).auth(viewToken.getToken()).asJson(new TypeReference<List<SessionRepresentation>>() {});
+        assertEquals(2, sessions.size());
+
+        // With `ViewToken` you can only read
+        int status = SimpleHttp.doDelete(getAccountUrl("sessions/" + sessionId), httpClient).acceptJson().auth(viewToken.getToken()).asStatus();
+        assertEquals(403, status);
+        sessions = SimpleHttp.doGet(getAccountUrl("sessions"), httpClient).auth(viewToken.getToken()).asJson(new TypeReference<List<SessionRepresentation>>() {});
+        assertEquals(2, sessions.size());
+
+        // Here you can delete the session
+        status = SimpleHttp.doDelete(getAccountUrl("sessions/" + sessionId), httpClient).acceptJson().auth(tokenUtil.getToken()).asStatus();
+        assertEquals(200, status);
+        sessions = SimpleHttp.doGet(getAccountUrl("sessions"), httpClient).auth(tokenUtil.getToken()).asJson(new TypeReference<List<SessionRepresentation>>() {});
+        assertEquals(1, sessions.size());
+    }
+}


### PR DESCRIPTION
This is the first part of KEYCLOAK-7416. Providing:

* Possibility to obtain information about the user agent from `ClientConnection`
* Possibility to obtain the user agent information associated with a user session
* Introducing a new library for user agent parsing

Some of the work was based on a previous PR from @douglaspalmer.

Next round of changes is about tracking the history of user agents as expected by the new account console.