### PR TITLE
KEYCLOAK-14201 Client Policy - Executor : Enforce Proof Key for Code Exchange (PKCE)

### DIFF
--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/PKCEEnforceExecutorFactory.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/PKCEEnforceExecutorFactory.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.keycloak.testsuite.services.clientpolicy.executor;
+package org.keycloak.services.clientpolicy.executor;
 
 import java.util.List;
 
@@ -27,13 +27,13 @@ import org.keycloak.provider.ProviderConfigProperty;
 import org.keycloak.services.clientpolicy.executor.AbstractAugumentingClientRegistrationPolicyExecutorFactory;
 import org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProvider;
 
-public class TestPKCEEnforceExecutorFactory extends AbstractAugumentingClientRegistrationPolicyExecutorFactory {
+public class PKCEEnforceExecutorFactory extends AbstractAugumentingClientRegistrationPolicyExecutorFactory {
 
-    public static final String PROVIDER_ID = "test-pkce-enforce-executor";
+    public static final String PROVIDER_ID = "pkce-enforce-executor";
 
     @Override
     public ClientPolicyExecutorProvider create(KeycloakSession session, ComponentModel model) {
-        return new TestPKCEEnforceExecutor(session, model);
+        return new PKCEEnforceExecutor(session, model);
     }
 
     @Override
@@ -55,7 +55,7 @@ public class TestPKCEEnforceExecutorFactory extends AbstractAugumentingClientReg
 
     @Override
     public String getHelpText() {
-        return null;
+        return "It makes the client enforce Proof Key for Code Exchange operation.";
     }
 
     @Override

--- a/services/src/main/resources/META-INF/services/org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProviderFactory
+++ b/services/src/main/resources/META-INF/services/org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProviderFactory
@@ -1,3 +1,4 @@
 org.keycloak.services.clientpolicy.executor.SecureResponseTypeExecutorFactory
 org.keycloak.services.clientpolicy.executor.SecureRequestObjectExecutorFactory
 org.keycloak.services.clientpolicy.executor.SecureClientAuthEnforceExecutorFactory
+org.keycloak.services.clientpolicy.executor.PKCEEnforceExecutorFactory

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/resources/META-INF/services/org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProviderFactory
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/resources/META-INF/services/org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProviderFactory
@@ -1,1 +1,0 @@
-org.keycloak.testsuite.services.clientpolicy.executor.TestPKCEEnforceExecutorFactory

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientPolicyBasicsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientPolicyBasicsTest.java
@@ -83,6 +83,7 @@ import org.keycloak.services.clientpolicy.condition.ClientUpdateContextCondition
 import org.keycloak.services.clientpolicy.condition.ClientRolesConditionFactory;
 import org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProvider;
 import org.keycloak.services.clientpolicy.executor.SecureClientAuthEnforceExecutorFactory;
+import org.keycloak.services.clientpolicy.executor.PKCEEnforceExecutorFactory;
 import org.keycloak.services.clientpolicy.executor.SecureRequestObjectExecutor;
 import org.keycloak.services.clientpolicy.executor.SecureRequestObjectExecutorFactory;
 import org.keycloak.services.clientpolicy.executor.SecureResponseTypeExecutorFactory;
@@ -94,7 +95,6 @@ import org.keycloak.testsuite.client.resources.TestApplicationResourceUrls;
 import org.keycloak.testsuite.client.resources.TestOIDCEndpointsApplicationResource;
 import org.keycloak.testsuite.rest.resource.TestingOIDCEndpointsApplicationResource.AuthorizationEndpointRequestObject;
 import org.keycloak.testsuite.services.clientpolicy.condition.TestRaiseExeptionConditionFactory;
-import org.keycloak.testsuite.services.clientpolicy.executor.TestPKCEEnforceExecutorFactory;
 import org.keycloak.testsuite.util.OAuthClient;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -409,11 +409,11 @@ public class ClientPolicyBasicsTest extends AbstractKeycloakTest {
         createPolicy(policyName, DefaultClientPolicyProviderFactory.PROVIDER_ID, null, null, null);
         logger.info("... Created Policy : " + policyName);
 
-        createExecutor("TestPKCEEnforceExecutor", TestPKCEEnforceExecutorFactory.PROVIDER_ID, null, (ComponentRepresentation provider) -> {
+        createExecutor("PKCEEnforceExecutor", PKCEEnforceExecutorFactory.PROVIDER_ID, null, (ComponentRepresentation provider) -> {
             setExecutorAugmentActivate(provider);
         });
-        registerExecutor("TestPKCEEnforceExecutor", policyName);
-        logger.info("... Registered Executor : TestPKCEEnforceExecutor");
+        registerExecutor("PKCEEnforceExecutor", policyName);
+        logger.info("... Registered Executor : PKCEEnforceExecutor");
 
         String clientId = "Zahlungs-App";
         String clientSecret = "secret";
@@ -477,15 +477,15 @@ public class ClientPolicyBasicsTest extends AbstractKeycloakTest {
         try {
             successfulLoginAndLogout(clientId, clientSecret);
  
-            createExecutor("TestPKCEEnforceExecutor", TestPKCEEnforceExecutorFactory.PROVIDER_ID, null, (ComponentRepresentation provider) -> {
+            createExecutor("PKCEEnforceExecutor", PKCEEnforceExecutorFactory.PROVIDER_ID, null, (ComponentRepresentation provider) -> {
                 setExecutorAugmentDeactivate(provider);
             });
-            registerExecutor("TestPKCEEnforceExecutor", policyName);
-            logger.info("... Registered Executor : TestPKCEEnforceExecutor");
+            registerExecutor("PKCEEnforceExecutor", policyName);
+            logger.info("... Registered Executor : PKCEEnforceExecutor");
 
             failLoginByNotFollowingPKCE(clientId);
 
-            updateExecutor("TestPKCEEnforceExecutor", (ComponentRepresentation provider) -> {
+            updateExecutor("PKCEEnforceExecutor", (ComponentRepresentation provider) -> {
                setExecutorAugmentActivate(provider);
             });
 
@@ -495,8 +495,8 @@ public class ClientPolicyBasicsTest extends AbstractKeycloakTest {
             assertEquals(false, getClientByAdmin(cid).isServiceAccountsEnabled());
             assertEquals(OAuth2Constants.PKCE_METHOD_S256, OIDCAdvancedConfigWrapper.fromClientRepresentation(getClientByAdmin(cid)).getPkceCodeChallengeMethod());
 
-            deleteExecutor("TestPKCEEnforceExecutor", policyName);
-            logger.info("... Deleted Executor : TestPKCEEnforceExecutor");
+            deleteExecutor("PKCEEnforceExecutor", policyName);
+            logger.info("... Deleted Executor : PKCEEnforceExecutor");
 
             updateClientByAdmin(cid, (ClientRepresentation clientRep) -> {
                 OIDCAdvancedConfigWrapper.fromClientRepresentation(clientRep).setPkceCodeChallengeMethod(null);
@@ -547,11 +547,11 @@ public class ClientPolicyBasicsTest extends AbstractKeycloakTest {
         registerCondition(CLIENTROLES_CONDITION_BETA_NAME, policyBetaName);
         logger.info("... Registered Condition : " + CLIENTROLES_CONDITION_BETA_NAME);
 
-        createExecutor("TestPKCEEnforceExecutor-beta", TestPKCEEnforceExecutorFactory.PROVIDER_ID, null, (ComponentRepresentation provider) -> {
+        createExecutor("PKCEEnforceExecutor-beta", PKCEEnforceExecutorFactory.PROVIDER_ID, null, (ComponentRepresentation provider) -> {
             setExecutorAugmentActivate(provider);
         });
-        registerExecutor("TestPKCEEnforceExecutor-beta", policyBetaName);
-        logger.info("... Registered Executor : TestPKCEEnforceExecutor-beta");
+        registerExecutor("PKCEEnforceExecutor-beta", policyBetaName);
+        logger.info("... Registered Executor : PKCEEnforceExecutor-beta");
 
         String clientAlphaId = "Alpha-App";
         String clientAlphaSecret = "secretAlpha";
@@ -872,11 +872,11 @@ public class ClientPolicyBasicsTest extends AbstractKeycloakTest {
         registerExecutor("SecureClientAuthEnforceExecutor", policyName);
         logger.info("... Registered Executor : SecureClientAuthEnforceExecutor");
 
-        createExecutor("TestPKCEEnforceExecutor", TestPKCEEnforceExecutorFactory.PROVIDER_ID, null, (ComponentRepresentation provider) -> {
+        createExecutor("PKCEEnforceExecutor", PKCEEnforceExecutorFactory.PROVIDER_ID, null, (ComponentRepresentation provider) -> {
             setExecutorAugmentActivate(provider);
         });
-        registerExecutor("TestPKCEEnforceExecutor", policyName);
-        logger.info("... Registered Executor : TestPKCEEnforceExecutor");
+        registerExecutor("PKCEEnforceExecutor", policyName);
+        logger.info("... Registered Executor : PKCEEnforceExecutor");
 
     }
 
@@ -1155,5 +1155,4 @@ public class ClientPolicyBasicsTest extends AbstractKeycloakTest {
     private void setExecutorAugmentedClientAuthMethod(ComponentRepresentation provider, String augmentedClientAuthMethod) {
         provider.getConfig().putSingle(SecureClientAuthEnforceExecutorFactory.CLIENT_AUTHNS_AUGMENT, augmentedClientAuthMethod);
     }
-
 }


### PR DESCRIPTION

This PR is for [KEYCLOAK-14201 Client Policy - Executor : Enforce Proof Key for Code Exchange (PKCE)](https://issues.redhat.com/browse/KEYCLOAK-14201) in [KEYCLOAK-13933 Client Policies](https://issues.redhat.com/browse/KEYCLOAK-13933), also is the part of the project [Client Policy Official Support](https://github.com/keycloak/kc-sig-fapi/projects) of [FAPI-SIG](https://github.com/keycloak/kc-sig-fapi) activity.

Generally speaking, the aim of this PR is to support policy executors defined in [Client Policy design document](https://github.com/keycloak/keycloak-community/blob/master/design/client-policies.md#which-kind-of-executors-are-provided)

As mentioned in the corresponding [JIRA ticket](https://issues.redhat.com/browse/KEYCLOAK-14201), its details are as follows.

- on the `REGISTER` event (i.e. before registering client by Dynamic Client Registration or Admin REST API)
- on the `UPDATE` event (i.e. before updating client by Dynamic Client Registration or Admin REST API)
  - enforce PKCE setting (`code_challenge_method` = `S256`) depending on this executor's setting.
  - check whether the client's PKCE setting is enabled or not. If not, return the error.
- on the `AUTHORIZATION_REQUEST` event (i.e. receive authz request from client)
  - do PKCE specification defining process the same as what has already been implemented in `AuthorizationEndpoint`.
- on the `TOKEN_REQUEST` event (i.e. receive token request from client)
  - do PKCE specification defining process the same as what has already been implemented in `TokenEndpoint`.

I've recognized that this executor do the same thing done by the existing `AuthorizationEndpoint` and `TokenEndpoint`, namely duplicate PKCE protocol processing.

When working on [KEYCLOAK-14208 Client Policy : Pre-set Policies](https://issues.redhat.com/browse/KEYCLOAK-14208), I'd like to remove PKCE part from `AuthorizationEndpoint` and `TokenEndpoint`.

