### PR TITLE
KEYCLOAK-14767 OpenShift Review Endpoint audience fix

### DIFF
--- a/core/src/main/java/org/keycloak/TokenVerifier.java
+++ b/core/src/main/java/org/keycloak/TokenVerifier.java
@@ -271,18 +271,18 @@ public class TokenVerifier<T extends JsonWebToken> {
         checks.remove(check);
     }
 
-    private <P extends Predicate<? super T>> TokenVerifier<T> replaceCheck(Class<? extends Predicate<?>> checkClass, boolean active, P predicate) {
+    private <P extends Predicate<? super T>> TokenVerifier<T> replaceCheck(Class<? extends Predicate<?>> checkClass, boolean active, P... predicate) {
         removeCheck(checkClass);
         if (active) {
-            checks.add(predicate);
+            checks.addAll(Arrays.asList(predicate));
         }
         return this;
     }
 
-    private <P extends Predicate<? super T>> TokenVerifier<T> replaceCheck(Predicate<? super T> check, boolean active, P predicate) {
+    private <P extends Predicate<? super T>> TokenVerifier<T> replaceCheck(Predicate<? super T> check, boolean active, P... predicate) {
         removeCheck(check);
         if (active) {
-            checks.add(predicate);
+            checks.addAll(Arrays.asList(predicate));
         }
         return this;
     }
@@ -366,11 +366,18 @@ public class TokenVerifier<T extends JsonWebToken> {
     /**
      * Add check for verifying that token contains the expectedAudience
      *
-     * @param expectedAudience Audience, which needs to be in the target token. Can't be null
+     * @param expectedAudiences Audiences, which needs to be in the target token. Can be <code>null</code>.
      * @return This token verifier
      */
-    public TokenVerifier<T> audience(String expectedAudience) {
-        return this.replaceCheck(AudienceCheck.class, true, new AudienceCheck(expectedAudience));
+    public TokenVerifier<T> audience(String... expectedAudiences) {
+        if (expectedAudiences == null || expectedAudiences.length == 0) {
+            return this.replaceCheck(AudienceCheck.class, true, new AudienceCheck(null));
+        }
+        AudienceCheck[] audienceChecks = new AudienceCheck[expectedAudiences.length];
+        for (int i = 0; i < expectedAudiences.length; ++i) {
+            audienceChecks[i] = new AudienceCheck(expectedAudiences[i]);
+        }
+        return this.replaceCheck(AudienceCheck.class, true, audienceChecks);
     }
 
     /**

--- a/services/src/main/java/org/keycloak/protocol/openshift/OpenShiftTokenReviewEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/openshift/OpenShiftTokenReviewEndpoint.java
@@ -93,7 +93,8 @@ public class OpenShiftTokenReviewEndpoint implements OIDCExtProvider, Environmen
         AccessToken token = null;
         try {
             TokenVerifier<AccessToken> verifier = TokenVerifier.create(reviewRequest.getSpec().getToken(), AccessToken.class)
-                    .realmUrl(Urls.realmIssuer(session.getContext().getUri().getBaseUri(), realm.getName()));
+                    .realmUrl(Urls.realmIssuer(session.getContext().getUri().getBaseUri(), realm.getName()))
+                    .audience(reviewRequest.getSpec().getAudiences());
 
             SignatureVerifierContext verifierContext = session.getProvider(SignatureProvider.class, verifier.getHeader().getAlgorithm().name()).verifier(verifier.getHeader().getKeyId());
             verifier.verifierContext(verifierContext);

--- a/services/src/main/java/org/keycloak/protocol/openshift/OpenShiftTokenReviewRequestRepresentation.java
+++ b/services/src/main/java/org/keycloak/protocol/openshift/OpenShiftTokenReviewRequestRepresentation.java
@@ -62,10 +62,14 @@ public class OpenShiftTokenReviewRequestRepresentation implements Serializable {
         this.spec = spec;
     }
 
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Spec implements Serializable {
 
         @JsonProperty("token")
         private String token;
+
+        @JsonProperty("audiences")
+        private String[] audiences;
 
         public String getToken() {
             return token;
@@ -75,6 +79,13 @@ public class OpenShiftTokenReviewRequestRepresentation implements Serializable {
             this.token = token;
         }
 
+        public String[] getAudiences() {
+            return audiences;
+        }
+
+        public void setAudiences(String[] audiences) {
+            this.audiences = audiences;
+        }
     }
 
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/KEYCLOAK-14767

This Pull Request replaces https://github.com/keycloak/keycloak/pull/7268. It introduces a **mandatory** audience check for OpenShift Token Review Endpoint.