### PR TITLE
KEYCLOAK-10894 Adds a ready indicating promise

### DIFF
--- a/adapters/oidc/js/src/main/resources/keycloak-authz.js
+++ b/adapters/oidc/js/src/main/resources/keycloak-authz.js
@@ -22,6 +22,17 @@
         var _instance = this;
         this.rpt = null;
 
+        var resolve = function () {};
+        var reject = function () {};
+
+        // detects if browser supports promises
+        if (typeof Promise !== "undefined" && Promise.toString().indexOf("[native code]") !== -1) {
+            this.ready = new Promise(function (res, rej) {
+              resolve = res;
+              reject = rej;
+            });
+        }
+
         this.init = function () {
             var request = new XMLHttpRequest();
 
@@ -30,8 +41,10 @@
                 if (request.readyState == 4) {
                     if (request.status == 200) {
                         _instance.config = JSON.parse(request.responseText);
+                        resolve();
                     } else {
                         console.error('Could not obtain configuration from server.');
+                        reject();
                     }
                 }
             }


### PR DESCRIPTION
https://issues.redhat.com/browse/KEYCLOAK-10894

This is non-intrusive and backwards compatible. With this change it is possible
to `await keycloakAuthorization.ready` to make sure the component has been
properly initialized.

The 'steps to reproduce' can now be altered to mitigate the problem by doing:

``` javascript 
const keycloak = new Keycloak("/keycloak.json");
keycloak.init({ promiseType: 'native'}).then(async () => {
  const authorization = new KeycloakAuthorization(keycloak);
  await authorization.ready();
  authorization.entitlement('resource-service');
});
```

I am a JavaScript developer, and I have had a hard time figuring out how to run the test-suite through maven, I keep encountering unrelated errors in the codebase. This change is intentionally very low impact.