### PR TITLE
[KEYCLOAK-13995] fixed update ClientMappers in Admin REST API

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientResource.java
@@ -701,6 +701,7 @@ public class ClientResource {
         }
 
         RepresentationToModel.updateClient(rep, client);
+        RepresentationToModel.updateClientProtocolMappers(rep, client);
         updateAuthorizationSettings(rep);
     }
 


### PR DESCRIPTION
As described in the [JIRA Ticket](https://issues.redhat.com/browse/KEYCLOAK-13995) it is currently not possible to update ProtocolMappers using the Admin Update-Client REST API call. Nevertheless, this is possible using the ClientRegistration update endpoint, so it seems to be a simple shortcoming of the implementation rather than an intentional behavior.

This change adds the same call that is used to implement the behavior in the ClientRegistration implementation to make updates to ClientMappers possible and therefore correct this unexpected behavior.

This change is manually tested on 8.0.2 and 9.0.3. We are trying to use the ansible keycloak_client module to implement a simple customer-specific k8s-ansible-operator and this is a real blocker for us. 