### PR TITLE
KEYCLOAK-13186 Remove role information from RefreshTokens

### DIFF
--- a/core/src/main/java/org/keycloak/representations/RefreshToken.java
+++ b/core/src/main/java/org/keycloak/representations/RefreshToken.java
@@ -34,8 +34,7 @@ public class RefreshToken extends AccessToken {
     }
 
     /**
-     * Deep copies issuer, subject, issuedFor, sessionState, realmAccess, and resourceAccess
-     * from AccessToken.
+     * Deep copies issuer, subject, issuedFor, sessionState from AccessToken.
      *
      * @param token
      */
@@ -48,15 +47,6 @@ public class RefreshToken extends AccessToken {
         this.nonce = token.nonce;
         this.audience = new String[] { token.issuer };
         this.scope = token.scope;
-        if (token.realmAccess != null) {
-            realmAccess = token.realmAccess.clone();
-        }
-        if (token.resourceAccess != null) {
-            resourceAccess = new HashMap<>();
-            for (Map.Entry<String, Access> entry : token.resourceAccess.entrySet()) {
-                resourceAccess.put(entry.getKey(), entry.getValue().clone());
-            }
-        }
     }
 
     @Override


### PR DESCRIPTION
We now no longer expose role assignment information into the RefreshToken.

Previously RefreshTokens contained information about the realm and
client specific roles which are assigned to a user. Since the role
information is usually either taken from the AccessToken, IDToken or
the User-Info endpoint and the RefreshToken is an internal format which
is opaque to the client, it would be a waste of space to keep that
information in the RefreshToken.

Although this is an internal change, it might be advisable to apply this change only with Keycloak 10.x or later.

See further discussion here:
https://lists.jboss.org/pipermail/keycloak-dev/2019-April/011936.html

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
