### PR TITLE
KEYCLOAK-10190 Fix NPE on missing clientSession in TokenEndpoint.codeToToken

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
@@ -301,7 +301,10 @@ public class TokenEndpoint {
             throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_GRANT, "Code is expired", Response.Status.BAD_REQUEST);
         }
 
-        UserSessionModel userSession = clientSession.getUserSession();
+        UserSessionModel userSession = null;
+        if (clientSession != null) {
+            userSession = clientSession.getUserSession();
+        }
 
         if (userSession == null) {
             event.error(Errors.USER_SESSION_NOT_FOUND);


### PR DESCRIPTION
In certain scenarios, e.g. when an auth code from another realm login is
used to perform the code to token exchange, it can happen that the
ClientSession is null which triggered an NPE when the userSession field is accessed.

Added null check for clientSession in TokenEndpoint.codeToToken to prevent an NPE.

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
