### PR TITLE
KEYCLOAK-10907 Add configurable token settings per client

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/AuthenticatedClientSessionAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/AuthenticatedClientSessionAdapter.java
@@ -148,9 +148,11 @@ public class AuthenticatedClientSessionAdapter implements AuthenticatedClientSes
             }
 
             @Override
-            public CrossDCMessageStatus getCrossDCMessageStatus(SessionEntityWrapper<AuthenticatedClientSessionEntity> sessionWrapper) {
-                return new CrossDCLastSessionRefreshChecker(provider.getLastSessionRefreshStore(), provider.getOfflineLastSessionRefreshStore())
-                        .shouldSaveClientSessionToRemoteCache(kcSession, client.getRealm(), sessionWrapper, userSession, offline, timestamp);
+            public CrossDCMessageStatus getCrossDCMessageStatus(
+                SessionEntityWrapper<AuthenticatedClientSessionEntity> sessionWrapper) {
+                return new CrossDCLastSessionRefreshChecker(provider.getLastSessionRefreshStore(),
+                    provider.getOfflineLastSessionRefreshStore()).shouldSaveClientSessionToRemoteCache(kcSession,
+                        client.getRealm(), sessionWrapper, userSession, offline, timestamp, client);
             }
 
             @Override

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/UserSessionAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/UserSessionAdapter.java
@@ -43,8 +43,6 @@ import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import static org.keycloak.models.sessions.infinispan.changes.sessions.CrossDCLastSessionRefreshListener.IGNORE_REMOTE_CACHE_UPDATE;
-
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
  */
@@ -228,8 +226,10 @@ public class UserSessionAdapter implements UserSessionModel {
 
             @Override
             public CrossDCMessageStatus getCrossDCMessageStatus(SessionEntityWrapper<UserSessionEntity> sessionWrapper) {
-                return new CrossDCLastSessionRefreshChecker(provider.getLastSessionRefreshStore(), provider.getOfflineLastSessionRefreshStore())
-                        .shouldSaveUserSessionToRemoteCache(UserSessionAdapter.this.session, UserSessionAdapter.this.realm, sessionWrapper, offline, lastSessionRefresh);
+                return new CrossDCLastSessionRefreshChecker(provider.getLastSessionRefreshStore(),
+                    provider.getOfflineLastSessionRefreshStore()).shouldSaveUserSessionToRemoteCache(
+                        UserSessionAdapter.this.session, UserSessionAdapter.this.realm, sessionWrapper, offline,
+                        lastSessionRefresh, UserSessionAdapter.this);
             }
 
             @Override

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/session/PersistentClientSessionEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/session/PersistentClientSessionEntity.java
@@ -37,6 +37,7 @@ import java.io.Serializable;
         @NamedQuery(name="deleteClientSessionsByUser", query="delete from PersistentClientSessionEntity sess where sess.userSessionId IN (select u.userSessionId from PersistentUserSessionEntity u where u.userId = :userId)"),
         @NamedQuery(name="deleteClientSessionsByUserSession", query="delete from PersistentClientSessionEntity sess where sess.userSessionId = :userSessionId and sess.offline = :offline"),
         @NamedQuery(name="deleteExpiredClientSessions", query="delete from PersistentClientSessionEntity sess where sess.userSessionId IN (select u.userSessionId from PersistentUserSessionEntity u where u.realmId = :realmId AND u.offline = :offline AND u.lastSessionRefresh < :lastSessionRefresh)"),
+        @NamedQuery(name="findExpiredClientSessionsByClient", query="select sess from PersistentClientSessionEntity sess where sess.clientId = :clientId and sess.userSessionId IN (select u.userSessionId from PersistentUserSessionEntity u where u.realmId = :realmId AND u.offline = :offline AND u.lastSessionRefresh < :lastSessionRefresh)"),
         @NamedQuery(name="findClientSessionsByUserSession", query="select sess from PersistentClientSessionEntity sess where sess.userSessionId=:userSessionId and sess.offline = :offline"),
         @NamedQuery(name="findClientSessionsByUserSessions", query="select sess from PersistentClientSessionEntity sess where sess.offline = :offline and sess.userSessionId IN (:userSessionIds) order by sess.userSessionId")
 })

--- a/server-spi-private/src/main/java/org/keycloak/models/Constants.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/Constants.java
@@ -59,6 +59,7 @@ public final class Constants {
     public static final String VERIFY_EMAIL_CODE = "VERIFY_EMAIL_CODE";
     public static final String EXECUTION = "execution";
     public static final String CLIENT_ID = "client_id";
+    public static final String CLIENT_UUID = "clientUuid";
     public static final String TAB_ID = "tab_id";
     public static final String KEY = "key";
     public static final String KC_ACTION = "kc_action";

--- a/services/src/main/java/org/keycloak/authentication/AuthenticationProcessor.java
+++ b/services/src/main/java/org/keycloak/authentication/AuthenticationProcessor.java
@@ -942,7 +942,8 @@ public class AuthenticationProcessor {
             if (userSession == null) {
                 userSession = session.sessions().createUserSession(authSession.getParentSession().getId(), realm, authSession.getAuthenticatedUser(), username, connection.getRemoteAddr(), authSession.getProtocol()
                         , remember, brokerSessionId, brokerUserId);
-            } else if (userSession.getUser() == null || !AuthenticationManager.isSessionValid(realm, userSession)) {
+            } else if (userSession.getUser() == null
+                || !AuthenticationManager.isSessionValid(realm, userSession, authSession.getClient())) {
                 userSession.restartSession(realm, authSession.getAuthenticatedUser(), username, connection.getRemoteAddr(), authSession.getProtocol()
                         , remember, brokerSessionId, brokerUserId);
             } else {

--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCConfigAttributes.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCConfigAttributes.java
@@ -43,6 +43,20 @@ public final class OIDCConfigAttributes {
 
     public static final String ACCESS_TOKEN_SIGNED_RESPONSE_ALG = "access.token.signed.response.alg";
 
+    public static final String REVOKE_REFRESH_TOKEN = "revoke.refresh.token";
+
+    public static final String REFRESH_TOKEN_MAX_REUSE = "refresh.token.max.reuse";
+
+    public static final String SSO_SESSION_IDLE_TIMEOUT = "sso.session.idle.timeout";
+
+    public static final String SSO_SESSION_MAX_LIFESPAN = "sso.session.max.lifespan";
+
+    public static final String OFFLINE_SESSION_IDLE_TIMEOUT = "offline.session.idle.timeout";
+
+    public static final String OFFLINE_SESSION_MAX_LIFESPAN_ENABLED = "offline.session.max.lifespan.enabled";
+
+    public static final String OFFLINE_SESSION_MAX_LIFESPAN = "offline.session.max.lifespan";
+
     public static final String ACCESS_TOKEN_LIFESPAN = "access.token.lifespan";
 
     public static final String PKCE_CODE_CHALLENGE_METHOD = "pkce.code.challenge.method";

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
@@ -347,7 +347,7 @@ public class TokenEndpoint {
             throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_GRANT, "Client not allowed to exchange code", Response.Status.BAD_REQUEST);
         }
 
-        if (!AuthenticationManager.isSessionValid(realm, userSession)) {
+        if (!AuthenticationManager.isSessionValid(realm, userSession, client)) {
             event.error(Errors.USER_SESSION_NOT_FOUND);
             throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_GRANT, "Session not active", Response.Status.BAD_REQUEST);
         }

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/UserInfoEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/UserInfoEndpoint.java
@@ -35,7 +35,6 @@ import org.keycloak.jose.jws.JWSBuilder;
 import org.keycloak.models.AuthenticatedClientSessionModel;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.ClientSessionContext;
-import org.keycloak.models.TokenManager;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
@@ -232,13 +231,13 @@ public class UserInfoEndpoint {
     private UserSessionModel findValidSession(AccessToken token, EventBuilder event, ClientModel client) {
         UserSessionModel userSession = new UserSessionCrossDCManager(session).getUserSessionWithClient(realm, token.getSessionState(), false, client.getId());
         UserSessionModel offlineUserSession = null;
-        if (AuthenticationManager.isSessionValid(realm, userSession)) {
+        if (AuthenticationManager.isSessionValid(realm, userSession, client)) {
             checkTokenIssuedAt(token, userSession, event);
             event.session(userSession);
             return userSession;
         } else {
             offlineUserSession = new UserSessionCrossDCManager(session).getUserSessionWithClient(realm, token.getSessionState(), true, client.getId());
-            if (AuthenticationManager.isOfflineSessionValid(realm, offlineUserSession)) {
+            if (AuthenticationManager.isOfflineSessionValid(realm, offlineUserSession, client)) {
                 checkTokenIssuedAt(token, offlineUserSession, event);
                 event.session(offlineUserSession);
                 return offlineUserSession;

--- a/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
@@ -149,7 +149,9 @@ public class AuthenticationManager {
         if (userSession.isRememberMe() && realm.getSsoSessionIdleTimeoutRememberMe() > 0) {
             maxIdle = realm.getSsoSessionIdleTimeoutRememberMe();
         } else {
-            String clientSsoSessionIdleTimeout = client.getAttribute(OIDCConfigAttributes.SSO_SESSION_IDLE_TIMEOUT);
+            String clientSsoSessionIdleTimeout = client != null
+                ? client.getAttribute(OIDCConfigAttributes.SSO_SESSION_IDLE_TIMEOUT)
+                : null;
             if (clientSsoSessionIdleTimeout != null && !clientSsoSessionIdleTimeout.trim().isEmpty()) {
                 maxIdle = Integer.parseInt(clientSsoSessionIdleTimeout);
             } else {
@@ -161,7 +163,9 @@ public class AuthenticationManager {
         if (userSession.isRememberMe() && realm.getSsoSessionMaxLifespanRememberMe() > 0) {
             maxLifespan = realm.getSsoSessionMaxLifespanRememberMe();
         } else {
-            String clientSsoSessionMaxLifespan = client.getAttribute(OIDCConfigAttributes.SSO_SESSION_MAX_LIFESPAN);
+            String clientSsoSessionMaxLifespan = client != null
+                ? client.getAttribute(OIDCConfigAttributes.SSO_SESSION_MAX_LIFESPAN)
+                : null;
             if (clientSsoSessionMaxLifespan != null && !clientSsoSessionMaxLifespan.trim().isEmpty()) {
                 maxLifespan = Integer.parseInt(clientSsoSessionMaxLifespan);
             } else {
@@ -182,7 +186,9 @@ public class AuthenticationManager {
         int currentTime = Time.currentTime();
         // Additional time window is added for the case when session was updated in different DC and the update to current DC was postponed
         int maxIdle;
-        String clientOfflineSessionIdleTimeout = client.getAttribute(OIDCConfigAttributes.OFFLINE_SESSION_IDLE_TIMEOUT);
+        String clientOfflineSessionIdleTimeout = client != null
+            ? client.getAttribute(OIDCConfigAttributes.OFFLINE_SESSION_IDLE_TIMEOUT)
+            : null;
         if (clientOfflineSessionIdleTimeout != null && !clientOfflineSessionIdleTimeout.trim().isEmpty()) {
             maxIdle = Integer.parseInt(clientOfflineSessionIdleTimeout) + SessionTimeoutHelper.IDLE_TIMEOUT_WINDOW_SECONDS;
         } else {
@@ -190,8 +196,9 @@ public class AuthenticationManager {
         }
 
         // KEYCLOAK-7688 Offline Session Max for Offline Token
-        String clientIsOfflineSessionMaxLifespanEnabled = client
-            .getAttribute(OIDCConfigAttributes.OFFLINE_SESSION_MAX_LIFESPAN_ENABLED);
+        String clientIsOfflineSessionMaxLifespanEnabled = client != null
+            ? client.getAttribute(OIDCConfigAttributes.OFFLINE_SESSION_MAX_LIFESPAN_ENABLED)
+            : null;
         boolean isOfflineSessionMaxLifespanEnabled = "ON".equals(clientIsOfflineSessionMaxLifespanEnabled)
             || (!"OFF".equals(clientIsOfflineSessionMaxLifespanEnabled) && realm.isOfflineSessionMaxLifespanEnabled());
 

--- a/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
@@ -1313,7 +1313,7 @@ public class AuthenticationManager {
                 }
             }
 
-            ClientModel client = realm.getClientByClientId(token.getIssuedFor());
+            ClientModel client = token.getIssuedFor() != null ? realm.getClientByClientId(token.getIssuedFor()) : null;
 
             if (!isSessionValid(realm, userSession, client)) {
                 // Check if accessToken was for the offline session.

--- a/services/src/main/java/org/keycloak/services/managers/UserSessionManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/UserSessionManager.java
@@ -123,6 +123,16 @@ public class UserSessionManager {
         persister.removeUserSession(userSession.getId(), true);
     }
 
+    public void revokeOfflineClientSession(UserSessionModel userSession, ClientModel client) {
+        if (logger.isTraceEnabled()) {
+            logger.tracef("Removing offline client session of user session '%s' for user '%s' and client '%s' ",
+                userSession.getId(), userSession.getLoginUsername(), client.getName());
+        }
+        userSession.setNote(Constants.CLIENT_UUID, client.getId());
+        kcSession.sessions().removeOfflineUserSession(userSession.getRealm(), userSession);
+        persister.removeClientSession(userSession.getId(), client.getId(), true);
+    }
+
     public boolean isOfflineTokenAllowed(ClientSessionContext clientSessionCtx) {
         RoleModel offlineAccessRole = clientSessionCtx.getClientSession().getRealm().getRole(Constants.OFFLINE_ACCESS_ROLE);
         if (offlineAccessRole == null) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/crossdc/LastSessionRefreshCrossDCTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/crossdc/LastSessionRefreshCrossDCTest.java
@@ -229,7 +229,7 @@ public class LastSessionRefreshCrossDCTest extends AbstractAdminCrossDCTest {
         boolean sessionValid = getTestingClientForStartedNodeInDc(1).server("test").fetch((KeycloakSession session) -> {
             RealmModel realm = session.realms().getRealmByName("test");
             UserSessionModel userSession = session.sessions().getUserSession(realm, sessionId);
-            return AuthenticationManager.isSessionValid(realm, userSession);
+            return AuthenticationManager.isSessionValid(realm, userSession, realm.getClientByClientId("test-app"));
         }, Boolean.class);
 
         Assert.assertTrue(sessionValid);
@@ -248,7 +248,7 @@ public class LastSessionRefreshCrossDCTest extends AbstractAdminCrossDCTest {
         sessionValid = getTestingClientForStartedNodeInDc(1).server("test").fetch((KeycloakSession session) -> {
             RealmModel realm = session.realms().getRealmByName("test");
             UserSessionModel userSession = session.sessions().getUserSession(realm, sessionId);
-            return AuthenticationManager.isSessionValid(realm, userSession);
+            return AuthenticationManager.isSessionValid(realm, userSession, realm.getClientByClientId("test-app"));
         }, Boolean.class);
 
         Assert.assertFalse(sessionValid);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/model/UserSessionProviderOfflineTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/model/UserSessionProviderOfflineTest.java
@@ -495,6 +495,7 @@ public class UserSessionProviderOfflineTest extends AbstractTestRealmKeycloakTes
 
                 // Set lastSessionRefresh to currentSession[0] to 0
                 session0.setLastSessionRefresh(Time.currentTime());
+                session0.getAuthenticatedClientSessions().values().iterator().next().setTimestamp(Time.currentTime());
             });
 
 
@@ -512,6 +513,7 @@ public class UserSessionProviderOfflineTest extends AbstractTestRealmKeycloakTes
 
                     UserSessionModel session0 = currentSession.sessions().getOfflineUserSession(realm, origSessions[0].getId());
                     session0.setLastSessionRefresh(Time.currentTime());
+                    session0.getAuthenticatedClientSessions().values().iterator().next().setTimestamp(Time.currentTime());
                 });
             }
 

--- a/themes/src/main/resources/theme/base/admin/resources/js/controllers/clients.js
+++ b/themes/src/main/resources/theme/base/admin/resources/js/controllers/clients.js
@@ -1016,6 +1016,12 @@ module.controller('ClientDetailCtrl', function($scope, realm, client, flows, $ro
         "plain",
         ""
     ];
+    
+    $scope.onOffSwitchOptions = [
+        "ON",
+        "OFF",
+        ""
+    ];
 
     $scope.realm = realm;
     $scope.samlAuthnStatement = false;
@@ -1036,6 +1042,13 @@ module.controller('ClientDetailCtrl', function($scope, realm, client, flows, $ro
     // https://tools.ietf.org/html/draft-ietf-oauth-mtls-08#section-3
     $scope.tlsClientCertificateBoundAccessTokens = false;
 
+    $scope.revokeRefreshToken = client.attributes['revoke.refresh.token'];
+    $scope.refreshTokenMaxReuse = client.attributes['refresh.token.max.reuse'] ? Number(client.attributes['refresh.token.max.reuse']) : 0;
+    $scope.ssoSessionIdleTimeout = TimeUnit2.asUnit(client.attributes['sso.session.idle.timeout']);
+    $scope.ssoSessionMaxLifespan = TimeUnit2.asUnit(client.attributes['sso.session.max.lifespan']);
+    $scope.offlineSessionIdleTimeout = TimeUnit2.asUnit(client.attributes['offline.session.idle.timeout']);
+    $scope.offlineSessionMaxLifespanEnabled = client.attributes['offline.session.max.lifespan.enabled'];
+    $scope.offlineSessionMaxLifespan = client.attributes['offline.session.max.lifespan'] ? TimeUnit2.asUnit(client.attributes['offline.session.max.lifespan']) : TimeUnit2.asUnit(5184000);
     $scope.accessTokenLifespan = TimeUnit2.asUnit(client.attributes['access.token.lifespan']);
 
     if(client.origin) {
@@ -1348,6 +1361,46 @@ module.controller('ClientDetailCtrl', function($scope, realm, client, flows, $ro
             return true;
         }
         return false;
+    }
+
+    $scope.changeRevokeRefreshToken = function() {
+        $scope.clientEdit.attributes['revoke.refresh.token'] = $scope.revokeRefreshToken;
+    };
+
+    $scope.updateRefreshTokenMaxReuse = function() {
+        $scope.clientEdit.attributes['refresh.token.max.reuse'] = $scope.refreshTokenMaxReuse;
+    };
+
+    $scope.updateSsoSessionIdleTimeout = function() {
+        if ($scope.ssoSessionIdleTimeout.time) {
+            $scope.clientEdit.attributes['sso.session.idle.timeout'] = $scope.ssoSessionIdleTimeout.toSeconds();
+        } else {
+            $scope.clientEdit.attributes['sso.session.idle.timeout'] = null;
+        }
+    }
+
+    $scope.updateSsoSessionMaxLifespan = function() {
+        if ($scope.ssoSessionMaxLifespan.time) {
+            $scope.clientEdit.attributes['sso.session.max.lifespan'] = $scope.ssoSessionMaxLifespan.toSeconds();
+        } else {
+            $scope.clientEdit.attributes['sso.session.max.lifespan'] = null;
+        }
+    }
+
+    $scope.updateOfflineSessionIdleTimeout = function() {
+        if ($scope.offlineSessionIdleTimeout.time) {
+            $scope.clientEdit.attributes['offline.session.idle.timeout'] = $scope.offlineSessionIdleTimeout.toSeconds();
+        } else {
+            $scope.clientEdit.attributes['offline.session.idle.timeout'] = null;
+        }
+    }
+
+    $scope.changeOfflineSessionMaxLifespanEnabled = function() {
+        $scope.clientEdit.attributes['offline.session.max.lifespan.enabled'] = $scope.offlineSessionMaxLifespanEnabled;
+    };
+
+    $scope.updateOfflineSessionMaxLifespan = function() {
+        $scope.clientEdit.attributes['offline.session.max.lifespan'] = $scope.offlineSessionMaxLifespan.toSeconds();
     }
 
     $scope.updateTimeouts = function() {

--- a/themes/src/main/resources/theme/base/admin/resources/partials/client-detail.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/client-detail.html
@@ -507,6 +507,109 @@
             <legend collapsed><span class="text">{{:: 'advanced-client-settings' | translate}}</span>  <kc-tooltip>{{:: 'advanced-client-settings.tooltip' | translate}}</kc-tooltip></legend>
 
             <div class="form-group">
+                <label class="col-md-2 control-label" for="revokeRefreshToken">{{:: 'revoke-refresh-token' | translate}}</label>
+                <div class="col-sm-6">
+                    <div>
+                        <select class="form-control" id="revokeRefreshToken"
+                                ng-change="changeRevokeRefreshToken()"
+                                ng-model="revokeRefreshToken"
+                                ng-options="switch for switch in onOffSwitchOptions">
+                        </select>
+                    </div>
+                </div>
+                <kc-tooltip>{{:: 'revoke-refresh-token.tooltip' | translate}}</kc-tooltip>
+            </div>
+
+            <div class="form-group" data-ng-show="revokeRefreshToken == 'ON'">
+                <label class="col-md-2 control-label" for="refreshTokenMaxReuse">{{:: 'refresh-token-max-reuse' | translate}}</label>
+                <div class="col-md-6">
+                    <input class="form-control" type="number" required min="0" 
+                           max="31536000" data-ng-model="refreshTokenMaxReuse" 
+                           id="refreshTokenMaxReuse" name="refreshTokenMaxReuse"
+                           data-ng-change="updateRefreshTokenMaxReuse()"/>
+                </div>
+                <kc-tooltip>{{:: 'refresh-token-max-reuse.tooltip' | translate}}</kc-tooltip>
+            </div>
+
+            <div class="form-group">
+                <label class="col-md-2 control-label" for="ssoSessionIdleTimeout">{{:: 'sso-session-idle' | translate}}</label>
+                <div class="col-md-6 time-selector">
+                    <input class="form-control" type="number" min="1" 
+                           max="31536000" data-ng-model="ssoSessionIdleTimeout.time"
+                           id="ssoSessionIdleTimeout" name="ssoSessionIdleTimeout"
+                           data-ng-change="updateSsoSessionIdleTimeout()"/>
+                    <select class="form-control" name="ssoSessionIdleTimeoutUnit" data-ng-model="ssoSessionIdleTimeout.unit" data-ng-change="updateSsoSessionIdleTimeout()">
+                        <option value="Minutes">{{:: 'minutes' | translate}}</option>
+                        <option value="Hours">{{:: 'hours' | translate}}</option>
+                        <option value="Days">{{:: 'days' | translate}}</option>
+                    </select>
+                </div>
+                <kc-tooltip>{{:: 'sso-session-idle.tooltip' | translate}}</kc-tooltip>
+            </div>
+
+            <div class="form-group">
+                <label class="col-md-2 control-label" for="ssoSessionMaxLifespan">{{:: 'sso-session-max' | translate}}</label>
+                <div class="col-md-6 time-selector">
+                    <input class="form-control" type="number" min="1"
+                           max="31536000" data-ng-model="ssoSessionMaxLifespan.time"
+                           id="ssoSessionMaxLifespan" name="ssoSessionMaxLifespan"
+                           data-ng-change="updateSsoSessionMaxLifespan()"/>
+                    <select class="form-control" name="ssoSessionMaxLifespanUnit" data-ng-model="ssoSessionMaxLifespan.unit" data-ng-change="updateSsoSessionMaxLifespan()">
+                        <option value="Minutes">{{:: 'minutes' | translate}}</option>
+                        <option value="Hours">{{:: 'hours' | translate}}</option>
+                        <option value="Days">{{:: 'days' | translate}}</option>
+                    </select>
+                </div>
+                <kc-tooltip>{{:: 'sso-session-max.tooltip' | translate}}</kc-tooltip>
+            </div>
+
+            <div class="form-group">
+                <label class="col-md-2 control-label" for="offlineSessionIdleTimeout">{{:: 'offline-session-idle' | translate}}</label>
+                <div class="col-md-6 time-selector">
+                    <input class="form-control" type="number" min="1"
+                           max="31536000" data-ng-model="offlineSessionIdleTimeout.time"
+                           id="offlineSessionIdleTimeout" name="offlineSessionIdleTimeout"
+                           data-ng-change="updateOfflineSessionIdleTimeout()"/>
+                    <select class="form-control" name="offlineSessionIdleTimeoutUnit" data-ng-model="offlineSessionIdleTimeout.unit" data-ng-change="updateOfflineSessionIdleTimeout()">
+                        <option value="Minutes">{{:: 'minutes' | translate}}</option>
+                        <option value="Hours">{{:: 'hours' | translate}}</option>
+                        <option value="Days">{{:: 'days' | translate}}</option>
+                    </select>
+                </div>
+                <kc-tooltip>{{:: 'offline-session-idle.tooltip' | translate}}</kc-tooltip>
+            </div>
+
+            <div class="form-group">
+                <label class="col-md-2 control-label" for="offlineSessionMaxLifespanEnabled">{{:: 'offline-session-max-limited' | translate}}</label>
+                <div class="col-sm-6">
+                    <div>
+                        <select class="form-control" id="offlineSessionMaxLifespanEnabled"
+                                ng-change="changeOfflineSessionMaxLifespanEnabled()"
+                                ng-model="offlineSessionMaxLifespanEnabled"
+                                ng-options="switch for switch in onOffSwitchOptions">
+                        </select>
+                    </div>
+                </div>
+                <kc-tooltip>{{:: 'offline-session-max-limited.tooltip' | translate}}</kc-tooltip>
+            </div>
+
+            <div class="form-group" data-ng-show="offlineSessionMaxLifespanEnabled == 'ON'">
+                <label class="col-md-2 control-label" for="offlineSessionMaxLifespan">{{:: 'offline-session-max' | translate}}</label>
+                <div class="col-md-6 time-selector">
+                    <input class="form-control" type="number" required min="1"
+                           max="31536000" data-ng-model="offlineSessionMaxLifespan.time"
+                           id="offlineSessionMaxLifespan" name="offlineSessionMaxLifespan"
+                           data-ng-change="updateOfflineSessionMaxLifespan()"/>
+                    <select class="form-control" name="offlineSessionMaxLifespanUnit" data-ng-model="offlineSessionMaxLifespan.unit" data-ng-change="updateOfflineSessionMaxLifespan()">
+                        <option value="Minutes">{{:: 'minutes' | translate}}</option>
+                        <option value="Hours">{{:: 'hours' | translate}}</option>
+                        <option value="Days">{{:: 'days' | translate}}</option>
+                    </select>
+                </div>
+                <kc-tooltip>{{:: 'offline-session-max.tooltip' | translate}}</kc-tooltip>
+            </div>
+
+            <div class="form-group">
                 <label class="col-md-2 control-label" for="accessTokenLifespan">{{:: 'access-token-lifespan' | translate}}</label>
 
                 <div class="col-md-6 time-selector">


### PR DESCRIPTION
[specification]
- Like "Access Token Lifespan", the following settings can be overridden per client.
  - Revoke Refresh Token
  - SSO Session Idle
  - SSO Session Max
  - Offline Session Idle
  - Offline Session Max
- The above values are set by the "Advanced Settings" of [Settings] tab in each client view on Admin Console.
- To be able to override the above values, some behaviors of UserSession and AuthenticatedClientSession are changed.

  [Administrator operation]

  1. Delete user session using Admin Console or Admin CLI or Admin REST API.
    -> UserSession and the all AuthenticatedClientSessions in the UserSession are deleted. This behavior is not changed.

  [User operation]

  2. Delete own user session using [Sessions] > [Logout All Sessions] in User Account.
    -> UserSession and the all AuthenticatedClientSessions in the UserSession are deleted. This behavior is not changed.

  3. Frontchannel logout with SSO Cookie (KEYCLOAK_IDENTITY).
    -> UserSession and the all AuthenticatedClientSessions in the UserSession are deleted. This behavior is not changed.

  [Client operation]

  4. Backchannel logout with the refresh token.
    -> UserSession and the all AuthenticatedClientSessions in the UserSession are deleted. This behavior is not changed.

  5. Token refresh with the refresh token.
    -> Check expiry time per client and delete AuthenticatedClientSession which is expired. When all AuthenticatedClientSessions in the UserSession are deleted, delete the UserSession.
This is a new behavior.

  6. Token introspection with the refresh token.
    -> Check expiry time per client and delete AuthenticatedClientSession which is expired. When all AuthenticatedClientSessions in the UserSession are deleted, delete the UserSession.
This is a new behavior.

  [Keycloak itself]

  7. Check expiry time of session periodically and delete session which is expired.
    -> Check expiry time per client and delete AuthenticatedClientSession which is expired. When all AuthenticatedClientSessions in the UserSession are deleted, delete the UserSession.
This is a new behavior.



JIRA ticket is the following.
https://issues.jboss.org/browse/KEYCLOAK-10907

