### PR TITLE
Insert nonce from request query string in access token

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
@@ -104,6 +104,7 @@ import java.security.MessageDigest;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -605,7 +606,13 @@ public class TokenEndpoint {
         UserSessionModel userSession = processor.getUserSession();
         updateUserSessionFromClientAuth(userSession);
 
-        TokenManager.AccessTokenResponseBuilder responseBuilder = tokenManager.responseBuilder(realm, client, event, session, userSession, clientSessionCtx)
+        Optional.ofNullable(formParams.getFirst(OIDCLoginProtocol.NONCE_PARAM))
+                .ifPresent(nonce -> {
+                    logger.debug(String.format("Overriding session's nonce to request's nonce %s", nonce));
+                    clientSessionCtx.getClientSession().setNote(OIDCLoginProtocol.NONCE_PARAM, nonce);
+                });
+
+         TokenManager.AccessTokenResponseBuilder responseBuilder = tokenManager.responseBuilder(realm, client, event, session, userSession, clientSessionCtx)
                 .generateAccessToken()
                 .generateRefreshToken();
 


### PR DESCRIPTION
Problem description
===================

To avoid replication attacks, it is important to handle the nonce
attribute while validating the Access Token. Keycloak's token endpoint
does not use the nonce attribute that the SP has provided in the
request's query string. The token endpoint just uses the nonce value
that is in the user's session.

When using stateless applications I do not have a session to handle it,
but I still would like to have the nonce attribute inside my access
token for the SP.

Proposal
=======

While generating the access token, Keycloak only uses the nonce
attribute of the user's session. I propose to verify if there is a nonce
value in the request's parameters, if it exists, then we override the
session's nonce with the request's nonce while generating the token.

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
