### PR TITLE
KEYCLOAK-15174: ResourceServerAdapter.toEntity checks for the wrong type

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/authorization/jpa/store/ResourceServerAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/authorization/jpa/store/ResourceServerAdapter.java
@@ -102,7 +102,7 @@ public class ResourceServerAdapter extends AbstractAuthorizationModel implements
     }
 
     public static ResourceServerEntity toEntity(EntityManager em, ResourceServer resource) {
-        if (resource instanceof ResourceAdapter) {
+        if (resource instanceof ResourceServerAdapter) {
             return ((ResourceServerAdapter)resource).getEntity();
         } else {
             return em.getReference(ResourceServerEntity.class, resource.getId());


### PR DESCRIPTION
ResourceServerAdapter.toEntity checks the wrong type. Changed to use the correct type.

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
