### PR TITLE
KEYCLOAK-15465 SAML Identity Broker - SP metadata writer always emits AttributeConsumingService isDefault attribute

### DIFF
--- a/saml-core/src/main/java/org/keycloak/saml/processing/core/saml/v2/writers/SAMLMetadataWriter.java
+++ b/saml-core/src/main/java/org/keycloak/saml/processing/core/saml/v2/writers/SAMLMetadataWriter.java
@@ -351,7 +351,9 @@ public class SAMLMetadataWriter extends BaseWriter {
         StaxUtil.writeStartElement(writer, METADATA_PREFIX, JBossSAMLConstants.ATTRIBUTE_CONSUMING_SERVICE.get(),
                 JBossSAMLURIConstants.METADATA_NSURI.get());
 
-        StaxUtil.writeAttribute(writer, JBossSAMLConstants.ISDEFAULT.get(), "" + attributeConsumer.isIsDefault());
+        if (attributeConsumer.isIsDefault() != null)
+           StaxUtil.writeAttribute(writer, JBossSAMLConstants.ISDEFAULT.get(), "" + attributeConsumer.isIsDefault());
+
         StaxUtil.writeAttribute(writer, JBossSAMLConstants.INDEX.get(), "" + attributeConsumer.getIndex());
 
         // Service Name


### PR DESCRIPTION
The AttributeConsumingService "isDefault" attribute of SAML SP Metadata is defined in the SAML specs as optional. Keycloak correctly defines it as `Boolean`, but if it is set to `null` the writer in `SAMLMetadataWriter` class will incorrectly render it as `isDefault="null"`.

The problem is not reproducible with plain Keycloak as it does not yet allow the user to configure the `AttributeConsumingService` section of the Service Provider metadata, but the error can be triggered in custom SAML Identity Provider modules.