### PR TITLE
KEYCLOAK-14115 Add a refresh to avoid failure

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/WaitUtils.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/WaitUtils.java
@@ -97,6 +97,28 @@ public final class WaitUtils {
     }
 
     /**
+     * Waits for DOMContent to load
+     */
+    public static void waitForDomContentToLoad() {
+        WebDriver driver = getCurrentDriver();
+
+        if (driver instanceof HtmlUnitDriver) {
+            return; // not needed
+        }
+
+        WebDriverWait wait = new WebDriverWait(driver, PAGELOAD_TIMEOUT_MILLIS / 1000);
+
+        try {
+            wait
+                    .pollingEvery(Duration.ofMillis(500))
+                    .until(javaScriptThrowsNoExceptions(
+                    "if (document.readyState !== 'complete') { throw \"Not ready\";}"));
+        } catch (TimeoutException e) {
+            log.warn("waitForPageToLoad time exceeded!");
+        }
+    }
+
+    /**
      * Waits for page to finish any pending redirects, REST API requests etc.
      * Because Keycloak's Admin Console is a single-page application, we need to
      * take extra steps to ensure the page is fully loaded

--- a/testsuite/integration-arquillian/tests/other/console/src/test/java/org/keycloak/testsuite/console/clients/ClientSettingsTest.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/test/java/org/keycloak/testsuite/console/clients/ClientSettingsTest.java
@@ -35,6 +35,7 @@ import static org.keycloak.testsuite.auth.page.login.Login.OIDC;
 import static org.keycloak.testsuite.auth.page.login.Login.SAML;
 import static org.keycloak.testsuite.console.page.clients.settings.ClientSettingsForm.OidcAccessType.BEARER_ONLY;
 import static org.keycloak.testsuite.console.page.clients.settings.ClientSettingsForm.OidcAccessType.CONFIDENTIAL;
+import static org.keycloak.testsuite.util.UIUtils.refreshPageAndWaitForLoad;
 import static org.keycloak.testsuite.util.WaitUtils.pause;
 
 /**
@@ -71,7 +72,6 @@ public class ClientSettingsTest extends AbstractClientTest {
         newClient.setRedirectUris(redirectUris);
         
         List<String> webOrigins = new ArrayList<>();
-        webOrigins.clear();
         webOrigins.add("http://example2.test");
         webOrigins.add("http://example3.test");
         newClient.setWebOrigins(webOrigins);
@@ -99,6 +99,8 @@ public class ClientSettingsTest extends AbstractClientTest {
     @Test
     @EnableFeature(value = Profile.Feature.ACCOUNT2, skipRestart = true)
     public void alwaysDisplayInAccountConsole() {
+        refreshPageAndWaitForLoad();
+
         newClient = createClientRep("always-display-in-console", OIDC);
         createClient(newClient);
 


### PR DESCRIPTION
alwaysDisplayInAccountConsole  in ClientSettingsTest have been failing for some days. This fixs add a refresh and a wait so that the page can be correctly loaded after changes are applied through API.
Test passed on this run:
https://keycloak-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/blue/organizations/jenkins/universal-test-pipeline-server/detail/universal-test-pipeline-server/1767/pipeline/