### PR TITLE
KEYCLOAK-14394 Update to WebAuthn4J 0.12.0.RELEASE

### DIFF
--- a/distribution/feature-packs/server-feature-pack/src/main/resources/licenses/keycloak/licenses.xml
+++ b/distribution/feature-packs/server-feature-pack/src/main/resources/licenses/keycloak/licenses.xml
@@ -521,22 +521,22 @@
     <dependency>
       <groupId>com.webauthn4j</groupId>
       <artifactId>webauthnj4-core</artifactId>
-      <version>0.10.2.RELEASE</version>
+      <version>0.12.0.RELEASE</version>
       <licenses>
         <license>
           <name>Apache Software License 2.0</name>
-          <url>https://raw.githubusercontent.com/webauthn4j/webauthn4j/0.10.2.RELEASE/LICENSE.txt</url>
+          <url>https://raw.githubusercontent.com/webauthn4j/webauthn4j/0.12.0.RELEASE/LICENSE.txt</url>
         </license>
       </licenses>
     </dependency>
     <dependency>
       <groupId>com.webauthn4j</groupId>
       <artifactId>webauthnj4-util</artifactId>
-      <version>0.10.2.RELEASE</version>
+      <version>0.12.0.RELEASE</version>
       <licenses>
         <license>
           <name>Apache Software License 2.0</name>
-          <url>https://raw.githubusercontent.com/webauthn4j/webauthn4j/0.10.2.RELEASE/LICENSE.txt</url>
+          <url>https://raw.githubusercontent.com/webauthn4j/webauthn4j/0.12.0.RELEASE/LICENSE.txt</url>
         </license>
       </licenses>
     </dependency>

--- a/distribution/feature-packs/server-feature-pack/src/main/resources/licenses/rh-sso/licenses.xml
+++ b/distribution/feature-packs/server-feature-pack/src/main/resources/licenses/rh-sso/licenses.xml
@@ -525,7 +525,7 @@
       <licenses>
         <license>
           <name>Apache Software License 2.0</name>
-          <url>https://raw.githubusercontent.com/webauthn4j/webauthn4j/0.10.2.RELEASE/LICENSE.txt</url>
+          <url>https://raw.githubusercontent.com/webauthn4j/webauthn4j/0.12.0.RELEASE/LICENSE.txt</url>
         </license>
       </licenses>
     </dependency>
@@ -536,7 +536,7 @@
       <licenses>
         <license>
           <name>Apache Software License 2.0</name>
-          <url>https://raw.githubusercontent.com/webauthn4j/webauthn4j/0.10.2.RELEASE/LICENSE.txt</url>
+          <url>https://raw.githubusercontent.com/webauthn4j/webauthn4j/0.12.0.RELEASE/LICENSE.txt</url>
         </license>
       </licenses>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,7 @@
         <spring-boot22.version>2.2.0.RELEASE</spring-boot22.version>
 
         <!-- webauthn support -->
-        <webauthn4j.version>0.10.2.RELEASE</webauthn4j.version>
+        <webauthn4j.version>0.12.0.RELEASE</webauthn4j.version>
         <org.apache.kerby.kerby-asn1.version>2.0.0</org.apache.kerby.kerby-asn1.version>
 
     </properties>

--- a/services/src/main/java/org/keycloak/authentication/requiredactions/WebAuthnRegister.java
+++ b/services/src/main/java/org/keycloak/authentication/requiredactions/WebAuthnRegister.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 
+import com.webauthn4j.WebAuthnRegistrationManager;
 import org.jboss.logging.Logger;
 import org.keycloak.WebAuthnConstants;
 import org.keycloak.authentication.CredentialRegistrator;
@@ -42,8 +43,6 @@ import org.keycloak.credential.WebAuthnCredentialProviderFactory;
 import org.keycloak.crypto.Algorithm;
 import org.keycloak.events.Details;
 import org.keycloak.events.Errors;
-import org.keycloak.forms.login.LoginFormsProvider;
-import org.keycloak.models.Constants;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.WebAuthnPolicy;
@@ -68,7 +67,6 @@ import com.webauthn4j.validator.attestation.statement.packed.PackedAttestationSt
 import com.webauthn4j.validator.attestation.statement.tpm.TPMAttestationStatementValidator;
 import com.webauthn4j.validator.attestation.statement.u2f.FIDOU2FAttestationStatementValidator;
 import com.webauthn4j.validator.attestation.trustworthiness.certpath.CertPathTrustworthinessValidator;
-import com.webauthn4j.validator.attestation.trustworthiness.ecdaa.DefaultECDAATrustworthinessValidator;
 import com.webauthn4j.validator.attestation.trustworthiness.self.DefaultSelfAttestationTrustworthinessValidator;
 import org.keycloak.models.credential.WebAuthnCredentialModel;
 
@@ -208,12 +206,12 @@ public class WebAuthnRegister implements RequiredActionProvider, CredentialRegis
         RegistrationRequest registrationRequest = new RegistrationRequest(attestationObject, clientDataJSON);
         RegistrationParameters registrationParameters = new RegistrationParameters(serverProperty, isUserVerificationRequired);
 
-        WebAuthnManager webAuthnManager = createWebAuthnManager();
+        WebAuthnRegistrationManager webAuthnRegistrationManager = createWebAuthnRegistrationManager();
         try {
             // parse
-            RegistrationData registrationData = webAuthnManager.parse(registrationRequest);
+            RegistrationData registrationData = webAuthnRegistrationManager.parse(registrationRequest);
             // validate
-            webAuthnManager.validate(registrationData, registrationParameters);
+            webAuthnRegistrationManager.validate(registrationData, registrationParameters);
 
             showInfoAfterWebAuthnApiCreate(registrationData);
 
@@ -252,8 +250,8 @@ public class WebAuthnRegister implements RequiredActionProvider, CredentialRegis
         }
     }
 
-    private WebAuthnManager createWebAuthnManager() {
-        return new WebAuthnManager(
+    private WebAuthnRegistrationManager createWebAuthnRegistrationManager() {
+        return new WebAuthnRegistrationManager(
                 Arrays.asList(
                         new NoneAttestationStatementValidator(),
                         new PackedAttestationStatementValidator(),
@@ -262,10 +260,8 @@ public class WebAuthnRegister implements RequiredActionProvider, CredentialRegis
                         new AndroidSafetyNetAttestationStatementValidator(),
                         new FIDOU2FAttestationStatementValidator()
                 ), this.certPathtrustValidator,
-                new DefaultECDAATrustworthinessValidator(),
                 new DefaultSelfAttestationTrustworthinessValidator(),
                 Collections.emptyList(), // Custom Registration Validator is not supported
-                Collections.emptyList(), // Custom Authentication Validator is not supported
                 new ObjectConverter()
                 );
     }

--- a/services/src/main/java/org/keycloak/credential/WebAuthnCredentialProvider.java
+++ b/services/src/main/java/org/keycloak/credential/WebAuthnCredentialProvider.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import com.webauthn4j.WebAuthnAuthenticationManager;
 import com.webauthn4j.converter.util.ObjectConverter;
 import org.jboss.logging.Logger;
 import org.keycloak.authentication.requiredactions.WebAuthnRegisterFactory;
@@ -167,7 +168,7 @@ public class WebAuthnCredentialProvider implements CredentialProvider<WebAuthnCr
         WebAuthnCredentialModelInput context = WebAuthnCredentialModelInput.class.cast(input);
         List<WebAuthnCredentialModelInput> auths = getWebAuthnCredentialModelList(realm, user);
 
-        WebAuthnManager webAuthnManager = WebAuthnManager.createNonStrictWebAuthnManager(); // not special setting is needed for authentication's validation.
+        WebAuthnAuthenticationManager webAuthnAuthenticationManager = new WebAuthnAuthenticationManager();
         AuthenticationData authenticationData = null;
 
         try {
@@ -182,14 +183,14 @@ public class WebAuthnCredentialProvider implements CredentialProvider<WebAuthnCr
                     );
 
                     // parse
-                    authenticationData = webAuthnManager.parse(context.getAuthenticationRequest());
+                    authenticationData = webAuthnAuthenticationManager.parse(context.getAuthenticationRequest());
                     // validate
                     AuthenticationParameters authenticationParameters = new AuthenticationParameters(
                             context.getAuthenticationParameters().getServerProperty(),
                             authenticator,
                             context.getAuthenticationParameters().isUserVerificationRequired()
                     );
-                    webAuthnManager.validate(authenticationData, authenticationParameters);
+                    webAuthnAuthenticationManager.validate(authenticationData, authenticationParameters);
 
 
                     logger.debugv("response.getAuthenticatorData().getFlags() = {0}", authenticationData.getAuthenticatorData().getFlags());


### PR DESCRIPTION
Adresses https://issues.redhat.com/browse/KEYCLOAK-14394

Update to WebAuthn4J 0.12.0.RELEASE.

Replace `WebAuthnManager` with `WebAuthnAuthenticationManager` and `WebAuthnRegistrationManager`, which are introduced in 0.12.0.RELEASE.
Originally `WebAuthnManager` is intended that its instance is shared between registration processing and authentication processing, but the design doesn't fit the case like Keycloak, `WebAuthnAuthenticationManager` and `WebAuthnRegistrationManager` are introduced.