### PR TITLE
KEYCLOAK-12698: Allow setting lifespan on executeActionsEmail

### DIFF
--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/UserResource.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/UserResource.java
@@ -189,6 +189,43 @@ public interface UserResource {
      * Sends an email to the user with a link within it.  If they click on the link they will be asked to perform some actions
      * i.e. reset password, update profile, etc.
      *
+     * The lifespan decides the number of seconds after which the generated token in the email link expires. The default
+     * value is 12 hours.
+     *
+     * @param actions
+     * @param lifespan
+     */
+    @PUT
+    @Path("execute-actions-email")
+    void executeActionsEmail(List<String> actions, @QueryParam("lifespan") Integer lifespan);
+
+    /**
+     * Sends an email to the user with a link within it.  If they click on the link they will be asked to perform some actions
+     * i.e. reset password, update profile, etc.
+     *
+     * If redirectUri is not null, then you must specify a client id.  This will set the URI you want the flow to link
+     * to after the email link is clicked and actions completed.  If both parameters are null, then no page is linked to
+     * at the end of the flow.
+     *
+     * The lifespan decides the number of seconds after which the generated token in the email link expires. The default
+     * value is 12 hours.
+     *
+     * @param clientId
+     * @param redirectUri
+     * @param lifespan
+     * @param actions
+     */
+    @PUT
+    @Path("execute-actions-email")
+    void executeActionsEmail(@QueryParam("client_id") String clientId,
+                             @QueryParam("redirect_uri") String redirectUri,
+                             @QueryParam("lifespan") Integer lifespan,
+                             List<String> actions);
+
+    /**
+     * Sends an email to the user with a link within it.  If they click on the link they will be asked to perform some actions
+     * i.e. reset password, update profile, etc.
+     *
      * If redirectUri is not null, then you must specify a client id.  This will set the URI you want the flow to link
      * to after the email link is clicked and actions completed.  If both parameters are null, then no page is linked to
      * at the end of the flow.


### PR DESCRIPTION
See https://issues.redhat.com/browse/KEYCLOAK-12698 for details. Please let me know if changes are required.