### PR TITLE
KEYCLOAK-12654: Data to sign is incorrect in redirect binding when URI has parameters

### DIFF
--- a/saml-core/src/main/java/org/keycloak/saml/BaseSAML2BindingBuilder.java
+++ b/saml-core/src/main/java/org/keycloak/saml/BaseSAML2BindingBuilder.java
@@ -355,8 +355,9 @@ public class BaseSAML2BindingBuilder<T extends BaseSAML2BindingBuilder> {
 
 
     public URI generateRedirectUri(String samlParameterName, String redirectUri, Document document) throws ConfigurationException, ProcessingException, IOException {
-        KeycloakUriBuilder builder = KeycloakUriBuilder.fromUri(redirectUri)
-                .queryParam(samlParameterName, base64Encoded(document));
+        KeycloakUriBuilder builder = KeycloakUriBuilder.fromUri(redirectUri);
+        int pos = builder.getQuery() == null? 0 : builder.getQuery().length();
+        builder.queryParam(samlParameterName, base64Encoded(document));
         if (relayState != null) {
             builder.queryParam("RelayState", relayState);
         }
@@ -365,6 +366,10 @@ public class BaseSAML2BindingBuilder<T extends BaseSAML2BindingBuilder> {
             builder.queryParam(GeneralConstants.SAML_SIG_ALG_REQUEST_KEY, signatureAlgorithm.getXmlSignatureMethod());
             URI uri = builder.build();
             String rawQuery = uri.getRawQuery();
+            if (pos > 0) {
+                // just set in the signature the added SAML parameters
+                rawQuery = rawQuery.substring(pos + 1);
+            }
             Signature signature = signatureAlgorithm.createSignature();
             byte[] sig = new byte[0];
             try {

--- a/services/src/main/java/org/keycloak/protocol/saml/SamlProtocolUtils.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/SamlProtocolUtils.java
@@ -128,11 +128,14 @@ public class SamlProtocolUtils {
 
     public static void verifyRedirectSignature(SAMLDocumentHolder documentHolder, KeyLocator locator, UriInfo uriInformation, String paramKey) throws VerificationException {
         MultivaluedMap<String, String> encodedParams = uriInformation.getQueryParameters(false);
+        verifyRedirectSignature(documentHolder, locator, encodedParams, paramKey);
+    }
+
+    public static void verifyRedirectSignature(SAMLDocumentHolder documentHolder, KeyLocator locator, MultivaluedMap<String, String> encodedParams, String paramKey) throws VerificationException {
         String request = encodedParams.getFirst(paramKey);
         String algorithm = encodedParams.getFirst(GeneralConstants.SAML_SIG_ALG_REQUEST_KEY);
         String signature = encodedParams.getFirst(GeneralConstants.SAML_SIGNATURE_REQUEST_KEY);
         String relayState = encodedParams.getFirst(GeneralConstants.RELAY_STATE);
-        String decodedAlgorithm = uriInformation.getQueryParameters(true).getFirst(GeneralConstants.SAML_SIG_ALG_REQUEST_KEY);
 
         if (request == null) throw new VerificationException("SAM was null");
         if (algorithm == null) throw new VerificationException("SigAlg was null");
@@ -153,6 +156,7 @@ public class SamlProtocolUtils {
         try {
             byte[] decodedSignature = RedirectBindingUtil.urlBase64Decode(signature);
 
+            String decodedAlgorithm = RedirectBindingUtil.urlDecode(encodedParams.getFirst(GeneralConstants.SAML_SIG_ALG_REQUEST_KEY));
             SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.getFromXmlMethod(decodedAlgorithm);
             Signature validator = signatureAlgorithm.createSignature(); // todo plugin signature alg
             Key key = locator.getKey(keyId);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/SamlRedirectBindingTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/SamlRedirectBindingTest.java
@@ -16,22 +16,26 @@
  */
 package org.keycloak.testsuite.saml;
 
+import java.io.IOException;
 import org.keycloak.dom.saml.v2.protocol.AuthnRequestType;
-import org.keycloak.saml.common.exceptions.ProcessingException;
-import org.keycloak.saml.common.util.DocumentUtil;
 import org.keycloak.saml.processing.api.saml.v2.request.SAML2Request;
 import org.keycloak.testsuite.util.SamlClient;
 import org.keycloak.testsuite.util.SamlClient.Binding;
-import org.keycloak.testsuite.util.SamlClientBuilder;
 import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.util.EntityUtils;
 import org.junit.Test;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
+import org.keycloak.dom.saml.v2.protocol.ResponseType;
+import org.keycloak.saml.common.constants.JBossSAMLURIConstants;
+import org.keycloak.saml.processing.core.saml.v2.common.SAMLDocumentHolder;
 import static org.keycloak.testsuite.saml.AbstractSamlTest.REALM_NAME;
 import static org.keycloak.testsuite.saml.AbstractSamlTest.SAML_ASSERTION_CONSUMER_URL_SALES_POST;
 import static org.keycloak.testsuite.saml.AbstractSamlTest.SAML_CLIENT_ID_SALES_POST;
+import static org.keycloak.testsuite.util.Matchers.isSamlStatusResponse;
+import org.keycloak.testsuite.util.SamlClientBuilder;
 
 /**
  *
@@ -49,5 +53,29 @@ public class SamlRedirectBindingTest extends AbstractSamlTest {
         assertThat(url, not(containsString("\n")));
         assertThat(url, not(containsString("\r")));
         assertThat(url, not(containsString("\t")));
+    }
+
+    @Test
+    public void testQueryParametersInSamlProcessingUriRedirectWithSignature() throws Exception {
+        SamlClient samlClient = new SamlClientBuilder()
+                .authnRequest(getAuthServerSamlEndpoint(REALM_NAME), SAML_CLIENT_ID_SALES_POST_SIG,
+                        SAML_ASSERTION_CONSUMER_URL_SALES_POST_SIG + "?param1=value1&param2=value2",
+                        Binding.REDIRECT)
+                .signWith(SAML_CLIENT_SALES_POST_SIG_PRIVATE_KEY, SAML_CLIENT_SALES_POST_SIG_PUBLIC_KEY)
+                .build()
+                .login().user(bburkeUser).build().doNotFollowRedirects()
+                .execute(hr -> {
+                    try {
+                        // obtain the document validating the signature (it should be valid)
+                        SAMLDocumentHolder doc = Binding.REDIRECT.extractResponse(hr, REALM_PUBLIC_KEY);
+                        // assert doc is OK and the destination really has the extra parameters
+                        assertThat(doc.getSamlObject(), isSamlStatusResponse(JBossSAMLURIConstants.STATUS_SUCCESS));
+                        assertThat(doc.getSamlObject(), instanceOf(ResponseType.class));
+                        ResponseType res = (ResponseType) doc.getSamlObject();
+                        assertThat(res.getDestination(), is(SAML_ASSERTION_CONSUMER_URL_SALES_POST_SIG + "?param1=value1&param2=value2"));
+                    } catch (IOException e) {
+                        throw new IllegalStateException(e);
+                    }
+                });
     }
 }


### PR DESCRIPTION
Fix for KEYCLOAK-12654.

The data to sign is just restricted to the added SAML parameters omitting previous ones in the URI. I also modified the `SamlProtocolUtils` to include a new variant of the `verifyRedirectSignature` in order to validate the redirect signature in the tests.

Tests have needed more modifications to do the signature validation.

Assign this to @hmlnarik for reviewing.