### PR TITLE
KEYCLOAK-14229 Add GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+name: Keycloak CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Cache Maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Build
+        run: mvn clean install -B -DskipTests -Pdistribution
+      - name: Tar Maven Repo
+        shell: bash
+        run: tar -czvf maven-repo.tgz -C ~ .m2/repository
+      - name: Persist Maven Repo
+        uses: actions/upload-artifact@v1
+        with:
+          name: maven-repo
+          path: maven-repo.tgz
+
+  test:
+    name: Test
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Download Maven Repo
+        uses: actions/download-artifact@v1
+        with:
+          name: maven-repo
+          path: .
+      - name: Extract Maven Repo
+        shell: bash
+        run: tar -xzvf maven-repo.tgz -C ~
+      - name: Build testsuite
+        run: mvn clean install -B -Pauth-server-wildfly -DskipTests -f testsuite/pom.xml
+      - name: Run base tests
+        run: mvn clean install -B -Pauth-server-wildfly -f testsuite/integration-arquillian/tests/base/pom.xml | misc/log/trimmer.sh; exit ${PIPESTATUS[0]}

--- a/misc/log/LogTrimmer.java
+++ b/misc/log/LogTrimmer.java
@@ -1,0 +1,52 @@
+import java.util.Scanner;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * A simple utility class for trimming test output (if successful).
+ *
+ * Created to shrink down the output for Travis.
+ *
+ * Created by st on 03/07/17.
+ */
+public class LogTrimmer {
+
+    private static Pattern TEST_START_PATTERN = Pattern.compile("(\\[INFO\\] )?Running (.*)");
+    private static int TEST_NAME_GROUP = 2;
+
+    public static void main(String[] args) {
+        try (Scanner scanner = new Scanner(System.in)) {
+            String testRunning = null;
+            String line = null;
+            Matcher testMatcher = null;
+            StringBuilder testText = new StringBuilder();
+
+            while (scanner.hasNextLine()) {
+                line = scanner.nextLine();
+                if (testRunning == null) {
+                    testMatcher = TEST_START_PATTERN.matcher(line);
+                    if (testMatcher.find()) {
+                        testRunning = testMatcher.group(TEST_NAME_GROUP);
+                        System.out.println(line);
+                    } else {
+                        System.out.println("-- " + line);
+                    }
+                } else {
+                    if (line.contains("Tests run:")) {
+                        if (!(line.contains("Failures: 0") && line.contains("Errors: 0"))) {
+                            System.out.println("--------- " + testRunning + " output start ---------");
+                            System.out.println(testText.toString());
+                            System.out.println("--------- " + testRunning + " output end  ---------");
+                        }
+                        System.out.println(line);
+                        testRunning = null;
+                        testText = new StringBuilder();
+                    } else {
+                        testText.append(testRunning.substring(testRunning.lastIndexOf('.') + 1) + " ++ " + line);
+                        testText.append("\n");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/misc/log/trimmer.sh
+++ b/misc/log/trimmer.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -e
+
+cd $(dirname $0)
+
+if [ ! -f "LogTrimmer.class" ]; then
+    javac LogTrimmer.java
+fi
+
+java LogTrimmer


### PR DESCRIPTION
GitHub Actions has a number of benefits to Travis, including:

* Doesn't kill jobs after 60 min of execution
* Doesn't have the same restriction on log size
* More parallel jobs (15 vs 5) and less waiting time in queues
* Faster machines (I don't have evidence for this, but it seems like they are significantly faster)
* Better caching, including ability to "save" artifacts from a workflow execution
* Has a whole bunch of nice actions that we can leverage, including ability to use it for more things from anything from adding automatic labels to PRs to doing the actual Keycloak release

I propose we migrate from Travis to GitHub Actions in stages. In this first attempt I'm running the whole base testsuite as one single workflow. It takes a while to execute, but since GitHub Actions has a shorter waiting time in the queue it still completes in less time than Travis.

We may want to break the base testsuite into multiple runs, but I don't like how we are doing it in Travis. Rather, it would be good to re-organize the testsuite into groups of tests like:

* OIDC
* SAML
* Core
* Database
* Federation
* ...

This would probably also make it easier for people to find the test and where to extend to add tests for new things.

The idea is to keep this running in parallell with Travis for a while until we are happy with it. We should also consider if we want to split the base testsuite into multiple steps, or perhaps instead use the parallell jobs for other things like admin console tests, etc.