### PR TITLE
KEYCLOAK-13844 "exp" claim should not be "0" when using offline token

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
@@ -648,12 +648,16 @@ public class TokenManager {
 
 
         token.setSessionState(session.getId());
-        token.expiration(getTokenExpiration(realm, client, session, clientSession));
+        ClientScopeModel offlineAccessScope = KeycloakModelUtils.getClientScopeByName(realm, OAuth2Constants.OFFLINE_ACCESS);
+        boolean offlineTokenRequested = offlineAccessScope == null ? false
+            : clientSessionCtx.getClientScopeIds().contains(offlineAccessScope.getId());
+        token.expiration(getTokenExpiration(realm, client, session, clientSession, offlineTokenRequested));
 
         return token;
     }
 
-    private int getTokenExpiration(RealmModel realm, ClientModel client,  UserSessionModel userSession, AuthenticatedClientSessionModel clientSession) {
+    private int getTokenExpiration(RealmModel realm, ClientModel client, UserSessionModel userSession,
+        AuthenticatedClientSessionModel clientSession, boolean offlineTokenRequested) {
         boolean implicitFlow = false;
         String responseType = clientSession.getNote(OIDCLoginProtocol.RESPONSE_TYPE_PARAM);
         if (responseType != null) {
@@ -681,9 +685,16 @@ public class TokenManager {
             expiration = Time.currentTime() + tokenLifespan;
         }
 
-        if (!userSession.isOffline()) {
-            int sessionExpires = userSession.getStarted() + (userSession.isRememberMe() && realm.getSsoSessionMaxLifespanRememberMe() > 0 ?
-                    realm.getSsoSessionMaxLifespanRememberMe() : realm.getSsoSessionMaxLifespan());
+        if (userSession.isOffline() || offlineTokenRequested) {
+            if (realm.isOfflineSessionMaxLifespanEnabled()) {
+                int sessionExpires = userSession.getStarted() + realm.getOfflineSessionMaxLifespan();
+                expiration = expiration <= sessionExpires ? expiration : sessionExpires;
+            }
+        } else {
+            int sessionExpires = userSession.getStarted()
+                + (userSession.isRememberMe() && realm.getSsoSessionMaxLifespanRememberMe() > 0
+                    ? realm.getSsoSessionMaxLifespanRememberMe()
+                    : realm.getSsoSessionMaxLifespan());
             expiration = expiration <= sessionExpires ? expiration : sessionExpires;
         }
 
@@ -766,6 +777,8 @@ public class TokenManager {
 
                 refreshToken = new RefreshToken(accessToken);
                 refreshToken.type(TokenUtil.TOKEN_TYPE_OFFLINE);
+                if (realm.isOfflineSessionMaxLifespanEnabled())
+                    refreshToken.expiration(getOfflineExpiration());
                 sessionManager.createOrUpdateOfflineSession(clientSessionCtx.getClientSession(), userSession);
             } else {
                 refreshToken = new RefreshToken(accessToken);
@@ -781,6 +794,13 @@ public class TokenManager {
                     realm.getSsoSessionMaxLifespanRememberMe() : realm.getSsoSessionMaxLifespan());
             int expiration = Time.currentTime() + (userSession.isRememberMe() && realm.getSsoSessionIdleTimeoutRememberMe() > 0 ?
                     realm.getSsoSessionIdleTimeoutRememberMe() : realm.getSsoSessionIdleTimeout());
+            return expiration <= sessionExpires ? expiration : sessionExpires;
+        }
+
+        private int getOfflineExpiration() {
+            int expiration = Time.currentTime() + realm.getOfflineSessionIdleTimeout();
+            int sessionExpires = userSession.getStarted() + realm.getOfflineSessionMaxLifespan();
+
             return expiration <= sessionExpires ? expiration : sessionExpires;
         }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OfflineTokenTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OfflineTokenTest.java
@@ -70,6 +70,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertFalse;
@@ -80,6 +83,9 @@ import static org.keycloak.testsuite.admin.ApiUtil.findRealmRoleByName;
 import static org.keycloak.testsuite.admin.ApiUtil.findUserByUsername;
 import static org.keycloak.testsuite.admin.ApiUtil.findUserByUsernameId;
 import static org.keycloak.testsuite.util.OAuthClient.APP_ROOT;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
@@ -557,7 +563,9 @@ public class OfflineTokenTest extends AbstractKeycloakTest {
         // Login as admin and see consents of user
         UserResource user = ApiUtil.findUserByUsernameId(appRealm, "test-user@localhost");
         List<Map<String, Object>> consents = user.getConsents();
-        assertTrue(consents.isEmpty());
+        for (Map<String, Object> consent : consents) {
+            assertNotEquals(consent.get("clientId"), "offline-client-2");
+        }
     }
 
     @Test
@@ -653,6 +661,17 @@ public class OfflineTokenTest extends AbstractKeycloakTest {
         prev[1] = rep.getOfflineSessionIdleTimeout().intValue();
         RealmBuilder realmBuilder = RealmBuilder.create();
         realmBuilder.offlineSessionMaxLifespanEnabled(isEnabled).offlineSessionMaxLifespan(sessionMax).offlineSessionIdleTimeout(sessionIdle);
+        adminClient.realm("test").update(realmBuilder.build());
+        return prev;
+    }
+
+    private int[] changeSessionSettings(int ssoSessionIdle, int accessTokenLifespan) {
+        int prev[] = new int[2];
+        RealmRepresentation rep = adminClient.realm("test").toRepresentation();
+        prev[0] = rep.getOfflineSessionMaxLifespan().intValue();
+        prev[1] = rep.getOfflineSessionIdleTimeout().intValue();
+        RealmBuilder realmBuilder = RealmBuilder.create();
+        realmBuilder.ssoSessionIdleTimeout(ssoSessionIdle).accessTokenLifespan(accessTokenLifespan);
         adminClient.realm("test").update(realmBuilder.build());
         return prev;
     }
@@ -820,6 +839,46 @@ public class OfflineTokenTest extends AbstractKeycloakTest {
         testRefreshWithOfflineToken(token, offlineToken, offlineTokenString, token.getSessionState(), serviceAccountUserId);
         testRefreshWithOfflineToken(token2, offlineToken2, offlineTokenString2, token2.getSessionState(), serviceAccountUserId);
 
+    }
+
+    @Test
+    public void testShortOfflineSessionMax() throws Exception {
+        int prevOfflineSession[] = null;
+        int prevSession[] = null;
+        try {
+            prevOfflineSession = changeOfflineSessionSettings(true, 60, 30);
+            prevSession = changeSessionSettings(1800, 300);
+
+            oauth.scope(OAuth2Constants.OFFLINE_ACCESS);
+            oauth.clientId("offline-client");
+            oauth.redirectUri(offlineClientAppUri);
+            oauth.doLogin("test-user@localhost", "password");
+
+            events.expectLogin().client("offline-client").detail(Details.REDIRECT_URI, offlineClientAppUri).assertEvent();
+
+            String code = oauth.getCurrentQuery().get(OAuth2Constants.CODE);
+
+            OAuthClient.AccessTokenResponse tokenResponse = oauth.doAccessTokenRequest(code, "secret1");
+            String offlineTokenString = tokenResponse.getRefreshToken();
+            RefreshToken offlineToken = oauth.parseRefreshToken(offlineTokenString);
+
+            Assert.assertThat(tokenResponse.getExpiresIn(), allOf(greaterThanOrEqualTo(59), lessThanOrEqualTo(60)));
+            Assert.assertThat(tokenResponse.getRefreshExpiresIn(), allOf(greaterThanOrEqualTo(29), lessThanOrEqualTo(30)));
+            assertEquals(TokenUtil.TOKEN_TYPE_OFFLINE, offlineToken.getType());
+
+            String introspectionResponse = oauth.introspectAccessTokenWithClientCredential("test-app", "password",
+                tokenResponse.getAccessToken());
+            ObjectMapper objectMapper = new ObjectMapper();
+            JsonNode jsonNode = objectMapper.readTree(introspectionResponse);
+            Assert.assertEquals(true, jsonNode.get("active").asBoolean());
+            Assert.assertEquals("test-user@localhost", jsonNode.get("email").asText());
+            Assert.assertThat(jsonNode.get("exp").asInt() - getCurrentTime(),
+                allOf(greaterThanOrEqualTo(59), lessThanOrEqualTo(60)));
+
+        } finally {
+            changeOfflineSessionSettings(false, prevOfflineSession[0], prevOfflineSession[1]);
+            changeSessionSettings(prevSession[0], prevSession[1]);
+        }
     }
 
 }


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/KEYCLOAK-13844
ML: https://groups.google.com/forum/#!topic/keycloak-dev/T4k3sMzYmuA

# Spec
## exp claim of the offline token
- Set the expiry calculated by the "offline session idle" to the exp claim of the offline token. However, if the expiry calculated by the "offline session max" is shorter than that of "offline session idle", set the "offline session max" one.

## exp claim of the access token
- If using the offline token and the "offline session max limited" is ON, set the shorter one between the expiry calculated by the "access token lifespan" and that of the "offline session max".

## backward compatibility
- The exact expiry is filled only when the "offline session max limited" is ON. If the "offline session max limited" is OFF, fill the exp claim with 0 (the same as it is). The "offline session max limited" is disabled by default.