### PR TITLE
KEYCLOAK-13635: Can't make mapper with certain chars

### DIFF
--- a/themes/src/main/resources/theme/base/admin/resources/js/app.js
+++ b/themes/src/main/resources/theme/base/admin/resources/js/app.js
@@ -2387,7 +2387,7 @@ module.directive('kcEnter', function() {
 // Don't allow URI reserved characters
 module.directive('kcNoReservedChars', function (Notifications, $translate) {
     return function($scope, element) {
-        element.bind("keydown keypress", function(event) {
+        element.bind("keypress", function(event) {
             var keyPressed = String.fromCharCode(event.which || event.keyCode || 0);
             
             // ] and ' can not be used inside a character set on POSIX and GNU

--- a/themes/src/main/resources/theme/base/admin/resources/templates/kc-provider-config.html
+++ b/themes/src/main/resources/theme/base/admin/resources/templates/kc-provider-config.html
@@ -3,7 +3,7 @@
         <label class="col-md-2 control-label">{{:: option.label | translate}}</label>
 
         <div class="col-md-6" data-ng-if="option.type == 'String'">
-            <input kc-no-reserved-chars class="form-control" type="text" data-ng-model="config[ option.name ]" >
+            <input class="form-control" type="text" data-ng-model="config[ option.name ]" >
         </div>
         <div class="col-md-6" data-ng-if="option.type == 'Password'">
             <input class="form-control" type="password" data-ng-model="config[ option.name ]" >


### PR DESCRIPTION
I could not find where this field could be used in a URL, but I believe I must have found one when I made the original change.  However, there is no way to do a keystroke validation where we know if the dollar sign is valid or not in this field.  So the validation is removed for this field.  Since the keystroke validation is just a "helper" anyway, we can rely on server side validation for this if it is truly disallowed.

This also fixes the issue with not being able to use special keys like Home, End, and right arrow.  This was a bug anywhere kc-no-reserved-chars was used.
