### PR TITLE
Fix minor warnings in module core

### DIFF
--- a/core/src/main/java/org/keycloak/jose/jwe/JWE.java
+++ b/core/src/main/java/org/keycloak/jose/jwe/JWE.java
@@ -18,7 +18,7 @@
 package org.keycloak.jose.jwe;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.security.spec.KeySpec;
 
 import org.keycloak.common.util.Base64;
@@ -223,13 +223,8 @@ public class JWE {
 
     public static String encryptUTF8(String password, String saltString, String payload) {
         byte[] bytes = null;
-        try {
-            bytes = payload.getBytes("UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException(e);
-        }
+        bytes = payload.getBytes(StandardCharsets.UTF_8);
         return encrypt(password, saltString, bytes);
-
     }
 
 
@@ -276,11 +271,7 @@ public class JWE {
 
     public static String decryptUTF8(String password, String saltString, String encodedJwe) {
         byte[] payload = decrypt(password, saltString, encodedJwe);
-        try {
-            return new String(payload, "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException(e);
-        }
+        return new String(payload, StandardCharsets.UTF_8);
     }
 
 }

--- a/core/src/main/java/org/keycloak/jose/jwe/enc/AesCbcHmacShaEncryptionProvider.java
+++ b/core/src/main/java/org/keycloak/jose/jwe/enc/AesCbcHmacShaEncryptionProvider.java
@@ -20,6 +20,7 @@ package org.keycloak.jose.jwe.enc;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.security.InvalidKeyException;
 import java.security.Key;
@@ -67,7 +68,7 @@ public abstract class AesCbcHmacShaEncryptionProvider implements JWEEncryptionPr
 
         byte[] cipherBytes = encryptBytes(contentBytes, initializationVector, aesKey);
 
-        byte[] aad = jwe.getBase64Header().getBytes("UTF-8");
+        byte[] aad = jwe.getBase64Header().getBytes(StandardCharsets.UTF_8);
         byte[] authenticationTag = computeAuthenticationTag(aad, initializationVector, cipherBytes, hmacShaKey);
 
         jwe.setEncryptedContentInfo(initializationVector, cipherBytes, authenticationTag);
@@ -91,7 +92,7 @@ public abstract class AesCbcHmacShaEncryptionProvider implements JWEEncryptionPr
             throw new IllegalStateException("Length of aes key should be " + expectedAesKeyLength +", but was " + aesKey.getEncoded().length);
         }
 
-        byte[] aad = jwe.getBase64Header().getBytes("UTF-8");
+        byte[] aad = jwe.getBase64Header().getBytes(StandardCharsets.UTF_8);
         byte[] authenticationTag = computeAuthenticationTag(aad, jwe.getInitializationVector(), jwe.getEncryptedContent(), hmacShaKey);
 
         byte[] expectedAuthTag = jwe.getAuthenticationTag();

--- a/core/src/main/java/org/keycloak/jose/jwe/enc/AesGcmEncryptionProvider.java
+++ b/core/src/main/java/org/keycloak/jose/jwe/enc/AesGcmEncryptionProvider.java
@@ -17,10 +17,9 @@
 
 package org.keycloak.jose.jwe.enc;
 
+import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
-import java.security.InvalidKeyException;
 import java.security.Key;
-import java.security.NoSuchAlgorithmException;
 
 import javax.crypto.Cipher;
 import javax.crypto.spec.GCMParameterSpec;
@@ -53,11 +52,11 @@ public abstract class AesGcmEncryptionProvider implements JWEEncryptionProvider 
 
         int expectedAesKeyLength = getExpectedAesKeyLength();
         if (expectedAesKeyLength != aesKey.getEncoded().length) {
-            throw new IllegalStateException("Length of aes key should be " + expectedAesKeyLength +", but was " + aesKey.getEncoded().length);
+            throw new IllegalStateException("Length of aes key should be " + expectedAesKeyLength + ", but was " + aesKey.getEncoded().length);
         }
 
         // https://tools.ietf.org/html/rfc7516#appendix-A.1.5
-        byte[] aad = jwe.getBase64Header().getBytes("UTF-8");
+        byte[] aad = jwe.getBase64Header().getBytes(StandardCharsets.UTF_8);
 
         byte[] cipherBytes = encryptBytes(contentBytes, initializationVector, aesKey, aad);
         byte[] authenticationTag = getAuthenticationTag(cipherBytes);
@@ -79,7 +78,7 @@ public abstract class AesGcmEncryptionProvider implements JWEEncryptionProvider 
         }
 
         // https://tools.ietf.org/html/rfc7516#appendix-A.1.5
-        byte[] aad = jwe.getBase64Header().getBytes("UTF-8");
+        byte[] aad = jwe.getBase64Header().getBytes(StandardCharsets.UTF_8);
         byte[] decryptedTargetContent = getAeadDecryptedTargetContent(jwe);
         byte[] contentBytes = decryptBytes(decryptedTargetContent, jwe.getInitializationVector(), aesKey, aad);
 
@@ -114,7 +113,7 @@ public abstract class AesGcmEncryptionProvider implements JWEEncryptionProvider 
         return authenticationTag;
     }
 
-    private byte[] getEncryptedContent(byte[] cipherBytes) throws NoSuchAlgorithmException, InvalidKeyException {
+    private byte[] getEncryptedContent(byte[] cipherBytes) {
         // AES GCM cipher text consists of a cipher text an authentication tag.
         // The cipher text be encoded as an individual term in JWE.
         // So extract it from the AES GCM cipher text.
@@ -140,8 +139,7 @@ public abstract class AesGcmEncryptionProvider implements JWEEncryptionProvider 
         if (aesKey == null) {
             throw new IllegalArgumentException("AES CEK key not present");
         }
-        byte[] aesBytes = aesKey.getEncoded();
-        return aesBytes;
+        return aesKey.getEncoded();
     }
 
     @Override

--- a/core/src/main/java/org/keycloak/json/StringOrArrayDeserializer.java
+++ b/core/src/main/java/org/keycloak/json/StringOrArrayDeserializer.java
@@ -24,7 +24,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Iterator;
 
 public class StringOrArrayDeserializer extends JsonDeserializer<Object> {
 
@@ -33,9 +32,8 @@ public class StringOrArrayDeserializer extends JsonDeserializer<Object> {
         JsonNode jsonNode = jsonParser.readValueAsTree();
         if (jsonNode.isArray()) {
             ArrayList<String> a = new ArrayList<>(1);
-            Iterator<JsonNode> itr = jsonNode.iterator();
-            while (itr.hasNext()) {
-                a.add(itr.next().textValue());
+            for (JsonNode node : jsonNode) {
+                a.add( node.textValue());
             }
             return a.toArray(new String[a.size()]);
         } else {

--- a/core/src/main/java/org/keycloak/representations/AccessToken.java
+++ b/core/src/main/java/org/keycloak/representations/AccessToken.java
@@ -48,7 +48,7 @@ public class AccessToken extends IDToken {
             Access access = new Access();
             access.verifyCaller = verifyCaller;
             if (roles != null) {
-                access.roles = new HashSet<String>();
+                access.roles = new HashSet<>();
                 access.roles.addAll(roles);
             }
             return access;
@@ -70,7 +70,7 @@ public class AccessToken extends IDToken {
         }
 
         public Access addRole(String role) {
-            if (roles == null) roles = new HashSet<String>();
+            if (roles == null) roles = new HashSet<>();
             roles.add(role);
             return this;
         }

--- a/core/src/main/java/org/keycloak/representations/AccessTokenResponse.java
+++ b/core/src/main/java/org/keycloak/representations/AccessTokenResponse.java
@@ -55,7 +55,7 @@ public class AccessTokenResponse {
     @JsonProperty("session_state")
     protected String sessionState;
 
-    protected Map<String, Object> otherClaims = new HashMap<String, Object>();
+    protected Map<String, Object> otherClaims = new HashMap<>();
 
     // OIDC Financial API Read Only Profile : scope MUST be returned in the response from Token Endpoint
     @JsonProperty("scope")

--- a/core/src/main/java/org/keycloak/representations/RefreshToken.java
+++ b/core/src/main/java/org/keycloak/representations/RefreshToken.java
@@ -52,7 +52,7 @@ public class RefreshToken extends AccessToken {
             realmAccess = token.realmAccess.clone();
         }
         if (token.resourceAccess != null) {
-            resourceAccess = new HashMap<String, Access>();
+            resourceAccess = new HashMap<>();
             for (Map.Entry<String, Access> entry : token.resourceAccess.entrySet()) {
                 resourceAccess.put(entry.getKey(), entry.getValue().clone());
             }

--- a/core/src/main/java/org/keycloak/representations/adapters/action/GlobalRequestResult.java
+++ b/core/src/main/java/org/keycloak/representations/adapters/action/GlobalRequestResult.java
@@ -32,37 +32,37 @@ public class GlobalRequestResult {
 
     public void addSuccessRequest(String reqUri) {
         if (successRequests == null) {
-            successRequests = new ArrayList<String>();
+            successRequests = new ArrayList<>();
         }
         successRequests.add(reqUri);
     }
 
     public void addFailedRequest(String reqUri) {
         if (failedRequests == null) {
-            failedRequests = new ArrayList<String>();
+            failedRequests = new ArrayList<>();
         }
         failedRequests.add(reqUri);
     }
 
     public void addAllSuccessRequests(List<String> reqUris) {
         if (successRequests == null) {
-            successRequests = new ArrayList<String>();
+            successRequests = new ArrayList<>();
         }
         successRequests.addAll(reqUris);
     }
 
     public void addAllFailedRequests(List<String> reqUris) {
         if (failedRequests == null) {
-            failedRequests = new ArrayList<String>();
+            failedRequests = new ArrayList<>();
         }
         failedRequests.addAll(reqUris);
     }
 
     public void addAll(GlobalRequestResult merged) {
-        if (merged.getSuccessRequests() != null && merged.getSuccessRequests().size() > 0) {
+        if (merged.getSuccessRequests() != null && !merged.getSuccessRequests().isEmpty()) {
             addAllSuccessRequests(merged.getSuccessRequests());
         }
-        if (merged.getFailedRequests() != null && merged.getFailedRequests().size() > 0) {
+        if (merged.getFailedRequests() != null && !merged.getFailedRequests().isEmpty()) {
             addAllFailedRequests(merged.getFailedRequests());
         }
     }

--- a/core/src/main/java/org/keycloak/representations/adapters/config/PolicyEnforcerConfig.java
+++ b/core/src/main/java/org/keycloak/representations/adapters/config/PolicyEnforcerConfig.java
@@ -255,7 +255,7 @@ public class PolicyEnforcerConfig {
 
         @JsonIgnore
         public boolean hasPattern() {
-            return getPath().indexOf("{") != -1;
+            return getPath().contains( "{" );
         }
 
         @JsonIgnore

--- a/core/src/main/java/org/keycloak/representations/docker/DockerAccess.java
+++ b/core/src/main/java/org/keycloak/representations/docker/DockerAccess.java
@@ -6,6 +6,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 
 /**
@@ -93,9 +94,9 @@ public class DockerAccess {
 
         final DockerAccess that = (DockerAccess) o;
 
-        if (type != null ? !type.equals(that.type) : that.type != null) return false;
-        if (name != null ? !name.equals(that.name) : that.name != null) return false;
-        return actions != null ? actions.equals(that.actions) : that.actions == null;
+        if (!Objects.equals(type, that.type)) return false;
+        if (!Objects.equals(name, that.name)) return false;
+        return Objects.equals(actions, that.actions);
 
     }
 

--- a/core/src/main/java/org/keycloak/representations/docker/DockerError.java
+++ b/core/src/main/java/org/keycloak/representations/docker/DockerError.java
@@ -3,6 +3,7 @@ package org.keycloak.representations.docker;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * JSON Representation of a Docker Error in the following format:
@@ -61,8 +62,8 @@ public class DockerError {
         final DockerError that = (DockerError) o;
 
         if (errorCode != that.errorCode) return false;
-        if (message != null ? !message.equals(that.message) : that.message != null) return false;
-        return dockerErrorDetails != null ? dockerErrorDetails.equals(that.dockerErrorDetails) : that.dockerErrorDetails == null;
+        if (!Objects.equals(message, that.message)) return false;
+        return Objects.equals(dockerErrorDetails, that.dockerErrorDetails);
     }
 
     @Override

--- a/core/src/main/java/org/keycloak/representations/docker/DockerErrorResponseToken.java
+++ b/core/src/main/java/org/keycloak/representations/docker/DockerErrorResponseToken.java
@@ -3,6 +3,7 @@ package org.keycloak.representations.docker;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
+import java.util.Objects;
 
 public class DockerErrorResponseToken {
 
@@ -21,7 +22,7 @@ public class DockerErrorResponseToken {
 
         final DockerErrorResponseToken that = (DockerErrorResponseToken) o;
 
-        return errorList != null ? errorList.equals(that.errorList) : that.errorList == null;
+        return Objects.equals(errorList, that.errorList);
     }
 
     @Override

--- a/core/src/main/java/org/keycloak/representations/docker/DockerResponse.java
+++ b/core/src/main/java/org/keycloak/representations/docker/DockerResponse.java
@@ -1,5 +1,7 @@
 package org.keycloak.representations.docker;
 
+import java.util.Objects;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
@@ -63,9 +65,9 @@ public class DockerResponse {
 
         final DockerResponse that = (DockerResponse) o;
 
-        if (token != null ? !token.equals(that.token) : that.token != null) return false;
-        if (expires_in != null ? !expires_in.equals(that.expires_in) : that.expires_in != null) return false;
-        return issued_at != null ? issued_at.equals(that.issued_at) : that.issued_at == null;
+        if (!Objects.equals(token, that.token)) return false;
+        if (!Objects.equals(expires_in, that.expires_in)) return false;
+        return Objects.equals(issued_at, that.issued_at);
 
     }
 

--- a/core/src/main/java/org/keycloak/representations/idm/AuthenticatorConfigRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/idm/AuthenticatorConfigRepresentation.java
@@ -29,7 +29,7 @@ public class AuthenticatorConfigRepresentation implements Serializable {
 
     private String id;
     private String alias;
-    private Map<String, String> config = new HashMap<String, String>();
+    private Map<String, String> config = new HashMap<>();
 
     public String getId() {
         return id;

--- a/core/src/main/java/org/keycloak/representations/idm/CredentialRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/idm/CredentialRepresentation.java
@@ -17,6 +17,8 @@
 
 package org.keycloak.representations.idm;
 
+import java.util.Objects;
+
 import org.keycloak.common.util.MultivaluedHashMap;
 
 /**
@@ -185,71 +187,47 @@ public class CredentialRepresentation {
         if (getClass() != obj.getClass())
             return false;
         CredentialRepresentation other = (CredentialRepresentation) obj;
-        if (algorithm == null) {
-            if (other.algorithm != null)
-                return false;
-        } else if (!algorithm.equals(other.algorithm))
+
+        if (!Objects.equals(algorithm, other.algorithm)) {
             return false;
-        if (config == null) {
-            if (other.config != null)
-                return false;
-        } else if (!config.equals(other.config))
+        }
+        if (!Objects.equals(config, other.config)) {
             return false;
-        if (counter == null) {
-            if (other.counter != null)
-                return false;
-        } else if (!counter.equals(other.counter))
+        }
+        if (!Objects.equals(counter, other.counter)) {
             return false;
-        if (createdDate == null) {
-            if (other.createdDate != null)
-                return false;
-        } else if (!createdDate.equals(other.createdDate))
+        }
+        if (!Objects.equals(createdDate, other.createdDate)) {
             return false;
-        if (device == null) {
-            if (other.device != null)
-                return false;
-        } else if (!device.equals(other.device))
+        }
+        if (!Objects.equals(device, other.device)) {
             return false;
-        if (digits == null) {
-            if (other.digits != null)
-                return false;
-        } else if (!digits.equals(other.digits))
+        }
+        if (!Objects.equals(digits, other.digits)) {
             return false;
-        if (hashIterations == null) {
-            if (other.hashIterations != null)
-                return false;
-        } else if (!hashIterations.equals(other.hashIterations))
+        }
+        if (!Objects.equals(hashIterations, other.hashIterations)) {
             return false;
-        if (hashedSaltedValue == null) {
-            if (other.hashedSaltedValue != null)
-                return false;
-        } else if (!hashedSaltedValue.equals(other.hashedSaltedValue))
+        }
+        if (!Objects.equals(hashedSaltedValue, other.hashedSaltedValue)) {
             return false;
-        if (period == null) {
-            if (other.period != null)
-                return false;
-        } else if (!period.equals(other.period))
+        }
+        if (!Objects.equals(period, other.period)) {
             return false;
-        if (salt == null) {
-            if (other.salt != null)
-                return false;
-        } else if (!salt.equals(other.salt))
+        }
+        if (!Objects.equals(salt, other.salt)) {
             return false;
-        if (temporary == null) {
-            if (other.temporary != null)
-                return false;
-        } else if (!temporary.equals(other.temporary))
+        }
+        if (!Objects.equals(temporary, other.temporary)) {
             return false;
-        if (type == null) {
-            if (other.type != null)
-                return false;
-        } else if (!type.equals(other.type))
+        }
+        if (!Objects.equals(type, other.type)) {
             return false;
-        if (value == null) {
-            if (other.value != null)
-                return false;
-        } else if (!value.equals(other.value))
+        }
+        if (!Objects.equals(value, other.value)) {
             return false;
+        }
+
         return true;
     }
 }

--- a/core/src/main/java/org/keycloak/representations/idm/EventRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/idm/EventRepresentation.java
@@ -17,9 +17,9 @@
 package org.keycloak.representations.idm;
 
 import java.util.Map;
+import java.util.Objects;
 
 /**
- *
  * @author Stan Silvert ssilvert@redhat.com (C) 2016 Red Hat Inc.
  */
 public class EventRepresentation {
@@ -114,14 +114,14 @@ public class EventRepresentation {
         EventRepresentation that = (EventRepresentation) o;
 
         if (time != that.time) return false;
-        if (type != null ? !type.equals(that.type) : that.type != null) return false;
-        if (realmId != null ? !realmId.equals(that.realmId) : that.realmId != null) return false;
-        if (clientId != null ? !clientId.equals(that.clientId) : that.clientId != null) return false;
-        if (userId != null ? !userId.equals(that.userId) : that.userId != null) return false;
-        if (sessionId != null ? !sessionId.equals(that.sessionId) : that.sessionId != null) return false;
-        if (ipAddress != null ? !ipAddress.equals(that.ipAddress) : that.ipAddress != null) return false;
-        if (error != null ? !error.equals(that.error) : that.error != null) return false;
-        return !(details != null ? !details.equals(that.details) : that.details != null);
+        if (!Objects.equals(type, that.type)) return false;
+        if (!Objects.equals(realmId, that.realmId)) return false;
+        if (!Objects.equals(clientId, that.clientId)) return false;
+        if (!Objects.equals(userId, that.userId)) return false;
+        if (!Objects.equals(sessionId, that.sessionId)) return false;
+        if (!Objects.equals(ipAddress, that.ipAddress)) return false;
+        if (!Objects.equals(error, that.error)) return false;
+        return Objects.equals(details, that.details);
 
     }
 

--- a/core/src/main/java/org/keycloak/representations/idm/IdentityProviderMapperRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/idm/IdentityProviderMapperRepresentation.java
@@ -29,7 +29,7 @@ public class IdentityProviderMapperRepresentation {
     protected String name;
     protected String identityProviderAlias;
     protected String identityProviderMapper;
-    protected Map<String, String> config = new HashMap<String, String>();
+    protected Map<String, String> config = new HashMap<>();
 
 
     public String getId() {

--- a/core/src/main/java/org/keycloak/representations/idm/KeysMetadataRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/idm/KeysMetadataRepresentation.java
@@ -19,7 +19,6 @@ package org.keycloak.representations.idm;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>

--- a/core/src/main/java/org/keycloak/representations/idm/RealmRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/idm/RealmRepresentation.java
@@ -350,7 +350,7 @@ public class RealmRepresentation {
     public ScopeMappingRepresentation clientScopeMapping(String clientName) {
         ScopeMappingRepresentation mapping = new ScopeMappingRepresentation();
         mapping.setClient(clientName);
-        if (scopeMappings == null) scopeMappings = new ArrayList<ScopeMappingRepresentation>();
+        if (scopeMappings == null) scopeMappings = new ArrayList<>();
         scopeMappings.add(mapping);
         return mapping;
     }
@@ -358,7 +358,7 @@ public class RealmRepresentation {
     public ScopeMappingRepresentation clientScopeScopeMapping(String clientScopeName) {
         ScopeMappingRepresentation mapping = new ScopeMappingRepresentation();
         mapping.setClientScope(clientScopeName);
-        if (scopeMappings == null) scopeMappings = new ArrayList<ScopeMappingRepresentation>();
+        if (scopeMappings == null) scopeMappings = new ArrayList<>();
         scopeMappings.add(mapping);
         return mapping;
     }
@@ -784,7 +784,7 @@ public class RealmRepresentation {
     }
 
     public void addProtocolMapper(ProtocolMapperRepresentation rep) {
-        if (protocolMappers == null) protocolMappers = new LinkedList<ProtocolMapperRepresentation>();
+        if (protocolMappers == null) protocolMappers = new LinkedList<>();
         protocolMappers.add(rep);
     }
 

--- a/core/src/main/java/org/keycloak/representations/idm/RequiredActionProviderRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/idm/RequiredActionProviderRepresentation.java
@@ -32,7 +32,7 @@ public class RequiredActionProviderRepresentation {
     private boolean enabled;
     private boolean defaultAction;
     private int priority;
-    private Map<String, String> config = new HashMap<String, String>();
+    private Map<String, String> config = new HashMap<>();
 
 
     public String getAlias() {

--- a/core/src/main/java/org/keycloak/representations/idm/ScopeMappingRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/idm/ScopeMappingRepresentation.java
@@ -71,7 +71,7 @@ public class ScopeMappingRepresentation {
     }
 
     public ScopeMappingRepresentation role(String role) {
-        if (this.roles == null) this.roles = new HashSet<String>();
+        if (this.roles == null) this.roles = new HashSet<>();
         this.roles.add(role);
         return this;
     }

--- a/core/src/main/java/org/keycloak/representations/idm/UserSessionRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/idm/UserSessionRepresentation.java
@@ -31,7 +31,7 @@ public class UserSessionRepresentation {
     private String ipAddress;
     private long start;
     private long lastAccess;
-    private Map<String, String> clients = new HashMap<String, String>();
+    private Map<String, String> clients = new HashMap<>();
 
     public String getId() {
         return id;

--- a/core/src/main/java/org/keycloak/representations/idm/authorization/PermissionTicketToken.java
+++ b/core/src/main/java/org/keycloak/representations/idm/authorization/PermissionTicketToken.java
@@ -19,9 +19,7 @@ package org.keycloak.representations.idm.authorization;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.keycloak.TokenIdGenerator;
 import org.keycloak.json.StringListMapDeserializer;

--- a/core/src/main/java/org/keycloak/representations/idm/authorization/PolicyEvaluationRequest.java
+++ b/core/src/main/java/org/keycloak/representations/idm/authorization/PolicyEvaluationRequest.java
@@ -23,8 +23,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-import org.keycloak.representations.idm.authorization.ResourceRepresentation;
-
 /**
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
  */

--- a/core/src/main/java/org/keycloak/util/TokenUtil.java
+++ b/core/src/main/java/org/keycloak/util/TokenUtil.java
@@ -187,8 +187,7 @@ public class TokenUtil {
                 .content(contentBytes);
         jwe.getKeyStorage()
                 .setEncryptionKey(encryptionKEK);
-        String encodedContent = jwe.encodeJwe(jweAlgorithmProvider, jweEncryptionProvider);
-        return encodedContent;
+        return jwe.encodeJwe(jweAlgorithmProvider, jweEncryptionProvider);
     }
 
     public static byte[] jweKeyEncryptionVerifyAndDecode(Key decryptionKEK, String encodedContent) throws JWEException {

--- a/core/src/test/java/org/keycloak/AtHashTest.java
+++ b/core/src/test/java/org/keycloak/AtHashTest.java
@@ -37,13 +37,13 @@ public class AtHashTest {
     }
 
     @Test
-    public void testAtHashRsa() throws Exception {
+    public void testAtHashRsa() {
         verifyHash(Algorithm.RS256,"jHkWEdUXMU1BwAsC4vtUsZwnNvTIxEl0z9K3vx5KF0Y", "77QmUPtjPfzWtF2AnpK9RQ");
         verifyHash(Algorithm.RS256,"ya29.eQETFbFOkAs8nWHcmYXKwEi0Zz46NfsrUU_KuQLOLTwWS40y6Fb99aVzEXC0U14m61lcPMIr1hEIBA", "aUAkJG-u6x4RTWuILWy-CA");
     }
 
     @Test
-    public void testAtHashEs() throws Exception {
+    public void testAtHashEs() {
         verifyHash(Algorithm.ES256,"jHkWEdUXMU1BwAsC4vtUsZwnNvTIxEl0z9K3vx5KF0Y", "77QmUPtjPfzWtF2AnpK9RQ");
         verifyHash(Algorithm.ES256,"ya29.eQETFbFOkAs8nWHcmYXKwEi0Zz46NfsrUU_KuQLOLTwWS40y6Fb99aVzEXC0U14m61lcPMIr1hEIBA", "aUAkJG-u6x4RTWuILWy-CA");
     }

--- a/core/src/test/java/org/keycloak/JsonParserTest.java
+++ b/core/src/test/java/org/keycloak/JsonParserTest.java
@@ -40,7 +40,7 @@ import java.util.regex.Pattern;
 public class JsonParserTest {
 
     @Test
-    public void regex() throws Exception {
+    public void regex() {
         Pattern p = Pattern.compile(".*(?!\\.pdf)");
         if (p.matcher("foo.pdf").matches()) {
             System.out.println(".pdf no match");

--- a/core/src/test/java/org/keycloak/RSAVerifierTest.java
+++ b/core/src/test/java/org/keycloak/RSAVerifierTest.java
@@ -98,7 +98,7 @@ public class RSAVerifierTest {
     }
 
     @Test
-    public void testPemWriter() throws Exception {
+    public void testPemWriter() {
         PublicKey realmPublicKey = idpPair.getPublic();
         StringWriter sw = new StringWriter();
         PEMWriter writer = new PEMWriter(sw);
@@ -152,7 +152,7 @@ public class RSAVerifierTest {
 
 
     @Test
-    public void testBadSignature() throws Exception {
+    public void testBadSignature() {
 
         String encoded = new JWSBuilder()
                 .jsonContent(token)
@@ -183,7 +183,7 @@ public class RSAVerifierTest {
     }
 
     @Test
-    public void testNotBeforeBad() throws Exception {
+    public void testNotBeforeBad() {
         token.notBefore(Time.currentTime() + 100);
 
         String encoded = new JWSBuilder()
@@ -216,7 +216,7 @@ public class RSAVerifierTest {
     }
 
     @Test
-    public void testExpirationBad() throws Exception {
+    public void testExpirationBad() {
         token.expiration(Time.currentTime() - 100);
 
         String encoded = new JWSBuilder()
@@ -232,7 +232,7 @@ public class RSAVerifierTest {
     }
 
     @Test
-    public void testTokenAuth() throws Exception {
+    public void testTokenAuth() {
         token = new AccessToken();
         token.subject("CN=Client")
                 .issuer("http://localhost:8080/auth/realms/demo")

--- a/core/src/test/java/org/keycloak/jose/JWETest.java
+++ b/core/src/test/java/org/keycloak/jose/JWETest.java
@@ -18,10 +18,10 @@
 package org.keycloak.jose;
 
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.security.KeyPair;
 
-import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 
@@ -32,11 +32,8 @@ import org.keycloak.common.util.Base64Url;
 import org.keycloak.common.util.KeyUtils;
 import org.keycloak.jose.jwe.*;
 import org.keycloak.jose.jwe.alg.JWEAlgorithmProvider;
-import org.keycloak.jose.jwe.alg.KeyEncryptionJWEAlgorithmProvider;
 import org.keycloak.jose.jwe.alg.RsaKeyEncryptionJWEAlgorithmProvider;
-import org.keycloak.jose.jwe.enc.AesCbcHmacShaEncryptionProvider;
 import org.keycloak.jose.jwe.enc.AesCbcHmacShaJWEEncryptionProvider;
-import org.keycloak.jose.jwe.enc.AesGcmEncryptionProvider;
 import org.keycloak.jose.jwe.enc.AesGcmJWEEncryptionProvider;
 import org.keycloak.jose.jwe.enc.JWEEncryptionProvider;
 
@@ -75,7 +72,7 @@ public class JWETest {
         JWEHeader jweHeader = new JWEHeader(JWEConstants.DIR, encAlgorithm, null);
         JWE jwe = new JWE()
                 .header(jweHeader)
-                .content(payload.getBytes("UTF-8"));
+                .content(payload.getBytes(StandardCharsets.UTF_8));
 
         jwe.getKeyStorage()
                 .setCEKKey(aesKey, JWEKeyStorage.KeyUse.ENCRYPTION)
@@ -95,7 +92,7 @@ public class JWETest {
 
         jwe.verifyAndDecodeJwe(encodedContent);
 
-        String decodedContent = new String(jwe.getContent(), "UTF-8");
+        String decodedContent = new String(jwe.getContent(), StandardCharsets.UTF_8);
 
         Assert.assertEquals(payload, decodedContent);
     }
@@ -126,7 +123,7 @@ public class JWETest {
     }
 
     @Test
-    public void testPassword() throws Exception {
+    public void testPassword() {
         byte[] salt = JWEUtils.generateSecret(8);
         String encodedSalt = Base64.encodeBytes(salt);
         String jwe = JWE.encryptUTF8("geheim", encodedSalt, PAYLOAD);
@@ -147,7 +144,7 @@ public class JWETest {
         JWEHeader jweHeader = new JWEHeader(JWEConstants.A128KW, JWEConstants.A128CBC_HS256, null);
         JWE jwe = new JWE()
                 .header(jweHeader)
-                .content(PAYLOAD.getBytes("UTF-8"));
+                .content(PAYLOAD.getBytes(StandardCharsets.UTF_8));
 
         jwe.getKeyStorage()
                 .setEncryptionKey(aesKey);
@@ -163,7 +160,7 @@ public class JWETest {
 
         jwe.verifyAndDecodeJwe(encodedContent);
 
-        String decodedContent = new String(jwe.getContent(), "UTF-8");
+        String decodedContent = new String(jwe.getContent(), StandardCharsets.UTF_8);
 
         Assert.assertEquals(PAYLOAD, decodedContent);
     }
@@ -173,13 +170,13 @@ public class JWETest {
         byte[] random = JWEUtils.generateSecret(8);
         System.out.print("new byte[] = {");
         for (byte b : random) {
-            System.out.print(""+Byte.toString(b)+",");
+            System.out.print(""+ b +",");
         }
     }
 
 
     @Test
-    public void externalJweAes128CbcHmacSha256Test() throws UnsupportedEncodingException, JWEException {
+    public void externalJweAes128CbcHmacSha256Test() throws JWEException {
         String externalJwe = "eyJlbmMiOiJBMTI4Q0JDLUhTMjU2IiwiYWxnIjoiZGlyIn0..qysUrI1iVtiG4Z4jyr7XXg.apdNSQhR7WDMg6IHf5aLVI0gGp6JuOHYmIUtflns4WHmyxOOnh_GShLI6DWaK_SiywTV5gZvZYtl8H8Iv5fTfLkc4tiDDjbdtmsOP7tqyRxVh069gU5UvEAgmCXbIKALutgYXcYe2WM4E6BIHPTSt8jXdkktFcm7XHiD7mpakZyjXsG8p3XVkQJ72WbJI_t6.Ks6gHeko7BRTZ4CFs5ijRA";
         System.out.println("External encoded content length: " + externalJwe.length());
 
@@ -193,7 +190,7 @@ public class JWETest {
 
         jwe.verifyAndDecodeJwe(externalJwe);
 
-        String decodedContent = new String(jwe.getContent(), "UTF-8");
+        String decodedContent = new String(jwe.getContent(), StandardCharsets.UTF_8);
 
         Assert.assertEquals(PAYLOAD, decodedContent);
     }
@@ -201,7 +198,7 @@ public class JWETest {
 
     // Works just on OpenJDK 8. Other JDKs (IBM, Oracle) have restrictions on maximum key size of AES to be 128
     // @Test
-    public void externalJweAes256CbcHmacSha512Test() throws UnsupportedEncodingException, JWEException {
+    public void externalJweAes256CbcHmacSha512Test() throws JWEException {
         String externalJwe = "eyJlbmMiOiJBMjU2Q0JDLUhTNTEyIiwiYWxnIjoiZGlyIn0..xUPndQ5U69CYaWMKr4nyeg.AzSzba6OdNsvTIoNpub8d2TmYnkY7W8Sd-1S33DjJwJsSaNcfvfXBq5bqXAGVAnLHrLZJKWoEYsmOrYHz3Nao-kpLtUpc4XZI8yiYUqkHTjmxZnfD02R6hz31a5KBCnDTtUEv23VSxm8yUyQKoUTpVHbJ3b2VQvycg2XFUXPsA6oaSSEpz-uwe1Vmun2hUBB.Qal4rMYn1RrXQ9AQ9ONUjUXvlS2ow8np-T8QWMBR0ns";
         System.out.println("External encoded content length: " + externalJwe.length());
 
@@ -215,7 +212,7 @@ public class JWETest {
 
         jwe.verifyAndDecodeJwe(externalJwe);
 
-        String decodedContent = new String(jwe.getContent(), "UTF-8");
+        String decodedContent = new String(jwe.getContent(), StandardCharsets.UTF_8);
 
         Assert.assertEquals(PAYLOAD, decodedContent);
     }
@@ -235,7 +232,7 @@ public class JWETest {
 
         jwe.verifyAndDecodeJwe(externalJwe);
 
-        String decodedContent = new String(jwe.getContent(), "UTF-8");
+        String decodedContent = new String(jwe.getContent(), StandardCharsets.UTF_8);
 
         Assert.assertEquals("Live long and prosper.", decodedContent);
 
@@ -270,7 +267,7 @@ public class JWETest {
         JWEHeader jweHeader = new JWEHeader(jweAlgorithmName, jweEncryptionName, null);
         JWE jwe = new JWE()
                 .header(jweHeader)
-                .content(PAYLOAD.getBytes("UTF-8"));
+                .content(PAYLOAD.getBytes(StandardCharsets.UTF_8));
 
         jwe.getKeyStorage()
                 .setEncryptionKey(keyPair.getPublic());
@@ -283,7 +280,7 @@ public class JWETest {
         jwe.getKeyStorage()
                 .setDecryptionKey(keyPair.getPrivate());
         jwe.verifyAndDecodeJwe(encodedContent, jweAlgorithmProvider, jweEncryptionProvider);
-        String decodedContent = new String(jwe.getContent(), "UTF-8");
+        String decodedContent = new String(jwe.getContent(), StandardCharsets.UTF_8);
         System.out.println("Decoded content: " + decodedContent);
         System.out.println("Decoded content length: " + decodedContent.length());
 
@@ -303,7 +300,7 @@ public class JWETest {
         JWEHeader jweHeader = new JWEHeader(jweAlgorithmName, jweEncryptionName, null);
         JWE jwe = new JWE()
                 .header(jweHeader)
-                .content(PAYLOAD.getBytes("UTF-8"));
+                .content(PAYLOAD.getBytes(StandardCharsets.UTF_8));
 
         jwe.getKeyStorage()
                 .setEncryptionKey(keyPair.getPublic());
@@ -323,7 +320,7 @@ public class JWETest {
             .setCEKKey(aesKey, JWEKeyStorage.KeyUse.ENCRYPTION)
             .setCEKKey(hmacKey, JWEKeyStorage.KeyUse.SIGNATURE);
         jwe.verifyAndDecodeJwe(encodedContent, jweAlgorithmProvider, jweEncryptionProvider);
-        String decodedContent = new String(jwe.getContent(), "UTF-8");
+        String decodedContent = new String(jwe.getContent(), StandardCharsets.UTF_8);
         System.out.println("Decoded content: " + decodedContent);
         System.out.println("Decoded content length: " + decodedContent.length());
 

--- a/core/src/test/java/org/keycloak/jose/JsonWebTokenTest.java
+++ b/core/src/test/java/org/keycloak/jose/JsonWebTokenTest.java
@@ -48,7 +48,7 @@ public class JsonWebTokenTest {
     }
 
     @Test
-    public void testAddAudience() throws IOException {
+    public void testAddAudience() {
         // Token with no audience
         JsonWebToken s = new JsonWebToken();
         s.addAudience("audience-1");

--- a/core/src/test/java/org/keycloak/jose/jwk/JWKTest.java
+++ b/core/src/test/java/org/keycloak/jose/jwk/JWKTest.java
@@ -25,6 +25,7 @@ import org.keycloak.common.util.PemUtils;
 import org.keycloak.crypto.JavaAlgorithm;
 import org.keycloak.util.JsonSerialization;
 
+import java.nio.charset.StandardCharsets;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.PrivateKey;
@@ -72,7 +73,7 @@ public class JWKTest {
         // Parse
         assertArrayEquals(publicKey.getEncoded(), publicKeyFromJwk.getEncoded());
 
-        byte[] data = "Some test string".getBytes("utf-8");
+        byte[] data = "Some test string".getBytes(StandardCharsets.UTF_8);
         byte[] sign = sign(data, JavaAlgorithm.RS256, keyPair.getPrivate());
         verify(data, sign, JavaAlgorithm.RS256, publicKeyFromJwk);
     }
@@ -116,7 +117,7 @@ public class JWKTest {
 
         assertArrayEquals(publicKey.getEncoded(), publicKeyFromJwk.getEncoded());
 
-        byte[] data = "Some test string".getBytes("utf-8");
+        byte[] data = "Some test string".getBytes(StandardCharsets.UTF_8);
         byte[] sign = sign(data, JavaAlgorithm.ES256, keyPair.getPrivate());
         verify(data, sign, JavaAlgorithm.ES256, publicKeyFromJwk);
     }


### PR DESCRIPTION
Fix minor warnings in module core:
use diamond operator,
simplify conditions,
replace UTF-8 on StandartCharsets.UTF-8

