### PR TITLE
KEYCLOAK-12599 allow Client Policy during impersonation token exchange

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/permissions/UserPermissions.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/permissions/UserPermissions.java
@@ -398,7 +398,26 @@ class UserPermissions implements UserPermissionEvaluator, UserPermissionManageme
             return false;
         }
 
-        return canImpersonate(new DefaultEvaluationContext(identity, session));
+
+        EvaluationContext context;
+
+        ClientModel client = root.adminAuth().getClient();
+
+        if (client!=null) {
+        context = new DefaultEvaluationContext(identity, session) {
+            @Override
+            public Map<String, Collection<String>> getBaseAttributes() {
+                Map<String, Collection<String>> attributes = super.getBaseAttributes();
+                attributes.put("kc.client.id", Arrays.asList(client.getClientId()));
+                return attributes;
+            }
+
+        };
+        } else {
+            context = new DefaultEvaluationContext(identity, session);
+        }
+
+        return canImpersonate(context);
     }
 
     @Override


### PR DESCRIPTION
Set kc.client.id in the authorization context when performing impersonation through token exchange. This allows the creation of Client Policies that get applied to the client_id performing the exchange, similar to what's already done in the case of client-to-client token exchange or direct naked impersonation.