### PR TITLE
KEYCLOAK-14978: Optimize addDefaultClientScopes()

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/protocol/AbstractLoginProtocolFactory.java
+++ b/server-spi-private/src/main/java/org/keycloak/protocol/AbstractLoginProtocolFactory.java
@@ -80,15 +80,19 @@ public abstract class AbstractLoginProtocolFactory implements LoginProtocolFacto
         Set<ClientScopeModel> defaultClientScopes = realm.getDefaultClientScopes(true).stream()
                 .filter(clientScope -> getId().equals(clientScope.getProtocol()))
                 .collect(Collectors.toSet());
-        for (ClientModel newClient : newClients) {
-            newClient.addClientScopes(defaultClientScopes, true);
+        if (!defaultClientScopes.isEmpty()) {
+            for (ClientModel newClient : newClients) {
+                newClient.addClientScopes(defaultClientScopes, true);
+            }
         }
 
         Set<ClientScopeModel> nonDefaultClientScopes = realm.getDefaultClientScopes(false).stream()
                 .filter(clientScope -> getId().equals(clientScope.getProtocol()))
                 .collect(Collectors.toSet());
-        for (ClientModel newClient : newClients) {
-            newClient.addClientScopes(nonDefaultClientScopes, false);
+        if (!nonDefaultClientScopes.isEmpty()) {
+            for (ClientModel newClient : newClients) {
+                newClient.addClientScopes(nonDefaultClientScopes, false);
+            }
         }
     }
 


### PR DESCRIPTION
Optimize addDefaultClientScopes() when there is no default scopes. This eliminates an extra database call to check whether the scopes already exist.
