### PR TITLE
KEYCLOAK-12600 NPE Sending an email on EventListenerProvider

### DIFF
--- a/services/src/main/java/org/keycloak/locale/DefaultLocaleSelectorProvider.java
+++ b/services/src/main/java/org/keycloak/locale/DefaultLocaleSelectorProvider.java
@@ -83,7 +83,9 @@ public class DefaultLocaleSelectorProvider implements LocaleSelectorProvider {
 
         final LocaleSelection userProfileSelection = getUserProfileSelection(realm, user);
         if (userProfileSelection != null) {
-            updateLocaleCookie(realm, userProfileSelection.getLocaleString(), uriInfo);
+            if (requestHeaders != null) {
+                updateLocaleCookie(realm, userProfileSelection.getLocaleString(), uriInfo);
+            }
             return userProfileSelection.getLocale();
         }
 


### PR DESCRIPTION
When internationalization is enabled, I get an NPE since the DefaultLocaleSelectorProvider try to update the cookie of a non exist Http Call. 