### PR TITLE
KEYCLOAK-12870 - Allow to pick arbitrary user for IdP linking

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/forms/login/LoginFormsProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/forms/login/LoginFormsProvider.java
@@ -40,6 +40,12 @@ public interface LoginFormsProvider extends Provider {
 
     String USERNAME_EDIT_DISABLED = "usernameEditDisabled";
 
+    String REGISTRATION_DISABLED = "registrationDisabled";
+
+    String IDENTITY_PROVIDERS_DISABLED = "identityProvidersDisabled";
+
+    String IDENTITY_PROVIDERS_FILTERED = "identityProvidersFiltered";
+
 
     /**
      * Adds a script to the html header
@@ -100,15 +106,15 @@ public interface LoginFormsProvider extends Provider {
 
     /**
      * Set one global error message.
-     * 
+     *
      * @param message key of message
      * @param parameters to be formatted into message
      */
     LoginFormsProvider setError(String message, Object ... parameters);
-    
+
     /**
      * Set multiple error messages.
-     * 
+     *
      * @param messages to be set
      */
     LoginFormsProvider setErrors(List<FormMessage> messages);

--- a/services/src/main/java/org/keycloak/forms/login/freemarker/LoginFormsUtil.java
+++ b/services/src/main/java/org/keycloak/forms/login/freemarker/LoginFormsUtil.java
@@ -25,6 +25,7 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 
 import javax.ws.rs.core.MultivaluedMap;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -42,11 +43,13 @@ public class LoginFormsUtil {
     public static List<IdentityProviderModel> filterIdentityProviders(List<IdentityProviderModel> providers, KeycloakSession session, RealmModel realm,
                                                                       Map<String, Object> attributes, MultivaluedMap<String, String> formData) {
 
-        Boolean usernameEditDisabled = (Boolean) attributes.get(LoginFormsProvider.USERNAME_EDIT_DISABLED);
-        if (usernameEditDisabled != null && usernameEditDisabled) {
+        Boolean identityProvidersFiltered = (Boolean) attributes.get(LoginFormsProvider.IDENTITY_PROVIDERS_FILTERED);
+        Boolean identityProvidersDisabled = (Boolean) attributes.get(LoginFormsProvider.IDENTITY_PROVIDERS_DISABLED);
+
+        if (identityProvidersFiltered != null && identityProvidersFiltered) {
             String username = formData.getFirst(UserModel.USERNAME);
             if (username == null) {
-                throw new IllegalStateException("USERNAME_EDIT_DISABLED but username not known");
+                throw new IllegalStateException("IDENTITY_PROVIDERS_FILTERED but username not known");
             }
 
             UserModel user = session.users().getUserByUsername(username, realm);
@@ -67,6 +70,8 @@ public class LoginFormsUtil {
                 }
             }
             return result;
+        } else if (identityProvidersDisabled != null && identityProvidersDisabled) {
+            return Collections.emptyList();
         } else {
             return providers;
         }

--- a/services/src/main/java/org/keycloak/services/messages/Messages.java
+++ b/services/src/main/java/org/keycloak/services/messages/Messages.java
@@ -78,6 +78,8 @@ public class Messages {
 
     public static final String FEDERATED_IDENTITY_CONFIRM_REAUTHENTICATE_MESSAGE = "federatedIdentityConfirmReauthenticateMessage";
 
+    public static final String FEDERATED_IDENTITY_CONFIRM_REAUTHENTICATE_NO_USER_MESSAGE = "federatedIdentityConfirmReauthenticateNoUserMessage";
+
     public static final String IDENTITY_PROVIDER_DIFFERENT_USER_MESSAGE = "identityProviderDifferentUserMessage";
 
     public static final String CONFIGURE_TOTP = "configureTotpMessage";

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractBrokerTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractBrokerTest.java
@@ -19,6 +19,9 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import org.keycloak.authentication.authenticators.broker.IdpConfirmLinkAuthenticatorFactory;
+import org.keycloak.authentication.authenticators.broker.IdpEmailVerificationAuthenticatorFactory;
+import org.keycloak.authentication.authenticators.broker.IdpUsernamePasswordFormFactory;
 import static org.keycloak.models.utils.DefaultAuthenticationFlows.IDP_REVIEW_PROFILE_CONFIG_ALIAS;
 import static org.keycloak.testsuite.broker.BrokerTestTools.waitForPage;
 
@@ -171,6 +174,13 @@ public abstract class AbstractBrokerTest extends AbstractInitializedBaseBrokerTe
             AuthenticatorConfigRepresentation config = flows.getAuthenticatorConfig(execution.getAuthenticationConfig());
             config.getConfig().put("update.profile.on.first.login", IdentityProviderRepresentation.UPFLM_OFF);
             flows.updateAuthenticatorConfig(config.getId(), config);
+        }
+    }
+
+    static void disableExistingUser(AuthenticationExecutionInfoRepresentation execution, AuthenticationManagementResource flows) {
+        if (execution.getProviderId() != null && (execution.getProviderId().equals(IdpCreateUserIfUniqueAuthenticatorFactory.PROVIDER_ID) || execution.getProviderId().equals(IdpConfirmLinkAuthenticatorFactory.PROVIDER_ID))) {
+            execution.setRequirement(AuthenticationExecutionModel.Requirement.DISABLED.name());
+            flows.updateExecutions(DefaultAuthenticationFlows.FIRST_BROKER_LOGIN_FLOW, execution);
         }
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractFirstBrokerLoginTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractFirstBrokerLoginTest.java
@@ -112,6 +112,39 @@ public abstract class AbstractFirstBrokerLoginTest extends AbstractInitializedBa
         assertNumFederatedIdentities(existingUser, 1);
     }
 
+    /**
+     * KEYCLOAK-12870
+     */
+    @Test
+    public void testLinkAccountByReauthenticationWithLoginAndPassword() {
+        updateExecutions(AbstractBrokerTest::disableUpdateProfileOnFirstLogin);
+        updateExecutions(AbstractBrokerTest::disableExistingUser);
+        String existingUser = createUser("consumer");
+
+        driver.navigate().to(getAccountUrl(bc.consumerRealmName()));
+        logInWithBroker(bc);
+
+        assertEquals("Authenticate to link your account with " + bc.getIDPAlias(), loginPage.getInfoMessage());
+
+        try {
+            this.loginPage.findSocialButton(bc.getIDPAlias());
+            Assert.fail("Not expected to see social button with " + bc.getIDPAlias());
+        } catch (NoSuchElementException expected) {
+        }
+
+        try {
+            this.loginPage.clickRegister();
+            Assert.fail("Not expected to see register link");
+        } catch (NoSuchElementException expected) {
+        }
+
+        loginPage.login("consumer", "password");
+        waitForPage(driver, "keycloak account management", true);
+        accountUpdateProfilePage.assertCurrent();
+
+        assertNumFederatedIdentities(existingUser, 1);
+    }
+
 
     /**
      * Refers to in old test suite: org.keycloak.testsuite.broker.AbstractFirstBrokerLoginTest#testLinkAccountByReauthenticationWithPassword_browserButtons

--- a/themes/src/main/resources-community/theme/base/login/messages/messages_fr.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_fr.properties
@@ -176,6 +176,7 @@ federatedIdentityEmailExistsMessage=Cet utilisateur avec ce courriel existe d\u0
 confirmLinkIdpTitle=Ce compte existe d\u00e9j\u00e0
 federatedIdentityConfirmLinkMessage=L''utilisateur {0} {1} existe d\u00e9j\u00e0. Que souhaitez-vous faire ?
 federatedIdentityConfirmReauthenticateMessage=Identifiez vous en tant que {0} afin de lier votre compte avec {1}
+federatedIdentityConfirmReauthenticateNoUserMessage=Identifiez vous afin de lier votre compte avec {0}
 confirmLinkIdpReviewProfile=V\u00e9rifiez vos informations de profil
 confirmLinkIdpContinue=Souhaitez-vous lier {0} \u00e0 votre compte existant
 

--- a/themes/src/main/resources-community/theme/base/login/messages/messages_it.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_it.properties
@@ -139,6 +139,7 @@ federatedIdentityExistsMessage=L''utente con {0} {1} esiste gi\u00e0. Effettua i
 confirmLinkIdpTitle=Account gi\u00e0 esistente
 federatedIdentityConfirmLinkMessage=L''utente con {0} {1} esiste gi\u00e0. Come vuoi procedere?
 federatedIdentityConfirmReauthenticateMessage=Autenticati come {0} per associare il tuo account con {1}
+federatedIdentityConfirmReauthenticateNoUserMessage=Autenticati per associare il tuo account con {0}
 confirmLinkIdpReviewProfile=Rivedi profilo
 confirmLinkIdpContinue=Aggiungi all''account esistente
 

--- a/themes/src/main/resources-community/theme/base/login/messages/messages_pl.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_pl.properties
@@ -182,6 +182,7 @@ federatedIdentityExistsMessage=Użytkownik z {0} {1} już istnieje. Zaloguj się
 confirmLinkIdpTitle=Konto już istnieje
 federatedIdentityConfirmLinkMessage=Użytkownik z {0} {1} już istnieje. Co chcesz zrobić?
 federatedIdentityConfirmReauthenticateMessage=Uwierzytelnij się jako {0} aby połączyć swoje konto z {1}
+federatedIdentityConfirmReauthenticateNoUserMessage=Uwierzytelnij się aby połączyć swoje konto z {0}
 confirmLinkIdpReviewProfile=Przejrzyj profil
 confirmLinkIdpContinue=Dodaj do istniejącego konta
 

--- a/themes/src/main/resources-community/theme/base/login/messages/messages_pt_BR.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_pt_BR.properties
@@ -143,6 +143,7 @@ federatedIdentityExistsMessage=Usu\u00E1rio com {0} {1} j\u00E1 existe. Por favo
 confirmLinkIdpTitle=Conta j\u00E1 existente
 federatedIdentityConfirmLinkMessage=Usu\u00E1rio com {0} {1} j\u00E1 existe. Como voc\u00EA quer continuar?
 federatedIdentityConfirmReauthenticateMessage=Autenticar como {0} para vincular sua conta com {1}
+federatedIdentityConfirmReauthenticateNoUserMessage=Autenticar para vincular sua conta com {0}
 confirmLinkIdpReviewProfile=Revisar informa\u00E7\u00F5es do perfil
 confirmLinkIdpContinue=Vincular {0} com uma conta existente
 

--- a/themes/src/main/resources-community/theme/base/login/messages/messages_ru.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_ru.properties
@@ -144,6 +144,7 @@ federatedIdentityExistsMessage=Пользователь с {0} {1} уже сущ
 confirmLinkIdpTitle=Учетная запись уже существует
 federatedIdentityConfirmLinkMessage=Пользователь с {0} {1} уже сущестует. Хотите продолжить?
 federatedIdentityConfirmReauthenticateMessage=Аутентифицируйтесь как {0} для того, чтобы связать Вашу учетную запись с {1}
+federatedIdentityConfirmReauthenticateNoUserMessage=Аутентифицируйтесь, чтобы связать Вашу учетную запись с {0}
 confirmLinkIdpReviewProfile=Обзор профиля
 confirmLinkIdpContinue=Добавить в существующую учетную запись
 

--- a/themes/src/main/resources-community/theme/base/login/messages/messages_sk.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_sk.properties
@@ -167,6 +167,7 @@ federatedIdentityExistsMessage=Používateľ s {0} {1} už existuje. Ak chcete p
 confirmLinkIdpTitle=Účet už existuje
 federatedIdentityConfirmLinkMessage=Používateľ s {0} {1} už existuje. Ako chcete pokračovať?
 federatedIdentityConfirmReauthenticateMessage=Overiť ako {0} prepojiť váš účet s {1}
+federatedIdentityConfirmReauthenticateNoUserMessage=Overiť prepojiť váš účet s {0}
 confirmLinkIdpReviewProfile=Skontrolujte profil
 confirmLinkIdpContinue=Pridať do existujúceho účtu
 

--- a/themes/src/main/resources/theme/base/login/login-username.ftl
+++ b/themes/src/main/resources/theme/base/login/login-username.ftl
@@ -50,7 +50,7 @@
         </#if>
       </div>
     <#elseif section = "info" >
-        <#if realm.password && realm.registrationAllowed && !usernameEditDisabled??>
+        <#if realm.password && realm.registrationAllowed && !registrationDisabled??>
             <div id="kc-registration">
                 <span>${msg("noAccount")} <a tabindex="6" href="${url.registrationUrl}">${msg("doRegister")}</a></span>
             </div>

--- a/themes/src/main/resources/theme/base/login/login.ftl
+++ b/themes/src/main/resources/theme/base/login/login.ftl
@@ -62,7 +62,7 @@
         </#if>
       </div>
     <#elseif section = "info" >
-        <#if realm.password && realm.registrationAllowed && !usernameEditDisabled??>
+        <#if realm.password && realm.registrationAllowed && !registrationDisabled??>
             <div id="kc-registration">
                 <span>${msg("noAccount")} <a tabindex="6" href="${url.registrationUrl}">${msg("doRegister")}</a></span>
             </div>

--- a/themes/src/main/resources/theme/base/login/messages/messages_en.properties
+++ b/themes/src/main/resources/theme/base/login/messages/messages_en.properties
@@ -192,6 +192,7 @@ federatedIdentityExistsMessage=User with {0} {1} already exists. Please login to
 confirmLinkIdpTitle=Account already exists
 federatedIdentityConfirmLinkMessage=User with {0} {1} already exists. How do you want to continue?
 federatedIdentityConfirmReauthenticateMessage=Authenticate as {0} to link your account with {1}
+federatedIdentityConfirmReauthenticateNoUserMessage=Authenticate to link your account with {0}
 confirmLinkIdpReviewProfile=Review profile
 confirmLinkIdpContinue=Add to existing account
 


### PR DESCRIPTION
To enable picking arbitrary user, turn off "Create User If Unique" (as well as any other execution that depends on it, like "Confirm Linking Existing Account").

Technical notes - added more fine-grained control over the visibility of different login form elements, via form attributes:
* `USERNAME_EDIT_DISABLED`: disable username editing, hide "Remember Me";
* `REGISTRATION_DISABLED`: hide registration link;
* `IDENTITY_PROVIDERS_FILTERED`: show only IdPs linked to the user;
* `IDENTITY_PROVIDERS_DISABLED`: hide the whole IdP/social block