### PR TITLE
KEYCLOAK-12162 Modularize config backends

### DIFF
--- a/distribution/feature-packs/server-feature-pack/src/main/resources/modules/system/layers/keycloak/org/keycloak/keycloak-wildfly-extensions/main/module.xml
+++ b/distribution/feature-packs/server-feature-pack/src/main/resources/modules/system/layers/keycloak/org/keycloak/keycloak-wildfly-extensions/main/module.xml
@@ -25,11 +25,15 @@
     </resources>
 
     <dependencies>
+        <module name="com.fasterxml.jackson.core.jackson-databind"/>
+        <module name="javax.servlet.api"/>
         <module name="org.keycloak.keycloak-common"/>
         <module name="org.keycloak.keycloak-core"/>
         <module name="org.keycloak.keycloak-server-spi"/>
         <module name="org.keycloak.keycloak-server-spi-private"/>
         <module name="org.keycloak.keycloak-services"/>
+        <module name="org.jboss.dmr"/>
+        <module name="org.jboss.logging"/>
         <module name="org.jboss.modules"/>
         <module name="org.jboss.resteasy.resteasy-jaxrs"/>
     </dependencies>

--- a/server-spi-private/src/main/java/org/keycloak/config/ConfigProviderFactory.java
+++ b/server-spi-private/src/main/java/org/keycloak/config/ConfigProviderFactory.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.config;
+
+import java.util.Optional;
+import org.keycloak.Config;
+
+public interface ConfigProviderFactory {
+
+    default boolean isFallback() {
+        return false;
+    }
+
+    Optional<Config.ConfigProvider> create();
+
+}

--- a/server-spi-private/src/main/java/org/keycloak/config/ConfigProviderFactory.java
+++ b/server-spi-private/src/main/java/org/keycloak/config/ConfigProviderFactory.java
@@ -22,10 +22,6 @@ import org.keycloak.Config;
 
 public interface ConfigProviderFactory {
 
-    default boolean isFallback() {
-        return false;
-    }
-
     Optional<Config.ConfigProvider> create();
 
 }

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -89,11 +89,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly.core</groupId>
-            <artifactId>wildfly-controller</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>
         </dependency>

--- a/services/src/main/java/org/keycloak/services/util/JsonConfigProviderFactory.java
+++ b/services/src/main/java/org/keycloak/services/util/JsonConfigProviderFactory.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.services.util;
+
+import org.keycloak.config.ConfigProviderFactory;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.util.Optional;
+import java.util.Properties;
+import org.jboss.logging.Logger;
+import org.keycloak.Config;
+import org.keycloak.common.util.SystemEnvProperties;
+import org.keycloak.services.ServicesLogger;
+
+public class JsonConfigProviderFactory implements ConfigProviderFactory {
+
+    private static final Logger LOG = Logger.getLogger(JsonConfigProviderFactory.class);
+
+    @Override
+    public boolean isFallback() {
+        return true;
+    }
+
+    @Override
+    public Optional<Config.ConfigProvider> create() {
+
+        JsonNode node = null;
+
+        try {
+            String configDir = System.getProperty("jboss.server.config.dir");
+            if (node == null && configDir != null) {
+                File f = new File(configDir + File.separator + "keycloak-server.json");
+                if (f.isFile()) {
+                    ServicesLogger.LOGGER.loadingFrom(f.getAbsolutePath());
+                    node = new ObjectMapper().readTree(f);
+                }
+            }
+
+            if (node == null) {
+                URL resource = Thread.currentThread().getContextClassLoader().getResource("META-INF/keycloak-server.json");
+                if (resource != null) {
+                    ServicesLogger.LOGGER.loadingFrom(resource);
+                    node = new ObjectMapper().readTree(resource);
+                }
+            }
+        } catch (IOException e) {
+            LOG.warn("Failed to load JSON config", e);
+        }
+
+        return createJsonProvider(node);
+
+    }
+
+    protected Optional<Config.ConfigProvider> createJsonProvider(JsonNode node) {
+        return Optional.ofNullable(node).map(n -> new JsonConfigProvider(n, getProperties()));
+    }
+
+    protected Properties getProperties() {
+        return new SystemEnvProperties();
+    }
+
+}

--- a/services/src/main/java/org/keycloak/services/util/JsonConfigProviderFactory.java
+++ b/services/src/main/java/org/keycloak/services/util/JsonConfigProviderFactory.java
@@ -19,7 +19,6 @@ package org.keycloak.services.util;
 
 import org.keycloak.config.ConfigProviderFactory;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
@@ -29,15 +28,11 @@ import org.jboss.logging.Logger;
 import org.keycloak.Config;
 import org.keycloak.common.util.SystemEnvProperties;
 import org.keycloak.services.ServicesLogger;
+import org.keycloak.util.JsonSerialization;
 
-public class JsonConfigProviderFactory implements ConfigProviderFactory {
+public abstract class JsonConfigProviderFactory implements ConfigProviderFactory {
 
     private static final Logger LOG = Logger.getLogger(JsonConfigProviderFactory.class);
-
-    @Override
-    public boolean isFallback() {
-        return true;
-    }
 
     @Override
     public Optional<Config.ConfigProvider> create() {
@@ -46,11 +41,11 @@ public class JsonConfigProviderFactory implements ConfigProviderFactory {
 
         try {
             String configDir = System.getProperty("jboss.server.config.dir");
-            if (node == null && configDir != null) {
+            if (configDir != null) {
                 File f = new File(configDir + File.separator + "keycloak-server.json");
                 if (f.isFile()) {
                     ServicesLogger.LOGGER.loadingFrom(f.getAbsolutePath());
-                    node = new ObjectMapper().readTree(f);
+                    node = JsonSerialization.mapper.readTree(f);
                 }
             }
 
@@ -58,7 +53,7 @@ public class JsonConfigProviderFactory implements ConfigProviderFactory {
                 URL resource = Thread.currentThread().getContextClassLoader().getResource("META-INF/keycloak-server.json");
                 if (resource != null) {
                     ServicesLogger.LOGGER.loadingFrom(resource);
-                    node = new ObjectMapper().readTree(resource);
+                    node = JsonSerialization.mapper.readTree(resource);
                 }
             }
         } catch (IOException e) {

--- a/services/src/main/java/org/keycloak/utils/CRLUtils.java
+++ b/services/src/main/java/org/keycloak/utils/CRLUtils.java
@@ -24,12 +24,10 @@ import java.security.cert.X509CRL;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import javax.security.auth.x500.X500Principal;
@@ -46,7 +44,6 @@ import org.jboss.logging.Logger;
 import org.keycloak.common.util.BouncyIntegration;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.truststore.TruststoreProvider;
-import org.wildfly.security.x500.X500;
 
 /**
  * @author <a href="mailto:brat000012001@gmail.com">Peter Nalyvayko</a>

--- a/testsuite/integration-arquillian/servers/auth-server/undertow/src/main/java/org/keycloak/testsuite/arquillian/undertow/KeycloakOnUndertow.java
+++ b/testsuite/integration-arquillian/servers/auth-server/undertow/src/main/java/org/keycloak/testsuite/arquillian/undertow/KeycloakOnUndertow.java
@@ -49,6 +49,7 @@ import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.services.filters.KeycloakSessionServletFilter;
 import org.keycloak.services.managers.ApplianceBootstrap;
 import org.keycloak.services.resources.KeycloakApplication;
+import org.keycloak.testsuite.JsonConfigProviderFactory;
 import org.keycloak.testsuite.KeycloakServer;
 import org.keycloak.testsuite.TestKeycloakSessionServletFilter;
 import org.keycloak.testsuite.utils.tls.TLSUtils;
@@ -69,7 +70,7 @@ import org.xnio.SslClientAuthMode;
 public class KeycloakOnUndertow implements DeployableContainer<KeycloakOnUndertowConfiguration> {
 
     protected final Logger log = Logger.getLogger(this.getClass());
-    
+
     private KeycloakUndertowJaxrsServer undertow;
     private KeycloakOnUndertowConfiguration configuration;
     private KeycloakSessionFactory sessionFactory;
@@ -90,7 +91,7 @@ public class KeycloakOnUndertow implements DeployableContainer<KeycloakOnUnderto
         di.addInitParameter(KeycloakApplication.KEYCLOAK_EMBEDDED, "true");
         if (configuration.getKeycloakConfigPropertyOverridesMap() != null) {
             try {
-                di.addInitParameter(KeycloakApplication.SERVER_CONTEXT_CONFIG_PROPERTY_OVERRIDES,
+                di.addInitParameter(JsonConfigProviderFactory.SERVER_CONTEXT_CONFIG_PROPERTY_OVERRIDES,
                   JsonSerialization.writeValueAsString(configuration.getKeycloakConfigPropertyOverridesMap()));
             } catch (IOException ex) {
                 throw new RuntimeException(ex);

--- a/testsuite/utils/src/main/java/org/keycloak/testsuite/JsonConfigProviderFactory.java
+++ b/testsuite/utils/src/main/java/org/keycloak/testsuite/JsonConfigProviderFactory.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import javax.servlet.ServletContext;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
+import org.keycloak.common.util.SystemEnvProperties;
+
+public class JsonConfigProviderFactory extends org.keycloak.services.util.JsonConfigProviderFactory {
+
+    public static final String SERVER_CONTEXT_CONFIG_PROPERTY_OVERRIDES = "keycloak.server.context.config.property-overrides";
+
+    @Override
+    protected Properties getProperties() {
+        return new SystemEnvProperties(getPropertyOverrides());
+    }
+
+    private Map<String, String> getPropertyOverrides() {
+
+        ServletContext context = ResteasyProviderFactory.getContextData(ServletContext.class);
+        Map<String, String> propertyOverridesMap = new HashMap<>();
+        String propertyOverrides = context.getInitParameter(SERVER_CONTEXT_CONFIG_PROPERTY_OVERRIDES);
+
+        try {
+            if (context.getInitParameter(SERVER_CONTEXT_CONFIG_PROPERTY_OVERRIDES) != null) {
+                JsonNode jsonObj = new ObjectMapper().readTree(propertyOverrides);
+                jsonObj.fields().forEachRemaining(e -> propertyOverridesMap.put(e.getKey(), e.getValue().asText()));
+            }
+        } catch (IOException e) {
+        }
+
+        return propertyOverridesMap;
+
+    }
+
+}

--- a/testsuite/utils/src/main/java/org/keycloak/testsuite/JsonConfigProviderFactory.java
+++ b/testsuite/utils/src/main/java/org/keycloak/testsuite/JsonConfigProviderFactory.java
@@ -18,7 +18,6 @@
 package org.keycloak.testsuite;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -26,6 +25,7 @@ import java.util.Properties;
 import javax.servlet.ServletContext;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.keycloak.common.util.SystemEnvProperties;
+import org.keycloak.util.JsonSerialization;
 
 public class JsonConfigProviderFactory extends org.keycloak.services.util.JsonConfigProviderFactory {
 
@@ -44,7 +44,7 @@ public class JsonConfigProviderFactory extends org.keycloak.services.util.JsonCo
 
         try {
             if (context.getInitParameter(SERVER_CONTEXT_CONFIG_PROPERTY_OVERRIDES) != null) {
-                JsonNode jsonObj = new ObjectMapper().readTree(propertyOverrides);
+                JsonNode jsonObj = JsonSerialization.mapper.readTree(propertyOverrides);
                 jsonObj.fields().forEachRemaining(e -> propertyOverridesMap.put(e.getKey(), e.getValue().asText()));
             }
         } catch (IOException e) {

--- a/testsuite/utils/src/main/resources/META-INF/services/org.keycloak.config.ConfigProviderFactory
+++ b/testsuite/utils/src/main/resources/META-INF/services/org.keycloak.config.ConfigProviderFactory
@@ -1,0 +1,1 @@
+org.keycloak.testsuite.JsonConfigProviderFactory

--- a/wildfly/extensions/src/main/java/org/keycloak/provider/wildfly/DMRConfigProviderFactory.java
+++ b/wildfly/extensions/src/main/java/org/keycloak/provider/wildfly/DMRConfigProviderFactory.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.provider.wildfly;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.Optional;
+import javax.servlet.ServletContext;
+import org.jboss.dmr.ModelNode;
+import org.jboss.logging.Logger;
+import org.keycloak.Config;
+import org.keycloak.common.util.Resteasy;
+import org.keycloak.services.ServicesLogger;
+
+public class DMRConfigProviderFactory extends JsonConfigProviderFactory {
+
+    // This param name is defined again in Keycloak Server Subsystem class
+    // org.keycloak.subsystem.server.extension.KeycloakServerDeploymentProcessor.  We have this value in
+    // two places to avoid dependency between Keycloak Subsystem and Keycloak Wildfly Extensions module.
+    public static final String KEYCLOAK_CONFIG_PARAM_NAME = "org.keycloak.server-subsystem.Config";
+
+    private static final Logger LOG = Logger.getLogger(DMRConfigProviderFactory.class);
+
+    @Override
+    public boolean isFallback() {
+        return false;
+    }
+
+    @Override
+    public Optional<Config.ConfigProvider> create() {
+
+        ServletContext context = Resteasy.getContextData(ServletContext.class);
+
+        JsonNode node = null;
+
+        try {
+            String dmrConfig = loadDmrConfig(context);
+            if (dmrConfig != null) {
+                node = new ObjectMapper().readTree(dmrConfig);
+                ServicesLogger.LOGGER.loadingFrom("standalone.xml or domain.xml");
+            }
+        } catch (IOException e) {
+            LOG.warn("Failed to load DMR config", e);
+        }
+
+        return createJsonProvider(node);
+
+    }
+
+    private String loadDmrConfig(ServletContext context) {
+        String dmrConfig = context.getInitParameter(KEYCLOAK_CONFIG_PARAM_NAME);
+        if (dmrConfig == null) {
+            return null;
+        }
+
+        ModelNode dmrConfigNode = ModelNode.fromString(dmrConfig);
+        if (dmrConfigNode.asPropertyList().isEmpty()) {
+            return null;
+        }
+
+        // note that we need to resolve expressions BEFORE we convert to JSON
+        return dmrConfigNode.resolve().toJSONString(true);
+    }
+
+}

--- a/wildfly/extensions/src/main/resources/META-INF/services/org.keycloak.config.ConfigProviderFactory
+++ b/wildfly/extensions/src/main/resources/META-INF/services/org.keycloak.config.ConfigProviderFactory
@@ -15,5 +15,4 @@
 # limitations under the License.
 #
 
-org.keycloak.provider.wildfly.JsonConfigProviderFactory
 org.keycloak.provider.wildfly.DMRConfigProviderFactory

--- a/wildfly/extensions/src/main/resources/META-INF/services/org.keycloak.config.ConfigProviderFactory
+++ b/wildfly/extensions/src/main/resources/META-INF/services/org.keycloak.config.ConfigProviderFactory
@@ -1,0 +1,19 @@
+#
+# Copyright 2019 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.keycloak.provider.wildfly.JsonConfigProviderFactory
+org.keycloak.provider.wildfly.DMRConfigProviderFactory


### PR DESCRIPTION
Support for modular config provider factories, loadable via ServiceLoader. This is a prerequisite for Quarkus (MicroProfile-based) configuration.