### PR TITLE
[KEYCLOAK-4730] - protocol mapper should reference client by id

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/membership/role/RoleLDAPStorageMapper.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/membership/role/RoleLDAPStorageMapper.java
@@ -236,10 +236,17 @@ public class RoleLDAPStorageMapper extends AbstractLDAPStorageMapper implements 
             if (clientId == null) {
                 throw new ModelException("Using client roles mapping is requested, but parameter client.id not found!");
             }
+
             ClientModel client = realm.getClientByClientId(clientId);
+            
+            if (client == null) {
+                client = realm.getClientById(clientId);
+            }
+            
             if (client == null) {
                 throw new ModelException("Can't found requested client with clientId: " + clientId);
             }
+
             return client;
         }
     }

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/membership/role/RoleLDAPStorageMapperFactory.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/membership/role/RoleLDAPStorageMapperFactory.java
@@ -19,6 +19,7 @@ package org.keycloak.storage.ldap.mappers.membership.role;
 
 import org.keycloak.component.ComponentModel;
 import org.keycloak.component.ComponentValidationException;
+import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.LDAPConstants;
 import org.keycloak.models.RealmModel;
@@ -36,6 +37,7 @@ import org.keycloak.storage.ldap.mappers.membership.MembershipType;
 import org.keycloak.storage.ldap.mappers.membership.UserRolesRetrieveStrategy;
 import org.keycloak.storage.ldap.mappers.membership.group.GroupMapperConfig;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
@@ -259,6 +261,17 @@ public class RoleLDAPStorageMapperFactory extends AbstractLDAPStorageMapperFacto
             if (clientId == null || clientId.trim().isEmpty()) {
                 throw new ComponentValidationException("ldapErrorMissingClientId");
             }
+            ClientModel clientModel = realm.getClientByClientId(clientId);
+
+            if (clientModel == null) {
+                clientModel = realm.getClientById(clientId);
+            }
+
+            if (clientModel == null) {
+                throw new ComponentValidationException("ldapErrorMissingClientId");
+            }
+
+            config.getConfig().putSingle(RoleMapperConfig.CLIENT_ID, clientModel.getId());
         }
 
         LDAPUtils.validateCustomLdapFilter(config.getConfig().getFirst(RoleMapperConfig.ROLES_LDAP_FILTER));

--- a/testsuite/integration-arquillian/tests/base/src/test/resources/export/partialexport-testrealm.json
+++ b/testsuite/integration-arquillian/tests/base/src/test/resources/export/partialexport-testrealm.json
@@ -904,7 +904,7 @@
                   "groupOfNames"
                 ],
                 "client.id": [
-                  "finance"
+                  "test-app"
                 ]
               }
             }


### PR DESCRIPTION
Keeping the possibility to create mappers using the client id but internally we store the client UID.

I'm not sure if a migration is necessary, but if so, let me know so I can prepare the scripts that update mappers to their corresponding client UID (instead of client id).