### PR TITLE
KEYCLOAK-9129 Don't expose Keycloak version in resource paths

### DIFF
--- a/common/src/main/java/org/keycloak/common/Version.java
+++ b/common/src/main/java/org/keycloak/common/Version.java
@@ -31,6 +31,7 @@ public class Version {
     public static String NAME_FULL;
     public static String NAME_HTML;
     public static String VERSION;
+    public static String VERSION_KEYCLOAK;
     public static String RESOURCES_VERSION;
     public static String BUILD_TIME;
     public static String DEFAULT_PROFILE;
@@ -45,6 +46,7 @@ public class Version {
             Version.NAME_HTML = props.getProperty("name-html");
             Version.DEFAULT_PROFILE = props.getProperty("default-profile");
             Version.VERSION = props.getProperty("version");
+            Version.VERSION_KEYCLOAK = props.getProperty("version-keycloak");
             Version.BUILD_TIME = props.getProperty("build-time");
             Version.RESOURCES_VERSION = Version.VERSION.toLowerCase();
 

--- a/common/src/main/resources/keycloak-version.properties
+++ b/common/src/main/resources/keycloak-version.properties
@@ -19,5 +19,6 @@ name=${product.name}
 name-full=${product.name.full}
 name-html=${product.name-html}
 version=${product.version}
+version-keycloak=${project.version}
 build-time=${product.build-time}
 default-profile=${product.default-profile}

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/MigrationModelEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/MigrationModelEntity.java
@@ -22,7 +22,10 @@ import javax.persistence.AccessType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
+import javax.persistence.NamedQueries;
+import javax.persistence.NamedQuery;
 import javax.persistence.Table;
+import java.util.Date;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -30,6 +33,9 @@ import javax.persistence.Table;
  */
 @Table(name="MIGRATION_MODEL")
 @Entity
+@NamedQueries({
+        @NamedQuery(name = "getLatest", query = "select m from MigrationModelEntity m ORDER BY m.updatedTime DESC")
+})
 public class MigrationModelEntity {
     public static final String SINGLETON_ID = "SINGLETON";
     @Id
@@ -39,6 +45,9 @@ public class MigrationModelEntity {
 
     @Column(name="VERSION", length = 36)
     protected String version;
+
+    @Column(name="UPDATE_TIME")
+    protected long updatedTime;
 
     public String getId() {
         return id;
@@ -54,6 +63,14 @@ public class MigrationModelEntity {
 
     public void setVersion(String version) {
         this.version = version;
+    }
+
+    public long getUpdateTime() {
+        return updatedTime;
+    }
+
+    public void setUpdatedTime(long updatedTime) {
+        this.updatedTime = updatedTime;
     }
 
     @Override

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-8.0.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-8.0.0.xml
@@ -202,4 +202,16 @@
 
     </changeSet>
 
+    <changeSet author="keycloak" id="8.0.0-resource-tag-support">
+        <addColumn tableName="MIGRATION_MODEL">
+            <column name="UPDATE_TIME" type="BIGINT" defaultValueNumeric="0">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+
+        <createIndex tableName="MIGRATION_MODEL" indexName="IDX_UPDATE_TIME">
+            <column name="UPDATE_TIME" type="BIGINT" />
+        </createIndex>
+    </changeSet>
+
 </databaseChangeLog>

--- a/server-spi/src/main/java/org/keycloak/migration/MigrationModel.java
+++ b/server-spi/src/main/java/org/keycloak/migration/MigrationModel.java
@@ -24,5 +24,6 @@ package org.keycloak.migration;
  */
 public interface MigrationModel {
     String getStoredVersion();
+    String getResourcesTag();
     void setStoredVersion(String version);
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/model/MigrationModelTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/model/MigrationModelTest.java
@@ -1,0 +1,70 @@
+package org.keycloak.testsuite.model;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.keycloak.common.Version;
+import org.keycloak.common.util.Time;
+import org.keycloak.connections.jpa.JpaConnectionProvider;
+import org.keycloak.migration.MigrationModel;
+import org.keycloak.models.jpa.entities.MigrationModelEntity;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.testsuite.AbstractKeycloakTest;
+import org.keycloak.testsuite.runonserver.RunOnServerDeployment;
+import org.keycloak.testsuite.runonserver.RunOnServerTest;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+
+public class MigrationModelTest extends AbstractKeycloakTest {
+
+    @Deployment
+    public static WebArchive deploy() {
+        return RunOnServerDeployment.create(MigrationModelTest.class);
+    }
+
+    @Override
+    public void addTestRealms(List<RealmRepresentation> testRealms) {
+    }
+
+    @Test
+    public void test() {
+        testingClient.server().run(session -> {
+            String currentVersion = Version.VERSION_KEYCLOAK.split("-")[0];
+
+            JpaConnectionProvider p = session.getProvider(JpaConnectionProvider.class);
+            EntityManager em = p.getEntityManager();
+
+            List<MigrationModelEntity> l = em.createQuery("select m from MigrationModelEntity m ORDER BY m.updatedTime DESC", MigrationModelEntity.class).getResultList();
+            Assert.assertEquals(1, l.size());
+            Assert.assertTrue(l.get(0).getId().matches("[\\da-z]{5}"));
+            Assert.assertEquals(currentVersion, l.get(0).getVersion());
+
+            MigrationModel m = session.realms().getMigrationModel();
+            Assert.assertEquals(currentVersion, m.getStoredVersion());
+            Assert.assertEquals(m.getResourcesTag(), l.get(0).getId());
+
+            Time.setOffset(-5000);
+
+            session.realms().getMigrationModel().setStoredVersion("6.0.0");
+            em.flush();
+
+            Time.setOffset(0);
+
+            l = em.createQuery("select m from MigrationModelEntity m ORDER BY m.updatedTime DESC", MigrationModelEntity.class).getResultList();
+            Assert.assertEquals(2, l.size());
+            Assert.assertTrue(l.get(0).getId().matches("[\\da-z]{5}"));
+            Assert.assertEquals(currentVersion, l.get(0).getVersion());
+            Assert.assertTrue(l.get(1).getId().matches("[\\da-z]{5}"));
+            Assert.assertEquals("6.0.0", l.get(1).getVersion());
+
+            m = session.realms().getMigrationModel();
+            Assert.assertEquals(l.get(0).getId(), m.getResourcesTag());
+            Assert.assertEquals(currentVersion, m.getStoredVersion());
+
+            em.remove(l.get(1));
+        });
+    }
+
+}


### PR DESCRIPTION
Keycloak version is currently exposed in resource URLs. This PR is a proposal on how to resolve it. It does this by adding a random 5 character URL-friendly ID to the database when Keycloak is updated. This ID is then used as the resource version in-place of the Keycloak version. This means the "resource version" used in URLs are random an unique to each installation so can't be used to decipher the Keycloak version.