### PR TITLE
KEYCLOAK-12579: LDAP groups duplicated during UI listing of user groups

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/membership/group/GroupLDAPStorageMapper.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/membership/group/GroupLDAPStorageMapper.java
@@ -322,12 +322,11 @@ public class GroupLDAPStorageMapper extends AbstractLDAPStorageMapper implements
             updateAttributesOfKCGroup(kcGroup, ldapGroups.get(kcGroup.getName()));
             syncResult.increaseUpdated();
         } else {
-            kcGroup = realm.createGroup(groupTreeEntry.getGroupName());
             if (kcParent == null) {
-                realm.moveGroup(kcGroup, null);
+                kcGroup = realm.createGroup(groupTreeEntry.getGroupName());
                 logger.debugf("Imported top-level group '%s' from LDAP", kcGroup.getName());
             } else {
-                realm.moveGroup(kcGroup, kcParent);
+                kcGroup = realm.createGroup(groupTreeEntry.getGroupName(), kcParent);
                 logger.debugf("Imported group '%s' from LDAP as child of group '%s'", kcGroup.getName(), kcParent.getName());
             }
 
@@ -406,7 +405,6 @@ public class GroupLDAPStorageMapper extends AbstractLDAPStorageMapper implements
 
                 kcGroup = realm.createGroup(groupName);
                 updateAttributesOfKCGroup(kcGroup, ldapGroup);
-                realm.moveGroup(kcGroup, null);
             }
 
             // Could theoretically happen on some LDAP servers if 'memberof' style is used and 'memberof' attribute of user references non-existing group

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmAdapter.java
@@ -1352,13 +1352,8 @@ public class RealmAdapter implements CachedRealmModel {
     }
 
     @Override
-    public GroupModel createGroup(String name) {
-        return cacheSession.createGroup(this, name);
-    }
-
-    @Override
-    public GroupModel createGroup(String id, String name) {
-        return cacheSession.createGroup(this, id, name);
+    public GroupModel createGroup(String id, String name, GroupModel toParent) {
+        return cacheSession.createGroup(this, id, name, toParent);
     }
 
     @Override

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmCacheSession.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmCacheSession.java
@@ -830,7 +830,7 @@ public class RealmCacheSession implements CacheRealmProvider {
     @Override
     public void moveGroup(RealmModel realm, GroupModel group, GroupModel toParent) {
         invalidateGroup(group.getId(), realm.getId(), true);
-        if (toParent != null) invalidateGroup(group.getId(), realm.getId(), false); // Queries already invalidated
+        if (toParent != null) invalidateGroup(toParent.getId(), realm.getId(), false); // Queries already invalidated
         listInvalidations.add(realm.getId());
 
         invalidationEvents.add(GroupMovedEvent.create(group, toParent, realm.getId()));
@@ -993,24 +993,18 @@ public class RealmCacheSession implements CacheRealmProvider {
         return getRealmDelegate().removeGroup(realm, group);
     }
 
-    @Override
-    public GroupModel createGroup(RealmModel realm, String name) {
-        GroupModel group = getRealmDelegate().createGroup(realm, name);
-        return groupAdded(realm, group);
-    }
-
-    private GroupModel groupAdded(RealmModel realm, GroupModel group) {
+    private GroupModel groupAdded(RealmModel realm, GroupModel group, GroupModel toParent) {
         listInvalidations.add(realm.getId());
-        cache.groupQueriesInvalidations(realm.getId(), invalidations);
-        invalidations.add(group.getId());
+        invalidateGroup(group.getId(), realm.getId(), true);
+        if (toParent != null) invalidateGroup(toParent.getId(), realm.getId(), false); // Queries already invalidated
         invalidationEvents.add(GroupAddedEvent.create(group.getId(), realm.getId()));
         return group;
     }
 
     @Override
-    public GroupModel createGroup(RealmModel realm, String id, String name) {
-        GroupModel group = getRealmDelegate().createGroup(realm, id, name);
-        return groupAdded(realm, group);
+    public GroupModel createGroup(RealmModel realm, String id, String name, GroupModel toParent) {
+        GroupModel group = getRealmDelegate().createGroup(realm, id, name, toParent);
+        return groupAdded(realm, group, toParent);
     }
 
     @Override

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/GroupAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/GroupAdapter.java
@@ -76,16 +76,13 @@ public class GroupAdapter implements GroupModel , JpaModel<GroupEntity> {
 
     @Override
     public GroupModel getParent() {
-        GroupEntity parent = group.getParent();
-        if (parent == null) return null;
-        return realm.getGroupById(parent.getId());
+        String parentId = this.getParentId();
+        return parentId == null? null : realm.getGroupById(parentId);
     }
 
     @Override
     public String getParentId() {
-        GroupEntity parent = group.getParent();
-        if (parent == null) return null;
-        return parent.getId();
+        return GroupEntity.TOP_PARENT_ID.equals(group.getParentId())? null : group.getParentId();
     }
 
     public static GroupEntity toEntity(GroupModel model, EntityManager em) {
@@ -97,13 +94,11 @@ public class GroupAdapter implements GroupModel , JpaModel<GroupEntity> {
 
     @Override
     public void setParent(GroupModel parent) {
-        if (parent == null) group.setParent(null);
-        else if (parent.getId().equals(getId())) {
-            return;
-        }
-        else {
+        if (parent == null) {
+            group.setParentId(GroupEntity.TOP_PARENT_ID);
+        } else if (!parent.getId().equals(getId())) {
             GroupEntity parentEntity = toEntity(parent, em);
-            group.setParent(parentEntity);
+            group.setParentId(parentEntity.getId());
         }
     }
 
@@ -126,7 +121,7 @@ public class GroupAdapter implements GroupModel , JpaModel<GroupEntity> {
     @Override
     public Set<GroupModel> getSubGroups() {
         TypedQuery<String> query = em.createNamedQuery("getGroupIdsByParent", String.class);
-        query.setParameter("parent", group);
+        query.setParameter("parent", group.getId());
         List<String> ids = query.getResultList();
         Set<GroupModel> set = new HashSet<>();
         for (String id : ids) {

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/RealmAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/RealmAdapter.java
@@ -1947,13 +1947,8 @@ public class RealmAdapter implements RealmModel, JpaModel<RealmEntity> {
     }
 
     @Override
-    public GroupModel createGroup(String name) {
-        return session.realms().createGroup(this, name);
-    }
-
-    @Override
-    public GroupModel createGroup(String id, String name) {
-        return session.realms().createGroup(this, id, name);
+    public GroupModel createGroup(String id, String name, GroupModel toParent) {
+        return session.realms().createGroup(this, id, name, toParent);
     }
 
     @Override

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/GroupEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/GroupEntity.java
@@ -28,17 +28,23 @@ import java.util.Collection;
  * @version $Revision: 1 $
  */
 @NamedQueries({
-        @NamedQuery(name="getGroupIdsByParent", query="select u.id from GroupEntity u where u.parent = :parent"),
+        @NamedQuery(name="getGroupIdsByParent", query="select u.id from GroupEntity u where u.parentId = :parent"),
         @NamedQuery(name="getGroupIdsByNameContaining", query="select u.id from GroupEntity u where u.realm.id = :realm and u.name like concat('%',:search,'%') order by u.name ASC"),
-        @NamedQuery(name="getTopLevelGroupIds", query="select u.id from GroupEntity u where u.parent is null and u.realm.id = :realm order by u.name ASC"),
+        @NamedQuery(name="getTopLevelGroupIds", query="select u.id from GroupEntity u where u.parentId = :parent and u.realm.id = :realm order by u.name ASC"),
         @NamedQuery(name="getGroupCount", query="select count(u) from GroupEntity u where u.realm.id = :realm"),
-        @NamedQuery(name="getTopLevelGroupCount", query="select count(u) from GroupEntity u where u.realm.id = :realm and u.parent is null")
+        @NamedQuery(name="getTopLevelGroupCount", query="select count(u) from GroupEntity u where u.realm.id = :realm and u.parentId = :parent")
 })
 @Entity
 @Table(name="KEYCLOAK_GROUP",
         uniqueConstraints = { @UniqueConstraint(columnNames = {"REALM_ID", "PARENT_GROUP", "NAME"})}
 )
 public class GroupEntity {
+
+    /**
+     * ID set in the PARENT column to mark the group as top level.
+     */
+    public static String TOP_PARENT_ID = " ";
+
     @Id
     @Column(name="ID", length = 36)
     @Access(AccessType.PROPERTY) // we do this because relationships often fetch id, but not entity.  This avoids an extra SQL
@@ -48,9 +54,8 @@ public class GroupEntity {
     @Column(name = "NAME")
     protected String name;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "PARENT_GROUP")
-    private GroupEntity parent;
+    @Column(name = "PARENT_GROUP")
+    private String parentId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "REALM_ID")
@@ -93,12 +98,12 @@ public class GroupEntity {
         this.realm = realm;
     }
 
-    public GroupEntity getParent() {
-        return parent;
+    public String getParentId() {
+        return parentId;
     }
 
-    public void setParent(GroupEntity parent) {
-        this.parent = parent;
+    public void setParentId(String parentId) {
+        this.parentId = parentId;
     }
 
     @Override

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-9.0.1.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-9.0.1.xml
@@ -23,4 +23,26 @@
         </createIndex>
     </changeSet>
 
+    <changeSet author="keycloak" id="9.0.1-KEYCLOAK-12579-drop-constraints">
+        <preConditions onFail="MARK_RAN" onSqlOutput="TEST">
+            <!-- sql server needs drop and re-create the constraint SIBLING_NAMES -->
+            <dbms type="mssql"/>
+        </preConditions>
+        <dropUniqueConstraint tableName="KEYCLOAK_GROUP" constraintName="SIBLING_NAMES"/>
+    </changeSet>
+
+    <changeSet author="keycloak" id="9.0.1-KEYCLOAK-12579-add-not-null-constraint">
+        <!-- Now the parent group cannot be NULL to make SIBLING_NAMES unique constraint work -->
+        <!-- Top level groups are now marked with the " " (one space) string -->
+        <addNotNullConstraint tableName="KEYCLOAK_GROUP" columnName="PARENT_GROUP" columnDataType="VARCHAR(36)" defaultNullValue=" "/>
+    </changeSet>
+
+    <changeSet author="keycloak" id="9.0.1-KEYCLOAK-12579-recreate-constraints">
+        <preConditions onFail="MARK_RAN" onSqlOutput="TEST">
+            <!-- sql server needs drop and re-create the constraint SIBLING_NAMES -->
+            <dbms type="mssql"/>
+        </preConditions>
+        <addUniqueConstraint columnNames="REALM_ID,PARENT_GROUP,NAME" constraintName="SIBLING_NAMES" tableName="KEYCLOAK_GROUP"/>
+    </changeSet>
+
 </databaseChangeLog>

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
@@ -667,13 +667,12 @@ public class RepresentationToModel {
     }
 
     public static void importGroup(RealmModel realm, GroupModel parent, GroupRepresentation group) {
-        GroupModel newGroup = realm.createGroup(group.getId(), group.getName());
+        GroupModel newGroup = realm.createGroup(group.getId(), group.getName(), parent);
         if (group.getAttributes() != null) {
             for (Map.Entry<String, List<String>> attr : group.getAttributes().entrySet()) {
                 newGroup.setAttribute(attr.getKey(), attr.getValue());
             }
         }
-        realm.moveGroup(newGroup, parent);
 
         if (group.getRealmRoles() != null) {
             for (String roleString : group.getRealmRoles()) {

--- a/server-spi/src/main/java/org/keycloak/models/RealmModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/RealmModel.java
@@ -471,8 +471,19 @@ public interface RealmModel extends RoleContainerModel {
     String getDefaultLocale();
     void setDefaultLocale(String locale);
 
-    GroupModel createGroup(String name);
-    GroupModel createGroup(String id, String name);
+    default GroupModel createGroup(String name) {
+        return createGroup(null, name, null);
+    };
+
+    default GroupModel createGroup(String id, String name) {
+        return createGroup(id, name, null);
+    };
+
+    default GroupModel createGroup(String name, GroupModel toParent) {
+        return createGroup(null, name, toParent);
+    };
+
+    GroupModel createGroup(String id, String name, GroupModel toParent);
 
     GroupModel getGroupById(String id);
     List<GroupModel> getGroups();

--- a/server-spi/src/main/java/org/keycloak/models/RealmProvider.java
+++ b/server-spi/src/main/java/org/keycloak/models/RealmProvider.java
@@ -56,9 +56,19 @@ public interface RealmProvider extends Provider, ClientProvider {
 
     boolean removeGroup(RealmModel realm, GroupModel group);
 
-    GroupModel createGroup(RealmModel realm, String name);
+    default GroupModel createGroup(RealmModel realm, String name) {
+        return createGroup(realm, null, name, null);
+    }
 
-    GroupModel createGroup(RealmModel realm, String id, String name);
+    default GroupModel createGroup(RealmModel realm, String id, String name) {
+        return createGroup(realm, id, name, null);
+    }
+
+    default GroupModel createGroup(RealmModel realm, String name, GroupModel toParent) {
+        return createGroup(realm, null, name, toParent);
+    }
+
+    GroupModel createGroup(RealmModel realm, String id, String name, GroupModel toParent);
 
     void addTopLevelGroup(RealmModel realm, GroupModel subGroup);
 

--- a/services/src/main/java/org/keycloak/services/resources/admin/GroupResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/GroupResource.java
@@ -144,7 +144,7 @@ public class GroupResource {
             }
             adminEvent.operation(OperationType.UPDATE);
         } else {
-            child = realm.createGroup(rep.getName());
+            child = realm.createGroup(rep.getName(), group);
             updateGroup(rep, child);
             URI uri = session.getContext().getUri().getBaseUriBuilder()
                                            .path(session.getContext().getUri().getMatchedURIs().get(2))
@@ -154,7 +154,6 @@ public class GroupResource {
             adminEvent.operation(OperationType.CREATE);
 
         }
-        realm.moveGroup(child, group);
         adminEvent.resourcePath(session.getContext().getUri()).representation(rep).success();
 
         GroupRepresentation childRep = ModelToRepresentation.toGroupHierarchy(child, true);

--- a/services/src/main/java/org/keycloak/services/resources/admin/GroupsResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/GroupsResource.java
@@ -164,7 +164,6 @@ public class GroupsResource {
             rep.setId(child.getId());
             adminEvent.operation(OperationType.CREATE).resourcePath(session.getContext().getUri(), child.getId());
         }
-        realm.moveGroup(child, null);
 
         adminEvent.representation(rep).success();
         return builder.build();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPGroupMapper2WaySyncTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPGroupMapper2WaySyncTest.java
@@ -82,18 +82,14 @@ public class LDAPGroupMapper2WaySyncTest extends AbstractLDAPTest {
             removeAllModelGroups(appRealm);
 
             GroupModel group1 = appRealm.createGroup("group1");
-            appRealm.moveGroup(group1, null);
             group1.setSingleAttribute(descriptionAttrName, "group1 - description1");
 
-            GroupModel group11 = appRealm.createGroup("group11");
-            appRealm.moveGroup(group11, group1);
+            GroupModel group11 = appRealm.createGroup("group11", group1);
 
-            GroupModel group12 = appRealm.createGroup("group12");
-            appRealm.moveGroup(group12, group1);
+            GroupModel group12 = appRealm.createGroup("group12", group1);
             group12.setSingleAttribute(descriptionAttrName, "group12 - description12");
 
             GroupModel group2 = appRealm.createGroup("group2");
-            appRealm.moveGroup(group2, null);
 
         });
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPGroupMapperSyncTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPGroupMapperSyncTest.java
@@ -276,9 +276,7 @@ public class LDAPGroupMapperSyncTest extends AbstractLDAPTest {
 
             // Create some new groups in keycloak
             GroupModel model1 = realm.createGroup("model1");
-            realm.moveGroup(model1, null);
-            GroupModel model2 = realm.createGroup("model2");
-            realm.moveGroup(model2, kcGroup1);
+            GroupModel model2 = realm.createGroup("model2", kcGroup1);
 
             // Sync groups again from LDAP. Nothing deleted
             syncResult = new GroupLDAPStorageMapperFactory().create(session, mapperModel).syncDataFromFederationProviderToKeycloak(realm);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPGroupMapperTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPGroupMapperTest.java
@@ -574,18 +574,13 @@ public class LDAPGroupMapperTest extends AbstractLDAPTest {
             RealmModel appRealm = ctx.getRealm();
 
             GroupModel group3 = appRealm.createGroup("group3");
-            session.realms().addTopLevelGroup(appRealm, group3);
-            GroupModel group31 = appRealm.createGroup("group31");
-            group3.addChild(group31);
-            GroupModel group32 = appRealm.createGroup("group32");
-            group3.addChild(group32);
+            GroupModel group31 = appRealm.createGroup("group31", group3);
+            GroupModel group32 = appRealm.createGroup("group32", group3);
 
             GroupModel group4 = appRealm.createGroup("group4");
-            session.realms().addTopLevelGroup(appRealm, group4);
 
-            GroupModel group14 = appRealm.createGroup("group14");
             GroupModel group1 = KeycloakModelUtils.findGroupByPath(appRealm, "/group1");
-            group1.addChild(group14);
+            GroupModel group14 = appRealm.createGroup("group14", group1);
 
         });
 


### PR DESCRIPTION
Fix for KEYCLOAK-12579. Just the database check is implemented. Some comments:

* The column PARENT_GROUP is now defined as not null and top level groups are marked with an empty string instead of NULL. This way the SIBLING_NAMES unique key also considers the top level group names.
* As a consequence of the previous unique key, the group cannot be created first at top level and then moved (previously a group creation always consisted in a createGroup, top level, and then moveGroup). Although it was done in the same transaction the INSERT was executed first and now with the active unique key it gave an error (violation of the unique key). I have modified the RealmModel and RealmProvider interfaces to add two more createGroup variants that let pass the final parent. The moveGroup is just needed to real movements (from one parent to a new one, once the group is already created).
* I have added the database changes for 9.0.0 version for the moment, we can change it later on if 9.0.0 is released.

Tested with internal H2 database, MySQL and postgres. Please try to test this with the other databases. DB2 is a bit special because it needs a different database modifications (the unique key was dropped in a previous version because it doesn't allows NULLs in unique keys). So for DB2 the three columns are set as not null (NAME and PARENT_GROUP) and the unique key is re-created. I did this without any testing cos I don't have any DB2 box, so it can fail.
