### PR TITLE
KEYCLOAK-12285 Add support for RestEasy 4 to admin client

### DIFF
--- a/integration/admin-client/pom.xml
+++ b/integration/admin-client/pom.xml
@@ -30,18 +30,50 @@
     <name>Keycloak Admin REST Client</name>
     <description/>
 
+    <properties>
+        <resteasy.versions>3.9.1.Final</resteasy.versions>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-core</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-common</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-client</artifactId>
+            <version>${resteasy.versions}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-multipart-provider</artifactId>
+            <version>${resteasy.versions}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jackson2-provider</artifactId>
+            <version>${resteasy.versions}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-jaxb-provider</artifactId>
+            <version>${resteasy.versions}</version>
         </dependency>
     </dependencies>
 

--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/ClientBuilderWrapper.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/ClientBuilderWrapper.java
@@ -1,6 +1,7 @@
 package org.keycloak.admin.client;
 
-import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
+import javax.net.ssl.SSLContext;
+import javax.ws.rs.client.ClientBuilder;
 
 public class ClientBuilderWrapper {
 
@@ -17,9 +18,15 @@ public class ClientBuilderWrapper {
         }
     }
 
-    public static ResteasyClientBuilder create() {
+    public static ClientBuilder create(SSLContext sslContext, boolean disableTrustManager) {
         try {
-            return (ResteasyClientBuilder) clazz.newInstance();
+            Object o = clazz.newInstance();
+            clazz.getMethod("sslContext", SSLContext.class).invoke(o, sslContext);
+            clazz.getMethod("connectionPoolSize", int.class).invoke(o, 10);
+            if (disableTrustManager) {
+                clazz.getMethod("disableTrustManager").invoke(o);
+            }
+            return (ClientBuilder) o;
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/ClientBuilderWrapper.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/ClientBuilderWrapper.java
@@ -1,0 +1,28 @@
+package org.keycloak.admin.client;
+
+import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
+
+public class ClientBuilderWrapper {
+
+    static Class clazz;
+    static {
+        try {
+            clazz = Class.forName("org.jboss.resteasy.client.jaxrs.internal.ResteasyClientBuilderImpl");
+        } catch (ClassNotFoundException e) {
+            try {
+                clazz = Class.forName("org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder");
+            } catch (ClassNotFoundException ex) {
+                throw new RuntimeException("RestEasy 3 or 4 not found on classpath");
+            }
+        }
+    }
+
+    public static ResteasyClientBuilder create() {
+        try {
+            return (ResteasyClientBuilder) clazz.newInstance();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/token/TokenManager.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/token/TokenManager.java
@@ -25,6 +25,7 @@ import org.keycloak.common.util.Time;
 import org.keycloak.representations.AccessTokenResponse;
 
 import javax.ws.rs.BadRequestException;
+import javax.ws.rs.client.Client;
 import javax.ws.rs.core.Form;
 
 import static org.keycloak.OAuth2Constants.CLIENT_CREDENTIALS;
@@ -46,9 +47,9 @@ public class TokenManager {
     private final TokenService tokenService;
     private final String accessTokenGrantType;
 
-    public TokenManager(Config config, ResteasyClient client) {
+    public TokenManager(Config config, Client client) {
         this.config = config;
-        ResteasyWebTarget target = client.target(config.getServerUrl());
+        ResteasyWebTarget target = (ResteasyWebTarget) client.target(config.getServerUrl());
         if (!config.isPublicClient()) {
             target.register(new BasicAuthFilter(config.getClientId(), config.getClientSecret()));
         }


### PR DESCRIPTION
This works on RestEasy 3, 4.3, but not 4.4. 

On 4.4. I'm getting `java.lang.NoClassDefFoundError: com/fasterxml/jackson/databind/jsontype/PolymorphicTypeValidator`. Seems like a bug in RestEasy 4.4.

Not sure how happy Quarkus would be about the use of reflection ;)

As a final point to this, I've got no clue how we would test it with different RestEasy versions.