### PR TITLE
Removed space which causes issues with newest version of Liquibase

### DIFF
--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-8.0.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-8.0.0.xml
@@ -198,7 +198,7 @@
         <dropColumn tableName="FED_USER_CREDENTIAL" columnName="ALGORITHM"/>
 
         <!--credential attributes are now held within the json of secret_data and credential_data (not this it was used in any case)-->
-        <dropTable tableName="FED_CREDENTIAL_ATTRIBUTE "/>
+        <dropTable tableName="FED_CREDENTIAL_ATTRIBUTE"/>
 
     </changeSet>
 


### PR DESCRIPTION
Newest version of Liquibase 3.8.7 throws exception on Keycloak v8.0.0. due to the whitespace.

Caused by: org.h2.jdbc.JdbcSQLSyntaxErrorException: Table "FED_CREDENTIAL_ATTRIBUTE " not found.

