### PR TITLE
KEYCLOAK-14302 Fix the setting of the lifespan for cache entries. 

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/cluster/infinispan/InfinispanClusterProviderFactory.java
+++ b/model/infinispan/src/main/java/org/keycloak/cluster/infinispan/InfinispanClusterProviderFactory.java
@@ -150,9 +150,9 @@ public class InfinispanClusterProviderFactory implements ClusterProviderFactory 
             try {
                 V result;
                 if (taskTimeoutInSeconds > 0) {
-                    result = (V) crossDCAwareCacheFactory.getCache().putIfAbsent(key, value);
-                } else {
                     result = (V) crossDCAwareCacheFactory.getCache().putIfAbsent(key, value, taskTimeoutInSeconds, TimeUnit.SECONDS);
+                } else {
+                    result = (V) crossDCAwareCacheFactory.getCache().putIfAbsent(key, value);
                 }
                 resultRef.set(result);
 


### PR DESCRIPTION
Cache entries in Infinispan can be created with a limited lifespan in InfinispanClusterProviderFactory. But the lifespan specified by a caller were never applied.
This bug caused that jobs were no longer executed after temporary network partition in multinode setup, because the cluster based locks used for the coordination were never released.


