### PR TITLE
KEYCLOAK-11996 Authorization Endpoint does not return an error when a request includes a parameter more than once

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/request/AuthorizationEndpointRequest.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/request/AuthorizationEndpointRequest.java
@@ -20,6 +20,8 @@ package org.keycloak.protocol.oidc.endpoints.request;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.keycloak.OAuthErrorException;
+
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
  */
@@ -46,6 +48,9 @@ public class AuthorizationEndpointRequest {
     String codeChallengeMethod;
 
     String acr;
+
+    // keep the error on parsing request in order to send it to the client after keycloak confirms the client's valid redirect uri.
+    OAuthErrorException invaidRequestParamException;
 
     public String getAcr() {
         return acr;
@@ -119,5 +124,13 @@ public class AuthorizationEndpointRequest {
 
     public String getDisplay() {
         return display;
+    }
+
+    public OAuthErrorException getInvaidRequestParamException() {
+        return invaidRequestParamException;
+    }
+
+    public void setInvaidRequestParamException(OAuthErrorException invaidRequestParamException) {
+        this.invaidRequestParamException = invaidRequestParamException;
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/request/AuthzEndpointQueryStringParser.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/request/AuthzEndpointQueryStringParser.java
@@ -18,6 +18,7 @@
 package org.keycloak.protocol.oidc.endpoints.request;
 
 import javax.ws.rs.core.MultivaluedMap;
+
 import java.util.Set;
 
 /**
@@ -34,12 +35,14 @@ class AuthzEndpointQueryStringParser extends AuthzEndpointRequestParser {
     }
 
     @Override
-    protected String getParameter(String paramName) {
+    protected String getParameter(String paramName, AuthorizationEndpointRequest request) {
+        checkParameterDuplicated(requestParams, paramName, request);
         return requestParams.getFirst(paramName);
     }
 
     @Override
-    protected Integer getIntParameter(String paramName) {
+    protected Integer getIntParameter(String paramName, AuthorizationEndpointRequest request) {
+        checkParameterDuplicated(requestParams, paramName, request);
         String paramVal = requestParams.getFirst(paramName);
         return paramVal==null ? null : Integer.parseInt(paramVal);
     }

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/request/AuthzEndpointRequestObjectParser.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/request/AuthzEndpointRequestObjectParser.java
@@ -65,7 +65,7 @@ class AuthzEndpointRequestObjectParser extends AuthzEndpointRequestParser {
     }
 
     @Override
-    protected String getParameter(String paramName) {
+    protected String getParameter(String paramName, AuthorizationEndpointRequest request) {
         JsonNode val = this.requestParams.get(paramName);
         if (val == null) {
             return null;
@@ -77,9 +77,9 @@ class AuthzEndpointRequestObjectParser extends AuthzEndpointRequestParser {
     }
 
     @Override
-    protected Integer getIntParameter(String paramName) {
+    protected Integer getIntParameter(String paramName, AuthorizationEndpointRequest request) {
         Object val = this.requestParams.get(paramName);
-        return val==null ? null : Integer.parseInt(getParameter(paramName));
+        return val==null ? null : Integer.parseInt(getParameter(paramName, request));
     }
 
     @Override

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/OAuthClient.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/OAuthClient.java
@@ -150,6 +150,8 @@ public class OAuthClient {
     private String codeChallengeMethod;
     private String origin;
 
+    private Map<String, String> extraParamsAuthzEndpoint;
+
     private boolean openid = true;
 
     private Supplier<CloseableHttpClient> httpClient = OAuthClient::newCloseableHttpClient;
@@ -215,6 +217,7 @@ public class OAuthClient {
         codeChallenge = null;
         codeChallengeMethod = null;
         origin = null;
+        extraParamsAuthzEndpoint = null;
         openid = true;
     }
 
@@ -841,7 +844,11 @@ public class OAuthClient {
         }
         if (codeChallengeMethod != null) {
             b.queryParam(OAuth2Constants.CODE_CHALLENGE_METHOD, codeChallengeMethod);
-        }  
+        }
+        if (extraParamsAuthzEndpoint != null) {
+            extraParamsAuthzEndpoint.keySet().stream().forEach(i -> b.queryParam(i, extraParamsAuthzEndpoint.get(i)));
+        }
+
         return b.build(realm).toString();
     }
 
@@ -1007,6 +1014,11 @@ public class OAuthClient {
     }
     public OAuthClient origin(String origin) {
         this.origin = origin;
+        return this;
+    }
+
+    public OAuthClient extraParamsAuthzEndpoint(Map<String, String> extraParamsAuthzEndpoint) {
+        this.extraParamsAuthzEndpoint = extraParamsAuthzEndpoint;
         return this;
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/AuthorizationCodeTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/AuthorizationCodeTest.java
@@ -226,7 +226,7 @@ public class AuthorizationCodeTest extends AbstractKeycloakTest {
 
         oauth.openLoginForm();
         assertEquals("Invalid Request", driver.findElement(By.className("instruction")).getText());
-        events.expectLogin().error(Errors.INVALID_REQUEST).user((String) null).session((String) null).clearDetails().assertEvent();
+        events.expectLogin().error(Errors.INVALID_REQUEST).user((String) null).session((String) null).client((String) null).clearDetails().assertEvent();
     }
     
 }


### PR DESCRIPTION
It seems that  keycloak does not follow some part of OAuth 2.0.
The details can be found in https://issues.jboss.org/browse/KEYCLOAK-11996.

