### PR TITLE
KEYCLOAK-15532: Add support for File type fields in Authenticator Config

### DIFF
--- a/themes/src/main/resources/theme/base/admin/resources/templates/kc-provider-config.html
+++ b/themes/src/main/resources/theme/base/admin/resources/templates/kc-provider-config.html
@@ -31,6 +31,14 @@
             </input>
         </div>
 
+        <div class="col-md-6" data-ng-if="option.type == 'File'">
+            <div class="controls kc-button-input-file">
+                <input class="form-control" type="text" data-ng-model="config[option.name][0]" >
+                <label for="{{option.name}}" class="btn btn-default">{{:: 'select-file' | translate}} <i class="pficon pficon-import"></i></label>
+                <input id="{{option.name}}" type="file" class="hidden" ng-file-select="uploadFile($files, option.name, config)">
+            </div>
+        </div>        
+
         <div class="col-md-6" data-ng-if="option.type == 'Script'">
             <div ng-model="config[option.name]" placeholder="Enter your script..." ui-ace="{ onLoad : initEditor, useWrapMode: true, showGutter: true, theme:'github', mode: 'javascript'}">
                 {{config[option.name]}}


### PR DESCRIPTION
The template for displaying the configuration of authenticators does not currently support the input type of File.

It would be handy to allow files to be uploaded for the authenticator we are developing rather than pasting the contents of the file into a text field.

Template: themes/src/main/resources/theme/base/admin/resources/templates/kc-provider-config.html

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
