### PR TITLE
KEYCLOAK-11347 - JSON ConfigProvider for Quarkus (temporary)

### DIFF
--- a/quarkus/extensions/pom.xml
+++ b/quarkus/extensions/pom.xml
@@ -34,6 +34,10 @@
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-server-spi-private</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
             <artifactId>keycloak-services</artifactId>
         </dependency>
         <dependency>

--- a/quarkus/extensions/src/main/java/org/keycloak/provider/quarkus/JsonConfigProviderFactory.java
+++ b/quarkus/extensions/src/main/java/org/keycloak/provider/quarkus/JsonConfigProviderFactory.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.provider.quarkus;
+
+public class JsonConfigProviderFactory extends org.keycloak.services.util.JsonConfigProviderFactory {
+
+}

--- a/quarkus/extensions/src/main/resources/META-INF/services/org.keycloak.config.ConfigProviderFactory
+++ b/quarkus/extensions/src/main/resources/META-INF/services/org.keycloak.config.ConfigProviderFactory
@@ -1,0 +1,18 @@
+#
+# Copyright 2019 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.keycloak.provider.quarkus.JsonConfigProviderFactory


### PR DESCRIPTION
Temporarily bring back JSON config for Quarkus-based distro, until MP-Config provider is completed