### PR TITLE
KEYCLOAK-14038: Re-allow special characters for Roles only

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/RoleContainerResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RoleContainerResource.java
@@ -60,7 +60,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.keycloak.utils.ReservedCharValidator;
 
 /**
  * @resource Roles
@@ -136,8 +135,6 @@ public class RoleContainerResource extends RoleResource {
         if (rep.getName() == null) {
             throw new BadRequestException();
         }
-        
-        ReservedCharValidator.validate(rep.getName());
 
         try {
             RoleModel role = roleContainer.addRole(rep.getName());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/ClientRolesTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/ClientRolesTest.java
@@ -39,7 +39,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import javax.ws.rs.BadRequestException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -89,12 +88,6 @@ public class ClientRolesTest extends AbstractClientTest {
         assertTrue(hasRole(rolesRsc, "role1"));
     }
     
-    @Test(expected = BadRequestException.class)
-    public void testAddRoleWithReservedCharacter() {
-        RoleRepresentation role1 = makeRole("r&ole1");
-        rolesRsc.create(role1);
-    }
-
     @Test
     public void testRemoveRole() {
         RoleRepresentation role2 = makeRole("role2");

--- a/testsuite/integration-arquillian/tests/other/console/src/test/java/org/keycloak/testsuite/console/roles/RealmRolesTest.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/test/java/org/keycloak/testsuite/console/roles/RealmRolesTest.java
@@ -112,21 +112,6 @@ public class RealmRolesTest extends AbstractRolesTest {
         assertNotNull(realmRolesPage.table().findRole(name));
     }
     
-    // KEYCLOAK-12768: Certain characters in names cause bad URIs.  Disallow.
-    @Test
-    public void testAddRoleWithBadCharsInName() {
-        String roleName = "hello;:]!@#role";
-        assertCurrentUrlEquals(realmRolesPage);
-        realmRolesPage.table().addRole();
-        assertCurrentUrlEquals(createRolePage);
-        createRolePage.form().setName(roleName);
-        assertAlertWarning();
-        createRolePage.form().save();
-        assertAlertSuccess();
-        realmRolesPage.navigateTo();
-        assertNotNull(realmRolesPage.table().findRole("hellorole"));
-    }
-    
     @Test
     public void testAddExistingRole() {
         addRole(testRole);

--- a/themes/src/main/resources/theme/base/admin/resources/partials/client-role-detail.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/client-role-detail.html
@@ -17,7 +17,7 @@
                 <label class="col-md-2 control-label" for="name">{{:: 'role-name' | translate}} <span class="required" data-ng-show="create">*</span></label>
 
                 <div class="col-md-6">
-                    <input kc-no-reserved-chars class="form-control" type="text" id="name" name="name" data-ng-model="role.name" autofocus
+                    <input class="form-control" type="text" id="name" name="name" data-ng-model="role.name" autofocus
                            required data-ng-readonly="!create">
                 </div>
             </div>

--- a/themes/src/main/resources/theme/base/admin/resources/partials/role-detail.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/role-detail.html
@@ -14,7 +14,7 @@
                 <label class="col-md-2 control-label" for="name"><span class="required" data-ng-show="create">*</span> {{:: 'role-name' | translate}}</label>
 
                 <div class="col-md-6">
-                    <input kc-no-reserved-chars class="form-control" type="text" id="name" name="name" data-ng-model="role.name" autofocus
+                    <input class="form-control" type="text" id="name" name="name" data-ng-model="role.name" autofocus
                            required data-ng-readonly="!create">
                 </div>
             </div>

--- a/themes/src/main/resources/theme/base/admin/resources/templates/kc-provider-config.html
+++ b/themes/src/main/resources/theme/base/admin/resources/templates/kc-provider-config.html
@@ -19,7 +19,7 @@
         <div class="col-md-6" data-ng-if="option.type == 'Role'">
             <div class="row">
                 <div class="col-md-8">
-                    <input kc-no-reserved-chars class="form-control" type="text" data-ng-model="config[ option.name ]" >
+                    <input class="form-control" type="text" data-ng-model="config[ option.name ]" >
                 </div>
                 <div class="col-md-2">
                     <button type="button" data-ng-click="openRoleSelector(option.name, config)" class="btn btn-default" tooltip-placement="top" tooltip-trigger="mouseover mouseout" tooltip="{{:: 'selectRole.tooltip' | translate}}">{{:: 'selectRole.label' | translate}}</button>


### PR DESCRIPTION
This PR reverses (for Roles only) the changes from KEYCLOAK-12768 where special characters in entities like Realms and Flows would break the admin console.

However, several in the community have complained that special characters for Roles should be allowed as some special characters like colon and forward slash are commonly used.

For Roles, the only special character that actually causes a problem in the console is the semi-colon.  However, the error is rather benign.  You just get a link to go back and everything works properly.

We can fix the semi-colon issue later if we want, but it's a minor issue that has been present in the console for years so I don't think it's worth the effort.
