### PR TITLE
KEYCLOAK-14044 Move impl of processAccessTokenResponse to OIDCIdentityProvider

### DIFF
--- a/services/src/main/java/org/keycloak/broker/oidc/KeycloakOIDCIdentityProvider.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/KeycloakOIDCIdentityProvider.java
@@ -52,8 +52,6 @@ import java.io.IOException;
  */
 public class KeycloakOIDCIdentityProvider extends OIDCIdentityProvider {
 
-    public static final String VALIDATED_ACCESS_TOKEN = "VALIDATED_ACCESS_TOKEN";
-
     public KeycloakOIDCIdentityProvider(KeycloakSession session, OIDCIdentityProviderConfig config) {
         super(session, config);
     }
@@ -61,13 +59,6 @@ public class KeycloakOIDCIdentityProvider extends OIDCIdentityProvider {
     @Override
     public Object callback(RealmModel realm, AuthenticationCallback callback, EventBuilder event) {
         return new KeycloakEndpoint(callback, realm, event);
-    }
-
-    @Override
-    protected void processAccessTokenResponse(BrokeredIdentityContext context, AccessTokenResponse response) {
-        // Don't verify audience on accessToken as it may not be there. It was verified on IDToken already
-        JsonWebToken access = validateToken(response.getToken(), true);
-        context.getContextData().put(VALIDATED_ACCESS_TOKEN, access);
     }
 
     protected class KeycloakEndpoint extends OIDCEndpoint {

--- a/services/src/main/java/org/keycloak/broker/oidc/OIDCIdentityProvider.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/OIDCIdentityProvider.java
@@ -81,6 +81,7 @@ public class OIDCIdentityProvider extends AbstractOAuth2IdentityProvider<OIDCIde
     public static final String USER_INFO = "UserInfo";
     public static final String FEDERATED_ACCESS_TOKEN_RESPONSE = "FEDERATED_ACCESS_TOKEN_RESPONSE";
     public static final String VALIDATED_ID_TOKEN = "VALIDATED_ID_TOKEN";
+    public static final String VALIDATED_ACCESS_TOKEN = "VALIDATED_ACCESS_TOKEN";
     public static final String ACCESS_TOKEN_EXPIRATION = "accessTokenExpiration";
     public static final String EXCHANGE_PROVIDER = "EXCHANGE_PROVIDER";
     private static final String BROKER_NONCE_PARAM = "BROKER_NONCE";
@@ -250,8 +251,9 @@ public class OIDCIdentityProvider extends AbstractOAuth2IdentityProvider<OIDCIde
     }
 
     protected void processAccessTokenResponse(BrokeredIdentityContext context, AccessTokenResponse response) {
-
-
+        // Don't verify audience on accessToken as it may not be there. It was verified on IDToken already
+        JsonWebToken access = validateToken(response.getToken(), true);
+        context.getContextData().put(VALIDATED_ACCESS_TOKEN, access);
     }
 
     protected SimpleHttp getRefreshTokenRequest(KeycloakSession session, String refreshToken, String clientId, String clientSecret) {


### PR DESCRIPTION
This resolves the problem that Identity Provider of type "Open ID Connect 1.0" cannot map claims from access token to user attributes using user attribute importer mapper. The reason it was not working is that the `OIDCIdentityProvider` did not store the access token in the context as the `processAccessTokenResponse()` method was empty. However the `KeycloakOIDCIdentityProvider` that derives from it did override the `processAccessTokenResponse()` method and added impl to add access token to context. So to solve it this PR moves the impl of `processAccessTokenResponse()` up to `OIDCIdentityProvider` so both classes store the access token in the context.