### PR TITLE
KEYCLOAK-14195 FAPI-RW Client Policy - Condition : Client - Client Role

### DIFF
--- a/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientRolesConditionFactory.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientRolesConditionFactory.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.keycloak.testsuite.services.clientpolicy.condition;
+package org.keycloak.services.clientpolicy.condition;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -25,25 +25,23 @@ import org.keycloak.component.ComponentModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.provider.ProviderConfigProperty;
-import org.keycloak.services.clientpolicy.condition.ClientPolicyConditionProvider;
-import org.keycloak.services.clientpolicy.condition.ClientPolicyConditionProviderFactory;
 
-public class TestClientRolesConditionFactory implements ClientPolicyConditionProviderFactory {
+public class ClientRolesConditionFactory implements ClientPolicyConditionProviderFactory {
 
-    public static final String PROVIDER_ID = "test-clientroles-condition";
+    public static final String PROVIDER_ID = "clientroles-condition";
     public static final String ROLES = "roles";
 
     private static final List<ProviderConfigProperty> configProperties = new ArrayList<ProviderConfigProperty>();
 
     static {
         ProviderConfigProperty property;
-        property = new ProviderConfigProperty(ROLES, null, null, ProviderConfigProperty.MULTIVALUED_STRING_TYPE, "view-profile");
+        property = new ProviderConfigProperty(ROLES, PROVIDER_ID + ".label", PROVIDER_ID + ".tooltip", ProviderConfigProperty.MULTIVALUED_STRING_TYPE, null);
         configProperties.add(property);
     }
 
     @Override
     public ClientPolicyConditionProvider create(KeycloakSession session, ComponentModel model) {
-        return new TestClientRolesCondition(session, model);
+        return new ClientRolesCondition(session, model);
 
     }
 
@@ -66,7 +64,7 @@ public class TestClientRolesConditionFactory implements ClientPolicyConditionPro
 
     @Override
     public String getHelpText() {
-        return null;
+        return "The condition checks whether one of the specified client roles is applied to the client to determine whether the policy is applied.";
     }
 
     @Override

--- a/services/src/main/resources/META-INF/services/org.keycloak.services.clientpolicy.condition.ClientPolicyConditionProviderFactory
+++ b/services/src/main/resources/META-INF/services/org.keycloak.services.clientpolicy.condition.ClientPolicyConditionProviderFactory
@@ -1,1 +1,2 @@
 org.keycloak.services.clientpolicy.condition.ClientUpdateContextConditionFactory
+org.keycloak.services.clientpolicy.condition.ClientRolesConditionFactory

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/resources/META-INF/services/org.keycloak.services.clientpolicy.condition.ClientPolicyConditionProviderFactory
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/resources/META-INF/services/org.keycloak.services.clientpolicy.condition.ClientPolicyConditionProviderFactory
@@ -1,2 +1,1 @@
-org.keycloak.testsuite.services.clientpolicy.condition.TestClientRolesConditionFactory
 org.keycloak.testsuite.services.clientpolicy.condition.TestRaiseExeptionConditionFactory

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientPolicyBasicsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientPolicyBasicsTest.java
@@ -73,12 +73,12 @@ import org.keycloak.services.clientpolicy.ClientPolicyProvider;
 import org.keycloak.services.clientpolicy.DefaultClientPolicyProviderFactory;
 import org.keycloak.services.clientpolicy.condition.ClientPolicyConditionProvider;
 import org.keycloak.services.clientpolicy.condition.ClientUpdateContextConditionFactory;
+import org.keycloak.services.clientpolicy.condition.ClientRolesConditionFactory;
 import org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProvider;
 import org.keycloak.testsuite.AbstractKeycloakTest;
 import org.keycloak.testsuite.AssertEvents;
 import org.keycloak.testsuite.admin.ApiUtil;
 import org.keycloak.testsuite.arquillian.annotation.EnableFeature;
-import org.keycloak.testsuite.services.clientpolicy.condition.TestClientRolesConditionFactory;
 import org.keycloak.testsuite.services.clientpolicy.condition.TestRaiseExeptionConditionFactory;
 import org.keycloak.testsuite.services.clientpolicy.executor.TestClientAuthenticationExecutorFactory;
 import org.keycloak.testsuite.services.clientpolicy.executor.TestPKCEEnforceExecutorFactory;
@@ -86,6 +86,7 @@ import org.keycloak.testsuite.util.OAuthClient;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.keycloak.testsuite.util.ServerURLs;
 
 @EnableFeature(value = Profile.Feature.CLIENT_POLICIES, skipRestart = true)
@@ -95,6 +96,13 @@ public class ClientPolicyBasicsTest extends AbstractKeycloakTest {
 
     static final String REALM_NAME = "test";
     static final String TEST_CLIENT = "test-app";
+
+    static final String CLIENTUPDATECONTEXT_CONDITION_NAME = "ClientUpdateContextCondition";
+    static final String CLIENTUPDATECONTEXT_CONDITION_ALPHA_NAME = "ClientUpdateContextCondition-alpha";
+
+    static final String CLIENTROLES_CONDITION_NAME = "ClientRolesCondition";
+    static final String CLIENTROLES_CONDITION_ALPHA_NAME = "ClientRolesCondition-alpha";
+    static final String CLIENTROLES_CONDITION_BETA_NAME = "ClientRolesCondition-beta";
 
     ClientRegistration reg;
 
@@ -399,21 +407,21 @@ public class ClientPolicyBasicsTest extends AbstractKeycloakTest {
         try {
             successfulLoginAndLogout(clientId, clientSecret);
  
-            createCondition("TestClientRolesCondition", TestClientRolesConditionFactory.PROVIDER_ID, null, (ComponentRepresentation provider) -> {
+            createCondition(CLIENTROLES_CONDITION_NAME, ClientRolesConditionFactory.PROVIDER_ID, null, (ComponentRepresentation provider) -> {
                 setConditionClientRoles(provider, new ArrayList<>(Arrays.asList("sample-client-role")));
             });
-            registerCondition("TestClientRolesCondition", policyName);
-            logger.info("... Registered Condition : TestClientRolesCondition");
+            registerCondition(CLIENTROLES_CONDITION_NAME, policyName);
+            logger.info("... Registered Condition : " + CLIENTROLES_CONDITION_NAME);
 
             failLoginByNotFollowingPKCE(clientId);
 
-            updateCondition("TestClientRolesCondition", (ComponentRepresentation provider) -> {
+            updateCondition(CLIENTROLES_CONDITION_NAME, (ComponentRepresentation provider) -> {
                 setConditionClientRoles(provider, new ArrayList<>(Arrays.asList("anothor-client-role")));
             });
 
             successfulLoginAndLogout(clientId, clientSecret);
 
-            deleteCondition("TestClientRolesCondition", policyName);
+            deleteCondition(CLIENTROLES_CONDITION_NAME, policyName);
 
             successfulLoginAndLogout(clientId, clientSecret);
 
@@ -428,17 +436,17 @@ public class ClientPolicyBasicsTest extends AbstractKeycloakTest {
         createPolicy(policyName, DefaultClientPolicyProviderFactory.PROVIDER_ID, null, null, null);
         logger.info("... Created Policy : " + policyName);
 
-        createCondition("TestClientRolesCondition", TestClientRolesConditionFactory.PROVIDER_ID, null, (ComponentRepresentation provider) -> {
+        createCondition(CLIENTROLES_CONDITION_NAME, ClientRolesConditionFactory.PROVIDER_ID, null, (ComponentRepresentation provider) -> {
             setConditionClientRoles(provider, new ArrayList<>(Arrays.asList("sample-client-role")));
         });
-        registerCondition("TestClientRolesCondition", policyName);
-        logger.info("... Registered Condition : TestClientRolesCondition");
+        registerCondition(CLIENTROLES_CONDITION_NAME, policyName);
+        logger.info("... Registered Condition : " + CLIENTROLES_CONDITION_NAME);
 
-        createCondition("ClientUpdateContextCondition", ClientUpdateContextConditionFactory.PROVIDER_ID, null, (ComponentRepresentation provider) -> {
+        createCondition(CLIENTUPDATECONTEXT_CONDITION_NAME, ClientUpdateContextConditionFactory.PROVIDER_ID, null, (ComponentRepresentation provider) -> {
             setConditionRegistrationMethods(provider, new ArrayList<>(Arrays.asList(ClientUpdateContextConditionFactory.BY_AUTHENTICATED_USER)));
         });
-        registerCondition("ClientUpdateContextCondition", policyName);
-        logger.info("... Registered Condition : ClientUpdateContextCondition");
+        registerCondition(CLIENTUPDATECONTEXT_CONDITION_NAME, policyName);
+        logger.info("... Registered Condition : " + CLIENTUPDATECONTEXT_CONDITION_NAME);
 
         String clientId = "Zahlungs-App";
         String clientSecret = "secret";
@@ -491,17 +499,17 @@ public class ClientPolicyBasicsTest extends AbstractKeycloakTest {
         createPolicy(policyAlphaName, DefaultClientPolicyProviderFactory.PROVIDER_ID, null, null, null);
         logger.info("... Created Policy : " + policyAlphaName);
 
-        createCondition("TestClientRolesCondition-alpha", TestClientRolesConditionFactory.PROVIDER_ID, null, (ComponentRepresentation provider) -> {
-            setConditionClientRoles(provider, new ArrayList<>(Arrays.asList("sample-client-role-alpha")));
+        createCondition(CLIENTROLES_CONDITION_ALPHA_NAME, ClientRolesConditionFactory.PROVIDER_ID, null, (ComponentRepresentation provider) -> {
+            setConditionClientRoles(provider, new ArrayList<>(Arrays.asList("sample-client-role-alpha", "sample-client-role-zeta")));
         });
-        registerCondition("TestClientRolesCondition-alpha", policyAlphaName);
-        logger.info("... Registered Condition : TestClientRolesCondition-alpha");
+        registerCondition(CLIENTROLES_CONDITION_ALPHA_NAME, policyAlphaName);
+        logger.info("... Registered Condition : " + CLIENTROLES_CONDITION_ALPHA_NAME);
 
-        createCondition("ClientUpdateContextCondition-alpha", ClientUpdateContextConditionFactory.PROVIDER_ID, null, (ComponentRepresentation provider) -> {
+        createCondition(CLIENTUPDATECONTEXT_CONDITION_ALPHA_NAME, ClientUpdateContextConditionFactory.PROVIDER_ID, null, (ComponentRepresentation provider) -> {
             setConditionRegistrationMethods(provider, new ArrayList<>(Arrays.asList(ClientUpdateContextConditionFactory.BY_AUTHENTICATED_USER)));
         });
-        registerCondition("ClientUpdateContextCondition-alpha", policyAlphaName);
-        logger.info("... Registered Condition : ClientUpdateContextCondition-alpha");
+        registerCondition(CLIENTUPDATECONTEXT_CONDITION_ALPHA_NAME, policyAlphaName);
+        logger.info("... Registered Condition : " + CLIENTUPDATECONTEXT_CONDITION_ALPHA_NAME);
 
         createExecutor("TestClientAuthenticationExecutor-alpha", TestClientAuthenticationExecutorFactory.PROVIDER_ID, null, (ComponentRepresentation provider) -> {
             setExecutorAcceptedClientAuthMethods(provider, new ArrayList<>(Arrays.asList(ClientIdAndSecretAuthenticator.PROVIDER_ID)));
@@ -515,11 +523,11 @@ public class ClientPolicyBasicsTest extends AbstractKeycloakTest {
         createPolicy(policyBetaName, DefaultClientPolicyProviderFactory.PROVIDER_ID, null, null, null);
         logger.info("... Created Policy : " + policyBetaName);
 
-        createCondition("TestClientRolesCondition-beta", TestClientRolesConditionFactory.PROVIDER_ID, null, (ComponentRepresentation provider) -> {
-            setConditionClientRoles(provider, new ArrayList<>(Arrays.asList("sample-client-role-beta")));
+        createCondition(CLIENTROLES_CONDITION_BETA_NAME, ClientRolesConditionFactory.PROVIDER_ID, null, (ComponentRepresentation provider) -> {
+            setConditionClientRoles(provider, new ArrayList<>(Arrays.asList("sample-client-role-beta", "sample-client-role-zeta")));
         });
-        registerCondition("TestClientRolesCondition-beta", policyBetaName);
-        logger.info("... Registered Condition : TestClientRolesCondition-beta");
+        registerCondition(CLIENTROLES_CONDITION_BETA_NAME, policyBetaName);
+        logger.info("... Registered Condition : " + CLIENTROLES_CONDITION_BETA_NAME);
 
         createExecutor("TestPKCEEnforceExecutor-beta", TestPKCEEnforceExecutorFactory.PROVIDER_ID, null, (ComponentRepresentation provider) -> {
             setExecutorAugmentActivate(provider);
@@ -530,7 +538,7 @@ public class ClientPolicyBasicsTest extends AbstractKeycloakTest {
         String clientAlphaId = "Alpha-App";
         String clientAlphaSecret = "secretAlpha";
         String cAlphaId = createClientByAdmin(clientAlphaId, (ClientRepresentation clientRep) -> {
-            clientRep.setDefaultRoles((String[]) Arrays.asList("sample-client-role-alpha").toArray(new String[1]));
+            clientRep.setDefaultRoles((String[]) Arrays.asList("sample-client-role-alpha", "sample-client-role-common").toArray(new String[2]));
             clientRep.setSecret(clientAlphaSecret);
             clientRep.setClientAuthenticatorType(JWTClientSecretAuthenticator.PROVIDER_ID);
         });
@@ -538,7 +546,7 @@ public class ClientPolicyBasicsTest extends AbstractKeycloakTest {
         String clientBetaId = "Beta-App";
         String clientBetaSecret = "secretBeta";
         String cBetaId = createClientByAdmin(clientBetaId, (ClientRepresentation clientRep) -> {
-            clientRep.setDefaultRoles((String[]) Arrays.asList("sample-client-role-beta").toArray(new String[1]));
+            clientRep.setDefaultRoles((String[]) Arrays.asList("sample-client-role-beta", "sample-client-role-common").toArray(new String[2]));
             clientRep.setSecret(clientBetaSecret);
         });
 
@@ -580,11 +588,11 @@ public class ClientPolicyBasicsTest extends AbstractKeycloakTest {
         createPolicy(policyName, DefaultClientPolicyProviderFactory.PROVIDER_ID, null, null, null);
         logger.info("... Created Policy : " + policyName);
 
-        createCondition("ClientUpdateContextCondition", ClientUpdateContextConditionFactory.PROVIDER_ID, null, (ComponentRepresentation provider) -> {
+        createCondition(CLIENTUPDATECONTEXT_CONDITION_NAME, ClientUpdateContextConditionFactory.PROVIDER_ID, null, (ComponentRepresentation provider) -> {
             setConditionRegistrationMethods(provider, new ArrayList<>(Arrays.asList(ClientUpdateContextConditionFactory.BY_AUTHENTICATED_USER)));
         });
-        registerCondition("ClientUpdateContextCondition", policyName);
-        logger.info("... Registered Condition : ClientUpdateContextCondition");
+        registerCondition(CLIENTUPDATECONTEXT_CONDITION_NAME, policyName);
+        logger.info("... Registered Condition : " + CLIENTUPDATECONTEXT_CONDITION_NAME);
 
         createExecutor("TestClientAuthenticationExecutor", TestClientAuthenticationExecutorFactory.PROVIDER_ID, null, (ComponentRepresentation provider) -> {
             setExecutorAcceptedClientAuthMethods(provider, new ArrayList<>(Arrays.asList(
@@ -602,17 +610,17 @@ public class ClientPolicyBasicsTest extends AbstractKeycloakTest {
         createPolicy(policyName, DefaultClientPolicyProviderFactory.PROVIDER_ID, null, null, null);
         logger.info("... Created Policy : " + policyName);
 
-        createCondition("ClientUpdateContextCondition", ClientUpdateContextConditionFactory.PROVIDER_ID, null, (ComponentRepresentation provider) -> {
+        createCondition(CLIENTUPDATECONTEXT_CONDITION_NAME, ClientUpdateContextConditionFactory.PROVIDER_ID, null, (ComponentRepresentation provider) -> {
             setConditionRegistrationMethods(provider, new ArrayList<>(Arrays.asList(ClientUpdateContextConditionFactory.BY_INITIAL_ACCESS_TOKEN)));
         });
-        registerCondition("ClientUpdateContextCondition", policyName);
-        logger.info("... Registered Condition : ClientUpdateContextCondition");
+        registerCondition(CLIENTUPDATECONTEXT_CONDITION_NAME, policyName);
+        logger.info("... Registered Condition : " + CLIENTUPDATECONTEXT_CONDITION_NAME);
 
-        createCondition("TestClientRolesCondition", TestClientRolesConditionFactory.PROVIDER_ID, null, (ComponentRepresentation provider) -> {
+        createCondition(CLIENTROLES_CONDITION_NAME, ClientRolesConditionFactory.PROVIDER_ID, null, (ComponentRepresentation provider) -> {
             setConditionClientRoles(provider, new ArrayList<>(Arrays.asList("sample-client-role")));
         });
-        registerCondition("TestClientRolesCondition", policyName);
-        logger.info("... Registered Condition : TestClientRolesCondition");
+        registerCondition(CLIENTROLES_CONDITION_NAME, policyName);
+        logger.info("... Registered Condition : " + CLIENTROLES_CONDITION_NAME);
 
         createExecutor("TestClientAuthenticationExecutor", TestClientAuthenticationExecutorFactory.PROVIDER_ID, null, (ComponentRepresentation provider) -> {
             setExecutorAcceptedClientAuthMethods(provider, new ArrayList<>(Arrays.asList(ClientIdAndSecretAuthenticator.PROVIDER_ID, JWTClientAuthenticator.PROVIDER_ID)));
@@ -887,7 +895,7 @@ public class ClientPolicyBasicsTest extends AbstractKeycloakTest {
     }
 
     private void setConditionClientRoles(ComponentRepresentation provider, List<String> clientRoles) {
-        provider.getConfig().put(TestClientRolesConditionFactory.ROLES, clientRoles);
+        provider.getConfig().put(ClientRolesConditionFactory.ROLES, clientRoles);
     }
 
     private void setExecutorAugmentActivate(ComponentRepresentation provider) {


### PR DESCRIPTION
This PR is for [KEYCLOAK-14195 Client Policy - Condition : Client - Client Role](https://issues.redhat.com/browse/KEYCLOAK-14195)  that is a sub task of [KEYCLOAK-13933 Client Policies](https://issues.redhat.com/browse/KEYCLOAK-13933) whose design document is Client Policies .

It is also needed to pass FAPI-RW conformance tests (both FAPI-RW OP w/ MTLS and FAPI-RW OP w/ Private Key).
