### PR TITLE
KEYCLOAK-14820 Import the NameIDPolicyFormat attribute from SAML IDP metadata descriptors

### DIFF
--- a/services/src/main/java/org/keycloak/broker/saml/SAMLIdentityProviderFactory.java
+++ b/services/src/main/java/org/keycloak/broker/saml/SAMLIdentityProviderFactory.java
@@ -125,6 +125,10 @@ public class SAMLIdentityProviderFactory extends AbstractIdentityProviderFactory
                     samlIdentityProviderConfig.setPostBindingAuthnRequest(postBindingResponse);
                     samlIdentityProviderConfig.setPostBindingLogout(postBindingLogout);
 
+                    List<String> nameIdFormatList = idpDescriptor.getNameIDFormat();
+                    if (nameIdFormatList != null && !nameIdFormatList.isEmpty())
+                        samlIdentityProviderConfig.setNameIDPolicyFormat(nameIdFormatList.get(0));
+
                     List<KeyDescriptorType> keyDescriptor = idpDescriptor.getKeyDescriptor();
                     String defaultCertificate = null;
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/IdentityProviderTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/IdentityProviderTest.java
@@ -891,6 +891,7 @@ public class IdentityProviderTest extends AbstractAdminTest {
           "postBindingAuthnRequest",
           "singleSignOnServiceUrl",
           "wantAuthnRequestsSigned",
+          "nameIDPolicyFormat",
           "signingCertificate",
           "addExtensionsElementWithKeyInfo"
         ));
@@ -901,6 +902,7 @@ public class IdentityProviderTest extends AbstractAdminTest {
         assertThat(config, hasEntry("singleSignOnServiceUrl", "http://localhost:8080/auth/realms/master/protocol/saml"));
         assertThat(config, hasEntry("wantAuthnRequestsSigned", "true"));
         assertThat(config, hasEntry("addExtensionsElementWithKeyInfo", "false"));
+        assertThat(config, hasEntry("nameIDPolicyFormat", "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent"));
         assertThat(config, hasEntry(is("signingCertificate"), notNullValue()));
     }
 


### PR DESCRIPTION
When creating a new SAML Identity Provider by importing existing IdP metadata, the "NameID Policy Format" property is not automatically filled with a value from the supplied metadata document.

This pull request adds the code required to load the property with the first policy format present in the document.