### PR TITLE
KEYCLOAK-14289 OAuth Authorization Server Metadata for Token Revocation

### DIFF
--- a/core/src/main/java/org/keycloak/protocol/oidc/representations/OIDCConfigurationRepresentation.java
+++ b/core/src/main/java/org/keycloak/protocol/oidc/representations/OIDCConfigurationRepresentation.java
@@ -118,6 +118,15 @@ public class OIDCConfigurationRepresentation {
     @JsonProperty("tls_client_certificate_bound_access_tokens")
     private Boolean tlsClientCertificateBoundAccessTokens;
 
+    @JsonProperty("revocation_endpoint")
+    private String revocationEndpoint;
+
+    @JsonProperty("revocation_endpoint_auth_methods_supported")
+    private List<String> revocationEndpointAuthMethodsSupported;
+
+    @JsonProperty("revocation_endpoint_auth_signing_alg_values_supported")
+    private List<String> revocationEndpointAuthSigningAlgValuesSupported;
+
     protected Map<String, Object> otherClaims = new HashMap<String, Object>();
 
     public String getIssuer() {
@@ -345,6 +354,30 @@ public class OIDCConfigurationRepresentation {
 
     public void setTlsClientCertificateBoundAccessTokens(Boolean tlsClientCertificateBoundAccessTokens) {
         this.tlsClientCertificateBoundAccessTokens = tlsClientCertificateBoundAccessTokens;
+    }
+
+    public String getRevocationEndpoint() {
+        return revocationEndpoint;
+    }
+
+    public void setRevocationEndpoint(String revocationEndpoint) {
+        this.revocationEndpoint = revocationEndpoint;
+    }
+
+    public List<String> getRevocationEndpointAuthMethodsSupported() {
+        return revocationEndpointAuthMethodsSupported;
+    }
+
+    public void setRevocationEndpointAuthMethodsSupported(List<String> revocationEndpointAuthMethodsSupported) {
+        this.revocationEndpointAuthMethodsSupported = revocationEndpointAuthMethodsSupported;
+    }
+
+    public List<String> getRevocationEndpointAuthSigningAlgValuesSupported() {
+        return revocationEndpointAuthSigningAlgValuesSupported;
+    }
+
+    public void setRevocationEndpointAuthSigningAlgValuesSupported(List<String> revocationEndpointAuthSigningAlgValuesSupported) {
+        this.revocationEndpointAuthSigningAlgValuesSupported = revocationEndpointAuthSigningAlgValuesSupported;
     }
 
     @JsonAnyGetter

--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCWellKnownProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCWellKnownProvider.java
@@ -43,6 +43,7 @@ import org.keycloak.wellknown.WellKnownProvider;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 
+import java.net.URI;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
@@ -134,6 +135,14 @@ public class OIDCWellKnownProvider implements WellKnownProvider {
         // https://tools.ietf.org/html/draft-ietf-oauth-mtls-08#section-6.2
         config.setTlsClientCertificateBoundAccessTokens(true);
 
+        URI revocationEndpoint = frontendUriBuilder.clone().path(OIDCLoginProtocolService.class, "revoke")
+            .build(realm.getName(), OIDCLoginProtocol.LOGIN_PROTOCOL);
+        if (isHttps(revocationEndpoint)) {
+            config.setRevocationEndpoint(revocationEndpoint.toString());
+            config.setRevocationEndpointAuthMethodsSupported(getClientAuthMethodsSupported());
+            config.setRevocationEndpointAuthSigningAlgValuesSupported(getSupportedClientSigningAlgorithms(false));
+        }
+
         return config;
     }
 
@@ -199,5 +208,9 @@ public class OIDCWellKnownProvider implements WellKnownProvider {
             result.add("none");
         }
         return result;
+    }
+
+    private boolean isHttps(URI uri) {
+        return uri.getScheme().equals("https");
     }
 }


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/KEYCLOAK-14289

# Spec
- Add `revocation_endpoint`, `revocation_endpoint_auth_methods_supported`, and `revocation_endpoint_auth_signing_alg_values_supported` according to https://tools.ietf.org/html/rfc8414#section-2.
- Display them only if the protocol is HTTPS according to https://tools.ietf.org/html/rfc7009#section-2.
> If the host of the token revocation endpoint can also be reached over HTTP, then the server SHOULD also offer a revocation service at the corresponding HTTP URI, but it MUST NOT publish this URI as a token revocation endpoint. This ensures that tokens accidentally sent over HTTP will be revoked.
- The value of `revocation_endpoint_auth_methods_supported` and `revocation_endpoint_auth_signing_alg_values_supported` are the same as that of `token_endpoint_auth_methods_supported` and `token_endpoint_auth_signing_alg_values_supported`.