### PR TITLE
KEYCLOAK-15146 Add support for searching users by emailVerified status

### DIFF
--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/UsersResource.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/UsersResource.java
@@ -55,6 +55,26 @@ public interface UsersResource {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
+    List<UserRepresentation> search(@QueryParam("username") String username,
+                                    @QueryParam("firstName") String firstName,
+                                    @QueryParam("lastName") String lastName,
+                                    @QueryParam("email") String email,
+                                    @QueryParam("emailVerified") Boolean emailVerified,
+                                    @QueryParam("first") Integer firstResult,
+                                    @QueryParam("max") Integer maxResults,
+                                    @QueryParam("enabled") Boolean enabled,
+                                    @QueryParam("briefRepresentation") Boolean briefRepresentation);
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<UserRepresentation> search(@QueryParam("emailVerified") Boolean emailVerified,
+                                    @QueryParam("first") Integer firstResult,
+                                    @QueryParam("max") Integer maxResults,
+                                    @QueryParam("enabled") Boolean enabled,
+                                    @QueryParam("briefRepresentation") Boolean briefRepresentation);
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
     List<UserRepresentation> search(@QueryParam("username") String username);
 
     @GET
@@ -155,6 +175,38 @@ public interface UsersResource {
                   @QueryParam("firstName") String first,
                   @QueryParam("email") String email,
                   @QueryParam("username") String username);
+
+    /**
+     * Returns the number of users that can be viewed and match the given filters.
+     * If none of the filters is specified this is equivalent to {{@link #count()}}.
+     *
+     * @param last          last name field of a user
+     * @param first         first name field of a user
+     * @param email         email field of a user
+     * @param emailVerified emailVerified field of a user
+     * @param username      username field of a user
+     * @return number of users matching the given filters
+     */
+    @Path("count")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    Integer count(@QueryParam("lastName") String last,
+                  @QueryParam("firstName") String first,
+                  @QueryParam("email") String email,
+                  @QueryParam("emailVerified") Boolean emailVerified,
+                  @QueryParam("username") String username);
+
+    /**
+     * Returns the number of users with the given status for emailVerified.
+     * If none of the filters is specified this is equivalent to {{@link #count()}}.
+     *
+     * @param emailVerified emailVerified field of a user
+     * @return number of users matching the given filters
+     */
+    @Path("count")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    Integer countEmailVerified(@QueryParam("emailVerified") Boolean emailVerified);
 
     @Path("{id}")
     UserResource get(@PathParam("id") String id);

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserProvider.java
@@ -78,6 +78,7 @@ import javax.persistence.LockModeType;
 public class JpaUserProvider implements UserProvider, UserCredentialStore {
 
     private static final String EMAIL = "email";
+    private static final String EMAIL_VERIFIED = "emailVerified";
     private static final String USERNAME = "username";
     private static final String FIRST_NAME = "firstName";
     private static final String LAST_NAME = "lastName";
@@ -687,6 +688,9 @@ public class JpaUserProvider implements UserProvider, UserCredentialStore {
                 case UserModel.EMAIL:
                     restrictions.add(qb.like(from.get("email"), "%" + value + "%"));
                     break;
+                case UserModel.EMAIL_VERIFIED:
+                    restrictions.add(qb.equal(from.get("emailVerified"), Boolean.parseBoolean(value.toLowerCase())));
+                    break;
             }
         }
 
@@ -732,6 +736,9 @@ public class JpaUserProvider implements UserProvider, UserCredentialStore {
                     break;
                 case UserModel.EMAIL:
                     restrictions.add(qb.like(from.get("user").get("email"), "%" + value + "%"));
+                    break;
+                case UserModel.EMAIL_VERIFIED:
+                    restrictions.add(qb.equal(from.get("emailVerified"), Boolean.parseBoolean(value.toLowerCase())));
                     break;
             }
         }
@@ -874,6 +881,9 @@ public class JpaUserProvider implements UserProvider, UserCredentialStore {
                     } else {
                         predicates.add(builder.like(builder.lower(root.get(key)), "%" + value.toLowerCase() + "%"));
                     }
+                    break;
+                case EMAIL_VERIFIED:
+                    predicates.add(builder.equal(root.get(key), Boolean.parseBoolean(value.toLowerCase())));
                     break;
                 case UserModel.ENABLED:
                     predicates.add(builder.equal(builder.lower(root.get(key)), Boolean.parseBoolean(value.toLowerCase())));

--- a/server-spi/src/main/java/org/keycloak/models/UserModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/UserModel.java
@@ -34,6 +34,7 @@ public interface UserModel extends RoleMapperModel {
     String FIRST_NAME = "firstName";
     String LAST_NAME = "lastName";
     String EMAIL = "email";
+    String EMAIL_VERIFIED = "emailVerified";
     String LOCALE = "locale";
     String ENABLED = "enabled";
     String INCLUDE_SERVICE_ACCOUNT = "keycloak.session.realm.users.query.include_service_account";

--- a/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
@@ -208,6 +208,7 @@ public class UsersResource {
                                              @QueryParam("firstName") String first,
                                              @QueryParam("email") String email,
                                              @QueryParam("username") String username,
+                                             @QueryParam("emailVerified") Boolean emailVerified,
                                              @QueryParam("first") Integer firstResult,
                                              @QueryParam("max") Integer maxResults,
                                              @QueryParam("enabled") Boolean enabled,
@@ -225,7 +226,7 @@ public class UsersResource {
             if (search.startsWith(SEARCH_ID_PARAMETER)) {
                 UserModel userModel = session.users().getUserById(search.substring(SEARCH_ID_PARAMETER.length()).trim(), realm);
                 if (userModel != null) {
-                    userModels = Arrays.asList(userModel);
+                    userModels = Collections.singletonList(userModel);
                 }
             } else {
                 Map<String, String> attributes = new HashMap<>();
@@ -235,7 +236,7 @@ public class UsersResource {
                 }
                 return searchForUser(attributes, realm, userPermissionEvaluator, briefRepresentation, firstResult, maxResults, false);
             }
-        } else if (last != null || first != null || email != null || username != null || enabled != null || exact != null) {
+        } else if (last != null || first != null || email != null || username != null  || emailVerified != null || enabled != null || exact != null) {
             Map<String, String> attributes = new HashMap<>();
             if (last != null) {
                 attributes.put(UserModel.LAST_NAME, last);
@@ -254,6 +255,9 @@ public class UsersResource {
             }
             if (exact != null) {
                 attributes.put(UserModel.EXACT, exact.toString());
+            }
+            if (emailVerified != null) {
+                attributes.put(UserModel.EMAIL_VERIFIED, emailVerified.toString());
             }
             return searchForUser(attributes, realm, userPermissionEvaluator, briefRepresentation, firstResult, maxResults, true);
         } else {
@@ -293,6 +297,7 @@ public class UsersResource {
                                  @QueryParam("lastName") String last,
                                  @QueryParam("firstName") String first,
                                  @QueryParam("email") String email,
+                                 @QueryParam("emailVerified") Boolean emailVerified,
                                  @QueryParam("username") String username) {
         UserPermissionEvaluator userPermissionEvaluator = auth.users();
         userPermissionEvaluator.requireQuery();
@@ -306,7 +311,7 @@ public class UsersResource {
             } else {
                 return session.users().getUsersCount(search.trim(), realm, auth.groups().getGroupsWithViewPermission());
             }
-        } else if (last != null || first != null || email != null || username != null) {
+        } else if (last != null || first != null || email != null || username != null || emailVerified != null) {
             Map<String, String> parameters = new HashMap<>();
             if (last != null) {
                 parameters.put(UserModel.LAST_NAME, last);
@@ -319,6 +324,9 @@ public class UsersResource {
             }
             if (username != null) {
                 parameters.put(UserModel.USERNAME, username);
+            }
+            if (emailVerified != null) {
+                parameters.put(UserModel.EMAIL_VERIFIED, emailVerified.toString());
             }
             if (userPermissionEvaluator.canView()) {
                 return session.users().getUsersCount(parameters, realm);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/AbstractKeycloakTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/AbstractKeycloakTest.java
@@ -76,6 +76,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Scanner;
+import java.util.function.Consumer;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -490,6 +491,12 @@ public abstract class AbstractKeycloakTest {
         homer.setRequiredActions(Arrays.asList(requiredActions));
 
         return ApiUtil.createUserWithAdminClient(adminClient.realm(realm), homer);
+    }
+
+    public String createUser(String realm, String username, String password, String firstName, String lastName, String email, Consumer<UserRepresentation> customizer) {
+        UserRepresentation user = createUserRepresentation(username, email, firstName, lastName, true, password);
+        customizer.accept(user);
+        return ApiUtil.createUserWithAdminClient(adminClient.realm(realm), user);
     }
 
     public String createUser(String realm, String username, String password, String firstName, String lastName, String email) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/UsersTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/UsersTest.java
@@ -44,6 +44,8 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 
 public class UsersTest extends AbstractAdminTest {
@@ -54,6 +56,47 @@ public class UsersTest extends AbstractAdminTest {
         for (UserRepresentation user : userRepresentations) {
             realm.users().delete(user.getId());
         }
+    }
+
+    /**
+     * https://issues.redhat.com/browse/KEYCLOAK-15146
+     */
+    @Test
+    public void findUsersByEmailVerifiedStatus() {
+
+        createUser(realmId, "user1", "password", "user1FirstName", "user1LastName", "user1@example.com", rep -> rep.setEmailVerified(true));
+        createUser(realmId, "user2", "password", "user2FirstName", "user2LastName", "user2@example.com", rep -> rep.setEmailVerified(false));
+
+        boolean emailVerified;
+        emailVerified = true;
+        List<UserRepresentation> usersEmailVerified = realm.users().search(null, null, null, null, emailVerified, null, null, null, true);
+        assertThat(usersEmailVerified, is(not(empty())));
+        assertThat(usersEmailVerified.get(0).getUsername(), is("user1"));
+
+        emailVerified = false;
+        List<UserRepresentation> usersEmailNotVerified = realm.users().search(null, null, null, null, emailVerified, null, null, null, true);
+        assertThat(usersEmailNotVerified, is(not(empty())));
+        assertThat(usersEmailNotVerified.get(0).getUsername(), is("user2"));
+    }
+
+    /**
+     * https://issues.redhat.com/browse/KEYCLOAK-15146
+     */
+    @Test
+    public void countUsersByEmailVerifiedStatus() {
+
+        createUser(realmId, "user1", "password", "user1FirstName", "user1LastName", "user1@example.com", rep -> rep.setEmailVerified(true));
+        createUser(realmId, "user2", "password", "user2FirstName", "user2LastName", "user2@example.com", rep -> rep.setEmailVerified(false));
+        createUser(realmId, "user3", "password", "user3FirstName", "user3LastName", "user3@example.com", rep -> rep.setEmailVerified(true));
+
+        boolean emailVerified;
+        emailVerified = true;
+        assertThat(realm.users().countEmailVerified(emailVerified), is(2));
+        assertThat(realm.users().count(null,null,null,emailVerified,null), is(2));
+
+        emailVerified = false;
+        assertThat(realm.users().countEmailVerified(emailVerified), is(1));
+        assertThat(realm.users().count(null,null,null,emailVerified,null), is(1));
     }
 
     @Test


### PR DESCRIPTION
We now allow to search for users by their emailVerified status.
This enables users to easily find users and deal with incomplete user accounts.

See: https://issues.redhat.com/browse/KEYCLOAK-15146

Note: It seems that there is no database index on `user_entity(realm_id, email_verified)`, but this is necessary to speedup lookups in larger user databases.

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
