### PR TITLE
[KEYCLOAK-14255] - Minor fixes and improvements

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/configuration/PropertyMapper.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/configuration/PropertyMapper.java
@@ -127,6 +127,13 @@ public class PropertyMapper {
         ConfigValue config = context.proceed(from);
 
         if (config == null) {
+            // fist try runtime configuration
+            Optional<ConfigValue> buildConfig = getBuiltTimeConfig(from, context);
+
+            if (buildConfig.isPresent()) {
+                return buildConfig.get();
+            }
+
             if (mapFrom != null) {
                 // if the property we want to map depends on another one, we use the value from the other property to call the mapper
                 String parentKey = MicroProfileConfigProvider.NS_KEYCLOAK + "." + mapFrom;
@@ -145,12 +152,6 @@ public class PropertyMapper {
                 }
             }
 
-            Optional<ConfigValue> buildConfig = getBuiltTimeConfig(from, context);
-
-            if (buildConfig.isPresent()) {
-                return buildConfig.get();
-            }
-            
             // if not defined, return the current value from the property as a default if the property is not explicitly set
             if (defaultValue == null
                     || (current != null && !current.getConfigSourceName().equalsIgnoreCase("default values"))) {

--- a/quarkus/runtime/src/main/java/org/keycloak/configuration/PropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/configuration/PropertyMappers.java
@@ -143,6 +143,7 @@ public final class PropertyMappers {
                     return "org.mariadb.jdbc.MySQLDataSource";
                 case "mysql":
                     return "com.mysql.cj.jdbc.MysqlXADataSource";
+                case "postgress":
                 case "postgres-95":
                 case "postgres-10":
                     return "org.postgresql.xa.PGXADataSource";
@@ -158,6 +159,7 @@ public final class PropertyMappers {
                     return "mariadb";
                 case "mysql":
                     return "mysql";
+                case "postgres":
                 case "postgres-95":
                 case "postgres-10":
                     return "postgresql";
@@ -165,22 +167,23 @@ public final class PropertyMappers {
             throw invalidDatabaseVendor(db, "h2-file", "h2-mem", "mariadb", "mysql", "postgres", "postgres-95", "postgres-10");
         }, "The database vendor. Possible values are: h2-mem, h2-file, mariadb, mysql, postgres95, postgres10.");
         create("db", "quarkus.datasource.jdbc.transactions", (db, context) -> "xa", null);
-        create("db.url", "db", "quarkus.datasource.jdbc.url", (db, context) -> {
-            switch (db.toLowerCase()) {
+        create("db.url", "db", "quarkus.datasource.jdbc.url", (value, context) -> {
+            switch (value.toLowerCase()) {
                 case "h2-file":
                     return "jdbc:h2:file:${kc.home.dir:${kc.db.url.path:~}}/${kc.data.dir:data}/keycloakdb${kc.db.url.properties:;;AUTO_SERVER=TRUE}";
                 case "h2-mem":
                     return "jdbc:h2:mem:keycloakdb${kc.db.url.properties:}";
                 case "mariadb":
                     return "jdbc:mariadb://${kc.db.url.host:localhost}/${kc.db.url.database:keycloak}${kc.db.url.properties:}";
+                case "postgres":
                 case "postgres-95":
                 case "postgres-10":
                     return "jdbc:postgresql://${kc.db.url.host:localhost}/${kc.db.url.database:keycloak}${kc.db.url.properties:}";
                 case "mysql":
                     return "jdbc:mysql://${kc.db.url.host:localhost}/${kc.db.url.database:keycloak}${kc.db.url.properties:}";
             }
-            return null;
-        }, "The database JDBC URL. If not provided a default URL is set based on the selected database vendor. For instance, if using 'postgres-10', the JDBC URL would be 'jdbc:postgresql://localhost/keycloak'. The host, database and properties can be overridden by setting the following system properties, respectively: -Dkc.db.url.host, -Dkc.db.url.database, -Dkc.db.url.properties.");
+            return value;
+        }, "The database JDBC URL. If not provided a default URL is set based on the selected database vendor. For instance, if using 'postgres', the JDBC URL would be 'jdbc:postgresql://localhost/keycloak'. The host, database and properties can be overridden by setting the following system properties, respectively: -Dkc.db.url.host, -Dkc.db.url.database, -Dkc.db.url.properties.");
         create("db.username", "quarkus.datasource.username", "The database username.");
         create("db.password", "quarkus.datasource.password", "The database password", true);
         create("db.schema", "quarkus.datasource.schema", "The database schema.");
@@ -202,6 +205,7 @@ public final class PropertyMappers {
         }, "Specifies clustering configuration. The specified value points to the infinispan configuration file prefixed with the 'cluster-` "
                 + "inside the distribution configuration directory. Supported values out of the box are 'local' and 'cluster'. Value 'local' points to the file cluster-local.xml and " +
                 "effectively disables clustering and use infinispan caches in the local mode. Value 'default' points to the file cluster-default.xml, which has clustering enabled for infinispan caches.");
+        create("cluster-stack", "kc.spi.connections-infinispan.default.stack", "Specified the default stack to use for cluster communication and node  discovery. Possible values are: tcp, udp, kubernetes, ec2.");
     }
 
     static ConfigValue getValue(ConfigSourceInterceptorContext context, String name) {

--- a/testsuite/integration-arquillian/servers/auth-server/quarkus/assembly.xml
+++ b/testsuite/integration-arquillian/servers/auth-server/quarkus/assembly.xml
@@ -44,9 +44,9 @@
     </fileSets>
     <files>
         <file>
-            <source>src/main/content/conf/cluster-${auth.server.quarkus.config}.xml</source>
+            <source>src/main/content/conf/cluster-${auth.server.quarkus.cluster.config}.xml</source>
             <outputDirectory>/auth-server-quarkus/conf</outputDirectory>
-            <destName>cluster.xml</destName>
+            <destName>cluster-${auth.server.quarkus.cluster.config}.xml</destName>
             <filtered>true</filtered>
         </file>
     </files>

--- a/testsuite/integration-arquillian/servers/auth-server/quarkus/pom.xml
+++ b/testsuite/integration-arquillian/servers/auth-server/quarkus/pom.xml
@@ -18,7 +18,7 @@
         <session.cache.owners>2</session.cache.owners>
         <offline.session.cache.owners>2</offline.session.cache.owners>
         <login.failure.cache.owners>2</login.failure.cache.owners>
-        <auth.server.quarkus.config>local</auth.server.quarkus.config>
+        <auth.server.quarkus.cluster.config>local</auth.server.quarkus.cluster.config>
     </properties>
     
     <dependencies>
@@ -199,7 +199,7 @@
         <profile>
             <id>auth-server-cluster-quarkus</id>
             <properties>
-                <auth.server.quarkus.config>ha</auth.server.quarkus.config>
+                <auth.server.quarkus.cluster.config>ha</auth.server.quarkus.cluster.config>
             </properties>
         </profile>
     </profiles>

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/containers/KeycloakQuarkusServerDeployableContainer.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/containers/KeycloakQuarkusServerDeployableContainer.java
@@ -153,7 +153,7 @@ public class KeycloakQuarkusServerDeployableContainer implements DeployableConta
             commands.add("-Djboss.node.name=" + configuration.getRoute());
         }
 
-        commands.add("--profile=" + System.getProperty("auth.server.quarkus.config", "local"));
+        commands.add("--cluster=" + System.getProperty("auth.server.quarkus.cluster.config", "local"));
 
         return commands.toArray(new String[commands.size()]);
     }

--- a/testsuite/integration-arquillian/tests/pom.xml
+++ b/testsuite/integration-arquillian/tests/pom.xml
@@ -229,7 +229,7 @@
 
         <auth.server.ocsp.responder.enabled>false</auth.server.ocsp.responder.enabled>
         <keycloak.x509cert.lookup.provider>default</keycloak.x509cert.lookup.provider>
-        <auth.server.quarkus.config>local</auth.server.quarkus.config>
+        <auth.server.quarkus.cluster.config>local</auth.server.quarkus.cluster.config>
     </properties>
 
     <build>
@@ -621,7 +621,7 @@
                             <auth.server.jboss.cluster>${auth.server.jboss.cluster}</auth.server.jboss.cluster>
                             <auth.server.jboss.legacy>${auth.server.jboss.legacy}</auth.server.jboss.legacy>
                             <auth.server.quarkus.cluster>${auth.server.quarkus.cluster}</auth.server.quarkus.cluster>
-                            <auth.server.quarkus.config>${auth.server.quarkus.config}</auth.server.quarkus.config>
+                            <auth.server.quarkus.cluster.config>${auth.server.quarkus.cluster.config}</auth.server.quarkus.cluster.config>
 
                             <!--cache server properties-->
                             <auth.server.crossdc>${auth.server.crossdc}</auth.server.crossdc>
@@ -756,7 +756,7 @@
                 <exclude.cluster>-</exclude.cluster>
                 <auth.server.cluster>true</auth.server.cluster>
                 <auth.server.quarkus.cluster>true</auth.server.quarkus.cluster>
-                <auth.server.quarkus.config>ha</auth.server.quarkus.config>
+                <auth.server.quarkus.cluster.config>ha</auth.server.quarkus.cluster.config>
                 <auth.server>quarkus</auth.server>
                 <auth.server.quarkus>true</auth.server.quarkus>
                 <auth.server.jboss>false</auth.server.jboss>


### PR DESCRIPTION
* Fixing the jdbc url resolution
* Fixing clustering tests
* Added a `cluster-stack` option for clustering. This one was already there when we started the clustering implementation, I'm just exposing it, otherwise, you would set it via the `--spi-connections-infinispan-default-stack`.

The `cluster-stack` right now maps to the default Jgroups stacks provided by Infinispan. But we can always provide our own.

I've tested this with Kubernetes and with this config, you should have a running cluster:

```
spec:
      containers:
        - image: pedroigor/keycloak-x:latest
          args: ["--auto-config","--http-enabled=true","--cluster-stack=kubernetes","-Djgroups.dns.query=jgroups-dns-ping.keycloak.svc.cluster.local","--db=postgres","--db-url=jdbc:postgresql://keycloak-postgres/keycloak","--db-username=keycloak","--db-password=password"]
         ...
```

The only caveat here is that we need to set the `jgroups.dns.query` system property. For now, I think is OK. But in the future we may want to provide better options for such configuration.