### PR TITLE
KEYCLOAK-11601 Fix a NPE when using token-exchange

### DIFF
--- a/services/src/main/java/org/keycloak/social/openshift/OpenshiftV3IdentityProvider.java
+++ b/services/src/main/java/org/keycloak/social/openshift/OpenshiftV3IdentityProvider.java
@@ -84,7 +84,7 @@ public class OpenshiftV3IdentityProvider extends AbstractOAuth2IdentityProvider<
 
     @Override
     protected BrokeredIdentityContext extractIdentityFromProfile(EventBuilder event, JsonNode profile) {
-        final BrokeredIdentityContext user = extractUserContext(profile.get("metadata"));
+        final BrokeredIdentityContext user = extractUserContext(profile);
         AbstractJsonUserAttributeMapper.storeUserProfileForMapper(user, profile, getConfig().getAlias());
         return user;
     }


### PR DESCRIPTION
When using the preview token-exchange feature with the `openshit-v3` identity provider, a NPE is triggered, because it tries to extract the `metadata` field twice from the user profile:

```
13:17:13,667 ERROR [org.keycloak.services.error.KeycloakErrorHandler] (default task-7) Uncaught server error: java.lang.NullPointerException
	at org.keycloak.broker.oidc.AbstractOAuth2IdentityProvider.getJsonProperty(AbstractOAuth2IdentityProvider.java:357)
	at org.keycloak.social.openshift.OpenshiftV3IdentityProvider.extractUserContext(OpenshiftV3IdentityProvider.java:61)
	at org.keycloak.social.openshift.OpenshiftV3IdentityProvider.extractIdentityFromProfile(OpenshiftV3IdentityProvider.java:87)
	at org.keycloak.broker.oidc.AbstractOAuth2IdentityProvider.validateExternalTokenThroughUserInfo(AbstractOAuth2IdentityProvider.java:489)
	at org.keycloak.broker.oidc.AbstractOAuth2IdentityProvider.exchangeExternalUserInfoValidationOnly(AbstractOAuth2IdentityProvider.java:548)
	at org.keycloak.broker.oidc.AbstractOAuth2IdentityProvider.exchangeExternalImpl(AbstractOAuth2IdentityProvider.java:528)
	at org.keycloak.broker.oidc.AbstractOAuth2IdentityProvider.exchangeExternal(AbstractOAuth2IdentityProvider.java:519)
	at org.keycloak.protocol.oidc.endpoints.TokenEndpoint.exchangeExternalToken(TokenEndpoint.java:917)
	at org.keycloak.protocol.oidc.endpoints.TokenEndpoint.tokenExchange(TokenEndpoint.java:696)
	at org.keycloak.protocol.oidc.endpoints.TokenEndpoint.processGrantRequest(TokenEndpoint.java:194)
.....
13:17:28,916 ERROR [org.keycloak.services.error.KeycloakErrorHandler] (default task-7) Uncaught server error: java.lang.NullPointerException
	at org.keycloak.broker.oidc.AbstractOAuth2IdentityProvider.getJsonProperty(AbstractOAuth2IdentityProvider.java:357)
	at org.keycloak.social.openshift.OpenshiftV3IdentityProvider.extractUserContext(OpenshiftV3IdentityProvider.java:61)
	at org.keycloak.social.openshift.OpenshiftV3IdentityProvider.extractIdentityFromProfile(OpenshiftV3IdentityProvider.java:87)
	at org.keycloak.broker.oidc.AbstractOAuth2IdentityProvider.validateExternalTokenThroughUserInfo(AbstractOAuth2IdentityProvider.java:489)
	at org.keycloak.broker.oidc.AbstractOAuth2IdentityProvider.exchangeExternalUserInfoValidationOnly(AbstractOAuth2IdentityProvider.java:548)
	at org.keycloak.broker.oidc.AbstractOAuth2IdentityProvider.exchangeExternalImpl(AbstractOAuth2IdentityProvider.java:528)
	at org.keycloak.broker.oidc.AbstractOAuth2IdentityProvider.exchangeExternal(AbstractOAuth2IdentityProvider.java:519)
	at org.keycloak.protocol.oidc.endpoints.TokenEndpoint.exchangeExternalToken(TokenEndpoint.java:917)
	at org.keycloak.protocol.oidc.endpoints.TokenEndpoint.tokenExchange(TokenEndpoint.java:696)
	at org.keycloak.protocol.oidc.endpoints.TokenEndpoint.processGrantRequest(TokenEndpoint.java:194)
......
13:17:53,492 ERROR [org.keycloak.services.error.KeycloakErrorHandler] (default task-7) Uncaught server error: java.lang.NullPointerException
	at org.keycloak.broker.oidc.AbstractOAuth2IdentityProvider.getJsonProperty(AbstractOAuth2IdentityProvider.java:357)
	at org.keycloak.social.openshift.OpenshiftV3IdentityProvider.extractUserContext(OpenshiftV3IdentityProvider.java:61)
	at org.keycloak.social.openshift.OpenshiftV3IdentityProvider.extractIdentityFromProfile(OpenshiftV3IdentityProvider.java:87)
	at org.keycloak.broker.oidc.AbstractOAuth2IdentityProvider.validateExternalTokenThroughUserInfo(AbstractOAuth2IdentityProvider.java:489)
	at org.keycloak.broker.oidc.AbstractOAuth2IdentityProvider.exchangeExternalUserInfoValidationOnly(AbstractOAuth2IdentityProvider.java:548)
	at org.keycloak.broker.oidc.AbstractOAuth2IdentityProvider.exchangeExternalImpl(AbstractOAuth2IdentityProvider.java:528)
	at org.keycloak.broker.oidc.AbstractOAuth2IdentityProvider.exchangeExternal(AbstractOAuth2IdentityProvider.java:519)
	at org.keycloak.protocol.oidc.endpoints.TokenEndpoint.exchangeExternalToken(TokenEndpoint.java:917)
	at org.keycloak.protocol.oidc.endpoints.TokenEndpoint.tokenExchange(TokenEndpoint.java:696)
	at org.keycloak.protocol.oidc.endpoints.TokenEndpoint.processGrantRequest(TokenEndpoint.java:194)
```