### PR TITLE
[ KEYCLOAK-12606 ] Passing email in login_hint query parameter during…

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/broker/IdpUsernamePasswordForm.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/broker/IdpUsernamePasswordForm.java
@@ -63,7 +63,7 @@ public class IdpUsernamePasswordForm extends UsernamePasswordForm {
             throw new AuthenticationFlowException("Not found serialized context in clientSession", AuthenticationFlowError.IDENTITY_PROVIDER_ERROR);
         }
 
-        formData.add(AuthenticationManager.FORM_USERNAME, existingUser.getUsername());
+        formData.putSingle(AuthenticationManager.FORM_USERNAME, existingUser.getUsername());
         return context.form()
                 .setFormData(formData)
                 .setAttribute(LoginFormsProvider.USERNAME_EDIT_DISABLED, true)


### PR DESCRIPTION
[JIRA Issue](https://issues.redhat.com/browse/KEYCLOAK-12606)

Using **putSingle** instead of **add** method. This will replace the username field value already set by the login_hint param in the **authenticate** method with an actual username field.