### PR TITLE
KEYCLOAK-15858 Finish renaming 'application role' to 'client role' in help texts

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/HardcodedLDAPRoleStorageMapperFactory.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/HardcodedLDAPRoleStorageMapperFactory.java
@@ -39,7 +39,7 @@ public class HardcodedLDAPRoleStorageMapperFactory extends AbstractLDAPStorageMa
 
     static {
         ProviderConfigProperty roleAttr = createConfigProperty(HardcodedLDAPRoleStorageMapper.ROLE, "Role",
-                "Role to grant to user.  Click 'Select Role' button to browse roles, or just type it in the textbox.  To reference an application role the syntax is appname.approle, i.e. myapp.myrole",
+                "Role to grant to user.  Click 'Select Role' button to browse roles, or just type it in the textbox.  To reference a client role the syntax is clientname.clientrole, i.e. myclient.myrole",
                 ProviderConfigProperty.ROLE_TYPE, null);
         configProperties.add(roleAttr);
     }

--- a/services/src/main/java/org/keycloak/authentication/authenticators/conditional/ConditionalRoleAuthenticatorFactory.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/conditional/ConditionalRoleAuthenticatorFactory.java
@@ -19,7 +19,7 @@ public class ConditionalRoleAuthenticatorFactory implements ConditionalAuthentic
     static {
         commonConfig = Collections.unmodifiableList(ProviderConfigurationBuilder.create()
             .property().name(CONDITIONAL_USER_ROLE).label("User role")
-            .helpText("Role the user should have to execute this flow. Click 'Select Role' button to browse roles, or just type it in the textbox. To specify an application role the syntax is appname.approle, i.e. myapp.myrole")
+            .helpText("Role the user should have to execute this flow. Click 'Select Role' button to browse roles, or just type it in the textbox. To reference a client role the syntax is clientname.clientrole, i.e. myclient.myrole")
             .type(ProviderConfigProperty.ROLE_TYPE).add()
             .build()
         );

--- a/services/src/main/java/org/keycloak/broker/oidc/mappers/AdvancedClaimToRoleMapper.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/mappers/AdvancedClaimToRoleMapper.java
@@ -70,7 +70,7 @@ public class AdvancedClaimToRoleMapper extends AbstractClaimMapper {
         ProviderConfigProperty roleProperty = new ProviderConfigProperty();
         roleProperty.setName(ConfigConstants.ROLE);
         roleProperty.setLabel("Role");
-        roleProperty.setHelpText("Role to grant to user if claim is present. Click 'Select Role' button to browse roles, or just type it in the textbox. To reference an application role the syntax is appname.approle, i.e. myapp.myrole");
+        roleProperty.setHelpText("Role to grant to user if claim is present. Click 'Select Role' button to browse roles, or just type it in the textbox. To reference a client role the syntax is clientname.clientrole, i.e. myclient.myrole");
         roleProperty.setType(ProviderConfigProperty.ROLE_TYPE);
         configProperties.add(roleProperty);
     }
@@ -149,7 +149,7 @@ public class AdvancedClaimToRoleMapper extends AbstractClaimMapper {
 
     @Override
     public String getHelpText() {
-        return "If all claims exists, grant the user the specified realm or application role.";
+        return "If all claims exists, grant the user the specified realm or client role.";
     }
 
     protected boolean hasAllClaimValues(IdentityProviderMapperModel mapperModel, BrokeredIdentityContext context) {

--- a/services/src/main/java/org/keycloak/broker/oidc/mappers/ClaimToRoleMapper.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/mappers/ClaimToRoleMapper.java
@@ -66,7 +66,7 @@ public class ClaimToRoleMapper extends AbstractClaimMapper {
         property = new ProviderConfigProperty();
         property.setName(ConfigConstants.ROLE);
         property.setLabel("Role");
-        property.setHelpText("Role to grant to user if claim is present.  Click 'Select Role' button to browse roles, or just type it in the textbox.  To reference an application role the syntax is appname.approle, i.e. myapp.myrole");
+        property.setHelpText("Role to grant to user if claim is present.  Click 'Select Role' button to browse roles, or just type it in the textbox.  To reference a client role the syntax is clientname.clientrole, i.e. myclient.myrole");
         property.setType(ProviderConfigProperty.ROLE_TYPE);
         configProperties.add(property);
     }
@@ -140,7 +140,7 @@ public class ClaimToRoleMapper extends AbstractClaimMapper {
 
     @Override
     public String getHelpText() {
-        return "If a claim exists, grant the user the specified realm or application role.";
+        return "If a claim exists, grant the user the specified realm or client role.";
     }
 
 }

--- a/services/src/main/java/org/keycloak/broker/oidc/mappers/ExternalKeycloakRoleToRoleMapper.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/mappers/ExternalKeycloakRoleToRoleMapper.java
@@ -56,13 +56,13 @@ public class ExternalKeycloakRoleToRoleMapper extends AbstractClaimMapper {
         property1 = new ProviderConfigProperty();
         property1.setName(EXTERNAL_ROLE);
         property1.setLabel("External role");
-        property1.setHelpText("External role to check for.  To reference an application role the syntax is appname.approle, i.e. myapp.myrole.");
+        property1.setHelpText("External role to check for.  To reference a client role the syntax is clientname.clientrole, i.e. myclient.myrole");
         property1.setType(ProviderConfigProperty.STRING_TYPE);
         configProperties.add(property1);
         property = new ProviderConfigProperty();
         property.setName(ConfigConstants.ROLE);
         property.setLabel("Role");
-        property.setHelpText("Role to grant to user if external role is present.  Click 'Select Role' button to browse roles, or just type it in the textbox.  To reference an application role the syntax is appname.approle, i.e. myapp.myrole");
+        property.setHelpText("Role to grant to user if external role is present.  Click 'Select Role' button to browse roles, or just type it in the textbox.  To reference a client role the syntax is clientname.clientrole, i.e. myclient.myrole");
         property.setType(ProviderConfigProperty.ROLE_TYPE);
         configProperties.add(property);
     }
@@ -144,7 +144,7 @@ public class ExternalKeycloakRoleToRoleMapper extends AbstractClaimMapper {
 
     @Override
     public String getHelpText() {
-        return "Looks for an external role in a keycloak access token.  If external role exists, grant the user the specified realm or application role.";
+        return "Looks for an external role in a keycloak access token.  If external role exists, grant the user the specified realm or client role.";
     }
 
 }

--- a/services/src/main/java/org/keycloak/broker/provider/HardcodedRoleMapper.java
+++ b/services/src/main/java/org/keycloak/broker/provider/HardcodedRoleMapper.java
@@ -45,7 +45,7 @@ public class HardcodedRoleMapper extends AbstractIdentityProviderMapper {
         property = new ProviderConfigProperty();
         property.setName(ConfigConstants.ROLE);
         property.setLabel("Role");
-        property.setHelpText("Role to grant to user.  Click 'Select Role' button to browse roles, or just type it in the textbox.  To reference an application role the syntax is appname.approle, i.e. myapp.myrole");
+        property.setHelpText("Role to grant to user.  Click 'Select Role' button to browse roles, or just type it in the textbox.  To reference a client role the syntax is clientname.clientrole, i.e. myclient.myrole");
         property.setType(ProviderConfigProperty.ROLE_TYPE);
         configProperties.add(property);
     }

--- a/services/src/main/java/org/keycloak/broker/saml/mappers/AdvancedAttributeToRoleMapper.java
+++ b/services/src/main/java/org/keycloak/broker/saml/mappers/AdvancedAttributeToRoleMapper.java
@@ -89,7 +89,7 @@ public class AdvancedAttributeToRoleMapper extends AbstractIdentityProviderMappe
         roleProperty.setLabel("Role");
         roleProperty.setHelpText("Role to grant to user if all attributes are present."
                 + " Click 'Select Role' button to browse roles, or just type it in the textbox."
-                + " To reference an application role the syntax is appname.approle, i.e. myapp.myrole");
+                + " To reference a client role the syntax is clientname.clientrole, i.e. myclient.myrole");
         roleProperty.setType(ProviderConfigProperty.ROLE_TYPE);
         configProperties.add(roleProperty);
     }
@@ -147,7 +147,7 @@ public class AdvancedAttributeToRoleMapper extends AbstractIdentityProviderMappe
 
     @Override
     public String getHelpText() {
-        return "If the set of attributes exists and can be matched, grant the user the specified realm or application role.";
+        return "If the set of attributes exists and can be matched, grant the user the specified realm or client role.";
     }
 
     static RoleModel getRoleModel(RealmModel realm, String roleName) {

--- a/services/src/main/java/org/keycloak/broker/saml/mappers/AttributeToRoleMapper.java
+++ b/services/src/main/java/org/keycloak/broker/saml/mappers/AttributeToRoleMapper.java
@@ -80,7 +80,7 @@ public class AttributeToRoleMapper extends AbstractIdentityProviderMapper {
         property = new ProviderConfigProperty();
         property.setName(ConfigConstants.ROLE);
         property.setLabel("Role");
-        property.setHelpText("Role to grant to user.  Click 'Select Role' button to browse roles, or just type it in the textbox.  To reference an application role the syntax is appname.approle, i.e. myapp.myrole");
+        property.setHelpText("Role to grant to user.  Click 'Select Role' button to browse roles, or just type it in the textbox.  To reference a client role the syntax is clientname.clientrole, i.e. myclient.myrole");
         property.setType(ProviderConfigProperty.ROLE_TYPE);
         configProperties.add(property);
     }
@@ -164,7 +164,7 @@ public class AttributeToRoleMapper extends AbstractIdentityProviderMapper {
 
     @Override
     public String getHelpText() {
-        return "If an attribute exists, grant the user the specified realm or application role.";
+        return "If an attribute exists, grant the user the specified realm or client role.";
     }
 
 }

--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/HardcodedRole.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/HardcodedRole.java
@@ -50,7 +50,7 @@ public class HardcodedRole extends AbstractOIDCProtocolMapper implements OIDCAcc
         property = new ProviderConfigProperty();
         property.setName(ROLE_CONFIG);
         property.setLabel("Role");
-        property.setHelpText("Role you want added to the token.  Click 'Select Role' button to browse roles, or just type it in the textbox.  To specify an application role the syntax is appname.approle, i.e. myapp.myrole");
+        property.setHelpText("Role you want added to the token.  Click 'Select Role' button to browse roles, or just type it in the textbox.  To reference a client role the syntax is clientname.clientrole, i.e. myclient.myrole");
         property.setType(ProviderConfigProperty.ROLE_TYPE);
         configProperties.add(property);
     }

--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/RoleNameMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/RoleNameMapper.java
@@ -51,7 +51,7 @@ public class RoleNameMapper extends AbstractOIDCProtocolMapper implements OIDCAc
         property = new ProviderConfigProperty();
         property.setName(ROLE_CONFIG);
         property.setLabel("Role");
-        property.setHelpText("Role name you want changed.  Click 'Select Role' button to browse roles, or just type it in the textbox.  To reference an application role the syntax is appname.approle, i.e. myapp.myrole");
+        property.setHelpText("Role name you want changed.  Click 'Select Role' button to browse roles, or just type it in the textbox.  To reference a client role the syntax is clientname.clientrole, i.e. myclient.myrole");
         property.setType(ProviderConfigProperty.ROLE_TYPE);
         configProperties.add(property);
         property = new ProviderConfigProperty();

--- a/services/src/main/java/org/keycloak/protocol/saml/mappers/RoleNameMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/mappers/RoleNameMapper.java
@@ -51,7 +51,7 @@ public class RoleNameMapper implements SAMLRoleNameMapper, ProtocolMapper {
         property = new ProviderConfigProperty();
         property.setName(ROLE_CONFIG);
         property.setLabel("Role");
-        property.setHelpText("Role name you want changed.  Click 'Select Role' button to browse roles, or just type it in the textbox.  To reference an application role the syntax is appname.approle, i.e. myapp.myrole");
+        property.setHelpText("Role name you want changed.  Click 'Select Role' button to browse roles, or just type it in the textbox.  To reference a client role the syntax is clientname.clientrole, i.e. myclient.myrole");
         property.setType(ProviderConfigProperty.ROLE_TYPE);
         configProperties.add(property);
         property = new ProviderConfigProperty();


### PR DESCRIPTION
https://issues.redhat.com/browse/KEYCLOAK-15858

This commit renames all `application role` to `client role` and adapt the sentence around it.