### PR TITLE
 [KEYCLOAK-11079] CrossDC server tests broken on Travis

### DIFF
--- a/travis-run-tests.sh
+++ b/travis-run-tests.sh
@@ -29,7 +29,7 @@ function should-tests-run() {
 
 function should-tests-run-crossdc-server() {
     # If this is not a pull request, it is build as a branch update. In that case test everything
-    [ "$TRAVIS_EVENT_TYPE" = "cron" ] && return 0
+    [ "$TRAVIS_PULL_REQUEST" = "false" ] && return 0
 
     git diff --name-only HEAD origin/${TRAVIS_BRANCH} |
         egrep -i 'crossdc|infinispan'

--- a/travis-run-tests.sh
+++ b/travis-run-tests.sh
@@ -29,7 +29,7 @@ function should-tests-run() {
 
 function should-tests-run-crossdc-server() {
     # If this is not a pull request, it is build as a branch update. In that case test everything
-    [ "$TRAVIS_PULL_REQUEST" = "false" ] && return 0
+    [ "$TRAVIS_EVENT_TYPE" == "cron" ] && return 0
 
     git diff --name-only HEAD origin/${TRAVIS_BRANCH} |
         egrep -i 'crossdc|infinispan'


### PR DESCRIPTION
This PR contains the fix to the bash script comparison. The reason why CrossDC server tests were still running.

It was tested here: https://travis-ci.org/abstractj/keycloak/builds/572333987

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
