### PR TITLE
KEYCLOAK-15383 Translation strings escaped twice in saml-post-form.ftl

### DIFF
--- a/themes/src/main/resources/theme/base/login/saml-post-form.ftl
+++ b/themes/src/main/resources/theme/base/login/saml-post-form.ftl
@@ -1,10 +1,10 @@
 <#import "template.ftl" as layout>
 <@layout.registrationLayout; section>
     <#if section = "header">
-        ${kcSanitize(msg("saml.post-form.title"))}
+        ${msg("saml.post-form.title")}
     <#elseif section = "form">
         <script>window.onload = function() {document.forms[0].submit()};</script>
-        <p>${kcSanitize(msg("saml.post-form.message"))}</p>
+        <p>${msg("saml.post-form.message")}</p>
         <form name="saml-post-binding" method="post" action="${samlPost.url}">
             <#if samlPost.SAMLRequest??>
                 <input type="hidden" name="SAMLRequest" value="${samlPost.SAMLRequest}"/>
@@ -17,8 +17,8 @@
             </#if>
 
             <noscript>
-                <p>${kcSanitize(msg("saml.post-form.js-disabled"))}</p>
-                <input type="submit" value="${kcSanitize(msg("doContinue"))}"/>
+                <p>${msg("saml.post-form.js-disabled")}</p>
+                <input type="submit" value="${msg("doContinue")}"/>
             </noscript>
         </form>
     </#if>


### PR DESCRIPTION
Very minor UI fix. Impact is very low as typically this page flashes just for a second or two before redirecting to the remote SAML IdP.