### PR TITLE
KEYCLOAK-13068 - Upgrade to Quarkus 1.2.1.Final

### DIFF
--- a/quarkus/pom.xml
+++ b/quarkus/pom.xml
@@ -31,8 +31,10 @@
     <packaging>pom</packaging>
 
     <properties>
-        <quarkus.version>1.0.1.Final</quarkus.version>
-        <resteasy.version>4.3.1.Final</resteasy.version>
+        <quarkus.version>1.2.1.Final</quarkus.version>
+        <resteasy.version>4.4.2.Final</resteasy.version>
+        <jackson.version>2.10.2</jackson.version>
+        <jackson.databind.version>${jackson.version}</jackson.databind.version>
 
         <surefire-plugin.version>2.22.0</surefire-plugin.version>
 

--- a/quarkus/server/pom.xml
+++ b/quarkus/server/pom.xml
@@ -198,6 +198,14 @@
 
         <!-- Keycloak Dependencies-->
         <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-multipart-provider</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>commons-logging-jboss-logging</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.webauthn4j</groupId>
             <artifactId>webauthn4j-core</artifactId>
             <exclusions>


### PR DESCRIPTION
- Update to Quarkus 1.2.1.Final, pin Jackson to 2.10.2
- Bring back `resteasy-multipart-provider` (needed by IdP and federation UI)
- Add `commons-logging-jboss-logging` (required by HttpClient)
