### PR TITLE
KEYCLOAK-13818: Optimize Realm Creation: Reduce client scope db hits

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/ClientAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/ClientAdapter.java
@@ -103,6 +103,13 @@ public class ClientAdapter implements ClientModel, CachedObject {
     }
 
     @Override
+    public void addClientScopes(Set<ClientScopeModel> clientScopes, boolean defaultScope) {
+        for (ClientScopeModel clientScope : clientScopes) {
+            addClientScope(clientScope, defaultScope);
+        }
+    }
+
+    @Override
     public void removeClientScope(ClientScopeModel clientScope) {
         getDelegateForUpdate();
         updated.removeClientScope(clientScope);

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/ClientAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/ClientAdapter.java
@@ -355,6 +355,18 @@ public class ClientAdapter implements ClientModel, JpaModel<ClientEntity> {
     public void addClientScope(ClientScopeModel clientScope, boolean defaultScope) {
         if (getClientScopes(defaultScope, false).containsKey(clientScope.getName())) return;
 
+        persist(clientScope, defaultScope);
+    }
+
+    @Override
+    public void addClientScopes(Set<ClientScopeModel> clientScopes, boolean defaultScope) {
+        Map<String, ClientScopeModel> existingClientScopes = getClientScopes(defaultScope, false);
+        clientScopes.stream()
+                .filter(clientScope -> !existingClientScopes.containsKey(clientScope.getName()))
+                .forEach(clientScope -> persist(clientScope, defaultScope));
+    }
+
+    private void persist(ClientScopeModel clientScope, boolean defaultScope) {
         ClientScopeClientMappingEntity entity = new ClientScopeClientMappingEntity();
         entity.setClientScope(ClientScopeAdapter.toClientScopeEntity(clientScope, em));
         entity.setClient(getEntity());

--- a/server-spi-private/src/main/java/org/keycloak/storage/client/AbstractReadOnlyClientStorageAdapter.java
+++ b/server-spi-private/src/main/java/org/keycloak/storage/client/AbstractReadOnlyClientStorageAdapter.java
@@ -23,6 +23,7 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.RoleModel;
 import org.keycloak.storage.ReadOnlyException;
 
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -221,6 +222,11 @@ public abstract class AbstractReadOnlyClientStorageAdapter extends AbstractClien
 
     @Override
     public void addClientScope(ClientScopeModel clientScope, boolean defaultScope) {
+        throw new ReadOnlyException("client is read only for this update");
+    }
+
+    @Override
+    public void addClientScopes(Set<ClientScopeModel> clientScopes, boolean defaultScope) {
         throw new ReadOnlyException("client is read only for this update");
     }
 

--- a/server-spi/src/main/java/org/keycloak/models/ClientModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/ClientModel.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.models;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -169,6 +170,13 @@ public interface ClientModel extends ClientScopeModel, RoleContainerModel,  Prot
      * @param defaultScope
      */
     void addClientScope(ClientScopeModel clientScope, boolean defaultScope);
+
+    /**
+     * Add clientScopes with this client. Add as default scopes (if parameter 'defaultScope' is true) or optional scopes (if parameter 'defaultScope' is false)
+     * @param clientScopes
+     * @param defaultScope
+     */
+    void addClientScopes(Set<ClientScopeModel> clientScopes, boolean defaultScope);
 
     void removeClientScope(ClientScopeModel clientScope);
 


### PR DESCRIPTION
KEYCLOAK-13818: Addressing performance issues with adding client scopes during realm creation. Removing redundant lookups by passing all scopes that need to be created at once.

Testing:
I created about 700 realms locally both before and after my change and I saw the time per realm create go from 22 seconds to 11.