### PR TITLE
KEYCLOAK-11194 Remove dead code from JavaScript adapter

### DIFF
--- a/adapters/oidc/js/src/main/resources/keycloak.js
+++ b/adapters/oidc/js/src/main/resources/keycloak.js
@@ -986,14 +986,6 @@
             return uuid;
         }
 
-        kc.callback_id = 0;
-
-        function createCallbackId() {
-            var id = '<id: ' + (kc.callback_id++) + (Math.random()) + '>';
-            return id;
-
-        }
-
         function parseCallback(url) {
             var oauth = parseCallbackUrl(url);
             if (!oauth) {


### PR DESCRIPTION
Removes some dead code in the JavaScript adapter, namely `createCallbackId` and associated code on the instance.