### PR TITLE
KEYCLOAK-10838 avoid null bytes from being padded into request data stored in session

### DIFF
--- a/adapters/spi/servlet-adapter-spi/src/main/java/org/keycloak/adapters/servlet/FilterSessionStore.java
+++ b/adapters/spi/servlet-adapter-spi/src/main/java/org/keycloak/adapters/servlet/FilterSessionStore.java
@@ -396,7 +396,7 @@ public class FilterSessionStore implements AdapterSessionStore {
             InputStream is = request.getInputStream();
 
             while ( (bytesRead = is.read(buffer) ) >= 0) {
-                os.write(buffer);
+                os.write(buffer, 0, bytesRead);
                 totalRead += bytesRead;
                 if (totalRead > maxBuffer) {
                     throw new RuntimeException("max buffer reached on a saved request");


### PR DESCRIPTION
The buffer used in the loop is 4096 bytes, and since the value bytesRead is ignored, the value written to session is padded with a number of null bytes (0x00). This ends up being processed by other servlet filters that are trying to parse request parameters, leading to the issue reported in https://issues.redhat.com/browse/KEYCLOAK-10838.