### PR TITLE
Platform support for 'mvn-golang-wrapper' for keycloak/keycloak on PowerPC64LE

### DIFF
--- a/testsuite/integration-arquillian/tests/base/pom.xml
+++ b/testsuite/integration-arquillian/tests/base/pom.xml
@@ -256,7 +256,7 @@
             <plugin>
                 <groupId>com.igormaznitsa</groupId>
                 <artifactId>mvn-golang-wrapper</artifactId>
-                <version>2.1.6</version>
+                <version>2.3.4</version>
                 <extensions>true</extensions>
                 <configuration>
                     <goVersion>1.9.2</goVersion>


### PR DESCRIPTION
Platform support for 'mvn-golang-wrapper' for keycloak/keycloak on PowerPC64LE - new 'mvn-golang-wrapper' 2.3.4 version is published in maven central.

Refer:-
https://github.com/raydac/mvn-golang/issues/70