### PR TITLE
[KEYCLOAK-1136] - Adding quarkus distribution to the build

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -66,6 +66,12 @@
                 <module>downloads</module>
             </modules>
         </profile>
+        <profile>
+            <id>quarkus</id>
+            <modules>
+                <module>server-x</module>
+            </modules>
+        </profile>
     </profiles>
 
 </project>

--- a/distribution/server-x/pom.xml
+++ b/distribution/server-x/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-distribution-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>8.0.0-SNAPSHOT</version>
+        <version>9.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>keycloak-server-x</artifactId>
@@ -33,6 +33,16 @@
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-themes</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-quarkus-server</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1741,6 +1741,15 @@
             <modules>
                 <module>quarkus</module>
             </modules>
+            <dependencyManagement>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.keycloak</groupId>
+                        <artifactId>keycloak-quarkus-server</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
+                </dependencies>
+            </dependencyManagement>
         </profile>
 
     </profiles>


### PR DESCRIPTION
These changes allow building the distribution alone where server-x is added as a dependency and properly built (including transitive deps).

We'll use that when building container images from Github repository.