### PR TITLE
KEYCLOAK-11003 Remove UPDATE_PASSWORD RequiredAction on non-temporary password reset

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/UserResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UserResource.java
@@ -617,7 +617,12 @@ public class UserResource {
             throw new ErrorResponseException(e.getMessage(), MessageFormat.format(messages.getProperty(e.getMessage(), e.getMessage()), e.getParameters()),
                     Status.BAD_REQUEST);
         }
-        if (cred.isTemporary() != null && cred.isTemporary()) user.addRequiredAction(UserModel.RequiredAction.UPDATE_PASSWORD);
+        if (cred.isTemporary() != null && cred.isTemporary()) {
+            user.addRequiredAction(UserModel.RequiredAction.UPDATE_PASSWORD);
+        } else {
+            // Remove a potentially existing UPDATE_PASSWORD action when explicitly assigning a non-temporary password.
+            user.removeRequiredAction(UserModel.RequiredAction.UPDATE_PASSWORD);
+        }
 
         adminEvent.operation(OperationType.ACTION).resourcePath(session.getContext().getUri()).success();
     }

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/admin/ApiUtil.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/admin/ApiUtil.java
@@ -173,8 +173,20 @@ public class ApiUtil {
      * @return ID of the new user
      */
     public static String createUserAndResetPasswordWithAdminClient(RealmResource realm, UserRepresentation user, String password) {
+        return createUserAndResetPasswordWithAdminClient(realm, user, password, false);
+    }
+
+    /**
+     * Creates a user and sets the password
+     * @param realm
+     * @param user
+     * @param password
+     * @param temporary
+     * @return ID of the new user
+     */
+    public static String createUserAndResetPasswordWithAdminClient(RealmResource realm, UserRepresentation user, String password, boolean temporary) {
         String id = createUserWithAdminClient(realm, user);
-        resetUserPassword(realm.users().get(id), password, false);
+        resetUserPassword(realm.users().get(id), password, temporary);
         return id;
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/UserTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/UserTest.java
@@ -194,6 +194,33 @@ public class UserTest extends AbstractAdminTest {
         createUser();
     }
 
+    /**
+     * See KEYCLOAK-11003
+     */
+    @Test
+    public void createUserWithTemporaryPasswordWithAdditionalPasswordUpdateShouldRemoveUpdatePasswordRequiredAction() {
+
+        String userId = createUser();
+
+        CredentialRepresentation credTmp = new CredentialRepresentation();
+        credTmp.setType(CredentialRepresentation.PASSWORD);
+        credTmp.setValue("temp");
+        credTmp.setTemporary(Boolean.TRUE);
+
+        realm.users().get(userId).resetPassword(credTmp);
+
+        CredentialRepresentation credPerm = new CredentialRepresentation();
+        credPerm.setType(CredentialRepresentation.PASSWORD);
+        credPerm.setValue("perm");
+        credPerm.setTemporary(null);
+
+        realm.users().get(userId).resetPassword(credPerm);
+
+        UserRepresentation userRep = realm.users().get(userId).toRepresentation();
+
+        Assert.assertFalse(userRep.getRequiredActions().contains(UserModel.RequiredAction.UPDATE_PASSWORD.name()));
+    }
+
     @Test
     public void createDuplicatedUser1() {
         createUser();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/BrowserButtonsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/BrowserButtonsTest.java
@@ -74,7 +74,7 @@ public class BrowserButtonsTest extends AbstractTestRealmKeycloakTest {
                 .requiredAction(UserModel.RequiredAction.UPDATE_PASSWORD.toString())
                 .build();
 
-        userId = ApiUtil.createUserAndResetPasswordWithAdminClient(testRealm(), user, "password");
+        userId = ApiUtil.createUserAndResetPasswordWithAdminClient(testRealm(), user, "password", true);
         expectedMessagesCount = 0;
         getCleanup().addUserId(userId);
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/MultipleTabsLoginTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/MultipleTabsLoginTest.java
@@ -80,7 +80,7 @@ public class MultipleTabsLoginTest extends AbstractTestRealmKeycloakTest {
                 .requiredAction(UserModel.RequiredAction.UPDATE_PASSWORD.toString())
                 .build();
 
-        userId = ApiUtil.createUserAndResetPasswordWithAdminClient(testRealm(), user, "password");
+        userId = ApiUtil.createUserAndResetPasswordWithAdminClient(testRealm(), user, "password", true);
         getCleanup().addUserId(userId);
 
         oauth.clientId("test-app");


### PR DESCRIPTION
We now remove a potentially existing UPDATE_PASSWORD action when
explicitly assigning a non-temporary password.

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
