### PR TITLE
Use embedded mode to inhibit System.exit() in KeycloakApplication()

### DIFF
--- a/quarkus/server/src/main/resources/META-INF/web.xml
+++ b/quarkus/server/src/main/resources/META-INF/web.xml
@@ -42,6 +42,10 @@
        <param-name>resteasy.disable.html.sanitizer</param-name>
        <param-value>true</param-value>
     </context-param>
+    <context-param>
+       <param-name>keycloak.embedded</param-name>
+       <param-value>true</param-value>
+    </context-param>
 
     <listener>
         <listener-class>


### PR DESCRIPTION
Currently, every log message emitted by the application constructor is put into a buffer, which is flushed only after the constructor returns (see KEYCLOAK-11701). Thus, if we call `System.exit()` inside the constructor, log output will be lost, including stack trace of the original exception. It's safe just to rethrow the exception, which will print out stack trace and terminate Quarkus runtime.