### PR TITLE
KEYCLOAK-14370 Client selection shortcut

### DIFF
--- a/themes/src/main/resources/theme/base/admin/resources/js/services.js
+++ b/themes/src/main/resources/theme/base/admin/resources/js/services.js
@@ -886,15 +886,11 @@ module.factory('RoleClientComposites', function($resource) {
 
 function clientSelectControl($scope, realm, Client) {
     $scope.clientsUiSelect = {
-        minimumInputLength: 1,
+        minimumInputLength: 0,
         delay: 500,
         allowClear: true,
         query: function (query) {
             var data = {results: []};
-            if ('' == query.term.trim()) {
-                query.callback(data);
-                return;
-            }
             Client.query({realm: realm, search: true, clientId: query.term.trim(), max: 20}, function(response) {
                 data.results = response;
                 query.callback(data);


### PR DESCRIPTION
We had a customer complaint about the changed client selection, e.g. in the user role mapping dialog.

We have very little additional clients. Hence, for us, it doesn't make sense to enter at least a single search character (and this is now required in order see something at all) before the client list is displayed and can be used to see whatever depends on it (e.g. client roles).

For me and when searching for a client role where I don't know the clients name, the changed behavior often leads to the workflow that I start with the most commonly used letter "e", check if I can "find the requested role in the client list" and continue with the other less probable letters if my search wasn't successful.

Hence, we tried to work around this by disabling the minimum character count condition from 1 to 0 (as part of a custom theme). This works perfectly for us. We would like to contribute this to the official Keycloak.