### PR TITLE
KEYCLOAK-11308 Fallback to imported realm version.

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/migration/MigrationModelManager.java
+++ b/server-spi-private/src/main/java/org/keycloak/migration/MigrationModelManager.java
@@ -124,6 +124,9 @@ public class MigrationModelManager {
         ModelVersion stored = null;
         if (rep.getKeycloakVersion() != null) {
             stored = convertRHSSOVersionToKeycloakVersion(rep.getKeycloakVersion());
+            if (stored == null) {
+                stored = new ModelVersion(rep.getKeycloakVersion());
+            }
         }
         if (stored == null) {
             stored = migrations[0].getVersion();


### PR DESCRIPTION
In case of missing RH SSO version lets stick with bare Keycloak version.