### PR TITLE
[KEYCLOAK-11621] Allow user creation via group MANAGE_MEMBERS and MANAGE_MEMBERSHIP permissions (Admin API)

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/permissions/GroupPermissionEvaluator.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/permissions/GroupPermissionEvaluator.java
@@ -56,6 +56,8 @@ public interface GroupPermissionEvaluator {
 
     void requireManageMembership(GroupModel group);
 
+    void requireManageMembers(GroupModel group);
+
     Map<String, Boolean> getAccess(GroupModel group);
 
     Set<String> getGroupsWithViewPermission();

--- a/services/src/main/java/org/keycloak/services/resources/admin/permissions/GroupPermissions.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/permissions/GroupPermissions.java
@@ -368,6 +368,13 @@ class GroupPermissions implements GroupPermissionEvaluator, GroupPermissionManag
     }
 
     @Override
+    public void requireManageMembers(GroupModel group) {
+        if (!canManageMembers(group)) {
+            throw new ForbiddenException();
+        }
+    }
+
+    @Override
     public Map<String, Boolean> getAccess(GroupModel group) {
         Map<String, Boolean> map = new HashMap<>();
         map.put("view", canView(group));

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/AbstractKeycloakTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/AbstractKeycloakTest.java
@@ -497,14 +497,19 @@ public abstract class AbstractKeycloakTest {
         return ApiUtil.createUserWithAdminClient(adminClient.realm(realm), homer);
     }
 
-    public static UserRepresentation createUserRepresentation(String username, String email, String firstName, String lastName, boolean enabled) {
+    public static UserRepresentation createUserRepresentation(String username, String email, String firstName, String lastName, List<String> groups, boolean enabled) {
         UserRepresentation user = new UserRepresentation();
         user.setUsername(username);
         user.setEmail(email);
         user.setFirstName(firstName);
         user.setLastName(lastName);
+        user.setGroups(groups);
         user.setEnabled(enabled);
         return user;
+    }
+
+    public static UserRepresentation createUserRepresentation(String username, String email, String firstName, String lastName, boolean enabled) {
+        return createUserRepresentation(username, email, firstName, lastName, null, enabled);
     }
 
     public static UserRepresentation createUserRepresentation(String username, String email, String firstName, String lastName, boolean enabled, String password) {

--- a/themes/src/main/resources-community/theme/base/admin/messages/admin-messages_de.properties
+++ b/themes/src/main/resources-community/theme/base/admin/messages/admin-messages_de.properties
@@ -1575,7 +1575,7 @@ permissions-enabled-users.tooltip=Legt fest, ob feingranulare Berechtigungen f\u
 #manage-permissions-group.tooltip=Fine grain permissions for admins that want to manage this group or the members of this group.
 #manage-authz-group-scope-description=Policies that decide if an admin can manage this group
 #view-authz-group-scope-description=Policies that decide if an admin can view this group
-#view-members-authz-group-scope-description=Policies that decide if an admin can manage the members of this group
+#view-members-authz-group-scope-description=Policies that decide if an admin can view the members of this group
 #token-exchange-authz-client-scope-description=Policies that decide which clients are allowed exchange tokens for a token that is targeted to this client.
 #token-exchange-authz-idp-scope-description=Policies that decide which clients are allowed exchange tokens for an external token minted by this identity provider.
 #manage-authz-client-scope-description=Policies that decide if an admin can manage this client
@@ -1591,7 +1591,7 @@ permissions-enabled-users.tooltip=Legt fest, ob feingranulare Berechtigungen f\u
 #impersonate-authz-users-scope-description=Policies that decide if admin can impersonate other users
 #map-roles-authz-users-scope-description=Policies that decide if admin can map roles for all users
 #user-impersonated-authz-users-scope-description=Policies that decide which users can be impersonated.  These policies are applied to the user being impersonated.
-#manage-membership-authz-group-scope-description=Policies that decide if admin can add or remove users from this group
+#manage-membership-authz-group-scope-description=Policies that decide if an admin can add or remove users from this group
 #manage-members-authz-group-scope-description=Policies that decide if an admin can manage the members of this group
 
 # KEYCLOAK-6771 Certificate Bound Token

--- a/themes/src/main/resources/theme/base/admin/messages/admin-messages_en.properties
+++ b/themes/src/main/resources/theme/base/admin/messages/admin-messages_en.properties
@@ -1694,7 +1694,7 @@ manage-permissions-client.tooltip=Fine grained permissions for administrators th
 manage-permissions-group.tooltip=Fine grained permissions for administrators that want to manage this group or the members of this group.
 manage-authz-group-scope-description=Policies that decide if an administrator can manage this group
 view-authz-group-scope-description=Policies that decide if an administrator can view this group
-view-members-authz-group-scope-description=Policies that decide if an administrator can manage the members of this group
+view-members-authz-group-scope-description=Policies that decide if an administrator can view the members of this group
 token-exchange-authz-client-scope-description=Policies that decide which clients are allowed exchange tokens for a token that is targeted to this client.
 token-exchange-authz-idp-scope-description=Policies that decide which clients are allowed exchange tokens for an external token minted by this identity provider.
 manage-authz-client-scope-description=Policies that decide if an administrator can manage this client
@@ -1710,7 +1710,7 @@ manage-group-membership-authz-users-scope-description=Policies that decide if an
 impersonate-authz-users-scope-description=Policies that decide if administrator can impersonate other users
 map-roles-authz-users-scope-description=Policies that decide if administrator can map roles for all users
 user-impersonated-authz-users-scope-description=Policies that decide which users can be impersonated.  These policies are applied to the user being impersonated.
-manage-membership-authz-group-scope-description=Policies that decide if administrator can add or remove users from this group
+manage-membership-authz-group-scope-description=Policies that decide if an administrator can add or remove users from this group
 manage-members-authz-group-scope-description=Policies that decide if an administrator can manage the members of this group
 
 # KEYCLOAK-6771 Certificate Bound Token


### PR DESCRIPTION
Jira Issues:
- [KEYCLOAK-11621](https://issues.redhat.com/browse/KEYCLOAK-11621)

Problem:
Using fine-grained admin permissions on groups, it is not permitted to create new users
within a group.

Cause:
The POST /{realm}/users API does not check permission for each group part of the new
user representation

Solution:
- Change access logic for POST /{realm}/users to require MANAGE_MEMBERS and
MANAGE_MEMBERSHIP permissions on each of the incoming groups

Tests:
Manual API testing performed:
  1. admin user from master realm:
    - POST /{realm}/users without groups                  => HTTP 201 user created
    - POST /{realm}/users with groups                     => HTTP 201 user created
  2. user with MANAGE_MEMBERS & MANAGE_MEMBERSHIP permissions on group1
    - POST /{realm}/users without groups                  => HTTP 403 user NOT created
    - POST /{realm}/users with group1                     => HTTP 201 user created
    - POST /{realm}/users with group1 & group2            => HTTP 403 user NOT created
    - POST /{realm}/users with group1 & wrong group path    => HTTP 400 user NOT created
  3. user with MANAGE_MEMBERS permission on group1
    - POST /{realm}/users without groups                  => HTTP 403 user NOT created
    - POST /{realm}/users with group1                     => HTTP 403 user NOT created
    - POST /{realm}/users with group1 & group2            => HTTP 403 user NOT created
    - POST /{realm}/users with group1 & wrong group path    => HTTP 400 user NOT created