### PR TITLE
KEYCLOAK-11494 Get users for role composite

### DIFF
--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/RoleResource.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/RoleResource.java
@@ -25,6 +25,7 @@ import org.keycloak.representations.idm.UserRepresentation;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
@@ -127,6 +128,23 @@ public interface RoleResource {
     @Produces(MediaType.APPLICATION_JSON)
     Set<UserRepresentation> getRoleUserMembers(@QueryParam("first") Integer firstResult,
                                                @QueryParam("max") Integer maxResults);
+    
+    /**
+     * Get role members
+     * <p/>
+     * Returns users that have the given role, paginated according to the query parameters
+     *
+     * @param firstResult Pagination offset
+     * @param maxResults  Pagination size
+     * @param composite   if true, will process a deep search through effectives roles and subgroups to get all the users who have the role directly or indirectly
+     * @return a list of users with the given role
+     */
+    @GET
+    @Path("users")
+    @Produces(MediaType.APPLICATION_JSON)
+    Set<UserRepresentation> getRoleUserMembers(@QueryParam("first") Integer firstResult,
+                                               @QueryParam("max") Integer maxResults,
+                                               @QueryParam("composite") @DefaultValue("false") boolean composite);
     
     /**
      * Get role groups

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RoleAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RoleAdapter.java
@@ -44,6 +44,7 @@ public class RoleAdapter implements RoleModel {
     protected RealmCacheSession cacheSession;
     protected RealmModel realm;
     protected Set<RoleModel> composites;
+    protected Set<RoleModel> parents;
     private final Supplier<RoleModel> modelSupplier;
 
     public RoleAdapter(CachedRole cached, RealmCacheSession session, RealmModel realm) {
@@ -56,8 +57,16 @@ public class RoleAdapter implements RoleModel {
     protected void getDelegateForUpdate() {
         if (updated == null) {
             cacheSession.registerRoleInvalidation(cached.getId(), cached.getName(), getContainerId());
+            
             updated = modelSupplier.get();
             if (updated == null) throw new IllegalStateException("Not found in database");
+        }
+    }
+    
+    protected void invalidateComposites() {
+        for (String roleId : cached.getComposites()) {
+            RoleModel role = realm.getRoleById(roleId);
+            cacheSession.registerRoleInvalidation(role.getId(), role.getName(), role.getContainerId());
         }
     }
 
@@ -121,10 +130,11 @@ public class RoleAdapter implements RoleModel {
     @Override
     public void removeCompositeRole(RoleModel role) {
         getDelegateForUpdate();
+        invalidateComposites();
         updated.removeCompositeRole(role);
     }
 
-    @Override
+    @Override 
     public Set<RoleModel> getComposites() {
         if (isUpdated()) return updated.getComposites();
 
@@ -140,6 +150,30 @@ public class RoleAdapter implements RoleModel {
         }
 
         return composites;
+    }
+    
+    @Override
+    public void addParentRole(RoleModel role) {
+        getDelegateForUpdate();
+        updated.addParentRole(role);
+    }
+    
+    @Override
+    public Set<RoleModel> getParents() {
+        if (isUpdated()) return updated.getParents();
+
+        if (parents == null) {
+            parents = new HashSet<RoleModel>();
+            for (String parentId : cached.getParents()) {
+                RoleModel role = realm.getRoleById(parentId);
+                if (role == null) {
+                    throw new IllegalStateException("Could not find parents in role " + getName() + ": " + parentId);
+                }
+                parents.add(role);
+            }
+        }
+
+        return parents;
     }
 
     @Override
@@ -239,5 +273,4 @@ public class RoleAdapter implements RoleModel {
     public int hashCode() {
         return getId().hashCode();
     }
-
 }

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/entities/CachedRole.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/entities/CachedRole.java
@@ -38,6 +38,7 @@ public class CachedRole extends AbstractRevisioned implements InRealm {
     final protected String description;
     final protected boolean composite;
     final protected Set<String> composites = new HashSet<String>();
+    final protected Set<String> parents = new HashSet<String>();
     private final LazyLoader<RoleModel, MultivaluedHashMap<String, String>> attributes;
 
     public CachedRole(Long revision, RoleModel model, RealmModel realm) {
@@ -51,6 +52,11 @@ public class CachedRole extends AbstractRevisioned implements InRealm {
                 composites.add(child.getId());
             }
         }
+        
+        for (RoleModel parent : model.getParents()) {
+            parents.add(parent.getId());
+        }
+        
         attributes = new DefaultLazyLoader<>(roleModel -> new MultivaluedHashMap<>(roleModel.getAttributes()), MultivaluedHashMap::new);
     }
 
@@ -72,6 +78,10 @@ public class CachedRole extends AbstractRevisioned implements InRealm {
 
     public Set<String> getComposites() {
         return composites;
+    }
+    
+    public Set<String> getParents() {
+        return parents;
     }
 
     public MultivaluedHashMap<String, String> getAttributes(Supplier<RoleModel> roleModel) {

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/RoleAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/RoleAdapter.java
@@ -118,6 +118,25 @@ public class RoleAdapter implements RoleModel, JpaModel<RoleEntity> {
         }
         return set;
     }
+    
+    @Override
+    public void addParentRole(RoleModel role) {
+        RoleEntity entity = RoleAdapter.toRoleEntity(role, em);
+        for (RoleEntity parent : getEntity().getParentRoles()) {
+            if (parent.equals(entity)) return;
+        }
+        getEntity().getParentRoles().add(entity);
+    }
+    
+    @Override
+    public Set<RoleModel> getParents() {
+        Set<RoleModel> set = new HashSet<RoleModel>();
+
+        for (RoleEntity parent : getEntity().getParentRoles()) {
+            set.add(new RoleAdapter(session, realm, em, parent));
+        }
+        return set;
+    }
 
     @Override
     public boolean hasRole(RoleModel role) {

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/RoleEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/RoleEntity.java
@@ -100,6 +100,9 @@ public class RoleEntity {
     @ManyToMany(fetch = FetchType.LAZY, cascade = {})
     @JoinTable(name = "COMPOSITE_ROLE", joinColumns = @JoinColumn(name = "COMPOSITE"), inverseJoinColumns = @JoinColumn(name = "CHILD_ROLE"))
     private Set<RoleEntity> compositeRoles = new HashSet<>();
+    
+    @ManyToMany(fetch = FetchType.LAZY, cascade = {}, mappedBy = "compositeRoles")
+    private Set<RoleEntity> parentRoles = new HashSet<>();
 
     @OneToMany(cascade = CascadeType.REMOVE, orphanRemoval = true, mappedBy="role")
     @Fetch(FetchMode.SELECT)
@@ -152,6 +155,14 @@ public class RoleEntity {
 
     public void setCompositeRoles(Set<RoleEntity> compositeRoles) {
         this.compositeRoles = compositeRoles;
+    }
+    
+    public Set<RoleEntity> getParentRoles() {
+        return parentRoles;
+    }
+
+    public void setParentRoles(Set<RoleEntity> parentRoles) {
+        this.parentRoles = parentRoles;
     }
 
     public boolean isClientRole() {

--- a/server-spi/src/main/java/org/keycloak/models/RoleModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/RoleModel.java
@@ -64,4 +64,8 @@ public interface RoleModel {
     List<String> getAttribute(String name);
 
     Map<String, List<String>> getAttributes();
+
+    Set<RoleModel> getParents();
+
+    void addParentRole(RoleModel role);
 }

--- a/services/src/main/java/org/keycloak/services/resources/admin/RoleContainerResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RoleContainerResource.java
@@ -17,6 +17,28 @@
 
 package org.keycloak.services.resources.admin;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
 import org.jboss.resteasy.annotations.cache.NoCache;
 import javax.ws.rs.NotFoundException;
 import org.keycloak.events.admin.OperationType;
@@ -39,25 +61,6 @@ import org.keycloak.services.ErrorResponse;
 import org.keycloak.services.resources.admin.permissions.AdminPermissionEvaluator;
 import org.keycloak.services.resources.admin.permissions.AdminPermissionManagement;
 import org.keycloak.services.resources.admin.permissions.AdminPermissions;
-
-import javax.ws.rs.BadRequestException;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.DefaultValue;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriInfo;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * @resource Roles
@@ -375,6 +378,7 @@ public class RoleContainerResource extends RoleResource {
         }
     }
 
+
     /**
      * Return List of Users that have the specified role name 
      *
@@ -390,7 +394,8 @@ public class RoleContainerResource extends RoleResource {
     @NoCache
     public  List<UserRepresentation> getUsersInRole(final @PathParam("role-name") String roleName, 
                                                     @QueryParam("first") Integer firstResult,
-                                                    @QueryParam("max") Integer maxResults) {
+                                                    @QueryParam("max") Integer maxResults,
+                                                    @QueryParam("composite") @DefaultValue("false") boolean composite) {
         
         auth.roles().requireView(roleContainer);
         firstResult = firstResult != null ? firstResult : 0;
@@ -403,14 +408,20 @@ public class RoleContainerResource extends RoleResource {
         }
         
         List<UserRepresentation> results = new ArrayList<UserRepresentation>();
-        List<UserModel> userModels = session.users().getRoleMembers(realm, role, firstResult, maxResults);
+        Set<UserModel> userModels = new HashSet<UserModel>();
+        
+        if (!composite) {
+            userModels = new HashSet<UserModel>(session.users().getRoleMembers(realm, role, firstResult, maxResults));
+        } else {
+            getAllUsersInRole(role, new HashSet<String>(), new HashSet<String>(), userModels);
+        }
 
         for (UserModel user : userModels) {
             results.add(ModelToRepresentation.toRepresentation(session, realm, user));
         }
         return results; 
         
-    }    
+    }   
     
     /**
      * Return List of Groups that have the specified role name 
@@ -447,4 +458,52 @@ public class RoleContainerResource extends RoleResource {
         		.map(g -> ModelToRepresentation.toRepresentation(g, fullRepresentation))
         		.collect(Collectors.toList());
     }   
+    
+	protected void getAllUsersInRoleFromGroup(RoleModel role, GroupModel group, Set<String> visitedRoles,
+			Set<String> visitedGroups, Set<UserModel> users) {
+		
+		if (!visitedGroups.contains(group.getId())) {
+			List<UserModel> usersInGroup = session.users().getGroupMembers(realm, group);
+		
+			users.addAll(usersInGroup);
+
+			// We define our current group as already visited
+			visitedGroups.add(group.getId());
+			
+			Set<GroupModel> subGroups = group.getSubGroups();
+
+			for(GroupModel subGroup : subGroups) {
+				getAllUsersInRoleFromGroup(role, subGroup, visitedRoles, visitedGroups, users);
+			}
+		}
+	}
+
+	protected void getAllUsersInRole(RoleModel role, Set<String> visitedRoles, Set<String> visitedGroups,
+			Set<UserModel> users) {
+		
+		if (!visitedRoles.contains(role.getId())) {
+			// We found the users directly assign to this role and we add them to our set of
+			// users
+			Set<UserModel> usersForCurrentRole = new HashSet<UserModel>(
+					session.users().getRoleMembers(realm, role));
+			
+			users.addAll(usersForCurrentRole);
+
+			// We define our current role as already visited
+			visitedRoles.add(role.getId());
+
+			Set<RoleModel> compositesRole = role.getParents();
+			
+			for (RoleModel compositeRole : compositesRole) {
+				getAllUsersInRole(compositeRole, visitedRoles, visitedGroups, users);
+			}
+
+			// We looks for groups directly assign to the role
+			List<GroupModel> groups = session.realms().getGroupsByRole(realm, role, -1, -1);
+
+			for (GroupModel group : groups) {
+				getAllUsersInRoleFromGroup(role, group, visitedRoles, visitedGroups, users);
+			}
+		}
+	}
 }

--- a/services/src/main/java/org/keycloak/services/resources/admin/RoleResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RoleResource.java
@@ -81,6 +81,7 @@ public abstract class RoleResource {
                 throw new NotFoundException("Could not find composite role");
             }
             auth.roles().requireMapComposite(composite);
+            composite.addParentRole(role);
             role.addCompositeRole(composite);
         }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/ClientRolesTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/ClientRolesTest.java
@@ -17,6 +17,22 @@
 
 package org.keycloak.testsuite.admin.client;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.validation.constraints.AssertFalse;
+import javax.ws.rs.core.Response;
+
+import org.drools.core.command.assertion.AssertEquals;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -25,21 +41,12 @@ import org.keycloak.admin.client.resource.RoleResource;
 import org.keycloak.admin.client.resource.RolesResource;
 import org.keycloak.events.admin.OperationType;
 import org.keycloak.events.admin.ResourceType;
+import org.keycloak.representations.idm.GroupRepresentation;
 import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.testsuite.Assert;
+import org.keycloak.testsuite.admin.ApiUtil;
 import org.keycloak.testsuite.util.AdminEventPaths;
-
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 /**
  * @author Stan Silvert ssilvert@redhat.com (C) 2016 Red Hat Inc.
@@ -170,14 +177,128 @@ public class ClientRolesTest extends AbstractClientTest {
         }
 
         // pagination
-        Set<UserRepresentation> usersInRole1 = roleResource.getRoleUserMembers(0, 5);
+        Set<UserRepresentation> usersInRole1 = roleResource.getRoleUserMembers(0, 5, false);
         assertEquals(5, usersInRole1.size());
-        Set<UserRepresentation> usersInRole2 = roleResource.getRoleUserMembers(5, 10);
+        Set<UserRepresentation> usersInRole2 = roleResource.getRoleUserMembers(5, 10, false);
         assertEquals(5, usersInRole2.size());
         for (UserRepresentation user : users) {
             Optional<UserRepresentation> result1 = usersInRole1.stream().filter(u -> user.getUsername().equals(u.getUsername())).findAny();
             Optional<UserRepresentation> result2 = usersInRole2.stream().filter(u -> user.getUsername().equals(u.getUsername())).findAny();
             assertTrue((result1.isPresent() || result2.isPresent()) && !(result1.isPresent() && result2.isPresent()));
         }
+    }
+    
+    @Test
+    public void usersInCompositeRole() {
+        String clientID = clientRsc.toRepresentation().getId();
+        
+        String role1Name = "role-1";
+        String role2Name = "role-2";
+        String role3Name = "role-3";
+        String role4Name = "role-4-group";
+        
+        // group creation
+        GroupRepresentation groupRep = new GroupRepresentation();
+        groupRep.setName("test-role-group");
+        groupRep.setPath("/test-role-group");
+        try (Response response = testRealmResource().groups().add(groupRep)) {
+            String groupId = ApiUtil.getCreatedId(response);
+            
+            getCleanup().addGroupId(groupId);
+
+            assertAdminEvents.assertEvent(getRealmId(), OperationType.CREATE, AdminEventPaths.groupPath(groupId), groupRep, ResourceType.GROUP);
+
+            // Set ID to the original rep
+            groupRep.setId(groupId);
+        }
+        
+        RoleRepresentation role1 = makeRole(role1Name);
+        rolesRsc.create(role1);
+        assertAdminEvents.assertEvent(getRealmId(), OperationType.CREATE, AdminEventPaths.clientRoleResourcePath(clientDbId, role1Name), role1, ResourceType.CLIENT_ROLE);
+        role1 = rolesRsc.get(role1Name).toRepresentation();
+        
+        RoleRepresentation role2 = makeRole(role2Name);
+        rolesRsc.create(role2);
+        assertAdminEvents.assertEvent(getRealmId(), OperationType.CREATE, AdminEventPaths.clientRoleResourcePath(clientDbId, role2Name), role2, ResourceType.CLIENT_ROLE);
+        role2 = rolesRsc.get(role2Name).toRepresentation();
+        
+        RoleRepresentation role3 = makeRole(role3Name);
+        testRealmResource().roles().create(role3);
+        assertAdminEvents.assertEvent(getRealmId(), OperationType.CREATE, AdminEventPaths.roleResourcePath(role3Name), role3, ResourceType.REALM_ROLE);
+        role3 = testRealmResource().roles().get(role3Name).toRepresentation();
+        
+        RoleRepresentation role4 = makeRole(role4Name);
+        rolesRsc.create(role4);
+        assertAdminEvents.assertEvent(getRealmId(), OperationType.CREATE, AdminEventPaths.clientRoleResourcePath(clientDbId, role4Name), role4, ResourceType.CLIENT_ROLE);
+        role4 = rolesRsc.get(role4Name).toRepresentation();
+        
+        // We define "role-2" and "role-3" as composites of "role-1"
+        List<RoleRepresentation> l = new LinkedList<>();
+        l.add(role2);
+        l.add(role3);
+        rolesRsc.get(role1Name).addComposites(l);
+        assertAdminEvents.assertEvent(getRealmId(), OperationType.CREATE, AdminEventPaths.clientRoleResourceCompositesPath(clientDbId, role1Name), l, ResourceType.CLIENT_ROLE);
+        
+        //create users and assign role1
+        List<RoleRepresentation> roleToAdd = Collections.singletonList(rolesRsc.get(role1Name).toRepresentation());
+        
+        String userName = "toto";
+        UserRepresentation user = new UserRepresentation();
+        user.setUsername(userName);
+        testRealmResource().users().create(user);
+        user = getFullUserRep(userName);
+        
+        testRealmResource().users().get(user.getId()).roles().clientLevel(clientID).add(roleToAdd);
+        
+        String userName2 = "tata";
+        UserRepresentation user2 = new UserRepresentation();
+        user2.setUsername(userName2);
+        testRealmResource().users().create(user2);
+        user2 = getFullUserRep(userName2);
+        
+        String userName3 = "titi";
+        UserRepresentation user3 = new UserRepresentation();
+        user3.setUsername(userName3);
+        testRealmResource().users().create(user3);
+        user3 = getFullUserRep(userName3);
+        
+        String userName4 = "joe";
+        UserRepresentation user4 = new UserRepresentation();
+        user4.setUsername(userName4);
+        testRealmResource().users().create(user4);
+        user4 = getFullUserRep(userName4);
+        
+        List<RoleRepresentation> roleToAddForUser4 = Collections.singletonList(rolesRsc.get(role4Name).toRepresentation());
+        testRealmResource().users().get(user4.getId()).roles().clientLevel(clientID).add(roleToAddForUser4);
+        
+        /** create a group, add users and role to it **/
+
+        // assign role1 and role4 to group
+        List<RoleRepresentation> rolesForGroup = new LinkedList<RoleRepresentation>();
+        rolesForGroup.add(role1);
+        rolesForGroup.add(role4);
+        
+        testRealmResource().groups().group(groupRep.getId()).roles().clientLevel(clientDbId).add(rolesForGroup);
+        
+        // assign users to group
+        
+        testRealmResource().users().get(user2.getId()).joinGroup(groupRep.getId());
+        testRealmResource().users().get(user3.getId()).joinGroup(groupRep.getId());
+        
+        /** units test **/
+        assertTrue(rolesRsc.get(role1Name).toRepresentation().isComposite());
+        
+        // test if user have "role-1", he should have it because it s a direct assignation
+        RoleResource roleResource1 = rolesRsc.get(role1Name);
+        Set<UserRepresentation> usersInRole1 = roleResource1.getRoleUserMembers();
+        assertEquals(1, usersInRole1.size());
+        
+        // test if user have "role-2, he should have it because "role-2" is "composite of "role-1" and the user have role 1 assigned
+        RoleResource roleResource2 = rolesRsc.get(role2Name);
+        Set<UserRepresentation> usersInRole2 = roleResource2.getRoleUserMembers(-1,-1,true);
+        assertEquals(3, usersInRole2.size());
+        
+        // joe should not be in the list because he is assign to role4 which belong to the group but is absolutely not related to role-2
+        assertEquals(0, usersInRole2.stream().filter(u -> u.getUsername().equals("joe")).collect(Collectors.toList()).size());
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/realm/RealmRolesTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/realm/RealmRolesTest.java
@@ -328,17 +328,17 @@ public class RealmRolesTest extends AbstractAdminTest {
         }
 
         RoleResource roleResource = adminClient.realm(REALM_NAME).roles().get(role.toRepresentation().getName());
-        Set<UserRepresentation> roleUserMembers = roleResource.getRoleUserMembers(0, 1);
+        Set<UserRepresentation> roleUserMembers = roleResource.getRoleUserMembers(0, 1, false);
 
         Set<String> expectedMembers = new HashSet<>();
         assertThat(roleUserMembers, hasSize(1));
         expectedMembers.add(roleUserMembers.iterator().next().getUsername());
 
-        roleUserMembers = roleResource.getRoleUserMembers(1, 1);
+        roleUserMembers = roleResource.getRoleUserMembers(1, 1, false);
         assertThat(roleUserMembers, hasSize(1));
         expectedMembers.add(roleUserMembers.iterator().next().getUsername());
 
-        roleUserMembers = roleResource.getRoleUserMembers(2, 1);
+        roleUserMembers = roleResource.getRoleUserMembers(2, 1, false);
         assertThat(roleUserMembers, is(empty()));
 
         assertThat(expectedMembers, containsInAnyOrder("test-role-member", "test-role-member2"));

--- a/themes/src/main/resources/theme/base/admin/resources/js/controllers/clients.js
+++ b/themes/src/main/resources/theme/base/admin/resources/js/controllers/clients.js
@@ -769,7 +769,8 @@ module.controller('ClientRoleMembersCtrl', function($scope, realm, client, role,
         role: role.name,
         client: client.id,
         max : 5,
-        first : 0
+        first : 0,
+        composite: false
     }
 
     $scope.firstPage = function() {
@@ -787,6 +788,19 @@ module.controller('ClientRoleMembersCtrl', function($scope, realm, client, role,
 
     $scope.nextPage = function() {
         $scope.query.first += parseInt($scope.query.max);
+        $scope.searchQuery();
+    }
+
+    $scope.deepSearch = function() {
+        $scope.query.first = 0;
+
+        if($scope.query.composite == false) {
+            $scope.query.max = 5;
+        } else {
+            $scope.query.first = 0;
+            $scope.query.max = -1;
+        }
+
         $scope.searchQuery();
     }
 

--- a/themes/src/main/resources/theme/base/admin/resources/js/controllers/roles.js
+++ b/themes/src/main/resources/theme/base/admin/resources/js/controllers/roles.js
@@ -7,7 +7,8 @@ module.controller('RoleMembersCtrl', function($scope, realm, role, RoleMembershi
         realm: realm.realm,
         role: role.name,
         max : 5,
-        first : 0
+        first : 0,
+        composite: false
     }
 
     $scope.remove = function() {
@@ -29,6 +30,19 @@ module.controller('RoleMembersCtrl', function($scope, realm, role, RoleMembershi
 
     $scope.nextPage = function() {
         $scope.query.first += parseInt($scope.query.max);
+        $scope.searchQuery();
+    }
+
+    $scope.deepSearch = function() {
+        $scope.query.first = 0;
+
+        if($scope.query.composite == false) {
+            $scope.query.max = 5;
+        } else {
+            $scope.query.first = 0;
+            $scope.query.max = -1;
+        }
+
         $scope.searchQuery();
     }
 

--- a/themes/src/main/resources/theme/base/admin/resources/partials/client-role-users.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/client-role-users.html
@@ -12,6 +12,12 @@
         <caption data-ng-show="users" class="hidden">{{:: 'table-of-role-members' | translate}}</caption>
         <thead>
         <tr>
+        <tr>
+            <td colspan="5">
+                <input data-ng-click="deepSearch()" ng-model="query.composite" type="checkbox" class="form-check-input" id="include-composite">
+                <label class="form-check-label" for="include-composite">Deep search in effectives roles ( can be slow )</label>
+            </td>
+        </tr>
         <tr data-ng-show="searchLoaded && users.length > 0">
             <th>{{:: 'username' | translate}}</th>
             <th>{{:: 'last-name' | translate}}</th>
@@ -21,7 +27,7 @@
         </tr>
         </tr>
         </thead>
-        <tfoot data-ng-show="users && (users.length >= query.max || query.first > 0)">
+        <tfoot data-ng-show="users && query.max != -1 && (users.length >= query.max || query.first > 0)">
         <tr>
             <td colspan="7">
                 <div class="table-nav">

--- a/themes/src/main/resources/theme/base/admin/resources/partials/realm-role-users.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/realm-role-users.html
@@ -9,7 +9,13 @@
     <table class="table table-striped table-bordered">
         <caption data-ng-show="users" class="hidden">{{:: 'table-of-role-members' | translate}}</caption>
         <thead>
-         <tr>
+        <tr>
+        <tr>
+            <td colspan="5">
+                <input data-ng-click="deepSearch()" ng-model="query.composite" type="checkbox" class="form-check-input" id="include-composite">
+                <label class="form-check-label" for="include-composite">Deep search in effectives roles ( can be slow )</label>
+            </td>
+        </tr>
         <tr data-ng-show="searchLoaded && users.length > 0">
             <th>{{:: 'username' | translate}}</th>
             <th>{{:: 'last-name' | translate}}</th>
@@ -19,7 +25,7 @@
         </tr>
         </tr>
         </thead>
-        <tfoot data-ng-show="users && (users.length >= query.max || query.first > 0)">
+        <tfoot data-ng-show="users && query.max != -1 && (users.length >= query.max || query.first > 0)">
         <tr>
             <td colspan="7">
                 <div class="table-nav">


### PR DESCRIPTION
https://issues.jboss.org/browse/KEYCLOAK-11494

The idea is to add an optional ( and false by default ) parameters to the existing endpoint `{role}/users`

Currently it got only the direct assignation, which is useless in a lot of scenario when there is composite role and groups having theses roles

This is a pull request to solve that, it also include a checkbox in the "Users in role" view to search in effectives roles.

The API always have this new parameters false by default, and even the UI, so there is no unwanted performance impact. But it appears that in a complex group structure with hundreds or thousands of childs for a group, the request can become very slow. All improvements and suggestion are welcome.

edit : I think my eclipse reindented some files, is there a code syle formatter profile specfic to keycloak for eclipse somewhere?