### PR TITLE
KEYCLOAK-15721 KeycloakPromise sometimes doesn't work

### DIFF
--- a/adapters/oidc/js/src/main/resources/keycloak.js
+++ b/adapters/oidc/js/src/main/resources/keycloak.js
@@ -74,38 +74,6 @@
         }
     }
 
-    function toKeycloakPromise(promise) {
-        promise.__proto__ = KeycloakPromise.prototype;
-        return promise;
-    }
-
-    function KeycloakPromise(executor) {
-        return toKeycloakPromise(new Promise(executor));
-    }
-
-    KeycloakPromise.prototype = Object.create(Promise.prototype);
-    KeycloakPromise.prototype.constructor = KeycloakPromise;
-
-    KeycloakPromise.prototype.success = function(callback) {
-        logPromiseDeprecation();
-
-        var promise = this.then(function handleSuccess(value) {
-            callback(value);
-        });
-
-        return toKeycloakPromise(promise);
-    };
-
-    KeycloakPromise.prototype.error = function(callback) {
-        logPromiseDeprecation();
-
-        var promise = this.catch(function handleError(error) {
-            callback(error);
-        });
-
-        return toKeycloakPromise(promise);
-    };
-
     function Keycloak (config) {
         if (!(this instanceof Keycloak)) {
             return new Keycloak(config);
@@ -1208,10 +1176,31 @@
                     p.reject(result);
                 }
             };
-            p.promise = new KeycloakPromise(function(resolve, reject) {
+            p.promise = new Promise(function(resolve, reject) {
                 p.resolve = resolve;
                 p.reject = reject;
             });
+
+            p.promise.success = function(callback) {
+                logPromiseDeprecation();
+
+                this.then(function handleSuccess(value) {
+                    callback(value);
+                });
+
+                return this;
+            }
+
+            p.promise.error = function(callback) {
+                logPromiseDeprecation();
+
+                this.catch(function handleError(error) {
+                    callback(error);
+                });
+
+                return this;
+            }
+
             return p;
         }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/javascript/JavascriptAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/javascript/JavascriptAdapterTest.java
@@ -708,9 +708,9 @@ public class JavascriptAdapterTest extends AbstractJavascriptTest {
     @Test
     public void testRefreshTokenWithDeprecatedPromiseHandles() {
         String refreshWithDeprecatedHandles = "var callback = arguments[arguments.length - 1];" +
-                "   window.keycloak.updateToken(9999).then(function (refreshed) {" +
+                "   window.keycloak.updateToken(9999).success(function (refreshed) {" +
             "            callback('Success handle');" +
-                "   }).catch(function () {" +
+                "   }).error(function () {" +
                 "       callback('Error handle');" +
                 "   });";
 


### PR DESCRIPTION
This also fixes the deprecated promises test which was for some reason broken by #7330 (it was checking the non-deprecated promises).