### PR TITLE
KEYCLOAK-12689 - Improvements for camelCase config properties

### DIFF
--- a/quarkus/extensions/pom.xml
+++ b/quarkus/extensions/pom.xml
@@ -57,6 +57,11 @@
             <artifactId>quarkus-arc</artifactId>
             <type>jar</type>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -73,6 +78,15 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <environmentVariables>
+                        <KEYCLOAK_CAMEL_CASE_SCOPE_CAMEL_CASE_PROP>foobar</KEYCLOAK_CAMEL_CASE_SCOPE_CAMEL_CASE_PROP>
+                    </environmentVariables>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/quarkus/extensions/src/main/java/org/keycloak/provider/quarkus/MicroProfileConfigProvider.java
+++ b/quarkus/extensions/src/main/java/org/keycloak/provider/quarkus/MicroProfileConfigProvider.java
@@ -33,6 +33,11 @@ public class MicroProfileConfigProvider implements Config.ConfigProvider {
         this.config = ConfigProvider.getConfig();
     }
 
+    // for testing only
+    MicroProfileConfigProvider(ClassLoader cl) {
+        this.config = ConfigProvider.getConfig(cl);
+    }
+
     @Override
     public String getProvider(String spi) {
         return scope(spi).get("provider");

--- a/quarkus/extensions/src/main/java/org/keycloak/provider/quarkus/MicroProfileConfigProvider.java
+++ b/quarkus/extensions/src/main/java/org/keycloak/provider/quarkus/MicroProfileConfigProvider.java
@@ -104,10 +104,31 @@ public class MicroProfileConfigProvider implements Config.ConfigProvider {
         }
 
         private <T> T getValue(String key, Class<T> clazz, T defaultValue) {
-            T value = config.getOptionalValue(prefix + "." + key, clazz).orElse(defaultValue);
-            return value;
+            String property = prefix + "." + key;
+            return config.getOptionalValue(toDashCase(property), clazz)
+                    .orElseGet(() -> config.getOptionalValue(property, clazz)
+                        .orElse(defaultValue));
         }
 
+    }
+
+    private static String toDashCase(String s) {
+
+        StringBuilder sb = new StringBuilder(s.length());
+        boolean l = false;
+
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            if (l && Character.isUpperCase(c)) {
+                sb.append('-');
+                c = Character.toLowerCase(c);
+                l = false;
+            } else {
+                l = Character.isLowerCase(c);
+            }
+            sb.append(c);
+        }
+        return sb.toString();
     }
 
 }

--- a/quarkus/extensions/src/test/java/org/keycloak/provider/quarkus/MicroProfileConfigProviderTest.java
+++ b/quarkus/extensions/src/test/java/org/keycloak/provider/quarkus/MicroProfileConfigProviderTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.provider.quarkus;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class MicroProfileConfigProviderTest {
+
+    public MicroProfileConfigProviderTest() {
+    }
+
+    @Test
+    public void testCamelCase() {
+        ClassLoader cl = this.getClass().getClassLoader().getParent();
+        MicroProfileConfigProvider provider = new MicroProfileConfigProvider(cl);
+        String value = provider.scope("camelCaseScope").get("camelCaseProp");
+        assertEquals(value, "foobar");
+    }
+}

--- a/quarkus/pom.xml
+++ b/quarkus/pom.xml
@@ -40,7 +40,6 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.test.skip>true</maven.test.skip>
         <noDeps>true</noDeps>
     </properties>
 


### PR DESCRIPTION
Temporary direct implementation in Keycloak. Should be redone as a ConfigSourceWrapper as soon as the proper support lands in SmallRye-Config.