### PR TITLE
[KEYCLOAK-13386] - SslRequired.EXTERNAL doesn't work for identity broker validations

### DIFF
--- a/common/src/main/java/org/keycloak/common/util/UriUtils.java
+++ b/common/src/main/java/org/keycloak/common/util/UriUtils.java
@@ -108,7 +108,7 @@ public class UriUtils {
             throw new IllegalArgumentException("Invalid protocol/scheme for url [" + name + "]");
         }
 
-        if (!"https".equals(protocol) && sslRequired.isRequired(url)) {
+        if (!"https".equals(protocol) && sslRequired.isRequired(parsed.getHost())) {
             throw new IllegalArgumentException("The url [" + name + "] requires secure connections");
         }
     }

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/updaters/RealmAttributeUpdater.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/updaters/RealmAttributeUpdater.java
@@ -9,7 +9,7 @@ import java.util.List;
  * Updater for realm attributes. See {@link ServerResourceUpdater} for further details.
  * @author hmlnarik
  */
-public class RealmAttributeUpdater extends ServerResourceUpdater<ServerResourceUpdater, RealmResource, RealmRepresentation> {
+public class RealmAttributeUpdater extends ServerResourceUpdater<RealmAttributeUpdater, RealmResource, RealmRepresentation> {
 
     public RealmAttributeUpdater(RealmResource resource) {
         super(resource, resource::toRepresentation, resource::update);


### PR DESCRIPTION
<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
