### PR TITLE
[KEYCLOAK-11784] - Not running part of the initilization code during startup

### DIFF
--- a/quarkus/extensions/src/main/java/org/keycloak/connections/liquibase/QuarkusJpaUpdaterProviderFactory.java
+++ b/quarkus/extensions/src/main/java/org/keycloak/connections/liquibase/QuarkusJpaUpdaterProviderFactory.java
@@ -48,7 +48,11 @@ public class QuarkusJpaUpdaterProviderFactory implements JpaUpdaterProviderFacto
 
     @Override
     public String getId() {
-        return "liquibase";
+        return "quarkus";
     }
 
+    @Override
+    public int order() {
+        return 100;
+    }
 }

--- a/quarkus/extensions/src/main/java/org/keycloak/connections/liquibase/QuarkusLiquibaseConnectionProvider.java
+++ b/quarkus/extensions/src/main/java/org/keycloak/connections/liquibase/QuarkusLiquibaseConnectionProvider.java
@@ -155,7 +155,7 @@ public class QuarkusLiquibaseConnectionProvider implements LiquibaseConnectionPr
 
     @Override
     public String getId() {
-        return "default";
+        return "quarkus";
     }
 
     @Override
@@ -185,5 +185,10 @@ public class QuarkusLiquibaseConnectionProvider implements LiquibaseConnectionPr
         logger.debugf("Using changelog file %s and changelogTableName %s", changelogLocation, database.getDatabaseChangeLogTableName());
 
         return new Liquibase(changelogLocation, resourceAccessor, database);
+    }
+
+    @Override
+    public int order() {
+        return 100;
     }
 }


### PR DESCRIPTION
Basically, avoid creating the master realm and not generating default key material during startup but when actually setting up the server at the welcome page. This is for the main dist.

For tests, the behavior is the same.

However, this is not yet all the changes I think we should be doing. They are:

* Avoid using the named query when fetching the migration model. It costs more than a single select to the database.
* Avoid running liquibase locks if the model is already initialized or we are not running in a clustered enviroment

Those should save us ~15% of the time.