### PR TITLE
KEYCLOAK-13439 Enhanced the processes of fetching a realm's IdentityProvider by alias or by id

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmAdapter.java
@@ -802,6 +802,17 @@ public class RealmAdapter implements CachedRealmModel {
 
         return null;
     }
+    
+    @Override
+    public IdentityProviderModel getIdentityProviderById(String internalId) {
+    	if (isUpdated()) return updated.getIdentityProviderById(internalId);
+    	for (IdentityProviderModel identityProviderModel : getIdentityProviders()) {
+            if (identityProviderModel.getInternalId().equals(internalId)) {
+                return identityProviderModel;
+            }
+        }
+    	return null;
+    }
 
     @Override
     public void addIdentityProvider(IdentityProviderModel identityProvider) {

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/IdentityProviderEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/IdentityProviderEntity.java
@@ -39,7 +39,8 @@ import java.util.Map;
 @Entity
 @Table(name="IDENTITY_PROVIDER")
 @NamedQueries({
-        @NamedQuery(name="findIdentityProviderByAlias", query="select identityProvider from IdentityProviderEntity identityProvider where identityProvider.alias = :alias")
+        @NamedQuery(name="findIdentityProvidersByAlias", query="select identityProvider from IdentityProviderEntity identityProvider where identityProvider.alias = :alias"),
+        @NamedQuery(name="findIdentityProviderByRealmAndAlias", query="select identityProvider from IdentityProviderEntity identityProvider where identityProvider.alias = :alias and identityProvider.realm.id = :realmId" )
 })
 public class IdentityProviderEntity {
 

--- a/server-spi/src/main/java/org/keycloak/models/RealmModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/RealmModel.java
@@ -345,6 +345,7 @@ public interface RealmModel extends RoleContainerModel {
     RequiredActionProviderModel getRequiredActionProviderByAlias(String alias);
 
     List<IdentityProviderModel> getIdentityProviders();
+    IdentityProviderModel getIdentityProviderById(String internalId);
     IdentityProviderModel getIdentityProviderByAlias(String alias);
     void addIdentityProvider(IdentityProviderModel identityProvider);
     void removeIdentityProviderByAlias(String alias);

--- a/services/src/main/java/org/keycloak/services/resources/admin/IdentityProviderResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/IdentityProviderResource.java
@@ -206,26 +206,20 @@ public class IdentityProviderResource {
 
     // return ID of IdentityProvider from realm based on internalId of this provider
     private static String getProviderIdByInternalId(RealmModel realm, String providerInternalId) {
-        List<IdentityProviderModel> providerModels = realm.getIdentityProviders();
-        for (IdentityProviderModel providerModel : providerModels) {
-            if (providerModel.getInternalId().equals(providerInternalId)) {
-                return providerModel.getAlias();
-            }
-        }
-
+        IdentityProviderModel identityProviderModel = realm.getIdentityProviderById(providerInternalId);
+        if(identityProviderModel != null)
+        	return identityProviderModel.getAlias();
         return null;
     }
 
     // sets internalId to IdentityProvider based on alias
     private static void lookUpProviderIdByAlias(RealmModel realm, IdentityProviderRepresentation providerRep) {
-        List<IdentityProviderModel> providerModels = realm.getIdentityProviders();
-        for (IdentityProviderModel providerModel : providerModels) {
-            if (providerModel.getAlias().equals(providerRep.getAlias())) {
-                providerRep.setInternalId(providerModel.getInternalId());
-                return;
-            }
-        }
-        throw new javax.ws.rs.NotFoundException();
+    	IdentityProviderModel providerModel = realm.getIdentityProviderByAlias(providerRep.getAlias());
+    	if(providerModel != null) {
+    		providerRep.setInternalId(providerModel.getInternalId());
+    		return;
+    	}
+    	throw new javax.ws.rs.NotFoundException();
     }
 
     private static void updateUsersAfterProviderAliasChange(List<UserModel> users, String oldProviderId, String newProviderId, RealmModel realm, KeycloakSession session) {

--- a/services/src/main/java/org/keycloak/services/resources/admin/IdentityProvidersResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/IdentityProvidersResource.java
@@ -213,15 +213,11 @@ public class IdentityProvidersResource {
     @Path("instances/{alias}")
     public IdentityProviderResource getIdentityProvider(@PathParam("alias") String alias) {
         this.auth.realm().requireViewIdentityProviders();
-        IdentityProviderModel identityProviderModel = null;
 
-        for (IdentityProviderModel storedIdentityProvider : this.realm.getIdentityProviders()) {
-            if (storedIdentityProvider.getAlias().equals(alias)
-                    || storedIdentityProvider.getInternalId().equals(alias)) {
-                identityProviderModel = storedIdentityProvider;
-            }
-        }
-
+        IdentityProviderModel identityProviderModel = this.realm.getIdentityProviderByAlias(alias);
+        if(identityProviderModel == null)
+        	identityProviderModel = this.realm.getIdentityProviderById(alias);
+        
         IdentityProviderResource identityProviderResource = new IdentityProviderResource(this.auth, realm, session, identityProviderModel, adminEvent);
         ResteasyProviderFactory.getInstance().injectProperties(identityProviderResource);
         


### PR DESCRIPTION
Enhanced the processes of fetching a realm's IdentityProviders by alias or by id, by removing the for loops, and making calls where IdPs come prefiltered by the database, which is faster.

This change is needed, because we plan to add quite a few identityproviders on a realm (of a saml federation), thus we need to speed-up the fetching of the IdPs.

Did not add additional tests, because all what was changed, was on existing methods, which were already covered by the tests in 
IdentityProviderTest class
- testUpdate() -> calls the IdentityProvidersResource.get() which in turn calls the functions which fetch Identity Providers by alias or by id  
- testRemove() -> calls the IdentityProvidersResource.get() and the IdentityProvidersResource.remove() which at some point, fetches the realm's Identity provider by id 