### PR TITLE
KEYCLOAK-12853 Add license information for account2 dependencies

### DIFF
--- a/distribution/feature-packs/server-feature-pack/src/main/resources/licenses/keycloak/licenses.xml
+++ b/distribution/feature-packs/server-feature-pack/src/main/resources/licenses/keycloak/licenses.xml
@@ -825,5 +825,172 @@
         </license>
       </licenses>
     </other>
+    <other>
+      <description>Axios</description>
+      <locations>
+        <file>themes/keycloak-preview/account/resources/node_modules/axios/dist/axios.min.js</file>
+      </locations>
+      <licenses>
+        <license>
+          <name>MIT License</name>
+          <url>https://raw.githubusercontent.com/axios/axios/v0.19.0/LICENSE</url>
+        </license>
+      </licenses>
+    </other>
+    <other>
+      <description>ChangeCase</description>
+      <locations>
+        <file>themes/keycloak-preview/account/resources/node_modules/camel-case/camel-case.js</file>
+        <file>themes/keycloak-preview/account/resources/node_modules/lower-case/lower-case.js</file>
+        <file>themes/keycloak-preview/account/resources/node_modules/no-case/no-case.js</file>
+        <file>themes/keycloak-preview/account/resources/node_modules/no-case/vendor/camel-case-regexp.js</file>
+        <file>themes/keycloak-preview/account/resources/node_modules/no-case/vendor/camel-case-upper-regexp.js</file>
+        <file>themes/keycloak-preview/account/resources/node_modules/no-case/vendor/non-word-regexp.js</file>
+        <file>themes/keycloak-preview/account/resources/node_modules/upper-case/upper-case.js</file>
+      </locations>
+      <licenses>
+        <license>
+          <name>MIT License</name>
+          <url>https://github.com/blakeembrey/change-case/blob/v3.0.0/LICENSE</url>
+        </license>
+      </licenses>
+    </other>
+    <other>
+      <description>Emotion</description>
+      <locations>
+        <file>themes/keycloak-preview/account/resources/node_modules/emotion/dist/emotion.umd.min.js</file>
+      </locations>
+      <licenses>
+        <license>
+          <name>MIT License</name>
+          <url>https://raw.githubusercontent.com/emotion-js/emotion/v9.2.12/packages/emotion/package.json</url>
+        </license>
+      </licenses>
+    </other>
+    <other>
+      <description>ExecutionEnvironment</description>
+      <locations>
+        <file>themes/keycloak-preview/account/resources/node_modules/exenv/index.js</file>
+      </locations>
+      <licenses>
+        <license>
+          <name>BSD 3-clause New or Revised License</name>
+          <url>https://raw.githubusercontent.com/JedWatson/exenv/v1.2.2/LICENSE</url>
+        </license>
+      </licenses>
+    </other>
+    <other>
+      <description>focus-trap-react</description>
+      <locations>
+        <file>themes/keycloak-preview/account/resources/node_modules/focus-trap-react/dist/focus-trap-react.js</file>
+      </locations>
+      <licenses>
+        <license>
+          <name>MIT License</name>
+          <url>https://raw.githubusercontent.com/davidtheclark/focus-trap-react/4.0.1/LICENSE</url>
+        </license>
+      </licenses>
+    </other>
+    <other>
+      <description>focus-trap</description>
+      <locations>
+        <file>themes/keycloak-preview/account/resources/node_modules/focus-trap/dist/focus-trap.min.js</file>
+      </locations>
+      <licenses>
+        <license>
+          <name>MIT License</name>
+          <url>https://raw.githubusercontent.com/davidtheclark/focus-trap/3.0.0/LICENSE</url>
+        </license>
+      </licenses>
+    </other>
+    <other>
+      <description>prop-types</description>
+      <locations>
+        <file>themes/keycloak-preview/account/resources/node_modules/prop-types/prop-types.min.js</file>
+      </locations>
+      <licenses>
+        <license>
+          <name>MIT License</name>
+          <url>https://raw.githubusercontent.com/facebook/prop-types/v15.6.2/LICENSE</url>
+        </license>
+      </licenses>
+    </other>
+    <other>
+      <description>React</description>
+      <locations>
+        <file>themes/keycloak-preview/account/resources/node_modules/react-dom/umd/react-dom.production.min.js</file>
+        <file>themes/keycloak-preview/account/resources/node_modules/react-router-dom/umd/react-router-dom.min.js</file>
+        <file>themes/keycloak-preview/account/resources/node_modules/react/umd/react.production.min.js</file>
+      </locations>
+      <licenses>
+        <license>
+          <name>MIT License</name>
+          <url>https://raw.githubusercontent.com/facebook/react/v16.8.5/LICENSE</url>
+        </license>
+      </licenses>
+    </other>
+    <other>
+      <description>SystemJS</description>
+      <locations>
+        <file>themes/keycloak-preview/account/resources/node_modules/systemjs/dist/system.src.js</file>
+      </locations>
+      <licenses>
+        <license>
+          <name>MIT License</name>
+          <url>https://raw.githubusercontent.com/systemjs/systemjs/0.20.19/LICENSE</url>
+        </license>
+      </licenses>
+    </other>
+    <other>
+      <description>Tippy.js</description>
+      <locations>
+        <file>themes/keycloak-preview/account/resources/node_modules/tippy.js/dist/tippy.min.js</file>
+      </locations>
+      <licenses>
+        <license>
+          <name>MIT License</name>
+          <url>https://raw.githubusercontent.com/atomiks/tippyjs/v3.4.1/LICENSE</url>
+        </license>
+      </licenses>
+    </other>
+    <other>
+      <description>Patternfly 4</description>
+      <locations>
+        <directory>themes/keycloak-preview/account/resources/node_modules/@patternfly/patternfly</directory>
+      </locations>
+      <licenses>
+        <license>
+          <name>MIT License</name>
+          <url>https://raw.githubusercontent.com/patternfly/patternfly-next/v2.26.5/LICENSE.txt</url>
+        </license>
+      </licenses>
+    </other>
+    <other>
+      <description>Patternfly 4 React</description>
+      <locations>
+        <directory>themes/keycloak-preview/account/resources/node_modules/@patternfly/react-core</directory>
+        <directory>themes/keycloak-preview/account/resources/node_modules/@patternfly/react-icons</directory>
+        <directory>themes/keycloak-preview/account/resources/node_modules/@patternfly/react-styles</directory>
+        <directory>themes/keycloak-preview/account/resources/node_modules/@patternfly/react-tokens</directory>
+      </locations>
+      <licenses>
+        <license>
+          <name>MIT License</name>
+          <url>https://github.com/patternfly/patternfly-react/blob/master/LICENSE</url>
+        </license>
+      </licenses>
+    </other>
+    <other>
+      <description>Tippy.js React</description>
+      <locations>
+        <file>themes/keycloak-preview/account/resources/node_modules/@tippy.js/react/dist/Tippy.min.js</file>
+      </locations>
+      <licenses>
+        <license>
+          <name>MIT License</name>
+          <url>https://raw.githubusercontent.com/atomiks/tippy.js-react/v1.1.1/LICENSE</url>
+        </license>
+      </licenses>
+    </other>
   </others>
 </licenseSummary>

--- a/distribution/feature-packs/server-feature-pack/src/main/resources/licenses/rh-sso/licenses.xml
+++ b/distribution/feature-packs/server-feature-pack/src/main/resources/licenses/rh-sso/licenses.xml
@@ -825,5 +825,172 @@
         </license>
       </licenses>
     </other>
+    <other>
+      <description>Axios</description>
+      <locations>
+        <file>themes/keycloak-preview/account/resources/node_modules/axios/dist/axios.min.js</file>
+      </locations>
+      <licenses>
+        <license>
+          <name>MIT License</name>
+          <url>https://raw.githubusercontent.com/axios/axios/v0.19.0/LICENSE</url>
+        </license>
+      </licenses>
+    </other>
+    <other>
+      <description>ChangeCase</description>
+      <locations>
+        <file>themes/keycloak-preview/account/resources/node_modules/camel-case/camel-case.js</file>
+        <file>themes/keycloak-preview/account/resources/node_modules/lower-case/lower-case.js</file>
+        <file>themes/keycloak-preview/account/resources/node_modules/no-case/no-case.js</file>
+        <file>themes/keycloak-preview/account/resources/node_modules/no-case/vendor/camel-case-regexp.js</file>
+        <file>themes/keycloak-preview/account/resources/node_modules/no-case/vendor/camel-case-upper-regexp.js</file>
+        <file>themes/keycloak-preview/account/resources/node_modules/no-case/vendor/non-word-regexp.js</file>
+        <file>themes/keycloak-preview/account/resources/node_modules/upper-case/upper-case.js</file>
+      </locations>
+      <licenses>
+        <license>
+          <name>MIT License</name>
+          <url>https://github.com/blakeembrey/change-case/blob/v3.0.0/LICENSE</url>
+        </license>
+      </licenses>
+    </other>
+    <other>
+      <description>Emotion</description>
+      <locations>
+        <file>themes/keycloak-preview/account/resources/node_modules/emotion/dist/emotion.umd.min.js</file>
+      </locations>
+      <licenses>
+        <license>
+          <name>MIT License</name>
+          <url>https://raw.githubusercontent.com/emotion-js/emotion/v9.2.12/packages/emotion/package.json</url>
+        </license>
+      </licenses>
+    </other>
+    <other>
+      <description>ExecutionEnvironment</description>
+      <locations>
+        <file>themes/keycloak-preview/account/resources/node_modules/exenv/index.js</file>
+      </locations>
+      <licenses>
+        <license>
+          <name>BSD 3-clause New or Revised License</name>
+          <url>https://raw.githubusercontent.com/JedWatson/exenv/v1.2.2/LICENSE</url>
+        </license>
+      </licenses>
+    </other>
+    <other>
+      <description>focus-trap-react</description>
+      <locations>
+        <file>themes/keycloak-preview/account/resources/node_modules/focus-trap-react/dist/focus-trap-react.js</file>
+      </locations>
+      <licenses>
+        <license>
+          <name>MIT License</name>
+          <url>https://raw.githubusercontent.com/davidtheclark/focus-trap-react/4.0.1/LICENSE</url>
+        </license>
+      </licenses>
+    </other>
+    <other>
+      <description>focus-trap</description>
+      <locations>
+        <file>themes/keycloak-preview/account/resources/node_modules/focus-trap/dist/focus-trap.min.js</file>
+      </locations>
+      <licenses>
+        <license>
+          <name>MIT License</name>
+          <url>https://raw.githubusercontent.com/davidtheclark/focus-trap/3.0.0/LICENSE</url>
+        </license>
+      </licenses>
+    </other>
+    <other>
+      <description>prop-types</description>
+      <locations>
+        <file>themes/keycloak-preview/account/resources/node_modules/prop-types/prop-types.min.js</file>
+      </locations>
+      <licenses>
+        <license>
+          <name>MIT License</name>
+          <url>https://raw.githubusercontent.com/facebook/prop-types/v15.6.2/LICENSE</url>
+        </license>
+      </licenses>
+    </other>
+    <other>
+      <description>React</description>
+      <locations>
+        <file>themes/keycloak-preview/account/resources/node_modules/react-dom/umd/react-dom.production.min.js</file>
+        <file>themes/keycloak-preview/account/resources/node_modules/react-router-dom/umd/react-router-dom.min.js</file>
+        <file>themes/keycloak-preview/account/resources/node_modules/react/umd/react.production.min.js</file>
+      </locations>
+      <licenses>
+        <license>
+          <name>MIT License</name>
+          <url>https://raw.githubusercontent.com/facebook/react/v16.8.5/LICENSE</url>
+        </license>
+      </licenses>
+    </other>
+    <other>
+      <description>SystemJS</description>
+      <locations>
+        <file>themes/keycloak-preview/account/resources/node_modules/systemjs/dist/system.src.js</file>
+      </locations>
+      <licenses>
+        <license>
+          <name>MIT License</name>
+          <url>https://raw.githubusercontent.com/systemjs/systemjs/0.20.19/LICENSE</url>
+        </license>
+      </licenses>
+    </other>
+    <other>
+      <description>Tippy.js</description>
+      <locations>
+        <file>themes/keycloak-preview/account/resources/node_modules/tippy.js/dist/tippy.min.js</file>
+      </locations>
+      <licenses>
+        <license>
+          <name>MIT License</name>
+          <url>https://raw.githubusercontent.com/atomiks/tippyjs/v3.4.1/LICENSE</url>
+        </license>
+      </licenses>
+    </other>
+    <other>
+      <description>Patternfly 4</description>
+      <locations>
+        <directory>themes/keycloak-preview/account/resources/node_modules/@patternfly/patternfly</directory>
+      </locations>
+      <licenses>
+        <license>
+          <name>MIT License</name>
+          <url>https://raw.githubusercontent.com/patternfly/patternfly-next/v2.26.5/LICENSE.txt</url>
+        </license>
+      </licenses>
+    </other>
+    <other>
+      <description>Patternfly 4 React</description>
+      <locations>
+        <directory>themes/keycloak-preview/account/resources/node_modules/@patternfly/react-core</directory>
+        <directory>themes/keycloak-preview/account/resources/node_modules/@patternfly/react-icons</directory>
+        <directory>themes/keycloak-preview/account/resources/node_modules/@patternfly/react-styles</directory>
+        <directory>themes/keycloak-preview/account/resources/node_modules/@patternfly/react-tokens</directory>
+      </locations>
+      <licenses>
+        <license>
+          <name>MIT License</name>
+          <url>https://github.com/patternfly/patternfly-react/blob/master/LICENSE</url>
+        </license>
+      </licenses>
+    </other>
+    <other>
+      <description>Tippy.js React</description>
+      <locations>
+        <file>themes/keycloak-preview/account/resources/node_modules/@tippy.js/react/dist/Tippy.min.js</file>
+      </locations>
+      <licenses>
+        <license>
+          <name>MIT License</name>
+          <url>https://raw.githubusercontent.com/atomiks/tippy.js-react/v1.1.1/LICENSE</url>
+        </license>
+      </licenses>
+    </other>
   </others>
 </licenseSummary>

--- a/themes/UPDATING-NODE-MODULES.md
+++ b/themes/UPDATING-NODE-MODULES.md
@@ -20,3 +20,7 @@ The node dependencies will be downloaded at build time, based on the content of 
     cd -
 
 You should verify the new set of packages don't break anything before commiting the new `package-lock.json`. Do not commit the `node_modules` directory for the new account console.
+
+## License Information
+
+Make sure to enter license information for new dependencies, as specified in `docs/dependency-license-information.md`. Javascript dependencies are included as `other` elements.


### PR DESCRIPTION
Went through the jar, and found the sources and license for each of the keycloak-preview node_modules.

Emotion doesn't have a declared license in the source repo, so I had to use the package.json, which states "MIT", and matches the LICENSE file distributed with the module.