### PR TITLE
KEYCLOAK-8100 Improve handling of available claims in IdentityBroker Mappers

### DIFF
--- a/services/src/main/java/org/keycloak/broker/oidc/mappers/AbstractClaimMapper.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/mappers/AbstractClaimMapper.java
@@ -39,6 +39,30 @@ public abstract class AbstractClaimMapper extends AbstractIdentityProviderMapper
     public static final String CLAIM_VALUE = "claim.value";
 
     public static Object getClaimValue(JsonWebToken token, String claim) {
+
+        switch(claim){
+            case "sub":
+                return token.getSubject();
+            case "jti":
+                return token.getId();
+            case "exp":
+                return token.getExpiration();
+            case "nbf":
+                return token.getNotBefore();
+            case "iat":
+                return token.getIssuedAt();
+            case "iss":
+                return token.getIssuer();
+            case "typ":
+                return token.getType();
+            case "azp":
+                return token.getIssuedFor();
+            case "aud":
+                return String.join(",", token.getAudience());
+            default:
+                // found no match, try other claims
+        }
+
         List<String> split = OIDCAttributeMapperHelper.splitClaimPath(claim);
         Map<String, Object> jsonObject = token.getOtherClaims();
         final int length = split.size();


### PR DESCRIPTION
We now expose the claims "jti", "exp", "nbf", "iat", "iss", "aud",
"sub", "typ", "azp" along side other claims for use in Identity Broker mappers.
Previously claims directly mapped to `JsonWebToken` fields were not
accessible for mappings.

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
