### PR TITLE
KEYCLOAK-14944 - Unit test failure in keycloak-services on Java 11

### DIFF
--- a/services/src/test/java/org/keycloak/connections/httpclient/DefaultHttpClientFactoryTest.java
+++ b/services/src/test/java/org/keycloak/connections/httpclient/DefaultHttpClientFactoryTest.java
@@ -48,7 +48,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class DefaultHttpClientFactoryTest {
 	private static final String DISABLE_TRUST_MANAGER_PROPERTY = "disable-trust-manager";
-	private static final String TEST_DOMAIN = "www.google.com";
+	private static final String TEST_DOMAIN = "keycloak.org";
 
 	@Test
 	public void createHttpClientProviderWithDisableTrustManager() throws IOException{
@@ -64,7 +64,7 @@ public class DefaultHttpClientFactoryTest {
 			Assume.assumeTrue( "Could not get test url for domain", testURL.isPresent() );
 			response = httpClient.execute(new HttpGet(testURL.get()));
 		}
-		assertEquals(HttpStatus.SC_OK,response.getStatusLine().getStatusCode());
+		assertEquals(HttpStatus.SC_NOT_FOUND,response.getStatusLine().getStatusCode());
 	}
 
 	@Test(expected = SSLPeerUnverifiedException.class)


### PR DESCRIPTION
Don't use google.com since SSL handshake is failing with Java 11 and no SNI.

Also, changed the asserted return code to `SC_NOT_FOUND` since keycloak.org returns a 404 when accessed by IP address. (NB: keycloak.org is an alias for keycloak.github.io, and the test might break if GitHub changes this behavior.)