### PR TITLE
KEYCLOAK-12326 when `WebAuthnCredentialModel` is set as a "password" …

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/account/LinkedAccountsResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/LinkedAccountsResource.java
@@ -50,6 +50,7 @@ import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.credential.PasswordCredentialModel;
+import org.keycloak.models.credential.WebAuthnCredentialModel;
 import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.provider.ProviderFactory;
 import org.keycloak.representations.account.AccountLinkUriRepresentation;
@@ -255,7 +256,8 @@ public class LinkedAccountsResource {
     }
     
     private boolean isPasswordSet() {
-        return session.userCredentialManager().isConfiguredFor(realm, user, PasswordCredentialModel.TYPE);
+        return session.userCredentialManager().isConfiguredFor(realm, user, PasswordCredentialModel.TYPE)
+                || session.userCredentialManager().isConfiguredFor(realm, user, WebAuthnCredentialModel.TYPE_PASSWORDLESS);
     }
     
     private boolean isValidProvider(String providerId) {

--- a/testsuite/integration-arquillian/tests/other/base-ui/src/test/java/org/keycloak/testsuite/ui/AbstractUiTest.java
+++ b/testsuite/integration-arquillian/tests/other/base-ui/src/test/java/org/keycloak/testsuite/ui/AbstractUiTest.java
@@ -19,8 +19,15 @@ package org.keycloak.testsuite.ui;
 
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.keycloak.authentication.authenticators.browser.WebAuthnAuthenticatorFactory;
+import org.keycloak.authentication.authenticators.browser.WebAuthnPasswordlessAuthenticatorFactory;
+import org.keycloak.authentication.requiredactions.WebAuthnPasswordlessRegisterFactory;
+import org.keycloak.authentication.requiredactions.WebAuthnRegisterFactory;
+import org.keycloak.representations.idm.AuthenticationExecutionRepresentation;
+import org.keycloak.representations.idm.AuthenticationFlowRepresentation;
 import org.keycloak.representations.idm.IdentityProviderRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.representations.idm.RequiredActionProviderSimpleRepresentation;
 import org.keycloak.testsuite.AbstractAuthTest;
 
 import java.util.Arrays;
@@ -29,6 +36,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.junit.Assume.assumeFalse;
+import static org.keycloak.models.AuthenticationExecutionModel.Requirement.REQUIRED;
 
 /**
  * @author Vaclav Muzikar <vmuzikar@redhat.com>
@@ -42,6 +50,7 @@ public abstract class AbstractUiTest extends AbstractAuthTest {
     public static final String DEFAULT_LOCALE_NAME = "English";
     public static final String LOCALE_CLIENT_NAME = "${client_localized-client}";
     public static final String LOCALE_CLIENT_NAME_LOCALIZED = "Přespříliš lokalizovaný klient";
+    public static final String WEBAUTHN_FLOW_ID = "75e2390e-f296-49e6-acf8-6d21071d7e10";
 
     @BeforeClass
     public static void assumeSupportedBrowser() {
@@ -73,6 +82,40 @@ public abstract class AbstractUiTest extends AbstractAuthTest {
         realm.setAdminTheme(LOCALIZED_THEME);
         realm.setAccountTheme(localizedTheme);
         realm.setEmailTheme(LOCALIZED_THEME);
+    }
+
+    protected void configureWebAuthNForRealm() {
+        // configure WebAuthn
+        // we can't do this during the realm import because we'd need to specify all built-in flows as well
+
+        AuthenticationFlowRepresentation flow = new AuthenticationFlowRepresentation();
+        flow.setId(WEBAUTHN_FLOW_ID);
+        flow.setAlias("webauthn flow");
+        flow.setProviderId("basic-flow");
+        flow.setBuiltIn(false);
+        flow.setTopLevel(true);
+        testRealmResource().flows().createFlow(flow);
+
+        AuthenticationExecutionRepresentation execution = new AuthenticationExecutionRepresentation();
+        execution.setAuthenticator(WebAuthnAuthenticatorFactory.PROVIDER_ID);
+        execution.setPriority(10);
+        execution.setRequirement(REQUIRED.toString());
+        execution.setParentFlow(WEBAUTHN_FLOW_ID);
+        testRealmResource().flows().addExecution(execution);
+
+        execution.setAuthenticator(WebAuthnPasswordlessAuthenticatorFactory.PROVIDER_ID);
+        testRealmResource().flows().addExecution(execution);
+
+        RequiredActionProviderSimpleRepresentation requiredAction = new RequiredActionProviderSimpleRepresentation();
+        requiredAction.setProviderId(WebAuthnRegisterFactory.PROVIDER_ID);
+        requiredAction.setName("blahblah");
+        testRealmResource().flows().registerRequiredAction(requiredAction);
+
+        requiredAction.setProviderId(WebAuthnPasswordlessRegisterFactory.PROVIDER_ID);
+        testRealmResource().flows().registerRequiredAction(requiredAction);
+
+        // no need to actually configure the authentication, in Account Console tests we just verify the registration
+
     }
 
     protected IdentityProviderRepresentation createIdentityProviderRepresentation(String alias, String providerId) {

--- a/testsuite/integration-arquillian/tests/other/base-ui/src/test/java/org/keycloak/testsuite/ui/account2/SigningInTest.java
+++ b/testsuite/integration-arquillian/tests/other/base-ui/src/test/java/org/keycloak/testsuite/ui/account2/SigningInTest.java
@@ -20,8 +20,6 @@ package org.keycloak.testsuite.ui.account2;
 import org.jboss.arquillian.graphene.page.Page;
 import org.junit.Before;
 import org.junit.Test;
-import org.keycloak.authentication.authenticators.browser.WebAuthnAuthenticatorFactory;
-import org.keycloak.authentication.authenticators.browser.WebAuthnPasswordlessAuthenticatorFactory;
 import org.keycloak.authentication.requiredactions.WebAuthnPasswordlessRegisterFactory;
 import org.keycloak.authentication.requiredactions.WebAuthnRegisterFactory;
 import org.keycloak.common.Profile;
@@ -30,12 +28,9 @@ import org.keycloak.models.credential.PasswordCredentialModel;
 import org.keycloak.models.credential.WebAuthnCredentialModel;
 import org.keycloak.models.utils.Base32;
 import org.keycloak.models.utils.TimeBasedOTP;
-import org.keycloak.representations.idm.AuthenticationExecutionRepresentation;
-import org.keycloak.representations.idm.AuthenticationFlowRepresentation;
 import org.keycloak.representations.idm.CredentialRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.RequiredActionProviderRepresentation;
-import org.keycloak.representations.idm.RequiredActionProviderSimpleRepresentation;
 import org.keycloak.testsuite.WebAuthnAssume;
 import org.keycloak.testsuite.admin.Users;
 import org.keycloak.testsuite.arquillian.annotation.EnableFeature;
@@ -52,9 +47,7 @@ import static java.util.Collections.emptyList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.keycloak.models.AuthenticationExecutionModel.Requirement.REQUIRED;
 import static org.keycloak.models.UserModel.RequiredAction.CONFIGURE_TOTP;
 import static org.keycloak.testsuite.auth.page.AuthRealm.TEST;
 import static org.keycloak.testsuite.util.UIUtils.refreshPageAndWaitForLoad;
@@ -69,7 +62,6 @@ import static org.keycloak.testsuite.util.WaitUtils.waitForPageToLoad;
 @EnableFeature(value = Profile.Feature.WEB_AUTHN, skipRestart = true, onlyForProduct = true)
 public class SigningInTest extends BaseAccountPageTest {
     public static final String PASSWORD_LABEL = "My Password";
-    public static final String WEBAUTHN_FLOW_ID = "75e2390e-f296-49e6-acf8-6d21071d7e10";
 
     @Page
     private SigningInPage signingInPage;
@@ -97,37 +89,7 @@ public class SigningInTest extends BaseAccountPageTest {
     @Override
     protected void afterAbstractKeycloakTestRealmImport() {
         super.afterAbstractKeycloakTestRealmImport();
-
-        // configure WebAuthn
-        // we can't do this during the realm import because we'd need to specify all built-in flows as well
-
-        AuthenticationFlowRepresentation flow = new AuthenticationFlowRepresentation();
-        flow.setId(WEBAUTHN_FLOW_ID);
-        flow.setAlias("webauthn flow");
-        flow.setProviderId("basic-flow");
-        flow.setBuiltIn(false);
-        flow.setTopLevel(true);
-        testRealmResource().flows().createFlow(flow);
-
-        AuthenticationExecutionRepresentation execution = new AuthenticationExecutionRepresentation();
-        execution.setAuthenticator(WebAuthnAuthenticatorFactory.PROVIDER_ID);
-        execution.setPriority(10);
-        execution.setRequirement(REQUIRED.toString());
-        execution.setParentFlow(WEBAUTHN_FLOW_ID);
-        testRealmResource().flows().addExecution(execution);
-
-        execution.setAuthenticator(WebAuthnPasswordlessAuthenticatorFactory.PROVIDER_ID);
-        testRealmResource().flows().addExecution(execution);
-
-        RequiredActionProviderSimpleRepresentation requiredAction = new RequiredActionProviderSimpleRepresentation();
-        requiredAction.setProviderId(WebAuthnRegisterFactory.PROVIDER_ID);
-        requiredAction.setName("blahblah");
-        testRealmResource().flows().registerRequiredAction(requiredAction);
-
-        requiredAction.setProviderId(WebAuthnPasswordlessRegisterFactory.PROVIDER_ID);
-        testRealmResource().flows().registerRequiredAction(requiredAction);
-
-        // no need to actually configure the authentication, in Account Console tests we just verify the registration
+        configureWebAuthNForRealm();
     }
 
     @Override

--- a/themes/src/main/resources/theme/keycloak-preview/account/src/app/account-service/account.service.ts
+++ b/themes/src/main/resources/theme/keycloak-preview/account/src/app/account-service/account.service.ts
@@ -17,6 +17,7 @@
 
 import {KeycloakService} from '../keycloak-service/keycloak.service';
 import {ContentAlert} from '../content/ContentAlert';
+import { Msg } from '../widgets/Msg';
 
 type ConfigResolve = (config: RequestInit) => void;
 
@@ -94,8 +95,9 @@ export class AccountServiceClient {
         }
 
         if (response != null && response.data != null) {
+            const message = Msg.localize(response.data['errorMessage'] || response.data['error'] || '');
             ContentAlert.danger(
-                `${response.statusText}: ${response.data['errorMessage'] ? response.data['errorMessage'] : ''} ${response.data['error'] ? response.data['error'] : ''}`
+                `${response.statusText}: ${message}`
             );
         } else {
             ContentAlert.danger(response.statusText);


### PR DESCRIPTION
…removing the IdP should be allowed

new stab at KEYCLOAK-12326 with tests in favor of #7019

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
