### PR TITLE
[KEYCLOAK-14221] - Allow to map subject to userinfo response

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/UserInfoEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/UserInfoEndpoint.java
@@ -215,16 +215,11 @@ public class UserInfoEndpoint {
 
         AccessToken userInfo = new AccessToken();
         
-        userInfo.subject(userModel.getId());
-        
         tokenManager.transformUserInfoAccessToken(session, userInfo, userSession, clientSessionCtx);
 
         Map<String, Object> claims = new HashMap<>();
+        claims.put("sub", userModel.getId());
         claims.putAll(userInfo.getOtherClaims());
-        // we always set the subject to the correct value and ignore any mapper (not directly related to subject mapping such as 
-        // pseudo-subjects). the endpoint should always return a valid subject identifier.
-        // any attempt to customize the value of this field should be done through a different claim
-        claims.put("sub", userInfo.getSubject());
 
         if (userInfo.getRealmAccess() != null) {
             Map<String, Set<String>> realmAccess = new HashMap<>();

--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/AbstractPairwiseSubMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/AbstractPairwiseSubMapper.java
@@ -90,7 +90,7 @@ public abstract class AbstractPairwiseSubMapper extends AbstractOIDCProtocolMapp
     }
 
     protected void setUserInfoTokenSubject(IDToken token, String pairwiseSub) {
-        token.setSubject(pairwiseSub);
+        token.getOtherClaims().put("sub", pairwiseSub);
     }
 
     @Override

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerSubMatchIntrospectionTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerSubMatchIntrospectionTest.java
@@ -1,6 +1,7 @@
 package org.keycloak.testsuite.broker;
 
 import org.junit.Ignore;
+import org.keycloak.protocol.oidc.mappers.OIDCAttributeMapperHelper;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.ProtocolMapperRepresentation;
 import org.keycloak.testsuite.util.ClientBuilder;
@@ -12,7 +13,7 @@ import static org.keycloak.testsuite.broker.BrokerTestTools.waitForPage;
 import static org.keycloak.testsuite.util.ProtocolMapperUtil.createHardcodedClaim;
 import static org.keycloak.testsuite.broker.BrokerTestTools.getConsumerRoot;
 
-public class KcOidcBrokerSubMatchIntrospectionest extends AbstractBrokerTest {
+public class KcOidcBrokerSubMatchIntrospectionTest extends AbstractBrokerTest {
 
     @Override
     protected BrokerConfiguration getBrokerConfiguration() {
@@ -33,8 +34,13 @@ public class KcOidcBrokerSubMatchIntrospectionest extends AbstractBrokerTest {
             public List<ClientRepresentation> createProviderClients() {
                 List<ClientRepresentation> clients = super.createProviderClients();
                 List<ProtocolMapperRepresentation> mappers = new ArrayList<>();
+
+                ProtocolMapperRepresentation hardcodedClaim = createHardcodedClaim("sub-override", "sub", "overriden",
+                        "String", false, false);
                 
-                mappers.add(createHardcodedClaim("sub-override", "sub", "overriden", "String", true, true));
+                hardcodedClaim.getConfig().put(OIDCAttributeMapperHelper.INCLUDE_IN_USERINFO, Boolean.TRUE.toString());
+                
+                mappers.add(hardcodedClaim);
                 
                 clients.get(0).setProtocolMappers(mappers);
                 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/UserInfoTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/UserInfoTest.java
@@ -623,8 +623,7 @@ public class UserInfoTest extends AbstractKeycloakTest {
                 .detail(Details.SIGNATURE_REQUIRED, "false")
                 .client(expectedClientId)
                 .assertEvent();
-        UserRepresentation user = adminClient.realm("test").users().search("test-user@localhost").get(0);
-        return UserInfoClientUtil.testSuccessfulUserInfoResponse(response, user.getId(), "test-user@localhost", "test-user@localhost");
+        return UserInfoClientUtil.testSuccessfulUserInfoResponse(response, "test-user@localhost", "test-user@localhost");
     }
 
     private void testSuccessSignedResponse(Algorithm sigAlg) throws Exception {


### PR DESCRIPTION
* Revert constraints added by https://issues.redhat.com/browse/KEYCLOAK-7450 so that the `sub` claim can be mapped when processing the userinfo response.