### PR TITLE
KEYCLOAK-15911: Fix UserStorageManager does not pick up new LDAP Config

### DIFF
--- a/services/src/main/java/org/keycloak/storage/UserStorageManager.java
+++ b/services/src/main/java/org/keycloak/storage/UserStorageManager.java
@@ -796,12 +796,6 @@ public class UserStorageManager implements UserProvider, OnUserCache, OnCreateCo
         if (!(factory instanceof UserStorageProviderFactory)) return;
         UserStorageProviderModel old = new UserStorageProviderModel(oldModel);
         UserStorageProviderModel newP= new UserStorageProviderModel(newModel);
-        if (old.getChangedSyncPeriod() != newP.getChangedSyncPeriod() || old.getFullSyncPeriod() != newP.getFullSyncPeriod()
-                || old.isImportEnabled() != newP.isImportEnabled()) {
-            new UserStorageSyncManager().notifyToRefreshPeriodicSync(session, realm, new UserStorageProviderModel(newModel), false);
-        }
-
+        new UserStorageSyncManager().notifyToRefreshPeriodicSync(session, realm, new UserStorageProviderModel(newModel), false);
     }
-
-
 }


### PR DESCRIPTION
This PR fixes the issue where the LDAP configuration is not updated when sync period or enabled flag is not changed. 
