### PR TITLE
KEYCLOAK-15236 FAPI-RW : Error Response on OAuth 2.0 Mutual TLS Client Authentication Error (400 error=invalid_client)

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/AuthenticationProcessor.java
+++ b/services/src/main/java/org/keycloak/authentication/AuthenticationProcessor.java
@@ -806,7 +806,7 @@ public class AuthenticationProcessor {
                 return ClientAuthUtil.errorResponse(Response.Status.BAD_REQUEST.getStatusCode(), "unauthorized_client", e.getMessage());
             } else {
                 event.error(Errors.INVALID_CLIENT_CREDENTIALS);
-                return ClientAuthUtil.errorResponse(Response.Status.BAD_REQUEST.getStatusCode(), "unauthorized_client", e.getError().toString() + ": " + e.getMessage());
+                return ClientAuthUtil.errorResponse(Response.Status.BAD_REQUEST.getStatusCode(), "invalid_client", e.getError().toString() + ": " + e.getMessage());
             }
         } else {
             ServicesLogger.LOGGER.errorAuthenticatingClient(failure);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/CustomFlowTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/CustomFlowTest.java
@@ -338,7 +338,7 @@ public class CustomFlowTest extends AbstractFlowTest {
 
         OAuthClient.AccessTokenResponse response = oauth.doGrantAccessTokenRequest("password", "test-user", "password");
         assertEquals(400, response.getStatusCode());
-        assertEquals("unauthorized_client", response.getError());
+        assertEquals("invalid_client", response.getError());
 
         events.expectLogin()
                 .client((String) null)

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ClientAuthSignedJWTTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ClientAuthSignedJWTTest.java
@@ -643,7 +643,7 @@ public class ClientAuthSignedJWTTest extends AbstractKeycloakTest {
         CloseableHttpResponse resp = sendRequest(oauth.getServiceAccountUrl(), parameters);
         OAuthClient.AccessTokenResponse response = new OAuthClient.AccessTokenResponse(resp);
 
-        assertError(response, null, "unauthorized_client", Errors.INVALID_CLIENT_CREDENTIALS);
+        assertError(response, null, "invalid_client", Errors.INVALID_CLIENT_CREDENTIALS);
     }
 
     @Test
@@ -655,7 +655,7 @@ public class ClientAuthSignedJWTTest extends AbstractKeycloakTest {
         CloseableHttpResponse resp = sendRequest(oauth.getServiceAccountUrl(), parameters);
         OAuthClient.AccessTokenResponse response = new OAuthClient.AccessTokenResponse(resp);
 
-        assertError(response, null, "unauthorized_client", Errors.INVALID_CLIENT_CREDENTIALS);
+        assertError(response, null, "invalid_client", Errors.INVALID_CLIENT_CREDENTIALS);
     }
 
     @Test
@@ -667,7 +667,7 @@ public class ClientAuthSignedJWTTest extends AbstractKeycloakTest {
         CloseableHttpResponse resp = sendRequest(oauth.getServiceAccountUrl(), parameters);
         OAuthClient.AccessTokenResponse response = new OAuthClient.AccessTokenResponse(resp);
 
-        assertError(response, null, "unauthorized_client", Errors.INVALID_CLIENT_CREDENTIALS);
+        assertError(response, null, "invalid_client", Errors.INVALID_CLIENT_CREDENTIALS);
     }
 
     @Test
@@ -682,7 +682,7 @@ public class ClientAuthSignedJWTTest extends AbstractKeycloakTest {
         CloseableHttpResponse resp = sendRequest(oauth.getServiceAccountUrl(), parameters);
         OAuthClient.AccessTokenResponse response = new OAuthClient.AccessTokenResponse(resp);
 
-        assertError(response, null, "unauthorized_client", Errors.INVALID_CLIENT_CREDENTIALS);
+        assertError(response, null, "invalid_client", Errors.INVALID_CLIENT_CREDENTIALS);
     }
 
     @Test
@@ -697,7 +697,7 @@ public class ClientAuthSignedJWTTest extends AbstractKeycloakTest {
         CloseableHttpResponse resp = sendRequest(oauth.getServiceAccountUrl(), parameters);
         OAuthClient.AccessTokenResponse response = new OAuthClient.AccessTokenResponse(resp);
 
-        assertError(response, "unknown-client", "unauthorized_client", Errors.INVALID_CLIENT_CREDENTIALS);
+        assertError(response, "unknown-client", "invalid_client", Errors.INVALID_CLIENT_CREDENTIALS);
     }
 
     @Test
@@ -839,7 +839,7 @@ public class ClientAuthSignedJWTTest extends AbstractKeycloakTest {
     @Test
     public void testMissingSubjectClaim() throws Exception {
         OAuthClient.AccessTokenResponse response = testMissingClaim("subject");
-        assertError(response, null, "unauthorized_client", Errors.INVALID_CLIENT_CREDENTIALS);
+        assertError(response, null, "invalid_client", Errors.INVALID_CLIENT_CREDENTIALS);
     }
 
     @Test


### PR DESCRIPTION
This PR is for https://issues.redhat.com/browse/KEYCLOAK-15236

It is needed to pass FAPI-RW conformance test (FAPI-RW OP w/MTLS).