### PR TITLE
[Keycloak-10162] Usage of ObjectInputStream without checking the object types

### DIFF
--- a/common/src/main/java/org/keycloak/common/util/DelegatingSerializationFilter.java
+++ b/common/src/main/java/org/keycloak/common/util/DelegatingSerializationFilter.java
@@ -1,0 +1,139 @@
+package org.keycloak.common.util;
+
+import org.jboss.logging.Logger;
+
+import java.io.ObjectInputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+
+public class DelegatingSerializationFilter {
+    private static final Logger LOG = Logger.getLogger(DelegatingSerializationFilter.class.getName());
+
+    private static final SerializationFilterAdapter serializationFilterAdapter = isJava6To8() ? new OnJava6To8() : new OnJavaAfter8();
+
+    private static boolean isJava6To8() {
+        List<String> olderVersions = Arrays.asList("1.6", "1.7", "1.8");
+        return olderVersions.contains(System.getProperty("java.specification.version"));
+    }
+
+    public void setFilter(ObjectInputStream ois, String filterPattern) {
+
+        LOG.info("Using: " + serializationFilterAdapter.getClass().getSimpleName());
+
+        if (serializationFilterAdapter.getObjectInputFilter(ois) == null) {
+            serializationFilterAdapter.setObjectInputFilter(ois, filterPattern);
+        }
+    }
+
+    interface SerializationFilterAdapter {
+
+        Object getObjectInputFilter(ObjectInputStream ois);
+
+        void setObjectInputFilter(ObjectInputStream ois, String filterPattern);
+    }
+
+    // If codebase stays on Java 8 for a while you could use Java 8 classes directly without reflection
+    static class OnJava6To8 implements SerializationFilterAdapter {
+
+        private static final Method getObjectInputFilterMethod;
+        private static final Method setObjectInputFilterMethod;
+        private static final Method createFilterMethod;
+
+        static {
+
+            Method getObjectInputFilter;
+            Method setObjectInputFilter;
+            Method createFilter;
+
+            try {
+                ClassLoader cl = Thread.currentThread().getContextClassLoader();
+                Class<?> objectInputFilterClass = cl.loadClass("sun.misc.ObjectInputFilter");
+                Class<?> objectInputFilterConfigClass = cl.loadClass("sun.misc.ObjectInputFilter$Config");
+                getObjectInputFilter = objectInputFilterConfigClass.getDeclaredMethod("getObjectInputFilter", ObjectInputStream.class);
+                setObjectInputFilter = objectInputFilterConfigClass.getDeclaredMethod("setObjectInputFilter", ObjectInputStream.class, objectInputFilterClass);
+                createFilter = objectInputFilterConfigClass.getDeclaredMethod("createFilter", String.class);
+            } catch (ClassNotFoundException | NoSuchMethodException e) {
+                LOG.warn("Could not configure SerializationFilterAdapter: " + e.getMessage());
+                getObjectInputFilter = null;
+                setObjectInputFilter = null;
+                createFilter = null;
+            }
+
+            getObjectInputFilterMethod = getObjectInputFilter;
+            setObjectInputFilterMethod = setObjectInputFilter;
+            createFilterMethod = createFilter;
+        }
+
+        public Object getObjectInputFilter(ObjectInputStream ois) {
+            try {
+                return getObjectInputFilterMethod.invoke(null, ois);
+            } catch (IllegalAccessException | InvocationTargetException e) {
+                LOG.warn("Could not read ObjectFilter from ObjectInputStream: " + e.getMessage());
+                return null;
+            }
+        }
+
+        public void setObjectInputFilter(ObjectInputStream ois, String filterPattern) {
+            try {
+                Object objectFilter = createFilterMethod.invoke(null, filterPattern);
+                setObjectInputFilterMethod.invoke(null, ois, objectFilter);
+            } catch (IllegalAccessException | InvocationTargetException e) {
+                LOG.warn("Could not set ObjectFilter: " + e.getMessage());
+            }
+        }
+    }
+
+    // If codebase moves to Java 9+ could use Java 9+ classes directly without reflection and keep the old variant with reflection
+    static class OnJavaAfter8 implements SerializationFilterAdapter {
+
+        private static final Method getObjectInputFilterMethod;
+        private static final Method setObjectInputFilterMethod;
+        private static final Method createFilterMethod;
+
+        static {
+
+            Method getObjectInputFilter;
+            Method setObjectInputFilter;
+            Method createFilter;
+
+            try {
+                ClassLoader cl = Thread.currentThread().getContextClassLoader();
+                Class<?> objectInputFilterClass = cl.loadClass("java.io.ObjectInputFilter");
+                Class<?> objectInputFilterConfigClass = cl.loadClass("java.io.ObjectInputFilter$Config");
+                Class<?> objectInputStreamClass = cl.loadClass("java.io.ObjectInputStream");
+                getObjectInputFilter = objectInputStreamClass.getDeclaredMethod("getObjectInputFilter");
+                setObjectInputFilter = objectInputStreamClass.getDeclaredMethod("setObjectInputFilter", objectInputFilterClass);
+                createFilter = objectInputFilterConfigClass.getDeclaredMethod("createFilter", String.class);
+            } catch (ClassNotFoundException | NoSuchMethodException e) {
+                LOG.warn("Could not configure SerializationFilterAdapter: " + e.getMessage());
+                getObjectInputFilter = null;
+                setObjectInputFilter = null;
+                createFilter = null;
+            }
+
+            getObjectInputFilterMethod = getObjectInputFilter;
+            setObjectInputFilterMethod = setObjectInputFilter;
+            createFilterMethod = createFilter;
+        }
+
+        public Object getObjectInputFilter(ObjectInputStream ois) {
+            try {
+                return getObjectInputFilterMethod.invoke(ois);
+            } catch (IllegalAccessException | InvocationTargetException e) {
+                LOG.warn("Could not read ObjectFilter from ObjectInputStream: " + e.getMessage());
+                return null;
+            }
+        }
+
+        public void setObjectInputFilter(ObjectInputStream ois, String filterPattern) {
+            try {
+                Object objectFilter = createFilterMethod.invoke(ois, filterPattern);
+                setObjectInputFilterMethod.invoke(ois, objectFilter);
+            } catch (IllegalAccessException | InvocationTargetException e) {
+                LOG.warn("Could not set ObjectFilter: " + e.getMessage());
+            }
+        }
+    }
+}

--- a/common/src/main/java/org/keycloak/common/util/DelegatingSerializationFilter.java
+++ b/common/src/main/java/org/keycloak/common/util/DelegatingSerializationFilter.java
@@ -11,7 +11,7 @@ import java.util.List;
 public class DelegatingSerializationFilter {
     private static final Logger LOG = Logger.getLogger(DelegatingSerializationFilter.class.getName());
 
-    private static final SerializationFilterAdapter serializationFilterAdapter = isJava6To8() ? new OnJava6To8() : new OnJavaAfter8();
+    private static final SerializationFilterAdapter serializationFilterAdapter = isJava6To8() ? createOnJava6To8Adapter() : new OnJavaAfter8();
 
     private static boolean isJava6To8() {
         List<String> olderVersions = Arrays.asList("1.6", "1.7", "1.8");
@@ -19,7 +19,6 @@ public class DelegatingSerializationFilter {
     }
 
     public void setFilter(ObjectInputStream ois, String filterPattern) {
-
         LOG.info("Using: " + serializationFilterAdapter.getClass().getSimpleName());
 
         if (serializationFilterAdapter.getObjectInputFilter(ois) == null) {
@@ -34,36 +33,35 @@ public class DelegatingSerializationFilter {
         void setObjectInputFilter(ObjectInputStream ois, String filterPattern);
     }
 
+    private static SerializationFilterAdapter createOnJava6To8Adapter() {
+        try {
+            ClassLoader cl = Thread.currentThread().getContextClassLoader();
+            Class<?> objectInputFilterClass = cl.loadClass("sun.misc.ObjectInputFilter");
+            Class<?> objectInputFilterConfigClass = cl.loadClass("sun.misc.ObjectInputFilter$Config");
+            Method getObjectInputFilter = objectInputFilterConfigClass.getDeclaredMethod("getObjectInputFilter", ObjectInputStream.class);
+            Method setObjectInputFilter = objectInputFilterConfigClass.getDeclaredMethod("setObjectInputFilter", ObjectInputStream.class, objectInputFilterClass);
+            Method createFilter = objectInputFilterConfigClass.getDeclaredMethod("createFilter", String.class);
+            return new OnJava6To8(getObjectInputFilter, setObjectInputFilter, createFilter);
+        } catch (ClassNotFoundException | NoSuchMethodException e) {
+            // This can happen for older JDK updates.
+            LOG.warn("Could not configure SerializationFilterAdapter. For better security, it is highly recommended to upgrade to newer JDK version update!");
+            LOG.warn("For the Java 7, the recommended update is at least 131 (1.7.0_131 or newer). For the Java 8, the recommended update is at least 121 (1.8.0_121 or newer).");
+            LOG.warn("Error details", e);
+            return new EmptyFilterAdapter();
+        }
+    }
+
     // If codebase stays on Java 8 for a while you could use Java 8 classes directly without reflection
     static class OnJava6To8 implements SerializationFilterAdapter {
 
-        private static final Method getObjectInputFilterMethod;
-        private static final Method setObjectInputFilterMethod;
-        private static final Method createFilterMethod;
+        private final Method getObjectInputFilterMethod;
+        private final Method setObjectInputFilterMethod;
+        private final Method createFilterMethod;
 
-        static {
-
-            Method getObjectInputFilter;
-            Method setObjectInputFilter;
-            Method createFilter;
-
-            try {
-                ClassLoader cl = Thread.currentThread().getContextClassLoader();
-                Class<?> objectInputFilterClass = cl.loadClass("sun.misc.ObjectInputFilter");
-                Class<?> objectInputFilterConfigClass = cl.loadClass("sun.misc.ObjectInputFilter$Config");
-                getObjectInputFilter = objectInputFilterConfigClass.getDeclaredMethod("getObjectInputFilter", ObjectInputStream.class);
-                setObjectInputFilter = objectInputFilterConfigClass.getDeclaredMethod("setObjectInputFilter", ObjectInputStream.class, objectInputFilterClass);
-                createFilter = objectInputFilterConfigClass.getDeclaredMethod("createFilter", String.class);
-            } catch (ClassNotFoundException | NoSuchMethodException e) {
-                LOG.warn("Could not configure SerializationFilterAdapter: " + e.getMessage());
-                getObjectInputFilter = null;
-                setObjectInputFilter = null;
-                createFilter = null;
-            }
-
-            getObjectInputFilterMethod = getObjectInputFilter;
-            setObjectInputFilterMethod = setObjectInputFilter;
-            createFilterMethod = createFilter;
+        private OnJava6To8(Method getObjectInputFilterMethod, Method setObjectInputFilterMethod, Method createFilterMethod) {
+            this.getObjectInputFilterMethod = getObjectInputFilterMethod;
+            this.setObjectInputFilterMethod = setObjectInputFilterMethod;
+            this.createFilterMethod = createFilterMethod;
         }
 
         public Object getObjectInputFilter(ObjectInputStream ois) {
@@ -84,6 +82,22 @@ public class DelegatingSerializationFilter {
             }
         }
     }
+
+
+    static class EmptyFilterAdapter implements SerializationFilterAdapter {
+
+        @Override
+        public Object getObjectInputFilter(ObjectInputStream ois) {
+            return null;
+        }
+
+        @Override
+        public void setObjectInputFilter(ObjectInputStream ois, String filterPattern) {
+
+        }
+
+    }
+
 
     // If codebase moves to Java 9+ could use Java 9+ classes directly without reflection and keep the old variant with reflection
     static class OnJavaAfter8 implements SerializationFilterAdapter {

--- a/common/src/main/java/org/keycloak/common/util/KerberosSerializationUtils.java
+++ b/common/src/main/java/org/keycloak/common/util/KerberosSerializationUtils.java
@@ -23,7 +23,6 @@ import javax.security.auth.kerberos.KerberosTicket;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.ObjectInput;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutput;
 import java.io.ObjectOutputStream;
@@ -109,9 +108,11 @@ public class KerberosSerializationUtils {
     private static Object deserialize(String serialized) throws ClassNotFoundException, IOException {
         byte[] bytes = Base64.decode(serialized);
         ByteArrayInputStream bis = new ByteArrayInputStream(bytes);
-        ObjectInput in = null;
+        ObjectInputStream in = null;
         try {
+            DelegatingSerializationFilter filter = new DelegatingSerializationFilter();
             in = new ObjectInputStream(bis);
+            filter.setFilter(in, "javax.security.auth.kerberos.KerberosTicket;javax.security.auth.kerberos.KerberosPrincipal;javax.security.auth.kerberos.KeyImpl;java.net.InetAddress;java.util.Date;!*");
             return in.readObject();
         } finally {
             try {

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -66,6 +66,11 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/core/src/main/java/org/keycloak/KeycloakPrincipal.java
+++ b/core/src/main/java/org/keycloak/KeycloakPrincipal.java
@@ -17,6 +17,10 @@
 
 package org.keycloak;
 
+import org.keycloak.common.util.DelegatingSerializationFilter;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
 import java.io.Serializable;
 import java.security.Principal;
 
@@ -62,5 +66,11 @@ public class KeycloakPrincipal<T extends KeycloakSecurityContext> implements Pri
     @Override
     public String toString() {
         return name;
+    }
+
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+        DelegatingSerializationFilter filter = new DelegatingSerializationFilter();
+        filter.setFilter(in, "org.keycloak.KeycloakSecurityContext;org.keycloak.KeycloakPrincipal;!*");
+        in.defaultReadObject();
     }
 }

--- a/core/src/main/java/org/keycloak/KeycloakPrincipal.java
+++ b/core/src/main/java/org/keycloak/KeycloakPrincipal.java
@@ -70,7 +70,7 @@ public class KeycloakPrincipal<T extends KeycloakSecurityContext> implements Pri
 
     private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
         DelegatingSerializationFilter filter = new DelegatingSerializationFilter();
-        filter.setFilter(in, "org.keycloak.KeycloakSecurityContext;org.keycloak.KeycloakPrincipal;!*");
+        filter.setFilter(in, "org.keycloak.KeycloakSecurityContext;org.keycloak.KeycloakPrincipal;java.util.*;!*");
         in.defaultReadObject();
     }
 }

--- a/core/src/main/java/org/keycloak/KeycloakSecurityContext.java
+++ b/core/src/main/java/org/keycloak/KeycloakSecurityContext.java
@@ -18,6 +18,7 @@
 package org.keycloak;
 
 import org.keycloak.common.util.Base64Url;
+import org.keycloak.common.util.DelegatingSerializationFilter;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.IDToken;
 import org.keycloak.util.JsonSerialization;
@@ -85,6 +86,8 @@ public class KeycloakSecurityContext implements Serializable {
     }
 
     private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+        DelegatingSerializationFilter filter = new DelegatingSerializationFilter();
+        filter.setFilter(in, "org.keycloak.KeycloakSecurityContext;!*");
         in.defaultReadObject();
 
         token = parseToken(tokenString, AccessToken.class);

--- a/distribution/saml-adapters/as7-eap6-adapter/eap6-adapter-zip/pom.xml
+++ b/distribution/saml-adapters/as7-eap6-adapter/eap6-adapter-zip/pom.xml
@@ -40,6 +40,12 @@
             <artifactId>keycloak-as7-modules</artifactId>
             <type>zip</type>
         </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-saml-as7-modules</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/testsuite/integration-arquillian/servers/app-server/jboss/eap6/pom.xml
+++ b/testsuite/integration-arquillian/servers/app-server/jboss/eap6/pom.xml
@@ -63,6 +63,18 @@
             <artifactId>integration-arquillian-util</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-eap6-adapter-dist</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-saml-eap6-adapter-dist</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
I have an issue with this PR which is why it is currently a draft PR.

This code is JDK 8 specific. JDK 9 introduced java.io.ObjectInputFilter. The filter was then backported to JDK 8 as sun.misc.ObjectInputFilter. How can we maintain JDK compatibility when the package name is different between versions?