### PR TITLE
KEYCLOAK-15559 Client Policy - Executor : Missing Help Text of Secure ResponseTypeExecutor

### DIFF
--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureResponseTypeExecutorFactory.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureResponseTypeExecutorFactory.java
@@ -54,7 +54,7 @@ public class SecureResponseTypeExecutorFactory implements ClientPolicyExecutorPr
 
     @Override
     public String getHelpText() {
-        return null;
+        return "The executor checks whether the client sent its authorization request with code id_token or code id_token token in its response type by following Financial-grade API Security Profile : Read and Write API Security Profile.";
     }
 
     @Override


### PR DESCRIPTION
This PR is for [KEYCLOAK-15559 Client Policy - Executor : Missing Help Text of SecureResponseTypeExecutor](https://issues.redhat.com/browse/KEYCLOAK-15559) 