### PR TITLE
KEYCLOAK-13819 SAML brokering with POST binding is broken by new SameSite policies

### DIFF
--- a/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
@@ -693,7 +693,7 @@ public class AuthenticationManager {
         logger.debugv("Expire {1} cookie .", AuthenticationSessionManager.AUTH_SESSION_ID);
 
         String oldPath = getOldCookiePath(realm, uriInfo);
-        expireCookie(realm, AuthenticationSessionManager.AUTH_SESSION_ID, oldPath, true, connection, null);
+        expireCookie(realm, AuthenticationSessionManager.AUTH_SESSION_ID, oldPath, true, connection, SameSiteAttributeValue.NONE);
     }
 
     protected static String getIdentityCookiePath(RealmModel realm, UriInfo uriInfo) {

--- a/services/src/main/java/org/keycloak/services/managers/AuthenticationSessionManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/AuthenticationSessionManager.java
@@ -19,6 +19,7 @@ package org.keycloak.services.managers;
 
 import org.jboss.logging.Logger;
 import org.keycloak.common.ClientConnection;
+import org.keycloak.common.util.ServerCookie.SameSiteAttributeValue;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
@@ -147,7 +148,7 @@ public class AuthenticationSessionManager {
         StickySessionEncoderProvider encoder = session.getProvider(StickySessionEncoderProvider.class);
         String encodedAuthSessionId = encoder.encodeSessionId(authSessionId);
 
-        CookieHelper.addCookie(AUTH_SESSION_ID, encodedAuthSessionId, cookiePath, null, null, -1, sslRequired, true);
+        CookieHelper.addCookie(AUTH_SESSION_ID, encodedAuthSessionId, cookiePath, null, null, -1, sslRequired, true, SameSiteAttributeValue.NONE);
 
         log.debugf("Set AUTH_SESSION_ID cookie with value %s", encodedAuthSessionId);
     }

--- a/services/src/main/java/org/keycloak/services/util/CookieHelper.java
+++ b/services/src/main/java/org/keycloak/services/util/CookieHelper.java
@@ -95,6 +95,16 @@ public class CookieHelper {
 
 
     public static Set<String> getCookieValue(String name) {
+        Set<String> ret = getInternalCookieValue(name);
+        if (ret.size() == 0) {
+            String legacy = name + LEGACY_COOKIE;
+            logger.debugv("Couldn't find any cookies with name '{0}', trying '{1}'", name, legacy);
+            ret = getInternalCookieValue(legacy);
+        }
+        return ret;
+    }
+
+    private static Set<String> getInternalCookieValue(String name) {
         HttpHeaders headers = Resteasy.getContextData(HttpHeaders.class);
 
         Set<String> cookiesVal = new HashSet<>();
@@ -134,7 +144,7 @@ public class CookieHelper {
         }
         else {
             String legacy = name + LEGACY_COOKIE;
-            logger.debugv("Couldn't find cookie {0}, trying {0}", name, legacy);
+            logger.debugv("Couldn't find cookie {0}, trying {1}", name, legacy);
             return cookies.get(legacy);
         }
     }

--- a/testsuite/integration-arquillian/servers/auth-server/undertow/src/main/java/org/keycloak/testsuite/arquillian/undertow/lb/SimpleUndertowLoadBalancer.java
+++ b/testsuite/integration-arquillian/servers/auth-server/undertow/src/main/java/org/keycloak/testsuite/arquillian/undertow/lb/SimpleUndertowLoadBalancer.java
@@ -40,7 +40,6 @@ import io.undertow.util.AttachmentKey;
 import io.undertow.util.Headers;
 import org.jboss.logging.Logger;
 import org.keycloak.common.util.reflections.Reflections;
-import org.keycloak.services.managers.AuthenticationSessionManager;
 import org.keycloak.testsuite.utils.tls.TLSUtils;
 
 import io.undertow.server.handlers.proxy.RouteIteratorFactory;
@@ -51,6 +50,9 @@ import org.xnio.OptionMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.StringTokenizer;
+
+import static org.keycloak.services.managers.AuthenticationSessionManager.AUTH_SESSION_ID;
+import static org.keycloak.services.util.CookieHelper.LEGACY_COOKIE;
 
 /**
  * Loadbalancer on embedded undertow. Supports sticky session over "AUTH_SESSION_ID" cookie and failover to different node when sticky node not available.
@@ -175,7 +177,7 @@ public class SimpleUndertowLoadBalancer {
     private HttpHandler createHandler() throws Exception {
 
         // TODO: configurable options if needed
-        String sessionCookieNames = AuthenticationSessionManager.AUTH_SESSION_ID;
+        String[] sessionIds = {AUTH_SESSION_ID, AUTH_SESSION_ID + LEGACY_COOKIE};
         int connectionsPerThread = 20;
         int problemServerRetry = 5; // In case of unavailable node, we will try to ping him every 5 seconds to check if it's back
         int maxTime = 3600000; // 1 hour for proxy request timeout, so we can debug the backend keycloak servers
@@ -190,7 +192,6 @@ public class SimpleUndertowLoadBalancer {
                 .setSoftMaxConnectionsPerThread(cachedConnectionsPerThread)
                 .setTtl(connectionIdleTimeout)
                 .setProblemServerRetry(problemServerRetry);
-        String[] sessionIds = sessionCookieNames.split(",");
         for (String id : sessionIds) {
             lb.addSessionCookieName(id);
         }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/cookies/CookieTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/cookies/CookieTest.java
@@ -49,6 +49,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.keycloak.services.managers.AuthenticationManager.KEYCLOAK_IDENTITY_COOKIE;
 import static org.keycloak.services.managers.AuthenticationManager.KEYCLOAK_SESSION_COOKIE;
+import static org.keycloak.services.managers.AuthenticationSessionManager.AUTH_SESSION_ID;
 import static org.keycloak.services.util.CookieHelper.LEGACY_COOKIE;
 import static org.keycloak.testsuite.admin.AbstractAdminTest.loadJson;
 import static org.keycloak.testsuite.util.URLAssert.assertCurrentUrlStartsWithLoginUrlOf;
@@ -174,9 +175,12 @@ public class CookieTest extends AbstractKeycloakTest {
         Cookie legacyIdentityCookie = driver.manage().getCookieNamed(KEYCLOAK_IDENTITY_COOKIE + LEGACY_COOKIE);
         Cookie sameSiteSessionCookie = driver.manage().getCookieNamed(KEYCLOAK_SESSION_COOKIE);
         Cookie legacySessionCookie = driver.manage().getCookieNamed(KEYCLOAK_SESSION_COOKIE + LEGACY_COOKIE);
+        Cookie sameSiteAuthSessionIdCookie = driver.manage().getCookieNamed(AUTH_SESSION_ID);
+        Cookie legacyAuthSessionIdCookie = driver.manage().getCookieNamed(AUTH_SESSION_ID + LEGACY_COOKIE);
 
         assertSameSiteCookies(sameSiteIdentityCookie, legacyIdentityCookie);
         assertSameSiteCookies(sameSiteSessionCookie, legacySessionCookie);
+        assertSameSiteCookies(sameSiteAuthSessionIdCookie, legacyAuthSessionIdCookie);
     }
 
     private void assertSameSiteCookies(Cookie sameSiteCookie, Cookie legacyCookie) {


### PR DESCRIPTION
Base testsuite run: https://keycloak-jenkins.com/job/universal-test-pipeline-server/1812/
Adapter tests: https://keycloak-jenkins.com/job/universal-test-pipeline-adapters/1409/
Some tests failed but none seem to be relevant to this change.

More comprehensive tests will be added as part of bigger task: https://issues.redhat.com/browse/KEYCLOAK-14235