### PR TITLE
KEYCLOAK-11033 Avoid NPE in password endpoint of AccountCredentialResource

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/account/AccountCredentialResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountCredentialResource.java
@@ -308,7 +308,10 @@ public class AccountCredentialResource {
         PasswordDetails details = new PasswordDetails();
         if (password != null) {
             details.setRegistered(true);
-            details.setLastUpdate(password.getCreatedDate());
+            Long createdDate = password.getCreatedDate();
+            if (createdDate != null) {
+                details.setLastUpdate(createdDate);
+            }
         } else {
             details.setRegistered(false);
         }


### PR DESCRIPTION
Added additional null guard since some credentials provide might not
maintain a "CreatedDate" for a password credentials.

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
