### PR TITLE
Check FIELD_PASSWORD_CONFIRM only if client submitted FIELD_PASSWORD_…

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/forms/RegistrationPassword.java
+++ b/services/src/main/java/org/keycloak/authentication/forms/RegistrationPassword.java
@@ -67,7 +67,7 @@ public class RegistrationPassword implements FormAction, FormActionFactory {
         context.getEvent().detail(Details.REGISTER_METHOD, "form");
         if (Validation.isBlank(formData.getFirst(RegistrationPage.FIELD_PASSWORD))) {
             errors.add(new FormMessage(RegistrationPage.FIELD_PASSWORD, Messages.MISSING_PASSWORD));
-        } else if (!formData.getFirst(RegistrationPage.FIELD_PASSWORD).equals(formData.getFirst(RegistrationPage.FIELD_PASSWORD_CONFIRM))) {
+        } else if (formData.containsKey(RegistrationPage.FIELD_PASSWORD_CONFIRM) && !formData.getFirst(RegistrationPage.FIELD_PASSWORD).equals(formData.getFirst(RegistrationPage.FIELD_PASSWORD_CONFIRM))) {
             errors.add(new FormMessage(RegistrationPage.FIELD_PASSWORD_CONFIRM, Messages.INVALID_PASSWORD_CONFIRM));
         }
         if (formData.getFirst(RegistrationPage.FIELD_PASSWORD) != null) {


### PR DESCRIPTION
I have a client that wishes to have a registration form without the password confirmation field. This field is a convenience for the user anyway and is not absolutely necessary.  Thus, I changed the implementation of RegistrationPassword.java to check the FIELD_PASSWORD_CONFIRM only if it was actually passed back in the form.  Otherwise, the check should be ignored.
