### PR TITLE
[KEYCLOAK-14953] Added Galleon feature pack to enable Galleon provisioning of the adaptors to WildFly.

### DIFF
--- a/adapters/oidc/wildfly/wildfly-subsystem/src/main/java/org/keycloak/subsystem/adapter/extension/KeycloakDependencyProcessor.java
+++ b/adapters/oidc/wildfly/wildfly-subsystem/src/main/java/org/keycloak/subsystem/adapter/extension/KeycloakDependencyProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -37,7 +37,7 @@ import org.jboss.modules.ModuleLoader;
  */
 public abstract class KeycloakDependencyProcessor implements DeploymentUnitProcessor {
 
-    private static final ModuleIdentifier KEYCLOAK_JBOSS_CORE_ADAPTER = ModuleIdentifier.create("org.keycloak.keycloak-jboss-adapter-core");
+    private static final ModuleIdentifier KEYCLOAK_JBOSS_CORE_ADAPTER = KeycloakSubsystemDefinition.KEYCLOAK_JBOSS_CORE_ADAPTER;
     private static final ModuleIdentifier KEYCLOAK_CORE_ADAPTER = ModuleIdentifier.create("org.keycloak.keycloak-adapter-core");
     private static final ModuleIdentifier KEYCLOAK_CORE = ModuleIdentifier.create("org.keycloak.keycloak-core");
     private static final ModuleIdentifier KEYCLOAK_COMMON = ModuleIdentifier.create("org.keycloak.keycloak-common");

--- a/adapters/oidc/wildfly/wildfly-subsystem/src/main/java/org/keycloak/subsystem/adapter/extension/KeycloakSubsystemDefinition.java
+++ b/adapters/oidc/wildfly/wildfly-subsystem/src/main/java/org/keycloak/subsystem/adapter/extension/KeycloakSubsystemDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,6 +21,8 @@ import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.operations.common.GenericSubsystemDescribeHandler;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.registry.RuntimePackageDependency;
+import org.jboss.modules.ModuleIdentifier;
 
 /**
  * Definition of subsystem=keycloak.
@@ -28,6 +30,9 @@ import org.jboss.as.controller.registry.ManagementResourceRegistration;
  * @author Stan Silvert ssilvert@redhat.com (C) 2013 Red Hat Inc.
  */
 public class KeycloakSubsystemDefinition extends SimpleResourceDefinition {
+
+    static final ModuleIdentifier KEYCLOAK_JBOSS_CORE_ADAPTER = ModuleIdentifier.create("org.keycloak.keycloak-jboss-adapter-core");
+
     protected KeycloakSubsystemDefinition() {
         super(KeycloakExtension.SUBSYSTEM_PATH,
                 KeycloakExtension.getResourceDescriptionResolver("subsystem"),
@@ -42,4 +47,10 @@ public class KeycloakSubsystemDefinition extends SimpleResourceDefinition {
         resourceRegistration.registerOperationHandler(GenericSubsystemDescribeHandler.DEFINITION, GenericSubsystemDescribeHandler.INSTANCE);
     }
 
+    @Override
+    public void registerAdditionalRuntimePackages(ManagementResourceRegistration resourceRegistration) {
+        // This module is required by deployment but not referenced by JBoss modules
+        resourceRegistration.registerAdditionalRuntimePackages(
+                RuntimePackageDependency.required(KEYCLOAK_JBOSS_CORE_ADAPTER.getName()));
+    }
 }

--- a/distribution/galleon-feature-packs/adapter-galleon-pack/pom.xml
+++ b/distribution/galleon-feature-packs/adapter-galleon-pack/pom.xml
@@ -218,13 +218,13 @@
                     <dependency>
                         <groupId>org.wildfly.core</groupId>
                         <artifactId>wildfly-embedded</artifactId>
-                        <version>${version.org.wildfly.core}</version>
+                        <version>${wildfly.core.version}</version>
                     </dependency>
                     <!-- If you add a dependency on wildfly-embedded you need to bring your own transitives -->
                     <dependency>
                         <groupId>org.wildfly.common</groupId>
                         <artifactId>wildfly-common</artifactId>
-                        <version>${version.org.wildfly.common}</version>
+                        <version>${wildfly.common.version}</version>
                     </dependency>
                 </dependencies>
                 <executions>
@@ -257,9 +257,6 @@
             </activation>
             <properties>
                 <galleon-adapter-group-id>org.keycloak</galleon-adapter-group-id>
-                <version.org.wildfly>20.0.0.Final</version.org.wildfly>
-                <version.org.wildfly.core>12.0.1.Final</version.org.wildfly.core>
-                <version.org.wildfly.common>1.5.4.Final</version.org.wildfly.common>
             </properties>
             <repositories>
                 <repository>
@@ -274,7 +271,7 @@
                 <dependency>
                     <groupId>org.wildfly</groupId>
                     <artifactId>wildfly-galleon-pack</artifactId>
-                    <version>${version.org.wildfly}</version>
+                    <version>${wildfly.version}</version>
                     <type>zip</type>
                     <scope>provided</scope>
                 </dependency>
@@ -289,15 +286,12 @@
             </activation>
             <properties>
                 <galleon-adapter-group-id>org.jboss.sso</galleon-adapter-group-id>
-                <version.org.jboss.eap>7.3.2.GA-redhat-00002</version.org.jboss.eap>
-                <version.org.wildfly.core>10.1.11.Final-redhat-00001</version.org.wildfly.core>
-                <version.org.wildfly.common>1.5.2.Final-redhat-00002</version.org.wildfly.common>
             </properties>
             <dependencies>
                 <dependency>
                     <groupId>org.jboss.eap</groupId>
                     <artifactId>wildfly-galleon-pack</artifactId>
-                    <version>${version.org.jboss.eap}</version>
+                    <version>${eap.version}</version>
                     <type>zip</type>
                     <scope>provided</scope>
                 </dependency>

--- a/distribution/galleon-feature-packs/adapter-galleon-pack/pom.xml
+++ b/distribution/galleon-feature-packs/adapter-galleon-pack/pom.xml
@@ -261,6 +261,15 @@
                 <version.org.wildfly.core>12.0.1.Final</version.org.wildfly.core>
                 <version.org.wildfly.common>1.5.4.Final</version.org.wildfly.common>
             </properties>
+            <repositories>
+                <repository>
+                    <id>jboss</id>
+                    <url>https://repository.jboss.org/nexus/content/groups/public/</url>
+                    <snapshots>
+                        <enabled>false</enabled>
+                    </snapshots>
+                </repository>
+            </repositories>
             <dependencies>
                 <dependency>
                     <groupId>org.wildfly</groupId>
@@ -280,9 +289,9 @@
             </activation>
             <properties>
                 <galleon-adapter-group-id>org.jboss.sso</galleon-adapter-group-id>
-                <version.org.jboss.eap>7.3.2.GA-redhat-SNAPSHOT</version.org.jboss.eap>
-                <version.org.wildfly.core>10.1.11.Final-redhat-SNAPSHOT</version.org.wildfly.core>
-                <version.org.wildfly.common>1.5.1.Final-redhat-00001</version.org.wildfly.common>
+                <version.org.jboss.eap>7.3.2.GA-redhat-00002</version.org.jboss.eap>
+                <version.org.wildfly.core>10.1.11.Final-redhat-00001</version.org.wildfly.core>
+                <version.org.wildfly.common>1.5.2.Final-redhat-00002</version.org.wildfly.common>
             </properties>
             <dependencies>
                 <dependency>

--- a/distribution/galleon-feature-packs/adapter-galleon-pack/pom.xml
+++ b/distribution/galleon-feature-packs/adapter-galleon-pack/pom.xml
@@ -1,0 +1,309 @@
+<!--
+~ Copyright 2016 Red Hat, Inc. and/or its affiliates
+~ and other contributors as indicated by the @author tags.
+~
+~ Licensed under the Apache License, Version 2.0 (the "License");
+~ you may not use this file except in compliance with the License.
+~ You may obtain a copy of the License at
+~
+~ http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing, software
+~ distributed under the License is distributed on an "AS IS" BASIS,
+~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~ See the License for the specific language governing permissions and
+~ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <parent>
+        <groupId>org.keycloak</groupId>
+        <artifactId>galleon-feature-packs-parent</artifactId>
+        <version>12.0.0-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    
+    <groupId>${galleon-adapter-group-id}</groupId>
+    <artifactId>keycloak-adapter-galleon-pack</artifactId>
+
+    <name>Keycloak Galleon Feature Pack: Adapter</name>
+    <packaging>pom</packaging>
+    
+    <properties>
+        <feature-pack.resources.directory>${basedir}/../../feature-packs/adapter-feature-pack/src/main/resources</feature-pack.resources.directory>
+        <version.org.wildfly.galleon-plugins>4.2.6.Final</version.org.wildfly.galleon-plugins>
+        <xmlFileSource>${feature-pack.resources.directory}/licenses/${product.slot}/licenses.xml</xmlFileSource>
+        <outputDirectory>${basedir}/target/resources/packages/licenses/content/docs/licenses-${product.slot}</outputDirectory>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-core</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-common</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-adapter-core</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-jboss-adapter-core</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-wildfly-subsystem</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-wildfly-adapter</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-wildfly-elytron-oidc-adapter</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-adapter-spi</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-undertow-adapter-spi</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-undertow-adapter</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Authorization -->
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-authz-client</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-resources</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${basedir}/target/resources</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${basedir}/src/main/resources</directory>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>copy-feature-pack-resources</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${basedir}/target/resources</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${feature-pack.resources.directory}</directory>
+                                    <includes>
+                                        <include>content/**</include>
+                                        <include>modules/**</include>
+                                    </includes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.wildfly.galleon-plugins</groupId>
+                <artifactId>wildfly-galleon-maven-plugin</artifactId>
+                <version>${version.org.wildfly.galleon-plugins}</version>
+                <dependencies>
+                    <!--
+                        feature-spec-gen uses wildfly-embedded to generate the feature specs, hence the designated
+                        wildfly-embedded version must match the pack one
+                    -->
+                    <dependency>
+                        <groupId>org.wildfly.core</groupId>
+                        <artifactId>wildfly-embedded</artifactId>
+                        <version>${version.org.wildfly.core}</version>
+                    </dependency>
+                    <!-- If you add a dependency on wildfly-embedded you need to bring your own transitives -->
+                    <dependency>
+                        <groupId>org.wildfly.common</groupId>
+                        <artifactId>wildfly-common</artifactId>
+                        <version>${version.org.wildfly.common}</version>
+                    </dependency>
+                </dependencies>
+                <executions>
+                    <execution>
+                        <id>keycloak-adapter-galleon-pack-build</id>
+                        <goals>
+                            <goal>build-feature-pack</goal>
+                        </goals>
+                        <phase>compile</phase>
+                        <configuration>
+                            <fork-embedded>false</fork-embedded>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.keycloak</groupId>
+                <artifactId>keycloak-distribution-licenses-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>community</id>
+            <activation>
+                <property>
+                    <name>!product</name>
+                </property>
+            </activation>
+            <properties>
+                <galleon-adapter-group-id>org.keycloak</galleon-adapter-group-id>
+                <version.org.wildfly>20.0.0.Final</version.org.wildfly>
+                <version.org.wildfly.core>12.0.0.Final</version.org.wildfly.core>
+                <version.org.wildfly.common>1.5.1.Final</version.org.wildfly.common>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.wildfly</groupId>
+                    <artifactId>wildfly-ee-galleon-pack</artifactId>
+                    <version>${version.org.wildfly}</version>
+                    <type>zip</type>
+                    <scope>provided</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>product</id>
+            <activation>
+                <property>
+                    <name>product</name>
+                </property>
+            </activation>
+            <properties>
+                <galleon-adapter-group-id>org.jboss.sso</galleon-adapter-group-id>
+                <version.org.jboss.eap>7.3.2.GA-redhat-SNAPSHOT</version.org.jboss.eap>
+                <version.org.wildfly.core>10.1.11.Final-redhat-SNAPSHOT</version.org.wildfly.core>
+                <version.org.wildfly.common>1.5.1.Final-redhat-00001</version.org.wildfly.common>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.jboss.eap</groupId>
+                    <artifactId>wildfly-ee-galleon-pack</artifactId>
+                    <version>${version.org.jboss.eap}</version>
+                    <type>zip</type>
+                    <scope>provided</scope>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.wildfly.galleon-plugins</groupId>
+                        <artifactId>wildfly-galleon-maven-plugin</artifactId>
+                        <configuration>
+                            <config-file>wildfly-feature-pack-build-eap.xml</config-file>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/distribution/galleon-feature-packs/adapter-galleon-pack/pom.xml
+++ b/distribution/galleon-feature-packs/adapter-galleon-pack/pom.xml
@@ -258,13 +258,13 @@
             <properties>
                 <galleon-adapter-group-id>org.keycloak</galleon-adapter-group-id>
                 <version.org.wildfly>20.0.0.Final</version.org.wildfly>
-                <version.org.wildfly.core>12.0.0.Final</version.org.wildfly.core>
-                <version.org.wildfly.common>1.5.1.Final</version.org.wildfly.common>
+                <version.org.wildfly.core>12.0.1.Final</version.org.wildfly.core>
+                <version.org.wildfly.common>1.5.4.Final</version.org.wildfly.common>
             </properties>
             <dependencies>
                 <dependency>
                     <groupId>org.wildfly</groupId>
-                    <artifactId>wildfly-ee-galleon-pack</artifactId>
+                    <artifactId>wildfly-galleon-pack</artifactId>
                     <version>${version.org.wildfly}</version>
                     <type>zip</type>
                     <scope>provided</scope>
@@ -287,7 +287,7 @@
             <dependencies>
                 <dependency>
                     <groupId>org.jboss.eap</groupId>
-                    <artifactId>wildfly-ee-galleon-pack</artifactId>
+                    <artifactId>wildfly-galleon-pack</artifactId>
                     <version>${version.org.jboss.eap}</version>
                     <type>zip</type>
                     <scope>provided</scope>

--- a/distribution/galleon-feature-packs/adapter-galleon-pack/src/main/resources/layers/standalone/keycloak-client-oidc/layer-spec.xml
+++ b/distribution/galleon-feature-packs/adapter-galleon-pack/src/main/resources/layers/standalone/keycloak-client-oidc/layer-spec.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" ?>
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="keycloak-elytron-oidc">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="keycloak-client-oidc">
     <dependencies>
+        <layer name="ee"/>
         <layer name="elytron"/>
+        <layer name="undertow"/>
     </dependencies>
      <feature spec="subsystem.keycloak"/>
     <feature spec="subsystem.elytron.custom-realm">

--- a/distribution/galleon-feature-packs/adapter-galleon-pack/src/main/resources/layers/standalone/keycloak-client-oidc/layer-spec.xml
+++ b/distribution/galleon-feature-packs/adapter-galleon-pack/src/main/resources/layers/standalone/keycloak-client-oidc/layer-spec.xml
@@ -5,7 +5,7 @@
         <layer name="elytron"/>
         <layer name="undertow"/>
     </dependencies>
-     <feature spec="subsystem.keycloak"/>
+    <feature spec="subsystem.keycloak"/>
     <feature spec="subsystem.elytron.custom-realm">
         <param name="custom-realm" value="KeycloakOIDCRealm"/>
         <param name="class-name" value="org.keycloak.adapters.elytron.KeycloakSecurityRealm"/>

--- a/distribution/galleon-feature-packs/adapter-galleon-pack/src/main/resources/layers/standalone/keycloak-elytron-oidc/layer-spec.xml
+++ b/distribution/galleon-feature-packs/adapter-galleon-pack/src/main/resources/layers/standalone/keycloak-elytron-oidc/layer-spec.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" ?>
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="keycloak-elytron-oidc">
+    <dependencies>
+        <layer name="elytron"/>
+    </dependencies>
+     <feature spec="subsystem.keycloak"/>
+    <feature spec="subsystem.elytron.custom-realm">
+        <param name="custom-realm" value="KeycloakOIDCRealm"/>
+        <param name="class-name" value="org.keycloak.adapters.elytron.KeycloakSecurityRealm"/>
+        <param name="module" value="org.keycloak.keycloak-wildfly-elytron-oidc-adapter"/>
+    </feature>
+    <feature spec="subsystem.elytron.security-domain">
+        <param name="security-domain" value="KeycloakDomain"/>
+        <param name="default-realm" value="KeycloakOIDCRealm"/>
+        <param name="permission-mapper" value="default-permission-mapper"/>
+        <param name="security-event-listener" value="local-audit"/>
+        <param name="realms" value="[{realm=KeycloakOIDCRealm}]"/>
+    </feature>
+    <feature spec="subsystem.elytron.constant-realm-mapper">
+        <param name="constant-realm-mapper" value="keycloak-oidc-realm-mapper"/>
+        <param name="realm-name" value="KeycloakOIDCRealm"/>
+    </feature>
+    <feature spec="subsystem.elytron.service-loader-http-server-mechanism-factory">
+        <param name="service-loader-http-server-mechanism-factory" value="keycloak-oidc-http-server-mechanism-factory"/>
+        <param name="module" value="org.keycloak.keycloak-wildfly-elytron-oidc-adapter"/>
+    </feature>
+    <feature spec="subsystem.elytron.aggregate-http-server-mechanism-factory">
+        <param name="aggregate-http-server-mechanism-factory" value="keycloak-http-server-mechanism-factory"/>
+        <param name="http-server-mechanism-factories" value="[keycloak-oidc-http-server-mechanism-factory, global]"/>
+    </feature>
+    <feature spec="subsystem.elytron.http-authentication-factory">
+        <param name="http-authentication-factory" value="keycloak-http-authentication"/>
+        <param name="http-server-mechanism-factory" value="keycloak-http-server-mechanism-factory"/>
+        <param name="security-domain" value="KeycloakDomain"/>
+        <param name="mechanism-configurations" value="[{mechanism-name=KEYCLOAK,mechanism-realm-configurations=[{realm-name=KeycloakOIDCRealm,realm-mapper=keycloak-oidc-realm-mapper}]}]"/>
+    </feature>
+    <feature spec="subsystem.undertow">
+        <feature spec="subsystem.undertow.application-security-domain">
+            <param name="application-security-domain" value="other" />
+            <unset param="security-domain"/>
+            <param name="http-authentication-factory" value="keycloak-http-authentication"/>
+        </feature>
+    </feature>
+</layer-spec>

--- a/distribution/galleon-feature-packs/adapter-galleon-pack/src/main/resources/packages/licenses/package.xml
+++ b/distribution/galleon-feature-packs/adapter-galleon-pack/src/main/resources/packages/licenses/package.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" ?>
+
+<package-spec xmlns="urn:jboss:galleon:package:2.0" name="licenses">
+</package-spec>

--- a/distribution/galleon-feature-packs/adapter-galleon-pack/wildfly-feature-pack-build-eap.xml
+++ b/distribution/galleon-feature-packs/adapter-galleon-pack/wildfly-feature-pack-build-eap.xml
@@ -1,0 +1,54 @@
+<!--
+  ~ Copyright 2020 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<build xmlns="urn:wildfly:feature-pack-build:3.0" producer="org.jboss.sso:keycloak-adapter-galleon-pack">
+    <transitive>
+        <dependency group-id="org.wildfly.core" artifact-id="wildfly-core-galleon-pack">
+            <name>org.wildfly.core:wildfly-core-galleon-pack</name>
+            <packages inherit="false">
+                <exclude name="product.conf"/>
+            </packages>
+            <default-configs inherit="false"/>
+        </dependency>
+        <dependency group-id="org.jboss.eap" artifact-id="wildfly-servlet-galleon-pack">
+            <name>org.jboss.eap:wildfly-servlet-galleon-pack</name>
+            <packages inherit="false">
+                <exclude name="product.conf"/>
+            </packages>
+            <default-configs inherit="false"/>
+        </dependency>
+    </transitive>
+    <dependencies>
+        <dependency group-id="org.jboss.eap" artifact-id="wildfly-ee-galleon-pack">
+            <name>org.jboss.eap:wildfly-ee-galleon-pack</name>
+            <packages inherit="false">
+                 <exclude name="product.conf"/>
+            </packages>
+            <default-configs inherit="false"/>
+        </dependency>
+    </dependencies>
+    <default-packages>
+        <package name="modules.all"/>
+        <package name="licenses"/>
+    </default-packages>
+    <generate-feature-specs>
+        <extensions>
+            <standalone>
+                <extension>org.keycloak.keycloak-adapter-subsystem</extension>
+            </standalone>
+        </extensions>
+    </generate-feature-specs>
+</build>

--- a/distribution/galleon-feature-packs/adapter-galleon-pack/wildfly-feature-pack-build-eap.xml
+++ b/distribution/galleon-feature-packs/adapter-galleon-pack/wildfly-feature-pack-build-eap.xml
@@ -30,10 +30,17 @@
             </packages>
             <default-configs inherit="false"/>
         </dependency>
-    </transitive>
-    <dependencies>
         <dependency group-id="org.jboss.eap" artifact-id="wildfly-ee-galleon-pack">
             <name>org.jboss.eap:wildfly-ee-galleon-pack</name>
+            <packages inherit="false">
+                <exclude name="product.conf"/>
+            </packages>
+            <default-configs inherit="false"/>
+        </dependency>
+    </transitive>
+    <dependencies>
+        <dependency group-id="org.jboss.eap" artifact-id="wildfly-galleon-pack">
+            <name>org.jboss.eap:wildfly-galleon-pack</name>
             <packages inherit="false">
                  <exclude name="product.conf"/>
             </packages>

--- a/distribution/galleon-feature-packs/adapter-galleon-pack/wildfly-feature-pack-build.xml
+++ b/distribution/galleon-feature-packs/adapter-galleon-pack/wildfly-feature-pack-build.xml
@@ -14,7 +14,7 @@
   ~ limitations under the License.
   -->
 
-<build xmlns="urn:wildfly:feature-pack-build:3.0" producer="org.keycloak:keycloak-galleon-pack">
+<build xmlns="urn:wildfly:feature-pack-build:3.0" producer="org.keycloak:keycloak-adapter-galleon-pack">
     <transitive>
         <dependency group-id="org.wildfly.core" artifact-id="wildfly-core-galleon-pack">
             <name>org.wildfly.core:wildfly-core-galleon-pack</name>
@@ -30,10 +30,17 @@
             </packages>
             <default-configs inherit="false"/>
         </dependency>
-    </transitive>
-    <dependencies>
         <dependency group-id="org.wildfly" artifact-id="wildfly-ee-galleon-pack">
             <name>org.wildfly:wildfly-ee-galleon-pack</name>
+            <packages inherit="false">
+                <exclude name="product.conf"/>
+            </packages>
+            <default-configs inherit="false"/>
+        </dependency>
+    </transitive>
+    <dependencies>
+        <dependency group-id="org.wildfly" artifact-id="wildfly-galleon-pack">
+            <name>org.wildfly:wildfly-galleon-pack</name>
             <packages inherit="false">
                 <exclude name="product.conf"/>
             </packages>

--- a/distribution/galleon-feature-packs/adapter-galleon-pack/wildfly-feature-pack-build.xml
+++ b/distribution/galleon-feature-packs/adapter-galleon-pack/wildfly-feature-pack-build.xml
@@ -1,0 +1,54 @@
+<!--
+  ~ Copyright 2020 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<build xmlns="urn:wildfly:feature-pack-build:3.0" producer="org.keycloak:keycloak-galleon-pack">
+    <transitive>
+        <dependency group-id="org.wildfly.core" artifact-id="wildfly-core-galleon-pack">
+            <name>org.wildfly.core:wildfly-core-galleon-pack</name>
+            <packages inherit="false">
+                <exclude name="product.conf"/>
+            </packages>
+            <default-configs inherit="false"/>
+        </dependency>
+        <dependency group-id="org.wildfly" artifact-id="wildfly-servlet-galleon-pack">
+            <name>org.wildfly:wildfly-servlet-galleon-pack</name>
+            <packages inherit="false">
+                <exclude name="product.conf"/>
+            </packages>
+            <default-configs inherit="false"/>
+        </dependency>
+    </transitive>
+    <dependencies>
+        <dependency group-id="org.wildfly" artifact-id="wildfly-ee-galleon-pack">
+            <name>org.wildfly:wildfly-ee-galleon-pack</name>
+            <packages inherit="false">
+                <exclude name="product.conf"/>
+            </packages>
+            <default-configs inherit="false"/>
+        </dependency>
+    </dependencies>
+    <default-packages>
+        <package name="modules.all"/>
+        <package name="licenses"/>
+    </default-packages>
+    <generate-feature-specs>
+        <extensions>
+            <standalone>
+                <extension>org.keycloak.keycloak-adapter-subsystem</extension>
+            </standalone>
+        </extensions>
+    </generate-feature-specs>
+</build>

--- a/distribution/galleon-feature-packs/pom.xml
+++ b/distribution/galleon-feature-packs/pom.xml
@@ -1,0 +1,36 @@
+<!--
+  ~ Copyright 2016 Red Hat, Inc. and/or its affiliates
+  ~ and other contributors as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <parent>
+        <artifactId>keycloak-distribution-parent</artifactId>
+        <groupId>org.keycloak</groupId>
+        <version>12.0.0-SNAPSHOT</version>
+    </parent>
+
+    <name>Feature Pack Builds</name>
+    <description/>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>galleon-feature-packs-parent</artifactId>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>adapter-galleon-pack</module>
+    </modules>
+</project>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -39,6 +39,7 @@
         <module>adapters</module>
         <module>saml-adapters</module>
         <module>feature-packs</module>
+        <module>galleon-feature-packs</module>
         <module>licenses-common</module>
         <module>maven-plugins</module>
         <module>server-dist</module>


### PR DESCRIPTION
This is the pull request for the changes we have been discussing recently regarding providing a Galleon feature pack from Keycloak to make it possible to install the Keycloak client adapters for OIDC using Galleon, this will also complement the work currently being undertaken to add support for the generation of bootable jars which is based on the provisioning of Galleon feature packs.

https://issues.redhat.com/browse/KEYCLOAK-14953

The following analysis submission contains a number of examples showing how community users can make use of this against WildFly.

https://github.com/wildfly/wildfly-proposals/pull/330

_Note: The Galleon CLI and galleon-maven-plugin mentioned in the analysis are community only features._

Locally I have been testing the use of the Galleon CLI against WildFly 19.0.0.Final, WildFly 20.0.0.Final and WildFly 20.0.1.Final so the feature pack produced by a Keycloak release is not tied to a single WildFly release so this doesn't introduce a need for lock stepping the releases.

**Example Project**

The simplest way to test this new feature pack is to create a bootable jar, first the topic branch of this PR will need to be built as the example has a SNAPSHOT dependency.

I have an installation of Keycloak running locally with the default ports i.e. localhost:8080 with the following added:

- A new realm called WildFly.
- A user in the WildFly realm granted the Users role.
- A client defined with the ID simple-webapp with a root URL of http://localhost:8090/simple-webapp/

Within the repository https://github.com/darranl/keycloak-experiments the project is called "simplified-bootable-webapp".

The project can be built with the command "mvn package", this will automatically provision a server in a jar with the Keycloak client adapter installed and enabled, it will then execute this CLI script to configure the client:
  https://github.com/darranl/keycloak-experiments/blob/master/simplified-bootable-webapp/configure-oidc.cli

Start the server with the command:
  java -jar target/simple-webapp-bootable.jar -Djboss.socket.binding.port-offset=10

Navigate to:
  http://localhost:8090/simple-webapp

Clicking "Access Secured Servlet" should then trigger the authentication process and redirect to Keycloak etc...

**Discussion Points**

A couple of areas still need consideration but easier to see in the context of this PR.

1. Initially @jfdenise called the new layer "keycloak-elytron-oidc", within Galleon layers we are making Elytron the preferred solution so I don't really want everything to end up with an "elytron" qualifier - I have renamed the layer "keycloak-client-oidc" but "keycloak-adapter-oidc" could make sense.  If anyone feels strongly now is the time to address that.

2. The examples in the analysis are using a fully qualified GAV to reference the feature pack.  There is an option to publish channels by adding a project equivalent to https://github.com/wildfly/wildfly-producers.  The producers project allows channels to be defined with version ranges.  As an example users of WildFly can specify the feature pack "wildfly:current" and they will always get the latest WildFly version.  Where community users use the Galleon CLI they can also use an update command to update their installation and the use of channels allows the versions to be constrained.

The use of producers to define channels is a community only feature and can be added later so I am just mentioning it here in case there is interest.

