### PR TITLE
KEYCLOAK-10266 Allows proper handling of Single Sign Out events (Spring Security adapter)

### DIFF
--- a/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/management/HttpSessionManager.java
+++ b/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/management/HttpSessionManager.java
@@ -17,15 +17,17 @@
 
 package org.keycloak.adapters.springsecurity.management;
 
+import java.util.List;
+
+import javax.servlet.http.HttpSession;
+
 import org.keycloak.adapters.spi.UserSessionManagement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.stereotype.Component;
-
-import javax.servlet.http.HttpSession;
-import javax.servlet.http.HttpSessionEvent;
-import javax.servlet.http.HttpSessionListener;
-import java.util.List;
+import org.springframework.context.ApplicationEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.security.web.session.HttpSessionCreatedEvent;
+import org.springframework.security.web.session.HttpSessionDestroyedEvent;
 
 /**
  * User session manager for handling logout of Spring Secured sessions.
@@ -33,22 +35,24 @@ import java.util.List;
  * @author <a href="mailto:srossillo@smartling.com">Scott Rossillo</a>
  * @version $Revision: 1 $
  */
-@Component
-public class HttpSessionManager implements HttpSessionListener, UserSessionManagement {
+public class HttpSessionManager implements ApplicationListener<ApplicationEvent>, UserSessionManagement {
 
     private static final Logger log = LoggerFactory.getLogger(HttpSessionManager.class);
     private SessionManagementStrategy sessions = new LocalSessionManagementStrategy();
 
     @Override
-    public void sessionCreated(HttpSessionEvent event) {
-        log.debug("Session created: {}", event.getSession().getId());
-        HttpSession session = event.getSession();
-        sessions.store(session);
-    }
-
-    @Override
-    public void sessionDestroyed(HttpSessionEvent event) {
-        sessions.remove(event.getSession().getId());
+    public void onApplicationEvent(ApplicationEvent event) {
+        if (event instanceof HttpSessionCreatedEvent) {
+            HttpSessionCreatedEvent e = (HttpSessionCreatedEvent) event;
+            HttpSession session = e.getSession();
+            log.debug("Session created: {}", session.getId());
+            sessions.store(session);
+        } else if (event instanceof HttpSessionDestroyedEvent) {
+            HttpSessionDestroyedEvent e = (HttpSessionDestroyedEvent) event;
+            HttpSession session = e.getSession();
+            sessions.remove(session.getId());
+            log.debug("Session destroyed: {}", session.getId());
+        }
     }
 
     @Override
@@ -70,4 +74,5 @@ public class HttpSessionManager implements HttpSessionListener, UserSessionManag
             }
         }
     }
+
 }


### PR DESCRIPTION
HttpSessionManager was incorrectly relying on web application listeners on session
destruction.
While it's used as a Spring Bean (declared in
KeycloakWebSecurityConfigurerAdapter) so it has to use Spring-based
facility.
See also https://lists.jboss.org/pipermail/keycloak-user/2016-March/005479.html

Accompanying PR for the documentation:
https://github.com/keycloak/keycloak-documentation/pull/751