### PR TITLE
[KEYCLOAK-15940] Tomcat SAML adapter lib missing dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -286,6 +286,10 @@
                         <groupId>org.glassfish.jaxb</groupId>
                         <artifactId>txw2</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>org.glassfish.ha</groupId>
+                        <artifactId>ha-api</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>

--- a/testsuite/integration-arquillian/pom.xml
+++ b/testsuite/integration-arquillian/pom.xml
@@ -58,9 +58,9 @@
         <arquillian-jetty9-container.version>1.0.0.CR3</arquillian-jetty9-container.version>
         <arquillian-container-karaf.version>2.2.0.Final</arquillian-container-karaf.version>
         <arquillian-infinispan-container.version>1.2.0.Beta2</arquillian-infinispan-container.version>
-        <arquillian-tomcat7-container-version>1.0.1.Final</arquillian-tomcat7-container-version>
-        <arquillian-tomcat8-container-version>1.0.1.Final</arquillian-tomcat8-container-version>
-        <arquillian-tomcat9-container-version>1.0.1.Final</arquillian-tomcat9-container-version>
+        <arquillian-tomcat7-container-version>1.1.0.Final</arquillian-tomcat7-container-version>
+        <arquillian-tomcat8-container-version>1.1.0.Final</arquillian-tomcat8-container-version>
+        <arquillian-tomcat9-container-version>1.1.0.Final</arquillian-tomcat9-container-version>
         <undertow-embedded.version>1.0.0.Alpha2</undertow-embedded.version>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <testcontainers.version>1.5.1</testcontainers.version>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/KEYCLOAK-15940

Excluding the `ha-api` dependency from the `com.sun.xml.ws:rt` added for saml-core. The dependency was added by [KEYCLOAK-11185](https://issues.redhat.com/browse/KEYCLOAK-11185) (compilation issues with jdk 9+) but the `ha-api` is not needed and it's creating some warnings in tomcat because it includes some class-path jars in the MANIFEST.MF that then do not exist. Without the `ha-api` all tomcat tests pass without issues and I have not seen any SAML problem in other clients (undertow, wildfly, tomcat,...) with jdk 11.

The arquillian tomcat container has also been upgraded to test the tomcat adapter using jdk-11 ([ARQ-2191](https://issues.redhat.com/browse/ARQ-2191) is required).

@mhajas Please review it and/or move this to the correct person.
