### PR TITLE
KEYCLOAK-14691 Hungarian translation to account, email and login themes

### DIFF
--- a/themes/src/main/resources-community/theme/base/account/messages/messages_hu.properties
+++ b/themes/src/main/resources-community/theme/base/account/messages/messages_hu.properties
@@ -1,0 +1,341 @@
+# encoding: utf-8
+doSave=Mentés
+doCancel=Mégsem
+doLogOutAllSessions=Minden munkamenet kiléptetése
+doRemove=Törlés
+doAdd=Hozzáadás
+doSignOut=Kilépés
+doLogIn=Belépés
+doLink=Összekötés
+
+editAccountHtmlTitle=Fiók szerkesztése
+personalInfoHtmlTitle=Személyes adatok
+federatedIdentitiesHtmlTitle=Összekapcsolt személyazonosságok
+accountLogHtmlTitle=Fiók napló
+changePasswordHtmlTitle=Jelszó csere
+deviceActivityHtmlTitle=Eszköz történet
+sessionsHtmlTitle=Munkamenetek
+accountManagementTitle=Keycloak Fiók Kezelő
+authenticatorTitle=Hitelesítő
+applicationsHtmlTitle=Alkalmazások
+linkedAccountsHtmlTitle=Összekötött fiókok
+
+accountManagementWelcomeMessage=Üdvözöljük a Keycloak Fiók Kezelőben
+personalInfoIntroMessage=Kezelje az alap személyes adatait
+accountSecurityTitle=Fiók biztonság
+accountSecurityIntroMessage=Szabályozza jelszó és fiók hozzáféréseit
+applicationsIntroMessage=Kezelje alkalmazás jogosultságait, hogy hozzáférjen a fiókjához
+resourceIntroMessage=Ossza meg az erőforrásait csapattagjai között
+passwordLastUpdateMessage=A jelszava ekkor módosult
+updatePasswordTitle=Módosítsa jelszavát
+updatePasswordMessageTitle=Kérem válasszon erős jelszót
+updatePasswordMessage=Egy erős jelszó számok, betűk és speciális karakterek keveréke, nehéz kitalálni, nem hasonlít valódi (szótári) szóra és csak ehhez a fiókhoz tartozik.
+personalSubTitle=Személyes adatai
+personalSubMessage=Kezelje alapvető személyes adatait: vezetéknév, keresztnév, email cím
+
+authenticatorCode=Egyszer használatos kód
+email=Email cím
+firstName=Keresztnév
+givenName=Keresztnév
+fullName=Teljes név
+lastName=Vezetéknév
+familyName=Vezetéknév
+password=Jelszó
+currentPassword=Jelenlegi jelszó
+passwordConfirm=Megerősítés
+passwordNew=Új jelszó
+username=Felhasználó név
+address=Cím
+street=Közterület
+locality=Település
+region=Állam, Tartomány, Megye, Régió
+postal_code=Irányítószám
+country=Ország
+emailVerified=Ellenőrzött email cím
+gssDelegationCredential=GSS Delegation Credential
+
+profileScopeConsentText=Felhasználói fiók
+emailScopeConsentText=Email cím
+addressScopeConsentText=Cím
+phoneScopeConsentText=Telefonszám
+offlineAccessScopeConsentText=Offline hozzáférés
+samlRoleListScopeConsentText=Szerepköreim
+rolesScopeConsentText=Felhasználói szerepkörök
+
+role_admin=Adminisztrátor
+role_realm-admin=Tartomány Adminisztrátor
+role_create-realm=Tartomány létrehozása
+role_view-realm=Tartományok megtekintése
+role_view-users=Felhasználók megtekintése
+role_view-applications=Alkalmazások megtekintése
+role_view-clients=Kliensek megtekintése
+role_view-events=Események megtekintése
+role_view-identity-providers=Személyazonosság-kezelők megtekintése
+role_view-consent=Jóváhagyó nyilatkozatok megtekintése
+role_manage-realm=Tartományok kezelése
+role_manage-users=Felhasználók kezelése
+role_manage-applications=Alkalmazások kezelése
+role_manage-identity-providers=Személyazonosság-kezelők karbantartása
+role_manage-clients=Kliensek kezelése
+role_manage-events=Események kezelése
+role_view-profile=Fiók megtekintése
+role_manage-account=Fiók kezelése
+role_manage-account-links=Fiók összekötések kezelése
+role_manage-consent=Jóváhagyó nyilatkozatok kezelése
+role_read-token=Olvasási token
+role_offline-access=Offline hozzáférés
+role_uma_authorization=Hozzáférés jogosultságokhoz (UMA)
+client_account=Fiók
+client_account-console=Fiók kezelés
+client_security-admin-console=Biztonsági, adminisztrátor fiók kezelés
+client_admin-cli=Admin CLI
+client_realm-management=Tartomány kezelés
+client_broker=Ügynök
+
+
+requiredFields=Kötelezően kitöltendő mezők
+allFieldsRequired=Minden mező kitöltése kötelező
+
+backToApplication=&laquo; Vissza az alkalmazásba
+backTo=Vissza a {0}-ba/be
+
+date=Dátum
+event=Esemény
+ip=IP cím
+client=Kliens
+clients=Kliensek
+details=Részletek
+started=Kezdete
+lastAccess=Utolsó hozzáférés
+expires=Lejárat
+applications=Alkalmazások
+
+account=Fiók
+federatedIdentity=Összekapcsolt személyazonosság
+authenticator=Hitelesítő
+device-activity=Eszköz történet
+sessions=Munkamentek
+log=Napló
+
+application=Alkalmazás
+availableRoles=Elérhető szerepkörök
+grantedPermissions=Engedélyezett jogosultságok
+grantedPersonalInfo=Engedélyezett személyes adatok
+additionalGrants=További engedélyek
+action=Művelet
+inResource=itt:
+fullAccess=Teljes hozzáférés
+offlineToken=Offline Token
+revoke=Engedély visszavonása
+
+configureAuthenticators=Beállított Hitelesítők
+mobile=Mobil eszköz
+totpStep1=Kérem telepítse az itt felsorolt alkalmazások egyikét a mobil eszközére:
+totpStep2=Indítsa el az alkalmazást a mobil eszközén és olvassa be ezt a (QR) kódot:
+totpStep3=Adja meg az alkalmazás által generált egyszer használatos kódot majd kattintson a Mentés gombra a beállítás befejezéséhez.
+totpStep3DeviceName=Adja meg a mobil eszköz nevét. Ez a későbbiekben segíthet az eszköz azonosításában.
+
+totpManualStep2=Indítsa el az alkalmazás és adja meg a következő kulcsot:
+totpManualStep3=Használja a következő beállításokat, ha az alkalmazása támogatja ezeket:
+totpUnableToScan=Nem tud (QR) kódot beolvasni?
+totpScanBarcode=Inkább (QR) kódot olvasna be?
+
+totp.totp=Idő alapú
+totp.hotp=Számláló alapú
+
+totpType=Típus
+totpAlgorithm=Algoritmus
+totpDigits=Számjegyek
+totpInterval=Intervallum
+totpCounter=Számláló
+totpDeviceName=Eszköz neve
+
+missingUsernameMessage=Kérem adja meg a felhasználó nevét.
+missingFirstNameMessage=Kérem adja meg a keresztnevet.
+invalidEmailMessage=Érvénytelen email cím.
+missingLastNameMessage=Kérem adja meg a vezetéknevet.
+missingEmailMessage=Kérem adja meg az email címet.
+missingPasswordMessage=Kérem adja meg a jelszót.
+notMatchPasswordMessage=A jelszavak nem egyeznek meg.
+invalidUserMessage=Érvénytelen felhasználó
+
+missingTotpMessage=Kérem adja meg a hitelesítő kódot.
+missingTotpDeviceNameMessage=Kérem adja meg az eszköz nevét.
+invalidPasswordExistingMessage=Érvénytelen jelenlegi jelszó.
+invalidPasswordConfirmMessage=A jelszavak nem egyeznek meg.
+invalidTotpMessage=Érvénytelen hitelesítő kód.
+
+usernameExistsMessage=Ez a felhasználó név már foglalt.
+emailExistsMessage=Ez az email cím már foglalt.
+
+readOnlyUserMessage=A felhasználói fiókja csak olvasható, módosítás nem lehetséges.
+readOnlyUsernameMessage=A felhasználó név nem módosítható.
+readOnlyPasswordMessage=A felhasználói fiókja csak olvasható, így jelszó módosítás nem lehetséges.
+
+successTotpMessage=A mobil hitelesítőt beállítottuk.
+successTotpRemovedMessage=A mobil hitelesítőt eltávolítottuk.
+
+successGrantRevokedMessage=Az engedélyt visszavontuk.
+
+accountUpdatedMessage=Felhasználói fiókját módosítottuk.
+accountPasswordUpdatedMessage=Jelszavát módosítottuk.
+
+missingIdentityProviderMessage=Nincs megadva személyazonosság-kezelő.
+invalidFederatedIdentityActionMessage=Érvénytelen, vagy nem létező művelet.
+identityProviderNotFoundMessage=A megadott személyazonosság-kezelő nem található.
+federatedIdentityLinkNotActiveMessage=Ez a személyazonosság összekötés már nem érvényes.
+federatedIdentityRemovingLastProviderMessage=Az utolsó összekapcsolt személyazonosság nem törölhető, mert Ön nem rendelkezik érvényes jelszóval.
+identityProviderRedirectErrorMessage=Nem sikerült az átirányítás a személyazonosság-kezelőre.
+identityProviderRemovedMessage=A személyazonosság-kezelő összekötést töröltük.
+identityProviderAlreadyLinkedMessage=Az összekapcsolt személyazonosság-kezelő által bizotsított személyazonosság már össze van kötve egy másik felhasználói fiókkal.
+staleCodeAccountMessage=Az oldal érvényességi ideje lejárt. Kérem próbálja meg újra a kérést.
+consentDenied=Jóváhagyó nyilatkozat elutasítva.
+
+accountDisabledMessage=Felhasználói fiókja inaktív, kérem vegye fel a kapcsolatot az alkalmazás adminisztrátorral.
+
+accountTemporarilyDisabledMessage=Felhasználói fiókja átmenetileg inaktív, kérem vegye fel a kapcsolatot az alkalmazás adminisztrátorral, vagy próbálkozzon később.
+invalidPasswordMinLengthMessage=Érvénytelen jelszó: minimum hossz {0}.
+invalidPasswordMinLowerCaseCharsMessage=Érvénytelen jelszó: legalább {0} darab kisbetűt kell tartalmaznia.
+invalidPasswordMinDigitsMessage=Érvénytelen jelszó: legalább {0} darab számjegyet kell tartalmaznia.
+invalidPasswordMinUpperCaseCharsMessage=Érvénytelen jelszó: legalább {0} darab nagybetűt kell tartalmaznia.
+invalidPasswordMinSpecialCharsMessage=Érvénytelen jelszó: legalább {0} darab speciális karaktert (pl. #!$@ stb.) kell tartalmaznia.
+invalidPasswordNotUsernameMessage=Érvénytelen jelszó: nem lehet azonos a felhasználó névvel.
+invalidPasswordRegexPatternMessage=Érvénytelen jelszó: a jelszó nem illeszkedik a megadott reguláris kifejezés mintára.
+invalidPasswordHistoryMessage=Érvénytelen jelszó: nem lehet azonos az utolsó {0} darab, korábban alkalmazott jelszóval.
+invalidPasswordBlacklistedMessage=Érvénytelen jelszó: a jelszó tiltó listán szerepel.
+invalidPasswordGenericMessage=Érvénytelen jelszó: az új jelszó nem felel meg a jelszó házirendnek.
+
+# Authorization
+myResources=Erőforrásaim
+myResourcesSub=Erőforrásaim
+doDeny=Tiltás
+doRevoke=Visszavonás
+doApprove=Jóváhagyás
+doRemoveSharing=Megosztás törlése
+doRemoveRequest=Kérelem törlése
+peopleAccessResource=Az erőforráshoz hozzáférő felhasználók
+resourceManagedPolicies=Az erőforrás hozzáféréshez szükséges jogosultságok
+resourceNoPermissionsGrantingAccess=Az erőforrás hozzáféréshez nem szükségesek jogosultságok
+anyAction=Bármelyik művelet
+description=Leírás
+name=Név
+scopes=Hatókör
+resource=Erőforrás
+user=Felhasználó
+peopleSharingThisResource=Az erőforrást megosztó felhasználók
+shareWithOthers=Megosztás más felhasználókkal
+needMyApproval=A jóváhagyásom szükséges
+requestsWaitingApproval=A kérése jóváhagyásra vár
+icon=Ikon
+requestor=Kérelmező
+owner=Tulajdonos
+resourcesSharedWithMe=Velem megosztott erőforrások
+permissionRequestion=Jogosultság kérelem
+permission=Jogosultság
+shares=megosztás(ok)
+notBeingShared=Az erőforrás nincs megosztva
+notHaveAnyResource=Nincsen erőforrása
+noResourcesSharedWithYou=Nincsenek Önnel megosztott erőforrásai
+havePermissionRequestsWaitingForApproval=Önnek {0} darab várakozó, jóváhagyandó jogosultság kérése van.
+clickHereForDetails=Kattintson ide a részletekért.
+resourceIsNotBeingShared=Az erőforrás nincs megosztva
+
+# Applications
+applicaitonName=Név
+applicationType=Alkalmazás típus
+#applicationInUse=In-use app only
+clearAllFilter=Szűrő mezők törlése
+activeFilters=Aktív szűrők
+filterByName=Név alapú keresés
+allApps=Minden alkalmazás
+internalApps=Belső alkalmazások
+thirdpartyApps=Harmadik féltől származó alkalmazások
+appResults=Eredmény
+clientNotFoundMessage=A kliens nem található.
+
+# Linked account
+authorizedProvider=Meghatalmazott szolgáltató
+authorizedProviderMessage=A felhasználói fiókjához kötött meghatalmazott szolgáltatók
+identityProvider=Személyazonosság-kezelő
+identityProviderMessage=Fiókja személyazonosság-kezelőkhöz kötéséhez eddig ezeket a beállításokat adta meg
+#socialLogin=Social Login
+userDefined=Felhasználó által meghatározott
+removeAccess=Hozzáférés törlése
+removeAccessMessage=Újra engedélyeznie kell a hozzáférést az alkalmazás ismételt használatához.
+
+#Authenticator
+authenticatorStatusMessage=A kétszintű hitelesítés jelenleg
+authenticatorFinishSetUpTitle=Kétszintű hitelesítés
+authenticatorFinishSetUpMessage=Minden Keycloak fiók bejelentkezéskor kérni fogunk Öntől egy második szintű hitelesítő kódot.
+authenticatorSubTitle=Állítsa be a második szintű hitelesítést
+authenticatorSubMessage=Felhasználói fiókjának biztonsági szintjét növelheti, ha legalább egy második szintű hitelesítést is bekapcsol az elérhető eljárások közül.
+authenticatorMobileTitle=Mobil eszköz alapú hitelesítés
+authenticatorMobileMessage=Mobil eszközön generált ellenőrző kód, mint második szintű hitelesítés.
+authenticatorMobileFinishSetUpMessage=A hitelesítés a mobil eszközéhez kötődik.
+authenticatorActionSetup=Beállítás
+authenticatorSMSTitle=SMS kód
+authenticatorSMSMessage=A Keycloak SMS ellenőrző kódot küld a telefonjára (második szintű hitelesítő kód).
+authenticatorSMSFinishSetUpMessage=A következő telefonszámokra SMS-t küldünk
+authenticatorDefaultStatus=Alapértelmezett
+authenticatorChangePhone=Módosítsa telefonszámát
+authenticatorBackupCodesTitle=Tartalék kódok
+authenticatorBackupCodesMessage=8 számjegyű tartalék kódok igénylése
+authenticatorBackupCodesFinishSetUpMessage=12 darab tartalék kódot generáltunk, mindegyiket csak egyszer használhatja fel.
+
+#Authenticator - Mobile Authenticator setup
+authenticatorMobileSetupTitle=Mobil hitelesítő eszköz beállítása
+smscodeIntroMessage=Adja meg a telefonszámát, melyre egy ellenőrző kódot küldünk.
+mobileSetupStep1=Telepítsen egy hitelesítő alkalmazást mobil eszközére az itt felsorolt, támogatott, alkalmazások közül.
+mobileSetupStep2=Indítsa el az alkalmazást és olvassa be a következő (QR) kódot:
+mobileSetupStep3=Adja meg a mobil alkalmazás által generált egyszer használatos kódot, majd kattintson a Mentés gombra a beállításhoz.
+scanBarCode=Inkább (QR) kódot olvasna be?
+enterBarCode=Adja meg az egyszer használatos kódot
+doCopy=Másolás
+doFinish=Befejezés
+
+#Authenticator - SMS Code setup
+authenticatorSMSCodeSetupTitle=SMS kód beállítása
+chooseYourCountry=Válassza ki az országot
+enterYourPhoneNumber=Adja meg a telefonszámát
+sendVerficationCode=Ellenőrző kód küldése
+enterYourVerficationCode=Adja meg az ellenőrző kódot
+
+#Authenticator - backup Code setup
+authenticatorBackupCodesSetupTitle=Tartalék kódok beállítása
+backupcodesIntroMessage=Ha elveszíti telefonját, még mindig hozzáférhet a felhasználói fiókjához tartalék kódok segítségével. A tartalék kódokat tartsa egy biztonságos, de könnyen hozzáférhető helyen.
+realmName=Tartomány
+doDownload=Letöltés
+doPrint=Nyomtatás
+backupCodesTips-1=Minden tartalék kód csak egyszer használható fel.
+backupCodesTips-2=Ezeket a kódokat ekkor generálta
+generateNewBackupCodes=Új tartalék kódok generálása
+backupCodesTips-3=Új tartalék kódok generálásakor a korábban generált kódok érvénytelenné válnak.
+backtoAuthenticatorPage=Vissza a hitelesítő lapra
+
+
+#Resources
+resources=Erőforrások
+sharedwithMe=Velem megosztott erőforrások
+share=Megosztás
+sharedwith=Megosztva
+accessPermissions=Hozzáférési jogosultságok
+permissionRequests=Jogosultság kérések
+approve=Jóváhagyás
+approveAll=Mindet jóváhagyja
+people=felhasználó
+perPage=oldalanként
+currentPage=Aktuális oldal
+sharetheResource=Erőforrás megosztása
+group=Csoport
+selectPermission=Jogosultság választás
+addPeople=Adjon hozzá felhasználókat az erőforrás megosztáshoz
+addTeam=Adjon meg csoportot az erőforrás megosztáshoz
+myPermissions=Jogosultságaim
+waitingforApproval=Jóváhagyásra vár
+anyPermission=Bármilyen jogosultság
+
+# Openshift messages
+openshift.scope.user_info=Felhasználó adatok
+openshift.scope.user_check-access=Felhasználó hozzáférés adatok
+openshift.scope.user_full=Teljes hozzáférés
+openshift.scope.list-projects=Projektek listája

--- a/themes/src/main/resources-community/theme/base/account/theme.properties
+++ b/themes/src/main/resources-community/theme/base/account/theme.properties
@@ -1,1 +1,1 @@
-locales=ca,cs,de,en,es,fr,it,ja,lt,nl,no,pl,pt-BR,ru,sk,sv,tr,zh-CN
+locales=ca,cs,de,en,es,fr,hu,it,ja,lt,nl,no,pl,pt-BR,ru,sk,sv,tr,zh-CN

--- a/themes/src/main/resources-community/theme/base/email/messages/messages_hu.properties
+++ b/themes/src/main/resources-community/theme/base/email/messages/messages_hu.properties
@@ -1,0 +1,47 @@
+# encoding: utf-8
+emailVerificationSubject=Email cím megerősítése
+emailVerificationBody=Ezzel az email címmel valaki létrehozott egy {2} tartomány felhasználói fiókot. Amennyiben a fiókot Ön hozta létre, kérem kattintson a lenti hivatkozásra, hogy megerősítse fiókját és ezt az email címet.\n\n{0}\n\nA hivatkozás érvényét veszti {3} múlva.\n\nHa nem ön hozta létre a felhasználói fiókot, akkor kérem hagyja figyelmen kívül ezt az üzenetet.
+emailVerificationBodyHtml=<p>Ezzel az email címmel valaki létrehozott egy {2} tartomány felhasználói fiókot. Amennyiben a fiókot Ön hozta létre, kérem kattintson a lenti hivatkozásra, hogy megerősítse fiókját és ezt az email címet.</p><p><a href="{0}">Hivatkozás a fiók és az email cím megerősítéséhez</a></p><p>A hivatkozás érvényét veszti {3} múlva.</p><p>Ha nem ön hozta létre a felhasználói fiókot, akkor kérem hagyja figyelmen kívül ezt az üzenetet.</p>
+emailTestSubject=[KEYCLOAK] - SMTP teszt üzenet
+emailTestBody=Ez egy KEYCLOAK teszt üzenet.
+emailTestBodyHtml=<p>Ez egy KEYCLOAK teszt üzenet.</p>
+identityProviderLinkSubject={0} összekötés
+identityProviderLinkBody=Valaki össze kívánja kötni az Ön "{1}" tartományi fiókját a(z) "{0}" személyazonosság-kezelő {2} felhasználói fiókjával. Amennyiben az összekötést Ön kezdeményezte kérem kattintson a lenti hivatkozásra, hogy összekösse fiókjait.\n\n{3}\n\nA hivatkozás érvényét veszti {5} múlva.\n\nHa nem ön kezdeményezte a felhasználói fiókok összekötését, akkor kérem hagyja figyelmen kívül ezt az üzenetet.\n\nHa összeköti a fiókjait, akkor beléphet a(z) {1} tartományba a(z) {0} szolgáltatón keresztül.
+identityProviderLinkBodyHtml=<p>Valaki össze kívánja kötni az Ön <b>{1}</b> tartomány fiókját a(z) <b>{0}</b> személyazonosság-kezelő {2} felhasználói fiókjával. Amennyiben az összekötést Ön kezdeményezte kérem kattintson a lenti hivatkozásra, hogy összekösse fiókjait.</p><p><a href="{3}">Hivatkozás a fiók összekötés megerősítéshez</a></p><p>A hivatkozás érvényét veszti {5} múlva.</p><p>Ha nem ön kezdeményezte a felhasználói fiókok összekötését, akkor kérem hagyja figyelmen kívül ezt az üzenetet.</p><p>Ha összeköti a fiókjait, akkor beléphet a(z) {1} tartományba a(z) {0} szolgáltatón keresztül.</p>
+passwordResetSubject=Jelszó visszaállítás
+passwordResetBody=Valaki vissza kívánja állítani az Ön "{2}" tartományi fiókjának jelszavát. Amennyiben a jelszó visszaállítást Ön kezdeményezte, kérem kattintson a lenti hivatkozásra a jelszava megváltoztatásához.\n\n{0}\n\nA hivatkozás érvényét veszti {3} múlva.\n\nHa nem ön kérte a jelszó visszaállítást, akkor kérem hagyja figyelmen kívül ezt az üzenetet, a jelszava nem fog megváltozni.
+passwordResetBodyHtml=<p>Valaki vissza kívánja állítani az Ön "{2}" tartományi fiókjának jelszavát. Amennyiben a jelszó visszaállítást Ön kezdeményezte, kérem kattintson a lenti hivatkozásra a jelszava megváltoztatásához.</p><p><a href="{0}">Hivatkozás a jelszó visszaállításhoz</a></p><p>A hivatkozás érvényét veszti {3} múlva.</p><p>Ha nem ön kérte a jelszó visszaállítást, akkor kérem hagyja figyelmen kívül ezt az üzenetet, a jelszava nem fog megváltozni.</p>
+executeActionsSubject=Felhasználói fiók adatok módosítása
+executeActionsBody=Az alkalmazás adminisztrátora kezdeményezte az Ön "{2}" tartományi felhasználói fiók adatainak módosítását a következő műveletekkel: {3}. Kérem kattintson a lenti hivatkozásra, hogy megkezdhesse a kért módosításokat.\n\n{0}\n\nA hivatkozás érvényét veszti {4} múlva.\n\nHa nincs tudomása arról, hogy az adminisztrátora módosításokat kért Öntől, akkor kérem hagyja figyelmen kívül ezt az üzenetet, az adatai nem fognak megváltozni.
+executeActionsBodyHtml=<p>Az alkalmazás adminisztrátora kezdeményezte az Ön "{2}" tartományi felhasználói fiók adatainak módosítását a következő műveletekkel: {3}. Kérem kattintson a lenti hivatkozásra, hogy megkezdhesse a kért módosításokat.</p><p><a href="{0}">Hivatkozás a felhasználói fiók adatok módosításához</a></p><p>A hivatkozás érvényét veszti {4} múlva.</p><p>Ha nincs tudomása arról, hogy az adminisztrátora módosításokat kért Öntől, akkor kérem hagyja figyelmen kívül ezt az üzenetet, az adatai nem fognak megváltozni.</p>
+eventLoginErrorSubject=Belépési hiba
+eventLoginErrorBody=Sikertelen belépési kísérlet történt {0} időpontban a(z) {1} címről. Kérem lépjen kapcsolatba az alkalmazás adminisztrátorral amennyiben nem ön próbált meg belépni.
+eventLoginErrorBodyHtml=<p>Sikertelen belépési kísérlet történt {0} időpontban a(z) {1} címről. Kérem lépjen kapcsolatba az alkalmazás adminisztrátorral amennyiben nem ön próbált meg belépni.</p>
+eventRemoveTotpSubject=Egyszer használatos jelszó (OTP) eltávolítása
+eventRemoveTotpBody=Az egyszer használatos jelszó (OTP) funkciót {0} időpontban a(z) {1} címről érkező kérés értelmében eltávolítottuk a fiókjáról. Kérem haladéktalanul lépjen kapcsolatba az alkalmazás adminisztrátorral amennyiben nem ön igényelte az OTP eltávolítását.
+eventRemoveTotpBodyHtml=<p>Az egyszer használatos jelszó (OTP) funkciót {0} időpontban a(z) {1} címről érkező kérés értelmében eltávolítottuk a fiókjáról. Kérem haladéktalanul lépjen kapcsolatba az alkalmazás adminisztrátorral amennyiben nem ön igényelte az OTP eltávolítását.</p>
+eventUpdatePasswordSubject=Jelszó csere
+eventUpdatePasswordBody=Jelszavát {0} időpontban a(z) {1} címről érkező kérés értelmében lecseréltük. Kérem haladéktalanul lépjen kapcsolatba az alkalmazás adminisztrátorral amennyiben nem ön igényelte a jelszó cserét.
+eventUpdatePasswordBodyHtml=<p>Jelszavát {0} időpontban a(z) {1} címről érkező kérés értelmében lecseréltük. Kérem haladéktalanul lépjen kapcsolatba az alkalmazás adminisztrátorral amennyiben nem ön igényelte a jelszó cserét.</p>
+eventUpdateTotpSubject=Egyszer használatos jelszó (OTP) csere
+eventUpdateTotpBody=Az egyszer használatos jelszó (OTP) beállításait {0} időpontban a(z) {1} címről érkező kérés értelmében módosítottuk a fiókján. Kérem haladéktalanul lépjen kapcsolatba az alkalmazás adminisztrátorral amennyiben nem ön igényelte az OTP beállítások módosítását.
+eventUpdateTotpBodyHtml=<p>Az egyszer használatos jelszó (OTP) beállításait {0} időpontban a(z) {1} címről érkező kérés értelmében módosítottuk a fiókján. Kérem haladéktalanul lépjen kapcsolatba az alkalmazás adminisztrátorral amennyiben nem ön igényelte az OTP beállítások módosítását.</p>
+
+requiredAction.CONFIGURE_TOTP=Egyszer használatos jelszó (OTP) beállítása
+requiredAction.terms_and_conditions=Felhasználási feltételek
+requiredAction.UPDATE_PASSWORD=Jelszó csere
+requiredAction.UPDATE_PROFILE=Fiók adatok módosítása
+requiredAction.VERIFY_EMAIL=Email cím megerősítése
+
+# units for link expiration timeout formatting
+linkExpirationFormatter.timePeriodUnit.seconds=másodperc
+linkExpirationFormatter.timePeriodUnit.seconds.1=másodperc
+linkExpirationFormatter.timePeriodUnit.minutes=perc
+linkExpirationFormatter.timePeriodUnit.minutes.1=perc
+linkExpirationFormatter.timePeriodUnit.hours=óra
+linkExpirationFormatter.timePeriodUnit.hours.1=óra
+linkExpirationFormatter.timePeriodUnit.days=nap
+linkExpirationFormatter.timePeriodUnit.days.1=nap
+
+emailVerificationBodyCode=Kérem erősítse meg az email címét a következő kód megadásával.\n\n{0}\n\n.
+emailVerificationBodyCodeHtml=<p>Kérem erősítse meg az email címét a következő kód megadásával.</p><p><b>{0}</b></p>

--- a/themes/src/main/resources-community/theme/base/email/theme.properties
+++ b/themes/src/main/resources-community/theme/base/email/theme.properties
@@ -1,1 +1,1 @@
-locales=ca,cs,de,en,es,fr,it,ja,lt,nl,no,pl,pt-BR,ru,sk,sv,tr,zh-CN
+locales=ca,cs,de,en,es,fr,hu,it,ja,lt,nl,no,pl,pt-BR,ru,sk,sv,tr,zh-CN

--- a/themes/src/main/resources-community/theme/base/login/messages/messages_hu.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_hu.properties
@@ -1,0 +1,352 @@
+# encoding: utf-8
+doLogIn=Belépés
+doRegister=Regisztráció
+doCancel=Mégsem
+doSubmit=Elküld
+doBack=Vissza
+doYes=Igen
+doNo=Nem
+doContinue=Folytat
+doIgnore=Mellőz
+doAccept=Elfogad
+doDecline=Elutasít
+doForgotPassword=Elfelejtette a jelszavát?
+doClickHere=Kattintson ide
+doImpersonate=Megszemélyesítés
+doTryAgain=Próbálja újra
+doTryAnotherWay=Pórbálja máshogyan
+kerberosNotConfigured=Nincs beállítva Kerberos
+kerberosNotConfiguredTitle=Nincs beállítva Kerberos
+bypassKerberosDetail=Vagy nem Kerberosszal lépett be, vagy a böngészője nem kezeli a Kerberos alapú belépést. Kérem kattintson a Folytat gombra, egy másik belépési módhoz.
+kerberosNotSetUp=Nincs beállítva Kerberos, nem lehet belépni.
+registerTitle=Regisztráció
+loginTitle=Belépés ide: {0}
+loginTitleHtml={0}
+impersonateTitle={0} megszemélyesített felhasználó
+impersonateTitleHtml=<strong>{0}</strong> megszemélyesített felhasználó
+realmChoice=Tartomány
+unknownUser=Ismeretlen felhasználó
+loginTotpTitle=Mobil hitelesítő eszköz beállítása
+loginProfileTitle=Felhasználói fiók adatok módosítása
+loginTimeout=Belépési kísérlete időtúllépés miatt meghiúsult, a belépési eljárás újraindul.
+oauthGrantTitle=Hozzáférés engedélyezése {0}-nak/nek
+oauthGrantTitleHtml={0}
+errorTitle=Nagyon sajnáljuk...
+errorTitleHtml=Nagyon <strong>sajnáljuk</strong> ...
+emailVerifyTitle=Email ellenőrzés
+emailForgotTitle=Elfelejtette a jelszavát?
+updatePasswordTitle=Jelszó módosítása
+codeSuccessTitle=Sikeres kérés kódja
+codeErrorTitle=Hibakód\: {0}
+displayUnsupported=A kért megjelenítési mód nem támogatott
+browserRequired=A belépéshez böngésző szükséges
+browserContinue=A belépés befejezéséhez böngésző szükséges
+browserContinuePrompt=Megnyitja a böngészőt és folytatja a belépést? [i/n]:
+browserContinueAnswer=i
+
+
+termsTitle=Felhasználási feltételek
+termsText=<p>Felhasználási feltételek helye</p>
+termsPlainText=Felhasználási feltételek helye
+
+recaptchaFailed=Érvénytelen Recaptcha
+recaptchaNotConfigured=Recaptcha szükséges, de nincsen beállítva
+consentDenied=Jóváhagyó nyilatkozat elutasítva.
+
+noAccount=Új felhasználó?
+username=Felhasználó név
+usernameOrEmail=Felhasználó név vagy email
+firstName=Keresztnév
+givenName=Keresztnév
+fullName=Teljes név
+lastName=Vezetéknév
+familyName=Vezetéknév
+password=Jelszó
+email=Email cím
+passwordConfirm=Jelszó megerősítése
+passwordNew=Új jelszó
+passwordNewConfirm=Új jelszó megerősítése
+rememberMe=Automatikus bejelentkezés
+authenticatorCode=Egyszer használatos hitelesítő kód
+address=Cím
+street=Közterület
+locality=Település
+region=Állam, Tartomány, Megye, Régió
+postal_code=Irányítószám
+country=Ország
+emailVerified=Ellenőrzött email cím
+gssDelegationCredential=GSS Delegation Credential
+
+profileScopeConsentText=Felhasználói fiók
+emailScopeConsentText=Email cím
+addressScopeConsentText=Cím
+phoneScopeConsentText=Telefonszám
+offlineAccessScopeConsentText=Offline hozzáférés
+samlRoleListScopeConsentText=Szerepköreim
+rolesScopeConsentText=Felhasználói szerepkörök
+restartLoginTooltip=Belépés újrakezdése
+loginTotpIntro=A felhasználói fiók hozzáféréshez be kell állítania egy egyszer használatos jelszót (OTP) generáló alkalmazást.
+loginTotpStep1=Kérem telepítse az itt felsorolt alkalmazások egyikét a mobil eszközére:
+loginTotpStep2=Indítsa el az alkalmazást a mobil eszközén és olvassa be ezt a (QR) kódot:
+loginTotpStep3=Adja meg az alkalmazás által generált egyszer használatos kódot majd kattintson az Elküld gombra a beállítás befejezéséhez.
+loginTotpStep3DeviceName=Adja meg a mobil eszköz nevét. Ez a későbbiekben segíthet az eszköz azonosításában.
+loginTotpManualStep2=Indítsa el az alkalmazást és adja meg a következő kulcsot:
+loginTotpManualStep3=Használja a következő beállításokat, ha az alkalmazása támogatja ezeket:
+loginTotpUnableToScan=Nem tud (QR) kódot beolvasni?
+loginTotpScanBarcode=Inkább (QR) kódot olvasna be?
+loginCredential=Jelszó
+loginOtpOneTime=Egyszer használatos kód
+loginTotpType=Típus
+loginTotpAlgorithm=Algoritmus
+loginTotpDigits=Számjegyek
+loginTotpInterval=Intervallum
+loginTotpCounter=Számláló
+loginTotpDeviceName=Eszköz neve
+
+loginTotp.totp=Idő alapú
+loginTotp.hotp=Számláló alapú
+loginChooseAuthenticator=Válasszon egy belépési módszert
+
+oauthGrantRequest=Engedélyezi a következő hozzáférés jogosultságokat?
+inResource=Itt:
+
+emailVerifyInstruction1=A megadott email címre elküldtük az email cím megerősítéséhez szükséges lépéseket tartalmazó üzenetet.
+emailVerifyInstruction2=Nem kapott megerősítő kódot tartalmazó email üzenetet?
+emailVerifyInstruction3=az ellenőrző kód ismételt kiküldéséhez.
+
+emailLinkIdpTitle={0} összekötés
+emailLinkIdp1=A(z) {1} {0} fiók és a(z) {2} fiókjának összekötéséhez szükséges tudnivalókat email üzenetben elküldtük Önnek.
+emailLinkIdp2=Nem kapott megerősítő kódot tartalmazó email üzenetet?
+emailLinkIdp3=az ellenőrző kód ismételt kiküldéséhez.
+emailLinkIdp4=Ha egy másik böngészőben már jóváhagyta az email címét
+emailLinkIdp5=a folytatáshoz.
+
+backToLogin=&laquo; Vissza a belépéshez
+
+emailInstruction=Adja meg a felhasználó nevét vagy email címét, hogy az új jelszó beállításához szükséges tudnivalókat elküldhessük Önnek.
+
+copyCodeInstruction=Kérem másolja ki ezt a kódot és illessze be az alkalmazásába:
+
+pageExpiredTitle=A lap érvényessége lejárt
+pageExpiredMsg1=Ahhoz, hogy újrakezdje a belépési eljárást
+pageExpiredMsg2=Ahhoz, hogy folytassa a belépési eljárást
+
+personalInfo=Személyes adatok:
+role_admin=Adminisztrátor
+role_realm-admin=Tartomány Adminisztrátor
+role_create-realm=Tartomány létrehozása
+role_create-client=Kliens létrehozása
+role_view-realm=Tartományok megtekintése
+role_view-users=Felhasználók megtekintése
+role_view-applications=Alkalmazások megtekintése
+role_view-clients=Kliensek megtekintése
+role_view-events=Események megtekintése
+role_view-identity-providers=Személyazonosság-kezelők megtekintése
+role_view-consent=Jóváhagyó nyilatkozatok megtekintése
+role_manage-realm=Tartományok kezelése
+role_manage-users=Felhasználók kezelése
+role_manage-applications=Alkalmazások kezelése
+role_manage-identity-providers=Személyazonosság-kezelők karbantartása
+role_manage-clients=Kliensek kezelése
+role_manage-events=Események kezelése
+role_view-profile=Fiók megtekintése
+role_manage-account=Fiók kezelése
+role_manage-account-links=Fiók összekötések kezelése
+role_manage-consent=Jóváhagyó nyilatkozatok kezelése
+role_read-token=Olvasási token
+role_offline-access=Offline hozzáférés
+role_uma_authorization=Hozzáférés jogosultságokhoz (UMA)
+client_account=Fiók
+client_account-console=Fiók kezelés
+client_security-admin-console=Biztonsági, adminisztrátor fiók kezelés
+client_admin-cli=Admin CLI
+client_realm-management=Tartomány kezelés
+client_broker=Ügynök
+
+requiredFields=Kötelezően kitöltendő mezők
+
+invalidUserMessage=Érvénytelen felhasználó név vagy jelszó.
+invalidUsernameMessage=Érvénytelen felhasználó név.
+invalidUsernameOrEmailMessage=Érvénytelen felhasználó név vagy email cím.
+invalidPasswordMessage=Érvénytelen jelszó.
+invalidEmailMessage=Érvénytelen email cím.
+accountDisabledMessage=Felhasználói fiókja inaktív, kérem vegye fel a kapcsolatot az alkalmazás adminisztrátorral.
+accountTemporarilyDisabledMessage=Felhasználói fiókja átmenetileg inaktív, kérem vegye fel a kapcsolatot az alkalmazás adminisztrátorral, vagy próbálkozzon később.
+expiredCodeMessage=Belépési időtúllépés, kérem lépjen be újra.
+expiredActionMessage=A művelet érvényességi ideje lejárt. Kérem lépjen be újra.
+expiredActionTokenNoSessionMessage=A művelet érvényességi ideje lejárt.
+expiredActionTokenSessionExistsMessage=A művelet érvényességi ideje lejárt. Kérem ismételje meg a műveletet.
+
+missingUsernameMessage=Kérem adja meg a felhasználó nevét.
+missingFirstNameMessage=Kérem adja meg a keresztnevet.
+missingLastNameMessage=Kérem adja meg a vezetéknevet.
+missingEmailMessage=Kérem adja meg az email címet.
+missingPasswordMessage=Kérem adja meg a jelszót.
+missingTotpMessage=Kérem adja meg a hitelesítő kódot.
+missingTotpDeviceNameMessage=Kérem adja meg az eszköz nevét.
+notMatchPasswordMessage=A jelszavak nem egyeznek meg.
+
+invalidPasswordExistingMessage=Érvénytelen jelenlegi jelszó.
+invalidPasswordBlacklistedMessage=Érvénytelen jelszó: a jelszó tiltó listán szerepel.
+invalidPasswordConfirmMessage=A jelszavak nem egyeznek meg.
+invalidTotpMessage=Érvénytelen hitelesítő kód.
+
+usernameExistsMessage=Ez a felhasználó név már foglalt.
+emailExistsMessage=Ez az email cím már foglalt.
+
+federatedIdentityExistsMessage=A megadott {0} {1} felhasználó már létezik. Kérem lépjen be a Keycloak Fiók Kezelőbe, hogy összeköthesse a fiókokat.
+
+confirmLinkIdpTitle=A felhasználói fiók már létezik
+federatedIdentityConfirmLinkMessage=A megadott {0} {1} felhasználó már létezik. Hogyan tovább?
+federatedIdentityConfirmReauthenticateMessage=Azonosítsa magát, hogy összeköthesse a felhasználói fiókját a(z) {0}-val/vel.
+nestedFirstBrokerFlowMessage=A {0} {1} felhasználó nincs összekötve egyetlen ismert felhasználóval sem.
+confirmLinkIdpReviewProfile=Fiók áttekintése
+confirmLinkIdpContinue=Hozzáadás meglévő fiókhoz
+
+configureTotpMessage=Fiókja aktiválásához előbb be kell állítania egy mobil hitelesítő eszközt.
+updateProfileMessage=Fiókja aktiválásához előbb módosítania kell a felhasználói adatait.
+updatePasswordMessage=Fiókja aktiválásához előbb le kell cserélnie a jelszavát.
+resetPasswordMessage=Cserélje le jelszavát!
+verifyEmailMessage=Fiókja aktiválásához előbb erősítse meg email címét.
+linkIdpMessage=Fiókja összekötéséhez előbb erősítse meg email címét a(z) {0}-val/vel.
+
+emailSentMessage=Hamarosan email üzenetet küldünk a további tudnivalókról.
+emailSendErrorMessage=Az email üzenetet nem tudtuk elküldeni, kérem próbálja meg később.
+
+accountUpdatedMessage=A felhasználói fiók adatai megváltoztak.
+accountPasswordUpdatedMessage=A jelszava megváltozott.
+
+delegationCompleteHeader=Sikeres belépés
+delegationCompleteMessage=Becsukhatja a böngésző ablakot és visszatérhet a konzolos alkalmazásához.
+delegationFailedHeader=Sikertelen belépés
+delegationFailedMessage=Becsukhatja a böngésző ablakot és visszatérhet a konzolos alkalmazásához, ahol újból megpróbálhat a belépni.
+
+noAccessMessage=Nincs hozzáférés
+
+invalidPasswordMinLengthMessage=Érvénytelen jelszó: minimum hossz {0}.
+invalidPasswordMinLowerCaseCharsMessage=Érvénytelen jelszó: legalább {0} darab kisbetűt kell tartalmaznia.
+invalidPasswordMinDigitsMessage=Érvénytelen jelszó: legalább {0} darab számjegyet kell tartalmaznia.
+invalidPasswordMinUpperCaseCharsMessage=Érvénytelen jelszó: legalább {0} darab nagybetűt kell tartalmaznia.
+invalidPasswordMinSpecialCharsMessage=Érvénytelen jelszó: legalább {0} darab speciális karaktert (pl. #!$@ stb.) kell tartalmaznia.
+invalidPasswordNotUsernameMessage=Érvénytelen jelszó: nem lehet azonos a felhasználó névvel.
+invalidPasswordRegexPatternMessage=Érvénytelen jelszó: a jelszó nem illeszkedik a megadott reguláris kifejezés mintára.
+invalidPasswordHistoryMessage=Érvénytelen jelszó: nem lehet azonos az utolsó {0} darab, korábban alkalmazott jelszóval.
+invalidPasswordGenericMessage=Érvénytelen jelszó: az új jelszó nem felel meg a jelszó házirendnek.
+
+failedToProcessResponseMessage=A válasz üzenet feldolgozása nem sikerült.
+httpsRequiredMessage=HTTPS protokoll használata kötelező.
+realmNotEnabledMessage=A tartomány inaktív.
+invalidRequestMessage=Érvénytelen kérés.
+failedLogout=A kilépés sikertelen.
+unknownLoginRequesterMessage=A belépést kérelmező ismeretlen.
+loginRequesterNotEnabledMessage=A belépést kérelmező inaktív.
+bearerOnlyMessage=Bearer-only alkalmazások nem kezdeményezhetnek böngésző alapú beléptetést.
+standardFlowDisabledMessage=Ez a kliens nem kezdeményezhet böngésző alapú beléptetést a megadott válasz típussal. A standard belépési eljárás (flow) tiltott a kliensen.
+implicitFlowDisabledMessage=Ez a kliens nem kezdeményezhet böngésző alapú beléptetést a megadott válasz típussal. Az implicit belépési eljárás (flow) tiltott a kliensen.
+invalidRedirectUriMessage=Érvénytelen átirányítási cím (URI)
+unsupportedNameIdFormatMessage=Nem támogatott NameIDFormat
+invalidRequesterMessage=Érvénytelen kérelmező
+registrationNotAllowedMessage=A felhasználó regisztráció tiltott.
+resetCredentialNotAllowedMessage=A jelszó visszaállítás tiltott.
+
+permissionNotApprovedMessage=A jogosultság nincsen jóváhagyva.
+noRelayStateInResponseMessage=Nincsen "relay state" a személyazonosság-kezelő válaszüzenetében.
+insufficientPermissionMessage=Nincs elég jogosultság a fiókok összekötéséhez.
+couldNotProceedWithAuthenticationRequestMessage=A személyazonosság-kezelő felé indított hitelesítési kérés sikertelen.
+couldNotObtainTokenMessage=Nem sikerült tokent igényelni a személyazonosság-kezelőtől.
+unexpectedErrorRetrievingTokenMessage=Váratlan hiba történt a személyazonosság-kezelő token igénylése közben.
+unexpectedErrorHandlingResponseMessage=Váratlan hiba történt a személyazonosság-kezelő válaszüzenetének feldolgozása közben.
+identityProviderAuthenticationFailedMessage=Nem sikerült a személyazonosság-kezelőn keresztül intézett hitelesítés.
+couldNotSendAuthenticationRequestMessage=Nem sikerült a személyazonosság-kezelőhöz intézett hitelesítés kérés elküldése.
+unexpectedErrorHandlingRequestMessage=Váratlan hiba történt a személyazonosság-kezelő hitelesítés kérés feldolgozása közben.
+invalidAccessCodeMessage=Érvénytelen hozzáférési kód.
+sessionNotActiveMessage=A munkamenet inaktív.
+invalidCodeMessage=Hiba történt, kérem lépjen be újra az alkalmazásán keresztül.
+identityProviderUnexpectedErrorMessage=Váratlan hiba történt a személyazonosság-kezelőn keresztül intézett hitelesítés során.
+identityProviderNotFoundMessage=A megadott azonosítóval személyazonosság-kezelő nem található.
+identityProviderLinkSuccess=Sikeresen megerősítette email címét. Kérem térjen vissza az eredeti böngészőjébe, és onnan folytassa a belépési eljárást.
+staleCodeMessage=Ez a lap már nem érvényes, kérem térjen vissza az alkalmazásába és lépjen be ismét.
+realmSupportsNoCredentialsMessage=Ez a tartomány nem támogat jelszó alapú azonosítást.
+credentialSetupRequired=Belépés sikertelen, jelszó beállítás szükséges.
+identityProviderNotUniqueMessage=Ez a tartomány több személyazonosság-kezelőt támogat. Nem sikerült meghatározni, hogy melyik személyazonosság-kezelőt kellene a hitelesítéshez alkalmazni.
+emailVerifiedMessage=Az email címét megerősítettük.
+staleEmailVerificationLink=Az a hivatkozás, amelyikre rákattintott elévült és érvényét vesztette. Talán már korábban megerősítette az email címét?
+identityProviderAlreadyLinkedMessage=A(z) {0}-tól/től visszakapott összekapcsolt személyazonosság már össze van kötve egy másik felhasználói fiókkal.
+confirmAccountLinking=Erősítse meg a(z) {0} személyazonosság-kezelő {1} fiókjának összekötését a felhasználói fiókjával.
+confirmEmailAddressVerification=Erősítse meg a(z) {0} email cím érvényességét.
+confirmExecutionOfActions=Hajtsa végre a következő művelet(ek)et
+
+backToApplication=&laquo; Vissza az alkalmazásba
+missingParameterMessage=Hiányzó paraméterek\: {0}
+clientNotFoundMessage=A kliens nem található.
+clientDisabledMessage=A kliens inaktív.
+invalidParameterMessage=Érvénytelen paraméter\: {0}
+alreadyLoggedIn=Már korábban belépett.
+differentUserAuthenticated=Ebben a munkamenetben már korábban belépett ''{0}'' felhasználó névvel. Kérem előbb lépjen ki a munkamenetből.
+brokerLinkingSessionExpired=Ügynök fiók összekötést kezdeményezett, de az aktuális munkamenete már érvénytelen.
+proceedWithAction=&raquo; Kattintson ide a folytatáshoz
+
+requiredAction.CONFIGURE_TOTP=Egyszer használatos jelszó (OTP) beállítása
+requiredAction.terms_and_conditions=Felhasználási feltételek
+requiredAction.UPDATE_PASSWORD=Jelszó csere
+requiredAction.UPDATE_PROFILE=Fiók adatok módosítása
+requiredAction.VERIFY_EMAIL=Email cím megerősítése
+
+doX509Login=Beléptetés mint\:
+clientCertificate=X509 kliens tanúsítvány\:
+noCertificate=[Nincs tanúsítvány]
+
+pageNotFound=A kért lap nem található
+internalServerError=Belső hiba történt
+
+console-username=Felhasználó név:
+console-password=Jelszó:
+console-otp=Egyszer használatos jelszó (OTP):
+console-new-password=Új jelszó:
+console-confirm-password=Jelszó megerősítés:
+console-update-password=Cserélje le jelszavát.
+console-verify-email=Meg kell erősítenie az email címét.  Email üzenetet küldtünk a(z) {0} email címre amely egy ellenőrző, megerősítő, kódot tartalmaz. Kérem írja be a kapott kódot a lenti beviteli mezőbe.
+console-email-code=Email üzenetben kapott ellenőrző kód:
+console-accept-terms=Elfogadja a felhasználási feltételeket? [i/n]:
+console-accept=i
+
+# Openshift messages
+openshift.scope.user_info=Felhasználó adatok
+openshift.scope.user_check-access=Felhasználó hozzáférés adatok
+openshift.scope.user_full=Teljes hozzáférés
+openshift.scope.list-projects=Projektek listája
+
+# SAML authentication
+saml.post-form.title=Hitelesítés átirányítás
+saml.post-form.message=Átirányítás folyamatban, kérem várjon.
+saml.post-form.js-disabled=A JavaScript nincs engedélyezve. A folytatás előtt ajánlott bekapcsolni a JavaScript támogatást. Kattintson a lenti gombra a folytatáshoz. 
+
+#authenticators
+otp-display-name=Hitelesítő alkalmazás
+otp-help-text=Adja meg az ellenőrző kódot a hitelesítő alkalmazásból
+password-display-name=Jelszó
+password-help-text=Lépjen be a jelszava megadásával
+auth-username-form-display-name=Felhasználó név
+auth-username-form-help-text=Kezdje meg a belépést a felhasználó nevének megadásával
+auth-username-password-form-display-name=Felhasználó név és jelszó
+auth-username-password-form-help-text=Lépjen be a felhasználó neve és jelszava megadásával.
+
+# WebAuthn
+webauthn-display-name=Biztonsági kulcs
+webauthn-help-text=Használja a biztonsági kulcsát a belépéshez.
+webauthn-passwordless-display-name=Biztonsági kulcs
+webauthn-passwordless-help-text=Használja a biztonsági kulcsát a jelszómentes belépéshez.
+webauthn-login-title=Biztonsági kulcs alapú belépés
+webauthn-registration-title=Biztonsági kulcs regisztráció
+webauthn-available-authenticators=Elérhető hitelesítő alkalmazások
+
+# WebAuthn Error
+webauthn-error-title=Biztonsági kulcs hiba
+webauthn-error-registration=Nem sikerült regisztrálni a biztonsági kulcsot.
+webauthn-error-api-get=Nem sikerült a hitelesítés a biztonsági kulccsal.
+webauthn-error-different-user=Az először hitelesített felhasználó nem az, akit a biztonsági kulccsal azonosítottunk.
+webauthn-error-auth-verification=A biztonsági kulcs alapú hitelesítés eredménye érvénytelen.
+webauthn-error-register-verification=A biztonsági kulcs alapú regisztráció eredménye érvénytelen.
+webauthn-error-user-not-found=Ismeretlen felhasználót hitelesítettünk a biztonsági kulcs alapján.
+
+identity-provider-redirector=Összekötés másik személyazonosság-kezelővel

--- a/themes/src/main/resources-community/theme/base/login/theme.properties
+++ b/themes/src/main/resources-community/theme/base/login/theme.properties
@@ -1,1 +1,1 @@
-locales=ca,cs,de,en,es,fr,it,ja,lt,nl,no,pl,pt-BR,ru,sk,sv,tr,zh-CN
+locales=ca,cs,de,en,es,fr,hu,it,ja,lt,nl,no,pl,pt-BR,ru,sk,sv,tr,zh-CN

--- a/themes/src/main/resources/theme/base/account/messages/messages_en.properties
+++ b/themes/src/main/resources/theme/base/account/messages/messages_en.properties
@@ -246,6 +246,7 @@ locale_de=Deutsch
 locale_en=English
 locale_es=Espa\u00f1ol
 locale_fr=Fran\u00e7ais
+locale_hu=Magyar
 locale_it=Italian
 locale_ja=\u65e5\u672c\u8a9e
 locale_nl=Nederlands

--- a/themes/src/main/resources/theme/base/login/messages/messages_en.properties
+++ b/themes/src/main/resources/theme/base/login/messages/messages_en.properties
@@ -281,6 +281,7 @@ locale_de=Deutsch
 locale_en=English
 locale_es=Espa\u00F1ol
 locale_fr=Fran\u00E7ais
+locale_hu=Magyar
 locale_it=Italiano
 locale_ja=\u65E5\u672C\u8A9E
 locale_nl=Nederlands


### PR DESCRIPTION
Hi! This is my Hungarian (magyar :)) translation for Keycloak's account, email and login themes, based on the current `messages_en.properties` files from `themes/src/main/resources/theme/base`.