### PR TITLE
KEYCLOAK-14225 Performance testsuite DataLoader broken

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,7 @@
         <infinispan.version>9.4.18.Final</infinispan.version>
         <jackson.version>2.10.1</jackson.version>
         <jackson.databind.version>${jackson.version}</jackson.databind.version>
+        <jackson.annotations.version>${jackson.databind.version}</jackson.annotations.version>
         <jakarta.mail.version>1.6.4</jakarta.mail.version>
         <jboss.logging.version>3.4.1.Final</jboss.logging.version>
         <jboss.logging.tools.version>2.2.1.Final</jboss.logging.tools.version>

--- a/testsuite/performance/tests/pom.xml
+++ b/testsuite/performance/tests/pom.xml
@@ -53,10 +53,6 @@
         <gatling-plugin.version>2.2.1</gatling-plugin.version>
         <scala-maven-plugin.version>3.2.2</scala-maven-plugin.version>
         <jboss-logging.version>3.3.0.Final</jboss-logging.version>
-        
-        <jackson.version>2.9.6</jackson.version>
-        <jackson.databind.version>${jackson.version}</jackson.databind.version>
-        <jackson.annotations.version>${jackson.databind.version}</jackson.annotations.version>
 
         <gatling.simulationClass>keycloak.OIDCLoginAndLogoutSimulation</gatling.simulationClass>
         <gatling.skip.run>true</gatling.skip.run>


### PR DESCRIPTION
- removing hardcoded `jackson.version` from performance testsuite pom
- moving `jackson.annotations.version` from performance testsuite pom to the root pom
