### PR TITLE
fix: Fix regex replacement for underscore and minus in decodeToken. Closes #KEYCLOAK-14917

### DIFF
--- a/adapters/oidc/js/src/main/resources/keycloak.js
+++ b/adapters/oidc/js/src/main/resources/keycloak.js
@@ -1053,8 +1053,8 @@
         function decodeToken(str) {
             str = str.split('.')[1];
 
-            str = str.replace('/-/g', '+');
-            str = str.replace('/_/g', '/');
+            str = str.replace(/-/g, '+');
+            str = str.replace(/_/g, '/');
             switch (str.length % 4) {
                 case 0:
                     break;


### PR DESCRIPTION
Closes https://issues.redhat.com/browse/KEYCLOAK-14917