### PR TITLE
KEYCLOAK-15592: Fix removing KEYCLOAK_ADAPTER_STATE cookie

### DIFF
--- a/adapters/spi/jetty-adapter-spi/src/main/java/org/keycloak/adapters/jetty/spi/JettyHttpFacade.java
+++ b/adapters/spi/jetty-adapter-spi/src/main/java/org/keycloak/adapters/jetty/spi/JettyHttpFacade.java
@@ -205,7 +205,7 @@ public class JettyHttpFacade implements HttpFacade {
 
         @Override
         public void resetCookie(String name, String path) {
-            setCookie(name, "", null, path, 0, false, false);
+            setCookie(name, "", path, null, 0, false, false);
         }
 
         @Override


### PR DESCRIPTION
This commit provides a fix for removing KEYCLOAK_ADAPTER_STATE cookie
by using 'path' and 'domain' parameters properly.

The issue is reported here: https://issues.redhat.com/browse/KEYCLOAK-15592

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
