### PR TITLE
KEYCLOAK-13915 Update Jetty 9.4.x dependency to latest version

### DIFF
--- a/adapters/oidc/jetty/jetty9.4/src/main/java/org/keycloak/adapters/jetty/Jetty94SessionManager.java
+++ b/adapters/oidc/jetty/jetty9.4/src/main/java/org/keycloak/adapters/jetty/Jetty94SessionManager.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.adapters.jetty;
 
+import org.eclipse.jetty.server.session.Session;
 import org.eclipse.jetty.server.session.SessionHandler;
 import org.keycloak.adapters.jetty.spi.JettySessionManager;
 
@@ -34,7 +35,15 @@ public class Jetty94SessionManager implements JettySessionManager {
     }
 
     @Override
-    public HttpSession getHttpSession(String id) {
-        return sessionHandler.getHttpSession(id);
+    public HttpSession getHttpSession(String extendedId) {
+        // inlined code from sessionHandler.getHttpSession(extendedId) since the method visibility changed to protected
+
+        String id = sessionHandler.getSessionIdManager().getId(extendedId);
+        Session session = sessionHandler.getSession(id);
+
+        if (session != null && !session.getExtendedId().equals(extendedId)) {
+            session.setIdChanged(true);
+        }
+        return session;
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
         <elytron.undertow-server.version>1.7.1.Final</elytron.undertow-server.version>
         <jetty92.version>9.2.4.v20141103</jetty92.version>
         <jetty93.version>9.3.9.v20160517</jetty93.version>
-        <jetty94.version>9.4.2.v20170220</jetty94.version>
+        <jetty94.version>9.4.29.v20200521</jetty94.version>
         <woodstox.version>6.0.3</woodstox.version>
         <xmlsec.version>2.1.4</xmlsec.version>
         <glassfish.json.version>1.1.6</glassfish.json.version>


### PR DESCRIPTION
Adapted Jetty94SessionManager to workaround Jetty 9.4 API changes.
The Method org.eclipse.jetty.server.session.SessionHandler#getHttpSession
was changed from public to protected which makes it no longer accessible.

As a workaround the method contents were inlined.

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
