### PR TITLE
KEYCLOAK-10003 Fix handling of request parameters for SMTP Connection Test

### DIFF
--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/RealmResource.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/RealmResource.java
@@ -213,11 +213,11 @@ public interface RealmResource {
                                 @FormParam("bindDn") String bindDn, @FormParam("bindCredential") String bindCredential,
                                 @FormParam("useTruststoreSpi") String useTruststoreSpi, @FormParam("connectionTimeout") String connectionTimeout);
 
-    @Path("testSMTPConnection/{config}")
+    @Path("testSMTPConnection")
     @POST
     @NoCache
     @Consumes(MediaType.APPLICATION_JSON)
-    Response testSMTPConnection(final @PathParam("config") String config) throws Exception;
+    Response testSMTPConnection(@FormParam("config") String config);
 
     @Path("clear-realm-cache")
     @POST

--- a/services/src/main/java/org/keycloak/services/resources/admin/RealmAdminResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RealmAdminResource.java
@@ -947,10 +947,10 @@ public class RealmAdminResource {
      * @return
      * @throws Exception
      */
-    @Path("testSMTPConnection/{config}")
+    @Path("testSMTPConnection")
     @POST
     @NoCache
-    public Response testSMTPConnection(final @PathParam("config") String config) throws Exception {
+    public Response testSMTPConnection(final @FormParam("config") String config) throws Exception {
         Map<String, String> settings = readValue(config, new TypeReference<Map<String, String>>() {
         });
 

--- a/themes/src/main/resources/theme/base/admin/resources/js/services.js
+++ b/themes/src/main/resources/theme/base/admin/resources/js/services.js
@@ -440,13 +440,16 @@ module.factory('RealmLDAPConnectionTester', function($resource, $httpParamSerial
     });
 });
 
-module.factory('RealmSMTPConnectionTester', function($resource) {
-    return $resource(authUrl + '/admin/realms/:realm/testSMTPConnection/:config', {
-        realm : '@realm',
-        config : '@config'
+module.factory('RealmSMTPConnectionTester', function($resource, $httpParamSerializer) {
+    return $resource(authUrl + '/admin/realms/:realm/testSMTPConnection', {
+        realm : '@realm'
     }, {
         send: {
-            method: 'POST'
+            method: 'POST',
+            headers : { 'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8' },
+            transformRequest: function (data) {
+                return $httpParamSerializer(data)
+            }
         }
     });
 });


### PR DESCRIPTION
We now transfer the SMTP connection configuration via HTTP POST
request body parameters instead of URL parameters.
The improves handling of SMTP connection configuration values with
special characters. As a side effect sensitive information like SMTP
credentials are now longer exposed via URL parameters.

Previously the SMTP connection test send the connection parameters
as encoded URL parameters in combination with parameters in the request body.
However the server side endpoint did only look at the URL parameters.

Certain values, e.g. passwords with + or ; could lead to broken URL parameters.

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
