### PR TITLE
KEYCLOAK-14490: Use snowpack optimze flag

### DIFF
--- a/themes/src/main/resources/theme/keycloak-preview/account/src/package.json
+++ b/themes/src/main/resources/theme/keycloak-preview/account/src/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "keycloak-preview account management written in React",
   "scripts": {
-    "build": "snowpack && npm run check-types && npm run babel && npm run move-web_modules",
+    "build": "snowpack --optimize && npm run check-types && npm run babel && npm run move-web_modules",
     "babel": "babel --source-maps --extensions \".js,.ts,.tsx\" app/ --out-dir ../resources/",
     "babel:watch": "npm run babel -- --watch",
     "check-types": "tsc --noImplicitAny --strictNullChecks --jsx react -p ./",


### PR DESCRIPTION
Since we are going to stay on Snowpack 1 a little longer, we might as well go ahead and start using the --optimize flag, which has been shown to decrease the download by almost 1 MB and decrease startup time.
