### PR TITLE
[KEYCLOAK-11024] RulesPolicyManagementTest failing with auth-server-u…

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/authorization/RulesPolicyManagementTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/authorization/RulesPolicyManagementTest.java
@@ -27,6 +27,7 @@ import org.keycloak.representations.idm.authorization.Logic;
 import org.keycloak.representations.idm.authorization.RulePolicyRepresentation;
 import org.keycloak.testsuite.ProfileAssume;
 import org.keycloak.testsuite.arquillian.annotation.RestartContainer;
+import org.keycloak.testsuite.util.ContainerAssume;
 
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.core.Response;
@@ -43,6 +44,7 @@ public class RulesPolicyManagementTest extends AbstractPolicyManagementTest {
 
     @BeforeClass
     public static void verifyEnvironment() {
+        ContainerAssume.assumeNotAuthServerUndertow();
         ProfileAssume.assumeFeatureEnabled(Profile.Feature.AUTHZ_DROOLS_POLICY);
     }
 


### PR DESCRIPTION
JIRA: [KEYCLOAK-11024](https://issues.jboss.org/browse/KEYCLOAK-11024)

Unfortunatelly, I was trying to simulate this bug, but unsuccessfully (only problem with undertow in **universal-pipeline**). In universal-pipeline, with `JBossBased` auth servers it works, but with undertow not. So I think, this approach would be enough so far.