### PR TITLE
KEYCLOAK-10942 Support eDirectory GUID

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPConfig.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPConfig.java
@@ -179,6 +179,10 @@ public class LDAPConfig {
         return getUuidLDAPAttributeName().equalsIgnoreCase(LDAPConstants.OBJECT_GUID);
     }
 
+    public boolean isEdirectoryGUID() {
+        return isEdirectory() && getUuidLDAPAttributeName().equalsIgnoreCase(LDAPConstants.NOVELL_EDIRECTORY_GUID);
+    }
+
     public boolean isPagination() {
         String pagination = config.getFirst(LDAPConstants.PAGINATION);
         return Boolean.parseBoolean(pagination);
@@ -257,6 +261,10 @@ public class LDAPConfig {
         return true;
     }
 
+    public boolean isEdirectory() {
+        return LDAPConstants.VENDOR_NOVELL_EDIRECTORY.equalsIgnoreCase(getVendor());
+    }
+
     @Override
     public int hashCode() {
         return config.hashCode() * 13 + binaryAttributeNames.hashCode();
@@ -270,4 +278,5 @@ public class LDAPConfig {
                 .append(", binaryAttributes: ").append(binaryAttributeNames)
                 .toString();
     }
+
 }

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPContextManager.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPContextManager.java
@@ -176,6 +176,9 @@ public final class LDAPContextManager implements AutoCloseable {
         if (ldapConfig.isObjectGUID()) {
             binaryAttrsBuilder.append(LDAPConstants.OBJECT_GUID).append(" ");
         }
+        if (ldapConfig.isEdirectory()) {
+            binaryAttrsBuilder.append(LDAPConstants.NOVELL_EDIRECTORY_GUID).append(" ");
+        }
         for (String attrName : ldapConfig.getBinaryAttributeNames()) {
             binaryAttrsBuilder.append(attrName).append(" ");
         }

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPOperationManager.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPOperationManager.java
@@ -658,7 +658,6 @@ public class LDAPOperationManager {
     }
 
     public String decodeEntryUUID(final Object entryUUID) {
-        String id;
         if (entryUUID instanceof byte[]) {
             if (this.config.isObjectGUID()) {
                 return LDAPUtil.decodeObjectGUID((byte[]) entryUUID);

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPOperationManager.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPOperationManager.java
@@ -388,7 +388,7 @@ public class LDAPOperationManager {
 
                 byte[] objectGUID = (byte[]) attributes.get(LDAPConstants.OBJECT_GUID).get();
 
-                filter = "(&(objectClass=*)(" + getUuidAttributeName() + LDAPConstants.EQUAL + LDAPUtil.convertObjectGUIToByteString(objectGUID) + "))";
+                filter = "(&(objectClass=*)(" + getUuidAttributeName() + LDAPConstants.EQUAL + LDAPUtil.convertObjectGUIDToByteString(objectGUID) + "))";
             } catch (NamingException ne) {
                 filter = null;
             }
@@ -659,13 +659,15 @@ public class LDAPOperationManager {
 
     public String decodeEntryUUID(final Object entryUUID) {
         String id;
-        if (this.config.isObjectGUID() && entryUUID instanceof byte[]) {
-            id = LDAPUtil.decodeObjectGUID((byte[]) entryUUID);
-        } else {
-            id = entryUUID.toString();
+        if (entryUUID instanceof byte[]) {
+            if (this.config.isObjectGUID()) {
+                return LDAPUtil.decodeObjectGUID((byte[]) entryUUID);
+            }
+            if (this.config.isEdirectory() && this.config.isEdirectoryGUID()) {
+                return LDAPUtil.decodeGuid((byte[]) entryUUID);
+            }
         }
-
-        return id;
+        return entryUUID.toString();
     }
 
     private <R> R execute(LdapOperation<R> operation) throws NamingException {

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPUtil.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPUtil.java
@@ -89,7 +89,7 @@ public class LDAPUtil {
      * <p>The returned string is useful to perform queries on AD based on the <code>objectGUID</code> value. Eg.:</p>
      *
      * <p>
-     * String filter = "(&(objectClass=*)(objectGUID" + EQUAL + convertObjectGUIToByteString(objectGUID) + "))";
+     * String filter = "(&(objectClass=*)(objectGUID" + EQUAL + convertObjectGUIDToByteString(objectGUID) + "))";
      * </p>
      *
      * @param objectGUID A raw byte array representing the value of the <code>objectGUID</code> attribute retrieved from
@@ -97,7 +97,7 @@ public class LDAPUtil {
      *
      * @return A byte-based String representation in the form of \[0]\[1]\[2]\[3]\[4]\[5]\[6]\[7]\[8]\[9]\[10]\[11]\[12]\[13]\[14]\[15]
      */
-    public static String convertObjectGUIToByteString(byte[] objectGUID) {
+    public static String convertObjectGUIDToByteString(byte[] objectGUID) {
         StringBuilder result = new StringBuilder();
 
         for (int i = 0; i < objectGUID.length; i++) {
@@ -129,24 +129,35 @@ public class LDAPUtil {
     public static String decodeObjectGUID(byte[] objectGUID) {
         StringBuilder displayStr = new StringBuilder();
 
-        displayStr.append(convertToDashedString(objectGUID));
+        byte[] withLittleEndian = new byte[] { objectGUID[3], objectGUID[2], objectGUID[1], objectGUID[0],
+            objectGUID[5], objectGUID[4],
+            objectGUID[7], objectGUID[6],
+            objectGUID[8], objectGUID[9], objectGUID[10], objectGUID[11], objectGUID[12], objectGUID[13], objectGUID[14], objectGUID[15]
+        };
+        displayStr.append(convertToDashedString(withLittleEndian));
 
+        return displayStr.toString();
+    }
+
+    public static String decodeGuid(byte[] guid) {
+        StringBuilder displayStr = new StringBuilder();
+        displayStr.append(convertToDashedString(guid));
         return displayStr.toString();
     }
 
     private static String convertToDashedString(byte[] objectGUID) {
         StringBuilder displayStr = new StringBuilder();
 
-        displayStr.append(prefixZeros((int) objectGUID[3] & 0xFF));
-        displayStr.append(prefixZeros((int) objectGUID[2] & 0xFF));
-        displayStr.append(prefixZeros((int) objectGUID[1] & 0xFF));
         displayStr.append(prefixZeros((int) objectGUID[0] & 0xFF));
+        displayStr.append(prefixZeros((int) objectGUID[1] & 0xFF));
+        displayStr.append(prefixZeros((int) objectGUID[2] & 0xFF));
+        displayStr.append(prefixZeros((int) objectGUID[3] & 0xFF));
         displayStr.append("-");
-        displayStr.append(prefixZeros((int) objectGUID[5] & 0xFF));
         displayStr.append(prefixZeros((int) objectGUID[4] & 0xFF));
+        displayStr.append(prefixZeros((int) objectGUID[5] & 0xFF));
         displayStr.append("-");
-        displayStr.append(prefixZeros((int) objectGUID[7] & 0xFF));
         displayStr.append(prefixZeros((int) objectGUID[6] & 0xFF));
+        displayStr.append(prefixZeros((int) objectGUID[7] & 0xFF));
         displayStr.append("-");
         displayStr.append(prefixZeros((int) objectGUID[8] & 0xFF));
         displayStr.append(prefixZeros((int) objectGUID[9] & 0xFF));

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPUtil.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPUtil.java
@@ -129,35 +129,42 @@ public class LDAPUtil {
     public static String decodeObjectGUID(byte[] objectGUID) {
         StringBuilder displayStr = new StringBuilder();
 
-        byte[] withLittleEndian = new byte[] { objectGUID[3], objectGUID[2], objectGUID[1], objectGUID[0],
-            objectGUID[5], objectGUID[4],
-            objectGUID[7], objectGUID[6],
-            objectGUID[8], objectGUID[9], objectGUID[10], objectGUID[11], objectGUID[12], objectGUID[13], objectGUID[14], objectGUID[15]
-        };
-        displayStr.append(convertToDashedString(withLittleEndian));
+        displayStr.append(convertToDashedString(objectGUID));
 
         return displayStr.toString();
     }
 
+    /**
+     * <p>Decode a raw byte array representing the value of the <code>guid</code> attribute retrieved from Novell
+     * eDirectory.</p>
+     *
+     * @param guid A raw byte array representing the value of the <code>guid</code> attribute retrieved from
+     * Novell eDirectory.
+     *
+     * @return A string representing the decoded value in the form of [0][1][2][3]-[4][5]-[6][7]-[8][9]-[10][11][12][13][14][15].
+     */
     public static String decodeGuid(byte[] guid) {
-        StringBuilder displayStr = new StringBuilder();
-        displayStr.append(convertToDashedString(guid));
-        return displayStr.toString();
+        byte[] withBigEndian = new byte[] { guid[3], guid[2], guid[1], guid[0],
+            guid[5], guid[4],
+            guid[7], guid[6],
+            guid[8], guid[9], guid[10], guid[11], guid[12], guid[13], guid[14], guid[15]
+        };
+        return convertToDashedString(withBigEndian);
     }
 
     private static String convertToDashedString(byte[] objectGUID) {
         StringBuilder displayStr = new StringBuilder();
 
-        displayStr.append(prefixZeros((int) objectGUID[0] & 0xFF));
-        displayStr.append(prefixZeros((int) objectGUID[1] & 0xFF));
-        displayStr.append(prefixZeros((int) objectGUID[2] & 0xFF));
         displayStr.append(prefixZeros((int) objectGUID[3] & 0xFF));
+        displayStr.append(prefixZeros((int) objectGUID[2] & 0xFF));
+        displayStr.append(prefixZeros((int) objectGUID[1] & 0xFF));
+        displayStr.append(prefixZeros((int) objectGUID[0] & 0xFF));
         displayStr.append("-");
-        displayStr.append(prefixZeros((int) objectGUID[4] & 0xFF));
         displayStr.append(prefixZeros((int) objectGUID[5] & 0xFF));
+        displayStr.append(prefixZeros((int) objectGUID[4] & 0xFF));
         displayStr.append("-");
-        displayStr.append(prefixZeros((int) objectGUID[6] & 0xFF));
         displayStr.append(prefixZeros((int) objectGUID[7] & 0xFF));
+        displayStr.append(prefixZeros((int) objectGUID[6] & 0xFF));
         displayStr.append("-");
         displayStr.append(prefixZeros((int) objectGUID[8] & 0xFF));
         displayStr.append(prefixZeros((int) objectGUID[9] & 0xFF));

--- a/server-spi-private/src/main/java/org/keycloak/models/LDAPConstants.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/LDAPConstants.java
@@ -122,6 +122,7 @@ public class LDAPConstants {
     public static final String CUSTOM_ATTRIBUTE_EXPIRY_DATE = "expiryDate";
     public static final String ENTRY_UUID = "entryUUID";
     public static final String OBJECT_GUID = "objectGUID";
+    public static final String NOVELL_EDIRECTORY_GUID = "guid";
     public static final String CREATE_TIMESTAMP = "createTimestamp";
     public static final String MODIFY_TIMESTAMP = "modifyTimestamp";
 


### PR DESCRIPTION
Supports usage of eDirectory GUID as UUID LDAP attribute.
The attribute is stored in eDirectory in binary format and therefore needs special conversion to dashed UUID.

Note: ObjectGUID from Microsoft Active Directory is encoded with a different byte order (cf. https://ldapwiki.com/wiki/Universally%20Unique%20Identifier).
