### PR TITLE
KEYCLOAK-14686  User Federation not respecting hostname policy verifi…

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPContextManager.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPContextManager.java
@@ -77,6 +77,11 @@ public final class LDAPContextManager implements AutoCloseable {
             }
         }
 
+        //These only need to be set here for StartTLS.
+        if (ldapConfig.isStartTls()) {
+            connProp.put("java.naming.ldap.factory.socket", "org.keycloak.truststore.SSLSocketFactory");
+        }
+
         ldapContext = new InitialLdapContext(connProp, null);
         if (ldapConfig.isStartTls()) {
             SSLSocketFactory sslSocketFactory = null;


### PR DESCRIPTION
KEYCLOAK-14686  User Federation not respecting hostname policy verifi

Because LDAPContextManager doesn't have Keycloak's SSLFactory classpath in an environement variable,  the default Java SSLFactory is used.  Because of this,  the a specied non-default truststore is also not used.

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
