### PR TITLE
KEYCLOAK-12736 Set time for admin events in milliseconds, instead of …

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/AdminEventBuilder.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/AdminEventBuilder.java
@@ -240,7 +240,7 @@ public class AdminEventBuilder {
         if(realm.isAdminEventsDetailsEnabled()) {
             includeRepresentation = true;
         }
-        adminEvent.setTime(Time.toMillis(Time.currentTime()));
+        adminEvent.setTime(Time.currentTimeMillis());
 
         if (store != null) {
             try {


### PR DESCRIPTION
…converted seconds

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
