### PR TITLE
[KEYCLOAK-14046] Allow finegrain group admins to create users in console

### DIFF
--- a/themes/src/main/resources/theme/base/admin/resources/partials/user-detail.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/user-detail.html
@@ -169,7 +169,7 @@
         </fieldset>
 
         <div class="form-group">
-            <div class="col-md-10 col-md-offset-2" data-ng-show="create && access.manageUsers">
+            <div class="col-md-10 col-md-offset-2" data-ng-show="create && (access.manageUsers || (serverInfo.featureEnabled('ADMIN_FINE_GRAINED_AUTHZ') && access.queryUsers))">
                 <button kc-save data-ng-show="changed">{{:: 'save' | translate}}</button>
                 <button kc-cancel data-ng-click="cancel()">{{:: 'cancel' | translate}}</button>
             </div>

--- a/themes/src/main/resources/theme/base/admin/resources/partials/user-list.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/user-list.html
@@ -18,7 +18,7 @@
                     </div>
                     <button id="viewAllUsers" class="btn btn-default" ng-click="query.search = null; firstPage()">{{:: 'view-all-users' | translate}}</button>
 
-                    <div class="pull-right" data-ng-show="access.manageUsers">
+                    <div class="pull-right" data-ng-show="(access.manageUsers || (serverInfo.featureEnabled('ADMIN_FINE_GRAINED_AUTHZ') && access.queryUsers))">
                         <button data-ng-click="unlockUsers()" class="btn btn-default">{{:: 'unlock-users' | translate}}</button>
                         <a id="createUser" class="btn btn-default" href="#/create/user/{{realm.realm}}">{{:: 'add-user' | translate}}</a>
                     </div>


### PR DESCRIPTION
- enable "Create" button and "Save" button in Admin Console Users views (list
and details)

The flag used to enable those button is computed as follow, since there's no computed flag
from backend on "admin user has fine grain admin permission on at least 1 group" :
  == (existing condition) || (feature "finegrain admin" is enabled && access.queryUsers)

If the admin user hasn't the correct permission on the right groups for the new user he's
trying to create, backend will forbid the creation by returning a 403

This change is following PR #7035, which added the Groups field in the User creation form

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
