### PR TITLE
KEYCLOAK-15481: Display forbidden screen in new account console

### DIFF
--- a/testsuite/integration-arquillian/tests/other/base-ui/src/test/java/org/keycloak/testsuite/ui/account2/PermissionsTest.java
+++ b/testsuite/integration-arquillian/tests/other/base-ui/src/test/java/org/keycloak/testsuite/ui/account2/PermissionsTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite.ui.account2;
+
+import org.jboss.arquillian.graphene.page.Page;
+import org.junit.Test;
+import org.keycloak.admin.client.resource.RoleScopeResource;
+import org.keycloak.testsuite.ui.account2.page.ForbiddenPage;
+import org.keycloak.testsuite.ui.account2.page.PersonalInfoPage;
+import org.keycloak.testsuite.ui.account2.page.SigningInPage;
+import org.keycloak.testsuite.ui.account2.page.WelcomeScreen;
+
+import java.util.stream.Collectors;
+
+import static org.keycloak.models.AccountRoles.MANAGE_ACCOUNT;
+import static org.keycloak.models.Constants.ACCOUNT_MANAGEMENT_CLIENT_ID;
+
+/**
+ * @author Vaclav Muzikar <vmuzikar@redhat.com>
+ */
+public class PermissionsTest extends AbstractAccountTest {
+    @Page
+    private WelcomeScreen welcomeScreen;
+
+    @Page
+    private PersonalInfoPage personalInfoPage;
+
+    @Page
+    private SigningInPage signingInPage;
+
+    @Page
+    private ForbiddenPage forbiddenPage;
+
+    @Test
+    public void manageAccountRoleRequired() {
+        // remove the default role from test user
+        String accountClientId = testRealmResource().clients().findByClientId(ACCOUNT_MANAGEMENT_CLIENT_ID).get(0).getId();
+        RoleScopeResource roleScopes = testUserResource().roles().clientLevel(accountClientId);
+        roleScopes.remove(roleScopes.listAll().stream()
+                .filter(r -> MANAGE_ACCOUNT.equals(r.getName()))
+                .collect(Collectors.toList()));
+
+        welcomeScreen.header().clickLoginBtn();
+        loginToAccount();
+        welcomeScreen.assertCurrent(); // no forbidden at welcome screen yet
+
+        welcomeScreen.clickPersonalInfoLink();
+        forbiddenPage.assertCurrent();
+
+        signingInPage.navigateToUsingSidebar();
+        forbiddenPage.assertCurrent();
+
+        // still possible to sign out
+        forbiddenPage.header().clickLogoutBtn();
+        welcomeScreen.assertCurrent();
+        welcomeScreen.header().assertLoginBtnVisible(true);
+        welcomeScreen.header().assertLogoutBtnVisible(false);
+    }
+}

--- a/testsuite/integration-arquillian/tests/other/base-ui/src/test/java/org/keycloak/testsuite/ui/account2/page/ForbiddenPage.java
+++ b/testsuite/integration-arquillian/tests/other/base-ui/src/test/java/org/keycloak/testsuite/ui/account2/page/ForbiddenPage.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite.ui.account2.page;
+
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+/**
+ * @author Vaclav Muzikar <vmuzikar@redhat.com>
+ */
+public class ForbiddenPage extends AbstractLoggedInPage {
+    @FindBy(tagName = "main")
+    private WebElement mainTag;
+
+    @Override
+    public String getPageId() {
+        return "forbidden";
+    }
+
+    @Override
+    public boolean isCurrent() {
+        return mainTag.getText().contains("You do not have access rights to this request.");
+    }
+}

--- a/themes/src/main/resources/theme/keycloak-preview/account/messages/messages_en.properties
+++ b/themes/src/main/resources/theme/keycloak-preview/account/messages/messages_en.properties
@@ -1,6 +1,8 @@
 # Put new messages for Account Console Here
 # Feel free to use any existing messages from the base theme
 pageNotFound=Page Not Found
+forbidden=Forbidden
+needAccessRights=You do not have access rights to this request.  Contact your administrator.
 invalidRoute={0} is not a valid route.
 actionRequiresIDP=This action requires redirection to your identity provider.
 continue=Continue

--- a/themes/src/main/resources/theme/keycloak-preview/account/src/app/ContentPages.tsx
+++ b/themes/src/main/resources/theme/keycloak-preview/account/src/app/ContentPages.tsx
@@ -19,6 +19,7 @@ import {Route, Switch} from 'react-router-dom';
 import {NavItem, NavExpandable} from '@patternfly/react-core';
 import {Msg} from './widgets/Msg';
 import {PageNotFound} from './content/page-not-found/PageNotFound';
+import { ForbiddenPage } from './content/forbidden-page/ForbiddenPage';
 
 export interface ContentItem {
     id?: string;
@@ -167,6 +168,7 @@ export function makeRoutes(): React.ReactNode {
 
     return (<Switch>
                 {routes}
+                <Route path="/forbidden" component={ForbiddenPage}/>
                 <Route component={PageNotFound}/>
             </Switch>);
 }

--- a/themes/src/main/resources/theme/keycloak-preview/account/src/app/account-service/account.service.ts
+++ b/themes/src/main/resources/theme/keycloak-preview/account/src/app/account-service/account.service.ts
@@ -18,6 +18,8 @@
 import {KeycloakService} from '../keycloak-service/keycloak.service';
 import {ContentAlert} from '../content/ContentAlert';
 
+declare const baseUrl: string;
+
 type ConfigResolve = (config: RequestInit) => void;
 
 export interface HttpResponse<T = {}> extends Response {
@@ -88,12 +90,16 @@ export class AccountServiceClient {
     }
 
     private handleError(response: HttpResponse): void {
-        if (response != null && response.status === 401) {
+        if (response !== null && response.status === 401) {
             // session timed out?
             this.kcSvc.login();
         }
 
-        if (response != null && response.data != null) {
+        if (response !== null && response.status === 403) {
+            window.location.href = baseUrl + '/#/forbidden';
+        }
+
+        if (response !== null && response.data != null) {
             ContentAlert.danger(
                 `${response.statusText}: ${response.data['errorMessage'] ? response.data['errorMessage'] : ''} ${response.data['error'] ? response.data['error'] : ''}`
             );

--- a/themes/src/main/resources/theme/keycloak-preview/account/src/app/content/forbidden-page/ForbiddenPage.tsx
+++ b/themes/src/main/resources/theme/keycloak-preview/account/src/app/content/forbidden-page/ForbiddenPage.tsx
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as React from 'react';
+
+import { WarningTriangleIcon } from '@patternfly/react-icons';
+import {Msg} from '../../widgets/Msg';
+import EmptyMessageState from '../../widgets/EmptyMessageState';
+
+
+export class ForbiddenPage extends React.Component {
+
+    public constructor() {
+        super({});
+    }
+
+    public render(): React.ReactNode {
+        return (
+            <EmptyMessageState icon={WarningTriangleIcon} messageKey="forbidden">
+                <Msg msgKey="needAccessRights"/>
+            </EmptyMessageState>
+        );
+    }
+};


### PR DESCRIPTION
Display forbidden screen in new account console if user tries to do something he doesn't have rights to do.

![forbidden](https://user-images.githubusercontent.com/507202/92653247-14811a00-f2bc-11ea-98af-fce4b4ec8d29.png)

