### PR TITLE
KEYCLOAK-15327 backchannel logout invalidate offline sessions fix

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanUserSessionProvider.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanUserSessionProvider.java
@@ -832,6 +832,17 @@ public class InfinispanUserSessionProvider implements UserSessionProvider {
     }
 
     @Override
+    public UserSessionModel getOfflineUserSessionByBrokerSessionId(RealmModel realm, String brokerSessionId) {
+        List<UserSessionModel> userSessions = getUserSessions(realm, UserSessionPredicate.create(realm.getId()).brokerSessionId(brokerSessionId), true);
+        return userSessions.isEmpty() ? null : userSessions.get(0);
+    }
+
+    @Override
+    public List<UserSessionModel> getOfflineUserSessionByBrokerUserId(RealmModel realm, String brokerUserId) {
+        return getUserSessions(realm, UserSessionPredicate.create(realm.getId()).brokerUserId(brokerUserId), true);
+    }
+
+    @Override
     public void removeOfflineUserSession(RealmModel realm, UserSessionModel userSession) {
         UserSessionEntity userSessionEntity = getUserSessionEntity(realm, userSession, true);
         if (userSessionEntity != null) {

--- a/server-spi/src/main/java/org/keycloak/models/UserSessionProvider.java
+++ b/server-spi/src/main/java/org/keycloak/models/UserSessionProvider.java
@@ -86,6 +86,8 @@ public interface UserSessionProvider extends Provider {
     /** Will automatically attach newly created offline client session to the offlineUserSession **/
     AuthenticatedClientSessionModel createOfflineClientSession(AuthenticatedClientSessionModel clientSession, UserSessionModel offlineUserSession);
     List<UserSessionModel> getOfflineUserSessions(RealmModel realm, UserModel user);
+    UserSessionModel getOfflineUserSessionByBrokerSessionId(RealmModel realm, String brokerSessionId);
+    List<UserSessionModel> getOfflineUserSessionByBrokerUserId(RealmModel realm, String brokerUserId);
 
     long getOfflineSessionsCount(RealmModel realm, ClientModel client);
     List<UserSessionModel> getOfflineUserSessions(RealmModel realm, ClientModel client, int first, int max);
@@ -95,4 +97,5 @@ public interface UserSessionProvider extends Provider {
 
     void close();
 
+    
 }


### PR DESCRIPTION
Currently the backchannel logout does not log out offline sessions if there is no corresponding active user session. Corresponding means the offline session and user session have the same session id.

Steps to reproduce:

* Setup Brokering Configuration (RP & OP) with Keycloak
* Configure the OP client with a backchannel logout url and activate `Backchannel Logout Revoke Offline Sessions`
* Login to RP via the OP broker using {{offline_access}} scope to create a offline session in addition to the user session.
   * User now has an active user session on the OP
   * User now has an active user session and a offline session on the RP
* Use the browser logout to log the active user session out on the RP,  offline session will remain
* Log the user out of the OP via browser. This should trigger a backchannel logout to the RP
* The offline session will not get invalidated