### PR TITLE
KEYCLOAK-11227 Removed enabled/disabled flag from Providers

### DIFF
--- a/distribution/feature-packs/server-feature-pack/src/main/resources/content/bin/migrate-domain-clustered.cli
+++ b/distribution/feature-packs/server-feature-pack/src/main/resources/content/bin/migrate-domain-clustered.cli
@@ -659,4 +659,12 @@ if (result == undefined) of /profile=$clusteredProfile/subsystem=jgroups/stack=u
     echo
 end-if
 
+if (result == "true") of /subsystem=keycloak-server/spi=truststore/provider=file:map-get(name=properties, key=disabled)
+    echo Disabling Truststore Provider
+    /subsystem=keycloak-server/spi=truststore/provider=file:write-attribute(name=enabled, value=false)
+    echo Removing deprecated option
+    /subsystem=keycloak-server/spi=truststore/provider=file:map-remove(name=properties, key=disabled)
+    echo
+end-if
+
 echo *** End Migration of /profile=$clusteredProfile ***

--- a/distribution/feature-packs/server-feature-pack/src/main/resources/content/bin/migrate-domain-standalone.cli
+++ b/distribution/feature-packs/server-feature-pack/src/main/resources/content/bin/migrate-domain-standalone.cli
@@ -560,4 +560,12 @@ if (outcome == failed) of /profile=$standaloneProfile/subsystem=infinispan/cache
     echo
 end-if
 
+if (result == "true") of /subsystem=keycloak-server/spi=truststore/provider=file:map-get(name=properties, key=disabled)
+    echo Disabling Truststore Provider
+    /subsystem=keycloak-server/spi=truststore/provider=file:write-attribute(name=enabled, value=false)
+    echo Removing deprecated option
+    /subsystem=keycloak-server/spi=truststore/provider=file:map-remove(name=properties, key=disabled)
+    echo
+end-if
+
 echo *** End Migration of /profile=$standaloneProfile ***

--- a/distribution/feature-packs/server-feature-pack/src/main/resources/content/bin/migrate-standalone-ha.cli
+++ b/distribution/feature-packs/server-feature-pack/src/main/resources/content/bin/migrate-standalone-ha.cli
@@ -719,4 +719,12 @@ if (result == undefined) of /subsystem=jgroups/stack=udp/protocol=FD_SOCK/:read-
     echo
 end-if
 
+if (result == "true") of /subsystem=keycloak-server/spi=truststore/provider=file:map-get(name=properties, key=disabled)
+    echo Disabling Truststore Provider
+    /subsystem=keycloak-server/spi=truststore/provider=file:write-attribute(name=enabled, value=false)
+    echo Removing deprecated option
+    /subsystem=keycloak-server/spi=truststore/provider=file:map-remove(name=properties, key=disabled)
+    echo
+end-if
+
 echo *** End Migration ***

--- a/distribution/feature-packs/server-feature-pack/src/main/resources/content/bin/migrate-standalone.cli
+++ b/distribution/feature-packs/server-feature-pack/src/main/resources/content/bin/migrate-standalone.cli
@@ -584,4 +584,12 @@ if (outcome == failed) of /subsystem=infinispan/cache-container=web/local-cache=
     echo
 end-if
 
+if (result == "true") of /subsystem=keycloak-server/spi=truststore/provider=file:map-get(name=properties, key=disabled)
+    echo Disabling Truststore Provider
+    /subsystem=keycloak-server/spi=truststore/provider=file:write-attribute(name=enabled, value=false)
+    echo Removing deprecated option
+    /subsystem=keycloak-server/spi=truststore/provider=file:map-remove(name=properties, key=disabled)
+    echo
+end-if
+
 echo *** End Migration ***

--- a/services/src/main/java/org/keycloak/truststore/FileTruststoreProviderFactory.java
+++ b/services/src/main/java/org/keycloak/truststore/FileTruststoreProviderFactory.java
@@ -22,6 +22,7 @@ import org.keycloak.Config;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 
+import javax.security.auth.x500.X500Principal;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -38,10 +39,7 @@ import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.Enumeration;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-
-import javax.security.auth.x500.X500Principal;
 
 /**
  * @author <a href="mailto:mstrukel@redhat.com">Marko Strukelj</a>
@@ -63,15 +61,9 @@ public class FileTruststoreProviderFactory implements TruststoreProviderFactory 
         String storepath = config.get("file");
         String pass = config.get("password");
         String policy = config.get("hostname-verification-policy");
-        Boolean disabled = config.getBoolean("disabled", null);
 
         // if "truststore" . "file" is not configured then it is disabled
-        if (storepath == null && pass == null && policy == null && disabled == null) {
-            return;
-        }
-
-        // if explicitly disabled
-        if (disabled != null && disabled) {
+        if (storepath == null && pass == null && policy == null) {
             return;
         }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/KEYCLOAK-11227

This Pull Requests removes "disabled" flag usages from Providers. This check if already performed by `DefaultKeycloakSessionFactory`.

I used the following expressions to hunt all the expressions:

```
grep -lir \"enabled\" --include="*ProviderFactory.java"
grep -lir \"disabled\" --include="*ProviderFactory.java"
```

@hmlnarik mentioned that we might need a migration mechanism here. After thinking about this for a while, I'm  not convinced. I believe mentioning it in the Release Notes should be enough.