### PR TITLE
KEYCLOAK-15697 SAML Identity Broker - Fix SP Entity ID tooltip

### DIFF
--- a/themes/src/main/resources/theme/base/admin/resources/partials/realm-identity-provider-saml.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/realm-identity-provider-saml.html
@@ -138,7 +138,7 @@
                 <div class="col-md-6">
                     <input kc-no-reserved-chars class="form-control" id="entityId" type="text" ng-model="identityProvider.config.entityId" required>
                 </div>
-                <kc-tooltip>{{:: 'identityProvider.config.entity-id.tooltip' | translate}}</kc-tooltip>
+                <kc-tooltip>{{:: 'identity-provider.saml.entity-id.tooltip' | translate}}</kc-tooltip>
             </div>
             <div class="form-group clearfix">
                 <label class="col-md-2 control-label" for="singleSignOnServiceUrl"><span class="required">*</span> {{:: 'single-signon-service-url' | translate}}</label>


### PR DESCRIPTION
The tooltip translation key for the recently-merged Service Provider Entity ID configuration item is wrong, sorry for that.