### PR TITLE
KEYCLOAK-14742 SAML2NameIDPolicyBuilder: add AllowCreate and SPNameQualifier properties

### DIFF
--- a/adapters/saml/core/src/main/java/org/keycloak/adapters/saml/AbstractInitiateLogin.java
+++ b/adapters/saml/core/src/main/java/org/keycloak/adapters/saml/AbstractInitiateLogin.java
@@ -101,7 +101,9 @@ public abstract class AbstractInitiateLogin implements AuthChallenge {
                 .destination(sso.getRequestBindingUrl())
                 .issuer(issuerURL)
                 .forceAuthn(deployment.isForceAuthentication()).isPassive(deployment.isIsPassive())
-                .nameIdPolicy(SAML2NameIDPolicyBuilder.format(nameIDPolicyFormat));
+                .nameIdPolicy(SAML2NameIDPolicyBuilder
+                    .format(nameIDPolicyFormat)
+                    .setAllowCreate(Boolean.TRUE));
         if (sso.getResponseBinding() != null) {
             String protocolBinding = JBossSAMLURIConstants.SAML_HTTP_REDIRECT_BINDING.get();
             if (sso.getResponseBinding() == SamlDeployment.Binding.POST) {

--- a/saml-core/src/main/java/org/keycloak/saml/SAML2NameIDPolicyBuilder.java
+++ b/saml-core/src/main/java/org/keycloak/saml/SAML2NameIDPolicyBuilder.java
@@ -24,8 +24,9 @@ import java.net.URI;
  * @author pedroigor
  */
 public class SAML2NameIDPolicyBuilder {
-
     private final NameIDPolicyType policyType;
+    private Boolean allowCreate;
+    private String spNameQualifier;
 
     private SAML2NameIDPolicyBuilder(String format) {
         this.policyType = new NameIDPolicyType();
@@ -36,8 +37,23 @@ public class SAML2NameIDPolicyBuilder {
         return new SAML2NameIDPolicyBuilder(format);
     }
 
+    public SAML2NameIDPolicyBuilder setAllowCreate(Boolean allowCreate) {
+        this.allowCreate = allowCreate;
+        return this;
+    }
+
+    public SAML2NameIDPolicyBuilder setSPNameQualifier(String spNameQualifier) {
+        this.spNameQualifier = spNameQualifier;
+        return this;
+    }
+
     public NameIDPolicyType build() {
-        this.policyType.setAllowCreate(Boolean.TRUE);
+        if (this.allowCreate != null)
+            this.policyType.setAllowCreate(this.allowCreate);
+
+        if (this.spNameQualifier != null)
+            this.policyType.setSPNameQualifier(this.spNameQualifier);
+
         return this.policyType;
     }
 }

--- a/services/src/main/java/org/keycloak/broker/saml/SAMLIdentityProvider.java
+++ b/services/src/main/java/org/keycloak/broker/saml/SAMLIdentityProvider.java
@@ -104,8 +104,11 @@ public class SAMLIdentityProvider extends AbstractIdentityProvider<SAMLIdentityP
                     .issuer(issuerURL)
                     .forceAuthn(getConfig().isForceAuthn())
                     .protocolBinding(protocolBinding)
-                    .nameIdPolicy(SAML2NameIDPolicyBuilder.format(nameIDPolicyFormat))
+                    .nameIdPolicy(SAML2NameIDPolicyBuilder
+                        .format(nameIDPolicyFormat)
+                        .setAllowCreate(Boolean.TRUE))
                     .subject(loginHint);
+
             JaxrsSAML2BindingBuilder binding = new JaxrsSAML2BindingBuilder(session)
                     .relayState(request.getState().getEncoded());
             boolean postBinding = getConfig().isPostBindingAuthnRequest();


### PR DESCRIPTION
Adds the following properties to the SAML2NameIDPolicyBuilder class:

* setAllowCreate
* setSPNameQualifier

and moves the hardcoded True value for the AllowCreate property to the appropriate place in SAMLIdentityProvider.

Supporting these properties is useful in writing custom SAML-derived Identity Provider modules. 
Also, if desired, the AllowCreate property could be easily exposed as a provider configuration switch in the UI.