### PR TITLE
Fix: getDefaultSslProtocols

### DIFF
--- a/services/src/main/java/org/keycloak/email/DefaultEmailSenderProvider.java
+++ b/services/src/main/java/org/keycloak/email/DefaultEmailSenderProvider.java
@@ -202,7 +202,7 @@ public class DefaultEmailSenderProvider implements EmailSenderProvider {
 
     private static String getSupportedSslProtocols() {
         try {
-            String[] protocols = SSLContext.getDefault().getSupportedSSLParameters().getProtocols();
+            String[] protocols = SSLContext.getDefault().getDefaultSSLParameters().getProtocols();
             if (protocols != null) {
                 return String.join(" ", protocols);
             }


### PR DESCRIPTION
Problem: some smtp as service providers, for example mailgun don't support sslv2 option hello
Due to getSupportedProtocols is called on regular system list looks like this 
```
TLSv1.3 TLSv1.2 TLSv1.1 TLSv1 SSLv3 SSLv2Hello
```
And keycloak tries to establish connectio nwith legacy unsupported SSLv2Hello

```
ec2-35-157-140-183.eu-central-1.compute.amazonaws.com(587)
1 1  0.1164 (0.1164)  C>S SSLv2 compatible client hello
  Version 3.3            
```

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
