### PR TITLE
KEYCLOAK-8249 Improve extraction of Bearer tokens from Authorization headers

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/UserInfoEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/UserInfoEndpoint.java
@@ -100,7 +100,7 @@ public class UserInfoEndpoint {
     @GET
     @NoCache
     public Response issueUserInfoGet(@Context final HttpHeaders headers) {
-        String accessToken = this.appAuthManager.extractAuthorizationHeaderToken(headers);
+        String accessToken = this.appAuthManager.extractAuthorizationHeaderTokenOrReturnNull(headers);
         return issueUserInfo(accessToken);
     }
 
@@ -110,7 +110,7 @@ public class UserInfoEndpoint {
     public Response issueUserInfoPost() {
         // Try header first
         HttpHeaders headers = request.getHttpHeaders();
-        String accessToken = this.appAuthManager.extractAuthorizationHeaderToken(headers);
+        String accessToken = this.appAuthManager.extractAuthorizationHeaderTokenOrReturnNull(headers);
 
         // Fallback to form parameter
         if (accessToken == null) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/UserInfoTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/UserInfoTest.java
@@ -449,6 +449,19 @@ public class UserInfoTest extends AbstractKeycloakTest {
     }
 
     @Test
+    public void testUnsuccessfulUserInfoRequestWithEmptyAccessToken() {
+        Client client = ClientBuilder.newClient();
+
+        try {
+            Response response = UserInfoClientUtil.executeUserInfoRequest_getMethod(client, "");
+            response.close();
+            assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+        } finally {
+            client.close();
+        }
+    }
+
+    @Test
     public void testUserInfoRequestWithSamlClient() throws Exception {
         // obtain an access token
         String accessToken = oauth.doGrantAccessTokenRequest("test", "test-user@localhost", "password", null, "saml-client", "secret").getAccessToken();


### PR DESCRIPTION
We now provide a simple way to extract the Bearer token string from
Authorization header with a null fallback.

This allows us to have more fine grained error handling for the
various endpoints.

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
