### PR TITLE
[KEYCLOAK-8253] Improve the time complexity of LDAP groups synchronization from exponential to linear time

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
@@ -40,6 +40,7 @@ import org.keycloak.models.jpa.entities.RoleEntity;
 import org.keycloak.models.utils.KeycloakModelUtils;
 
 import javax.persistence.EntityManager;
+import javax.persistence.FlushModeType;
 import javax.persistence.TypedQuery;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -498,7 +499,11 @@ public class JpaRealmProvider implements RealmProvider {
         RealmEntity realmEntity = em.getReference(RealmEntity.class, realm.getId());
         groupEntity.setRealm(realmEntity);
         em.persist(groupEntity);
-        em.flush();
+        // KEYCLOAK-8253 - Skip / postpone the EM flush if there's an active WIP transaction and EM flush mode is set to AUTO (the default)
+        // This improves the time performance of LDAP groups sync and EM flush in that case is performed anyway as part of the TX commit
+        if (!session.getTransactionManager().isActive() || em.getFlushMode() != FlushModeType.AUTO) {
+            em.flush();
+        }
         realmEntity.getGroups().add(groupEntity);
 
         GroupAdapter adapter = new GroupAdapter(realm, em, groupEntity);
@@ -509,8 +514,6 @@ public class JpaRealmProvider implements RealmProvider {
     public void addTopLevelGroup(RealmModel realm, GroupModel subGroup) {
         subGroup.setParent(null);
     }
-
-
 
     @Override
     public ClientModel addClient(RealmModel realm, String clientId) {


### PR DESCRIPTION

    [KEYCLOAK-8253] Improve the time complexity of LDAP groups synchronization
    (in the direction from LDAP provider to Keycloak) from exponential to
    linear time in the case of syncing flat LDAP groups structure
    
    Add a corresponding test (intentionally configured as to be ignored
    by CI/CD due to higher demand on time, required fo the test completion)
    
    Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

NOTE: This fix covers only subcase of syncing flat structure of LDAP groups from the federation provider to Keycloak. The subcase of syncing tree structure will be covered later, as it requires more testing yet. Also, the corresponding testcase could be improved yet (see the inline commented for loop in the PR).

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
