### PR TITLE
KEYCLOAK-14235 Support for running broker tests with different hostnames for auth server and IdP

### DIFF
--- a/testsuite/integration-arquillian/HOW-TO-RUN.md
+++ b/testsuite/integration-arquillian/HOW-TO-RUN.md
@@ -974,3 +974,22 @@ Run tests using the `auth-server-quarkus` profile:
 Right now, the server runs in a separate process. To debug the server set `auth.server.debug` system property to `true`.
 
 To configure the debugger port, set the `auth.server.debug.port` system property with any valid port number. Default is `5005`. 
+
+## Cookies testing
+In order to reproduce some specific cookies behaviour in browsers (like SameSite policies or 3rd party cookie blocking),
+some subset of tests needs to be ran with different hosts for auth server and app/IdP server in order to simulate third
+party contexts. Those hosts must be different from localhost as that host has some special treatment from browsers. At
+the same time both hosts must use different domains to be considered cross-origin, e.g. `127.0.0.1.nip.io` and
+`127.0.0.1.xip.io`. NOT `app1.127.0.0.1.nip.io` and `app2.127.0.0.1.nip.io`!!
+
+Also, those new cookies policies are currently not yet enabled by default (which will change in the near future). To test
+those policies, you need the latest stable Firefox together with `firefox-strict-cookies` profile. This profile sets the
+browser to Firefox, configures the proper cookies behavior and makes Firefox to run in the headless mode (which is ok
+because this is not UI testing). For debugging purposes you can override the headless mode with `-DfirefoxHeadless=false`. 
+
+**Broker tests:**
+
+    mvn clean install -f testsuite/integration-arquillian/tests/base \
+                      -Pfirefox-strict-cookies \
+                      -Dtest=**.broker.** \
+                      -Dauth.server.host=[some_host] -Dauth.server.host2=[some_other_host]

--- a/testsuite/integration-arquillian/tests/base/pom.xml
+++ b/testsuite/integration-arquillian/tests/base/pom.xml
@@ -197,6 +197,7 @@
                                         <include>password-blacklists/**</include>
                                         <include>log4j.properties</include>
                                         <include>vault/**</include>
+                                        <include>firefox-cookies-prefs.js</include>
                                     </includes>
                                     <!--<filtering>true</filtering>-->
                                 </resource>

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/LoginExpiredPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/LoginExpiredPage.java
@@ -20,6 +20,8 @@ package org.keycloak.testsuite.pages;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 
+import static org.keycloak.testsuite.util.UIUtils.clickLink;
+
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
  */
@@ -33,11 +35,11 @@ public class LoginExpiredPage extends AbstractPage {
 
 
     public void clickLoginRestartLink() {
-        loginRestartLink.click();
+        clickLink(loginRestartLink);
     }
 
     public void clickLoginContinueLink() {
-        loginContinueLink.click();
+        clickLink(loginContinueLink);
     }
 
 

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/LoginPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/LoginPage.java
@@ -85,26 +85,26 @@ public class LoginPage extends LanguageComboboxAwarePage {
         passwordInput.clear();
         passwordInput.sendKeys(password);
 
-        submitButton.click();
+        clickLink(submitButton);
     }
 
     public void login(String password) {
         passwordInput.clear();
         passwordInput.sendKeys(password);
 
-        submitButton.click();
+        clickLink(submitButton);
     }
 
     public void missingPassword(String username) {
         usernameInput.clear();
         usernameInput.sendKeys(username);
         passwordInput.clear();
-        submitButton.click();
+        clickLink(submitButton);
 
     }
     public void missingUsername() {
         usernameInput.clear();
-        submitButton.click();
+        clickLink(submitButton);
 
     }
 
@@ -164,11 +164,11 @@ public class LoginPage extends LanguageComboboxAwarePage {
     }
 
     public void resetPassword() {
-        resetPasswordLink.click();
+        clickLink(resetPasswordLink);
     }
 
     public void recoverUsername() {
-        recoverUsernameLink.click();
+        clickLink(recoverUsernameLink);
     }
 
     public void setRememberMe(boolean enable) {

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/UpdateAccountInformationPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/UpdateAccountInformationPage.java
@@ -3,6 +3,8 @@ package org.keycloak.testsuite.pages;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 
+import static org.keycloak.testsuite.util.UIUtils.clickLink;
+
 public class UpdateAccountInformationPage extends LanguageComboboxAwarePage {
 
     @FindBy(id = "username")
@@ -36,7 +38,7 @@ public class UpdateAccountInformationPage extends LanguageComboboxAwarePage {
         lastNameInput.clear();
         lastNameInput.sendKeys(lastName);
 
-        submitButton.click();
+        clickLink(submitButton);
     }
 
     public void updateAccountInformation(String email,
@@ -51,7 +53,7 @@ public class UpdateAccountInformationPage extends LanguageComboboxAwarePage {
         lastNameInput.clear();
         lastNameInput.sendKeys(lastName);
 
-        submitButton.click();
+        clickLink(submitButton);
     }
 
     public void updateAccountInformation(String firstName,
@@ -62,7 +64,7 @@ public class UpdateAccountInformationPage extends LanguageComboboxAwarePage {
         lastNameInput.clear();
         lastNameInput.sendKeys(lastName);
 
-        submitButton.click();
+        clickLink(submitButton);
     }
 
     @Override

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/AccountBrokerTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/AccountBrokerTest.java
@@ -35,7 +35,6 @@ import org.keycloak.testsuite.util.UserBuilder;
 
 import javax.ws.rs.core.Response;
 
-import java.util.Collections;
 import java.util.List;
 
 import static org.keycloak.testsuite.admin.ApiUtil.createUserWithAdminClient;
@@ -76,13 +75,13 @@ public class AccountBrokerTest extends AbstractBaseBrokerTest {
         log.debug("adding identity provider to realm " + bc.consumerRealmName());
 
         RealmResource realm = adminClient.realm(bc.consumerRealmName());
-        realm.identityProviders().create(bc.setUpIdentityProvider(suiteContext)).close();
+        realm.identityProviders().create(bc.setUpIdentityProvider()).close();
         realm.identityProviders().get(bc.getIDPAlias());
     }
 
     @Before
     public void addClients() {
-        List<ClientRepresentation> clients = bc.createProviderClients(suiteContext);
+        List<ClientRepresentation> clients = bc.createProviderClients();
         if (clients != null) {
             RealmResource providerRealm = adminClient.realm(bc.providerRealmName());
             for (ClientRepresentation client : clients) {
@@ -97,7 +96,7 @@ public class AccountBrokerTest extends AbstractBaseBrokerTest {
             }
         }
 
-        clients = bc.createConsumerClients(suiteContext);
+        clients = bc.createConsumerClients();
         if (clients != null) {
             RealmResource consumerRealm = adminClient.realm(bc.consumerRealmName());
             for (ClientRepresentation client : clients) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/BrokerLinkAndTokenExchangeTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/BrokerLinkAndTokenExchangeTest.java
@@ -312,7 +312,7 @@ public class BrokerLinkAndTokenExchangeTest extends AbstractServletsAdapterTest 
     }
 
     public void createParentChild() {
-        BrokerTestTools.createKcOidcBroker(adminClient, CHILD_IDP, PARENT_IDP, suiteContext);
+        BrokerTestTools.createKcOidcBroker(adminClient, CHILD_IDP, PARENT_IDP);
     }
 
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/ClientInitiatedAccountLinkTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/ClientInitiatedAccountLinkTest.java
@@ -197,7 +197,7 @@ public class ClientInitiatedAccountLinkTest extends AbstractServletsAdapterTest 
     }
 
     public void createParentChild() {
-        BrokerTestTools.createKcOidcBroker(adminClient, CHILD_IDP, PARENT_IDP, suiteContext);
+        BrokerTestTools.createKcOidcBroker(adminClient, CHILD_IDP, PARENT_IDP);
     }
 
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractBrokerTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractBrokerTest.java
@@ -21,6 +21,8 @@ import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.keycloak.models.utils.DefaultAuthenticationFlows.IDP_REVIEW_PROFILE_CONFIG_ALIAS;
+import static org.keycloak.testsuite.broker.BrokerTestTools.getConsumerRoot;
+import static org.keycloak.testsuite.broker.BrokerTestTools.getProviderRoot;
 import static org.keycloak.testsuite.broker.BrokerTestTools.waitForPage;
 
 /**
@@ -46,7 +48,7 @@ public abstract class AbstractBrokerTest extends AbstractInitializedBaseBrokerTe
     }
 
     protected void loginUser() {
-        driver.navigate().to(getAccountUrl(bc.consumerRealmName()));
+        driver.navigate().to(getAccountUrl(getConsumerRoot(), bc.consumerRealmName()));
 
         logInWithBroker(bc);
 
@@ -84,7 +86,7 @@ public abstract class AbstractBrokerTest extends AbstractInitializedBaseBrokerTe
 
         Integer userCount = adminClient.realm(bc.consumerRealmName()).users().count();
 
-        driver.navigate().to(getAccountUrl(bc.consumerRealmName()));
+        driver.navigate().to(getAccountUrl(getConsumerRoot(), bc.consumerRealmName()));
         logInWithBroker(bc);
 
         assertEquals(accountPage.buildUri().toASCIIString().replace("master", "consumer") + "/", driver.getCurrentUrl());
@@ -95,15 +97,15 @@ public abstract class AbstractBrokerTest extends AbstractInitializedBaseBrokerTe
     protected void testSingleLogout() {
         log.debug("Testing single log out");
 
-        driver.navigate().to(getAccountUrl(bc.providerRealmName()));
+        driver.navigate().to(getAccountUrl(getProviderRoot(), bc.providerRealmName()));
 
         Assert.assertTrue("Should be logged in the account page", driver.getTitle().endsWith("Account Management"));
 
-        logoutFromRealm(bc.providerRealmName());
+        logoutFromRealm(getProviderRoot(), bc.providerRealmName());
 
         Assert.assertTrue("Should be on " + bc.providerRealmName() + " realm", driver.getCurrentUrl().contains("/auth/realms/" + bc.providerRealmName()));
 
-        driver.navigate().to(getAccountUrl(bc.consumerRealmName()));
+        driver.navigate().to(getAccountUrl(getConsumerRoot(), bc.consumerRealmName()));
 
         Assert.assertTrue("Should be on " + bc.consumerRealmName() + " realm on login page",
                 driver.getCurrentUrl().contains("/auth/realms/" + bc.consumerRealmName() + "/protocol/openid-connect/"));

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractIdentityProviderMapperTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractIdentityProviderMapperTest.java
@@ -3,14 +3,12 @@ package org.keycloak.testsuite.broker;
 import org.junit.Before;
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.admin.client.resource.UsersResource;
-import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.IdentityProviderRepresentation;
 import org.keycloak.representations.idm.MappingsRepresentation;
 import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.testsuite.util.UserBuilder;
 
-import javax.ws.rs.core.Response;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -39,7 +37,7 @@ public abstract class AbstractIdentityProviderMapperTest extends AbstractBaseBro
     protected IdentityProviderRepresentation setupIdentityProvider() {
         log.debug("adding identity provider to realm " + bc.consumerRealmName());
 
-        final IdentityProviderRepresentation idp = bc.setUpIdentityProvider(suiteContext);
+        final IdentityProviderRepresentation idp = bc.setUpIdentityProvider();
         realm.identityProviders().create(idp).close();
         return idp;
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractInitializedBaseBrokerTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractInitializedBaseBrokerTest.java
@@ -55,7 +55,7 @@ public abstract class AbstractInitializedBaseBrokerTest extends AbstractBaseBrok
 
         log.debug("adding identity provider to realm " + bc.consumerRealmName());
         RealmResource realm = adminClient.realm(bc.consumerRealmName());
-        realm.identityProviders().create(bc.setUpIdentityProvider(suiteContext)).close();
+        realm.identityProviders().create(bc.setUpIdentityProvider()).close();
         identityProviderResource = realm.identityProviders().get(bc.getIDPAlias());
 
         addClientsToProviderAndConsumer();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractRoleMapperTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractRoleMapperTest.java
@@ -3,6 +3,8 @@ package org.keycloak.testsuite.broker;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
+import static org.keycloak.testsuite.broker.BrokerTestTools.getConsumerRoot;
+import static org.keycloak.testsuite.util.WaitUtils.pause;
 
 import java.util.Collections;
 import java.util.List;
@@ -13,6 +15,7 @@ import org.keycloak.models.IdentityProviderMapperSyncMode;
 import org.keycloak.representations.idm.IdentityProviderRepresentation;
 import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
+import org.openqa.selenium.firefox.FirefoxDriver;
 
 /**
  * @author hmlnarik,
@@ -52,7 +55,7 @@ public abstract class AbstractRoleMapperTest extends AbstractIdentityProviderMap
         if (createAfterFirstLogin) {
             createMapperInIdp(idp, syncMode);
         }
-        logoutFromRealm(bc.consumerRealmName());
+        logoutFromRealm(getConsumerRoot(), bc.consumerRealmName());
 
         updateUser();
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractUserAttributeMapperTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractUserAttributeMapperTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
+import static org.keycloak.testsuite.broker.BrokerTestTools.getConsumerRoot;
 
 import java.util.List;
 import java.util.Map;
@@ -108,7 +109,7 @@ public abstract class AbstractUserAttributeMapperTest extends AbstractIdentityPr
 
         assertUserAttributes(initialUserAttributes, userRep);
 
-        logoutFromRealm(bc.consumerRealmName());
+        logoutFromRealm(getConsumerRoot(), bc.consumerRealmName());
 
         // update user in provider realm
         UserRepresentation userRepProvider = findUser(bc.providerRealmName(), bc.getUserLogin(), email);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractUsernameTemplateMapperTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractUsernameTemplateMapperTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.keycloak.testsuite.broker.BrokerTestTools.waitForPage;
 import static org.keycloak.testsuite.broker.KcOidcBrokerConfiguration.ATTRIBUTE_TO_MAP_NAME;
+import static org.keycloak.testsuite.broker.BrokerTestTools.getConsumerRoot;
 
 import java.util.List;
 
@@ -62,7 +63,7 @@ public abstract class AbstractUsernameTemplateMapperTest extends AbstractIdentit
         String mappedUserName = String.format(getMapperTemplate(), userName);
         findUser(bc.consumerRealmName(), mappedUserName, bc.getUserEmail());
 
-        logoutFromRealm(bc.consumerRealmName());
+        logoutFromRealm(getConsumerRoot(), bc.consumerRealmName());
 
         updateUser(updatedUserName);
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AccountLinkTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AccountLinkTest.java
@@ -119,7 +119,7 @@ public class AccountLinkTest extends AbstractKeycloakTest {
 
 
     public void createParentChild() {
-        BrokerTestTools.createKcOidcBroker(adminClient, CHILD_IDP, PARENT_IDP, suiteContext);
+        BrokerTestTools.createKcOidcBroker(adminClient, CHILD_IDP, PARENT_IDP);
     }
 
     @Test

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/BrokerConfiguration.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/BrokerConfiguration.java
@@ -4,7 +4,6 @@ import org.keycloak.models.IdentityProviderSyncMode;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.IdentityProviderRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
-import org.keycloak.testsuite.arquillian.SuiteContext;
 
 import java.util.List;
 
@@ -24,21 +23,21 @@ public interface BrokerConfiguration {
      */
     RealmRepresentation createConsumerRealm();
 
-    List<ClientRepresentation> createProviderClients(SuiteContext suiteContext);
+    List<ClientRepresentation> createProviderClients();
 
-    List<ClientRepresentation> createConsumerClients(SuiteContext suiteContext);
+    List<ClientRepresentation> createConsumerClients();
 
     /**
      * @return Representation of the identity provider for declaration in the broker
      */
-    default IdentityProviderRepresentation setUpIdentityProvider(SuiteContext suiteContext) {
-        return setUpIdentityProvider(suiteContext, IdentityProviderSyncMode.IMPORT);
+    default IdentityProviderRepresentation setUpIdentityProvider() {
+        return setUpIdentityProvider(IdentityProviderSyncMode.IMPORT);
     }
 
     /**
      * @return Representation of the identity provider for declaration in the broker
      */
-    IdentityProviderRepresentation setUpIdentityProvider(SuiteContext suiteContext, IdentityProviderSyncMode force);
+    IdentityProviderRepresentation setUpIdentityProvider(IdentityProviderSyncMode force);
 
     /**
      * @return Name of realm containing identity provider. Must be consistent with {@link #createProviderRealm()}
@@ -53,7 +52,7 @@ public interface BrokerConfiguration {
     /**
      * @return Client ID of the identity provider as set in provider realm.
      */
-    String getIDPClientIdInProviderRealm(SuiteContext suiteContext);
+    String getIDPClientIdInProviderRealm();
 
     /**
      * @return User login name of the brokered user

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/BrokerTestTools.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/BrokerTestTools.java
@@ -1,16 +1,10 @@
 package org.keycloak.testsuite.broker;
 
+import org.apache.http.client.utils.URIBuilder;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.IdentityProviderRepresentation;
-import org.keycloak.testsuite.arquillian.SuiteContext;
-
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-
+import org.keycloak.testsuite.arquillian.AuthServerTestEnricher;
 import org.keycloak.testsuite.pages.PageUtils;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
@@ -18,7 +12,16 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedCondition;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.keycloak.testsuite.arquillian.AuthServerTestEnricher.AUTH_SERVER_HOST;
 import static org.keycloak.testsuite.broker.BrokerTestConstants.IDP_OIDC_PROVIDER_ID;
+import static org.keycloak.testsuite.util.WaitUtils.waitForPageToLoad;
 
 /**
  *
@@ -26,8 +29,23 @@ import static org.keycloak.testsuite.broker.BrokerTestConstants.IDP_OIDC_PROVIDE
  */
 public class BrokerTestTools {
 
-    public static String getAuthRoot(SuiteContext suiteContext) {
-        return suiteContext.getAuthServerInfo().getContextRoot().toString();
+    private static String providerRoot;
+    private static String consumerRoot;
+
+    public static String getProviderRoot() {
+        if (providerRoot == null) {
+            // everything is identical to consumerRoot but the host (it's technically the same server instance)
+            providerRoot = new URIBuilder(URI.create(getConsumerRoot()))
+                    .setHost(System.getProperty("auth.server.host2", AUTH_SERVER_HOST)).toString();
+        }
+        return providerRoot;
+    }
+
+    public static String getConsumerRoot() {
+        if (consumerRoot == null) {
+            consumerRoot = AuthServerTestEnricher.getAuthServerContextRoot();
+        }
+        return consumerRoot;
     }
 
     public static IdentityProviderRepresentation createIdentityProvider(String alias, String providerId) {
@@ -42,6 +60,8 @@ public class BrokerTestTools {
     }
 
     public static void waitForPage(WebDriver driver, final String title, final boolean isHtmlTitle) {
+        waitForPageToLoad();
+
         WebDriverWait wait = new WebDriverWait(driver, 5);
         ExpectedCondition<Boolean> condition = (WebDriver input) -> isHtmlTitle ? input.getTitle().toLowerCase().contains(title) : PageUtils.getPageTitle(input).toLowerCase().contains(title);
 
@@ -76,16 +96,15 @@ public class BrokerTestTools {
      * @param adminClient
      * @param childRealm
      * @param idpRealm
-     * @param suiteContext
      */
-    public static void createKcOidcBroker(Keycloak adminClient, String childRealm, String idpRealm, SuiteContext suiteContext) {
-        createKcOidcBroker(adminClient, childRealm, idpRealm, suiteContext, idpRealm, false);
+    public static void createKcOidcBroker(Keycloak adminClient, String childRealm, String idpRealm) {
+        createKcOidcBroker(adminClient, childRealm, idpRealm, idpRealm, false);
 
 
 
     }
 
-    public static void createKcOidcBroker(Keycloak adminClient, String childRealm, String idpRealm, SuiteContext suiteContext, String alias, boolean linkOnly) {
+    public static void createKcOidcBroker(Keycloak adminClient, String childRealm, String idpRealm, String alias, boolean linkOnly) {
         IdentityProviderRepresentation idp = createIdentityProvider(alias, IDP_OIDC_PROVIDER_ID);
         idp.setLinkOnly(linkOnly);
         idp.setStoreToken(true);
@@ -94,10 +113,10 @@ public class BrokerTestTools {
 
         config.put("clientId", childRealm);
         config.put("clientSecret", childRealm);
-        config.put("authorizationUrl", getAuthRoot(suiteContext) + "/auth/realms/" + idpRealm + "/protocol/openid-connect/auth");
-        config.put("tokenUrl", getAuthRoot(suiteContext) + "/auth/realms/" + idpRealm + "/protocol/openid-connect/token");
-        config.put("logoutUrl", getAuthRoot(suiteContext) + "/auth/realms/" + idpRealm + "/protocol/openid-connect/logout");
-        config.put("userInfoUrl", getAuthRoot(suiteContext) + "/auth/realms/" + idpRealm + "/protocol/openid-connect/userinfo");
+        config.put("authorizationUrl", getProviderRoot() + "/auth/realms/" + idpRealm + "/protocol/openid-connect/auth");
+        config.put("tokenUrl", getProviderRoot() + "/auth/realms/" + idpRealm + "/protocol/openid-connect/token");
+        config.put("logoutUrl", getProviderRoot() + "/auth/realms/" + idpRealm + "/protocol/openid-connect/logout");
+        config.put("userInfoUrl", getProviderRoot() + "/auth/realms/" + idpRealm + "/protocol/openid-connect/userinfo");
         config.put("backchannelSupported", "true");
         adminClient.realm(childRealm).identityProviders().create(idp);
 
@@ -107,10 +126,10 @@ public class BrokerTestTools {
         client.setSecret(childRealm);
         client.setEnabled(true);
 
-        client.setRedirectUris(Collections.singletonList(getAuthRoot(suiteContext) +
+        client.setRedirectUris(Collections.singletonList(getConsumerRoot() +
                 "/auth/realms/" + childRealm + "/broker/" + idpRealm + "/endpoint/*"));
 
-        client.setAdminUrl(getAuthRoot(suiteContext) +
+        client.setAdminUrl(getConsumerRoot() +
                 "/auth/realms/" + childRealm + "/broker/" + idpRealm + "/endpoint");
         adminClient.realm(idpRealm).clients().create(client);
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/HardcodedUserAttributeMapperTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/HardcodedUserAttributeMapperTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 import static org.keycloak.models.IdentityProviderMapperSyncMode.FORCE;
 import static org.keycloak.models.IdentityProviderMapperSyncMode.IMPORT;
+import static org.keycloak.testsuite.broker.BrokerTestTools.getConsumerRoot;
 
 import java.util.HashMap;
 
@@ -87,7 +88,7 @@ public class HardcodedUserAttributeMapperTest extends AbstractIdentityProviderMa
         if (createAfterFirstLogin) {
             createMapperInIdp(idp, syncMode);
         }
-        logoutFromRealm(bc.consumerRealmName());
+        logoutFromRealm(getConsumerRoot(), bc.consumerRealmName());
 
         if (user.getAttributes() != null) {
             user.setAttributes(new HashMap<>());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/JsonUserAttributeMapperTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/JsonUserAttributeMapperTest.java
@@ -26,6 +26,7 @@ import static org.keycloak.models.IdentityProviderMapperSyncMode.LEGACY;
 import static org.keycloak.testsuite.broker.KcOidcBrokerConfiguration.HARDOCDED_CLAIM;
 import static org.keycloak.testsuite.broker.KcOidcBrokerConfiguration.HARDOCDED_VALUE;
 import static org.keycloak.testsuite.broker.KcOidcBrokerConfiguration.USER_INFO_CLAIM;
+import static org.keycloak.testsuite.broker.BrokerTestTools.getConsumerRoot;
 
 /**
  * @author <a href="mailto:external.martin.idel@bosch.io">Martin Idel</a>
@@ -113,7 +114,7 @@ public class JsonUserAttributeMapperTest extends AbstractIdentityProviderMapperT
         if (createAfterFirstLogin) {
             createGithubProviderMapper(idp, syncMode);
         }
-        logoutFromRealm(bc.consumerRealmName());
+        logoutFromRealm(getConsumerRoot(), bc.consumerRealmName());
 
         if (!createAfterFirstLogin) {
             updateClaimSentToIDP(claim, updatedValue);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOIDCBrokerWithSignatureTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOIDCBrokerWithSignatureTest.java
@@ -43,6 +43,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.keycloak.testsuite.admin.ApiUtil.createUserWithAdminClient;
 import static org.keycloak.testsuite.admin.ApiUtil.resetUserPassword;
+import static org.keycloak.testsuite.broker.BrokerTestTools.getConsumerRoot;
 
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
@@ -76,7 +77,7 @@ public class KcOIDCBrokerWithSignatureTest extends AbstractBaseBrokerTest {
         log.debug("adding identity provider to realm " + bc.consumerRealmName());
 
         RealmResource realm = adminClient.realm(bc.consumerRealmName());
-        Response resp = realm.identityProviders().create(bc.setUpIdentityProvider(suiteContext));
+        Response resp = realm.identityProviders().create(bc.setUpIdentityProvider());
         resp.close();
     }
 
@@ -96,7 +97,7 @@ public class KcOIDCBrokerWithSignatureTest extends AbstractBaseBrokerTest {
         logInAsUserInIDPForFirstTime();
         assertLoggedInAccountManagement();
 
-        logoutFromRealm(bc.consumerRealmName());
+        logoutFromRealm(getConsumerRoot(), bc.consumerRealmName());
 
         // Rotate public keys on the parent broker
         rotateKeys();
@@ -105,7 +106,7 @@ public class KcOIDCBrokerWithSignatureTest extends AbstractBaseBrokerTest {
         logInAsUserInIDP();
         assertErrorPage("Unexpected error when authenticating with identity provider");
 
-        logoutFromRealm(bc.consumerRealmName());
+        logoutFromRealm(getConsumerRoot(), bc.consumerRealmName());
 
         // Set time offset. New keys can be downloaded. Check that user is able to login.
         setTimeOffset(20);
@@ -144,7 +145,7 @@ public class KcOIDCBrokerWithSignatureTest extends AbstractBaseBrokerTest {
         logInAsUserInIDPForFirstTime();
         assertLoggedInAccountManagement();
 
-        logoutFromRealm(bc.consumerRealmName());
+        logoutFromRealm(getConsumerRoot(), bc.consumerRealmName());
 
         // Rotate public keys on the parent broker
         rotateKeys();
@@ -153,7 +154,7 @@ public class KcOIDCBrokerWithSignatureTest extends AbstractBaseBrokerTest {
         logInAsUserInIDP();
         assertErrorPage("Unexpected error when authenticating with identity provider");
 
-        logoutFromRealm(bc.consumerRealmName());
+        logoutFromRealm(getConsumerRoot(), bc.consumerRealmName());
 
         // Even after time offset is user not able to login, because it uses old key hardcoded in identityProvider config
         setTimeOffset(20);
@@ -180,7 +181,7 @@ public class KcOIDCBrokerWithSignatureTest extends AbstractBaseBrokerTest {
         logInAsUserInIDPForFirstTime();
         assertLoggedInAccountManagement();
 
-        logoutFromRealm(bc.consumerRealmName());
+        logoutFromRealm(getConsumerRoot(), bc.consumerRealmName());
 
         // Set key id to an invalid one
         cfg.setPublicKeySignatureVerifierKeyId("invalid-key-id");
@@ -194,21 +195,21 @@ public class KcOIDCBrokerWithSignatureTest extends AbstractBaseBrokerTest {
         updateIdentityProvider(idpRep);
         logInAsUserInIDP();
         assertLoggedInAccountManagement();
-        logoutFromRealm(bc.consumerRealmName());
+        logoutFromRealm(getConsumerRoot(), bc.consumerRealmName());
 
         // Set key id to empty
         cfg.setPublicKeySignatureVerifierKeyId("");
         updateIdentityProvider(idpRep);
         logInAsUserInIDP();
         assertLoggedInAccountManagement();
-        logoutFromRealm(bc.consumerRealmName());
+        logoutFromRealm(getConsumerRoot(), bc.consumerRealmName());
 
         // Unset key id
         cfg.setPublicKeySignatureVerifierKeyId(null);
         updateIdentityProvider(idpRep);
         logInAsUserInIDP();
         assertLoggedInAccountManagement();
-        logoutFromRealm(bc.consumerRealmName());
+        logoutFromRealm(getConsumerRoot(), bc.consumerRealmName());
     }
 
 
@@ -221,7 +222,7 @@ public class KcOIDCBrokerWithSignatureTest extends AbstractBaseBrokerTest {
         logInAsUserInIDPForFirstTime();
         assertLoggedInAccountManagement();
 
-        logoutFromRealm(bc.consumerRealmName());
+        logoutFromRealm(getConsumerRoot(), bc.consumerRealmName());
 
         // Check that key is cached
         IdentityProviderRepresentation idpRep = getIdentityProvider();
@@ -246,7 +247,7 @@ public class KcOIDCBrokerWithSignatureTest extends AbstractBaseBrokerTest {
         logInAsUserInIDPForFirstTime();
         assertLoggedInAccountManagement();
 
-        logoutFromRealm(bc.consumerRealmName());
+        logoutFromRealm(getConsumerRoot(), bc.consumerRealmName());
 
         // Check that key is cached
         IdentityProviderRepresentation idpRep = getIdentityProvider();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerAcrParameterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerAcrParameterTest.java
@@ -7,6 +7,7 @@ import org.keycloak.testsuite.Assert;
 import java.util.List;
 
 import static org.keycloak.testsuite.broker.BrokerTestTools.waitForPage;
+import static org.keycloak.testsuite.broker.BrokerTestTools.getConsumerRoot;
 
 public class KcOidcBrokerAcrParameterTest extends AbstractBrokerTest {
 
@@ -20,7 +21,7 @@ public class KcOidcBrokerAcrParameterTest extends AbstractBrokerTest {
 
     @Override
     protected void loginUser() {
-        driver.navigate().to(getAccountUrl(bc.consumerRealmName()));
+        driver.navigate().to(getAccountUrl(getConsumerRoot(), bc.consumerRealmName()));
 
         driver.navigate().to(driver.getCurrentUrl() + "&" + ACR_VALUES + "=" + ACR_3);
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerClientSecretBasicAuthTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerClientSecretBasicAuthTest.java
@@ -3,7 +3,6 @@ package org.keycloak.testsuite.broker;
 import org.keycloak.models.IdentityProviderSyncMode;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.representations.idm.IdentityProviderRepresentation;
-import org.keycloak.testsuite.arquillian.SuiteContext;
 
 import java.util.Map;
 
@@ -22,10 +21,10 @@ public class KcOidcBrokerClientSecretBasicAuthTest extends AbstractBrokerTest {
     private class KcOidcBrokerConfigurationWithBasicAuthAuthentication extends KcOidcBrokerConfiguration {
 
         @Override
-        public IdentityProviderRepresentation setUpIdentityProvider(SuiteContext suiteContext, IdentityProviderSyncMode syncMode) {
+        public IdentityProviderRepresentation setUpIdentityProvider(IdentityProviderSyncMode syncMode) {
             IdentityProviderRepresentation idp = createIdentityProvider(IDP_OIDC_ALIAS, IDP_OIDC_PROVIDER_ID);
             Map<String, String> config = idp.getConfig();
-            applyDefaultConfiguration(suiteContext, config, syncMode);
+            applyDefaultConfiguration(config, syncMode);
             config.put("clientAuthMethod", OIDCLoginProtocol.CLIENT_SECRET_BASIC);
             return idp;
         }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerClientSecretJwtTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerClientSecretJwtTest.java
@@ -13,7 +13,6 @@ import org.keycloak.models.IdentityProviderSyncMode;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.IdentityProviderRepresentation;
-import org.keycloak.testsuite.arquillian.SuiteContext;
 
 public class KcOidcBrokerClientSecretJwtTest extends AbstractBrokerTest {
 
@@ -25,8 +24,8 @@ public class KcOidcBrokerClientSecretJwtTest extends AbstractBrokerTest {
     private class KcOidcBrokerConfigurationWithJWTAuthentication extends KcOidcBrokerConfiguration {
 
         @Override
-        public List<ClientRepresentation> createProviderClients(SuiteContext suiteContext) {
-            List<ClientRepresentation> clientsRepList = super.createProviderClients(suiteContext);
+        public List<ClientRepresentation> createProviderClients() {
+            List<ClientRepresentation> clientsRepList = super.createProviderClients();
             log.info("Update provider clients to accept JWT authentication");
             for (ClientRepresentation client: clientsRepList) {
                 client.setClientAuthenticatorType(JWTClientSecretAuthenticator.PROVIDER_ID);
@@ -36,10 +35,10 @@ public class KcOidcBrokerClientSecretJwtTest extends AbstractBrokerTest {
         }
 
         @Override
-        public IdentityProviderRepresentation setUpIdentityProvider(SuiteContext suiteContext, IdentityProviderSyncMode syncMode) {
+        public IdentityProviderRepresentation setUpIdentityProvider(IdentityProviderSyncMode syncMode) {
             IdentityProviderRepresentation idp = createIdentityProvider(IDP_OIDC_ALIAS, IDP_OIDC_PROVIDER_ID);
             Map<String, String> config = idp.getConfig();
-            applyDefaultConfiguration(suiteContext, config, syncMode);
+            applyDefaultConfiguration(config, syncMode);
             config.put("clientAuthMethod", OIDCLoginProtocol.CLIENT_SECRET_JWT);
             return idp;
         }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerConfiguration.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerConfiguration.java
@@ -13,7 +13,6 @@ import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.IdentityProviderRepresentation;
 import org.keycloak.representations.idm.ProtocolMapperRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
-import org.keycloak.testsuite.arquillian.SuiteContext;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -56,18 +55,18 @@ public class KcOidcBrokerConfiguration implements BrokerConfiguration {
     }
 
     @Override
-    public List<ClientRepresentation> createProviderClients(SuiteContext suiteContext) {
+    public List<ClientRepresentation> createProviderClients() {
         ClientRepresentation client = new ClientRepresentation();
         client.setId(CLIENT_ID);
-        client.setClientId(getIDPClientIdInProviderRealm(suiteContext));
+        client.setClientId(getIDPClientIdInProviderRealm());
         client.setName(CLIENT_ID);
         client.setSecret(CLIENT_SECRET);
         client.setEnabled(true);
 
-        client.setRedirectUris(Collections.singletonList(getAuthRoot(suiteContext) +
+        client.setRedirectUris(Collections.singletonList(getConsumerRoot() +
                 "/auth/realms/" + REALM_CONS_NAME + "/broker/" + IDP_OIDC_ALIAS + "/endpoint/*"));
 
-        client.setAdminUrl(getAuthRoot(suiteContext) +
+        client.setAdminUrl(getConsumerRoot() +
                 "/auth/realms/" + REALM_CONS_NAME + "/broker/" + IDP_OIDC_ALIAS + "/endpoint");
 
         ProtocolMapperRepresentation emailMapper = new ProtocolMapperRepresentation();
@@ -154,7 +153,7 @@ public class KcOidcBrokerConfiguration implements BrokerConfiguration {
     }
 
     @Override
-    public List<ClientRepresentation> createConsumerClients(SuiteContext suiteContext) {
+    public List<ClientRepresentation> createConsumerClients() {
         ClientRepresentation client = new ClientRepresentation();
         client.setId("broker-app");
         client.setClientId("broker-app");
@@ -163,34 +162,34 @@ public class KcOidcBrokerConfiguration implements BrokerConfiguration {
         client.setEnabled(true);
         client.setDirectAccessGrantsEnabled(true);
 
-        client.setRedirectUris(Collections.singletonList(getAuthRoot(suiteContext) +
+        client.setRedirectUris(Collections.singletonList(getConsumerRoot() +
                 "/auth/*"));
 
-        client.setBaseUrl(getAuthRoot(suiteContext) +
+        client.setBaseUrl(getConsumerRoot() +
                 "/auth/realms/" + REALM_CONS_NAME + "/app");
 
         return Collections.singletonList(client);
     }
 
     @Override
-    public IdentityProviderRepresentation setUpIdentityProvider(SuiteContext suiteContext, IdentityProviderSyncMode syncMode) {
+    public IdentityProviderRepresentation setUpIdentityProvider(IdentityProviderSyncMode syncMode) {
         IdentityProviderRepresentation idp = createIdentityProvider(IDP_OIDC_ALIAS, IDP_OIDC_PROVIDER_ID);
 
         Map<String, String> config = idp.getConfig();
-        applyDefaultConfiguration(suiteContext, config, syncMode);
+        applyDefaultConfiguration(config, syncMode);
 
         return idp;
     }
 
-    protected void applyDefaultConfiguration(final SuiteContext suiteContext, final Map<String, String> config, IdentityProviderSyncMode syncMode) {
+    protected void applyDefaultConfiguration(final Map<String, String> config, IdentityProviderSyncMode syncMode) {
         config.put(IdentityProviderModel.SYNC_MODE, syncMode.toString());
         config.put("clientId", CLIENT_ID);
         config.put("clientSecret", CLIENT_SECRET);
         config.put("prompt", "login");
-        config.put("authorizationUrl", getAuthRoot(suiteContext) + "/auth/realms/" + REALM_PROV_NAME + "/protocol/openid-connect/auth");
-        config.put("tokenUrl", getAuthRoot(suiteContext) + "/auth/realms/" + REALM_PROV_NAME + "/protocol/openid-connect/token");
-        config.put("logoutUrl", getAuthRoot(suiteContext) + "/auth/realms/" + REALM_PROV_NAME + "/protocol/openid-connect/logout");
-        config.put("userInfoUrl", getAuthRoot(suiteContext) + "/auth/realms/" + REALM_PROV_NAME + "/protocol/openid-connect/userinfo");
+        config.put("authorizationUrl", getProviderRoot() + "/auth/realms/" + REALM_PROV_NAME + "/protocol/openid-connect/auth");
+        config.put("tokenUrl", getProviderRoot() + "/auth/realms/" + REALM_PROV_NAME + "/protocol/openid-connect/token");
+        config.put("logoutUrl", getProviderRoot() + "/auth/realms/" + REALM_PROV_NAME + "/protocol/openid-connect/logout");
+        config.put("userInfoUrl", getProviderRoot() + "/auth/realms/" + REALM_PROV_NAME + "/protocol/openid-connect/userinfo");
         config.put("defaultScope", "email profile");
         config.put("backchannelSupported", "true");
     }
@@ -201,7 +200,7 @@ public class KcOidcBrokerConfiguration implements BrokerConfiguration {
     }
 
     @Override
-    public String getIDPClientIdInProviderRealm(SuiteContext suiteContext) {
+    public String getIDPClientIdInProviderRealm() {
         return CLIENT_ID;
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerFrontendUrlTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerFrontendUrlTest.java
@@ -17,7 +17,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
-import org.keycloak.testsuite.arquillian.SuiteContext;
 import org.keycloak.testsuite.util.ReverseProxy;
 
 public final class KcOidcBrokerFrontendUrlTest extends AbstractBrokerTest {
@@ -42,8 +41,8 @@ public final class KcOidcBrokerFrontendUrlTest extends AbstractBrokerTest {
             }
 
             @Override 
-            public List<ClientRepresentation> createProviderClients(SuiteContext suiteContext) {
-                List<ClientRepresentation> clients = super.createProviderClients(suiteContext);
+            public List<ClientRepresentation> createProviderClients() {
+                List<ClientRepresentation> clients = super.createProviderClients();
 
                 List<String> redirectUris = new ArrayList<>();
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerHiddenIdpHintTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerHiddenIdpHintTest.java
@@ -23,10 +23,11 @@ import org.keycloak.representations.idm.IdentityProviderRepresentation;
 import static org.keycloak.testsuite.broker.BrokerTestTools.waitForPage;
 
 import org.keycloak.testsuite.Assert;
-import org.keycloak.testsuite.arquillian.SuiteContext;
+
 import static org.keycloak.testsuite.broker.BrokerTestConstants.IDP_OIDC_ALIAS;
 import static org.keycloak.testsuite.broker.BrokerTestConstants.IDP_OIDC_PROVIDER_ID;
 import static org.keycloak.testsuite.broker.BrokerTestTools.createIdentityProvider;
+import static org.keycloak.testsuite.broker.BrokerTestTools.getConsumerRoot;
 
 /**
  * Migrated from old testsuite.  Previous version by Pedro Igor.
@@ -44,11 +45,11 @@ public class KcOidcBrokerHiddenIdpHintTest extends AbstractInitializedBaseBroker
     private class KcOidcHiddenBrokerConfiguration extends KcOidcBrokerConfiguration {
         
         @Override
-        public IdentityProviderRepresentation setUpIdentityProvider(SuiteContext suiteContext, IdentityProviderSyncMode syncMode) {
+        public IdentityProviderRepresentation setUpIdentityProvider(IdentityProviderSyncMode syncMode) {
             IdentityProviderRepresentation idp = createIdentityProvider(IDP_OIDC_ALIAS, IDP_OIDC_PROVIDER_ID);
 
             Map<String, String> config = idp.getConfig();
-            applyDefaultConfiguration(suiteContext, config, syncMode);
+            applyDefaultConfiguration(config, syncMode);
             config.put("hideOnLoginPage", "true");
             return idp;
         }
@@ -56,7 +57,7 @@ public class KcOidcBrokerHiddenIdpHintTest extends AbstractInitializedBaseBroker
 
     @Test
     public void testSuccessfulRedirectToProviderHiddenOnLoginPage() {
-        driver.navigate().to(getAccountUrl(bc.consumerRealmName()));
+        driver.navigate().to(getAccountUrl(getConsumerRoot(), bc.consumerRealmName()));
         waitForPage(driver, "log in to", true);
         String url = driver.getCurrentUrl() + "&kc_idp_hint=" + bc.getIDPAlias();
         driver.navigate().to(url);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerIdpHintTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerIdpHintTest.java
@@ -18,6 +18,7 @@ package org.keycloak.testsuite.broker;
 
 import org.junit.Test;
 import static org.keycloak.testsuite.broker.BrokerTestTools.waitForPage;
+import static org.keycloak.testsuite.broker.BrokerTestTools.getConsumerRoot;
 
 import org.keycloak.testsuite.Assert;
 
@@ -36,7 +37,7 @@ public class KcOidcBrokerIdpHintTest extends AbstractInitializedBaseBrokerTest {
 
     @Test
     public void testSuccessfulRedirect() {
-        driver.navigate().to(getAccountUrl(bc.consumerRealmName()));
+        driver.navigate().to(getAccountUrl(getConsumerRoot(), bc.consumerRealmName()));
         waitForPage(driver, "log in to", true);
         String url = driver.getCurrentUrl() + "&kc_idp_hint=" + bc.getIDPAlias();
         driver.navigate().to(url);
@@ -54,7 +55,7 @@ public class KcOidcBrokerIdpHintTest extends AbstractInitializedBaseBrokerTest {
     // KEYCLOAK-5260
     @Test
     public void testSuccessfulRedirectToProviderAfterLoginPageShown() {
-        driver.navigate().to(getAccountUrl(bc.consumerRealmName()));
+        driver.navigate().to(getAccountUrl(getConsumerRoot(), bc.consumerRealmName()));
         waitForPage(driver, "log in to", true);
         
         String urlWithHint = driver.getCurrentUrl() + "&kc_idp_hint=" + bc.getIDPAlias();        
@@ -70,7 +71,7 @@ public class KcOidcBrokerIdpHintTest extends AbstractInitializedBaseBrokerTest {
                 driver.getCurrentUrl().contains("/auth/realms/" + bc.providerRealmName() + "/"));
         
         // redirect shouldn't happen
-        driver.navigate().to(getAccountUrl(bc.consumerRealmName()));
+        driver.navigate().to(getAccountUrl(getConsumerRoot(), bc.consumerRealmName()));
         waitForPage(driver, "log in to", true);
         Assert.assertTrue("Driver should be on the consumer realm page",
                 driver.getCurrentUrl().contains("/auth/realms/" + bc.consumerRealmName() + "/"));
@@ -78,7 +79,7 @@ public class KcOidcBrokerIdpHintTest extends AbstractInitializedBaseBrokerTest {
     
         @Test
     public void testInvalidIdentityProviderHint() {
-        driver.navigate().to(getAccountUrl(bc.consumerRealmName()));
+        driver.navigate().to(getAccountUrl(getConsumerRoot(), bc.consumerRealmName()));
         waitForPage(driver, "log in to", true);
         String url = driver.getCurrentUrl() + "&kc_idp_hint=bogus-idp";
         driver.navigate().to(url);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerLoginHintTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerLoginHintTest.java
@@ -9,6 +9,7 @@ import static org.keycloak.testsuite.broker.BrokerTestConstants.USER_EMAIL;
 import static org.keycloak.testsuite.broker.BrokerTestTools.createIdentityProvider;
 import static org.keycloak.testsuite.broker.BrokerTestTools.waitForPage;
 import static org.keycloak.testsuite.util.WaitUtils.waitForPageToLoad;
+import static org.keycloak.testsuite.broker.BrokerTestTools.getConsumerRoot;
 
 import org.junit.Test;
 import org.keycloak.admin.client.resource.UserResource;
@@ -17,7 +18,6 @@ import org.keycloak.models.IdentityProviderSyncMode;
 import org.keycloak.representations.idm.IdentityProviderRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.testsuite.Assert;
-import org.keycloak.testsuite.arquillian.SuiteContext;
 import org.keycloak.testsuite.updaters.Creator;
 import org.keycloak.testsuite.util.UserBuilder;
 
@@ -31,11 +31,11 @@ public class KcOidcBrokerLoginHintTest extends AbstractBrokerTest {
     private class KcOidcBrokerConfigurationWithLoginHint extends KcOidcBrokerConfiguration {
         
         @Override
-        public IdentityProviderRepresentation setUpIdentityProvider(SuiteContext suiteContext, IdentityProviderSyncMode syncMode) {
+        public IdentityProviderRepresentation setUpIdentityProvider(IdentityProviderSyncMode syncMode) {
             IdentityProviderRepresentation idp = createIdentityProvider(IDP_OIDC_ALIAS, IDP_OIDC_PROVIDER_ID);
 
             Map<String, String> config = idp.getConfig();
-            applyDefaultConfiguration(suiteContext, config, syncMode);
+            applyDefaultConfiguration(config, syncMode);
             config.put("loginHint", "true");
             return idp;
         }
@@ -43,7 +43,7 @@ public class KcOidcBrokerLoginHintTest extends AbstractBrokerTest {
 
     @Override
     protected void loginUser() {
-        driver.navigate().to(getAccountUrl(bc.consumerRealmName()));
+        driver.navigate().to(getAccountUrl(getConsumerRoot(), bc.consumerRealmName()));
         
         driver.navigate().to(driver.getCurrentUrl() + "&login_hint=" + USER_EMAIL);
 
@@ -99,7 +99,7 @@ public class KcOidcBrokerLoginHintTest extends AbstractBrokerTest {
                         .enabled(true)
                         .build()
             )) {
-            driver.navigate().to(getAccountUrl(bc.consumerRealmName()));
+            driver.navigate().to(getAccountUrl(getConsumerRoot(), bc.consumerRealmName()));
             waitForPageToLoad();
             driver.navigate().to(driver.getCurrentUrl() + "&login_hint=" + USER_EMAIL + "&kc_idp_hint=" + IDP_OIDC_ALIAS);
             waitForPageToLoad();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerLogoutTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerLogoutTest.java
@@ -16,8 +16,9 @@ import static org.keycloak.testsuite.admin.ApiUtil.createUserWithAdminClient;
 import static org.keycloak.testsuite.admin.ApiUtil.resetUserPassword;
 import static org.keycloak.testsuite.broker.BrokerTestConstants.REALM_CONS_NAME;
 import static org.keycloak.testsuite.broker.BrokerTestConstants.REALM_PROV_NAME;
-import static org.keycloak.testsuite.broker.BrokerTestTools.getAuthRoot;
 import static org.keycloak.testsuite.broker.BrokerTestTools.waitForPage;
+import static org.keycloak.testsuite.broker.BrokerTestTools.getConsumerRoot;
+import static org.keycloak.testsuite.broker.BrokerTestTools.getProviderRoot;
 
 public class KcOidcBrokerLogoutTest extends AbstractBaseBrokerTest {
 
@@ -50,7 +51,7 @@ public class KcOidcBrokerLogoutTest extends AbstractBaseBrokerTest {
         log.debug("adding identity provider to realm " + bc.consumerRealmName());
 
         final RealmResource realm = adminClient.realm(bc.consumerRealmName());
-        realm.identityProviders().create(bc.setUpIdentityProvider(suiteContext)).close();
+        realm.identityProviders().create(bc.setUpIdentityProvider()).close();
     }
 
     @Before
@@ -63,8 +64,8 @@ public class KcOidcBrokerLogoutTest extends AbstractBaseBrokerTest {
         logInAsUserInIDPForFirstTime();
         assertLoggedInAccountManagement();
 
-        logoutFromRealm(bc.consumerRealmName());
-        driver.navigate().to(getAccountUrl(REALM_PROV_NAME));
+        logoutFromRealm(getConsumerRoot(), bc.consumerRealmName());
+        driver.navigate().to(getAccountUrl(getProviderRoot(), REALM_PROV_NAME));
         waitForPage(driver, "log in to provider", true);
     }
 
@@ -73,8 +74,8 @@ public class KcOidcBrokerLogoutTest extends AbstractBaseBrokerTest {
         logInAsUserInIDPForFirstTime();
         assertLoggedInAccountManagement();
 
-        logoutFromRealm(bc.consumerRealmName(), "kc-oidc-idp");
-        driver.navigate().to(getAccountUrl(REALM_PROV_NAME));
+        logoutFromRealm(getConsumerRoot(), bc.consumerRealmName(), "kc-oidc-idp");
+        driver.navigate().to(getAccountUrl(getProviderRoot(), REALM_PROV_NAME));
 
         waitForAccountManagementTitle();
     }
@@ -84,14 +85,14 @@ public class KcOidcBrokerLogoutTest extends AbstractBaseBrokerTest {
         logInAsUserInIDPForFirstTime();
         assertLoggedInAccountManagement();
 
-        logoutFromRealm(bc.consumerRealmName(), "something-else");
-        driver.navigate().to(getAccountUrl(REALM_PROV_NAME));
+        logoutFromRealm(getConsumerRoot(), bc.consumerRealmName(), "something-else");
+        driver.navigate().to(getAccountUrl(getProviderRoot(), REALM_PROV_NAME));
         waitForPage(driver, "log in to provider", true);
     }
 
     @Test
     public void logoutAfterBrowserRestart() {
-        driver.navigate().to(getLoginUrl(bc.consumerRealmName(), "broker-app"));
+        driver.navigate().to(getLoginUrl(getConsumerRoot(), bc.consumerRealmName(), "broker-app"));
         logInWithBroker(bc);
         updateAccountInformation();
 
@@ -99,7 +100,7 @@ public class KcOidcBrokerLogoutTest extends AbstractBaseBrokerTest {
         String code = oauth.getCurrentQuery().get(OAuth2Constants.CODE);
         OAuthClient.AccessTokenResponse response = oauth.realm(bc.consumerRealmName())
                 .clientId("broker-app")
-                .redirectUri(getAuthRoot(suiteContext) + "/auth/realms/" + REALM_CONS_NAME + "/app")
+                .redirectUri(getConsumerRoot() + "/auth/realms/" + REALM_CONS_NAME + "/app")
                 .doAccessTokenRequest(code, "broker-app-secret");
         assertEquals(200, response.getStatusCode());
 
@@ -111,8 +112,8 @@ public class KcOidcBrokerLogoutTest extends AbstractBaseBrokerTest {
         driver.manage().deleteCookieNamed(AuthenticationManager.KEYCLOAK_IDENTITY_COOKIE);
         driver.manage().deleteCookieNamed(AuthenticationManager.KEYCLOAK_IDENTITY_COOKIE + CookieHelper.LEGACY_COOKIE);
 
-        logoutFromRealm(bc.consumerRealmName(), null, idToken);
-        driver.navigate().to(getAccountUrl(REALM_PROV_NAME));
+        logoutFromRealm(getConsumerRoot(), bc.consumerRealmName(), null, idToken);
+        driver.navigate().to(getAccountUrl(getProviderRoot(), REALM_PROV_NAME));
 
         waitForPage(driver, "log in to provider", true);
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerNoLoginHintTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerNoLoginHintTest.java
@@ -8,13 +8,13 @@ import static org.keycloak.testsuite.broker.BrokerTestConstants.IDP_OIDC_PROVIDE
 import static org.keycloak.testsuite.broker.BrokerTestConstants.USER_EMAIL;
 import static org.keycloak.testsuite.broker.BrokerTestTools.createIdentityProvider;
 import static org.keycloak.testsuite.broker.BrokerTestTools.waitForPage;
+import static org.keycloak.testsuite.broker.BrokerTestTools.getConsumerRoot;
 import org.apache.commons.lang3.StringUtils;
 import org.keycloak.admin.client.resource.UsersResource;
 import org.keycloak.models.IdentityProviderSyncMode;
 import org.keycloak.representations.idm.IdentityProviderRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.testsuite.Assert;
-import org.keycloak.testsuite.arquillian.SuiteContext;
 
 public class KcOidcBrokerNoLoginHintTest extends AbstractBrokerTest {
 
@@ -26,11 +26,11 @@ public class KcOidcBrokerNoLoginHintTest extends AbstractBrokerTest {
     private class KcOidcBrokerConfigurationWithNoLoginHint extends KcOidcBrokerConfiguration {
         
         @Override
-        public IdentityProviderRepresentation setUpIdentityProvider(SuiteContext suiteContext, IdentityProviderSyncMode syncMode) {
+        public IdentityProviderRepresentation setUpIdentityProvider(IdentityProviderSyncMode syncMode) {
             IdentityProviderRepresentation idp = createIdentityProvider(IDP_OIDC_ALIAS, IDP_OIDC_PROVIDER_ID);
 
             Map<String, String> config = idp.getConfig();
-            applyDefaultConfiguration(suiteContext, config, syncMode);
+            applyDefaultConfiguration(config, syncMode);
             config.put("loginHint", "false");
             return idp;
         }
@@ -38,7 +38,7 @@ public class KcOidcBrokerNoLoginHintTest extends AbstractBrokerTest {
 
     @Override
     protected void loginUser() {
-        driver.navigate().to(getAccountUrl(bc.consumerRealmName()));
+        driver.navigate().to(getAccountUrl(getConsumerRoot(), bc.consumerRealmName()));
         
         driver.navigate().to(driver.getCurrentUrl() + "&login_hint=" + USER_EMAIL);
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerNonceParameterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerNonceParameterTest.java
@@ -1,26 +1,18 @@
 package org.keycloak.testsuite.broker;
 
-import static org.keycloak.testsuite.broker.BrokerTestTools.waitForPage;
+import org.junit.Assert;
+import org.junit.Test;
+import org.keycloak.jose.jws.JWSInput;
+import org.keycloak.jose.jws.JWSInputException;
+import org.keycloak.representations.IDToken;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.testsuite.util.ClientBuilder;
+import org.keycloak.testsuite.util.OAuthClient;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.keycloak.OAuth2Constants;
-import org.keycloak.admin.client.resource.UsersResource;
-import org.keycloak.jose.jws.JWSInput;
-import org.keycloak.jose.jws.JWSInputException;
-import org.keycloak.representations.AccessToken;
-import org.keycloak.representations.IDToken;
-import org.keycloak.representations.idm.ClientRepresentation;
-import org.keycloak.representations.idm.UserRepresentation;
-import org.keycloak.services.managers.AuthenticationManager;
-import org.keycloak.testsuite.arquillian.SuiteContext;
-import org.keycloak.testsuite.util.ClientBuilder;
-import org.keycloak.testsuite.util.OAuthClient;
-import org.openqa.selenium.Cookie;
+import static org.keycloak.testsuite.broker.BrokerTestTools.getConsumerRoot;
 
 public class KcOidcBrokerNonceParameterTest extends AbstractBrokerTest {
 
@@ -28,12 +20,12 @@ public class KcOidcBrokerNonceParameterTest extends AbstractBrokerTest {
     protected BrokerConfiguration getBrokerConfiguration() {
         return new KcOidcBrokerConfiguration() {
             @Override
-            public List<ClientRepresentation> createConsumerClients(SuiteContext suiteContext) {
-                List<ClientRepresentation> clients = new ArrayList<>(super.createConsumerClients(suiteContext));
+            public List<ClientRepresentation> createConsumerClients() {
+                List<ClientRepresentation> clients = new ArrayList<>(super.createConsumerClients());
                 
                 clients.add(ClientBuilder.create().clientId("consumer-client")
                         .publicClient()
-                        .redirectUris("http://localhost:8180/auth/realms/master/app/auth/*", "https://localhost:8543/auth/realms/master/app/auth/*")
+                        .redirectUris(getConsumerRoot() + "/auth/realms/master/app/auth/*")
                         .publicClient().build());
                 
                 return clients;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerParameterForwardTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerParameterForwardTest.java
@@ -6,6 +6,7 @@ import static org.keycloak.testsuite.broker.BrokerTestConstants.IDP_OIDC_ALIAS;
 import static org.keycloak.testsuite.broker.BrokerTestConstants.IDP_OIDC_PROVIDER_ID;
 import static org.keycloak.testsuite.broker.BrokerTestTools.createIdentityProvider;
 import static org.keycloak.testsuite.broker.BrokerTestTools.waitForPage;
+import static org.keycloak.testsuite.broker.BrokerTestTools.getConsumerRoot;
 
 import java.util.List;
 import java.util.Map;
@@ -15,7 +16,6 @@ import org.keycloak.models.IdentityProviderSyncMode;
 import org.keycloak.representations.idm.IdentityProviderRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.testsuite.Assert;
-import org.keycloak.testsuite.arquillian.SuiteContext;
 
 public class KcOidcBrokerParameterForwardTest extends AbstractBrokerTest {
 
@@ -32,10 +32,10 @@ public class KcOidcBrokerParameterForwardTest extends AbstractBrokerTest {
     private class KcOidcBrokerConfigurationWithParameterForward extends KcOidcBrokerConfiguration {
 
         @Override
-        public IdentityProviderRepresentation setUpIdentityProvider(SuiteContext suiteContext, IdentityProviderSyncMode syncMode) {
+        public IdentityProviderRepresentation setUpIdentityProvider(IdentityProviderSyncMode syncMode) {
             IdentityProviderRepresentation idp = createIdentityProvider(IDP_OIDC_ALIAS, IDP_OIDC_PROVIDER_ID);
             Map<String, String> config = idp.getConfig();
-            applyDefaultConfiguration(suiteContext, config, syncMode);
+            applyDefaultConfiguration(config, syncMode);
             config.put("forwardParameters", FORWARDED_PARAMETER +", " + PARAMETER_NOT_SET);
             return idp;
         }
@@ -43,7 +43,7 @@ public class KcOidcBrokerParameterForwardTest extends AbstractBrokerTest {
 
     @Override
     protected void loginUser() {
-        driver.navigate().to(getAccountUrl(bc.consumerRealmName()));
+        driver.navigate().to(getAccountUrl(getConsumerRoot(), bc.consumerRealmName()));
 
         String queryString = "&" + FORWARDED_PARAMETER + "=" + FORWARDED_PARAMETER_VALUE + "&" + PARAMETER_NOT_FORWARDED + "=" + "value";
         driver.navigate().to(driver.getCurrentUrl() + queryString);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerPrivateKeyJwtTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerPrivateKeyJwtTest.java
@@ -23,7 +23,6 @@ import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.IdentityProviderRepresentation;
 import org.keycloak.representations.idm.KeysMetadataRepresentation.KeyMetadataRepresentation;
-import org.keycloak.testsuite.arquillian.SuiteContext;
 import org.keycloak.testsuite.util.KeyUtils;
 
 import java.util.HashMap;
@@ -44,8 +43,8 @@ public class KcOidcBrokerPrivateKeyJwtTest extends AbstractBrokerTest {
     private class KcOidcBrokerConfigurationWithJWTAuthentication extends KcOidcBrokerConfiguration {
 
         @Override
-        public List<ClientRepresentation> createProviderClients(SuiteContext suiteContext) {
-            List<ClientRepresentation> clientsRepList = super.createProviderClients(suiteContext);
+        public List<ClientRepresentation> createProviderClients() {
+            List<ClientRepresentation> clientsRepList = super.createProviderClients();
             log.info("Update provider clients to accept JWT authentication");
             KeyMetadataRepresentation keyRep = KeyUtils.getActiveKey(adminClient.realm(consumerRealmName()).keys().getKeyMetadata(), Algorithm.RS256);
             for (ClientRepresentation client: clientsRepList) {
@@ -59,10 +58,10 @@ public class KcOidcBrokerPrivateKeyJwtTest extends AbstractBrokerTest {
         }
 
         @Override
-        public IdentityProviderRepresentation setUpIdentityProvider(SuiteContext suiteContext, IdentityProviderSyncMode syncMode) {
+        public IdentityProviderRepresentation setUpIdentityProvider(IdentityProviderSyncMode syncMode) {
             IdentityProviderRepresentation idp = createIdentityProvider(IDP_OIDC_ALIAS, IDP_OIDC_PROVIDER_ID);
             Map<String, String> config = idp.getConfig();
-            applyDefaultConfiguration(suiteContext, config, syncMode);
+            applyDefaultConfiguration(config, syncMode);
             config.put("clientSecret", null);
             config.put("clientAuthMethod", OIDCLoginProtocol.PRIVATE_KEY_JWT);
             return idp;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerPromptParameterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerPromptParameterTest.java
@@ -5,12 +5,12 @@ import org.keycloak.models.IdentityProviderSyncMode;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.testsuite.Assert;
-import org.keycloak.testsuite.arquillian.SuiteContext;
 
 import java.util.List;
 import java.util.Map;
 
 import static org.keycloak.testsuite.broker.BrokerTestTools.waitForPage;
+import static org.keycloak.testsuite.broker.BrokerTestTools.getConsumerRoot;
 
 public class KcOidcBrokerPromptParameterTest extends AbstractBrokerTest {
 
@@ -25,7 +25,7 @@ public class KcOidcBrokerPromptParameterTest extends AbstractBrokerTest {
 
     @Override
     protected void loginUser() {
-        driver.navigate().to(getAccountUrl(bc.consumerRealmName()));
+        driver.navigate().to(getAccountUrl(getConsumerRoot(), bc.consumerRealmName()));
 
         driver.navigate().to(driver.getCurrentUrl() + "&" + OIDCLoginProtocol.PROMPT_PARAM + "=" + PROMPT_CONSENT);
 
@@ -77,8 +77,8 @@ public class KcOidcBrokerPromptParameterTest extends AbstractBrokerTest {
 
     private class KcOidcBrokerConfiguration2 extends KcOidcBrokerConfiguration {
         @Override
-        protected void applyDefaultConfiguration(final SuiteContext suiteContext, final Map<String, String> config, IdentityProviderSyncMode syncMode) {
-            super.applyDefaultConfiguration(suiteContext, config, syncMode);
+        protected void applyDefaultConfiguration(final Map<String, String> config, IdentityProviderSyncMode syncMode) {
+            super.applyDefaultConfiguration(config, syncMode);
             config.remove("prompt");
         }
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerSubMatchIntrospectionest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerSubMatchIntrospectionest.java
@@ -1,22 +1,16 @@
 package org.keycloak.testsuite.broker;
 
-import static org.keycloak.testsuite.broker.BrokerTestTools.waitForPage;
-import static org.keycloak.testsuite.util.ProtocolMapperUtil.createHardcodedClaim;
+import org.junit.Ignore;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.ProtocolMapperRepresentation;
+import org.keycloak.testsuite.util.ClientBuilder;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.keycloak.jose.jws.JWSInput;
-import org.keycloak.jose.jws.JWSInputException;
-import org.keycloak.representations.IDToken;
-import org.keycloak.representations.idm.ClientRepresentation;
-import org.keycloak.representations.idm.ProtocolMapperRepresentation;
-import org.keycloak.testsuite.arquillian.SuiteContext;
-import org.keycloak.testsuite.util.ClientBuilder;
-import org.keycloak.testsuite.util.OAuthClient;
+import static org.keycloak.testsuite.broker.BrokerTestTools.waitForPage;
+import static org.keycloak.testsuite.util.ProtocolMapperUtil.createHardcodedClaim;
+import static org.keycloak.testsuite.broker.BrokerTestTools.getConsumerRoot;
 
 public class KcOidcBrokerSubMatchIntrospectionest extends AbstractBrokerTest {
 
@@ -24,20 +18,20 @@ public class KcOidcBrokerSubMatchIntrospectionest extends AbstractBrokerTest {
     protected BrokerConfiguration getBrokerConfiguration() {
         return new KcOidcBrokerConfiguration() {
             @Override
-            public List<ClientRepresentation> createConsumerClients(SuiteContext suiteContext) {
-                List<ClientRepresentation> clients = new ArrayList<>(super.createConsumerClients(suiteContext));
+            public List<ClientRepresentation> createConsumerClients() {
+                List<ClientRepresentation> clients = new ArrayList<>(super.createConsumerClients());
                 
                 clients.add(ClientBuilder.create().clientId("consumer-client")
                         .publicClient()
-                        .redirectUris("http://localhost:8180/auth/realms/master/app/auth/*", "https://localhost:8543/auth/realms/master/app/auth/*")
+                        .redirectUris(getConsumerRoot() + "/auth/realms/master/app/auth/*")
                         .publicClient().build());
                 
                 return clients;
             }
 
             @Override
-            public List<ClientRepresentation> createProviderClients(SuiteContext suiteContext) {
-                List<ClientRepresentation> clients = super.createProviderClients(suiteContext);
+            public List<ClientRepresentation> createProviderClients() {
+                List<ClientRepresentation> clients = super.createProviderClients();
                 List<ProtocolMapperRepresentation> mappers = new ArrayList<>();
                 
                 mappers.add(createHardcodedClaim("sub-override", "sub", "overriden", "String", true, true));
@@ -51,7 +45,7 @@ public class KcOidcBrokerSubMatchIntrospectionest extends AbstractBrokerTest {
 
     @Override
     public void testLogInAsUserInIDP() {
-        driver.navigate().to(getAccountUrl(bc.consumerRealmName()));
+        driver.navigate().to(getAccountUrl(getConsumerRoot(), bc.consumerRealmName()));
 
         oauth.realm(bc.consumerRealmName());
         oauth.clientId("consumer-client");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerUiLocalesDisabledTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerUiLocalesDisabledTest.java
@@ -5,7 +5,6 @@ import org.keycloak.models.IdentityProviderSyncMode;
 import org.keycloak.representations.idm.IdentityProviderRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.testsuite.Assert;
-import org.keycloak.testsuite.arquillian.SuiteContext;
 
 import java.util.List;
 import java.util.Map;
@@ -18,6 +17,7 @@ import static org.keycloak.testsuite.broker.BrokerTestConstants.IDP_OIDC_ALIAS;
 import static org.keycloak.testsuite.broker.BrokerTestConstants.IDP_OIDC_PROVIDER_ID;
 import static org.keycloak.testsuite.broker.BrokerTestTools.createIdentityProvider;
 import static org.keycloak.testsuite.broker.BrokerTestTools.waitForPage;
+import static org.keycloak.testsuite.broker.BrokerTestTools.getConsumerRoot;
 
 public class KcOidcBrokerUiLocalesDisabledTest extends AbstractBrokerTest {
 
@@ -29,10 +29,10 @@ public class KcOidcBrokerUiLocalesDisabledTest extends AbstractBrokerTest {
     private class KcOidcBrokerConfigurationWithUiLocalesDisabled extends KcOidcBrokerConfiguration {
 
         @Override
-        public IdentityProviderRepresentation setUpIdentityProvider(SuiteContext suiteContext, IdentityProviderSyncMode syncMode) {
+        public IdentityProviderRepresentation setUpIdentityProvider(IdentityProviderSyncMode syncMode) {
             IdentityProviderRepresentation idp = createIdentityProvider(IDP_OIDC_ALIAS, IDP_OIDC_PROVIDER_ID);
             Map<String, String> config = idp.getConfig();
-            applyDefaultConfiguration(suiteContext, config, syncMode);
+            applyDefaultConfiguration(config, syncMode);
             config.put("uiLocales", "false");
             return idp;
         }
@@ -40,7 +40,7 @@ public class KcOidcBrokerUiLocalesDisabledTest extends AbstractBrokerTest {
 
     @Override
     protected void loginUser() {
-        driver.navigate().to(getAccountUrl(bc.consumerRealmName()));
+        driver.navigate().to(getAccountUrl(getConsumerRoot(), bc.consumerRealmName()));
 
         driver.navigate().to(driver.getCurrentUrl());
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerUiLocalesEnabledTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerUiLocalesEnabledTest.java
@@ -5,7 +5,6 @@ import org.keycloak.models.IdentityProviderSyncMode;
 import org.keycloak.representations.idm.IdentityProviderRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.testsuite.Assert;
-import org.keycloak.testsuite.arquillian.SuiteContext;
 
 import java.util.List;
 import java.util.Map;
@@ -17,6 +16,7 @@ import static org.keycloak.testsuite.broker.BrokerTestConstants.IDP_OIDC_ALIAS;
 import static org.keycloak.testsuite.broker.BrokerTestConstants.IDP_OIDC_PROVIDER_ID;
 import static org.keycloak.testsuite.broker.BrokerTestTools.createIdentityProvider;
 import static org.keycloak.testsuite.broker.BrokerTestTools.waitForPage;
+import static org.keycloak.testsuite.broker.BrokerTestTools.getConsumerRoot;
 
 public class KcOidcBrokerUiLocalesEnabledTest extends AbstractBrokerTest {
 
@@ -28,10 +28,10 @@ public class KcOidcBrokerUiLocalesEnabledTest extends AbstractBrokerTest {
     private class KcOidcBrokerConfigurationWithUiLocalesEnabled extends KcOidcBrokerConfiguration {
 
         @Override
-        public IdentityProviderRepresentation setUpIdentityProvider(SuiteContext suiteContext, IdentityProviderSyncMode syncMode) {
+        public IdentityProviderRepresentation setUpIdentityProvider(IdentityProviderSyncMode syncMode) {
             IdentityProviderRepresentation idp = createIdentityProvider(IDP_OIDC_ALIAS, IDP_OIDC_PROVIDER_ID);
             Map<String, String> config = idp.getConfig();
-            applyDefaultConfiguration(suiteContext, config, syncMode);
+            applyDefaultConfiguration(config, syncMode);
             config.put("uiLocales", "true");
             return idp;
         }
@@ -39,7 +39,7 @@ public class KcOidcBrokerUiLocalesEnabledTest extends AbstractBrokerTest {
 
     @Override
     protected void loginUser() {
-        driver.navigate().to(getAccountUrl(bc.consumerRealmName()));
+        driver.navigate().to(getAccountUrl(getConsumerRoot(), bc.consumerRealmName()));
 
         driver.navigate().to(driver.getCurrentUrl());
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerVaultConfiguration.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerVaultConfiguration.java
@@ -2,7 +2,6 @@ package org.keycloak.testsuite.broker;
 
 import org.keycloak.models.IdentityProviderSyncMode;
 import org.keycloak.representations.idm.IdentityProviderRepresentation;
-import org.keycloak.testsuite.arquillian.SuiteContext;
 
 import static org.keycloak.testsuite.broker.BrokerTestConstants.VAULT_CLIENT_SECRET;
 
@@ -14,8 +13,8 @@ public class KcOidcBrokerVaultConfiguration extends KcOidcBrokerConfiguration {
     public static final KcOidcBrokerVaultConfiguration INSTANCE = new KcOidcBrokerVaultConfiguration();
 
     @Override
-    public IdentityProviderRepresentation setUpIdentityProvider(SuiteContext suiteContext, IdentityProviderSyncMode syncMode) {
-        IdentityProviderRepresentation idpRep = super.setUpIdentityProvider(suiteContext, syncMode);
+    public IdentityProviderRepresentation setUpIdentityProvider(IdentityProviderSyncMode syncMode) {
+        IdentityProviderRepresentation idpRep = super.setUpIdentityProvider(syncMode);
 
         idpRep.getConfig().put("clientSecret", VAULT_CLIENT_SECRET);
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerWithConsentTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerWithConsentTest.java
@@ -3,6 +3,7 @@ package org.keycloak.testsuite.broker;
 import static org.junit.Assert.assertEquals;
 import static org.keycloak.testsuite.broker.BrokerRunOnServerUtil.removeBrokerExpiredSessions;
 import static org.keycloak.testsuite.broker.BrokerTestTools.waitForPage;
+import static org.keycloak.testsuite.broker.BrokerTestTools.getConsumerRoot;
 
 import java.util.List;
 
@@ -45,7 +46,7 @@ public class KcOidcBrokerWithConsentTest extends AbstractInitializedBaseBrokerTe
      */
     @Test
     public void testConsentDeniedWithExpiredClientSession() {
-        driver.navigate().to(getAccountUrl(bc.consumerRealmName()));
+        driver.navigate().to(getAccountUrl(getConsumerRoot(), bc.consumerRealmName()));
         log.debug("Clicking social " + bc.getIDPAlias());
         loginPage.clickSocial(bc.getIDPAlias());
         waitForPage(driver, "log in to", true);
@@ -72,7 +73,7 @@ public class KcOidcBrokerWithConsentTest extends AbstractInitializedBaseBrokerTe
      */
     @Test
     public void testConsentDeniedWithExpiredAndClearedClientSession() {
-        driver.navigate().to(getAccountUrl(bc.consumerRealmName()));
+        driver.navigate().to(getAccountUrl(getConsumerRoot(), bc.consumerRealmName()));
         logInWithBroker(bc);
 
         // Set time offset
@@ -101,7 +102,7 @@ public class KcOidcBrokerWithConsentTest extends AbstractInitializedBaseBrokerTe
         updateExecutions(AbstractBrokerTest::disableUpdateProfileOnFirstLogin);
         createUser(bc.consumerRealmName(), "consumer", "password", "FirstName", "LastName", "consumer@localhost.com");
 
-        driver.navigate().to(getAccountUrl(bc.consumerRealmName()));
+        driver.navigate().to(getAccountUrl(getConsumerRoot(), bc.consumerRealmName()));
         loginPage.login("consumer", "password");
 
         accountPage.federatedIdentity();
@@ -147,7 +148,7 @@ public class KcOidcBrokerWithConsentTest extends AbstractInitializedBaseBrokerTe
     @Test
     public void testLoginCancelConsent() {
         updateExecutions(AbstractBrokerTest::disableUpdateProfileOnFirstLogin);
-        driver.navigate().to(getAccountUrl(bc.consumerRealmName()));
+        driver.navigate().to(getAccountUrl(getConsumerRoot(), bc.consumerRealmName()));
         logInWithBroker(bc);
 
         // User rejected consent
@@ -165,7 +166,7 @@ public class KcOidcBrokerWithConsentTest extends AbstractInitializedBaseBrokerTe
         updateExecutions(AbstractBrokerTest::disableUpdateProfileOnFirstLogin);
         createUser(bc.consumerRealmName(), "consumer", "password", "FirstName", "LastName", "consumer@localhost.com");
 
-        driver.navigate().to(getAccountUrl(bc.consumerRealmName()));
+        driver.navigate().to(getAccountUrl(getConsumerRoot(), bc.consumerRealmName()));
         loginPage.login("consumer", "password");
 
         accountPage.federatedIdentity();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcFirstBrokerLoginNewAuthTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcFirstBrokerLoginNewAuthTest.java
@@ -12,11 +12,11 @@ import org.keycloak.testsuite.admin.ApiUtil;
 import org.keycloak.testsuite.pages.PasswordPage;
 import org.keycloak.testsuite.pages.SelectAuthenticatorPage;
 import org.keycloak.testsuite.util.UserBuilder;
-import org.keycloak.testsuite.util.WaitUtils;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.keycloak.testsuite.broker.BrokerTestTools.waitForPage;
+import static org.keycloak.testsuite.broker.BrokerTestTools.getConsumerRoot;
 
 /**
  * Tests first-broker-login flow with new authenticators.
@@ -195,7 +195,7 @@ public class KcOidcFirstBrokerLoginNewAuthTest extends AbstractInitializedBaseBr
         user.update(userRep);
 
         // Login. TOTP will be required at login time.
-        driver.navigate().to(getAccountUrl(bc.consumerRealmName()));
+        driver.navigate().to(getAccountUrl(getConsumerRoot(), bc.consumerRealmName()));
         loginPage.login(username, "password");
 
         totpPage.assertCurrent();
@@ -211,7 +211,7 @@ public class KcOidcFirstBrokerLoginNewAuthTest extends AbstractInitializedBaseBr
 
     // Login with broker and click "Link account"
     private void loginWithBrokerAndConfirmLinkAccount() {
-        driver.navigate().to(getAccountUrl(bc.consumerRealmName()));
+        driver.navigate().to(getAccountUrl(getConsumerRoot(), bc.consumerRealmName()));
 
         logInWithBroker(bc);
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcFirstBrokerLoginTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcFirstBrokerLoginTest.java
@@ -11,6 +11,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.keycloak.testsuite.admin.ApiUtil.removeUserByUsername;
 import static org.keycloak.testsuite.broker.BrokerTestTools.waitForPage;
+import static org.keycloak.testsuite.broker.BrokerTestTools.getConsumerRoot;
 
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
@@ -35,7 +36,7 @@ public class KcOidcFirstBrokerLoginTest extends AbstractFirstBrokerLoginTest {
         String username = "firstandlastname";
         createUser(bc.providerRealmName(), username, BrokerTestConstants.USER_PASSWORD, firstname, lastname, "firstnamelastname@example.org");
 
-        driver.navigate().to(getAccountUrl(bc.consumerRealmName()));
+        driver.navigate().to(getAccountUrl(getConsumerRoot(), bc.consumerRealmName()));
         logInWithIdp(bc.getIDPAlias(), username, BrokerTestConstants.USER_PASSWORD);
 
         accountUpdateProfilePage.assertCurrent();
@@ -52,8 +53,8 @@ public class KcOidcFirstBrokerLoginTest extends AbstractFirstBrokerLoginTest {
     @Test
     public void testLinkAccountByReauthenticationWithDifferentBroker() {
         KcSamlBrokerConfiguration samlBrokerConfig = KcSamlBrokerConfiguration.INSTANCE;
-        ClientRepresentation samlClient = samlBrokerConfig.createProviderClients(suiteContext).get(0);
-        IdentityProviderRepresentation samlBroker = samlBrokerConfig.setUpIdentityProvider(suiteContext);
+        ClientRepresentation samlClient = samlBrokerConfig.createProviderClients().get(0);
+        IdentityProviderRepresentation samlBroker = samlBrokerConfig.setUpIdentityProvider();
         RealmResource consumerRealm = adminClient.realm(bc.consumerRealmName());
 
         try {
@@ -61,12 +62,12 @@ public class KcOidcFirstBrokerLoginTest extends AbstractFirstBrokerLoginTest {
             adminClient.realm(bc.providerRealmName()).clients().create(samlClient);
             consumerRealm.identityProviders().create(samlBroker);
 
-            driver.navigate().to(getAccountUrl(bc.consumerRealmName()));
+            driver.navigate().to(getAccountUrl(getConsumerRoot(), bc.consumerRealmName()));
 
             logInWithBroker(samlBrokerConfig);
             waitForAccountManagementTitle();
             accountUpdateProfilePage.assertCurrent();
-            logoutFromRealm(bc.consumerRealmName());
+            logoutFromRealm(getConsumerRoot(), bc.consumerRealmName());
 
             logInWithBroker(bc);
 
@@ -98,14 +99,14 @@ public class KcOidcFirstBrokerLoginTest extends AbstractFirstBrokerLoginTest {
     @Test
     public void testFilterMultipleBrokerWhenReauthenticating() {
         KcSamlBrokerConfiguration samlBrokerConfig = KcSamlBrokerConfiguration.INSTANCE;
-        ClientRepresentation samlClient = samlBrokerConfig.createProviderClients(suiteContext).get(0);
-        IdentityProviderRepresentation samlBroker = samlBrokerConfig.setUpIdentityProvider(suiteContext);
+        ClientRepresentation samlClient = samlBrokerConfig.createProviderClients().get(0);
+        IdentityProviderRepresentation samlBroker = samlBrokerConfig.setUpIdentityProvider();
         RealmResource consumerRealm = adminClient.realm(bc.consumerRealmName());
 
         // create another oidc broker
         KcOidcBrokerConfiguration oidcBrokerConfig = KcOidcBrokerConfiguration.INSTANCE;
-        ClientRepresentation oidcClient = oidcBrokerConfig.createProviderClients(suiteContext).get(0);
-        IdentityProviderRepresentation oidcBroker = oidcBrokerConfig.setUpIdentityProvider(suiteContext);
+        ClientRepresentation oidcClient = oidcBrokerConfig.createProviderClients().get(0);
+        IdentityProviderRepresentation oidcBroker = oidcBrokerConfig.setUpIdentityProvider();
         oidcBroker.setAlias("kc-oidc-idp2");
         oidcBroker.setDisplayName("kc-oidc-idp2");
 
@@ -116,12 +117,12 @@ public class KcOidcFirstBrokerLoginTest extends AbstractFirstBrokerLoginTest {
             consumerRealm.identityProviders().create(samlBroker);
             consumerRealm.identityProviders().create(oidcBroker);
 
-            driver.navigate().to(getAccountUrl(bc.consumerRealmName()));
+            driver.navigate().to(getAccountUrl(getConsumerRoot(), bc.consumerRealmName()));
 
             logInWithBroker(samlBrokerConfig);
             waitForAccountManagementTitle();
             accountUpdateProfilePage.assertCurrent();
-            logoutFromRealm(bc.consumerRealmName());
+            logoutFromRealm(getConsumerRoot(), bc.consumerRealmName());
 
             logInWithBroker(bc);
 
@@ -162,8 +163,8 @@ public class KcOidcFirstBrokerLoginTest extends AbstractFirstBrokerLoginTest {
     @Test
     public void testNestedFirstBrokerFlow() {
         KcSamlBrokerConfiguration samlBrokerConfig = KcSamlBrokerConfiguration.INSTANCE;
-        ClientRepresentation samlClient = samlBrokerConfig.createProviderClients(suiteContext).get(0);
-        IdentityProviderRepresentation samlBroker = samlBrokerConfig.setUpIdentityProvider(suiteContext);
+        ClientRepresentation samlClient = samlBrokerConfig.createProviderClients().get(0);
+        IdentityProviderRepresentation samlBroker = samlBrokerConfig.setUpIdentityProvider();
         RealmResource consumerRealm = adminClient.realm(bc.consumerRealmName());
 
         try {
@@ -171,7 +172,7 @@ public class KcOidcFirstBrokerLoginTest extends AbstractFirstBrokerLoginTest {
             adminClient.realm(bc.providerRealmName()).clients().create(samlClient);
             consumerRealm.identityProviders().create(samlBroker);
 
-            driver.navigate().to(getAccountUrl(bc.consumerRealmName()));
+            driver.navigate().to(getAccountUrl(getConsumerRoot(), bc.consumerRealmName()));
 
             createUser(bc.getUserLogin());
 
@@ -207,8 +208,8 @@ public class KcOidcFirstBrokerLoginTest extends AbstractFirstBrokerLoginTest {
     @Test
     public void testLoginWithDifferentBrokerWhenUpdatingProfile() {
         KcSamlBrokerConfiguration samlBrokerConfig = KcSamlBrokerConfiguration.INSTANCE;
-        ClientRepresentation samlClient = samlBrokerConfig.createProviderClients(suiteContext).get(0);
-        IdentityProviderRepresentation samlBroker = samlBrokerConfig.setUpIdentityProvider(suiteContext);
+        ClientRepresentation samlClient = samlBrokerConfig.createProviderClients().get(0);
+        IdentityProviderRepresentation samlBroker = samlBrokerConfig.setUpIdentityProvider();
         RealmResource consumerRealm = adminClient.realm(bc.consumerRealmName());
 
         try {
@@ -216,11 +217,11 @@ public class KcOidcFirstBrokerLoginTest extends AbstractFirstBrokerLoginTest {
             adminClient.realm(bc.providerRealmName()).clients().create(samlClient);
             consumerRealm.identityProviders().create(samlBroker);
 
-            driver.navigate().to(getAccountUrl(bc.consumerRealmName()));
+            driver.navigate().to(getAccountUrl(getConsumerRoot(), bc.consumerRealmName()));
             logInWithBroker(samlBrokerConfig);
             waitForPage(driver, "update account information", false);
             updateAccountInformationPage.updateAccountInformation("FirstName", "LastName");
-            logoutFromRealm(bc.consumerRealmName());
+            logoutFromRealm(getConsumerRoot(), bc.consumerRealmName());
 
             logInWithBroker(bc);
 
@@ -246,7 +247,7 @@ public class KcOidcFirstBrokerLoginTest extends AbstractFirstBrokerLoginTest {
         updateExecutions(AbstractBrokerTest::setUpMissingUpdateProfileOnFirstLogin);
 
         createUser(bc.providerRealmName(), "no-first-name", "password", null, "LastName", "no-first-name@localhost.com");
-        driver.navigate().to(getAccountUrl(bc.consumerRealmName()));
+        driver.navigate().to(getAccountUrl(getConsumerRoot(), bc.consumerRealmName()));
         log.debug("Clicking social " + bc.getIDPAlias());
         loginPage.clickSocial(bc.getIDPAlias());
         waitForPage(driver, "log in to", true);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcSamlBrokerAllowedClockSkewTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcSamlBrokerAllowedClockSkewTest.java
@@ -53,7 +53,7 @@ public class KcSamlBrokerAllowedClockSkewTest extends AbstractInitializedBaseBro
         Document doc = SAML2Request.convert(loginRep);
 
         new SamlClientBuilder()
-          .authnRequest(getAuthServerSamlEndpoint(bc.consumerRealmName()), doc, SamlClient.Binding.POST).build()   // Request to consumer IdP
+          .authnRequest(getConsumerSamlEndpoint(bc.consumerRealmName()), doc, SamlClient.Binding.POST).build()   // Request to consumer IdP
           .login().idp(bc.getIDPAlias()).build()
 
           .processSamlResponse(SamlClient.Binding.POST)    // AuthnRequest to producer IdP
@@ -79,7 +79,7 @@ public class KcSamlBrokerAllowedClockSkewTest extends AbstractInitializedBaseBro
             Document doc = SAML2Request.convert(loginRep);
 
             SAMLDocumentHolder samlResponse = new SamlClientBuilder()
-              .authnRequest(getAuthServerSamlEndpoint(bc.consumerRealmName()), doc, SamlClient.Binding.POST).build()   // Request to consumer IdP
+              .authnRequest(getConsumerSamlEndpoint(bc.consumerRealmName()), doc, SamlClient.Binding.POST).build()   // Request to consumer IdP
               .login().idp(bc.getIDPAlias()).build()
 
               .processSamlResponse(SamlClient.Binding.POST)    // AuthnRequest to producer IdP

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcSamlBrokerSessionNotOnOrAfterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcSamlBrokerSessionNotOnOrAfterTest.java
@@ -32,7 +32,7 @@ public class KcSamlBrokerSessionNotOnOrAfterTest extends AbstractBrokerTest {
     @Test
     public void testConsumerIdpInitiatedLoginContainsSessionNotOnOrAfter() throws Exception {
         SAMLDocumentHolder samlResponse = new SamlClientBuilder()
-                .idpInitiatedLogin(getAuthServerSamlEndpoint(REALM_CONS_NAME), "sales-post").build()
+                .idpInitiatedLogin(getConsumerSamlEndpoint(REALM_CONS_NAME), "sales-post").build()
                 // Request login via kc-saml-idp
                 .login().idp(IDP_SAML_ALIAS).build()
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcSamlSignedDocumentOnlyBrokerTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcSamlSignedDocumentOnlyBrokerTest.java
@@ -4,7 +4,6 @@ import org.keycloak.models.IdentityProviderSyncMode;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.IdentityProviderRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
-import org.keycloak.testsuite.arquillian.SuiteContext;
 
 import java.util.HashMap;
 import java.util.List;
@@ -37,8 +36,8 @@ public class KcSamlSignedDocumentOnlyBrokerTest extends AbstractBrokerTest {
         }
 
         @Override
-        public List<ClientRepresentation> createProviderClients(SuiteContext suiteContext) {
-            List<ClientRepresentation> clientRepresentationList = super.createProviderClients(suiteContext);
+        public List<ClientRepresentation> createProviderClients() {
+            List<ClientRepresentation> clientRepresentationList = super.createProviderClients();
 
             for (ClientRepresentation client : clientRepresentationList) {
                 client.setClientAuthenticatorType("client-secret");
@@ -62,8 +61,8 @@ public class KcSamlSignedDocumentOnlyBrokerTest extends AbstractBrokerTest {
         }
 
         @Override
-        public IdentityProviderRepresentation setUpIdentityProvider(SuiteContext suiteContext, IdentityProviderSyncMode syncMode) {
-            IdentityProviderRepresentation result = super.setUpIdentityProvider(suiteContext, syncMode);
+        public IdentityProviderRepresentation setUpIdentityProvider(IdentityProviderSyncMode syncMode) {
+            IdentityProviderRepresentation result = super.setUpIdentityProvider(syncMode);
 
             Map<String, String> config = result.getConfig();
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/AbstractSamlTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/AbstractSamlTest.java
@@ -18,9 +18,7 @@ import java.security.spec.X509EncodedKeySpec;
 import java.util.Base64;
 import java.util.List;
 
-import static org.keycloak.testsuite.arquillian.AuthServerTestEnricher.AUTH_SERVER_PORT;
-import static org.keycloak.testsuite.arquillian.AuthServerTestEnricher.AUTH_SERVER_SCHEME;
-import static org.keycloak.testsuite.arquillian.AuthServerTestEnricher.AUTH_SERVER_SSL_REQUIRED;
+import static org.keycloak.testsuite.arquillian.AuthServerTestEnricher.getAuthServerContextRoot;
 import static org.keycloak.testsuite.utils.io.IOUtil.loadRealm;
 
 /**
@@ -33,13 +31,13 @@ public abstract class AbstractSamlTest extends AbstractAuthTest {
     public static final String REALM_PUBLIC_KEY = "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCrVrCuTtArbgaZzL1hvh0xtL5mc7o0NqPVnYXkLvgcwiC3BjLGw1tGEGoJaXDuSaRllobm53JBhjx33UNv+5z/UMG4kytBWxheNVKnL6GgqlNabMaFfPLPCF8kAgKnsi79NMo+n6KnSY8YeUmec/p2vjO2NjsSAVcWEQMVhJ31LwIDAQAB";
     public static final String REALM_SIGNING_CERTIFICATE = "MIIBkTCB+wIGAUkZB1wLMA0GCSqGSIb3DQEBCwUAMA8xDTALBgNVBAMTBGRlbW8wHhcNMTQxMDE2MTI1NDEzWhcNMjQxMDE2MTI1NTUzWjAPMQ0wCwYDVQQDEwRkZW1vMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCrVrCuTtArbgaZzL1hvh0xtL5mc7o0NqPVnYXkLvgcwiC3BjLGw1tGEGoJaXDuSaRllobm53JBhjx33UNv+5z/UMG4kytBWxheNVKnL6GgqlNabMaFfPLPCF8kAgKnsi79NMo+n6KnSY8YeUmec/p2vjO2NjsSAVcWEQMVhJ31LwIDAQABMA0GCSqGSIb3DQEBCwUAA4GBAI9moVwZxiEvzfvyL0zqyzRP4qnEdYQ/l/Nl78OAed25hdKpVpNv8i7DwM1QscWQhrtfGImD0480eoOUfe1rU9k6gNdNpR6kYAz17A/OsovpTFF0cIQE7HPqumpHfdbeW0jEjLNT2Od/PXdaIijVOdbJn8iF//nnItrwPbNUBU75";
 
-    public static final String SAML_ASSERTION_CONSUMER_URL_SALES_POST = AUTH_SERVER_SCHEME + "://localhost:" + (AUTH_SERVER_SSL_REQUIRED ? AUTH_SERVER_PORT : 8080) + "/sales-post/saml";
+    public static final String SAML_ASSERTION_CONSUMER_URL_SALES_POST = getAuthServerContextRoot() + "/sales-post/saml";
     public static final String SAML_CLIENT_ID_SALES_POST = "http://localhost:8280/sales-post/";
 
-    public static final String SAML_ASSERTION_CONSUMER_URL_SALES_POST2 = AUTH_SERVER_SCHEME + "://localhost:" + (AUTH_SERVER_SSL_REQUIRED ? AUTH_SERVER_PORT : 8080) + "/sales-post2/saml";
+    public static final String SAML_ASSERTION_CONSUMER_URL_SALES_POST2 = getAuthServerContextRoot() + "/sales-post2/saml";
     public static final String SAML_CLIENT_ID_SALES_POST2 = "http://localhost:8280/sales-post2/";
 
-    public static final String SAML_ASSERTION_CONSUMER_URL_SALES_POST_SIG = AUTH_SERVER_SCHEME + "://localhost:" + (AUTH_SERVER_SSL_REQUIRED ? AUTH_SERVER_PORT : 8080) + "/sales-post-sig/";
+    public static final String SAML_ASSERTION_CONSUMER_URL_SALES_POST_SIG = getAuthServerContextRoot() + "/sales-post-sig/";
     public static final String SAML_CLIENT_ID_SALES_POST_SIG = "http://localhost:8280/sales-post-sig/";
     public static final String SAML_URL_SALES_POST_SIG = "http://localhost:8080/sales-post-sig/";
     public static final String SAML_CLIENT_SALES_POST_SIG_PRIVATE_KEY = "MIICdQIBADANBgkqhkiG9w0BAQEFAASCAl8wggJbAgEAAoGBANUbxrvEY3pkiQNt55zJLKBwN+zKmNQw08ThAmOKzwHfXoK+xlDSFxNMtTKJGkeUdnKzaTfESEcEfKYULUA41y/NnOlvjS0CEsc7Wq0Ce63TSSGMB2NHea4tV0aQz/MwLsbmz2IjAFWHA5CHL5WwacIf3UTOSNnhJUSvnkomjJAlAgMBAAECgYANpO2gb/5+g5lSIuNFYov86bJq8r2+ODIW1OE2Rljioc6HSHeiDRF1JuAjECwikRrUVTBTZbnK8jqY14neJsWAKBzGo+ToaQALsNZ9B91DxxL50K5oVOzw5shAS9TnRjN40+KIXFED4ydq4JRdoqb8+cN+N3i0+Cu7tdm+UaHTAQJBAOwFs3ZwqQEqmv9vmgmIFwFpJm1aIw25gEOf3Hy45GP4bL/j0FQgwcXYRbLE5bPqhw/liLKc1GQ97bVm6zs8SvUCQQDnJZA6TFRMiDjezinE1J4e0v4RupyDniVjbE5ArTK5/FRVkjw4Ny0AqZUEyIIqlTeZlCq45pCJy4a2hymDGVJxAj9gzfXNnmezEsZ//kYvoqHM8lPQhifaeTsigW7tuOf0GPCBw+6uksDnZM0xhZCxOoArBPoMSEbU1pGo1Y2lvhUCQF6E5sBgHAybm53Ich4Rz4LNRqWbSIstrR5F2I3sBRU2kInZXZSjQ1zE+7HUCB4/nFfJ1dp8NdiTCEg1Zw072pECQQDnxyQALmWhQbBTl0tq6CwYf9rZDwBzxuY+CXB8Ky1gOmXwan96KZvV4rK8MQQs6HIiYC/j+5lX3A3zlXTFldaz";

--- a/testsuite/integration-arquillian/tests/base/src/test/resources/arquillian.xml
+++ b/testsuite/integration-arquillian/tests/base/src/test/resources/arquillian.xml
@@ -38,6 +38,7 @@
         <property name="firefoxLegacy">${firefoxLegacyDriver}</property>
         <property name="firefoxDriverVersion">${firefoxDriverVersion}</property>
         <property name="firefoxUserPreferences">${firefoxUserPreferences}</property>
+        <property name="firefoxHeadless">${firefoxHeadless}</property>
 
         <!-- chrome -->
         <property name="chromeBinary">${chromeBinary}</property>
@@ -88,6 +89,7 @@
         <property name="firefoxLegacy">${firefoxLegacyDriver}</property>
         <property name="firefoxDriverVersion">${firefoxDriverVersion}</property>
         <property name="firefoxUserPreferences">${firefoxUserPreferences}</property>
+        <property name="firefoxHeadless">${firefoxHeadless}</property>
 
         <!-- chrome -->
         <property name="chromeBinary">${chromeBinary}</property>

--- a/testsuite/integration-arquillian/tests/base/src/test/resources/firefox-cookies-prefs.js
+++ b/testsuite/integration-arquillian/tests/base/src/test/resources/firefox-cookies-prefs.js
@@ -1,0 +1,4 @@
+user_pref("network.cookie.sameSite.laxByDefault", true);
+user_pref("network.cookie.sameSite.laxPlusPOST.timeout", 0);
+user_pref("network.cookie.sameSite.noneRequiresSecure", true);
+user_pref("network.cookie.cookieBehavior", 1); // only accept from the originating site (block third party cookies)

--- a/testsuite/integration-arquillian/tests/pom.xml
+++ b/testsuite/integration-arquillian/tests/pom.xml
@@ -93,6 +93,8 @@
         <auth.server.profile/>
         <auth.server.feature/>
 
+        <auth.server.host2>${auth.server.host}</auth.server.host2> <!-- for broker and JS adapter tests; defaults to auth.server.host -->
+
         <app.server.skip.unpack>true</app.server.skip.unpack>
         <app.server.artifactId>integration-arquillian-servers-app-server-${app.server}</app.server.artifactId>
         <app.server.home>${containers.home}/app-server-${app.server}</app.server.home>
@@ -183,6 +185,7 @@
         <firefoxLegacyDriver>false</firefoxLegacyDriver>
         <firefoxDriverVersion/>
         <firefoxUserPreferences/>
+        <firefoxHeadless>false</firefoxHeadless>
         <chromeBinary/>
         <chromeArguments/>
         <chromeDriverVersion/>
@@ -508,6 +511,8 @@
                             <auth.server.profile>${auth.server.profile}</auth.server.profile>
                             <auth.server.feature>${auth.server.feature}</auth.server.feature>
 
+                            <auth.server.host2>${auth.server.host2}</auth.server.host2> <!-- for broker tests -->
+
                             <app.server>${app.server}</app.server>
                             <app.server.home>${app.server.home}</app.server.home>
                             <app.server.config.dir>${app.server.config.dir}</app.server.config.dir>
@@ -573,6 +578,7 @@
                             <firefoxLegacyDriver>${firefoxLegacyDriver}</firefoxLegacyDriver>
                             <firefoxDriverVersion>${firefoxDriverVersion}</firefoxDriverVersion>
                             <firefoxUserPreferences>${firefoxUserPreferences}</firefoxUserPreferences>
+                            <firefoxHeadless>${firefoxHeadless}</firefoxHeadless>
 
                             <appium.platformName>${appium.platformName}</appium.platformName>
                             <appium.deviceName>${appium.deviceName}</appium.deviceName>
@@ -1904,6 +1910,7 @@
                                         <storepass>${dependency.keystore.password}</storepass>
                                         <alias>${auth.server.host}</alias>
                                         <dname>CN=${auth.server.host}, OU=Keycloak, O=Red Hat, L=Westword, ST=MA, C=US</dname>
+                                        <ext>SAN=dns:${auth.server.host},dns:${auth.server.host2}</ext> <!-- for broker tests; IdP is the same server as auth server -->
                                         <keyalg>RSA</keyalg>
                                         <keysize>2048</keysize>
                                         <sigalg>SHA256withRSA</sigalg>
@@ -1963,6 +1970,15 @@
                     </plugins>
                 </pluginManagement>
             </build>
+        </profile>
+
+        <profile>
+            <id>firefox-strict-cookies</id>
+            <properties>
+                <browser>firefox</browser>
+                <firefoxUserPreferences>${project.build.directory}/dependency/firefox-cookies-prefs.js</firefoxUserPreferences>
+                <firefoxHeadless>true</firefoxHeadless>
+            </properties>
         </profile>
 
     </profiles>


### PR DESCRIPTION
Since this PR slightly touches adapter tests as well, I run the tests here: https://keycloak-jenkins.com/job/universal-test-pipeline-adapters/1440/