### PR TITLE
KEYCLOAK-14732: RuntimeExceptions thrown during factory initialization do not print full stack trace

### DIFF
--- a/wildfly/extensions/src/main/java/org/keycloak/provider/wildfly/WildflyPlatform.java
+++ b/wildfly/extensions/src/main/java/org/keycloak/provider/wildfly/WildflyPlatform.java
@@ -36,7 +36,7 @@ public class WildflyPlatform implements PlatformProvider {
 
     @Override
     public void exit(Throwable cause) {
-        ServicesLogger.LOGGER.fatal(cause);
+        ServicesLogger.LOGGER.fatal("Error during startup", cause);
         exit(1);
     }
 


### PR DESCRIPTION

This will change the log statement from
```
20:37:17,649 FATAL [org.keycloak.services] (ServerService Thread Pool -- 67) java.lang.NumberFormatException: For input string: "PT1M"
```
to
```
20:37:17,649 FATAL [org.keycloak.services] (ServerService Thread Pool -- 67) Error during startup: java.lang.NumberFormatException: For input string: "PT1M"
	at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
	at java.lang.Integer.parseInt(Integer.java:580)
	at java.lang.Integer.parseInt(Integer.java:615)
        ...
```