### PR TITLE
KEYCLOAK-15270 Account REST API doesn't verify audience

### DIFF
--- a/examples/providers/domain-extension/src/main/java/org/keycloak/examples/domainextension/rest/ExampleRestResource.java
+++ b/examples/providers/domain-extension/src/main/java/org/keycloak/examples/domainextension/rest/ExampleRestResource.java
@@ -15,7 +15,7 @@ public class ExampleRestResource {
 	
 	public ExampleRestResource(KeycloakSession session) {
 		this.session = session;
-        this.auth = new AppAuthManager().authenticateBearerToken(session, session.getContext().getRealm());
+        this.auth = new AppAuthManager.BearerTokenAuthenticator(session).authenticate();
 	}
 	
     @Path("companies")

--- a/services/src/main/java/org/keycloak/authorization/util/Tokens.java
+++ b/services/src/main/java/org/keycloak/authorization/util/Tokens.java
@@ -30,9 +30,7 @@ import org.keycloak.services.managers.AuthenticationManager.AuthResult;
 public class Tokens {
 
     public static AccessToken getAccessToken(KeycloakSession keycloakSession) {
-        AppAuthManager authManager = new AppAuthManager();
-        KeycloakContext context = keycloakSession.getContext();
-        AuthResult authResult = authManager.authenticateBearerToken(keycloakSession, context.getRealm(), context.getUri(), context.getConnection(), context.getRequestHeaders());
+        AuthResult authResult = new AppAuthManager.BearerTokenAuthenticator(keycloakSession).authenticate();
 
         if (authResult != null) {
             return authResult.getToken();
@@ -42,9 +40,9 @@ public class Tokens {
     }
 
     public static AccessToken getAccessToken(String accessToken, KeycloakSession keycloakSession) {
-        AppAuthManager authManager = new AppAuthManager();
-        KeycloakContext context = keycloakSession.getContext();
-        AuthResult authResult = authManager.authenticateBearerToken(accessToken, keycloakSession, context.getRealm(), context.getUri(), context.getConnection(), context.getRequestHeaders());
+        AuthResult authResult = new AppAuthManager.BearerTokenAuthenticator(keycloakSession)
+                .setTokenString(accessToken)
+                .authenticate();
 
         if (authResult != null) {
             return authResult.getToken();

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
@@ -84,7 +84,6 @@ import org.keycloak.services.CorsErrorResponseException;
 import org.keycloak.services.ServicesLogger;
 import org.keycloak.services.Urls;
 import org.keycloak.services.clientpolicy.ClientPolicyException;
-import org.keycloak.services.clientpolicy.DefaultClientPolicyManager;
 import org.keycloak.services.clientpolicy.TokenRefreshContext;
 import org.keycloak.services.clientpolicy.TokenRequestContext;
 import org.keycloak.services.managers.AppAuthManager;
@@ -797,7 +796,7 @@ public class TokenEndpoint {
 
             }
 
-            AuthenticationManager.AuthResult authResult = AuthenticationManager.verifyIdentityToken(session, realm, session.getContext().getUri(), clientConnection, true, true, false, subjectToken, headers);
+            AuthenticationManager.AuthResult authResult = AuthenticationManager.verifyIdentityToken(session, realm, session.getContext().getUri(), clientConnection, true, true, null, false, subjectToken, headers);
             if (authResult == null) {
                 event.detail(Details.REASON, "subject_token validation failure");
                 event.error(Errors.INVALID_TOKEN);

--- a/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
@@ -779,7 +779,7 @@ public class AuthenticationManager {
         }
 
         String tokenString = cookie.getValue();
-        AuthResult authResult = verifyIdentityToken(session, realm, session.getContext().getUri(), session.getContext().getConnection(), checkActive, false, true, tokenString, session.getContext().getRequestHeaders(), VALIDATE_IDENTITY_COOKIE);
+        AuthResult authResult = verifyIdentityToken(session, realm, session.getContext().getUri(), session.getContext().getConnection(), checkActive, false, null, true, tokenString, session.getContext().getRequestHeaders(), VALIDATE_IDENTITY_COOKIE);
         if (authResult == null) {
             expireIdentityCookie(realm, session.getContext().getUri(), session.getContext().getConnection());
             expireOldIdentityCookie(realm, session.getContext().getUri(), session.getContext().getConnection());
@@ -1261,7 +1261,7 @@ public class AuthenticationManager {
     }
 
     public static AuthResult verifyIdentityToken(KeycloakSession session, RealmModel realm, UriInfo uriInfo, ClientConnection connection, boolean checkActive, boolean checkTokenType,
-                                                    boolean isCookie, String tokenString, HttpHeaders headers, Predicate<? super AccessToken>... additionalChecks) {
+                                                 String checkAudience, boolean isCookie, String tokenString, HttpHeaders headers, Predicate<? super AccessToken>... additionalChecks) {
         try {
             TokenVerifier<AccessToken> verifier = TokenVerifier.create(tokenString, AccessToken.class)
               .withDefaultChecks()
@@ -1269,6 +1269,11 @@ public class AuthenticationManager {
               .checkActive(checkActive)
               .checkTokenType(checkTokenType)
               .withChecks(additionalChecks);
+
+            if (checkAudience != null) {
+                verifier.audience(checkAudience);
+            }
+
             String kid = verifier.getHeader().getKeyId();
             String algorithm = verifier.getHeader().getAlgorithm().name();
 

--- a/services/src/main/java/org/keycloak/services/resources/IdentityBrokerService.java
+++ b/services/src/main/java/org/keycloak/services/resources/IdentityBrokerService.java
@@ -445,8 +445,11 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
         this.event.event(EventType.IDENTITY_PROVIDER_RETRIEVE_TOKEN);
 
         try {
-            AppAuthManager authManager = new AppAuthManager();
-            AuthenticationManager.AuthResult authResult = authManager.authenticateBearerToken(this.session, this.realmModel, this.session.getContext().getUri(), this.clientConnection, this.request.getHttpHeaders());
+            AuthenticationManager.AuthResult authResult = new AppAuthManager.BearerTokenAuthenticator(session)
+                    .setRealm(realmModel)
+                    .setConnection(clientConnection)
+                    .setHeaders(request.getHttpHeaders())
+                    .authenticate();
 
             if (authResult != null) {
                 AccessToken token = authResult.getToken();

--- a/services/src/main/java/org/keycloak/services/resources/account/AccountLoader.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountLoader.java
@@ -114,7 +114,10 @@ public class AccountLoader {
     }
 
     private AccountRestService getAccountRestService(ClientModel client, String versionStr) {
-        AuthenticationManager.AuthResult authResult = new AppAuthManager().authenticateBearerToken(session);
+        AuthenticationManager.AuthResult authResult = new AppAuthManager.BearerTokenAuthenticator(session)
+                .setAudience(client.getClientId())
+                .authenticate();
+
         if (authResult == null) {
             throw new NotAuthorizedException("Bearer token required");
         }

--- a/services/src/main/java/org/keycloak/services/resources/admin/AdminConsole.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/AdminConsole.java
@@ -88,12 +88,10 @@ public class AdminConsole {
     @Context
     protected Providers providers;
 
-    protected AppAuthManager authManager;
     protected RealmModel realm;
 
     public AdminConsole(RealmModel realm) {
         this.realm = realm;
-        this.authManager = new AppAuthManager();
     }
 
     public static class WhoAmI {
@@ -196,7 +194,12 @@ public class AdminConsole {
     @NoCache
     public Response whoAmI(final @Context HttpHeaders headers) {
         RealmManager realmManager = new RealmManager(session);
-        AuthenticationManager.AuthResult authResult = authManager.authenticateBearerToken(session, realm, session.getContext().getUri(), clientConnection, headers);
+        AuthenticationManager.AuthResult authResult = new AppAuthManager.BearerTokenAuthenticator(session)
+                .setRealm(realm)
+                .setConnection(clientConnection)
+                .setHeaders(headers)
+                .authenticate();
+
         if (authResult == null) {
             return Response.status(401).build();
         }

--- a/services/src/main/java/org/keycloak/services/resources/admin/AdminRoot.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/AdminRoot.java
@@ -72,7 +72,6 @@ public class AdminRoot {
     @Context
     protected HttpResponse response;
 
-    protected AppAuthManager authManager;
     protected TokenManager tokenManager;
 
     @Context
@@ -80,7 +79,6 @@ public class AdminRoot {
 
     public AdminRoot() {
         this.tokenManager = new TokenManager();
-        this.authManager = new AppAuthManager();
     }
 
     public static UriBuilder adminBaseUrl(UriInfo uriInfo) {
@@ -153,7 +151,7 @@ public class AdminRoot {
 
 
     protected AdminAuth authenticateRealmAdminRequest(HttpHeaders headers) {
-        String tokenString = authManager.extractAuthorizationHeaderToken(headers);
+        String tokenString = AppAuthManager.extractAuthorizationHeaderToken(headers);
         if (tokenString == null) throw new NotAuthorizedException("Bearer");
         AccessToken token;
         try {
@@ -169,7 +167,13 @@ public class AdminRoot {
             throw new NotAuthorizedException("Unknown realm in token");
         }
         session.getContext().setRealm(realm);
-        AuthenticationManager.AuthResult authResult = authManager.authenticateBearerToken(session, realm, session.getContext().getUri(), clientConnection, headers);
+
+        AuthenticationManager.AuthResult authResult = new AppAuthManager.BearerTokenAuthenticator(session)
+                .setRealm(realm)
+                .setConnection(clientConnection)
+                .setHeaders(headers)
+                .authenticate();
+
         if (authResult == null) {
             logger.debug("Token not valid");
             throw new NotAuthorizedException("Bearer");

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/domainextension/rest/ExampleRestResource.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/domainextension/rest/ExampleRestResource.java
@@ -32,7 +32,7 @@ public class ExampleRestResource {
 	
 	public ExampleRestResource(KeycloakSession session) {
 		this.session = session;
-        this.auth = new AppAuthManager().authenticateBearerToken(session, session.getContext().getRealm());
+        this.auth = new AppAuthManager.BearerTokenAuthenticator(session).authenticate();
 	}
 	
     @Path("companies")

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/AccountFormServiceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/AccountFormServiceTest.java
@@ -1203,7 +1203,7 @@ public class AccountFormServiceTest extends AbstractTestRealmKeycloakTest {
 
             Map<String, AccountApplicationsPage.AppEntry> apps = applicationsPage.getApplications();
             Assert.assertThat(apps.keySet(), containsInAnyOrder(
-              /* "root-url-client", */ "Account", "Account Console", "test-app", "test-app-scope", "third-party", "test-app-authz", "My Named Test App", "Test App Named - ${client_account}", "direct-grant"));
+              /* "root-url-client", */ "Account", "Account Console", "test-app", "test-app-scope", "third-party", "test-app-authz", "My Named Test App", "Test App Named - ${client_account}", "direct-grant", "custom-audience"));
 
             rsu.add(testRealm().roles().get("user").toRepresentation())
               .update();
@@ -1211,7 +1211,7 @@ public class AccountFormServiceTest extends AbstractTestRealmKeycloakTest {
             driver.navigate().refresh();
             apps = applicationsPage.getApplications();
             Assert.assertThat(apps.keySet(), containsInAnyOrder(
-              "root-url-client", "Account", "Account Console", "test-app", "test-app-scope", "third-party", "test-app-authz", "My Named Test App", "Test App Named - ${client_account}", "direct-grant"));
+              "root-url-client", "Account", "Account Console", "test-app", "test-app-scope", "third-party", "test-app-authz", "My Named Test App", "Test App Named - ${client_account}", "direct-grant", "custom-audience"));
         }
     }
 
@@ -1230,7 +1230,7 @@ public class AccountFormServiceTest extends AbstractTestRealmKeycloakTest {
 
             Map<String, AccountApplicationsPage.AppEntry> apps = applicationsPage.getApplications();
             Assert.assertThat(apps.keySet(), containsInAnyOrder(
-              "root-url-client", "Account", "Account Console", "test-app", "test-app-scope", "third-party", "test-app-authz", "My Named Test App", "Test App Named - ${client_account}", "direct-grant"));
+              "root-url-client", "Account", "Account Console", "test-app", "test-app-scope", "third-party", "test-app-authz", "My Named Test App", "Test App Named - ${client_account}", "direct-grant", "custom-audience"));
         }
     }
 
@@ -1245,7 +1245,7 @@ public class AccountFormServiceTest extends AbstractTestRealmKeycloakTest {
         applicationsPage.assertCurrent();
 
         Map<String, AccountApplicationsPage.AppEntry> apps = applicationsPage.getApplications();
-        Assert.assertThat(apps.keySet(), containsInAnyOrder("root-url-client", "Account", "Account Console", "Broker", "test-app", "test-app-scope", "third-party", "test-app-authz", "My Named Test App", "Test App Named - ${client_account}", "direct-grant"));
+        Assert.assertThat(apps.keySet(), containsInAnyOrder("root-url-client", "Account", "Account Console", "Broker", "test-app", "test-app-scope", "third-party", "test-app-authz", "My Named Test App", "Test App Named - ${client_account}", "direct-grant", "custom-audience"));
 
         AccountApplicationsPage.AppEntry accountEntry = apps.get("Account");
         Assert.assertThat(accountEntry.getRolesAvailable(), containsInAnyOrder(

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/AccountRestServiceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/AccountRestServiceTest.java
@@ -49,6 +49,7 @@ import org.keycloak.representations.idm.AuthenticationFlowRepresentation;
 import org.keycloak.representations.idm.ClientScopeRepresentation;
 import org.keycloak.representations.idm.CredentialRepresentation;
 import org.keycloak.representations.idm.ErrorRepresentation;
+import org.keycloak.representations.idm.ProtocolMapperRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.RequiredActionProviderRepresentation;
 import org.keycloak.representations.idm.RequiredActionProviderSimpleRepresentation;
@@ -76,6 +77,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.keycloak.common.Profile.Feature.ACCOUNT_API;
@@ -374,7 +376,7 @@ public class AccountRestServiceTest extends AbstractRestServiceTest {
                 null, UserModel.RequiredAction.UPDATE_PASSWORD.toString(), false, 1);
 
         CredentialRepresentation password1 = password.getUserCredentials().get(0);
-        Assert.assertNull(password1.getSecretData());
+        assertNull(password1.getSecretData());
         Assert.assertNotNull(password1.getCredentialData());
 
         AccountCredentialResource.CredentialContainer otp = credentials.get(1);
@@ -421,7 +423,7 @@ public class AccountRestServiceTest extends AbstractRestServiceTest {
         Assert.assertEquals(1, credentials.size());
         password = credentials.get(0);
         Assert.assertEquals(PasswordCredentialModel.TYPE, password.getType());
-        Assert.assertNull(password.getUserCredentials());
+        assertNull(password.getUserCredentials());
     }
 
 
@@ -532,8 +534,8 @@ public class AccountRestServiceTest extends AbstractRestServiceTest {
         credentials = getCredentials();
         assertExpectedCredentialTypes(credentials, PasswordCredentialModel.TYPE, OTPCredentialModel.TYPE);
         AccountCredentialResource.CredentialContainer otpCredential = credentials.get(1);
-        Assert.assertNull(otpCredential.getCreateAction());
-        Assert.assertNull(otpCredential.getUpdateAction());
+        assertNull(otpCredential.getCreateAction());
+        assertNull(otpCredential.getUpdateAction());
 
         // Revert - re-enable requiredAction and remove OTP credential from the user
         setRequiredActionEnabledStatus(UserModel.RequiredAction.CONFIGURE_TOTP.name(), true);
@@ -658,7 +660,7 @@ public class AccountRestServiceTest extends AbstractRestServiceTest {
     public void listApplications() throws Exception {
         oauth.clientId("in-use-client");
         OAuthClient.AccessTokenResponse tokenResponse = oauth.doGrantAccessTokenRequest("secret1", "view-applications-access", "password");
-        Assert.assertNull(tokenResponse.getErrorDescription());
+        assertNull(tokenResponse.getErrorDescription());
 
         TokenUtil token = new TokenUtil("view-applications-access", "password");
         List<ClientRepresentation> applications = SimpleHttp
@@ -680,7 +682,7 @@ public class AccountRestServiceTest extends AbstractRestServiceTest {
     public void listApplicationsFiltered() throws Exception {
         oauth.clientId("in-use-client");
         OAuthClient.AccessTokenResponse tokenResponse = oauth.doGrantAccessTokenRequest("secret1", "view-applications-access", "password");
-        Assert.assertNull(tokenResponse.getErrorDescription());
+        assertNull(tokenResponse.getErrorDescription());
 
         TokenUtil token = new TokenUtil("view-applications-access", "password");
         List<ClientRepresentation> applications = SimpleHttp
@@ -703,7 +705,7 @@ public class AccountRestServiceTest extends AbstractRestServiceTest {
         oauth.scope(OAuth2Constants.OFFLINE_ACCESS);
         oauth.clientId("offline-client");
         OAuthClient.AccessTokenResponse offlineTokenResponse = oauth.doGrantAccessTokenRequest("secret1", "view-applications-access", "password");
-        Assert.assertNull(offlineTokenResponse.getErrorDescription());
+        assertNull(offlineTokenResponse.getErrorDescription());
 
         TokenUtil token = new TokenUtil("view-applications-access", "password");
         List<ClientRepresentation> applications = SimpleHttp
@@ -767,7 +769,7 @@ public class AccountRestServiceTest extends AbstractRestServiceTest {
     public void listApplicationsWithRootUrl() throws Exception {
         oauth.clientId("root-url-client");
         OAuthClient.AccessTokenResponse tokenResponse = oauth.doGrantAccessTokenRequest("password", "view-applications-access", "password");
-        Assert.assertNull(tokenResponse.getErrorDescription());
+        assertNull(tokenResponse.getErrorDescription());
 
         TokenUtil token = new TokenUtil("view-applications-access", "password");
         List<ClientRepresentation> applications = SimpleHttp
@@ -1180,7 +1182,7 @@ public class AccountRestServiceTest extends AbstractRestServiceTest {
         oauth.scope(OAuth2Constants.OFFLINE_ACCESS);
         oauth.clientId("offline-client");
         OAuthClient.AccessTokenResponse offlineTokenResponse = oauth.doGrantAccessTokenRequest("secret1", "view-applications-access", "password");
-        Assert.assertNull(offlineTokenResponse.getErrorDescription());
+        assertNull(offlineTokenResponse.getErrorDescription());
 
         TokenUtil token = new TokenUtil("view-applications-access", "password");
 
@@ -1221,5 +1223,48 @@ public class AccountRestServiceTest extends AbstractRestServiceTest {
         SimpleHttp.Response response = SimpleHttp.doGet(getAccountUrl("credentials"), httpClient).auth(tokenUtil.getToken()).asResponse();
         assertEquals("API version not found", response.asJson().get("error").textValue());
         assertEquals(404, response.getStatus());
+    }
+
+    @Test
+    public void testAudience() throws Exception {
+        oauth.clientId("custom-audience");
+        OAuthClient.AccessTokenResponse tokenResponse = oauth.doGrantAccessTokenRequest("password", "test-user@localhost", "password");
+        assertNull(tokenResponse.getErrorDescription());
+
+        SimpleHttp.Response response = SimpleHttp.doGet(getAccountUrl(null), httpClient)
+                .auth(tokenResponse.getAccessToken())
+                .header("Accept", "application/json")
+                .asResponse();
+        assertEquals(401, response.getStatus());
+
+        // update to correct audience
+        org.keycloak.representations.idm.ClientRepresentation clientRep = testRealm().clients().findByClientId("custom-audience").get(0);
+        ProtocolMapperRepresentation mapperRep = clientRep.getProtocolMappers().stream().filter(m -> m.getName().equals("aud")).findFirst().orElse(null);
+        assertNotNull("Audience mapper not found", mapperRep);
+        mapperRep.getConfig().put("included.custom.audience", "account");
+        testRealm().clients().get(clientRep.getId()).getProtocolMappers().update(mapperRep.getId(), mapperRep);
+
+        tokenResponse = oauth.doGrantAccessTokenRequest("password", "test-user@localhost", "password");
+        assertNull(tokenResponse.getErrorDescription());
+
+        response = SimpleHttp.doGet(getAccountUrl(null), httpClient)
+                .auth(tokenResponse.getAccessToken())
+                .header("Accept", "application/json")
+                .asResponse();
+        assertEquals(200, response.getStatus());
+
+        // remove audience completely
+        testRealm().clients().get(clientRep.getId()).getProtocolMappers().delete(mapperRep.getId());
+
+        tokenResponse = oauth.doGrantAccessTokenRequest("password", "test-user@localhost", "password");
+        assertNull(tokenResponse.getErrorDescription());
+
+        response = SimpleHttp.doGet(getAccountUrl(null), httpClient)
+                .auth(tokenResponse.getAccessToken())
+                .header("Accept", "application/json")
+                .asResponse();
+        assertEquals(401, response.getStatus());
+
+        // custom-audience client is used only in this test so no need to revert the changes
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/resources/testrealm.json
+++ b/testsuite/integration-arquillian/tests/base/src/test/resources/testrealm.json
@@ -414,7 +414,77 @@
       "enabled": true,
       "directAccessGrantsEnabled": true,
       "secret": "password",
-      "webOrigins": [ "http://localtest.me:8180" ]
+      "webOrigins": [ "http://localtest.me:8180" ],
+      "protocolMappers": [
+        {
+          "name": "aud-account",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "config": {
+            "included.client.audience": "account",
+            "id.token.claim": "true",
+            "access.token.claim": "true"
+          }
+        },
+        {
+          "name": "aud-admin",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "config": {
+            "included.client.audience": "security-admin-console",
+            "id.token.claim": "true",
+            "access.token.claim": "true"
+          }
+        }
+      ]
+    },
+
+    {
+      "clientId": "custom-audience",
+      "enabled": true,
+      "directAccessGrantsEnabled": true,
+      "secret": "password",
+      "protocolMappers": [
+        {
+          "name": "aud",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "config": {
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "included.custom.audience": "foo-bar"
+          }
+        },
+        {
+          "name": "client roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-client-role-mapper",
+          "config": {
+            "user.attribute": "foo",
+            "access.token.claim": "true",
+            "claim.name": "resource_access.${client_id}.roles",
+            "jsonType.label": "String",
+            "multivalued": "true"
+          }
+        },
+        {
+          "name": "realm roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "config": {
+            "user.attribute": "foo",
+            "access.token.claim": "true",
+            "claim.name": "realm_access.roles",
+            "jsonType.label": "String",
+            "multivalued": "true"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "profile",
+        "email"
+      ]
     }
   ],
   "roles" : {


### PR DESCRIPTION
Test pipeline runs:
https://keycloak-jenkins.com/job/universal-test-pipeline-server/2124/
https://keycloak-jenkins.com/job/universal-test-pipeline-adapters/1714/
The failures are unrelated to this change except for `AccountFormServiceTest`. The test is now fixed, the fix was very simple, so I didn't re-run the whole pipelines just for that. You should be able to see it passed in Travis below.