### PR TITLE
KEYCLOAK-15806: Extension to SignatureAlgorithm to support more Algorithms

### DIFF
--- a/saml-core/src/main/java/org/keycloak/saml/SignatureAlgorithm.java
+++ b/saml-core/src/main/java/org/keycloak/saml/SignatureAlgorithm.java
@@ -29,7 +29,9 @@ public enum SignatureAlgorithm {
     RSA_SHA1("http://www.w3.org/2000/09/xmldsig#rsa-sha1", "http://www.w3.org/2000/09/xmldsig#sha1", "SHA1withRSA"),
     RSA_SHA256("http://www.w3.org/2001/04/xmldsig-more#rsa-sha256", "http://www.w3.org/2001/04/xmlenc#sha256", "SHA256withRSA"),
     RSA_SHA512("http://www.w3.org/2001/04/xmldsig-more#rsa-sha512", "http://www.w3.org/2001/04/xmlenc#sha512", "SHA512withRSA"),
-    DSA_SHA1("http://www.w3.org/2000/09/xmldsig#dsa-sha1", "http://www.w3.org/2000/09/xmldsig#sha1", "SHA1withDSA")
+    DSA_SHA1("http://www.w3.org/2000/09/xmldsig#dsa-sha1", "http://www.w3.org/2000/09/xmldsig#sha1", "SHA1withDSA"),
+    RSA_SHA256_MGF1("http://www.w3.org/2007/05/xmldsig-more#sha256-rsa-MGF1", "http://www.w3.org/2001/04/xmlenc#sha256", "SHA256withRSAandMGF1"),
+    RSA_SHA512_MGF1("http://www.w3.org/2007/05/xmldsig-more#sha512-rsa-MGF1", "http://www.w3.org/2001/04/xmlenc#sha512", "SHA512withRSAandMGF1")
     ;
     private final String xmlSignatureMethod;
     private final String xmlSignatureDigestMethod;
@@ -43,11 +45,15 @@ public enum SignatureAlgorithm {
         signatureMethodMap.put(RSA_SHA256.getXmlSignatureMethod(), RSA_SHA256);
         signatureMethodMap.put(RSA_SHA512.getXmlSignatureMethod(), RSA_SHA512);
         signatureMethodMap.put(DSA_SHA1.getXmlSignatureMethod(), DSA_SHA1);
+        signatureMethodMap.put(DSA_SHA1.getXmlSignatureMethod(), RSA_SHA256_MGF1);
+        signatureMethodMap.put(DSA_SHA1.getXmlSignatureMethod(), RSA_SHA512_MGF1);
 
         signatureDigestMethodMap.put(RSA_SHA1.getXmlSignatureDigestMethod(), RSA_SHA1);
         signatureDigestMethodMap.put(RSA_SHA256.getXmlSignatureDigestMethod(), RSA_SHA256);
         signatureDigestMethodMap.put(RSA_SHA512.getXmlSignatureDigestMethod(), RSA_SHA512);
         signatureDigestMethodMap.put(DSA_SHA1.getXmlSignatureDigestMethod(), DSA_SHA1);
+        signatureDigestMethodMap.put(DSA_SHA1.getXmlSignatureDigestMethod(), RSA_SHA256_MGF1);
+        signatureDigestMethodMap.put(DSA_SHA1.getXmlSignatureDigestMethod(), RSA_SHA512_MGF1);
     }
 
     public static SignatureAlgorithm getFromXmlMethod(String xml) {


### PR DESCRIPTION
    Extension to SignatureAlgorithm to support more Algorithms (RSA_SHA256_MGF1, RSA_SHA512_MGF1).
    Also included in realms.js so it can be chosen as signature algorithm when brokering through SAML.

