### PR TITLE
KEYCLOAK-13119 Fixing migration to Keycloak 2.2.0+ to correctly preserve default idp

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/models/utils/DefaultAuthenticationFlows.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/DefaultAuthenticationFlows.java
@@ -417,6 +417,7 @@ public class DefaultAuthenticationFlows {
                 Map<String, String> config = new HashMap<>();
                 config.put("defaultProvider", defaultProvider);
                 configModel.setConfig(config);
+                configModel.setAlias(defaultProvider);
                 configModel = realm.addAuthenticatorConfig(configModel);
 
                 execution.setAuthenticatorConfig(configModel.getId());


### PR DESCRIPTION
Fixing migration to Keycloak 2.2.0+ to correctly preserve default identity provider