### PR TITLE
KEYCLOAK-13823: "Dir" Full export/import: On import, service account roles and authorization info are not imported

### DIFF
--- a/services/src/main/java/org/keycloak/exportimport/dir/DirImportProvider.java
+++ b/services/src/main/java/org/keycloak/exportimport/dir/DirImportProvider.java
@@ -25,9 +25,7 @@ import org.keycloak.exportimport.util.ExportImportSessionTask;
 import org.keycloak.exportimport.util.ImportUtils;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
-import org.keycloak.models.RealmModel;
 import org.keycloak.models.utils.KeycloakModelUtils;
-import org.keycloak.models.utils.RepresentationToModel;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.util.JsonSerialization;
 
@@ -38,6 +36,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.keycloak.services.managers.RealmManager;
 
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
@@ -168,13 +167,13 @@ public class DirImportProvider implements ImportProvider {
             }
         }
 
-        // Import authorization last, as authzPolicies can require users already in DB
+        // Import authorization and initialize service accounts last, as they require users already in DB
         KeycloakModelUtils.runJobInTransaction(factory, new ExportImportSessionTask() {
 
             @Override
             public void runExportImportTask(KeycloakSession session) throws IOException {
-                RealmModel realm = session.realms().getRealmByName(realmName);
-                RepresentationToModel.importRealmAuthorizationSettings(realmRep, realm, session);
+                RealmManager realmManager = new RealmManager(session);
+                realmManager.setupClientServiceAccountsAndAuthorizationOnImport(realmRep, false);
             }
 
         });

--- a/services/src/main/java/org/keycloak/exportimport/util/ImportUtils.java
+++ b/services/src/main/java/org/keycloak/exportimport/util/ImportUtils.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.jboss.logging.Logger;
 import org.keycloak.Config;
-import org.keycloak.common.constants.ServiceAccountConstants;
 import org.keycloak.exportimport.ExportImportConfig;
 import org.keycloak.exportimport.Strategy;
 import org.keycloak.models.KeycloakSession;
@@ -261,12 +260,9 @@ public class ImportUtils {
     private static void importUsers(KeycloakSession session, RealmProvider model, String realmName, List<UserRepresentation> userReps) {
         RealmModel realm = model.getRealmByName(realmName);
         for (UserRepresentation user : userReps) {
-            if (!user.getUsername().startsWith(ServiceAccountConstants.SERVICE_ACCOUNT_USER_PREFIX)) {
-                RepresentationToModel.createUser(session, realm, user);
-            }
+            RepresentationToModel.createUser(session, realm, user);
         }
     }
-
 
     private static void importFederatedUsers(KeycloakSession session, RealmProvider model, String realmName, List<UserRepresentation> userReps) {
         RealmModel realm = model.getRealmByName(realmName);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/exportimport/ExportImportTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/exportimport/ExportImportTest.java
@@ -149,6 +149,9 @@ public class ExportImportTest extends AbstractKeycloakTest {
 
         testFullExportImport();
 
+        RealmResource testRealmRealm = adminClient.realm("test-realm");
+        ExportImportUtil.assertDataImportedInRealm(adminClient, testingClient, testRealmRealm.toRepresentation());
+
         // There should be 6 files in target directory (3 realm, 3 user)
         assertEquals(6, new File(targetDirPath).listFiles().length);
     }
@@ -164,6 +167,9 @@ public class ExportImportTest extends AbstractKeycloakTest {
         testingClient.testing().exportImport().setUsersPerFile(5);
 
         testRealmExportImport();
+
+        RealmResource testRealmRealm = adminClient.realm("test-realm");
+        ExportImportUtil.assertDataImportedInRealm(adminClient, testingClient, testRealmRealm.toRepresentation());
 
         // There should be 4 files in target directory (1 realm, 12 users, 5 users per file)
         // (+ additional user service-account-test-app-authz that should not be there ???)

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/exportimport/ExportImportUtil.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/exportimport/ExportImportUtil.java
@@ -122,6 +122,7 @@ public class ExportImportUtil {
         ClientRepresentation application = ApiUtil.findClientByClientId(realmRsc, "Application").toRepresentation();
         ClientRepresentation otherApp = ApiUtil.findClientByClientId(realmRsc, "OtherApp").toRepresentation();
         ClientRepresentation accountApp = ApiUtil.findClientByClientId(realmRsc, Constants.ACCOUNT_MANAGEMENT_CLIENT_ID).toRepresentation();
+        ClientRepresentation testAppAuthzApp = ApiUtil.findClientByClientId(realmRsc, "test-app-authz").toRepresentation();
         ClientResource nonExisting = ApiUtil.findClientByClientId(realmRsc, "NonExisting");
         Assert.assertNotNull(application);
         Assert.assertNotNull(otherApp);
@@ -346,7 +347,7 @@ public class ExportImportUtil {
         Assert.assertNull(findMapperByName(applicationMappers, OIDCLoginProtocol.LOGIN_PROTOCOL, "given name"));
         Assert.assertNull(findMapperByName(applicationMappers, OIDCLoginProtocol.LOGIN_PROTOCOL, KerberosConstants.GSS_DELEGATION_CREDENTIAL_DISPLAY_NAME));
 
-        Assert.assertEquals(4, otherApp.getProtocolMappers().size());
+        Assert.assertEquals(1, otherApp.getProtocolMappers().size());
         List<ProtocolMapperRepresentation> otherAppMappers = otherApp.getProtocolMappers();
         Assert.assertNull(findMapperByName(otherAppMappers, OIDCLoginProtocol.LOGIN_PROTOCOL, "username"));
         ProtocolMapperRepresentation gssCredentialMapper = findMapperByName(otherAppMappers, OIDCLoginProtocol.LOGIN_PROTOCOL, KerberosConstants.GSS_DELEGATION_CREDENTIAL_DISPLAY_NAME);
@@ -410,12 +411,24 @@ public class ExportImportUtil {
         // Test service accounts
         Assert.assertFalse(application.isServiceAccountsEnabled());
         Assert.assertTrue(otherApp.isServiceAccountsEnabled());
+        Assert.assertTrue(testAppAuthzApp.isServiceAccountsEnabled());
         Assert.assertNull(testingClient.testing().getUserByServiceAccountClient(realm.getRealm(), application.getClientId()));//session.users().getUserByServiceAccountClient(application));
-        UserRepresentation linked = testingClient.testing().getUserByServiceAccountClient(realm.getRealm(), otherApp.getClientId());//session.users().getUserByServiceAccountClient(otherApp);
-        Assert.assertNotNull(linked);
-        Assert.assertEquals("my-service-user", linked.getUsername());
-        
-        assertAuthorizationSettings(realmRsc);
+        UserRepresentation otherAppSA = testingClient.testing().getUserByServiceAccountClient(realm.getRealm(), otherApp.getClientId());//session.users().getUserByServiceAccountClient(otherApp);
+        Assert.assertNotNull(otherAppSA);
+        Assert.assertEquals("service-account-otherapp", otherAppSA.getUsername());
+        UserRepresentation testAppAuthzSA = testingClient.testing().getUserByServiceAccountClient(realm.getRealm(), testAppAuthzApp.getClientId());
+        Assert.assertNotNull(testAppAuthzSA);
+        Assert.assertEquals("service-account-test-app-authz", testAppAuthzSA.getUsername());
+
+        // test service account maintains the roles in OtherApp
+        allRoles = allRoles(realmRsc, otherAppSA);
+        Assert.assertEquals(3, allRoles.size());
+        Assert.assertTrue(containsRole(allRoles, findRealmRole(realmRsc, "user")));
+        Assert.assertTrue(containsRole(allRoles, findClientRole(realmRsc, otherApp.getId(), "otherapp-user")));
+        Assert.assertTrue(containsRole(allRoles, findClientRole(realmRsc, otherApp.getId(), "otherapp-admin")));
+
+        assertAuthorizationSettingsOtherApp(realmRsc);
+        assertAuthorizationSettingsTestAppAuthz(realmRsc);
     }
 
 
@@ -571,7 +584,20 @@ public class ExportImportUtil {
         return false;
     }
 
-    private static void assertAuthorizationSettings(RealmResource realmRsc) {
+    private static void assertAuthorizationSettingsOtherApp(RealmResource realmRsc) {
+        AuthorizationResource authzResource = ApiUtil.findAuthorizationSettings(realmRsc, "OtherApp");
+        Assert.assertNotNull(authzResource);
+
+        List<ResourceRepresentation> resources = authzResource.resources().resources();
+        Assert.assertThat(resources.stream().map(ResourceRepresentation::getName).collect(Collectors.toList()),
+                Matchers.containsInAnyOrder("Default Resource", "test"));
+
+        List<PolicyRepresentation> policies = authzResource.policies().policies();
+        Assert.assertThat(policies.stream().map(PolicyRepresentation::getName).collect(Collectors.toList()),
+                Matchers.containsInAnyOrder("User Policy", "Default Permission", "test-permission"));
+    }
+
+    private static void assertAuthorizationSettingsTestAppAuthz(RealmResource realmRsc) {
         AuthorizationResource authzResource = ApiUtil.findAuthorizationSettings(realmRsc, "test-app-authz");
 
         Assert.assertNotNull(authzResource);

--- a/testsuite/integration-arquillian/tests/base/src/test/resources/import/import-without-clients.json
+++ b/testsuite/integration-arquillian/tests/base/src/test/resources/import/import-without-clients.json
@@ -72,7 +72,6 @@
     "FreeOTP",
     "Google Authenticator"
   ],
-  "clientTemplates": [],
   "browserSecurityHeaders": {
     "xContentTypeOptions": "nosniff",
     "xRobotsTag": "none",
@@ -657,6 +656,5 @@
     "_browser_header.contentSecurityPolicy": "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
     "waitIncrementSeconds": "60"
   },
-  "keycloakVersion": "4.0.0.Beta2-SNAPSHOT",
   "userManagedAccessAllowed": false
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/resources/import/partial-import.json
+++ b/testsuite/integration-arquillian/tests/base/src/test/resources/import/partial-import.json
@@ -49,7 +49,6 @@
     "FreeOTP",
     "Google Authenticator"
   ],
-  "clientTemplates": [],
   "browserSecurityHeaders": {
     "xContentTypeOptions": "nosniff",
     "xRobotsTag": "none",
@@ -634,6 +633,5 @@
     "_browser_header.contentSecurityPolicy": "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
     "waitIncrementSeconds": "60"
   },
-  "keycloakVersion": "4.0.0.Beta2-SNAPSHOT",
   "userManagedAccessAllowed": false
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/resources/model/testrealm.json
+++ b/testsuite/integration-arquillian/tests/base/src/test/resources/model/testrealm.json
@@ -227,9 +227,13 @@
             ]
         },
         {
-            "username": "my-service-user",
+            "username": "service-account-otherapp",
             "enabled": true,
-            "serviceAccountClientId": "OtherApp"
+            "serviceAccountClientId": "OtherApp",
+            "realmRoles" : [ "user" ],
+            "applicationRoles": {
+                "OtherApp": [  "otherapp-user", "otherapp-admin" ]
+            }
         }
     ],
     "clients": [
@@ -253,6 +257,7 @@
             "standardFlowEnabled": false,
             "directAccessGrantsEnabled": false,
             "serviceAccountsEnabled": true,
+            "authorizationServicesEnabled" : true,
             "clientAuthenticatorType": "client-jwt",
             "authenticationFlowBindingOverrides": {
                 "browser": "73dcb1e4-2c7c-4494-825d-f2677cbc114c"
@@ -271,7 +276,68 @@
                         "Claim JSON Type" : "String"
                     }
                 }
-            ]
+            ],
+            "authorizationSettings" : {
+                "allowRemoteResourceManagement": true,
+                "policyEnforcementMode": "ENFORCING",
+                "resources": [
+                    {
+                        "name": "Default Resource",
+                        "type": "urn:test:resources:default",
+                        "ownerManagedAccess": false,
+                        "attributes": {},
+                        "uris": [
+                            "/*"
+                        ]
+                    },
+                    {
+                        "name": "test",
+                        "type": "test",
+                        "ownerManagedAccess": true,
+                        "displayName": "test",
+                        "attributes": {},
+                        "uris": [
+                            "/test"
+                        ]
+                    }
+                ],
+                "policies": [
+                    {
+                        "name": "User Policy",
+                        "description": "User policy test",
+                        "type": "user",
+                        "logic": "POSITIVE",
+                        "decisionStrategy": "UNANIMOUS",
+                        "config": {
+                            "users": "[\"wburke\"]"
+                        }
+                    },
+                    {
+                        "name": "Default Permission",
+                        "description": "A permission that applies to the default resource type",
+                        "type": "resource",
+                        "logic": "POSITIVE",
+                        "decisionStrategy": "UNANIMOUS",
+                        "config": {
+                            "defaultResourceType": "urn:test:resources:default",
+                            "applyPolicies": "[\"User Policy\"]"
+                        }
+                    },
+                    {
+                        "name": "test-permission",
+                        "description": "test-permission",
+                        "type": "resource",
+                        "logic": "POSITIVE",
+                        "decisionStrategy": "UNANIMOUS",
+                        "config": {
+                            "resources": "[\"test\"]",
+                            "applyPolicies": "[\"User Policy\"]"
+                        }
+                    }
+                ],
+                "scopes": [],
+                "decisionStrategy": "UNANIMOUS"
+            }
         },
         {
             "clientId": "test-app-authz",


### PR DESCRIPTION
Fix for KEYCLOAK-13823. Service account creation is moved to the end of the import if the provider is directory (-Dkeycloak.migration.provider=dir). Current code always creates the service account and avoids the import of any service account later when users are imported (so roles are lost in the account and it has problems with the authorization info too). With this change the service account creation is moved to the end of the dir import, where the auth info was imported before.