### PR TITLE
[KEYCLOAK-12713] Fix default redirect URI for broker client in new realm

### DIFF
--- a/services/src/main/java/org/keycloak/services/managers/RealmManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/RealmManager.java
@@ -54,6 +54,7 @@ import org.keycloak.sessions.AuthenticationSessionProvider;
 import org.keycloak.storage.UserStorageProviderModel;
 import org.keycloak.services.clientregistration.policy.DefaultClientRegistrationPolicies;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -470,6 +471,7 @@ public class RealmManager {
             client.setName("${client_" + Constants.BROKER_SERVICE_CLIENT_ID + "}");
             client.setFullScopeAllowed(false);
             client.setProtocol(OIDCLoginProtocol.LOGIN_PROTOCOL);
+            client.setRedirectUris(new HashSet(Arrays.asList("none")));
 
             for (String role : Constants.BROKER_SERVICE_ROLES) {
                 RoleModel roleModel = client.addRole(role);


### PR DESCRIPTION
Problem: The redirect URIs field is not set for the broker client, created
at new realm creation. It is a mandatory field, so it should be populated,
with "none" value.

Cause: The setupBrokerService() method does not populate the redirect URIs
field

Solution: Modify the RealmManager.java:setupBrokerService() method to add
the "none" default redirect URI value
