### PR TITLE
KEYCLOAK-14679 Unable to log in with WebAuthn on unsupported browsers

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/requiredactions/WebAuthnRegister.java
+++ b/services/src/main/java/org/keycloak/authentication/requiredactions/WebAuthnRegister.java
@@ -360,7 +360,7 @@ public class WebAuthnRegister implements RequiredActionProvider, CredentialRegis
                 .detail(ERR_DETAIL_LABEL, errorMessage)
                 .error(Errors.INVALID_USER_CREDENTIALS);
             errorResponse = context.form()
-                .setError(errorCase)
+                .setError(errorCase, errorMessage)
                 .setAttribute(WEB_AUTHN_TITLE_ATTR, WEBAUTHN_REGISTER_TITLE)
                 .createWebAuthnErrorPage();
             context.challenge(errorResponse);
@@ -372,7 +372,7 @@ public class WebAuthnRegister implements RequiredActionProvider, CredentialRegis
                 .detail(ERR_DETAIL_LABEL, errorMessage)
                 .error(Errors.INVALID_REGISTRATION);
             errorResponse = context.form()
-                .setError(errorCase)
+                .setError(errorCase, errorMessage)
                 .setAttribute(WEB_AUTHN_TITLE_ATTR, WEBAUTHN_REGISTER_TITLE)
                 .createWebAuthnErrorPage();
             context.challenge(errorResponse);

--- a/themes/src/main/resources/theme/base/login/messages/messages_en.properties
+++ b/themes/src/main/resources/theme/base/login/messages/messages_en.properties
@@ -363,14 +363,15 @@ webauthn-passwordless-help-text=Use your security key for passwordless log in.
 webauthn-login-title=Security Key login
 webauthn-registration-title=Security Key Registration
 webauthn-available-authenticators=Available authenticators
+webauthn-unsupported-browser-text=WebAuthn is not supported by this browser. Try another one or contact your administrator.
 
 # WebAuthn Error
 webauthn-error-title=Security Key Error
-webauthn-error-registration=Failed to register your Security key.
-webauthn-error-api-get=Failed to authenticate by the Security key.
+webauthn-error-registration=Failed to register your Security key.<br/> {0}
+webauthn-error-api-get=Failed to authenticate by the Security key.<br/> {0}
 webauthn-error-different-user=First authenticated user is not the one authenticated by the Security key.
-webauthn-error-auth-verification=Security key authentication result is invalid.
-webauthn-error-register-verification=Security key registration result is invalid.
+webauthn-error-auth-verification=Security key authentication result is invalid.<br/> {0}
+webauthn-error-register-verification=Security key registration result is invalid.<br/> {0}
 webauthn-error-user-not-found=Unknown user authenticated by the Security key.
 
 identity-provider-redirector=Connect with another Identity Provider

--- a/themes/src/main/resources/theme/base/login/webauthn-authenticate.ftl
+++ b/themes/src/main/resources/theme/base/login/webauthn-authenticate.ftl
@@ -62,6 +62,14 @@
 
 
     function doAuthenticate(allowCredentials) {
+
+        // Check if WebAuthn is supported by this browser
+        if (!window.PublicKeyCredential) {
+            $("#error").val("${msg("webauthn-unsupported-browser-text")?no_esc}");
+            $("#webauth").submit();
+            return;
+        }
+
         let challenge = "${challenge}";
         let userVerification = "${userVerification}";
         let rpId = "${rpId}";

--- a/themes/src/main/resources/theme/base/login/webauthn-register.ftl
+++ b/themes/src/main/resources/theme/base/login/webauthn-register.ftl
@@ -22,6 +22,14 @@
         <script type="text/javascript">
 
             function registerSecurityKey() {
+
+                // Check if WebAuthn is supported by this browser
+                if (!window.PublicKeyCredential) {
+                    $("#error").val("${msg("webauthn-unsupported-browser-text")?no_esc}");
+                    $("#register").submit();
+                    return;
+                }
+
                 // mandatory parameters
                 let challenge = "${challenge}";
                 let userid = "${userid}";


### PR DESCRIPTION
JIRA: [KEYCLOAK-14679 ](https://issues.redhat.com/browse/KEYCLOAK-14679)

I wasn't able to create test for that case. But this solution is very common.(f.e. see [here](https://developers.google.com/web/updates/2018/03/webauthn-credential-management))

I've tried to do that with `JavascriptExecutor` driver to make the `PublicKeyCredential` undefined and so on. But it was unsuccessful. Any advice, how to do that? :) 
