### PR TITLE
Fix quarkus README layout collapse

### DIFF
--- a/quarkus/README.md
+++ b/quarkus/README.md
@@ -2,6 +2,7 @@
 
 The module holds the codebase to run Keycloak on top of [Quarkus](https://quarkus.io/):
 
+```
 ├── deployment
 │   ├── Build-time codebase with all the necessary steps to build and configure the server
 │
@@ -10,7 +11,7 @@ The module holds the codebase to run Keycloak on top of [Quarkus](https://quarku
 │
 └── server
     ├── The server itself, only responsible for generating the server artifacts
-    
+``` 
 
 ## Activating the Module
 


### PR DESCRIPTION
- Fix the collapse of the tree display in the README
- Use code blocks to avoid the effects of proportional fonts

**Before**

<kbd>
  <img src="https://user-images.githubusercontent.com/34432106/95952553-4cd3c500-0e33-11eb-8c07-6ca187370948.png">
</kbd>

**After**
<kbd>
  <img src="https://user-images.githubusercontent.com/34432106/95953218-85c06980-0e34-11eb-9727-50fd0b523c73.png">
</kbd>