### PR TITLE
KEYCLOAK-14825 Make adapter tests running with FF to test cookies

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/SuiteContext.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/SuiteContext.java
@@ -62,7 +62,7 @@ public final class SuiteContext {
      */
     private static final boolean adapterCompatTesting = parseBoolean(System.getProperty("testsuite.adapter.compat.testing"));
 
-    private static final boolean browserStrictCookies = parseBoolean(System.getProperty("browser.strict.cookies"));
+    public static final boolean BROWSER_STRICT_COOKIES = parseBoolean(System.getProperty("browser.strict.cookies"));
 
     public SuiteContext(Set<ContainerInfo> arquillianContainers) {
         this.container = arquillianContainers;
@@ -192,10 +192,6 @@ public final class SuiteContext {
 
     public boolean isAdapterCompatTesting() {
         return adapterCompatTesting;
-    }
-
-    public boolean hasBrowserStrictCookies() {
-        return browserStrictCookies;
     }
 
     @Override

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/UIUtils.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/UIUtils.java
@@ -218,4 +218,18 @@ public final class UIUtils {
         String ariaInvalid = element.getAttribute(ARIA_INVALID_ATTR_NAME);
         return !Boolean.parseBoolean(ariaInvalid);
     }
+
+    public static String getRawPageSource(WebDriver driver) {
+        if (driver instanceof FirefoxDriver) {
+            // firefox has some weird "bug" – it wraps xml in html
+            return driver.findElement(By.tagName("body")).getText();
+        }
+        else {
+            return driver.getPageSource();
+        }
+    }
+
+    public static String getRawPageSource() {
+        return getRawPageSource(getCurrentDriver());
+    }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/AbstractAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/AbstractAdapterTest.java
@@ -21,6 +21,7 @@ import org.apache.commons.io.IOUtils;
 import org.jboss.arquillian.graphene.page.Page;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -32,6 +33,7 @@ import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.testsuite.AbstractAuthTest;
 import org.keycloak.testsuite.adapter.page.AppServerContextRoot;
 import org.keycloak.testsuite.arquillian.AppServerTestEnricher;
+import org.keycloak.testsuite.arquillian.SuiteContext;
 import org.keycloak.testsuite.arquillian.annotation.AppServerContainer;
 import org.keycloak.testsuite.arquillian.annotation.AuthServerContainerExclude;
 import org.keycloak.testsuite.util.ServerURLs;
@@ -278,6 +280,12 @@ public abstract class AbstractAdapterTest extends AbstractAuthTest {
             archive.add(new StringAsset(contextXmlContent), "/META-INF/context.xml");
         } catch (IOException ex) {
             throw new RuntimeException(ex);
+        }
+    }
+
+    public static void addSameSiteUndertowHandlers(WebArchive archive) {
+        if (SuiteContext.BROWSER_STRICT_COOKIES) {
+            archive.addAsWebInfResource(undertowHandlersConf, UNDERTOW_HANDLERS_CONF);
         }
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/AbstractExampleAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/AbstractExampleAdapterTest.java
@@ -66,6 +66,7 @@ public abstract class AbstractExampleAdapterTest extends AbstractAdapterTest {
                 .importFrom(new File(EXAMPLES_HOME + "/" + name + "-" + EXAMPLES_VERSION_SUFFIX + ".war"))
                 .as(WebArchive.class)
                 .addAsWebInfResource(jbossDeploymentStructure, JBOSS_DEPLOYMENT_STRUCTURE_XML);
+        addSameSiteUndertowHandlers(webArchive);
 
         additionalResources.accept(webArchive);
 
@@ -97,6 +98,7 @@ public abstract class AbstractExampleAdapterTest extends AbstractAdapterTest {
                 .as(WebArchive.class)
                 .addAsWebInfResource(jbossDeploymentStructure, JBOSS_DEPLOYMENT_STRUCTURE_XML)
                 .add(new StringAsset(webXmlContent), "/WEB-INF/web.xml");
+        addSameSiteUndertowHandlers(webArchive);
 
         additionalResources.accept(webArchive);
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/AbstractServletsAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/AbstractServletsAdapterTest.java
@@ -24,10 +24,8 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.testsuite.adapter.filter.AdapterActionsFilter;
 import org.keycloak.testsuite.util.DroneUtils;
-import org.keycloak.testsuite.util.WaitUtils;
 import org.keycloak.testsuite.utils.arquillian.DeploymentArchiveProcessorUtils;
 import org.keycloak.testsuite.utils.io.IOUtil;
-import org.openqa.selenium.By;
 
 import javax.ws.rs.core.UriBuilder;
 import java.io.IOException;
@@ -80,6 +78,7 @@ public abstract class AbstractServletsAdapterTest extends AbstractAdapterTest {
                 .addClasses(servletClasses)
                 .addAsWebInfResource(webXML, "web.xml")
                 .addAsWebInfResource(jbossDeploymentStructure, JBOSS_DEPLOYMENT_STRUCTURE_XML);
+        addSameSiteUndertowHandlers(deployment);
 
         URL keystore = AbstractServletsAdapterTest.class.getResource(webInfPath + "keystore.jks");
         if (keystore != null) {
@@ -120,6 +119,7 @@ public abstract class AbstractServletsAdapterTest extends AbstractAdapterTest {
         WebArchive deployment = ShrinkWrap.create(WebArchive.class, customArchiveName + ".war")
                 .addClasses(servletClasses)
                 .addAsWebInfResource(jbossDeploymentStructure, JBOSS_DEPLOYMENT_STRUCTURE_XML);
+        addSameSiteUndertowHandlers(deployment);
 
         // if a role-mappings.properties file exist in WEB-INF, include it in the deployment.
         URL roleMappingsConfig = AbstractServletsAdapterTest.class.getResource(webInfPath + "role-mappings.properties");
@@ -167,6 +167,7 @@ public abstract class AbstractServletsAdapterTest extends AbstractAdapterTest {
         WebArchive deployment = ShrinkWrap.create(WebArchive.class, name + ".war")
                 .addClasses(servletClasses)
                 .addAsWebInfResource(jbossDeploymentStructure, JBOSS_DEPLOYMENT_STRUCTURE_XML);
+        addSameSiteUndertowHandlers(deployment);
 
         String webXMLContent;
         try {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/SAMLLoginResponseHandlingTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/SAMLLoginResponseHandlingTest.java
@@ -46,6 +46,7 @@ import static org.keycloak.testsuite.saml.AbstractSamlTest.REALM_PRIVATE_KEY;
 import static org.keycloak.testsuite.saml.AbstractSamlTest.REALM_PUBLIC_KEY;
 import static org.keycloak.testsuite.util.Matchers.bodyHC;
 import static org.keycloak.testsuite.util.Matchers.statusCodeIsHC;
+import static org.keycloak.testsuite.util.UIUtils.getRawPageSource;
 import static org.keycloak.testsuite.util.URLAssert.assertCurrentUrlStartsWith;
 import static org.keycloak.testsuite.util.WaitUtils.waitForPageToLoad;
 import static org.keycloak.testsuite.util.WaitUtils.waitUntilElement;
@@ -197,7 +198,7 @@ public class SAMLLoginResponseHandlingTest extends AbstractSAMLServletAdapterTes
 
         driver.navigate().to(employee2ServletPage.getUriBuilder().clone().path("getAssertionFromDocument").build().toURL());
         waitForPageToLoad();
-        Assert.assertEquals("", driver.getPageSource());
+        Assert.assertEquals("", getRawPageSource());
 
         employee2ServletPage.logout();
         checkLoggedOut(employee2ServletPage, testRealmSAMLPostLoginPage);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/SAMLServletAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/SAMLServletAdapterTest.java
@@ -29,6 +29,7 @@ import static org.keycloak.testsuite.saml.AbstractSamlTest.REALM_PRIVATE_KEY;
 import static org.keycloak.testsuite.saml.AbstractSamlTest.REALM_PUBLIC_KEY;
 import static org.keycloak.testsuite.util.Matchers.bodyHC;
 import static org.keycloak.testsuite.util.Matchers.statusCodeIsHC;
+import static org.keycloak.testsuite.util.UIUtils.getRawPageSource;
 import static org.keycloak.testsuite.util.URLAssert.assertCurrentUrlStartsWith;
 import static org.keycloak.testsuite.util.WaitUtils.waitForPageToLoad;
 import static org.keycloak.testsuite.util.WaitUtils.waitUntilElement;
@@ -1373,7 +1374,7 @@ public class SAMLServletAdapterTest extends AbstractSAMLServletAdapterTest {
 
         driver.navigate().to(employeeDomServletPage.getUriBuilder().clone().path("getAssertionFromDocument").build().toURL());
         waitForPageToLoad();
-        String xml = driver.getPageSource();
+        String xml = getRawPageSource();
         Assert.assertNotEquals("", xml);
         Document doc = DocumentUtil.getDocument(new StringReader(xml));
         String certBase64 = DocumentUtil.getElement(doc, new QName("http://www.w3.org/2000/09/xmldsig#", "X509Certificate")).getTextContent();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/javascript/JavascriptAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/javascript/JavascriptAdapterTest.java
@@ -17,6 +17,7 @@ import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.testsuite.Assert;
 import org.keycloak.testsuite.AssertEvents;
 import org.keycloak.testsuite.admin.ApiUtil;
+import org.keycloak.testsuite.arquillian.SuiteContext;
 import org.keycloak.testsuite.auth.page.account.Applications;
 import org.keycloak.testsuite.auth.page.login.OAuthGrant;
 import org.keycloak.testsuite.auth.page.login.UpdatePassword;
@@ -156,13 +157,13 @@ public class JavascriptAdapterTest extends AbstractJavascriptTest {
 
         // when 3rd party cookies are disabled, the adapter has to do a full redirect to KC to check whether the user
         // is logged in or not – it can't rely on silent check-sso iframe
-        testExecutor.init(checkSSO, this::assertInitNotAuth, suiteContext.hasBrowserStrictCookies())
+        testExecutor.init(checkSSO, this::assertInitNotAuth, SuiteContext.BROWSER_STRICT_COOKIES)
                 .login(this::assertOnLoginPage)
                 .loginForm(testUser, this::assertOnTestAppUrl)
                 .init(checkSSO, this::assertInitAuth, false)
                 .refresh()
                 .init(checkSSO
-                        , this::assertInitAuth, suiteContext.hasBrowserStrictCookies());
+                        , this::assertInitAuth, SuiteContext.BROWSER_STRICT_COOKIES);
     }
 
     @Test
@@ -170,14 +171,14 @@ public class JavascriptAdapterTest extends AbstractJavascriptTest {
         JSObjectBuilder checkSSO = defaultArguments().checkSSOOnLoad()
                 .add("silentCheckSsoRedirectUri", authServerContextRootPage.toString().replace(AUTH_SERVER_HOST, JS_APP_HOST) + JAVASCRIPT_URL + "/silent-check-sso.html");
 
-        testExecutor.init(checkSSO, this::assertInitNotAuth, suiteContext.hasBrowserStrictCookies())
+        testExecutor.init(checkSSO, this::assertInitNotAuth, SuiteContext.BROWSER_STRICT_COOKIES)
                 .login(this::assertOnLoginPage)
                 .loginForm(testUser, this::assertOnTestAppUrl)
                 .init(checkSSO, this::assertInitAuth, false)
                 .refresh()
                 .init(checkSSO
                         .disableCheckLoginIframe()
-                        , this::assertInitAuth, suiteContext.hasBrowserStrictCookies());
+                        , this::assertInitAuth, SuiteContext.BROWSER_STRICT_COOKIES);
     }
 
     @Test
@@ -192,7 +193,7 @@ public class JavascriptAdapterTest extends AbstractJavascriptTest {
                 .refresh()
                 .init(checkSSO
                         // with the fall back disabled, the adapter won't do full redirect to KC
-                        , suiteContext.hasBrowserStrictCookies() ? this::assertInitNotAuth : this::assertInitAuth);
+                        , SuiteContext.BROWSER_STRICT_COOKIES ? this::assertInitNotAuth : this::assertInitAuth);
     }
 
     @Test
@@ -201,7 +202,7 @@ public class JavascriptAdapterTest extends AbstractJavascriptTest {
 
         // when 3rd party cookies are disabled, the adapter has to do a full redirect to KC to check whether the user
         // is logged in or not – it can't rely on the login iframe
-        testExecutor.init(checkSSO, this::assertInitNotAuth, suiteContext.hasBrowserStrictCookies())
+        testExecutor.init(checkSSO, this::assertInitNotAuth, SuiteContext.BROWSER_STRICT_COOKIES)
                 .login(this::assertOnLoginPage)
                 .loginForm(testUser, this::assertOnTestAppUrl)
                 .init(checkSSO, this::assertInitAuth, false)
@@ -216,7 +217,7 @@ public class JavascriptAdapterTest extends AbstractJavascriptTest {
                 .add("silentCheckSsoRedirectUri", authServerContextRootPage.toString().replace(AUTH_SERVER_HOST, JS_APP_HOST) + JAVASCRIPT_URL + "/silent-check-sso.html");
 
         testExecutor.init(checkSSO
-                , this::assertInitNotAuth, suiteContext.hasBrowserStrictCookies());
+                , this::assertInitNotAuth, SuiteContext.BROWSER_STRICT_COOKIES);
     }
 
     @Test
@@ -230,7 +231,7 @@ public class JavascriptAdapterTest extends AbstractJavascriptTest {
                 .wait(2000, (driver1, output, events) -> { // iframe is initialized after ~1 second, 2 seconds is just to be sure
                     assertAdapterIsLoggedIn(driver1, output, events);
                     final String logMsg = "3rd party cookies aren't supported by this browser.";
-                    if (suiteContext.hasBrowserStrictCookies()) {
+                    if (SuiteContext.BROWSER_STRICT_COOKIES) {
                         // this is here not really to test the log but also to make sure the browser is configured properly
                         // and cookies were blocked
                         assertEventsWebElementContains(logMsg, driver1, output, events);
@@ -584,7 +585,7 @@ public class JavascriptAdapterTest extends AbstractJavascriptTest {
                     .add("refreshToken", refreshToken)
                 , (driver1, output, events) -> {
                     assertInitAuth(driver1, output, events);
-                    if (suiteContext.hasBrowserStrictCookies()) {
+                    if (SuiteContext.BROWSER_STRICT_COOKIES) {
                         // iframe is unsupported so a token refresh had to be performed
                         assertEventsContains("Auth Refresh Success").validate(driver1, output, events);
                     }


### PR DESCRIPTION
Pipeline runs:
https://keycloak-jenkins.com/job/universal-test-pipeline-server/1980/
https://keycloak-jenkins.com/job/universal-test-pipeline-adapters/1579/ (failures are unrelated to this change)