### PR TITLE
KEYCLOAK-6698 - Add substitution of system properties and environment variables in theme.properties file

### DIFF
--- a/services/src/main/java/org/keycloak/theme/ExtendingThemeManager.java
+++ b/services/src/main/java/org/keycloak/theme/ExtendingThemeManager.java
@@ -20,6 +20,8 @@ package org.keycloak.theme;
 import org.jboss.logging.Logger;
 import org.keycloak.Config;
 import org.keycloak.common.Version;
+import org.keycloak.common.util.StringPropertyReplacer;
+import org.keycloak.common.util.SystemEnvProperties;
 import org.keycloak.models.KeycloakSession;
 
 import java.io.IOException;
@@ -289,6 +291,7 @@ public class ExtendingThemeManager implements ThemeProvider {
                         properties.putAll(p);
                     }
                 }
+                substituteProperties(properties);
                 this.properties = properties;
                 return properties;
             } else {
@@ -296,6 +299,14 @@ public class ExtendingThemeManager implements ThemeProvider {
             }
         }
 
+        /**
+         * Iterate over all string properties defined in "theme.properties" then substitute the value with system property or environment variables.
+         * See {@link StringPropertyReplacer#replaceProperties} for details about the different formats.
+         */
+        private void substituteProperties(final Properties properties) {
+            for (final String propertyName : properties.stringPropertyNames()) {
+                properties.setProperty(propertyName, StringPropertyReplacer.replaceProperties(properties.getProperty(propertyName), new SystemEnvProperties()));
+            }
+        }
     }
-
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/theme/ExtendingThemeTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/theme/ExtendingThemeTest.java
@@ -1,0 +1,69 @@
+package org.keycloak.testsuite.theme;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.testsuite.AbstractKeycloakTest;
+import org.keycloak.theme.Theme;
+import org.keycloak.theme.ThemeProvider;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * @author <a href="mailto:vincent.letarouilly@gmail.com">Vincent Letarouilly</a>
+ */
+public class ExtendingThemeTest extends AbstractKeycloakTest {
+
+    private static final String THEME_NAME = "environment-agnostic";
+
+    @Before
+    public void setUp() {
+        System.setProperty("existing_system_property", "Keycloak is awesome");
+    }
+
+    @Override
+    public void addTestRealms(List<RealmRepresentation> testRealms) {
+    }
+
+    // KEYCLOAK-6698
+    @Test
+    public void systemPropertiesSubstitutionInThemeProperties() {
+        testingClient.server().run(session -> {
+            try {
+                ThemeProvider extending = session.getProvider(ThemeProvider.class, "extending");
+                Theme theme = extending.getTheme(THEME_NAME, Theme.Type.LOGIN);
+                Assert.assertEquals("Keycloak is awesome", theme.getProperties().getProperty("system.property.found"));
+                Assert.assertEquals("${missing_system_property}", theme.getProperties().getProperty("system.property.missing"));
+                Assert.assertEquals("defaultValue", theme.getProperties().getProperty("system.property.missing.with.default"));
+            } catch (IOException e) {
+                Assert.fail(e.getMessage());
+            }
+        });
+    }
+
+    // KEYCLOAK-6698
+    @Test
+    public void environmentVariablesSubstitutionInThemeProperties() {
+        testingClient.server().run(session -> {
+            try {
+                ThemeProvider extending = session.getProvider(ThemeProvider.class, "extending");
+                Theme theme = extending.getTheme(THEME_NAME, Theme.Type.LOGIN);
+                Assert.assertEquals("${env.MISSING_ENVIRONMENT_VARIABLE}", theme.getProperties().getProperty("env.missing"));
+                Assert.assertEquals("defaultValue", theme.getProperties().getProperty("env.missingWithDefault"));
+                if (System.getenv().containsKey("HOMEPATH")) {
+                    // Windows
+                    Assert.assertEquals(System.getenv().get("HOMEPATH"), theme.getProperties().getProperty("env.windowsHome"));
+                } else if (System.getenv().containsKey("HOME")) {
+                    // Unix
+                    Assert.assertEquals(System.getenv().get("HOME"), theme.getProperties().getProperty("env.unixHome"));
+                } else {
+                    Assert.fail("No default env variable found, can't verify");
+                }
+            } catch (IOException e) {
+                Assert.fail(e.getMessage());
+            }
+        });
+    }
+}

--- a/testsuite/integration-arquillian/tests/base/src/test/resources/META-INF/keycloak-themes.json
+++ b/testsuite/integration-arquillian/tests/base/src/test/resources/META-INF/keycloak-themes.json
@@ -1,0 +1,18 @@
+{
+  "themes": [
+    {
+      "name": "address",
+      "types": [
+        "admin",
+        "account",
+        "login"
+      ]
+    },
+    {
+      "name": "environment-agnostic",
+      "types": [
+        "login"
+      ]
+    }
+  ]
+}

--- a/testsuite/integration-arquillian/tests/base/src/test/resources/theme/environment-agnostic/login/theme.properties
+++ b/testsuite/integration-arquillian/tests/base/src/test/resources/theme/environment-agnostic/login/theme.properties
@@ -1,0 +1,27 @@
+#
+# Copyright 2016 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+parent=keycloak
+
+system.property.found=${existing_system_property}
+system.property.missing=${missing_system_property}
+system.property.missing.with.default=${missing_system_property:defaultValue}
+
+env.unixHome=${env.HOME}
+env.windowsHome=${env.HOMEPATH}
+env.missing=${env.MISSING_ENVIRONMENT_VARIABLE}
+env.missingWithDefault=${env.MISSING_ENVIRONMENT_VARIABLE:defaultValue}


### PR DESCRIPTION
Hello everyone,

Did the work for this issue https://issues.jboss.org/browse/KEYCLOAK-6698
Although I do not know the procedure to re-open the ticket.

Regards