### PR TITLE
KEYCLOAK-15836 : Do not override System property mail.smtp.ssl.protoc…

### DIFF
--- a/services/src/main/java/org/keycloak/email/DefaultEmailSenderProvider.java
+++ b/services/src/main/java/org/keycloak/email/DefaultEmailSenderProvider.java
@@ -92,8 +92,7 @@ public class DefaultEmailSenderProvider implements EmailSenderProvider {
             }
 
             if (ssl || starttls) {
-                props.put("mail.smtp.ssl.protocols", SUPPORTED_SSL_PROTOCOLS);
-
+                props.put("mail.smtp.ssl.protocols", System.getProperty("mail.smtp.ssl.protocols", SUPPORTED_SSL_PROTOCOLS));
                 setupTruststore(props);
             }
 


### PR DESCRIPTION
Proposal of this PR : 

- Each enduser should be able to select allowed protocol to use to connect to an smtp server over ssl.
- To not impact expected behavior of Keycloak (KEYCLOAK-13285), default supported SSL Context protocol still applied but only if jvm parameter mail.smtp.ssl.protocols is not already set (ex JAVA_OPTS= -Dmail.smtp.ssl.protocols=...) 