### PR TITLE
KEYCLOAK-12852: Internal query params not removed after AIA

### DIFF
--- a/testsuite/integration-arquillian/tests/other/base-ui/src/test/java/org/keycloak/testsuite/ui/account2/SigningInTest.java
+++ b/testsuite/integration-arquillian/tests/other/base-ui/src/test/java/org/keycloak/testsuite/ui/account2/SigningInTest.java
@@ -181,8 +181,7 @@ public class SigningInTest extends BaseAccountPageTest {
         passwordCred.clickUpdateBtn();
         updatePasswordPage.assertCurrent();
         updatePasswordPage.updatePasswords(newPwd, newPwd);
-        // TODO uncomment this once KEYCLOAK-12852 is resolved
-        // signingInPage.assertCurrent();
+        signingInPage.assertCurrent();
 
         assertUserCredential(PASSWORD_LABEL, false, passwordCred);
         assertNotEquals(previousCreatedAt, passwordCred.getCreatedAt());
@@ -206,8 +205,7 @@ public class SigningInTest extends BaseAccountPageTest {
             updatePasswordPage.assertCurrent();
             String originalPassword = Users.getPasswordOf(testUser);
             updatePasswordPage.updatePasswords(originalPassword, originalPassword);
-            // TODO uncomment this once KEYCLOAK-12852 is resolved
-            // signingInPage.assertCurrent();
+             signingInPage.assertCurrent();
 
             // Credential set-up now
             assertFalse(passwordCredentialType.isSetUpLinkVisible());
@@ -224,8 +222,7 @@ public class SigningInTest extends BaseAccountPageTest {
         assertFalse(otpCredentialType.isSetUp());
         otpCredentialType.clickSetUpLink();
         otpSetupPage.cancel();
-        // TODO uncomment this once KEYCLOAK-12852 is resolved
-        // signingInPage.assertCurrent();
+         signingInPage.assertCurrent();
         assertFalse(otpCredentialType.isSetUp());
 
         assertEquals("Authenticator Application", otpCredentialType.getTitle());
@@ -351,8 +348,7 @@ public class SigningInTest extends BaseAccountPageTest {
         otpSetupPage.setTotp(code);
         otpSetupPage.setUserLabel(label);
         otpSetupPage.submit();
-        // TODO uncomment this once KEYCLOAK-12852 is resolved
-        // signingInPage.assertCurrent();
+        signingInPage.assertCurrent();
 
         return getNewestUserCredential(otpCredentialType);
     }
@@ -364,8 +360,7 @@ public class SigningInTest extends BaseAccountPageTest {
         webAuthnRegisterPage.confirmAIA();
         webAuthnRegisterPage.registerWebAuthnCredential(label);
         waitForPageToLoad();
-        // TODO uncomment this once KEYCLOAK-12852 is resolved
-        // signingInPage.assertCurrent();
+        signingInPage.assertCurrent();
 
         return getNewestUserCredential(credentialType);
     }

--- a/themes/src/main/resources/theme/keycloak-preview/account/resources/app/content/aia-page/AppInitiatedActionPage.tsx
+++ b/themes/src/main/resources/theme/keycloak-preview/account/resources/app/content/aia-page/AppInitiatedActionPage.tsx
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,7 +31,7 @@ import {
   EmptyStateBody
 } from '@patternfly/react-core';
 import { PassportIcon } from '@patternfly/react-icons';
- 
+
 // Note: This class demonstrates two features of the ContentPages framework:
 // 1) The PageDef is available as a React property.
 // 2) You can add additional custom properties to the PageDef.  In this case,
@@ -52,13 +52,13 @@ interface AppInitiatedActionPageProps extends RouteComponentProps {
  * @author Stan Silvert
  */
 class ApplicationInitiatedActionPage extends React.Component<AppInitiatedActionPageProps> {
-    
+
     public constructor(props: AppInitiatedActionPageProps) {
         super(props);
     }
 
     private handleClick = (): void => {
-        new AIACommand(this.props.pageDef.kcAction, this.props.location.pathname).execute();
+        new AIACommand(this.props.pageDef.kcAction).execute();
     }
 
     public render(): React.ReactNode {

--- a/themes/src/main/resources/theme/keycloak-preview/account/resources/app/content/signingin-page/SigningInPage.tsx
+++ b/themes/src/main/resources/theme/keycloak-preview/account/resources/app/content/signingin-page/SigningInPage.tsx
@@ -85,8 +85,6 @@ interface SigningInPageState {
  * @author Stan Silvert ssilvert@redhat.com (C) 2018 Red Hat Inc.
  */
 class SigningInPage extends React.Component<SigningInPageProps, SigningInPageState> {
-    private readonly updatePassword: AIACommand = new AIACommand('UPDATE_PASSWORD', this.props.location.pathname);
-    private readonly setUpTOTP: AIACommand = new AIACommand('CONFIGURE_TOTP', this.props.location.pathname);
 
     public constructor(props: SigningInPageProps) {
         super(props);
@@ -207,7 +205,7 @@ class SigningInPage extends React.Component<SigningInPageProps, SigningInPageSta
 
         let updateAIA: AIACommand;
         if (credContainer.updateAction) {
-            updateAIA = new AIACommand(credContainer.updateAction, this.props.location.pathname);
+            updateAIA = new AIACommand(credContainer.updateAction);
         }
 
         return (
@@ -244,7 +242,7 @@ class SigningInPage extends React.Component<SigningInPageProps, SigningInPageSta
 
         let setupAction: AIACommand;
         if (credContainer.createAction) {
-            setupAction = new AIACommand(credContainer.createAction, this.props.location.pathname);
+            setupAction = new AIACommand(credContainer.createAction);
         }
         const credContainerDisplayName: string = Msg.localize(credContainer.displayName);
 

--- a/themes/src/main/resources/theme/keycloak-preview/account/resources/app/util/AIACommand.ts
+++ b/themes/src/main/resources/theme/keycloak-preview/account/resources/app/util/AIACommand.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,41 +14,19 @@
  * limitations under the License.
  */
 
-
-
-declare const baseUrl: string;
-declare const realm: string;
-declare const referrer: string;
-declare const referrerUri: string;
+import {KeycloakService} from '../keycloak-service/keycloak.service';
 
 /**
  * @author Stan Silvert
  */
 export class AIACommand {
-    constructor(private action: string, private redirectPath: string) {}
+
+    constructor(private action: string) {}
 
     public execute(): void  {
-        let redirectURI: string = baseUrl;
-        
-        if (typeof referrer !== 'undefined') {
-            // '_hash_' is a workaround for when uri encoding is not
-            // sufficient to escape the # character properly.
-            // The problem is that both the redirect and the application URL contain a hash.
-            // The browser will consider anything after the first hash to be client-side.  So
-            // it sees the hash in the redirect param and stops.
-            redirectURI += "?referrer=" + referrer + "&referrer_uri=" + referrerUri.replace('#', '_hash_');
-        }
+        KeycloakService.Instance.login({
+            action: this.action,
+        })
 
-        redirectURI = encodeURIComponent(redirectURI);
-        
-        const href: string = "/auth/realms/" + realm +
-                             "/protocol/openid-connect/auth/" +
-                             "?response_type=code" +
-                             "&client_id=account&scope=openid" +
-                             "&kc_action=" + this.action + 
-                             "&redirect_uri=" + redirectURI +
-                             encodeURIComponent("/#" + this.redirectPath); // return to this page
-
-        window.location.href = href;
     }
 }


### PR DESCRIPTION
PR for Keycloak 11

https://issues.redhat.com/browse/KEYCLOAK-12852