### PR TITLE
KEYCLOAK-14031 Use ClientProvider to lookup clients after a cache invalidation

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmCacheSession.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmCacheSession.java
@@ -1052,7 +1052,7 @@ public class RealmCacheSession implements CacheRealmProvider {
             managedApplications.put(id, adapter);
             return adapter;
         } else if (invalidations.contains(id)) {
-            return getRealmDelegate().getClientById(id, realm);
+            return getClientDelegate().getClientById(id, realm);
         } else if (managedApplications.containsKey(id)) {
             return managedApplications.get(id);
         }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/storage/ClientStorageTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/storage/ClientStorageTest.java
@@ -318,6 +318,10 @@ public class ClientStorageTest extends AbstractTestRealmKeycloakTest {
             ClientModel hardcoded = realm.getClientByClientId("hardcoded-client");
             Assert.assertNotNull(hardcoded);
             Assert.assertFalse(hardcoded instanceof ClientAdapter);
+
+            ClientModel hardcodedById = realm.getClientById(hardcoded.getId());
+            Assert.assertNotNull(hardcodedById);
+            Assert.assertFalse(hardcodedById instanceof ClientAdapter);
         });
     }
 
@@ -329,6 +333,10 @@ public class ClientStorageTest extends AbstractTestRealmKeycloakTest {
             ClientModel hardcoded = realm.getClientByClientId("hardcoded-client");
             Assert.assertNotNull(hardcoded);
             Assert.assertTrue(hardcoded instanceof org.keycloak.models.cache.infinispan.ClientAdapter);
+
+            ClientModel hardcodedById = realm.getClientById(hardcoded.getId());
+            Assert.assertNotNull(hardcodedById);
+            Assert.assertTrue(hardcodedById instanceof org.keycloak.models.cache.infinispan.ClientAdapter);
         });
     }
 


### PR DESCRIPTION
Use ClientProvider to lookup clients after a cache invalidation has happened. This will make sure that also custom ClientStorageProviders will be considered during the lookup.

JIRA: https://issues.redhat.com/browse/KEYCLOAK-14031