### PR TITLE
[KEYCLOAK-11765] Do not log when failure.getError is blank/empty

### DIFF
--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/OAuthRequestAuthenticator.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/OAuthRequestAuthenticator.java
@@ -336,7 +336,7 @@ public class OAuthRequestAuthenticator {
         } catch (ServerRequest.HttpFailure failure) {
             log.error("failed to turn code into token");
             log.error("status from server: " + failure.getStatus());
-            if (failure.getError() != null && !failure.getError().isBlank()) {
+            if (failure.getError() != null && !failure.getError().trim().isEmpty()) {
                 log.error("   " + failure.getError());
             }
             return challenge(403, OIDCAuthenticationError.Reason.CODE_TO_TOKEN_FAILURE, null);

--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/OAuthRequestAuthenticator.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/OAuthRequestAuthenticator.java
@@ -336,7 +336,7 @@ public class OAuthRequestAuthenticator {
         } catch (ServerRequest.HttpFailure failure) {
             log.error("failed to turn code into token");
             log.error("status from server: " + failure.getStatus());
-            if (failure.getError() != null) {
+            if (failure.getError() != null && !failure.getError().isBlank()) {
                 log.error("   " + failure.getError());
             }
             return challenge(403, OIDCAuthenticationError.Reason.CODE_TO_TOKEN_FAILURE, null);


### PR DESCRIPTION
Sometimes the error message is blank, which results in an empty error line getting logged. 
Since the catch always logs "failed to turn code into token" and "status from server: " + failure.getStatus() (on separate lines) this extra blank line is simply noise in the log.

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
