### PR TITLE
KEYCLOAK-12934 LOAD_ROLES_BY_MEMBER_ATTRIBUTE_RECURSIVELY user roles …

### DIFF
--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/ComponentResource.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/ComponentResource.java
@@ -16,12 +16,18 @@
  */
 package org.keycloak.admin.client.resource;
 
+import java.util.List;
+
 import org.keycloak.representations.idm.ComponentRepresentation;
+import org.keycloak.representations.idm.ComponentTypeRepresentation;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
 /**
@@ -38,4 +44,15 @@ public interface ComponentResource {
 
     @DELETE
     void remove();
+
+    /**
+     * List of subcomponent types that are available to configure for a particular parent component.
+     *
+     * @param subtype fully qualified name of the java class of the provider, which is subtype of this component
+     * @return
+     */
+    @GET
+    @Path("sub-component-types")
+    @Produces(MediaType.APPLICATION_JSON)
+    List<ComponentTypeRepresentation> getSubcomponentConfig(@QueryParam("type") String subtype);
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/UserStorageRestTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/UserStorageRestTest.java
@@ -18,6 +18,7 @@
 package org.keycloak.testsuite.admin;
 
 import org.junit.Test;
+import org.keycloak.admin.client.resource.ComponentResource;
 import org.keycloak.common.constants.KerberosConstants;
 import org.keycloak.common.util.MultivaluedHashMap;
 import org.keycloak.events.admin.OperationType;
@@ -26,7 +27,15 @@ import org.keycloak.models.AuthenticationExecutionModel;
 import org.keycloak.models.LDAPConstants;
 import org.keycloak.representations.idm.AuthenticationExecutionInfoRepresentation;
 import org.keycloak.representations.idm.ComponentRepresentation;
+import org.keycloak.representations.idm.ComponentTypeRepresentation;
+import org.keycloak.representations.idm.ConfigPropertyRepresentation;
 import org.keycloak.storage.UserStorageProvider;
+import org.keycloak.storage.ldap.mappers.LDAPStorageMapper;
+import org.keycloak.storage.ldap.mappers.membership.CommonLDAPGroupMapperConfig;
+import org.keycloak.storage.ldap.mappers.membership.group.GroupLDAPStorageMapperFactory;
+import org.keycloak.storage.ldap.mappers.membership.group.GroupMapperConfig;
+import org.keycloak.storage.ldap.mappers.membership.role.RoleLDAPStorageMapperFactory;
+import org.keycloak.storage.ldap.mappers.membership.role.RoleMapperConfig;
 import org.keycloak.testsuite.Assert;
 import org.keycloak.testsuite.admin.authentication.AbstractAuthenticationTest;
 import org.keycloak.testsuite.util.AdminEventPaths;
@@ -83,12 +92,7 @@ public class UserStorageRestTest extends AbstractAdminTest {
         Assert.assertEquals(kerberosExecution.getRequirement(), AuthenticationExecutionModel.Requirement.DISABLED.toString());
 
         // create LDAP provider with kerberos
-        ComponentRepresentation ldapRep = new ComponentRepresentation();
-        ldapRep.setName("ldap2");
-        ldapRep.setProviderId("ldap");
-        ldapRep.setProviderType(UserStorageProvider.class.getName());
-        ldapRep.setConfig(new MultivaluedHashMap<>());
-        ldapRep.getConfig().putSingle("priority", Integer.toString(2));
+        ComponentRepresentation ldapRep = createBasicLDAPProviderRep();
         ldapRep.getConfig().putSingle(KerberosConstants.ALLOW_KERBEROS_AUTHENTICATION, "true");
 
         String id = createComponent(ldapRep);
@@ -147,12 +151,7 @@ public class UserStorageRestTest extends AbstractAdminTest {
         assertAdminEvents.assertEvent(realmId, OperationType.UPDATE, AdminEventPaths.authUpdateExecutionPath("browser"), kerberosExecution, ResourceType.AUTH_EXECUTION);
 
         // create LDAP provider with kerberos
-        ComponentRepresentation ldapRep = new ComponentRepresentation();
-        ldapRep.setName("ldap2");
-        ldapRep.setProviderId("ldap");
-        ldapRep.setProviderType(UserStorageProvider.class.getName());
-        ldapRep.setConfig(new MultivaluedHashMap<>());
-        ldapRep.getConfig().putSingle("priority", Integer.toString(2));
+        ComponentRepresentation ldapRep = createBasicLDAPProviderRep();
         ldapRep.getConfig().putSingle(KerberosConstants.ALLOW_KERBEROS_AUTHENTICATION, "true");
 
         String id = createComponent(ldapRep);
@@ -188,12 +187,7 @@ public class UserStorageRestTest extends AbstractAdminTest {
         Assert.assertEquals(kerberosExecution.getRequirement(), AuthenticationExecutionModel.Requirement.DISABLED.toString());
 
         // create LDAP provider with kerberos
-        ComponentRepresentation ldapRep = new ComponentRepresentation();
-        ldapRep.setName("ldap2");
-        ldapRep.setProviderId("ldap");
-        ldapRep.setProviderType(UserStorageProvider.class.getName());
-        ldapRep.setConfig(new MultivaluedHashMap<>());
-        ldapRep.getConfig().putSingle("priority", Integer.toString(2));
+        ComponentRepresentation ldapRep = createBasicLDAPProviderRep();
         ldapRep.getConfig().putSingle(KerberosConstants.ALLOW_KERBEROS_AUTHENTICATION, "true");
 
 
@@ -242,12 +236,7 @@ public class UserStorageRestTest extends AbstractAdminTest {
     public void testValidateAndCreateLdapProvider() {
         // Invalid filter
 
-        ComponentRepresentation ldapRep = new ComponentRepresentation();
-        ldapRep.setName("ldap2");
-        ldapRep.setProviderId("ldap");
-        ldapRep.setProviderType(UserStorageProvider.class.getName());
-        ldapRep.setConfig(new MultivaluedHashMap<>());
-        ldapRep.getConfig().putSingle("priority", Integer.toString(2));
+        ComponentRepresentation ldapRep = createBasicLDAPProviderRep();
         ldapRep.getConfig().putSingle(LDAPConstants.CUSTOM_USER_SEARCH_FILTER, "dc=something");
 
         Response resp = realm.components().add(ldapRep);
@@ -297,12 +286,7 @@ public class UserStorageRestTest extends AbstractAdminTest {
 
     @Test
     public void testUpdateProvider() {
-        ComponentRepresentation ldapRep = new ComponentRepresentation();
-        ldapRep.setName("ldap2");
-        ldapRep.setProviderId("ldap");
-        ldapRep.setProviderType(UserStorageProvider.class.getName());
-        ldapRep.setConfig(new MultivaluedHashMap<>());
-        ldapRep.getConfig().putSingle("priority", Integer.toString(2));
+        ComponentRepresentation ldapRep = createBasicLDAPProviderRep();
         ldapRep.getConfig().putSingle(LDAPConstants.BIND_DN, "cn=manager");
         ldapRep.getConfig().putSingle(LDAPConstants.BIND_CREDENTIAL, "password");
         String id = createComponent(ldapRep);
@@ -345,8 +329,88 @@ public class UserStorageRestTest extends AbstractAdminTest {
     }
 
 
+    // KEYCLOAK-12934
+    @Test
+    public void testLDAPMapperProviderConfigurationForVendorOther() {
+        ComponentRepresentation ldapRep = createBasicLDAPProviderRep();
+        ldapRep.getConfig().putSingle(LDAPConstants.VENDOR, LDAPConstants.VENDOR_OTHER);
+        String ldapModelId = createComponent(ldapRep);
 
+        ComponentTypeRepresentation groupLDAPMapperType = findMapperTypeConfiguration(ldapModelId, GroupLDAPStorageMapperFactory.PROVIDER_ID);
+        ConfigPropertyRepresentation groupRetrieverConfigProperty = getUserRolesRetrieveStrategyConfigProperty(groupLDAPMapperType, CommonLDAPGroupMapperConfig.USER_ROLES_RETRIEVE_STRATEGY);
 
+        // LOAD_GROUPS_BY_MEMBER_ATTRIBUTE_RECURSIVELY is expected to be present just for the active directory
+        List<String> options = groupRetrieverConfigProperty.getOptions();
+        Assert.assertNames(options, GroupMapperConfig.LOAD_GROUPS_BY_MEMBER_ATTRIBUTE, GroupMapperConfig.GET_GROUPS_FROM_USER_MEMBEROF_ATTRIBUTE);
+        Assert.assertFalse(groupRetrieverConfigProperty.getHelpText().contains("LOAD_GROUPS_BY_MEMBER_ATTRIBUTE_RECURSIVELY"));
+
+        ComponentTypeRepresentation roleLDAPMapperType = findMapperTypeConfiguration(ldapModelId, RoleLDAPStorageMapperFactory.PROVIDER_ID);
+        ConfigPropertyRepresentation roleRetrieverConfigProperty = getUserRolesRetrieveStrategyConfigProperty(roleLDAPMapperType, CommonLDAPGroupMapperConfig.USER_ROLES_RETRIEVE_STRATEGY);
+
+        // LOAD_ROLES_BY_MEMBER_ATTRIBUTE_RECURSIVELY is expected to be present just for the active directory
+        options = roleRetrieverConfigProperty.getOptions();
+        Assert.assertNames(options, RoleMapperConfig.LOAD_ROLES_BY_MEMBER_ATTRIBUTE, RoleMapperConfig.GET_ROLES_FROM_USER_MEMBEROF_ATTRIBUTE);
+        Assert.assertFalse(roleRetrieverConfigProperty.getHelpText().contains("LOAD_ROLES_BY_MEMBER_ATTRIBUTE_RECURSIVELY"));
+
+        // Cleanup including mappers
+        removeComponent(ldapModelId);
+    }
+
+    // KEYCLOAK-12934
+    @Test
+    public void testLDAPMapperProviderConfigurationForVendorMSAD() {
+        ComponentRepresentation ldapRep = createBasicLDAPProviderRep();
+        ldapRep.getConfig().putSingle(LDAPConstants.VENDOR, LDAPConstants.VENDOR_ACTIVE_DIRECTORY);
+        String ldapModelId = createComponent(ldapRep);
+
+        ComponentTypeRepresentation groupLDAPMapperType = findMapperTypeConfiguration(ldapModelId, GroupLDAPStorageMapperFactory.PROVIDER_ID);
+        ConfigPropertyRepresentation groupRetrieverConfigProperty = getUserRolesRetrieveStrategyConfigProperty(groupLDAPMapperType, CommonLDAPGroupMapperConfig.USER_ROLES_RETRIEVE_STRATEGY);
+
+        // LOAD_GROUPS_BY_MEMBER_ATTRIBUTE_RECURSIVELY is expected to be present just for the active directory
+        List<String> options = groupRetrieverConfigProperty.getOptions();
+        Assert.assertNames(options, GroupMapperConfig.LOAD_GROUPS_BY_MEMBER_ATTRIBUTE, GroupMapperConfig.GET_GROUPS_FROM_USER_MEMBEROF_ATTRIBUTE,
+                GroupMapperConfig.LOAD_GROUPS_BY_MEMBER_ATTRIBUTE_RECURSIVELY);
+        Assert.assertTrue(groupRetrieverConfigProperty.getHelpText().contains("LOAD_GROUPS_BY_MEMBER_ATTRIBUTE_RECURSIVELY"));
+
+        ComponentTypeRepresentation roleLDAPMapperType = findMapperTypeConfiguration(ldapModelId, RoleLDAPStorageMapperFactory.PROVIDER_ID);
+        ConfigPropertyRepresentation roleRetrieverConfigProperty = getUserRolesRetrieveStrategyConfigProperty(roleLDAPMapperType, CommonLDAPGroupMapperConfig.USER_ROLES_RETRIEVE_STRATEGY);
+
+        // LOAD_ROLES_BY_MEMBER_ATTRIBUTE_RECURSIVELY is expected to be present just for the active directory
+        options = roleRetrieverConfigProperty.getOptions();
+        Assert.assertNames(options, RoleMapperConfig.LOAD_ROLES_BY_MEMBER_ATTRIBUTE, RoleMapperConfig.GET_ROLES_FROM_USER_MEMBEROF_ATTRIBUTE,
+                RoleMapperConfig.LOAD_ROLES_BY_MEMBER_ATTRIBUTE_RECURSIVELY);
+        Assert.assertTrue(roleRetrieverConfigProperty.getHelpText().contains("LOAD_ROLES_BY_MEMBER_ATTRIBUTE_RECURSIVELY"));
+
+        // Cleanup including mappers
+        removeComponent(ldapModelId);
+    }
+
+    private ComponentRepresentation createBasicLDAPProviderRep() {
+        ComponentRepresentation ldapRep = new ComponentRepresentation();
+        ldapRep.setName("ldap2");
+        ldapRep.setProviderId("ldap");
+        ldapRep.setProviderType(UserStorageProvider.class.getName());
+        ldapRep.setConfig(new MultivaluedHashMap<>());
+        ldapRep.getConfig().putSingle("priority", Integer.toString(2));
+        return ldapRep;
+    }
+
+    private ComponentTypeRepresentation findMapperTypeConfiguration(String ldapModelId, String mapperProviderId) {
+        ComponentResource ldapProvider = realm.components().component(ldapModelId);
+        List<ComponentTypeRepresentation> componentTypes = ldapProvider.getSubcomponentConfig(LDAPStorageMapper.class.getName());
+
+        return componentTypes.stream()
+                .filter(componentType -> mapperProviderId.equals(componentType.getId()))
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("Not able to find mapper with provider id: " + mapperProviderId));
+    }
+
+    private  ConfigPropertyRepresentation getUserRolesRetrieveStrategyConfigProperty(ComponentTypeRepresentation componentType, String propertyName) {
+        return componentType.getProperties().stream()
+                .filter(configPropertyRep -> propertyName.equals(configPropertyRep.getName()))
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("Not able to find config property with name: " + propertyName));
+    }
 
 /*
     @Test


### PR DESCRIPTION
…retrieve strategy role-ldap-mapper option should only be displayed if LDAP provider vendor is Active Directory

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
