### PR TITLE
KEYCLOAK-14109, KEYCLOAK-14737. Upgrades to Jetty 9.4.29 and Spring Boot 2.3.

### DIFF
--- a/adapters/oidc/jetty/jetty9.4/src/main/java/org/keycloak/adapters/jetty/KeycloakJettyAuthenticator.java
+++ b/adapters/oidc/jetty/jetty9.4/src/main/java/org/keycloak/adapters/jetty/KeycloakJettyAuthenticator.java
@@ -50,8 +50,9 @@ public class KeycloakJettyAuthenticator extends AbstractKeycloakJettyAuthenticat
     protected Authentication createAuthentication(UserIdentity userIdentity, final Request request) {
         return new KeycloakAuthentication(getAuthMethod(), userIdentity) {
             @Override
-            public void logout() {
-                logoutCurrent(request);
+            public Authentication logout(ServletRequest servletRequest) {
+                logoutCurrent((Request) servletRequest);
+                return super.logout(servletRequest);
             }
         };
     }

--- a/adapters/saml/jetty/jetty9.4/pom.xml
+++ b/adapters/saml/jetty/jetty9.4/pom.xml
@@ -29,7 +29,7 @@
     <artifactId>keycloak-saml-jetty94-adapter</artifactId>
     <name>Keycloak Jetty 9.4.x SAML Integration</name>
     <properties>
-        <jetty9.version>9.4.2.v20170220</jetty9.version>
+        <jetty9.version>${jetty94.version}</jetty9.version>
         <keycloak.osgi.export>
             org.keycloak.adapters.jetty.*
         </keycloak.osgi.export>

--- a/adapters/saml/jetty/jetty9.4/src/main/java/org/keycloak/adapters/saml/jetty/Jetty9SessionManager.java
+++ b/adapters/saml/jetty/jetty9.4/src/main/java/org/keycloak/adapters/saml/jetty/Jetty9SessionManager.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.adapters.saml.jetty;
 
+import org.eclipse.jetty.server.session.Session;
 import org.eclipse.jetty.server.session.SessionHandler;
 import org.keycloak.adapters.jetty.spi.JettySessionManager;
 
@@ -34,7 +35,15 @@ public class Jetty9SessionManager implements JettySessionManager {
     }
 
     @Override
-    public HttpSession getHttpSession(String id) {
-        return sessionHandler.getHttpSession(id);
+    public HttpSession getHttpSession(String extendedId) {
+        // inlined code from sessionHandler.getHttpSession(extendedId) since the method visibility changed to protected
+
+        String id = sessionHandler.getSessionIdManager().getId(extendedId);
+        Session session = sessionHandler.getSession(id);
+
+        if (session != null && !session.getExtendedId().equals(extendedId)) {
+            session.setIdChanged(true);
+        }
+        return session;
     }
 }

--- a/adapters/saml/jetty/jetty9.4/src/main/java/org/keycloak/adapters/saml/jetty/KeycloakSamlAuthenticator.java
+++ b/adapters/saml/jetty/jetty9.4/src/main/java/org/keycloak/adapters/saml/jetty/KeycloakSamlAuthenticator.java
@@ -47,8 +47,9 @@ public class KeycloakSamlAuthenticator extends AbstractSamlAuthenticator {
     public Authentication createAuthentication(UserIdentity userIdentity, final Request request) {
         return new KeycloakAuthentication(getAuthMethod(), userIdentity) {
             @Override
-            public void logout() {
-                logoutCurrent(request);
+            public Authentication logout(ServletRequest servletRequest) {
+                logoutCurrent((Request) servletRequest);
+                return super.logout(servletRequest);
             }
         };
     }

--- a/pom.xml
+++ b/pom.xml
@@ -178,6 +178,7 @@
         <spring-boot15.version>1.5.20.RELEASE</spring-boot15.version>
         <spring-boot21.version>2.1.3.RELEASE</spring-boot21.version>
         <spring-boot22.version>2.2.0.RELEASE</spring-boot22.version>
+        <spring-boot23.version>2.3.0.RELEASE</spring-boot23.version>
 
         <!-- webauthn support -->
         <webauthn4j.version>0.12.0.RELEASE</webauthn4j.version>

--- a/testsuite/integration-arquillian/test-apps/spring-boot-adapter-app/pom.xml
+++ b/testsuite/integration-arquillian/test-apps/spring-boot-adapter-app/pom.xml
@@ -17,7 +17,7 @@
         <java.version>1.8</java.version>
         <jetty.version>${jetty94.version}</jetty.version>
 
-        <springboot-version>1.5</springboot-version>
+        <springboot-version>2.3</springboot-version>
 
         <spring-boot-adapter-jetty>false</spring-boot-adapter-jetty>
         <spring.boot.tomcat.adapter.artifactId>keycloak-tomcat-adapter</spring.boot.tomcat.adapter.artifactId>
@@ -417,6 +417,39 @@
 
             <properties>
                 <spring-boot.version>${spring-boot22.version}</spring-boot.version>
+            </properties>
+
+            <dependencyManagement>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.eclipse.jetty</groupId>
+                        <artifactId>jetty-bom</artifactId>
+                        <version>${jetty.version}</version>
+                        <type>pom</type>
+                    </dependency>
+                </dependencies>
+            </dependencyManagement>
+
+            <dependencies>
+                <dependency>
+                    <groupId>org.keycloak</groupId>
+                    <artifactId>keycloak-spring-boot-2-adapter</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <profile>
+            <id>spring.boot.2.3</id>
+
+            <activation>
+                <property>
+                    <name>springboot-version</name>
+                    <value>2.3</value>
+                </property>
+            </activation>
+
+            <properties>
+                <spring-boot.version>${spring-boot23.version}</spring-boot.version>
             </properties>
 
             <dependencyManagement>

--- a/testsuite/integration-arquillian/tests/other/springboot-tests/pom.xml
+++ b/testsuite/integration-arquillian/tests/other/springboot-tests/pom.xml
@@ -216,6 +216,13 @@
         </profile>
 
         <profile>
+            <id>springboot23</id>
+            <properties>
+                <springboot.version.option>2.3</springboot.version.option>
+            </properties>
+        </profile>
+
+        <profile>
             <id>turn-on-repo-url</id>
             <activation>
                 <property>


### PR DESCRIPTION
This PR includes both changes for upgrading Jetty to version 9.4.29 (KEYCLOAK-14737) and Spring Boot to version 2.3 (KEYCLOAK-14109).

**WARNING:** Do not forget to merge https://github.com/keycloak/keycloak-pipeline/pull/315 once this PR is merged.