### PR TITLE
KEYCLOAK-11325 - Quarkus distribution

### DIFF
--- a/distribution/server-x/assembly.xml
+++ b/distribution/server-x/assembly.xml
@@ -1,0 +1,94 @@
+<!--
+  ~ Copyright 2016 Red Hat, Inc. and/or its affiliates
+  ~ and other contributors as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<assembly>
+    <id>server-dist</id>
+
+    <formats>
+        <format>zip</format>
+        <format>tar.gz</format>
+    </formats>
+
+    <includeBaseDirectory>true</includeBaseDirectory>
+
+    <fileSets>
+        <fileSet>
+            <directory>target/${project.build.finalName}</directory>
+            <outputDirectory/>
+            <filtered>false</filtered>
+        </fileSet>
+        <fileSet>
+            <directory>target/unpacked-themes/theme</directory>
+            <outputDirectory>themes</outputDirectory>
+        </fileSet>
+        <fileSet>
+            <directory>src/main</directory>
+            <outputDirectory></outputDirectory>
+            <includes>
+                <include>*.*</include>
+            </includes>
+        </fileSet>
+        <fileSet>
+            <directory>src/main/content/themes</directory>
+            <outputDirectory>themes/</outputDirectory>
+            <includes>
+                <include>*.*</include>
+            </includes>
+        </fileSet>
+        <fileSet>
+            <directory>src/main/content/bin</directory>
+            <outputDirectory>bin/</outputDirectory>
+            <includes>
+                <include>*.*</include>
+            </includes>
+            <fileMode>0755</fileMode>
+        </fileSet>
+        <fileSet>
+            <directory>target/keycloak-client-tools/bin</directory>
+            <outputDirectory>bin</outputDirectory>
+        </fileSet>
+        <fileSet>
+            <directory>src/main/content/providers</directory>
+            <outputDirectory>providers</outputDirectory>
+            <includes>
+                <include>*.*</include>
+            </includes>
+        </fileSet>
+        <fileSet>
+            <directory>../../quarkus/server/target</directory>
+            <outputDirectory>lib/</outputDirectory>
+            <includes>
+                <include>keycloak-runner.jar</include>
+            </includes>
+        </fileSet>
+        <fileSet>
+            <directory>../../</directory>
+            <outputDirectory></outputDirectory>
+            <includes>
+                <include>License.html</include>
+            </includes>
+        </fileSet>
+    </fileSets>
+    <files>
+        <file>
+            <source>src/main/version.txt</source>
+            <outputDirectory/>
+            <filtered>true</filtered>
+        </file>
+    </files>
+
+</assembly>

--- a/distribution/server-x/pom.xml
+++ b/distribution/server-x/pom.xml
@@ -1,0 +1,113 @@
+<!--
+  ~ Copyright 2016 Red Hat, Inc. and/or its affiliates
+  ~ and other contributors as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>keycloak-distribution-parent</artifactId>
+        <groupId>org.keycloak</groupId>
+        <version>8.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>keycloak-server-x</artifactId>
+    <packaging>pom</packaging>
+    <name>Keycloak.X Server Distribution</name>
+    <description/>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-themes</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>keycloak.x-${project.version}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack-theme</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.keycloak</groupId>
+                                    <artifactId>keycloak-themes</artifactId>
+                                    <outputDirectory>target/unpacked-themes</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>unpack-cli</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.keycloak</groupId>
+                                    <artifactId>keycloak-client-cli-dist</artifactId>
+                                    <type>zip</type>
+                                    <outputDirectory>target/</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>assemble</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>assembly.xml</descriptor>
+                            </descriptors>
+                            <recompressZippedFiles>true</recompressZippedFiles>
+                            <finalName>${project.build.finalName}</finalName>
+                            <appendAssemblyId>false</appendAssemblyId>
+                            <outputDirectory>${project.build.directory}</outputDirectory>
+                            <workDirectory>${project.build.directory}/assembly/work</workDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/distribution/server-x/src/main/README.txt
+++ b/distribution/server-x/src/main/README.txt
@@ -1,0 +1,12 @@
+Keycloak.X
+
+To run on Linux/Unix:
+
+$ cd bin
+$ ./kc.sh
+
+To run on Windows:
+
+> ...\bin\kc.bat
+
+After the server boots, open http://localhost:8080 in your web browser. The welcome page will indicate that the server is running.

--- a/distribution/server-x/src/main/content/bin/kc.bat
+++ b/distribution/server-x/src/main/content/bin/kc.bat
@@ -1,0 +1,9 @@
+@echo off
+
+if "%OS%" == "Windows_NT" (
+  set "DIRNAME=%~dp0%"
+) else (
+  set DIRNAME=.\
+)
+
+java -Dkeycloak.theme.dir=%DIRNAME%\..\themes -cp "%DIRNAME%\..\providers\*;%DIRNAME%\..\lib\keycloak-runner.jar" io.quarkus.runner.GeneratedMain %*

--- a/distribution/server-x/src/main/content/bin/kc.sh
+++ b/distribution/server-x/src/main/content/bin/kc.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+case "`uname`" in
+    CYGWIN*)
+        CFILE = `cygpath "$0"`
+        RESOLVED_NAME=`readlink -f "$CFILE"`
+        ;;
+    Darwin*)
+        RESOLVED_NAME=`readlink "$0"`
+        ;;
+    FreeBSD)
+        RESOLVED_NAME=`readlink -f "$0"`
+        ;;
+    Linux)
+        RESOLVED_NAME=`readlink -f "$0"`
+        ;;
+esac
+
+if [ "x$RESOLVED_NAME" = "x" ]; then
+    RESOLVED_NAME="$0"
+fi
+
+DIRNAME=`dirname "$RESOLVED_NAME"`
+java -Dkeycloak.theme.dir=$DIRNAME/../themes -cp "$DIRNAME/../providers/*:$DIRNAME/../lib/keycloak-runner.jar" io.quarkus.runner.GeneratedMain "$@"

--- a/distribution/server-x/src/main/content/providers/README.txt
+++ b/distribution/server-x/src/main/content/providers/README.txt
@@ -1,0 +1,1 @@
+Copy custom providers into this directory then restart the Keycloak server.

--- a/distribution/server-x/src/main/content/themes/README.txt
+++ b/distribution/server-x/src/main/content/themes/README.txt
@@ -1,0 +1,3 @@
+Themes are used to configure the look and feel of login pages and the account management console. It is not recommended to
+modify the existing built-in themes, instead you should create a new theme that extends a built-in theme. See the theme
+section in the documentation for more details.

--- a/distribution/server-x/src/main/version.txt
+++ b/distribution/server-x/src/main/version.txt
@@ -1,0 +1,1 @@
+Keycloak.X - Version ${product.version}


### PR DESCRIPTION
Initial Quarkus distribution

Currently not built via the distribution parent and requires the quarkus keycloak-runner.jar file to be created prior.

Creates the following directory structure;
- /lib - containing the keycloak-runner.jar file
- /themes - containing the unpacked themes + readme
- /providers -  readme
- /bin - containing bat and sh scripts + admin cli & client registration cli

To run, use either the kc.sh or kc.bat files depending on OS.

Custom themes and providers work by placing into the specified directories.