### PR TITLE
Remove trailing whitespace in liquibase drop statement

### DIFF
--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-8.0.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-8.0.0.xml
@@ -198,7 +198,7 @@
         <dropColumn tableName="FED_USER_CREDENTIAL" columnName="ALGORITHM"/>
 
         <!--credential attributes are now held within the json of secret_data and credential_data (not this it was used in any case)-->
-        <dropTable tableName="FED_CREDENTIAL_ATTRIBUTE "/>
+        <dropTable tableName="FED_CREDENTIAL_ATTRIBUTE"/>
 
     </changeSet>
 


### PR DESCRIPTION
The liquibase script 'jpa-changelog-8.0.0.xml' has a trailing whitespace for a table name, which leads to errors when applying the liquibase update on a H2 database. Removing this trailing slash fixes those errors.