### PR TITLE
KEYCLOAK-16426 add attributes to keycloak.d.ts

### DIFF
--- a/adapters/oidc/js/src/main/resources/keycloak.d.ts
+++ b/adapters/oidc/js/src/main/resources/keycloak.d.ts
@@ -292,13 +292,23 @@ declare namespace Keycloak {
 	}
 
 	interface KeycloakTokenParsed {
+		acr?: string;
+		aud?: string;
+		auth_time?: number;
+		azp?: string;
+		email_varified?: boolean;
 		exp?: number;
 		iat?: number;
+		iss?: string;
+		jti?: string;
 		nonce?: string;
-		sub?: string;
-		session_state?: string;
+		preferred_username?: string;
 		realm_access?: KeycloakRoles;
 		resource_access?: KeycloakResourceAccess;
+		scope?: string;
+		session_state?: string;
+		sub?: string;
+		typ?: string;
 	}
 
 	interface KeycloakResourceAccess {


### PR DESCRIPTION
<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
I am using keycloak adaptor in TypeScript App.
I noticed some attributes of the "KeycloakTokenParsed" is missing in the keycloak.d.ts.

![image](https://user-images.githubusercontent.com/49754654/96145199-f1432d80-0f3f-11eb-89bf-b928a6192b8e.png)
