### PR TITLE
KEYCLOAK-15113: Move away from deprecated Promise.success()/error()

### DIFF
--- a/adapters/oidc/js/src/main/resources/keycloak.d.ts
+++ b/adapters/oidc/js/src/main/resources/keycloak.d.ts
@@ -546,13 +546,13 @@ declare namespace Keycloak {
 		 *          still valid, or if the token is no longer valid.
 		 * @example
 		 * ```js
-		 * keycloak.updateToken(5).success(function(refreshed) {
+		 * keycloak.updateToken(5).then(function(refreshed) {
 		 *   if (refreshed) {
 		 *     alert('Token was successfully refreshed');
 		 *   } else {
 		 *     alert('Token is still valid');
 		 *   }
-		 * }).error(function() {
+		 * }).catch(function() {
 		 *   alert('Failed to refresh the token, or the session has expired');
 		 * });
 		 */

--- a/examples/broker/facebook-authentication/src/main/webapp/js/app.js
+++ b/examples/broker/facebook-authentication/src/main/webapp/js/app.js
@@ -20,7 +20,7 @@ var module = angular.module('app', []);
 angular.element(document).ready(function ($http) {
     var keycloakAuth = new Keycloak('keycloak.json');
 
-    keycloakAuth.init({ onLoad: 'login-required' }).success(function () {
+    keycloakAuth.init({ onLoad: 'login-required' }).then(function () {
         module.factory('Auth', function() {
             var Auth = {};
 
@@ -59,8 +59,8 @@ angular.element(document).ready(function ($http) {
                     deferred.resolve(config);
 
                     if (keycloakAuth.token) {
-                        keycloakAuth.updateToken(5).success(function() {
-                        }).error(function() {
+                        keycloakAuth.updateToken(5).then(function() {
+                        }).catch(function() {
                             deferred.reject('Failed to refresh token');
                         });
                     }

--- a/examples/broker/google-authentication/src/main/webapp/js/app.js
+++ b/examples/broker/google-authentication/src/main/webapp/js/app.js
@@ -20,7 +20,7 @@ var module = angular.module('app', []);
 angular.element(document).ready(function ($http) {
     var keycloakAuth = new Keycloak('keycloak.json');
 
-    keycloakAuth.init({ onLoad: 'login-required' }).success(function () {
+    keycloakAuth.init({ onLoad: 'login-required' }).then(function () {
         module.factory('Auth', function() {
             var Auth = {};
 
@@ -59,8 +59,8 @@ angular.element(document).ready(function ($http) {
                     deferred.resolve(config);
 
                     if (keycloakAuth.token) {
-                        keycloakAuth.updateToken(5).success(function() {
-                        }).error(function() {
+                        keycloakAuth.updateToken(5).then(function() {
+                        }).catch(function() {
                             deferred.reject('Failed to refresh token');
                         });
                     }
@@ -87,7 +87,7 @@ angular.element(document).ready(function ($http) {
         });
 
         angular.bootstrap(document, ["app"]);
-    }).error(function () {
+    }).catch(function () {
         window.location.reload();
     });
 });

--- a/examples/broker/saml-broker-authentication/src/main/webapp/js/app.js
+++ b/examples/broker/saml-broker-authentication/src/main/webapp/js/app.js
@@ -20,7 +20,7 @@ var module = angular.module('app', []);
 angular.element(document).ready(function ($http) {
     var keycloakAuth = new Keycloak('keycloak.json');
 
-    keycloakAuth.init({ onLoad: 'login-required' }).success(function () {
+    keycloakAuth.init({ onLoad: 'login-required' }).then(function () {
         module.factory('Auth', function() {
             var Auth = {};
 
@@ -53,8 +53,8 @@ angular.element(document).ready(function ($http) {
                     deferred.resolve(config);
 
                     if (keycloakAuth.token) {
-                        keycloakAuth.updateToken(5).success(function() {
-                        }).error(function() {
+                        keycloakAuth.updateToken(5).then(function() {
+                        }).catch(function() {
                             deferred.reject('Failed to refresh token');
                         });
                     }
@@ -81,7 +81,7 @@ angular.element(document).ready(function ($http) {
         });
 
         angular.bootstrap(document, ["app"]);
-    }).error(function () {
+    }).catch(function () {
         window.location = keycloakAuth.createLoginUrl({
             idpHint: 'saml-identity-provider'
         })

--- a/examples/broker/twitter-authentication/src/main/webapp/js/app.js
+++ b/examples/broker/twitter-authentication/src/main/webapp/js/app.js
@@ -20,7 +20,7 @@ var module = angular.module('app', []);
 angular.element(document).ready(function ($http) {
     var keycloakAuth = new Keycloak('keycloak.json');
 
-    keycloakAuth.init({ onLoad: 'login-required' }).success(function () {
+    keycloakAuth.init({ onLoad: 'login-required' }).then(function () {
         module.factory('Auth', function() {
             var Auth = {};
 
@@ -63,8 +63,8 @@ angular.element(document).ready(function ($http) {
                     deferred.resolve(config);
 
                     if (keycloakAuth.token) {
-                        keycloakAuth.updateToken(5).success(function() {
-                        }).error(function() {
+                        keycloakAuth.updateToken(5).then(function() {
+                        }).catch(function() {
                             deferred.reject('Failed to refresh token');
                         });
                     }
@@ -91,7 +91,7 @@ angular.element(document).ready(function ($http) {
         });
 
         angular.bootstrap(document, ["app"]);
-    }).error(function () {
+    }).catch(function () {
         window.location.reload();
     });
 });

--- a/examples/cordova-native/www/index.html
+++ b/examples/cordova-native/www/index.html
@@ -60,7 +60,7 @@
               responseMode: 'query',
               onLoad: 'check-sso',
               redirectUri: 'android-app://org.keycloak.examples.cordova/https/keycloak-cordova-example.github.io/login'
-            }).success(updateState).error(error);
+            }).then(updateState).catch(error);
         }, false);
     </script>
     <style>

--- a/examples/cordova/www/index.html
+++ b/examples/cordova/www/index.html
@@ -55,7 +55,7 @@
         }
 
         document.addEventListener("deviceready", function() {
-            keycloak.init({ onLoad: "check-sso" }).success(updateState).error(error);
+            keycloak.init({ onLoad: "check-sso" }).then(updateState).catch(error);
         }, false);
     </script>
     <style>

--- a/examples/cors/angular-product-app/src/main/webapp/js/app.js
+++ b/examples/cors/angular-product-app/src/main/webapp/js/app.js
@@ -31,7 +31,7 @@ angular.element(document).ready(function ($http) {
     var keycloakAuth = new Keycloak('keycloak.json');
     auth.loggedIn = false;
 
-    keycloakAuth.init({ onLoad: 'login-required' }).success(function () {
+    keycloakAuth.init({ onLoad: 'login-required' }).then(function () {
         console.log('here login');
         auth.loggedIn = true;
         auth.authz = keycloakAuth;
@@ -40,7 +40,7 @@ angular.element(document).ready(function ($http) {
             return auth;
         });
         angular.bootstrap(document, ["product"]);
-    }).error(function () {
+    }).catch(function () {
             alert("failed to login");
         });
 
@@ -112,12 +112,12 @@ module.factory('authInterceptor', function($q, Auth) {
         request: function (config) {
             var deferred = $q.defer();
             if (Auth.authz.token) {
-                Auth.authz.updateToken(5).success(function() {
+                Auth.authz.updateToken(5).then(function() {
                     config.headers = config.headers || {};
                     config.headers.Authorization = 'Bearer ' + Auth.authz.token;
 
                     deferred.resolve(config);
-                }).error(function() {
+                }).catch(function() {
                         deferred.reject('Failed to refresh token');
                     });
             }

--- a/examples/demo-template/angular-product-app/src/main/webapp/js/app.js
+++ b/examples/demo-template/angular-product-app/src/main/webapp/js/app.js
@@ -30,7 +30,7 @@ angular.element(document).ready(function ($http) {
     var keycloakAuth = new Keycloak('keycloak.json');
     auth.loggedIn = false;
 
-    keycloakAuth.init({ onLoad: 'login-required' }).success(function () {
+    keycloakAuth.init({ onLoad: 'login-required' }).then(function () {
         auth.loggedIn = true;
         auth.authz = keycloakAuth;
         auth.logoutUrl = keycloakAuth.authServerUrl + "/realms/demo/protocol/openid-connect/logout?redirect_uri=/angular-product/index.html";
@@ -38,7 +38,7 @@ angular.element(document).ready(function ($http) {
             return auth;
         });
         angular.bootstrap(document, ["product"]);
-    }).error(function () {
+    }).catch(function () {
             window.location.reload();
         });
 
@@ -62,12 +62,12 @@ module.factory('authInterceptor', function($q, Auth) {
         request: function (config) {
             var deferred = $q.defer();
             if (Auth.authz.token) {
-                Auth.authz.updateToken(5).success(function() {
+                Auth.authz.updateToken(5).then(function() {
                     config.headers = config.headers || {};
                     config.headers.Authorization = 'Bearer ' + Auth.authz.token;
 
                     deferred.resolve(config);
-                }).error(function() {
+                }).catch(function() {
                         deferred.reject('Failed to refresh token');
                     });
             }

--- a/examples/demo-template/customer-app-js/src/main/webapp/customers/view.html
+++ b/examples/demo-template/customer-app-js/src/main/webapp/customers/view.html
@@ -98,8 +98,8 @@ User <b id="subject"></b> made this request.
     }
 
     keycloak.init({ onLoad: 'login-required' })
-        .success(reloadData)
-        .error(function(errorData) {
+        .then(reloadData)
+        .catch(function(errorData) {
             document.getElementById('customers').innerHTML = '<b>Failed to load data. Error: ' + JSON.stringify(errorData) + '</b>';
         });
 

--- a/examples/js-console/src/main/webapp/index.html
+++ b/examples/js-console/src/main/webapp/index.html
@@ -90,13 +90,13 @@
     }
 
     function refreshToken(minValidity) {
-        keycloak.updateToken(minValidity).success(function(refreshed) {
+        keycloak.updateToken(minValidity).then(function(refreshed) {
             if (refreshed) {
                 output(keycloak.tokenParsed);
             } else {
                 output('Token not refreshed, valid for ' + Math.round(keycloak.tokenParsed.exp + keycloak.timeSkew - new Date().getTime() / 1000) + ' seconds');
             }
-        }).error(function() {
+        }).catch(function() {
             output('Failed to refresh token');
         });
     }
@@ -173,9 +173,9 @@
         flow: 'standard'
     };
 
-    keycloak.init(initOptions).success(function(authenticated) {
+    keycloak.init(initOptions).then(function(authenticated) {
         output('Init Success (' + (authenticated ? 'Authenticated' : 'Not Authenticated') + ')');
-    }).error(function() {
+    }).catch(function() {
         output('Init Error');
     });
 

--- a/testsuite/integration-arquillian/test-apps/cors/angular-product/src/main/webapp/js/app.js
+++ b/testsuite/integration-arquillian/test-apps/cors/angular-product/src/main/webapp/js/app.js
@@ -48,7 +48,7 @@ angular.element(document).ready(function ($http) {
     var keycloakAuth = new Keycloak('keycloak.json');
     auth.loggedIn = false;
 
-    keycloakAuth.init({ onLoad: 'login-required' }).success(function () {
+    keycloakAuth.init({ onLoad: 'login-required' }).then(function () {
         console.log('here login');
         auth.loggedIn = true;
         auth.authz = keycloakAuth;
@@ -57,7 +57,7 @@ angular.element(document).ready(function ($http) {
             return auth;
         });
         angular.bootstrap(document, ["product"]);
-    }).error(function () {
+    }).catch(function () {
             alert("failed to login");
         });
 
@@ -117,12 +117,12 @@ module.factory('authInterceptor', function($q, Auth) {
         request: function (config) {
             var deferred = $q.defer();
             if (Auth.authz.token) {
-                Auth.authz.updateToken(5).success(function() {
+                Auth.authz.updateToken(5).then(function() {
                     config.headers = config.headers || {};
                     config.headers.Authorization = 'Bearer ' + Auth.authz.token;
 
                     deferred.resolve(config);
-                }).error(function() {
+                }).catch(function() {
                         deferred.reject('Failed to refresh token');
                     });
             }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/javascript/JavascriptAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/javascript/JavascriptAdapterTest.java
@@ -702,9 +702,9 @@ public class JavascriptAdapterTest extends AbstractJavascriptTest {
     @Test
     public void testRefreshTokenWithDeprecatedPromiseHandles() {
         String refreshWithDeprecatedHandles = "var callback = arguments[arguments.length - 1];" +
-                "   window.keycloak.updateToken(9999).success(function (refreshed) {" +
+                "   window.keycloak.updateToken(9999).then(function (refreshed) {" +
             "            callback('Success handle');" +
-                "   }).error(function () {" +
+                "   }).catch(function () {" +
                 "       callback('Error handle');" +
                 "   });";
 

--- a/themes/src/main/resources/theme/base/admin/resources/js/app.js
+++ b/themes/src/main/resources/theme/base/admin/resources/js/app.js
@@ -96,7 +96,7 @@ angular.element(document).ready(function () {
         return auth;
     });
 
-    keycloakAuth.init({ onLoad: 'login-required', pkceMethod: 'S256' }).success(function () {
+    keycloakAuth.init({ onLoad: 'login-required', pkceMethod: 'S256' }).then(function () {
         auth.authz = keycloakAuth;
 
         whoAmI(function(data) {
@@ -117,7 +117,7 @@ angular.element(document).ready(function () {
         });
 
         loadSelect2Localization();
-    }).error(function () {
+    }).catch(function () {
         window.location.reload();
     });
 });
@@ -128,12 +128,12 @@ module.factory('authInterceptor', function($q, Auth) {
             if (!config.url.match(/.html$/)) {
                 var deferred = $q.defer();
                 if (Auth.authz.token) {
-                    Auth.authz.updateToken(5).success(function () {
+                    Auth.authz.updateToken(5).then(function () {
                         config.headers = config.headers || {};
                         config.headers.Authorization = 'Bearer ' + Auth.authz.token;
 
                         deferred.resolve(config);
-                    }).error(function () {
+                    }).catch(function () {
                         location.reload();
                     });
                 }


### PR DESCRIPTION
Move away from deprecated Promise.success()/error() by using the native method .then()/.catch() instead.