### PR TITLE
KEYCLOAK-14178 Avoid erroneous HTML escaping in KeycloakServer

### DIFF
--- a/testsuite/utils/src/main/java/org/keycloak/testsuite/KeycloakServer.java
+++ b/testsuite/utils/src/main/java/org/keycloak/testsuite/KeycloakServer.java
@@ -401,16 +401,11 @@ public class KeycloakServer {
 
             di.setDefaultServletConfig(new DefaultServletConfig(true));
 
-            ServletInfo restEasyDispatcher = Servlets.servlet("Keycloak REST Interface", HttpServlet30Dispatcher.class);
-
-            restEasyDispatcher.addInitParam(ResteasyContextParameters.RESTEASY_SERVLET_MAPPING_PREFIX, "/");
-            restEasyDispatcher.addInitParam(ResteasyContextParameters.RESTEASY_DISABLE_HTML_SANITIZER, "true");
-            restEasyDispatcher.setAsyncSupported(true);
-
-            di.addServlet(restEasyDispatcher);
+            // Note that the ResteasyServlet is configured via server.undertowDeployment(...);
+            // KEYCLOAK-14178
+            deployment.setProperty(ResteasyContextParameters.RESTEASY_DISABLE_HTML_SANITIZER, true);
 
             FilterInfo filter = Servlets.filter("SessionFilter", TestKeycloakSessionServletFilter.class);
-
             filter.setAsyncSupported(true);
 
             di.addFilter(filter);

--- a/testsuite/utils/src/main/java/org/keycloak/testsuite/KeycloakServer.java
+++ b/testsuite/utils/src/main/java/org/keycloak/testsuite/KeycloakServer.java
@@ -25,6 +25,7 @@ import io.undertow.servlet.api.FilterInfo;
 import io.undertow.servlet.api.ServletInfo;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.plugins.server.servlet.HttpServlet30Dispatcher;
+import org.jboss.resteasy.plugins.server.servlet.ResteasyContextParameters;
 import org.jboss.resteasy.plugins.server.undertow.UndertowJaxrsServer;
 import org.jboss.resteasy.spi.ResteasyDeployment;
 import org.keycloak.common.Version;
@@ -402,7 +403,8 @@ public class KeycloakServer {
 
             ServletInfo restEasyDispatcher = Servlets.servlet("Keycloak REST Interface", HttpServlet30Dispatcher.class);
 
-            restEasyDispatcher.addInitParam("resteasy.servlet.mapping.prefix", "/");
+            restEasyDispatcher.addInitParam(ResteasyContextParameters.RESTEASY_SERVLET_MAPPING_PREFIX, "/");
+            restEasyDispatcher.addInitParam(ResteasyContextParameters.RESTEASY_DISABLE_HTML_SANITIZER, "true");
             restEasyDispatcher.setAsyncSupported(true);
 
             di.addServlet(restEasyDispatcher);


### PR DESCRIPTION
This PR disables the Resteasy HTML Sanitizer in KeycloakServer.
Previously KeycloakTest server erroneously escapes html in error pages.

See the linked JIRA issue for details.

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
