### PR TITLE
KEYCLOAK-15821 Extend Keycloak boot time

### DIFF
--- a/distribution/feature-packs/adapter-feature-pack/src/main/resources/configuration/standalone/subsystems.xml
+++ b/distribution/feature-packs/adapter-feature-pack/src/main/resources/configuration/standalone/subsystems.xml
@@ -20,7 +20,7 @@
 <config>
    <subsystems>
        <subsystem>logging.xml</subsystem>
-       <subsystem>deployment-scanner.xml</subsystem>
+       <subsystem>keycloak-deployment-scanner.xml</subsystem>
        <subsystem supplement="web-build">ee.xml</subsystem>
        <subsystem>io.xml</subsystem>
        <subsystem>jmx.xml</subsystem>

--- a/distribution/feature-packs/server-feature-pack/src/main/resources/configuration/domain/template.xml
+++ b/distribution/feature-packs/server-feature-pack/src/main/resources/configuration/domain/template.xml
@@ -24,6 +24,10 @@
     </extensions>
 
     <system-properties>
+        <property name="jboss.as.management.blocking.timeout" value="86400"/>
+    </system-properties>
+
+    <system-properties>
         <!-- IPv4 is not required, but setting this helps avoid unintended use of IPv6 -->
         <property name="java.net.preferIPv4Stack" value="true"/>
     </system-properties>

--- a/distribution/feature-packs/server-feature-pack/src/main/resources/configuration/host/host-master.xml
+++ b/distribution/feature-packs/server-feature-pack/src/main/resources/configuration/host/host-master.xml
@@ -27,6 +27,10 @@
         <?EXTENSIONS?>
     </extensions>
 
+    <system-properties>
+        <property name="jboss.as.management.blocking.timeout" value="86400"/>
+    </system-properties>
+
     <management>
         <security-realms>
             <security-realm name="ManagementRealm">

--- a/distribution/feature-packs/server-feature-pack/src/main/resources/configuration/host/host-slave.xml
+++ b/distribution/feature-packs/server-feature-pack/src/main/resources/configuration/host/host-slave.xml
@@ -22,6 +22,10 @@
         <?EXTENSIONS?>
     </extensions>
 
+    <system-properties>
+        <property name="jboss.as.management.blocking.timeout" value="86400"/>
+    </system-properties>
+
     <management>
         <security-realms>
             <security-realm name="ManagementRealm">

--- a/distribution/feature-packs/server-feature-pack/src/main/resources/configuration/host/host.xml
+++ b/distribution/feature-packs/server-feature-pack/src/main/resources/configuration/host/host.xml
@@ -28,6 +28,10 @@
         <?EXTENSIONS?>
     </extensions>
 
+    <system-properties>
+        <property name="jboss.as.management.blocking.timeout" value="86400"/>
+    </system-properties>
+
     <management>
         <security-realms>
             <security-realm name="ManagementRealm">

--- a/distribution/feature-packs/server-feature-pack/src/main/resources/configuration/standalone/subsystems-ha.xml
+++ b/distribution/feature-packs/server-feature-pack/src/main/resources/configuration/standalone/subsystems-ha.xml
@@ -23,7 +23,7 @@
         <subsystem>bean-validation.xml</subsystem>
         <subsystem>core-management.xml</subsystem>
         <subsystem supplement="default">keycloak-datasources.xml</subsystem>
-        <subsystem>deployment-scanner.xml</subsystem>
+        <subsystem>keycloak-deployment-scanner.xml</subsystem>
         <subsystem>ee.xml</subsystem>
         <subsystem supplement="ha">ejb3.xml</subsystem>
         <subsystem>io.xml</subsystem>

--- a/distribution/feature-packs/server-feature-pack/src/main/resources/configuration/standalone/subsystems.xml
+++ b/distribution/feature-packs/server-feature-pack/src/main/resources/configuration/standalone/subsystems.xml
@@ -23,7 +23,7 @@
        <subsystem>bean-validation.xml</subsystem>
        <subsystem>core-management.xml</subsystem>
        <subsystem supplement="default">keycloak-datasources.xml</subsystem>
-       <subsystem>deployment-scanner.xml</subsystem>
+       <subsystem>keycloak-deployment-scanner.xml</subsystem>
        <subsystem>ee.xml</subsystem>
        <subsystem>ejb3.xml</subsystem>
        <subsystem>io.xml</subsystem>

--- a/distribution/feature-packs/server-feature-pack/src/main/resources/configuration/standalone/template.xml
+++ b/distribution/feature-packs/server-feature-pack/src/main/resources/configuration/standalone/template.xml
@@ -6,6 +6,10 @@
         <?EXTENSIONS?>
     </extensions>
 
+    <system-properties>
+        <property name="jboss.as.management.blocking.timeout" value="86400"/>
+    </system-properties>
+
     <management>
         <security-realms>
             <security-realm name="ManagementRealm">

--- a/wildfly/server-subsystem/src/main/resources/cli/default-keycloak-subsys-config.cli
+++ b/wildfly/server-subsystem/src/main/resources/cli/default-keycloak-subsys-config.cli
@@ -20,3 +20,5 @@
 /subsystem=keycloak-server/spi=jta-lookup/provider=jboss/:add(enabled=true)
 /subsystem=keycloak-server/spi=publicKeyStorage/:add
 /subsystem=keycloak-server/spi=publicKeyStorage/provider=infinispan/:add(properties={minTimeBetweenRequests => "10"},enabled=true)
+/system-property=jboss.as.management.blocking.timeout:add(value=86400)
+/subsystem=deployment-scanner/scanner=default:write-attribute(name=deployment-timeout,value=86400)

--- a/wildfly/server-subsystem/src/main/resources/subsystem-templates/keycloak-deployment-scanner.xml
+++ b/wildfly/server-subsystem/src/main/resources/subsystem-templates/keycloak-deployment-scanner.xml
@@ -1,0 +1,31 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2017, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
+<config>
+    <extension-module>org.jboss.as.deployment-scanner</extension-module>
+    <subsystem xmlns="urn:jboss:domain:deployment-scanner:2.0">
+        <deployment-scanner path="deployments" relative-to="jboss.server.base.dir" scan-interval="5000" deployment-timeout="86400" runtime-failure-causes-rollback="${jboss.deployment.scanner.rollback.on.failure:false}"/>
+    </subsystem>
+</config>
+


### PR DESCRIPTION
The implementation of suggestion mentioned in https://access.redhat.com/solutions/1190323 and https://mirocupak.com/enabling-long-deployments-on-wildfly/

A test image is available via docker run docker.io/slaskawi/keycloak:keycloak15821