### PR TITLE
KEYCLOAK-12165 Fix UserSessionProviderTest to work correctly

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/model/UserSessionProviderTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/model/UserSessionProviderTest.java
@@ -254,29 +254,30 @@ public class UserSessionProviderTest extends AbstractTestRealmKeycloakTest {
     @ModelTest
     public void testRemoveUserSessionsByUser(KeycloakSession session) {
         RealmModel realm = session.realms().getRealmByName("test");
-        UserSessionModel[] sessions = createSessions(session);
 
+        KeycloakModelUtils.runJobInTransaction(session.getKeycloakSessionFactory(), (KeycloakSession kcSession) -> {
+            createSessions(kcSession);
+        });
         Map<String, Integer> clientSessionsKept = new HashMap<>();
-        for (UserSessionModel s : sessions) {
-            s = session.sessions().getUserSession(realm, s.getId());
+        for (UserSessionModel s : session.sessions().getUserSessions(realm,
+            session.users().getUserByUsername("user2", realm))) {
 
-            if (!s.getUser().getUsername().equals("user1")) {
-                clientSessionsKept.put(s.getId(),  s.getAuthenticatedClientSessions().keySet().size());
-            }
+            clientSessionsKept.put(s.getId(), s.getAuthenticatedClientSessions().keySet().size());
         }
 
-        session.sessions().removeUserSessions(realm, session.users().getUserByUsername("user1", realm));
+        KeycloakModelUtils.runJobInTransaction(session.getKeycloakSessionFactory(), (KeycloakSession kcSession) -> {
+            kcSession.sessions().removeUserSessions(realm, kcSession.users().getUserByUsername("user1", realm));
+        });
 
         assertTrue(session.sessions().getUserSessions(realm, session.users().getUserByUsername("user1", realm)).isEmpty());
-        List<UserSessionModel> userSessions = session.sessions().getUserSessions(realm, session.users().getUserByUsername("user2", realm));
+        List<UserSessionModel> userSessions = session.sessions().getUserSessions(realm,
+            session.users().getUserByUsername("user2", realm));
 
-        assertSame(userSessions.size(), 0);
-
-        session.getTransactionManager().commit();
-        // Null test removed, it seems that NULL is not a valid state under the new testsuite so we are testing for Size=0
+        assertSame(userSessions.size(), 1);
 
         for (UserSessionModel userSession : userSessions) {
-            Assert.assertEquals((int) clientSessionsKept.get(userSession.getId()), userSession.getAuthenticatedClientSessions().size());
+            Assert.assertEquals((int) clientSessionsKept.get(userSession.getId()),
+                userSession.getAuthenticatedClientSessions().size());
         }
     }
 
@@ -293,11 +294,15 @@ public class UserSessionProviderTest extends AbstractTestRealmKeycloakTest {
 
     @Test
     @ModelTest
-    public  void testRemoveUserSessionsByRealm(KeycloakSession session) {
+    public void testRemoveUserSessionsByRealm(KeycloakSession session) {
         RealmModel realm = session.realms().getRealmByName("test");
-        UserSessionModel[] sessions = createSessions(session);
+        KeycloakModelUtils.runJobInTransaction(session.getKeycloakSessionFactory(), (KeycloakSession kcSession) -> {
+            createSessions(kcSession);
+        });
 
-        session.sessions().removeUserSessions(realm);
+        KeycloakModelUtils.runJobInTransaction(session.getKeycloakSessionFactory(), (KeycloakSession kcSession) -> {
+            kcSession.sessions().removeUserSessions(realm);
+        });
 
         assertTrue(session.sessions().getUserSessions(realm, session.users().getUserByUsername("user1", realm)).isEmpty());
         assertTrue(session.sessions().getUserSessions(realm, session.users().getUserByUsername("user2", realm)).isEmpty());


### PR DESCRIPTION
Changed `createSessions` method to commit correctly, and then fixed failed tests (`testRemoveUserSessionsByUser` and `testRemoveUserSessionsByRealm`).