### PR TITLE
KEYCLOAK-14022 Update GroupMembershipMapper.java

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/GroupMembershipMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/GroupMembershipMapper.java
@@ -103,9 +103,7 @@ public class GroupMembershipMapper extends AbstractOIDCProtocolMapper implements
                 membership.add(group.getName());
             }
         }
-        String protocolClaim = mappingModel.getConfig().get(OIDCAttributeMapperHelper.TOKEN_CLAIM_NAME);
-
-        token.getOtherClaims().put(protocolClaim, membership);
+        OIDCAttributeMapperHelper.mapClaim(token, mappingModel, membership);
     }
 
     public static ProtocolMapperModel create(String name,


### PR DESCRIPTION
Fixed issue with group membership mapper that not split claim name with . or \.

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
