### PR TITLE
Default key store file for enabling HTTPS

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/configuration/PropertyMapper.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/configuration/PropertyMapper.java
@@ -23,10 +23,10 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiFunction;
+import java.util.function.Supplier;
 
 import io.smallrye.config.ConfigSourceInterceptorContext;
 import io.smallrye.config.ConfigValue;
-import org.keycloak.quarkus.KeycloakRecorder;
 
 public class PropertyMapper {
 
@@ -36,6 +36,10 @@ public class PropertyMapper {
 
     static PropertyMapper createWithDefault(String fromProperty, String toProperty, String defaultValue, String description) {
         return MAPPERS.computeIfAbsent(toProperty, s -> new PropertyMapper(fromProperty, s, defaultValue, null, description));
+    }
+
+    static PropertyMapper createWithDefault(String fromProperty, String toProperty, Supplier<String> defaultValue, String description) {
+        return MAPPERS.computeIfAbsent(toProperty, s -> new PropertyMapper(fromProperty, s, defaultValue.get(), null, description));
     }
 
     static PropertyMapper createWithDefault(String fromProperty, String toProperty, String defaultValue, BiFunction<String, ConfigSourceInterceptorContext, String> transformer, String description) {
@@ -112,6 +116,10 @@ public class PropertyMapper {
         this.buildTime = buildTime;
         this.description = description;
         this.mask = mask;
+    }
+
+    ConfigValue getOrDefault(ConfigSourceInterceptorContext context, ConfigValue current) {
+        return getOrDefault(null, context, current);        
     }
 
     ConfigValue getOrDefault(String name, ConfigSourceInterceptorContext context, ConfigValue current) {


### PR DESCRIPTION
* Default key store file for configuring HTTPS if none provider
* If OK, we can do the same for PEM files

Right now we try to look up the file at runtime, but we probably want to load it at build time. That would change how we map some configuration options so that blocking code like that is not executed when starting the server, but when running the configuration. There is a usability impact if we do that because the configuration would be an additional step.