### PR TITLE
KEYCLOAK-8779: Partial export and import to an existing realm is breaking clients with service accounts

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/partialimport/PartialImportTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/partialimport/PartialImportTest.java
@@ -16,6 +16,7 @@
  */
 package org.keycloak.testsuite.admin.partialimport;
 
+import java.io.IOException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -56,7 +57,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import org.keycloak.admin.client.resource.AuthorizationResource;
+import org.keycloak.common.constants.ServiceAccountConstants;
+import org.keycloak.partialimport.ResourceType;
+import org.keycloak.representations.idm.authorization.ResourceServerRepresentation;
 import static org.keycloak.testsuite.auth.page.AuthRealm.MASTER;
+import org.keycloak.util.JsonSerialization;
 
 /**
  * Tests for the partial import endpoint in admin client.  Also tests the
@@ -79,9 +85,20 @@ public class PartialImportTest extends AbstractAuthTest {
     private static final String CLIENT_ROLE_PREFIX = "clientRole";
     private static final String[] IDP_ALIASES = {"twitter", "github", "facebook", "google", "linkedin", "microsoft", "stackoverflow"};
     private static final int NUM_ENTITIES = IDP_ALIASES.length;
+    private static final ResourceServerRepresentation resourceServerSampleSettings;
 
     private PartialImportRepresentation piRep;
     private String realmId;
+
+    static {
+        try {
+            resourceServerSampleSettings = JsonSerialization.readValue(
+                PartialImportTest.class.getResourceAsStream("/import/sample-authz-partial-import.json"),
+                ResourceServerRepresentation.class);
+        } catch (IOException e) {
+            throw new IllegalStateException("Cannot load sample resource server configuration", e);
+        }
+    }
 
     @Before
     public void initAdminEvents() {
@@ -226,8 +243,9 @@ public class PartialImportTest extends AbstractAuthTest {
         piRep.setGroups(groups);
     }
 
-    private void addClients() {
+    private void addClients(boolean withServiceAccounts) throws IOException {
         List<ClientRepresentation> clients = new ArrayList<>();
+        List<UserRepresentation> serviceAccounts = new ArrayList<>();
 
         for (int i = 0; i < NUM_ENTITIES; i++) {
             ClientRepresentation client = new ClientRepresentation();
@@ -235,8 +253,28 @@ public class PartialImportTest extends AbstractAuthTest {
             client.setName(CLIENT_PREFIX + i);
             client.setRootUrl("foo");
             clients.add(client);
+            if (withServiceAccounts) {
+                client.setServiceAccountsEnabled(true);
+                client.setBearerOnly(false);
+                client.setPublicClient(false);
+                client.setAuthorizationSettings(resourceServerSampleSettings);
+                client.setAuthorizationServicesEnabled(true);
+                // create the user service account
+                UserRepresentation serviceAccount = new UserRepresentation();
+                serviceAccount.setUsername(ServiceAccountConstants.SERVICE_ACCOUNT_USER_PREFIX + client.getClientId());
+                serviceAccount.setEnabled(true);
+                serviceAccount.setEmail(serviceAccount.getUsername() + "@placeholder.org");
+                serviceAccount.setServiceAccountClientId(client.getClientId());
+                serviceAccounts.add(serviceAccount);
+            }
         }
 
+        if (withServiceAccounts) {
+            if (piRep.getUsers() == null) {
+                piRep.setUsers(new ArrayList<>());
+            }
+            piRep.getUsers().addAll(serviceAccounts);
+        }
         piRep.setClients(clients);
     }
 
@@ -379,7 +417,6 @@ public class PartialImportTest extends AbstractAuthTest {
 
         assertAdminEvents.assertEmpty();
 
-
         for (PartialImportResult result : results.getResults()) {
             String id = result.getId();
             UserResource userRsc = testRealmResource().users().get(id);
@@ -390,9 +427,9 @@ public class PartialImportTest extends AbstractAuthTest {
     }
 
     @Test
-    public void testAddClients() {
+    public void testAddClients() throws IOException {
         setFail();
-        addClients();
+        addClients(false);
 
         PartialImportResults results = doImport();
         assertEquals(NUM_ENTITIES, results.getAdded());
@@ -402,6 +439,35 @@ public class PartialImportTest extends AbstractAuthTest {
             ClientResource clientRsc = testRealmResource().clients().get(id);
             ClientRepresentation client = clientRsc.toRepresentation();
             assertTrue(client.getName().startsWith(CLIENT_PREFIX));
+        }
+    }
+
+    @Test
+    public void testAddClientsWithServiceAccountsAndAuthorization() throws IOException {
+        setFail();
+        addClients(true);
+
+        PartialImportResults results = doImport();
+        assertEquals(NUM_ENTITIES * 2, results.getAdded());
+
+        for (PartialImportResult result : results.getResults()) {
+            if (result.getResourceType().equals(ResourceType.CLIENT)) {
+                String id = result.getId();
+                ClientResource clientRsc = testRealmResource().clients().get(id);
+                ClientRepresentation client = clientRsc.toRepresentation();
+                assertTrue(client.getName().startsWith(CLIENT_PREFIX));
+                Assert.assertTrue(client.isServiceAccountsEnabled());
+                Assert.assertTrue(client.getAuthorizationServicesEnabled());
+                AuthorizationResource authRsc = clientRsc.authorization();
+                ResourceServerRepresentation authRep = authRsc.exportSettings();
+                Assert.assertNotNull(authRep);
+                Assert.assertEquals(2, authRep.getResources().size());
+                Assert.assertEquals(3, authRep.getPolicies().size());
+            } else {
+                UserResource userRsc = testRealmResource().users().get(result.getId());
+                Assert.assertTrue(userRsc.toRepresentation().getUsername().startsWith(
+                        ServiceAccountConstants.SERVICE_ACCOUNT_USER_PREFIX + CLIENT_PREFIX));
+            }
         }
     }
 
@@ -475,8 +541,8 @@ public class PartialImportTest extends AbstractAuthTest {
     }
 
     @Test
-    public void testAddClientsFail() {
-        addClients();
+    public void testAddClientsFail() throws IOException {
+        addClients(false);
         testFail();
     }
 
@@ -520,9 +586,20 @@ public class PartialImportTest extends AbstractAuthTest {
     }
 
     @Test
-    public void testAddClientsSkip() {
-        addClients();
+    public void testAddClientsSkip() throws IOException {
+        addClients(false);
         testSkip();
+    }
+
+    @Test
+    public void testAddClientsSkipWithServiceAccountsAndAuthorization() throws IOException {
+        addClients(true);
+        setSkip();
+        PartialImportResults results = doImport();
+        assertEquals(NUM_ENTITIES * 2, results.getAdded());
+
+        results = doImport();
+        assertEquals(NUM_ENTITIES * 2, results.getSkipped());
     }
 
     @Test
@@ -565,9 +642,44 @@ public class PartialImportTest extends AbstractAuthTest {
     }
 
     @Test
-    public void testAddClientsOverwrite() {
-        addClients();
+    public void testAddClientsOverwrite() throws IOException {
+        addClients(false);
         testOverwrite();
+    }
+
+    @Test
+    public void testAddClientsOverwriteWithServiceAccountsAndAuthorization() throws IOException {
+        addClients(true);
+        setOverwrite();
+        PartialImportResults results = doImport();
+        assertEquals(NUM_ENTITIES * 2, results.getAdded());
+
+        results = doImport();
+        assertEquals(NUM_ENTITIES * 2, results.getOverwritten());
+    }
+
+    @Test
+    public void testAddClientsOverwriteServiceAccountsWithNoServiceAccounts() throws IOException {
+        addClients(true);
+        setOverwrite();
+        PartialImportResults results = doImport();
+        assertEquals(NUM_ENTITIES * 2, results.getAdded());
+        // check the service accounts are there
+        for (int i = 0; i < NUM_ENTITIES; i++) {
+            List<UserRepresentation> l = testRealmResource().users().search(ServiceAccountConstants.SERVICE_ACCOUNT_USER_PREFIX + CLIENT_PREFIX + i);
+            Assert.assertEquals(1, l.size());
+        }
+        // re-import without service accounts enabled
+        piRep = new PartialImportRepresentation();
+        addClients(false);
+        setOverwrite();
+        results = doImport();
+        assertEquals(NUM_ENTITIES, results.getOverwritten());
+        // check the service accounts have been removed
+        for (int i = 0; i < NUM_ENTITIES; i++) {
+            List<UserRepresentation> l = testRealmResource().users().search(ServiceAccountConstants.SERVICE_ACCOUNT_USER_PREFIX + CLIENT_PREFIX + i);
+            Assert.assertEquals(0, l.size());
+        }
     }
 
     @Test
@@ -588,42 +700,61 @@ public class PartialImportTest extends AbstractAuthTest {
         testOverwrite();
     }
 
-
-    private void importEverything() {
+    private void importEverything(boolean withServiceAccounts) throws IOException {
         addUsers();
         addGroups();
-        addClients();
+        addClients(withServiceAccounts);
         addProviders();
         addRealmRoles();
         addClientRoles();
 
         PartialImportResults results = doImport();
         assertNull(results.getErrorMessage());
-        assertEquals(NUM_ENTITIES * NUM_RESOURCE_TYPES, results.getAdded());
+        if (withServiceAccounts) {
+            assertEquals(NUM_ENTITIES * (NUM_RESOURCE_TYPES + 1), results.getAdded());
+        } else {
+            assertEquals(NUM_ENTITIES * NUM_RESOURCE_TYPES, results.getAdded());
+        }
     }
 
     @Test
-    public void testEverythingFail() {
+    public void testEverythingFail() throws IOException {
         setFail();
-        importEverything();
+        importEverything(false);
         PartialImportResults results = doImport(); // second import will fail because not allowed to skip or overwrite
         assertNotNull(results.getErrorMessage());
     }
 
     @Test
-    public void testEverythingSkip() {
+    public void testEverythingSkip() throws IOException {
         setSkip();
-        importEverything();
+        importEverything(false);
         PartialImportResults results = doImport();
         assertEquals(NUM_ENTITIES * NUM_RESOURCE_TYPES, results.getSkipped());
     }
 
     @Test
-    public void testEverythingOverwrite() {
+    public void testEverythingSkipWithServiceAccounts() throws IOException {
+        setSkip();
+        importEverything(true);
+        PartialImportResults results = doImport();
+        assertEquals(NUM_ENTITIES * (NUM_RESOURCE_TYPES + 1), results.getSkipped());
+    }
+
+    @Test
+    public void testEverythingOverwrite() throws IOException {
         setOverwrite();
-        importEverything();
+        importEverything(false);
         PartialImportResults results = doImport();
         assertEquals(NUM_ENTITIES * NUM_RESOURCE_TYPES, results.getOverwritten());
+    }
+
+    @Test
+    public void testEverythingOverwriteWithServiceAccounts() throws IOException {
+        setOverwrite();
+        importEverything(true);
+        PartialImportResults results = doImport();
+        assertEquals(NUM_ENTITIES * (NUM_RESOURCE_TYPES + 1), results.getOverwritten());
     }
 
     //KEYCLOAK-3042

--- a/testsuite/integration-arquillian/tests/base/src/test/resources/import/sample-authz-partial-import.json
+++ b/testsuite/integration-arquillian/tests/base/src/test/resources/import/sample-authz-partial-import.json
@@ -1,0 +1,61 @@
+{
+    "allowRemoteResourceManagement": true,
+    "policyEnforcementMode": "ENFORCING",
+    "resources": [
+        {
+            "name": "Default Resource",
+            "type": "urn:test:resources:default",
+            "ownerManagedAccess": false,
+            "attributes": {},
+            "uris": [
+                "/*"
+            ]
+        },
+        {
+            "name": "test",
+            "type": "test",
+            "ownerManagedAccess": true,
+            "displayName": "test",
+            "attributes": {},
+            "uris": [
+                "/test"
+            ]
+        }
+    ],
+    "policies": [
+        {
+            "name": "Default Policy",
+            "description": "A policy that grants access only for users within this realm",
+            "type": "js",
+            "logic": "POSITIVE",
+            "decisionStrategy": "AFFIRMATIVE",
+            "config": {
+                "code": "// by default, grants any permission associated with this policy: $evaluation.grant();"
+            }
+        },
+        {
+            "name": "Default Permission",
+            "description": "A permission that applies to the default resource type",
+            "type": "resource",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+                "defaultResourceType": "urn:test:resources:default",
+                "applyPolicies": "[\"Default Policy\"]"
+            }
+        },
+        {
+            "name": "test-permission",
+            "description": "test-permission",
+            "type": "resource",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+                "resources": "[\"test\"]",
+                "applyPolicies": "[\"Default Policy\"]"
+            }
+        }
+    ],
+    "scopes": [],
+    "decisionStrategy": "UNANIMOUS"
+}


### PR DESCRIPTION
Hi,
Changes for KEYCLOAK-8779 and related KEYCLOAK-6987. It's the import side of the KEYCLOAK-4923. Add @ssilvert for the review if possible (both PRs are quite related).

The solution just adds three things:

1. The authorization resource server was missed in the import. The import of the resource server is checked to also import the authz information if it's there.
2. The service account of a client is deleted when overwrite is selected for the import. If not, the service account remains in the system and it can trigger issues later on if the client activates services accounts again. This is the issue for KEYCLOAK-6987, in this JIRA the client is imported without the service account, so the old service account remains but the client ID is different, so when the server tries to create the new service account it conflicts in name with the old one).
3. Tests for the above two changes.

After working on this PR I realized that it modifies different classes (KEYCLOAK-4923 modifies export, and this one import). So it can reviewed at the same time.