### PR TITLE
KEYCLOAK-15226: fix decoding issue for utf-8 encoded tokens

### DIFF
--- a/adapters/oidc/js/src/main/resources/keycloak.js
+++ b/adapters/oidc/js/src/main/resources/keycloak.js
@@ -1052,10 +1052,16 @@
                     throw 'Invalid token';
             }
 
-            str = decodeURIComponent(escape(atob(str)));
+            str = b64DecodeUnicode(str);
 
             str = JSON.parse(str);
             return str;
+        }
+
+        function b64DecodeUnicode(str) {
+            return decodeURIComponent(atob(str).split('').map(function(c) {
+                return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);
+            }).join(''));
         }
 
         function createUUID() {


### PR DESCRIPTION
<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
The goal of this PR is to fix the previous one:
https://github.com/keycloak/keycloak/pull/307
because the old way to decode utf-8 has been deprecated.

More information can be found here:
https://stackoverflow.com/questions/30106476/using-javascripts-atob-to-decode-base64-doesnt-properly-decode-utf-8-strings

Basically, the fix consists in replacing:
`str = decodeURIComponent(escape(atob(str)));`
with
```
function b64DecodeUnicode(str) {
 return decodeURIComponent(Array.prototype.map.call(atob(str), function(c) {
 return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)
 }).join(''))
}
str = b64DecodeUnicode(str);
```