### PR TITLE
KEYCLOAK-12674 Performance degradation after upgrade to Keycloak 8

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmAdapter.java
@@ -1232,9 +1232,10 @@ public class RealmAdapter implements CachedRealmModel {
         return cached.getExecutionsById().get(id);
     }
 
+    @Override
     public AuthenticationExecutionModel getAuthenticationExecutionByFlowId(String flowId) {
-        getDelegateForUpdate();
-        return updated.getAuthenticationExecutionByFlowId(flowId);
+        if (isUpdated()) return updated.getAuthenticationExecutionByFlowId(flowId);
+        return cached.getAuthenticationExecutionByFlowId(flowId);
     }
 
     @Override

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/entities/CachedRealm.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/entities/CachedRealm.java
@@ -120,6 +120,7 @@ public class CachedRealm extends AbstractExtendableRevisioned {
     protected Map<String, RequiredActionProviderModel> requiredActionProvidersByAlias = new HashMap<>();
     protected MultivaluedHashMap<String, AuthenticationExecutionModel> authenticationExecutions = new MultivaluedHashMap<>();
     protected Map<String, AuthenticationExecutionModel> executionsById = new HashMap<>();
+    protected Map<String, AuthenticationExecutionModel> executionsByFlowId = new HashMap<>();
 
     protected AuthenticationFlowModel browserFlow;
     protected AuthenticationFlowModel registrationFlow;
@@ -256,6 +257,9 @@ public class CachedRealm extends AbstractExtendableRevisioned {
             for (AuthenticationExecutionModel execution : model.getAuthenticationExecutions(flow.getId())) {
                 authenticationExecutions.add(flow.getId(), execution);
                 executionsById.put(execution.getId(), execution);
+                if (execution.getFlowId() != null) {
+                    executionsByFlowId.put(execution.getFlowId(), execution);
+                }
             }
         }
 
@@ -585,6 +589,10 @@ public class CachedRealm extends AbstractExtendableRevisioned {
         return authenticationExecutions;
     }
 
+    public AuthenticationExecutionModel getAuthenticationExecutionByFlowId(String flowId) {
+        return executionsByFlowId.get(flowId);
+    }
+    
     public Map<String, AuthenticationExecutionModel> getExecutionsById() {
         return executionsById;
     }


### PR DESCRIPTION
Attempting a fix for the reported performance regression. Preliminary performance test of OIDC scenario shows a restoration of the original level of performance.