### PR TITLE
KEYCLOAK-14967 Closing streams obtained from JPA layer

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
@@ -51,7 +51,9 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.keycloak.models.ModelException;
+
 import static org.keycloak.common.util.StackUtil.getShortStackTrace;
+import static org.keycloak.utils.StreamsUtil.closing;
 
 
 /**
@@ -260,7 +262,7 @@ public class JpaRealmProvider implements RealmProvider, ClientProvider, GroupPro
         query.setParameter("realm", realm.getId());
         Stream<String> roles = query.getResultStream();
 
-        return roles.map(realm::getRoleById);
+        return closing(roles.map(realm::getRoleById));
     }
 
     @Override
@@ -297,7 +299,7 @@ public class JpaRealmProvider implements RealmProvider, ClientProvider, GroupPro
 
         Stream<RoleEntity> results = query.getResultStream();
 
-        return results.map(role -> new RoleAdapter(session, realm, em, role));
+        return closing(results.map(role -> new RoleAdapter(session, realm, em, role)));
     }
     
     @Override
@@ -325,7 +327,7 @@ public class JpaRealmProvider implements RealmProvider, ClientProvider, GroupPro
         
         Stream<RoleEntity> results = query.getResultStream();
         
-        return results.map(role -> new RoleAdapter(session, realm, em, role));
+        return closing(results.map(role -> new RoleAdapter(session, realm, em, role)));
     }
 
     @Override
@@ -628,7 +630,7 @@ public class JpaRealmProvider implements RealmProvider, ClientProvider, GroupPro
         query.setParameter("realm", realm.getId());
         Stream<String> clients = query.getResultStream();
 
-        return clients.map(c -> session.clients().getClientById(realm, c)).filter(Objects::nonNull);
+        return closing(clients.map(c -> session.clients().getClientById(realm, c)).filter(Objects::nonNull));
     }
 
     @Override
@@ -637,7 +639,7 @@ public class JpaRealmProvider implements RealmProvider, ClientProvider, GroupPro
         query.setParameter("realm", realm.getId());
         Stream<String> clientStream = query.getResultStream();
 
-        return clientStream.map(c -> session.clients().getClientById(realm, c)).filter(Objects::nonNull);
+        return closing(clientStream.map(c -> session.clients().getClientById(realm, c)).filter(Objects::nonNull));
     }
 
     @Override
@@ -677,7 +679,7 @@ public class JpaRealmProvider implements RealmProvider, ClientProvider, GroupPro
         query.setParameter("clientId", clientId);
         query.setParameter("realm", realm.getId());
         Stream<String> results = query.getResultStream();
-        return results.map(c -> session.clients().getClientById(realm, c));
+        return closing(results.map(c -> session.clients().getClientById(realm, c)));
     }
 
     @Override

--- a/server-spi-private/src/main/java/org/keycloak/utils/StreamsUtil.java
+++ b/server-spi-private/src/main/java/org/keycloak/utils/StreamsUtil.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.utils;
+
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+public class StreamsUtil {
+    public static <T> Stream<T> closing(Stream<T> stream) {
+        return Stream.of(stream).flatMap(Function.identity());
+    }
+}


### PR DESCRIPTION
Automatically closing the streams obtained from Hibernate to release any DB resources right after a stream is processed. 
