### PR TITLE
KEYCLOAK-13973: Remove impersonation button on user detail page if feature is disabled

### DIFF
--- a/themes/src/main/resources/theme/base/admin/resources/partials/user-detail.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/user-detail.html
@@ -121,7 +121,7 @@
                 </div>
             </div>
 
-            <div class="form-group clearfix" data-ng-hide="create || !access.impersonation">
+            <div class="form-group clearfix" data-ng-hide="create || !access.impersonation || !serverInfo.featureEnabled('IMPERSONATION')">
                 <label class="col-md-2 control-label" for="impersonate">{{:: 'impersonate-user' | translate}}</label>
 
                 <div class="col-md-6">


### PR DESCRIPTION
The impersonation button in the user list is already removed when the impersonation feature is disabled. Remove the button from the detail page too.

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
