### PR TITLE
[KEYCLOAK-13829] - DML for DELETE is executed even though attribute does not exist

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/models/jpa/UserAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/UserAdapter.java
@@ -168,19 +168,23 @@ public class UserAdapter implements UserModel, JpaModel<UserEntity> {
 
     @Override
     public void removeAttribute(String name) {
-        // KEYCLOAK-3296 : Remove attribute through HQL to avoid StaleUpdateException
-        Query query = em.createNamedQuery("deleteUserAttributesByNameAndUser");
-        query.setParameter("name", name);
-        query.setParameter("userId", user.getId());
-        int numUpdated = query.executeUpdate();
-
-        // KEYCLOAK-3494 : Also remove attributes from local user entity
         List<UserAttributeEntity> toRemove = new ArrayList<>();
         for (UserAttributeEntity attr : user.getAttributes()) {
             if (attr.getName().equals(name)) {
                 toRemove.add(attr);
             }
         }
+
+        if (toRemove.isEmpty()) {
+            return;
+        }
+
+        // KEYCLOAK-3296 : Remove attribute through HQL to avoid StaleUpdateException
+        Query query = em.createNamedQuery("deleteUserAttributesByNameAndUser");
+        query.setParameter("name", name);
+        query.setParameter("userId", user.getId());
+        query.executeUpdate();
+        // KEYCLOAK-3494 : Also remove attributes from local user entity
         user.getAttributes().removeAll(toRemove);
     }
 


### PR DESCRIPTION
@mposolda This seems to be related to this fix https://issues.redhat.com/browse/KEYCLOAK-3296.

I could not think about any reason why we can't execute DELETE only in case the attribute exists.