### PR TITLE
KEYCLOAK-15208: PermissionTicketAdapter checks for the wrong type

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/authorization/jpa/store/PermissionTicketAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/authorization/jpa/store/PermissionTicketAdapter.java
@@ -130,7 +130,7 @@ public class PermissionTicketAdapter implements PermissionTicket, JpaModel<Permi
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || !(o instanceof Policy)) return false;
+        if (o == null || !(o instanceof PermissionTicket)) return false;
 
         PermissionTicket that = (PermissionTicket) o;
         return that.getId().equals(getId());


### PR DESCRIPTION
in .equals() method, it should check for PermissionTicket type rather than Policy