### PR TITLE
[KEYCLOAK-13044] Fix owner name representations of UMA tickets for client-owned resources

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
@@ -1018,10 +1018,15 @@ public class ModelToRepresentation {
             representation.setResourceName(resource.getName());
             KeycloakSession keycloakSession = authorization.getKeycloakSession();
             RealmModel realm = authorization.getRealm();
-            UserModel owner = keycloakSession.users().getUserById(ticket.getOwner(), realm);
+            UserModel userOwner = keycloakSession.users().getUserById(ticket.getOwner(), realm);
             UserModel requester = keycloakSession.users().getUserById(ticket.getRequester(), realm);
             representation.setRequesterName(requester.getUsername());
-            representation.setOwnerName(owner.getUsername());
+            if (userOwner != null) {
+                representation.setOwnerName(userOwner.getUsername());
+            } else {
+                ClientModel clientOwner = realm.getClientById(ticket.getOwner());
+                representation.setOwnerName(clientOwner.getClientId());
+            }
         }
 
         Scope scope = ticket.getScope();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/UmaRepresentationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/UmaRepresentationTest.java
@@ -1,0 +1,182 @@
+package org.keycloak.testsuite.authz;
+
+import org.jboss.resteasy.spi.ResteasyUriInfo;
+import org.junit.Assert;
+import org.junit.Test;
+import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.authorization.AuthorizationProvider;
+import org.keycloak.authorization.client.resource.PermissionResource;
+import org.keycloak.forms.account.freemarker.model.AuthorizationBean;
+import org.keycloak.forms.account.freemarker.model.AuthorizationBean.ResourceBean;
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.UserModel;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.representations.idm.authorization.*;
+import org.keycloak.testsuite.arquillian.annotation.AuthServerContainerExclude;
+import org.keycloak.testsuite.arquillian.annotation.AuthServerContainerExclude.AuthServer;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+
+@AuthServerContainerExclude(AuthServer.REMOTE)
+public class UmaRepresentationTest extends AbstractResourceServerTest {
+    private ResourceRepresentation resource;
+    private PermissionResource permission;
+
+    private void createPermissionTicket() {
+        PermissionTicketRepresentation ticket = new PermissionTicketRepresentation();
+        ticket.setOwner(resource.getOwner().getId());
+        ticket.setResource(resource.getId());
+        ticket.setRequesterName("kolo");
+        ticket.setScopeName("ScopeA");
+        ticket.setGranted(true);
+        permission.create(ticket);
+    }
+
+    @Test
+    public void testCanRepresentPermissionTicketWithNamesOfResourceOwnedByUser() throws Exception {
+        resource = addResource("Resource A", "marta", true, "ScopeA");
+        permission = getAuthzClient().protection("marta", "password").permission();
+        createPermissionTicket();
+
+        List<PermissionTicketRepresentation> permissionTickets = permission.find(resource.getId(), null, null, null, null, true, null, null);
+        Assert.assertFalse(permissionTickets.isEmpty());
+        Assert.assertEquals(1, permissionTickets.size());
+
+        PermissionTicketRepresentation ticket = permissionTickets.get(0);
+        Assert.assertEquals(ticket.getOwnerName(), "marta");
+        Assert.assertEquals(ticket.getRequesterName(), "kolo");
+        Assert.assertEquals(ticket.getResourceName(), "Resource A");
+        Assert.assertEquals(ticket.getScopeName(), "ScopeA");
+        Assert.assertTrue(ticket.isGranted());
+    }
+
+    @Test
+    public void testCanRepresentPermissionTicketWithNamesOfResourceOwnedByClient() throws Exception {
+        resource = addResource("Resource A", getClient(getRealm()).toRepresentation().getId(), true, "ScopeA");
+        permission = getAuthzClient().protection().permission();
+        createPermissionTicket();
+
+        List<PermissionTicketRepresentation> permissionTickets = permission.find(resource.getId(), null, null, null, null, true, null, null);
+        Assert.assertFalse(permissionTickets.isEmpty());
+        Assert.assertEquals(1, permissionTickets.size());
+
+        PermissionTicketRepresentation ticket = permissionTickets.get(0);
+        Assert.assertEquals(ticket.getOwnerName(), "resource-server-test");
+        Assert.assertEquals(ticket.getRequesterName(), "kolo");
+        Assert.assertEquals(ticket.getResourceName(), "Resource A");
+        Assert.assertEquals(ticket.getScopeName(), "ScopeA");
+        Assert.assertTrue(ticket.isGranted());
+    }
+
+    @Test
+    public void testCanRepresentPolicyResultGrantOfResourceOwnedByUser() throws Exception {
+        resource = addResource("Resource A", "marta", true, "ScopeA");
+        permission = getAuthzClient().protection("marta", "password").permission();
+        createPermissionTicket();
+
+        RealmResource realm = getRealm();
+        String resourceServerId = getClient(realm).toRepresentation().getId();
+        UserRepresentation user = realm.users().search("kolo").get(0);
+
+        PolicyEvaluationRequest request = new PolicyEvaluationRequest();
+        request.setUserId(user.getId());
+        request.setClientId(resourceServerId);
+        request.addResource("Resource A", "ScopeA");
+        PolicyEvaluationResponse result = getClient(realm).authorization().policies().evaluate(request);
+        Assert.assertEquals(result.getStatus(), DecisionEffect.PERMIT);
+
+        List<PolicyEvaluationResponse.EvaluationResultRepresentation> evaluations = result.getResults();
+        Assert.assertFalse(evaluations.isEmpty());
+        Assert.assertEquals(1, evaluations.size());
+
+        List<PolicyEvaluationResponse.PolicyResultRepresentation> policies = evaluations.get(0).getPolicies();
+        Assert.assertFalse(evaluations.isEmpty());
+        Assert.assertEquals(1, evaluations.size());
+
+        String description = policies.get(0).getPolicy().getDescription();
+        Assert.assertTrue(description.startsWith("Resource owner (marta) grants access"));
+    }
+
+    @Test
+    public void testCanRepresentPolicyResultGrantOfResourceOwnedByClient() throws Exception {
+        resource = addResource("Resource A", getClient(getRealm()).toRepresentation().getId(), true, "ScopeA");
+        permission = getAuthzClient().protection().permission();
+        createPermissionTicket();
+
+        RealmResource realm = getRealm();
+        String resourceServerId = getClient(realm).toRepresentation().getId();
+        UserRepresentation user = realm.users().search("kolo").get(0);
+
+        PolicyEvaluationRequest request = new PolicyEvaluationRequest();
+        request.setUserId(user.getId());
+        request.setClientId(resourceServerId);
+        request.addResource("Resource A", "ScopeA");
+        PolicyEvaluationResponse result = getClient(realm).authorization().policies().evaluate(request);
+        Assert.assertEquals(result.getStatus(), DecisionEffect.PERMIT);
+
+        List<PolicyEvaluationResponse.EvaluationResultRepresentation> evaluations = result.getResults();
+        Assert.assertFalse(evaluations.isEmpty());
+        Assert.assertEquals(1, evaluations.size());
+
+        List<PolicyEvaluationResponse.PolicyResultRepresentation> policies = evaluations.get(0).getPolicies();
+        Assert.assertFalse(evaluations.isEmpty());
+        Assert.assertEquals(1, evaluations.size());
+
+        String description = policies.get(0).getPolicy().getDescription();
+        Assert.assertTrue(description.startsWith("Resource owner (resource-server-test) grants access"));
+    }
+
+    @Test
+    public void testCanRepresentResourceBeanOfResourceOwnedByUser() throws Exception {
+        resource = addResource("Resource A", "marta", true, "ScopeA");
+        testingClient.server().run(UmaRepresentationTest::testCanRepresentResourceBeanOfResourceOwnedByUser);
+    }
+
+    public static void testCanRepresentResourceBeanOfResourceOwnedByUser(KeycloakSession session) {
+        session.getContext().setRealm(session.realms().getRealmByName("authz-test"));
+        AuthorizationProvider authorization = session.getProvider(AuthorizationProvider.class);
+
+        AuthorizationBean authorizationBean  = new AuthorizationBean(session, null, session.getContext().getUri());
+        ClientModel client = session.getContext().getRealm().getClientByClientId("resource-server-test");
+        UserModel user = session.userStorageManager().getUserByUsername("marta", session.getContext().getRealm());
+        ResourceBean resourceBean = authorizationBean.new ResourceBean(
+            authorization.getStoreFactory().getResourceStore().findByName(
+                "Resource A", user.getId(), client.getId()
+            )
+        );
+
+        Assert.assertEquals("Resource A", resourceBean.getName());
+        Assert.assertEquals("marta", resourceBean.getOwnerName());
+        Assert.assertNotNull(resourceBean.getUserOwner());
+        Assert.assertEquals("marta", resourceBean.getUserOwner().getUsername());
+        Assert.assertNull(resourceBean.getClientOwner());
+    }
+
+    @Test
+    public void testCanRepresentResourceBeanOfResourceOwnedByClient() throws Exception {
+        resource = addResource("Resource A", getClient(getRealm()).toRepresentation().getId(), true, "ScopeA");
+        testingClient.server().run(UmaRepresentationTest::testCanRepresentResourceBeanOfResourceOwnedByClient);
+    }
+
+    public static void testCanRepresentResourceBeanOfResourceOwnedByClient(KeycloakSession session) {
+        session.getContext().setRealm(session.realms().getRealmByName("authz-test"));
+        AuthorizationProvider authorization = session.getProvider(AuthorizationProvider.class);
+
+        AuthorizationBean authorizationBean  = new AuthorizationBean(session, null, session.getContext().getUri());
+        ClientModel client = session.getContext().getRealm().getClientByClientId("resource-server-test");
+        ResourceBean resourceBean = authorizationBean.new ResourceBean(
+            authorization.getStoreFactory().getResourceStore().findByName(
+                "Resource A", client.getId(), client.getId()
+            )
+        );
+
+        Assert.assertEquals("Resource A", resourceBean.getName());
+        Assert.assertEquals("resource-server-test", resourceBean.getOwnerName());
+        Assert.assertNotNull(resourceBean.getClientOwner());
+        Assert.assertEquals("resource-server-test", resourceBean.getClientOwner().getClientId());
+        Assert.assertNull(resourceBean.getUserOwner());
+    }
+}

--- a/themes/src/main/resources/theme/base/account/resources.ftl
+++ b/themes/src/main/resources/theme/base/account/resources.ftl
@@ -262,7 +262,7 @@
                                         <#if resource.displayName??>${resource.displayName}<#else>${resource.name}</#if>
                                     </td>
                                     <td>
-                                        <#if resource.owner.email??>${resource.owner.email}<#else>${resource.owner.username}</#if>
+                                        ${resource.ownerName}
                                     </td>
                                     <td>
                                         <#if resource.resourceServer.baseUri??>
@@ -362,7 +362,7 @@
                                                 <#if resource.displayName??>${resource.displayName}<#else>${resource.name}</#if>
                                             </td>
                                             <td>
-                                                <#if resource.owner.email??>${resource.owner.email}<#else>${resource.owner.username}</#if>
+                                                ${resource.ownerName}
                                             </td>
                                             <td>
                                                 <ul>


### PR DESCRIPTION
When creating resources owned by a client (instead of a user) and adding UMA permission tickets -- say, with the `keycloak-authz-client` library --, and later requesting information on the ticket that included information on the owner's name, the server would fail with a `NullPointerException`. This is because it was always assumed that the resource owner is a user. Since this wasn't the case here, querying the user would return a null value, and inspecting its fields would raise an exception.

This issue existed in two points in the code-base prior to this commit (searching for other instances of permission ticket representations didn't return any results):

- `org.keycloak.models.utils.ModelToRepresentation.toRepresentation()` (called by the Protection API; more specifically, when the `returnNames` argument is `true`)
- `org.keycloak.authorization.admin.representation.PolicyEvaluationResponseBuilder.toRepresentation()` (called by the Policy Evaluation page)

This PR adds a client query fallback in case a user isn't found, and represents it with its `clientId` field.