### PR TITLE
KEYCLOAK-14846 Default roles processing is really slow 

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmAdapter.java
@@ -796,6 +796,16 @@ public class RealmAdapter implements CachedRealmModel {
     }
 
     @Override
+    public Stream<ClientModel> getClientsWithDefaultRolesStream() {
+        return cacheSession.getClientsWithDefaultRolesStream(this);
+    }
+
+    @Override
+    public Stream<ClientModel> getClientsWithDefaultRolesStream(Integer firstResult, Integer maxResults) {
+        return cacheSession.getClientsWithDefaultRolesStream(this, firstResult, maxResults);
+    }
+
+    @Override
     public Long getClientsCount() {
         return cacheSession.getClientsCount(this);
     }

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmCacheSession.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmCacheSession.java
@@ -562,6 +562,16 @@ public class RealmCacheSession implements CacheRealmProvider {
     }
 
     @Override
+    public Stream<ClientModel> getClientsWithDefaultRolesStream(RealmModel realm) {
+        return getClientDelegate().getClientsWithDefaultRolesStream(realm);
+    }
+
+    @Override
+    public Stream<ClientModel> getClientsWithDefaultRolesStream(RealmModel realm, Integer firstResult, Integer maxResults) {
+        return getClientDelegate().getClientsWithDefaultRolesStream(realm, firstResult, maxResults);
+    }
+
+    @Override
     public Stream<ClientModel> getAlwaysDisplayInConsoleClientsStream(RealmModel realm) {
         return getClientDelegate().getAlwaysDisplayInConsoleClientsStream(realm);
     }

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
@@ -603,6 +603,26 @@ public class JpaRealmProvider implements RealmProvider, ClientProvider, GroupPro
     }
 
     @Override
+    public Stream<ClientModel> getClientsWithDefaultRolesStream(RealmModel realm, Integer firstResult, Integer maxResults) {
+        TypedQuery<String> query = em.createNamedQuery("getClientsIdsWithDefaultRoles", String.class);
+        if (firstResult != null && firstResult > 0) {
+            query.setFirstResult(firstResult);
+        }
+        if (maxResults != null && maxResults > 0) {
+            query.setMaxResults(maxResults);
+        }
+        query.setParameter("realm", realm.getId());
+        Stream<String> clients = query.getResultStream();
+
+        return closing(clients.map(client -> session.clients().getClientById(realm,client)).filter(Objects::nonNull));
+    }
+
+    @Override
+    public Stream<ClientModel> getClientsWithDefaultRolesStream(RealmModel realm) {
+        return getClientsWithDefaultRolesStream(realm, null, null);
+    }
+
+    @Override
     public Stream<ClientModel> getClientsStream(RealmModel realm, Integer firstResult, Integer maxResults) {
         TypedQuery<String> query = em.createNamedQuery("getClientIdsByRealm", String.class);
         if (firstResult != null && firstResult > 0) {

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/RealmAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/RealmAdapter.java
@@ -836,6 +836,16 @@ public class RealmAdapter implements RealmModel, JpaModel<RealmEntity> {
     }
 
     @Override
+    public Stream<ClientModel> getClientsWithDefaultRolesStream() {
+        return session.clients().getClientsWithDefaultRolesStream(this);
+    }
+
+    @Override
+    public Stream<ClientModel> getClientsWithDefaultRolesStream(Integer firstResult, Integer maxResults) {
+        return session.clients().getClientsWithDefaultRolesStream(this, firstResult, maxResults);
+    }
+
+    @Override
     public Stream<ClientModel> getAlwaysDisplayInConsoleClientsStream() {
         return session.clients().getAlwaysDisplayInConsoleClientsStream(this);
     }

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/ClientEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/ClientEntity.java
@@ -54,6 +54,7 @@ import java.util.Set;
         @NamedQuery(name="getClientsByRealm", query="select client from ClientEntity client where client.realm = :realm"),
         @NamedQuery(name="getClientById", query="select client from ClientEntity client where client.id = :id and client.realm.id = :realm"),
         @NamedQuery(name="getClientIdsByRealm", query="select client.id from ClientEntity client where client.realm.id = :realm order by client.clientId"),
+        @NamedQuery(name="getClientsIdsWithDefaultRoles", query="select client.id from ClientEntity client where client.realm.id=:realm and client.defaultRoles.size > 0 order by client.clientId"),
         @NamedQuery(name="getAlwaysDisplayInConsoleClients", query="select client.id from ClientEntity client where client.alwaysDisplayInConsole = true and client.realm.id = :realm  order by client.clientId"),
         @NamedQuery(name="findClientIdByClientId", query="select client.id from ClientEntity client where client.clientId = :clientId and client.realm.id = :realm"),
         @NamedQuery(name="searchClientsByClientId", query="select client.id from ClientEntity client where lower(client.clientId) like lower(concat('%',:clientId,'%')) and client.realm.id = :realm order by client.clientId"),

--- a/model/map/src/main/java/org/keycloak/models/map/client/MapClientProvider.java
+++ b/model/map/src/main/java/org/keycloak/models/map/client/MapClientProvider.java
@@ -158,6 +158,28 @@ public class MapClientProvider implements ClientProvider {
     }
 
     @Override
+    public Stream<ClientModel> getClientsWithDefaultRolesStream(RealmModel realm, Integer firstResult, Integer maxResults) {
+        Stream<ClientModel> s = getClientsWithDefaultRolesStream(realm);
+        if (firstResult != null && firstResult >= 0) {
+            s = s.skip(firstResult);
+        }
+        if (maxResults != null && maxResults >= 0) {
+            s = s.limit(maxResults);
+        }
+        return s;
+    }
+
+    @Override
+    public Stream<ClientModel> getClientsWithDefaultRolesStream(RealmModel realm) {
+        Predicate<MapClientEntity> hasDefaultRoles = client -> !client.getDefaultRoles().isEmpty();
+        return getNotRemovedUpdatedClientsStream()
+                .filter(entityRealmFilter(realm))
+                .filter(hasDefaultRoles)
+                .sorted(COMPARE_BY_CLIENT_ID)
+                .map(entityToAdapterFunc(realm));
+    }
+
+    @Override
     public ClientModel addClient(RealmModel realm, String id, String clientId) {
         final UUID entityId = id == null ? UUID.randomUUID() : UUID.fromString(id);
 

--- a/server-spi/src/main/java/org/keycloak/models/ClientProvider.java
+++ b/server-spi/src/main/java/org/keycloak/models/ClientProvider.java
@@ -76,6 +76,25 @@ public interface ClientProvider extends ClientLookupProvider, Provider {
     }
 
     /**
+     * Returns the clients which contain default roles of the given realm as a stream.
+     * @param realm Realm.
+     * @param firstResult First result to return. Ignored if negative or {@code null}.
+     * @param maxResults Maximum number of results to return. Ignored if negative or {@code null}.
+     * @return Stream of the clients. Never returns {@code null}.
+     */
+    Stream<ClientModel> getClientsWithDefaultRolesStream(RealmModel realm, Integer firstResult, Integer maxResults);
+
+    /**
+     * Returns all the clients which contain default roles of the given realm as a stream.
+     * Effectively the same as the call {@code getClientsStream(realm, null, null)}.
+     * @param realm Realm.
+     * @return Stream of the clients. Never returns {@code null}.
+     */
+    default Stream<ClientModel> getClientsWithDefaultRolesStream(RealmModel realm) {
+        return this.getClientsWithDefaultRolesStream(realm, null, null);
+    }
+
+    /**
      * Adds a client with given {@code clientId} to the given realm.
      * The internal ID of the client will be created automatically.
      * @param realm Realm owning this client.

--- a/server-spi/src/main/java/org/keycloak/models/RealmModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/RealmModel.java
@@ -308,6 +308,10 @@ public interface RealmModel extends RoleContainerModel {
 
     Stream<ClientModel> getClientsStream(Integer firstResult, Integer maxResults);
 
+    Stream<ClientModel> getClientsWithDefaultRolesStream();
+
+    Stream<ClientModel> getClientsWithDefaultRolesStream(Integer firstResult,Integer maxResults);
+
     Long getClientsCount();
 
     @Deprecated

--- a/server-spi/src/main/java/org/keycloak/models/utils/DefaultRoles.java
+++ b/server-spi/src/main/java/org/keycloak/models/utils/DefaultRoles.java
@@ -22,11 +22,9 @@ import org.keycloak.models.RoleModel;
 import org.keycloak.models.UserModel;
 
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -40,10 +38,10 @@ public class DefaultRoles {
         }
 
         Function<ClientModel, Set<RoleModel>> defaultRoles = i -> i.getDefaultRoles().stream().map(i::getRole).collect(Collectors.toSet());
-        realm.getClientsStream().map(defaultRoles).forEach(set::addAll);
-
+        realm.getClientsWithDefaultRolesStream().map(defaultRoles).forEach(set::addAll);
         return set;
     }
+
     public static void addDefaultRoles(RealmModel realm, UserModel userModel) {
         for (RoleModel role : getDefaultRoles(realm)) {
             userModel.grantRole(role);

--- a/services/src/main/java/org/keycloak/storage/ClientStorageManager.java
+++ b/services/src/main/java/org/keycloak/storage/ClientStorageManager.java
@@ -191,6 +191,16 @@ public class ClientStorageManager implements ClientProvider {
     }
 
     @Override
+    public Stream<ClientModel> getClientsWithDefaultRolesStream(RealmModel realm, Integer firstResult, Integer maxResults) {
+        return session.clientLocalStorage().getClientsWithDefaultRolesStream(realm, firstResult, maxResults);
+    }
+
+    @Override
+    public Stream<ClientModel> getClientsWithDefaultRolesStream(RealmModel realm) {
+        return session.clientLocalStorage().getClientsWithDefaultRolesStream(realm);
+    }
+
+    @Override
     public long getClientsCount(RealmModel realm) {
         return session.clientLocalStorage().getClientsCount(realm);
     }


### PR DESCRIPTION
Default roles processing is really slow with a large number of clients.
JIRA: [KEYCLOAK-14846](https://issues.redhat.com/browse/KEYCLOAK-14846)

This approach should decrease time to obtain default roles to user. Before this, the static _getDefaultRoles_ method in _DefaultRoles_ class had to iterate over all clients instead of using only clients with defined default roles. I've tried to test with 1500 clients, which 150 of them have defined, at least one, default role and protocol mapper. I've created 80 users and averaged creation time (which includes default roles processing). The time needed for retrieving the roles is 40% smaller, than before.

For long-term consideration, IMO, it should be good to provide DB indexing for clients and roles.