### PR TITLE
[KEYCLOAK-14037] Enable s390x build support in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,20 +24,44 @@ env:
     - TESTS=crossdc-adapter
     - TESTS=broker
 
+matrix:
+  include:
+    - os: linux
+      arch: s390x
+      dist: bionic
+      env: TESTS=unit
+    - os: linux
+      arch: s390x
+      dist: bionic
+      env: TESTS=server-group1
+    - os: linux
+      arch: s390x
+      dist: bionic
+      env: TESTS=server-group4
+    - os: linux
+      arch: s390x
+      dist: bionic
+      env: TESTS=crossdc-server
+    - os: linux
+      arch: s390x
+      dist: bionic
+      env: TESTS=crossdc-adapter
+    - os: linux
+      arch: s390x
+      dist: bionic
+      env: TESTS=broker
+
 jdk:
   - openjdk8
 
 install: true
 
 before_install:
-  - "export PHANTOMJS_VERSION=2.1.1"
-  - "phantomjs --version"
-  - "export PATH=$PWD/travis_phantomjs/phantomjs-$PHANTOMJS_VERSION-linux-x86_64/bin:$PATH"
-  - "phantomjs --version"
-  - "if [ $(phantomjs --version) != '$PHANTOMJS_VERSION' ]; then rm -rf $PWD/travis_phantomjs; mkdir -p $PWD/travis_phantomjs; fi"
-  - "if [ $(phantomjs --version) != '$PHANTOMJS_VERSION' ]; then wget https://github.com/Medium/phantomjs/releases/download/v$PHANTOMJS_VERSION/phantomjs-$PHANTOMJS_VERSION-linux-x86_64.tar.bz2 -O $PWD/travis_phantomjs/phantomjs-$PHANTOMJS_VERSION-linux-x86_64.tar.bz2; fi"
-  - "if [ $(phantomjs --version) != '$PHANTOMJS_VERSION' ]; then tar -xvf $PWD/travis_phantomjs/phantomjs-$PHANTOMJS_VERSION-linux-x86_64.tar.bz2 -C $PWD/travis_phantomjs; fi"
-  - "phantomjs --version"
+  - .travis/before_install.sh
+  - if [[ $(uname -m) == 's390x' ]]; then 
+      export QT_QPA_PLATFORM=offscreen;
+      export PATH="$PWD/jdk8u252-b09/bin:$PATH";
+    fi
 
 before_script:
   - export -f travis_fold

--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -ex;
+
+if test ${TRAVIS_ARCH} = "s390x";
+then
+  sudo apt-get update
+  sudo apt-get install -y phantomjs maven
+  curl -fsSL https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09_openj9-0.20.0/OpenJDK8U-jdk_s390x_linux_openj9_8u252b09_openj9-0.20.0.tar.gz | tar xz
+else
+  export PHANTOMJS_VERSION=2.1.1;
+  phantomjs --version;
+  export PATH=$PWD/travis_phantomjs/phantomjs-$PHANTOMJS_VERSION-linux-x86_64/bin:$PATH;
+  phantomjs --version;
+  if [ $(phantomjs --version) != $PHANTOMJS_VERSION ]; then 
+    rm -rf $PWD/travis_phantomjs; mkdir -p $PWD/travis_phantomjs;
+    wget https://github.com/Medium/phantomjs/releases/download/v$PHANTOMJS_VERSION/phantomjs-$PHANTOMJS_VERSION-linux-x86_64.tar.bz2 -O $PWD/travis_phantomjs/phantomjs-$PHANTOMJS_VERSION-linux-x86_64.tar.bz2;
+    tar -xvf $PWD/travis_phantomjs/phantomjs-$PHANTOMJS_VERSION-linux-x86_64.tar.bz2 -C $PWD/travis_phantomjs; 
+  fi;
+  phantomjs --version;
+fi


### PR DESCRIPTION
JIRA: [KEYCLOAK-14037](https://issues.redhat.com/browse/KEYCLOAK-14037)
Enable s390x builds in Keycloak Travis CI.

**Note:** Some tests are skipped for s390x as there is some known issue with phantomjs which causes these tests fail.