### PR TITLE
KEYCLOAK-13998 ConditionalRoleAuthenticator doesn't work with composite roles

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/conditional/ConditionalRoleAuthenticatorFactory.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/conditional/ConditionalRoleAuthenticatorFactory.java
@@ -18,7 +18,9 @@ public class ConditionalRoleAuthenticatorFactory implements ConditionalAuthentic
 
     static {
         commonConfig = Collections.unmodifiableList(ProviderConfigurationBuilder.create()
-            .property().name(CONDITIONAL_USER_ROLE).label("User role").helpText("Role the user should have to execute this flow").type(ProviderConfigProperty.STRING_TYPE).add()
+            .property().name(CONDITIONAL_USER_ROLE).label("User role")
+            .helpText("Role the user should have to execute this flow. Click 'Select Role' button to browse roles, or just type it in the textbox. To specify an application role the syntax is appname.approle, i.e. myapp.myrole")
+            .type(ProviderConfigProperty.ROLE_TYPE).add()
             .build()
         );
     }


### PR DESCRIPTION
- Check if user has role by invoking user.hasRole() instead of getting matches with user.getRoleMappings() which only returns direct roles
- Add error message in case of non existent role name
- Add a role picker to the UI
- Update tooltip text for ConditionalRoleAuthenticator to mention the syntax for client roles (same text as OIDC Hardcoded Role Mapper)