### PR TITLE
KEYCLOAK-10932 Honor given_name and family_name in OIDC brokering

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/broker/provider/BrokeredIdentityContext.java
+++ b/server-spi-private/src/main/java/org/keycloak/broker/provider/BrokeredIdentityContext.java
@@ -203,6 +203,11 @@ public class BrokeredIdentityContext {
         this.authenticationSession = authenticationSession;
     }
 
+    /**
+     * @deprecated use {@link #setFirstName(String)} and {@link #setLastName(String)} instead
+     * @param name
+     */
+    @Deprecated
     public void setName(String name) {
         if (name != null) {
             int i = name.lastIndexOf(' ');

--- a/services/src/main/java/org/keycloak/broker/oidc/OIDCIdentityProvider.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/OIDCIdentityProvider.java
@@ -393,6 +393,8 @@ public class OIDCIdentityProvider extends AbstractOAuth2IdentityProvider<OIDCIde
         String id = idToken.getSubject();
         BrokeredIdentityContext identity = new BrokeredIdentityContext(id);
         String name = (String) idToken.getOtherClaims().get(IDToken.NAME);
+        String givenName = (String)idToken.getOtherClaims().get(IDToken.GIVEN_NAME);
+        String familyName = (String)idToken.getOtherClaims().get(IDToken.FAMILY_NAME);
         String preferredUsername = (String) idToken.getOtherClaims().get(getusernameClaimNameForIdToken());
         String email = (String) idToken.getOtherClaims().get(IDToken.EMAIL);
 
@@ -436,6 +438,8 @@ public class OIDCIdentityProvider extends AbstractOAuth2IdentityProvider<OIDCIde
 
                     id = getJsonProperty(userInfo, "sub");
                     name = getJsonProperty(userInfo, "name");
+                    givenName = getJsonProperty(userInfo, IDToken.GIVEN_NAME);
+                    familyName = getJsonProperty(userInfo, IDToken.FAMILY_NAME);
                     preferredUsername = getUsernameFromUserInfo(userInfo);
                     email = getJsonProperty(userInfo, "email");
                     AbstractJsonUserAttributeMapper.storeUserProfileForMapper(identity, userInfo, getConfig().getAlias());
@@ -445,7 +449,19 @@ public class OIDCIdentityProvider extends AbstractOAuth2IdentityProvider<OIDCIde
         identity.getContextData().put(VALIDATED_ID_TOKEN, idToken);
 
         identity.setId(id);
-        identity.setName(name);
+
+        if (givenName != null) {
+            identity.setFirstName(givenName);
+        }
+
+        if (familyName != null) {
+            identity.setLastName(familyName);
+        }
+
+        if (givenName == null && familyName == null) {
+            identity.setName(name);
+        }
+
         identity.setEmail(email);
 
         identity.setBrokerUserId(getConfig().getAlias() + "." + id);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractBaseBrokerTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractBaseBrokerTest.java
@@ -222,11 +222,15 @@ public abstract class AbstractBaseBrokerTest extends AbstractKeycloakTest {
     }
 
     protected void logInWithBroker(BrokerConfiguration bc) {
-        log.debug("Clicking social " + bc.getIDPAlias());
-        loginPage.clickSocial(bc.getIDPAlias());
+        logInWithIdp(bc.getIDPAlias(), bc.getUserLogin(), bc.getUserPassword());
+    }
+
+    protected void logInWithIdp(String idpAlias, String username, String password) {
+        log.debug("Clicking social " + idpAlias);
+        loginPage.clickSocial(idpAlias);
         waitForPage(driver, "log in to", true);
         log.debug("Logging in");
-        loginPage.login(bc.getUserLogin(), bc.getUserPassword());
+        loginPage.login(username, password);
     }
 
     /** Logs in the IDP and updates account information */

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcFirstBrokerLoginTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcFirstBrokerLoginTest.java
@@ -22,6 +22,28 @@ public class KcOidcFirstBrokerLoginTest extends AbstractFirstBrokerLoginTest {
         return KcOidcBrokerConfiguration.INSTANCE;
     }
 
+    /**
+     * KEYCLOAK-10932
+     */
+    @Test
+    public void loginWithFirstnameLastnamePopulatedFromClaims() {
+
+        updateExecutions(AbstractBrokerTest::disableUpdateProfileOnFirstLogin);
+
+        String firstname = "Firstname";
+        String lastname = "Lastname";
+        String username = "firstandlastname";
+        createUser(bc.providerRealmName(), username, BrokerTestConstants.USER_PASSWORD, firstname, lastname, "firstnamelastname@example.org");
+
+        driver.navigate().to(getAccountUrl(bc.consumerRealmName()));
+        logInWithIdp(bc.getIDPAlias(), username, BrokerTestConstants.USER_PASSWORD);
+
+        accountUpdateProfilePage.assertCurrent();
+
+        assertEquals(username, accountUpdateProfilePage.getUsername());
+        assertEquals(firstname, accountUpdateProfilePage.getFirstName());
+        assertEquals(lastname, accountUpdateProfilePage.getLastName());
+    }
 
     /**
      * Tests that duplication is detected and user wants to link federatedIdentity with existing account. He will confirm link by reauthentication


### PR DESCRIPTION
Previously firstname and lastname were derived from the name claim.
We now use direct mappings to extract firstname and lastname from
given_name and family_name claims.

Added test to KcOidcFirstBrokerLoginTest

Marked org.keycloak.broker.provider.BrokeredIdentityContext#setName
as deprecated to avoid breaking existing integrations.

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
