### PR TITLE
KEYCLOAK-15460 Fix missing event types in SAML endpoint

### DIFF
--- a/services/src/main/java/org/keycloak/broker/saml/SAMLEndpoint.java
+++ b/services/src/main/java/org/keycloak/broker/saml/SAMLEndpoint.java
@@ -258,6 +258,7 @@ public class SAMLEndpoint {
             RequestAbstractType requestAbstractType = (RequestAbstractType) holder.getSamlObject();
             // validate destination
             if (requestAbstractType.getDestination() == null && containsUnencryptedSignature(holder)) {
+                event.event(EventType.IDENTITY_PROVIDER_RESPONSE);
                 event.detail(Details.REASON, "missing_required_destination");
                 event.error(Errors.INVALID_REQUEST);
                 return ErrorPage.error(session, null, Response.Status.BAD_REQUEST, Messages.INVALID_REQUEST);
@@ -518,6 +519,7 @@ public class SAMLEndpoint {
             StatusResponseType statusResponse = (StatusResponseType)holder.getSamlObject();
             // validate destination
             if (statusResponse.getDestination() == null && containsUnencryptedSignature(holder)) {
+                event.event(EventType.IDENTITY_PROVIDER_RESPONSE);
                 event.detail(Details.REASON, "missing_required_destination");
                 event.error(Errors.INVALID_SAML_LOGOUT_RESPONSE);
                 return ErrorPage.error(session, null, Response.Status.BAD_REQUEST, Messages.INVALID_REQUEST);


### PR DESCRIPTION
A change was done in https://github.com/keycloak/keycloak/commit/32f13016fafcaadec9092a8b078d7a7717a18b29 which isn't setting the type for events and causing an internal error.

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
