### PR TITLE
KEYCLOAK-15252 Allow themes to get info about hidden IdPs

### DIFF
--- a/services/src/test/java/org/keycloak/test/login/freemarker/model/IdentityProviderBeanTest.java
+++ b/services/src/test/java/org/keycloak/test/login/freemarker/model/IdentityProviderBeanTest.java
@@ -36,32 +36,32 @@ public class IdentityProviderBeanTest {
     @Test
     public void testIdentityProviderComparator() {
 
-        IdentityProvider o1 = new IdentityProvider("alias1", "displayName1", "id1", "ur1", null);
-        IdentityProvider o2 = new IdentityProvider("alias2", "displayName2", "id2", "ur2", null);
+        IdentityProvider o1 = new IdentityProvider("alias1", "displayName1", "id1", "ur1", null, false);
+        IdentityProvider o2 = new IdentityProvider("alias2", "displayName2", "id2", "ur2", null, false);
 
         // guiOrder not defined at any object
         Assert.assertEquals(0, IdentityProviderBean.IDP_COMPARATOR_INSTANCE.compare(o1, o2));
         Assert.assertEquals(0, IdentityProviderBean.IDP_COMPARATOR_INSTANCE.compare(o2, o1));
 
         // guiOrder is not a number so it is same as not defined
-        o1 = new IdentityProvider("alias1", "displayName1", "id1", "ur1", "not a number");
+        o1 = new IdentityProvider("alias1", "displayName1", "id1", "ur1", "not a number", false);
         Assert.assertEquals(0, IdentityProviderBean.IDP_COMPARATOR_INSTANCE.compare(o1, o2));
         Assert.assertEquals(0, IdentityProviderBean.IDP_COMPARATOR_INSTANCE.compare(o2, o1));
 
         // guiOrder is defined for one only to it is always first
-        o1 = new IdentityProvider("alias1", "displayName1", "id1", "ur1", "0");
+        o1 = new IdentityProvider("alias1", "displayName1", "id1", "ur1", "0", false);
         Assert.assertEquals(-10000, IdentityProviderBean.IDP_COMPARATOR_INSTANCE.compare(o1, o2));
         Assert.assertEquals(10000, IdentityProviderBean.IDP_COMPARATOR_INSTANCE.compare(o2, o1));
 
         // guiOrder is defined for both but is same
-        o1 = new IdentityProvider("alias1", "displayName1", "id1", "ur1", "0");
-        o2 = new IdentityProvider("alias2", "displayName2", "id2", "ur2", "0");
+        o1 = new IdentityProvider("alias1", "displayName1", "id1", "ur1", "0", false);
+        o2 = new IdentityProvider("alias2", "displayName2", "id2", "ur2", "0", false);
         Assert.assertEquals(0, IdentityProviderBean.IDP_COMPARATOR_INSTANCE.compare(o1, o2));
         Assert.assertEquals(0, IdentityProviderBean.IDP_COMPARATOR_INSTANCE.compare(o2, o1));
 
         // guiOrder is reflected
-        o1 = new IdentityProvider("alias1", "displayName1", "id1", "ur1", "0");
-        o2 = new IdentityProvider("alias2", "displayName2", "id2", "ur2", "1");
+        o1 = new IdentityProvider("alias1", "displayName1", "id1", "ur1", "0", false);
+        o2 = new IdentityProvider("alias2", "displayName2", "id2", "ur2", "1", false);
         Assert.assertEquals(-1, IdentityProviderBean.IDP_COMPARATOR_INSTANCE.compare(o1, o2));
         Assert.assertEquals(1, IdentityProviderBean.IDP_COMPARATOR_INSTANCE.compare(o2, o1));
 
@@ -70,8 +70,8 @@ public class IdentityProviderBeanTest {
 
     @Test
     public void testIdentityProviderComparatorForEqualObjects() {
-        IdentityProvider o1 = new IdentityProvider("alias1", "displayName1", "id1", "ur1", null);
-        IdentityProvider o2 = new IdentityProvider("alias2", "displayName2", "id2", "ur2", null);
+        IdentityProvider o1 = new IdentityProvider("alias1", "displayName1", "id1", "ur1", null, false);
+        IdentityProvider o2 = new IdentityProvider("alias2", "displayName2", "id2", "ur2", null, false);
 
         // Gui order is not specified on the objects, but those are 2 different objects. Assert we have 2 items in the list and first is lower
         List<IdentityProvider> idp2 = new ArrayList<>();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/login/IdentityProviderBeanTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/login/IdentityProviderBeanTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite.login;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.keycloak.forms.login.freemarker.model.IdentityProviderBean;
+import org.keycloak.forms.login.freemarker.model.IdentityProviderBean.IdentityProvider;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.IdentityProviderModel;
+import org.keycloak.models.RealmModel;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.testsuite.AbstractTestRealmKeycloakTest;
+import org.keycloak.testsuite.arquillian.annotation.ModelTest;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Unit test for {@link org.keycloak.forms.login.freemarker.model.IdentityProviderBean}
+ */
+public class IdentityProviderBeanTest extends AbstractTestRealmKeycloakTest {
+    @Override
+    public void configureTestRealm(RealmRepresentation testRealm) {
+
+    }
+
+    @Test
+    @ModelTest
+    public void testIdentityProviderAllVisible(KeycloakSession keycloakSession) throws URISyntaxException {
+        RealmModel realm = keycloakSession.realms().getRealm("test");
+
+        IdentityProviderModel o1 = buildIdpModel("alias1", "displayName1", "id1", "ur1", null, false);
+        IdentityProviderModel o2 = buildIdpModel("alias2", "displayName2", "id2", "ur2", null, false);
+
+        List<IdentityProviderModel> lstIdp = new ArrayList<>();
+        lstIdp.add(o1);
+        lstIdp.add(o2);
+
+        IdentityProviderBean bean = new IdentityProviderBean(realm, keycloakSession, lstIdp, new URI("http://my.test.uri/"));
+
+        Assert.assertEquals(2, bean.getProviders().size());
+        Assert.assertEquals(2, bean.getVisibleProvidersCount());
+        Assert.assertEquals(true, bean.isDisplayInfo());
+        Assert.assertEquals(true, bean.isDisplaySocial());
+    }
+
+    @Test
+    @ModelTest
+    public void testIdentityProviderNoneVisible(KeycloakSession keycloakSession) throws URISyntaxException {
+        RealmModel realm = keycloakSession.realms().getRealmByName("test");
+
+        IdentityProviderModel o1 = buildIdpModel("alias1", "displayName1", "id1", "ur1", null, true);
+        IdentityProviderModel o2 = buildIdpModel("alias2", "displayName2", "id2", "ur2", null, true);
+
+        List<IdentityProviderModel> lstIdp = new ArrayList<>();
+        lstIdp.add(o1);
+        lstIdp.add(o2);
+
+        IdentityProviderBean bean = new IdentityProviderBean(realm, keycloakSession, lstIdp, new URI("http://my.test.uri/"));
+
+        Assert.assertEquals(2, bean.getProviders().size());
+        Assert.assertEquals(0, bean.getVisibleProvidersCount());
+        Assert.assertEquals(true, bean.isDisplayInfo());
+        Assert.assertEquals(false, bean.isDisplaySocial());
+    }
+
+    @Test
+    @ModelTest
+    public void testIdentityProviderOnlyOneVisible(KeycloakSession keycloakSession) throws URISyntaxException {
+        RealmModel realm = keycloakSession.realms().getRealmByName("test");
+
+        IdentityProviderModel o1 = buildIdpModel("alias1", "displayName1", "id1", "ur1", null, false);
+        IdentityProviderModel o2 = buildIdpModel("alias2", "displayName2", "id2", "ur2", null, true);
+
+        List<IdentityProviderModel> lstIdp = new ArrayList<>();
+        lstIdp.add(o1);
+        lstIdp.add(o2);
+
+        IdentityProviderBean bean = new IdentityProviderBean(realm, keycloakSession, lstIdp, new URI("http://my.test.uri/"));
+
+        Assert.assertEquals(2, bean.getProviders().size());
+        Assert.assertEquals(1, bean.getVisibleProvidersCount());
+        Assert.assertEquals(true, bean.isDisplayInfo());
+        Assert.assertEquals(true, bean.isDisplaySocial());
+    }
+
+    private static IdentityProviderModel buildIdpModel(String alias, String displayName, String providerId, String loginUrl, Integer guiOrder, boolean hideOnLoginPage)
+    {
+        IdentityProviderModel output = new IdentityProviderModel();
+        output.setAlias(alias);
+        output.setDisplayName(displayName);
+        output.setProviderId(providerId);
+        output.setEnabled(true);
+        output.setLinkOnly(false);
+        output.getConfig().put("singleSignOnServiceUrl", loginUrl);
+        output.getConfig().put("guiOrder", String.valueOf(guiOrder));
+        output.getConfig().put("hideOnLoginPage", String.valueOf(hideOnLoginPage));
+
+        return output;
+    }
+}

--- a/themes/src/main/resources/theme/base/login/login-username.ftl
+++ b/themes/src/main/resources/theme/base/login/login-username.ftl
@@ -1,10 +1,10 @@
 <#import "template.ftl" as layout>
-<@layout.registrationLayout displayInfo=social.displayInfo displayWide=(realm.password && social.providers??); section>
+<@layout.registrationLayout displayInfo=social.displayInfo displayWide=(realm.password && social.displaySocial); section>
     <#if section = "header">
         ${msg("doLogIn")}
     <#elseif section = "form">
-    <div id="kc-form" <#if realm.password && social.providers??>class="${properties.kcContentWrapperClass!}"</#if>>
-      <div id="kc-form-wrapper" <#if realm.password && social.providers??>class="${properties.kcFormSocialAccountContentClass!} ${properties.kcFormSocialAccountClass!}"</#if>>
+    <div id="kc-form" <#if realm.password && social.displaySocial>class="${properties.kcContentWrapperClass!}"</#if>>
+      <div id="kc-form-wrapper" <#if realm.password && social.displaySocial>class="${properties.kcFormSocialAccountContentClass!} ${properties.kcFormSocialAccountClass!}"</#if>>
         <#if realm.password>
             <form id="kc-form-login" onsubmit="login.disabled = true; return true;" action="${url.loginAction}" method="post">
                 <div class="${properties.kcFormGroupClass!}">
@@ -39,11 +39,13 @@
             </form>
         </#if>
         </div>
-        <#if realm.password && social.providers??>
+        <#if realm.password && social.displaySocial>
             <div id="kc-social-providers" class="${properties.kcFormSocialAccountContentClass!} ${properties.kcFormSocialAccountClass!}">
-                <ul class="${properties.kcFormSocialAccountListClass!} <#if social.providers?size gt 4>${properties.kcFormSocialAccountDoubleListClass!}</#if>">
+                <ul class="${properties.kcFormSocialAccountListClass!} <#if social.visibleProvidersCount gt 4>${properties.kcFormSocialAccountDoubleListClass!}</#if>">
                     <#list social.providers as p>
-                        <li class="${properties.kcFormSocialAccountListLinkClass!}"><a href="${p.loginUrl}" id="zocial-${p.alias}" class="zocial ${p.providerId}"> <span>${p.displayName}</span></a></li>
+                        <#if !p.hideOnLoginPage>
+                            <li class="${properties.kcFormSocialAccountListLinkClass!}"><a href="${p.loginUrl}" id="zocial-${p.alias}" class="zocial ${p.providerId}"> <span>${p.displayName}</span></a></li>
+                        </#if>
                     </#list>
                 </ul>
             </div>

--- a/themes/src/main/resources/theme/base/login/login.ftl
+++ b/themes/src/main/resources/theme/base/login/login.ftl
@@ -1,10 +1,10 @@
 <#import "template.ftl" as layout>
-<@layout.registrationLayout displayInfo=social.displayInfo displayWide=(realm.password && social.providers??); section>
+<@layout.registrationLayout displayInfo=social.displayInfo displayWide=(realm.password && social.displaySocial); section>
     <#if section = "header">
         ${msg("doLogIn")}
     <#elseif section = "form">
-    <div id="kc-form" <#if realm.password && social.providers??>class="${properties.kcContentWrapperClass!}"</#if>>
-      <div id="kc-form-wrapper" <#if realm.password && social.providers??>class="${properties.kcFormSocialAccountContentClass!} ${properties.kcFormSocialAccountClass!}"</#if>>
+    <div id="kc-form" <#if realm.password && social.displaySocial>class="${properties.kcContentWrapperClass!}"</#if>>
+      <div id="kc-form-wrapper" <#if realm.password && social.displaySocial>class="${properties.kcFormSocialAccountContentClass!} ${properties.kcFormSocialAccountClass!}"</#if>>
         <#if realm.password>
             <form id="kc-form-login" onsubmit="login.disabled = true; return true;" action="${url.loginAction}" method="post">
                 <div class="${properties.kcFormGroupClass!}">
@@ -51,11 +51,13 @@
             </form>
         </#if>
         </div>
-        <#if realm.password && social.providers??>
+        <#if realm.password && social.displaySocial>
             <div id="kc-social-providers" class="${properties.kcFormSocialAccountContentClass!} ${properties.kcFormSocialAccountClass!}">
-                <ul class="${properties.kcFormSocialAccountListClass!} <#if social.providers?size gt 4>${properties.kcFormSocialAccountDoubleListClass!}</#if>">
+                <ul class="${properties.kcFormSocialAccountListClass!} <#if social.visibleProvidersCount gt 4>${properties.kcFormSocialAccountDoubleListClass!}</#if>">
                     <#list social.providers as p>
-                        <li class="${properties.kcFormSocialAccountListLinkClass!}"><a href="${p.loginUrl}" id="zocial-${p.alias}" class="zocial ${p.providerId}"> <span>${p.displayName}</span></a></li>
+                        <#if !p.hideOnLoginPage>
+                            <li class="${properties.kcFormSocialAccountListLinkClass!}"><a href="${p.loginUrl}" id="zocial-${p.alias}" class="zocial ${p.providerId}"> <span>${p.displayName}</span></a></li>
+                        </#if>
                     </#list>
                 </ul>
             </div>


### PR DESCRIPTION
Currently IdPs that have the `Hide on Login page` flag enabled are not exposed in the `social.providers` Freemarker data model. 
This makes impossible any kind of theme-based rendering or other processing (like showing them as grayed out, or using their `loginUrl` in javascript, or placing their UI in other pages than the login one, etc.).
This very simple pull request lets the `social.providers` item contain both hidden and visible IdPs and makes the theme take care of the hiding.