### PR TITLE
[KEYCLOAK-13877] - ConcurrentTransactionsTest failed

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/UserAttributeEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/UserAttributeEntity.java
@@ -36,6 +36,7 @@ import javax.persistence.Table;
  * @version $Revision: 1 $
  */
 @NamedQueries({
+        @NamedQuery(name="getUserAttributeIdByNameAndUser",query = "select attr.id from UserAttributeEntity attr where attr.user.id = :userId and attr.name = :name"),
         @NamedQuery(name="deleteUserAttributesByRealm", query="delete from  UserAttributeEntity attr where attr.user IN (select u from UserEntity u where u.realmId=:realmId)"),
         @NamedQuery(name="deleteUserAttributesByNameAndUser", query="delete from  UserAttributeEntity attr where attr.user.id = :userId and attr.name = :name"),
         @NamedQuery(name="deleteUserAttributesByNameAndUserOtherThan", query="delete from  UserAttributeEntity attr where attr.user.id = :userId and attr.name = :name and attr.id <> :attrId"),


### PR DESCRIPTION
ConcurrentTransactionsTest failed with OptimisticLockException
JIRA: [KEYCLOAK-13877](https://issues.redhat.com/browse/KEYCLOAK-13877)

The managing of `OptimisticLockException` is always very problematic. 
In the test, there are two places, where can be the exception thrown. 
Some attribute is removed and then set up. 
Like in [`setAttribute`](https://github.com/keycloak/keycloak/blob/0870041b0bf261fc062a23c46765b63b8fcb1197/model/jpa/src/main/java/org/keycloak/models/jpa/UserAdapter.java#L151) method, the attribute is removed and then created a new one. In `setSingleAttribute` method, it should be the same. 

There is used conditional query, which can be more efficient than getting and filtering of all attributes. 
 The operations are faster, hence it should avoid collision of transactions. 
The test was successfully concurrently executed with more than 40 threads.

Purpose of this PR might be resolved, but for the future, there should be discussed approach for managing of `OptimisticLockException`.