### PR TITLE
KEYCLOAK-15806: Extension to SignatureAlgorithm to support more Algorithms

### DIFF
--- a/saml-core/src/main/java/org/keycloak/saml/SignatureAlgorithm.java
+++ b/saml-core/src/main/java/org/keycloak/saml/SignatureAlgorithm.java
@@ -28,7 +28,9 @@ import java.util.Map;
 public enum SignatureAlgorithm {
     RSA_SHA1("http://www.w3.org/2000/09/xmldsig#rsa-sha1", "http://www.w3.org/2000/09/xmldsig#sha1", "SHA1withRSA"),
     RSA_SHA256("http://www.w3.org/2001/04/xmldsig-more#rsa-sha256", "http://www.w3.org/2001/04/xmlenc#sha256", "SHA256withRSA"),
+    RSA_SHA256_MGF1("http://www.w3.org/2007/05/xmldsig-more#sha256-rsa-MGF1", "http://www.w3.org/2001/04/xmlenc#sha256", "SHA256withRSAandMGF1"),
     RSA_SHA512("http://www.w3.org/2001/04/xmldsig-more#rsa-sha512", "http://www.w3.org/2001/04/xmlenc#sha512", "SHA512withRSA"),
+    RSA_SHA512_MGF1("http://www.w3.org/2007/05/xmldsig-more#sha512-rsa-MGF1", "http://www.w3.org/2001/04/xmlenc#sha512", "SHA512withRSAandMGF1"),
     DSA_SHA1("http://www.w3.org/2000/09/xmldsig#dsa-sha1", "http://www.w3.org/2000/09/xmldsig#sha1", "SHA1withDSA")
     ;
     private final String xmlSignatureMethod;
@@ -41,12 +43,16 @@ public enum SignatureAlgorithm {
     static {
         signatureMethodMap.put(RSA_SHA1.getXmlSignatureMethod(), RSA_SHA1);
         signatureMethodMap.put(RSA_SHA256.getXmlSignatureMethod(), RSA_SHA256);
+        signatureMethodMap.put(RSA_SHA256_MGF1.getXmlSignatureMethod(), RSA_SHA256_MGF1);
         signatureMethodMap.put(RSA_SHA512.getXmlSignatureMethod(), RSA_SHA512);
+        signatureMethodMap.put(RSA_SHA512_MGF1.getXmlSignatureMethod(), RSA_SHA512_MGF1);
         signatureMethodMap.put(DSA_SHA1.getXmlSignatureMethod(), DSA_SHA1);
 
         signatureDigestMethodMap.put(RSA_SHA1.getXmlSignatureDigestMethod(), RSA_SHA1);
         signatureDigestMethodMap.put(RSA_SHA256.getXmlSignatureDigestMethod(), RSA_SHA256);
+        signatureDigestMethodMap.put(RSA_SHA256_MGF1.getXmlSignatureDigestMethod(), RSA_SHA256_MGF1);
         signatureDigestMethodMap.put(RSA_SHA512.getXmlSignatureDigestMethod(), RSA_SHA512);
+        signatureDigestMethodMap.put(RSA_SHA512_MGF1.getXmlSignatureDigestMethod(), RSA_SHA512_MGF1);
         signatureDigestMethodMap.put(DSA_SHA1.getXmlSignatureDigestMethod(), DSA_SHA1);
     }
 

--- a/themes/src/main/resources/theme/base/admin/resources/js/controllers/clients.js
+++ b/themes/src/main/resources/theme/base/admin/resources/js/controllers/clients.js
@@ -1056,7 +1056,9 @@ module.controller('ClientDetailCtrl', function($scope, realm, client, flows, $ro
     $scope.signatureAlgorithms = [
         "RSA_SHA1",
         "RSA_SHA256",
+        "RSA_SHA256_MGF1",
         "RSA_SHA512",
+        "RSA_SHA512_MGF1",
         "DSA_SHA1"
     ];
     $scope.nameIdFormats = [
@@ -1155,10 +1157,14 @@ module.controller('ClientDetailCtrl', function($scope, realm, client, flows, $ro
             $scope.signatureAlgorithm = $scope.signatureAlgorithms[0];
         } else if ($scope.client.attributes['saml.signature.algorithm'] == 'RSA_SHA256') {
             $scope.signatureAlgorithm = $scope.signatureAlgorithms[1];
-        } else if ($scope.client.attributes['saml.signature.algorithm'] == 'RSA_SHA512') {
+        } else if ($scope.client.attributes['saml.signature.algorithm'] == 'RSA_SHA256_MGF1') {
             $scope.signatureAlgorithm = $scope.signatureAlgorithms[2];
-        } else if ($scope.client.attributes['saml.signature.algorithm'] == 'DSA_SHA1') {
+        } else if ($scope.client.attributes['saml.signature.algorithm'] == 'RSA_SHA512') {
             $scope.signatureAlgorithm = $scope.signatureAlgorithms[3];
+        } else if ($scope.client.attributes['saml.signature.algorithm'] == 'RSA_SHA512_MGF1') {
+            $scope.signatureAlgorithm = $scope.signatureAlgorithms[4];
+        } else if ($scope.client.attributes['saml.signature.algorithm'] == 'DSA_SHA1') {
+            $scope.signatureAlgorithm = $scope.signatureAlgorithms[5];
         }
         if ($scope.client.attributes['saml_name_id_format'] == 'username') {
             $scope.nameIdFormat = $scope.nameIdFormats[0];

--- a/themes/src/main/resources/theme/base/admin/resources/js/controllers/realm.js
+++ b/themes/src/main/resources/theme/base/admin/resources/js/controllers/realm.js
@@ -840,7 +840,9 @@ module.controller('RealmIdentityProviderCtrl', function($scope, $filter, $upload
         $scope.signatureAlgorithms = [
             "RSA_SHA1",
             "RSA_SHA256",
+            "RSA_SHA256_MGF1",
             "RSA_SHA512",
+            "RSA_SHA512_MGF1",
             "DSA_SHA1"
         ];
         $scope.xmlKeyNameTranformers = [


### PR DESCRIPTION
    Extension to SignatureAlgorithm to support more Algorithms (RSA_SHA256_MGF1, RSA_SHA512_MGF1).
    Also included in realms.js so it can be chosen as signature algorithm when brokering through SAML.

