### PR TITLE
KEYCLOAK-6225, Add support to fallback to next LDAP storage provider when Kerberos is used

### DIFF
--- a/common/src/main/java/org/keycloak/common/constants/KerberosConstants.java
+++ b/common/src/main/java/org/keycloak/common/constants/KerberosConstants.java
@@ -91,5 +91,12 @@ public class KerberosConstants {
      * Display name for the above in admin console and consent screens
      */
     public static final String GSS_DELEGATION_CREDENTIAL_DISPLAY_NAME = "gss delegation credential";
+    
+    /**
+     * Internal attribute used in "state" map. Contains authenticated user to be used to continue LDAP access.
+     * KEYCLOAK-6225 - Support for provider fallback during authentication flow.
+     */
+    public static final String SPNEGO_AUTHENTICATED_USER = "SpnegoAuthenticatedUser";
+    
 
 }

--- a/federation/kerberos/src/main/java/org/keycloak/federation/kerberos/KerberosFederationProvider.java
+++ b/federation/kerberos/src/main/java/org/keycloak/federation/kerberos/KerberosFederationProvider.java
@@ -184,7 +184,7 @@ public class KerberosFederationProvider implements UserStorageProvider,
     }
 
     @Override
-    public CredentialValidationOutput authenticate(RealmModel realm, CredentialInput input) {
+    public CredentialValidationOutput authenticate(RealmModel realm, CredentialInput input, CredentialValidationOutput prevAttempt) {
         if (!(input instanceof UserCredentialModel)) return null;
         UserCredentialModel credential = (UserCredentialModel)input;
         if (credential.getType().equals(UserCredentialModel.KERBEROS)) {

--- a/server-spi/src/main/java/org/keycloak/credential/CredentialAuthentication.java
+++ b/server-spi/src/main/java/org/keycloak/credential/CredentialAuthentication.java
@@ -17,10 +17,7 @@
 package org.keycloak.credential;
 
 import org.keycloak.models.CredentialValidationOutput;
-import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
-
-import java.util.Set;
 
 /**
  * Single purpose method that knows how to authenticate a user based on a credential type.  This is used when the user
@@ -31,5 +28,5 @@ import java.util.Set;
  */
 public interface CredentialAuthentication {
     boolean supportsCredentialAuthenticationFor(String type);
-    CredentialValidationOutput authenticate(RealmModel realm, CredentialInput input);
+    CredentialValidationOutput authenticate(RealmModel realm, CredentialInput input, CredentialValidationOutput prevAttempt);
 }


### PR DESCRIPTION
This PR was tested using several LDAP Federations, all attached to a single kerberos REALM.
Each Federation was configured to a different "Users DN" to create a unique users list to each Federation.
 
