### PR TITLE
KEYCLOAK-15221 Add sid claim to ID Token and fix backchannel logout Content-Type

### DIFF
--- a/core/src/main/java/org/keycloak/representations/IDToken.java
+++ b/core/src/main/java/org/keycloak/representations/IDToken.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.representations;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.keycloak.TokenCategory;
@@ -52,6 +53,7 @@ public class IDToken extends JsonWebToken {
     public static final String UPDATED_AT = "updated_at";
     public static final String CLAIMS_LOCALES = "claims_locales";
     public static final String ACR = "acr";
+    public static final String SESSION_ID = "sid";
 
     // Financial API - Part 2: Read and Write API Security Profile
     // http://openid.net/specs/openid-financial-api-part-2.html#authorization-server
@@ -64,7 +66,9 @@ public class IDToken extends JsonWebToken {
 
     protected Long auth_time;
 
+    // session_state is deprecated, sid should be used instead
     @JsonProperty(SESSION_STATE)
+    @JsonAlias(SESSION_ID)
     protected String sessionState;
 
     @JsonProperty(AT_HASH)
@@ -171,6 +175,11 @@ public class IDToken extends JsonWebToken {
      */
     public void setAuthTime(int authTime) {
         this.auth_time = Long.valueOf(authTime);
+    }
+
+    @JsonProperty(SESSION_ID)
+    public String getSessionId() {
+        return sessionState;
     }
 
     public String getSessionState() {

--- a/services/src/main/java/org/keycloak/services/managers/ResourceAdminManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/ResourceAdminManager.java
@@ -214,7 +214,7 @@ public class ResourceAdminManager {
             }
             CloseableHttpClient httpClient = session.getProvider(HttpClientProvider.class).getHttpClient();
             UrlEncodedFormEntity formEntity;
-            formEntity = new UrlEncodedFormEntity(parameters, "UTF-8");
+            formEntity = new UrlEncodedFormEntity(parameters);
             post.setEntity(formEntity);
             try (CloseableHttpResponse response = httpClient.execute(post)) {
                 try {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/AccessTokenTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/AccessTokenTest.java
@@ -16,8 +16,11 @@
  */
 package org.keycloak.testsuite.oauth;
 
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.TreeNode;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.TextNode;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpPost;
@@ -110,6 +113,7 @@ import static org.keycloak.testsuite.util.OAuthClient.AUTH_SERVER_ROOT;
 import static org.keycloak.testsuite.util.ProtocolMapperUtil.createRoleNameMapper;
 import static org.keycloak.testsuite.Assert.assertExpiration;
 
+import org.keycloak.util.JsonSerialization;
 import org.openqa.selenium.By;
 
 /**
@@ -220,6 +224,13 @@ public class AccessTokenTest extends AbstractKeycloakTest {
         assertNotEquals("test-user@localhost", token.getSubject());
 
         assertEquals(sessionId, token.getSessionState());
+
+        JWSInput idToken = new JWSInput(response.getIdToken());
+        ObjectMapper mapper = JsonSerialization.mapper;
+        JsonParser parser = mapper.getFactory().createParser(idToken.readContentAsString());
+        TreeNode treeNode = mapper.readTree(parser);
+        String sid = ((TextNode) treeNode.get("sid")).asText();
+        assertEquals(sessionId, sid);
 
         assertNull(token.getNbf());
         assertEquals(0, token.getNotBefore());


### PR DESCRIPTION
Like noted in the dev mailing list by Mateusz Małek <mmalek@agh.edu.pl> there are 2 issues with the backchannel logout implementation:

* The ID Token in Keycloak doesn't contain a `sid` claim
* The Content-Type of the Back-Channel logout POST request is `application/x-www-form-urlencoded; charset=UTF-8` instead of `application/x-www-form-urlencoded`