### PR TITLE
KEYCLOAK-14444 Fix SAML sending wrong role list attributes

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/saml/SamlProtocol.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/SamlProtocol.java
@@ -432,7 +432,7 @@ public class SamlProtocol implements LoginProtocol {
             if (mapper instanceof SAMLLoginResponseMapper) {
                 loginResponseMappers.add(new ProtocolMapperProcessor<SAMLLoginResponseMapper>((SAMLLoginResponseMapper) mapper, mapping));
             }
-            if (mapper instanceof SAMLRoleListMapper) {
+            if (mapper instanceof SAMLRoleListMapper && roleListMapper == null) {
                 roleListMapper = new ProtocolMapperProcessor<SAMLRoleListMapper>((SAMLRoleListMapper) mapper, mapping);
             }
         }


### PR DESCRIPTION
Fix as per what has been reported at [KEYCLOAK-14444](https://issues.redhat.com/browse/KEYCLOAK-14444).