### PR TITLE
KEYCLOAK-8100 Expose sub claim in OIDC IdentityBroker Mappers

### DIFF
--- a/services/src/main/java/org/keycloak/broker/oidc/mappers/AbstractClaimMapper.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/mappers/AbstractClaimMapper.java
@@ -39,6 +39,14 @@ public abstract class AbstractClaimMapper extends AbstractIdentityProviderMapper
     public static final String CLAIM_VALUE = "claim.value";
 
     public static Object getClaimValue(JsonWebToken token, String claim) {
+
+        switch (claim) {
+            case "sub":
+                return token.getSubject();
+            default:
+                // found no match, try other claims
+        }
+
         List<String> split = OIDCAttributeMapperHelper.splitClaimPath(claim);
         Map<String, Object> jsonObject = token.getOtherClaims();
         final int length = split.size();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/UsernameTemplateMapperTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/UsernameTemplateMapperTest.java
@@ -1,0 +1,102 @@
+package org.keycloak.testsuite.broker;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import org.junit.Before;
+import org.junit.Test;
+import org.keycloak.admin.client.resource.IdentityProviderResource;
+import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.broker.oidc.mappers.UserAttributeMapper;
+import org.keycloak.broker.oidc.mappers.UsernameTemplateMapper;
+import org.keycloak.representations.idm.IdentityProviderMapperRepresentation;
+import org.keycloak.representations.idm.IdentityProviderRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+
+import static org.junit.Assert.assertEquals;
+
+public class UsernameTemplateMapperTest extends AbstractBaseBrokerTest {
+
+    private String idpUserId;
+
+    @Override
+    protected BrokerConfiguration getBrokerConfiguration() {
+        return KcOidcBrokerConfiguration.INSTANCE;
+    }
+
+    @Before
+    public void addClients() {
+        addClientsToProviderAndConsumer();
+    }
+
+    @Before
+    public void addIdentityProviderToConsumerRealm() {
+
+        log.debug("adding identity provider to realm " + bc.consumerRealmName());
+
+        RealmResource realm = adminClient.realm(bc.consumerRealmName());
+        IdentityProviderRepresentation idp = bc.setUpIdentityProvider(suiteContext);
+        realm.identityProviders().create(idp).close();
+
+        IdentityProviderResource idpResource = realm.identityProviders().get(idp.getAlias());
+        for (IdentityProviderMapperRepresentation mapper : createIdentityProviderMappers()) {
+            mapper.setIdentityProviderAlias(bc.getIDPAlias());
+            idpResource.addMapper(mapper).close();
+        }
+    }
+
+    @Before
+    public void createUserInIdp() {
+        idpUserId = createUser(bc.providerRealmName(), bc.getUserLogin(), bc.getUserPassword(), "First", "Last", bc.getUserEmail());
+    }
+
+    protected Iterable<IdentityProviderMapperRepresentation> createIdentityProviderMappers() {
+
+        IdentityProviderMapperRepresentation userTemplateImporterMapper = new IdentityProviderMapperRepresentation();
+        userTemplateImporterMapper.setName("custom-username-import-mapper");
+        userTemplateImporterMapper.setIdentityProviderMapper(UsernameTemplateMapper.PROVIDER_ID);
+        userTemplateImporterMapper.setConfig(ImmutableMap.<String, String>builder()
+                .put(UsernameTemplateMapper.TEMPLATE, "${ALIAS}:${CLAIM.sub}")
+                .build());
+
+        IdentityProviderMapperRepresentation jwtClaimsAttrMapper = new IdentityProviderMapperRepresentation();
+        jwtClaimsAttrMapper.setName("jwt-claims-mapper");
+        jwtClaimsAttrMapper.setIdentityProviderMapper(UserAttributeMapper.PROVIDER_ID);
+        jwtClaimsAttrMapper.setConfig(ImmutableMap.<String, String>builder()
+                .put(UserAttributeMapper.CLAIM, "sub")
+                .put(UserAttributeMapper.USER_ATTRIBUTE, "mappedSub")
+                .put(UserAttributeMapper.CLAIM_VALUE, "${CLAIM.sub};test")
+                .build());
+
+        return Lists.newArrayList(userTemplateImporterMapper, jwtClaimsAttrMapper);
+    }
+
+    /**
+     * See: KEYCLOAK-8100
+     */
+    @Test
+    public void usernameShouldBeDerivedFromAliasAndIdpSubClaim() {
+
+        logInAsUserInIDP();
+        logoutFromRealm(bc.consumerRealmName());
+
+        UserRepresentation user = adminClient.realm(bc.consumerRealmName()).users().search(bc.getUserEmail(), 0, 1).get(0);
+
+        String username = user.getUsername();
+
+        assertEquals("Should render alias:sub as Username", bc.getIDPAlias() + ":" + idpUserId, username);
+    }
+
+    /**
+     * See: KEYCLOAK-8100
+     */
+    @Test
+    public void userAttributeShouldBeDerivedFromIdpSubClaim() {
+
+        logInAsUserInIDP();
+        logoutFromRealm(bc.consumerRealmName());
+
+        UserRepresentation user = adminClient.realm(bc.consumerRealmName()).users().search(bc.getUserEmail(), 0, 1).get(0);
+
+        assertEquals("Should render idpSub as mappedSub attribute", idpUserId, user.getAttributes().get("mappedSub").get(0));
+    }
+}


### PR DESCRIPTION
We now expose the claim "sub" along side other claims for use in Identity Broker mappers.
Previously claims directly mapped to `JsonWebToken` fields (like sub) were not accessible for mappings.

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
