### PR TITLE
KEYCLOAK-14585: effectiveUrl wrongly formatted

### DIFF
--- a/themes/src/main/resources/theme/keycloak-preview/account/src/app/content/applications-page/ApplicationsPage.tsx
+++ b/themes/src/main/resources/theme/keycloak-preview/account/src/app/content/applications-page/ApplicationsPage.tsx
@@ -161,7 +161,7 @@ export class ApplicationsPage extends React.Component<ApplicationsPageProps, App
                       {application.description &&
                         <GridItem><strong>{Msg.localize('description') + ': '}</strong> {application.description}</GridItem>
                       }
-                      <GridItem><strong>{Msg.localize('effectiveUrl') + ': '}</strong> {application.effectiveUrl}</GridItem>
+                      <GridItem><strong>URL: </strong> {application.effectiveUrl}</GridItem>
                       {application.consent &&
                         <React.Fragment>
                           <GridItem span={12}>


### PR DESCRIPTION
This should be URL instead.  The user doesn't know what "Effective URL" means.
