### PR TITLE
KEYCLOAK-15459 Fix serialization of multi-subtag locales in admin console's “whoami” response

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/AdminConsole.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/AdminConsole.java
@@ -166,6 +166,11 @@ public class AdminConsole {
         public void setLocale(Locale locale) {
             this.locale = locale;
         }
+
+        @JsonProperty(value = "locale")
+        public String getLocaleLanguageTag() {
+            return locale != null ? locale.toLanguageTag() : null;
+        }
     }
 
     /**

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/AdminConsoleWhoAmILocaleTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/AdminConsoleWhoAmILocaleTest.java
@@ -36,7 +36,7 @@ public class AdminConsoleWhoAmILocaleTest extends AbstractKeycloakTest {
     private static final String DEFAULT_LOCALE = "en";
     private static final String REALM_LOCALE = "no";
     private static final String USER_LOCALE = "de";
-    private static final String EXTRA_LOCALE = "ru";
+    private static final String EXTRA_LOCALE = "zh-CN";
 
     private CloseableHttpClient client;
 


### PR DESCRIPTION
* Serialize locale as a well-formed IETF BCP 47 language tag.
* Alter test to cover a locale made of more than one subtag.