### PR TITLE
KEYCLOAK-10782: Credentials tab on clients can only be displayed with view-realm

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/AuthenticationManagementResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/AuthenticationManagementResource.java
@@ -135,7 +135,7 @@ public class AuthenticationManagementResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     public List<Map<String, Object>> getClientAuthenticatorProviders() {
-        auth.realm().requireViewRealm();
+        auth.realm().requireViewClientAuthenticatorProviders();
 
         List<ProviderFactory> factories = session.getKeycloakSessionFactory().getProviderFactories(ClientAuthenticator.class);
         return buildProviderMetadata(factories);
@@ -1095,7 +1095,7 @@ public class AuthenticationManagementResource {
     @Produces(MediaType.APPLICATION_JSON)
     @NoCache
     public Map<String, List<ConfigPropertyRepresentation>> getPerClientConfigDescription() {
-        auth.realm().requireViewRealm();
+        auth.realm().requireViewClientAuthenticatorProviders();
 
         List<ProviderFactory> factories = session.getKeycloakSessionFactory().getProviderFactories(ClientAuthenticator.class);
 

--- a/services/src/main/java/org/keycloak/services/resources/admin/permissions/RealmPermissionEvaluator.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/permissions/RealmPermissionEvaluator.java
@@ -62,4 +62,6 @@ public interface RealmPermissionEvaluator {
     void requireViewRequiredActions();
 
     void requireViewAuthenticationFlows();
+
+    void requireViewClientAuthenticatorProviders();
 }

--- a/services/src/main/java/org/keycloak/services/resources/admin/permissions/RealmPermissions.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/permissions/RealmPermissions.java
@@ -197,5 +197,11 @@ class RealmPermissions implements RealmPermissionEvaluator {
         }
     }
 
+    @Override
+    public void requireViewClientAuthenticatorProviders() {
+        if (!(canViewRealm() || root.hasOneAdminRole(AdminRoles.QUERY_CLIENTS, AdminRoles.VIEW_CLIENTS, AdminRoles.MANAGE_CLIENTS))) {
+            throw new ForbiddenException();
+        }
+    }
 
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/PermissionsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/PermissionsTest.java
@@ -764,6 +764,32 @@ public class PermissionsTest extends AbstractKeycloakTest {
                 realm.flows().getFlows();
             }
         }, clients.get(AdminRoles.QUERY_CLIENTS), true);
+        // the same for ClientAuthenticatorProviders and PerClientConfigDescription
+        invoke(new Invocation() {
+            public void invoke(RealmResource realm) {
+                realm.flows().getClientAuthenticatorProviders();
+            }
+        }, clients.get(AdminRoles.QUERY_CLIENTS), true);
+        invoke(new Invocation() {
+            public void invoke(RealmResource realm) {
+                realm.flows().getClientAuthenticatorProviders();
+            }
+        }, clients.get(AdminRoles.VIEW_CLIENTS), true);
+        invoke(new Invocation() {
+            public void invoke(RealmResource realm) {
+                realm.flows().getClientAuthenticatorProviders();
+            }
+        }, clients.get(AdminRoles.MANAGE_CLIENTS), true);
+        invoke(new Invocation() {
+            public void invoke(RealmResource realm) {
+                realm.flows().getClientAuthenticatorProviders();
+            }
+        }, clients.get(AdminRoles.QUERY_USERS), false);
+        invoke(new Invocation() {
+            public void invoke(RealmResource realm) {
+                realm.flows().getPerClientConfigDescription();
+            }
+        }, clients.get(AdminRoles.QUERY_CLIENTS), true);
     }
 
     @Test


### PR DESCRIPTION
PR for KEYCLOAK-10782. I have requested "query-clients" for those two endpoints, if you think "view-clients" or "manage-clients" should be used instead just let me know (I was not sure what to requests, so I did more or less the same than in KEYCLOAK-9489).
