### PR TITLE
[KEYCLOAK-8253] Syncing flat LDAP groups structure to Keycloak improve the search performance to log(N) time

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPGroupMapperSyncTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPGroupMapperSyncTest.java
@@ -422,9 +422,9 @@ public class LDAPGroupMapperSyncTest extends AbstractLDAPTest {
                     LDAPTestUtils.createLDAPGroup(session,
                                                   appRealm,
                                                   ctx.getLdapModel(),
-                                                  String.format("group-%s", i),
+                                                  String.format("group-%s", j),
                                                   descriptionAttrName,
-                                                  String.format("Testing group-%s, created at: %s", i, new Date().toString())
+                                                  String.format("Testing group-%s, created at: %s", j, new Date().toString())
                     );
                 }
                 logger.debugf("Done creating %s LDAP groups!", groupsPerIteration);


### PR DESCRIPTION

    [KEYCLOAK-8253] When syncing flat (all groups being the top-level ones) structure
    of LDAP groups from federation provider to Keycloak, perform the search if the
    currently processed group already exists in Keycloak in log(N) time
    
    Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
