### PR TITLE
KEYCLOAK-9551 Make refresh_token generation for client_credentials grant optional

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCAdvancedConfigWrapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCAdvancedConfigWrapper.java
@@ -114,6 +114,21 @@ public class OIDCAdvancedConfigWrapper {
         return Boolean.parseBoolean(useUtlsHokToken);
     }
 
+    // KEYCLOAK-9551 Client Credentials Grant generates refresh token
+    // https://tools.ietf.org/html/rfc6749#section-4.4.3
+    public boolean isUseRefreshTokenForClientCredentialsGrant() {
+        // "true" -> we allow use of refresh_token for client_credentials grant by default for backwards compatibility
+        String val = getAttribute(OIDCConfigAttributes.USE_REFRESH_TOKEN_FOR_CLIENT_CREDENTIALS_GRANT, "true");
+        return Boolean.parseBoolean(val);
+    }
+
+    // KEYCLOAK-9551 Client Credentials Grant generates refresh token
+    // https://tools.ietf.org/html/rfc6749#section-4.4.3
+    public void setUseRefreshTokenForClientCredentialsGrant(boolean enable) {
+        String val =  String.valueOf(enable);
+        setAttribute(OIDCConfigAttributes.USE_REFRESH_TOKEN_FOR_CLIENT_CREDENTIALS_GRANT, val);
+    }
+
     public void setUseMtlsHoKToken(boolean useUtlsHokToken) {
         String val = String.valueOf(useUtlsHokToken);
         setAttribute(OIDCConfigAttributes.USE_MTLS_HOK_TOKEN, val);
@@ -200,6 +215,14 @@ public class OIDCAdvancedConfigWrapper {
         } else {
             return clientRep.getAttributes()==null ? null : clientRep.getAttributes().get(attrKey);
         }
+    }
+
+    private String getAttribute(String attrKey, String defaultValue) {
+        String value = getAttribute(attrKey);
+        if (value == null) {
+            return defaultValue;
+        }
+        return value;
     }
 
     private void setAttribute(String attrKey, String attrValue) {

--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCConfigAttributes.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCConfigAttributes.java
@@ -58,6 +58,8 @@ public final class OIDCConfigAttributes {
     
     public static final String BACKCHANNEL_LOGOUT_REVOKE_OFFLINE_TOKENS = "backchannel.logout.revoke.offline.tokens";
 
+    public static final String USE_REFRESH_TOKEN_FOR_CLIENT_CREDENTIALS_GRANT = "client_credentials.use_refresh_token";
+
     private OIDCConfigAttributes() {
     }
 

--- a/themes/src/main/resources/theme/base/admin/messages/admin-messages_en.properties
+++ b/themes/src/main/resources/theme/base/admin/messages/admin-messages_en.properties
@@ -391,6 +391,8 @@ oidc-compatibility-modes=OpenID Connect Compatibility Modes
 oidc-compatibility-modes.tooltip=Expand this section to configure settings for backwards compatibility with older OpenID Connect / OAuth2 adapters. It is useful especially if your client uses older version of Keycloak / RH-SSO adapter.
 exclude-session-state-from-auth-response=Exclude Session State From Authentication Response
 exclude-session-state-from-auth-response.tooltip=If this is on, the parameter 'session_state' will not be included in OpenID Connect Authentication Response. It is useful if your client uses older OIDC / OAuth2 adapter, which does not support 'session_state' parameter.
+use-refresh-token-for-client-credentials-grant=Use Refresh Tokens For Client Credentials Grant
+use-refresh-token-for-client-credentials-grant.tooltip=If this is on, a refresh_token will be created and added to the token response if the client_credentials grant is used. The OAuth 2.0 RFC6749 Section 4.4.3 states that a refresh_token should not be generated when client_credentials grant is used. If this is off then no refresh_token will be generated and the associated user session will be removed.
 
 # client import
 import-client=Import Client

--- a/themes/src/main/resources/theme/base/admin/resources/js/controllers/clients.js
+++ b/themes/src/main/resources/theme/base/admin/resources/js/controllers/clients.js
@@ -1283,6 +1283,17 @@ module.controller('ClientDetailCtrl', function($scope, realm, client, flows, $ro
            }
        }
 
+        // KEYCLOAK-9551 Client Credentials Grant generates refresh token
+        // https://tools.ietf.org/html/rfc6749#section-4.4.3
+        var useRefreshToken = $scope.client.attributes["client_credentials.use_refresh_token"];
+        // older clients don't have this property set, but might expect refresh_tokens for client_credentials grant,
+        // so we enable use refresh_token for backwards compatibility in that case.
+        if (typeof useRefreshToken === "undefined" || useRefreshToken === "true") {
+            $scope.useRefreshTokenForClientCredentialsGrant = true;
+        } else {
+            $scope.useRefreshTokenForClientCredentialsGrant = false;
+        }
+
         if ($scope.client.attributes["display.on.consent.screen"]) {
             if ($scope.client.attributes["display.on.consent.screen"] == "true") {
                 $scope.displayOnConsentScreen = true;
@@ -1626,6 +1637,14 @@ module.controller('ClientDetailCtrl', function($scope, realm, client, flows, $ro
             $scope.clientEdit.attributes["tls.client.certificate.bound.access.tokens"] = "true";
         } else {
             $scope.clientEdit.attributes["tls.client.certificate.bound.access.tokens"] = "false";
+        }
+
+        // KEYCLOAK-9551 Client Credentials Grant generates refresh token
+        // https://tools.ietf.org/html/rfc6749#section-4.4.3
+        if ($scope.useRefreshTokenForClientCredentialsGrant === true) {
+            $scope.clientEdit.attributes["client_credentials.use_refresh_token"] = "true";
+        } else {
+            $scope.clientEdit.attributes["client_credentials.use_refresh_token"] = "false";
         }
 
         if ($scope.displayOnConsentScreen == true) {

--- a/themes/src/main/resources/theme/base/admin/resources/partials/client-detail.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/client-detail.html
@@ -529,6 +529,13 @@
                 </div>
                 <kc-tooltip>{{:: 'exclude-session-state-from-auth-response.tooltip' | translate}}</kc-tooltip>
             </div>
+            <div class="form-group clearfix block" data-ng-show="protocol == 'openid-connect'">
+                <label class="col-md-2 control-label" for="useRefreshTokenForClientCredentialsGrant">{{:: 'use-refresh-token-for-client-credentials-grant' | translate}}</label>
+                <div class="col-md-6">
+                    <input ng-model="useRefreshTokenForClientCredentialsGrant" ng-click="switchChange()" name="useRefreshTokenForClientCredentialsGrant" id="useRefreshTokenForClientCredentialsGrant" onoffswitch on-text="{{:: 'onText' | translate}}" off-text="{{:: 'offText' | translate}}"/>
+                </div>
+                <kc-tooltip>{{:: 'use-refresh-token-for-client-credentials-grant.tooltip' | translate}}</kc-tooltip>
+            </div>
         </fieldset>
 
         <fieldset>


### PR DESCRIPTION
Previously Keycloak always generated a `refresh_token` when `client_credentials`
grant was used. However, the [OAuth 2.0 RFC6749](https://tools.ietf.org/html/rfc6749#section-4.4.3) states that a refresh
token should not be generated when the client_credentials grant is used.

This PR introduces a new client setting in the `OpenID Connect Compatibility Modes` section 
called `Use Refresh Tokens For Client Credentials Grant`.
If this is `on`, then a `refresh_token` with a valid user-session is generated
for token requests with client_credential grant as before. This is also the default.

If this is `off`, no refresh_token is generated and the associated UserSession
of the service-account user is immediately destroyed after token generation, to avoid dangling sessions.
The returned `AccessTokenResponse` response contains only an `access_token`
and an optional `id_token`. The `refresh_token` field will be null.

The setting "Use Refresh Tokens For Client Credentials Grant" must be configured explicitly.

Existing clients will be treated as if "use refresh tokens" is enabled to remain backwards compatible.