### PR TITLE
KEYCLOAK-12937 adding OSGi metadata to module manifest

### DIFF
--- a/adapters/oidc/installed/pom.xml
+++ b/adapters/oidc/installed/pom.xml
@@ -30,6 +30,29 @@
     <name>Keycloak Installed Application</name>
     <description/>
 
+    <properties>
+        <keycloak.osgi.export>
+            org.keycloak.adapters.installed
+        </keycloak.osgi.export>
+        <keycloak.osgi.import>
+            javax.crypto,
+            javax.crypto.spec,
+            javax.ws.rs.client,
+            javax.ws.rs.core,
+            org.jboss.resteasy.client.jaxrs,
+            org.keycloak,
+            org.keycloak.adapters,
+            org.keycloak.adapters.rotation,
+            org.keycloak.common,
+            org.keycloak.common.util,
+            org.keycloak.jose.jwe,
+            org.keycloak.representations,
+            org.keycloak.representations.adapters.config,
+            org.keycloak.representations.idm,
+            org.keycloak.util
+        </keycloak.osgi.import>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.keycloak</groupId>
@@ -73,5 +96,42 @@
         </dependency>
 
     </dependencies>
+
+    <build>
+        <plugins>
+            <!-- Adding OSGI metadata to the JAR without changing the packaging type. -->
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <instructions>
+                        <Bundle-ClassPath>.</Bundle-ClassPath>
+                        <Bundle-Name>${project.name}</Bundle-Name>
+                        <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
+                        <Import-Package>${keycloak.osgi.import}</Import-Package>
+                        <Export-Package>${keycloak.osgi.export}</Export-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>


### PR DESCRIPTION
The Keycloak Installed Application adapter module currently has no OSGi-metadata in its MANIFEST.MF file.

Several other modules do have OSGi-metadata their respective manifests, such as Keycloak Core, Keycloak Adapter Core, and Keycloak Authz Client. I looked at those modules for examples, to ensure consistency between the manifests of different modules.

I compared the results of different modules, and I'm satisfied with the results.

I have tested this for an Eclipse RCP application, and it works without issue. Some of this module's dependencies are not readily available as OSGi bundles - my company OSGi-fies libraries for internal use.