### PR TITLE
KEYCLOAK-11775 Add the possibily to customize issuer uri

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,5 @@ target
 # testsuite #
 #############
 *offline-token.txt
+
+.vscode/

--- a/core/src/main/java/org/keycloak/KeycloakSecurityContext.java
+++ b/core/src/main/java/org/keycloak/KeycloakSecurityContext.java
@@ -75,7 +75,9 @@ public class KeycloakSecurityContext implements Serializable {
 
     public String getRealm() {
         // Assumption that issuer contains realm name
-        return token.getIssuer().substring(token.getIssuer().lastIndexOf('/') + 1);
+        // NOTE(angelinsky7): New assumption that the realm contains realm name
+        // return token.getIssuer().substring(token.getIssuer().lastIndexOf('/') + 1);
+        return token.getRealm().substring(token.getRealm().lastIndexOf('/') + 1);
     }
 
     // SERIALIZATION

--- a/core/src/main/java/org/keycloak/RSATokenVerifier.java
+++ b/core/src/main/java/org/keycloak/RSATokenVerifier.java
@@ -41,11 +41,19 @@ public class RSATokenVerifier {
     }
 
     public static AccessToken verifyToken(String tokenString, PublicKey publicKey, String realmUrl) throws VerificationException {
-        return RSATokenVerifier.create(tokenString).publicKey(publicKey).realmUrl(realmUrl).verify().getToken();
+        return verifyToken(tokenString, publicKey, realmUrl, realmUrl);
+    }
+
+    public static AccessToken verifyToken(String tokenString, PublicKey publicKey, String realmUrl, String issuerUrl) throws VerificationException {
+        return RSATokenVerifier.create(tokenString).publicKey(publicKey).realmUrl(realmUrl).issuerUrl(issuerUrl).verify().getToken();
     }
 
     public static AccessToken verifyToken(String tokenString, PublicKey publicKey, String realmUrl, boolean checkActive, boolean checkTokenType) throws VerificationException {
-        return RSATokenVerifier.create(tokenString).publicKey(publicKey).realmUrl(realmUrl).checkActive(checkActive).checkTokenType(checkTokenType).verify().getToken();
+        return verifyToken(tokenString, publicKey, realmUrl, realmUrl, checkActive, checkTokenType);
+    }
+
+    public static AccessToken verifyToken(String tokenString, PublicKey publicKey, String realmUrl, String issuerUrl, boolean checkActive, boolean checkTokenType) throws VerificationException {
+        return RSATokenVerifier.create(tokenString).publicKey(publicKey).realmUrl(realmUrl).issuerUrl(issuerUrl).checkActive(checkActive).checkTokenType(checkTokenType).verify().getToken();
     }
 
     public RSATokenVerifier publicKey(PublicKey publicKey) {
@@ -55,6 +63,11 @@ public class RSATokenVerifier {
 
     public RSATokenVerifier realmUrl(String realmUrl) {
         tokenVerifier.realmUrl(realmUrl);
+        return this;
+    }
+
+    public RSATokenVerifier issuerUrl(String issuerUrl) {
+        tokenVerifier.issuerUrl(issuerUrl);
         return this;
     }
 

--- a/core/src/main/java/org/keycloak/representations/AccessToken.java
+++ b/core/src/main/java/org/keycloak/representations/AccessToken.java
@@ -215,6 +215,11 @@ public class AccessToken extends IDToken {
         return (AccessToken) super.issuer(issuer);
     }
 
+    @Override 
+    public AccessToken realm(String realm){
+        return (AccessToken) super.realm(realm);
+    }
+
     @Override
     public AccessToken subject(String subject) {
         return (AccessToken) super.subject(subject);

--- a/core/src/main/java/org/keycloak/representations/JsonWebToken.java
+++ b/core/src/main/java/org/keycloak/representations/JsonWebToken.java
@@ -49,6 +49,8 @@ public class JsonWebToken implements Serializable, Token {
     protected int issuedAt;
     @JsonProperty("iss")
     protected String issuer;
+    @JsonProperty("realm")
+    protected String realm;
     @JsonProperty("aud")
     @JsonSerialize(using = StringOrArraySerializer.class)
     @JsonDeserialize(using = StringOrArrayDeserializer.class)
@@ -139,6 +141,15 @@ public class JsonWebToken implements Serializable, Token {
 
     public JsonWebToken issuer(String issuer) {
         this.issuer = issuer;
+        return this;
+    }
+
+    public String getRealm() {
+        return realm;
+    }
+
+    public JsonWebToken realm(String realm){
+        this.realm = realm;
         return this;
     }
 

--- a/core/src/main/java/org/keycloak/representations/idm/RealmRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/idm/RealmRepresentation.java
@@ -17,15 +17,16 @@
 
 package org.keycloak.representations.idm;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import org.keycloak.common.util.MultivaluedHashMap;
-
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import org.keycloak.common.util.MultivaluedHashMap;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -47,6 +48,8 @@ public class RealmRepresentation {
     protected Integer ssoSessionIdleTimeoutRememberMe;
     protected Integer ssoSessionMaxLifespanRememberMe;
     protected Integer offlineSessionIdleTimeout;
+    protected String issuerUrl;
+    protected Boolean realmUrlCheckDeactivated;
     // KEYCLOAK-7688 Offline Session Max for Offline Token
     protected Boolean offlineSessionMaxLifespanEnabled;
     protected Integer offlineSessionMaxLifespan;
@@ -334,6 +337,22 @@ public class RealmRepresentation {
 
     public void setOfflineSessionIdleTimeout(Integer offlineSessionIdleTimeout) {
         this.offlineSessionIdleTimeout = offlineSessionIdleTimeout;
+    }
+
+    public String getIssuerUrl() {
+        return issuerUrl;
+    }
+
+    public void setIssuerUrl(String issuerUrl) {
+        this.issuerUrl = issuerUrl;
+    }
+
+    public void setRealmUrlCheckDeactivated(Boolean realmUrlCheckDeactivated){
+        this.realmUrlCheckDeactivated = realmUrlCheckDeactivated;
+    }
+
+    public Boolean isRealmUrlCheckDeactivated(){
+        return realmUrlCheckDeactivated;
     }
 
     // KEYCLOAK-7688 Offline Session Max for Offline Token
@@ -1136,4 +1155,5 @@ public class RealmRepresentation {
     public Boolean isUserManagedAccessAllowed() {
         return userManagedAccessAllowed;
     }
+
 }

--- a/core/src/test/java/org/keycloak/RSAVerifierTest.java
+++ b/core/src/test/java/org/keycloak/RSAVerifierTest.java
@@ -94,6 +94,7 @@ public class RSAVerifierTest {
         token.type(TokenUtil.TOKEN_TYPE_BEARER)
                 .subject("CN=Client")
                 .issuer("http://localhost:8080/auth/realm")
+                .realm("http://localhost:8080/auth/realm")
                 .addAccess("service").addRole("admin");
     }
 
@@ -124,7 +125,7 @@ public class RSAVerifierTest {
     }
 
     private AccessToken verifySkeletonKeyToken(String encoded) throws VerificationException {
-        return RSATokenVerifier.verifyToken(encoded, idpPair.getPublic(), "http://localhost:8080/auth/realm");
+        return RSATokenVerifier.verifyToken(encoded, idpPair.getPublic(), "http://localhost:8080/auth/realm", "http://localhost:8080/auth/realm");
     }
 
 

--- a/core/src/test/java/org/keycloak/SkeletonKeyTokenTest.java
+++ b/core/src/test/java/org/keycloak/SkeletonKeyTokenTest.java
@@ -143,6 +143,7 @@ public class SkeletonKeyTokenTest {
         AccessToken token = new AccessToken();
         token.id("111");
         token.issuer("http://localhost:8080/auth/acme");
+        token.realm("http://localhost:8080/auth/acme");
         token.addAccess("foo").addRole("admin");
         token.addAccess("bar").addRole("user");
         return token;

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmAdapter.java
@@ -17,18 +17,39 @@
 
 package org.keycloak.models.cache.infinispan;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
 import org.keycloak.Config;
 import org.keycloak.common.enums.SslRequired;
 import org.keycloak.component.ComponentModel;
-import org.keycloak.models.*;
+import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.AuthenticationFlowModel;
+import org.keycloak.models.AuthenticatorConfigModel;
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.ClientScopeModel;
+import org.keycloak.models.GroupModel;
+import org.keycloak.models.IdentityProviderMapperModel;
+import org.keycloak.models.IdentityProviderModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.OTPPolicy;
+import org.keycloak.models.PasswordPolicy;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.RequiredActionProviderModel;
+import org.keycloak.models.RequiredCredentialModel;
+import org.keycloak.models.RoleModel;
+import org.keycloak.models.WebAuthnPolicy;
 import org.keycloak.models.cache.CachedRealmModel;
 import org.keycloak.models.cache.UserCache;
 import org.keycloak.models.cache.infinispan.entities.CachedRealm;
 import org.keycloak.storage.UserStorageProvider;
 import org.keycloak.storage.client.ClientStorageProvider;
-
-import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -368,6 +389,36 @@ public class RealmAdapter implements CachedRealmModel {
     public void setEditUsernameAllowed(boolean editUsernameAllowed) {
         getDelegateForUpdate();
         updated.setEditUsernameAllowed(editUsernameAllowed);
+    }
+
+    @Override
+    public String getIssuerUrl() {
+        if (isUpdated()) return updated.getIssuerUrl();
+        return cached.getIssuerUrl();
+    }
+
+    @Override
+    public void setIssuerUrl(String issuerUrl) {
+        getDelegateForUpdate();
+        updated.setIssuerUrl(issuerUrl);
+    }
+
+    @Override
+    public String getIssuerUrlOrDefault(String defaultValue) {
+        if (isUpdated()) return updated.getIssuerUrlOrDefault(defaultValue);
+        return cached.getIssuerUrlOrDefault(defaultValue);
+    }
+
+    @Override
+    public void setRealmUrlCheckDeactivated(Boolean realmUrlCheckDeactivated){
+        getDelegateForUpdate();
+        updated.setRealmUrlCheckDeactivated(realmUrlCheckDeactivated);
+    }
+
+    @Override
+    public Boolean isRealmUrlCheckDeactivated(){
+        if (isUpdated()) return updated.isRealmUrlCheckDeactivated();
+        return cached.isRealmUrlCheckDeactivated();
     }
 
     @Override

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/entities/CachedRealm.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/entities/CachedRealm.java
@@ -17,6 +17,15 @@
 
 package org.keycloak.models.cache.infinispan.entities;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import org.keycloak.common.enums.SslRequired;
 import org.keycloak.common.util.MultivaluedHashMap;
 import org.keycloak.component.ComponentModel;
@@ -34,15 +43,6 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.RequiredActionProviderModel;
 import org.keycloak.models.RequiredCredentialModel;
 import org.keycloak.models.WebAuthnPolicy;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -64,6 +64,8 @@ public class CachedRealm extends AbstractExtendableRevisioned {
     protected boolean resetPasswordAllowed;
     protected boolean identityFederationEnabled;
     protected boolean editUsernameAllowed;
+    protected String issuerUrl;
+    protected boolean realmUrlCheckDeactivated;
     //--- brute force settings
     protected boolean bruteForceProtected;
     protected boolean permanentLockout;
@@ -173,6 +175,8 @@ public class CachedRealm extends AbstractExtendableRevisioned {
         resetPasswordAllowed = model.isResetPasswordAllowed();
         identityFederationEnabled = model.isIdentityFederationEnabled();
         editUsernameAllowed = model.isEditUsernameAllowed();
+        issuerUrl = model.getIssuerUrl();
+        realmUrlCheckDeactivated = model.isRealmUrlCheckDeactivated();
         //--- brute force settings
         bruteForceProtected = model.isBruteForceProtected();
         permanentLockout = model.isPermanentLockout();
@@ -398,6 +402,25 @@ public class CachedRealm extends AbstractExtendableRevisioned {
 
     public boolean isEditUsernameAllowed() {
         return editUsernameAllowed;
+    }
+
+    public String getIssuerUrl(){
+        return issuerUrl;
+    }
+
+    public String getIssuerUrlOrDefault(String defaultValue) {
+        if(issuerUrl != null && !issuerUrl.isEmpty()){
+            return issuerUrl;
+        }
+        return defaultValue;
+    }
+
+    public void setRealmUrlCheckDeactivated(Boolean realmUrlCheckDeactivated){
+        this.realmUrlCheckDeactivated = realmUrlCheckDeactivated;
+    }
+
+    public Boolean isRealmUrlCheckDeactivated(){
+        return realmUrlCheckDeactivated;
     }
 
     public String getDefaultSignatureAlgorithm() {

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/RealmAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/RealmAdapter.java
@@ -17,25 +17,69 @@
 
 package org.keycloak.models.jpa;
 
+import static java.util.Objects.nonNull;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import javax.persistence.EntityManager;
+import javax.persistence.LockModeType;
+import javax.persistence.TypedQuery;
+
 import org.jboss.logging.Logger;
 import org.keycloak.common.enums.SslRequired;
 import org.keycloak.common.util.MultivaluedHashMap;
 import org.keycloak.component.ComponentFactory;
 import org.keycloak.component.ComponentModel;
-import org.keycloak.models.*;
-import org.keycloak.models.jpa.entities.*;
+import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.AuthenticationFlowModel;
+import org.keycloak.models.AuthenticatorConfigModel;
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.ClientScopeModel;
+import org.keycloak.models.Constants;
+import org.keycloak.models.GroupModel;
+import org.keycloak.models.IdentityProviderMapperModel;
+import org.keycloak.models.IdentityProviderModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.ModelException;
+import org.keycloak.models.OTPPolicy;
+import org.keycloak.models.PasswordPolicy;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.RequiredActionProviderModel;
+import org.keycloak.models.RequiredCredentialModel;
+import org.keycloak.models.RoleModel;
+import org.keycloak.models.WebAuthnPolicy;
+import org.keycloak.models.jpa.entities.AuthenticationExecutionEntity;
+import org.keycloak.models.jpa.entities.AuthenticationFlowEntity;
+import org.keycloak.models.jpa.entities.AuthenticatorConfigEntity;
+import org.keycloak.models.jpa.entities.ClientEntity;
+import org.keycloak.models.jpa.entities.ClientScopeEntity;
+import org.keycloak.models.jpa.entities.ComponentConfigEntity;
+import org.keycloak.models.jpa.entities.ComponentEntity;
+import org.keycloak.models.jpa.entities.DefaultClientScopeRealmMappingEntity;
+import org.keycloak.models.jpa.entities.GroupEntity;
+import org.keycloak.models.jpa.entities.IdentityProviderEntity;
+import org.keycloak.models.jpa.entities.IdentityProviderMapperEntity;
+import org.keycloak.models.jpa.entities.RealmAttributeEntity;
+import org.keycloak.models.jpa.entities.RealmAttributes;
+import org.keycloak.models.jpa.entities.RealmEntity;
+import org.keycloak.models.jpa.entities.RequiredActionProviderEntity;
+import org.keycloak.models.jpa.entities.RequiredCredentialEntity;
+import org.keycloak.models.jpa.entities.RoleEntity;
 import org.keycloak.models.utils.ComponentUtil;
 import org.keycloak.models.utils.KeycloakModelUtils;
-
-import javax.persistence.EntityManager;
-import javax.persistence.TypedQuery;
-
-import java.util.*;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
-
-import javax.persistence.LockModeType;
-import static java.util.Objects.nonNull;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -394,6 +438,35 @@ public class RealmAdapter implements RealmModel, JpaModel<RealmEntity> {
     public void setEditUsernameAllowed(boolean editUsernameAllowed) {
         realm.setEditUsernameAllowed(editUsernameAllowed);
         em.flush();
+    }
+
+    @Override
+    public String getIssuerUrl() {
+        return getAttribute(RealmAttributes.ISSUER_URL);
+    }
+
+    @Override
+    public void setIssuerUrl(String issuerUrl) {
+        setAttribute(RealmAttributes.ISSUER_URL, issuerUrl);
+    }
+
+    @Override
+    public String getIssuerUrlOrDefault(String defaultValue) {
+        String result = getIssuerUrl();
+        if(result != null && !result.isEmpty()) {
+            return result;
+        }
+        return defaultValue;
+    }
+
+    @Override
+    public void setRealmUrlCheckDeactivated(Boolean realmUrlCheckDeactivated){
+        setAttribute(RealmAttributes.IS_REALMURL_CHECK_DEACTIVATED, realmUrlCheckDeactivated);
+    }
+
+    @Override
+    public Boolean isRealmUrlCheckDeactivated(){
+        return getAttribute(RealmAttributes.IS_REALMURL_CHECK_DEACTIVATED, false);
     }
 
     @Override

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/RealmAttributes.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/RealmAttributes.java
@@ -47,4 +47,8 @@ public interface RealmAttributes {
     String WEBAUTHN_POLICY_AVOID_SAME_AUTHENTICATOR_REGISTER = "webAuthnPolicyAvoidSameAuthenticatorRegister";
     String WEBAUTHN_POLICY_ACCEPTABLE_AAGUIDS = "webAuthnPolicyAcceptableAaguids";
 
+    String ISSUER_URL = "issuerUrl";
+    
+    String IS_REALMURL_CHECK_DEACTIVATED = "IsRealmUrlCheckDeactivated";
+
 }

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
@@ -288,6 +288,8 @@ public class ModelToRepresentation {
         rep.setMaxDeltaTimeSeconds(realm.getMaxDeltaTimeSeconds());
         rep.setFailureFactor(realm.getFailureFactor());
         rep.setUserManagedAccessAllowed(realm.isUserManagedAccessAllowed());
+        rep.setIssuerUrl(realm.getIssuerUrl());
+        rep.setRealmUrlCheckDeactivated(realm.isRealmUrlCheckDeactivated());
 
         rep.setEventsEnabled(realm.isEventsEnabled());
         if (realm.getEventsExpiration() != 0) {

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
@@ -177,6 +177,8 @@ public class RepresentationToModel {
         if (rep.isAdminEventsEnabled() != null) newRealm.setAdminEventsEnabled(rep.isAdminEventsEnabled());
         if (rep.isAdminEventsDetailsEnabled() != null)
             newRealm.setAdminEventsDetailsEnabled(rep.isAdminEventsDetailsEnabled());
+        if(rep.getIssuerUrl() != null) newRealm.setIssuerUrl(rep.getIssuerUrl());
+        if(rep.isRealmUrlCheckDeactivated() != null) newRealm.setRealmUrlCheckDeactivated(rep.isRealmUrlCheckDeactivated());
 
         if (rep.getNotBefore() != null) newRealm.setNotBefore(rep.getNotBefore());
 
@@ -959,6 +961,8 @@ public class RepresentationToModel {
         if (rep.isDuplicateEmailsAllowed() != null) realm.setDuplicateEmailsAllowed(rep.isDuplicateEmailsAllowed());
         if (rep.isResetPasswordAllowed() != null) realm.setResetPasswordAllowed(rep.isResetPasswordAllowed());
         if (rep.isEditUsernameAllowed() != null) realm.setEditUsernameAllowed(rep.isEditUsernameAllowed());
+        if (rep.getIssuerUrl() != null) realm.setIssuerUrl(rep.getIssuerUrl());
+        if (rep.isRealmUrlCheckDeactivated() != null) realm.setRealmUrlCheckDeactivated(rep.isRealmUrlCheckDeactivated());
         if (rep.getSslRequired() != null) realm.setSslRequired(SslRequired.valueOf(rep.getSslRequired().toUpperCase()));
         if (rep.getAccessCodeLifespan() != null) realm.setAccessCodeLifespan(rep.getAccessCodeLifespan());
         if (rep.getAccessCodeLifespanUserAction() != null)

--- a/server-spi/src/main/java/org/keycloak/models/RealmModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/RealmModel.java
@@ -17,6 +17,12 @@
 
 package org.keycloak.models;
 
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import org.keycloak.common.enums.SslRequired;
 import org.keycloak.component.ComponentModel;
 import org.keycloak.provider.ProviderEvent;
@@ -24,8 +30,6 @@ import org.keycloak.storage.UserStorageProvider;
 import org.keycloak.storage.UserStorageProviderModel;
 import org.keycloak.storage.client.ClientStorageProvider;
 import org.keycloak.storage.client.ClientStorageProviderModel;
-
-import java.util.*;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -109,6 +113,16 @@ public interface RealmModel extends RoleContainerModel {
     void setRememberMe(boolean rememberMe);
 
     boolean isEditUsernameAllowed();
+
+    String getIssuerUrl();
+
+    void setIssuerUrl(String issuerUrl);
+
+    String getIssuerUrlOrDefault(String defaultValue);
+
+    void setRealmUrlCheckDeactivated(Boolean isRealmUrlCheckDeactivated);
+
+    Boolean isRealmUrlCheckDeactivated();
 
     void setEditUsernameAllowed(boolean editUsernameAllowed);
 

--- a/services/src/main/java/org/keycloak/authentication/actiontoken/ActionTokenContext.java
+++ b/services/src/main/java/org/keycloak/authentication/actiontoken/ActionTokenContext.java
@@ -122,7 +122,9 @@ public class ActionTokenContext<T extends JsonWebToken> {
         authSession.setRedirectUri(redirectUri);
         authSession.setClientNote(OIDCLoginProtocol.REDIRECT_URI_PARAM, redirectUri);
         authSession.setClientNote(OIDCLoginProtocol.RESPONSE_TYPE_PARAM, OAuth2Constants.CODE);
-        authSession.setClientNote(OIDCLoginProtocol.ISSUER, Urls.realmIssuer(uriInfo.getBaseUri(), realm.getName()));
+        String realmUrl = Urls.realmIssuer(uriInfo.getBaseUri(), realm.getName());
+        authSession.setClientNote(OIDCLoginProtocol.REALM, realmUrl);
+        authSession.setClientNote(OIDCLoginProtocol.ISSUER, realm.getIssuerUrlOrDefault(realmUrl));
 
         return authSession;
     }

--- a/services/src/main/java/org/keycloak/authentication/actiontoken/DefaultActionToken.java
+++ b/services/src/main/java/org/keycloak/authentication/actiontoken/DefaultActionToken.java
@@ -149,7 +149,7 @@ public class DefaultActionToken extends DefaultActionTokenKey implements ActionT
     }
 
     private static String getIssuer(RealmModel realm, UriInfo uri) {
-        return Urls.realmIssuer(uri.getBaseUri(), realm.getName());
+        return realm.getIssuerUrlOrDefault(Urls.realmIssuer(uri.getBaseUri(), realm.getName()));
     }
 
 }

--- a/services/src/main/java/org/keycloak/authentication/authenticators/client/JWTClientAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/client/JWTClientAuthenticator.java
@@ -141,10 +141,10 @@ public class JWTClientAuthenticator extends AbstractClientAuthenticator {
             }
 
             // Allow both "issuer" or "token-endpoint" as audience
-            String issuerUrl = Urls.realmIssuer(context.getUriInfo().getBaseUri(), realm.getName());
+            String realmUrl = Urls.realmIssuer(context.getUriInfo().getBaseUri(), realm.getName());
             String tokenUrl = OIDCLoginProtocolService.tokenUrl(context.getUriInfo().getBaseUriBuilder()).build(realm.getName()).toString();
-            if (!token.hasAudience(issuerUrl) && !token.hasAudience(tokenUrl)) {
-                throw new RuntimeException("Token audience doesn't match domain. Realm issuer is '" + issuerUrl + "' but audience from token is '" + Arrays.asList(token.getAudience()).toString() + "'");
+            if (!token.hasAudience(realmUrl) && !token.hasAudience(tokenUrl)) {
+                throw new RuntimeException("Token audience doesn't match domain. Realm issuer is '" + realmUrl + "' but audience from token is '" + Arrays.asList(token.getAudience()).toString() + "'");
             }
 
             if (!token.isActive()) {

--- a/services/src/main/java/org/keycloak/authentication/authenticators/client/JWTClientSecretAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/client/JWTClientSecretAuthenticator.java
@@ -130,10 +130,10 @@ public class JWTClientSecretAuthenticator extends AbstractClientAuthenticator {
             // JWT contents and verification in client_secret_jwt is the same as in private_key_jwt
             
             // Allow both "issuer" or "token-endpoint" as audience
-            String issuerUrl = Urls.realmIssuer(context.getUriInfo().getBaseUri(), realm.getName());
+            String realmUrl = Urls.realmIssuer(context.getUriInfo().getBaseUri(), realm.getName());
             String tokenUrl = OIDCLoginProtocolService.tokenUrl(context.getUriInfo().getBaseUriBuilder()).build(realm.getName()).toString();
-            if (!token.hasAudience(issuerUrl) && !token.hasAudience(tokenUrl)) {
-                throw new RuntimeException("Token audience doesn't match domain. Realm issuer is '" + issuerUrl + "' but audience from token is '" + Arrays.asList(token.getAudience()).toString() + "'");
+            if (!token.hasAudience(realmUrl) && !token.hasAudience(tokenUrl)) {
+                throw new RuntimeException("Token audience doesn't match domain. Realm issuer is '" + realmUrl + "' but audience from token is '" + Arrays.asList(token.getAudience()).toString() + "'");
             }
 
             if (!token.isActive()) {

--- a/services/src/main/java/org/keycloak/authorization/admin/PolicyEvaluationService.java
+++ b/services/src/main/java/org/keycloak/authorization/admin/PolicyEvaluationService.java
@@ -283,7 +283,9 @@ public class PolicyEvaluationService {
 
             accessToken.issuedFor(client.getClientId());
             accessToken.audience(client.getId());
-            accessToken.issuer(Urls.realmIssuer(keycloakSession.getContext().getUri().getBaseUri(), realm.getName()));
+            String realmUrl = Urls.realmIssuer(keycloakSession.getContext().getUri().getBaseUri(), realm.getName());
+            accessToken.realm(realmUrl);
+            accessToken.issuer(realm.getIssuerUrlOrDefault(realmUrl));
             accessToken.setRealmAccess(new AccessToken.Access());
 
         }

--- a/services/src/main/java/org/keycloak/authorization/authorization/AuthorizationTokenService.java
+++ b/services/src/main/java/org/keycloak/authorization/authorization/AuthorizationTokenService.java
@@ -292,7 +292,9 @@ public class AuthorizationTokenService {
 
             authSession.setAuthenticatedUser(userSessionModel.getUser());
             authSession.setProtocol(OIDCLoginProtocol.LOGIN_PROTOCOL);
-            authSession.setClientNote(OIDCLoginProtocol.ISSUER, Urls.realmIssuer(keycloakSession.getContext().getUri().getBaseUri(), realm.getName()));
+            String realmUrl = Urls.realmIssuer(keycloakSession.getContext().getUri().getBaseUri(), realm.getName());
+            authSession.setClientNote(OIDCLoginProtocol.REALM, realmUrl);
+            authSession.setClientNote(OIDCLoginProtocol.ISSUER, realm.getIssuerUrlOrDefault(realmUrl));
 
             AuthenticationManager.setClientScopesInSession(authSession);
             clientSessionCtx = TokenManager.attachAuthenticationSession(keycloakSession, userSessionModel, authSession);

--- a/services/src/main/java/org/keycloak/forms/account/freemarker/model/RealmBean.java
+++ b/services/src/main/java/org/keycloak/forms/account/freemarker/model/RealmBean.java
@@ -72,4 +72,9 @@ public class RealmBean {
     public boolean isUserManagedAccessAllowed() {
         return realm.isUserManagedAccessAllowed();
     }
+
+    public String getIssuerUrl() {
+        return realm.getIssuerUrl();
+    }
+
 }

--- a/services/src/main/java/org/keycloak/forms/login/freemarker/model/RealmBean.java
+++ b/services/src/main/java/org/keycloak/forms/login/freemarker/model/RealmBean.java
@@ -94,4 +94,8 @@ public class RealmBean {
         return false;
     }
 
+    public String issuerUrl() {
+        return realm.getIssuerUrl();
+    }
+
 }

--- a/services/src/main/java/org/keycloak/protocol/docker/DockerAuthV2Protocol.java
+++ b/services/src/main/java/org/keycloak/protocol/docker/DockerAuthV2Protocol.java
@@ -42,6 +42,7 @@ public class DockerAuthV2Protocol implements LoginProtocol {
     public static final String SERVICE_PARAM = "service";
     public static final String SCOPE_PARAM = "scope";
     public static final String ISSUER = "docker.iss"; // don't want to overlap with OIDC notes
+    public static final String REALM = "docker.realm";
     public static final String ISO_8601_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss'Z'";
 
     private KeycloakSession session;

--- a/services/src/main/java/org/keycloak/protocol/docker/DockerEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/docker/DockerEndpoint.java
@@ -83,7 +83,9 @@ public class DockerEndpoint extends AuthorizationEndpointBase {
         authenticationSession.setClientNote(DockerAuthV2Protocol.ACCOUNT_PARAM, account);
         authenticationSession.setClientNote(DockerAuthV2Protocol.SERVICE_PARAM, service);
         authenticationSession.setClientNote(DockerAuthV2Protocol.SCOPE_PARAM, scope);
-        authenticationSession.setClientNote(DockerAuthV2Protocol.ISSUER, Urls.realmIssuer(session.getContext().getUri().getBaseUri(), realm.getName()));
+        String realmUrl = Urls.realmIssuer(session.getContext().getUri().getBaseUri(), realm.getName());
+        authenticationSession.setClientNote(DockerAuthV2Protocol.REALM, realmUrl);
+        authenticationSession.setClientNote(DockerAuthV2Protocol.ISSUER, realm.getIssuerUrlOrDefault(realmUrl));
 
     }
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/AccessTokenIntrospectionProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/AccessTokenIntrospectionProvider.java
@@ -17,7 +17,13 @@
  */
 package org.keycloak.protocol.oidc;
 
+import java.io.IOException;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
 import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import org.keycloak.OAuthErrorException;
 import org.keycloak.TokenVerifier;
 import org.keycloak.common.VerificationException;
@@ -28,10 +34,6 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.services.Urls;
 import org.keycloak.util.JsonSerialization;
-
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import java.io.IOException;
 
 /**
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
@@ -71,10 +73,14 @@ public class AccessTokenIntrospectionProvider implements TokenIntrospectionProvi
 
     protected AccessToken verifyAccessToken(String token) throws OAuthErrorException, IOException {
         AccessToken accessToken;
+        String realmUrl = Urls.realmIssuer(session.getContext().getUri().getBaseUri(), realm.getName());
+        String issuerUrl = realm.getIssuerUrlOrDefault(realmUrl);
 
         try {
             TokenVerifier<AccessToken> verifier = TokenVerifier.create(token, AccessToken.class)
-                    .realmUrl(Urls.realmIssuer(session.getContext().getUri().getBaseUri(), realm.getName()));
+                    .realmUrl(realmUrl)
+                    .issuerUrl(issuerUrl)
+                    .checkRealmUrl(realmUrl.equals(issuerUrl) || !realm.isRealmUrlCheckDeactivated());
 
             SignatureVerifierContext verifierContext = session.getProvider(SignatureProvider.class, verifier.getHeader().getAlgorithm().name()).verifier(verifier.getHeader().getKeyId());
             verifier.verifierContext(verifierContext);

--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocol.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocol.java
@@ -85,6 +85,7 @@ public class OIDCLoginProtocol implements LoginProtocol {
 
     public static final String LOGOUT_REDIRECT_URI = "OIDC_LOGOUT_REDIRECT_URI";
     public static final String ISSUER = "iss";
+    public static final String REALM = "realm";
 
     public static final String RESPONSE_MODE_PARAM = "response_mode";
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCWellKnownProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCWellKnownProvider.java
@@ -81,7 +81,9 @@ public class OIDCWellKnownProvider implements WellKnownProvider {
         UriBuilder uriBuilder = RealmsResource.protocolUrl(uriInfo);
 
         OIDCConfigurationRepresentation config = new OIDCConfigurationRepresentation();
-        config.setIssuer(Urls.realmIssuer(uriInfo.getBaseUri(), realm.getName()));
+        String realmUrl = Urls.realmIssuer(uriInfo.getBaseUri(), realm.getName());
+        config.setRealm(realmUrl);
+        config.setIssuer(realm.getIssuerUrlOrDefault(realmUrl));
         config.setAuthorizationEndpoint(uriBuilder.clone().path(OIDCLoginProtocolService.class, "auth").build(realm.getName(), OIDCLoginProtocol.LOGIN_PROTOCOL).toString());
         config.setTokenEndpoint(uriBuilder.clone().path(OIDCLoginProtocolService.class, "token").build(realm.getName(), OIDCLoginProtocol.LOGIN_PROTOCOL).toString());
         config.setTokenIntrospectionEndpoint(uriBuilder.clone().path(OIDCLoginProtocolService.class, "token").path(TokenEndpoint.class, "introspect").build(realm.getName(), OIDCLoginProtocol.LOGIN_PROTOCOL).toString());

--- a/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
@@ -596,6 +596,7 @@ public class TokenManager {
 
         AuthenticatedClientSessionModel clientSession = clientSessionCtx.getClientSession();
         token.issuer(clientSession.getNote(OIDCLoginProtocol.ISSUER));
+        token.realm(clientSession.getNote(OIDCLoginProtocol.REALM));
         token.setNonce(clientSessionCtx.getAttribute(OIDCLoginProtocol.NONCE_PARAM, String.class));
         token.setScope(clientSessionCtx.getScopeString());
 
@@ -759,6 +760,8 @@ public class TokenManager {
             idToken.issuedNow();
             idToken.issuedFor(accessToken.getIssuedFor());
             idToken.issuer(accessToken.getIssuer());
+            // NOTE(angelinsky7): added to pass the realm
+            idToken.realm(accessToken.getRealm());
             idToken.setNonce(accessToken.getNonce());
             idToken.setAuthTime(accessToken.getAuthTime());
             idToken.setSessionState(accessToken.getSessionState());

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpoint.java
@@ -423,7 +423,9 @@ public class AuthorizationEndpoint extends AuthorizationEndpointBase {
         authenticationSession.setAction(AuthenticationSessionModel.Action.AUTHENTICATE.name());
         authenticationSession.setClientNote(OIDCLoginProtocol.RESPONSE_TYPE_PARAM, request.getResponseType());
         authenticationSession.setClientNote(OIDCLoginProtocol.REDIRECT_URI_PARAM, request.getRedirectUriParam());
-        authenticationSession.setClientNote(OIDCLoginProtocol.ISSUER, Urls.realmIssuer(session.getContext().getUri().getBaseUri(), realm.getName()));
+        String realmUrl = Urls.realmIssuer(session.getContext().getUri().getBaseUri(), realm.getName());
+        authenticationSession.setClientNote(OIDCLoginProtocol.REALM, realmUrl);
+        authenticationSession.setClientNote(OIDCLoginProtocol.ISSUER, realm.getIssuerUrlOrDefault(realmUrl));
 
         if (request.getState() != null) authenticationSession.setClientNote(OIDCLoginProtocol.STATE_PARAM, request.getState());
         if (request.getNonce() != null) authenticationSession.setClientNote(OIDCLoginProtocol.NONCE_PARAM, request.getNonce());

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
@@ -572,7 +572,9 @@ public class TokenEndpoint {
 
         authSession.setProtocol(OIDCLoginProtocol.LOGIN_PROTOCOL);
         authSession.setAction(AuthenticatedClientSessionModel.Action.AUTHENTICATE.name());
-        authSession.setClientNote(OIDCLoginProtocol.ISSUER, Urls.realmIssuer(session.getContext().getUri().getBaseUri(), realm.getName()));
+        String realmUrl = Urls.realmIssuer(session.getContext().getUri().getBaseUri(), realm.getName());
+        authSession.setClientNote(OIDCLoginProtocol.REALM, realmUrl);
+        authSession.setClientNote(OIDCLoginProtocol.ISSUER, realm.getIssuerUrlOrDefault(realmUrl));
         authSession.setClientNote(OIDCLoginProtocol.SCOPE_PARAM, scope);
 
         AuthenticationFlowModel flow = AuthenticationFlowResolver.resolveDirectGrantFlow(authSession);
@@ -662,7 +664,9 @@ public class TokenEndpoint {
 
         authSession.setAuthenticatedUser(clientUser);
         authSession.setProtocol(OIDCLoginProtocol.LOGIN_PROTOCOL);
-        authSession.setClientNote(OIDCLoginProtocol.ISSUER, Urls.realmIssuer(session.getContext().getUri().getBaseUri(), realm.getName()));
+        String realmUrl = Urls.realmIssuer(session.getContext().getUri().getBaseUri(), realm.getName());
+        authSession.setClientNote(OIDCLoginProtocol.REALM, realmUrl);
+        authSession.setClientNote(OIDCLoginProtocol.ISSUER, realm.getIssuerUrlOrDefault(realmUrl));
         authSession.setClientNote(OIDCLoginProtocol.SCOPE_PARAM, scope);
 
         UserSessionModel userSession = session.sessions().createUserSession(authSession.getParentSession().getId(), realm, clientUser, clientUsername,
@@ -885,7 +889,9 @@ public class TokenEndpoint {
 
         authSession.setAuthenticatedUser(targetUser);
         authSession.setProtocol(OIDCLoginProtocol.LOGIN_PROTOCOL);
-        authSession.setClientNote(OIDCLoginProtocol.ISSUER, Urls.realmIssuer(session.getContext().getUri().getBaseUri(), realm.getName()));
+        String realmUrl = Urls.realmIssuer(session.getContext().getUri().getBaseUri(), realm.getName());
+        authSession.setClientNote(OIDCLoginProtocol.REALM, realmUrl);
+        authSession.setClientNote(OIDCLoginProtocol.ISSUER, realm.getIssuerUrlOrDefault(realmUrl));
         authSession.setClientNote(OIDCLoginProtocol.SCOPE_PARAM, scope);
 
         event.session(targetUserSession);

--- a/services/src/main/java/org/keycloak/protocol/oidc/representations/OIDCConfigurationRepresentation.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/representations/OIDCConfigurationRepresentation.java
@@ -34,6 +34,9 @@ public class OIDCConfigurationRepresentation {
     @JsonProperty("issuer")
     private String issuer;
 
+    @JsonProperty("realm")
+    private String realm;
+
     @JsonProperty("authorization_endpoint")
     private String authorizationEndpoint;
 
@@ -130,6 +133,14 @@ public class OIDCConfigurationRepresentation {
 
     public void setIssuer(String issuer) {
         this.issuer = issuer;
+    }
+
+    public String getRealm(){
+        return realm;
+    }
+
+    public void setRealm(String realm){
+        this.realm = realm;
     }
 
     public String getAuthorizationEndpoint() {

--- a/services/src/main/java/org/keycloak/protocol/openshift/OpenShiftTokenReviewEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/openshift/OpenShiftTokenReviewEndpoint.java
@@ -92,6 +92,8 @@ public class OpenShiftTokenReviewEndpoint implements OIDCExtProvider, Environmen
 
         AccessToken token = null;
         try {
+            //TODO(angelinsky7): not the issuer url but the realm url
+            //TODO(angelinsky7): for now i don't know what to do...
             TokenVerifier<AccessToken> verifier = TokenVerifier.create(reviewRequest.getSpec().getToken(), AccessToken.class)
                     .realmUrl(Urls.realmIssuer(session.getContext().getUri().getBaseUri(), realm.getName()));
 

--- a/services/src/main/java/org/keycloak/services/clientregistration/ClientRegistrationTokenUtils.java
+++ b/services/src/main/java/org/keycloak/services/clientregistration/ClientRegistrationTokenUtils.java
@@ -131,7 +131,7 @@ public class ClientRegistrationTokenUtils {
     }
 
     private static String getIssuer(KeycloakSession session, RealmModel realm) {
-        return Urls.realmIssuer(session.getContext().getUri().getBaseUri(), realm.getName());
+        return realm.getIssuerUrlOrDefault(Urls.realmIssuer(session.getContext().getUri().getBaseUri(), realm.getName()));
     }
 
     protected static class TokenVerification {

--- a/services/src/main/java/org/keycloak/services/resources/LoginActionsService.java
+++ b/services/src/main/java/org/keycloak/services/resources/LoginActionsService.java
@@ -392,7 +392,9 @@ public class LoginActionsService {
         authSession.setRedirectUri(redirectUri);
         authSession.setClientNote(OIDCLoginProtocol.RESPONSE_TYPE_PARAM, OAuth2Constants.CODE);
         authSession.setClientNote(OIDCLoginProtocol.REDIRECT_URI_PARAM, redirectUri);
-        authSession.setClientNote(OIDCLoginProtocol.ISSUER, Urls.realmIssuer(session.getContext().getUri().getBaseUri(), realm.getName()));
+        String realmUrl = Urls.realmIssuer(session.getContext().getUri().getBaseUri(), realm.getName());
+        authSession.setClientNote(OIDCLoginProtocol.REALM, realmUrl);
+        authSession.setClientNote(OIDCLoginProtocol.ISSUER, realm.getIssuerUrlOrDefault(realmUrl));
 
         return authSession;
     }
@@ -483,6 +485,8 @@ public class LoginActionsService {
                 throw new ExplainedTokenVerificationException(aToken, Errors.SSL_REQUIRED, Messages.HTTPS_REQUIRED);
             }
 
+            //TODO(angelinsky7): not the issuer url but the realm url
+            //TODO(angelinsky7): for now i don't know what to do...
             TokenVerifier<DefaultActionTokenKey> verifier = tokenVerifier
                     .withChecks(
                             // Token introspection checks

--- a/services/src/main/java/org/keycloak/services/resources/admin/AdminRoot.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/AdminRoot.java
@@ -16,12 +16,26 @@
  */
 package org.keycloak.services.resources.admin;
 
+import java.io.IOException;
+import java.util.Locale;
+import java.util.Properties;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.NotAuthorizedException;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriInfo;
+
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.spi.HttpRequest;
 import org.jboss.resteasy.spi.HttpResponse;
-import javax.ws.rs.NotFoundException;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
-import javax.ws.rs.NotAuthorizedException;
 import org.keycloak.common.ClientConnection;
 import org.keycloak.jose.jws.JWSInput;
 import org.keycloak.jose.jws.JWSInputException;
@@ -38,19 +52,6 @@ import org.keycloak.services.resources.Cors;
 import org.keycloak.services.resources.admin.info.ServerInfoAdminResource;
 import org.keycloak.services.resources.admin.permissions.AdminPermissions;
 import org.keycloak.theme.Theme;
-
-import javax.ws.rs.GET;
-import javax.ws.rs.HttpMethod;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriBuilder;
-import javax.ws.rs.core.UriInfo;
-import java.io.IOException;
-import java.util.Locale;
-import java.util.Properties;
 
 /**
  * Root resource for admin console and admin REST API
@@ -161,7 +162,7 @@ public class AdminRoot {
         } catch (JWSInputException e) {
             throw new NotAuthorizedException("Bearer token format error");
         }
-        String realmName = token.getIssuer().substring(token.getIssuer().lastIndexOf('/') + 1);
+        String realmName = token.getRealm().substring(token.getRealm().lastIndexOf('/') + 1);
         RealmManager realmManager = new RealmManager(session);
         RealmModel realm = realmManager.getRealmByName(realmName);
         if (realm == null) {

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientScopeEvaluateResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientScopeEvaluateResource.java
@@ -191,7 +191,9 @@ public class ClientScopeEvaluateResource {
 
             authSession.setAuthenticatedUser(user);
             authSession.setProtocol(OIDCLoginProtocol.LOGIN_PROTOCOL);
-            authSession.setClientNote(OIDCLoginProtocol.ISSUER, Urls.realmIssuer(uriInfo.getBaseUri(), realm.getName()));
+            String realmUrl = Urls.realmIssuer(uriInfo.getBaseUri(), realm.getName());
+            authSession.setClientNote(OIDCLoginProtocol.REALM,realmUrl);
+            authSession.setClientNote(OIDCLoginProtocol.ISSUER, realm.getIssuerUrlOrDefault(realmUrl));
             authSession.setClientNote(OIDCLoginProtocol.SCOPE_PARAM, scopeParam);
 
             userSession = session.sessions().createUserSession(authSession.getParentSession().getId(), realm, user, user.getUsername(),

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/OIDCPairwiseClientRegistrationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/OIDCPairwiseClientRegistrationTest.java
@@ -391,6 +391,9 @@ public class OIDCPairwiseClientRegistrationTest extends AbstractClientRegistrati
         // its iss Claim Value MUST be the same as in the ID Token issued when the original authentication occurred
         Assert.assertEquals(idToken.getIssuer(), refreshedRefreshToken.getIssuer());
 
+        // NOTE(angelinsky7): no need to store realm name in issuer anymore
+        Assert.assertEquals(idToken.getRealm(), refreshedRefreshToken.getRealm());
+
         // its sub Claim Value MUST be the same as in the ID Token issued when the original authentication occurred
         Assert.assertEquals(idToken.getSubject(), refreshedRefreshToken.getSubject());
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/url/FixedHostnameTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/url/FixedHostnameTest.java
@@ -144,7 +144,8 @@ public class FixedHostnameTest extends AbstractKeycloakTest {
 
         ClientInitialAccessPresentation initialAccess = testAdminClient.realm(realm).clientInitialAccess().create(rep);
         JsonWebToken token = new JWSInput(initialAccess.getToken()).readJsonContent(JsonWebToken.class);
-        assertEquals(expectedBaseUrl + "/auth/realms/" + realm, token.getIssuer());
+        // NOTE(angelinsky7): no need to store realm name in issuer anymore
+        assertEquals(expectedBaseUrl + "/auth/realms/" + realm, token.getRealm());
 
         ClientRegistration clientReg = ClientRegistration.create().url(authServerUrl, realm).build();
         clientReg.auth(Auth.token(initialAccess.getToken()));
@@ -155,7 +156,8 @@ public class FixedHostnameTest extends AbstractKeycloakTest {
 
         String registrationAccessToken = response.getRegistrationAccessToken();
         JsonWebToken registrationToken = new JWSInput(registrationAccessToken).readJsonContent(JsonWebToken.class);
-        assertEquals(expectedBaseUrl + "/auth/realms/" + realm, registrationToken.getIssuer());
+        // NOTE(angelinsky7): no need to store realm name in issuer anymore
+        assertEquals(expectedBaseUrl + "/auth/realms/" + realm, registrationToken.getRealm());
     }
 
     private void assertTokenIssuer(String realm, String expectedBaseUrl) throws Exception {
@@ -164,13 +166,15 @@ public class FixedHostnameTest extends AbstractKeycloakTest {
         OAuthClient.AccessTokenResponse tokenResponse = oauth.doGrantAccessTokenRequest("password", "test-user@localhost", "password");
 
         AccessToken token = new JWSInput(tokenResponse.getAccessToken()).readJsonContent(AccessToken.class);
-        assertEquals(expectedBaseUrl + "/auth/realms/" + realm, token.getIssuer());
+        // NOTE(angelinsky7): no need to store realm name in issuer anymore
+        assertEquals(expectedBaseUrl + "/auth/realms/" + realm, token.getRealm());
 
         String introspection = oauth.introspectAccessTokenWithClientCredential(oauth.getClientId(), "password", tokenResponse.getAccessToken());
         ObjectMapper objectMapper = new ObjectMapper();
         JsonNode introspectionNode = objectMapper.readTree(introspection);
         assertTrue(introspectionNode.get("active").asBoolean());
-        assertEquals(expectedBaseUrl + "/auth/realms/" + realm, introspectionNode.get("iss").asText());
+        // NOTE(angelinsky7): no need to store realm name in issuer anymore
+        assertEquals(expectedBaseUrl + "/auth/realms/" + realm, introspectionNode.get("realm").asText());
     }
 
     private void assertWellKnown(String realm, String expectedBaseUrl) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/util/AssertAdminEvents.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/util/AssertAdminEvents.java
@@ -277,7 +277,9 @@ public class AssertAdminEvents implements TestRule {
             AccessToken token = input.readJsonContent(AccessToken.class);
 
             AuthDetailsRepresentation authDetails = new AuthDetailsRepresentation();
-            String realmId = token.getIssuer().substring(token.getIssuer().lastIndexOf('/') + 1);
+            // NOTE(angelinsky7): New assumption that the realm contains realm name
+            // String realmId = token.getIssuer().substring(token.getIssuer().lastIndexOf('/') + 1);
+            String realmId = token.getRealm().substring(token.getRealm().lastIndexOf('/') + 1);
             authDetails.setRealmId(realmId);
             authDetails.setUserId(token.getSubject());
             return authDetails;

--- a/testsuite/utils/src/main/java/org/keycloak/testsuite/KeycloakServer.java
+++ b/testsuite/utils/src/main/java/org/keycloak/testsuite/KeycloakServer.java
@@ -72,7 +72,7 @@ public class KeycloakServer {
     private boolean sysout = false;
 
     public static class KeycloakServerConfig {
-        private String host = "localhost";
+        private String host = "0.0.0.0";
         private int port = 8081;
         private int portHttps = -1;
         private int workerThreads = Math.max(Runtime.getRuntime().availableProcessors(), 2) * 8;

--- a/themes/src/main/resources-community/theme/base/admin/messages/admin-messages_fr.properties
+++ b/themes/src/main/resources-community/theme/base/admin/messages/admin-messages_fr.properties
@@ -5,6 +5,8 @@ enabled=Actif
 name=Nom
 displayName=Display name
 displayNameHtml=HTML Display name
+issuerUrl=Issuer URI
+realmUrlCheckDeactivated=Désactive la vérification de l''url du realm
 save=Sauver
 cancel=Annuler
 onText=Oui
@@ -31,6 +33,8 @@ endpoints=Endpoints
 
 # Realm settings
 realm-detail.enabled.tooltip=Les utilisateurs et les clients peuvent acc\u00e9der au domaine si celui-ci est actif
+realm-detail.issuerUrl.tooltip=Force la valeur de l''Issuer. Si cette valeur est vide, l''Issuer sera générée automatiquement avec l''adresse du realm (comportement par défaut) 
+realm-detail.realmUrlCheckDeactivated.tooltip=Si la valeur de l''Issueur est forcée, est-ce que la vérification de l''url du realm peut être désactivée.
 realm-detail.oidc-endpoints.tooltip=Affiche les configurations de l''endpoint OpenID Connect
 registrationAllowed=Enregistrement d''utilisateur
 registrationAllowed.tooltip=Activer/d\u00e9sactiver la page d''enregistrement. Un lien pour l''enregistrement sera visible sur la page de connexion.

--- a/themes/src/main/resources/theme/base/admin/messages/admin-messages_en.properties
+++ b/themes/src/main/resources/theme/base/admin/messages/admin-messages_en.properties
@@ -7,6 +7,8 @@ link-only-column=Link only
 name=Name
 displayName=Display name
 displayNameHtml=HTML Display name
+issuerUrl=Issuer URI
+realmUrlCheckDeactivated=Deactivate the realm url check
 save=Save
 cancel=Cancel
 next=Next
@@ -23,7 +25,9 @@ false=False
 endpoints=Endpoints
 
 # Realm settings
-realm-detail.enabled.tooltip=Users and clients can only access a realm if it's enabled
+realm-detail.enabled.tooltip=Users and clients can only access a realm if it''s enabled
+realm-detail.issuerUrl.tooltip=Force the Issuer value. If this field is empty, the Issuer will be automatically generated with the realm address (default behavior).
+realm-detail.realmUrlCheckDeactivated.tooltip=If the issuer value is forced, is the realm url check deactivated.
 realm-detail.protocol-endpoints.tooltip=Shows the configuration of the protocol endpoints
 realm-detail.protocol-endpoints.oidc=OpenID Endpoint Configuration
 realm-detail.protocol-endpoints.saml=SAML 2.0 Identity Provider Metadata

--- a/themes/src/main/resources/theme/base/admin/resources/partials/realm-detail.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/realm-detail.html
@@ -58,6 +58,22 @@
             </div>
 
             <div class="form-group">
+                <label class="col-md-2 control-label" for="issuerUrl">{{:: 'issuerUrl' | translate}}</label> 
+                <div class="col-md-6">
+                    <input class="form-control" type="text" id="issuerUrl" name="issuerUrl" data-ng-model="realm.issuerUrl">
+                </div>
+                <kc-tooltip>{{:: 'realm-detail.issuerUrl.tooltip' | translate}}</kc-tooltip>
+            </div>
+
+            <div class="form-group">
+                <label class="col-md-2 control-label" for="realmUrlCheckDeactivated">{{:: 'realmUrlCheckDeactivated' | translate}}</label>
+                <div class="col-md-6">
+                    <input ng-model="realm.realmUrlCheckDeactivated" name="realmUrlCheckDeactivated" id="realmUrlCheckDeactivated" ng-disabled="!(realm.issuerUrl != null && realm.issuerUrl.length > 0)" onoffswitch on-text="{{:: 'onText' | translate}}" off-text="{{:: 'offText' | translate}}" />
+                </div>
+                <kc-tooltip>{{:: 'realm-detail.realmUrlCheckDeactivated.tooltip' | translate}}</kc-tooltip>
+            </div>
+
+            <div class="form-group">
                 <div class="col-md-10 col-md-offset-2" data-ng-show="createRealm && access.manageRealm">
                     <button kc-save data-ng-show="changed">{{:: 'save' | translate}}</button>
                     <button kc-cancel data-ng-click="cancel()">{{:: 'cancel' | translate}}</button>


### PR DESCRIPTION


I would like to have the possibility to customize the Issuer (iss field) URI the way i want.
Like that, i could use keycloak with a different frontchannel and backchannel URL. (https/http also) without having to use a complex configuration workaround (the redirection trick for example).

Keycloak issue : https://issues.jboss.org/browse/KEYCLOAK-11775
Proposition :

    Add a custom field in the admin to let the user choose the hard value of the iss field, if the field is empty, the current behavior is used, if the field is set the value of the field is directly used.
    Add a checkbox field to let the user decide if the token should check if the realm URL match (like that we can have the same iss uri and a different realm url)

Price to pay (yes always): Because keycloak need to know in what realm the token is, we need to add a "realm" field in the token, that is the current value of the iss field. (in fact the iss field is actually used for 2 different thing now :

    Storing the Isssuer URI (use to know if the token was correctly issued by this instance of keycloak
    Storing the Realm that was used (like that keycloak can get it from his internal store, parsing the url to get the realm name...)

Because this kind of change is sensible, i've made a patch file for the 7.0.0, a pull request for the master and a docker image based on the 7.0.0 that anyone could use to test if it solve their issue with the frontchannel/backchannel url difference and the https/http issue.

docker : docker pull angelinsky7/keycloak:7.0.0-custom_iss

For me it's working... without anything else.

