### PR TITLE
[KEYCLOAK-14343] Truststore SPI support for LDAP with StartTLS [KEYCLOAK-14358] Enable StartTLS LDAP tests

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/truststore/TruststoreProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/truststore/TruststoreProvider.java
@@ -19,10 +19,10 @@ package org.keycloak.truststore;
 
 import org.keycloak.provider.Provider;
 
-import java.security.KeyStore;
 import java.security.cert.X509Certificate;
+import java.security.KeyStore;
 import java.util.Map;
-
+import javax.net.ssl.SSLSocketFactory;
 import javax.security.auth.x500.X500Principal;
 
 /**
@@ -31,6 +31,8 @@ import javax.security.auth.x500.X500Principal;
 public interface TruststoreProvider extends Provider {
 
     HostnameVerificationPolicy getPolicy();
+
+    SSLSocketFactory getSSLSocketFactory();
 
     KeyStore getTruststore();
 

--- a/services/src/main/java/org/keycloak/truststore/FileTruststoreProvider.java
+++ b/services/src/main/java/org/keycloak/truststore/FileTruststoreProvider.java
@@ -20,7 +20,7 @@ package org.keycloak.truststore;
 import java.security.KeyStore;
 import java.security.cert.X509Certificate;
 import java.util.Map;
-
+import javax.net.ssl.SSLSocketFactory;
 import javax.security.auth.x500.X500Principal;
 
 /**
@@ -29,6 +29,7 @@ import javax.security.auth.x500.X500Principal;
 public class FileTruststoreProvider implements TruststoreProvider {
 
     private final HostnameVerificationPolicy policy;
+    private final SSLSocketFactory sslSocketFactory;
     private final KeyStore truststore;
     private final Map<X500Principal, X509Certificate> rootCertificates;
     private final Map<X500Principal, X509Certificate> intermediateCertificates;
@@ -38,11 +39,19 @@ public class FileTruststoreProvider implements TruststoreProvider {
         this.truststore = truststore;
         this.rootCertificates = rootCertificates;
         this.intermediateCertificates = intermediateCertificates;
+
+        SSLSocketFactory jsseSSLSocketFactory = new JSSETruststoreConfigurator(this).getSSLSocketFactory();
+        this.sslSocketFactory = (jsseSSLSocketFactory != null) ? jsseSSLSocketFactory : (SSLSocketFactory) javax.net.ssl.SSLSocketFactory.getDefault();
     }
 
     @Override
     public HostnameVerificationPolicy getPolicy() {
         return policy;
+    }
+
+    @Override
+    public SSLSocketFactory getSSLSocketFactory() {
+        return sslSocketFactory;
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/truststore/FileTruststoreProviderFactory.java
+++ b/services/src/main/java/org/keycloak/truststore/FileTruststoreProviderFactory.java
@@ -22,7 +22,6 @@ import org.keycloak.Config;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 
-import javax.security.auth.x500.X500Principal;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -40,6 +39,7 @@ import java.security.cert.X509Certificate;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
+import javax.security.auth.x500.X500Principal;
 
 /**
  * @author <a href="mailto:mstrukel@redhat.com">Marko Strukelj</a>

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/LDAPRule.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/LDAPRule.java
@@ -242,10 +242,14 @@ public class LDAPRule extends ExternalResource {
         switch (defaultProperties.getProperty(LDAPEmbeddedServer.PROPERTY_ENABLE_STARTTLS)) {
             case "true":
                 config.put(LDAPConstants.START_TLS, "true");
+                // Use truststore from TruststoreSPI also for StartTLS connections
+                config.put(LDAPConstants.USE_TRUSTSTORE_SPI, LDAPConstants.USE_TRUSTSTORE_ALWAYS);
                 break;
             default:
                 // Default to startTLS disabled
                 config.put(LDAPConstants.START_TLS, "false");
+                // By default use truststore from TruststoreSPI only for LDAP over SSL connections
+                config.put(LDAPConstants.USE_TRUSTSTORE_SPI, LDAPConstants.USE_TRUSTSTORE_LDAPS_ONLY);
         }
         switch (defaultProperties.getProperty(LDAPEmbeddedServer.PROPERTY_SET_CONFIDENTIALITY_REQUIRED)) {
             case "true":

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/LDAPTestConfiguration.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/LDAPTestConfiguration.java
@@ -72,6 +72,7 @@ public class LDAPTestConfiguration {
         PROP_MAPPINGS.put(KerberosConstants.ALLOW_PASSWORD_AUTHENTICATION, "idm.test.kerberos.allow.password.authentication");
         PROP_MAPPINGS.put(KerberosConstants.UPDATE_PROFILE_FIRST_LOGIN, "idm.test.kerberos.update.profile.first.login");
         PROP_MAPPINGS.put(KerberosConstants.USE_KERBEROS_FOR_PASSWORD_AUTHENTICATION, "idm.test.kerberos.use.kerberos.for.password.authentication");
+        PROP_MAPPINGS.put(LDAPConstants.USE_TRUSTSTORE_SPI, "idm.test.ldap.truststore.spi");
 
         DEFAULT_VALUES.put(LDAPConstants.CONNECTION_URL, "ldap://localhost:10389");
         DEFAULT_VALUES.put(LDAPConstants.BASE_DN, "dc=keycloak,dc=org");
@@ -85,6 +86,7 @@ public class LDAPTestConfiguration {
         DEFAULT_VALUES.put(LDAPConstants.USERNAME_LDAP_ATTRIBUTE, null);
         DEFAULT_VALUES.put(LDAPConstants.USER_OBJECT_CLASSES, null);
         DEFAULT_VALUES.put(LDAPConstants.EDIT_MODE, UserStorageProvider.EditMode.READ_ONLY.toString());
+        DEFAULT_VALUES.put(LDAPConstants.USE_TRUSTSTORE_SPI, LDAPConstants.USE_TRUSTSTORE_ALWAYS);
 
         DEFAULT_VALUES.put(KerberosConstants.ALLOW_KERBEROS_AUTHENTICATION, "false");
         DEFAULT_VALUES.put(KerberosConstants.KERBEROS_REALM, "KEYCLOAK.ORG");
@@ -102,7 +104,7 @@ public class LDAPTestConfiguration {
         ldapTestConfiguration.loadConnectionProperties(connectionPropertiesLocation);
         return ldapTestConfiguration;
     }
-    
+
     public static String getResource(String resourcePath) {
         URL urlPath = LDAPTestConfiguration.class.getResource(resourcePath);
         String absolutePath = new File(urlPath.getFile()).getAbsolutePath();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPUserLoginTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPUserLoginTest.java
@@ -20,7 +20,6 @@ package org.keycloak.testsuite.federation.ldap;
 
 import org.jboss.arquillian.graphene.page.Page;
 import org.junit.FixMethodOrder;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExternalResource;
@@ -240,8 +239,6 @@ public class LDAPUserLoginTest extends AbstractLDAPTest {
 
     // Check LDAP federated user (in)valid login(s) with simple authentication & startTLS encryption enabled
     // Test variant: Bind credential set to secret (default)
-    // KEYCLOAK-14358 - Disable the StartTLS LDAP tests till KEYCLOAK-14343 & KEYCLOAK-14354 are corrected
-    //                  since they don't work properly with auth server Wildfly due these bugs
     @Test
     @LDAPConnectionParameters(bindType=LDAPConnectionParameters.BindType.SIMPLE, encryption=LDAPConnectionParameters.Encryption.STARTTLS)
     public void loginLDAPUserAuthenticationSimpleEncryptionStartTLS() {
@@ -251,8 +248,6 @@ public class LDAPUserLoginTest extends AbstractLDAPTest {
 
     // Check LDAP federated user (in)valid login(s) with simple authentication & startTLS encryption enabled
     // Test variant: Bind credential set to vault
-    // KEYCLOAK-14358 - Disable the StartTLS LDAP tests till KEYCLOAK-14343 & KEYCLOAK-14354 are corrected
-    //                  since they don't work properly with auth server Wildfly due these bugs
     @Test
     @LDAPConnectionParameters(bindCredential=LDAPConnectionParameters.BindCredential.VAULT, bindType=LDAPConnectionParameters.BindType.SIMPLE, encryption=LDAPConnectionParameters.Encryption.STARTTLS)
     public void loginLDAPUserCredentialVaultAuthenticationSimpleEncryptionStartTLS() {
@@ -298,9 +293,6 @@ public class LDAPUserLoginTest extends AbstractLDAPTest {
 
     // Check LDAP federated user (in)valid login(s) with anonymous authentication & startTLS encryption enabled
     // Test variant: Bind credential set to secret (default)
-    // KEYCLOAK-14358 - Disable the StartTLS LDAP tests till KEYCLOAK-14343 & KEYCLOAK-14354 are corrected
-    //                  since they don't work properly with auth server Wildfly due these bugs
-    @Ignore
     @Test
     @LDAPConnectionParameters(bindType=LDAPConnectionParameters.BindType.NONE, encryption=LDAPConnectionParameters.Encryption.STARTTLS)
     public void loginLDAPUserAuthenticationNoneEncryptionStartTLS() {
@@ -310,9 +302,6 @@ public class LDAPUserLoginTest extends AbstractLDAPTest {
 
     // Check LDAP federated user (in)valid login(s) with anonymous authentication & startTLS encryption enabled
     // Test variant: Bind credential set to vault
-    // KEYCLOAK-14358 - Disable the StartTLS LDAP tests till KEYCLOAK-14343 & KEYCLOAK-14354 are corrected
-    //                  since they don't work properly with auth server Wildfly due these bugs
-    @Ignore
     @Test
     @LDAPConnectionParameters(bindCredential=LDAPConnectionParameters.BindCredential.VAULT, bindType=LDAPConnectionParameters.BindType.NONE, encryption=LDAPConnectionParameters.Encryption.STARTTLS)
     public void loginLDAPUserCredentialVaultAuthenticationNoneEncryptionStartTLS() {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPUserLoginTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPUserLoginTest.java
@@ -242,7 +242,6 @@ public class LDAPUserLoginTest extends AbstractLDAPTest {
     // Test variant: Bind credential set to secret (default)
     // KEYCLOAK-14358 - Disable the StartTLS LDAP tests till KEYCLOAK-14343 & KEYCLOAK-14354 are corrected
     //                  since they don't work properly with auth server Wildfly due these bugs
-    @Ignore
     @Test
     @LDAPConnectionParameters(bindType=LDAPConnectionParameters.BindType.SIMPLE, encryption=LDAPConnectionParameters.Encryption.STARTTLS)
     public void loginLDAPUserAuthenticationSimpleEncryptionStartTLS() {
@@ -254,7 +253,6 @@ public class LDAPUserLoginTest extends AbstractLDAPTest {
     // Test variant: Bind credential set to vault
     // KEYCLOAK-14358 - Disable the StartTLS LDAP tests till KEYCLOAK-14343 & KEYCLOAK-14354 are corrected
     //                  since they don't work properly with auth server Wildfly due these bugs
-    @Ignore
     @Test
     @LDAPConnectionParameters(bindCredential=LDAPConnectionParameters.BindCredential.VAULT, bindType=LDAPConnectionParameters.BindType.SIMPLE, encryption=LDAPConnectionParameters.Encryption.STARTTLS)
     public void loginLDAPUserCredentialVaultAuthenticationSimpleEncryptionStartTLS() {


### PR DESCRIPTION
    commit 2cacd3c6a65c6751d3fdeac97d6694d08c3fe145
    Author: Tero Saarni <tero.saarni@est.tech>
    Date:   Fri May 29 11:11:14 2020 +0300

    [KEYCLOAK-14343] Truststore SPI support for LDAP with StartTLS
    
    Signed-off-by:  Tero Saarni <tero.saarni@est.tech>
    Co-authored-by: Jan Lieskovsky <jlieskov@redhat.com>

--

    commit 35dac0171626716dcdfe7704356670f7f806e225
    Author: Jan Lieskovsky <jlieskov@redhat.com>
    Date:   Mon Jun 8 18:20:19 2020 +0200

    [KEYCLOAK-14358] Enable StartTLS LDAP tests
    
    Thanks to KEYCLOAK-14343 Use Truststore SPI StartTLS bug fix
    they will work with Truststore SPI used by auth server Wildfly too
    
    Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

--

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
