### PR TITLE
[KEYCLOAK-8253] Refactor the LDAP groups synchronization functionality (from LDAP provider to Keycloak) to improve sync time performance

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
@@ -40,6 +40,7 @@ import org.keycloak.models.jpa.entities.RoleEntity;
 import org.keycloak.models.utils.KeycloakModelUtils;
 
 import javax.persistence.EntityManager;
+import javax.persistence.FlushModeType;
 import javax.persistence.TypedQuery;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -497,7 +498,11 @@ public class JpaRealmProvider implements RealmProvider {
         RealmEntity realmEntity = em.getReference(RealmEntity.class, realm.getId());
         groupEntity.setRealm(realmEntity);
         em.persist(groupEntity);
-        em.flush();
+        // KEYCLOAK-8253 - Skip / postpone the EM flush if there's an active WIP transaction and EM flush mode is set to AUTO (the default)
+        // This improves the time performance of LDAP groups sync and EM flush in that case is performed anyway as part of the TX commit
+        if (!session.getTransactionManager().isActive() || em.getFlushMode() != FlushModeType.AUTO) {
+            em.flush();
+        }
         realmEntity.getGroups().add(groupEntity);
 
         GroupAdapter adapter = new GroupAdapter(realm, em, groupEntity);
@@ -508,8 +513,6 @@ public class JpaRealmProvider implements RealmProvider {
     public void addTopLevelGroup(RealmModel realm, GroupModel subGroup) {
         subGroup.setParent(null);
     }
-
-
 
     @Override
     public ClientModel addClient(RealmModel realm, String clientId) {


### PR DESCRIPTION
    [KEYCLOAK-8253] Refactor the LDAP groups synchronization functionality
    (from LDAP provider to Keycloak) to improve sync time performance
    
    Add a corresponding test (to be ignored by CI by default due to its
    higher time / performance demand required for its completion)
    
    Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

**_Note:_**

  Although it was suggested more Keycloak constructs (roles & possibly also [clients](https://issues.jboss.org/browse/KEYCLOAK-8275)) might be prone to the very same defect / bottleneck, not going to cover those in the initial proposal, till the proposed approach is reviewed / approved as the feasible one.

  Also, see next comment(s) for overview of stats, how the syncing process differs in time, with(out) this change.

**_Testing instructions:_**

**Important:**  For both test use cases below, first comment out the ```   @Ignore("This test is not suitable for regular CI testing due to higher time / performance demand") ``` row for the `test06_ldapGroupsSyncHasLinearTimeComplexity()` test

Then:

- Perform the following to test & report time stats once 1k groups are synced (the default):

```
$ cat run_test.sh 
#!/usr/bin/env bash

pushd keycloak

export DOCKER_HOST="tcp://0.0.0.0:2375"
mvn clean verify -f testsuite/integration-arquillian/pom.xml  -Dtest=org.keycloak.testsuite.federation.ldap.LDAPGroupMapperSyncTest#test06_ldapGroupsSyncHasLinearTimeComplexity -Dtest.ldap.groups.sync.linear.time.groups.count=7000 -Pdb-postgres 

popd
```
- Perform the following to test & report time stats once per 100 groups being synced:

```
$ cat run_test.sh 
#!/usr/bin/env bash

pushd keycloak

export DOCKER_HOST="tcp://0.0.0.0:2375"
mvn clean verify -f testsuite/integration-arquillian/pom.xml -Dtest=org.keycloak.testsuite.federation.ldap.LDAPGroupMapperSyncTest#test06_ldapGroupsSyncHasLinearTimeComplexity -Dtest.ldap.groups.sync.linear.time.groups.count=7000 -Dtest.ldap.groups.sync.linear.time.test.period=100 -Pdb-postgres

popd

```
Note: Change the `-Pdb-postgres` argument to any other available DB backend:

```
keycloak]$ grep -rHn '<id>db-*' testsuite/integration-arquillian/pom.xml
testsuite/integration-arquillian/pom.xml:394:            <id>db-default-properties</id>
testsuite/integration-arquillian/pom.xml:409:            <id>db-mysql</id>
testsuite/integration-arquillian/pom.xml:431:            <id>db-allocator-db-mysql</id>
testsuite/integration-arquillian/pom.xml:444:            <id>db-postgres</id>
testsuite/integration-arquillian/pom.xml:465:            <id>db-allocator-db-postgres</id>
testsuite/integration-arquillian/pom.xml:478:            <id>db-allocator-db-postgresplus</id>
testsuite/integration-arquillian/pom.xml:492:            <id>db-mariadb</id>
testsuite/integration-arquillian/pom.xml:514:            <id>db-allocator-db-mariadb</id>
testsuite/integration-arquillian/pom.xml:527:            <id>db-mssql2017</id>
testsuite/integration-arquillian/pom.xml:549:            <id>db-allocator-db-mssql2016</id>
testsuite/integration-arquillian/pom.xml:562:            <id>db-oracle11g</id>
testsuite/integration-arquillian/pom.xml:585:            <id>db-allocator-db-oracle12cR1RAC</id>
```
to test against that DB backend image, rather than the PostgreSQL one, like in the example above.


<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
