### PR TITLE
KEYCLOAK-11992 Use StandartCharsets.UTF-8 for strings in module core

### DIFF
--- a/core/src/main/java/org/keycloak/jose/jwe/JWE.java
+++ b/core/src/main/java/org/keycloak/jose/jwe/JWE.java
@@ -18,7 +18,7 @@
 package org.keycloak.jose.jwe;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.security.spec.KeySpec;
 
 import org.keycloak.common.util.Base64;
@@ -222,14 +222,8 @@ public class JWE {
     }
 
     public static String encryptUTF8(String password, String saltString, String payload) {
-        byte[] bytes = null;
-        try {
-            bytes = payload.getBytes("UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException(e);
-        }
+        byte[] bytes = payload.getBytes(StandardCharsets.UTF_8);
         return encrypt(password, saltString, bytes);
-
     }
 
 
@@ -276,11 +270,7 @@ public class JWE {
 
     public static String decryptUTF8(String password, String saltString, String encodedJwe) {
         byte[] payload = decrypt(password, saltString, encodedJwe);
-        try {
-            return new String(payload, "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException(e);
-        }
+        return new String(payload, StandardCharsets.UTF_8);
     }
 
 }

--- a/core/src/main/java/org/keycloak/jose/jwe/enc/AesCbcHmacShaEncryptionProvider.java
+++ b/core/src/main/java/org/keycloak/jose/jwe/enc/AesCbcHmacShaEncryptionProvider.java
@@ -20,6 +20,7 @@ package org.keycloak.jose.jwe.enc;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.security.InvalidKeyException;
 import java.security.Key;
@@ -67,7 +68,7 @@ public abstract class AesCbcHmacShaEncryptionProvider implements JWEEncryptionPr
 
         byte[] cipherBytes = encryptBytes(contentBytes, initializationVector, aesKey);
 
-        byte[] aad = jwe.getBase64Header().getBytes("UTF-8");
+        byte[] aad = jwe.getBase64Header().getBytes(StandardCharsets.UTF_8);
         byte[] authenticationTag = computeAuthenticationTag(aad, initializationVector, cipherBytes, hmacShaKey);
 
         jwe.setEncryptedContentInfo(initializationVector, cipherBytes, authenticationTag);
@@ -91,7 +92,7 @@ public abstract class AesCbcHmacShaEncryptionProvider implements JWEEncryptionPr
             throw new IllegalStateException("Length of aes key should be " + expectedAesKeyLength +", but was " + aesKey.getEncoded().length);
         }
 
-        byte[] aad = jwe.getBase64Header().getBytes("UTF-8");
+        byte[] aad = jwe.getBase64Header().getBytes(StandardCharsets.UTF_8);
         byte[] authenticationTag = computeAuthenticationTag(aad, jwe.getInitializationVector(), jwe.getEncryptedContent(), hmacShaKey);
 
         byte[] expectedAuthTag = jwe.getAuthenticationTag();

--- a/core/src/main/java/org/keycloak/jose/jwe/enc/AesGcmEncryptionProvider.java
+++ b/core/src/main/java/org/keycloak/jose/jwe/enc/AesGcmEncryptionProvider.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.jose.jwe.enc;
 
+import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.security.InvalidKeyException;
 import java.security.Key;
@@ -57,7 +58,7 @@ public abstract class AesGcmEncryptionProvider implements JWEEncryptionProvider 
         }
 
         // https://tools.ietf.org/html/rfc7516#appendix-A.1.5
-        byte[] aad = jwe.getBase64Header().getBytes("UTF-8");
+        byte[] aad = jwe.getBase64Header().getBytes(StandardCharsets.UTF_8);
 
         byte[] cipherBytes = encryptBytes(contentBytes, initializationVector, aesKey, aad);
         byte[] authenticationTag = getAuthenticationTag(cipherBytes);
@@ -79,7 +80,7 @@ public abstract class AesGcmEncryptionProvider implements JWEEncryptionProvider 
         }
 
         // https://tools.ietf.org/html/rfc7516#appendix-A.1.5
-        byte[] aad = jwe.getBase64Header().getBytes("UTF-8");
+        byte[] aad = jwe.getBase64Header().getBytes(StandardCharsets.UTF_8);
         byte[] decryptedTargetContent = getAeadDecryptedTargetContent(jwe);
         byte[] contentBytes = decryptBytes(decryptedTargetContent, jwe.getInitializationVector(), aesKey, aad);
 

--- a/core/src/main/java/org/keycloak/jose/jws/JWSBuilder.java
+++ b/core/src/main/java/org/keycloak/jose/jws/JWSBuilder.java
@@ -25,7 +25,7 @@ import org.keycloak.util.JsonSerialization;
 
 import javax.crypto.SecretKey;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.security.PrivateKey;
 
 /**
@@ -76,11 +76,7 @@ public class JWSBuilder {
         if (kid != null) builder.append(",\"kid\" : \"").append(kid).append("\"");
         if (contentType != null) builder.append(",\"cty\":\"").append(contentType).append("\"");
         builder.append("}");
-        try {
-            return Base64Url.encode(builder.toString().getBytes("UTF-8"));
-        } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException(e);
-        }
+        return Base64Url.encode(builder.toString().getBytes(StandardCharsets.UTF_8));
     }
 
     protected String encodeAll(StringBuilder encoding, byte[] signature) {
@@ -115,7 +111,7 @@ public class JWSBuilder {
             encode(signer.getAlgorithm(), data, buffer);
             byte[] signature = null;
             try {
-                signature = signer.sign(buffer.toString().getBytes("UTF-8"));
+                signature = signer.sign(buffer.toString().getBytes(StandardCharsets.UTF_8));
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
@@ -134,12 +130,7 @@ public class JWSBuilder {
             StringBuilder buffer = new StringBuilder();
             byte[] data = marshalContent();
             encode(algorithm, data, buffer);
-            byte[] signature = null;
-            try {
-                signature = RSAProvider.sign(buffer.toString().getBytes("UTF-8"), algorithm, privateKey);
-            } catch (UnsupportedEncodingException e) {
-                throw new RuntimeException(e);
-            }
+            byte[] signature = RSAProvider.sign(buffer.toString().getBytes(StandardCharsets.UTF_8), algorithm, privateKey);
             return encodeAll(buffer, signature);
         }
 
@@ -163,12 +154,7 @@ public class JWSBuilder {
             StringBuilder buffer = new StringBuilder();
             byte[] data = marshalContent();
             encode(Algorithm.HS256, data, buffer);
-            byte[] signature = null;
-            try {
-                signature = HMACProvider.sign(buffer.toString().getBytes("UTF-8"), Algorithm.HS256, sharedSecret);
-            } catch (UnsupportedEncodingException e) {
-                throw new RuntimeException(e);
-            }
+            byte[] signature = HMACProvider.sign(buffer.toString().getBytes(StandardCharsets.UTF_8), Algorithm.HS256, sharedSecret);
             return encodeAll(buffer, signature);
         }
 
@@ -177,12 +163,7 @@ public class JWSBuilder {
             StringBuilder buffer = new StringBuilder();
             byte[] data = marshalContent();
             encode(Algorithm.HS384, data, buffer);
-            byte[] signature = null;
-            try {
-                signature = HMACProvider.sign(buffer.toString().getBytes("UTF-8"), Algorithm.HS384, sharedSecret);
-            } catch (UnsupportedEncodingException e) {
-                throw new RuntimeException(e);
-            }
+            byte[] signature = HMACProvider.sign(buffer.toString().getBytes(StandardCharsets.UTF_8), Algorithm.HS384, sharedSecret);
             return encodeAll(buffer, signature);
         }
 
@@ -191,12 +172,7 @@ public class JWSBuilder {
             StringBuilder buffer = new StringBuilder();
             byte[] data = marshalContent();
             encode(Algorithm.HS512, data, buffer);
-            byte[] signature = null;
-            try {
-                signature = HMACProvider.sign(buffer.toString().getBytes("UTF-8"), Algorithm.HS512, sharedSecret);
-            } catch (UnsupportedEncodingException e) {
-                throw new RuntimeException(e);
-            }
+            byte[] signature = HMACProvider.sign(buffer.toString().getBytes(StandardCharsets.UTF_8), Algorithm.HS512, sharedSecret);
             return encodeAll(buffer, signature);
         }
 
@@ -205,12 +181,7 @@ public class JWSBuilder {
             StringBuilder buffer = new StringBuilder();
             byte[] data = marshalContent();
             encode(Algorithm.HS256, data, buffer);
-            byte[] signature = null;
-            try {
-                signature = HMACProvider.sign(buffer.toString().getBytes("UTF-8"), Algorithm.HS256, sharedSecret);
-            } catch (UnsupportedEncodingException e) {
-                throw new RuntimeException(e);
-            }
+            byte[] signature = HMACProvider.sign(buffer.toString().getBytes(StandardCharsets.UTF_8), Algorithm.HS256, sharedSecret);
             return encodeAll(buffer, signature);
         }
 
@@ -219,12 +190,7 @@ public class JWSBuilder {
             StringBuilder buffer = new StringBuilder();
             byte[] data = marshalContent();
             encode(Algorithm.HS384, data, buffer);
-            byte[] signature = null;
-            try {
-                signature = HMACProvider.sign(buffer.toString().getBytes("UTF-8"), Algorithm.HS384, sharedSecret);
-            } catch (UnsupportedEncodingException e) {
-                throw new RuntimeException(e);
-            }
+            byte[] signature = HMACProvider.sign(buffer.toString().getBytes(StandardCharsets.UTF_8), Algorithm.HS384, sharedSecret);
             return encodeAll(buffer, signature);
         }
 
@@ -233,12 +199,7 @@ public class JWSBuilder {
             StringBuilder buffer = new StringBuilder();
             byte[] data = marshalContent();
             encode(Algorithm.HS512, data, buffer);
-            byte[] signature = null;
-            try {
-                signature = HMACProvider.sign(buffer.toString().getBytes("UTF-8"), Algorithm.HS512, sharedSecret);
-            } catch (UnsupportedEncodingException e) {
-                throw new RuntimeException(e);
-            }
+            byte[] signature = HMACProvider.sign(buffer.toString().getBytes(StandardCharsets.UTF_8), Algorithm.HS512, sharedSecret);
             return encodeAll(buffer, signature);
         }
     }

--- a/core/src/main/java/org/keycloak/jose/jws/JWSInput.java
+++ b/core/src/main/java/org/keycloak/jose/jws/JWSInput.java
@@ -21,7 +21,7 @@ import org.keycloak.common.util.Base64Url;
 import org.keycloak.util.JsonSerialization;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -106,10 +106,6 @@ public class JWSInput {
     }
 
     public String readContentAsString() {
-        try {
-            return new String(content, "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException(e);
-        }
+        return new String(content, StandardCharsets.UTF_8);
     }
 }

--- a/core/src/main/java/org/keycloak/jose/jws/crypto/HMACProvider.java
+++ b/core/src/main/java/org/keycloak/jose/jws/crypto/HMACProvider.java
@@ -25,6 +25,8 @@ import org.keycloak.jose.jws.JWSInput;
 import javax.crypto.Mac;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
+
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
@@ -81,7 +83,7 @@ public class HMACProvider implements SignatureProvider {
 
     public static boolean verify(JWSInput input, SecretKey key) {
         try {
-            byte[] signature = sign(input.getEncodedSignatureInput().getBytes("UTF-8"), input.getHeader().getAlgorithm(), key);
+            byte[] signature = sign(input.getEncodedSignatureInput().getBytes(StandardCharsets.UTF_8), input.getHeader().getAlgorithm(), key);
             return MessageDigest.isEqual(signature, Base64Url.decode(input.getEncodedSignature()));
         } catch (Exception e) {
             throw new RuntimeException(e);
@@ -91,7 +93,7 @@ public class HMACProvider implements SignatureProvider {
 
     public static boolean verify(JWSInput input, byte[] sharedSecret) {
         try {
-            byte[] signature = sign(input.getEncodedSignatureInput().getBytes("UTF-8"), input.getHeader().getAlgorithm(), sharedSecret);
+            byte[] signature = sign(input.getEncodedSignatureInput().getBytes(StandardCharsets.UTF_8), input.getHeader().getAlgorithm(), sharedSecret);
             return MessageDigest.isEqual(signature, Base64Url.decode(input.getEncodedSignature()));
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/core/src/main/java/org/keycloak/jose/jws/crypto/HashUtils.java
+++ b/core/src/main/java/org/keycloak/jose/jws/crypto/HashUtils.java
@@ -21,7 +21,7 @@ import org.keycloak.common.util.Base64Url;
 import org.keycloak.crypto.HashException;
 import org.keycloak.crypto.JavaAlgorithm;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.util.Arrays;
 
@@ -32,15 +32,11 @@ public class HashUtils {
 
     // See "at_hash" and "c_hash" in OIDC specification
     public static String oidcHash(String jwtAlgorithmName, String input) {
-        try {
-            byte[] inputBytes = input.getBytes("UTF-8");
-            String javaAlgName = JavaAlgorithm.getJavaAlgorithmForHash(jwtAlgorithmName);
-            byte[] hash = hash(javaAlgName, inputBytes);
+        byte[] inputBytes = input.getBytes(StandardCharsets.UTF_8);
+        String javaAlgName = JavaAlgorithm.getJavaAlgorithmForHash(jwtAlgorithmName);
+        byte[] hash = hash(javaAlgName, inputBytes);
 
-            return encodeHashToOIDC(hash);
-        } catch (UnsupportedEncodingException e) {
-            throw new HashException("Error when creating token hash", e);
-        }
+        return encodeHashToOIDC(hash);
     }
 
 

--- a/core/src/main/java/org/keycloak/jose/jws/crypto/RSAProvider.java
+++ b/core/src/main/java/org/keycloak/jose/jws/crypto/RSAProvider.java
@@ -22,6 +22,7 @@ import org.keycloak.common.util.PemUtils;
 import org.keycloak.jose.jws.Algorithm;
 import org.keycloak.jose.jws.JWSInput;
 
+import java.nio.charset.StandardCharsets;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.Signature;
@@ -78,7 +79,7 @@ public class RSAProvider implements SignatureProvider {
         try {
             Signature verifier = getSignature(input.getHeader().getAlgorithm());
             verifier.initVerify(publicKey);
-            verifier.update(input.getEncodedSignatureInput().getBytes("UTF-8"));
+            verifier.update(input.getEncodedSignatureInput().getBytes(StandardCharsets.UTF_8));
             return verifier.verify(input.getSignature());
         } catch (Exception e) {
             return false;


### PR DESCRIPTION
<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
