### PR TITLE
[KEYCLOAK-8071] - Properly validating requested scopes

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpoint.java
@@ -34,6 +34,7 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.protocol.AuthorizationEndpointBase;
 import org.keycloak.protocol.oidc.OIDCAdvancedConfigWrapper;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
+import org.keycloak.protocol.oidc.TokenManager;
 import org.keycloak.protocol.oidc.endpoints.request.AuthorizationEndpointRequest;
 import org.keycloak.protocol.oidc.endpoints.request.AuthorizationEndpointRequestParserProcessor;
 import org.keycloak.protocol.oidc.utils.OIDCRedirectUriBuilder;
@@ -133,6 +134,12 @@ public class AuthorizationEndpoint extends AuthorizationEndpointBase {
 
         if (!TokenUtil.isOIDCRequest(request.getScope())) {
             ServicesLogger.LOGGER.oidcScopeMissing();
+        }
+
+        if (!TokenManager.isValidScope(request.getScope(), client)) {
+            ServicesLogger.LOGGER.invalidParameter(OIDCLoginProtocol.SCOPE_PARAM);
+            event.error(Errors.INVALID_REQUEST);
+            return redirectErrorToClient(parsedResponseMode, OAuthErrorException.INVALID_REQUEST, "Invalid scopes: " + request.getScope());
         }
 
         errorResponse = checkOIDCParams();

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
@@ -567,7 +567,7 @@ public class TokenEndpoint {
             event.error(Errors.CONSENT_DENIED);
             throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_CLIENT, "Client requires user consent", Response.Status.BAD_REQUEST);
         }
-        String scope = formParams.getFirst(OAuth2Constants.SCOPE);
+        String scope = getRequestedScopes();
 
         RootAuthenticationSessionModel rootAuthSession = new AuthenticationSessionManager(session).createAuthenticationSession(realm, false);
         AuthenticationSessionModel authSession = rootAuthSession.createAuthenticationSession(client);
@@ -657,7 +657,7 @@ public class TokenEndpoint {
             throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_REQUEST, "User '" + clientUsername + "' disabled", Response.Status.UNAUTHORIZED);
         }
 
-        String scope = formParams.getFirst(OAuth2Constants.SCOPE);
+        String scope = getRequestedScopes();
 
         RootAuthenticationSessionModel rootAuthSession = new AuthenticationSessionManager(session).createAuthenticationSession(realm, false);
         AuthenticationSessionModel authSession = rootAuthSession.createAuthenticationSession(client);
@@ -696,6 +696,18 @@ public class TokenEndpoint {
         event.success();
 
         return cors.builder(Response.ok(res, MediaType.APPLICATION_JSON_TYPE)).build();
+    }
+
+    private String getRequestedScopes() {
+        String scope = formParams.getFirst(OAuth2Constants.SCOPE);
+
+        if (!TokenManager.isValidScope(scope, client)) {
+            event.error(Errors.INVALID_REQUEST);
+            throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_SCOPE, "Invalid scopes: " + scope,
+                    Status.BAD_REQUEST);
+        }
+
+        return scope;
     }
 
     public Response tokenExchange() {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/AccountBrokerTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/AccountBrokerTest.java
@@ -89,7 +89,7 @@ public class AccountBrokerTest extends AbstractBaseBrokerTest {
                 log.debug("adding client " + client.getName() + " to realm " + bc.providerRealmName());
 
                 // Remove default client scopes for this test
-                client.setDefaultClientScopes(Collections.emptyList());
+//                client.setDefaultClientScopes(Collections.emptyList());
 
                 fixAuthServerHostAndPortForClientRepresentation(client);
 
@@ -150,7 +150,7 @@ public class AccountBrokerTest extends AbstractBaseBrokerTest {
         Assert.assertEquals(1, identities.size());
 
         Assert.assertEquals("kc-oidc-idp", identities.get(0).getProvider());
-        Assert.assertEquals("user@localhost.com", identities.get(0).getSubject());
+        Assert.assertEquals("testuser", identities.get(0).getSubject());
         Assert.assertEquals("remove-link-kc-oidc-idp", identities.get(0).getAction().getAttribute("id"));
 
         identities.get(0).getAction().click();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OAuthGrantTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OAuthGrantTest.java
@@ -210,7 +210,6 @@ public class OAuthGrantTest extends AbstractKeycloakTest {
         // Grant permissions on grant screen
         oauth.clientId(THIRD_PARTY_APP);
         oauth.doLoginGrant("test-user@localhost", "password");
-        oauth.scope(OAuth2Constants.GRANT_TYPE);
 
         // Create new clientScope and add to client
         RealmResource appRealm = adminClient.realm(REALM_NAME);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OfflineTokenTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OfflineTokenTest.java
@@ -163,30 +163,8 @@ public class OfflineTokenTest extends AbstractKeycloakTest {
         oauth.scope(OAuth2Constants.OFFLINE_ACCESS);
         oauth.clientId("offline-client");
         oauth.redirectUri(offlineClientAppUri);
-        oauth.doLogin("test-user@localhost", "password");
-
-        EventRepresentation loginEvent = events.expectLogin()
-                .client("offline-client")
-                .detail(Details.REDIRECT_URI, offlineClientAppUri)
-                .assertEvent();
-
-        String sessionId = loginEvent.getSessionId();
-        String codeId = loginEvent.getDetails().get(Details.CODE_ID);
-
-        String code = oauth.getCurrentQuery().get(OAuth2Constants.CODE);
-
-        OAuthClient.AccessTokenResponse tokenResponse = oauth.doAccessTokenRequest(code, "secret1");
-        String offlineTokenString = tokenResponse.getRefreshToken();
-        RefreshToken refreshToken = oauth.parseRefreshToken(offlineTokenString);
-
-        // Token is refreshed, but it's not offline token
-        events.expectCodeToToken(codeId, sessionId)
-                .client("offline-client")
-                .detail(Details.REFRESH_TOKEN_TYPE, TokenUtil.TOKEN_TYPE_REFRESH)
-                .assertEvent();
-
-        assertEquals(TokenUtil.TOKEN_TYPE_REFRESH, refreshToken.getType());
-        assertFalse(tokenResponse.getScope().contains(OAuth2Constants.OFFLINE_ACCESS));
+        oauth.openLoginForm();
+        assertTrue(driver.getCurrentUrl().contains("error_description=Invalid+scopes"));
 
         // Revert changes
         ClientManager.realm(adminClient.realm("test")).clientId("offline-client")

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/OIDCScopeTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/OIDCScopeTest.java
@@ -306,7 +306,7 @@ public class OIDCScopeTest extends AbstractOIDCScopeTest {
                 .removeDetail(Details.REDIRECT_URI).assertEvent();
 
         // Login with scope parameter. Just 'profile' is there
-        oauth.scope("openid profile email");
+        oauth.scope("openid profile");
         oauth.doLogin("john", "password");
         loginEvent = events.expectLogin()
                 .user(userId)


### PR DESCRIPTION
I also added the check to the authorization endpoint as per OAuth2 spec. One may argue that it would introduce an additional check and potentially a performance penalty to authorization requests, but to be compliant we need it.