### PR TITLE
[KEYCLOAK-14139] Upgrade login screen to PF4

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/AbstractUsernameFormAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/AbstractUsernameFormAuthenticator.java
@@ -29,14 +29,19 @@ import org.keycloak.models.ModelDuplicateException;
 import org.keycloak.models.PasswordPolicy;
 import org.keycloak.models.UserCredentialModel;
 import org.keycloak.models.UserModel;
+import org.keycloak.models.utils.FormMessage;
 import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.representations.idm.CredentialRepresentation;
 import org.keycloak.services.ServicesLogger;
 import org.keycloak.services.managers.AuthenticationManager;
 import org.keycloak.services.messages.Messages;
+import org.keycloak.services.validation.Validation;
 
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
+
+import static org.keycloak.services.validation.Validation.FIELD_PASSWORD;
+import static org.keycloak.services.validation.Validation.FIELD_USERNAME;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -55,9 +60,19 @@ public abstract class AbstractUsernameFormAuthenticator extends AbstractFormAuth
     }
 
     protected Response challenge(AuthenticationFlowContext context, String error) {
+        return challenge(context, error, null);
+    }
+
+    protected Response challenge(AuthenticationFlowContext context, String error, String field) {
         LoginFormsProvider form = context.form()
                 .setExecution(context.getExecution().getId());
-        if (error != null) form.setError(error);
+        if (error != null) {
+            if (field != null) {
+                form.addError(new FormMessage(field, error));
+            } else {
+                form.setError(error);
+            }
+        }
         return createLoginForm(form);
     }
 
@@ -104,7 +119,7 @@ public abstract class AbstractUsernameFormAuthenticator extends AbstractFormAuth
         if (user == null) {
             dummyHash(context);
             context.getEvent().error(Errors.USER_NOT_FOUND);
-            Response challengeResponse = challenge(context, getDefaultChallengeMessage(context));
+            Response challengeResponse = challenge(context, getDefaultChallengeMessage(context), FIELD_USERNAME);
             context.failureChallenge(AuthenticationFlowError.INVALID_USER, challengeResponse);
         }
     }
@@ -138,7 +153,7 @@ public abstract class AbstractUsernameFormAuthenticator extends AbstractFormAuth
         String username = inputData.getFirst(AuthenticationManager.FORM_USERNAME);
         if (username == null) {
             context.getEvent().error(Errors.USER_NOT_FOUND);
-            Response challengeResponse = challenge(context, getDefaultChallengeMessage(context));
+            Response challengeResponse = challenge(context, getDefaultChallengeMessage(context), FIELD_USERNAME);
             context.failureChallenge(AuthenticationFlowError.INVALID_USER, challengeResponse);
             return null;
         }
@@ -207,7 +222,7 @@ public abstract class AbstractUsernameFormAuthenticator extends AbstractFormAuth
     private boolean badPasswordHandler(AuthenticationFlowContext context, UserModel user, boolean clearUser,boolean isEmptyPassword) {
         context.getEvent().user(user);
         context.getEvent().error(Errors.INVALID_USER_CREDENTIALS);
-        Response challengeResponse = challenge(context, getDefaultChallengeMessage(context));
+        Response challengeResponse = challenge(context, getDefaultChallengeMessage(context), FIELD_PASSWORD);
         if(isEmptyPassword) {
             context.forceChallenge(challengeResponse);
         }else{
@@ -225,7 +240,7 @@ public abstract class AbstractUsernameFormAuthenticator extends AbstractFormAuth
             if (context.getProtector().isTemporarilyDisabled(context.getSession(), context.getRealm(), user)) {
                 context.getEvent().user(user);
                 context.getEvent().error(Errors.USER_TEMPORARILY_DISABLED);
-                Response challengeResponse = challenge(context, tempDisabledError());
+                Response challengeResponse = challenge(context, tempDisabledError(), FIELD_USERNAME);
                 context.forceChallenge(challengeResponse);
                 return true;
             }

--- a/services/src/main/java/org/keycloak/authentication/authenticators/challenge/BasicAuthAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/challenge/BasicAuthAuthenticator.java
@@ -120,6 +120,11 @@ public class BasicAuthAuthenticator extends AbstractUsernameFormAuthenticator im
     }
 
     @Override
+    protected Response challenge(AuthenticationFlowContext context, String error, String field) {
+        return challenge(context, error);
+    }
+
+    @Override
     public void action(AuthenticationFlowContext context) {
 
     }

--- a/services/src/main/java/org/keycloak/authentication/authenticators/resetcred/ResetCredentialChooseUser.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/resetcred/ResetCredentialChooseUser.java
@@ -31,8 +31,10 @@ import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
+import org.keycloak.models.utils.FormMessage;
 import org.keycloak.provider.ProviderConfigProperty;
 import org.keycloak.services.messages.Messages;
+import org.keycloak.services.validation.Validation;
 
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -85,7 +87,7 @@ public class ResetCredentialChooseUser implements Authenticator, AuthenticatorFa
         if (username == null || username.isEmpty()) {
             event.error(Errors.USERNAME_MISSING);
             Response challenge = context.form()
-                    .setError(Messages.MISSING_USERNAME)
+                    .addError(new FormMessage(Validation.FIELD_USERNAME, Messages.MISSING_USERNAME))
                     .createPasswordReset();
             context.failureChallenge(AuthenticationFlowError.INVALID_USER, challenge);
             return;

--- a/services/src/main/java/org/keycloak/forms/login/freemarker/model/IdentityProviderBean.java
+++ b/services/src/main/java/org/keycloak/forms/login/freemarker/model/IdentityProviderBean.java
@@ -22,11 +22,15 @@ import org.keycloak.models.OrderedModel;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.services.Urls;
+import org.keycloak.theme.Theme;
 
+import java.io.IOException;
 import java.net.URI;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
@@ -69,8 +73,22 @@ public class IdentityProviderBean {
         if (!hideOnLoginPage) {
             orderedSet.add(new IdentityProvider(identityProvider.getAlias(),
                     displayName, identityProvider.getProviderId(), loginUrl,
-                    config != null ? config.get("guiOrder") : null));
+                    config != null ? config.get("guiOrder") : null, getLoginIconClasses(identityProvider.getAlias())));
         }
+    }
+
+    // Get icon classes defined in properties of current theme with key 'kcLogoIdP-{alias}'
+    // f.e. kcLogoIdP-github = fa fa-github
+    private String getLoginIconClasses(String alias) {
+        final String ICON_THEME_PREFIX = "kcLogoIdP-";
+
+        try {
+            Theme theme = session.theme().getTheme(Theme.Type.LOGIN);
+            return Optional.ofNullable(theme.getProperties().getProperty(ICON_THEME_PREFIX + alias)).orElse("");
+        } catch (IOException e) {
+            //NOP
+        }
+        return "";
     }
 
     public List<IdentityProvider> getProviders() {
@@ -88,13 +106,19 @@ public class IdentityProviderBean {
         private final String loginUrl;
         private final String guiOrder;
         private final String displayName;
+        private final String iconClasses;
 
         public IdentityProvider(String alias, String displayName, String providerId, String loginUrl, String guiOrder) {
+            this(alias, displayName, providerId, loginUrl, guiOrder, "");
+        }
+
+        public IdentityProvider(String alias, String displayName, String providerId, String loginUrl, String guiOrder, String iconClasses) {
             this.alias = alias;
             this.displayName = displayName;
             this.providerId = providerId;
             this.loginUrl = loginUrl;
             this.guiOrder = guiOrder;
+            this.iconClasses = iconClasses;
         }
 
         public String getAlias() {
@@ -116,6 +140,10 @@ public class IdentityProviderBean {
 
         public String getDisplayName() {
             return displayName;
+        }
+
+        public String getIconClasses() {
+            return iconClasses;
         }
     }
 

--- a/services/src/main/java/org/keycloak/theme/beans/MessagesPerFieldBean.java
+++ b/services/src/main/java/org/keycloak/theme/beans/MessagesPerFieldBean.java
@@ -21,7 +21,7 @@ import java.util.Map;
 
 /**
  * Bean used to hold form messages per field. Stored under <code>messagesPerField</code> key in Freemarker context.
- * 
+ *
  * @author Vlastimil Elias (velias at redhat dot com)
  */
 public class MessagesPerFieldBean {
@@ -44,7 +44,7 @@ public class MessagesPerFieldBean {
 
     /**
      * Check if message for given field exists
-     * 
+     *
      * @param field
      * @return
      */
@@ -53,8 +53,37 @@ public class MessagesPerFieldBean {
     }
 
     /**
+     * Check if exists error message for given fields
+     *
+     * @param fields
+     * @return
+     */
+    public boolean existsError(String... fields) {
+        for (String field : fields) {
+            if (exists(field) && messagesPerField.get(field).isError())
+                return true;
+        }
+        return false;
+    }
+
+    /**
+     * Get first error message for given fields
+     *
+     * @param fields
+     * @return message text or empty string
+     */
+    public String getFirstError(String... fields) {
+        for (String field : fields) {
+            if (existsError(field)) {
+                return get(field);
+            }
+        }
+        return "";
+    }
+
+    /**
      * Get message for given field.
-     * 
+     *
      * @param fieldName
      * @return message text or empty string
      */
@@ -69,7 +98,7 @@ public class MessagesPerFieldBean {
 
     /**
      * Print text if message for given field exists. Useful eg. to add css styles for fields with message.
-     * 
+     *
      * @param fieldName to check for
      * @param text to print
      * @return text if message exists for given field, else empty string

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/auth/page/login/FeedbackMessage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/auth/page/login/FeedbackMessage.java
@@ -29,46 +29,71 @@ import static org.keycloak.testsuite.util.UIUtils.getTextFromElement;
 
 /**
  * @author Vaclav Muzikar <vmuzikar@redhat.com>
+ * @author Martin Bartos <mabartos@redhat.com>
  */
 public class FeedbackMessage {
-    @FindBy(css = ".alert")
+
+    private final String SUCCESS = "success";
+    private final String WARNING = "warning";
+    private final String ERROR = "error";
+    private final String INFO = "info";
+
+    @FindBy(css = "div[class^='alert']")
     private WebElement alertRoot;
+
+    @FindBy(css = "span[id^='input-error']")
+    private WebElement inputErrorRoot;
 
     public boolean isPresent() {
         try {
             return alertRoot.isDisplayed();
+        } catch (NoSuchElementException e) {
+            return getInputError() != null && !getInputError().isEmpty();
         }
-        catch (NoSuchElementException e) {
-            return false;
+    }
+
+    public String getInputError() {
+        try {
+            return getTextFromElement(inputErrorRoot);
+        } catch (NoSuchElementException e) {
+            return null;
         }
     }
 
     public String getText() {
-        return getTextFromElement(alertRoot.findElement(By.className("kc-feedback-text")));
+        try {
+            return getTextFromElement(alertRoot.findElement(By.className("kc-feedback-text")));
+        } catch (NoSuchElementException e) {
+            return getInputError();
+        }
     }
 
     public String getType() {
-        String cssClass = alertRoot.getAttribute("class");
-        Matcher classMatcher = Pattern.compile("alert-(.+)").matcher(cssClass);
-        if (!classMatcher.find()) {
-            throw new RuntimeException("Failed to identify feedback message type");
+        try {
+            String cssClass = alertRoot.getAttribute("class");
+            Matcher classMatcher = Pattern.compile("alert-(.+)").matcher(cssClass);
+            if (!classMatcher.find()) {
+                throw new RuntimeException("Failed to identify feedback message type");
+            }
+            return classMatcher.group(1);
+        } catch (NoSuchElementException e) {
+            return getInputError() != null ? ERROR : null;
         }
-        return classMatcher.group(1);
     }
 
     public boolean isSuccess() {
-        return getType().equals("success");
+        return getType().contains(SUCCESS);
     }
 
     public boolean isWarning() {
-        return getType().equals("warning");
+        return getType().contains(WARNING);
     }
 
     public boolean isError() {
-        return getType().equals("error");
+        return getType().contains(ERROR);
     }
 
     public boolean isInfo() {
-        return getType().equals("info");
+        return getType().contains(INFO);
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/auth/page/login/OIDCLogin.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/auth/page/login/OIDCLogin.java
@@ -36,7 +36,7 @@ public class OIDCLogin extends Login {
     }
 
     public boolean isCurrent(String realm) {
-        return DroneUtils.getCurrentDriver().getTitle().equals("Log in to " + realm) || DroneUtils.getCurrentDriver().getTitle().equals("Anmeldung bei " + realm);
+        return DroneUtils.getCurrentDriver().getTitle().equals("Sign in to " + realm) || DroneUtils.getCurrentDriver().getTitle().equals("Anmeldung bei " + realm);
     }
 
 }

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/BypassKerberosPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/BypassKerberosPage.java
@@ -29,7 +29,7 @@ public class BypassKerberosPage extends AbstractPage {
     private WebElement continueButton;
 
    public boolean isCurrent() {
-        return driver.getTitle().equals("Log in to test") || driver.getTitle().equals("Anmeldung bei test");
+        return driver.getTitle().equals("Sign in to test") || driver.getTitle().equals("Anmeldung bei test");
     }
 
     public void clickContinue() {

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/LoginPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/LoginPage.java
@@ -21,10 +21,12 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.keycloak.testsuite.util.DroneUtils;
 import org.keycloak.testsuite.util.OAuthClient;
 import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 
 import static org.keycloak.testsuite.util.UIUtils.clickLink;
+import static org.keycloak.testsuite.util.UIUtils.getTextFromElement;
 
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
@@ -39,6 +41,9 @@ public class LoginPage extends LanguageComboboxAwarePage {
 
     @FindBy(id = "password")
     private WebElement passwordInput;
+
+    @FindBy(id = "input-error")
+    private WebElement inputError;
 
     @FindBy(id = "totp")
     private WebElement totp;
@@ -124,8 +129,20 @@ public class LoginPage extends LanguageComboboxAwarePage {
         cancelButton.click();
     }
 
+    public String getInputError() {
+        try {
+            return getTextFromElement(inputError);
+        } catch (NoSuchElementException e) {
+            return null;
+        }
+    }
+
     public String getError() {
-        return loginErrorMessage != null ? loginErrorMessage.getText() : null;
+        try {
+            return getTextFromElement(loginErrorMessage);
+        } catch (NoSuchElementException e) {
+            return null;
+        }
     }
 
     public String getInstruction() {
@@ -146,20 +163,20 @@ public class LoginPage extends LanguageComboboxAwarePage {
     }
 
     public boolean isCurrent(String realm) {
-        return DroneUtils.getCurrentDriver().getTitle().equals("Log in to " + realm) || DroneUtils.getCurrentDriver().getTitle().equals("Anmeldung bei " + realm);
+        return DroneUtils.getCurrentDriver().getTitle().equals("Sign in to " + realm) || DroneUtils.getCurrentDriver().getTitle().equals("Anmeldung bei " + realm);
     }
 
     public void clickRegister() {
         registerLink.click();
     }
 
-    public void clickSocial(String providerId) {
-        WebElement socialButton = findSocialButton(providerId);
+    public void clickSocial(String alias) {
+        WebElement socialButton = findSocialButton(alias);
         clickLink(socialButton);
     }
 
-    public WebElement findSocialButton(String providerId) {
-        String id = "zocial-" + providerId;
+    public WebElement findSocialButton(String alias) {
+        String id = "social-" + alias;
         return DroneUtils.getCurrentDriver().findElement(By.id(id));
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/LoginPasswordResetPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/LoginPasswordResetPage.java
@@ -16,6 +16,8 @@
  */
 package org.keycloak.testsuite.pages;
 
+import org.keycloak.testsuite.util.UIUtils;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 
@@ -26,6 +28,9 @@ public class LoginPasswordResetPage extends LanguageComboboxAwarePage {
 
     @FindBy(id = "username")
     private WebElement usernameInput;
+
+    @FindBy(id = "input-error-username")
+    private WebElement usernameError;
 
     @FindBy(css = "input[type=\"submit\"]")
     private WebElement submitButton;
@@ -62,8 +67,20 @@ public class LoginPasswordResetPage extends LanguageComboboxAwarePage {
         return emailSuccessMessage != null ? emailSuccessMessage.getText() : null;
     }
 
+    public String getUsernameError() {
+        try {
+            return UIUtils.getTextFromElement(usernameError);
+        } catch (NoSuchElementException e) {
+            return null;
+        }
+    }
+
     public String getErrorMessage() {
-        return emailErrorMessage != null ? emailErrorMessage.getText() : null;
+        try {
+            return UIUtils.getTextFromElement(emailErrorMessage);
+        } catch (NoSuchElementException e) {
+            return null;
+        }
     }
 
     public String getUsername() {

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/LoginPasswordUpdatePage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/LoginPasswordUpdatePage.java
@@ -40,7 +40,7 @@ public class LoginPasswordUpdatePage extends LanguageComboboxAwarePage {
     @FindBy(className = "alert-error")
     private WebElement loginErrorMessage;
 
-    @FindBy(xpath = "//span[@class='kc-feedback-text']")
+    @FindBy(className = "kc-feedback-text")
     private WebElement feedbackMessage;
 
     @FindBy(id = "logout-sessions")

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/LoginUsernameOnlyPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/LoginUsernameOnlyPage.java
@@ -1,7 +1,10 @@
 package org.keycloak.testsuite.pages;
 
+import org.keycloak.testsuite.util.UIUtils;
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
 
 /**
  * login page for UsernameForm. It contains only username, but not password
@@ -10,6 +13,8 @@ import org.openqa.selenium.NoSuchElementException;
  */
 public class LoginUsernameOnlyPage extends LoginPage {
 
+    @FindBy(id = "input-error-username")
+    private WebElement usernameError;
 
     @Override
     public void login(String username) {
@@ -19,10 +24,17 @@ public class LoginUsernameOnlyPage extends LoginPage {
         submitButton.click();
     }
 
-
+    public String getUsernameError() {
+        try {
+            return UIUtils.getTextFromElement(usernameError);
+        } catch (NoSuchElementException e) {
+            return null;
+        }
+    }
 
     /**
      * Not supported for this implementation
+     *
      * @return
      */
     @Deprecated

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/PasswordPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/PasswordPage.java
@@ -1,8 +1,8 @@
 package org.keycloak.testsuite.pages;
 
 import org.jboss.arquillian.test.api.ArquillianResource;
-import org.keycloak.testsuite.util.DroneUtils;
 import org.keycloak.testsuite.util.OAuthClient;
+import org.keycloak.testsuite.util.UIUtils;
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
@@ -20,6 +20,9 @@ public class PasswordPage extends LanguageComboboxAwarePage {
 
     @FindBy(id = "password")
     private WebElement passwordInput;
+
+    @FindBy(id = "input-error-password")
+    private WebElement passwordError;
 
     @FindBy(name = "login")
     private WebElement submitButton;
@@ -46,8 +49,20 @@ public class PasswordPage extends LanguageComboboxAwarePage {
         return passwordInput.getAttribute("value");
     }
 
+    public String getPasswordError() {
+        try {
+            return UIUtils.getTextFromElement(passwordError);
+        } catch (NoSuchElementException e) {
+            return null;
+        }
+    }
+
     public String getError() {
-        return loginErrorMessage != null ? loginErrorMessage.getText() : null;
+        try {
+            return UIUtils.getTextFromElement(loginErrorMessage);
+        } catch (NoSuchElementException e) {
+            return null;
+        }
     }
 
 

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/SelectAuthenticatorPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/SelectAuthenticatorPage.java
@@ -80,7 +80,7 @@ public class SelectAuthenticatorPage extends LanguageComboboxAwarePage {
     @Override
     public boolean isCurrent() {
         // Check the title
-        if (!DroneUtils.getCurrentDriver().getTitle().startsWith("Log in to ") && !DroneUtils.getCurrentDriver().getTitle().startsWith("Anmeldung bei ")) {
+        if (!DroneUtils.getCurrentDriver().getTitle().startsWith("Sign in to ") && !DroneUtils.getCurrentDriver().getTitle().startsWith("Anmeldung bei ")) {
             return false;
         }
 

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/x509/X509IdentityConfirmationPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/x509/X509IdentityConfirmationPage.java
@@ -82,7 +82,7 @@ public class X509IdentityConfirmationPage extends LanguageComboboxAwarePage {
     }
 
     public boolean isCurrent() {
-        return driver.getTitle().equals("Log in to test") || driver.getTitle().equals("Anmeldung bei test");
+        return driver.getTitle().equals("Sign in to test") || driver.getTitle().equals("Anmeldung bei test");
     }
 
     @Override

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/OAuthClient.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/OAuthClient.java
@@ -1497,8 +1497,8 @@ public class OAuthClient {
         return driver;
     }
 
-    private WebElement findSocialButton(String providerId) {
-        String id = "zocial-" + providerId;
+    private WebElement findSocialButton(String alias) {
+        String id = "social-" + alias;
         return DroneUtils.getCurrentDriver().findElement(By.id(id));
     }
     

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/saml/LoginBuilder.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/saml/LoginBuilder.java
@@ -116,9 +116,9 @@ public class LoginBuilder implements Step {
     private HttpUriRequest handleLoginPage(String loginPage, URI currentURI) {
         if (idpAlias != null) {
             org.jsoup.nodes.Document theLoginPage = Jsoup.parse(loginPage);
-            Element zocialLink = theLoginPage.getElementById("zocial-" + this.idpAlias);
-            assertThat("Unknown idp: " + this.idpAlias, zocialLink, Matchers.notNullValue());
-            final String link = zocialLink.attr("href");
+            Element socialLink = theLoginPage.getElementById("social-" + this.idpAlias);
+            assertThat("Unknown idp: " + this.idpAlias, socialLink, Matchers.notNullValue());
+            final String link = socialLink.attr("href");
             assertThat("Invalid idp link: " + this.idpAlias, link, Matchers.notNullValue());
             return new HttpGet(currentURI.resolve(link));
         }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/AccountFormServiceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/AccountFormServiceTest.java
@@ -282,7 +282,7 @@ public class AccountFormServiceTest extends AbstractTestRealmKeycloakTest {
         loginPage.open();
         loginPage.login("test-user@localhost", "password");
 
-        Assert.assertEquals("Invalid username or password.", loginPage.getError());
+        Assert.assertEquals("Invalid username or password.", loginPage.getInputError());
 
         events.expectLogin().session((String) null).error(Errors.INVALID_USER_CREDENTIALS)
                 .removeDetail(Details.CONSENT)
@@ -865,7 +865,7 @@ public class AccountFormServiceTest extends AbstractTestRealmKeycloakTest {
         loginPage.login("change-username", "password");
 
         Assert.assertTrue(loginPage.isCurrent());
-        Assert.assertEquals("Invalid username or password.", loginPage.getError());
+        Assert.assertEquals("Invalid username or password.", loginPage.getInputError());
 
         loginPage.login("change-username-updated", "password");
     }
@@ -890,7 +890,7 @@ public class AccountFormServiceTest extends AbstractTestRealmKeycloakTest {
         loginPage.login("change-username@localhost", "password");
 
         Assert.assertTrue(loginPage.isCurrent());
-        Assert.assertEquals("Invalid username or password.", loginPage.getError());
+        Assert.assertEquals("Invalid username or password.", loginPage.getInputError());
 
         loginPage.login("change-username-updated@localhost", "password");
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/custom/CustomAuthFlowCookieTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/custom/CustomAuthFlowCookieTest.java
@@ -78,6 +78,6 @@ public class CustomAuthFlowCookieTest extends AbstractCustomAccountManagementTes
         //SSO shouln't work
         //navigate to different client of the same realm and verify user is not logged in
         oauth.openLoginForm();
-        assertEquals("Log in to test", driver.getTitle());
+        assertEquals("Sign in to test", driver.getTitle());
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/RequiredActionEmailVerificationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/RequiredActionEmailVerificationTest.java
@@ -784,7 +784,7 @@ public class RequiredActionEmailVerificationTest extends AbstractTestRealmKeyclo
             // Browser 2: Log in
             driver2.navigate().to(accountPage.buildUri().toString());
 
-            assertThat(driver2.getTitle(), is("Log in to " + testRealmName));
+            assertThat(driver2.getTitle(), is("Sign in to " + testRealmName));
             driver2.findElement(By.id("username")).sendKeys("test-user@localhost");
             driver2.findElement(By.id("password")).sendKeys("password");
             driver2.findElement(By.id("password")).submit();
@@ -954,7 +954,7 @@ public class RequiredActionEmailVerificationTest extends AbstractTestRealmKeyclo
 
         // login page should be shown in the second browser
         assertThat(driver2.getPageSource(), Matchers.containsString("kc-login"));
-        assertThat(driver2.getPageSource(), Matchers.containsString("Log In"));
+        assertThat(driver2.getPageSource(), Matchers.containsString("Sign in"));
 
         // email should be verified and required actions empty
         UserRepresentation user = testRealm().users().get(testUserId).toRepresentation();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/ClientInitiatedAccountLinkTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/ClientInitiatedAccountLinkTest.java
@@ -571,7 +571,7 @@ public class ClientInitiatedAccountLinkTest extends AbstractServletsAdapterTest 
         loginUpdateProfilePage.update("Joe", "Doe", "joe@parent.com");
 
         errorPage.assertCurrent();
-        Assert.assertEquals("You are already authenticated as different user 'child' in this session. Please log out first.", errorPage.getError());
+        Assert.assertEquals("You are already authenticated as different user 'child' in this session. Please sign out first.", errorPage.getError());
 
         logoutAll();
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/UserTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/UserTest.java
@@ -373,7 +373,7 @@ public class UserTest extends AbstractAdminTest {
 
         driver.navigate().to(accountUrl);
 
-        assertEquals("Log In", PageUtils.getPageTitle(driver));
+        assertEquals("Sign in to your account", PageUtils.getPageTitle(driver));
 
         loginPage.login("user_hashed_creds", "admin");
 
@@ -1910,7 +1910,7 @@ public class UserTest extends AbstractAdminTest {
 
         driver.navigate().to(accountUrl);
 
-        assertEquals("Log In", PageUtils.getPageTitle(driver));
+        assertEquals("Sign in to your account", PageUtils.getPageTitle(driver));
 
         loginPage.login("user1", "password");
 
@@ -2167,7 +2167,7 @@ public class UserTest extends AbstractAdminTest {
 
         String accountUrl = RealmsResource.accountUrl(UriBuilder.fromUri(getAuthServerRoot())).build(REALM_NAME).toString();
         driver.navigate().to(accountUrl);
-        assertEquals("Test user should be on the login page.", "Log In", PageUtils.getPageTitle(driver));
+        assertEquals("Test user should be on the login page.", "Sign in to your account", PageUtils.getPageTitle(driver));
         loginPage.login(userName, userPass);
         assertTrue("Test user should be successfully logged in.", driver.getTitle().contains("Account Management"));
         accountPage.logOut();
@@ -2180,7 +2180,7 @@ public class UserTest extends AbstractAdminTest {
         realm.users().get(userId).removeCredential(passwordCredential.get().getId());
 
         driver.navigate().to(accountUrl);
-        assertEquals("Test user should be on the login page.", "Log In", PageUtils.getPageTitle(driver));
+        assertEquals("Test user should be on the login page.", "Sign in to your account", PageUtils.getPageTitle(driver));
         loginPage.login(userName, userPass);
         assertTrue("Test user should fail to log in after password was deleted.",
                 driver.getCurrentUrl().contains(String.format("/realms/%s/login-actions/authenticate", REALM_NAME)));

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractAdvancedBrokerTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractAdvancedBrokerTest.java
@@ -234,7 +234,7 @@ public abstract class AbstractAdvancedBrokerTest extends AbstractBrokerTest {
         driver.navigate().to(getAccountUrl(getConsumerRoot(), bc.consumerRealmName()));
 
         try {
-            waitForPage(driver, "log in to", true);
+            waitForPage(driver, "sign in to", true);
         } catch (TimeoutException e) {
             log.debug(driver.getTitle());
             log.debug(driver.getPageSource());
@@ -251,12 +251,12 @@ public abstract class AbstractAdvancedBrokerTest extends AbstractBrokerTest {
             loginPage.login(bc.getUserLogin(), "invalid");
         }
 
-        assertEquals("Invalid username or password.", loginPage.getError());
+        assertEquals("Invalid username or password.", loginPage.getInputError());
 
         loginPage.clickSocial(bc.getIDPAlias());
 
         try {
-            waitForPage(driver, "log in to", true);
+            waitForPage(driver, "sign in to", true);
         } catch (TimeoutException e) {
             log.debug(driver.getTitle());
             log.debug(driver.getPageSource());
@@ -291,7 +291,7 @@ public abstract class AbstractAdvancedBrokerTest extends AbstractBrokerTest {
         waitForPage(driver, "grant access", false);
         consentPage.cancel();
 
-        waitForPage(driver, "log in to", true);
+        waitForPage(driver, "sign in to", true);
 
         // Revert consentRequired
         adminClient.realm(bc.providerRealmName())
@@ -563,7 +563,7 @@ public abstract class AbstractAdvancedBrokerTest extends AbstractBrokerTest {
             updateAccountInformationPage.assertCurrent();
             updateAccountInformationPage.updateAccountInformation("FirstName", "LastName");
             accountPage.logOut();
-            waitForPage(driver, "log in to", true);
+            waitForPage(driver, "sign in to", true);
             log.debug("Logging in");
             assertTrue(this.driver.getCurrentUrl().contains("/auth/realms/" + bc.consumerRealmName() + "/protocol/openid-connect/auth"));
         } finally {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractBaseBrokerTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractBaseBrokerTest.java
@@ -228,10 +228,10 @@ public abstract class AbstractBaseBrokerTest extends AbstractKeycloakTest {
     }
 
     protected void logInWithIdp(String idpAlias, String username, String password) {
-        waitForPage(driver, "log in to", true);
+        waitForPage(driver, "sign in to", true);
         log.debug("Clicking social " + idpAlias);
         loginPage.clickSocial(idpAlias);
-        waitForPage(driver, "log in to", true);
+        waitForPage(driver, "sign in to", true);
         log.debug("Logging in");
         loginPage.login(username, password);
     }
@@ -300,7 +300,7 @@ public abstract class AbstractBaseBrokerTest extends AbstractKeycloakTest {
         try {
             Retry.execute(() -> {
                 try {
-                    waitForPage(driver, "log in to " + realm, true);
+                    waitForPage(driver, "sign in to " + realm, true);
                 } catch (TimeoutException ex) {
                     driver.navigate().refresh();
                     log.debug("[Retriable] Timed out waiting for login page");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractFirstBrokerLoginTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractFirstBrokerLoginTest.java
@@ -274,7 +274,7 @@ public abstract class AbstractFirstBrokerLoginTest extends AbstractInitializedBa
 
         log.debug("Clicking social " + bc.getIDPAlias());
         loginPage.clickSocial(bc.getIDPAlias());
-        waitForPage(driver, "log in to", true);
+        waitForPage(driver, "sign in to", true);
         Assert.assertTrue("Driver should be on the provider realm page right now",
                 driver.getCurrentUrl().contains("/auth/realms/" + bc.providerRealmName() + "/"));
         log.debug("Logging in");
@@ -745,7 +745,7 @@ public abstract class AbstractFirstBrokerLoginTest extends AbstractInitializedBa
         driver.navigate().to(getAccountUrl(getConsumerRoot(), bc.consumerRealmName()));
         log.debug("Clicking social " + bc.getIDPAlias());
         loginPage.clickSocial(bc.getIDPAlias());
-        waitForPage(driver, "log in to", true);
+        waitForPage(driver, "sign in to", true);
         Assert.assertTrue("Driver should be on the provider realm page right now",
                 driver.getCurrentUrl().contains("/auth/realms/" + bc.providerRealmName() + "/"));
         log.debug("Logging in");
@@ -980,7 +980,7 @@ public abstract class AbstractFirstBrokerLoginTest extends AbstractInitializedBa
         driver.navigate().to(getAccountUrl(getConsumerRoot(), bc.consumerRealmName()));
         log.debug("Clicking social " + bc.getIDPAlias());
         loginPage.clickSocial(bc.getIDPAlias());
-        waitForPage(driver, "log in to", true);
+        waitForPage(driver, "sign in to", true);
         Assert.assertTrue("Driver should be on the provider realm page right now",
                 driver.getCurrentUrl().contains("/auth/realms/" + bc.providerRealmName() + "/"));
         log.debug("Logging in");
@@ -998,7 +998,7 @@ public abstract class AbstractFirstBrokerLoginTest extends AbstractInitializedBa
         driver.navigate().to(getAccountUrl(getConsumerRoot(), bc.consumerRealmName()));
         log.debug("Clicking social " + bc.getIDPAlias());
         loginPage.clickSocial(bc.getIDPAlias());
-        waitForPage(driver, "log in to", true);
+        waitForPage(driver, "sign in to", true);
         Assert.assertTrue("Driver should be on the provider realm page right now",
                 driver.getCurrentUrl().contains("/auth/realms/" + bc.providerRealmName() + "/"));
         log.debug("Logging in");
@@ -1016,7 +1016,7 @@ public abstract class AbstractFirstBrokerLoginTest extends AbstractInitializedBa
         driver.navigate().to(getAccountUrl(getConsumerRoot(), bc.consumerRealmName()));
         log.debug("Clicking social " + bc.getIDPAlias());
         loginPage.clickSocial(bc.getIDPAlias());
-        waitForPage(driver, "log in to", true);
+        waitForPage(driver, "sign in to", true);
         Assert.assertTrue("Driver should be on the provider realm page right now",
                 driver.getCurrentUrl().contains("/auth/realms/" + bc.providerRealmName() + "/"));
         log.debug("Logging in");
@@ -1042,7 +1042,7 @@ public abstract class AbstractFirstBrokerLoginTest extends AbstractInitializedBa
         driver.navigate().to(getAccountUrl(getConsumerRoot(), bc.consumerRealmName()));
         log.debug("Clicking social " + bc.getIDPAlias());
         loginPage.clickSocial(bc.getIDPAlias());
-        waitForPage(driver, "log in to", true);
+        waitForPage(driver, "sign in to", true);
         Assert.assertTrue("Driver should be on the provider realm page right now",
                 driver.getCurrentUrl().contains("/auth/realms/" + bc.providerRealmName() + "/"));
         log.debug("Logging in");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractNestedBrokerTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractNestedBrokerTest.java
@@ -30,13 +30,13 @@ public abstract class AbstractNestedBrokerTest extends AbstractBaseBrokerTest {
     /** Logs in subconsumer realm via consumer IDP via provider IDP and updates account information */
     protected void logInAsUserInNestedIDPForFirstTime() {
         driver.navigate().to(getAccountUrl(getConsumerRoot(), nbc.subConsumerRealmName()));
-        waitForPage(driver, "log in to", true);
+        waitForPage(driver, "sign in to", true);
         log.debug("Clicking social " + nbc.getSubConsumerIDPDisplayName());
         loginPage.clickSocial(nbc.getSubConsumerIDPDisplayName());
-        waitForPage(driver, "log in to", true);
+        waitForPage(driver, "sign in to", true);
         log.debug("Clicking social " + nbc.getIDPAlias());
         loginPage.clickSocial(nbc.getIDPAlias());
-        waitForPage(driver, "log in to", true);
+        waitForPage(driver, "sign in to", true);
         log.debug("Logging in");
         loginPage.login(nbc.getUserLogin(), nbc.getUserPassword());
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractSamlLoginHintTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractSamlLoginHintTest.java
@@ -25,7 +25,7 @@ public abstract class AbstractSamlLoginHintTest extends AbstractInitializedBaseB
         log.debug("Clicking social " + bc.getIDPAlias());
         addLoginHintOnSocialButton(username);
         loginPage.clickSocial(bc.getIDPAlias());
-        waitForPage(driver, "log in to", true);
+        waitForPage(driver, "sign in to", true);
         Assert.assertTrue("Driver should be on the provider realm page right now",
                 driver.getCurrentUrl().contains("/auth/realms/" + bc.providerRealmName() + "/"));
         log.debug("Logging in");
@@ -47,7 +47,7 @@ public abstract class AbstractSamlLoginHintTest extends AbstractInitializedBaseB
         log.debug("Clicking social " + bc.getIDPAlias());
         addLoginHintOnSocialButton("");
         loginPage.clickSocial(bc.getIDPAlias());
-        waitForPage(driver, "log in to", true);
+        waitForPage(driver, "sign in to", true);
         Assert.assertTrue("Driver should be on the provider realm page right now",
                 driver.getCurrentUrl().contains("/auth/realms/" + bc.providerRealmName() + "/"));
         log.debug("Logging in");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerAcrParameterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerAcrParameterTest.java
@@ -28,7 +28,7 @@ public class KcOidcBrokerAcrParameterTest extends AbstractBrokerTest {
         log.debug("Clicking social " + bc.getIDPAlias());
         loginPage.clickSocial(bc.getIDPAlias());
 
-        waitForPage(driver, "log in to", true);
+        waitForPage(driver, "sign in to", true);
 
         Assert.assertTrue("Driver should be on the provider realm page right now",
                 driver.getCurrentUrl().contains("/auth/realms/" + bc.providerRealmName() + "/"));

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerFrontendUrlTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerFrontendUrlTest.java
@@ -64,7 +64,7 @@ public final class KcOidcBrokerFrontendUrlTest extends AbstractBrokerTest {
         driver.navigate().to(proxy.getUrl() + "/realms/consumer/account");
         log.debug("Clicking social " + bc.getIDPAlias());
         loginPage.clickSocial(bc.getIDPAlias());
-        waitForPage(driver, "log in to", true);
+        waitForPage(driver, "sign in to", true);
         log.debug("Logging in");
 
         // make sure the frontend url is used to build the redirect uri when redirecting to the broker

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerHiddenIdpHintTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerHiddenIdpHintTest.java
@@ -58,10 +58,10 @@ public class KcOidcBrokerHiddenIdpHintTest extends AbstractInitializedBaseBroker
     @Test
     public void testSuccessfulRedirectToProviderHiddenOnLoginPage() {
         driver.navigate().to(getAccountUrl(getConsumerRoot(), bc.consumerRealmName()));
-        waitForPage(driver, "log in to", true);
+        waitForPage(driver, "sign in to", true);
         String url = driver.getCurrentUrl() + "&kc_idp_hint=" + bc.getIDPAlias();
         driver.navigate().to(url);
-        waitForPage(driver, "log in to", true);
+        waitForPage(driver, "sign in to", true);
         Assert.assertTrue("Driver should be on the provider realm page right now",
                 driver.getCurrentUrl().contains("/auth/realms/" + bc.providerRealmName() + "/"));
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerIdpHintTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerIdpHintTest.java
@@ -38,10 +38,10 @@ public class KcOidcBrokerIdpHintTest extends AbstractInitializedBaseBrokerTest {
     @Test
     public void testSuccessfulRedirect() {
         driver.navigate().to(getAccountUrl(getConsumerRoot(), bc.consumerRealmName()));
-        waitForPage(driver, "log in to", true);
+        waitForPage(driver, "sign in to", true);
         String url = driver.getCurrentUrl() + "&kc_idp_hint=" + bc.getIDPAlias();
         driver.navigate().to(url);
-        waitForPage(driver, "log in to", true);
+        waitForPage(driver, "sign in to", true);
         Assert.assertTrue("Driver should be on the provider realm page right now",
                 driver.getCurrentUrl().contains("/auth/realms/" + bc.providerRealmName() + "/"));
 
@@ -56,23 +56,23 @@ public class KcOidcBrokerIdpHintTest extends AbstractInitializedBaseBrokerTest {
     @Test
     public void testSuccessfulRedirectToProviderAfterLoginPageShown() {
         driver.navigate().to(getAccountUrl(getConsumerRoot(), bc.consumerRealmName()));
-        waitForPage(driver, "log in to", true);
+        waitForPage(driver, "sign in to", true);
         
         String urlWithHint = driver.getCurrentUrl() + "&kc_idp_hint=" + bc.getIDPAlias();        
         driver.navigate().to(urlWithHint);
-        waitForPage(driver, "log in to", true);
+        waitForPage(driver, "sign in to", true);
         Assert.assertTrue("Driver should be on the provider realm page right now",
                 driver.getCurrentUrl().contains("/auth/realms/" + bc.providerRealmName() + "/"));
         
         // do the same thing a second time
         driver.navigate().to(urlWithHint);
-        waitForPage(driver, "log in to", true);
+        waitForPage(driver, "sign in to", true);
         Assert.assertTrue("Driver should be on the provider realm page right now",
                 driver.getCurrentUrl().contains("/auth/realms/" + bc.providerRealmName() + "/"));
         
         // redirect shouldn't happen
         driver.navigate().to(getAccountUrl(getConsumerRoot(), bc.consumerRealmName()));
-        waitForPage(driver, "log in to", true);
+        waitForPage(driver, "sign in to", true);
         Assert.assertTrue("Driver should be on the consumer realm page",
                 driver.getCurrentUrl().contains("/auth/realms/" + bc.consumerRealmName() + "/"));
     }
@@ -80,10 +80,10 @@ public class KcOidcBrokerIdpHintTest extends AbstractInitializedBaseBrokerTest {
         @Test
     public void testInvalidIdentityProviderHint() {
         driver.navigate().to(getAccountUrl(getConsumerRoot(), bc.consumerRealmName()));
-        waitForPage(driver, "log in to", true);
+        waitForPage(driver, "sign in to", true);
         String url = driver.getCurrentUrl() + "&kc_idp_hint=bogus-idp";
         driver.navigate().to(url);
-        waitForPage(driver, "log in to", true);
+        waitForPage(driver, "sign in to", true);
         
         // Still on consumer login page
         Assert.assertTrue(driver.getCurrentUrl().contains("/auth/realms/" + bc.consumerRealmName() + "/"));

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerLoginHintTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerLoginHintTest.java
@@ -51,7 +51,7 @@ public class KcOidcBrokerLoginHintTest extends AbstractBrokerTest {
         log.debug("Clicking social " + bc.getIDPAlias());
         loginPage.clickSocial(bc.getIDPAlias());
 
-        waitForPage(driver, "log in to", true);
+        waitForPage(driver, "sign in to", true);
 
         Assert.assertTrue("Driver should be on the provider realm page right now",
                 driver.getCurrentUrl().contains("/auth/realms/" + bc.providerRealmName() + "/"));

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerLogoutTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerLogoutTest.java
@@ -66,7 +66,7 @@ public class KcOidcBrokerLogoutTest extends AbstractBaseBrokerTest {
 
         logoutFromRealm(getConsumerRoot(), bc.consumerRealmName());
         driver.navigate().to(getAccountUrl(getProviderRoot(), REALM_PROV_NAME));
-        waitForPage(driver, "log in to provider", true);
+        waitForPage(driver, "sign in to provider", true);
     }
 
     @Test
@@ -87,7 +87,7 @@ public class KcOidcBrokerLogoutTest extends AbstractBaseBrokerTest {
 
         logoutFromRealm(getConsumerRoot(), bc.consumerRealmName(), "something-else");
         driver.navigate().to(getAccountUrl(getProviderRoot(), REALM_PROV_NAME));
-        waitForPage(driver, "log in to provider", true);
+        waitForPage(driver, "sign in to provider", true);
     }
 
     @Test
@@ -115,6 +115,6 @@ public class KcOidcBrokerLogoutTest extends AbstractBaseBrokerTest {
         logoutFromRealm(getConsumerRoot(), bc.consumerRealmName(), null, idToken);
         driver.navigate().to(getAccountUrl(getProviderRoot(), REALM_PROV_NAME));
 
-        waitForPage(driver, "log in to provider", true);
+        waitForPage(driver, "sign in to provider", true);
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerNoLoginHintTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerNoLoginHintTest.java
@@ -46,7 +46,7 @@ public class KcOidcBrokerNoLoginHintTest extends AbstractBrokerTest {
         log.debug("Clicking social " + bc.getIDPAlias());
         loginPage.clickSocial(bc.getIDPAlias());
 
-        waitForPage(driver, "log in to", true);
+        waitForPage(driver, "sign in to", true);
 
         Assert.assertTrue("Driver should be on the provider realm page right now",
                 driver.getCurrentUrl().contains("/auth/realms/" + bc.providerRealmName() + "/"));

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerParameterForwardTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerParameterForwardTest.java
@@ -51,7 +51,7 @@ public class KcOidcBrokerParameterForwardTest extends AbstractBrokerTest {
         log.debug("Clicking social " + bc.getIDPAlias());
         loginPage.clickSocial(bc.getIDPAlias());
 
-        waitForPage(driver, "log in to", true);
+        waitForPage(driver, "sign in to", true);
 
         Assert.assertThat("Driver should be on the provider realm page right now",
                 driver.getCurrentUrl(), containsString("/auth/realms/" + bc.providerRealmName() + "/"));

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerPromptNoneRedirectTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerPromptNoneRedirectTest.java
@@ -66,7 +66,7 @@ public class KcOidcBrokerPromptNoneRedirectTest extends AbstractInitializedBaseB
            The presence of the default provider should cause the request with prompt=none to be propagated to the idp instead of resulting
            in a login required error because the user is not yet authenticated in the consumer realm. */
         driver.navigate().to(getAccountUrl(getConsumerRoot(), bc.consumerRealmName()));
-        waitForPage(driver, "log in to", true);
+        waitForPage(driver, "sign in to", true);
         String url = driver.getCurrentUrl() + "&kc_idp_hint=" + bc.getIDPAlias() + "&prompt=none";
         driver.navigate().to(url);
 
@@ -81,7 +81,7 @@ public class KcOidcBrokerPromptNoneRedirectTest extends AbstractInitializedBaseB
            all the way to the idp where the user is authenticated. */
         logoutFromRealm(getConsumerRoot(), bc.consumerRealmName(), bc.getIDPAlias());
         driver.navigate().to(getAccountUrl(getConsumerRoot(), bc.consumerRealmName()));
-        waitForPage(driver, "log in to", true);
+        waitForPage(driver, "sign in to", true);
         url = driver.getCurrentUrl() + "&prompt=none";
         driver.navigate().to(url);
         Assert.assertTrue(driver.getCurrentUrl().contains(bc.consumerRealmName() + "/account/login-redirect?error=login_required"));
@@ -99,7 +99,7 @@ public class KcOidcBrokerPromptNoneRedirectTest extends AbstractInitializedBaseB
            the consumer realm and the IDP, the IDP should return an error=login_required to the broker and the broker must
            in turn return the same error to the client. */
         driver.navigate().to(getAccountUrl(getConsumerRoot(), bc.consumerRealmName()));
-        waitForPage(driver, "log in to", true);
+        waitForPage(driver, "sign in to", true);
         String url = driver.getCurrentUrl() + "&prompt=none&kc_idp_hint=" + bc.getIDPAlias();
         driver.navigate().to(url);
         Assert.assertTrue(driver.getCurrentUrl().contains(bc.consumerRealmName() + "/account/login-redirect?error=login_required"));
@@ -201,7 +201,7 @@ public class KcOidcBrokerPromptNoneRedirectTest extends AbstractInitializedBaseB
 
         /* send an auth request to the consumer realm with prompt=none and a default provider. */
         driver.navigate().to(getAccountUrl(getConsumerRoot(), bc.consumerRealmName()));
-        waitForPage(driver, "log in to", true);
+        waitForPage(driver, "sign in to", true);
         String url = driver.getCurrentUrl() + "&kc_idp_hint=" + bc.getIDPAlias() + "&prompt=none";
         driver.navigate().to(url);
         Assert.assertTrue(driver.getCurrentUrl().contains(bc.consumerRealmName() + "/account/login-redirect?error=interaction_required"));
@@ -212,7 +212,7 @@ public class KcOidcBrokerPromptNoneRedirectTest extends AbstractInitializedBaseB
      */
     protected void authenticateDirectlyInIDP() {
         driver.navigate().to(getAccountUrl(getProviderRoot(), bc.providerRealmName()));
-        waitForPage(driver, "log in to", true);
+        waitForPage(driver, "sign in to", true);
         Assert.assertTrue("Driver should be on the provider realm page right now",
                 driver.getCurrentUrl().contains("/auth/realms/" + bc.providerRealmName() + "/"));
         loginPage.login(bc.getUserLogin(), bc.getUserPassword());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerPromptParameterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerPromptParameterTest.java
@@ -32,7 +32,7 @@ public class KcOidcBrokerPromptParameterTest extends AbstractBrokerTest {
         log.debug("Clicking social " + bc.getIDPAlias());
         loginPage.clickSocial(bc.getIDPAlias());
 
-        waitForPage(driver, "log in to", true);
+        waitForPage(driver, "sign in to", true);
 
         Assert.assertTrue("Driver should be on the provider realm page right now",
                 driver.getCurrentUrl().contains("/auth/realms/" + bc.providerRealmName() + "/"));

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerSubMatchIntrospectionTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerSubMatchIntrospectionTest.java
@@ -58,7 +58,7 @@ public class KcOidcBrokerSubMatchIntrospectionTest extends AbstractBrokerTest {
 
         log.debug("Clicking social " + bc.getIDPAlias());
         loginPage.clickSocial(bc.getIDPAlias());
-        waitForPage(driver, "log in to", true);
+        waitForPage(driver, "sign in to", true);
 
         log.debug("Logging in");
         loginPage.login(bc.getUserLogin(), bc.getUserPassword());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerTest.java
@@ -254,7 +254,7 @@ public final class KcOidcBrokerTest extends AbstractAdvancedBrokerTest {
             idpConfirmLinkPage.clickLinkAccount();
 
             loginPage.clickSocial(samlBrokerConfig.getIDPAlias());
-            waitForPage(driver, "log in to", true);
+            waitForPage(driver, "sign in to", true);
             log.debug("Logging in");
             loginTotpPage.login(totp.generateTOTP(totpSecret));
 
@@ -368,7 +368,7 @@ public final class KcOidcBrokerTest extends AbstractAdvancedBrokerTest {
 
         log.debug("Clicking social " + bc.getIDPAlias());
         loginPage.clickSocial(bc.getIDPAlias());
-        waitForPage(driver, "log in to", true);
+        waitForPage(driver, "sign in to", true);
 
         RealmResource realm = adminClient.realm(bc.providerRealmName());
         ClientRepresentation rep = realm.clients().findByClientId(BrokerTestConstants.CLIENT_ID).get(0);
@@ -389,7 +389,7 @@ public final class KcOidcBrokerTest extends AbstractAdvancedBrokerTest {
 
         log.debug("Clicking social " + bc.getIDPAlias());
         loginPage.clickSocial(bc.getIDPAlias());
-        waitForPage(driver, "log in to", true);
+        waitForPage(driver, "sign in to", true);
 
         RealmResource realm = adminClient.realm(bc.providerRealmName());
         ClientRepresentation rep = realm.clients().findByClientId(BrokerTestConstants.CLIENT_ID).get(0);
@@ -435,7 +435,7 @@ public final class KcOidcBrokerTest extends AbstractAdvancedBrokerTest {
             final String LINK = oauth.AUTH_SERVER_ROOT + "/realms/" + REALM_NAME + "/broker/" + IDP_NAME + "/endpoint?code=foo123";
 
             driver.navigate().to(LINK);
-            waitForPage(driver, "log in to provider", true);
+            waitForPage(driver, "sign in to provider", true);
 
             errorPage.assertCurrent();
             assertThat(errorPage.getError(), Matchers.is("Missing state parameter in response from identity provider."));
@@ -491,7 +491,7 @@ public final class KcOidcBrokerTest extends AbstractAdvancedBrokerTest {
             driver.navigate().to(getAccountUrl(getConsumerRoot(), bc.consumerRealmName()));
             WaitUtils.waitForPageToLoad();
 
-            assertThat(driver.getTitle(), Matchers.containsString("Log in to " + bc.consumerRealmName()));
+            assertThat(driver.getTitle(), Matchers.containsString("Sign in to " + bc.consumerRealmName()));
             logInWithIdp(IDP_NAME, USERNAME, USERNAME);
             accountUpdateProfilePage.assertCurrent();
 
@@ -501,7 +501,7 @@ public final class KcOidcBrokerTest extends AbstractAdvancedBrokerTest {
             driver.navigate().to(getAccountUrl(getProviderRoot(), bc.providerRealmName()));
             WaitUtils.waitForPageToLoad();
 
-            assertThat(driver.getTitle(), Matchers.containsString("Log in to " + bc.providerRealmName()));
+            assertThat(driver.getTitle(), Matchers.containsString("Sign in to " + bc.providerRealmName()));
 
             loginPage.login(USERNAME, USERNAME);
             WaitUtils.waitForPageToLoad();
@@ -513,7 +513,7 @@ public final class KcOidcBrokerTest extends AbstractAdvancedBrokerTest {
             driver.navigate().to(getAccountUrl(getConsumerRoot(), bc.consumerRealmName()));
             WaitUtils.waitForPageToLoad();
 
-            assertThat(driver.getTitle(), Matchers.containsString("Log in to " + bc.consumerRealmName()));
+            assertThat(driver.getTitle(), Matchers.containsString("Sign in to " + bc.consumerRealmName()));
             logInWithIdp(IDP_NAME, USERNAME, USERNAME);
 
             accountUpdateProfilePage.assertCurrent();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerUiLocalesDisabledTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerUiLocalesDisabledTest.java
@@ -48,7 +48,7 @@ public class KcOidcBrokerUiLocalesDisabledTest extends AbstractBrokerTest {
         log.debug("Clicking social " + bc.getIDPAlias());
         loginPage.clickSocial(bc.getIDPAlias());
 
-        waitForPage(driver, "log in to", true);
+        waitForPage(driver, "sign in to", true);
 
         Assert.assertThat("Driver should be on the provider realm page right now",
                 driver.getCurrentUrl(), containsString("/auth/realms/" + bc.providerRealmName() + "/"));

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerUiLocalesEnabledTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerUiLocalesEnabledTest.java
@@ -47,7 +47,7 @@ public class KcOidcBrokerUiLocalesEnabledTest extends AbstractBrokerTest {
         log.debug("Clicking social " + bc.getIDPAlias());
         loginPage.clickSocial(bc.getIDPAlias());
 
-        waitForPage(driver, "log in to", true);
+        waitForPage(driver, "sign in to", true);
 
         Assert.assertThat("Driver should be on the provider realm page right now",
                 driver.getCurrentUrl(), containsString("/auth/realms/" + bc.providerRealmName() + "/"));

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerWithConsentTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerWithConsentTest.java
@@ -49,7 +49,7 @@ public class KcOidcBrokerWithConsentTest extends AbstractInitializedBaseBrokerTe
         driver.navigate().to(getAccountUrl(getConsumerRoot(), bc.consumerRealmName()));
         log.debug("Clicking social " + bc.getIDPAlias());
         loginPage.clickSocial(bc.getIDPAlias());
-        waitForPage(driver, "log in to", true);
+        waitForPage(driver, "sign in to", true);
         log.debug("Logging in");
         loginPage.login(bc.getUserLogin(), bc.getUserPassword());
 
@@ -155,7 +155,7 @@ public class KcOidcBrokerWithConsentTest extends AbstractInitializedBaseBrokerTe
         grantPage.assertCurrent();
         grantPage.cancel();
 
-        assertEquals("Log in to " + bc.consumerRealmName(), driver.getTitle());
+        assertEquals("Sign in to " + bc.consumerRealmName(), driver.getTitle());
     }
 
     /**

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcFirstBrokerLoginNewAuthTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcFirstBrokerLoginNewAuthTest.java
@@ -60,7 +60,7 @@ public class KcOidcFirstBrokerLoginNewAuthTest extends AbstractInitializedBaseBr
 
         // Try bad password first
         passwordPage.login("bad-password");
-        Assert.assertEquals("Invalid password.", passwordPage.getError());
+        Assert.assertEquals("Invalid password.", passwordPage.getPasswordError());
 
         // Try good password
         passwordPage.login("password");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcFirstBrokerLoginTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcFirstBrokerLoginTest.java
@@ -250,7 +250,7 @@ public class KcOidcFirstBrokerLoginTest extends AbstractFirstBrokerLoginTest {
         driver.navigate().to(getAccountUrl(getConsumerRoot(), bc.consumerRealmName()));
         log.debug("Clicking social " + bc.getIDPAlias());
         loginPage.clickSocial(bc.getIDPAlias());
-        waitForPage(driver, "log in to", true);
+        waitForPage(driver, "sign in to", true);
         Assert.assertTrue("Driver should be on the provider realm page right now",
                 driver.getCurrentUrl().contains("/auth/realms/" + bc.providerRealmName() + "/"));
         log.debug("Logging in");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcSamlBrokerLoginHintWithOptionEnabledTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcSamlBrokerLoginHintWithOptionEnabledTest.java
@@ -21,7 +21,7 @@ public class KcSamlBrokerLoginHintWithOptionEnabledTest extends AbstractSamlLogi
         String fishyLoginHint = "<an-xml-tag>";
         addLoginHintOnSocialButton(fishyLoginHint);
         loginPage.clickSocial(bc.getIDPAlias());
-        waitForPage(driver, "log in to", true);
+        waitForPage(driver, "sign in to", true);
         Assert.assertTrue("Driver should be on the provider realm page right now",
                 driver.getCurrentUrl().contains("/auth/realms/" + bc.providerRealmName() + "/"));
         log.debug("Logging in");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcSamlIdPInitiatedSsoTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcSamlIdPInitiatedSsoTest.java
@@ -145,7 +145,7 @@ public class KcSamlIdPInitiatedSsoTest extends AbstractKeycloakTest {
     public void testProviderIdpInitiatedLogin() throws Exception {
         driver.navigate().to(getSamlIdpInitiatedUrl(REALM_PROV_NAME, "samlbroker"));
 
-        waitForPage("log in to", true);
+        waitForPage("sign in to", true);
 
         Assert.assertThat("Driver should be on the provider realm page right now",
                 driver.getCurrentUrl(), containsString("/auth/realms/" + REALM_PROV_NAME + "/"));

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/cookies/CookieTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/cookies/CookieTest.java
@@ -118,7 +118,7 @@ public class CookieTest extends AbstractKeycloakTest {
                 assertThat(pageContent, not(containsString("Last name")));
 
                 // ... but were redirected to login page
-                assertThat(pageContent, containsString("Log In"));
+                assertThat(pageContent, containsString("Sign In"));
                 assertThat(pageContent, containsString("Forgot Password?"));
             }
         }
@@ -156,7 +156,7 @@ public class CookieTest extends AbstractKeycloakTest {
                 assertThat(pageContent, not(containsString("Last name")));
 
                 // ... but were redirected to login page
-                assertThat(pageContent, containsString("Log In"));
+                assertThat(pageContent, containsString("Sign In"));
                 assertThat(pageContent, containsString("Forgot Password?"));
             }
         }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/kerberos/AbstractKerberosSingleRealmTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/kerberos/AbstractKerberosSingleRealmTest.java
@@ -95,7 +95,7 @@ public abstract class AbstractKerberosSingleRealmTest extends AbstractKerberosTe
             String context = spnegoResponse.readEntity(String.class);
             spnegoResponse.close();
 
-            org.junit.Assert.assertTrue(context.contains("Log in to test"));
+            org.junit.Assert.assertTrue(context.contains("Sign in to test"));
 
             events.clear();
         } finally {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/kerberos/KerberosStandaloneTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/kerberos/KerberosStandaloneTest.java
@@ -129,7 +129,7 @@ public class KerberosStandaloneTest extends AbstractKerberosSingleRealmTest {
         String context = spnegoResponse.readEntity(String.class);
         spnegoResponse.close();
 
-        Assert.assertTrue(context.contains("Log in to test"));
+        Assert.assertTrue(context.contains("Sign in to test"));
 
         String url = ActionURIUtils.getActionURIFromPageSource(context);
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPPasswordModifyExtensionTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPPasswordModifyExtensionTest.java
@@ -107,7 +107,7 @@ public class LDAPPasswordModifyExtensionTest extends AbstractLDAPTest  {
 
         loginPage.open();
         loginPage.login("johnkeycloak", "Bad-password1");
-        Assert.assertEquals("Invalid username or password.", loginPage.getError());
+        Assert.assertEquals("Invalid username or password.", loginPage.getInputError());
 
         loginPage.open();
         loginPage.login("johnkeycloak", "New-password1");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPProvidersIntegrationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPProvidersIntegrationTest.java
@@ -254,7 +254,7 @@ public class LDAPProvidersIntegrationTest extends AbstractLDAPTest {
         loginPage.login("johnkeycloak", "Password1");
         loginPage.assertCurrent();
 
-        Assert.assertEquals("Invalid username or password.", loginPage.getError());
+        Assert.assertEquals("Invalid username or password.", loginPage.getInputError());
 
         // Re-add LDAP provider
         Map<String, String> cfg = getLDAPRule().getConfig();
@@ -319,7 +319,7 @@ public class LDAPProvidersIntegrationTest extends AbstractLDAPTest {
     public void loginLdapWithoutPassword() {
         loginPage.open();
         loginPage.login("john@email.org", "");
-        Assert.assertEquals("Invalid username or password.", loginPage.getError());
+        Assert.assertEquals("Invalid username or password.", loginPage.getInputError());
     }
 
     @Test
@@ -334,7 +334,7 @@ public class LDAPProvidersIntegrationTest extends AbstractLDAPTest {
 
         loginPage.open();
         loginPage.login("johnkeycloak", "Bad-password1");
-        Assert.assertEquals("Invalid username or password.", loginPage.getError());
+        Assert.assertEquals("Invalid username or password.", loginPage.getInputError());
 
         loginPage.open();
         loginPage.login("johnkeycloak", "New-password1");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPSpecialCharsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPSpecialCharsTest.java
@@ -122,11 +122,11 @@ public class LDAPSpecialCharsTest extends AbstractLDAPTest {
         // Fail login with wildcard
         loginPage.open();
         loginPage.login("john*", "Password1");
-        Assert.assertEquals("Invalid username or password.", loginPage.getError());
+        Assert.assertEquals("Invalid username or password.", loginPage.getInputError());
 
         // Fail login with wildcard
         loginPage.login("j*", "Password1");
-        Assert.assertEquals("Invalid username or password.", loginPage.getError());
+        Assert.assertEquals("Invalid username or password.", loginPage.getInputError());
 
         // Success login as username exactly match
         loginPage.login("jamees,key*cložak)ppp", "Password1");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPUserLoginTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPUserLoginTest.java
@@ -152,7 +152,7 @@ public class LDAPUserLoginTest extends AbstractLDAPTest {
         // Run the test actions
         loginPage.open();
         loginPage.login(username, password);
-        Assert.assertEquals("Invalid username or password.", loginPage.getError());
+        Assert.assertEquals("Invalid username or password.", loginPage.getInputError());
 
         if (username.equals(DEFAULT_TEST_USERS.get("INVALID_USER_EMAIL")) || username.equals(DEFAULT_TEST_USERS.get("INVALID_USER_NAME"))) {
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/BrowserFlowTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/BrowserFlowTest.java
@@ -1086,7 +1086,7 @@ public class BrowserFlowTest extends AbstractTestRealmKeycloakTest {
         loginPage.assertCurrent();
         loginPage.login(user.getUsername(), "wrong_password");
 
-        Assert.assertEquals("Invalid username or password.", loginPage.getError());
+        Assert.assertEquals("Invalid username or password.", loginPage.getInputError());
         events.clear();
 
         loginPage.assertCurrent();
@@ -1117,18 +1117,21 @@ public class BrowserFlowTest extends AbstractTestRealmKeycloakTest {
             loginUsernameOnlyPage.open();
             loginUsernameOnlyPage.assertCurrent();
             loginUsernameOnlyPage.login("non_existing_user");
-            Assert.assertEquals("Invalid username.", loginUsernameOnlyPage.getError());
+            Assert.assertEquals("Invalid username.", loginUsernameOnlyPage.getUsernameError());
+            Assert.assertEquals("Invalid username.", loginUsernameOnlyPage.getUsernameError());
 
             realm.setLoginWithEmailAllowed(true);
             testRealm().update(realm);
             loginUsernameOnlyPage.login("non_existing_user");
-            Assert.assertEquals("Invalid username or email.", loginUsernameOnlyPage.getError());
+            Assert.assertEquals("Invalid username or email.", loginUsernameOnlyPage.getUsernameError());
+            Assert.assertEquals("Invalid username or email.", loginUsernameOnlyPage.getUsernameError());
 
             loginUsernameOnlyPage.login(user.getUsername());
 
             passwordPage.assertCurrent();
             passwordPage.login("wrong_password");
-            Assert.assertEquals("Invalid password.", passwordPage.getError());
+            Assert.assertEquals("Invalid password.", passwordPage.getPasswordError());
+            Assert.assertEquals("Invalid password.", passwordPage.getPasswordError());
 
             passwordPage.assertCurrent();
             events.clear();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/BruteForceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/BruteForceTest.java
@@ -364,7 +364,6 @@ public class BruteForceTest extends AbstractTestRealmKeycloakTest {
     public void testEmail() throws Exception {
         String userId = adminClient.realm("test").users().search("user2", null, null, null, 0, 1).get(0).getId();
 
-        loginSuccess("user2@localhost");
         loginInvalidPassword("user2@localhost");
         loginInvalidPassword("user2@localhost");
         expectTemporarilyDisabled("user2@localhost", userId);
@@ -490,7 +489,6 @@ public class BruteForceTest extends AbstractTestRealmKeycloakTest {
     public void testResetPassword() throws Exception {
         String userId = adminClient.realm("test").users().search("user2", null, null, null, 0, 1).get(0).getId();
 
-        loginSuccess("user2");
         loginInvalidPassword("user2");
         loginInvalidPassword("user2");
         expectTemporarilyDisabled("user2", userId, "invalid");
@@ -528,8 +526,6 @@ public class BruteForceTest extends AbstractTestRealmKeycloakTest {
         appPage.logout();
 
         events.clear();
-
-        loginSuccess("user2");
     }
 
     public void expectTemporarilyDisabled() throws Exception {
@@ -546,7 +542,7 @@ public class BruteForceTest extends AbstractTestRealmKeycloakTest {
 
         loginPage.assertCurrent();
         String src = driver.getPageSource();
-        Assert.assertEquals("Invalid username or password.", loginPage.getError());
+        Assert.assertEquals("Invalid username or password.", loginPage.getInputError());
         ExpectedEvent event = events.expectLogin()
                 .session((String) null)
                 .error(Errors.USER_TEMPORARILY_DISABLED)
@@ -585,7 +581,7 @@ public class BruteForceTest extends AbstractTestRealmKeycloakTest {
 
     public void loginSuccess(String username) throws Exception {
         loginPage.open();
-        loginPage.login("test-user@localhost", "password");
+        loginPage.login(username, "password");
 
         loginTotpPage.assertCurrent();
 
@@ -682,7 +678,7 @@ public class BruteForceTest extends AbstractTestRealmKeycloakTest {
 
         loginPage.assertCurrent();
 
-        Assert.assertEquals("Invalid username or password.", loginPage.getError());
+        Assert.assertEquals("Invalid username or password.", loginPage.getInputError());
 
         events.clear();
     }
@@ -693,7 +689,7 @@ public class BruteForceTest extends AbstractTestRealmKeycloakTest {
 
         loginPage.assertCurrent();
 
-        Assert.assertEquals("Invalid username or password.", loginPage.getError());
+        Assert.assertEquals("Invalid username or password.", loginPage.getInputError());
         events.clear();
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/LoginHotpTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/LoginHotpTest.java
@@ -157,7 +157,7 @@ public class LoginHotpTest extends AbstractTestRealmKeycloakTest {
 
         Assert.assertTrue(loginPage.isCurrent());
 
-        Assert.assertEquals("Invalid username or password.", loginPage.getError());
+        Assert.assertEquals("Invalid username or password.", loginPage.getInputError());
 
         events.expectLogin().error("invalid_user_credentials").session((String) null)
                 .removeDetail(Details.CONSENT)

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/LoginTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/LoginTest.java
@@ -211,7 +211,7 @@ public class LoginTest extends AbstractTestRealmKeycloakTest {
         Response response = client.target(b.build(oauth.getRealm())).request().post(oauth.getLoginEntityForPOST());
         
         Assert.assertThat(response.getStatus(), is(equalTo(200)));
-        Assert.assertThat(response, Matchers.body(containsString("Log In")));
+        Assert.assertThat(response, Matchers.body(containsString("Sign in")));
 
         response.close();
         client.close();
@@ -245,7 +245,7 @@ public class LoginTest extends AbstractTestRealmKeycloakTest {
         Assert.assertEquals("login-test2", loginPage.getUsername());
         Assert.assertEquals("", loginPage.getPassword());
 
-        Assert.assertEquals("Invalid username or password.", loginPage.getError());
+        Assert.assertEquals("Invalid username or password.", loginPage.getInputError());
 
         events.expectLogin().user(user2Id).session((String) null).error("invalid_user_credentials")
                 .detail(Details.USERNAME, "login-test2")
@@ -271,7 +271,7 @@ public class LoginTest extends AbstractTestRealmKeycloakTest {
         Assert.assertEquals("login-test", loginPage.getUsername());
         Assert.assertEquals("", loginPage.getPassword());
 
-        Assert.assertEquals("Invalid username or password.", loginPage.getError());
+        Assert.assertEquals("Invalid username or password.", loginPage.getInputError());
 
         events.expectLogin().user(userId).session((String) null).error("invalid_user_credentials")
                 .detail(Details.USERNAME, "login-test")
@@ -290,7 +290,7 @@ public class LoginTest extends AbstractTestRealmKeycloakTest {
         Assert.assertEquals("login-test", loginPage.getUsername());
         Assert.assertEquals("", loginPage.getPassword());
 
-        Assert.assertEquals("Invalid username or password.", loginPage.getError());
+        Assert.assertEquals("Invalid username or password.", loginPage.getInputError());
 
         events.expectLogin().user(userId).session((String) null).error("invalid_user_credentials")
                 .detail(Details.USERNAME, "login-test")
@@ -319,7 +319,7 @@ public class LoginTest extends AbstractTestRealmKeycloakTest {
             Assert.assertEquals("", loginPage.getPassword());
 
             // KEYCLOAK-2024
-            Assert.assertEquals("Invalid username or password.", loginPage.getError());
+            Assert.assertEquals("Invalid username or password.", loginPage.getInputError());
 
             events.expectLogin().user(userId).session((String) null).error("invalid_user_credentials")
                     .detail(Details.USERNAME, "login-test")
@@ -397,7 +397,7 @@ public class LoginTest extends AbstractTestRealmKeycloakTest {
         Assert.assertEquals("invalid", loginPage.getUsername());
         Assert.assertEquals("", loginPage.getPassword());
 
-        Assert.assertEquals("Invalid username or password.", loginPage.getError());
+        Assert.assertEquals("Invalid username or password.", loginPage.getInputError());
 
         events.expectLogin().user((String) null).session((String) null).error("user_not_found")
                 .detail(Details.USERNAME, "invalid")
@@ -419,7 +419,7 @@ public class LoginTest extends AbstractTestRealmKeycloakTest {
 
         loginPage.assertCurrent();
 
-        Assert.assertEquals("Invalid username or password.", loginPage.getError());
+        Assert.assertEquals("Invalid username or password.", loginPage.getInputError());
 
         events.expectLogin().user((String) null).session((String) null).error("user_not_found")
                 .removeDetail(Details.CONSENT)
@@ -860,12 +860,7 @@ public class LoginTest extends AbstractTestRealmKeycloakTest {
         oauth.openLoginForm();
 
         loginPage.assertCurrent();
-        try {
-            String loginError = loginPage.getError();
-            Assert.fail("Not expected to have error on loginForm. Error is: " + loginError);
-        } catch (NoSuchElementException nsee) {
-            // Expected
-        }
+        Assert.assertNull("Not expected to have error on loginForm.", loginPage.getError());
 
         loginPage.login("test-user@localhost", "password");
         appPage.assertCurrent();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/LoginTotpTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/LoginTotpTest.java
@@ -166,7 +166,7 @@ public class LoginTotpTest extends AbstractTestRealmKeycloakTest {
 
         Assert.assertTrue(loginPage.isCurrent());
 
-        Assert.assertEquals("Invalid username or password.", loginPage.getError());
+        Assert.assertEquals("Invalid username or password.", loginPage.getInputError());
 
         events.expectLogin().error("invalid_user_credentials").session((String) null)
                 .removeDetail(Details.CONSENT)

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/MultiFactorAuthenticationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/MultiFactorAuthenticationTest.java
@@ -134,7 +134,7 @@ public class MultiFactorAuthenticationTest extends AbstractTestRealmKeycloakTest
             Assert.assertEquals(Arrays.asList(SelectAuthenticatorPage.PASSWORD, SelectAuthenticatorPage.AUTHENTICATOR_APPLICATION), selectAuthenticatorPage.getAvailableLoginMethods());
 
             // Assert help texts
-            Assert.assertEquals("Log in by entering your password.", selectAuthenticatorPage.getLoginMethodHelpText(SelectAuthenticatorPage.PASSWORD));
+            Assert.assertEquals("Sign in by entering your password.", selectAuthenticatorPage.getLoginMethodHelpText(SelectAuthenticatorPage.PASSWORD));
             Assert.assertEquals("Enter a verification code from authenticator application.", selectAuthenticatorPage.getLoginMethodHelpText(SelectAuthenticatorPage.AUTHENTICATOR_APPLICATION));
 
             // Select OTP and see that just single OTP is available for this user

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/MultipleTabsLoginTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/MultipleTabsLoginTest.java
@@ -198,7 +198,7 @@ public class MultipleTabsLoginTest extends AbstractTestRealmKeycloakTest {
 
         loginPage.login("invalid", "invalid");
         loginPage.assertCurrent();
-        Assert.assertEquals("Invalid username or password.", loginPage.getError());
+        Assert.assertEquals("Invalid username or password.", loginPage.getInputError());
 
         // Simulate going back to tab1 and confirm login form. Login page with "action expired" message should be shown (NOTE: WebDriver does it with GET, when real browser would do it with POST. Improve test if needed...)
         driver.navigate().to(actionUrl1);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/ResetPasswordTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/ResetPasswordTest.java
@@ -381,7 +381,7 @@ public class ResetPasswordTest extends AbstractTestRealmKeycloakTest {
 
         resetPasswordPage.assertCurrent();
 
-        assertEquals("Please specify username.", resetPasswordPage.getErrorMessage());
+        assertEquals("Please specify username.", resetPasswordPage.getUsernameError());
 
         assertEquals(0, greenMail.getReceivedMessages().length);
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/SSOTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/SSOTest.java
@@ -159,7 +159,7 @@ public class SSOTest extends AbstractTestRealmKeycloakTest {
 
             oauth2.openLoginForm();
 
-            assertTrue(driver2.getTitle().equals("Log in to test"));
+            assertTrue(driver2.getTitle().equals("Sign in to test"));
         } finally {
             driver2.close();
         }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/i18n/LoginPageTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/i18n/LoginPageTest.java
@@ -129,7 +129,7 @@ public class LoginPageTest extends AbstractI18NTest {
         Assert.assertTrue(response.readEntity(String.class).contains("Anmeldung bei test"));
 
         response = client.target(driver.getCurrentUrl()).request().acceptLanguage("en").get();
-        Assert.assertTrue(response.readEntity(String.class).contains("Log in to test"));
+        Assert.assertTrue(response.readEntity(String.class).contains("Sign in to test"));
 
         client.close();
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/migration/cluster/MultiVersionClusterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/migration/cluster/MultiVersionClusterTest.java
@@ -204,7 +204,7 @@ public class MultiVersionClusterTest extends AbstractClusterTest {
             oauth.realm(MASTER).clientId("account").redirectUri(legacyNode.getContextRoot().toString() + "/auth/realms/master/account/");
             
             oauth.openLoginForm();
-            assertThat(DroneUtils.getCurrentDriver().getTitle(), containsString("Log in to "));
+            assertThat(DroneUtils.getCurrentDriver().getTitle(), containsString("Sign in to "));
             loginPage.login("admin", "admin");
 
             assertThat("Login was not successful.", oauth.getCurrentQuery().get(OAuth2Constants.CODE), notNullValue());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/AccessTokenDuplicateEmailsNotCleanedUpTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/AccessTokenDuplicateEmailsNotCleanedUpTest.java
@@ -80,7 +80,7 @@ public class AccessTokenDuplicateEmailsNotCleanedUpTest extends AbstractKeycloak
     public void loginWithDuplicateEmail() throws Exception {
         oauth.doLogin("duplicate-email-user@localhost", "password");
 
-        assertEquals("Username already exists.", driver.findElement(By.xpath("//span[@class='kc-feedback-text']")).getText());
+        assertEquals("Username already exists.", driver.findElement(By.className("kc-feedback-text")).getText());
     }
     
     @Test

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/AccessTokenDuplicateEmailsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/AccessTokenDuplicateEmailsTest.java
@@ -117,13 +117,13 @@ public class AccessTokenDuplicateEmailsTest extends AbstractKeycloakTest {
     public void loginWithNonDuplicateEmail() throws Exception {
         oauth.doLogin("non-duplicate-email-user@localhost", "password");
 
-        assertEquals("Invalid username or password.", driver.findElement(By.xpath("//span[@class='kc-feedback-text']")).getText());
+        assertEquals("Invalid username or password.", driver.findElement(By.className("kc-feedback-text")).getText());
     }
     
     @Test
     public void loginWithDuplicateEmail() throws Exception {
         oauth.doLogin("duplicate-email-user@localhost", "password");
 
-        assertEquals("Invalid username or password.", driver.findElement(By.xpath("//span[@class='kc-feedback-text']")).getText());
+        assertEquals("Invalid username or password.", driver.findElement(By.className("kc-feedback-text")).getText());
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/AccessTokenNoEmailLoginTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/AccessTokenNoEmailLoginTest.java
@@ -78,6 +78,6 @@ public class AccessTokenNoEmailLoginTest extends AbstractKeycloakTest {
     public void loginWithEmail() throws Exception {
         oauth.doLoginGrant("non-duplicate-email-user@localhost", "password");
         
-        assertEquals("Invalid username or password.", driver.findElement(By.xpath("//span[@class='kc-feedback-text']")).getText());
+        assertEquals("Invalid username or password.", driver.findElement(By.className("kc-feedback-text")).getText());
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/BasicSamlTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/BasicSamlTest.java
@@ -241,7 +241,7 @@ public class BasicSamlTest extends AbstractSamlTest {
 
           .assertResponse(Matchers.bodyHC(containsString(
             Objects.equals(reloginRequired, Boolean.TRUE)
-              ? "Log in"
+              ? "Sign in"
               : GeneralConstants.SAML_RESPONSE_KEY
           )))
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/x509/X509BrowserLoginTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/x509/X509BrowserLoginTest.java
@@ -414,7 +414,7 @@ public class X509BrowserLoginTest extends AbstractX509AuthenticationTest {
         Assert.assertEquals("test-user@localhost", loginPage.getUsername());
         Assert.assertEquals("", loginPage.getPassword());
 
-        Assert.assertEquals("Invalid username or password.", loginPage.getError());
+        Assert.assertEquals("Invalid username or password.", loginPage.getInputError());
     }
 
     @Test

--- a/testsuite/integration-arquillian/tests/other/base-ui/src/test/java/org/keycloak/testsuite/ui/account2/DeviceActivityTest.java
+++ b/testsuite/integration-arquillian/tests/other/base-ui/src/test/java/org/keycloak/testsuite/ui/account2/DeviceActivityTest.java
@@ -266,7 +266,7 @@ public class DeviceActivityTest extends BaseAccountPageTest {
             ClientModel client = session.clientLocalStorage().getClientByClientId(TEST_CLIENT_ID, realm);
             UserModel user = session.users().getUserByUsername("test", realm); // cannot use testUser.getUsername() because it throws NotSerializableException for no apparent reason (or maybe I'm just stupid :D)
 
-            UserSessionModel userSession = session.sessions().createUserSession(sessionId, realm, user, "test", ip, "form", false, null, null);
+            UserSessionModel userSession = session.sessions().createUserSession(sessionId, realm, user, "test", ip, "form", false, null, null, null);
             session.sessions().createClientSession(realm, client, userSession);
         });
 

--- a/testsuite/integration-arquillian/tests/other/base-ui/src/test/java/org/keycloak/testsuite/ui/account2/SigningInTest.java
+++ b/testsuite/integration-arquillian/tests/other/base-ui/src/test/java/org/keycloak/testsuite/ui/account2/SigningInTest.java
@@ -275,12 +275,12 @@ public class SigningInTest extends BaseAccountPageTest {
 
         if (passwordless) {
             credentialType = webAuthnPwdlessCredentialType;
-            expectedHelpText = "Use your security key for passwordless log in.";
+            expectedHelpText = "Use your security key for passwordless sign in.";
             providerId = WebAuthnPasswordlessRegisterFactory.PROVIDER_ID;
         }
         else {
             credentialType = webAuthnCredentialType;
-            expectedHelpText = "Use your security key to log in.";
+            expectedHelpText = "Use your security key to sign in.";
             providerId = WebAuthnRegisterFactory.PROVIDER_ID;
         }
 

--- a/testsuite/integration-arquillian/tests/other/console/src/test/java/org/keycloak/testsuite/console/realm/LoginSettingsTest.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/test/java/org/keycloak/testsuite/console/realm/LoginSettingsTest.java
@@ -146,7 +146,7 @@ public class LoginSettingsTest extends AbstractRealmTest {
         testAccountPage.signOut();
         log.debug("edited");
         
-        log.info("log in with edited username");
+        log.info("sign in with edited username");
         assertCurrentUrlStartsWithLoginUrlOf(testAccountPage);
         testRealmLoginPage.form().login(NEW_USERNAME, PASSWORD);
         assertCurrentUrlStartsWith(testAccountPage);
@@ -268,7 +268,7 @@ public class LoginSettingsTest extends AbstractRealmTest {
         String id = createUserAndResetPasswordWithAdminClient(testRealmResource(), newUser, PASSWORD);
         newUser.setId(id);
         
-        log.info("log in as new user");
+        log.info("sign in as new user");
         testAccountPage.navigateTo();        
         testRealmLoginPage.form().login(newUser);
         assertCurrentUrlStartsWith(testAccountPage);

--- a/testsuite/integration-arquillian/tests/other/springboot-tests/src/test/java/org/keycloak/testsuite/springboot/AccountLinkSpringBootTest.java
+++ b/testsuite/integration-arquillian/tests/other/springboot-tests/src/test/java/org/keycloak/testsuite/springboot/AccountLinkSpringBootTest.java
@@ -530,7 +530,7 @@ public class AccountLinkSpringBootTest extends AbstractSpringBootTest {
 
         assertThat(errorPage.getError(), is(equalTo("You are already authenticated as different user '"
                 + CHILD_USERNAME_1
-                + "' in this session. Please log out first.")));
+                + "' in this session. Please sign out first.")));
 
         logoutAll();
 

--- a/testsuite/integration-arquillian/tests/other/sssd/src/test/java/org/keycloak/testsuite/sssd/SSSDTest.java
+++ b/testsuite/integration-arquillian/tests/other/sssd/src/test/java/org/keycloak/testsuite/sssd/SSSDTest.java
@@ -103,9 +103,9 @@ public class SSSDTest extends AbstractKeycloakTest {
         log.debug("Testing invalid password for user " + username);
 
         profilePage.open();
-        Assert.assertEquals("Browser should be on login page now", "Log in to " + REALM_NAME, driver.getTitle());
+        Assert.assertEquals("Browser should be on login page now", "Sign in to " + REALM_NAME, driver.getTitle());
         accountLoginPage.login(username, "invalid-password");
-        Assert.assertEquals("Invalid username or password.", accountLoginPage.getError());
+        Assert.assertEquals("Invalid username or password.", accountLoginPage.getInputError());
     }
 
     @Test
@@ -115,10 +115,10 @@ public class SSSDTest extends AbstractKeycloakTest {
         log.debug("Testing disabled user " + username);
 
         profilePage.open();
-        Assert.assertEquals("Browser should be on login page now", "Log in to " + REALM_NAME, driver.getTitle());
+        Assert.assertEquals("Browser should be on login page now", "Sign in to " + REALM_NAME, driver.getTitle());
         accountLoginPage.login(username, getPassword(username));
 
-        Assert.assertEquals("Invalid username or password.", accountLoginPage.getError());
+        Assert.assertEquals("Invalid username or password.", accountLoginPage.getInputError());
     }
 
     @Test
@@ -128,7 +128,7 @@ public class SSSDTest extends AbstractKeycloakTest {
         log.debug("Testing password for user " + username);
 
         profilePage.open();
-        Assert.assertEquals("Browser should be on login page now", "Log in to " + REALM_NAME, driver.getTitle());
+        Assert.assertEquals("Browser should be on login page now", "Sign in to " + REALM_NAME, driver.getTitle());
         accountLoginPage.login(username, getPassword(username));
         Assert.assertTrue(profilePage.isCurrent());
     }
@@ -139,7 +139,7 @@ public class SSSDTest extends AbstractKeycloakTest {
 
         for (String username : getUsernames()) {
             profilePage.open();
-            Assert.assertEquals("Browser should be on login page now", "Log in to " + REALM_NAME, driver.getTitle());
+            Assert.assertEquals("Browser should be on login page now", "Sign in to " + REALM_NAME, driver.getTitle());
             accountLoginPage.login(username, getPassword(username));
             Assert.assertTrue(profilePage.isCurrent());
             verifyUserGroups(username, getGroups(username));
@@ -152,7 +152,7 @@ public class SSSDTest extends AbstractKeycloakTest {
         log.debug("Testing correct password, but no e-mail provided");
         String username = getUser(NO_EMAIL_USER);
         profilePage.open();
-        Assert.assertEquals("Browser should be on login page now", "Log in to " + REALM_NAME, driver.getTitle());
+        Assert.assertEquals("Browser should be on login page now", "Sign in to " + REALM_NAME, driver.getTitle());
         accountLoginPage.login(username, getPassword(username));
         Assert.assertTrue(profilePage.isCurrent());
     }
@@ -163,7 +163,7 @@ public class SSSDTest extends AbstractKeycloakTest {
 
         profilePage.open();
         String username = getUsername();
-        Assert.assertEquals("Browser should be on login page now", "Log in to " + REALM_NAME, driver.getTitle());
+        Assert.assertEquals("Browser should be on login page now", "Sign in to " + REALM_NAME, driver.getTitle());
         accountLoginPage.login(username, getPassword(username));
         Assert.assertTrue(profilePage.isCurrent());
         verifyUserGroups(username, getGroups(username));

--- a/themes/src/main/resources/theme/base/login/login-config-totp.ftl
+++ b/themes/src/main/resources/theme/base/login/login-config-totp.ftl
@@ -1,11 +1,10 @@
 <#import "template.ftl" as layout>
-<@layout.registrationLayout displayInfo=true displayRequiredFields=true; section>
+<@layout.registrationLayout displayRequiredFields=false; section>
 
     <#if section = "header">
         ${msg("loginTotpTitle")}
 
     <#elseif section = "form">
-
     <ol id="kc-totp-settings">
         <li>
             <p>${msg("loginTotpStep1")}</p>
@@ -69,7 +68,7 @@
             </div>
 
             <div class="${properties.kcInputWrapperClass!}">
-                <input type="text" class="form-control" id="userLabel" name="userLabel" autocomplete="off">
+                <input type="text" class="${properties.kcInputClass!}" id="userLabel" name="userLabel" autocomplete="off">
             </div>
         </div>
 

--- a/themes/src/main/resources/theme/base/login/login-password.ftl
+++ b/themes/src/main/resources/theme/base/login/login-password.ftl
@@ -1,28 +1,38 @@
 <#import "template.ftl" as layout>
-<@layout.registrationLayout displayInfo=false displayWide=false; section>
+<@layout.registrationLayout displayMessage=!messagesPerField.existsError('password'); section>
     <#if section = "header">
         ${msg("doLogIn")}
     <#elseif section = "form">
-    <div id="kc-form">
-      <div id="kc-form-wrapper">
-            <form id="kc-form-login" onsubmit="login.disabled = true; return true;" action="${url.loginAction}" method="post">
+        <div id="kc-form">
+            <div id="kc-form-wrapper">
+                <form id="kc-form-login" onsubmit="login.disabled = true; return true;" action="${url.loginAction}"
+                      method="post">
+                    <div class="${properties.kcFormGroupClass!} no-bottom-margin">
+                        <hr/>
+                        <label for="password" class="${properties.kcLabelClass!}">${msg("password")}</label>
+                        <input tabindex="2" id="password" class="${properties.kcInputClass!}" name="password"
+                               type="password" autocomplete="on"
+                               aria-invalid="<#if messagesPerField.existsError('password')>true</#if>"
+                        />
+                        <#if messagesPerField.existsError('password')>
+                            <span id="input-error-password" class="${properties.kcInputErrorMessageClass!}" aria-live="polite">
+                                ${kcSanitize(messagesPerField.get('password'))?no_esc}
+                            </span>
+                        </#if>
+                    </div>
 
-                <div class="${properties.kcFormGroupClass!}">
-                    <label for="password" class="${properties.kcLabelClass!}">${msg("password")}</label>
-                    <input tabindex="2" id="password" class="${properties.kcInputClass!}" name="password" type="password" autocomplete="off" />
-                </div>
-
-                <div class="${properties.kcFormGroupClass!} ${properties.kcFormSettingClass!}">
-                    <div id="kc-form-options">
+                    <div class="${properties.kcFormGroupClass!} ${properties.kcFormSettingClass!}">
+                        <div id="kc-form-options">
                         </div>
                         <div class="${properties.kcFormOptionsWrapperClass!}">
                             <#if realm.resetPasswordAllowed>
-                                <span><a tabindex="5" href="${url.loginResetCredentialsUrl}">${msg("doForgotPassword")}</a></span>
+                                <span><a tabindex="5"
+                                         href="${url.loginResetCredentialsUrl}">${msg("doForgotPassword")}</a></span>
                             </#if>
                         </div>
-                  </div>
+                    </div>
 
-                  <div id="kc-form-buttons" class="${properties.kcFormGroupClass!}">
+                    <div id="kc-form-buttons" class="${properties.kcFormGroupClass!}">
                     <input tabindex="4" class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}" name="login" id="kc-login" type="submit" value="${msg("doLogIn")}"/>
                   </div>
             </form>

--- a/themes/src/main/resources/theme/base/login/login-reset-password.ftl
+++ b/themes/src/main/resources/theme/base/login/login-reset-password.ftl
@@ -1,5 +1,5 @@
 <#import "template.ftl" as layout>
-<@layout.registrationLayout displayInfo=true; section>
+<@layout.registrationLayout displayInfo=true displayMessage=!messagesPerField.existsError('username'); section>
     <#if section = "header">
         ${msg("emailForgotTitle")}
     <#elseif section = "form">
@@ -10,9 +10,15 @@
                 </div>
                 <div class="${properties.kcInputWrapperClass!}">
                     <#if auth?has_content && auth.showUsername()>
-                        <input type="text" id="username" name="username" class="${properties.kcInputClass!}" autofocus value="${auth.attemptedUsername}"/>
+                        <input type="text" id="username" name="username" class="${properties.kcInputClass!}" autofocus value="${auth.attemptedUsername}" aria-invalid="<#if messagesPerField.existsError('username')>true</#if>"/>
                     <#else>
-                        <input type="text" id="username" name="username" class="${properties.kcInputClass!}" autofocus/>
+                        <input type="text" id="username" name="username" class="${properties.kcInputClass!}" autofocus aria-invalid="<#if messagesPerField.existsError('username')>true</#if>"/>
+                    </#if>
+
+                    <#if messagesPerField.existsError('username')>
+                        <span id="input-error-username" class="${properties.kcInputErrorMessageClass!}" aria-live="polite">
+                                    ${kcSanitize(messagesPerField.get('username'))?no_esc}
+                        </span>
                     </#if>
                 </div>
             </div>

--- a/themes/src/main/resources/theme/base/login/login-update-password.ftl
+++ b/themes/src/main/resources/theme/base/login/login-update-password.ftl
@@ -1,5 +1,5 @@
 <#import "template.ftl" as layout>
-<@layout.registrationLayout displayInfo=true; section>
+<@layout.registrationLayout ; section>
     <#if section = "header">
         ${msg("updatePasswordTitle")}
     <#elseif section = "form">

--- a/themes/src/main/resources/theme/base/login/login-username.ftl
+++ b/themes/src/main/resources/theme/base/login/login-username.ftl
@@ -1,54 +1,86 @@
 <#import "template.ftl" as layout>
-<@layout.registrationLayout displayInfo=social.displayInfo displayWide=(realm.password && social.providers??); section>
+<@layout.registrationLayout displayMessage=!messagesPerField.existsError('username') displayInfo=(realm.password && realm.registrationAllowed && !registrationDisabled??); section>
     <#if section = "header">
-        ${msg("doLogIn")}
+        ${msg("loginAccountTitle")}
     <#elseif section = "form">
-    <div id="kc-form" <#if realm.password && social.providers??>class="${properties.kcContentWrapperClass!}"</#if>>
-      <div id="kc-form-wrapper" <#if realm.password && social.providers??>class="${properties.kcFormSocialAccountContentClass!} ${properties.kcFormSocialAccountClass!}"</#if>>
-        <#if realm.password>
-            <form id="kc-form-login" onsubmit="login.disabled = true; return true;" action="${url.loginAction}" method="post">
-                <div class="${properties.kcFormGroupClass!}">
-                    <label for="username" class="${properties.kcLabelClass!}"><#if !realm.loginWithEmailAllowed>${msg("username")}<#elseif !realm.registrationEmailAsUsername>${msg("usernameOrEmail")}<#else>${msg("email")}</#if></label>
+        <div id="kc-form">
+            <div id="kc-form-wrapper">
+                <#if realm.password>
+                    <form id="kc-form-login" onsubmit="login.disabled = true; return true;" action="${url.loginAction}"
+                          method="post">
+                        <div class="${properties.kcFormGroupClass!}">
+                            <label for="username"
+                                   class="${properties.kcLabelClass!}"><#if !realm.loginWithEmailAllowed>${msg("username")}<#elseif !realm.registrationEmailAsUsername>${msg("usernameOrEmail")}<#else>${msg("email")}</#if></label>
 
-                    <#if usernameEditDisabled??>
-                        <input tabindex="1" id="username" class="${properties.kcInputClass!}" name="username" value="${(login.username!'')}" type="text" disabled />
-                    <#else>
-                        <input tabindex="1" id="username" class="${properties.kcInputClass!}" name="username" value="${(login.username!'')}"  type="text" autofocus autocomplete="off" />
-                    </#if>
-                </div>
+                            <#if usernameEditDisabled??>
+                                <input tabindex="1" id="username"
+                                       aria-invalid="<#if message?has_content && message.type = 'error'>true</#if>"
+                                       class="${properties.kcInputClass!}" name="username"
+                                       value="${(login.username!'')}"
+                                       type="text" disabled/>
+                            <#else>
+                                <input tabindex="1" id="username"
+                                       aria-invalid="<#if messagesPerField.existsError('username')>true</#if>"
+                                       class="${properties.kcInputClass!}" name="username"
+                                       value="${(login.username!'')}"
+                                       type="text" autofocus autocomplete="off"/>
+                            </#if>
 
-                <div class="${properties.kcFormGroupClass!} ${properties.kcFormSettingClass!}">
-                    <div id="kc-form-options">
-                        <#if realm.rememberMe && !usernameEditDisabled??>
-                            <div class="checkbox">
-                                <label>
-                                    <#if login.rememberMe??>
-                                        <input tabindex="3" id="rememberMe" name="rememberMe" type="checkbox" checked> ${msg("rememberMe")}
-                                    <#else>
-                                        <input tabindex="3" id="rememberMe" name="rememberMe" type="checkbox"> ${msg("rememberMe")}
-                                    </#if>
-                                </label>
-                            </div>
-                        </#if>
+                            <#if messagesPerField.existsError('username')>
+                                <span id="input-error-username" class="${properties.kcInputErrorMessageClass!}" aria-live="polite">
+                                    ${kcSanitize(messagesPerField.get('username'))?no_esc}
+                                </span>
+                            </#if>
                         </div>
-                  </div>
 
-                  <div id="kc-form-buttons" class="${properties.kcFormGroupClass!}">
-                    <input tabindex="4" class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}" name="login" id="kc-login" type="submit" value="${msg("doLogIn")}"/>
-                  </div>
-            </form>
-        </#if>
+                        <div class="${properties.kcFormGroupClass!} ${properties.kcFormSettingClass!}">
+                            <div id="kc-form-options">
+                                <#if realm.rememberMe && !usernameEditDisabled??>
+                                    <div class="checkbox">
+                                        <label>
+                                            <#if login.rememberMe??>
+                                                <input tabindex="3" id="rememberMe" name="rememberMe" type="checkbox"
+                                                       checked> ${msg("rememberMe")}
+                                            <#else>
+                                                <input tabindex="3" id="rememberMe" name="rememberMe"
+                                                       type="checkbox"> ${msg("rememberMe")}
+                                            </#if>
+                                        </label>
+                                    </div>
+                                </#if>
+                            </div>
+                        </div>
+
+                        <div id="kc-form-buttons" class="${properties.kcFormGroupClass!}">
+                            <input tabindex="4"
+                                   class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}"
+                                   name="login" id="kc-login" type="submit" value="${msg("doLogIn")}"/>
+                        </div>
+                    </form>
+                </#if>
         </div>
-        <#if realm.password && social.providers??>
-            <div id="kc-social-providers" class="${properties.kcFormSocialAccountContentClass!} ${properties.kcFormSocialAccountClass!}">
-                <ul class="${properties.kcFormSocialAccountListClass!} <#if social.providers?size gt 4>${properties.kcFormSocialAccountDoubleListClass!}</#if>">
-                    <#list social.providers as p>
-                        <li class="${properties.kcFormSocialAccountListLinkClass!}"><a href="${p.loginUrl}" id="zocial-${p.alias}" class="zocial ${p.providerId}"> <span>${p.displayName}</span></a></li>
-                    </#list>
-                </ul>
-            </div>
-        </#if>
-      </div>
+
+            <#if realm.password && social.providers??>
+                <div id="kc-social-providers" class="${properties.kcFormSocialAccountSectionClass!}">
+                    <hr/>
+                    <h4>${msg("identity-provider-login-label")}</h4>
+
+                    <ul class="${properties.kcFormSocialAccountListClass!} <#if social.providers?size gt 3>${properties.kcFormSocialAccountListGridClass!}</#if>">
+                        <#list social.providers as p>
+                            <a id="social-${p.alias}" class="${properties.kcFormSocialAccountListButtonClass!} <#if social.providers?size gt 3>${properties.kcFormSocialAccountGridItem!}</#if>"
+                               type="button" href="${p.loginUrl}">
+                                <#if p.iconClasses?has_content>
+                                    <i class="${properties.kcCommonLogoIdP!} ${p.iconClasses!}" aria-hidden="true"></i>
+                                    <span class="${properties.kcFormSocialAccountNameClass!} kc-social-icon-text">${p.displayName}</span>
+                                <#else>
+                                    <span class="${properties.kcFormSocialAccountNameClass!}">${p.displayName}</span>
+                                </#if>
+                            </a>
+                        </#list>
+                    </ul>
+                </div>
+            </#if>
+
     <#elseif section = "info" >
         <#if realm.password && realm.registrationAllowed && !registrationDisabled??>
             <div id="kc-registration">

--- a/themes/src/main/resources/theme/base/login/login.ftl
+++ b/themes/src/main/resources/theme/base/login/login.ftl
@@ -1,10 +1,10 @@
 <#import "template.ftl" as layout>
-<@layout.registrationLayout displayInfo=social.displayInfo displayWide=(realm.password && social.providers??); section>
+<@layout.registrationLayout displayMessage=!messagesPerField.existsError('username','password') displayInfo=realm.password && realm.registrationAllowed && !registrationDisabled??; section>
     <#if section = "header">
-        ${msg("doLogIn")}
+        ${msg("loginAccountTitle")}
     <#elseif section = "form">
-    <div id="kc-form" <#if realm.password && social.providers??>class="${properties.kcContentWrapperClass!}"</#if>>
-      <div id="kc-form-wrapper" <#if realm.password && social.providers??>class="${properties.kcFormSocialAccountContentClass!} ${properties.kcFormSocialAccountClass!}"</#if>>
+    <div id="kc-form">
+      <div id="kc-form-wrapper">
         <#if realm.password>
             <form id="kc-form-login" onsubmit="login.disabled = true; return true;" action="${url.loginAction}" method="post">
                 <div class="${properties.kcFormGroupClass!}">
@@ -13,13 +13,24 @@
                     <#if usernameEditDisabled??>
                         <input tabindex="1" id="username" class="${properties.kcInputClass!}" name="username" value="${(login.username!'')}" type="text" disabled />
                     <#else>
-                        <input tabindex="1" id="username" class="${properties.kcInputClass!}" name="username" value="${(login.username!'')}"  type="text" autofocus autocomplete="off" />
+                        <input tabindex="1" id="username" class="${properties.kcInputClass!}" name="username" value="${(login.username!'')}"  type="text" autofocus autocomplete="off"
+                               aria-invalid="<#if messagesPerField.existsError('username','password')>true</#if>"
+                        />
+
+                        <#if messagesPerField.existsError('username','password')>
+                            <span id="input-error" class="${properties.kcInputErrorMessageClass!}" aria-live="polite">
+                                    ${kcSanitize(messagesPerField.getFirstError('username','password'))?no_esc}
+                            </span>
+                        </#if>
                     </#if>
                 </div>
 
                 <div class="${properties.kcFormGroupClass!}">
                     <label for="password" class="${properties.kcLabelClass!}">${msg("password")}</label>
-                    <input tabindex="2" id="password" class="${properties.kcInputClass!}" name="password" type="password" autocomplete="off" />
+
+                    <input tabindex="2" id="password" class="${properties.kcInputClass!}" name="password" type="password" autocomplete="off"
+                           aria-invalid="<#if messagesPerField.existsError('username','password')>true</#if>"
+                    />
                 </div>
 
                 <div class="${properties.kcFormGroupClass!} ${properties.kcFormSettingClass!}">
@@ -51,20 +62,36 @@
             </form>
         </#if>
         </div>
+
         <#if realm.password && social.providers??>
-            <div id="kc-social-providers" class="${properties.kcFormSocialAccountContentClass!} ${properties.kcFormSocialAccountClass!}">
-                <ul class="${properties.kcFormSocialAccountListClass!} <#if social.providers?size gt 4>${properties.kcFormSocialAccountDoubleListClass!}</#if>">
+            <div id="kc-social-providers" class="${properties.kcFormSocialAccountSectionClass!}">
+                <hr/>
+                <h4>${msg("identity-provider-login-label")}</h4>
+
+                <ul class="${properties.kcFormSocialAccountListClass!} <#if social.providers?size gt 3>${properties.kcFormSocialAccountListGridClass!}</#if>">
                     <#list social.providers as p>
-                        <li class="${properties.kcFormSocialAccountListLinkClass!}"><a href="${p.loginUrl}" id="zocial-${p.alias}" class="zocial ${p.providerId}"> <span>${p.displayName}</span></a></li>
+                        <a id="social-${p.alias}" class="${properties.kcFormSocialAccountListButtonClass!} <#if social.providers?size gt 3>${properties.kcFormSocialAccountGridItem!}</#if>"
+                                type="button" href="${p.loginUrl}">
+                            <#if p.iconClasses?has_content>
+                                <i class="${properties.kcCommonLogoIdP!} ${p.iconClasses!}" aria-hidden="true"></i>
+                                <span class="${properties.kcFormSocialAccountNameClass!} kc-social-icon-text">${p.displayName!}</span>
+                            <#else>
+                                <span class="${properties.kcFormSocialAccountNameClass!}">${p.displayName!}</span>
+                            </#if>
+                        </a>
                     </#list>
                 </ul>
             </div>
         </#if>
-      </div>
+
+    </div>
     <#elseif section = "info" >
         <#if realm.password && realm.registrationAllowed && !registrationDisabled??>
-            <div id="kc-registration">
-                <span>${msg("noAccount")} <a tabindex="6" href="${url.registrationUrl}">${msg("doRegister")}</a></span>
+            <div id="kc-registration-container">
+                <div id="kc-registration">
+                    <span>${msg("noAccount")} <a tabindex="6"
+                                                 href="${url.registrationUrl}">${msg("doRegister")}</a></span>
+                </div>
             </div>
         </#if>
     </#if>

--- a/themes/src/main/resources/theme/base/login/messages/messages_en.properties
+++ b/themes/src/main/resources/theme/base/login/messages/messages_en.properties
@@ -1,4 +1,4 @@
-doLogIn=Log In
+doLogIn=Sign In
 doRegister=Register
 doCancel=Cancel
 doSubmit=Submit
@@ -19,7 +19,8 @@ kerberosNotConfiguredTitle=Kerberos Not Configured
 bypassKerberosDetail=Either you are not logged in by Kerberos or your browser is not set up for Kerberos login.  Please click continue to login in through other means
 kerberosNotSetUp=Kerberos is not set up.  You cannot login.
 registerTitle=Register
-loginTitle=Log in to {0}
+loginAccountTitle=Sign in to your account
+loginTitle=Sign in to {0}
 loginTitleHtml={0}
 impersonateTitle={0} Impersonate User
 impersonateTitleHtml=<strong>{0}</strong> Impersonate User
@@ -172,7 +173,7 @@ invalidPasswordMessage=Invalid password.
 invalidEmailMessage=Invalid email address.
 accountDisabledMessage=Account is disabled, contact your administrator.
 accountTemporarilyDisabledMessage=Account is temporarily disabled; contact your administrator or retry later.
-expiredCodeMessage=Login timeout. Please log in again.
+expiredCodeMessage=Login timeout. Please sign in again.
 expiredActionMessage=Action expired. Please continue with login now.
 expiredActionTokenNoSessionMessage=Action expired.
 expiredActionTokenSessionExistsMessage=Action expired. Please start again.
@@ -267,7 +268,7 @@ identityProviderUnexpectedErrorMessage=Unexpected error when authenticating with
 identityProviderMissingStateMessage=Missing state parameter in response from identity provider.
 identityProviderNotFoundMessage=Could not find an identity provider with the identifier.
 identityProviderLinkSuccess=You successfully verified your email. Please go back to your original browser and continue there with the login.
-staleCodeMessage=This page is no longer valid, please go back to your application and log in again
+staleCodeMessage=This page is no longer valid, please go back to your application and sign in again
 realmSupportsNoCredentialsMessage=Realm does not support any credential type.
 credentialSetupRequired=Cannot login, credential setup required.
 identityProviderNotUniqueMessage=Realm supports multiple identity providers. Could not determine which identity provider should be used to authenticate with.
@@ -305,7 +306,7 @@ clientNotFoundMessage=Client not found.
 clientDisabledMessage=Client disabled.
 invalidParameterMessage=Invalid parameter\: {0}
 alreadyLoggedIn=You are already logged in.
-differentUserAuthenticated=You are already authenticated as different user ''{0}'' in this session. Please log out first.
+differentUserAuthenticated=You are already authenticated as different user ''{0}'' in this session. Please sign out first.
 brokerLinkingSessionExpired=Requested broker account linking, but current session is no longer valid.
 proceedWithAction=&raquo; Click here to proceed
 
@@ -349,17 +350,17 @@ saml.post-form.js-disabled=JavaScript is disabled. We strongly recommend to enab
 otp-display-name=Authenticator Application
 otp-help-text=Enter a verification code from authenticator application.
 password-display-name=Password
-password-help-text=Log in by entering your password.
+password-help-text=Sign in by entering your password.
 auth-username-form-display-name=Username
-auth-username-form-help-text=Start log in by entering your username
+auth-username-form-help-text=Start sign in by entering your username
 auth-username-password-form-display-name=Username and password
-auth-username-password-form-help-text=Log in by entering your username and password.
+auth-username-password-form-help-text=Sign in by entering your username and password.
 
 # WebAuthn
 webauthn-display-name=Security Key
-webauthn-help-text=Use your security key to log in.
+webauthn-help-text=Use your security key to sign in.
 webauthn-passwordless-display-name=Security Key
-webauthn-passwordless-help-text=Use your security key for passwordless log in.
+webauthn-passwordless-help-text=Use your security key for passwordless sign in.
 webauthn-login-title=Security Key login
 webauthn-registration-title=Security Key Registration
 webauthn-available-authenticators=Available authenticators
@@ -373,5 +374,7 @@ webauthn-error-auth-verification=Security key authentication result is invalid.
 webauthn-error-register-verification=Security key registration result is invalid.
 webauthn-error-user-not-found=Unknown user authenticated by the Security key.
 
+# Identity provider
 identity-provider-redirector=Connect with another Identity Provider
+identity-provider-login-label=Or sign in with
 

--- a/themes/src/main/resources/theme/base/login/register.ftl
+++ b/themes/src/main/resources/theme/base/login/register.ftl
@@ -31,43 +31,43 @@
                 </div>
             </div>
 
-          <#if !realm.registrationEmailAsUsername>
-            <div class="${properties.kcFormGroupClass!} ${messagesPerField.printIfExists('username',properties.kcFormGroupErrorClass!)}">
-                <div class="${properties.kcLabelWrapperClass!}">
-                    <label for="username" class="${properties.kcLabelClass!}">${msg("username")}</label>
+            <#if !realm.registrationEmailAsUsername>
+                <div class="${properties.kcFormGroupClass!} ${messagesPerField.printIfExists('username',properties.kcFormGroupErrorClass!)}">
+                    <div class="${properties.kcLabelWrapperClass!}">
+                        <label for="username" class="${properties.kcLabelClass!}">${msg("username")}</label>
+                    </div>
+                    <div class="${properties.kcInputWrapperClass!}">
+                        <input type="text" id="username" class="${properties.kcInputClass!}" name="username" value="${(register.formData.username!'')}" autocomplete="username" />
+                    </div>
                 </div>
-                <div class="${properties.kcInputWrapperClass!}">
-                    <input type="text" id="username" class="${properties.kcInputClass!}" name="username" value="${(register.formData.username!'')}" autocomplete="username" />
-                </div>
-            </div>
-          </#if>
+            </#if>
 
             <#if passwordRequired??>
-            <div class="${properties.kcFormGroupClass!} ${messagesPerField.printIfExists('password',properties.kcFormGroupErrorClass!)}">
-                <div class="${properties.kcLabelWrapperClass!}">
-                    <label for="password" class="${properties.kcLabelClass!}">${msg("password")}</label>
+                <div class="${properties.kcFormGroupClass!} ${messagesPerField.printIfExists('password',properties.kcFormGroupErrorClass!)}">
+                    <div class="${properties.kcLabelWrapperClass!}">
+                        <label for="password" class="${properties.kcLabelClass!}">${msg("password")}</label>
+                    </div>
+                    <div class="${properties.kcInputWrapperClass!}">
+                        <input type="password" id="password" class="${properties.kcInputClass!}" name="password" autocomplete="new-password"/>
+                    </div>
                 </div>
-                <div class="${properties.kcInputWrapperClass!}">
-                    <input type="password" id="password" class="${properties.kcInputClass!}" name="password" autocomplete="new-password"/>
-                </div>
-            </div>
 
-            <div class="${properties.kcFormGroupClass!} ${messagesPerField.printIfExists('password-confirm',properties.kcFormGroupErrorClass!)}">
-                <div class="${properties.kcLabelWrapperClass!}">
-                    <label for="password-confirm" class="${properties.kcLabelClass!}">${msg("passwordConfirm")}</label>
+                <div class="${properties.kcFormGroupClass!} ${messagesPerField.printIfExists('password-confirm',properties.kcFormGroupErrorClass!)}">
+                    <div class="${properties.kcLabelWrapperClass!}">
+                        <label for="password-confirm" class="${properties.kcLabelClass!}">${msg("passwordConfirm")}</label>
+                    </div>
+                    <div class="${properties.kcInputWrapperClass!}">
+                        <input type="password" id="password-confirm" class="${properties.kcInputClass!}" name="password-confirm" />
+                    </div>
                 </div>
-                <div class="${properties.kcInputWrapperClass!}">
-                    <input type="password" id="password-confirm" class="${properties.kcInputClass!}" name="password-confirm" />
-                </div>
-            </div>
             </#if>
 
             <#if recaptchaRequired??>
-            <div class="form-group">
-                <div class="${properties.kcInputWrapperClass!}">
-                    <div class="g-recaptcha" data-size="compact" data-sitekey="${recaptchaSiteKey}"></div>
+                <div class="form-group">
+                    <div class="${properties.kcInputWrapperClass!}">
+                        <div class="g-recaptcha" data-size="compact" data-sitekey="${recaptchaSiteKey}"></div>
+                    </div>
                 </div>
-            </div>
             </#if>
 
             <div class="${properties.kcFormGroupClass!}">

--- a/themes/src/main/resources/theme/base/login/template.ftl
+++ b/themes/src/main/resources/theme/base/login/template.ftl
@@ -1,4 +1,4 @@
-<#macro registrationLayout bodyClass="" displayInfo=false displayMessage=true displayRequiredFields=false displayWide=false showAnotherWayIfPresent=true>
+<#macro registrationLayout bodyClass="" displayInfo=false displayMessage=true displayRequiredFields=false showAnotherWayIfPresent=true>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"  "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" class="${properties.kcHtmlClass!}">
 
@@ -37,21 +37,22 @@
 </head>
 
 <body class="${properties.kcBodyClass!}">
-  <div class="${properties.kcLoginClass!}">
+<div class="${properties.kcLoginClass!}">
     <div id="kc-header" class="${properties.kcHeaderClass!}">
-      <div id="kc-header-wrapper" class="${properties.kcHeaderWrapperClass!}">${kcSanitize(msg("loginTitleHtml",(realm.displayNameHtml!'')))?no_esc}</div>
+        <div id="kc-header-wrapper"
+             class="${properties.kcHeaderWrapperClass!}">${kcSanitize(msg("loginTitleHtml",(realm.displayNameHtml!'')))?no_esc}</div>
     </div>
-    <div class="${properties.kcFormCardClass!} <#if displayWide>${properties.kcFormCardAccountClass!}</#if>">
-      <header class="${properties.kcFormHeaderClass!}">
-        <#if realm.internationalizationEnabled  && locale.supported?size gt 1>
-            <div id="kc-locale">
-                <div id="kc-locale-wrapper" class="${properties.kcLocaleWrapperClass!}">
-                    <div class="kc-dropdown" id="kc-locale-dropdown">
-                        <a href="#" id="kc-current-locale-link">${locale.current}</a>
-                        <ul>
-                            <#list locale.supported as l>
-                                <li class="kc-dropdown-item"><a href="${l.url}">${l.label}</a></li>
-                            </#list>
+    <div class="${properties.kcFormCardClass!}">
+        <header class="${properties.kcFormHeaderClass!}">
+            <#if realm.internationalizationEnabled  && locale.supported?size gt 1>
+                <div id="kc-locale">
+                    <div id="kc-locale-wrapper" class="${properties.kcLocaleWrapperClass!}">
+                        <div class="kc-dropdown" id="kc-locale-dropdown">
+                            <a href="#" id="kc-current-locale-link">${locale.current}</a>
+                            <ul>
+                                <#list locale.supported as l>
+                                    <li class="kc-dropdown-item"><a href="${l.url}">${l.label}</a></li>
+                                </#list>
                         </ul>
                     </div>
                 </div>
@@ -78,31 +79,27 @@
                     </div>
                     <div class="col-md-10">
                         <#nested "show-username">
-                        <div class="${properties.kcFormGroupClass!}">
-                            <div id="kc-username">
-                                <label id="kc-attempted-username">${auth.attemptedUsername}</label>
-                                <a id="reset-login" href="${url.loginRestartFlowUrl}">
-                                    <div class="kc-login-tooltip">
-                                        <i class="${properties.kcResetFlowIcon!}"></i>
-                                        <span class="kc-tooltip-text">${msg("restartLoginTooltip")}</span>
-                                    </div>
-                                </a>
-                            </div>
+                        <div id="kc-username" class="${properties.kcFormGroupClass!}">
+                            <label id="kc-attempted-username">${auth.attemptedUsername}</label>
+                            <a id="reset-login" href="${url.loginRestartFlowUrl}">
+                                <div class="kc-login-tooltip">
+                                    <i class="${properties.kcResetFlowIcon!}"></i>
+                                    <span class="kc-tooltip-text">${msg("restartLoginTooltip")}</span>
+                                </div>
+                            </a>
                         </div>
                     </div>
                 </div>
             <#else>
                 <#nested "show-username">
-                <div class="${properties.kcFormGroupClass!}">
-                    <div id="kc-username">
-                        <label id="kc-attempted-username">${auth.attemptedUsername}</label>
-                        <a id="reset-login" href="${url.loginRestartFlowUrl}">
-                            <div class="kc-login-tooltip">
-                                <i class="${properties.kcResetFlowIcon!}"></i>
-                                <span class="kc-tooltip-text">${msg("restartLoginTooltip")}</span>
-                            </div>
-                        </a>
-                    </div>
+                <div id="kc-username" class="${properties.kcFormGroupClass!}">
+                    <label id="kc-attempted-username">${auth.attemptedUsername}</label>
+                    <a id="reset-login" href="${url.loginRestartFlowUrl}">
+                        <div class="kc-login-tooltip">
+                            <i class="${properties.kcResetFlowIcon!}"></i>
+                            <span class="kc-tooltip-text">${msg("restartLoginTooltip")}</span>
+                        </div>
+                    </a>
                 </div>
             </#if>
         </#if>
@@ -113,27 +110,28 @@
           <#-- App-initiated actions should not see warning messages about the need to complete the action -->
           <#-- during login.                                                                               -->
           <#if displayMessage && message?has_content && (message.type != 'warning' || !isAppInitiatedAction??)>
-              <div class="alert alert-${message.type}">
-                  <#if message.type = 'success'><span class="${properties.kcFeedbackSuccessIcon!}"></span></#if>
-                  <#if message.type = 'warning'><span class="${properties.kcFeedbackWarningIcon!}"></span></#if>
-                  <#if message.type = 'error'><span class="${properties.kcFeedbackErrorIcon!}"></span></#if>
-                  <#if message.type = 'info'><span class="${properties.kcFeedbackInfoIcon!}"></span></#if>
-                  <span class="kc-feedback-text">${kcSanitize(message.summary)?no_esc}</span>
+              <div class="alert-${message.type} ${properties.kcAlertClass!} pf-m-<#if message.type = 'error'>danger<#else>${message.type}</#if>">
+                  <div class="pf-c-alert__icon">
+                      <#if message.type = 'success'><span class="${properties.kcFeedbackSuccessIcon!}"></span></#if>
+                      <#if message.type = 'warning'><span class="${properties.kcFeedbackWarningIcon!}"></span></#if>
+                      <#if message.type = 'error'><span class="${properties.kcFeedbackErrorIcon!}"></span></#if>
+                      <#if message.type = 'info'><span class="${properties.kcFeedbackInfoIcon!}"></span></#if>
+                  </div>
+                      <span class="${properties.kcAlertTitleClass!}">${kcSanitize(message.summary)?no_esc}</span>
               </div>
           </#if>
 
           <#nested "form">
 
-          <#if auth?has_content && auth.showTryAnotherWayLink() && showAnotherWayIfPresent>
-          <form id="kc-select-try-another-way-form" action="${url.loginAction}" method="post" <#if displayWide>class="${properties.kcContentWrapperClass!}"</#if>>
-              <div <#if displayWide>class="${properties.kcFormSocialAccountContentClass!} ${properties.kcFormSocialAccountClass!}"</#if>>
-                  <div class="${properties.kcFormGroupClass!}">
-                    <input type="hidden" name="tryAnotherWay" value="on" />
-                    <a href="#" id="try-another-way" onclick="document.forms['kc-select-try-another-way-form'].submit();return false;">${msg("doTryAnotherWay")}</a>
-                  </div>
-              </div>
-          </form>
-          </#if>
+            <#if auth?has_content && auth.showTryAnotherWayLink() && showAnotherWayIfPresent>
+                <form id="kc-select-try-another-way-form" action="${url.loginAction}" method="post">
+                    <div class="${properties.kcFormGroupClass!}">
+                        <input type="hidden" name="tryAnotherWay" value="on"/>
+                        <a href="#" id="try-another-way"
+                           onclick="document.forms['kc-select-try-another-way-form'].submit();return false;">${msg("doTryAnotherWay")}</a>
+                    </div>
+                </form>
+            </#if>
 
           <#if displayInfo>
               <div id="kc-info" class="${properties.kcSignUpClass!}">

--- a/themes/src/main/resources/theme/keycloak/login/resources/css/login.css
+++ b/themes/src/main/resources/theme/keycloak/login/resources/css/login.css
@@ -4,11 +4,152 @@
     height: 100%;
 }
 
-.alert-error {
-    background-color: #ffffff;
-    border-color: #cc0000;
-    color: #333333;
+/*IE compatibility*/
+.pf-c-form-control {
+    font-size: 14px;
+    font-size: var(--pf-global--FontSize--sm);
+    border-width: 1px;
+    border-width: var(--pf-global--BorderWidth--sm);;
+    border-color: #EDEDED #EDEDED #8A8D90 #EDEDED;
+    border-color: var(--pf-global--BorderColor--300) var(--pf-global--BorderColor--300) var(--pf-global--BorderColor--200) var(--pf-global--BorderColor--300);
+    background-color: #FFFFFF;
+    background-color: var(--pf-global--BackgroundColor--100);
+    height: 36px;
+    height: calc(var(--pf-c-form-control--FontSize) * var(--pf-c-form-control--LineHeight) + var(--pf-c-form-control--BorderWidth) * 2 + var(--pf-c-form-control--PaddingTop) + var(--pf-c-form-control--PaddingBottom));
+    padding: 5px 0.5rem;
+    padding: var(--pf-c-form-control--PaddingTop) var(--pf-c-form-control--PaddingRight) var(--pf-c-form-control--PaddingBottom) var(--pf-c-form-control--PaddingLeft);
 }
+
+.pf-c-form-control:hover, .pf-c-form-control:focus {
+    border-bottom-color: #0066CC;
+    border-bottom-color: var(--pf-global--primary-color--100);
+    border-bottom-width: 2px;
+    border-bottom-width: var(--pf-global--BorderWidth--md);
+}
+
+.pf-c-form-control[aria-invalid="true"] {
+    border-bottom-color: #C9190B;
+    border-bottom-color: var(--pf-global--danger-color--100);
+    border-bottom-width: 2px;
+    border-bottom-width: var(--pf-global--BorderWidth--md);
+}
+
+.pf-c-alert.pf-m-inline {
+    margin-bottom: 0.5rem; /* default - IE compatibility */
+    margin-bottom: var(--pf-global--spacer--sm);
+    padding: 0.25rem;
+    padding: var(--pf-global--spacer--xs);
+    border: solid #ededed;
+    border: solid var(--pf-global--BorderColor--300);
+    border-width: 1px;
+    border-width: var(--pf-c-alert--m-inline--BorderTopWidth) var(--pf-c-alert--m-inline--BorderRightWidth) var(--pf-c-alert--m-inline--BorderBottomWidth) var(--pf-c-alert--m-inline--BorderLeftWidth);
+    display: -ms-flexbox;
+    display: grid;
+    -ms-grid-columns: max-content 1fr max-content;
+    grid-template-columns:max-content 1fr max-content;
+    grid-template-columns: var(--pf-c-alert--grid-template-columns);
+    grid-template-rows: 1fr auto;
+    grid-template-rows: var(--pf-c-alert--grid-template-rows);
+}
+
+.pf-c-alert.pf-m-inline::before {
+    position: absolute;
+    top: -1px;
+    top: var(--pf-c-alert--m-inline--before--Top);
+    bottom: -1px;
+    bottom: var(--pf-c-alert--m-inline--before--Bottom);
+    left: 0;
+    width: 3px;
+    width: var(--pf-c-alert--m-inline--before--Width);
+    content: "";
+    background-color: #FFFFFF;
+    background-color: var(--pf-global--BackgroundColor--100);
+}
+
+.pf-c-alert.pf-m-inline.pf-m-success::before {
+    background-color: #92D400;
+    background-color: var(--pf-global--success-color--100);
+}
+
+.pf-c-alert.pf-m-inline.pf-m-danger::before {
+    background-color: #C9190B;
+    background-color: var(--pf-global--danger-color--100);
+}
+
+.pf-c-alert.pf-m-inline.pf-m-warning::before {
+    background-color: #F0AB00;
+    background-color: var(--pf-global--warning-color--100);
+}
+
+.pf-c-alert.pf-m-inline .pf-c-alert__icon {
+    padding: 1rem 0.5rem 1rem 1rem;
+    padding: var(--pf-c-alert--m-inline__icon--PaddingTop) var(--pf-c-alert--m-inline__icon--PaddingRight) var(--pf-c-alert--m-inline__icon--PaddingBottom) var(--pf-c-alert--m-inline__icon--PaddingLeft);
+    font-size: 16px;
+    font-size: var(--pf-c-alert--m-inline__icon--FontSize);
+}
+
+.pf-c-alert.pf-m-success .pf-c-alert__icon {
+    color: #92D400;
+    color: var(--pf-global--success-color--100);
+}
+
+.pf-c-alert.pf-m-success .pf-c-alert__title {
+    color: #486B00;
+    color: var(--pf-global--success-color--200);
+}
+
+.pf-c-alert.pf-m-danger .pf-c-alert__icon {
+    color: #C9190B;
+    color: var(--pf-global--danger-color--100);
+}
+
+.pf-c-alert.pf-m-danger .pf-c-alert__title {
+    color: #A30000;
+    color: var(--pf-global--danger-color--200);
+}
+
+.pf-c-alert.pf-m-warning .pf-c-alert__icon {
+    color: #F0AB00;
+    color: var(--pf-global--warning-color--100);
+}
+
+.pf-c-alert.pf-m-warning .pf-c-alert__title {
+    color: #795600;
+    color: var(--pf-global--warning-color--200);
+}
+
+.pf-c-alert__title {
+    font-size: 14px; /* default - IE compatibility */
+    font-size: var(--pf-global--FontSize--sm);
+    padding: 5px 8px;
+    padding: var(--pf-c-alert__title--PaddingTop) var(--pf-c-alert__title--PaddingRight) var(--pf-c-alert__title--PaddingBottom) var(--pf-c-alert__title--PaddingLeft);
+}
+
+.pf-c-button{
+    padding:0.375rem 1rem;
+    padding: var(--pf-global--spacer--form-element) var(--pf-global--spacer--md);
+}
+
+/* default - IE compatibility */
+.pf-m-primary {
+    color: #FFFFFF;
+    background-color: #0066CC;
+    background-color: var(--pf-global--primary-color--100);
+}
+
+/* default - IE compatibility */
+.pf-m-primary:hover {
+    background-color: #004080;
+    background-color: var(--pf-global--primary-color--200);
+}
+
+/* default - IE compatibility */
+.pf-c-button.pf-m-control {
+    border: solid 1px;
+    border: solid var(--pf-global--BorderWidth--sm);
+    border-color: rgba(230, 230, 230, 0.5);
+}
+/*End of IE compatibility*/
 
 #kc-locale ul {
     display: none;
@@ -116,32 +257,38 @@ div.kc-logo-text span {
     width: 100%;
 }
 
-#kc-attempted-username{
+#kc-attempted-username {
     font-size: 20px;
-    font-family:inherit;
+    font-family: inherit;
     font-weight: normal;
-    padding-right:10px;
+    padding-right: 10px;
 }
 
-#kc-username{
+#kc-username {
     text-align: center;
+    margin-bottom:-10px;
 }
 
-#kc-webauthn-settings-form{
-    padding-top:8px;
+#kc-webauthn-settings-form {
+    padding-top: 8px;
 }
 
-/* #kc-content-wrapper {
-    overflow-y: hidden;
-} */
+#kc-content-wrapper {
+    margin-top: 20px;
+}
+
+#kc-form-wrapper {
+    margin-top: 10px;
+}
 
 #kc-info {
-    padding-bottom: 200px;
-    margin-bottom: -200px;
+    margin: 20px -40px -30px;
 }
 
 #kc-info-wrapper {
     font-size: 13px;
+    padding: 15px 35px;
+    background-color: #F0F0F0;
 }
 
 #kc-form-options span {
@@ -158,7 +305,7 @@ div.kc-logo-text span {
 }
 
 #kc-registration {
-    margin-bottom: 15px;
+    margin-bottom: 0;
 }
 
 /* TOTP */
@@ -170,7 +317,8 @@ div.kc-logo-text span {
 }
 
 .required {
-    color: #CB2915;
+    color: #A30000; /* default - IE compatibility */
+    color: var(--pf-global--danger-color--200);
 }
 
 ol#kc-totp-settings {
@@ -179,7 +327,7 @@ ol#kc-totp-settings {
 }
 
 ul#kc-totp-supported-apps {
-  margin-bottom: 10px;
+    margin-bottom: 10px;
 }
 
 #kc-totp-secret-qr-code {
@@ -228,22 +376,61 @@ ul#kc-totp-supported-apps {
 }
 
 /* Social */
-
-#kc-social-providers ul {
-    padding: 0;
+.kc-social-links {
+    margin-top: 20px;
 }
 
-#kc-social-providers li {
-    display: block;
+.kc-social-provider-logo {
+    font-size: 23px;
+    width: 30px;
+    height: 25px;
+    float: left;
 }
 
-#kc-social-providers li:first-of-type {
-    margin-top: 0;
+.kc-social-gray {
+    color: #737679; /* default - IE compatibility */
+    color: var(--pf-global--Color--200);
 }
 
-.kc-login-tooltip{
-    position:relative;
+.kc-social-item {
+    margin-bottom: 0.5rem; /* default - IE compatibility */
+    margin-bottom: var(--pf-global--spacer--sm);
+    font-size: 15px;
+    text-align: center;
+}
+
+.kc-social-provider-name {
+    position: relative;
+    top: 3px;
+}
+
+.kc-social-icon-text {
+    left: -15px;
+}
+
+.kc-social-grid {
+    display:grid;
+    grid-column-gap: 10px;
+    grid-row-gap: 5px;
+    grid-column-end: span 6;
+    --pf-l-grid__item--GridColumnEnd: span 6;
+}
+
+.kc-social-grid .kc-social-icon-text {
+    left: -10px;
+}
+
+.kc-login-tooltip {
+    position: relative;
     display: inline-block;
+}
+
+.kc-social-section {
+    text-align: center;
+}
+
+.kc-social-section hr{
+    margin-bottom: 10px
 }
 
 .kc-login-tooltip .kc-tooltip-text{
@@ -282,49 +469,6 @@ ul#kc-totp-supported-apps {
     border-color: transparent black transparent transparent;
 }
 
-.zocial,
-a.zocial  {
-    width: 100%;
-    font-weight: normal;
-    font-size: 14px;
-    text-shadow: none;
-    border: 0;
-    background: #f5f5f5;
-    color: #72767b;
-    border-radius: 0;
-    white-space: normal;
-}
-.zocial:before {
-  border-right: 0;
-  margin-right: 0;
-}
-.zocial span:before {
-    padding: 7px 10px;
-    font-size: 14px;
-}
-.zocial:hover {
-    background: #ededed !important;
-}
-
-.zocial.facebook,
-.zocial.github,
-.zocial.google,
-.zocial.microsoft,
-.zocial.stackoverflow,
-.zocial.linkedin,
-.zocial.twitter {
-    background-image: none;
-    border: 0;
-
-    box-shadow: none;
-    text-shadow: none;
-}
-
-/* Copy of zocial windows classes to be used for microsoft's social provider button */
-.zocial.microsoft:before{ content: "\f15d"; }
-.zocial.stackoverflow:before{ color: inherit; }
-
-
 @media (min-width: 768px) {
     #kc-container-wrapper {
         position: absolute;
@@ -345,7 +489,7 @@ a.zocial  {
 @media (max-width: 767px) {
 
     .login-pf body {
-      background: white;
+        background: white;
     }
 
     #kc-header {
@@ -356,11 +500,11 @@ a.zocial  {
     }
 
     #kc-header-wrapper {
-      font-size: 16px;
-      font-weight: bold;
-      padding: 20px 60px 0 0;
-      color: #72767b;
-      letter-spacing: 0;
+        font-size: 16px;
+        font-weight: bold;
+        padding: 20px 60px 0 0;
+        color: #72767b;
+        letter-spacing: 0;
     }
 
     div.kc-logo-text {
@@ -376,15 +520,7 @@ a.zocial  {
 
     #kc-info-wrapper {
         border-top: 1px solid rgba(255, 255, 255, 0.1);
-        margin-top: 15px;
-        padding-top: 15px;
-        padding-left: 0px;
-        padding-right: 15px;
-    }
-
-    #kc-social-providers li {
-        display: block;
-        margin-right: 5px;
+        background-color: transparent;
     }
 
     .login-pf .container {
@@ -429,78 +565,58 @@ a.zocial  {
 }
 
 #kc-form-buttons {
-  margin-top: 40px;
+    margin-top: 20px;
 }
 
 .login-pf-page .login-pf-brand {
-  margin-top: 20px;
-  max-width: 360px;
-  width: 40%;
+    margin-top: 20px;
+    max-width: 360px;
+    width: 40%;
 }
 
 .card-pf {
-  background: #fff;
-  margin: 0 auto;
-  padding: 0 20px;
-  max-width: 500px;
-  border-top: 0;
-  box-shadow: 0 0 0;
+    margin: 0 auto;
+    box-shadow: var(--pf-global--BoxShadow--lg);
+    padding: 0 20px;
+    max-width: 500px;
+    border-top: 4px solid;
+    border-color: #0066CC; /* default - IE compatibility */
+    border-color: var(--pf-global--primary-color--100);
 }
 
-/*tablet*/
-@media (max-width: 840px) {
-    .login-pf-page .card-pf{
-      max-width: none;
-      margin-left: 20px;
-      margin-right: 20px;
-      padding: 20px 20px 30px 20px;
-    }
-}
+/*phone*/
 @media (max-width: 767px) {
-    .login-pf-page .card-pf{
-      max-width: none;
-      margin-left: 0;
-      margin-right: 0;
-      padding-top: 0;
+    .login-pf-page .card-pf {
+        max-width: none;
+        margin-left: 0;
+        margin-right: 0;
+        padding-top: 0;
+        border-top: 0;
+        box-shadow: 0 0;
     }
-    .card-pf.login-pf-accounts{
-      max-width: none;
+
+    .kc-social-grid {
+        grid-column-end: 12;
+        --pf-l-grid__item--GridColumnEnd: span 12;
+    }
+
+    .kc-social-grid .kc-social-icon-text {
+        left: -15px;
     }
 }
 
 .login-pf-page .login-pf-signup {
-  font-size: 15px;
-  color: #72767b;
+    font-size: 15px;
+    color: #72767b;
 }
 #kc-content-wrapper .row {
-  margin-left: 0;
-  margin-right: 0;
-}
-
-@media (min-width: 768px) {
-  .login-pf-page .login-pf-social-section:first-of-type {
-    padding-right: 39px;
-    border-right: 1px solid #d1d1d1;
-    margin-right: -1px;
-  }
-  .login-pf-page .login-pf-social-section:last-of-type {
-    padding-left: 40px;
-  }
-  .login-pf-page .login-pf-social-section .login-pf-social-link:last-of-type {
-    margin-bottom: 0;
-  }
-}
-
-.login-pf-page .login-pf-social-link {
-  margin-bottom: 25px;
-}
-.login-pf-page .login-pf-social-link a {
-  padding: 2px 0;
+    margin-left: 0;
+    margin-right: 0;
 }
 
 .login-pf-page.login-pf-page-accounts {
-  margin-left: auto;
-  margin-right: auto;
+    margin-left: auto;
+    margin-right: auto;
 }
 
 .login-pf-page .btn-primary {
@@ -516,7 +632,7 @@ a.zocial  {
 }
 
 .login-pf-page .card-pf{
-  margin-bottom: 10px;
+    margin-bottom: 10px;
 }
 
 #kc-form-login div.form-group:last-of-type,
@@ -525,11 +641,10 @@ a.zocial  {
     margin-bottom: 0px;
 }
 
-#kc-back {
-    margin-top: 5px;
+.no-bottom-margin {
+    margin-bottom: 0;
 }
 
-form#kc-select-back-form div.login-pf-social-section {
-    padding-left: 0px;
-    border-left: 0px;
+#kc-back {
+    margin-top: 5px;
 }

--- a/themes/src/main/resources/theme/keycloak/login/theme.properties
+++ b/themes/src/main/resources/theme/keycloak/login/theme.properties
@@ -2,7 +2,7 @@ parent=base
 import=common/keycloak
 
 styles=css/login.css
-stylesCommon=node_modules/patternfly/dist/css/patternfly.min.css node_modules/patternfly/dist/css/patternfly-additions.min.css lib/zocial/zocial.css
+stylesCommon=web_modules/@fortawesome/fontawesome-free/css/icons/all.css web_modules/@patternfly/react-core/dist/styles/base.css web_modules/@patternfly/react-core/dist/styles/app.css node_modules/patternfly/dist/css/patternfly.min.css node_modules/patternfly/dist/css/patternfly-additions.min.css
 
 meta=viewport==width=device-width,initial-scale=1
 
@@ -15,37 +15,44 @@ kcLogoClass=login-pf-brand
 
 kcContainerClass=container-fluid
 kcContentClass=col-sm-8 col-sm-offset-2 col-md-6 col-md-offset-3 col-lg-6 col-lg-offset-3
-kcContentWrapperClass=row
 
 kcHeaderClass=login-pf-page-header
 kcFeedbackAreaClass=col-md-12
 kcLocaleClass=col-xs-12 col-sm-1
-kcAlertIconClasserror=pficon pficon-error-circle-o
+
+## Alert
+kcAlertClass=pf-c-alert pf-m-inline
+kcAlertTitleClass=pf-c-alert__title kc-feedback-text
 
 kcFormAreaClass=col-sm-10 col-sm-offset-1 col-md-8 col-md-offset-2 col-lg-8 col-lg-offset-2
 kcFormCardClass=card-pf
-kcFormCardAccountClass=login-pf-accounts
-kcFormSocialAccountClass=login-pf-social-section
-kcFormSocialAccountContentClass=col-xs-12 col-sm-6
-kcFormSocialAccountListClass=login-pf-social list-unstyled login-pf-social-all
-kcFormSocialAccountDoubleListClass=login-pf-social-double-col
-kcFormSocialAccountListLinkClass=login-pf-social-link
+
+### Social providers
+kcFormSocialAccountListClass=pf-c-login__main-footer-links kc-social-links
+kcFormSocialAccountListGridClass=pf-l-grid kc-social-grid
+kcFormSocialAccountListButtonClass=pf-c-button pf-m-control pf-m-block kc-social-item kc-social-gray
+kcFormSocialAccountGridItem=pf-l-grid__item
+
+kcFormSocialAccountNameClass=kc-social-provider-name
+kcFormSocialAccountLinkClass=pf-c-login__main-footer-links-item-link
+kcFormSocialAccountSectionClass=kc-social-section kc-social-gray
 kcFormHeaderClass=login-pf-header
 
-kcFeedbackErrorIcon=pficon pficon-error-circle-o
-kcFeedbackWarningIcon=pficon pficon-warning-triangle-o
-kcFeedbackSuccessIcon=pficon pficon-ok
-kcFeedbackInfoIcon=pficon pficon-info
+kcFeedbackErrorIcon=fa fa-fw fa-exclamation-circle
+kcFeedbackWarningIcon=fa fa-fw fa-exclamation-triangle
+kcFeedbackSuccessIcon=fa fa-fw fa-check-circle
+kcFeedbackInfoIcon=fa fa-fw fa-info-circle
 
-kcResetFlowIcon=pficon pficon-arrow fa-2x
+kcResetFlowIcon=pficon pficon-arrow fa
 kcWebAuthnKeyIcon=pficon pficon-key
 
 kcFormClass=form-horizontal
 kcFormGroupClass=form-group
 kcFormGroupErrorClass=has-error
-kcLabelClass=control-label
+kcLabelClass=pf-c-form__label pf-c-form__label-text
 kcLabelWrapperClass=col-xs-12 col-sm-12 col-md-12 col-lg-12
-kcInputClass=form-control
+kcInputClass=pf-c-form-control
+kcInputErrorMessageClass=pf-c-form__helper-text pf-m-error required kc-feedback-text
 kcInputWrapperClass=col-xs-12 col-sm-12 col-md-12 col-lg-12
 kcFormOptionsClass=col-xs-12 col-sm-12 col-md-12 col-lg-12
 kcFormButtonsClass=col-xs-12 col-sm-12 col-md-12 col-lg-12
@@ -58,13 +65,13 @@ kcInfoAreaClass=col-xs-12 col-sm-4 col-md-4 col-lg-5 details
 
 ##### css classes for form buttons
 # main class used for all buttons
-kcButtonClass=btn
+kcButtonClass=pf-c-button
 # classes defining priority of the button - primary or default (there is typically only one priority button for the form)
-kcButtonPrimaryClass=btn-primary
+kcButtonPrimaryClass=pf-m-primary
 kcButtonDefaultClass=btn-default
 # classes defining size of the button
 kcButtonLargeClass=btn-lg
-kcButtonBlockClass=btn-block
+kcButtonBlockClass=pf-m-block
 
 ##### css classes for input
 kcInputLargeClass=input-lg
@@ -94,3 +101,22 @@ kcSelectOTPListClass=card-pf card-pf-view card-pf-view-select card-pf-view-singl
 kcSelectOTPListItemClass=card-pf-body card-pf-top-element
 kcAuthenticatorOtpCircleClass=fa fa-mobile card-pf-icon-circle
 kcSelectOTPItemHeadingClass=card-pf-title text-center
+
+##### css classes for identity providers logos
+kcCommonLogoIdP=kc-social-provider-logo kc-social-gray
+
+## Social
+kcLogoIdP-facebook=fa fa-facebook
+kcLogoIdP-google=fa fa-google
+kcLogoIdP-github=fa fa-github
+kcLogoIdP-linkedin=fa fa-linkedin
+kcLogoIdP-instagram=fa fa-instagram
+## windows instead of microsoft - not included in PF4
+kcLogoIdP-microsoft=fa fa-windows
+kcLogoIdP-bitbucket=fa fa-bitbucket
+kcLogoIdP-gitlab=fa fa-gitlab
+kcLogoIdP-paypal=fa fa-paypal
+kcLogoIdP-stackoverflow=fa fa-stack-overflow
+kcLogoIdP-twitter=fa fa-twitter
+kcLogoIdP-openshift-v4=pf-icon pf-icon-openshift
+kcLogoIdP-openshift-v3=pf-icon pf-icon-openshift


### PR DESCRIPTION
JIRA: [KEYCLOAK-14139](https://issues.redhat.com/browse/KEYCLOAK-14139)

Design of new login screen with PF4 components. If there are less or equal than 4 identity providers, they are shown with full width as you can see below in mobile version. Title was changed to 'Log in to your account', because there would be 3 times title 'Log in' in a column. WDYT?

![newLogin](https://user-images.githubusercontent.com/38039883/95203461-15d23380-07e3-11eb-9d5d-1eb634973864.png)

Mobile version:
![mobileNew](https://user-images.githubusercontent.com/38039883/95203456-14087000-07e3-11eb-91be-9bec4a0fc339.png)

Custom icons for identity providers can be provided in `theme.properties`. 
You can see custom identity provider above with name `my-oidc`, so if you would like to add icon for that, just add line, like below, to `theme.properties` in login folder with pattern `kcLogoIdP-{alias}`. You can choose icons from PF4 icons website.

f.e `kcLogoIdP-my-oidc = fa fa-bell`

We are trying to complete task with PF4 upgrade ASAP (to the end of the current sprint). So, some design changes should be solved in a follow-up tasks.

Please @Pepo48, @vmuzikar , @ssilvert, could your review this? Thank you.