### PR TITLE
resolveValidRedirects list should include original relative paths

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/utils/RedirectUtils.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/utils/RedirectUtils.java
@@ -58,11 +58,10 @@ public class RedirectUtils {
         // If the valid redirect URI is relative (no scheme, host, port) then use the request's scheme, host, and port
         Set<String> resolveValidRedirects = new HashSet<>();
         for (String validRedirect : validRedirects) {
+            resolveValidRedirects.add(validRedirect); // add even relative urls.
             if (validRedirect.startsWith("/")) {
                 validRedirect = relativeToAbsoluteURI(session, rootUrl, validRedirect);
                 logger.debugv("replacing relative valid redirect with: {0}", validRedirect);
-                resolveValidRedirects.add(validRedirect);
-            } else {
                 resolveValidRedirects.add(validRedirect);
             }
         }


### PR DESCRIPTION
<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->

Small change to revert an issue with relative redirects from the client no longer working.  This was introduced here:
https://github.com/keycloak/keycloak/commit/b8881b8ea062afa2f1b5a613dd856900b73f2121#diff-06c49f05afed242e78d9a65acac073fbL60
