### PR TITLE
KEYCLOAK-12265 Move KerberosEmbeddedServer to testsuite

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -27,6 +27,12 @@ To build only the server run:
 
     mvn -Pdistribution -pl distribution/server-dist -am -Dmaven.test.skip clean install
 
+---
+**NOTE**
+
+Classes from `org.keycloak.testsuite.*` packages aren't suitable to be used in production.
+
+---
 
 ## Starting Keycloak
 

--- a/examples/kerberos/README.md
+++ b/examples/kerberos/README.md
@@ -31,11 +31,6 @@ You can also move the file to another location if you want.
 and configured LDAP federation provider with Kerberos/SPNEGO authentication support enabled and with `gss delegation credential` protocol mapper 
 added to the application.
 
-**WARNING:** It's recommended to use JDK8 to run Keycloak server. For JDK7 you may be faced with the bug described [here](http://darranl.blogspot.cz/2014/09/kerberos-encrypteddata-null-key-keytype.html) . 
-Alternatively you can use OpenJDK7 but in this case you will need to use aes256-cts-hmac-sha1-96 for both KDC and Kerberos client configuration. For server, 
-you can add system property to the command when running ApacheDS Kerberos server `-Dkerberos.encTypes=aes256-cts-hmac-sha1-96` (see below) and for 
-client add encryption types to configuration file like `/etc/krb5.conf` (but they should be already available. See below).
-
 Also if you are on Linux, make sure that record like:
 ```
 127.0.0.1       localhost
@@ -51,6 +46,8 @@ See [this file](../../testsuite/integration-arquillian/tests/base/src/test/resou
 On OS X the file to edit (or create) is `/Library/Preferences/edu.mit.Kerberos` with the same syntax as `krb5.conf`.
 On Windows the file to edit (or create) is `c:\Windows\krb5.ini` with the same syntax as `krb5.conf`.
 
+**WARNING**: `test-krb5.conf` is just a sample configuration which contains insecure algorithms. Therefore it shouldn't be used in production.
+
 **6)**  Run ApacheDS based LDAP server. You can run the command like this (assuming you're in the `kerberos` directory with this example):
 
 ```
@@ -60,6 +57,8 @@ mvn exec:java -Pkerberos
 This will also automatically import the LDIF from `kerberos-example-users.ldif` of kerberos example into the LDAP server. Replace with your own LDIF file if you want different users.
 
 A bit more details about embedded Kerberos server in [Executing Tests](https://github.com/keycloak/keycloak/blob/master/docs/tests.md#kerberos-server).
+
+**WARNING**: ApacheDS kerberos server shouldn't be used in production.
 
   
 **7)** Configure browser (Firefox, Chrome or other) and enable SPNEGO authentication and credential delegation for `localhost` . 

--- a/examples/kerberos/pom.xml
+++ b/examples/kerberos/pom.xml
@@ -96,7 +96,7 @@
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>exec-maven-plugin</artifactId>
                         <configuration>
-                            <mainClass>org.keycloak.util.ldap.KerberosEmbeddedServer</mainClass>
+                            <mainClass>org.keycloak.testsuite.KerberosEmbeddedServer</mainClass>
                             <classpathScope>test</classpathScope>
                             <systemProperties>
                                 <systemProperty>

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/KerberosRule.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/KerberosRule.java
@@ -23,7 +23,7 @@ import java.util.Properties;
 
 import org.jboss.logging.Logger;
 import org.keycloak.testsuite.client.resources.TestingResource;
-import org.keycloak.util.ldap.KerberosEmbeddedServer;
+import org.keycloak.testsuite.KerberosEmbeddedServer;
 import org.keycloak.util.ldap.LDAPEmbeddedServer;
 
 /**

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/kerberos/KerberosLdapCrossRealmTrustTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/kerberos/KerberosLdapCrossRealmTrustTest.java
@@ -28,7 +28,7 @@ import org.keycloak.storage.ldap.LDAPStorageProviderFactory;
 import org.keycloak.storage.ldap.kerberos.LDAPProviderKerberosConfig;
 import org.keycloak.testsuite.Assert;
 import org.keycloak.testsuite.util.KerberosRule;
-import org.keycloak.util.ldap.KerberosEmbeddedServer;
+import org.keycloak.testsuite.KerberosEmbeddedServer;
 
 import javax.ws.rs.core.Response;
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/kerberos/KerberosLdapTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/kerberos/KerberosLdapTest.java
@@ -38,7 +38,7 @@ import org.keycloak.storage.UserStorageProvider;
 import org.keycloak.storage.ldap.LDAPStorageProviderFactory;
 import org.keycloak.storage.ldap.kerberos.LDAPProviderKerberosConfig;
 import org.keycloak.testsuite.util.KerberosRule;
-import org.keycloak.util.ldap.KerberosEmbeddedServer;
+import org.keycloak.testsuite.KerberosEmbeddedServer;
 
 /**
  * Test for the LDAPStorageProvider with kerberos enabled (kerberos with LDAP integration)

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/kerberos/KerberosStandaloneCrossRealmTrustTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/kerberos/KerberosStandaloneCrossRealmTrustTest.java
@@ -26,7 +26,7 @@ import org.keycloak.federation.kerberos.KerberosConfig;
 import org.keycloak.federation.kerberos.KerberosFederationProviderFactory;
 import org.keycloak.representations.idm.ComponentRepresentation;
 import org.keycloak.testsuite.util.KerberosRule;
-import org.keycloak.util.ldap.KerberosEmbeddedServer;
+import org.keycloak.testsuite.KerberosEmbeddedServer;
 
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/kerberos/KerberosStandaloneTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/kerberos/KerberosStandaloneTest.java
@@ -38,7 +38,7 @@ import org.keycloak.storage.UserStorageProvider;
 import org.keycloak.testsuite.ActionURIUtils;
 import org.keycloak.testsuite.arquillian.annotation.UncaughtServerErrorExpected;
 import org.keycloak.testsuite.util.KerberosRule;
-import org.keycloak.util.ldap.KerberosEmbeddedServer;
+import org.keycloak.testsuite.KerberosEmbeddedServer;
 
 /**
  * Test for the KerberosFederationProvider (kerberos without LDAP integration)

--- a/testsuite/utils/pom.xml
+++ b/testsuite/utils/pom.xml
@@ -324,7 +324,7 @@
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>exec-maven-plugin</artifactId>
                         <configuration>
-                            <mainClass>org.keycloak.util.ldap.KerberosEmbeddedServer</mainClass>
+                            <mainClass>org.keycloak.testsuite.KerberosEmbeddedServer</mainClass>
                             <classpathScope>test</classpathScope>
                         </configuration>
                     </plugin>

--- a/testsuite/utils/src/main/java/org/keycloak/testsuite/KerberosEmbeddedServer.java
+++ b/testsuite/utils/src/main/java/org/keycloak/testsuite/KerberosEmbeddedServer.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.keycloak.util.ldap;
+package org.keycloak.testsuite;
 
 import org.apache.directory.api.ldap.model.constants.SupportedSaslMechanisms;
 import org.apache.directory.api.ldap.model.exception.LdapInvalidDnException;
@@ -35,6 +35,7 @@ import org.apache.directory.shared.kerberos.KerberosTime;
 import org.apache.directory.shared.kerberos.KerberosUtils;
 import org.apache.directory.shared.kerberos.codec.types.EncryptionType;
 import org.jboss.logging.Logger;
+import org.keycloak.util.ldap.LDAPEmbeddedServer;
 
 import javax.security.auth.kerberos.KerberosPrincipal;
 import java.io.IOException;


### PR DESCRIPTION
Moving KerberosEmbeddedServer to testsuite because it's not suitable to be used in production and it's only used in tests.
