### PR TITLE
Make password policy identifiers public

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/policy/DigitsPasswordPolicyProviderFactory.java
+++ b/server-spi-private/src/main/java/org/keycloak/policy/DigitsPasswordPolicyProviderFactory.java
@@ -26,7 +26,7 @@ import org.keycloak.models.KeycloakSessionFactory;
  */
 public class DigitsPasswordPolicyProviderFactory implements PasswordPolicyProviderFactory {
 
-    static final String ID = "digits";
+    public static final String ID = "digits";
 
     @Override
     public String getId() {

--- a/server-spi-private/src/main/java/org/keycloak/policy/LengthPasswordPolicyProviderFactory.java
+++ b/server-spi-private/src/main/java/org/keycloak/policy/LengthPasswordPolicyProviderFactory.java
@@ -26,7 +26,7 @@ import org.keycloak.models.KeycloakSessionFactory;
  */
 public class LengthPasswordPolicyProviderFactory implements PasswordPolicyProviderFactory {
 
-    static final String ID = "length";
+    public static final String ID = "length";
 
     @Override
     public String getId() {

--- a/server-spi-private/src/main/java/org/keycloak/policy/NotUsernamePasswordPolicyProviderFactory.java
+++ b/server-spi-private/src/main/java/org/keycloak/policy/NotUsernamePasswordPolicyProviderFactory.java
@@ -26,7 +26,7 @@ import org.keycloak.models.KeycloakSessionFactory;
  */
 public class NotUsernamePasswordPolicyProviderFactory implements PasswordPolicyProviderFactory {
 
-    static final String ID = "notUsername";
+    public static final String ID = "notUsername";
 
     @Override
     public String getId() {

--- a/server-spi-private/src/main/java/org/keycloak/policy/RegexPatternsPasswordPolicyProviderFactory.java
+++ b/server-spi-private/src/main/java/org/keycloak/policy/RegexPatternsPasswordPolicyProviderFactory.java
@@ -26,7 +26,7 @@ import org.keycloak.models.KeycloakSessionFactory;
  */
 public class RegexPatternsPasswordPolicyProviderFactory implements PasswordPolicyProviderFactory {
 
-    static final String ID = "regexPattern";
+    public static final String ID = "regexPattern";
 
     @Override
     public String getId() {


### PR DESCRIPTION
If a password policy should be modified programmatically the constant
key identifiers to set the values should be accessible globally
