### PR TITLE
KEYCLOAK-12838 DatasetLoader in performance swallows exceptions

### DIFF
--- a/testsuite/performance/tests/src/main/java/org/keycloak/performance/dataset/Creatable.java
+++ b/testsuite/performance/tests/src/main/java/org/keycloak/performance/dataset/Creatable.java
@@ -2,6 +2,7 @@ package org.keycloak.performance.dataset;
 
 import java.io.IOException;
 import javax.ws.rs.ClientErrorException;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 import static org.keycloak.admin.client.CreatedResponseUtil.getCreatedId;
 import org.keycloak.admin.client.Keycloak;
@@ -32,7 +33,7 @@ public interface Creatable<REP> extends Updatable<REP> {
     public Response create(Keycloak adminClient);
 
     public default boolean createCheckingForConflict(Keycloak adminClient) {
-        logger().trace("creating " + this);
+        logger().debug("Creating " + this);
         boolean conflict = false;
         try {
             Response response = create(adminClient);
@@ -41,23 +42,26 @@ public interface Creatable<REP> extends Updatable<REP> {
             } else {
                 String responseBody = response.readEntity(String.class);
                 response.close();
-                if (response.getStatus() == 409) { // some endpoints dont't throw exception on 409, throwing here
-                    throw new ClientErrorException(HTTP_409_SUFFIX, response);
-                }
-                if (responseBody != null && !responseBody.isEmpty()) {
-                    logger().trace(responseBody);
-                    setRepresentation(EntityTemplate.OBJECT_MAPPER.readValue(responseBody, (Class<REP>) getRepresentation().getClass()));
-                } else {
-                    setId(getCreatedId(response));
+                switch (response.getStatus()) {
+                    case 201: // created
+                        if (responseBody != null && !responseBody.isEmpty()) {
+                            logger().trace(String.format("Response status: %s, body: %s", response.getStatus(), responseBody));
+                            setRepresentation(EntityTemplate.OBJECT_MAPPER.readValue(responseBody, (Class<REP>) getRepresentation().getClass()));
+                        } else {
+                            setId(getCreatedId(response));
+                        }
+                        break;
+                    case 409: // some client endpoints dont't throw exception on 409 response, throwing from here
+                        throw new ClientErrorException(HTTP_409_SUFFIX, response);
+                    default:
+                        throw new RuntimeException(String.format("Error when creating entity %s.", this), new WebApplicationException(response));
                 }
             }
         } catch (ClientErrorException ex) {
             if (ex.getResponse().getStatus() == 409) {
                 conflict = true;
-                logger().trace("entity already exists");
+                logger().debug(String.format("Entity %s already exists.", this));
                 readAndSetId(adminClient);
-            } else {
-                throw ex;
             }
         } catch (IOException ex) {
             throw new RuntimeException(ex);

--- a/testsuite/performance/tests/src/main/resources/logback.xml
+++ b/testsuite/performance/tests/src/main/resources/logback.xml
@@ -31,6 +31,10 @@
         <appender-ref ref="CONSOLE_MSG_ONLY" />
     </logger>
 
+    <!--logging for dataset-->
+    <logger name="org.keycloak.performance.dataset" level="INFO" additivity="false">
+        <appender-ref ref="CONSOLE_MSG_ONLY" />
+    </logger>
     
     <logger name="ch.qos.logback" level="WARN"/>
 


### PR DESCRIPTION
- fixed thread-pool handling in the `DataLoader` class
- added some more exception handling