### PR TITLE
Create indexes on EVENT_ENTITY table to address performance issues

### DIFF
--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-9.0.1.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-9.0.1.xml
@@ -44,5 +44,14 @@
         </preConditions>
         <addUniqueConstraint columnNames="REALM_ID,PARENT_GROUP,NAME" constraintName="SIBLING_NAMES" tableName="KEYCLOAK_GROUP"/>
     </changeSet>
+  
+    <changeSet author="nthomas" id="9.0.1-create-indexes-on-EVENT_ENTITY">
+        <createIndex indexName="IDX_EVENT_ENTITY_REALM_ID" tableName="EVENT_ENTITY">
+            <column name="REALM_ID"/>
+        </createIndex>
+        <createIndex indexName="IDX_EVENT_ENTITY_EVENT_TIME" tableName="EVENT_ENTITY">
+            <column name="EVENT_TIME"/>
+        </createIndex>
+     </changeSet>
 
 </databaseChangeLog>


### PR DESCRIPTION
creating an index for table EVENT_ENTITY for fields REALM_ID and EVENT_TIME

The problem this addresses is a massive cpu spikes every 15 min in the database.

The reason for the cpu spike is delete statements for every single realm every 15 minutes in the form of:
delete from ebdb.EVENT_ENTITY where REALM_ID='someRealmName' and EVENT_TIME<1552406715494;

However both REALM_ID and EVENT_TIME are unindexed fields meaning a full table scan is necessary and if you have a lot of rows this can take some time.

Creating this index has dropped the 15 min cpu spikes to virtually nothing while not increasing the baseline cpu

side note: I was unable to create a JIRA issue for this for some reason.
Link to issue on google groups: https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!topic/keycloak-dev/6ZQ0eUlF-40
