### PR TITLE
KEYCLOAK-9436 Filter out git-Logo.svg to fix zip for Windows

### DIFF
--- a/themes/pom.xml
+++ b/themes/pom.xml
@@ -109,6 +109,8 @@
                     <exclude>**/Gruntfile.js</exclude>
                     <exclude>**/Gemfile*</exclude>
                     <exclude>**/.*</exclude>
+                    <!-- Remove once rcue stops shipping this file -->
+                    <exclude>**/git-Logo.svg</exclude>
                     <!-- Remove once account2 manual filter list is removed -->
                     <exclude>**/keycloak-preview/account/resources/node_modules/**</exclude>
                 </excludes>


### PR DESCRIPTION
Should be safe to filter, upstream PR redhat-rcue/rcue#89 will remove
eventually, and tests use lowercase version of this file.
