### PR TITLE
KEYCLOAK-14826 Fix non-ssl auth-server tests failures

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/updaters/ClientAttributeUpdater.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/updaters/ClientAttributeUpdater.java
@@ -10,6 +10,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertThat;
@@ -76,6 +77,11 @@ public class ClientAttributeUpdater extends ServerResourceUpdater<ClientAttribut
 
     public ClientAttributeUpdater setRedirectUris(List<String> values) {
         this.rep.setRedirectUris(values);
+        return this;
+    }
+    
+    public ClientAttributeUpdater filterRedirectUris(Predicate<String> filter) {
+        this.rep.setRedirectUris(this.rep.getRedirectUris().stream().filter(filter).collect(Collectors.toList()));
         return this;
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/IdentityProviderTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/IdentityProviderTest.java
@@ -186,8 +186,7 @@ public class IdentityProviderTest extends AbstractAdminTest {
             oidcConfig.setAuthorizationUrl("invalid://test");
 
             try (Response response = this.realm.identityProviders().create(newIdentityProvider)) {
-                assertEquals(AUTH_SERVER_SSL_REQUIRED ? Response.Status.BAD_REQUEST.getStatusCode() :
-                        Response.Status.CREATED.getStatusCode(), response.getStatus());
+                assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
                 ErrorRepresentation error = response.readEntity(ErrorRepresentation.class);
                 assertEquals("The url [authorization_url] is malformed", error.getErrorMessage());
             }
@@ -196,8 +195,7 @@ public class IdentityProviderTest extends AbstractAdminTest {
             oidcConfig.setTokenUrl("http://test");
 
             try (Response response = this.realm.identityProviders().create(newIdentityProvider)) {
-                assertEquals(AUTH_SERVER_SSL_REQUIRED ? Response.Status.BAD_REQUEST.getStatusCode() :
-                        Response.Status.CREATED.getStatusCode(), response.getStatus());
+                assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
                 ErrorRepresentation error = response.readEntity(ErrorRepresentation.class);
                 assertEquals("The url [token_url] requires secure connections", error.getErrorMessage());
             }
@@ -207,8 +205,7 @@ public class IdentityProviderTest extends AbstractAdminTest {
             oidcConfig.setJwksUrl("http://test");
 
             try (Response response = this.realm.identityProviders().create(newIdentityProvider)) {
-                assertEquals(AUTH_SERVER_SSL_REQUIRED ? Response.Status.BAD_REQUEST.getStatusCode() :
-                        Response.Status.CREATED.getStatusCode(), response.getStatus());
+                assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
                 ErrorRepresentation error = response.readEntity(ErrorRepresentation.class);
                 assertEquals("The url [jwks_url] requires secure connections", error.getErrorMessage());
             }
@@ -219,8 +216,7 @@ public class IdentityProviderTest extends AbstractAdminTest {
             oidcConfig.setLogoutUrl("http://test");
 
             try (Response response = this.realm.identityProviders().create(newIdentityProvider)) {
-                assertEquals(AUTH_SERVER_SSL_REQUIRED ? Response.Status.BAD_REQUEST.getStatusCode() :
-                        Response.Status.CREATED.getStatusCode(), response.getStatus());
+                assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
                 ErrorRepresentation error = response.readEntity(ErrorRepresentation.class);
                 assertEquals("The url [logout_url] requires secure connections", error.getErrorMessage());
             }
@@ -232,8 +228,7 @@ public class IdentityProviderTest extends AbstractAdminTest {
             oidcConfig.setUserInfoUrl("http://test");
 
             try (Response response = this.realm.identityProviders().create(newIdentityProvider)) {
-                assertEquals(AUTH_SERVER_SSL_REQUIRED ? Response.Status.BAD_REQUEST.getStatusCode() :
-                        Response.Status.CREATED.getStatusCode(), response.getStatus());
+                assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
                 ErrorRepresentation error = response.readEntity(ErrorRepresentation.class);
                 assertEquals("The url [userinfo_url] requires secure connections", error.getErrorMessage());
             }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/ImpersonationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/ImpersonationTest.java
@@ -78,8 +78,13 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.keycloak.testsuite.util.OAuthClient.AUTH_SERVER_ROOT;
 import static org.keycloak.testsuite.util.ServerURLs.getAuthServerContextRoot;
 
@@ -221,7 +226,9 @@ public class ImpersonationTest extends AbstractKeycloakTest {
         loginPage.assertCurrent();
 
         // Impersonate and get SSO cookie. Setup that cookie for webDriver
-        driver.manage().addCookie(testSuccessfulImpersonation("realm-admin", "test"));
+        for (Cookie cookie : testSuccessfulImpersonation("realm-admin", "test")) {
+            driver.manage().addCookie(cookie);
+        }
 
         // Open the URL again - should be directly redirected to the app due the SSO login
         driver.navigate().to(loginFormUrl);
@@ -235,7 +242,7 @@ public class ImpersonationTest extends AbstractKeycloakTest {
 
 
     // Return the SSO cookie from the impersonated session
-    protected Cookie testSuccessfulImpersonation(String admin, String adminRealm) {
+    protected Set<Cookie> testSuccessfulImpersonation(String admin, String adminRealm) {
         ResteasyClientBuilder resteasyClientBuilder = new ResteasyClientBuilder();
         resteasyClientBuilder.connectionPoolSize(10);
         resteasyClientBuilder.httpEngine(AdminClientUtil.getCustomClientHttpEngine(resteasyClientBuilder, 10));
@@ -248,7 +255,7 @@ public class ImpersonationTest extends AbstractKeycloakTest {
         }
     }
 
-    private Cookie impersonate(Keycloak adminClient, String admin, String adminRealm) {
+    private Set<Cookie> impersonate(Keycloak adminClient, String admin, String adminRealm) {
         BasicCookieStore cookieStore = new BasicCookieStore();
         try (CloseableHttpClient httpClient = HttpClientBuilder.create().setDefaultCookieStore(cookieStore).build()) {
 
@@ -284,12 +291,15 @@ public class ImpersonationTest extends AbstractKeycloakTest {
             Assert.assertNotNull(notes.get(ImpersonationSessionNote.IMPERSONATOR_ID.toString()));
             Assert.assertEquals(admin, notes.get(ImpersonationSessionNote.IMPERSONATOR_USERNAME.toString()));
 
-            org.apache.http.cookie.Cookie cookie = cookieStore.getCookies().stream()
-                    .filter(c -> c.getName().equals(AuthenticationManager.KEYCLOAK_IDENTITY_COOKIE))
-                    .findAny().orElse(null);
-            Assert.assertNotNull(cookie);
+            Set<Cookie> cookies = cookieStore.getCookies().stream()
+                    .filter(c -> c.getName().startsWith(AuthenticationManager.KEYCLOAK_IDENTITY_COOKIE))
+                    .map(c -> new Cookie(c.getName(), c.getValue(), c.getDomain(), c.getPath(), c.getExpiryDate(), c.isSecure(), true) )
+                    .collect(Collectors.toSet());
 
-            return new Cookie(cookie.getName(), cookie.getValue(), cookie.getDomain(), cookie.getPath(), cookie.getExpiryDate(), cookie.isSecure(), true);
+            Assert.assertNotNull(cookies);
+            Assert.assertThat(cookies, is(not(empty())));
+
+            return cookies;
         }
         catch (IOException e) {
             throw new RuntimeException(e);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientPolicyBasicsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientPolicyBasicsTest.java
@@ -86,6 +86,7 @@ import org.keycloak.testsuite.util.OAuthClient;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.keycloak.testsuite.util.ServerURLs;
 
 @EnableFeature(value = Profile.Feature.CLIENT_POLICIES, skipRestart = true)
 public class ClientPolicyBasicsTest extends AbstractKeycloakTest {
@@ -827,7 +828,7 @@ public class ClientPolicyBasicsTest extends AbstractKeycloakTest {
         clientRep.setBearerOnly(Boolean.FALSE);
         clientRep.setPublicClient(Boolean.FALSE);
         clientRep.setServiceAccountsEnabled(Boolean.TRUE);
-        clientRep.setRedirectUris(Collections.singletonList("https://localhost:8543/auth/realms/master/app/auth"));
+        clientRep.setRedirectUris(Collections.singletonList(ServerURLs.getAuthServerContextRoot() + "/auth/realms/master/app/auth"));
         op.accept(clientRep);
         Response resp = adminClient.realm(REALM_NAME).clients().create(clientRep);
         if (resp.getStatus() == Response.Status.BAD_REQUEST.getStatusCode()) {
@@ -858,8 +859,8 @@ public class ClientPolicyBasicsTest extends AbstractKeycloakTest {
     private String createClientDynamically(String clientName, Consumer<OIDCClientRepresentation> op) throws ClientRegistrationException {
         OIDCClientRepresentation clientRep = new OIDCClientRepresentation();
         clientRep.setClientName(clientName);
-        clientRep.setClientUri("https://localhost:8543");
-        clientRep.setRedirectUris(Collections.singletonList("https://localhost:8543/auth/realms/master/app/auth"));
+        clientRep.setClientUri(ServerURLs.getAuthServerContextRoot());
+        clientRep.setRedirectUris(Collections.singletonList(ServerURLs.getAuthServerContextRoot() + "/auth/realms/master/app/auth"));
         op.accept(clientRep);
         OIDCClientRepresentation response = reg.oidc().create(clientRep);
         reg.auth(Auth.token(response));

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/cluster/AuthenticationSessionFailoverClusterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/cluster/AuthenticationSessionFailoverClusterTest.java
@@ -30,6 +30,7 @@ import org.keycloak.models.UserModel;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.services.managers.AuthenticationSessionManager;
+import org.keycloak.services.util.CookieHelper;
 import org.keycloak.testsuite.Assert;
 import org.keycloak.testsuite.admin.ApiUtil;
 import org.keycloak.testsuite.pages.AppPage;
@@ -165,6 +166,9 @@ public class AuthenticationSessionFailoverClusterTest extends AbstractFailoverCl
 
     public static String getAuthSessionCookieValue(WebDriver driver) {
         Cookie authSessionCookie = driver.manage().getCookieNamed(AuthenticationSessionManager.AUTH_SESSION_ID);
+        if (authSessionCookie == null) {
+            authSessionCookie = driver.manage().getCookieNamed(AuthenticationSessionManager.AUTH_SESSION_ID + CookieHelper.LEGACY_COOKIE);
+        }
         Assert.assertNotNull(authSessionCookie);
         return authSessionCookie.getValue();
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/ResetPasswordTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/ResetPasswordTest.java
@@ -1116,19 +1116,22 @@ public class ResetPasswordTest extends AbstractTestRealmKeycloakTest {
         final String REDIRECT_URI = OAuthClient.AUTH_SERVER_ROOT + "/realms/master/app/auth";
         final String CLIENT_ID = "test-app";
 
-        try (BrowserTabUtil tabUtil = BrowserTabUtil.getInstanceAndSetEnv(driver)) {
-            assertThat(tabUtil.getCountOfTabs(), Matchers.is(1));
+        try (ClientAttributeUpdater cau = ClientAttributeUpdater.forClient(getAdminClient(), TEST_REALM_NAME, CLIENT_ID)
+                .filterRedirectUris(uri -> uri.contains(getAuthServerRoot().toString()))
+                .update()) {
+            try (BrowserTabUtil tabUtil = BrowserTabUtil.getInstanceAndSetEnv(driver)) {
+                assertThat(tabUtil.getCountOfTabs(), Matchers.is(1));
 
-            loginPage.open();
-            resetPasswordTwiceInNewTab(defaultUser, CLIENT_ID, false, REDIRECT_URI);
-            assertThat(driver.getCurrentUrl(), Matchers.containsString(REDIRECT_URI));
+                loginPage.open();
+                resetPasswordTwiceInNewTab(defaultUser, CLIENT_ID, false, REDIRECT_URI);
+                assertThat(driver.getCurrentUrl(), Matchers.containsString(REDIRECT_URI));
 
-            oauth.openLogout();
+                oauth.openLogout();
 
-            loginPage.open();
-            resetPasswordTwiceInNewTab(defaultUser, CLIENT_ID, true, REDIRECT_URI);
-            assertThat(driver.getCurrentUrl(), Matchers.containsString(REDIRECT_URI));
-
+                loginPage.open();
+                resetPasswordTwiceInNewTab(defaultUser, CLIENT_ID, true, REDIRECT_URI);
+                assertThat(driver.getCurrentUrl(), Matchers.containsString(REDIRECT_URI));
+            }
         }
     }
 


### PR DESCRIPTION
For developing purposes the testsuite is often used with `-Dauth.server.ssl.required` set to `false`. We are not running it as part of our CI, so there were some failures. This PR prepares the testsuite for the addition of these tests to CI