### PR TITLE
[KEYCLOAK-15986] Migration get failed through migrate-domain-clustered.cli/migrate-domain-standalone.cli when host.xml is not present

### DIFF
--- a/distribution/feature-packs/server-feature-pack/src/main/resources/content/bin/migrate-domain-clustered.cli
+++ b/distribution/feature-packs/server-feature-pack/src/main/resources/content/bin/migrate-domain-clustered.cli
@@ -1,4 +1,6 @@
-embed-host-controller --domain-config=domain.xml
+set hostConfig=host.xml
+
+embed-host-controller --domain-config=domain.xml --host-config=$hostConfig
 
 # Early versions of keycloak used "ha" for the clustered profile name.
 # Yours maybe be something completely different.

--- a/distribution/feature-packs/server-feature-pack/src/main/resources/content/bin/migrate-domain-standalone.cli
+++ b/distribution/feature-packs/server-feature-pack/src/main/resources/content/bin/migrate-domain-standalone.cli
@@ -1,4 +1,6 @@
-embed-host-controller --domain-config=domain.xml
+set hostConfig=host.xml
+
+embed-host-controller --domain-config=domain.xml --host-config=$hostConfig
 
 # Early versions of keycloak used "default" for the standalone profile name.
 # Yours maybe be something completely different.


### PR DESCRIPTION
This PR fix the issue - https://issues.redhat.com/browse/KEYCLOAK-15986 .
The migration through domain migration cli scripts get failed if anyone has deleted or renamed default host.xml so to fix this issue I just added  host-config parameter to embed-host-controller cli command , hence anyone can set the appropriate host-configuration file in "hostConfig" property . 