### PR TITLE
[KEYCLOAK-8789] Fix getAttribute(String name) implementations so they…

### DIFF
--- a/server-spi/src/main/java/org/keycloak/storage/adapter/AbstractUserAdapter.java
+++ b/server-spi/src/main/java/org/keycloak/storage/adapter/AbstractUserAdapter.java
@@ -323,7 +323,7 @@ public abstract class AbstractUserAdapter implements UserModel {
 
     @Override
     public List<String> getAttribute(String name) {
-        return null;
+        return Collections.emptyList();
     }
 
     @Override

--- a/server-spi/src/main/java/org/keycloak/storage/adapter/AbstractUserAdapterFederatedStorage.java
+++ b/server-spi/src/main/java/org/keycloak/storage/adapter/AbstractUserAdapterFederatedStorage.java
@@ -364,7 +364,8 @@ public abstract class AbstractUserAdapterFederatedStorage implements UserModel {
 
     @Override
     public List<String> getAttribute(String name) {
-        return getFederatedStorage().getAttributes(realm, this.getId()).get(name);
+        List<String> result = getFederatedStorage().getAttributes(realm, this.getId()).get(name);
+        return (result == null) ? Collections.emptyList() : result;
     }
 
     @Override


### PR DESCRIPTION
… never return null

 - user adapter classes were violating the UserModel contract as the javadoc for the method states that null must never be returned

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
