### PR TITLE
KEYCLOAK-13858 SAML2 Identity Provider - Support for login_hint

### DIFF
--- a/services/src/main/java/org/keycloak/broker/saml/SAMLIdentityProvider.java
+++ b/services/src/main/java/org/keycloak/broker/saml/SAMLIdentityProvider.java
@@ -54,6 +54,9 @@ import java.util.Iterator;
 import java.util.Set;
 import java.util.TreeSet;
 
+import static org.keycloak.protocol.saml.SamlSingleSignOnUrlUtils.createSingleSignOnServiceUrl;
+
+
 /**
  * @author Pedro Igor
  */
@@ -76,7 +79,7 @@ public class SAMLIdentityProvider extends AbstractIdentityProvider<SAMLIdentityP
             UriInfo uriInfo = request.getUriInfo();
             RealmModel realm = request.getRealm();
             String issuerURL = getEntityId(uriInfo, realm);
-            String destinationUrl = getConfig().getSingleSignOnServiceUrl();
+            String destinationUrl = createSingleSignOnServiceUrl(getConfig(), request.getHttpRequest().getUri().getQueryParameters());
             String nameIDPolicyFormat = getConfig().getNameIDPolicyFormat();
 
             if (nameIDPolicyFormat == null) {

--- a/services/src/main/java/org/keycloak/broker/saml/SAMLIdentityProviderConfig.java
+++ b/services/src/main/java/org/keycloak/broker/saml/SAMLIdentityProviderConfig.java
@@ -52,6 +52,7 @@ public class SAMLIdentityProviderConfig extends IdentityProviderModel {
     public static final String WANT_ASSERTIONS_SIGNED = "wantAssertionsSigned";
     public static final String WANT_AUTHN_REQUESTS_SIGNED = "wantAuthnRequestsSigned";
     public static final String XML_SIG_KEY_INFO_KEY_NAME_TRANSFORMER = "xmlSigKeyInfoKeyNameTransformer";
+    public static final String PASS_LOGIN_HINT = "loginHint";
 
     public SAMLIdentityProviderConfig() {
     }
@@ -221,6 +222,14 @@ public class SAMLIdentityProviderConfig extends IdentityProviderModel {
 
     public void setBackchannelSupported(boolean backchannel) {
         getConfig().put(BACKCHANNEL_SUPPORTED, String.valueOf(backchannel));
+    }
+
+    public boolean isLoginHint() {
+        return Boolean.valueOf(getConfig().get(PASS_LOGIN_HINT));
+    }
+
+    public void setLoginHint(boolean loginHint) {
+        getConfig().put(PASS_LOGIN_HINT, String.valueOf(loginHint));
     }
 
     /**

--- a/services/src/main/java/org/keycloak/broker/saml/SAMLIdentityProviderFactory.java
+++ b/services/src/main/java/org/keycloak/broker/saml/SAMLIdentityProviderFactory.java
@@ -124,6 +124,7 @@ public class SAMLIdentityProviderFactory extends AbstractIdentityProviderFactory
                     samlIdentityProviderConfig.setPostBindingResponse(postBindingResponse);
                     samlIdentityProviderConfig.setPostBindingAuthnRequest(postBindingResponse);
                     samlIdentityProviderConfig.setPostBindingLogout(postBindingLogout);
+                    samlIdentityProviderConfig.setLoginHint(false);
 
                     List<KeyDescriptorType> keyDescriptor = idpDescriptor.getKeyDescriptor();
                     String defaultCertificate = null;

--- a/services/src/main/java/org/keycloak/protocol/saml/SamlSingleSignOnUrlUtils.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/SamlSingleSignOnUrlUtils.java
@@ -1,0 +1,40 @@
+package org.keycloak.protocol.saml;
+
+import org.keycloak.broker.saml.SAMLIdentityProviderConfig;
+
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.UriBuilder;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import static java.util.Optional.ofNullable;
+
+public class SamlSingleSignOnUrlUtils {
+
+    private static final String LOGIN_HINT_PARAM = "login_hint";
+    private static final Set<String> SAML_LOGIN_HINT_QUERY_PARAMETER_NAMES = new HashSet<>(Arrays.asList("login_hint", "username"));
+    private static final String LOGIN_HINT_INVALID_CHARACTERS = "![ -~]";
+
+    public static String createSingleSignOnServiceUrl(SAMLIdentityProviderConfig configuration, MultivaluedMap<String, String> urlQueryParameters) {
+        if (configuration == null) {
+            throw new IllegalArgumentException("An instance of SAMLIdentityProviderConfig must be provided");
+        }
+
+        final UriBuilder uriBuilder = UriBuilder.fromUri(configuration.getSingleSignOnServiceUrl());
+        if (configuration.isLoginHint()) {
+            ofNullable(urlQueryParameters)
+                    .map(queryParameters -> queryParameters.getFirst(LOGIN_HINT_PARAM))
+                    .map(String::trim)
+                    .map(SamlSingleSignOnUrlUtils::sanitizeLoginHint)
+                    .filter(hint -> !hint.isEmpty())
+                    .ifPresent(hint -> SAML_LOGIN_HINT_QUERY_PARAMETER_NAMES.forEach(parameterName -> uriBuilder.replaceQueryParam(parameterName, hint)));
+        }
+        return uriBuilder.build().toString();
+    }
+
+    private static String sanitizeLoginHint(String loginHint) {
+        return loginHint.replaceAll(LOGIN_HINT_INVALID_CHARACTERS, "")
+                .replace("?", "");
+    }
+}

--- a/services/src/test/java/org/keycloak/protocol/saml/SamlSingleSignOnUrlUtilsTest.java
+++ b/services/src/test/java/org/keycloak/protocol/saml/SamlSingleSignOnUrlUtilsTest.java
@@ -1,0 +1,144 @@
+package org.keycloak.protocol.saml;
+
+import org.junit.Test;
+import org.keycloak.broker.saml.SAMLIdentityProviderConfig;
+
+import javax.ws.rs.core.MultivaluedHashMap;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.keycloak.protocol.saml.SamlSingleSignOnUrlUtils.createSingleSignOnServiceUrl;
+
+public class SamlSingleSignOnUrlUtilsTest {
+    private static final String SAML_SSO_URL = "https://whatever.adfs.net/adfs/test";
+
+    @Test(expected = IllegalArgumentException.class)
+    public void createSingleSignOnServiceUrlWithoutConfigurationThrowsAnException() {
+        createSingleSignOnServiceUrl(null, loginHint("test@test.com"));
+    }
+
+    @Test
+    public void createSingleSignOnServiceUrlWithLoginHintEnabledWithoutHint() {
+        SAMLIdentityProviderConfig configuration = withHintEnabled();
+        String url = createSingleSignOnServiceUrl(configuration, noLoginHint());
+        assertThat(url, is(equalTo(configuration.getSingleSignOnServiceUrl())));
+    }
+
+    @Test
+    public void createSingleSignOnServiceUrlWithLoginHintEnabledWithEmptyHint() {
+        SAMLIdentityProviderConfig configuration = withHintEnabled();
+        String url = createSingleSignOnServiceUrl(configuration, loginHint("    "));
+        assertThat(url, is(equalTo(configuration.getSingleSignOnServiceUrl())));
+    }
+
+    @Test
+    public void createSingleSignOnServiceUrlWithLoginHintEnabledWithValidHint() {
+        SAMLIdentityProviderConfig configuration = withHintEnabled();
+        String url = createSingleSignOnServiceUrl(configuration, loginHint("  a-valid@email.com    "));
+        assertThat(url, is(equalTo(configuration.getSingleSignOnServiceUrl()+"?login_hint=a-valid%40email.com&username=a-valid%40email.com")));
+    }
+
+    @Test
+    public void createSingleSignOnServiceUrlWithLoginHintEnabledWithValidHintAndExistingHintInUrl() {
+        SAMLIdentityProviderConfig configuration = withExistingLoginHintAndHintEnabled();
+        String url = createSingleSignOnServiceUrl(configuration, loginHint("  a-valid@email.com    "));
+        assertThat(url, is(equalTo(SAML_SSO_URL+"?login_hint=a-valid%40email.com&username=a-valid%40email.com")));
+    }
+
+    @Test
+    public void createSingleSignOnServiceUrlWithLoginHintEnabledWithInvalidHint() {
+        SAMLIdentityProviderConfig configuration = withHintEnabled();
+        String url = createSingleSignOnServiceUrl(configuration, loginHint("a-invalidŒ@email.com"));
+        assertThat(url, is(equalTo(SAML_SSO_URL+"?login_hint=a-invalid%C5%92%40email.com&username=a-invalid%C5%92%40email.com")));
+    }
+
+    @Test
+    public void createSingleSignOnServiceUrlWithLoginHintEnabledWithUnencodedCharacters() {
+        SAMLIdentityProviderConfig configuration = withHintEnabled();
+        String url = createSingleSignOnServiceUrl(configuration, loginHint("with-unencoded?=@characters&.com"));
+        assertThat(url, is(equalTo(SAML_SSO_URL+"?login_hint=with-unencoded%3D%40characters%26.com&username=with-unencoded%3D%40characters%26.com")));
+    }
+
+    @Test
+    public void createSingleSignOnServiceUrlWithLoginHintDisabledWithoutHint() {
+        SAMLIdentityProviderConfig configuration = withHintDisabled();
+        String url = createSingleSignOnServiceUrl(configuration, noLoginHint());
+        assertThat(url, is(equalTo(configuration.getSingleSignOnServiceUrl())));
+    }
+
+    @Test
+    public void createSingleSignOnServiceUrlWithLoginHintDisabledWithEmptyHint() {
+        SAMLIdentityProviderConfig configuration = withHintDisabled();
+        String url = createSingleSignOnServiceUrl(configuration, loginHint("    "));
+        assertThat(url, is(equalTo(configuration.getSingleSignOnServiceUrl())));
+    }
+
+    @Test
+    public void createSingleSignOnServiceUrlWithLoginHintDisabledWithValidHint() {
+        SAMLIdentityProviderConfig configuration = withHintDisabled();
+        String url = createSingleSignOnServiceUrl(configuration, loginHint("  a-valid@email.com    "));
+        assertThat(url, is(equalTo(configuration.getSingleSignOnServiceUrl())));
+    }
+
+    @Test
+    public void createSingleSignOnServiceUrlWithLoginHintDisabledWithValidHintAndExistingHintInUrl() {
+        SAMLIdentityProviderConfig configuration = withExistingLoginHintAndHintDisabled();
+        String url = createSingleSignOnServiceUrl(configuration, loginHint("  a-valid@email.com    "));
+        assertThat(url, is(equalTo(configuration.getSingleSignOnServiceUrl())));
+    }
+
+    @Test
+    public void createSingleSignOnServiceUrlWithLoginHintDisabledWithInvalidHint() {
+        SAMLIdentityProviderConfig configuration = withHintDisabled();
+        String url = createSingleSignOnServiceUrl(configuration, loginHint("a-invalidŒ@email.com"));
+        assertThat(url, is(equalTo(configuration.getSingleSignOnServiceUrl())));
+    }
+
+    @Test
+    public void createSingleSignOnServiceUrlWithLoginHintDisabledWithUnencodedCharacters() {
+        SAMLIdentityProviderConfig configuration = withHintDisabled();
+        String url = createSingleSignOnServiceUrl(configuration, loginHint("with-unencoded?=@characters&.com"));
+        assertThat(url, is(equalTo(configuration.getSingleSignOnServiceUrl())));
+    }
+
+    private SAMLIdentityProviderConfig withHintDisabled() {
+        SAMLIdentityProviderConfig configuration = new SAMLIdentityProviderConfig();
+        configuration.setLoginHint(false);
+        configuration.setSingleSignOnServiceUrl(SAML_SSO_URL);
+        return configuration;
+    }
+
+    private SAMLIdentityProviderConfig withHintEnabled() {
+        SAMLIdentityProviderConfig configuration = new SAMLIdentityProviderConfig();
+        configuration.setLoginHint(true);
+        configuration.setSingleSignOnServiceUrl(SAML_SSO_URL);
+        return configuration;
+    }
+
+    private SAMLIdentityProviderConfig withExistingLoginHintAndHintEnabled() {
+        SAMLIdentityProviderConfig configuration = new SAMLIdentityProviderConfig();
+        configuration.setLoginHint(true);
+        configuration.setSingleSignOnServiceUrl(SAML_SSO_URL+"?login_hint=another@email.com&username=another@email.com");
+        return configuration;
+    }
+
+    private SAMLIdentityProviderConfig withExistingLoginHintAndHintDisabled() {
+        SAMLIdentityProviderConfig configuration = new SAMLIdentityProviderConfig();
+        configuration.setLoginHint(false);
+        configuration.setSingleSignOnServiceUrl(SAML_SSO_URL+"?login_hint=another@email.com&username=another@email.com");
+        return configuration;
+    }
+
+    private MultivaluedHashMap noLoginHint() {
+        MultivaluedHashMap<String, String> queryParameters = new MultivaluedHashMap<>();
+        queryParameters.putSingle("not_an_hint", "nothing");
+        return queryParameters;
+    }
+
+    private MultivaluedHashMap<String, String> loginHint(String hint) {
+        MultivaluedHashMap<String, String> queryParameters = new MultivaluedHashMap<>();
+        queryParameters.putSingle("login_hint", hint);
+        return queryParameters;
+    }
+}

--- a/testsuite/integration-arquillian/HOW-TO-RUN.md
+++ b/testsuite/integration-arquillian/HOW-TO-RUN.md
@@ -22,7 +22,7 @@ Adding this system property when running any test:
     -Darquillian.debug=true
 
 will add lots of info to the log. Especially about:
-* The test method names, which will be executed for each test class, will be written at the proper running order to the log at the beginning of each test class(done by KcArquillian class).
+* The test method names, which will be executed for each test class, wGenericPrincipalFactoryill be written at the proper running order to the log at the beginning of each test class(done by KcArquillian class).
 * All the triggered arquillian lifecycle events and executed observers listening to those events will be written to the log
 * The bootstrap of WebDriver will be unlimited. By default there is just 1 minute timeout and test is cancelled when WebDriver is not bootstrapped within it.
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/BrokerTestTools.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/BrokerTestTools.java
@@ -114,4 +114,11 @@ public class BrokerTestTools {
                 "/auth/realms/" + childRealm + "/broker/" + idpRealm + "/endpoint");
         adminClient.realm(idpRealm).clients().create(client);
     }
+
+
+    public static void waitForPagePrefix(WebDriver driver, String providerUrlPrefix) {
+        WebDriverWait wait = new WebDriverWait(driver, 5);
+        ExpectedCondition<Boolean> condition = (WebDriver input) -> input.getCurrentUrl().startsWith(providerUrlPrefix);
+        wait.until(condition);
+    }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcSamlBrokerConfiguration.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcSamlBrokerConfiguration.java
@@ -34,6 +34,18 @@ import static org.keycloak.testsuite.broker.BrokerTestTools.*;
 public class KcSamlBrokerConfiguration implements BrokerConfiguration {
 
     public static final KcSamlBrokerConfiguration INSTANCE = new KcSamlBrokerConfiguration();
+    public static final KcSamlBrokerConfiguration INSTANCE_PASS_LOGIN_HINT = new KcSamlBrokerConfiguration(true);
+
+    private final boolean passLoginHint;
+
+    KcSamlBrokerConfiguration(boolean passLoginHint) {
+        this.passLoginHint = passLoginHint;
+    }
+
+    KcSamlBrokerConfiguration() {
+        this(false);
+    }
+
 
     @Override
     public RealmRepresentation createProviderRealm() {
@@ -205,6 +217,7 @@ public class KcSamlBrokerConfiguration implements BrokerConfiguration {
         config.put(VALIDATE_SIGNATURE, "false");
         config.put(WANT_AUTHN_REQUESTS_SIGNED, "false");
         config.put(BACKCHANNEL_SUPPORTED, "false");
+        config.put(PASS_LOGIN_HINT, Boolean.toString(this.passLoginHint));
 
         return idp;
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/SamlLoginWithHintTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/SamlLoginWithHintTest.java
@@ -1,0 +1,69 @@
+package org.keycloak.testsuite.broker;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.representations.idm.IdentityProviderRepresentation;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.WebElement;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.keycloak.testsuite.broker.BrokerTestTools.waitForPagePrefix;
+
+
+public class SamlLoginWithHintTest extends AbstractBaseBrokerTest {
+
+    @Override
+    protected BrokerConfiguration getBrokerConfiguration() {
+        return KcSamlBrokerConfiguration.INSTANCE_PASS_LOGIN_HINT;
+    }
+
+    @Before
+    public void addIdentityProviderToConsumerRealm() {
+        log.debug("adding identity provider to realm " + bc.consumerRealmName());
+        RealmResource realm = adminClient.realm(bc.consumerRealmName());
+        IdentityProviderRepresentation idp = bc.setUpIdentityProvider(suiteContext);
+        realm.identityProviders().create(idp).close();
+    }
+
+    @Test
+    public void testLoginWithHint() {
+        driver.navigate().to(getAccountUrl(bc.consumerRealmName()));
+        addLoginHintOnSocialButton("test@acme.com");
+        log.debug("Clicking social " + bc.getIDPAlias());
+        loginPage.clickSocial(bc.getIDPAlias());
+
+        waitForPagePrefix(driver, getProviderUrlPrefix());
+
+        assertTrue("Url should contain a 'login_hint' query parameter",
+                driver.getCurrentUrl().contains("login_hint=test%40acme.com"));
+        assertTrue("Url should contain a 'username' query parameter",
+                driver.getCurrentUrl().contains("username=test%40acme.com"));
+    }
+
+    @Test
+    public void testLoginWithoutHint() {
+        driver.navigate().to(getAccountUrl(bc.consumerRealmName()));
+        log.debug("Clicking social " + bc.getIDPAlias());
+        loginPage.clickSocial(bc.getIDPAlias());
+
+        waitForPagePrefix(driver, getProviderUrlPrefix());
+
+        assertFalse("Url should not contain a 'login_hint' query parameter",
+                driver.getCurrentUrl().contains("login_hint"));
+        assertFalse("Url should not contain a 'username' query parameter",
+                driver.getCurrentUrl().contains("username"));
+    }
+
+    private String getProviderUrlPrefix() {
+        return getAuthServerRoot() + "realms/provider/protocol/saml";
+    }
+
+    private void addLoginHintOnSocialButton(String hint) {
+        JavascriptExecutor executor = (JavascriptExecutor) driver;
+        WebElement button = loginPage.findSocialButton(bc.getIDPAlias());
+        String url = button.getAttribute("href") + "&login_hint="+hint;
+        executor.executeScript("document.getElementById('"+button.getAttribute("id")+"').setAttribute('href', '"+url+"')");
+    }
+}

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/SamlLoginWithoutHintTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/SamlLoginWithoutHintTest.java
@@ -1,0 +1,55 @@
+package org.keycloak.testsuite.broker;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.representations.idm.IdentityProviderRepresentation;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.WebElement;
+
+import static org.junit.Assert.assertFalse;
+import static org.keycloak.testsuite.broker.BrokerTestTools.waitForPagePrefix;
+
+
+public class SamlLoginWithoutHintTest extends AbstractBaseBrokerTest {
+
+    @Override
+    protected BrokerConfiguration getBrokerConfiguration() {
+        return KcSamlBrokerConfiguration.INSTANCE;
+    }
+
+    @Before
+    public void addIdentityProviderToConsumerRealm() {
+        log.debug("adding identity provider to realm " + bc.consumerRealmName());
+        RealmResource realm = adminClient.realm(bc.consumerRealmName());
+        IdentityProviderRepresentation idp = bc.setUpIdentityProvider(suiteContext);
+        realm.identityProviders().create(idp).close();
+    }
+
+    @Test
+    public void testLoginWithHint() {
+        driver.navigate().to(getAccountUrl(bc.consumerRealmName()));
+        addLoginHintOnSocialButton("test@acme.com");
+        log.debug("Clicking social " + bc.getIDPAlias());
+        loginPage.clickSocial(bc.getIDPAlias());
+
+        waitForPagePrefix(driver, getProviderUrlPrefix());
+
+        assertFalse("Url should not contain a 'login_hint' query parameter",
+                driver.getCurrentUrl().contains("login_hint=test%40acme.com"));
+        assertFalse("Url should not contain a 'username' query parameter",
+                driver.getCurrentUrl().contains("username=test%40acme.com"));
+    }
+
+    private String getProviderUrlPrefix() {
+        return getAuthServerRoot() + "realms/provider/protocol/saml";
+    }
+
+    private void addLoginHintOnSocialButton(String hint) {
+        JavascriptExecutor executor = (JavascriptExecutor) driver;
+        WebElement button = loginPage.findSocialButton(bc.getIDPAlias());
+        String url = button.getAttribute("href") + "&login_hint="+hint;
+        executor.executeScript("document.getElementById('"+button.getAttribute("id")+"').setAttribute('href', '"+url+"')");
+    }
+
+}

--- a/themes/src/main/resources/theme/base/admin/messages/admin-messages_en.properties
+++ b/themes/src/main/resources/theme/base/admin/messages/admin-messages_en.properties
@@ -585,6 +585,7 @@ token-url=Token URL
 token-url.tooltip=The Token URL.
 loginHint=Pass login_hint
 loginHint.tooltip=Pass login_hint to identity provider.
+loginHint.samlTooltip=Pass login_hint to identity provider through the SSO Service URL using two query parameters: login_hint and username
 uiLocales=Pass current locale
 uiLocales.tooltip=Pass the current locale to the identity provider as a ui_locales parameter.
 logout-url=Logout URL
@@ -800,7 +801,7 @@ select-a-role=Select a role
 select-realm-role=Select realm role
 client-roles.tooltip=Client roles that can be selected.
 select-client-role=Select client role
-        
+
 client-saml-endpoint=Client SAML Endpoint
 add-client-scope=Add client scope
 

--- a/themes/src/main/resources/theme/base/admin/resources/partials/realm-identity-provider-saml.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/realm-identity-provider-saml.html
@@ -232,12 +232,20 @@
                 <kc-tooltip>{{:: 'identity-provider.force-authentication.tooltip' | translate}}</kc-tooltip>
             </div>
             <div class="form-group">
+                <label class="col-sm-2 control-label" for="loginHint">{{:: 'loginHint' | translate}}</label>
+                <div class="col-sm-4">
+                    <input ng-model="identityProvider.config.loginHint" id="loginHint" onoffswitchvalue on-text="{{:: 'onText' | translate}}" off-text="{{:: 'offText' | translate}}" />
+                </div>
+                <kc-tooltip>{{:: 'loginHint.samlTooltip' | translate}}</kc-tooltip>
+            </div>
+            <div class="form-group">
                 <label class="col-md-2 control-label" for="validateSignature">{{:: 'validate-signature' | translate}}</label>
                 <div class="col-md-6">
                     <input ng-model="identityProvider.config.validateSignature" id="validateSignature" onoffswitchvalue on-text="{{:: 'onText' | translate}}" off-text="{{:: 'offText' | translate}}" />
                 </div>
                 <kc-tooltip>{{:: 'saml.validate-signature.tooltip' | translate}}</kc-tooltip>
             </div>
+
             <div class="form-group clearfix" data-ng-show="identityProvider.config.validateSignature == 'true'">
                 <label class="col-md-2 control-label" for="signingCertificate">{{:: 'validating-x509-certificate' | translate}}</label>
                 <div class="col-md-6">


### PR DESCRIPTION
## Motivation

When working with SAML IDPs, it is currently not possible to use provider-specific features such as `login_hint` forwarding. The purpose here is to be able to automatically prefill an IDP login form with a given username.

For instance, this feature is supported by ADFS: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-oapx/a8622e66-2285-43c0-bbb9-abfcecdaed86

Here is the use case scenario we have to solve: https://groups.google.com/forum/#!topic/keycloak-user/hbTf_OyhFCA

## Limitations

* Considering `login_hint` is not part of the SAML protocol, this feature should not be used with incompatibles IDPs (_e.g._ a SAML client provider on Keycloak).
* By default, Keycloak's login form is not designed to include a login_hint in the destination url of SAML Social buttons. This must be made in a dedicated url builder and/or in a custom login template.

## Solution

* This PR takes a query parameter named `login_hint` into account and forward it in the destination url of your SAML Identity provider. 
* This parameter is sanitized and is added to the destination url as two query parameters named `login_hint` and `username`. When no login_hint is provided, nothing is forwarded.
* This does not require any change in the identity provider configuration, except enabling a "Pass login_hint" toggle, which is `false`by default.


JIRA issue: https://issues.redhat.com/browse/KEYCLOAK-13858