### PR TITLE
KEYCLOAK-10904 ExportImportTest unstable

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
@@ -32,6 +32,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.jboss.logging.Logger;
+import org.keycloak.Config;
 import org.keycloak.OAuth2Constants;
 import org.keycloak.authorization.AuthorizationProvider;
 import org.keycloak.authorization.AuthorizationProviderFactory;
@@ -2634,7 +2635,8 @@ public class RepresentationToModel {
     }
 
     public static ResourceServer createResourceServer(ClientModel client, KeycloakSession session, boolean addDefaultRoles) {
-        if (client.isBearerOnly() || client.isPublicClient()) {
+        if ((client.isBearerOnly() || client.isPublicClient())
+                && !(client.getClientId().equals(Config.getAdminRealm() + "-realm") || client.getClientId().equals(Constants.REALM_MANAGEMENT_CLIENT_ID))) {
             throw new RuntimeException("Only confidential clients are allowed to set authorization settings");
         }
         AuthorizationProvider authorization = session.getProvider(AuthorizationProvider.class);

--- a/testsuite/performance/tests/src/test/resources/dataset/1r_100c_10000u_1hi_10000res_100sc_100po_100pe.properties
+++ b/testsuite/performance/tests/src/test/resources/dataset/1r_100c_10000u_1hi_10000res_100sc_100po_100pe.properties
@@ -27,7 +27,7 @@ client.webOrigins=
 client.protocol=openid-connect
 client.publicClient=<#if index % 3 == 0>true<#else>false</#if>
 client.bearerOnly=<#if index % 3 == 1>true<#else>false</#if>
-client.authorizationServicesEnabled=${(!isPublicClient())?c}
+client.authorizationServicesEnabled=${(!isPublicClient() && !isBearerOnly())?c}
 client.serviceAccountsEnabled=${authorizationServicesEnabled?c}
 
 # CLIENT ROLE

--- a/testsuite/performance/tests/src/test/resources/dataset/default.properties
+++ b/testsuite/performance/tests/src/test/resources/dataset/default.properties
@@ -29,7 +29,7 @@ client.webOrigins=
 client.protocol=openid-connect
 client.publicClient=<#if index % 3 == 0>true<#else>false</#if>
 client.bearerOnly=<#if index % 3 == 1>true<#else>false</#if>
-client.authorizationServicesEnabled=${(!isPublicClient())?c}
+client.authorizationServicesEnabled=${(!isPublicClient() && !isBearerOnly())?c}
 client.serviceAccountsEnabled=${authorizationServicesEnabled?c}
 
 # CLIENT ROLE


### PR DESCRIPTION
- adding an exception for realm-management clients into the client confidentiality check
- fixing some performance test datasets to enable authz only for confidential clients