### PR TITLE
KEYCLOAK-12406 Add "Client Session Max" and "Client Session Idle" for…

### DIFF
--- a/core/src/main/java/org/keycloak/representations/idm/RealmRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/idm/RealmRepresentation.java
@@ -50,6 +50,8 @@ public class RealmRepresentation {
     // KEYCLOAK-7688 Offline Session Max for Offline Token
     protected Boolean offlineSessionMaxLifespanEnabled;
     protected Integer offlineSessionMaxLifespan;
+    protected Integer clientSessionIdleTimeout;
+    protected Integer clientSessionMaxLifespan;
     protected Integer accessCodeLifespan;
     protected Integer accessCodeLifespanUserAction;
     protected Integer accessCodeLifespanLogin;
@@ -367,6 +369,22 @@ public class RealmRepresentation {
 
     public void setOfflineSessionMaxLifespan(Integer offlineSessionMaxLifespan) {
         this.offlineSessionMaxLifespan = offlineSessionMaxLifespan;
+    }
+
+    public Integer getClientSessionIdleTimeout() {
+        return clientSessionIdleTimeout;
+    }
+
+    public void setClientSessionIdleTimeout(Integer clientSessionIdleTimeout) {
+        this.clientSessionIdleTimeout = clientSessionIdleTimeout;
+    }
+
+    public Integer getClientSessionMaxLifespan() {
+        return clientSessionMaxLifespan;
+    }
+
+    public void setClientSessionMaxLifespan(Integer clientSessionMaxLifespan) {
+        this.clientSessionMaxLifespan = clientSessionMaxLifespan;
     }
 
     public List<ScopeMappingRepresentation> getScopeMappings() {

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmAdapter.java
@@ -481,6 +481,32 @@ public class RealmAdapter implements CachedRealmModel {
     }
 
     @Override
+    public int getClientSessionIdleTimeout() {
+        if (isUpdated())
+            return updated.getClientSessionIdleTimeout();
+        return cached.getClientSessionIdleTimeout();
+    }
+
+    @Override
+    public void setClientSessionIdleTimeout(int seconds) {
+        getDelegateForUpdate();
+        updated.setClientSessionIdleTimeout(seconds);
+    }
+
+    @Override
+    public int getClientSessionMaxLifespan() {
+        if (isUpdated())
+            return updated.getClientSessionMaxLifespan();
+        return cached.getClientSessionMaxLifespan();
+    }
+
+    @Override
+    public void setClientSessionMaxLifespan(int seconds) {
+        getDelegateForUpdate();
+        updated.setClientSessionMaxLifespan(seconds);
+    }
+
+    @Override
     public int getAccessTokenLifespan() {
         if (isUpdated()) return updated.getAccessTokenLifespan();
         return cached.getAccessTokenLifespan();

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/entities/CachedRealm.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/entities/CachedRealm.java
@@ -86,6 +86,8 @@ public class CachedRealm extends AbstractExtendableRevisioned {
     // KEYCLOAK-7688 Offline Session Max for Offline Token
     protected boolean offlineSessionMaxLifespanEnabled;
     protected int offlineSessionMaxLifespan;
+    protected int clientSessionIdleTimeout;
+    protected int clientSessionMaxLifespan;
     protected int accessTokenLifespan;
     protected int accessTokenLifespanForImplicitFlow;
     protected int accessCodeLifespan;
@@ -197,6 +199,8 @@ public class CachedRealm extends AbstractExtendableRevisioned {
         // KEYCLOAK-7688 Offline Session Max for Offline Token
         offlineSessionMaxLifespanEnabled = model.isOfflineSessionMaxLifespanEnabled();
         offlineSessionMaxLifespan = model.getOfflineSessionMaxLifespan();
+        clientSessionIdleTimeout = model.getClientSessionIdleTimeout();
+        clientSessionMaxLifespan = model.getClientSessionMaxLifespan();
         accessTokenLifespan = model.getAccessTokenLifespan();
         accessTokenLifespanForImplicitFlow = model.getAccessTokenLifespanForImplicitFlow();
         accessCodeLifespan = model.getAccessCodeLifespan();
@@ -445,6 +449,14 @@ public class CachedRealm extends AbstractExtendableRevisioned {
 
     public int getOfflineSessionMaxLifespan() {
         return offlineSessionMaxLifespan;
+    }
+
+    public int getClientSessionIdleTimeout() {
+        return clientSessionIdleTimeout;
+    }
+
+    public int getClientSessionMaxLifespan() {
+        return clientSessionMaxLifespan;
     }
 
     public int getAccessTokenLifespan() {

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/RealmAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/RealmAdapter.java
@@ -524,6 +524,26 @@ public class RealmAdapter implements RealmModel, JpaModel<RealmEntity> {
     }
 
     @Override
+    public int getClientSessionIdleTimeout() {
+        return getAttribute(RealmAttributes.CLIENT_SESSION_IDLE_TIMEOUT, 0);
+    }
+
+    @Override
+    public void setClientSessionIdleTimeout(int seconds) {
+        setAttribute(RealmAttributes.CLIENT_SESSION_IDLE_TIMEOUT, seconds);
+    }
+
+    @Override
+    public int getClientSessionMaxLifespan() {
+        return getAttribute(RealmAttributes.CLIENT_SESSION_MAX_LIFESPAN, 0);
+    }
+
+    @Override
+    public void setClientSessionMaxLifespan(int seconds) {
+        setAttribute(RealmAttributes.CLIENT_SESSION_MAX_LIFESPAN, seconds);
+    }
+
+    @Override
     public int getAccessCodeLifespan() {
         return realm.getAccessCodeLifespan();
     }

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/RealmAttributes.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/RealmAttributes.java
@@ -34,7 +34,8 @@ public interface RealmAttributes {
     String OFFLINE_SESSION_MAX_LIFESPAN_ENABLED = "offlineSessionMaxLifespanEnabled";
 
     String OFFLINE_SESSION_MAX_LIFESPAN = "offlineSessionMaxLifespan";
-    
+    String CLIENT_SESSION_IDLE_TIMEOUT = "clientSessionIdleTimeout";
+    String CLIENT_SESSION_MAX_LIFESPAN = "clientSessionMaxLifespan";
     String WEBAUTHN_POLICY_RP_ENTITY_NAME = "webAuthnPolicyRpEntityName";
     String WEBAUTHN_POLICY_SIGNATURE_ALGORITHMS = "webAuthnPolicySignatureAlgorithms";
 

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
@@ -364,6 +364,8 @@ public class ModelToRepresentation {
         // KEYCLOAK-7688 Offline Session Max for Offline Token
         rep.setOfflineSessionMaxLifespanEnabled(realm.isOfflineSessionMaxLifespanEnabled());
         rep.setOfflineSessionMaxLifespan(realm.getOfflineSessionMaxLifespan());
+        rep.setClientSessionIdleTimeout(realm.getClientSessionIdleTimeout());
+        rep.setClientSessionMaxLifespan(realm.getClientSessionMaxLifespan());
         rep.setAccessCodeLifespan(realm.getAccessCodeLifespan());
         rep.setAccessCodeLifespanUserAction(realm.getAccessCodeLifespanUserAction());
         rep.setAccessCodeLifespanLogin(realm.getAccessCodeLifespanLogin());

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
@@ -220,6 +220,11 @@ public class RepresentationToModel {
             newRealm.setOfflineSessionMaxLifespan(rep.getOfflineSessionMaxLifespan());
         else newRealm.setOfflineSessionMaxLifespan(Constants.DEFAULT_OFFLINE_SESSION_MAX_LIFESPAN);
 
+        if (rep.getClientSessionIdleTimeout() != null)
+            newRealm.setClientSessionIdleTimeout(rep.getClientSessionIdleTimeout());
+        if (rep.getClientSessionMaxLifespan() != null)
+            newRealm.setClientSessionMaxLifespan(rep.getClientSessionMaxLifespan());
+
         if (rep.getAccessCodeLifespan() != null) newRealm.setAccessCodeLifespan(rep.getAccessCodeLifespan());
         else newRealm.setAccessCodeLifespan(60);
 
@@ -1088,6 +1093,10 @@ public class RepresentationToModel {
         if (rep.getOfflineSessionMaxLifespanEnabled() != null) realm.setOfflineSessionMaxLifespanEnabled(rep.getOfflineSessionMaxLifespanEnabled());
         if (rep.getOfflineSessionMaxLifespan() != null)
             realm.setOfflineSessionMaxLifespan(rep.getOfflineSessionMaxLifespan());
+        if (rep.getClientSessionIdleTimeout() != null)
+            realm.setClientSessionIdleTimeout(rep.getClientSessionIdleTimeout());
+        if (rep.getClientSessionMaxLifespan() != null)
+            realm.setClientSessionMaxLifespan(rep.getClientSessionMaxLifespan());
         if (rep.getRequiredCredentials() != null) {
             realm.updateRequiredCredentials(rep.getRequiredCredentials());
         }

--- a/server-spi/src/main/java/org/keycloak/models/RealmModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/RealmModel.java
@@ -196,6 +196,12 @@ public interface RealmModel extends RoleContainerModel {
     int getOfflineSessionMaxLifespan();
     void setOfflineSessionMaxLifespan(int seconds);
 
+    int getClientSessionIdleTimeout();
+    void setClientSessionIdleTimeout(int seconds);
+
+    int getClientSessionMaxLifespan();
+    void setClientSessionMaxLifespan(int seconds);
+
     void setAccessTokenLifespan(int seconds);
 
     int getAccessTokenLifespanForImplicitFlow();

--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCConfigAttributes.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCConfigAttributes.java
@@ -44,7 +44,8 @@ public final class OIDCConfigAttributes {
     public static final String ACCESS_TOKEN_SIGNED_RESPONSE_ALG = "access.token.signed.response.alg";
 
     public static final String ACCESS_TOKEN_LIFESPAN = "access.token.lifespan";
-
+    public static final String CLIENT_SESSION_IDLE_TIMEOUT = "client.session.idle.timeout";
+    public static final String CLIENT_SESSION_MAX_LIFESPAN = "client.session.max.lifespan";
     public static final String PKCE_CODE_CHALLENGE_METHOD = "pkce.code.challenge.method";
 
     private OIDCConfigAttributes() {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/realm/RealmTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/realm/RealmTest.java
@@ -620,6 +620,10 @@ public class RealmTest extends AbstractAdminTest {
         if (realm.getSsoSessionMaxLifespan() != null) assertEquals(realm.getSsoSessionMaxLifespan(), storedRealm.getSsoSessionMaxLifespan());
         if (realm.getSsoSessionIdleTimeoutRememberMe() != null) Assert.assertEquals(realm.getSsoSessionIdleTimeoutRememberMe(), storedRealm.getSsoSessionIdleTimeoutRememberMe());
         if (realm.getSsoSessionMaxLifespanRememberMe() != null) Assert.assertEquals(realm.getSsoSessionMaxLifespanRememberMe(), storedRealm.getSsoSessionMaxLifespanRememberMe());
+        if (realm.getClientSessionIdleTimeout() != null)
+            Assert.assertEquals(realm.getClientSessionIdleTimeout(), storedRealm.getClientSessionIdleTimeout());
+        if (realm.getClientSessionMaxLifespan() != null)
+            Assert.assertEquals(realm.getClientSessionMaxLifespan(), storedRealm.getClientSessionMaxLifespan());
         if (realm.getRequiredCredentials() != null) {
             assertNotNull(storedRealm.getRequiredCredentials());
             for (String cred : realm.getRequiredCredentials()) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/AccessTokenTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/AccessTokenTest.java
@@ -1122,6 +1122,47 @@ public class AccessTokenTest extends AbstractKeycloakTest {
     }
 
     @Test
+    public void testClientSessionMaxLifespan() throws Exception {
+        ClientResource client = ApiUtil.findClientByClientId(adminClient.realm("test"), "test-app");
+        ClientRepresentation clientRepresentation = client.toRepresentation();
+
+        RealmResource realm = adminClient.realm("test");
+        RealmRepresentation rep = realm.toRepresentation();
+        int accessTokenLifespan = rep.getAccessTokenLifespan();
+        Integer originalClientSessionMaxLifespan = rep.getClientSessionMaxLifespan();
+
+        try {
+            oauth.doLogin("test-user@localhost", "password");
+            String code = oauth.getCurrentQuery().get(OAuth2Constants.CODE);
+            OAuthClient.AccessTokenResponse response = oauth.doAccessTokenRequest(code, "password");
+            assertEquals(200, response.getStatusCode());
+            assertExpiration(response.getExpiresIn(), accessTokenLifespan);
+
+            rep.setClientSessionMaxLifespan(accessTokenLifespan - 100);
+            realm.update(rep);
+
+            String refreshToken = response.getRefreshToken();
+            response = oauth.doRefreshTokenRequest(refreshToken, "password");
+            assertEquals(200, response.getStatusCode());
+            assertExpiration(response.getExpiresIn(), accessTokenLifespan - 100);
+
+            clientRepresentation.getAttributes().put(OIDCConfigAttributes.CLIENT_SESSION_MAX_LIFESPAN,
+                Integer.toString(accessTokenLifespan - 200));
+            client.update(clientRepresentation);
+
+            refreshToken = response.getRefreshToken();
+            response = oauth.doRefreshTokenRequest(refreshToken, "password");
+            assertEquals(200, response.getStatusCode());
+            assertExpiration(response.getExpiresIn(), accessTokenLifespan - 200);
+        } finally {
+            rep.setClientSessionMaxLifespan(originalClientSessionMaxLifespan);
+            realm.update(rep);
+            clientRepresentation.getAttributes().put(OIDCConfigAttributes.CLIENT_SESSION_MAX_LIFESPAN, null);
+            client.update(clientRepresentation);
+        }
+    }
+
+    @Test
     public void accessTokenRequest_ClientPS384_RealmRS256() throws Exception {
         conductAccessTokenRequest(Algorithm.HS256, Algorithm.PS384, Algorithm.RS256);
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/util/RealmBuilder.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/util/RealmBuilder.java
@@ -272,4 +272,14 @@ public class RealmBuilder {
         rep.setOfflineSessionMaxLifespanEnabled(offlineSessionMaxLifespanEnabled);
         return this;
     }
+
+    public RealmBuilder clientSessionIdleTimeout(int clientSessionIdleTimeout) {
+        rep.setClientSessionIdleTimeout(clientSessionIdleTimeout);
+        return this;
+    }
+
+    public RealmBuilder clientSessionMaxLifespan(int clientSessionMaxLifespan) {
+        rep.setClientSessionMaxLifespan(clientSessionMaxLifespan);
+        return this;
+    }
 }

--- a/themes/src/main/resources/theme/base/admin/messages/admin-messages_en.properties
+++ b/themes/src/main/resources/theme/base/admin/messages/admin-messages_en.properties
@@ -128,7 +128,10 @@ offline-session-max-limited=Offline Session Max Limited
 offline-session-max-limited.tooltip=Enable Offline Session Max.
 offline-session-max=Offline Session Max
 offline-session-max.tooltip=Max time before an offline session is expired regardless of activity. 
-
+client-session-idle=Client Session Idle
+client-session-idle.tooltip=Time a client session is allowed to be idle before it expires. Tokens are invalidated when a client session is expired. If not set it uses the standard SSO Session Idle value.
+client-session-max=Client Session Max
+client-session-max.tooltip=Max time before a client session is expired. Tokens are invalidated when a client session is expired. If not set, it uses the standard SSO Session Max value.
 access-token-lifespan=Access Token Lifespan
 access-token-lifespan.tooltip=Max time before an access token is expired. This value is recommended to be short relative to the SSO timeout.
 access-token-lifespan-for-implicit-flow=Access Token Lifespan For Implicit Flow

--- a/themes/src/main/resources/theme/base/admin/resources/js/controllers/clients.js
+++ b/themes/src/main/resources/theme/base/admin/resources/js/controllers/clients.js
@@ -1090,6 +1090,8 @@ module.controller('ClientDetailCtrl', function($scope, realm, client, flows, $ro
 
     $scope.accessTokenLifespan = TimeUnit2.asUnit(client.attributes['access.token.lifespan']);
     $scope.samlAssertionLifespan = TimeUnit2.asUnit(client.attributes['saml.assertion.lifespan']);
+    $scope.clientSessionIdleTimeout = TimeUnit2.asUnit(client.attributes['client.session.idle.timeout']);
+    $scope.clientSessionMaxLifespan = TimeUnit2.asUnit(client.attributes['client.session.max.lifespan']);
 
     if(client.origin) {
         if ($scope.access.viewRealm) {
@@ -1421,6 +1423,22 @@ module.controller('ClientDetailCtrl', function($scope, realm, client, flows, $ro
             $scope.clientEdit.attributes['saml.assertion.lifespan'] = $scope.samlAssertionLifespan.toSeconds();
         } else {
             $scope.clientEdit.attributes['saml.assertion.lifespan'] = null;
+        }
+    }
+
+    $scope.updateClientSessionIdleTimeout = function() {
+        if ($scope.clientSessionIdleTimeout.time) {
+            $scope.clientEdit.attributes['client.session.idle.timeout'] = $scope.clientSessionIdleTimeout.toSeconds();
+        } else {
+            $scope.clientEdit.attributes['client.session.idle.timeout'] = null;
+        }
+    }
+
+    $scope.updateClientSessionMaxLifespan = function() {
+        if ($scope.clientSessionMaxLifespan.time) {
+            $scope.clientEdit.attributes['client.session.max.lifespan'] = $scope.clientSessionMaxLifespan.toSeconds();
+        } else {
+            $scope.clientEdit.attributes['client.session.max.lifespan'] = null;
         }
     }
 

--- a/themes/src/main/resources/theme/base/admin/resources/js/controllers/realm.js
+++ b/themes/src/main/resources/theme/base/admin/resources/js/controllers/realm.js
@@ -1160,6 +1160,8 @@ module.controller('RealmTokenDetailCtrl', function($scope, Realm, realm, $http, 
     $scope.realm.offlineSessionIdleTimeout = TimeUnit2.asUnit(realm.offlineSessionIdleTimeout);
     // KEYCLOAK-7688 Offline Session Max for Offline Token
     $scope.realm.offlineSessionMaxLifespan = TimeUnit2.asUnit(realm.offlineSessionMaxLifespan);
+    $scope.realm.clientSessionIdleTimeout = TimeUnit2.asUnit(realm.clientSessionIdleTimeout);
+    $scope.realm.clientSessionMaxLifespan = TimeUnit2.asUnit(realm.clientSessionMaxLifespan);
     $scope.realm.accessCodeLifespan = TimeUnit2.asUnit(realm.accessCodeLifespan);
     $scope.realm.accessCodeLifespanLogin = TimeUnit2.asUnit(realm.accessCodeLifespanLogin);
     $scope.realm.accessCodeLifespanUserAction = TimeUnit2.asUnit(realm.accessCodeLifespanUserAction);
@@ -1215,6 +1217,8 @@ module.controller('RealmTokenDetailCtrl', function($scope, Realm, realm, $http, 
         $scope.realm.offlineSessionIdleTimeout = $scope.realm.offlineSessionIdleTimeout.toSeconds();
         // KEYCLOAK-7688 Offline Session Max for Offline Token
         $scope.realm.offlineSessionMaxLifespan = $scope.realm.offlineSessionMaxLifespan.toSeconds();
+        $scope.realm.clientSessionIdleTimeout = $scope.realm.clientSessionIdleTimeout.toSeconds();
+        $scope.realm.clientSessionMaxLifespan = $scope.realm.clientSessionMaxLifespan.toSeconds();
         $scope.realm.accessCodeLifespan = $scope.realm.accessCodeLifespan.toSeconds();
         $scope.realm.accessCodeLifespanUserAction = $scope.realm.accessCodeLifespanUserAction.toSeconds();
         $scope.realm.accessCodeLifespanLogin = $scope.realm.accessCodeLifespanLogin.toSeconds();

--- a/themes/src/main/resources/theme/base/admin/resources/partials/client-detail.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/client-detail.html
@@ -547,6 +547,38 @@
                 <kc-tooltip>{{:: 'saml-assertion-lifespan.tooltip' | translate}}</kc-tooltip>
             </div>
 
+            <div class="form-group" data-ng-show="protocol == 'openid-connect'">
+                <label class="col-md-2 control-label" for="clientSessionIdleTimeout">{{:: 'client-session-idle' | translate}}</label>
+                <div class="col-md-6 time-selector">
+                    <input class="form-control" type="number" min="0"
+                           max="31536000" data-ng-model="clientSessionIdleTimeout.time"
+                           id="clientSessionIdleTimeout" name="clientSessionIdleTimeout"
+                           data-ng-change="updateClientSessionIdleTimeout()"/>
+                    <select class="form-control" name="clientSessionIdleTimeoutUnit" data-ng-model="clientSessionIdleTimeout.unit" data-ng-change="updateClientSessionIdleTimeout()">
+                        <option value="Minutes">{{:: 'minutes' | translate}}</option>
+                        <option value="Hours">{{:: 'hours' | translate}}</option>
+                        <option value="Days">{{:: 'days' | translate}}</option>
+                    </select>
+                </div>
+                <kc-tooltip>{{:: 'client-session-idle.tooltip' | translate}}</kc-tooltip>
+            </div>
+
+            <div class="form-group" data-ng-show="protocol == 'openid-connect'">
+                <label class="col-md-2 control-label" for="clientSessionMaxLifespan">{{:: 'client-session-max' | translate}}</label>
+                <div class="col-md-6 time-selector">
+                    <input class="form-control" type="number" min="0"
+                           max="31536000" data-ng-model="clientSessionMaxLifespan.time"
+                           id="clientSessionMaxLifespan" name="clientSessionMaxLifespan"
+                           data-ng-change="updateClientSessionMaxLifespan()"/>
+                    <select class="form-control" name="clientSessionMaxLifespanUnit" data-ng-model="clientSessionMaxLifespan.unit" data-ng-change="updateClientSessionMaxLifespan()">
+                        <option value="Minutes">{{:: 'minutes' | translate}}</option>
+                        <option value="Hours">{{:: 'hours' | translate}}</option>
+                        <option value="Days">{{:: 'days' | translate}}</option>
+                    </select>
+                </div>
+                <kc-tooltip>{{:: 'client-session-max.tooltip' | translate}}</kc-tooltip>
+            </div>
+
             <div class="form-group clearfix block" data-ng-show="protocol == 'openid-connect'">
                 <label class="col-md-2 control-label" for="tlsClientCertificateBoundAccessTokens">{{:: 'tls-client-certificate-bound-access-tokens' | translate}}</label>
                 <div class="col-sm-6">

--- a/themes/src/main/resources/theme/base/admin/resources/partials/realm-tokens.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/realm-tokens.html
@@ -146,6 +146,36 @@
         </div>
 
         <div class="form-group">
+            <label class="col-md-2 control-label" for="clientSessionIdleTimeout">{{:: 'client-session-idle' | translate}}</label>
+            <div class="col-md-6 time-selector">
+                <input class="form-control" type="number" required min="0"
+                       max="31536000" data-ng-model="realm.clientSessionIdleTimeout.time"
+                       id="clientSessionIdleTimeout" name="clientSessionIdleTimeout"/>
+                <select class="form-control" name="clientSessionIdleTimeoutUnit" data-ng-model="realm.clientSessionIdleTimeout.unit">
+                    <option value="Minutes">{{:: 'minutes' | translate}}</option>
+                    <option value="Hours">{{:: 'hours' | translate}}</option>
+                    <option value="Days">{{:: 'days' | translate}}</option>
+                </select>
+            </div>
+            <kc-tooltip>{{:: 'client-session-idle.tooltip' | translate}}</kc-tooltip>
+        </div>
+
+        <div class="form-group">
+            <label class="col-md-2 control-label" for="clientSessionMaxLifespan">{{:: 'client-session-max' | translate}}</label>
+            <div class="col-md-6 time-selector">
+                <input class="form-control" type="number" required min="0"
+                       max="31536000" data-ng-model="realm.clientSessionMaxLifespan.time"
+                       id="clientSessionMaxLifespan" name="clientSessionMaxLifespan"/>
+                <select class="form-control" name="clientSessionMaxLifespanUnit" data-ng-model="realm.clientSessionMaxLifespan.unit">
+                    <option value="Minutes">{{:: 'minutes' | translate}}</option>
+                    <option value="Hours">{{:: 'hours' | translate}}</option>
+                    <option value="Days">{{:: 'days' | translate}}</option>
+                </select>
+            </div>
+            <kc-tooltip>{{:: 'client-session-max.tooltip' | translate}}</kc-tooltip>
+        </div>
+
+        <div class="form-group">
             <label class="col-md-2 control-label" for="accessTokenLifespan">{{:: 'access-token-lifespan' | translate}}</label>
 
             <div class="col-md-6 time-selector">


### PR DESCRIPTION
… OIDC

JIRA:
https://issues.redhat.com/browse/KEYCLOAK-12103
https://issues.redhat.com/browse/KEYCLOAK-12406

# Current exp claim
## access token / ID token
  - MIN ([Access Token Lifespan] or [Client Access Token Lifespan] or [Access Token Lifespan For Implicit Flow], [SSO Session Max] or [SSO Session Max Remember Me])

## refresh token
  - MIN ([SSO Session Max] or [SSO Session Max Remember Me], [SSO Session Idle] or [SSO Session Idle Remember Me])

# Future exp claim
## access token / ID token
  - MIN ([Access Token Lifespan] or [Client Access Token Lifespan] or [Access Token Lifespan For Implicit Flow], [SSO Session Max] or [SSO Session Max Remember Me] **or [Client Session Max]**)

## refresh token
  - MIN ([SSO Session Max] or [SSO Session Max Remember Me] **or [Client Session Max]**, [SSO Session Idle] or [SSO Session Idle Remember Me] **or [Client Session Idle]**)

## points
 - [Client Session Max] and [Client Session Idle] can be overridden per client.
 - Even if [Client Session Max] or [Client Session Idle] is set, when [Client Session Max] > [SSO Session Max] or [Client Session Idle] > [SSO Session Idle], [SSO Session Max] or [SSO Session Idle] is adopted.


# Other points
In JIRA ticket, 
> A new claim "exp_max" should be added to the Refresh Token which is set to "Client Session Max".

However, "exp_max" is not adopted because we can use the existing "exp" claim.
Currently, keycloak judges the expiration of refresh token with the "exp" claim, and if we change it to use the "exp_max" claim, the "exp" claim will be an unnecessary claim. 