### PR TITLE
KEYCLOAK-15287 Ability to add custom claims to the AccessTokenResponse

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
@@ -55,6 +55,7 @@ import org.keycloak.models.utils.RoleUtils;
 import org.keycloak.protocol.ProtocolMapper;
 import org.keycloak.protocol.ProtocolMapperUtils;
 import org.keycloak.protocol.oidc.mappers.OIDCAccessTokenMapper;
+import org.keycloak.protocol.oidc.mappers.OIDCAccessTokenResponseMapper;
 import org.keycloak.protocol.oidc.mappers.OIDCIDTokenMapper;
 import org.keycloak.protocol.oidc.mappers.UserInfoTokenMapper;
 import org.keycloak.protocol.oidc.utils.OIDCResponseType;
@@ -604,6 +605,20 @@ public class TokenManager {
         return token;
     }
 
+    public AccessTokenResponse transformAccessTokenResponse(KeycloakSession session, AccessTokenResponse accessTokenResponse,
+            UserSessionModel userSession, ClientSessionContext clientSessionCtx) {
+
+        for (Map.Entry<ProtocolMapperModel, ProtocolMapper> entry : ProtocolMapperUtils.getSortedProtocolMappers(session, clientSessionCtx)) {
+            ProtocolMapperModel mapping = entry.getKey();
+            ProtocolMapper mapper = entry.getValue();
+            if (mapper instanceof OIDCAccessTokenResponseMapper) {
+                accessTokenResponse = ((OIDCAccessTokenResponseMapper) mapper).transformAccessTokenResponse(accessTokenResponse, mapping, session, userSession, clientSessionCtx);
+            }
+        }
+
+        return accessTokenResponse;
+    }
+
     public AccessToken transformUserInfoAccessToken(KeycloakSession session, AccessToken token,
                                             UserSessionModel userSession, ClientSessionContext clientSessionCtx) {
 
@@ -998,6 +1013,8 @@ public class TokenManager {
             int userNotBefore = session.users().getNotBeforeOfUser(realm, userSession.getUser());
             if (userNotBefore > notBefore) notBefore = userNotBefore;
             res.setNotBeforePolicy(notBefore);
+
+            transformAccessTokenResponse(session, res, userSession, clientSessionCtx);
 
             // OIDC Financial API Read Only Profile : scope MUST be returned in the response from Token Endpoint
             String responseScope = clientSessionCtx.getScopeString();

--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/AbstractOIDCProtocolMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/AbstractOIDCProtocolMapper.java
@@ -26,6 +26,7 @@ import org.keycloak.models.UserSessionModel;
 import org.keycloak.protocol.ProtocolMapper;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.representations.AccessToken;
+import org.keycloak.representations.AccessTokenResponse;
 import org.keycloak.representations.IDToken;
 
 /**
@@ -93,6 +94,18 @@ public abstract class AbstractOIDCProtocolMapper implements ProtocolMapper {
         return token;
     }
 
+    public AccessTokenResponse transformAccessTokenResponse(AccessTokenResponse accessTokenResponse, ProtocolMapperModel mappingModel,
+                                                            KeycloakSession session, UserSessionModel userSession,
+                                                            ClientSessionContext clientSessionCtx) {
+
+        if (!OIDCAttributeMapperHelper.includeInAccessTokenResponse(mappingModel)) {
+            return accessTokenResponse;
+        }
+
+        setClaim(accessTokenResponse, mappingModel, userSession, session, clientSessionCtx);
+        return accessTokenResponse;
+    }
+
     /**
      * Intended to be overridden in {@link ProtocolMapper} implementations to add claims to an token.
      * @param token
@@ -117,5 +130,18 @@ public abstract class AbstractOIDCProtocolMapper implements ProtocolMapper {
                             ClientSessionContext clientSessionCtx) {
         // we delegate to the old #setClaim(...) method for backwards compatibility
         setClaim(token, mappingModel, userSession);
+    }
+
+    /**
+     * Intended to be overridden in {@link ProtocolMapper} implementations to add claims to an token.
+     * @param accessTokenResponse
+     * @param mappingModel
+     * @param userSession
+     * @param keycloakSession
+     * @param clientSessionCtx
+     */
+    protected void setClaim(AccessTokenResponse accessTokenResponse, ProtocolMapperModel mappingModel, UserSessionModel userSession, KeycloakSession keycloakSession,
+                            ClientSessionContext clientSessionCtx) {
+
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/HardcodedClaim.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/HardcodedClaim.java
@@ -17,10 +17,13 @@
 
 package org.keycloak.protocol.oidc.mappers;
 
+import org.keycloak.models.ClientSessionContext;
+import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.ProtocolMapperModel;
 import org.keycloak.models.UserSessionModel;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.representations.AccessTokenResponse;
 import org.keycloak.representations.IDToken;
 
 import java.util.ArrayList;
@@ -34,7 +37,8 @@ import java.util.Map;
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
  */
-public class HardcodedClaim extends AbstractOIDCProtocolMapper implements OIDCAccessTokenMapper, OIDCIDTokenMapper, UserInfoTokenMapper {
+public class HardcodedClaim extends AbstractOIDCProtocolMapper implements OIDCAccessTokenMapper, OIDCIDTokenMapper, UserInfoTokenMapper,
+        OIDCAccessTokenResponseMapper {
 
     private static final List<ProviderConfigProperty> configProperties = new ArrayList<ProviderConfigProperty>();
 
@@ -86,6 +90,15 @@ public class HardcodedClaim extends AbstractOIDCProtocolMapper implements OIDCAc
         String attributeValue = mappingModel.getConfig().get(CLAIM_VALUE);
         if (attributeValue == null) return;
         OIDCAttributeMapperHelper.mapClaim(token, mappingModel, attributeValue);
+    }
+
+    @Override
+    protected void setClaim(AccessTokenResponse accessTokenResponse, ProtocolMapperModel mappingModel, UserSessionModel userSession,
+            KeycloakSession keycloakSession, ClientSessionContext clientSessionCtx) {
+
+        String attributeValue = mappingModel.getConfig().get(CLAIM_VALUE);
+        if (attributeValue == null) return;
+        OIDCAttributeMapperHelper.mapClaim(accessTokenResponse, mappingModel, attributeValue);
     }
 
     public static ProtocolMapperModel create(String name,

--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/OIDCAccessTokenResponseMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/OIDCAccessTokenResponseMapper.java
@@ -1,0 +1,18 @@
+package org.keycloak.protocol.oidc.mappers;
+
+import org.keycloak.models.ClientSessionContext;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.ProtocolMapperModel;
+import org.keycloak.models.UserSessionModel;
+import org.keycloak.representations.AccessTokenResponse;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+public interface OIDCAccessTokenResponseMapper {
+
+    AccessTokenResponse transformAccessTokenResponse(AccessTokenResponse accessTokenResponse, ProtocolMapperModel mappingModel,
+                                                     KeycloakSession session, UserSessionModel userSession,
+                                                     ClientSessionContext clientSessionCtx);
+}

--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/OIDCAttributeMapperHelper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/OIDCAttributeMapperHelper.java
@@ -23,6 +23,7 @@ import org.keycloak.protocol.ProtocolMapper;
 import org.keycloak.protocol.ProtocolMapperUtils;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.representations.AccessTokenResponse;
 import org.keycloak.representations.IDToken;
 import org.keycloak.services.ServicesLogger;
 import org.keycloak.util.JsonSerialization;
@@ -50,6 +51,9 @@ public class OIDCAttributeMapperHelper {
     public static final String INCLUDE_IN_ID_TOKEN = "id.token.claim";
     public static final String INCLUDE_IN_ID_TOKEN_LABEL = "includeInIdToken.label";
     public static final String INCLUDE_IN_ID_TOKEN_HELP_TEXT = "includeInIdToken.tooltip";
+    public static final String INCLUDE_IN_ACCESS_TOKEN_RESPONSE = "access.tokenResponse.claim";
+    public static final String INCLUDE_IN_ACCESS_TOKEN_RESPONSE_LABEL = "includeInAccessTokenResponse.label";
+    public static final String INCLUDE_IN_ACCESS_TOKEN_RESPONSE_HELP_TEXT = "includeInAccessTokenResponse.tooltip";
 
     public static final String INCLUDE_IN_USERINFO = "userinfo.token.claim";
     public static final String INCLUDE_IN_USERINFO_LABEL = "includeInUserInfo.label";
@@ -188,6 +192,14 @@ public class OIDCAttributeMapperHelper {
     }
 
     public static void mapClaim(IDToken token, ProtocolMapperModel mappingModel, Object attributeValue) {
+        mapClaim(mappingModel, attributeValue, token.getOtherClaims());
+    }
+
+    public static void mapClaim(AccessTokenResponse token, ProtocolMapperModel mappingModel, Object attributeValue) {
+        mapClaim(mappingModel, attributeValue, token.getOtherClaims());
+    }
+
+    private static void mapClaim(ProtocolMapperModel mappingModel, Object attributeValue, Map<String, Object> jsonObject) {
         attributeValue = mapAttributeValue(mappingModel, attributeValue);
         if (attributeValue == null) return;
 
@@ -198,16 +210,16 @@ public class OIDCAttributeMapperHelper {
         List<String> split = splitClaimPath(protocolClaim);
         final int length = split.size();
         int i = 0;
-        Map<String, Object> jsonObject = token.getOtherClaims();
         for (String component : split) {
             i++;
             if (i == length) {
                 jsonObject.put(component, attributeValue);
             } else {
-                Map<String, Object> nested = (Map<String, Object>)jsonObject.get(component);
+                @SuppressWarnings("unchecked")
+                Map<String, Object> nested = (Map<String, Object>) jsonObject.get(component);
 
                 if (nested == null) {
-                    nested = new HashMap<String, Object>();
+                    nested = new HashMap<>();
                     jsonObject.put(component, nested);
                 }
 
@@ -250,6 +262,10 @@ public class OIDCAttributeMapperHelper {
 
     public static boolean includeInAccessToken(ProtocolMapperModel mappingModel) {
         return "true".equals(mappingModel.getConfig().get(INCLUDE_IN_ACCESS_TOKEN));
+    }
+
+    public static boolean includeInAccessTokenResponse(ProtocolMapperModel mappingModel) {
+        return "true".equals(mappingModel.getConfig().get(INCLUDE_IN_ACCESS_TOKEN_RESPONSE));
     }
 
     public static boolean isMultivalued(ProtocolMapperModel mappingModel) {
@@ -327,6 +343,16 @@ public class OIDCAttributeMapperHelper {
             property.setType(ProviderConfigProperty.BOOLEAN_TYPE);
             property.setDefaultValue("true");
             property.setHelpText(INCLUDE_IN_USERINFO_HELP_TEXT);
+            configProperties.add(property);
+        }
+
+        if (OIDCAccessTokenResponseMapper.class.isAssignableFrom(protocolMapperClass)) {
+            ProviderConfigProperty property = new ProviderConfigProperty();
+            property.setName(INCLUDE_IN_ACCESS_TOKEN_RESPONSE);
+            property.setLabel(INCLUDE_IN_ACCESS_TOKEN_RESPONSE_LABEL);
+            property.setType(ProviderConfigProperty.BOOLEAN_TYPE);
+            property.setDefaultValue("false");
+            property.setHelpText(INCLUDE_IN_ACCESS_TOKEN_RESPONSE_HELP_TEXT);
             configProperties.add(property);
         }
     }

--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/UserSessionNoteMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/UserSessionNoteMapper.java
@@ -17,12 +17,15 @@
 
 package org.keycloak.protocol.oidc.mappers;
 
+import org.keycloak.models.ClientSessionContext;
+import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.ProtocolMapperModel;
 import org.keycloak.models.UserSessionModel;
 import org.keycloak.models.UserSessionNoteDescriptor;
 import org.keycloak.protocol.ProtocolMapperUtils;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.representations.AccessTokenResponse;
 import org.keycloak.representations.IDToken;
 
 import java.util.ArrayList;
@@ -35,7 +38,7 @@ import java.util.Map;
  *
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
  */
-public class UserSessionNoteMapper extends AbstractOIDCProtocolMapper implements OIDCAccessTokenMapper, OIDCIDTokenMapper {
+public class UserSessionNoteMapper extends AbstractOIDCProtocolMapper implements OIDCAccessTokenMapper, OIDCIDTokenMapper, OIDCAccessTokenResponseMapper {
 
     private static final List<ProviderConfigProperty> configProperties = new ArrayList<>();
 
@@ -83,6 +86,16 @@ public class UserSessionNoteMapper extends AbstractOIDCProtocolMapper implements
         String noteValue = userSession.getNote(noteName);
         if (noteValue == null) return;
         OIDCAttributeMapperHelper.mapClaim(token, mappingModel, noteValue);
+    }
+
+    @Override
+    protected void setClaim(AccessTokenResponse accessTokenResponse, ProtocolMapperModel mappingModel, UserSessionModel userSession,
+            KeycloakSession keycloakSession, ClientSessionContext clientSessionCtx) {
+
+        String noteName = mappingModel.getConfig().get(ProtocolMapperUtils.USER_SESSION_NOTE);
+        String noteValue = userSession.getNote(noteName);
+        if (noteValue == null) return;
+        OIDCAttributeMapperHelper.mapClaim(accessTokenResponse, mappingModel, noteValue);
     }
 
     public static ProtocolMapperModel createClaimMapper(String name,

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/OAuthClient.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/OAuthClient.java
@@ -82,6 +82,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyStore;
 import java.security.PrivateKey;
 import java.security.PublicKey;
@@ -1331,6 +1332,8 @@ public class OAuthClient {
 
         private Map<String, String> headers;
 
+        private Map<String, Object> otherClaims;
+
         public AccessTokenResponse(CloseableHttpResponse response) throws Exception {
             try {
                 statusCode = response.getStatusLine().getStatusCode();
@@ -1347,25 +1350,46 @@ public class OAuthClient {
                     Assert.fail("Invalid content type. Status: " + statusCode + ", contentType: " + contentType);
                 }
 
-                String s = IOUtils.toString(response.getEntity().getContent(), "UTF-8");
-                Map responseJson = JsonSerialization.readValue(s, Map.class);
+                String s = IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8);
+                @SuppressWarnings("unchecked")
+                Map<String, Object> responseJson = JsonSerialization.readValue(s, Map.class);
 
                 if (statusCode == 200) {
-                    idToken = (String) responseJson.get("id_token");
-                    accessToken = (String) responseJson.get("access_token");
-                    issuedTokenType = (String) responseJson.get("issued_token_type");
-                    tokenType = (String) responseJson.get("token_type");
-                    expiresIn = (Integer) responseJson.get("expires_in");
-                    refreshExpiresIn = (Integer) responseJson.get("refresh_expires_in");
-                    sessionState = (String) responseJson.get("session_state");
+                    otherClaims = new HashMap<>();
 
-                    // OIDC Financial API Read Only Profile : scope MUST be returned in the response from Token Endpoint
-                    if (responseJson.containsKey(OAuth2Constants.SCOPE)) {
-                        scope = (String) responseJson.get(OAuth2Constants.SCOPE);
-                    }
-
-                    if (responseJson.containsKey(OAuth2Constants.REFRESH_TOKEN)) {
-                        refreshToken = (String) responseJson.get(OAuth2Constants.REFRESH_TOKEN);
+                    for (Map.Entry<String, Object> entry : responseJson.entrySet()) {
+                        switch (entry.getKey()) {
+                            case OAuth2Constants.ID_TOKEN:
+                                idToken = (String) entry.getValue();
+                                break;
+                            case OAuth2Constants.ACCESS_TOKEN:
+                                accessToken = (String) entry.getValue();
+                                break;
+                            case OAuth2Constants.ISSUED_TOKEN_TYPE:
+                                issuedTokenType = (String) entry.getValue();
+                                break;
+                            case "token_type":
+                                tokenType = (String) entry.getValue();
+                                break;
+                            case "expires_in":
+                                expiresIn = (Integer) entry.getValue();
+                                break;
+                            case "refresh_expires_in":
+                                refreshExpiresIn = (Integer) entry.getValue();
+                                break;
+                            case OAuth2Constants.SESSION_STATE:
+                                sessionState = (String) entry.getValue();
+                                break;
+                            case OAuth2Constants.SCOPE:
+                                scope = (String) entry.getValue();
+                                break;
+                            case OAuth2Constants.REFRESH_TOKEN:
+                                refreshToken = (String) entry.getValue();
+                                break;
+                            default:
+                                otherClaims.put(entry.getKey(), entry.getValue());
+                                break;
+                        }
                     }
                 } else {
                     error = (String) responseJson.get(OAuth2Constants.ERROR);
@@ -1427,6 +1451,10 @@ public class OAuthClient {
 
         public Map<String, String> getHeaders() {
             return headers;
+        }
+
+        public Map<String, Object> getOtherClaims() {
+            return otherClaims;
         }
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/AccessTokenResponseTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/AccessTokenResponseTest.java
@@ -1,0 +1,85 @@
+package org.keycloak.testsuite.oauth;
+
+import static org.junit.Assert.assertEquals;
+import static org.keycloak.testsuite.admin.AbstractAdminTest.loadJson;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.keycloak.OAuth2Constants;
+import org.keycloak.models.utils.KeycloakModelUtils;
+import org.keycloak.protocol.oidc.OIDCLoginProtocol;
+import org.keycloak.protocol.oidc.mappers.HardcodedClaim;
+import org.keycloak.protocol.oidc.mappers.OIDCAttributeMapperHelper;
+import org.keycloak.representations.idm.ProtocolMapperRepresentation;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.testsuite.AbstractKeycloakTest;
+import org.keycloak.testsuite.AssertEvents;
+import org.keycloak.testsuite.util.ClientManager;
+import org.keycloak.testsuite.util.OAuthClient;
+import org.keycloak.testsuite.util.UserBuilder;
+
+public class AccessTokenResponseTest extends AbstractKeycloakTest {
+
+    @Rule
+    public AssertEvents events = new AssertEvents(this);
+
+    @Before
+    public void clientConfiguration() {
+        ClientManager.realm(adminClient.realm("test")).clientId("test-app").directAccessGrant(true);
+        /*
+         * Configure the default client ID. Seems like OAuthClient is keeping the state of clientID
+         * For example: If some test case configure oauth.clientId("sample-public-client"), other tests
+         * will fail and the clientID will always be "sample-public-client
+         * @see AccessTokenTest#testAuthorizationNegotiateHeaderIgnored()
+         */
+        oauth.clientId("test-app");
+    }
+
+    @Override
+    public void addTestRealms(List<RealmRepresentation> testRealms) {
+        RealmRepresentation realm = loadJson(getClass().getResourceAsStream("/testrealm.json"), RealmRepresentation.class);
+
+        UserBuilder user = UserBuilder.create()
+                .id(KeycloakModelUtils.generateId())
+                .username("no-permissions")
+                .addRoles("user")
+                .password("password");
+        realm.getUsers().add(user.build());
+
+        ProtocolMapperRepresentation customClaimHardcodedMapper = new ProtocolMapperRepresentation();
+        customClaimHardcodedMapper.setName("custom-claim-hardcoded-mapper");
+        customClaimHardcodedMapper.setProtocol(OIDCLoginProtocol.LOGIN_PROTOCOL);
+        customClaimHardcodedMapper.setProtocolMapper(HardcodedClaim.PROVIDER_ID);
+        Map<String, String> config = new HashMap<>();
+        config.put(OIDCAttributeMapperHelper.TOKEN_CLAIM_NAME, "custom_hardcoded_claim");
+        config.put(HardcodedClaim.CLAIM_VALUE, "custom_claim");
+        config.put(OIDCAttributeMapperHelper.INCLUDE_IN_ACCESS_TOKEN_RESPONSE, "true");
+        customClaimHardcodedMapper.setConfig(config);
+
+        realm.getClients().stream().filter(clientRepresentation -> "test-app".equals(clientRepresentation.getClientId()))
+                .forEach(clientRepresentation -> {
+                    clientRepresentation.setProtocolMappers(Collections.singletonList(customClaimHardcodedMapper));
+                    clientRepresentation.setFullScopeAllowed(false);
+                });
+
+        testRealms.add(realm);
+    }
+
+    @Test
+    public void accessTokenRequest() {
+        oauth.doLogin("test-user@localhost", "password");
+
+        String code = oauth.getCurrentQuery().get(OAuth2Constants.CODE);
+        OAuthClient.AccessTokenResponse response = oauth.doAccessTokenRequest(code, "password");
+
+        assertEquals(200, response.getStatusCode());
+
+        assertEquals("custom_claim", response.getOtherClaims().get("custom_hardcoded_claim"));
+    }
+}


### PR DESCRIPTION
This adds the ability to add custom claims to the OIDC access token response when successful using a similar API to how ProtocolMappers add claims to tokens currently.
