### PR TITLE
KEYCLOAK-12436 Fixes NPE in QuarkusCacheManagerProvider when default settings are used

### DIFF
--- a/quarkus/extensions/src/main/java/org/keycloak/provider/quarkus/QuarkusCacheManagerProvider.java
+++ b/quarkus/extensions/src/main/java/org/keycloak/provider/quarkus/QuarkusCacheManagerProvider.java
@@ -77,7 +77,7 @@ public final class QuarkusCacheManagerProvider implements ManagedCacheManagerPro
     }
 
     private InputStream loadDefaultConfiguration(Config.Scope config) throws FileNotFoundException {
-        if (config.getBoolean("clustered")) {
+        if (config.getBoolean("clustered", false)) {
             log.debugf("Using default clustered cache configuration.");
             return FileLookupFactory.newInstance()
                     .lookupFileStrict("default-clustered-cache.xml", Thread.currentThread().getContextClassLoader());    


### PR DESCRIPTION
org.keycloak.provider.quarkus.QuarkusCacheManagerProvider#loadDefaultConfiguration
fails with an NPE (while trying to unbox null into a boolean) if the current
config does not contain "clustered". This happens when quarkus:dev mode is used
without parameters.

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
