### PR TITLE
KEYCLOAK-9837 Not hide exception in email templating

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/email/EmailException.java
+++ b/server-spi-private/src/main/java/org/keycloak/email/EmailException.java
@@ -26,6 +26,10 @@ public class EmailException extends Exception {
         super(cause);
     }
 
+    public EmailException(String message) {
+    	super(message);
+    }
+    
     public EmailException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/services/src/main/java/org/keycloak/email/freemarker/FreeMarkerEmailTemplateProvider.java
+++ b/services/src/main/java/org/keycloak/email/freemarker/FreeMarkerEmailTemplateProvider.java
@@ -28,6 +28,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 
+import org.jboss.logging.Logger;
 import org.keycloak.broker.provider.BrokeredIdentityContext;
 import org.keycloak.common.util.ObjectUtil;
 import org.keycloak.email.EmailException;
@@ -54,6 +55,7 @@ import org.keycloak.theme.beans.MessageFormatterMethod;
  */
 public class FreeMarkerEmailTemplateProvider implements EmailTemplateProvider {
 
+    private static final Logger logger = Logger.getLogger(FreeMarkerEmailTemplateProvider.class);
     protected KeycloakSession session;
     /**
      * authenticationSession can be null for some email sendings, it is filled only for email sendings performed as part of the authentication session (email verification, password reset, broker link
@@ -217,6 +219,7 @@ public class FreeMarkerEmailTemplateProvider implements EmailTemplateProvider {
                 textBody = freeMarker.processTemplate(attributes, textTemplate, theme);
             } catch (final FreeMarkerException e) {
                 textBody = null;
+                logger.warn("Failed to template plain text email.", e);
             }
             String htmlTemplate = String.format("html/%s", template);
             String htmlBody;
@@ -224,6 +227,11 @@ public class FreeMarkerEmailTemplateProvider implements EmailTemplateProvider {
                 htmlBody = freeMarker.processTemplate(attributes, htmlTemplate, theme);
             } catch (final FreeMarkerException e) {
                 htmlBody = null;
+                logger.warn("Failed to template html email.", e);
+            }
+
+            if (textBody == null && htmlBody == null) {
+            	throw new EmailException("Both plain text and html are empty!");
             }
 
             return new EmailTemplate(subject, textBody, htmlBody);

--- a/services/src/main/java/org/keycloak/email/freemarker/FreeMarkerEmailTemplateProvider.java
+++ b/services/src/main/java/org/keycloak/email/freemarker/FreeMarkerEmailTemplateProvider.java
@@ -38,6 +38,7 @@ import org.keycloak.email.freemarker.beans.EventBean;
 import org.keycloak.email.freemarker.beans.ProfileBean;
 import org.keycloak.events.Event;
 import org.keycloak.events.EventType;
+import org.keycloak.forms.login.freemarker.model.UrlBean;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakUriInfo;
 import org.keycloak.models.RealmModel;
@@ -46,7 +47,6 @@ import org.keycloak.sessions.AuthenticationSessionModel;
 import org.keycloak.theme.FreeMarkerException;
 import org.keycloak.theme.FreeMarkerUtil;
 import org.keycloak.theme.Theme;
-import org.keycloak.forms.login.freemarker.model.UrlBean;
 import org.keycloak.theme.beans.LinkExpirationFormatterMethod;
 import org.keycloak.theme.beans.MessageFormatterMethod;
 
@@ -219,7 +219,7 @@ public class FreeMarkerEmailTemplateProvider implements EmailTemplateProvider {
                 textBody = freeMarker.processTemplate(attributes, textTemplate, theme);
             } catch (final FreeMarkerException e) {
                 textBody = null;
-                logger.warn("Failed to template plain text email.", e);
+                throw new EmailException("Failed to template plain text email.", e);
             }
             String htmlTemplate = String.format("html/%s", template);
             String htmlBody;
@@ -227,11 +227,7 @@ public class FreeMarkerEmailTemplateProvider implements EmailTemplateProvider {
                 htmlBody = freeMarker.processTemplate(attributes, htmlTemplate, theme);
             } catch (final FreeMarkerException e) {
                 htmlBody = null;
-                logger.warn("Failed to template html email.", e);
-            }
-
-            if (textBody == null && htmlBody == null) {
-            	throw new EmailException("Both plain text and html are empty!");
+                throw new EmailException("Failed to template html email.", e);
             }
 
             return new EmailTemplate(subject, textBody, htmlBody);

--- a/services/src/main/java/org/keycloak/email/freemarker/FreeMarkerEmailTemplateProvider.java
+++ b/services/src/main/java/org/keycloak/email/freemarker/FreeMarkerEmailTemplateProvider.java
@@ -55,7 +55,6 @@ import org.keycloak.theme.beans.MessageFormatterMethod;
  */
 public class FreeMarkerEmailTemplateProvider implements EmailTemplateProvider {
 
-    private static final Logger logger = Logger.getLogger(FreeMarkerEmailTemplateProvider.class);
     protected KeycloakSession session;
     /**
      * authenticationSession can be null for some email sendings, it is filled only for email sendings performed as part of the authentication session (email verification, password reset, broker link
@@ -218,7 +217,6 @@ public class FreeMarkerEmailTemplateProvider implements EmailTemplateProvider {
             try {
                 textBody = freeMarker.processTemplate(attributes, textTemplate, theme);
             } catch (final FreeMarkerException e) {
-                textBody = null;
                 throw new EmailException("Failed to template plain text email.", e);
             }
             String htmlTemplate = String.format("html/%s", template);
@@ -226,7 +224,6 @@ public class FreeMarkerEmailTemplateProvider implements EmailTemplateProvider {
             try {
                 htmlBody = freeMarker.processTemplate(attributes, htmlTemplate, theme);
             } catch (final FreeMarkerException e) {
-                htmlBody = null;
                 throw new EmailException("Failed to template html email.", e);
             }
 


### PR DESCRIPTION
If the email template is not valid (ex. on a custom theme), there is an exception that does not explicit the correct error cause. It's an exception about javax.mail (email without body).

Instead, in the console output, I want to see the Freemarker error that helps me to fix the template.