### PR TITLE
KEYCLOAK-14218 Fixes missing localization of date/time values

### DIFF
--- a/themes/src/main/resources-community/theme/base/admin/messages/admin-messages_de.properties
+++ b/themes/src/main/resources-community/theme/base/admin/messages/admin-messages_de.properties
@@ -21,6 +21,9 @@ false=Nein
 
 endpoints=Endpoints
 
+dateFormat=dd.MM.yyyy
+timeFormat=HH:mm:ss
+
 # Realm settings
 realm-detail.enabled.tooltip=Benutzer und Clients k\u00F6nnen das Realm nur verwenden, wenn es aktiviert ist
 #realm-detail.oidc-endpoints.tooltip=Shows the configuration of the OpenID Connect endpoints

--- a/themes/src/main/resources/theme/base/admin/messages/admin-messages_en.properties
+++ b/themes/src/main/resources/theme/base/admin/messages/admin-messages_en.properties
@@ -22,6 +22,10 @@ false=False
 
 endpoints=Endpoints
 
+# Angular date filter format strings: https://docs.angularjs.org/api/ng/filter/date
+dateFormat=shortDate
+timeFormat=mediumTime
+
 # Realm settings
 realm-detail.enabled.tooltip=Users and clients can only access a realm if it's enabled
 realm-detail.protocol-endpoints.tooltip=Shows the configuration of the protocol endpoints

--- a/themes/src/main/resources/theme/base/admin/resources/partials/client-initial-access.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/client-initial-access.html
@@ -38,8 +38,8 @@
         <tbody>
         <tr ng-repeat="ia in clientInitialAccess | filter:search2 | orderBy:'timestamp'">
             <td>{{ia.id}}</td>
-            <td>{{(ia.timestamp * 1000)|date:'shortDate'}}&nbsp;{{(ia.timestamp * 1000)|date:'mediumTime'}}</td>
-            <td><span data-ng-show="ia.expiration > 0">{{((ia.timestamp + ia.expiration) * 1000)|date:'shortDate'}}&nbsp;{{((ia.timestamp + ia.expiration) * 1000)|date:'mediumTime'}}</span></td>
+            <td>{{(ia.timestamp * 1000)|date:('dateFormat' | translate)}}&nbsp;{{(ia.timestamp * 1000)|date:('timeFormat' | translate)}}</td>
+            <td><span data-ng-show="ia.expiration > 0">{{((ia.timestamp + ia.expiration) * 1000)|date:('dateFormat' | translate)}}&nbsp;{{((ia.timestamp + ia.expiration) * 1000)|date:('timeFormat' | translate)}}</span></td>
             <td>{{ia.count}}</td>
             <td>{{ia.remainingCount}}</td>
             <td class="kc-action-cell" data-ng-click="remove(ia.id)">{{:: 'delete' | translate}}</td>

--- a/themes/src/main/resources/theme/base/admin/resources/partials/realm-events-admin.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/realm-events-admin.html
@@ -114,7 +114,7 @@
             </tfoot>
             <tbody>
                 <tr data-ng-repeat="event in events">
-                    <td>{{event.time|date:'shortDate'}}<br>{{event.time|date:'mediumTime'}}</td>
+                    <td>{{event.time|date:('dateFormat' | translate)}}<br>{{event.time|date:('timeFormat' | translate)}}</td>
                     <td data-ng-class="events-error">{{event.operationType}}</td>
                     <td data-ng-class="events-error">{{event.resourceType}}</td>
                     <td>{{event.resourcePath}}</td>

--- a/themes/src/main/resources/theme/base/admin/resources/partials/realm-events.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/realm-events.html
@@ -81,7 +81,7 @@
         </tfoot>
         <tbody>
             <tr ng-repeat="event in events">
-                <td>{{event.time|date:'shortDate'}}<br>{{event.time|date:'mediumTime'}}</td>
+                <td>{{event.time|date:('dateFormat' | translate)}}<br>{{event.time|date:('timeFormat' | translate)}}</td>
                 <td>{{event.type}}</td>
                 <td>
                     <table class="table table-striped table-bordered">

--- a/themes/src/main/resources/theme/base/admin/resources/partials/user-detail.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/user-detail.html
@@ -20,7 +20,7 @@
             <div class="form-group">
                 <label class="col-md-2 control-label"for="id">{{:: 'created-at' | translate}}</label>
                 <div class="col-md-6">
-                    {{user.createdTimestamp|date:'shortDate'}}&nbsp;{{user.createdTimestamp|date:'mediumTime'}}
+                    {{user.createdTimestamp|date:('dateFormat' | translate)}}&nbsp;{{user.createdTimestamp|date:('timeFormat' | translate)}}
                 </div>
             </div>
 


### PR DESCRIPTION
* Added two new messages `dateFormat` and `timeFormat` for supplying locale specific date and time formats.
* Piping these messages through Angular's `translate` filter and using the result as argument to Angular's `date` filter.
* Added messages for “en” locale which render date and time exactly as before.
* Added messages for “de” locale which render date and time as a German speaking user would expect.