### PR TITLE
KEYCLOAK-10944 Fix 500 Error Code on Update Password

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/account/AccountFormService.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountFormService.java
@@ -208,7 +208,7 @@ public class AccountFormService extends AbstractSecuredLocalService {
                     if (forwardedError != null) {
                         try {
                             FormMessage errorMessage = JsonSerialization.readValue(forwardedError, FormMessage.class);
-                            account.setError(Response.Status.INTERNAL_SERVER_ERROR, errorMessage.getMessage(), errorMessage.getParameters());
+                            account.setError(Response.Status.ACCEPTED, errorMessage.getMessage(), errorMessage.getParameters());
                             authSession.removeAuthNote(ACCOUNT_MGMT_FORWARDED_ERROR_NOTE);
                         } catch (IOException ioe) {
                             throw new RuntimeException(ioe);

--- a/services/src/main/java/org/keycloak/services/resources/account/AccountFormService.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountFormService.java
@@ -208,7 +208,7 @@ public class AccountFormService extends AbstractSecuredLocalService {
                     if (forwardedError != null) {
                         try {
                             FormMessage errorMessage = JsonSerialization.readValue(forwardedError, FormMessage.class);
-                            account.setError(Response.Status.ACCEPTED, errorMessage.getMessage(), errorMessage.getParameters());
+                            account.setError(Response.Status.INTERNAL_SERVER_ERROR, errorMessage.getMessage(), errorMessage.getParameters());
                             authSession.removeAuthNote(ACCOUNT_MGMT_FORWARDED_ERROR_NOTE);
                         } catch (IOException ioe) {
                             throw new RuntimeException(ioe);
@@ -585,7 +585,7 @@ public class AccountFormService extends AbstractSecuredLocalService {
             ServicesLogger.LOGGER.failedToUpdatePassword(me);
             setReferrerOnPage();
             errorEvent.detail(Details.REASON, me.getMessage()).error(Errors.PASSWORD_REJECTED);
-            return account.setError(Response.Status.INTERNAL_SERVER_ERROR, me.getMessage(), me.getParameters()).createResponse(AccountPages.PASSWORD);
+            return account.setError(Response.Status.OK, me.getMessage(), me.getParameters()).createResponse(AccountPages.PASSWORD);
         } catch (Exception ape) {
             ServicesLogger.LOGGER.failedToUpdatePassword(ape);
             setReferrerOnPage();

--- a/services/src/main/java/org/keycloak/services/resources/account/AccountFormService.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountFormService.java
@@ -585,7 +585,7 @@ public class AccountFormService extends AbstractSecuredLocalService {
             ServicesLogger.LOGGER.failedToUpdatePassword(me);
             setReferrerOnPage();
             errorEvent.detail(Details.REASON, me.getMessage()).error(Errors.PASSWORD_REJECTED);
-            return account.setError(Response.Status.OK, me.getMessage(), me.getParameters()).createResponse(AccountPages.PASSWORD);
+            return account.setError(Response.Status.NOT_ACCEPTABLE, me.getMessage(), me.getParameters()).createResponse(AccountPages.PASSWORD);
         } catch (Exception ape) {
             ServicesLogger.LOGGER.failedToUpdatePassword(ape);
             setReferrerOnPage();


### PR DESCRIPTION
https://issues.jboss.org/browse/KEYCLOAK-10944

This PR contains a fix to Update Password which was previously throwing an internal server error response code which is returned to the user and was inconsistent with other screens where the password policy validation error is returned as an OK Response (200 response code)

I have not found an existing test to update otherwise I would do this to. I have tested this manually and it works locally
