### PR TITLE
KEYCLOAK-13243 - Increase transaction timeout on Quarkus

### DIFF
--- a/quarkus/server/src/main/resources/application.properties
+++ b/quarkus/server/src/main/resources/application.properties
@@ -3,5 +3,6 @@
 quarkus.application.name=Keycloak
 quarkus.servlet.context-path = /
 quarkus.datasource.driver=org.h2.Driver
+quarkus.transaction-manager.default-transaction-timeout = 300s
 
 resteasy.disable.html.sanitizer = true


### PR DESCRIPTION
The default transaction timeout on Quarkus is 60s ([source](https://quarkus.io/guides/all-config#quarkus-narayana-jta_quarkus.transaction-manager.default-transaction-timeout)). This might be insufficient for initial schema creation and/or import under heavy load and/or virtualization. The value of 300s should be enough (this is what Wildfy/EAP have currently).