### PR TITLE
KEYCLOAK-14724 Normalizing redirect URLs breaks redirection to Angular apps

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/utils/RedirectUtils.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/utils/RedirectUtils.java
@@ -86,7 +86,7 @@ public class RedirectUtils {
         if (redirectUri != null) {
             try {
                 URI uri = URI.create(redirectUri);
-                redirectUri = uri.normalize().toString();
+                redirectUri = uri.toString();
             } catch (IllegalArgumentException cause) {
                 logger.debug("Invalid redirect uri", cause);
                 return null;


### PR DESCRIPTION
Angular uses // in order to separate outlets, if normalization is applied to URLs like the following one:
http://localhost:8081/svm/pa/data-entry/measures-enter/(left-outlet:06TK0011/M01-A1TK/0//right-outlet:true)
Keycloak redirects to:
http://localhost:8081/svm/pa/data-entry/measures-enter/(left-outlet:06TK0011/M01-A1TK/0/right-outlet:true)
breaking Angular apps

