### PR TITLE
KEYCLOAK-10792 MigrationTest fails in pipeline: fix log file checker to start from the right position after server restart

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/LogChecker.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/LogChecker.java
@@ -43,11 +43,11 @@ public class LogChecker {
         }
     }
 
-    public static TextFileChecker getJBossServerLogsChecker(boolean verbose, String jbossHome) throws IOException {
+    public static TextFileChecker getJBossServerLogsChecker(String jbossHome) throws IOException {
         String[] pathsToCheck = getJBossServerLogFiles(jbossHome);
         Path[] pathsArray = Arrays.stream(pathsToCheck).map(File::new).map(File::toPath).toArray(Path[]::new);
 
-        return new TextFileChecker(verbose, pathsArray);
+        return new TextFileChecker(pathsArray);
     }
 
 }

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/TextFileChecker.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/TextFileChecker.java
@@ -41,15 +41,8 @@ public class TextFileChecker {
 
     private final Path[] paths;
 
-    private final boolean verbose;
-
-    public TextFileChecker(boolean verbose, Path... paths) {
-        this.verbose = verbose;
-        this.paths = paths;
-    }
-
     public TextFileChecker(Path... paths) {
-        this(false, paths);
+        this.paths = paths;
     }
 
     private void updateLastCheckedPositionsOfAllFilesToEndOfFile(Path path) throws IOException {
@@ -60,7 +53,7 @@ public class TextFileChecker {
         }
     }
 
-    public void checkFiles(Consumer<Stream<String>> lineChecker) throws IOException {
+    public void checkFiles(boolean verbose, Consumer<Stream<String>> lineChecker) throws IOException {
         for (Path path : paths) {
             log.logf(verbose ? Level.INFO : Level.DEBUG, "Checking server log: '%s'", path.toAbsolutePath());
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/util/TextFileCheckerTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/util/TextFileCheckerTest.java
@@ -86,7 +86,7 @@ public class TextFileCheckerTest {
 
     public void assertCheckedOutputIs(String... expectedOutput) throws IOException {
         List<String> target = new LinkedList<>();
-        tfc.checkFiles(collector(target));
+        tfc.checkFiles(false, collector(target));
         Assert.assertThat(target,
           expectedOutput == null || expectedOutput.length == 0
             ? Matchers.empty()


### PR DESCRIPTION
https://issues.jboss.org/browse/KEYCLOAK-10792