### PR TITLE
KEYCLOAK-10977 Allow disabling Kerberos athentication with LDAP feder…

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/UserStorageRestTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/UserStorageRestTest.java
@@ -99,12 +99,32 @@ public class UserStorageRestTest extends AbstractAdminTest {
         realm.flows().updateExecutions("browser", kerberosExecution);
         assertAdminEvents.assertEvent(realmId, OperationType.UPDATE, AdminEventPaths.authUpdateExecutionPath("browser"), kerberosExecution, ResourceType.AUTH_EXECUTION);
 
-        // update LDAP provider with kerberos
+        // update LDAP provider with kerberos (without changing kerberos switch)
         ldapRep = realm.components().component(id).toRepresentation();
         realm.components().component(id).update(ldapRep);
         assertAdminEvents.clear();
 
-        // Assert kerberos authenticator ALTERNATIVE
+        // Assert kerberos authenticator is still DISABLED
+        kerberosExecution = findKerberosExecution();
+        Assert.assertEquals(kerberosExecution.getRequirement(), AuthenticationExecutionModel.Requirement.DISABLED.toString());
+
+        // update LDAP provider with kerberos (with changing kerberos switch to disabled)
+        ldapRep = realm.components().component(id).toRepresentation();
+        ldapRep.getConfig().putSingle(KerberosConstants.ALLOW_KERBEROS_AUTHENTICATION, "false");
+        realm.components().component(id).update(ldapRep);
+        assertAdminEvents.clear();
+
+        // Assert kerberos authenticator is still DISABLED
+        kerberosExecution = findKerberosExecution();
+        Assert.assertEquals(kerberosExecution.getRequirement(), AuthenticationExecutionModel.Requirement.DISABLED.toString());
+
+        // update LDAP provider with kerberos (with changing kerberos switch to enabled)
+        ldapRep = realm.components().component(id).toRepresentation();
+        ldapRep.getConfig().putSingle(KerberosConstants.ALLOW_KERBEROS_AUTHENTICATION, "true");
+        realm.components().component(id).update(ldapRep);
+        assertAdminEvents.clear();
+
+        // Assert kerberos authenticator is still ALTERNATIVE
         kerberosExecution = findKerberosExecution();
         Assert.assertEquals(kerberosExecution.getRequirement(), AuthenticationExecutionModel.Requirement.ALTERNATIVE.toString());
 


### PR DESCRIPTION
…ation provider

As mentioned in the issue [KEYCLOAK-10977](https://issues.jboss.org/browse/KEYCLOAK-10977) there is a problem keep the Kerberos authentication disabled using a LDAP federation provider with Kerberos settings. Evertime a LDAP sync is triggered the Kerberos Authentication gets enabled again.

I created a fix for this behavior by adding an extra check to the `CredentialsHelper` to avoid switching the Authenticator execution if it's already disbaled. IMHO this is sufficient to fix the problem without any side effects. 

We checked this using an AD integration and it works fine so far.