### PR TITLE
KEYCLOAK-13807 Fix switch parameter order of mapping and url in registerConstraintMapping

### DIFF
--- a/adapters/oidc/fuse7/jetty94/src/main/java/org/keycloak/adapters/osgi/jetty94/PaxWebIntegrationService.java
+++ b/adapters/oidc/fuse7/jetty94/src/main/java/org/keycloak/adapters/osgi/jetty94/PaxWebIntegrationService.java
@@ -177,7 +177,7 @@ public class PaxWebIntegrationService {
         }
         log.debug("Adding security constraint name=" + name + ", url=" + constraintMapping.getUrl() + ", dataConstraint=" + constraintMapping.getDataConstraint() + ", canAuthenticate="
                 + constraintMapping.isAuthentication() + ", roles=" + constraintMapping.getRoles());
-        service.registerConstraintMapping(name, constraintMapping.getUrl(), constraintMapping.getMapping(), constraintMapping.getDataConstraint(), constraintMapping.isAuthentication(), constraintMapping.getRoles(), httpContext);
+        service.registerConstraintMapping(name, constraintMapping.getMapping(), constraintMapping.getUrl(), constraintMapping.getDataConstraint(), constraintMapping.isAuthentication(), constraintMapping.getRoles(), httpContext);
     }
 
     protected void addConstraintMapping(WebContainer service, ConstraintMapping constraintMapping) {
@@ -202,7 +202,7 @@ public class PaxWebIntegrationService {
 
         log.debug("Adding security constraint name=" + name + ", url=" + constraintMapping.getPathSpec() + ", dataConstraint=" + dataConstraintStr + ", canAuthenticate="
         + constraint.getAuthenticate() + ", roles=" + rolesList);
-        service.registerConstraintMapping(name, constraintMapping.getPathSpec(), null, dataConstraintStr, constraint.getAuthenticate(), rolesList, httpContext);
+        service.registerConstraintMapping(name, null, constraintMapping.getPathSpec(), dataConstraintStr, constraint.getAuthenticate(), rolesList, httpContext);
     }
 
     protected void removingWebContainerCallback(ServiceReference serviceReference) {
@@ -228,7 +228,7 @@ public class PaxWebIntegrationService {
                 }
                 log.debug("Adding security constraint name=" + name + ", url=" + constraintMapping.getUrl() + ", dataConstraint=" + constraintMapping.getDataConstraint() + ", canAuthenticate="
                         + constraintMapping.isAuthentication() + ", roles=" + constraintMapping.getRoles());
-                service.registerConstraintMapping(name, constraintMapping.getUrl(), constraintMapping.getMapping(), constraintMapping.getDataConstraint(), constraintMapping.isAuthentication(), constraintMapping.getRoles(), httpContext);
+                service.registerConstraintMapping(name, constraintMapping.getMapping(), constraintMapping.getUrl(), constraintMapping.getDataConstraint(), constraintMapping.isAuthentication(), constraintMapping.getRoles(), httpContext);
                 return true;
             }
             return false;
@@ -270,7 +270,7 @@ public class PaxWebIntegrationService {
 
                 log.debug("Adding security constraint name=" + name + ", url=" + constraintMapping.getPathSpec() + ", dataConstraint=" + dataConstraintStr + ", canAuthenticate="
                         + constraint.getAuthenticate() + ", roles=" + rolesList);
-                service.registerConstraintMapping(name, constraintMapping.getPathSpec(), null, dataConstraintStr, constraint.getAuthenticate(), rolesList, httpContext);
+                service.registerConstraintMapping(name, null, constraintMapping.getPathSpec(), dataConstraintStr, constraint.getAuthenticate(), rolesList, httpContext);
                 return true;
             }
             return false;

--- a/adapters/oidc/osgi-adapter/src/main/java/org/keycloak/adapters/osgi/PaxWebIntegrationService.java
+++ b/adapters/oidc/osgi-adapter/src/main/java/org/keycloak/adapters/osgi/PaxWebIntegrationService.java
@@ -171,7 +171,7 @@ public class PaxWebIntegrationService {
         }
         log.debug("Adding security constraint name=" + name + ", url=" + constraintMapping.getUrl() + ", dataConstraint=" + constraintMapping.getDataConstraint() + ", canAuthenticate="
                 + constraintMapping.isAuthentication() + ", roles=" + constraintMapping.getRoles());
-        service.registerConstraintMapping(name, constraintMapping.getUrl(), constraintMapping.getMapping(), constraintMapping.getDataConstraint(), constraintMapping.isAuthentication(), constraintMapping.getRoles(), httpContext);
+        service.registerConstraintMapping(name, constraintMapping.getMapping(), constraintMapping.getUrl(), constraintMapping.getDataConstraint(), constraintMapping.isAuthentication(), constraintMapping.getRoles(), httpContext);
     }
 
     protected void addConstraintMapping(WebContainer service, ConstraintMapping constraintMapping) {
@@ -196,7 +196,7 @@ public class PaxWebIntegrationService {
 
         log.debug("Adding security constraint name=" + name + ", url=" + constraintMapping.getPathSpec() + ", dataConstraint=" + dataConstraintStr + ", canAuthenticate="
         + constraint.getAuthenticate() + ", roles=" + rolesList);
-        service.registerConstraintMapping(name, constraintMapping.getPathSpec(), null, dataConstraintStr, constraint.getAuthenticate(), rolesList, httpContext);
+        service.registerConstraintMapping(name, null, constraintMapping.getPathSpec(), dataConstraintStr, constraint.getAuthenticate(), rolesList, httpContext);
     }
 
     protected void removingWebContainerCallback(ServiceReference serviceReference) {
@@ -223,7 +223,7 @@ public class PaxWebIntegrationService {
                 }
                 log.debug("Adding security constraint name=" + name + ", url=" + constraintMapping.getUrl() + ", dataConstraint=" + constraintMapping.getDataConstraint() + ", canAuthenticate="
                         + constraintMapping.isAuthentication() + ", roles=" + constraintMapping.getRoles());
-                service.registerConstraintMapping(name, constraintMapping.getUrl(), constraintMapping.getMapping(), constraintMapping.getDataConstraint(), constraintMapping.isAuthentication(), constraintMapping.getRoles(), httpContext);
+                service.registerConstraintMapping(name, constraintMapping.getMapping(), constraintMapping.getUrl(), constraintMapping.getDataConstraint(), constraintMapping.isAuthentication(), constraintMapping.getRoles(), httpContext);
                 return true;
             }
             return false;
@@ -266,7 +266,7 @@ public class PaxWebIntegrationService {
 
                 log.debug("Adding security constraint name=" + name + ", url=" + constraintMapping.getPathSpec() + ", dataConstraint=" + dataConstraintStr + ", canAuthenticate="
                         + constraint.getAuthenticate() + ", roles=" + rolesList);
-                service.registerConstraintMapping(name, constraintMapping.getPathSpec(), null, dataConstraintStr, constraint.getAuthenticate(), rolesList, httpContext);
+                service.registerConstraintMapping(name, null, constraintMapping.getPathSpec(), dataConstraintStr, constraint.getAuthenticate(), rolesList, httpContext);
                 return true;
             }
             return false;


### PR DESCRIPTION
The parameter order in registerConstraintMapping is wrong.
If you have a look at [WebContainer ](https://github.com/ops4j/org.ops4j.pax.web/blob/master/pax-web-api/src/main/java/org/ops4j/pax/web/service/WebContainer.java#L544) interface

you can see that the second parameter is the mapping and the third parameter url.

But in some PaxWebIntegrationService implementations (except Undertow) the two parameters are switched.
