### PR TITLE
KEYCLOAK-12926 Improve Locale based message lookup

### DIFF
--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/resources/theme-resources/messages/messages_de.properties
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/resources/theme-resources/messages/messages_de.properties
@@ -1,0 +1,1 @@
+test.keycloak-12926-only_de=only de

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/resources/theme-resources/messages/messages_de_AT.properties
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/resources/theme-resources/messages/messages_de_AT.properties
@@ -1,0 +1,1 @@
+test.keycloak-12926-resolving2=only de_AT

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/resources/theme-resources/messages/messages_de_AT_variant.properties
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/resources/theme-resources/messages/messages_de_AT_variant.properties
@@ -1,0 +1,1 @@
+test.keycloak-12926-resolving1=only de_AT_variant

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/resources/theme-resources/messages/messages_en_US.properties
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/resources/theme-resources/messages/messages_en_US.properties
@@ -1,4 +1,3 @@
 test.keycloak-8818= Hello from theme-resources
 fullName=Full name (Theme-resources)
-test.keycloak-12926=Test en
-test.keycloak-12926-resolving3=fallback en
+test.keycloak-12926=Test en_US

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/resources/theme-resources/messages/messages_en_US_variant.properties
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/resources/theme-resources/messages/messages_en_US_variant.properties
@@ -1,4 +1,3 @@
 test.keycloak-8818= Hello from theme-resources
 fullName=Full name (Theme-resources)
-test.keycloak-12926=Test en
-test.keycloak-12926-resolving3=fallback en
+test.keycloak-12926=Test en_US_variant

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/theme/ThemeResourceProviderTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/theme/ThemeResourceProviderTest.java
@@ -60,4 +60,39 @@ public class ThemeResourceProviderTest extends AbstractTestRealmKeycloakTest {
             }
         });
     }
+
+    /**
+     * See KEYCLOAK-12926
+     */
+    @Test
+    public void getMessagesLocaleResolving() {
+        testingClient.server().run(session -> {
+            try {
+                ThemeProvider extending = session.getProvider(ThemeProvider.class, "extending");
+                Theme theme = extending.getTheme("base", Theme.Type.LOGIN);
+                Assert.assertEquals("Test en_US_variant", theme.getMessages("messages", new Locale("en", "US", "variant")).get("test.keycloak-12926"));
+                Assert.assertEquals("Test en_US", theme.getMessages("messages", new Locale("en", "US")).get("test.keycloak-12926"));
+                Assert.assertEquals("Test en", theme.getMessages("messages", Locale.ENGLISH).get("test.keycloak-12926"));
+                Assert.assertEquals("Test en_US", theme.getMessages("messages", new Locale("en", "US")).get("test.keycloak-12926"));
+                Assert.assertEquals("Test en", theme.getMessages("messages", Locale.ENGLISH).get("test.keycloak-12926"));
+
+                Assert.assertEquals("only de_AT_variant", theme.getMessages("messages", new Locale("de", "AT", "variant")).get("test.keycloak-12926-resolving1"));
+                Assert.assertNull(theme.getMessages("messages", new Locale("de", "AT")).get("test.keycloak-12926-resolving1"));
+
+                Assert.assertEquals("only de_AT", theme.getMessages("messages", new Locale("de", "AT", "variant")).get("test.keycloak-12926-resolving2"));
+                Assert.assertNull(theme.getMessages("messages", new Locale("de")).get("test.keycloak-12926-resolving2"));
+
+                Assert.assertEquals("only de", theme.getMessages("messages", new Locale("de", "AT", "variant")).get("test.keycloak-12926-only_de"));
+                Assert.assertNull(theme.getMessages("messages", Locale.ENGLISH).get("test.keycloak-12926-only_de"));
+
+                Assert.assertEquals("fallback en", theme.getMessages("messages", new Locale("de", "AT", "variant")).get("test.keycloak-12926-resolving3"));
+                Assert.assertEquals("fallback en", theme.getMessages("messages", new Locale("de", "AT")).get("test.keycloak-12926-resolving3"));
+                Assert.assertEquals("fallback en", theme.getMessages("messages", new Locale("de")).get("test.keycloak-12926-resolving3"));
+                Assert.assertNull(theme.getMessages("messages", Locale.ENGLISH).get("fallback en"));
+
+            } catch (IOException e) {
+                Assert.fail(e.getMessage());
+            }
+        });
+    }
 }


### PR DESCRIPTION
We now consider intermediate Locales when performing a Locale based
ResourceBundle lookup, before using an Locale.ENGLISH fallback.

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
