### PR TITLE
KEYCLOAK-14653 Changed operation type to UPDATE when updating client scopes

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/events/admin/ResourceType.java
+++ b/server-spi-private/src/main/java/org/keycloak/events/admin/ResourceType.java
@@ -151,6 +151,11 @@ public enum ResourceType {
     /**
      *
      */
+    , CLIENT_SCOPE_CLIENT_MAPPING
+
+    /**
+     *
+     */
     , CLUSTER_NODE
 
     /**

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientResource.java
@@ -332,7 +332,8 @@ public class ClientResource {
         }
         client.addClientScope(clientScope, defaultScope);
 
-        adminEvent.operation(OperationType.CREATE).resource(ResourceType.CLIENT).resourcePath(session.getContext().getUri()).success();
+        final ClientRepresentation rep = ModelToRepresentation.toRepresentation(client, session);
+        adminEvent.operation(OperationType.UPDATE).resource(ResourceType.CLIENT).resourcePath(session.getContext().getUri()).representation(rep).success();
     }
 
 
@@ -348,7 +349,8 @@ public class ClientResource {
         }
         client.removeClientScope(clientScope);
 
-        adminEvent.operation(OperationType.DELETE).resource(ResourceType.CLIENT).resourcePath(session.getContext().getUri()).success();
+        final ClientRepresentation rep = ModelToRepresentation.toRepresentation(client, session);
+        adminEvent.operation(OperationType.UPDATE).resource(ResourceType.CLIENT).resourcePath(session.getContext().getUri()).representation(rep).success();
     }
 
 
@@ -534,9 +536,9 @@ public class ClientResource {
         if (node == null) {
             throw new BadRequestException("Node not found in params");
         }
-        
+
         ReservedCharValidator.validate(node);
-        
+
         if (logger.isDebugEnabled()) logger.debug("Register node: " + node);
         client.registerNode(node, Time.currentTime());
         adminEvent.operation(OperationType.CREATE).resource(ResourceType.CLUSTER_NODE).resourcePath(session.getContext().getUri(), node).success();

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientResource.java
@@ -332,8 +332,7 @@ public class ClientResource {
         }
         client.addClientScope(clientScope, defaultScope);
 
-        final ClientScopeRepresentation rep = ModelToRepresentation.toRepresentation(clientScope, session);
-        adminEvent.operation(OperationType.CREATE).resource(ResourceType.CLIENT_SCOPE_CLIENT_MAPPING).resourcePath(session.getContext().getUri()).representation(rep).success();
+        adminEvent.operation(OperationType.CREATE).resource(ResourceType.CLIENT_SCOPE_CLIENT_MAPPING).resourcePath(session.getContext().getUri()).success();
     }
 
 
@@ -349,8 +348,7 @@ public class ClientResource {
         }
         client.removeClientScope(clientScope);
 
-        final ClientScopeRepresentation rep = ModelToRepresentation.toRepresentation(clientScope, session);
-        adminEvent.operation(OperationType.DELETE).resource(ResourceType.CLIENT_SCOPE_CLIENT_MAPPING).resourcePath(session.getContext().getUri()).representation(rep).success();
+        adminEvent.operation(OperationType.DELETE).resource(ResourceType.CLIENT_SCOPE_CLIENT_MAPPING).resourcePath(session.getContext().getUri()).success();
     }
 
 

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientResource.java
@@ -332,8 +332,8 @@ public class ClientResource {
         }
         client.addClientScope(clientScope, defaultScope);
 
-        final ClientRepresentation rep = ModelToRepresentation.toRepresentation(client, session);
-        adminEvent.operation(OperationType.UPDATE).resource(ResourceType.CLIENT).resourcePath(session.getContext().getUri()).representation(rep).success();
+        final ClientScopeRepresentation rep = ModelToRepresentation.toRepresentation(clientScope, session);
+        adminEvent.operation(OperationType.CREATE).resource(ResourceType.CLIENT_SCOPE_CLIENT_MAPPING).resourcePath(session.getContext().getUri()).representation(rep).success();
     }
 
 
@@ -349,8 +349,8 @@ public class ClientResource {
         }
         client.removeClientScope(clientScope);
 
-        final ClientRepresentation rep = ModelToRepresentation.toRepresentation(client, session);
-        adminEvent.operation(OperationType.UPDATE).resource(ResourceType.CLIENT).resourcePath(session.getContext().getUri()).representation(rep).success();
+        final ClientScopeRepresentation rep = ModelToRepresentation.toRepresentation(clientScope, session);
+        adminEvent.operation(OperationType.DELETE).resource(ResourceType.CLIENT_SCOPE_CLIENT_MAPPING).resourcePath(session.getContext().getUri()).representation(rep).success();
     }
 
 


### PR DESCRIPTION
Changed operation type to UPDATE when updating client scopes and added representation in the admin event.

Fix for issue: https://issues.redhat.com/browse/KEYCLOAK-14653