### PR TITLE
Add certificate timestamp validation

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/x509/AbstractX509ClientCertificateAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/x509/AbstractX509ClientCertificateAuthenticator.java
@@ -61,6 +61,7 @@ public abstract class AbstractX509ClientCertificateAuthenticator implements Auth
     public static final String ENABLE_OCSP = "x509-cert-auth.ocsp-checking-enabled";
     public static final String ENABLE_CRLDP = "x509-cert-auth.crldp-checking-enabled";
     public static final String CANONICAL_DN = "x509-cert-auth.canonical-dn-enabled";
+    public static final String TIMESTAMP_VALIDATION = "x509-cert-auth.timestamp-validation-enabled";
     public static final String SERIALNUMBER_HEX = "x509-cert-auth.serialnumber-hex-enabled";
     public static final String CRL_RELATIVE_PATH = "x509-cert-auth.crl-relative-path";
     public static final String OCSPRESPONDER_URI = "x509-cert-auth.ocsp-responder-uri";

--- a/services/src/main/java/org/keycloak/authentication/authenticators/x509/AbstractX509ClientCertificateAuthenticatorFactory.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/x509/AbstractX509ClientCertificateAuthenticatorFactory.java
@@ -143,6 +143,13 @@ public abstract class AbstractX509ClientCertificateAuthenticatorFactory implemen
         attributeOrPropertyValue.setHelpText("A name of user attribute to map the extracted user identity to existing user. The name must be a valid, existing user attribute if User Mapping Method is set to Custom Attribute Mapper. " +
                 "Multiple values are relevant when attribute mapping is related to multiple values, e.g. 'Certificate Serial Number and IssuerDN'");
 
+        ProviderConfigProperty timestampValidationValue = new ProviderConfigProperty();
+        timestampValidationValue.setType(BOOLEAN_TYPE);
+        timestampValidationValue.setName(TIMESTAMP_VALIDATION);
+        timestampValidationValue.setLabel("Check certificate validity");
+        timestampValidationValue.setDefaultValue(true);
+        timestampValidationValue.setHelpText("Will verify that the certificate has not expired yet and is already valid by checking the attributes 'notBefore' and 'notAfter'.");
+
         ProviderConfigProperty crlCheckingEnabled = new ProviderConfigProperty();
         crlCheckingEnabled.setType(BOOLEAN_TYPE);
         crlCheckingEnabled.setName(ENABLE_CRL);
@@ -209,6 +216,7 @@ public abstract class AbstractX509ClientCertificateAuthenticatorFactory implemen
                 regExp,
                 userMapperList,
                 attributeOrPropertyValue,
+                timestampValidationValue,
                 crlCheckingEnabled,
                 crlDPEnabled,
                 cRLRelativePath,

--- a/services/src/main/java/org/keycloak/authentication/authenticators/x509/CertificateValidator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/x509/CertificateValidator.java
@@ -18,6 +18,7 @@
 
 package org.keycloak.authentication.authenticators.x509;
 
+import org.keycloak.common.util.Time;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.utils.CRLUtils;
 import org.keycloak.common.util.OCSPUtils;
@@ -46,7 +47,6 @@ import java.security.cert.X509CRL;
 import java.security.cert.X509Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.CRLException;
-import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -474,14 +474,12 @@ public class CertificateValidator {
             return this;
         }
         X509Certificate x509Certificate = _certChain[_certChain.length - 1];
-        // this might create time-offset issues but those will probably be negligible for certificates should
-        // be renewed and exchanged in due time
-        if (x509Certificate.getNotBefore().getTime() > Instant.now().toEpochMilli()) {
-            String message = "certificate is not valid yet: " + x509Certificate.getNotBefore().toInstant().toString();
+        if (x509Certificate.getNotBefore().getTime() > Time.currentTimeMillis()) {
+            String message = "certificate is not valid yet: " + x509Certificate.getNotBefore().toString();
             throw new GeneralSecurityException(message);
         }
-        if (x509Certificate.getNotAfter().getTime() < Instant.now().toEpochMilli()) {
-            String message = "certificate has expired on: " + x509Certificate.getNotAfter().toInstant().toString();
+        if (x509Certificate.getNotAfter().getTime() < Time.currentTimeMillis()) {
+            String message = "certificate has expired on: " + x509Certificate.getNotAfter().toString();
             throw new GeneralSecurityException(message);
         }
         return this;

--- a/services/src/main/java/org/keycloak/authentication/authenticators/x509/CertificateValidator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/x509/CertificateValidator.java
@@ -18,12 +18,15 @@
 
 package org.keycloak.authentication.authenticators.x509;
 
-import org.keycloak.common.util.Time;
-import org.keycloak.models.KeycloakSession;
-import org.keycloak.utils.CRLUtils;
 import org.keycloak.common.util.OCSPUtils;
+import org.keycloak.common.util.Time;
 import org.keycloak.models.Constants;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.saml.common.exceptions.ProcessingException;
+import org.keycloak.saml.processing.core.util.XMLSignatureUtil;
 import org.keycloak.services.ServicesLogger;
+import org.keycloak.truststore.TruststoreProvider;
+import org.keycloak.utils.CRLUtils;
 
 import javax.naming.Context;
 import javax.naming.NamingException;
@@ -31,37 +34,33 @@ import javax.naming.directory.Attribute;
 import javax.naming.directory.Attributes;
 import javax.naming.directory.DirContext;
 import javax.naming.directory.InitialDirContext;
+import javax.security.auth.x500.X500Principal;
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
-import java.io.IOException;
-import java.io.InputStream;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLConnection;
 import java.security.GeneralSecurityException;
+import java.security.cert.CRLException;
 import java.security.cert.CertPathValidatorException;
+import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509CRL;
 import java.security.cert.X509Certificate;
-import java.security.cert.CertificateException;
-import java.security.cert.CRLException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Hashtable;
-import java.util.List;
-import java.util.Set;
 import java.util.LinkedList;
-import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
-import javax.security.auth.x500.X500Principal;
-
-import org.keycloak.saml.common.exceptions.ProcessingException;
-import org.keycloak.saml.processing.core.util.XMLSignatureUtil;
-import org.keycloak.truststore.TruststoreProvider;
 
 /**
  * @author <a href="mailto:pnalyvayko@agi.com">Peter Nalyvayko</a>
@@ -473,14 +472,24 @@ public class CertificateValidator {
         if (!isValidationEnabled) {
             return this;
         }
-        X509Certificate x509Certificate = _certChain[_certChain.length - 1];
-        if (x509Certificate.getNotBefore().getTime() > Time.currentTimeMillis()) {
-            String message = "certificate is not valid yet: " + x509Certificate.getNotBefore().toString();
-            throw new GeneralSecurityException(message);
-        }
-        if (x509Certificate.getNotAfter().getTime() < Time.currentTimeMillis()) {
-            String message = "certificate has expired on: " + x509Certificate.getNotAfter().toString();
-            throw new GeneralSecurityException(message);
+        for (int i = 0; i < _certChain.length; i++)
+        {
+            X509Certificate x509Certificate = _certChain[i];
+            if (x509Certificate.getNotBefore().getTime() > Time.currentTimeMillis()) {
+                String serialNumber = x509Certificate.getSerialNumber().toString(16).replaceAll("..(?!$)",
+                  "$0 ");
+                String message =
+                  "certificate with serialnumber '" + serialNumber
+                    + "' is not valid yet: " + x509Certificate.getNotBefore().toString();
+                throw new GeneralSecurityException(message);
+            }
+            if (x509Certificate.getNotAfter().getTime() < Time.currentTimeMillis()) {
+                String serialNumber = x509Certificate.getSerialNumber().toString(16).replaceAll("..(?!$)",
+                  "$0 ");
+                String message = "certificate with serialnumber '" + serialNumber
+                                   + "' has expired on: " + x509Certificate.getNotAfter().toString();
+                throw new GeneralSecurityException(message);
+            }
         }
         return this;
     }

--- a/services/src/main/java/org/keycloak/authentication/authenticators/x509/X509AuthenticatorConfigModel.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/x509/X509AuthenticatorConfigModel.java
@@ -253,6 +253,15 @@ public class X509AuthenticatorConfigModel extends AuthenticatorConfigModel {
         getConfig().put(CANONICAL_DN, Boolean.toString(value));
         return this;
     }
+
+    public boolean isCertValidationEnabled() {
+        return Boolean.parseBoolean(getConfig().get(TIMESTAMP_VALIDATION));
+    }
+
+    public X509AuthenticatorConfigModel setCertValidationEnabled(boolean value) {
+        getConfig().put(TIMESTAMP_VALIDATION, Boolean.toString(value));
+        return this;
+    }
     
     public boolean isSerialnumberHex() {
         return Boolean.parseBoolean(getConfig().get(SERIALNUMBER_HEX));

--- a/services/src/main/java/org/keycloak/authentication/authenticators/x509/X509ClientCertificateAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/x509/X509ClientCertificateAuthenticator.java
@@ -31,9 +31,7 @@ import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.authentication.authenticators.browser.AbstractUsernameFormAuthenticator;
 import org.keycloak.events.Details;
 import org.keycloak.events.Errors;
-import org.keycloak.forms.login.LoginFormsPages;
 import org.keycloak.forms.login.LoginFormsProvider;
-import org.keycloak.forms.login.freemarker.Templates;
 import org.keycloak.models.ModelDuplicateException;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.utils.FormMessage;
@@ -86,7 +84,8 @@ public class X509ClientCertificateAuthenticator extends AbstractX509ClientCertif
                 CertificateValidator validator = builder.build(certs);
                 validator.checkRevocationStatus()
                          .validateKeyUsage()
-                         .validateExtendedKeyUsage();
+                         .validateExtendedKeyUsage()
+                         .validateTimestamps(config.isCertValidationEnabled());
             } catch(Exception e) {
                 logger.error(e.getMessage(), e);
                 // TODO use specific locale to load error messages

--- a/services/src/test/java/org/keycloak/authentication/authenticators/x509/CertificateValidatorTest.java
+++ b/services/src/test/java/org/keycloak/authentication/authenticators/x509/CertificateValidatorTest.java
@@ -29,117 +29,108 @@ import java.util.Date;
  * <br>
  *
  */
-public class CertificateValidatorTest
-{
+public class CertificateValidatorTest {
 
-  private static final BouncyCastleProvider BOUNCY_CASTLE_PROVIDER = new BouncyCastleProvider();
+    private static final BouncyCastleProvider BOUNCY_CASTLE_PROVIDER = new BouncyCastleProvider();
 
-  /**
-   * will validate that the certificate validation succeeds if the certificate is currently valid
-   */
-  @Test
-  public void testValidityOfCertificatesSuccess() throws GeneralSecurityException
-  {
-    KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
-    kpg.initialize(512);
-    KeyPair keyPair = kpg.generateKeyPair();
-    X509Certificate certificate =
-      createCertificate("CN=keycloak-test", new Date(),
-        new Date(System.currentTimeMillis() + 1000L * 60), keyPair);
+    /**
+     * will validate that the certificate validation succeeds if the certificate is currently valid
+     */
+    @Test
+    public void testValidityOfCertificatesSuccess() throws GeneralSecurityException {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(512);
+        KeyPair keyPair = kpg.generateKeyPair();
+        X509Certificate certificate =
+            createCertificate("CN=keycloak-test", new Date(),
+                new Date(System.currentTimeMillis() + 1000L * 60), keyPair);
 
-    CertificateValidator.CertificateValidatorBuilder builder = new CertificateValidator.CertificateValidatorBuilder();
-    CertificateValidator validator = builder.build(new X509Certificate[] { certificate });
-    try
-    {
-      validator.validateTimestamps(true);
-    } catch (Exception ex)
-    {
-      ex.printStackTrace();
-      Assert.fail(ex.getMessage());
+        CertificateValidator.CertificateValidatorBuilder builder =
+            new CertificateValidator.CertificateValidatorBuilder();
+        CertificateValidator validator = builder.build(new X509Certificate[] { certificate });
+        try {
+            validator.validateTimestamps(true);
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            Assert.fail(ex.getMessage());
+        }
     }
-  }
 
-  /**
-   * will validate that the certificate validation throws an exception if the certificate is not valid yet
-   */
-  @Test
-  public void testValidityOfCertificatesNotValidYet() throws GeneralSecurityException
-  {
-    KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
-    kpg.initialize(512);
-    KeyPair keyPair = kpg.generateKeyPair();
-    X509Certificate certificate =
-      createCertificate("CN=keycloak-test", new Date(System.currentTimeMillis() + 1000L * 60),
-        new Date(System.currentTimeMillis() + 1000L * 60), keyPair);
+    /**
+     * will validate that the certificate validation throws an exception if the certificate is not valid yet
+     */
+    @Test
+    public void testValidityOfCertificatesNotValidYet() throws GeneralSecurityException {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(512);
+        KeyPair keyPair = kpg.generateKeyPair();
+        X509Certificate certificate =
+            createCertificate("CN=keycloak-test", new Date(System.currentTimeMillis() + 1000L * 60),
+                new Date(System.currentTimeMillis() + 1000L * 60), keyPair);
 
-    CertificateValidator.CertificateValidatorBuilder builder = new CertificateValidator.CertificateValidatorBuilder();
-    CertificateValidator validator = builder.build(new X509Certificate[] { certificate });
-    try
-    {
-      validator.validateTimestamps(true);
-      Assert.fail("certificate validation must fail for certificate is not valid yet");
-    } catch (Exception ex)
-    {
-      MatcherAssert.assertThat(ex.getMessage(), Matchers.containsString("not valid yet"));
-      Assert.assertEquals(GeneralSecurityException.class, ex.getClass());
+        CertificateValidator.CertificateValidatorBuilder builder =
+            new CertificateValidator.CertificateValidatorBuilder();
+        CertificateValidator validator = builder.build(new X509Certificate[] { certificate });
+        try {
+            validator.validateTimestamps(true);
+            Assert.fail("certificate validation must fail for certificate is not valid yet");
+        } catch (Exception ex) {
+            MatcherAssert.assertThat(ex.getMessage(), Matchers.containsString("not valid yet"));
+            Assert.assertEquals(GeneralSecurityException.class, ex.getClass());
+        }
     }
-  }
 
-  /**
-   * will validate that the certificate validation throws an exception if the certificate has expired
-   */
-  @Test
-  public void testValidityOfCertificatesHasExpired() throws GeneralSecurityException
-  {
-    KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
-    kpg.initialize(512);
-    KeyPair keyPair = kpg.generateKeyPair();
-    X509Certificate certificate =
-      createCertificate("CN=keycloak-test", new Date(System.currentTimeMillis() - 1000L * 60 * 2),
-        new Date(System.currentTimeMillis() - 1000L * 60), keyPair);
+    /**
+     * will validate that the certificate validation throws an exception if the certificate has expired
+     */
+    @Test
+    public void testValidityOfCertificatesHasExpired() throws GeneralSecurityException {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(512);
+        KeyPair keyPair = kpg.generateKeyPair();
+        X509Certificate certificate =
+            createCertificate("CN=keycloak-test", new Date(System.currentTimeMillis() - 1000L * 60 * 2),
+                new Date(System.currentTimeMillis() - 1000L * 60), keyPair);
 
-    CertificateValidator.CertificateValidatorBuilder builder = new CertificateValidator.CertificateValidatorBuilder();
-    CertificateValidator validator = builder.build(new X509Certificate[] { certificate });
-    try
-    {
-      validator.validateTimestamps(true);
-      Assert.fail("certificate validation must fail for certificate has expired");
-    } catch (Exception ex)
-    {
-      MatcherAssert.assertThat(ex.getMessage(), Matchers.containsString("has expired"));
-      Assert.assertEquals(GeneralSecurityException.class, ex.getClass());
+        CertificateValidator.CertificateValidatorBuilder builder =
+            new CertificateValidator.CertificateValidatorBuilder();
+        CertificateValidator validator = builder.build(new X509Certificate[] { certificate });
+        try {
+            validator.validateTimestamps(true);
+            Assert.fail("certificate validation must fail for certificate has expired");
+        } catch (Exception ex) {
+            MatcherAssert.assertThat(ex.getMessage(), Matchers.containsString("has expired"));
+            Assert.assertEquals(GeneralSecurityException.class, ex.getClass());
+        }
     }
-  }
 
 
-  /**
-   * will create a self-signed certificate
-   *
-   * @param dn the DN of the subject and issuer
-   * @param startDate startdate of the validity of the created certificate
-   * @param expiryDate expiration date of the created certificate
-   * @param keyPair the keypair that is used to create the certificate
-   * @return a X509-Certificate in version 3
-   */
-  public X509Certificate createCertificate(String dn,
-                                           Date startDate,
-                                           Date expiryDate,
-                                           KeyPair keyPair)
-  {
-    X500Name subjectDN = new X500Name(dn);
-    X500Name issuerDN = new X500Name(dn);
-    // @formatter:off
+    /**
+     * will create a self-signed certificate
+     *
+     * @param dn the DN of the subject and issuer
+     * @param startDate startdate of the validity of the created certificate
+     * @param expiryDate expiration date of the created certificate
+     * @param keyPair the keypair that is used to create the certificate
+     * @return a X509-Certificate in version 3
+     */
+    public X509Certificate createCertificate(String dn,
+                                             Date startDate,
+                                             Date expiryDate,
+                                             KeyPair keyPair) {
+        X500Name subjectDN = new X500Name(dn);
+        X500Name issuerDN = new X500Name(dn);
+        // @formatter:off
     SubjectPublicKeyInfo subjPubKeyInfo = SubjectPublicKeyInfo.getInstance(
                                                         ASN1Sequence.getInstance(keyPair.getPublic().getEncoded()));
     // @formatter:on
-    BigInteger serialNumber = new BigInteger(130, new SecureRandom());
+        BigInteger serialNumber = new BigInteger(130, new SecureRandom());
 
-    X509v3CertificateBuilder certGen = new X509v3CertificateBuilder(issuerDN, serialNumber, startDate, expiryDate,
-      subjectDN, subjPubKeyInfo);
-    ContentSigner contentSigner = null;
-    try
-    {
-      // @formatter:off
+        X509v3CertificateBuilder certGen = new X509v3CertificateBuilder(issuerDN, serialNumber, startDate, expiryDate,
+            subjectDN, subjPubKeyInfo);
+        ContentSigner contentSigner = null;
+        try {
+            // @formatter:off
       contentSigner = new JcaContentSignerBuilder("SHA256withRSA")
                                                               .setProvider(BOUNCY_CASTLE_PROVIDER)
                                                               .build(keyPair.getPrivate());
@@ -147,11 +138,10 @@ public class CertificateValidatorTest
                                                               .setProvider(BOUNCY_CASTLE_PROVIDER)
                                                               .getCertificate(certGen.build(contentSigner));
       // @formatter:on
-      return x509Certificate;
-    } catch (CertificateException | OperatorCreationException e)
-    {
-      throw new IllegalStateException(e);
+            return x509Certificate;
+        } catch (CertificateException | OperatorCreationException e) {
+            throw new IllegalStateException(e);
+        }
     }
-  }
 
 }

--- a/services/src/test/java/org/keycloak/authentication/authenticators/x509/CertificateValidatorTest.java
+++ b/services/src/test/java/org/keycloak/authentication/authenticators/x509/CertificateValidatorTest.java
@@ -1,0 +1,157 @@
+package org.keycloak.authentication.authenticators.x509;
+
+import org.bouncycastle.asn1.ASN1Sequence;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
+import org.bouncycastle.cert.X509v3CertificateBuilder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.OperatorCreationException;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.math.BigInteger;
+import java.security.GeneralSecurityException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.SecureRandom;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.Date;
+
+/**
+ * author Pascal Knueppel <br>
+ * created at: 07.11.2019 - 16:24 <br>
+ * <br>
+ *
+ */
+public class CertificateValidatorTest
+{
+
+  private static final BouncyCastleProvider BOUNCY_CASTLE_PROVIDER = new BouncyCastleProvider();
+
+  /**
+   * will validate that the certificate validation succeeds if the certificate is currently valid
+   */
+  @Test
+  public void testValidityOfCertificatesSuccess() throws GeneralSecurityException
+  {
+    KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+    kpg.initialize(512);
+    KeyPair keyPair = kpg.generateKeyPair();
+    X509Certificate certificate =
+      createCertificate("CN=keycloak-test", new Date(),
+        new Date(System.currentTimeMillis() + 1000L * 60), keyPair);
+
+    CertificateValidator.CertificateValidatorBuilder builder = new CertificateValidator.CertificateValidatorBuilder();
+    CertificateValidator validator = builder.build(new X509Certificate[] { certificate });
+    try
+    {
+      validator.validateTimestamps(true);
+    } catch (Exception ex)
+    {
+      ex.printStackTrace();
+      Assert.fail(ex.getMessage());
+    }
+  }
+
+  /**
+   * will validate that the certificate validation throws an exception if the certificate is not valid yet
+   */
+  @Test
+  public void testValidityOfCertificatesNotValidYet() throws GeneralSecurityException
+  {
+    KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+    kpg.initialize(512);
+    KeyPair keyPair = kpg.generateKeyPair();
+    X509Certificate certificate =
+      createCertificate("CN=keycloak-test", new Date(System.currentTimeMillis() + 1000L * 60),
+        new Date(System.currentTimeMillis() + 1000L * 60), keyPair);
+
+    CertificateValidator.CertificateValidatorBuilder builder = new CertificateValidator.CertificateValidatorBuilder();
+    CertificateValidator validator = builder.build(new X509Certificate[] { certificate });
+    try
+    {
+      validator.validateTimestamps(true);
+      Assert.fail("certificate validation must fail for certificate is not valid yet");
+    } catch (Exception ex)
+    {
+      MatcherAssert.assertThat(ex.getMessage(), Matchers.containsString("not valid yet"));
+      Assert.assertEquals(GeneralSecurityException.class, ex.getClass());
+    }
+  }
+
+  /**
+   * will validate that the certificate validation throws an exception if the certificate has expired
+   */
+  @Test
+  public void testValidityOfCertificatesHasExpired() throws GeneralSecurityException
+  {
+    KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+    kpg.initialize(512);
+    KeyPair keyPair = kpg.generateKeyPair();
+    X509Certificate certificate =
+      createCertificate("CN=keycloak-test", new Date(System.currentTimeMillis() - 1000L * 60 * 2),
+        new Date(System.currentTimeMillis() - 1000L * 60), keyPair);
+
+    CertificateValidator.CertificateValidatorBuilder builder = new CertificateValidator.CertificateValidatorBuilder();
+    CertificateValidator validator = builder.build(new X509Certificate[] { certificate });
+    try
+    {
+      validator.validateTimestamps(true);
+      Assert.fail("certificate validation must fail for certificate has expired");
+    } catch (Exception ex)
+    {
+      MatcherAssert.assertThat(ex.getMessage(), Matchers.containsString("has expired"));
+      Assert.assertEquals(GeneralSecurityException.class, ex.getClass());
+    }
+  }
+
+
+  /**
+   * will create a self-signed certificate
+   *
+   * @param dn the DN of the subject and issuer
+   * @param startDate startdate of the validity of the created certificate
+   * @param expiryDate expiration date of the created certificate
+   * @param keyPair the keypair that is used to create the certificate
+   * @return a X509-Certificate in version 3
+   */
+  public X509Certificate createCertificate(String dn,
+                                           Date startDate,
+                                           Date expiryDate,
+                                           KeyPair keyPair)
+  {
+    X500Name subjectDN = new X500Name(dn);
+    X500Name issuerDN = new X500Name(dn);
+    // @formatter:off
+    SubjectPublicKeyInfo subjPubKeyInfo = SubjectPublicKeyInfo.getInstance(
+                                                        ASN1Sequence.getInstance(keyPair.getPublic().getEncoded()));
+    // @formatter:on
+    BigInteger serialNumber = new BigInteger(130, new SecureRandom());
+
+    X509v3CertificateBuilder certGen = new X509v3CertificateBuilder(issuerDN, serialNumber, startDate, expiryDate,
+      subjectDN, subjPubKeyInfo);
+    ContentSigner contentSigner = null;
+    try
+    {
+      // @formatter:off
+      contentSigner = new JcaContentSignerBuilder("SHA256withRSA")
+                                                              .setProvider(BOUNCY_CASTLE_PROVIDER)
+                                                              .build(keyPair.getPrivate());
+      X509Certificate x509Certificate = new JcaX509CertificateConverter()
+                                                              .setProvider(BOUNCY_CASTLE_PROVIDER)
+                                                              .getCertificate(certGen.build(contentSigner));
+      // @formatter:on
+      return x509Certificate;
+    } catch (CertificateException | OperatorCreationException e)
+    {
+      throw new IllegalStateException(e);
+    }
+  }
+
+}

--- a/services/src/test/java/org/keycloak/authentication/authenticators/x509/X509AuthenticatorConfigModelTest.java
+++ b/services/src/test/java/org/keycloak/authentication/authenticators/x509/X509AuthenticatorConfigModelTest.java
@@ -9,17 +9,15 @@ import org.junit.Test;
  * <br>
  *
  */
-public class X509AuthenticatorConfigModelTest
-{
+public class X509AuthenticatorConfigModelTest {
 
-  /**
-   * this test will verify that no exception occurs if no settings are stored for the timestamp validation
-   */
-  @Test
-  public void testTimestampValidationAttributeReturnsNull()
-  {
-    X509AuthenticatorConfigModel configModel = new X509AuthenticatorConfigModel();
-    Assert.assertNull(configModel.getConfig().get(AbstractX509ClientCertificateAuthenticator.TIMESTAMP_VALIDATION));
-    Assert.assertFalse(configModel.isCertValidationEnabled());
-  }
+    /**
+     * this test will verify that no exception occurs if no settings are stored for the timestamp validation
+     */
+    @Test
+    public void testTimestampValidationAttributeReturnsNull() {
+        X509AuthenticatorConfigModel configModel = new X509AuthenticatorConfigModel();
+        Assert.assertNull(configModel.getConfig().get(AbstractX509ClientCertificateAuthenticator.TIMESTAMP_VALIDATION));
+        Assert.assertFalse(configModel.isCertValidationEnabled());
+    }
 }

--- a/services/src/test/java/org/keycloak/authentication/authenticators/x509/X509AuthenticatorConfigModelTest.java
+++ b/services/src/test/java/org/keycloak/authentication/authenticators/x509/X509AuthenticatorConfigModelTest.java
@@ -1,0 +1,25 @@
+package org.keycloak.authentication.authenticators.x509;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * author Pascal Knueppel <br>
+ * created at: 02.12.2019 - 10:59 <br>
+ * <br>
+ *
+ */
+public class X509AuthenticatorConfigModelTest
+{
+
+  /**
+   * this test will verify that no exception occurs if no settings are stored for the timestamp validation
+   */
+  @Test
+  public void testTimestampValidationAttributeReturnsNull()
+  {
+    X509AuthenticatorConfigModel configModel = new X509AuthenticatorConfigModel();
+    Assert.assertNull(configModel.getConfig().get(AbstractX509ClientCertificateAuthenticator.TIMESTAMP_VALIDATION));
+    Assert.assertFalse(configModel.isCertValidationEnabled());
+  }
+}


### PR DESCRIPTION
User-certificates that are used for mutual client authentication can
now be rejected if the certificate is not valid yed or has already
been expired
