### PR TITLE
[KEYCLOAK-10304] Configure JS Adapter to use PKCE for new Account Management

### DIFF
--- a/themes/src/main/resources/theme/keycloak-preview/account/index.ftl
+++ b/themes/src/main/resources/theme/keycloak-preview/account/index.ftl
@@ -98,7 +98,7 @@
                 realm: realm,
                 clientId: 'account-console'
             });
-            keycloak.init({onLoad: 'check-sso'}).success(function(authenticated) {
+            keycloak.init({onLoad: 'check-sso', pkceMethod: 'S256'}).success(function(authenticated) {
                 isReactLoading = true;
                 toggleReact();
                 if (!keycloak.authenticated) {

--- a/themes/src/main/resources/theme/keycloak-preview/account/resources/app/keycloak-service/keycloak.d.ts
+++ b/themes/src/main/resources/theme/keycloak-preview/account/resources/app/keycloak-service/keycloak.d.ts
@@ -24,9 +24,9 @@ export = Keycloak;
 
 /**
  * Creates a new Keycloak client instance.
- * @param config Path to a JSON config file or a plain config object.
+ * @param config A configuration object or path to a JSON config file.
  */
-declare function Keycloak(config?: string|{}): Keycloak.KeycloakInstance;
+declare function Keycloak<TPromise extends Keycloak.KeycloakPromiseType = 'legacy'>(config?: Keycloak.KeycloakConfig | string): Keycloak.KeycloakInstance<TPromise>;
 
 declare namespace Keycloak {
 	type KeycloakAdapterName = 'cordova' | 'cordova-native' |'default' | any;
@@ -34,11 +34,29 @@ declare namespace Keycloak {
 	type KeycloakResponseMode = 'query'|'fragment';
 	type KeycloakResponseType = 'code'|'id_token token'|'code id_token token';
 	type KeycloakFlow = 'standard'|'implicit'|'hybrid';
-	type KeycloakPromiseType = 'native'
+	type KeycloakPromiseType = 'legacy' | 'native';
+	type KeycloakPkceMethod = 'S256';
+
+	interface KeycloakConfig {
+		/**
+		 * URL to the Keycloak server, for example: http://keycloak-server/auth
+		 */
+		url?: string;
+		/**
+		 * Name of the realm, for example: 'myrealm'
+		 */
+		realm: string;
+		/**
+		 * Client identifier, example: 'myapp'
+		 */
+		clientId: string;
+	}
 
 	interface KeycloakInitOptions {
 		/**
-		 * @private Undocumented.
+		 * Adds a [cryptographic nonce](https://en.wikipedia.org/wiki/Cryptographic_nonce)
+		 * to verify that the authentication response matches the request.
+		 * @default true
 		 */
 		useNonce?: boolean;
 
@@ -106,17 +124,45 @@ declare namespace Keycloak {
 		redirectUri?: string;
 
 		/**
+		 * Specifies an uri to redirect to after silent check-sso.
+		 * Silent check-sso will only happen, when this redirect uri is given and
+		 * the specified uri is available whithin the application.
+		 */
+		silentCheckSsoRedirectUri?: string;
+
+		/**
 		 * Set the OpenID Connect flow.
 		 * @default standard
 		 */
 		flow?: KeycloakFlow;
 
 		/**
-		 * Set the promise type. If set to `'native'` all methods returning a promise
-		 * will return a native JavaScript promise. If not set will return
-		 * Keycloak specific promise objects.
+		 * Set the promise type. If set to `native` all methods returning a promise
+		 * will return a native JavaScript promise. If not not specified then
+		 * Keycloak specific legacy promise objects will be returned instead.
+		 *
+		 * Since native promises have become the industry standard it is highly
+		 * recommended that you always specify `native` as the promise type.
+		 *
+		 * Note that in upcoming versions of Keycloak the default will be changed
+		 * to `native`, and support for legacy promises will eventually be removed.
+		 *
+		 * @default legacy
 		 */
 		promiseType?: KeycloakPromiseType;
+
+		/**
+		 * Configures the Proof Key for Code Exchange (PKCE) method to use.
+		 * The currently allowed method is 'S256'.
+		 * If not configured, PKCE will not be used.
+		 */
+		pkceMethod?: KeycloakPkceMethod;
+
+		/**
+		 * Enables logging messages from Keycloak to the console.
+		 * @default false
+		 */
+		enableLogging?: boolean
 	}
 
 	interface KeycloakLoginOptions {
@@ -230,8 +276,8 @@ declare namespace Keycloak {
 		nonce?: string;
 		sub?: string;
 		session_state?: string;
-		realm_access?: { roles: string[] };
-		resource_access?: string[];
+		realm_access?: KeycloakRoles;
+		resource_access?: KeycloakResourceAccess;
 	}
 
 	interface KeycloakResourceAccess {
@@ -245,10 +291,17 @@ declare namespace Keycloak {
 	// export interface KeycloakUserInfo {}
 
 	/**
+	 * Conditional CompatPromise type in order to support
+	 * both legacy promises and native promises as return types.
+	 */
+	type CompatPromise<TPromiseType extends KeycloakPromiseType, TSuccess, TError> =
+		TPromiseType extends 'native' ? Promise<TSuccess> : KeycloakPromise<TSuccess, TError>;
+
+	/**
 	 * A client for the Keycloak authentication server.
 	 * @see {@link https://keycloak.gitbooks.io/securing-client-applications-guide/content/topics/oidc/javascript-adapter.html|Keycloak JS adapter documentation}
 	 */
-	interface KeycloakInstance {
+	interface KeycloakInstance<TPromise extends KeycloakPromiseType = 'legacy'> {
 		/**
 		 * Is true if the user is authenticated, false otherwise.
 		 */
@@ -413,32 +466,32 @@ declare namespace Keycloak {
 		 * @param initOptions Initialization options.
 		 * @returns A promise to set functions to be invoked on success or error.
 		 */
-		init(initOptions: KeycloakInitOptions): KeycloakPromise<boolean, KeycloakError>;
+		init(initOptions: KeycloakInitOptions): CompatPromise<TPromise, boolean, KeycloakError>;
 
 		/**
 		 * Redirects to login form.
 		 * @param options Login options.
 		 */
-		login(options?: KeycloakLoginOptions): KeycloakPromise<void, void>;
+		login(options?: KeycloakLoginOptions): CompatPromise<TPromise, void, void>;
 
 		/**
 		 * Redirects to logout.
 		 * @param options Logout options.
 		 * @param options.redirectUri Specifies the uri to redirect to after logout.
 		 */
-		logout(options?: any): KeycloakPromise<void, void>;
+		logout(options?: any): CompatPromise<TPromise, void, void>;
 
 		/**
 		 * Redirects to registration form.
 		 * @param options Supports same options as Keycloak#login but `action` is
 		 *                set to `'register'`.
 		 */
-		register(options?: any): KeycloakPromise<void, void>;
+		register(options?: any): CompatPromise<TPromise, void, void>;
 
 		/**
 		 * Redirects to the Account Management Console.
 		 */
-		accountManagement(): KeycloakPromise<void, void>;
+		accountManagement(): CompatPromise<TPromise, void, void>;
 
 		/**
 		 * Returns the URL to login form.
@@ -490,7 +543,7 @@ declare namespace Keycloak {
 		 *   alert('Failed to refresh the token, or the session has expired');
 		 * });
 		 */
-		updateToken(minValidity: number): KeycloakPromise<boolean, boolean>;
+		updateToken(minValidity: number): CompatPromise<TPromise, boolean, boolean>;
 
 		/**
 		 * Clears authentication state, including tokens. This can be useful if
@@ -517,11 +570,11 @@ declare namespace Keycloak {
 		 * Loads the user's profile.
 		 * @returns A promise to set functions to be invoked on success or error.
 		 */
-		loadUserProfile(): KeycloakPromise<KeycloakProfile, void>;
+		loadUserProfile(): CompatPromise<TPromise, KeycloakProfile, void>;
 
 		/**
 		 * @private Undocumented.
 		 */
-		loadUserInfo(): KeycloakPromise<{}, void>;
+		loadUserInfo(): CompatPromise<TPromise, {}, void>;
 	}
 }


### PR DESCRIPTION
## JIRA ID

[KEYCLOAK-10304](https://issues.redhat.com/browse/KEYCLOAK-10304)

## Additional Information

* The Typescript definitions were updated to reflect the changes from `master` branch

## Verification Steps

1. Build the new account console following the steps described [here](https://github.com/keycloak/keycloak/blob/master/themes/src/main/resources/theme/keycloak-preview/account/resources/README.md).
2. Use the new account console and verify that the `code_challenge` and `code_challenge_method` is present in the request:

![](https://i.imgur.com/4NDTguJ.png)

3. Try other features from the new account console and check if nothing was broken

## References

* [JavaScript adapter reference](https://issues.redhat.com/browse/KEYCLOAK-10304)
* [RFC 7636: Proof Key for Code Exchange](https://tools.ietf.org/html/rfc7636)