### PR TITLE
KEYCLOAK-10330 Force Jackson2 provider to be used by Keycloak admin c…

### DIFF
--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/JacksonProvider.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/JacksonProvider.java
@@ -1,0 +1,6 @@
+package org.keycloak.admin.client;
+
+import org.jboss.resteasy.plugins.providers.jackson.ResteasyJackson2Provider;
+
+public class JacksonProvider extends ResteasyJackson2Provider {
+}

--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/Keycloak.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/Keycloak.java
@@ -67,6 +67,8 @@ public class Keycloak implements AutoCloseable {
 
         if (customJacksonProvider != null) {
             clientBuilder.register(customJacksonProvider, 100);
+        } else {
+            clientBuilder.register(JacksonProvider.class, 100);
         }
 
         return clientBuilder.build();


### PR DESCRIPTION
…lient, to prevent json-b provider taking over

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
