### PR TITLE
KEYCLOAK-14310 Added fix that considers Content-Type for data encoding

### DIFF
--- a/server-spi-private/pom.xml
+++ b/server-spi-private/pom.xml
@@ -92,4 +92,20 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!-- Include inner test classes in execution -->
+                    <excludes>
+                        <exclude/>
+                    </excludes>
+                    <!-- Surefire misses to pass on correct encoding to forked JVM, even though encoding is set correct. -->
+                    <argLine>-Dfile.encoding=UTF-8</argLine>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/server-spi-private/src/main/java/org/keycloak/broker/provider/util/SimpleHttp.java
+++ b/server-spi-private/src/main/java/org/keycloak/broker/provider/util/SimpleHttp.java
@@ -242,7 +242,7 @@ public class SimpleHttp {
     }
 
     private StringEntity getJsonEntity() throws IOException {
-        return new StringEntity(JsonSerialization.writeValueAsString(entity));
+        return new StringEntity(JsonSerialization.writeValueAsString(entity), ContentType.getByMimeType(headers.get("Content-Type")));
     }
 
     private UrlEncodedFormEntity getFormEntityFromParameter() throws IOException{

--- a/server-spi-private/src/main/java/org/keycloak/broker/provider/util/SimpleHttp.java
+++ b/server-spi-private/src/main/java/org/keycloak/broker/provider/util/SimpleHttp.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.Header;
 import org.apache.http.HeaderIterator;
 import org.apache.http.HttpEntity;
+import org.apache.http.HttpHeaders;
 import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.HttpClient;
@@ -204,8 +205,8 @@ public class SimpleHttp {
             if (params != null) {
                 ((HttpEntityEnclosingRequestBase) httpRequest).setEntity(getFormEntityFromParameter());
             } else if (entity != null) {
-                if (headers == null || !headers.containsKey("Content-Type")) {
-                    header("Content-Type", "application/json");
+                if (headers == null || !headers.containsKey(HttpHeaders.CONTENT_TYPE)) {
+                    header(HttpHeaders.CONTENT_TYPE, "application/json");
                 }
                 ((HttpEntityEnclosingRequestBase) httpRequest).setEntity(getJsonEntity());
             } else {
@@ -242,7 +243,7 @@ public class SimpleHttp {
     }
 
     private StringEntity getJsonEntity() throws IOException {
-        return new StringEntity(JsonSerialization.writeValueAsString(entity), ContentType.getByMimeType(headers.get("Content-Type")));
+        return new StringEntity(JsonSerialization.writeValueAsString(entity), ContentType.getByMimeType(headers.get(HttpHeaders.CONTENT_TYPE)));
     }
 
     private UrlEncodedFormEntity getFormEntityFromParameter() throws IOException{

--- a/server-spi-private/src/test/java/org/keycloak/broker/provider/util/SimpleHttpTest.java
+++ b/server-spi-private/src/test/java/org/keycloak/broker/provider/util/SimpleHttpTest.java
@@ -1,15 +1,26 @@
 package org.keycloak.broker.provider.util;
 
 import org.apache.http.HttpEntity;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpVersion;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.ResponseHandler;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.conn.ClientConnectionManager;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.message.BasicHttpResponse;
+import org.apache.http.params.HttpParams;
+import org.apache.http.protocol.HttpContext;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
+import org.keycloak.common.util.StreamUtil;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
@@ -19,6 +30,7 @@ import java.util.Collection;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.fail;
 
 /**
  * @author <a href="mailto:viruszold@gmail.com">Andrey Khlebnikov</a>
@@ -64,5 +76,102 @@ public final class SimpleHttpTest {
             response.setEntity(entity);
             return response;
         }
+
     }
+
+    @RunWith(Parameterized.class)
+    public static final class RequestConsideringEncodingTest {
+        private String value;
+
+        public RequestConsideringEncodingTest(String value) {
+            this.value = value;
+        }
+
+        @Parameters(name = "{index}: requestWithEncoding({0})")
+        public static Collection<Object[]> entities() {
+            return Arrays.asList(new Object[][] { { "English" }, { "Русский" }, { "GermanÜmläütß" } });
+        }
+
+        @Test
+        public void requestWithEncoding() throws IOException {
+            HttpClientMock client = new HttpClientMock();
+            SimpleHttp.doPost("", client).json(new DummyEntity(value)).asResponse();
+            assertEquals("{\"value\":\"" + value + "\"}", client.data);
+        }
+
+        public static final class DummyEntity {
+            public String value;
+            public DummyEntity(String value) {
+                this.value = value;
+            }
+        }
+
+        /**
+         * As no mocking framework is wanted, this is done the good old way.
+         */
+        public static final class HttpClientMock implements HttpClient {
+
+            String data;
+
+            @Override
+            public HttpParams getParams() {
+                fail(); return null;
+            }
+
+            @Override
+            public ClientConnectionManager getConnectionManager() {
+                fail(); return null;
+            }
+
+            @Override
+            public HttpResponse execute(HttpUriRequest paramHttpUriRequest) throws IOException, ClientProtocolException {
+                HttpPost post = (HttpPost) paramHttpUriRequest;
+                data = StreamUtil.readString(post.getEntity().getContent());
+                return null;
+            }
+
+            @Override
+            public HttpResponse execute(HttpUriRequest paramHttpUriRequest, HttpContext paramHttpContext)
+                    throws IOException, ClientProtocolException {
+                fail(); return null;
+            }
+
+            @Override
+            public HttpResponse execute(HttpHost paramHttpHost, HttpRequest paramHttpRequest) throws IOException, ClientProtocolException {
+                fail(); return null;
+            }
+
+            @Override
+            public HttpResponse execute(HttpHost paramHttpHost, HttpRequest paramHttpRequest, HttpContext paramHttpContext)
+                    throws IOException, ClientProtocolException {
+                fail(); return null;
+            }
+
+            @Override
+            public <T> T execute(HttpUriRequest paramHttpUriRequest, ResponseHandler<? extends T> paramResponseHandler)
+                    throws IOException, ClientProtocolException {
+                fail(); return null;
+            }
+
+            @Override
+            public <T> T execute(HttpUriRequest paramHttpUriRequest, ResponseHandler<? extends T> paramResponseHandler,
+                    HttpContext paramHttpContext) throws IOException, ClientProtocolException {
+                fail(); return null;
+            }
+
+            @Override
+            public <T> T execute(HttpHost paramHttpHost, HttpRequest paramHttpRequest, ResponseHandler<? extends T> paramResponseHandler)
+                    throws IOException, ClientProtocolException {
+                fail(); return null;
+            }
+
+            @Override
+            public <T> T execute(HttpHost paramHttpHost, HttpRequest paramHttpRequest, ResponseHandler<? extends T> paramResponseHandler,
+                    HttpContext paramHttpContext) throws IOException, ClientProtocolException {
+                fail(); return null;
+            }
+
+        }
+    }
+
 }


### PR DESCRIPTION
KEYCLOAK-14310
Added fix that considers Content-Type for data encoding and added corresponding test

A Unit Test was added because creating a suitable integration test would cause a non corresponding effort. The test was aligned with the existing test for this class which addresses a similar issue with encoding. The modifications to the pom are needed because surefire by default does not pick up the tests in inner classes. This prevented the existing test from being executed in maven builds. Additionally surefire has problems picking up the encoding in the forked JVM, even though the surefire encoding is set correct to UTF-8 in the build.