### PR TITLE
KEYCLOAK-9404 Add support for multiple variants of the same social identity provider

### DIFF
--- a/themes/src/main/resources/theme/base/admin/resources/js/controllers/realm.js
+++ b/themes/src/main/resources/theme/base/admin/resources/js/controllers/realm.js
@@ -1057,8 +1057,6 @@ module.controller('RealmIdentityProviderCtrl', function($scope, $filter, $upload
     
     $scope.configuredProviders = angular.copy(realm.identityProviders);
 
-    removeUsedSocial();
-    
     $scope.authFlows = [];
     for (var i=0 ; i<authFlows.length ; i++) {
         if (authFlows[i].providerId == 'basic-flow') {
@@ -1245,22 +1243,6 @@ module.controller('RealmIdentityProviderCtrl', function($scope, $filter, $upload
                 Notifications.success("The identity provider has been deleted.");
             });
         });
-    };
-    
-    // KEYCLOAK-5932: remove social providers that have already been defined
-    function removeUsedSocial() {
-        var i = $scope.allProviders.length;
-        while (i--) {
-            if ($scope.allProviders[i].groupName !== 'Social') continue;
-            if ($scope.configuredProviders != null) {
-                for (var j = 0; j < $scope.configuredProviders.length; j++) {
-                    if ($scope.configuredProviders[j].providerId === $scope.allProviders[i].id) {
-                        $scope.allProviders.splice(i, 1);
-                        break;
-                    }
-                }
-            }
-        }
     };
 
     if (instance && instance.alias) {

--- a/themes/src/main/resources/theme/base/admin/resources/partials/realm-identity-provider-bitbucket.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/realm-identity-provider-bitbucket.html
@@ -8,6 +8,7 @@
     <kc-tabs-identity-provider></kc-tabs-identity-provider>
 
     <form class="form-horizontal" name="realmForm" novalidate kc-read-only="!access.manageIdentityProviders">
+
         <fieldset>
             <div class="form-group clearfix">
                 <label class="col-md-2 control-label" for="redirectUri">{{:: 'redirect-uri' | translate}}</label>
@@ -17,6 +18,22 @@
                 <kc-tooltip>{{:: 'redirect-uri.tooltip' | translate}}</kc-tooltip>
             </div>
         </fieldset>
+
+        <div class="form-group clearfix">
+            <label class="col-md-2 control-label" for="identifier"><span class="required">*</span> {{:: 'alias' | translate}}</label>
+            <div class="col-md-6">
+                <input kc-no-reserved-chars class="form-control" id="identifier" type="text" ng-model="identityProvider.alias" data-ng-readonly="!newIdentityProvider" required>
+            </div>
+            <kc-tooltip>{{:: 'identity-provider.alias.tooltip' | translate}}</kc-tooltip>
+        </div>
+        <div class="form-group clearfix">
+            <label class="col-md-2 control-label" for="displayName"> {{:: 'display-name' | translate}}</label>
+            <div class="col-md-6">
+                <input class="form-control" id="displayName" type="text" ng-model="identityProvider.displayName">
+            </div>
+            <kc-tooltip>{{:: 'identity-provider.display-name.tooltip' | translate}}</kc-tooltip>
+        </div>
+
         <fieldset>
             <div class="form-group clearfix">
                 <label class="col-md-2 control-label" for="clientId"><span class="required">*</span> {{:: 'bitbucket-consumer-key' | translate}}</label>

--- a/themes/src/main/resources/theme/base/admin/resources/partials/realm-identity-provider-gitlab.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/realm-identity-provider-gitlab.html
@@ -17,6 +17,22 @@
                 <kc-tooltip>{{:: 'redirect-uri.tooltip' | translate}}</kc-tooltip>
             </div>
         </fieldset>
+
+        <div class="form-group clearfix">
+            <label class="col-md-2 control-label" for="identifier"><span class="required">*</span> {{:: 'alias' | translate}}</label>
+            <div class="col-md-6">
+                <input kc-no-reserved-chars class="form-control" id="identifier" type="text" ng-model="identityProvider.alias" data-ng-readonly="!newIdentityProvider" required>
+            </div>
+            <kc-tooltip>{{:: 'identity-provider.alias.tooltip' | translate}}</kc-tooltip>
+        </div>
+        <div class="form-group clearfix">
+            <label class="col-md-2 control-label" for="displayName"> {{:: 'display-name' | translate}}</label>
+            <div class="col-md-6">
+                <input class="form-control" id="displayName" type="text" ng-model="identityProvider.displayName">
+            </div>
+            <kc-tooltip>{{:: 'identity-provider.display-name.tooltip' | translate}}</kc-tooltip>
+        </div>
+
         <fieldset>
             <div class="form-group clearfix">
                 <label class="col-md-2 control-label" for="clientId"><span class="required">*</span> {{:: 'gitlab-application-id' | translate}}</label>

--- a/themes/src/main/resources/theme/base/admin/resources/partials/realm-identity-provider-social.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/realm-identity-provider-social.html
@@ -8,6 +8,8 @@
     <kc-tabs-identity-provider></kc-tabs-identity-provider>
 
     <form class="form-horizontal" name="realmForm" novalidate kc-read-only="!access.manageIdentityProviders">
+
+
         <fieldset>
             <div class="form-group clearfix">
                 <label class="col-md-2 control-label" for="redirectUri">{{:: 'redirect-uri' | translate}}</label>
@@ -18,6 +20,20 @@
             </div>
         </fieldset>
         <fieldset>
+            <div class="form-group clearfix">
+                <label class="col-md-2 control-label" for="identifier"><span class="required">*</span> {{:: 'alias' | translate}}</label>
+                <div class="col-md-6">
+                    <input kc-no-reserved-chars class="form-control" id="identifier" type="text" ng-model="identityProvider.alias" data-ng-readonly="!newIdentityProvider" required>
+                </div>
+                <kc-tooltip>{{:: 'identity-provider.alias.tooltip' | translate}}</kc-tooltip>
+            </div>
+            <div class="form-group clearfix">
+                <label class="col-md-2 control-label" for="displayName"> {{:: 'display-name' | translate}}</label>
+                <div class="col-md-6">
+                    <input class="form-control" id="displayName" type="text" ng-model="identityProvider.displayName">
+                </div>
+                <kc-tooltip>{{:: 'identity-provider.display-name.tooltip' | translate}}</kc-tooltip>
+            </div>
             <div class="form-group clearfix">
                 <label class="col-md-2 control-label" for="clientId"><span class="required">*</span> {{:: 'client-id' | translate}}</label>
                 <div class="col-md-6">

--- a/themes/src/main/resources/theme/base/admin/resources/partials/realm-identity-provider-social.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/realm-identity-provider-social.html
@@ -8,8 +8,6 @@
     <kc-tabs-identity-provider></kc-tabs-identity-provider>
 
     <form class="form-horizontal" name="realmForm" novalidate kc-read-only="!access.manageIdentityProviders">
-
-
         <fieldset>
             <div class="form-group clearfix">
                 <label class="col-md-2 control-label" for="redirectUri">{{:: 'redirect-uri' | translate}}</label>

--- a/themes/src/main/resources/theme/base/admin/resources/partials/realm-identity-provider.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/realm-identity-provider.html
@@ -46,6 +46,7 @@
                     <tr>
                         <th>{{:: 'name' | translate}}</th>
                         <th>{{:: 'provider' | translate}}</th>
+                        <th>{{:: 'alias' | translate}}</th>
                         <th>{{:: 'enabled' | translate}}</th>
                         <th>{{:: 'hidden' | translate}}</th>
                         <th>{{:: 'link-only-column' | translate}}</th>
@@ -63,6 +64,7 @@
                             </a>
                         </td>
                         <td>{{identityProvider.providerId}}</td>
+                        <td>{{identityProvider.alias}}</td>
                         <td translate="{{identityProvider.enabled}}"></td>
                         <td translate="{{identityProvider.config.hideOnLoginPage == 'true'}}"></td>
                         <td translate="{{identityProvider.linkOnly}}"></td>


### PR DESCRIPTION
This effectively reverts KEYCLOAK-5932 (removal of used social idp)
and allows to specify dedicated aliases and display names for
social IdPs.

This enables users to connect a realm with multiple social IdPs of
the same type, e.g. "google apps", with different configurations.

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
