### PR TITLE
KEYCLAOK-12069: keycloak.js changes broke new account console

### DIFF
--- a/services/src/main/java/org/keycloak/services/managers/RealmManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/RealmManager.java
@@ -406,6 +406,7 @@ public class RealmManager {
             client = KeycloakModelUtils.createClient(realm, Constants.ACCOUNT_MANAGEMENT_CLIENT_ID);
             client.setName("${client_" + Constants.ACCOUNT_MANAGEMENT_CLIENT_ID + "}");
             client.setEnabled(true);
+            client.setPublicClient(true);
             client.setFullScopeAllowed(false);
 
             client.setRootUrl(Constants.AUTH_BASE_URL_PROP);

--- a/services/src/main/java/org/keycloak/services/resources/account/AccountConsole.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountConsole.java
@@ -43,6 +43,8 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import javax.ws.rs.core.UriInfo;
+import org.keycloak.services.resources.RealmsResource;
 
 /**
  * Created by st on 29/03/17.
@@ -84,12 +86,15 @@ public class AccountConsole {
         } else {
             Map<String, Object> map = new HashMap<>();
 
-            URI baseUri = session.getContext().getUri().getBaseUri();
+            
 
-            map.put("authUrl", session.getContext().getUri(UrlType.FRONTEND).getBaseUri().toString());
-            map.put("baseUrl", session.getContext().getUri(UrlType.FRONTEND).getBaseUriBuilder().replacePath("/realms/" + realm.getName() + "/account").build().toString());
+            UriInfo uriInfo = session.getContext().getUri(UrlType.FRONTEND);
+            URI authUrl = uriInfo.getBaseUri();
+            map.put("authUrl", authUrl.toString());
+            map.put("baseUrl", uriInfo.getBaseUriBuilder().path(RealmsResource.class).path(realm.getName()).path(Constants.ACCOUNT_MANAGEMENT_CLIENT_ID).build(realm).toString());
             map.put("realm", realm);
-            map.put("resourceUrl", Urls.themeRoot(baseUri).getPath() + "/account/" + theme.getName());
+            map.put("resourceUrl", Urls.themeRoot(authUrl).getPath() + "/" + Constants.ACCOUNT_MANAGEMENT_CLIENT_ID + "/" + theme.getName());
+            
             map.put("resourceVersion", Version.RESOURCES_VERSION);
             
             String[] referrer = getReferrer();

--- a/themes/src/main/resources/theme/keycloak-preview/account/index.ftl
+++ b/themes/src/main/resources/theme/keycloak-preview/account/index.ftl
@@ -57,7 +57,7 @@
         <link rel="icon" href="${resourceUrl}/app/assets/img/favicon.ico" type="image/x-icon"/>
         <link rel="stylesheet" href="${resourceUrl}/node_modules/@patternfly/patternfly/patternfly.min.css">
 
-        <script src="${authUrl}/js/keycloak.js"></script>
+        <script src="${authUrl}js/keycloak.js"></script>
         
         <#if properties.developmentMode?has_content && properties.developmentMode == "true">
         <!-- Don't use this in production: -->
@@ -86,7 +86,7 @@
     <body>
 
         <script>
-            var keycloak = Keycloak('${authUrl}/realms/${realm.name}/account/keycloak.json');
+            var keycloak = Keycloak('${authUrl}realms/${realm.name}/account/keycloak.json');
             keycloak.init({onLoad: 'check-sso'}).success(function(authenticated) {
                 toggleReact();
                 if (!keycloak.authenticated) {

--- a/themes/src/main/resources/theme/keycloak-preview/account/resources/app/content/aia-page/AppInitiatedActionPage.tsx
+++ b/themes/src/main/resources/theme/keycloak-preview/account/resources/app/content/aia-page/AppInitiatedActionPage.tsx
@@ -80,7 +80,6 @@ class ApplicationInitiatedActionPage extends React.Component<AppInitiatedActionP
                              "?response_type=code" +
                              "&client_id=account&scope=openid" +
                              "&kc_action=" + this.props.pageDef.kcAction + 
-                             "&silent_cancel=true" +
                              "&redirect_uri=" + redirectURI +
                              encodeURIComponent("/#" + this.props.location.pathname); // return to this page
 

--- a/themes/src/main/resources/theme/keycloak-preview/account/resources/content.js
+++ b/themes/src/main/resources/theme/keycloak-preview/account/resources/content.js
@@ -14,14 +14,14 @@ var content = [
                 label: 'password',
                 modulePath: '/app/content/aia-page/AppInitiatedActionPage',
                 componentName: 'AppInitiatedActionPage',
-                kcAction: 'update_password'
+                kcAction: 'UPDATE_PASSWORD'
             },
             {
                 path: 'security/authenticator',
                 label: 'authenticator',
                 modulePath: '/app/content/aia-page/AppInitiatedActionPage',
                 componentName: 'AppInitiatedActionPage',
-                kcAction: 'configure_totp'
+                kcAction: 'CONFIGURE_TOTP'
             },
             {
                 path: 'security/device-activity',


### PR DESCRIPTION
KEYCLOAK-11971 broke the new account console.  This PR fixes it by:
1) Removing extra slash when requesting keycloak.js and keycloak.json
2) Making "account" be a public client.
