### PR TITLE
KEYCLOAK-11781 Some dutch translations contain strange characters

### DIFF
--- a/themes/src/main/resources-community/theme/base/login/messages/messages_nl.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_nl.properties
@@ -1,3 +1,4 @@
+# encoding: utf-8
 doLogIn=Inloggen
 doRegister=Registreer
 doCancel=Annuleer

--- a/themes/src/main/resources-community/theme/base/login/messages/messages_nl.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_nl.properties
@@ -104,7 +104,7 @@ loginTotp.hotp=Counter-based
 oauthGrantRequest=Wilt u deze toegangsrechten verlenen?
 inResource=in
 
-emailVerifyInstruction1=Een e-mail met instructies om uw e-mailadres te verifi\u00ebren is zojuist verzonden.
+emailVerifyInstruction1=Een e-mail met instructies om uw e-mailadres te verifiëren is zojuist verzonden.
 emailVerifyInstruction2=Heeft u geen verificatiecode ontvangen in uw e-mail?
 emailVerifyInstruction3=om opnieuw een e-mail te versturen.
 
@@ -190,8 +190,8 @@ configureTotpMessage=U moet de Mobile Authenticator configuren om uw account te 
 updateProfileMessage=U moet uw gebruikersprofiel bijwerken om uw account te activeren.
 updatePasswordMessage=U moet uw wachtwoord wijzigen om uw account te activeren.
 resetPasswordMessage=U moet uw wachtwoord wijzigen.
-verifyEmailMessage=U moet uw e-mailadres verifi\u00ebren om uw account te activeren.
-linkIdpMessage=U moet uw e-mailadres verifi\u00ebren om uw account te koppelen aan {0}.
+verifyEmailMessage=U moet uw e-mailadres verifiëren om uw account te activeren.
+linkIdpMessage=U moet uw e-mailadres verifiëren om uw account te koppelen aan {0}.
 
 emailSentMessage=U ontvangt binnenkort een e-mail met verdere instructies.
 emailSendErrorMessage=Het versturen van de e-mail is mislukt, probeer het later opnieuw.
@@ -223,7 +223,7 @@ invalidRequestMessage=Ongeldige request
 failedLogout=Afmelden is mislukt
 unknownLoginRequesterMessage=De login requester is onbekend
 loginRequesterNotEnabledMessage=De login requester is niet geactiveerd
-bearerOnlyMessage=Bearer-only applicaties mogen geen browserlogin initi\u00ebren
+bearerOnlyMessage=Bearer-only applicaties mogen geen browserlogin initiëren
 standardFlowDisabledMessage=Client mag geen browserlogin starten met het opgegeven response_type. Standard flow is uitgeschakeld voor de client.
 implicitFlowDisabledMessage=Client mag geen browserlogin starten met opgegeven response_type. Implicit flow is uitgeschakeld voor de klant.
 invalidRedirectUriMessage=Ongeldige redirect-URI
@@ -289,7 +289,7 @@ console-otp=Eenmalige code:
 console-new-password=Nieuw wachtwoord:
 console-confirm-password=Bevestig wachtwoord:
 console-update-password=Een update van uw wachtwoord is verplicht.
-console-verify-email=U bent verplicht om uw e-mailadres te verifi\u00ebren. Een e-mail met de verificatiecode is naar {0} gestuurd. Voer deze code hieronder in.
+console-verify-email=U bent verplicht om uw e-mailadres te verifiëren. Een e-mail met de verificatiecode is naar {0} gestuurd. Voer deze code hieronder in.
 console-email-code=E-mail Code:
 console-accept-terms=Accepteert u de voorwaarden? [y/n]:
 console-accept=y

--- a/themes/src/main/resources-community/theme/base/login/messages/messages_nl.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_nl.properties
@@ -103,7 +103,7 @@ loginTotp.hotp=Counter-based
 oauthGrantRequest=Wilt u deze toegangsrechten verlenen?
 inResource=in
 
-emailVerifyInstruction1=Een e-mail met instructies om uw e-mailadres te verifiëren is zojuist verzonden.
+emailVerifyInstruction1=Een e-mail met instructies om uw e-mailadres te verifi\u00ebren is zojuist verzonden.
 emailVerifyInstruction2=Heeft u geen verificatiecode ontvangen in uw e-mail?
 emailVerifyInstruction3=om opnieuw een e-mail te versturen.
 
@@ -189,8 +189,8 @@ configureTotpMessage=U moet de Mobile Authenticator configuren om uw account te 
 updateProfileMessage=U moet uw gebruikersprofiel bijwerken om uw account te activeren.
 updatePasswordMessage=U moet uw wachtwoord wijzigen om uw account te activeren.
 resetPasswordMessage=U moet uw wachtwoord wijzigen.
-verifyEmailMessage=U moet uw e-mailadres verifiëren om uw account te activeren.
-linkIdpMessage=U moet uw e-mailadres verifiëren om uw account te koppelen aan {0}.
+verifyEmailMessage=U moet uw e-mailadres verifi\u00ebren om uw account te activeren.
+linkIdpMessage=U moet uw e-mailadres verifi\u00ebren om uw account te koppelen aan {0}.
 
 emailSentMessage=U ontvangt binnenkort een e-mail met verdere instructies.
 emailSendErrorMessage=Het versturen van de e-mail is mislukt, probeer het later opnieuw.
@@ -222,7 +222,7 @@ invalidRequestMessage=Ongeldige request
 failedLogout=Afmelden is mislukt
 unknownLoginRequesterMessage=De login requester is onbekend
 loginRequesterNotEnabledMessage=De login requester is niet geactiveerd
-bearerOnlyMessage=Bearer-only applicaties mogen geen browserlogin initiëren
+bearerOnlyMessage=Bearer-only applicaties mogen geen browserlogin initi\u00ebren
 standardFlowDisabledMessage=Client mag geen browserlogin starten met het opgegeven response_type. Standard flow is uitgeschakeld voor de client.
 implicitFlowDisabledMessage=Client mag geen browserlogin starten met opgegeven response_type. Implicit flow is uitgeschakeld voor de klant.
 invalidRedirectUriMessage=Ongeldige redirect-URI
@@ -288,7 +288,7 @@ console-otp=Eenmalige code:
 console-new-password=Nieuw wachtwoord:
 console-confirm-password=Bevestig wachtwoord:
 console-update-password=Een update van uw wachtwoord is verplicht.
-console-verify-email=U bent verplicht om uw e-mailadres te verifiëren. Een e-mail met de verificatiecode is naar {0} gestuurd. Voer deze code hieronder in.
+console-verify-email=U bent verplicht om uw e-mailadres te verifi\u00ebren. Een e-mail met de verificatiecode is naar {0} gestuurd. Voer deze code hieronder in.
 console-email-code=E-mail Code:
 console-accept-terms=Accepteert u de voorwaarden? [y/n]:
 console-accept=y


### PR DESCRIPTION
Fixes a display error with Dutch translations containing accented characters.
Bug report: https://issues.jboss.org/browse/KEYCLOAK-11781