### PR TITLE
[KEYCLOAK-13005] Make sure the master URL is used if the consumer POS…

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/saml/SamlService.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/SamlService.java
@@ -307,7 +307,7 @@ public class SamlService extends AuthorizationEndpointBase {
                 } else {
                     redirect = client.getAttribute(SamlProtocol.SAML_ASSERTION_CONSUMER_URL_REDIRECT_ATTRIBUTE);
                 }
-                if (redirect == null) {
+                if (redirect == null || redirect.trim().isEmpty()) {
                     redirect = client.getManagementUrl();
                 }
 

--- a/services/src/main/java/org/keycloak/protocol/saml/installation/SamlSPDescriptorClientInstallation.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/installation/SamlSPDescriptorClientInstallation.java
@@ -56,10 +56,10 @@ public class SamlSPDescriptorClientInstallation implements ClientInstallationPro
             logoutUrl = client.getAttribute(SamlProtocol.SAML_SINGLE_LOGOUT_SERVICE_URL_REDIRECT_ATTRIBUTE);
             binding = JBossSAMLURIConstants.SAML_HTTP_REDIRECT_BINDING.get();
         }
-        if (assertionUrl == null || assertionUrl.isEmpty()) assertionUrl = client.getManagementUrl();
-        if (assertionUrl == null || assertionUrl.isEmpty()) assertionUrl = FALLBACK_ERROR_URL_STRING;
-        if (logoutUrl == null || assertionUrl.isEmpty()) logoutUrl = client.getManagementUrl();
-        if (logoutUrl == null || assertionUrl.isEmpty()) logoutUrl = FALLBACK_ERROR_URL_STRING;
+        if (assertionUrl == null || assertionUrl.trim().isEmpty()) assertionUrl = client.getManagementUrl();
+        if (assertionUrl == null || assertionUrl.trim().isEmpty()) assertionUrl = FALLBACK_ERROR_URL_STRING;
+        if (logoutUrl == null || logoutUrl.trim().isEmpty()) logoutUrl = client.getManagementUrl();
+        if (logoutUrl == null || logoutUrl.trim().isEmpty()) logoutUrl = FALLBACK_ERROR_URL_STRING;
         String nameIdFormat = samlClient.getNameIDFormat();
         if (nameIdFormat == null) nameIdFormat = SamlProtocol.SAML_DEFAULT_NAMEID_FORMAT;
         String spCertificate = SPMetadataDescriptor.xmlKeyInfo("        ", null, samlClient.getClientSigningCertificate(), KeyTypes.SIGNING.value(), true);


### PR DESCRIPTION
…T or REDIRECT URL is an empty string

 - Fixes issue where admin console sets an empty string when the consumer POST or REDIRECT URL is deleted

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
