### PR TITLE
KEYCLOAK-14904: Fix AccountRestService

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/account/AccountRestService.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountRestService.java
@@ -214,12 +214,26 @@ public class AccountRestService {
             user.setLastName(userRep.getLastName());
 
             if (userRep.getAttributes() != null) {
-                for (String k : user.getAttributes().keySet()) {
+                Set<String> attributeKeys = new HashSet<>(user.getAttributes().keySet());
+                // We store username and other attributes as attributes (for future UserProfile)
+                // but don't propagate them to the UserRepresentation, so userRep will never contain them
+                // if the user did not explicitly add them
+                attributeKeys.remove(UserModel.FIRST_NAME);
+                attributeKeys.remove(UserModel.LAST_NAME);
+                attributeKeys.remove(UserModel.EMAIL);
+                attributeKeys.remove(UserModel.USERNAME);
+                for (String k : attributeKeys) {
                     if (!userRep.getAttributes().containsKey(k)) {
                         user.removeAttribute(k);
                     }
                 }
 
+                Map<String, List<String>> attributes = userRep.getAttributes();
+                // Make sure we don't accidentally update any of the fields through attributes
+                attributes.remove(UserModel.FIRST_NAME);
+                attributes.remove(UserModel.LAST_NAME);
+                attributes.remove(UserModel.EMAIL);
+                attributes.remove(UserModel.USERNAME);
                 for (Map.Entry<String, List<String>> e : userRep.getAttributes().entrySet()) {
                     user.setAttribute(e.getKey(), e.getValue());
                 }


### PR DESCRIPTION
This is a followup for https://github.com/keycloak/keycloak/pull/7080

It fixes a bug and a potential exploit I just noticed while working on a followup for changing the database model - sadly one day too late:

When updating the account through the `AccountRestService`, `username`, `email`, `firstName` and `lastName` will be deleted from the attributes of the `UserModel`, i.e. the user will not have a valid username anymore. This was not noted before because all tests implicitly connect to a `jpa/UserAdapter` which stores the fields in different columns in the database and not as attributes, so in that case, nothing happens (caching might break though).

This is automatically fixed when introducing the LegacyProfile here: https://github.com/keycloak/keycloak/pull/7155
However, since that PR probably needs some time to be reviewed, I'll propose this fix in the meantime.
Sadly, I don't know a relatively cheap way to provide a test showing the problem (I guess I'd have to use an LDAP provider in conjunction with the AccountRestService)

In addition, I noticed that the code allows a user to set the `username` by setting an attribute named `username` - and this will set the username without any checks (I added a test to show that this is possible, it will fail with the current master). As a quick fix, I'll just not set the special attributes if they are specified in the representation without saying anything. Since this is an edge case that will also be handled in the UserProfile more gracefully soon, I hope this is enough for now.

I had a look at https://github.com/keycloak/keycloak/pull/7155 to try to figure out whether I missed something else, but couldn't see anything else. I also went through each usage of `removeAttribute` as this is the problematic function and found only this use and `UserResource` where this was already done correctly.