### PR TITLE
KEYCLOAK-8493: Added danish translation from abandoned PR-5567

### DIFF
--- a/themes/src/main/resources-community/theme/base/account/messages/messages_da.properties
+++ b/themes/src/main/resources-community/theme/base/account/messages/messages_da.properties
@@ -1,0 +1,346 @@
+# encoding: UTF-8
+doSave=Gem
+doCancel=Annuller
+doLogOutAllSessions=Log alle sessioner ud
+doRemove=Fjern
+doAdd=Tilføj
+doSignOut=Log Ud
+doLogIn=Log Ind
+doLink=Link
+
+editAccountHtmlTitle=Ændre Konto
+personalInfoHtmlTitle=Personlig information
+federatedIdentitiesHtmlTitle=Forbundne identiter
+accountLogHtmlTitle=Konto Log
+changePasswordHtmlTitle=Skift Adgangskode
+deviceActivityHtmlTitle=Enheds aktivitet
+sessionsHtmlTitle=Sessioner
+accountManagementTitle=Keycloak Account Management
+authenticatorTitle=Authenticator
+applicationsHtmlTitle=Applikationer
+linkedAccountsHtmlTitle=Linkede konti
+
+accountManagementWelcomeMessage=Velkommen til Keycloak Account Management
+personalInfoIntroMessage=Administrer dine informationer
+accountSecurityTitle=Kontosikkerhed
+accountSecurityIntroMessage=Kontroller din adgangskode og kontoadgang.
+applicationsIntroMessage=Spor og administrer dine app tilladelser for at tilgå din konto
+resourceIntroMessage=Del dine ressourcer med team medlemmer
+passwordLastUpdateMessage=Din adgangskode blev opdateret
+updatePasswordTitle=Opdater Adgangskode
+updatePasswordMessageTitle=Sørg for at vælge en stærk adgangskode
+updatePasswordMessage=En stærk adgangskode indeholder en blanding af tal, bogstaver og symboler. Det er svært at gætte, ligner ikke et rigtigt ord og bør kun bruges til denne konto.
+personalSubTitle=Dine Personlige Informationer
+personalSubMessage=Administrer disse grundinformationer; dit fornavn, efternavn og email adresse
+
+authenticatorCode=Engangskode
+email=Email
+firstName=Fornavn
+givenName=Fornavn
+fullName=Fulde navn
+lastName=Efternavn
+familyName=Efternavn
+password=Adgangskode
+currentPassword=Nuværende Adgangskode
+passwordConfirm=Bekræft ny adgangskode
+passwordNew=Ny adgangskode
+username=Brugernavn
+address=Adresse
+street=Vejnavn
+locality=By
+region=Region
+postal_code=Postnummer
+country=Land
+emailVerified=Email verificeret
+gssDelegationCredential=GSS Delegation Credential
+
+profileScopeConsentText=Brugerprofil
+emailScopeConsentText=Email adresse
+addressScopeConsentText=Adresse
+phoneScopeConsentText=Telefonnummer
+offlineAccessScopeConsentText=Offline Adgang
+samlRoleListScopeConsentText=Mine Roller
+
+role_admin=Admin
+role_realm-admin=Rige Admin
+role_create-realm=Opret rige
+role_create-client=Opret klient
+role_view-realm=Se rige
+role_view-users=Se brugere
+role_view-applications=Se applikationer
+role_view-clients=Se klienter
+role_view-events=Se hændelser
+role_view-identity-providers=Se identitetsudbydere
+role_manage-realm=Administrer rige
+role_manage-users=Administrer brugere
+role_manage-applications=Administrer applikationer
+role_manage-identity-providers=Administrer identitetsudbydere
+role_manage-clients=Administrer klienter
+role_manage-events=Administrer hændelser
+role_view-profile=Se profil
+role_manage-account=Administrer konto
+role_manage-account-links=Administrer konto links
+role_read-token=Se token
+role_offline-access=Offline adgang
+client_account=Konto
+client_security-admin-console=Sikkerheds Admin Konsol
+client_admin-cli=Admin CLI
+client_realm-management=Rige administration
+client_broker=Broker
+
+
+requiredFields=Påkrævede felter
+allFieldsRequired=Alle felter er påkrævede
+
+backToApplication=&laquo; Tilbage til applikation
+backTo=Tilbage til {0}
+
+date=Dato
+event=Hændelse
+ip=IP
+client=Klient
+clients=Klienter
+details=Detaljer
+started=Påbegyndt
+lastAccess=Seneste Adgang
+expires=Udløber
+applications=Applikationer
+
+account=Konto
+federatedIdentity=Federated Identity
+authenticator=Authenticator
+device-activity=Enheds aktivitet
+sessions=Sessioner
+log=Log
+
+application=Applikation
+availableRoles=Tilgængelige Roller
+grantedPermissions=Tildelte Rettigheder
+grantedPersonalInfo=Tildelt Personlig Info
+additionalGrants=Yderligere Tildelinger
+action=Action
+inResource=i
+fullAccess=Fuld adgang
+offlineToken=Offline Token
+revoke=Tilbagekald tildeling
+
+configureAuthenticators=Konfigurerede Authenticators
+mobile=Mobil
+totpStep1=Installer en af følgende applikationer på din mobil
+totpStep2=Åben applikationen og skan stregkoden
+totpStep3=Indtast engangskoden fra applikationen og tryk Indsend for at gennemføre opsætningen
+
+totpManualStep2=Åben applikationen og indtast nøglen
+totpManualStep3=Brug følgende konfigurations værdier hvis applikationen tillader det
+
+totpUnableToScan=Kan du ikke skanne?
+totpScanBarcode=Skan stregkode?
+
+totp.totp=Tidsbaseret
+totp.hotp=Tællerbaseret
+
+totpType=Type
+totpAlgorithm=Algoritme
+totpDigits=Tal
+totpInterval=Interval
+totpCounter=Tæller
+
+missingUsernameMessage=Angiv brugernavn
+missingFirstNameMessage=Angiv fornavn.
+invalidEmailMessage=Ugyldig email adresse.
+missingLastNameMessage=Angiv efternavn
+missingEmailMessage=Angiv email adresse.
+missingPasswordMessage=Angiv adgangskode
+notMatchPasswordMessage=Adgangskoderne er ikke ens
+invalidUserMessage=Ugyldig bruger
+
+missingTotpMessage=Angiv autentificerings kode.
+invalidPasswordExistingMessage=Ugyldig eksisterende adgangskode.
+invalidPasswordConfirmMessage=Adgangskoderne er ikke ens
+invalidTotpMessage=Ugyldig autentificerings kode.
+
+usernameExistsMessage=Brugernavnet eksisterer allerede.
+emailExistsMessage=Email adressen eksisterer allerede.
+
+readOnlyUserMessage=Du kan ikke opdatere din konto da den er read-only.
+readOnlyUsernameMessage=Du kan ikke opdatere dit brugernavn da det er read-only.
+readOnlyPasswordMessage=Du kan ikke opdatere din adgangskode da den er read-only.
+
+successTotpMessage=Mobil authenticator konfigureret.
+successTotpRemovedMessage=Mobil authenticator fjernet.
+
+successGrantRevokedMessage=Tildeling tilbagekaldt.
+
+accountUpdatedMessage=Din konto er blevet opdateret.
+accountPasswordUpdatedMessage=Din adgangskode er blevet opdateret.
+
+missingIdentityProviderMessage=Identitetsudbyder ikke specificeret.
+invalidFederatedIdentityActionMessage=Ugyldig eller manglende handling.
+identityProviderNotFoundMessage=Den angivede identitetsudbyder kunne ikke findes.
+federatedIdentityLinkNotActiveMessage=Denne identiet er ikke aktiv længere.
+identityProviderRedirectErrorMessage=Kunne ikke redirecte til identitetsudbyder.
+identityProviderRemovedMessage=Identitetsudbyder fjernet.
+identityProviderAlreadyLinkedMessage=Forbundsidentitet returneret af {} er allerede forbundet til en anden bruger.
+staleCodeAccountMessage=Siden er udløbet. Prøv igen.
+consentDenied=Samtykke afslået.
+
+accountDisabledMessage=Kontoen er deaktiveret, kontakt en administrator.
+
+accountTemporarilyDisabledMessage=Kontoen er midlertidigt deaktiveret, kontakt en administrator eller prøv igen senere.
+invalidPasswordMinLengthMessage=Ugyldig adgangskode: minimum længde {0}.
+invalidPasswordMinLowerCaseCharsMessage=Ugyldig adgangskode: skal minimum indeholde {0} små bogstaver.
+invalidPasswordMinDigitsMessage=Ugyldig adgangskode: skal minimum indeholde {0} tal.
+invalidPasswordMinUpperCaseCharsMessage=Ugyldig adgangskode: skal minimum indeholde {0} store bogstaver.
+invalidPasswordMinSpecialCharsMessage=Ugyldig adgangskode: skal minimum indeholde {0} specialtegn.
+invalidPasswordNotUsernameMessage=Ugyldig adgangskode: må ikke være identisk med brugernavnet.
+invalidPasswordRegexPatternMessage=Ugyldig adgangskode: Ikke i stand til at matche regex mønstre.
+invalidPasswordHistoryMessage=Ugyldig adgangskode: må ikke være identisk med nogle af de seneste {0} adgangskoder.
+invalidPasswordBlacklistedMessage=Ugyldig adgangskode: adgangskoden er sortlisted.
+invalidPasswordGenericMessage=Ugyldig adgangskode: ny adgangskode matcher ikke vores adgangskode politikker.
+
+# Authorization
+myResources=Mine Ressourcer
+myResourcesSub=Mine ressourcer
+doDeny=Afslå
+doRevoke=Tilbagekald
+doApprove=Godkend
+doRemoveSharing=Fjern Deling
+doRemoveRequest=Fjern Forespørgsel
+peopleAccessResource=Folk med adgang til denne ressource
+resourceManagedPolicies=Tilladelsen som giver adgang til denne ressource
+resourceNoPermissionsGrantingAccess=Ingen tilladelser giver adgang til denne ressource
+anyAction=Enhver handling
+description=Beskrivelse
+name=Navn
+scopes=Scopes
+resource=Ressource
+user=Bruger
+peopleSharingThisResource=Folk som deler denne ressource
+shareWithOthers=Del med andre
+needMyApproval=Mangler min godkendelse
+requestsWaitingApproval=Din forespørgsel afventer godkendelse
+icon=Ikon
+requestor=Forespørger
+owner=Ejer
+resourcesSharedWithMe=Ressourcer delt med mig
+permissionRequestion=Rettigsheds forespørgsel
+permission=Tilladelse
+shares=share(s)
+
+locale_ca=Catal\u00e0
+locale_de=Deutsch
+locale_en=English
+locale_es=Espa\u00f1ol
+locale_fr=Fran\u00e7ais
+locale_it=Italian
+locale_ja=\u65e5\u672c\u8a9e
+locale_nl=Nederlands
+locale_no=Norsk
+locale_lt=Lietuvi\u0173
+locale_pt-BR=Portugu\u00eas (Brasil)
+locale_ru=\u0420\u0443\u0441\u0441\u043a\u0438\u0439
+locale_sk=Sloven\u010dina
+locale_sv=Svenska
+locale_zh-CN=\u4e2d\u6587\u7b80\u4f53
+
+# Applications
+applicaitonName=Navn
+applicationType=Applikationstype
+applicationInUse=In-use app only
+clearAllFilter=Ryd alle filtre
+activeFilters=Aktive filtre
+filterByName=Filtrer På Navn...
+allApps=Alle applikationer
+internalApps=Interne applikationer
+thirdpartyApps=Tredje-parts applikationer
+appResults=Resultater
+
+# Linked account
+authorizedProvider=Autoriseret Udbyder
+authorizedProviderMessage=Autoriserede udbydere forbundet med din konto
+
+identityProvider=Identitetsudbyder
+identityProviderMessage=For at forbinde din konto med de identitetsudbydere du har konfigureret
+socialLogin=Social Log ind
+userDefined=Brugerdefineret
+removeAccess=Fjern Adgang
+removeAccessMessage=Du skal give adgang igen, hvis du vil bruge denne app konto.
+
+#Authenticator
+authenticatorStatusMessage=To-faktor godkendelse er
+authenticatorFinishSetUpTitle=Din to-faktor godkendelse
+authenticatorFinishSetUpMessage=Hver gang du logger ind på din Keycloak konto, vil du blive bedt om at give din to-faktor godkendelses kode.
+authenticatorSubTitle=Opsæt to-faktor godkendelse
+authenticatorSubMessage=For at forbedre sikkerheden på din konto, aktiver mindst en af de tilgængelige to-faktor godkendelses metoder.
+authenticatorMobileTitle=Mobile Authenticator
+authenticatorMobileMessage=Brug Mobile Authenticator for at få godkendelses koder som to-faktor godkendelse.
+authenticatorMobileFinishSetUpMessage=Authenticatoren er blevet bundet til din telefon.
+authenticatorActionSetup=Opsæt
+authenticatorSMSTitle=SMS Kode
+authenticatorSMSMessage=Keycloak vil sende godkendelses koden til din telefon som to-faktor godkendelse.
+
+authenticatorSMSFinishSetUpMessage=Tekst beskeder er sendt til
+authenticatorDefaultStatus=Standard
+authenticatorChangePhone=Ændre Telefonnummer
+authenticatorBackupCodesTitle=Backup Koder
+authenticatorBackupCodesMessage=Få dine 8-cifre backup koder
+authenticatorBackupCodesFinishSetUpMessage=12 backup koder blev genereret denne gang. Alle kan bruges.
+
+#Authenticator - Mobile Authenticator setup
+authenticatorMobileSetupTitle=Mobile Authenticator Opsætning
+smscodeIntroMessage=Indtast dit mobil nummer og en verifikationskode vil blive sendt til din telefon.
+mobileSetupStep1=Installer en authenticator applikation på din telefon. De understøttede applikationer er listed her.
+mobileSetupStep2=Åben applikationen og skan stregkoden.
+mobileSetupStep3=Indtast engangskoden fra authenticator applikationen og tryk Gem for at færdiggøre opsætningen.
+scanBarCode=Vil du skanne stregkoden?
+enterBarCode=Indtast engangskoden
+doCopy=Kopier
+doFinish=Afslut
+
+#Authenticator - SMS Code setup
+authenticatorSMSCodeSetupTitle=SMS Kode Opsætning
+chooseYourCountry=Vælg dit land
+enterYourPhoneNumber=Indtast dit telefonnummer
+sendVerficationCode=Send Verifikationskode
+enterYourVerficationCode=Indtast din verifikationskode
+
+#Authenticator - backup Code setup
+authenticatorBackupCodesSetupTitle=Backup Kode Opsætning
+backupcodesIntroMessage=Hvis du mister adgangen til din telefon, kan du stadig logge ind på konto ved at bruge backup koder. Opbevar dem sikkert og tilgængeligt.
+realmName=Rige
+doDownload=Download
+doPrint=Print
+doCopy=Kopier
+backupCodesTips-1=Hver backup kode kan kun bruges en gang.
+backupCodesTips-2=Disse koder blev generet d.
+generateNewBackupCodes=Generer Nye Backup Koder
+backupCodesTips-3=Når du genererer nye backup koder, vil de gamle ikke længere virke.
+backtoAuthenticatorPage=Tilbage til Authenticator siden
+
+
+#Resources
+resources=Ressourcer
+myResources=Mine Ressourcer
+sharedwithMe=Delt med mig
+share=Del
+resource=Ressource
+application=Applikation
+date=Dato
+sharedwith=Delt med
+owner=Ejer
+accessPermissions=Adgangstilladelser
+permissionRequests=Rettigheds forespørgsler
+approve=Godkend
+approveAll=Godkend alle
+sharedwith=Delt med
+people=Folk
+perPage=per side
+currentPage=Nuværende Side
+sharetheResource=Del Ressourcen
+user=Bruger
+group=Gruppe
+selectPermission=Vælg tilladelse
+addPeople=Tilføj folk at dele ressourcen med
+addTeam=Tilføj hold at dele ressourcen med
+myPermissions=Mine Tilladelser
+waitingforApproval=Afventer godkendelse

--- a/themes/src/main/resources-community/theme/base/account/theme.properties
+++ b/themes/src/main/resources-community/theme/base/account/theme.properties
@@ -1,1 +1,1 @@
-locales=ca,cs,de,en,es,fr,hu,it,ja,lt,nl,no,pl,pt-BR,ru,sk,sv,tr,zh-CN
+locales=ca,cs,da,de,en,es,fr,hu,it,ja,lt,nl,no,pl,pt-BR,ru,sk,sv,tr,zh-CN

--- a/themes/src/main/resources-community/theme/base/email/messages/messages_da.properties
+++ b/themes/src/main/resources-community/theme/base/email/messages/messages_da.properties
@@ -1,0 +1,47 @@
+# encoding: UTF-8
+emailVerificationSubject=Verificer email
+emailVerificationBody=Nogen har oprettet en {2} konto med denne email adresse. Hvis dette var dig, bedes du trykke på forbindet herunder for at verificere din email adresse \n\n{0}\n\nDette link vil udløbe inden for {3}.\n\nHvis det var dig der har oprettet denne konto, bedes du se bort fra denne mail.
+emailVerificationBodyHtml=<p>Nogen har oprettet en {2} konto med denne email adresse. Hvis dette var dig, bedes du trykke på forbindet herunder for at verificere din email adresse</p><p><a href="{0}">Link til email verificering</a></p><p>Dette link vil udløbe inden for {3}.</p><p>Hvis det var dig der har oprettet denne konto, bedes du se bort fra denne mail.</p>
+emailTestSubject=[KEYCLOAK] - SMTP test besked
+emailTestBody=Dette er en test besked
+emailTestBodyHtml=<p>Dette er en test besked</p>
+identityProviderLinkSubject=Link {0}
+identityProviderLinkBody=Nogen vil forbinde din "{1}" konto med "{0}" kontoen som er tilknyttet brugeren {2}. Hvis dette var dig, bedes du klikke på forbindet herunder for at forbinde de to konti\n\n{3}\n\nDette link vil udløbe efter {5}.\n\nHvis du ikke vil forbinde disse konti, kan du bare ignore denne besked. Hvis du vælger at forbinde de to konti, kan du logge ind som {1} via {0}.
+identityProviderLinkBodyHtml=<p>Someone wants to link your <b>{1}</b> account with <b>{0}</b> account of user {2} . Hvis dette var dig, bedes du klikke på forbindet herunder for at forbinde de to konti</p><p><a href="{3}">Bekræft</a></p><p>Dette link vil udløbe efter {5}.</p><p>nHvis du ikke vil forbinde disse konti, kan du bare ignore denne besked. Hvis du vælger at forbinde de to konti, kan du logge ind som {1} via {0}.
+passwordResetSubject=Gendan adgangskode
+passwordResetBody=Nogen har forsøgt at nulstille adgangskoden til {2}. Hvis dette var dig, bedes du klikke på linket herunder for at nulstille adgangskoden.\n\n{0}\n\nDette link og kode vil udløbe efter {3}.\n\nHvis du ikke ønsker at nulstille din adgangskode, kan du se bort fra denne besked.
+passwordResetBodyHtml=<p>Nogen har forsøgt at nulstille adgangskoden til {2}. Hvis dette var dig, bedes du klikke på linket herunder for at nulstille adgangskoden.</p><p><a href="{0}">Nulstil adgangskode</a></p><p>Dette link og kode vil udløbe efter {3}.</p><p>Hvis du ikke ønsker at nulstille din adgangskode, kan du se bort fra denne besked.</p>
+executeActionsSubject=Opdater din konto
+executeActionsBody=Din administrator beder dig opdatere din {2} konto ved at udføre følgende handling(er): {3}. Klik på linket herunder for at starte processen.\n\n{0}\n\nDette link udløber efter {4}.\n\nHvis du ikke mener at din administrator har efterspurgt dette, kan du blot se bort fra denne besked.
+executeActionsBodyHtml=<p>Din administrator beder dig opdatere din {2} konto ved at udføre følgende handling(er): {3}. Klik på linket herunder for at starte processen.</p><p><a href="{0}">Opdater konto</a></p><p>Dette link udløber efter {4}.</p><p>Hvis du ikke mener at din administrator har efterspurgt dette, kan du blot se bort fra denne besked.</p>
+eventLoginErrorSubject=Logind fejl
+eventLoginErrorBody=Et fejlet logind forsøg er blevet registreret på din konto d. {0} fra {1}. Hvis dette ikke var dig, bedes du kontakte din administrator omgående.
+eventLoginErrorBodyHtml=<p>Et fejlet logind forsøg er blevet registreret på din konto d. {0} fra {1}. Hvis dette ikke var dig, bedes du kontakte din administrator omgående.</p>
+eventRemoveTotpSubject=Fjern OTP
+eventRemoveTotpBody=OTP er blevet fjernet fra din konto d. {0} fra {1}. Hvis dette ikke var dig, bedes du kontakte din administrator omgående.
+eventRemoveTotpBodyHtml=<p>OTP er blevet fjernet fra din konto d. {0} fra {1}. Hvis dette ikke var dig, bedes du kontakte din administrator omgående.</p>
+eventUpdatePasswordSubject=Opdater adgangskode
+eventUpdatePasswordBody=Din adgangskode er blevet opdateret d. {0} fra {1}. Hvis dette ikke var dig, bedes du kontakte din administrator omgående.
+eventUpdatePasswordBodyHtml=<p>Din adgangskode er blevet opdateret d. {0} fra {1}. Hvis dette ikke var dig, bedes du kontakte din administrator omgående.</p>
+eventUpdateTotpSubject=Opdater OTP
+eventUpdateTotpBody=OTP blev opdateret på din konto d. {0} fra {1}. Hvis dette ikke var dig, bedes du kontakte din administrator omgående.
+eventUpdateTotpBodyHtml=<p>OTP blev opdateret på din konto d. {0} fra {1}. Hvis dette ikke var dig, bedes du kontakte din administrator omgående.</p>
+
+requiredAction.CONFIGURE_TOTP=Konfigurer OTP
+requiredAction.terms_and_conditions=Vilkår og Betingelser
+requiredAction.UPDATE_PASSWORD=Opdater Adgangskode
+requiredAction.UPDATE_PROFILE=Opdater Profil
+requiredAction.VERIFY_EMAIL=Verificer Email
+
+# units for link expiration timeout formatting
+forbindexpirationFormatter.timePeriodUnit.seconds=sekunder
+forbindexpirationFormatter.timePeriodUnit.seconds.1=sekund
+forbindexpirationFormatter.timePeriodUnit.minutes=minutter
+forbindexpirationFormatter.timePeriodUnit.minutes.1=minut
+forbindexpirationFormatter.timePeriodUnit.hours=timer
+forbindexpirationFormatter.timePeriodUnit.hours.1=time
+forbindexpirationFormatter.timePeriodUnit.days=dage
+forbindexpirationFormatter.timePeriodUnit.days.1=dag
+
+emailVerificationBodyCode=Verificer din email adresse ved at indtaste følgende kode.\n\n{0}\n\n.
+emailVerificationBodyCodeHtml=<p>Verificer din email adresse ved at indtaste følgende kode.</p><p><b>{0}</b></p>

--- a/themes/src/main/resources-community/theme/base/email/theme.properties
+++ b/themes/src/main/resources-community/theme/base/email/theme.properties
@@ -1,1 +1,1 @@
-locales=ca,cs,de,en,es,fr,hu,it,ja,lt,nl,no,pl,pt-BR,ru,sk,sv,tr,zh-CN
+locales=ca,cs,da,de,en,es,fr,hu,it,ja,lt,nl,no,pl,pt-BR,ru,sk,sv,tr,zh-CN

--- a/themes/src/main/resources-community/theme/base/login/messages/messages_da.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_da.properties
@@ -1,0 +1,361 @@
+# encoding: UTF-8
+doLogIn=Log ind
+doRegister=Registrer
+doCancel=Annuller
+doSubmit=Indsend
+doYes=Ja
+doNo=Nej
+doContinue=Fortsæt
+doIgnore=Ignorer
+doAccept=Accepter
+doDecline=Afslå
+doForgotPassword=Glemt adgangskode?
+doClickHere=Klik her
+doImpersonate=Efterlign
+kerberosNotConfigured=Kerberos er ikke konfigureret
+kerberosNotConfiguredTitle=Kerberos er ikke konfigureret
+bypassKerberosDetail=Enten er du ikke logget ind via Kerberos eller også er din browser ikke sat op til Kerberos login. Tryk fortsæt for at logge ind på anden vis
+kerberosNotSetUp=Kerberos er ikke sat op. Du kan ikke logge ind.
+registerTitle=Registrer
+loginTitle=Log ind i {0}
+loginTitleHtml={0}
+impersonateTitle={0} Efterlign bruger
+impersonateTitleHtml=<strong>{0}</strong> Efterlign bruger
+realmChoice=Rige
+unknownUser=Ukendt bruger
+loginTotpTitle=Mobil Godkendelses Opsætning
+loginProfileTitle=Opdater brugerinformationer
+loginTimeout=Dit login tog for lang tid. Login processen vil nu begynde forfra.
+oauthGrantTitle=Giv adgang til {0}
+oauthGrantTitleHtml={0}
+errorTitle=Vi beklager...
+errorTitleHtml=Vi <strong>beklager</strong> ...
+emailVerifyTitle=Email verificering
+emailForgotTitle=Glemt din adgangskode?
+updatePasswordTitle=Opdater adgangskode
+codeSuccessTitle=Success kode
+codeErrorTitle=Fejl kode\: {0}
+displayUnsupported=Den ønskede skærmtype understøttes ikke
+browserRequired=Brwoseren skal logges ind
+browserContinue=Browser påkrævet for at kunne gennemføre login
+browserContinuePrompt=Åben browser for at fortsætte login? [j/n]:
+browserContinueAnswer=j
+
+termsTitle=Vilkår og betingelser
+termsText=<p>Vilkår og betingelser mangler at blive beskrevet</p>
+termsPlainText=Vilkår og betingelser mangler at blive beskrevet.
+
+recaptchaFailed=Ugyldig Recaptcha
+recaptchaNotConfigured=Recaptcha er påkrævet, men ikke konfigureret
+consentDenied=Samtykke afslået.
+
+noAccount=Ny bruger?
+username=Brugernavn
+usernameOrEmail=Brugernavn eller email
+firstName=Fornavn
+givenName=Fornavn
+fullName=Fulde navn
+lastName=Efternavn
+familyName=Efternavn
+email=Email
+password=Adgangskode
+passwordConfirm=Bekræft adgangskode
+passwordNew=Ny Adgangskode
+passwordNewConfirm=Bekræft ny adgangskode
+rememberMe=Husk mig
+authenticatorCode=Engangskode
+address=Adresse
+street=Vej
+locality=By
+region=Region
+postal_code=Postnummer
+country=Land
+emailVerified=Email verificeret
+gssDelegationCredential=GSS Delegation Credential
+
+profileScopeConsentText=Brugerprofil
+emailScopeConsentText=Email adresse
+addressScopeConsentText=Adresse
+phoneScopeConsentText=Telefonnummer
+offlineAccessScopeConsentText=Offline Adgang
+samlRoleListScopeConsentText=Mine roller
+
+loginTotpIntro=Du skal opsætte en Engangskodegenerator for at kunne tilgå denne konto.
+loginTotpStep1=Installer en af følgende applikationer på din mobil
+loginTotpStep2=Åben applikationen og skan stregkoden
+loginTotpStep3=Indtast engangskoden fra applikationen og tryk Indsend for at gennemføre opsætningen
+loginTotpManualStep2=Åben applikationen og indtast nøglen
+loginTotpManualStep3=Brug følgende konfigurations værdier hvis applikationen tillader det
+loginTotpUnableToScan=Kan du ikke skanne?
+loginTotpScanBarcode=Skan stregkode?
+loginOtpOneTime=Engangskode
+loginTotpType=Type
+loginTotpAlgorithm=Algoritme
+loginTotpDigits=Cifre
+loginTotpInterval=Interval
+loginTotpCounter=Tæller
+
+loginTotp.totp=Tidsbaseret
+loginTotp.hotp=Tællerbaseret
+
+oauthGrantRequest=Bevilger du disse adgangs privilegier?
+inResource=ind
+emailVerifyInstruction1=En email med instruktioner til, hvordan du verificerer din mail adresse er blevet sendt til dig.
+emailVerifyInstruction2=Har du ikke modtaget en verificerings kode i din inbox?
+emailVerifyInstruction3=for at gensende emailen.
+
+emailLinkIdpTitle=Link {0}
+emailLinkIdp1=En email med instruktioner til hvordan du linker {0} konto {1} med din {2} konto er blevet sendt til dig.
+emailLinkIdp2=Har du ikke modtaget en verificerings kode i din inbox?
+emailLinkIdp3=for at gensende emailen.
+emailLinkIdp4=Hvis du allerede har verificeret din email i en anden browser
+emailLinkIdp5=for at fortsætte.
+
+backToLogin=&laquo; Tilbage til log ind
+
+emailInstruction=Indtast dit brugernavn eller email adresse, så sender vi instruktioner til dig om hvordan du angiver en ny adgangskode.
+
+copyCodeInstruction=Kopier denne kode og indsæt den i din applikation:
+
+pageExpiredTitle=Siden er udløbet
+pageExpiredMsg1=For at genstarte login processen
+pageExpiredMsg2=For at fortsætte login processen
+
+personalInfo=Personlig information:
+role_admin=Admin
+role_realm-admin=Rige Admin
+role_create-realm=Opret rige
+role_create-client=Opret klient
+role_view-realm=Se rige
+role_view-users=Se brugere
+role_view-applications=Se applikationer
+role_view-clients=Se klienter
+role_view-events=Se hændelser
+role_view-identity-providers=Se identitetsudbydere
+role_manage-realm=Administrer rige
+role_manage-users=Administrer brugere
+role_manage-applications=Administrer applikationer
+role_manage-identity-providers=Administrer identitetsudbydere
+role_manage-clients=Administrer klienter
+role_manage-events=Administrer hændelser
+role_view-profile=Se profil
+role_manage-account=Administrer konto
+role_manage-account-links=Administrer konto links
+role_read-token=Se token
+role_offline-access=Offline adgang
+client_account=Konto
+client_account-console=Kontokonsol
+client_security-admin-console=Sikkerhefds Admin Konsol
+client_admin-cli=Admin CLI
+client_realm-management=Rige administration
+client_broker=Broker
+
+invalidUserMessage=Ugyldig brugernavn eller adgangskode.
+invalidEmailMessage=Ugyldig email adresse.
+accountDisabledMessage=Kontoen er deaktiveret, kontakt en administrator.
+accountTemporarilyDisabledMessage=Kontoen er midlertidigt deaktiveret, kontakt en administrator eller prøv igen senere.
+expiredCodeMessage=Log ind tog for lang tid. Prøv igen.
+expiredActionMessage=Handlingen er udløbet. Fortsæt med log ind nu.
+expiredActionTokenNoSessionMessage=Handling udløbet.
+expiredActionTokenSessionExistsMessage=Handlingen er udløbet. Start venligst forfra.
+
+missingFirstNameMessage=Angiv fornavn.
+missingLastNameMessage=Angiv efternavn.
+missingEmailMessage=Angiv email adressse.
+missingUsernameMessage=Angiv brugernavn.
+missingPasswordMessage=Angiv password.
+missingTotpMessage=Angiv autentificerings kode.
+notMatchPasswordMessage=Passwords er ikke ens.
+
+invalidPasswordExistingMessage=Ugyldig eksisterende adgangskode.
+invalidPasswordBlacklistedMessage=Ugyldig adgangskode: Adgangskoden er sortlisted.
+invalidPasswordConfirmMessage=Adgangskoderne er ikke ens
+invalidTotpMessage=Ugyldig autentificerings kode.
+
+usernameExistsMessage=Brugernavnet eksisterer allerede.
+emailExistsMessage=Email adressen eksisterer allerede.
+
+federatedIdentityExistsMessage=Bruger med {0} {1} eksisterer allerede. Log ind i konto administration for at linke kontoen.
+
+confirmLinkIdpTitle=Kontoen eksisterer allerede
+federatedIdentityConfirmLinkMessage=Bruger med {0} {1} eksisterer allerede. Hvordan vil du fortsætte?
+federatedIdentityConfirmReauthenticateMessage=Log ind som {0} for at linke din konto med {1}
+confirmLinkIdpReviewProfile=Se profil
+confirmLinkIdpContinue=Tilføj til eksisterende konto
+
+configureTotpMessage=Du skal opsætte en Mobile Authenticator for at kunne aktivere din konto.
+updateProfileMessage=Du skal opdatere din brugerprofil for at kunne aktivere din konto.
+updatePasswordMessage=Du skal ændre din adgangskode for at kunne aktivere din konto.
+resetPasswordMessage=Du skal ændre din adgangskode.
+verifyEmailMessage=Du skal verificere din email adresse for at kunne aktivere din konto.
+linkIdpMessage=Du skal verificere din email adresse for at kunne kontoen med {0}.
+
+emailSentMessage=Du vil snarest modtage en email med yderligere instruktioner.
+emailSendErrorMessage=Kunne ikke sende email, prøv igen senere.
+
+accountUpdatedMessage=Din konto er blevet opdateret.
+accountPasswordUpdatedMessage=Din adgangskode er blevet opdateret.
+
+delegationCompleteHeader=Login lykkedes
+delegationCompleteMessage=Du kan nu lukke dette browser vindue og gå tilbage til din konsol applikation.
+delegationFailedHeader=Log ind fejlede
+delegationFailedMessage=Du kan nu lukke dette browser vindue og gå tilbage til din konsol applikation for at forsøge at logge ind igen.
+
+noAccessMessage=Ingen adgang
+
+invalidPasswordMinLengthMessage=Ugyldig adgangskode: minimum længde {0}.
+invalidPasswordMinDigitsMessage=Ugyldig adgangskode: skal minimum indeholde {0} tal.
+invalidPasswordMinLowerCaseCharsMessage=Ugyldig adgangskode: skal minimum indeholde {0} små bogstaver.
+invalidPasswordMinUpperCaseCharsMessage=Ugyldig adgangskode: skal minimum indeholde {0} store bogstaver.
+invalidPasswordMinSpecialCharsMessage=Ugyldig adgangskode: skal minimum indeholde {0} specialtegn.
+invalidPasswordNotUsernameMessage=Ugyldig adgangskode: må ikke være identisk med brugernavnet.
+invalidPasswordRegexPatternMessage=Ugyldig adgangskode: Ikke i stand til at matche regex mønstre.
+invalidPasswordHistoryMessage=Ugyldig adgangskode: må ikke være identisk med nogle af de seneste {0} adgangskoder.
+invalidPasswordGenericMessage=Ugyldig adgangskode: ny adgangskode matcher ikke vores adgangskode politikker.
+
+failedToProcessResponseMessage=Ude af stand til at processere svaret
+httpsRequiredMessage=HTTPS påkrævet
+realmNotEnabledMessage=Riget er ikke aktiveret
+invalidRequestMessage=Ugyldig Forespørgsel
+failedLogout=Logud fejlede
+unknownLoginRequesterMessage=Ukendt log ind forespørger
+loginRequesterNotEnabledMessage=Log ind forespørgeren er ikke aktiveret
+bearerOnlyMessage=Bearer-only applikationer må ikke foretage browser login
+standardFlowDisabledMessage=Klienten må ikke foretage browser login med den givne response_type. Standard flowet er deaktiveret for klienten.
+implicitFlowDisabledMessage=Klienten må ikke foretage browser login med den givne response_type. Implicit flowet er deaktiveret for klienten.
+
+invalidRedirectUriMessage=Ugyldig redirect uri
+unsupportedNameIdFormatMessage=Ikke understøttet NameIDFormat
+invalidRequesterMessage=Ugyldig forespørger
+registrationNotAllowedMessage=Registrering er ikke tilladt
+resetCredentialNotAllowedMessage=Reset Credential er ikke tilladt
+
+permissionNotApprovedMessage=Tilladelse ikke godkendt.
+noRelayStateInResponseMessage=Ingen relæ tilstand i svaret fra identitetsudbyderen.
+insufficientPermissionMessage=Utilstrækkelig tilladelse for at kunne linke identiter.
+couldNotProceedWithAuthenticationRequestMessage=Kunne ikke fortsætte med godkendelsesanmodning til identitetsudbyderen.
+couldNotObtainTokenMessage=Kunne ikke opnå token fra identitetsudbyder.
+unexpectedErrorRetrievingTokenMessage=Uventet fejl i forsøget på at hente token fra identitetsudbyder.
+unexpectedErrorHandlingResponseMessage=Uventet fejl i forsøget på at behandle svaret fra identitetsudbyder.
+identityProviderAuthenticationFailedMessage=Log ind fejlede. Kunne ikke logge ind ved identitetsudbyder.
+couldNotSendAuthenticationRequestMessage=Kunne ikke sende log ind forespørgsel til identitetsudbyder.
+unexpectedErrorHandlingRequestMessage=Uventet fejl under håndteringen af forespørgsel til identitetsudbyder.
+invalidAccessCodeMessage=Ugyldig adgangskode.
+sessionNotActiveMessage=Sessionen er ikke aktiv.
+invalidCodeMessage=Der opstod en fejl, log ind igen via din applikation.
+identityProviderUnexpectedErrorMessage=Uventet fejl under log ind ved identitetsudbyder
+identityProviderNotFoundMessage=Kunne ikke finde en identitetsudbyder med det angivede id.
+identityProviderLinkSuccess=Din email er nu verificeret. Gå tilbage til din oprindelige browser og fortsæt log ind derfra.
+staleCodeMessage=Siden er ikke længere gyldig, gå tilbage til din applikation og login igen
+realmSupportsNoCredentialsMessage=Riget understøtter ikke nogen legimatitionstype.
+credentialSetupRequired=Kan ikke logge ind. Legimatitionstype skal konfigureres.
+identityProviderNotUniqueMessage=Riget understøtter flere forskellige identitetsudbydere. Kunne ikke beslutte hvilken identitetsudbyder der skulle bruges til at logge ind med.
+emailVerifiedMessage=Din email adresse er verificeret.
+staleEmailVerificationLink=Linket du har klikket på er et gammelt udløbet link. Måske har du allerede verificeret din mailadresse?
+identityProviderAlreadyLinkedMessage=Forbundsidentitet returneret af {0} er allerede linket til en anden bruger.
+confirmAccountLinking=Bekræft sammenkobling af konto {0} fra identitetsudbyder {1} med din konto.
+confirmEmailAddressVerification=Bekræft gyldigheden af email adresse {0}.
+confirmExecutionOfActions=Udfør følgende handling(er)
+
+locale_ca=Catal\u00E0
+locale_da=Dansk
+locale_de=Deutsch
+locale_en=English
+locale_es=Espa\u00F1ol
+locale_fr=Fran\u00e7ais
+locale_it=Italiano
+locale_ja=\u65E5\u672C\u8A9E
+locale_nl=Nederlands
+locale_no=Norsk
+locale_pt_BR=Portugu\u00EAs (Brasil)
+locale_pt-BR=Portugu\u00EAs (Brasil)
+locale_ru=\u0420\u0443\u0441\u0441\u043A\u0438\u0439
+locale_lt=Lietuvi\u0173
+locale_zh-CN=\u4e2d\u6587\u7b80\u4f53
+locale_sk=Sloven\u010Dina
+locale_sv=Svenska
+
+backToApplication=&laquo; Tilbage til applikation
+missingParameterMessage=Manglende parametre\: {0}
+clientNotFoundMessage=Klienten kunne ikke findes.
+clientDisabledMessage=Klienten er deaktiveret.
+invalidParameterMessage=Ugyldig parameter\: {0}
+alreadyLoggedIn=Du er allerede logget ind.
+differentUserAuthenticated=Du er allerede logget ind som en anden bruger ''{0}'' i denne session. Log venligst ud først.
+brokerLinkingSessionExpired=Har forespørgt kobling mellem mæglerkonti, men den nuværende session er ikke længere gyldig.
+
+proceedWithAction=&raquo; Tryk her for at fortsætte
+
+requiredAction.CONFIGURE_TOTP=Konfigurer OTP
+requiredAction.terms_and_conditions=Vilkår og betingelser
+requiredAction.UPDATE_PASSWORD=Opdater Adgangskode
+requiredAction.UPDATE_PROFILE=Opdater Profil
+requiredAction.VERIFY_EMAIL=Verificer email adresse
+
+doX509Login=Du vil blive logget ind som\:
+clientCertificate=X509 client certificate\:
+noCertificate=[No Certificate]
+
+pageNotFound=Siden kunne ikke findes
+internalServerError=Der opstod en intern server fejl.
+
+console-username=Brugernavn:
+console-password=Adgangskode:
+console-otp=Engangskode:
+console-new-password=Ny Adgangskode:
+console-confirm-password=Bekræft Adgangskode:
+console-update-password=Du skal opdatere din adgangskode.
+console-verify-email=Du skal verificere din email adresse. En email er blevet sendt til {0} som indeholder en verificerings kode. Indtast koden i input feltet herunder.
+
+console-email-code=Email Kode:
+console-accept-terms=Accepter Vilkår? [j/n]:
+console-accept=j
+
+auth-username-form-display-name=Brugernavn
+auth-username-form-help-text=Start log ind ved at indtaste dit brugernavn
+auth-username-password-form-display-name=Brugernavn og adgangskode
+auth-username-password-form-help-text=Log ind ved at indtaste dit brugernavn og adgangskode
+
+doBack=Tilbage
+doTryAgain=Prøv igen
+doTryAnotherWay=Prøv på en anden måde
+rolesScopeConsentText=Brugerroller
+restartLoginTooltip=Start log ind forfra
+loginTotpStep3DeviceName=Angiv et udstyrsnavn for at kunne holde rede på udstyr med engangskode.
+loginCredential=Credential
+loginTotpDeviceName=Udstyrsnavn
+loginChooseAuthenticator=Vælg metode til log ind
+requiredFields=Nødvendige felter
+invalidUsernameMessage=Ugyldigt brugernavn.
+invalidUsernameOrEmailMessage=Ugyldigt brugernavn eller email.
+invalidPasswordMessage=Ugyldig adangskode.
+missingTotpDeviceNameMessage=Angiv venligst et udstyrsnavn.
+nestedFirstBrokerFlowMessage={0} brugeren {1} er ikke forbundet til nogen kendt bruger.
+locale_cs=\u010Ce\u0161tina
+locale_pl=Polish
+openshift.scope.user_info=Brugerinformation
+openshift.scope.user_check-access=Brugeradgangsinformation
+openshift.scope.user_full=Fuld adgang
+openshift.scope.list-projects=Vis liste af projekter
+saml.post-form.title=Log ind Redirect
+saml.post-form.message=Redirigerer, vent venligst.
+saml.post-form.js-disabled=JavaScript er disabled. Vi anbefaler stærkt at enbable det. Klik på knappen nedenfor for at fortsætte.
+otp-display-name=Engangskodegenerator
+otp-help-text=Indtast en godkendelseskode fra engangskodegeneratoren.
+password-display-name=Adgangskode
+password-help-text=Log ind ved at indtaste din adgangskode.
+webauthn-display-name=Sikkerhedsnøgle
+webauthn-help-text=Brug din sikkerhedsnøgle for at logge ind.
+webauthn-passwordless-display-name=Sikkerhedsnøgle
+webauthn-passwordless-help-text=Brug din sikkerhedsnøgle for at logge ind uden adgangskode.
+webauthn-login-title=Log ind med sikkerhedsnøgle
+webauthn-registration-title=Registrering af Sikkerhedsnøgle
+webauthn-available-authenticators=Tilgængelige log ind måder
+webauthn-error-title=Sikkerhedsnøglefejl
+webauthn-error-registration=Det lykkedes ikke at registrere din sikkerhedsnøgle.
+webauthn-error-api-get=Det lykkedes ikke at logge ind med din sikkerhedsnøgle.
+webauthn-error-different-user=Den første authenticatede bruger er ikke den der er authenticated med sikkerhedsnøglen.
+webauthn-error-auth-verification=Resultatet fra log ind med sikkerhedsnøgle er ugyldigt.
+webauthn-error-register-verification=Resultatet fra registrering med sikkerhedsnøglen er ugyldigt.
+webauthn-error-user-not-found=Ukendt bruger authenticated med sikkerhedsnøglen.
+identity-provider-redirector=Forbind med en anden Identitetsudbyder

--- a/themes/src/main/resources-community/theme/base/login/theme.properties
+++ b/themes/src/main/resources-community/theme/base/login/theme.properties
@@ -1,1 +1,1 @@
-locales=ca,cs,de,en,es,fr,hu,it,ja,lt,nl,no,pl,pt-BR,ru,sk,sv,tr,zh-CN
+locales=ca,cs,da,de,en,es,fr,hu,it,ja,lt,nl,no,pl,pt-BR,ru,sk,sv,tr,zh-CN

--- a/themes/src/main/resources/theme/base/login/messages/messages_en.properties
+++ b/themes/src/main/resources/theme/base/login/messages/messages_en.properties
@@ -277,6 +277,7 @@ confirmExecutionOfActions=Perform the following action(s)
 
 locale_ca=Catal\u00E0
 locale_cs=\u010Ce\u0161tina
+locale_da=Dansk
 locale_de=Deutsch
 locale_en=English
 locale_es=Espa\u00F1ol


### PR DESCRIPTION
This is based on:

	Author: Thomas Sørensen <tvs@flexdanmark.dk>
	Date:   Thu Sep 13 14:24:43 2018 +0200

	Added danish translation. by FuKe · Pull Request #5567
	https://github.com/keycloak/keycloak/pull/5567

However, I:

* Fixed up a couple of theme.properties merge conflicts compared to
  current master
* Fixed some spelling mistakes and added missing entries
* Introduced Danish to list of locales in messages_en.properties
* Squashed it all into a single commit as pr.
  https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md
