### PR TITLE
KEYCLOAK-12670 inconsistent param name full to briefRepresentation

### DIFF
--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/GroupsResource.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/GroupsResource.java
@@ -73,7 +73,7 @@ public interface GroupsResource {
      * @param search max number of occurrences
      * @param first index of the first element
      * @param max max number of occurrences
-     * @param fullRepresentation if true, return groups with their attributes
+     * @param briefRepresentation if false, return groups with their attributes
      * @return A list containing the slice of all groups.
      */
     @GET
@@ -83,7 +83,7 @@ public interface GroupsResource {
     List<GroupRepresentation> groups(@QueryParam("search") String search,
                                      @QueryParam("first") Integer first,
                                      @QueryParam("max") Integer max,
-                                     @QueryParam("full") @DefaultValue("false") boolean fullRepresentation);
+                                     @QueryParam("briefRepresentation") @DefaultValue("true") boolean briefRepresentation);
     /**
      * Counts all groups.
      * @return A map containing key "count" with number of groups as value.

--- a/services/src/main/java/org/keycloak/services/resources/admin/GroupsResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/GroupsResource.java
@@ -75,17 +75,17 @@ public class GroupsResource {
     public List<GroupRepresentation> getGroups(@QueryParam("search") String search,
                                                @QueryParam("first") Integer firstResult,
                                                @QueryParam("max") Integer maxResults,
-                                               @QueryParam("full") @DefaultValue("false") boolean fullRepresentation) {
+                                               @QueryParam("briefRepresentation") @DefaultValue("true") boolean briefRepresentation) {
         auth.groups().requireList();
 
         List<GroupRepresentation> results;
 
         if (Objects.nonNull(search)) {
-            results = ModelToRepresentation.searchForGroupByName(realm, fullRepresentation, search.trim(), firstResult, maxResults);
+            results = ModelToRepresentation.searchForGroupByName(realm, !briefRepresentation, search.trim(), firstResult, maxResults);
         } else if(Objects.nonNull(firstResult) && Objects.nonNull(maxResults)) {
-            results = ModelToRepresentation.toGroupHierarchy(realm, fullRepresentation, firstResult, maxResults);
+            results = ModelToRepresentation.toGroupHierarchy(realm, !briefRepresentation, firstResult, maxResults);
         } else {
-            results = ModelToRepresentation.toGroupHierarchy(realm, fullRepresentation);
+            results = ModelToRepresentation.toGroupHierarchy(realm, !briefRepresentation);
         }
 
         return results;

--- a/services/src/main/java/org/keycloak/services/resources/admin/RoleContainerResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RoleContainerResource.java
@@ -419,7 +419,7 @@ public class RoleContainerResource extends RoleResource {
      * @param roleName
      * @param firstResult
      * @param maxResults
-     * @param fullRepresentation if true, return a full representation of the GroupRepresentation objects
+     * @param briefRepresentation if false, return a full representation of the GroupRepresentation objects
      * @return
      */
     @Path("{role-name}/groups")
@@ -429,7 +429,7 @@ public class RoleContainerResource extends RoleResource {
     public  List<GroupRepresentation> getGroupsInRole(final @PathParam("role-name") String roleName, 
                                                     @QueryParam("first") Integer firstResult,
                                                     @QueryParam("max") Integer maxResults,
-                                                    @QueryParam("full") @DefaultValue("false") boolean fullRepresentation) {
+                                                    @QueryParam("briefRepresentation") @DefaultValue("true") boolean briefRepresentation) {
         
         auth.roles().requireView(roleContainer);
         firstResult = firstResult != null ? firstResult : 0;
@@ -444,7 +444,7 @@ public class RoleContainerResource extends RoleResource {
         List<GroupModel> groupsModel = session.realms().getGroupsByRole(realm, role, firstResult, maxResults);
 
         return groupsModel.stream()
-        		.map(g -> ModelToRepresentation.toRepresentation(g, fullRepresentation))
+        		.map(g -> ModelToRepresentation.toRepresentation(g, !briefRepresentation))
         		.collect(Collectors.toList());
     }   
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/group/GroupTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/group/GroupTest.java
@@ -690,7 +690,7 @@ public class GroupTest extends AbstractGroupTest {
 		group.setAttributes(attributes);
         group = createGroup(realm, group);
         
-        List<GroupRepresentation> groups = groupsResource.groups("groupWithAttribute", 0, 20, true);
+        List<GroupRepresentation> groups = groupsResource.groups("groupWithAttribute", 0, 20, false);
         
         assertFalse(groups.isEmpty());
         assertTrue(groups.get(0).getAttributes().containsKey("attribute1"));


### PR DESCRIPTION
Replace the `full` param by `briefRepresentation` param in 2 APIs

https://issues.redhat.com/browse/KEYCLOAK-12670

I didn't change the `toRepresentation` for groups method because it will be incompatible with other pull request ! So instead I just reverse `briefRepresentation` while calling it.

If we want to adapt `toRepresentation` it should probably be done in a refactoring task.