### PR TITLE
KEYCLOAK-12094 Change to remove client sessions when the client deleted

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/RealmAdminResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RealmAdminResource.java
@@ -600,18 +600,19 @@ public class RealmAdminResource {
     public List<Map<String, String>> getClientSessionStats() {
         auth.realm().requireViewRealm();
 
-        Map<String, Map<String, String>> data = new HashMap();
+        Map<String, Map<String, String>> data = new HashMap<>();
         {
-            Map<String, Long> activeCount =session.sessions().getActiveClientSessionStats(realm, false);
+            Map<String, Long> activeCount = session.sessions().getActiveClientSessionStats(realm, false);
             for (Map.Entry<String, Long> entry : activeCount.entrySet()) {
                 Map<String, String> map = new HashMap<>();
                 ClientModel client = realm.getClientById(entry.getKey());
+                if (client == null)
+                    continue;
                 map.put("id", client.getId());
                 map.put("clientId", client.getClientId());
                 map.put("active", entry.getValue().toString());
                 map.put("offline", "0");
                 data.put(client.getId(), map);
-
             }
         }
         {
@@ -621,6 +622,8 @@ public class RealmAdminResource {
                 if (map == null) {
                     map = new HashMap<>();
                     ClientModel client = realm.getClientById(entry.getKey());
+                    if (client == null)
+                        continue;
                     map.put("id", client.getId());
                     map.put("clientId", client.getClientId());
                     map.put("active", "0");
@@ -630,7 +633,8 @@ public class RealmAdminResource {
             }
         }
         List<Map<String, String>> result = new LinkedList<>();
-        for (Map<String, String> item : data.values()) result.add(item);
+        for (Map<String, String> item : data.values())
+            result.add(item);
         return result;
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/realm/RealmTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/realm/RealmTest.java
@@ -757,7 +757,8 @@ public class RealmTest extends AbstractAdminTest {
         System.out.println(sessionStats.size());
 
         oauth.doLogin("testuser", "password");
-        AccessTokenResponse tokenResponse = oauth.doAccessTokenRequest(oauth.getCurrentQuery().get(OAuth2Constants.CODE), "secret");
+        AccessTokenResponse tokenResponse = oauth.doAccessTokenRequest(oauth.getCurrentQuery().get(OAuth2Constants.CODE),
+            "secret");
         assertEquals(200, tokenResponse.getStatusCode());
 
         sessionStats = realm.getClientSessionStats();
@@ -765,6 +766,13 @@ public class RealmTest extends AbstractAdminTest {
         assertEquals(1, sessionStats.size());
         assertEquals("test-app", sessionStats.get(0).get("clientId"));
         assertEquals("1", sessionStats.get(0).get("active"));
+
+        String clientUuid = sessionStats.get(0).get("id");
+        realm.clients().get(clientUuid).remove();
+
+        sessionStats = realm.getClientSessionStats();
+
+        assertEquals(0, sessionStats.size());
     }
 
     private void setupTestAppAndUser() {


### PR DESCRIPTION
The problem is that client sessions were left when the client was deleted.

I changed to the following:
- When a client deleted, CLIENT_REMOVED_SESSION_EVENT is added.
- In CLIENT_REMOVED_SESSION_EVENT, client sessions are unregistered from its user session and removed.
- This is worked for both online and offline.