### PR TITLE
KEYCLOAK-11630: remove check that leads to too many redirects error

### DIFF
--- a/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/filter/KeycloakSecurityContextRequestFilter.java
+++ b/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/filter/KeycloakSecurityContextRequestFilter.java
@@ -78,7 +78,7 @@ public class KeycloakSecurityContextRequestFilter extends GenericFilterBean impl
                 refreshableSecurityContext.setCurrentRequestInfo(deployment, adapterTokenStore);
             }
 
-            if (!refreshableSecurityContext.isActive() || deployment.isAlwaysRefreshToken()) {
+            if (deployment.isAlwaysRefreshToken()) {
                 if (refreshableSecurityContext.refreshExpiredToken(false)) {
                     request.setAttribute(KeycloakSecurityContext.class.getName(), refreshableSecurityContext);
                 } else {


### PR DESCRIPTION
In the context of KEYCLOAK-7798, the following change has been introduced in org.keycloak.adapters.springsecurity.filter.KeycloakSecurityContextRequestFilter in the adapters module in the doFilter method:

Here is the PR for more details: https://github.com/keycloak/keycloak/pull/5688/files

Before change:
```
            if (deployment.isAlwaysRefreshToken()) {
                if (refreshableSecurityContext.refreshExpiredToken(false)) {
                    request.setAttribute(KeycloakSecurityContext.class.getName(), refreshableSecurityContext);
                } else {
                    clearAuthenticationContext();
                }
            }
```
After change :
```
            if (!refreshableSecurityContext.isActive() || deployment.isAlwaysRefreshToken()) {
                if (refreshableSecurityContext.refreshExpiredToken(false)) {
                    request.setAttribute(KeycloakSecurityContext.class.getName(), refreshableSecurityContext);
                } else {
                    clearAuthenticationContext();
                }
            }
```
For some reason, this change leads to too many redirects error when used with Spring and spring-session-data-mongodb. It could have also issues with other spring-sessions modules, I have not tested. The main issue is the added !refreshableSecurityContext.isActive(), when removed everything works fine.

I created a demo repository for this purpose: https://github.com/zak905/spring-boot-keycloak-mongo-session-bug