### PR TITLE
[KEYCLOAK-13927] Allow deleting permission tickets with the Authz client

### DIFF
--- a/authz/client/src/main/java/org/keycloak/authorization/client/resource/PermissionResource.java
+++ b/authz/client/src/main/java/org/keycloak/authorization/client/resource/PermissionResource.java
@@ -71,7 +71,7 @@ public class PermissionResource {
     /**
      * Creates a new permission ticket for a set of one or more resource and scope(s).
      *
-     * @param request the {@link PermissionRequest} representing the resource and scope(s) (not {@code null})
+     * @param requests the {@link PermissionRequest} representing the resource and scope(s) (not {@code null})
      * @return a permission response holding a permission ticket with the requested permissions
      */
     public PermissionResponse create(final List<PermissionRequest> requests) {

--- a/authz/client/src/main/java/org/keycloak/authorization/client/resource/PermissionResource.java
+++ b/authz/client/src/main/java/org/keycloak/authorization/client/resource/PermissionResource.java
@@ -237,13 +237,43 @@ public class PermissionResource {
         if (ticket.getId() == null) {
             throw new IllegalArgumentException("Permission ticket must have an id");
         }
-        Callable callable = new Callable() {
+        Callable<Void> callable = new Callable<Void>() {
             @Override
-            public Object call() throws Exception {
-                http.<List>put(serverConfiguration.getPermissionEndpoint()+"/ticket")
+            public Void call() throws Exception {
+                http.<Void>put(serverConfiguration.getPermissionEndpoint()+"/ticket")
                         .json(JsonSerialization.writeValueAsBytes(ticket))
                         .authorizationBearer(pat.call())
-                        .response().json(List.class).execute();
+                        .response()
+                        .execute();
+                return null;
+            }
+        };
+        try {
+            callable.call();
+        } catch (Exception cause) {
+            Throwables.retryAndWrapExceptionIfNecessary(callable, pat, "Error updating permission ticket", cause);
+        }
+    }
+
+    /**
+     * Deletes a permission ticket.
+     *
+     * @param ticket the permission ticket
+     */
+    public void delete(final PermissionTicketRepresentation ticket) {
+        if (ticket == null) {
+            throw new IllegalArgumentException("Permission ticket must not be null or empty");
+        }
+        if (ticket.getId() == null) {
+            throw new IllegalArgumentException("Permission ticket must have an id");
+        }
+        Callable<Void> callable = new Callable<Void>() {
+            @Override
+            public Void call() throws Exception {
+                http.<Void>delete(serverConfiguration.getPermissionEndpoint() + "/ticket/" + ticket.getId())
+                        .authorizationBearer(pat.call())
+                        .response()
+                        .execute();
                 return null;
             }
         };

--- a/authz/client/src/main/java/org/keycloak/authorization/client/resource/PermissionResource.java
+++ b/authz/client/src/main/java/org/keycloak/authorization/client/resource/PermissionResource.java
@@ -256,21 +256,17 @@ public class PermissionResource {
     }
 
     /**
-     * Deletes a permission ticket.
-     *
-     * @param ticket the permission ticket
+     * Deletes a permission ticket by ID.
+     * @param ticketId the permission ticket ID
      */
-    public void delete(final PermissionTicketRepresentation ticket) {
-        if (ticket == null) {
-            throw new IllegalArgumentException("Permission ticket must not be null or empty");
-        }
-        if (ticket.getId() == null) {
-            throw new IllegalArgumentException("Permission ticket must have an id");
+    public void delete(final String ticketId) {
+        if (ticketId == null || ticketId.trim().isEmpty()) {
+            throw new IllegalArgumentException("Permission ticket ID must not be null or empty");
         }
         Callable<Void> callable = new Callable<Void>() {
             @Override
             public Void call() throws Exception {
-                http.<Void>delete(serverConfiguration.getPermissionEndpoint() + "/ticket/" + ticket.getId())
+                http.<Void>delete(serverConfiguration.getPermissionEndpoint() + "/ticket/" + ticketId)
                         .authorizationBearer(pat.call())
                         .response()
                         .execute();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/UserManagedAccessTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/UserManagedAccessTest.java
@@ -255,6 +255,22 @@ public class UserManagedAccessTest extends AbstractResourceServerTest {
         assertNotNull(permissions);
         assertPermissions(permissions, resource.getName(), "ScopeA", "ScopeB");
         assertTrue(permissions.isEmpty());
+
+
+        for (PermissionTicketRepresentation ticket : tickets) {
+            getAuthzClient().protection().permission().delete(ticket);
+        }
+
+        tickets = getAuthzClient().protection().permission().find(resource.getId(), null, null, null, null, null, null, null);
+
+        assertEquals(0, tickets.size());
+        try {
+
+            response = authorize("kolo", "password", resource.getId(), new String[] {"ScopeA", "ScopeB"});
+            fail("User should not have access to resource from another user");
+        } catch (AuthorizationDeniedException ade) {
+
+        }
     }
 
     @Test
@@ -513,6 +529,14 @@ public class UserManagedAccessTest extends AbstractResourceServerTest {
         for (PermissionTicketRepresentation ticket : permissionTickets) {
             assertTrue(ticket.isGranted());
         }
+
+        for (PermissionTicketRepresentation ticket : permissionTickets) {
+            permissionResource.delete(ticket);
+        }
+
+        permissionTickets = permissionResource.findByResource(resource.getId());
+
+        assertEquals(0, permissionTickets.size());
     }
 
     @Test
@@ -588,9 +612,11 @@ public class UserManagedAccessTest extends AbstractResourceServerTest {
 
         for (PermissionTicketRepresentation representation : new ArrayList<>(permissionTickets)) {
             if (representation.isGranted()) {
-                permissionTickets.remove(representation);
+                permissionResource.delete(representation);
             }
         }
+
+        permissionTickets = permissionResource.findByResource(resource.getId());
 
         assertEquals(1, permissionTickets.size());
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/UserManagedAccessTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/UserManagedAccessTest.java
@@ -258,14 +258,13 @@ public class UserManagedAccessTest extends AbstractResourceServerTest {
 
 
         for (PermissionTicketRepresentation ticket : tickets) {
-            getAuthzClient().protection().permission().delete(ticket);
+            getAuthzClient().protection().permission().delete(ticket.getId());
         }
 
         tickets = getAuthzClient().protection().permission().find(resource.getId(), null, null, null, null, null, null, null);
 
         assertEquals(0, tickets.size());
         try {
-
             response = authorize("kolo", "password", resource.getId(), new String[] {"ScopeA", "ScopeB"});
             fail("User should not have access to resource from another user");
         } catch (AuthorizationDeniedException ade) {
@@ -531,7 +530,7 @@ public class UserManagedAccessTest extends AbstractResourceServerTest {
         }
 
         for (PermissionTicketRepresentation ticket : permissionTickets) {
-            permissionResource.delete(ticket);
+            permissionResource.delete(ticket.getId());
         }
 
         permissionTickets = permissionResource.findByResource(resource.getId());
@@ -612,7 +611,7 @@ public class UserManagedAccessTest extends AbstractResourceServerTest {
 
         for (PermissionTicketRepresentation representation : new ArrayList<>(permissionTickets)) {
             if (representation.isGranted()) {
-                permissionResource.delete(representation);
+                permissionResource.delete(representation.getId());
             }
         }
 


### PR DESCRIPTION
This allows deleting permission tickets with the Authz client.