### PR TITLE
KEYCLOAK-11196 Document the type for the `useNonce` option

### DIFF
--- a/adapters/oidc/js/src/main/resources/keycloak.d.ts
+++ b/adapters/oidc/js/src/main/resources/keycloak.d.ts
@@ -39,7 +39,9 @@ declare namespace Keycloak {
 
 	interface KeycloakInitOptions {
 		/**
-		 * @private Undocumented.
+		 * Adds a [cryptographic nonce](https://en.wikipedia.org/wiki/Cryptographic_nonce)
+		 * to verify that the authentication response matches the request.
+		 * @default true
 		 */
 		useNonce?: boolean;
 


### PR DESCRIPTION
Documents the publicly exposed `useNonce` option in the type interface.