### PR TITLE
KEYCLOAK-15773 Enable admin endpoints and admin-console via Feature flags

### DIFF
--- a/common/src/main/java/org/keycloak/common/Profile.java
+++ b/common/src/main/java/org/keycloak/common/Profile.java
@@ -43,9 +43,24 @@ public class Profile {
         EXPERIMENTAL,
         DEPRECATED;
     }
+
     public enum Feature {
+
         ACCOUNT2(Type.DEFAULT),
         ACCOUNT_API(Type.DEFAULT),
+
+        /**
+         * Controls the availability of the `/admin` endpoint with the Admin REST-API and Console
+         */
+        ADMIN(Type.DEFAULT),
+
+        /**
+         * Controls the availability of the Keycloak Admin-Console
+         * Note that, the Admin-Console requires the {@link #ADMIN} feature.
+         */
+        ADMIN_CONSOLE(Type.DEFAULT),
+
+
         ADMIN_FINE_GRAINED_AUTHZ(Type.PREVIEW),
         DOCKER(Type.DISABLED_BY_DEFAULT),
         IMPERSONATION(Type.DEFAULT),

--- a/services/src/main/java/org/keycloak/services/resources/KeycloakApplication.java
+++ b/services/src/main/java/org/keycloak/services/resources/KeycloakApplication.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.keycloak.Config;
+import org.keycloak.common.Profile;
 import org.keycloak.common.util.Resteasy;
 import org.keycloak.config.ConfigProviderFactory;
 import org.keycloak.exportimport.ExportImportManager;
@@ -102,7 +103,9 @@ public class KeycloakApplication extends Application {
 
             singletons.add(new RobotsResource());
             singletons.add(new RealmsResource());
-            singletons.add(new AdminRoot());
+            if (Profile.isFeatureEnabled(Profile.Feature.ADMIN)) {
+                singletons.add(new AdminRoot());
+            }
             classes.add(ThemeResource.class);
             classes.add(JsResource.class);
 

--- a/services/src/main/java/org/keycloak/services/resources/admin/AdminRoot.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/AdminRoot.java
@@ -23,6 +23,7 @@ import javax.ws.rs.NotFoundException;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import javax.ws.rs.NotAuthorizedException;
 import org.keycloak.common.ClientConnection;
+import org.keycloak.common.Profile;
 import org.keycloak.jose.jws.JWSInput;
 import org.keycloak.jose.jws.JWSInputException;
 import org.keycloak.models.ClientModel;
@@ -63,6 +64,10 @@ import java.util.Properties;
 public class AdminRoot {
     protected static final Logger logger = Logger.getLogger(AdminRoot.class);
 
+    private static final boolean ADMIN_CONSOLE_ENABLED = Profile.isFeatureEnabled(Profile.Feature.ADMIN_CONSOLE);
+
+    private static final boolean ADMIN_ENABLED = Profile.isFeatureEnabled(Profile.Feature.ADMIN);
+
     @Context
     protected ClientConnection clientConnection;
 
@@ -97,6 +102,11 @@ public class AdminRoot {
      */
     @GET
     public Response masterRealmAdminConsoleRedirect() {
+
+        if (!ADMIN_CONSOLE_ENABLED) {
+            return Response.noContent().build();
+        }
+
         RealmModel master = new RealmManager(session).getKeycloakAdminstrationRealm();
         return Response.status(302).location(
                 session.getContext().getUri(UrlType.ADMIN).getBaseUriBuilder().path(AdminRoot.class).path(AdminRoot.class, "getAdminConsole").path("/").build(master.getName())
@@ -112,6 +122,11 @@ public class AdminRoot {
     @Path("index.{html:html}") // expression is actually "index.html" but this is a hack to get around jax-doclet bug
     @GET
     public Response masterRealmAdminConsoleRedirectHtml() {
+
+        if (!ADMIN_CONSOLE_ENABLED) {
+            return Response.noContent().build();
+        }
+
         return masterRealmAdminConsoleRedirect();
     }
 
@@ -142,6 +157,11 @@ public class AdminRoot {
      */
     @Path("{realm}/console")
     public AdminConsole getAdminConsole(final @PathParam("realm") String name) {
+
+        if (!ADMIN_CONSOLE_ENABLED) {
+            return null;
+        }
+
         RealmManager realmManager = new RealmManager(session);
         RealmModel realm = locateRealm(name, realmManager);
         AdminConsole service = new AdminConsole(realm);
@@ -204,6 +224,11 @@ public class AdminRoot {
      */
     @Path("realms")
     public Object getRealmsAdmin(@Context final HttpHeaders headers) {
+
+        if (!ADMIN_ENABLED) {
+            return null;
+        }
+
         if (request.getHttpMethod().equals(HttpMethod.OPTIONS)) {
             return new AdminCorsPreflightService(request);
         }
@@ -228,6 +253,11 @@ public class AdminRoot {
      */
     @Path("serverinfo")
     public Object getServerInfo(@Context final HttpHeaders headers) {
+
+        if (!ADMIN_ENABLED) {
+            return null;
+        }
+
         if (request.getHttpMethod().equals(HttpMethod.OPTIONS)) {
             return new AdminCorsPreflightService(request);
         }


### PR DESCRIPTION
This PR introduces two new Feature flags for the DEFAULT Profile:
- ADMIN
Controls whether the `AdminRoot` JAX-RS resource with the /admin endpoint is deployed

- ADMIN_CONSOLE
Controls whether the `admin-console` endpoints are served

This enables administrators to configure the `/admin` endpoint's availability,
including the admin REST API and the admin-console per instance.
This allows admins to have public-facing `worker` instances and
internal `admin` instances, which reduces the attack surface for the
public-facing Keycloaks.

Admin Endpoints and admin-console can be disabled via System-Properties
or a profile.properties file.

```
-Dkeycloak.profile.feature.admin=disabled
-Dkeycloak.profile.feature.admin_console=disabled
```

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
