### PR TITLE
KEYCLOAK-11684 Add support to display passwords in password fields

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/console/page/fragment/KcPassword.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/console/page/fragment/KcPassword.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite.console.page.fragment;
+
+import org.jboss.arquillian.graphene.fragment.Root;
+import org.openqa.selenium.ElementNotInteractableException;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+import static org.keycloak.testsuite.util.UIUtils.setTextInputValue;
+
+/**
+ * @author Vaclav Muzikar <vmuzikar@redhat.com>
+ */
+public class KcPassword {
+    @Root
+    private WebElement inputField;
+
+    @FindBy(xpath = "../span[contains(@class,'input-group-addon') and ./span[contains(@class,'fa-eye')]]")
+    private WebElement eyeButton;
+
+    public void setValue(final String value) {
+        setTextInputValue(inputField, value);
+    }
+
+    public boolean isMasked() {
+        return inputField.getAttribute("class").contains("password-conceal");
+    }
+
+    public boolean isEyeButtonDisabled() {
+        return eyeButton.getAttribute("class").contains("disabled");
+    }
+
+    public void clickEyeButton() {
+        if (isEyeButtonDisabled()) {
+            throw new ElementNotInteractableException("The eye button is disabled and cannot be clicked");
+        }
+        eyeButton.click();
+    }
+
+    public WebElement getElement() {
+        return inputField;
+    }
+}

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/idp/CreateIdentityProvider.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/idp/CreateIdentityProvider.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite.console.page.idp;
+
+import org.jboss.arquillian.graphene.page.Page;
+import org.keycloak.testsuite.console.page.AdminConsoleCreate;
+
+/**
+ * @author Vaclav Muzikar <vmuzikar@redhat.com>
+ */
+public class CreateIdentityProvider extends AdminConsoleCreate {
+    public static final String PROVIDER_ID = "provider-id";
+
+    @Page
+    private IdentityProviderForm form;
+
+    public CreateIdentityProvider() {
+        setEntity("identity-provider");
+    }
+
+    @Override
+    public String getUriFragment() {
+        return super.getUriFragment() + "/{" + PROVIDER_ID + "}";
+    }
+
+    public void setProviderId(String id) {
+        setUriParameter(PROVIDER_ID, id);
+    }
+
+    public String getProviderId() {
+        return (String) getUriParameter(PROVIDER_ID);
+    }
+
+    public IdentityProviderForm form() {
+        return form;
+    }
+}

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/idp/IdentityProvider.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/idp/IdentityProvider.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite.console.page.idp;
+
+import org.jboss.arquillian.graphene.page.Page;
+
+/**
+ * @author Vaclav Muzikar <vmuzikar@redhat.com>
+ */
+public class IdentityProvider extends IdentityProviders {
+    public static final String PROVIDER_ID = "id";
+    public static final String ALIAS = "alias";
+
+    @Page
+    private IdentityProviderForm form;
+
+    @Override
+    public String getUriFragment() {
+        return super.getUriFragment() + "/provider/{" + PROVIDER_ID + "}/{" + ALIAS + "}";
+    }
+
+    public void setIds(String providerId, String alias) {
+        setUriParameter(PROVIDER_ID, providerId);
+        setUriParameter(ALIAS, alias);
+    }
+
+    public String getProviderId() {
+        return (String) getUriParameter(PROVIDER_ID);
+    }
+
+    public String getAlias() {
+        return (String) getUriParameter(ALIAS);
+    }
+
+    public IdentityProviderForm form() {
+        return form;
+    }
+}

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/idp/IdentityProviderForm.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/idp/IdentityProviderForm.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite.console.page.idp;
+
+import org.keycloak.testsuite.console.page.fragment.KcPassword;
+import org.keycloak.testsuite.page.Form;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+import static org.keycloak.testsuite.util.UIUtils.setTextInputValue;
+
+/**
+ * @author Vaclav Muzikar <vmuzikar@redhat.com>
+ */
+public class IdentityProviderForm extends Form {
+    @FindBy(id = "clientId")
+    private WebElement clientIdInput;
+
+    @FindBy(id = "clientSecret")
+    private KcPassword clientSecretInput;
+
+    public void setClientId(final String value) {
+        setTextInputValue(clientIdInput, value);
+    }
+
+    public void setClientSecret(final String value) {
+        clientSecretInput.setValue(value);
+    }
+
+    public KcPassword clientSecret() {
+        return clientSecretInput;
+    }
+}

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/idp/IdentityProviders.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/idp/IdentityProviders.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite.console.page.idp;
+
+import org.jboss.arquillian.graphene.fragment.Root;
+import org.keycloak.testsuite.console.page.AdminConsoleRealm;
+import org.keycloak.testsuite.console.page.fragment.DataTable;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.ui.Select;
+
+import static org.keycloak.testsuite.util.UIUtils.isElementVisible;
+import static org.keycloak.testsuite.util.UIUtils.performOperationWithPageReload;
+
+/**
+ * @author Vaclav Muzikar <vmuzikar@redhat.com>
+ */
+public class IdentityProviders extends AdminConsoleRealm {
+    @FindBy(xpath = "//div[contains(@class,'blank-slate')]//select")
+    private Select addProviderBlankSlateSelect;
+
+    @FindBy(tagName = "table")
+    private IdentityProvidersTable table;
+
+    @Override
+    public String getUriFragment() {
+        return super.getUriFragment() + "/identity-provider-settings";
+    }
+
+    public IdentityProvidersTable table() {
+        return table;
+    }
+
+    public void addProvider(final String providerId) {
+        Select idpSelect = table.isVisible() ? table.addProviderTableSelect : addProviderBlankSlateSelect;
+        performOperationWithPageReload(() -> idpSelect.selectByValue(providerId));
+    }
+
+    public class IdentityProvidersTable extends DataTable {
+        @Root
+        private WebElement tableRoot;
+
+        @FindBy(tagName = "select")
+        private Select addProviderTableSelect;
+
+        public boolean isVisible() {
+            return isElementVisible(tableRoot);
+        }
+
+        public void clickProvider(final String alias) {
+            clickRowByLinkText(alias);
+        }
+    }
+}

--- a/themes/src/main/resources/theme/base/admin/resources/js/app.js
+++ b/themes/src/main/resources/theme/base/admin/resources/js/app.js
@@ -3158,9 +3158,54 @@ module.directive('kcPassword', function ($compile, Notifications) {
     return {
         restrict: 'A',
         link: function ($scope, elem, attr, ctrl) {
+            function toggleMask(evt) {
+                if(elem.hasClass('password-conceal')) {
+                    view();
+                } else {
+                    conceal();
+                }
+            }
+
+            function view() {
+                elem.removeClass('password-conceal');
+
+                var t = elem.next().children().first();
+                t.addClass('fa-eye-slash');
+                t.removeClass('fa-eye');
+            }
+
+            function conceal() {
+                elem.addClass('password-conceal');
+
+                var t = elem.next().children().first();
+                t.removeClass('fa-eye-slash');
+                t.addClass('fa-eye');
+            }
+
             elem.addClass("password-conceal");
             elem.attr("type","text");
             elem.attr("autocomplete", "off");
+
+            var p = elem.parent();
+
+            var inputGroup = $('<div class="input-group"></div>');
+            var eye = $('<span class="input-group-addon btn btn-default"><span class="fa fa-eye"></span></span>')
+                        .on('click', toggleMask);
+
+            $scope.$watch(attr.ngModel, function(v) {
+                if (v && v == '**********') {
+                    elem.next().addClass('disabled')
+                } else if (v && v.indexOf('${v') == 0) {
+                    elem.next().addClass('disabled')
+                    view();
+                } else {
+                    elem.next().removeClass('disabled')
+                }
+            })
+
+            elem.detach().appendTo(inputGroup);
+            inputGroup.append(eye);
+            p.append(inputGroup);
         }
     }
 });


### PR DESCRIPTION
Behaviour is:

* If value starts with "${" the eye is disabled, and it's shown in clear
* If value is masked value (**********) the eye is disabled and it's shown as masked/password
* Anything else the eye controls if it's shown or masked

This means that reloading the page after saving ${vault..} will display it in clear-text. If a regular password it will disable the eye as there is no point in "viewing" the masked password.

It also means that while typing in a vault entry when you've entered ${ it will automatically show it, so you don't have to manually click on the eye.