### PR TITLE
KEYCLOAK-9321 Remove invalid token_introspection_endpoint

### DIFF
--- a/authz/client/src/main/java/org/keycloak/authorization/client/representation/ServerConfiguration.java
+++ b/authz/client/src/main/java/org/keycloak/authorization/client/representation/ServerConfiguration.java
@@ -36,8 +36,8 @@ public class ServerConfiguration {
     @JsonProperty("token_endpoint")
     private String tokenEndpoint;
 
-    @JsonProperty("token_introspection_endpoint")
-    private String tokenIntrospectionEndpoint;
+    @JsonProperty("introspection_endpoint")
+    private String introspectionEndpoint;
 
     @JsonProperty("userinfo_endpoint")
     private String userinfoEndpoint;
@@ -120,8 +120,8 @@ public class ServerConfiguration {
         return tokenEndpoint;
     }
 
-    public String getTokenIntrospectionEndpoint() {
-        return tokenIntrospectionEndpoint;
+    public String getIntrospectionEndpoint() {
+        return introspectionEndpoint;
     }
 
     public String getUserinfoEndpoint() {

--- a/authz/client/src/main/java/org/keycloak/authorization/client/resource/ProtectionResource.java
+++ b/authz/client/src/main/java/org/keycloak/authorization/client/resource/ProtectionResource.java
@@ -75,7 +75,7 @@ public class ProtectionResource {
      * @return the {@link TokenIntrospectionResponse}
      */
     public TokenIntrospectionResponse introspectRequestingPartyToken(String rpt) {
-        return this.http.<TokenIntrospectionResponse>post(serverConfiguration.getTokenIntrospectionEndpoint())
+        return this.http.<TokenIntrospectionResponse>post(serverConfiguration.getIntrospectionEndpoint())
                 .authentication()
                     .client()
                 .form()

--- a/authz/client/src/main/java/org/keycloak/authorization/client/util/Throwables.java
+++ b/authz/client/src/main/java/org/keycloak/authorization/client/util/Throwables.java
@@ -69,7 +69,7 @@ public final class Throwables {
             HttpResponseException httpe = HttpResponseException.class.cast(cause);
 
             if (httpe.getStatusCode() == 403) {
-                TokenIntrospectionResponse response = token.getHttp().<TokenIntrospectionResponse>post(token.getServerConfiguration().getTokenIntrospectionEndpoint())
+                TokenIntrospectionResponse response = token.getHttp().<TokenIntrospectionResponse>post(token.getServerConfiguration().getIntrospectionEndpoint())
                         .authentication()
                         .client()
                         .param("token", token.call())

--- a/core/src/main/java/org/keycloak/protocol/oidc/representations/OIDCConfigurationRepresentation.java
+++ b/core/src/main/java/org/keycloak/protocol/oidc/representations/OIDCConfigurationRepresentation.java
@@ -40,12 +40,8 @@ public class OIDCConfigurationRepresentation {
     @JsonProperty("token_endpoint")
     private String tokenEndpoint;
 
-    /**
-     * The name 'token_introspection_endpoint' is deprecated and will be replaced by 'introspection_endpoint' as defined by RFC-8414.
-     * Until there, we just add {@code getIntrospectionEndpoint} claim to avoid breaking backward compatibility.
-     */
-    @JsonProperty("token_introspection_endpoint")
-    private String tokenIntrospectionEndpoint;
+    @JsonProperty("introspection_endpoint")
+    private String introspectionEndpoint;
 
     @JsonProperty("userinfo_endpoint")
     private String userinfoEndpoint;
@@ -148,22 +144,12 @@ public class OIDCConfigurationRepresentation {
         this.tokenEndpoint = tokenEndpoint;
     }
 
-    public String getTokenIntrospectionEndpoint() {
-        return this.tokenIntrospectionEndpoint;
+    public String getIntrospectionEndpoint() {
+        return this.introspectionEndpoint;
     }
 
-    /**
-     * See KEYCLOAK-8308. This method should be removed once the standard name is used to advertise the introspection endpoint.
-     * @return
-     */
-    @Deprecated
-    @JsonProperty("introspection_endpoint")
-    private String getIntrospectionEndpoint() {
-        return getTokenIntrospectionEndpoint();
-    }
-
-    public void setTokenIntrospectionEndpoint(String tokenIntrospectionEndpoint) {
-        this.tokenIntrospectionEndpoint = tokenIntrospectionEndpoint;
+    public void setIntrospectionEndpoint(String introspectionEndpoint) {
+        this.introspectionEndpoint = introspectionEndpoint;
     }
 
     public String getUserinfoEndpoint() {

--- a/services/src/main/java/org/keycloak/authorization/config/UmaConfiguration.java
+++ b/services/src/main/java/org/keycloak/authorization/config/UmaConfiguration.java
@@ -50,7 +50,7 @@ public class UmaConfiguration extends OIDCConfigurationRepresentation {
         configuration.setGrantTypesSupported(oidcConfig.getGrantTypesSupported());
         configuration.setTokenEndpointAuthMethodsSupported(oidcConfig.getTokenEndpointAuthMethodsSupported());
         configuration.setTokenEndpointAuthSigningAlgValuesSupported(oidcConfig.getTokenEndpointAuthSigningAlgValuesSupported());
-        configuration.setTokenIntrospectionEndpoint(oidcConfig.getTokenIntrospectionEndpoint());
+        configuration.setIntrospectionEndpoint(oidcConfig.getIntrospectionEndpoint());
         configuration.setLogoutEndpoint(oidcConfig.getLogoutEndpoint());
 
         UriBuilder uriBuilder = session.getContext().getUri().getBaseUriBuilder();

--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCWellKnownProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCWellKnownProvider.java
@@ -90,7 +90,7 @@ public class OIDCWellKnownProvider implements WellKnownProvider {
         config.setIssuer(Urls.realmIssuer(frontendUriInfo.getBaseUri(), realm.getName()));
         config.setAuthorizationEndpoint(frontendUriBuilder.clone().path(OIDCLoginProtocolService.class, "auth").build(realm.getName(), OIDCLoginProtocol.LOGIN_PROTOCOL).toString());
         config.setTokenEndpoint(backendUriBuilder.clone().path(OIDCLoginProtocolService.class, "token").build(realm.getName(), OIDCLoginProtocol.LOGIN_PROTOCOL).toString());
-        config.setTokenIntrospectionEndpoint(backendUriBuilder.clone().path(OIDCLoginProtocolService.class, "token").path(TokenEndpoint.class, "introspect").build(realm.getName(), OIDCLoginProtocol.LOGIN_PROTOCOL).toString());
+        config.setIntrospectionEndpoint(backendUriBuilder.clone().path(OIDCLoginProtocolService.class, "token").path(TokenEndpoint.class, "introspect").build(realm.getName(), OIDCLoginProtocol.LOGIN_PROTOCOL).toString());
         config.setUserinfoEndpoint(backendUriBuilder.clone().path(OIDCLoginProtocolService.class, "issueUserInfo").build(realm.getName(), OIDCLoginProtocol.LOGIN_PROTOCOL).toString());
         config.setLogoutEndpoint(frontendUriBuilder.clone().path(OIDCLoginProtocolService.class, "logout").build(realm.getName(), OIDCLoginProtocol.LOGIN_PROTOCOL).toString());
         config.setJwksUri(backendUriBuilder.clone().path(OIDCLoginProtocolService.class, "certs").build(realm.getName(), OIDCLoginProtocol.LOGIN_PROTOCOL).toString());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/UmaDiscoveryDocumentTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/UmaDiscoveryDocumentTest.java
@@ -69,7 +69,7 @@ public class UmaDiscoveryDocumentTest extends AbstractKeycloakTest {
             assertEquals(configuration.getAuthorizationEndpoint(), OIDCLoginProtocolService.authUrl(UriBuilder.fromUri(OAuthClient.AUTH_SERVER_ROOT)).build("test").toString());
             assertEquals(configuration.getTokenEndpoint(), oauth.getAccessTokenUrl());
             assertEquals(configuration.getJwksUri(), oauth.getCertsUrl("test"));
-            assertEquals(configuration.getTokenIntrospectionEndpoint(), oauth.getTokenIntrospectionUrl());
+            assertEquals(configuration.getIntrospectionEndpoint(), oauth.getTokenIntrospectionUrl());
 
             String registrationUri = UriBuilder
                     .fromUri(OAuthClient.AUTH_SERVER_ROOT)

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/OIDCWellKnownProviderTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/OIDCWellKnownProviderTest.java
@@ -215,7 +215,7 @@ public class OIDCWellKnownProviderTest extends AbstractKeycloakTest {
         Client client = ClientBuilder.newClient();
         try {
             ObjectNode oidcConfig = JsonSerialization.readValue(getOIDCDiscoveryConfiguration(client), ObjectNode.class);
-            assertEquals(oidcConfig.get("introspection_endpoint").asText(), getOIDCDiscoveryRepresentation(client).getTokenIntrospectionEndpoint());
+            assertEquals(oidcConfig.get("introspection_endpoint").asText(), getOIDCDiscoveryRepresentation(client).getIntrospectionEndpoint());
         } finally {
             client.close();
         }


### PR DESCRIPTION
The discovery document is advertizing both token_introspection_endpoint
and introspection_endpoint. The former has been removed as it is not
defined by OAuth2/OIDC (RFC-8414).

Change documented here: https://github.com/keycloak/keycloak-documentation/pull/981
