### PR TITLE
KEYCLOAK-14711, Fixed URL Safe base64 normalisation

### DIFF
--- a/adapters/oidc/js/src/main/resources/keycloak.js
+++ b/adapters/oidc/js/src/main/resources/keycloak.js
@@ -1053,8 +1053,8 @@
         function decodeToken(str) {
             str = str.split('.')[1];
 
-            str = str.replace('/-/g', '+');
-            str = str.replace('/_/g', '/');
+            str = str.replace(/-/g, '+');
+            str = str.replace(/_/g, '/');
             switch (str.length % 4) {
                 case 0:
                     break;


### PR DESCRIPTION
URL Safe characters `-` and `_` should be replaced with `+` and `/` accordingly.

In current version RegExp was wrapped into quotes, so it was not actually a RegExp, but simple string