### PR TITLE
KEYCLOAK-14602 Remove extra navigation in test

### DIFF
--- a/testsuite/integration-arquillian/tests/other/base-ui/src/test/java/org/keycloak/testsuite/ui/account2/SessionTest.java
+++ b/testsuite/integration-arquillian/tests/other/base-ui/src/test/java/org/keycloak/testsuite/ui/account2/SessionTest.java
@@ -65,11 +65,9 @@ public class SessionTest extends AbstractAccountTest {
     public void reactPageSsoTimeoutTest() {
         deviceActivityPage.navigateToUsingSidebar();
         deviceActivityPage.assertCurrent();
-        personalInfoPage.navigateToUsingSidebar();
-        personalInfoPage.assertCurrent();
 
         waitForSessionToExpire();
-        deviceActivityPage.navigateToUsingSidebar();
+        personalInfoPage.navigateToUsingSidebar();
         assertCurrentUrlStartsWithLoginUrlOf(accountWelcomeScreen);
     }
 


### PR DESCRIPTION
Looks like Selenium is inserting some kind of refresh on the method "getCurrentUrl()" and "executeWithJavaScript()" that is making the test to fail when waiting between the navigation. And like the test is just expected to check the timeout the functionality of the test is still the same.