### PR TITLE
KEYCLOAK-14190 Client Policy - Condition : The way of creating/updating a client

### DIFF
--- a/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientUpdateContextCondition.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientUpdateContextCondition.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.keycloak.testsuite.services.clientpolicy.condition;
+package org.keycloak.services.clientpolicy.condition;
 
 import org.jboss.logging.Logger;
 import org.keycloak.component.ComponentModel;
@@ -30,14 +30,14 @@ import org.keycloak.services.clientpolicy.condition.ClientPolicyConditionProvide
 import org.keycloak.services.clientregistration.ClientRegistrationTokenUtils;
 import org.keycloak.util.TokenUtil;
 
-public class TestAuthnMethodsCondition implements ClientPolicyConditionProvider {
+public class ClientUpdateContextCondition implements ClientPolicyConditionProvider {
 
-    private static final Logger logger = Logger.getLogger(TestAuthnMethodsCondition.class);
+    private static final Logger logger = Logger.getLogger(ClientUpdateContextCondition.class);
 
     private final KeycloakSession session;
     private final ComponentModel componentModel;
 
-    public TestAuthnMethodsCondition(KeycloakSession session, ComponentModel componentModel) {
+    public ClientUpdateContextCondition(KeycloakSession session, ComponentModel componentModel) {
         this.session = session;
         this.componentModel = componentModel;
     }
@@ -58,9 +58,9 @@ public class TestAuthnMethodsCondition implements ClientPolicyConditionProvider 
         if (authMethod == null) return false;
 
         ClientPolicyLogger.log(logger, "auth method = " + authMethod);
-        componentModel.getConfig().get(TestAuthnMethodsConditionFactory.AUTH_METHOD).stream().forEach(i -> ClientPolicyLogger.log(logger, "auth method expected = " + i));
+        componentModel.getConfig().get(ClientUpdateContextConditionFactory.UPDATE_CLIENT_SOURCE).stream().forEach(i -> ClientPolicyLogger.log(logger, "auth method expected = " + i));
 
-        boolean isMatched = componentModel.getConfig().get(TestAuthnMethodsConditionFactory.AUTH_METHOD).stream().anyMatch(i -> i.equals(authMethod));
+        boolean isMatched = componentModel.getConfig().get(ClientUpdateContextConditionFactory.UPDATE_CLIENT_SOURCE).stream().anyMatch(i -> i.equals(authMethod));
         if (isMatched) {
             ClientPolicyLogger.log(logger, "auth method matched.");
         } else {
@@ -73,16 +73,16 @@ public class TestAuthnMethodsCondition implements ClientPolicyConditionProvider 
         String authMethod = null;
 
         if (context.getToken() == null) {
-            authMethod = TestAuthnMethodsConditionFactory.BY_ANONYMOUS;
+            authMethod = ClientUpdateContextConditionFactory.BY_ANONYMOUS;
         } else if (isInitialAccessToken(context.getToken())) {
-            authMethod = TestAuthnMethodsConditionFactory.BY_INITIAL_ACCESS_TOKEN;
+            authMethod = ClientUpdateContextConditionFactory.BY_INITIAL_ACCESS_TOKEN;
         } else if (isRegistrationAccessToken(context.getToken())) {
-            authMethod = TestAuthnMethodsConditionFactory.BY_REGISTRATION_ACCESS_TOKEN;
+            authMethod = ClientUpdateContextConditionFactory.BY_REGISTRATION_ACCESS_TOKEN;
         } else if (isBearerToken(context.getToken())) {
             if (context.getAuthenticatedUser() != null || context.getAuthenticatedClient() != null) {
-                authMethod = TestAuthnMethodsConditionFactory.BY_AUTHENTICATED_USER;
+                authMethod = ClientUpdateContextConditionFactory.BY_AUTHENTICATED_USER;
             } else {
-                authMethod = TestAuthnMethodsConditionFactory.BY_ANONYMOUS;
+                authMethod = ClientUpdateContextConditionFactory.BY_ANONYMOUS;
             }
         }
 

--- a/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientUpdateContextConditionFactory.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientUpdateContextConditionFactory.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.keycloak.testsuite.services.clientpolicy.condition;
+package org.keycloak.services.clientpolicy.condition;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -29,11 +29,11 @@ import org.keycloak.provider.ProviderConfigProperty;
 import org.keycloak.services.clientpolicy.condition.ClientPolicyConditionProvider;
 import org.keycloak.services.clientpolicy.condition.ClientPolicyConditionProviderFactory;
 
-public class TestAuthnMethodsConditionFactory implements ClientPolicyConditionProviderFactory {
+public class ClientUpdateContextConditionFactory implements ClientPolicyConditionProviderFactory {
 
-    public static final String PROVIDER_ID = "test-authnmethods-condition";
+    public static final String PROVIDER_ID = "clientupdatecontext-condition";
 
-    public static final String AUTH_METHOD = "auth-method";
+    public static final String UPDATE_CLIENT_SOURCE = "update-client-source";
 
     public static final String BY_AUTHENTICATED_USER = "ByAuthenticatedUser";
     public static final String BY_ANONYMOUS = "ByAnonymous";
@@ -44,7 +44,7 @@ public class TestAuthnMethodsConditionFactory implements ClientPolicyConditionPr
 
     static {
         ProviderConfigProperty property;
-        property = new ProviderConfigProperty(AUTH_METHOD, null, null, ProviderConfigProperty.MULTIVALUED_LIST_TYPE, BY_AUTHENTICATED_USER);
+        property = new ProviderConfigProperty(UPDATE_CLIENT_SOURCE, null, null, ProviderConfigProperty.MULTIVALUED_LIST_TYPE, BY_AUTHENTICATED_USER);
         List<String> updateProfileValues = Arrays.asList(BY_AUTHENTICATED_USER, BY_ANONYMOUS, BY_INITIAL_ACCESS_TOKEN, BY_REGISTRATION_ACCESS_TOKEN);
         property.setOptions(updateProfileValues);
         configProperties.add(property);
@@ -52,7 +52,7 @@ public class TestAuthnMethodsConditionFactory implements ClientPolicyConditionPr
 
     @Override
     public ClientPolicyConditionProvider create(KeycloakSession session, ComponentModel model) {
-        return new TestAuthnMethodsCondition(session, model);
+        return new ClientUpdateContextCondition(session, model);
     }
  
     @Override
@@ -74,7 +74,7 @@ public class TestAuthnMethodsConditionFactory implements ClientPolicyConditionPr
 
     @Override
     public String getHelpText() {
-        return null;
+        return "The condition checks the context how is client created/updated to determine whether the policy is applied. For example it checks if client is created with admin REST API or OIDC dynamic client registration. And for the letter case if it is ANONYMOUS client registration or AUTHENTICATED client registration with Initial access token or Registration access token and so on.";
     }
 
     @Override

--- a/services/src/main/resources/META-INF/services/org.keycloak.services.clientpolicy.condition.ClientPolicyConditionProviderFactory
+++ b/services/src/main/resources/META-INF/services/org.keycloak.services.clientpolicy.condition.ClientPolicyConditionProviderFactory
@@ -1,0 +1,1 @@
+org.keycloak.services.clientpolicy.condition.ClientUpdateContextConditionFactory

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/resources/META-INF/services/org.keycloak.services.clientpolicy.condition.ClientPolicyConditionProviderFactory
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/resources/META-INF/services/org.keycloak.services.clientpolicy.condition.ClientPolicyConditionProviderFactory
@@ -1,3 +1,2 @@
-org.keycloak.testsuite.services.clientpolicy.condition.TestAuthnMethodsConditionFactory
 org.keycloak.testsuite.services.clientpolicy.condition.TestClientRolesConditionFactory
 org.keycloak.testsuite.services.clientpolicy.condition.TestRaiseExeptionConditionFactory

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientPolicyBasicsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientPolicyBasicsTest.java
@@ -72,12 +72,12 @@ import org.keycloak.services.clientpolicy.ClientPolicyException;
 import org.keycloak.services.clientpolicy.ClientPolicyProvider;
 import org.keycloak.services.clientpolicy.DefaultClientPolicyProviderFactory;
 import org.keycloak.services.clientpolicy.condition.ClientPolicyConditionProvider;
+import org.keycloak.services.clientpolicy.condition.ClientUpdateContextConditionFactory;
 import org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProvider;
 import org.keycloak.testsuite.AbstractKeycloakTest;
 import org.keycloak.testsuite.AssertEvents;
 import org.keycloak.testsuite.admin.ApiUtil;
 import org.keycloak.testsuite.arquillian.annotation.EnableFeature;
-import org.keycloak.testsuite.services.clientpolicy.condition.TestAuthnMethodsConditionFactory;
 import org.keycloak.testsuite.services.clientpolicy.condition.TestClientRolesConditionFactory;
 import org.keycloak.testsuite.services.clientpolicy.condition.TestRaiseExeptionConditionFactory;
 import org.keycloak.testsuite.services.clientpolicy.executor.TestClientAuthenticationExecutorFactory;
@@ -433,11 +433,11 @@ public class ClientPolicyBasicsTest extends AbstractKeycloakTest {
         registerCondition("TestClientRolesCondition", policyName);
         logger.info("... Registered Condition : TestClientRolesCondition");
 
-        createCondition("TestAuthnMethodsCondition", TestAuthnMethodsConditionFactory.PROVIDER_ID, null, (ComponentRepresentation provider) -> {
-            setConditionRegistrationMethods(provider, new ArrayList<>(Arrays.asList(TestAuthnMethodsConditionFactory.BY_AUTHENTICATED_USER)));
+        createCondition("ClientUpdateContextCondition", ClientUpdateContextConditionFactory.PROVIDER_ID, null, (ComponentRepresentation provider) -> {
+            setConditionRegistrationMethods(provider, new ArrayList<>(Arrays.asList(ClientUpdateContextConditionFactory.BY_AUTHENTICATED_USER)));
         });
-        registerCondition("TestAuthnMethodsCondition", policyName);
-        logger.info("... Registered Condition : TestAuthnMethodsCondition");
+        registerCondition("ClientUpdateContextCondition", policyName);
+        logger.info("... Registered Condition : ClientUpdateContextCondition");
 
         String clientId = "Zahlungs-App";
         String clientSecret = "secret";
@@ -496,11 +496,11 @@ public class ClientPolicyBasicsTest extends AbstractKeycloakTest {
         registerCondition("TestClientRolesCondition-alpha", policyAlphaName);
         logger.info("... Registered Condition : TestClientRolesCondition-alpha");
 
-        createCondition("TestAuthnMethodsCondition-alpha", TestAuthnMethodsConditionFactory.PROVIDER_ID, null, (ComponentRepresentation provider) -> {
-            setConditionRegistrationMethods(provider, new ArrayList<>(Arrays.asList(TestAuthnMethodsConditionFactory.BY_AUTHENTICATED_USER)));
+        createCondition("ClientUpdateContextCondition-alpha", ClientUpdateContextConditionFactory.PROVIDER_ID, null, (ComponentRepresentation provider) -> {
+            setConditionRegistrationMethods(provider, new ArrayList<>(Arrays.asList(ClientUpdateContextConditionFactory.BY_AUTHENTICATED_USER)));
         });
-        registerCondition("TestAuthnMethodsCondition-alpha", policyAlphaName);
-        logger.info("... Registered Condition : TestAuthnMethodsCondition-alpha");
+        registerCondition("ClientUpdateContextCondition-alpha", policyAlphaName);
+        logger.info("... Registered Condition : ClientUpdateContextCondition-alpha");
 
         createExecutor("TestClientAuthenticationExecutor-alpha", TestClientAuthenticationExecutorFactory.PROVIDER_ID, null, (ComponentRepresentation provider) -> {
             setExecutorAcceptedClientAuthMethods(provider, new ArrayList<>(Arrays.asList(ClientIdAndSecretAuthenticator.PROVIDER_ID)));
@@ -579,11 +579,11 @@ public class ClientPolicyBasicsTest extends AbstractKeycloakTest {
         createPolicy(policyName, DefaultClientPolicyProviderFactory.PROVIDER_ID, null, null, null);
         logger.info("... Created Policy : " + policyName);
 
-        createCondition("TestAuthnMethodsCondition", TestAuthnMethodsConditionFactory.PROVIDER_ID, null, (ComponentRepresentation provider) -> {
-            setConditionRegistrationMethods(provider, new ArrayList<>(Arrays.asList(TestAuthnMethodsConditionFactory.BY_AUTHENTICATED_USER)));
+        createCondition("ClientUpdateContextCondition", ClientUpdateContextConditionFactory.PROVIDER_ID, null, (ComponentRepresentation provider) -> {
+            setConditionRegistrationMethods(provider, new ArrayList<>(Arrays.asList(ClientUpdateContextConditionFactory.BY_AUTHENTICATED_USER)));
         });
-        registerCondition("TestAuthnMethodsCondition", policyName);
-        logger.info("... Registered Condition : TestAuthnMethodsCondition");
+        registerCondition("ClientUpdateContextCondition", policyName);
+        logger.info("... Registered Condition : ClientUpdateContextCondition");
 
         createExecutor("TestClientAuthenticationExecutor", TestClientAuthenticationExecutorFactory.PROVIDER_ID, null, (ComponentRepresentation provider) -> {
             setExecutorAcceptedClientAuthMethods(provider, new ArrayList<>(Arrays.asList(
@@ -601,11 +601,11 @@ public class ClientPolicyBasicsTest extends AbstractKeycloakTest {
         createPolicy(policyName, DefaultClientPolicyProviderFactory.PROVIDER_ID, null, null, null);
         logger.info("... Created Policy : " + policyName);
 
-        createCondition("TestAuthnMethodsCondition", TestAuthnMethodsConditionFactory.PROVIDER_ID, null, (ComponentRepresentation provider) -> {
-            setConditionRegistrationMethods(provider, new ArrayList<>(Arrays.asList(TestAuthnMethodsConditionFactory.BY_INITIAL_ACCESS_TOKEN)));
+        createCondition("ClientUpdateContextCondition", ClientUpdateContextConditionFactory.PROVIDER_ID, null, (ComponentRepresentation provider) -> {
+            setConditionRegistrationMethods(provider, new ArrayList<>(Arrays.asList(ClientUpdateContextConditionFactory.BY_INITIAL_ACCESS_TOKEN)));
         });
-        registerCondition("TestAuthnMethodsCondition", policyName);
-        logger.info("... Registered Condition : TestAuthnMethodsCondition");
+        registerCondition("ClientUpdateContextCondition", policyName);
+        logger.info("... Registered Condition : ClientUpdateContextCondition");
 
         createCondition("TestClientRolesCondition", TestClientRolesConditionFactory.PROVIDER_ID, null, (ComponentRepresentation provider) -> {
             setConditionClientRoles(provider, new ArrayList<>(Arrays.asList("sample-client-role")));
@@ -882,7 +882,7 @@ public class ClientPolicyBasicsTest extends AbstractKeycloakTest {
     }
 
     private void setConditionRegistrationMethods(ComponentRepresentation provider, List<String> registrationMethods) {
-        provider.getConfig().put(TestAuthnMethodsConditionFactory.AUTH_METHOD, registrationMethods);
+        provider.getConfig().put(ClientUpdateContextConditionFactory.UPDATE_CLIENT_SOURCE, registrationMethods);
     }
 
     private void setConditionClientRoles(ComponentRepresentation provider, List<String> clientRoles) {


### PR DESCRIPTION
This PR is for [KEYCLOAK-14190 Client Policy - Condition : The way of creating/updating a client](https://issues.redhat.com/browse/KEYCLOAK-14190) that is a sub task of [KEYCLOAK-13933 Client Policies](https://issues.redhat.com/browse/KEYCLOAK-13933) whose design document is [Client Policies](https://github.com/keycloak/keycloak-community/blob/master/design/client-policies.md) .