### PR TITLE
Set Explicit Charset for GET 

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/broker/provider/util/SimpleHttp.java
+++ b/server-spi-private/src/main/java/org/keycloak/broker/provider/util/SimpleHttp.java
@@ -205,7 +205,7 @@ public class SimpleHttp {
                 ((HttpEntityEnclosingRequestBase) httpRequest).setEntity(getFormEntityFromParameter());
             } else if (entity != null) {
                 if (headers == null || !headers.containsKey("Content-Type")) {
-                    header("Content-Type", "application/json; charset=utf-8;");
+                    header("Content-Type", "application/json; charset=utf-8");
                 }
                 ((HttpEntityEnclosingRequestBase) httpRequest).setEntity(getJsonEntity());
             } else {

--- a/server-spi-private/src/main/java/org/keycloak/broker/provider/util/SimpleHttp.java
+++ b/server-spi-private/src/main/java/org/keycloak/broker/provider/util/SimpleHttp.java
@@ -205,7 +205,7 @@ public class SimpleHttp {
                 ((HttpEntityEnclosingRequestBase) httpRequest).setEntity(getFormEntityFromParameter());
             } else if (entity != null) {
                 if (headers == null || !headers.containsKey("Content-Type")) {
-                    header("Content-Type", "application/json");
+                    header("Content-Type", "application/json; charset=utf-8;");
                 }
                 ((HttpEntityEnclosingRequestBase) httpRequest).setEntity(getJsonEntity());
             } else {


### PR DESCRIPTION
Unset Charset can create vulnerabilities.

https://cwe.mitre.org/data/definitions/436.html

Specific examples: 

http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2005-4080

http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2005-4260

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
