### PR TITLE
KEYCLOAK-9551 Make refresh_token generation for client_credentials optional

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCAdvancedConfigWrapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCAdvancedConfigWrapper.java
@@ -113,6 +113,18 @@ public class OIDCAdvancedConfigWrapper {
         return Boolean.parseBoolean(useUtlsHokToken);
     }
 
+    public boolean isSkipRefreshTokenForClientCredentialsEnabled() {
+        String issueRefreshTokenForClientCredentials = getAttribute(OIDCConfigAttributes.SKIP_REFRESH_TOKEN_FOR_CLIENT_CREDENTIALS_GRANT);
+        return Boolean.parseBoolean(issueRefreshTokenForClientCredentials);
+    }
+
+    // KEYCLOAK-9551 Client Credentials Grant generates refresh token
+    // https://tools.ietf.org/html/rfc6749#section-4.4.3
+    public void setSkipRefreshTokenForClientCredentialsEnabled(boolean enable) {
+        String val = String.valueOf(enable);
+        setAttribute(OIDCConfigAttributes.SKIP_REFRESH_TOKEN_FOR_CLIENT_CREDENTIALS_GRANT, val);
+    }
+
     public void setUseMtlsHoKToken(boolean useUtlsHokToken) {
         String val = String.valueOf(useUtlsHokToken);
         setAttribute(OIDCConfigAttributes.USE_MTLS_HOK_TOKEN, val);

--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCConfigAttributes.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCConfigAttributes.java
@@ -47,6 +47,8 @@ public final class OIDCConfigAttributes {
 
     public static final String PKCE_CODE_CHALLENGE_METHOD = "pkce.code.challenge.method";
 
+    public static final String SKIP_REFRESH_TOKEN_FOR_CLIENT_CREDENTIALS_GRANT = "client_credentials.skip_refresh_token";
+
     private OIDCConfigAttributes() {
     }
 

--- a/themes/src/main/resources/theme/base/admin/messages/admin-messages_en.properties
+++ b/themes/src/main/resources/theme/base/admin/messages/admin-messages_en.properties
@@ -366,6 +366,8 @@ oidc-compatibility-modes=OpenID Connect Compatibility Modes
 oidc-compatibility-modes.tooltip=Expand this section to configure settings for backwards compatibility with older OpenID Connect / OAuth2 adapters. It is useful especially if your client uses older version of Keycloak / RH-SSO adapter.
 exclude-session-state-from-auth-response=Exclude Session State From Authentication Response
 exclude-session-state-from-auth-response.tooltip=If this is on, the parameter 'session_state' will not be included in OpenID Connect Authentication Response. It is useful if your client uses older OIDC / OAuth2 adapter, which does not support 'session_state' parameter.
+skip-refresh-token-for-client-credentials=Skip creation of refresh_token for client_credentials grant
+skip-refresh-token-for-client-credentials.tooltip=If this is on, a refresh_token will not be created and added to the token response if the client_credentials grant is used. The OAuth 2.0 RFC6749#section-4.4.3 states that a refresh_token should not be generated. If this is off then refresh_tokens will be generated.
 
 # client import
 import-client=Import Client

--- a/themes/src/main/resources/theme/base/admin/resources/js/controllers/clients.js
+++ b/themes/src/main/resources/theme/base/admin/resources/js/controllers/clients.js
@@ -1204,6 +1204,16 @@ module.controller('ClientDetailCtrl', function($scope, realm, client, flows, $ro
            }
        }
 
+        // KEYCLOAK-9551 Client Credentials Grant generates refresh token
+        // https://tools.ietf.org/html/rfc6749#section-4.4.3
+        if ($scope.client.attributes["client_credentials.skip_refresh_token"]) {
+            if ($scope.client.attributes["client_credentials.skip_refresh_token"] == "true") {
+                $scope.skipRefreshTokenForClientCredentials = true;
+            } else {
+                $scope.skipRefreshTokenForClientCredentials = false;
+            }
+        }
+
         if ($scope.client.attributes["display.on.consent.screen"]) {
             if ($scope.client.attributes["display.on.consent.screen"] == "true") {
                 $scope.displayOnConsentScreen = true;
@@ -1490,6 +1500,14 @@ module.controller('ClientDetailCtrl', function($scope, realm, client, flows, $ro
             $scope.clientEdit.attributes["tls.client.certificate.bound.access.tokens"] = "true";
         } else {
             $scope.clientEdit.attributes["tls.client.certificate.bound.access.tokens"] = "false";
+        }
+
+        // KEYCLOAK-9551 Client Credentials Grant generates refresh token
+        // https://tools.ietf.org/html/rfc6749#section-4.4.3
+        if ($scope.skipRefreshTokenForClientCredentials == true) {
+            $scope.clientEdit.attributes["client_credentials.skip_refresh_token"] = "true";
+        } else {
+            $scope.clientEdit.attributes["client_credentials.skip_refresh_token"] = "false";
         }
 
         if ($scope.displayOnConsentScreen == true) {

--- a/themes/src/main/resources/theme/base/admin/resources/partials/client-detail.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/client-detail.html
@@ -501,6 +501,13 @@
                 </div>
                 <kc-tooltip>{{:: 'exclude-session-state-from-auth-response.tooltip' | translate}}</kc-tooltip>
             </div>
+            <div class="form-group clearfix block" data-ng-show="protocol == 'openid-connect'">
+                <label class="col-md-2 control-label" for="skipRefreshTokenForClientCredentials">{{:: 'skip-refresh-token-for-client-credentials' | translate}}</label>
+                <div class="col-md-6">
+                    <input ng-model="skipRefreshTokenForClientCredentials" ng-click="switchChange()" name="skipRefreshTokenForClientCredentials" id="skipRefreshTokenForClientCredentials" onoffswitch on-text="{{:: 'onText' | translate}}" off-text="{{:: 'offText' | translate}}"/>
+                </div>
+                <kc-tooltip>{{:: 'skip-refresh-token-for-client-credentials.tooltip' | translate}}</kc-tooltip>
+            </div>
         </fieldset>
 
         <fieldset data-ng-show="protocol == 'openid-connect'">


### PR DESCRIPTION
Previously Keycloak always generated a `refresh_token` when the `client_credentials`
grant was used. However, the [OAuth 2.0 RFC6749](https://tools.ietf.org/html/rfc6749#section-4.4.3) states that a refresh
token should not be generated when the client_credentials grant is used.

This PR introduces a new in the client setting in the
`OpenID Connect Compatibility Modes` section called
`Skip creation of refresh_token for client_credentials grant`.
If this is `on` refresh_tokens are not generated for client_credential
grant token requests. As a side effect this also destroys the
user-session which is created for the token request of the
service-account user.
The returned token response contains only an access_token and an
optional id_token. A refresh token will not be generated.
If this is `off`, which is also the default, a refresh_token and session
is created as before.

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
