### PR TITLE
[KEYCLOAK-15089] Fix filtering for enabled users

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserProvider.java
@@ -874,7 +874,7 @@ public class JpaUserProvider implements UserProvider, UserCredentialStore {
                     }
                     break;
                 case UserModel.ENABLED:
-                    predicates.add(builder.equal(builder.lower(root.get(key)), Boolean.parseBoolean(value.toLowerCase())));
+                    predicates.add(builder.equal(root.get(key), Boolean.parseBoolean(value.toLowerCase())));
             }
         }
 


### PR DESCRIPTION
Fix the problem for unable to filter enabled/disabled users using PostgreSQL or MariaDB
I'm not sure what is happening with this PR: https://github.com/keycloak/keycloak/pull/7319/
But just in case it does not enter I'm making this because it's kinda a bug which I personally introduce (and I'm sorry)
