### PR TITLE
[KEYCLOAK-11717] Drop the public key credential related elements from the Edit Account screen of the Account console

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/AccountFormServiceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/AccountFormServiceTest.java
@@ -58,6 +58,7 @@ import org.keycloak.testsuite.pages.LoginPage;
 import org.keycloak.testsuite.pages.RegisterPage;
 import org.keycloak.testsuite.updaters.ClientAttributeUpdater;
 import org.keycloak.testsuite.updaters.RoleScopeUpdater;
+import org.keycloak.testsuite.util.DroneUtils;
 import org.keycloak.testsuite.util.IdentityProviderBuilder;
 import org.keycloak.testsuite.util.OAuthClient;
 import org.keycloak.testsuite.util.RealmBuilder;
@@ -65,10 +66,12 @@ import org.keycloak.testsuite.util.UIUtils;
 import org.keycloak.testsuite.util.UserBuilder;
 import java.io.Closeable;
 import java.io.IOException;
-import java.util.Collections;
 import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -1225,7 +1228,7 @@ public class AccountFormServiceTest extends AbstractTestRealmKeycloakTest {
 
         events.clear();
     }
-    
+
     @Test
     public void testReferrerLinkContents() {
         RealmResource testRealm = testRealm();
@@ -1273,5 +1276,26 @@ public class AccountFormServiceTest extends AbstractTestRealmKeycloakTest {
         Assert.assertNull(profilePage.getBackToApplicationLinkText());
 
         events.clear();
+    }
+
+    @Test
+    public void testNoPublicKeyCredentialRelatedElementsPresentOnEditAccountScreen() {
+        profilePage.open();
+        loginPage.login("test-user@localhost", "password");
+        Assert.assertTrue(profilePage.isCurrent());
+
+        int noSuchElementExceptionCount = 0;
+        for (String pkcElementId : Arrays.asList("user.attributes.public_key_credential_id",
+                                                 "user.attributes.public_key_credential_label",
+                                                 "user.attributes.public_key_credential_aaguid")) {
+            try {
+                DroneUtils.getCurrentDriver().findElement(By.id(pkcElementId));
+            } catch (NoSuchElementException nsee) {
+                // Expected to happen in every iteration of the for loop
+                noSuchElementExceptionCount++;
+            }
+        }
+        // None of PK credential ID, label, and AAGUID can be present on Edit Account screen
+        assertEquals(3, noSuchElementExceptionCount);
     }
 }

--- a/themes/src/main/resources/theme/base/account/account.ftl
+++ b/themes/src/main/resources/theme/base/account/account.ftl
@@ -56,37 +56,6 @@
             </div>
         </div>
 
-
-        <div class="form-group">
-            <div class="col-sm-2 col-md-2">
-                <label for="publicKeyCredentialId" class="control-label">${msg("Public Key Credential ID")}</label>
-            </div>
-
-            <div class="col-sm-10 col-md-10">
-                <input type="text" class="form-control" id="user.attributes.public_key_credential_id" name="user.attributes.public_key_credential_id" disabled="disabled" value="${(account.attributes.public_key_credential_id!'')}"/>
-            </div>
-        </div>
-
-        <div class="form-group">
-            <div class="col-sm-2 col-md-2">
-                <label for="publicKeyCredentialLabel" class="control-label">${msg("Public Key Credential Label")}</label>
-            </div>
-
-            <div class="col-sm-10 col-md-10">
-                <input type="text" class="form-control" id="user.attributes.public_key_credential_label" name="user.attributes.public_key_credential_label" value="${(account.attributes.public_key_credential_label!'')}"/>
-            </div>
-        </div>
-
-        <div class="form-group">
-            <div class="col-sm-2 col-md-2">
-                <label for="publicKeyCredentialAaguid" class="control-label">${msg("Public Key Credential AAGUID")}</label>
-            </div>
-
-            <div class="col-sm-10 col-md-10">
-                <input type="text" class="form-control" id="user.attributes.public_key_credential_aaguid" name="user.attributes.public_key_credential_aaguid" disabled="disabled" value="${(account.attributes.public_key_credential_aaguid!'')}"/>
-            </div>
-        </div>
-
         <div class="form-group">
             <div id="kc-form-buttons" class="col-md-offset-2 col-md-10 submit">
                 <div class="">


### PR DESCRIPTION

    [KEYCLOAK-11717] Drop the public key credential related elements
    from the Edit Account screen of the Account console
    
    Add a testcase for it
    
    Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
