### PR TITLE
KEYCLOAK-11785 - Re-work initialization for Keycloak.X

### DIFF
--- a/quarkus/extensions/pom.xml
+++ b/quarkus/extensions/pom.xml
@@ -36,6 +36,29 @@
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-services</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+            <type>jar</type>
+        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jboss.jandex</groupId>
+                <artifactId>jandex-maven-plugin</artifactId>
+                <version>1.0.6</version>
+                <executions>
+                    <execution>
+                        <id>make-index</id>
+                        <goals>
+                            <goal>jandex</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/quarkus/extensions/src/main/java/org/keycloak/provider/quarkus/QuarkusStartup.java
+++ b/quarkus/extensions/src/main/java/org/keycloak/provider/quarkus/QuarkusStartup.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.provider.quarkus;
+
+import io.quarkus.arc.Arc;
+import org.keycloak.services.resources.KeycloakApplication;
+
+public class QuarkusStartup implements KeycloakApplication.Startup {
+
+    @Override
+    public void execute(Runnable command) {
+        QuarkusStartupObserver observer = Arc.container().instance(QuarkusStartupObserver.class).get();
+        observer.setCommand(command);
+    }
+
+}

--- a/quarkus/extensions/src/main/java/org/keycloak/provider/quarkus/QuarkusStartupObserver.java
+++ b/quarkus/extensions/src/main/java/org/keycloak/provider/quarkus/QuarkusStartupObserver.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.provider.quarkus;
+
+import io.quarkus.runtime.StartupEvent;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+
+@ApplicationScoped
+public class QuarkusStartupObserver {
+
+    private Runnable command;
+
+    public void setCommand(Runnable command) {
+        this.command = command;
+    }
+
+    private void startupEvent(@Observes StartupEvent event) {
+        if (command != null) {
+            command.run();
+        }
+    }
+
+}

--- a/quarkus/extensions/src/main/resources/META-INF/services/org.keycloak.services.resources.KeycloakApplication$Startup
+++ b/quarkus/extensions/src/main/resources/META-INF/services/org.keycloak.services.resources.KeycloakApplication$Startup
@@ -1,0 +1,18 @@
+#
+# Copyright 2019 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.keycloak.provider.quarkus.QuarkusStartup

--- a/services/src/main/java/org/keycloak/services/resources/KeycloakApplication.java
+++ b/services/src/main/java/org/keycloak/services/resources/KeycloakApplication.java
@@ -97,6 +97,8 @@ public class KeycloakApplication extends Application {
 
     public static final String SERVER_CONTEXT_CONFIG_PROPERTY_OVERRIDES = "keycloak.server.context.config.property-overrides";
 
+    public static final AtomicBoolean BOOTSTRAP_ADMIN_USER = new AtomicBoolean(false);
+
     private static final Logger logger = Logger.getLogger(KeycloakApplication.class);
 
     protected boolean embedded = false;
@@ -106,8 +108,6 @@ public class KeycloakApplication extends Application {
 
     protected KeycloakSessionFactory sessionFactory;
     protected String contextPath;
-
-    private AtomicBoolean bootstrapAdminUser = new AtomicBoolean(false);
 
     public KeycloakApplication() {
 
@@ -197,7 +197,7 @@ public class KeycloakApplication extends Application {
             @Override
             public void run(KeycloakSession session) {
                 boolean shouldBootstrapAdmin = new ApplianceBootstrap(session).isNoMasterUser();
-                bootstrapAdminUser.set(shouldBootstrapAdmin);
+                BOOTSTRAP_ADMIN_USER.set(shouldBootstrapAdmin);
             }
 
         });
@@ -383,10 +383,6 @@ public class KeycloakApplication extends Application {
     @Override
     public Set<Object> getSingletons() {
         return singletons;
-    }
-
-    boolean isBootstrap() {
-        return bootstrapAdminUser.get();
     }
 
     public void importRealms() {

--- a/services/src/main/java/org/keycloak/services/resources/WelcomeResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/WelcomeResource.java
@@ -68,7 +68,7 @@ public class WelcomeResource {
 
     private static final String KEYCLOAK_STATE_CHECKER = "WELCOME_STATE_CHECKER";
 
-    private boolean bootstrap;
+    private boolean bootstrap = true;
 
     @Context
     protected HttpHeaders headers;
@@ -76,8 +76,10 @@ public class WelcomeResource {
     @Context
     private KeycloakSession session;
 
-    public WelcomeResource(boolean bootstrap) {
-        this.bootstrap = bootstrap;
+    @Context
+    private KeycloakApplication application;
+
+    public WelcomeResource() {
     }
 
     /**
@@ -228,7 +230,7 @@ public class WelcomeResource {
     }
 
     private void checkBootstrap() {
-        if (bootstrap) {
+        if (bootstrap && application.isBootstrap()) {
             bootstrap  = new ApplianceBootstrap(session).isNoMasterUser();
         }
     }

--- a/services/src/main/java/org/keycloak/services/resources/WelcomeResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/WelcomeResource.java
@@ -68,16 +68,11 @@ public class WelcomeResource {
 
     private static final String KEYCLOAK_STATE_CHECKER = "WELCOME_STATE_CHECKER";
 
-    private boolean bootstrap = true;
-
     @Context
     protected HttpHeaders headers;
 
     @Context
     private KeycloakSession session;
-
-    @Context
-    private KeycloakApplication application;
 
     public WelcomeResource() {
     }
@@ -107,7 +102,7 @@ public class WelcomeResource {
     public Response createUser(final MultivaluedMap<String, String> formData) {
         checkBootstrap();
 
-        if (!bootstrap) {
+        if (!shouldBootstrap()) {
             return createWelcomePage(null, null);
         } else {
             if (!isLocal()) {
@@ -141,7 +136,7 @@ public class WelcomeResource {
 
             ApplianceBootstrap applianceBootstrap = new ApplianceBootstrap(session);
             if (applianceBootstrap.isNoMasterUser()) {
-                bootstrap = false;
+                setBootstrap(false);
                 applianceBootstrap.createMasterRealmUser(username, password);
 
                 ServicesLogger.LOGGER.createdInitialAdminUser(username);
@@ -179,20 +174,21 @@ public class WelcomeResource {
 
     private Response createWelcomePage(String successMessage, String errorMessage) {
         try {
-          Theme theme = getTheme();
+            Theme theme = getTheme();
 
-          Map<String, Object> map = new HashMap<>();
+            Map<String, Object> map = new HashMap<>();
 
-          map.put("productName", Version.NAME);
-          map.put("productNameFull", Version.NAME_FULL);
+            map.put("productName", Version.NAME);
+            map.put("productNameFull", Version.NAME_FULL);
 
-          map.put("properties", theme.getProperties());
+            map.put("properties", theme.getProperties());
 
-          URI uri = Urls.themeRoot(session.getContext().getUri().getBaseUri());
-          String resourcesPath = uri.getPath() + "/" + theme.getType().toString().toLowerCase() +"/" + theme.getName();
-          map.put("resourcesPath", resourcesPath);
+            URI uri = Urls.themeRoot(session.getContext().getUri().getBaseUri());
+            String resourcesPath = uri.getPath() + "/" + theme.getType().toString().toLowerCase() + "/" + theme.getName();
+            map.put("resourcesPath", resourcesPath);
 
-           map.put("bootstrap", bootstrap);
+            boolean bootstrap = shouldBootstrap();
+            map.put("bootstrap", bootstrap);
             if (bootstrap) {
                 boolean isLocal = isLocal();
                 map.put("localUser", isLocal);
@@ -230,9 +226,16 @@ public class WelcomeResource {
     }
 
     private void checkBootstrap() {
-        if (bootstrap && application.isBootstrap()) {
-            bootstrap  = new ApplianceBootstrap(session).isNoMasterUser();
-        }
+        if (shouldBootstrap())
+            KeycloakApplication.BOOTSTRAP_ADMIN_USER.compareAndSet(true, new ApplianceBootstrap(session).isNoMasterUser());
+    }
+
+    private boolean shouldBootstrap() {
+        return KeycloakApplication.BOOTSTRAP_ADMIN_USER.get();
+    }
+
+    private void setBootstrap(boolean value) {
+        KeycloakApplication.BOOTSTRAP_ADMIN_USER.set(value);
     }
 
     private boolean isLocal() {


### PR DESCRIPTION
Moved all the heavy lifting, which is mostly DB-related, to the dedicated `startup()` method. This can be optionally deferred by providing a `org.keycloak.services.resources.KeycloakApplication$Startup` implementation. On Quarkus, this is essential since many critical subsystems (e.g logging, Agroal) are not yet ready when you're inside the application constructor.