### PR TITLE
Specify the same Hash function for both `OAEP` and `MGF1` padding when encrypting the SAML Key

### DIFF
--- a/saml-core/src/main/java/org/keycloak/saml/processing/core/util/XMLEncryptionUtil.java
+++ b/saml-core/src/main/java/org/keycloak/saml/processing/core/util/XMLEncryptionUtil.java
@@ -93,10 +93,18 @@ public class XMLEncryptionUtil {
 
         try {
             String keyWrapAlgo = getXMLEncryptionURLForKeyUnwrap(pubKeyAlg, keySize);
-            keyCipher = XMLCipher.getInstance(keyWrapAlgo);
 
-            keyCipher.init(XMLCipher.WRAP_MODE, keyUsedToEncryptSecretKey);
-            return keyCipher.encryptKey(document, keyToBeEncrypted);
+            switch(keyWrapAlgo) {
+                case XMLCipher.RSA_OAEP:
+                    keyCipher = XMLCipher.getInstance(keyWrapAlgo, "", "SHA-256");
+                    keyCipher.init(XMLCipher.WRAP_MODE, keyUsedToEncryptSecretKey);
+                    return keyCipher.encryptKey(document, keyToBeEncrypted, "SHA-256", null);
+                default:
+                    keyCipher = XMLCipher.getInstance(keyWrapAlgo);
+                    keyCipher.init(XMLCipher.WRAP_MODE, keyUsedToEncryptSecretKey);
+                    return keyCipher.encryptKey(document, keyToBeEncrypted);
+            }
+
         } catch (XMLEncryptionException e) {
             throw logger.processingError(e);
         }


### PR DESCRIPTION
Hi all 👋,

First of all, please note that this is by no means a complete PR as it has no tests. I've put this code in a rush to establish the conversation around the problem/solution and from there I'm happy to make any amendments.

As a way of background, I'm a part of the Grafana team and one of the people that worked in our SAML integration. 

The problem at hand is that encrypted assertions do not work with Keycloak due to an interoperability problem if encryption/decryption algorithms between Java and Go (in this case specifically OAEP).

The decryption algorithm specified in the XML by `XMLCipher` when using `XMLCipher.RSA_OAEP ` is `http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p`. 

Per [this source](https://stackoverflow.com/questions/49678052/rsa-oaep-golang-encrypt-java-decrypt-badpaddingexception-decryption-error) 

> OAEP uses two hash algorithms: one on the label (fka parameters) and one within the Mask Generation Function (MGF1); these can be different. See 7.1.1 and B.2.1 in [rfc8017](https://tools.ietf.org/html/rfc8017).

By default, `XMLCipher` uses `SHA1` (per the `constructOAEPParameters` function on `XMLCipher.class`) for the MGF1 and `SHA256` for the label as Java allows these parameters to be different by using [OAEPParameterSpec](https://docs.oracle.com/javase/8/docs/api/javax/crypto/spec/OAEPParameterSpec.html) class.

However, [Go does not have that amount of flexibility and only allows you to specify one hashing function for both](https://github.com/golang/go/issues/19974).

From my understanding, there's really no reason for these to be different other than the default behaviour per the [XMLenc spec on this algorithm](https://www.w3.org/TR/xmlenc-core1/#sec-RSA-OAEP) which states that we should use `SHA1` if one is not specified.

Within this PR, I have made the Cipher use `SHA256` for both parts of the encryption algorithm. But safe to say that there are multiple angles to this e.g. make it configurable within Keycloak via a System Prop or the UI.

This is currently blocking the integration of Grafana with SAML via Keycloak. 