### PR TITLE
CORS policy(spring oauth2 integrated keycloak)

### DIFF
--- a/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/filter/KeycloakPreAuthActionsFilter.java
+++ b/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/filter/KeycloakPreAuthActionsFilter.java
@@ -18,6 +18,7 @@
 package org.keycloak.adapters.springsecurity.filter;
 
 import org.keycloak.adapters.AdapterDeploymentContext;
+import org.keycloak.adapters.KeycloakDeployment;
 import org.keycloak.adapters.NodesRegistrationManagement;
 import org.keycloak.adapters.PreAuthActionsHandler;
 import org.keycloak.adapters.spi.HttpFacade;
@@ -78,7 +79,16 @@ public class KeycloakPreAuthActionsFilter extends GenericFilterBean implements A
             throws IOException, ServletException {
 
         HttpFacade facade = new SimpleHttpFacade((HttpServletRequest)request, (HttpServletResponse)response);
-        nodesRegistrationManagement.tryRegister(deploymentContext.resolveDeployment(facade));
+        KeycloakDeployment deployment = deploymentContext.resolveDeployment(facade);
+        
+        if (deployment == null) {
+            return;
+        }
+
+        if (deployment.isConfigured()) {
+            nodesRegistrationManagement.tryRegister(deploymentContext.resolveDeployment(facade));
+        }
+
         PreAuthActionsHandler handler = preAuthActionsHandlerFactory.createPreAuthActionsHandler(facade);
         if (handler.handleRequest()) {
             log.debug("Pre-auth filter handled request: {}", ((HttpServletRequest) request).getRequestURI());

--- a/adapters/oidc/spring-security/src/test/java/org/keycloak/adapters/springsecurity/filter/KeycloakPreAuthActionsFilterTest.java
+++ b/adapters/oidc/spring-security/src/test/java/org/keycloak/adapters/springsecurity/filter/KeycloakPreAuthActionsFilterTest.java
@@ -59,6 +59,7 @@ public class KeycloakPreAuthActionsFilterTest {
         when(applicationContext.getBean(AdapterDeploymentContext.class)).thenReturn(deploymentContext);
         when(deploymentContext.resolveDeployment(any(HttpFacade.class))).thenReturn(deployment);
         when(preAuthActionsHandlerFactory.createPreAuthActionsHandler(any(HttpFacade.class))).thenReturn(preAuthActionsHandler);
+        when(deployment.isConfigured()).thenReturn(true);
         filter.initFilterBean();
     }
     

--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/Keycloak.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/Keycloak.java
@@ -96,7 +96,7 @@ public class Keycloak implements AutoCloseable {
     }
 
     public static Keycloak getInstance(String serverUrl, String realm, String username, String password, String clientId, String clientSecret, SSLContext sslContext, ResteasyJackson2Provider customJacksonProvider) {
-        return getInstance(serverUrl, realm, username, password, clientId, clientSecret, sslContext, null, false, null);
+        return getInstance(serverUrl, realm, username, password, clientId, clientSecret, sslContext, customJacksonProvider, false, null);
     }
 
     public static Keycloak getInstance(String serverUrl, String realm, String username, String password, String clientId) {

--- a/services/src/main/java/org/keycloak/forms/account/freemarker/model/SessionsBean.java
+++ b/services/src/main/java/org/keycloak/forms/account/freemarker/model/SessionsBean.java
@@ -37,7 +37,7 @@ public class SessionsBean {
     private RealmModel realm;
 
     public SessionsBean(RealmModel realm, List<UserSessionModel> sessions) {
-        this.events = new LinkedList<UserSessionBean>();
+        this.events = new LinkedList<>();
         for (UserSessionModel session : sessions) {
             this.events.add(new UserSessionBean(realm, session));
         }
@@ -78,7 +78,7 @@ public class SessionsBean {
         }
 
         public Set<String> getClients() {
-            Set<String> clients = new HashSet<String>();
+            Set<String> clients = new HashSet<>();
             for (String clientUUID : session.getAuthenticatedClientSessions().keySet()) {
                 ClientModel client = realm.getClientById(clientUUID);
                 clients.add(client.getClientId());

--- a/services/src/main/java/org/keycloak/forms/login/freemarker/model/RegisterBean.java
+++ b/services/src/main/java/org/keycloak/forms/login/freemarker/model/RegisterBean.java
@@ -25,10 +25,10 @@ import java.util.Map;
  */
 public class RegisterBean {
 
-    private Map<String, String> formData = new HashMap<String, String>();
+    private Map<String, String> formData;
 
     public RegisterBean(MultivaluedMap<String, String> formData) {
-        this.formData = new HashMap<String, String>();
+        this.formData = new HashMap<>();
 
         if (formData != null) {
             for (String k : formData.keySet()) {

--- a/services/src/main/java/org/keycloak/forms/login/freemarker/model/X509ConfirmBean.java
+++ b/services/src/main/java/org/keycloak/forms/login/freemarker/model/X509ConfirmBean.java
@@ -25,7 +25,7 @@ import java.util.Map;
  */
 public class X509ConfirmBean {
 
-    private Map<String, String> formData = new HashMap<>();
+    private Map<String, String> formData;
 
     public X509ConfirmBean(MultivaluedMap<String, String> formData) {
         this.formData = new HashMap<>();

--- a/services/src/main/java/org/keycloak/keys/DefaultKeyManager.java
+++ b/services/src/main/java/org/keycloak/keys/DefaultKeyManager.java
@@ -137,9 +137,7 @@ public class DefaultKeyManager implements KeyManager {
     public List<KeyWrapper> getKeys(RealmModel realm) {
         List<KeyWrapper> keys = new LinkedList<>();
         for (KeyProvider p : getProviders(realm)) {
-            for (KeyWrapper key : p .getKeys()) {
-                keys.add(key);
-            }
+            keys.addAll(p.getKeys());
         }
         return keys;
     }

--- a/services/src/main/java/org/keycloak/partialimport/ClientRolesPartialImport.java
+++ b/services/src/main/java/org/keycloak/partialimport/ClientRolesPartialImport.java
@@ -120,8 +120,8 @@ public class ClientRolesPartialImport {
                 throw noClientFound(clientId);
             }
 
-            toOverwrite.put(clientId, new HashSet<RoleRepresentation>());
-            toSkip.put(clientId, new HashSet<RoleRepresentation>());
+            toOverwrite.put(clientId, new HashSet<>());
+            toSkip.put(clientId, new HashSet<>());
             for (RoleRepresentation roleRep : repList.get(clientId)) {
                 if (exists(realm, session, clientId, roleRep)) {
                     switch (partialImportRep.getPolicy()) {

--- a/services/src/main/java/org/keycloak/protocol/docker/DockerAuthV2ProtocolFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/docker/DockerAuthV2ProtocolFactory.java
@@ -28,7 +28,7 @@ public class DockerAuthV2ProtocolFactory extends AbstractLoginProtocolFactory im
         addAllRequestedScopeMapper.setName(AllowAllDockerProtocolMapper.PROVIDER_ID);
         addAllRequestedScopeMapper.setProtocolMapper(AllowAllDockerProtocolMapper.PROVIDER_ID);
         addAllRequestedScopeMapper.setProtocol(DockerAuthV2Protocol.LOGIN_PROTOCOL);
-        addAllRequestedScopeMapper.setConfig(Collections.EMPTY_MAP);
+        addAllRequestedScopeMapper.setConfig(Collections.emptyMap());
         builtins.put(AllowAllDockerProtocolMapper.PROVIDER_ID, addAllRequestedScopeMapper);
         defaultBuiltins.add(addAllRequestedScopeMapper);
     }

--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCWellKnownProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCWellKnownProvider.java
@@ -42,6 +42,8 @@ import org.keycloak.wellknown.WellKnownProvider;
 
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
+
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -140,11 +142,7 @@ public class OIDCWellKnownProvider implements WellKnownProvider {
     }
 
     private static List<String> list(String... values) {
-        List<String> s = new LinkedList<>();
-        for (String v : values) {
-            s.add(v);
-        }
-        return s;
+        return Arrays.asList(values);
     }
 
     private List<String> getClientAuthMethodsSupported() {

--- a/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
@@ -470,10 +470,9 @@ public class TokenManager {
             }
             return roleMappings;
         } else {
-            Set<RoleModel> scopeMappings = new HashSet<>();
 
             // 1 - Client roles of this client itself
-            scopeMappings.addAll(client.getRoles());
+            Set<RoleModel> scopeMappings = new HashSet<>(client.getRoles());
 
             // 2 - Role mappings of client itself + default client scopes + optional client scopes requested by scope parameter (if applyScopeParam is true)
             for (ClientScopeModel clientScope : clientScopes) {

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/UserInfoEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/UserInfoEndpoint.java
@@ -192,7 +192,7 @@ public class UserInfoEndpoint {
         AccessToken userInfo = new AccessToken();
         tokenManager.transformUserInfoAccessToken(session, userInfo, userSession, clientSessionCtx);
 
-        Map<String, Object> claims = new HashMap<String, Object>();
+        Map<String, Object> claims = new HashMap<>();
         claims.put("sub", userModel.getId());
         claims.putAll(userInfo.getOtherClaims());
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/AddressMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/AddressMapper.java
@@ -78,7 +78,7 @@ public class AddressMapper extends AbstractOIDCProtocolMapper implements OIDCAcc
         address.setName("address");
         address.setProtocolMapper(PROVIDER_ID);
         address.setProtocol(OIDCLoginProtocol.LOGIN_PROTOCOL);
-        config = new HashMap<String, String>();
+        config = new HashMap<>();
         config.put(OIDCAttributeMapperHelper.INCLUDE_IN_ACCESS_TOKEN, Boolean.toString(accessToken));
         config.put(OIDCAttributeMapperHelper.INCLUDE_IN_ID_TOKEN, Boolean.toString(idToken));
         config.put(OIDCAttributeMapperHelper.INCLUDE_IN_USERINFO, Boolean.toString(userInfo));

--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/AudienceProtocolMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/AudienceProtocolMapper.java
@@ -35,7 +35,7 @@ import org.keycloak.representations.IDToken;
  */
 public class AudienceProtocolMapper extends AbstractOIDCProtocolMapper implements OIDCAccessTokenMapper, OIDCIDTokenMapper {
 
-    private static final List<ProviderConfigProperty> configProperties = new ArrayList<ProviderConfigProperty>();
+    private static final List<ProviderConfigProperty> configProperties = new ArrayList<>();
 
     public static final String INCLUDED_CLIENT_AUDIENCE = "included.client.audience";
     private static final String INCLUDED_CLIENT_AUDIENCE_LABEL = "included.client.audience.label";
@@ -121,7 +121,7 @@ public class AudienceProtocolMapper extends AbstractOIDCProtocolMapper implement
         mapper.setProtocolMapper(PROVIDER_ID);
         mapper.setProtocol(OIDCLoginProtocol.LOGIN_PROTOCOL);
 
-        Map<String, String> config = new HashMap<String, String>();
+        Map<String, String> config = new HashMap<>();
         if (includedClientAudience != null) {
             config.put(INCLUDED_CLIENT_AUDIENCE, includedClientAudience);
         }

--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/FullNameMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/FullNameMapper.java
@@ -39,7 +39,7 @@ import java.util.Optional;
  */
 public class FullNameMapper extends AbstractOIDCProtocolMapper implements OIDCAccessTokenMapper, OIDCIDTokenMapper, UserInfoTokenMapper {
 
-    private static final List<ProviderConfigProperty> configProperties = new ArrayList<ProviderConfigProperty>();
+    private static final List<ProviderConfigProperty> configProperties = new ArrayList<>();
 
     static {
         OIDCAttributeMapperHelper.addIncludeInTokensConfig(configProperties, FullNameMapper.class);
@@ -88,7 +88,7 @@ public class FullNameMapper extends AbstractOIDCProtocolMapper implements OIDCAc
         mapper.setName(name);
         mapper.setProtocolMapper(PROVIDER_ID);
         mapper.setProtocol(OIDCLoginProtocol.LOGIN_PROTOCOL);
-        Map<String, String> config = new HashMap<String, String>();
+        Map<String, String> config = new HashMap<>();
         if (accessToken) config.put(OIDCAttributeMapperHelper.INCLUDE_IN_ACCESS_TOKEN, "true");
         if (idToken) config.put(OIDCAttributeMapperHelper.INCLUDE_IN_ID_TOKEN, "true");
         if (userInfo) config.put(OIDCAttributeMapperHelper.INCLUDE_IN_USERINFO, "true");

--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/HardcodedClaim.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/HardcodedClaim.java
@@ -96,7 +96,7 @@ public class HardcodedClaim extends AbstractOIDCProtocolMapper implements OIDCAc
         mapper.setName(name);
         mapper.setProtocolMapper(PROVIDER_ID);
         mapper.setProtocol(OIDCLoginProtocol.LOGIN_PROTOCOL);
-        Map<String, String> config = new HashMap<String, String>();
+        Map<String, String> config = new HashMap<>();
         config.put(OIDCAttributeMapperHelper.TOKEN_CLAIM_NAME, hardcodedName);
         config.put(CLAIM_VALUE, hardcodedValue);
         config.put(OIDCAttributeMapperHelper.JSON_TYPE, claimType);

--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/HardcodedRole.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/HardcodedRole.java
@@ -41,7 +41,7 @@ import java.util.Map;
  */
 public class HardcodedRole extends AbstractOIDCProtocolMapper implements OIDCAccessTokenMapper {
 
-    private static final List<ProviderConfigProperty> configProperties = new ArrayList<ProviderConfigProperty>();
+    private static final List<ProviderConfigProperty> configProperties = new ArrayList<>();
 
     public static final String ROLE_CONFIG = "role";
 
@@ -113,7 +113,7 @@ public class HardcodedRole extends AbstractOIDCProtocolMapper implements OIDCAcc
         mapper.setName(name);
         mapper.setProtocolMapper(mapperId);
         mapper.setProtocol(OIDCLoginProtocol.LOGIN_PROTOCOL);
-        Map<String, String> config = new HashMap<String, String>();
+        Map<String, String> config = new HashMap<>();
         config.put(ROLE_CONFIG, role);
         mapper.setConfig(config);
         return mapper;

--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/RoleNameMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/RoleNameMapper.java
@@ -41,7 +41,7 @@ import java.util.Map;
  */
 public class RoleNameMapper extends AbstractOIDCProtocolMapper implements OIDCAccessTokenMapper {
 
-    private static final List<ProviderConfigProperty> configProperties = new ArrayList<ProviderConfigProperty>();
+    private static final List<ProviderConfigProperty> configProperties = new ArrayList<>();
 
     public static final String ROLE_CONFIG = "role";
     public static String NEW_ROLE_NAME = "new.role.name";
@@ -136,7 +136,7 @@ public class RoleNameMapper extends AbstractOIDCProtocolMapper implements OIDCAc
         mapper.setName(name);
         mapper.setProtocolMapper(mapperId);
         mapper.setProtocol(OIDCLoginProtocol.LOGIN_PROTOCOL);
-        Map<String, String> config = new HashMap<String, String>();
+        Map<String, String> config = new HashMap<>();
         config.put(ROLE_CONFIG, role);
         config.put(NEW_ROLE_NAME, newName);
         mapper.setConfig(config);

--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/UserSessionNoteMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/UserSessionNoteMapper.java
@@ -37,7 +37,7 @@ import java.util.Map;
  */
 public class UserSessionNoteMapper extends AbstractOIDCProtocolMapper implements OIDCAccessTokenMapper, OIDCIDTokenMapper {
 
-    private static final List<ProviderConfigProperty> configProperties = new ArrayList<ProviderConfigProperty>();
+    private static final List<ProviderConfigProperty> configProperties = new ArrayList<>();
 
     static {
         ProviderConfigProperty property;
@@ -93,7 +93,7 @@ public class UserSessionNoteMapper extends AbstractOIDCProtocolMapper implements
         mapper.setName(name);
         mapper.setProtocolMapper(PROVIDER_ID);
         mapper.setProtocol(OIDCLoginProtocol.LOGIN_PROTOCOL);
-        Map<String, String> config = new HashMap<String, String>();
+        Map<String, String> config = new HashMap<>();
         config.put(ProtocolMapperUtils.USER_SESSION_NOTE, userSessionNote);
         config.put(OIDCAttributeMapperHelper.TOKEN_CLAIM_NAME, tokenClaimName);
         config.put(OIDCAttributeMapperHelper.JSON_TYPE, jsonType);

--- a/services/src/main/java/org/keycloak/protocol/saml/mappers/AttributeStatementHelper.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/mappers/AttributeStatementHelper.java
@@ -90,7 +90,7 @@ public class AttributeStatementHelper {
         property.setName(AttributeStatementHelper.SAML_ATTRIBUTE_NAMEFORMAT);
         property.setLabel("SAML Attribute NameFormat");
         property.setHelpText("SAML Attribute NameFormat.  Can be basic, URI reference, or unspecified.");
-        List<String> types = new ArrayList(3);
+        List<String> types = new ArrayList<>(3);
         types.add(AttributeStatementHelper.BASIC);
         types.add(AttributeStatementHelper.URI_REFERENCE);
         types.add(AttributeStatementHelper.UNSPECIFIED);
@@ -104,7 +104,7 @@ public class AttributeStatementHelper {
         mapper.setName(name);
         mapper.setProtocolMapper(mapperId);
         mapper.setProtocol(SamlProtocol.LOGIN_PROTOCOL);
-        Map<String, String> config = new HashMap<String, String>();
+        Map<String, String> config = new HashMap<>();
         if (userAttribute != null) config.put(ProtocolMapperUtils.USER_ATTRIBUTE, userAttribute);
         config.put(SAML_ATTRIBUTE_NAME, samlAttributeName);
         if (friendlyName != null) {


### PR DESCRIPTION
My application is separated from the front end. The front end uses Vue's proxy to access the back end app. The back end uses spring oauth2 integrated keycloak. The keycloak is configured using the “confidential ” type.

This is error info（please）:
Access to XMLHttpRequest at 'http://192.168.3.99:8001/oauth2/authorization/demo' (redirected from 'http://192.168.3.99:9080/sitianjian/auth/user-info') from origin 'http://192.168.3.99:9080' has been blocked by CORS policy: Response to preflight request doesn't pass access control check: Redirect is not allowed for a preflight request.

So above My keycloak config:
![image](https://user-images.githubusercontent.com/5885520/71257283-49d08b00-236e-11ea-9c3e-6d5cac0f0cdf.png)

![image](https://user-images.githubusercontent.com/5885520/71257299-55bc4d00-236e-11ea-9e04-54d6407df1a1.png)
