### PR TITLE
[KEYCLOAK-15408] [KEYCLOAK-15442] [KEYCLOAK-15474] Various "upgrade Keycloak to next Wildfly version" automated script fixes

### DIFF
--- a/misc/scripts/upgrade-wildfly/upgrade-keycloak-to-wildfly-tag.py
+++ b/misc/scripts/upgrade-wildfly/upgrade-keycloak-to-wildfly-tag.py
@@ -65,6 +65,8 @@ if __name__ == '__main__':
         wu.performRhssoAdapterLicenseFilesUpdateTask(wildflyPomFile, wildflyCorePomFile)
         # Subtask - Update properties of the deprecated Wildfly testing module if necessary
         wu.performDeprecatedWildflyTestingModuleUpdateTask()
+        # Subtask - Update version of jboss-parent if necessary
+        wu.performJbossParentVersionUpdateTask(wildflyPomFile, wildflyCorePomFile)
 
         for filename in [wildflyPomFile, wildflyCorePomFile]:
             os.remove(filename)

--- a/misc/scripts/upgrade-wildfly/upgrade-keycloak-to-wildfly-tag.py
+++ b/misc/scripts/upgrade-wildfly/upgrade-keycloak-to-wildfly-tag.py
@@ -63,6 +63,8 @@ if __name__ == '__main__':
         wu.performKeycloakAdapterLicenseFilesUpdateTask(wildflyPomFile, wildflyCorePomFile)
         # Subtask - Update RH-SSO adapters
         wu.performRhssoAdapterLicenseFilesUpdateTask(wildflyPomFile, wildflyCorePomFile)
+        # Subtask - Update properties of the deprecated Wildfly testing module if necessary
+        wu.performDeprecatedWildflyTestingModuleUpdateTask()
 
         for filename in [wildflyPomFile, wildflyCorePomFile]:
             os.remove(filename)

--- a/misc/scripts/upgrade-wildfly/upgrade-keycloak-to-wildfly-tag.py
+++ b/misc/scripts/upgrade-wildfly/upgrade-keycloak-to-wildfly-tag.py
@@ -17,56 +17,101 @@
 # * limitations under the License.
 # *
 # *
-#
-# Purpose: Update various necessary bits of Keycloak to align with the specified Wildfly tag. Perform this by:
-#
-#          * Incrementing the jboss-parent element version if necessary,
-#          * Updating versions of artifacts shared with Wildfly and Wildfly Core in main Keycloak pom.xml file,
-#          * Updating versions of artifacts shared with Wildfly and Wildfly Core utilized by Keycloak adapters
-#
-# Usage:   Run as, e.g.:
-#          ./upgrade-keycloak-to-wildfly-tag.py 20.0.0.Final
-#
-#          Or call the script without arguments to get the further help
 
-import os, sys
+import click, logging, os, sys
 
 import wildfly.upgrade as wu
 
-def usage():
-    print("Run as: \n\t%s Wildfly.Tag.To.Upgrade.To \ne.g.:\n\t%s 20.0.0.Final\n" % (sys.argv[0], sys.argv[0]))
+CONTEXT_SETTINGS  = dict(help_option_names = ['-h', '--help'])
+FORCE_OPTION_HELP = """
+    Force elements / files updates.
 
-if __name__ == '__main__':
+    In common mode of operation (without the "-f" or "--force" options) the
+    script upgrades the version of the Keycloak characteristic in question
+    (POM property, dependency, or some other XML element shared with Wildfly
+    application server) ONLY if the new version is HIGHER than the version of
+    the corresponding element currently present in the local copy of the
+    Keycloak repository, the script is operating on.
 
-    if len(sys.argv) != 2:
-        usage()
-        sys.exit(1)
+    The -f, --force options instruct the script to allow an upgrade to replace
+    newer version of a particular Keycloak characteristic with an older one.
+    Useful to perform e.g. Keycloak downgrades to previous Wildfly versions.
+"""
 
-    wildflyTag = wu.isWellFormedWildflyTag(sys.argv[1])
+@click.command(context_settings=CONTEXT_SETTINGS)
+@click.argument('tag', required = True, type=click.STRING)
+@click.option('-f', '--force', help=FORCE_OPTION_HELP, is_flag=True)
+@click.option('-v', '--verbose', help='Enable verbose output.', is_flag=True)
+@click.version_option(prog_name=sys.argv[0], version=wu.__version__)
+def processParameters(tag, verbose, force):
+    """
+    NAME
+
+    upgrade-keycloak-to-wildfly-tag.py - Rebase Keycloak on top of the
+    specified Wildfly tag (release)
+
+    DESCRIPTION
+
+        Update the versions of various Keycloak characteristics (versions of
+        POM properties, adapter dependencies, and other attributes actually
+        binding the Keycloak POM build configuration to the particular Wildfly
+        tag) to their corresponding values as used by the Wildfly application
+        server of version matching the tag / release, passed to the script as
+        argument.
+
+    EXAMPLES
+
+        Upgrade Keycloak to Wildfly 20 (using "20.0.1.Final" Wildfly tag):
+
+            $ python upgrade-keycloak-to-wildfly-tag.py 20.0.1.Final
+
+        Downgrade Keycloak to Wildfly 16 (using "16.0.0.Final" Wildfly tag,
+        script verbose mode to display the details about elements being
+        updated, and force option to perform the actual downgrade):
+
+            $ python upgrade-keycloak-to-wildfly-tag.py -v -f 16.0.0.Final
+    """
+
+    # Set loglevel to debug if '-v' or '--verbose' option was specified
+    wu.__loglevel__ = logging.DEBUG if verbose else logging.INFO
+
+    upgradeKeycloakToWildflyTag(tag, forceUpdates = force)
+
+def upgradeKeycloakToWildflyTag(tag, forceUpdates = False):
+    wildflyTag = wu.isWellFormedWildflyTag(tag)
     wildflyPomBaseUrl = "https://github.com/wildfly/wildfly/raw/%s/pom.xml" % wildflyTag
 
-    wu.getModuleLogger().info("Retrieving Wildfly's pom.xml for tag: %s" % wildflyTag)
+    taskLogger = wu.getTaskLogger("Rebase Keycloak on top of Wildfly '%s'" % wildflyTag)
+    taskLogger.info("Retrieving Wildfly's pom.xml for tag: %s" % wildflyTag)
     wildflyPomFile = wu.saveUrlToNamedTemporaryFile(wildflyPomBaseUrl)
-
     wildflyPomXmlRoot = wu.getXmlRoot(wildflyPomFile)
+
     wildflyCoreTag = wu.isWellFormedWildflyTag( wu.getPomProperty(wildflyPomXmlRoot, "version.org.wildfly.core")[0].text )
     wildflyCorePomBaseUrl = "https://github.com/wildfly/wildfly-core/raw/%s/pom.xml" % wildflyCoreTag
-
-    wu.getModuleLogger().info("Retrieving Wildfly-Core pom.xml for tag: %s" % wildflyCoreTag)
+    taskLogger.info("Retrieving Wildfly-Core pom.xml for tag: %s" % wildflyCoreTag)
     wildflyCorePomFile = wu.saveUrlToNamedTemporaryFile(wildflyCorePomBaseUrl)
 
     if wildflyPomFile != None and wildflyCorePomFile != None:
 
         # Subtask - Update main Keycloak pom.xml file
-        wu.updateMainKeycloakPomFile(wildflyPomFile, wildflyCorePomFile)
+        wu.performMainKeycloakPomFileUpdateTask(wildflyPomFile, wildflyCorePomFile, forceUpdates)
         # Subtask - Update Keycloak adapters
-        wu.performKeycloakAdapterLicenseFilesUpdateTask(wildflyPomFile, wildflyCorePomFile)
+        wu.performKeycloakAdapterLicenseFilesUpdateTask(wildflyPomFile, wildflyCorePomFile, forceUpdates)
         # Subtask - Update RH-SSO adapters
-        wu.performRhssoAdapterLicenseFilesUpdateTask(wildflyPomFile, wildflyCorePomFile)
+        wu.performRhssoAdapterLicenseFilesUpdateTask(wildflyPomFile, wildflyCorePomFile, forceUpdates)
         # Subtask - Update properties of the deprecated Wildfly testing module if necessary
-        wu.performDeprecatedWildflyTestingModuleUpdateTask()
+        wu.performDeprecatedWildflyTestingModuleUpdateTask(forceUpdates)
         # Subtask - Update version of jboss-parent if necessary
-        wu.performJbossParentVersionUpdateTask(wildflyPomFile, wildflyCorePomFile)
+        wu.performJbossParentVersionUpdateTask(wildflyTag, wildflyPomFile, wildflyCorePomFile, forceUpdates)
 
         for filename in [wildflyPomFile, wildflyCorePomFile]:
             os.remove(filename)
+
+    rebaseDoneMessage = (
+        "Done rebasing Keycloak to Wildfly '%s' release!" % wildflyTag,
+        "\n\tRun 'git status' to list the changed files and 'git diff <path>' to inspect changes done to a specific file."
+    )
+    taskLogger.info(wu._empty_string.join(rebaseDoneMessage))
+
+if __name__ == '__main__':
+    processParameters()


### PR DESCRIPTION

1. commit 4b634619f3d6e0160c44c028ca7200e765cd14cc -- [KEYCLOAK-15408] Update also properties of the deprecated Wildfly testing module as part of running the Wildfly upgrade script

2. commit eacb827c40699a0210937c41b3990baa4aef95ef -- [KEYCLOAK-15442] Update (synchronize with Wildfly) the version of `jboss-parent` as part of running the Wildfly upgrade script

3. commit 3e6d1dfa0deb00f34da2b8ee027b764406e04fd8 -- [KEYCLOAK-15474] Add `--verbose` and `--force` options for the script. Fix a bug when updating adapter license files -- prevent a possible attempt to `git move` the license file of the same version

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
