### PR TITLE
KEYCLOAK-11527 Override version of jboss-as-subsystem-test for produc…

### DIFF
--- a/adapters/saml/as7-eap6/subsystem/pom.xml
+++ b/adapters/saml/as7-eap6/subsystem/pom.xml
@@ -140,11 +140,21 @@ projects that depend on this project.-->
                     <name>product</name>
                 </property>
             </activation>
+            <repositories>
+                <repository>
+                    <id>redhat-ga</id>
+                    <url>https://maven.repository.redhat.com/ga/</url>
+                    <snapshots>
+                        <enabled>false</enabled>
+                    </snapshots>
+                </repository>
+            </repositories>
             <dependencies>
                 <!-- Downstream version 7.5.*.Final is type pom see KEYCLOAK-11527 -->
                 <dependency>
                     <groupId>org.jboss.as</groupId>
                     <artifactId>jboss-as-subsystem-test</artifactId>
+                    <version>${jboss.as.subsystem.test.version}</version>
                     <type>pom</type>
                     <scope>test</scope>
                 </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
         <wildfly.core.version>9.0.2.Final</wildfly.core.version>
 
         <jboss.as.version>7.2.0.Final</jboss.as.version>
+        <jboss.as.subsystem.test.version>7.5.22.Final-redhat-1</jboss.as.subsystem.test.version>
 
         <!-- Versions used mostly for Undertow server, aligned with WildFly -->
         <jboss.aesh.version>0.66.19</jboss.aesh.version>


### PR DESCRIPTION
The https://github.com/keycloak/keycloak/commit/9200a33346b87dfbe4befde745924041c375b6ba isn't enough because in the rh-sso pipeline we run commands like 
` mvn -f ./pom.xml help:evaluate -B -Dexpression=product.rhsso.version -Pproduct '-P!community' -Pjboss-release -Pdistribution-downloads`
without PME alignment where ***redhat*** suffixes are added. As there is no org.jboss.as:jboss-as-subsystem-test:pom in the 7.2.0.Final version it fails with compilation error. 
@hmlnarik @vmuzikar WDYT? 