### PR TITLE
KEYCLOAK-15545 Fix null pointer exception when updating flow via API

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/AuthenticationManagementResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/AuthenticationManagementResource.java
@@ -278,14 +278,18 @@ public class AuthenticationManagementResource {
         }
 
         //if the name changed
-        if (!checkFlow.getAlias().equals(flow.getAlias())) {
+        if (checkFlow.getAlias() != null && !checkFlow.getAlias().equals(flow.getAlias())) {
             checkFlow.setAlias(flow.getAlias());
-        }
+        } else if (checkFlow.getAlias() == null && flow.getAlias() != null) {
+            checkFlow.setAlias(flow.getAlias());
+	}
 
         //check if the description changed
-        if (!checkFlow.getDescription().equals(flow.getDescription())) {
+        if (checkFlow.getDescription() != null && !checkFlow.getDescription().equals(flow.getDescription())) {
             checkFlow.setDescription(flow.getDescription());
-        }
+        } else if (checkFlow.getDescription() == null && flow.getDescription() != null) {
+            checkFlow.setDescription(flow.getDescription());
+	}
 
         //update the flow
         flow.setId(existingFlow.getId());


### PR DESCRIPTION
<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->

Avoid null pointer exception when making updates to flows via API.  Ensures that if either description or alias are changed or go from undefined to defined, the update occurs.