### PR TITLE
KEYCLOAK-14318 Client Configuration Empty Root URL and relative Base URL is valid

### DIFF
--- a/services/src/main/java/org/keycloak/services/util/ResolveRelative.java
+++ b/services/src/main/java/org/keycloak/services/util/ResolveRelative.java
@@ -38,7 +38,7 @@ public class ResolveRelative {
     public static String resolveRelativeUri(String frontendUrl, String adminUrl, String rootUrl, String url) {
         if (url == null || !url.startsWith("/")) {
             return url;
-        } else if (rootUrl != null) {
+        } else if (rootUrl != null && !rootUrl.isEmpty()) {
             return resolveRootUrl(frontendUrl, adminUrl, rootUrl) + url;
         } else {
             return UriBuilder.fromUri(frontendUrl).replacePath(url).build().toString();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/ClientTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/ClientTest.java
@@ -116,6 +116,14 @@ public class ClientTest extends AbstractAdminTest {
         rep.setRootUrl(null);
         rep.setBaseUrl("invalid");
         createClientExpectingValidationError(rep, "Invalid URL in baseUrl");
+
+        rep.setRootUrl(null);
+        rep.setBaseUrl("/valid");
+        createClientExpectingSuccessfulClientCreation(rep);
+
+        rep.setRootUrl("");
+        rep.setBaseUrl("/valid");
+        createClientExpectingSuccessfulClientCreation(rep);
     }
 
     @Test
@@ -136,6 +144,14 @@ public class ClientTest extends AbstractAdminTest {
         ClientRepresentation stored = realm.clients().get(rep.getId()).toRepresentation();
         assertNull(stored.getRootUrl());
         assertNull(stored.getBaseUrl());
+
+        rep.setRootUrl(null);
+        rep.setBaseUrl("/valid");
+        updateClientExpectingSuccessfulClientUpdate(rep, null, "/valid");
+
+        rep.setRootUrl("");
+        rep.setBaseUrl("/valid");
+        updateClientExpectingSuccessfulClientUpdate(rep, "", "/valid");
     }
 
     private void createClientExpectingValidationError(ClientRepresentation rep, String expectedError) {
@@ -151,6 +167,16 @@ public class ClientTest extends AbstractAdminTest {
         response.close();
     }
 
+    private void createClientExpectingSuccessfulClientCreation(ClientRepresentation rep) {
+        Response response = realm.clients().create(rep);
+        assertEquals(201, response.getStatus());
+
+        String id = ApiUtil.getCreatedId(response);
+        realm.clients().get(id).remove();
+
+        response.close();
+    }
+
     private void updateClientExpectingValidationError(ClientRepresentation rep, String expectedError) {
         try {
             realm.clients().get(rep.getId()).update(rep);
@@ -162,6 +188,15 @@ public class ClientTest extends AbstractAdminTest {
             assertEquals("invalid_input", error.getError());
             assertEquals(expectedError, error.getErrorDescription());
         }
+    }
+
+    private void updateClientExpectingSuccessfulClientUpdate(ClientRepresentation rep, String expectedRootUrl, String expectedBaseUrl) {
+
+        realm.clients().get(rep.getId()).update(rep);
+
+        ClientRepresentation stored = realm.clients().get(rep.getId()).toRepresentation();
+        assertEquals(expectedRootUrl, stored.getRootUrl());
+        assertEquals(expectedBaseUrl, stored.getBaseUrl());
     }
 
     @Test


### PR DESCRIPTION
Hi,

please see Ticket https://issues.redhat.com/browse/KEYCLOAK-14318 to see how to reproduce the bug. With this change it's possible to enter an empty Root URL (empty string, null was an option before too) and a relative Base URL in a client configuration.

Kind regards
Benjamin