### PR TITLE
KEYCLOAK-14870: Fix bug where user is incorrectly imported

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/UserAttributeLDAPStorageMapper.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/UserAttributeLDAPStorageMapper.java
@@ -22,6 +22,7 @@ import org.keycloak.component.ComponentModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.LDAPConstants;
 import org.keycloak.models.ModelDuplicateException;
+import org.keycloak.models.ModelException;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.utils.KeycloakModelUtils;
@@ -42,8 +43,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import org.keycloak.models.ModelException;
 
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
@@ -192,24 +191,21 @@ public class UserAttributeLDAPStorageMapper extends AbstractLDAPStorageMapper {
                 @Override
                 public void setSingleAttribute(String name, String value) {
                     if (UserModel.USERNAME.equals(name)) {
-                        checkDuplicateUsername(userModelAttrName, value, realm, ldapProvider.getSession(), this);
+                        setUsername(value);
                     } else if (UserModel.EMAIL.equals(name)) {
-                        checkDuplicateEmail(userModelAttrName, value, realm, ldapProvider.getSession(), this);
-                    }
-                    if (setLDAPAttribute(name, value)) {
+                        setEmail(value);
+                    } else if (setLDAPAttribute(name, value)) {
                         super.setSingleAttribute(name, value);
                     }
                 }
 
                 @Override
                 public void setAttribute(String name, List<String> values) {
-                    String valueToSet = (values != null && values.size() > 0) ? values.get(0) : null;
                     if (UserModel.USERNAME.equals(name)) {
-                        checkDuplicateUsername(userModelAttrName, valueToSet, realm, ldapProvider.getSession(), this);
+                        setUsername((values != null && values.size() > 0) ? values.get(0) : null);
                     } else if (UserModel.EMAIL.equals(name)) {
-                        checkDuplicateEmail(userModelAttrName, valueToSet, realm, ldapProvider.getSession(), this);
-                    }
-                    if (setLDAPAttribute(name, values)) {
+                        setEmail((values != null && values.size() > 0) ? values.get(0) : null);
+                    } else if (setLDAPAttribute(name, values)) {
                         super.setAttribute(name, values);
                     }
                 }
@@ -223,17 +219,19 @@ public class UserAttributeLDAPStorageMapper extends AbstractLDAPStorageMapper {
 
                 @Override
                 public void setUsername(String username) {
-                    checkDuplicateUsername(userModelAttrName, username, realm, ldapProvider.getSession(), this);
-                    setLDAPAttribute(UserModel.USERNAME, username);
-                    super.setUsername(username);
+                    String lowercaseUsername = KeycloakModelUtils.toLowerCaseSafe(username);
+                    checkDuplicateUsername(userModelAttrName, lowercaseUsername, realm, ldapProvider.getSession(), this);
+                    setLDAPAttribute(UserModel.USERNAME, lowercaseUsername);
+                    super.setUsername(lowercaseUsername);
                 }
 
                 @Override
                 public void setEmail(String email) {
+                    String lowercaseEmail = KeycloakModelUtils.toLowerCaseSafe(email);
                     checkDuplicateEmail(userModelAttrName, email, realm, ldapProvider.getSession(), this);
 
                     setLDAPAttribute(UserModel.EMAIL, email);
-                    super.setEmail(email);
+                    super.setEmail(lowercaseEmail);
                 }
 
                 @Override

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/UserAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/UserAdapter.java
@@ -167,12 +167,19 @@ public class UserAdapter implements CachedUserModel {
     @Override
     public void setSingleAttribute(String name, String value) {
         getDelegateForUpdate();
+        if (UserModel.USERNAME.equals(name) || UserModel.EMAIL.equals(name)) {
+            value = KeycloakModelUtils.toLowerCaseSafe(value);
+        }
         updated.setSingleAttribute(name, value);
     }
 
     @Override
     public void setAttribute(String name, List<String> values) {
         getDelegateForUpdate();
+        if (UserModel.USERNAME.equals(name) || UserModel.EMAIL.equals(name)) {
+            String lowerCasedFirstValue = KeycloakModelUtils.toLowerCaseSafe((values != null && values.size() > 0) ? values.get(0) : null);
+            if (lowerCasedFirstValue != null) values.set(0, lowerCasedFirstValue);
+        }
         updated.setAttribute(name, values);
     }
 

--- a/server-spi-private/src/main/java/org/keycloak/storage/adapter/InMemoryUserAdapter.java
+++ b/server-spi-private/src/main/java/org/keycloak/storage/adapter/InMemoryUserAdapter.java
@@ -26,6 +26,7 @@ import org.keycloak.models.RoleModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.UserModelDefaultMethods;
 import org.keycloak.models.utils.DefaultRoles;
+import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.models.utils.RoleUtils;
 import org.keycloak.storage.ReadOnlyException;
 
@@ -123,6 +124,9 @@ public class InMemoryUserAdapter extends UserModelDefaultMethods {
     @Override
     public void setSingleAttribute(String name, String value) {
         checkReadonly();
+        if (UserModel.USERNAME.equals(name) || UserModel.EMAIL.equals(name)) {
+            value = KeycloakModelUtils.toLowerCaseSafe(value);
+        }
         attributes.putSingle(name, value);
 
     }
@@ -130,6 +134,10 @@ public class InMemoryUserAdapter extends UserModelDefaultMethods {
     @Override
     public void setAttribute(String name, List<String> values) {
         checkReadonly();
+        if (UserModel.USERNAME.equals(name) || UserModel.EMAIL.equals(name)) {
+            String lowerCasedFirstValue = KeycloakModelUtils.toLowerCaseSafe((values != null && values.size() > 0) ? values.get(0) : null);
+            if (lowerCasedFirstValue != null) values.set(0, lowerCasedFirstValue);
+        }
         attributes.put(name, values);
 
     }

--- a/server-spi/src/main/java/org/keycloak/storage/adapter/AbstractUserAdapterFederatedStorage.java
+++ b/server-spi/src/main/java/org/keycloak/storage/adapter/AbstractUserAdapterFederatedStorage.java
@@ -340,9 +340,9 @@ public abstract class AbstractUserAdapterFederatedStorage extends UserModelDefau
     public void setSingleAttribute(String name, String value) {
         if (UserModel.USERNAME.equals(name)) {
             setUsername(value);
+        } else {
+            getFederatedStorage().setSingleAttribute(realm, this.getId(), mapAttribute(name), value);
         }
-        getFederatedStorage().setSingleAttribute(realm, this.getId(), mapAttribute(name), value);
-
     }
 
     @Override
@@ -355,9 +355,9 @@ public abstract class AbstractUserAdapterFederatedStorage extends UserModelDefau
     public void setAttribute(String name, List<String> values) {
         if (UserModel.USERNAME.equals(name)) {
             setUsername((values != null && values.size() > 0) ? values.get(0) : null);
+        } else {
+            getFederatedStorage().setAttribute(realm, this.getId(), mapAttribute(name), values);
         }
-        getFederatedStorage().setAttribute(realm, this.getId(), mapAttribute(name), values);
-
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/authentication/authenticators/broker/IdpCreateUserIfUniqueAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/broker/IdpCreateUserIfUniqueAuthenticator.java
@@ -74,12 +74,11 @@ public class IdpCreateUserIfUniqueAuthenticator extends AbstractIdpAuthenticator
 
             UserModel federatedUser = session.users().addUser(realm, username);
             federatedUser.setEnabled(true);
-            federatedUser.setEmail(brokerContext.getEmail());
-            federatedUser.setFirstName(brokerContext.getFirstName());
-            federatedUser.setLastName(brokerContext.getLastName());
 
             for (Map.Entry<String, List<String>> attr : serializedCtx.getAttributes().entrySet()) {
-                federatedUser.setAttribute(attr.getKey(), attr.getValue());
+                if (!UserModel.USERNAME.equalsIgnoreCase(attr.getKey())) {
+                    federatedUser.setAttribute(attr.getKey(), attr.getValue());
+                }
             }
 
             AuthenticatorConfigModel config = context.getAuthenticatorConfig();


### PR DESCRIPTION
This should fix the underlying cause for the issue:

The user is first created, then special attributes like email are set and then, all attributes are set. However, the UserModel change introduced the same changes in the `SerializedBrokerContext` so that the list of attributes contains all special attributes - in particular the `username`. So the username gets set again on a recently created user and this does not (and never did) put the username to lower case.

Any suggestions on how to write a test for this issue? I guess I would need federated storage in conjunction with identity brokering and I haven't found any tests I could start from.