### PR TITLE
KEYCLOAK-14919 Dynamic registration - Scope ignored

### DIFF
--- a/services/src/main/java/org/keycloak/services/clientregistration/oidc/DescriptionConverter.java
+++ b/services/src/main/java/org/keycloak/services/clientregistration/oidc/DescriptionConverter.java
@@ -46,9 +46,11 @@ import org.keycloak.util.JWKSUtils;
 import java.net.URI;
 import java.security.PublicKey;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
@@ -62,6 +64,9 @@ public class DescriptionConverter {
         client.setName(clientOIDC.getClientName());
         client.setRedirectUris(clientOIDC.getRedirectUris());
         client.setBaseUrl(clientOIDC.getClientUri());
+
+        String scopeParam = clientOIDC.getScope();
+        if (scopeParam != null) client.setOptionalClientScopes(new ArrayList<>(Arrays.asList(scopeParam.split(" "))));
 
         List<String> oidcResponseTypes = clientOIDC.getResponseTypes();
         if (oidcResponseTypes == null || oidcResponseTypes.isEmpty()) {
@@ -215,6 +220,9 @@ public class DescriptionConverter {
         response.setRegistrationClientUri(uri.toString());
         response.setResponseTypes(getOIDCResponseTypes(client));
         response.setGrantTypes(getOIDCGrantTypes(client));
+
+        List<String> scopes = client.getOptionalClientScopes();
+        if (scopes != null) response.setScope(scopes.stream().collect(Collectors.joining(" ")));
 
         OIDCAdvancedConfigWrapper config = OIDCAdvancedConfigWrapper.fromClientRepresentation(client);
         if (config.isUserInfoSignatureRequired()) {


### PR DESCRIPTION
This PR is for [KEYCLOAK-14919](https://issues.redhat.com/browse/KEYCLOAK-14919).

The following shows brief specification.

- Client Scope Type Used
  Optional Client Scope

- Dynamic Client Registration
  -  CREATE
     -  with registered scope
         no default client scope is set onto the client
         specified optional client scopes are set onto the client
     -  with not registered scope
         403 Forbidden due to default Client Registration Policy
     -  without scope
         operated as usual
         all default client scope are set onto the client
         all optional client scopes are set onto the client
  -  GET
     -  with registered scope
         optional client scopes that were specified on client registration are returned
     -  with not registered scope
        N/A
     -  without scope
         operated as usual
         all optional client scopes are returned
  -  UPDATE
      out of scope

- Admin REST API
     -  with registered scope
         no default client scope is set onto the client
         specified optional client scopes are set onto the client
     -  with not registered scope
         403 Forbidden due to default Client Registration Policy
     -  without scope
         operated as usual
         all default client scope are set onto the client
         all optional client scopes are set onto the client
  -  GET
     -  with registered scope
         vacant default scopes are returned as `defaultClientScopes`
         optional client scopes that were specified on client registration are returned as `optionalClientScopes`
     -  with not registered scope
        N/A
     -  without scope
         operated as usual
         all defult client scopes are returned as `defaultClientScopes`
         all optional client scopes are returned as `optionalClientScopes`
  -  UPDATE
      out of scope
