### PR TITLE
KEYCLOAK-15256 GroupMembershipMapper support nested json fields

### DIFF
--- a/services/pom.xml
+++ b/services/pom.xml
@@ -32,6 +32,7 @@
 
     <properties>
         <version.swagger.doclet>1.1.2</version.swagger.doclet>
+        <mockito.version>1.9.5</mockito.version>
     </properties>
 
     <dependencies>
@@ -164,6 +165,12 @@
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/GroupMembershipMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/GroupMembershipMapper.java
@@ -103,9 +103,8 @@ public class GroupMembershipMapper extends AbstractOIDCProtocolMapper implements
                 membership.add(group.getName());
             }
         }
-        String protocolClaim = mappingModel.getConfig().get(OIDCAttributeMapperHelper.TOKEN_CLAIM_NAME);
 
-        token.getOtherClaims().put(protocolClaim, membership);
+        OIDCAttributeMapperHelper.mapClaim(token, mappingModel, membership);
     }
 
     public static ProtocolMapperModel create(String name,

--- a/services/src/test/java/org/keycloak/protocol/oidc/mappers/GroupMembershipMapperTest.java
+++ b/services/src/test/java/org/keycloak/protocol/oidc/mappers/GroupMembershipMapperTest.java
@@ -1,0 +1,55 @@
+package org.keycloak.protocol.oidc.mappers;
+
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.keycloak.models.*;
+import org.keycloak.protocol.ProtocolMapperUtils;
+import org.keycloak.representations.IDToken;
+import org.mockito.Mockito;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+
+public class GroupMembershipMapperTest {
+    @Test
+    public void shouldGenerateNestedJsonStructure() {
+
+        IDToken token = new IDToken();
+        ProtocolMapperModel protocolMapperModel = newProtocolMapper(true);
+        UserSessionModel userSessionModel = newUserSessionWithGroups("group1", "group2");
+
+        GroupMembershipMapper groupMembershipMapper = new GroupMembershipMapper();
+        groupMembershipMapper.setClaim(token, protocolMapperModel, userSessionModel);
+
+        Map<String, Object> otherClaims = token.getOtherClaims();
+        assertThat(otherClaims, Matchers.hasKey("a"));
+        assertThat((Map<String, Object>) otherClaims.get("a"), Matchers.hasKey("b"));
+        assertThat(((Map<?, List<?>>) otherClaims.get("a")).get("b"), Matchers.contains("group1", "group2"));
+    }
+
+    private ProtocolMapperModel newProtocolMapper(boolean multivalued) {
+        ProtocolMapperModel protocolMapperModel = GroupMembershipMapper.create("name", "a.b", false, "", true, false);
+        if (multivalued)
+            protocolMapperModel.getConfig().put(ProtocolMapperUtils.MULTIVALUED, "true");
+        return protocolMapperModel;
+    }
+
+    private UserSessionModel newUserSessionWithGroups(String ...groupNames) {
+        UserSessionModel userSessionModel = Mockito.mock(UserSessionModel.class, RETURNS_DEEP_STUBS);
+        Set<GroupModel> groups = groups(groupNames);
+        Mockito.when(userSessionModel.getUser().getGroups()).thenReturn(groups);
+        return userSessionModel;
+    }
+
+    private Set<GroupModel> groups(String ...groupNames) {
+        return Arrays.stream(groupNames).map(name -> {
+            GroupModel groupModel = Mockito.mock(GroupModel.class);
+            Mockito.when(groupModel.getName()).thenReturn(name);
+
+            return groupModel;
+        }).collect(Collectors.toSet());
+    }
+}


### PR DESCRIPTION
Problem

TokenClaimName=https://hasura\.io/jwt/claims.x-hasura-allowed-ids
Results in generating "https://hasura\\.io/jwt/claims.x-hasura-allowed-ids": [....]

Rather then:
"https://hasura.io/jwt/claims": {"x-hasura-allowed-ids": [...]}

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
