### PR TITLE
KEYCLOAK-15176: Use .equals() instead of == when possible

### DIFF
--- a/federation/sssd/src/main/java/org/keycloak/federation/sssd/SSSDFederationProvider.java
+++ b/federation/sssd/src/main/java/org/keycloak/federation/sssd/SSSDFederationProvider.java
@@ -148,19 +148,19 @@ public class SSSDFederationProvider implements UserStorageProvider,
 
     @Override
     public void preRemove(RealmModel realm, RoleModel role) {
-        // complete we dont'care if a role is removed
+        // complete we don't care if a role is removed
 
     }
 
     @Override
     public void preRemove(RealmModel realm, GroupModel group) {
-        // complete we dont'care if a role is removed
+        // complete we don't care if a role is removed
 
     }
 
     public boolean isValid(RealmModel realm, UserModel local) {
         User user = new Sssd(local.getUsername()).getUser();
-        return user.equals(local);
+        return user.equivalentTo(local);
     }
 
     @Override

--- a/federation/sssd/src/main/java/org/keycloak/federation/sssd/api/Sssd.java
+++ b/federation/sssd/src/main/java/org/keycloak/federation/sssd/api/Sssd.java
@@ -28,6 +28,7 @@ import org.keycloak.models.UserModel;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Vector;
 
 /**
@@ -114,7 +115,7 @@ public class Sssd {
         return user;
     }
 
-    public class User {
+    public static class User {
 
         private final String email;
         private final String firstName;
@@ -139,32 +140,10 @@ public class Sssd {
             return lastName;
         }
 
-        @Override
-        public boolean equals(Object o) {
-            if (o == null) return false;
-
-            UserModel userModel = (UserModel) o;
-            if (firstName != null && !firstName.equals(userModel.getFirstName())) {
-                return false;
-            }
-            if (lastName != null && !lastName.equals(userModel.getLastName())) {
-                return false;
-            }
-            if (email != null) {
-                return email.equals(userModel.getEmail());
-            }
-            if (email != userModel.getEmail()) {
-                return false;
-            }
-            return true;
-        }
-
-        @Override
-        public int hashCode() {
-            int result = email != null ? email.hashCode() : 0;
-            result = 31 * result + (firstName != null ? firstName.hashCode() : 0);
-            result = 31 * result + (lastName != null ? lastName.hashCode() : 0);
-            return result;
+        public boolean equivalentTo(UserModel user) {
+            return Objects.equals(email, user.getEmail()) &&
+                    Objects.equals(firstName, user.getFirstName()) &&
+                    Objects.equals(lastName, user.getLastName());
         }
     }
 }

--- a/model/map/src/main/java/org/keycloak/models/map/client/MapClientProvider.java
+++ b/model/map/src/main/java/org/keycloak/models/map/client/MapClientProvider.java
@@ -57,7 +57,7 @@ public class MapClientProvider implements ClientProvider {
         public int compare(MapClientEntity o1, MapClientEntity o2) {
             String c1 = o1 == null ? null : o1.getClientId();
             String c2 = o2 == null ? null : o2.getClientId();
-            return c1 == c2 ? 0
+            return Objects.equals(c1, c2) ? 0
               : c1 == null ? -1
               : c2 == null ? 1
               : c1.compareTo(c2);

--- a/server-spi-private/src/main/java/org/keycloak/authorization/permission/Permissions.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/permission/Permissions.java
@@ -18,14 +18,7 @@
 
 package org.keycloak.authorization.permission;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -80,7 +73,7 @@ public final class Permissions {
         });
 
         // resource server isn't current user
-        if (resourceServer.getId() != identity.getId()) {
+        if (!Objects.equals(resourceServer.getId(), identity.getId())) {
             // obtain all resources where owner is the current user
             resourceStore.findByOwner(identity.getId(), resourceServer.getId(), resource -> {
                 if (limit.decrementAndGet() >= 0) {


### PR DESCRIPTION
Use .equals() instead of == when possible especially for string comparison