### PR TITLE
KEYCLOAK-8938 TypeError: kc.login(...).success is not a function

### DIFF
--- a/adapters/oidc/js/src/main/resources/keycloak.js
+++ b/adapters/oidc/js/src/main/resources/keycloak.js
@@ -1297,17 +1297,17 @@
                 return {
                     login: function(options) {
                         window.location.replace(kc.createLoginUrl(options));
-                        return createPromise().promise;
+                        return createPromise(false).promise;
                     },
 
                     logout: function(options) {
                         window.location.replace(kc.createLogoutUrl(options));
-                        return createPromise().promise;
+                        return createPromise(false).promise;
                     },
 
                     register: function(options) {
                         window.location.replace(kc.createRegisterUrl(options));
-                        return createPromise().promise;
+                        return createPromise(false).promise;
                     },
 
                     accountManagement : function() {


### PR DESCRIPTION
<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
