### PR TITLE
Add localization for locales in german

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/i18n/EmailTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/i18n/EmailTest.java
@@ -147,7 +147,7 @@ public class EmailTest extends AbstractI18NTest {
         
         infoPage.clickToContinueDe();
         
-        loginPasswordUpdatePage.openLanguage("English");
+        loginPasswordUpdatePage.openLanguage("Englisch");
         loginPasswordUpdatePage.changePassword("pass", "pass");
         WaitUtils.waitForPageToLoad();
         

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/i18n/LoginPageTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/i18n/LoginPageTest.java
@@ -252,8 +252,8 @@ public class LoginPageTest extends AbstractI18NTest {
         Assert.assertTrue(pageSource.contains(expectedGermanMessage));
 
         // Revert language
-        page.openLanguage("English");
-        Assert.assertEquals("English", page.getLanguageDropdownText());
+        page.openLanguage("Englisch");
+        Assert.assertEquals("Englisch", page.getLanguageDropdownText());
         pageSource = driver.getPageSource();
         Assert.assertTrue(pageSource.contains(expectedEnglishMessage));
         Assert.assertFalse(pageSource.contains(expectedGermanMessage));

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/i18n/LoginPageTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/i18n/LoginPageTest.java
@@ -86,7 +86,7 @@ public class LoginPageTest extends AbstractI18NTest {
         ProfileAssume.assumeCommunity();
 
         loginPage.open();
-        Assert.assertEquals("English", loginPage.getLanguageDropdownText());
+        Assert.assertEquals("Englisch", loginPage.getLanguageDropdownText());
 
         switchLanguageToGermanAndBack("Username or email", "Benutzername oder E-Mail", loginPage);
     }
@@ -158,7 +158,7 @@ public class LoginPageTest extends AbstractI18NTest {
 
         loginPage.login("test-user@localhost", "password");
         changePasswordPage.assertCurrent();
-        Assert.assertEquals("English", changePasswordPage.getLanguageDropdownText());
+        Assert.assertEquals("Englisch", changePasswordPage.getLanguageDropdownText());
 
         // Switch language
         switchLanguageToGermanAndBack("Update password", "Passwort aktualisieren", changePasswordPage);

--- a/themes/src/main/resources-community/theme/base/login/messages/messages_de.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_de.properties
@@ -240,6 +240,25 @@ confirmAccountLinking=Best\u00E4tigen Sie den Account {0} des Identity Provider 
 confirmEmailAddressVerification=Best\u00E4tigen Sie, dass die E-Mail-Adresse {0} g\u00FCltig ist.
 confirmExecutionOfActions=F\u00FChren Sie die folgende(n) Aktion(en) aus
 
+locale_ca=Katalanisch
+locale_de=Deutsch
+locale_en=Englisch
+locale_es=Spanisch
+locale_fr=Franz\u00F6sisch
+locale_it=Itali\u00E4nisch
+locale_ja=Japanisch
+locale_nl=Niederl\u00E4ndisch
+locale_no=Norwegisch
+locale_pl=Polnisch
+locale_pt_BR=Portugiesisch
+locale_pt-BR=Portugiesisch
+locale_ru=Russisch
+locale_lt=Litauisch
+locale_zh-CN=Chinesisch
+locale_sk=Slovakisch
+locale_sv=Schwedisch
+locale_tr=T\u00FCrkisch
+
 backToApplication=&laquo; Zur\u00FCck zur Applikation
 missingParameterMessage=Fehlender Parameter\: {0}
 clientNotFoundMessage=Client nicht gefunden.


### PR DESCRIPTION
I noticed, that the translations for the locale identifiers in german were missing, so I added them.
