### PR TITLE
[KEYCLOAK-16055] Update DefaultKeyManager kid is null logging

### DIFF
--- a/services/src/main/java/org/keycloak/keys/DefaultKeyManager.java
+++ b/services/src/main/java/org/keycloak/keys/DefaultKeyManager.java
@@ -94,7 +94,7 @@ public class DefaultKeyManager implements KeyManager {
     @Override
     public KeyWrapper getKey(RealmModel realm, String kid, KeyUse use, String algorithm) {
         if (kid == null) {
-            logger.warnv("kid is null, can't find public key", realm.getName(), kid);
+            logger.warnv("kid is null, can't find public key: realm={0}", realm.getName());
             return null;
         }
 


### PR DESCRIPTION
Got this "kid is null, can't find public key" without a hint to which realm it's belonging. Not sure if the realm name is dropped because it's null(?), but at least the log message is now explicit. Dropping kid because the text says it's null. Haven't tested whether this breaks tests etc.
