### PR TITLE
KEYCLOAK-16065 Replace last UrlConnection uses with HttpClientProvider

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/x509/CertificateValidator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/x509/CertificateValidator.java
@@ -18,8 +18,12 @@
 
 package org.keycloak.authentication.authenticators.x509;
 
-import org.keycloak.common.util.OCSPUtils;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+
 import org.keycloak.common.util.Time;
+import org.keycloak.connections.httpclient.HttpClientProvider;
 import org.keycloak.models.Constants;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.saml.common.exceptions.ProcessingException;
@@ -158,10 +162,12 @@ public class CertificateValidator {
 
     public static class BouncyCastleOCSPChecker extends OCSPChecker {
 
+        private final KeycloakSession session;
         private final String responderUri;
         private final X509Certificate responderCert;
 
-        BouncyCastleOCSPChecker(String responderUri, X509Certificate responderCert) {
+        BouncyCastleOCSPChecker(KeycloakSession session, String responderUri, X509Certificate responderCert) {
+            this.session = session;
             this.responderUri = responderUri;
             this.responderCert = responderCert;
         }
@@ -180,7 +186,7 @@ public class CertificateValidator {
                 // 1) signed by the issuer certificate,
                 // 2) Includes the value of OCSPsigning in ExtendedKeyUsage v3 extension
                 // 3) Certificate is valid at the time
-                ocspRevocationStatus = OCSPUtils.check(cert, issuerCertificate);
+                ocspRevocationStatus = OCSPUtils.check(session, cert, issuerCertificate);
             }
             else {
                 URI uri;
@@ -196,7 +202,7 @@ public class CertificateValidator {
                 // OCSP responder's certificate is assumed to be the issuer's certificate
                 // certificate.
                 // responderUri overrides the contents (if any) of the certificate's AIA extension
-                ocspRevocationStatus = OCSPUtils.check(cert, issuerCertificate, uri, responderCert, null);
+                ocspRevocationStatus = OCSPUtils.check(session, cert, issuerCertificate, uri, responderCert, null);
             }
             return ocspRevocationStatus;
         }
@@ -217,10 +223,10 @@ public class CertificateValidator {
 
         private final List<CRLLoaderImpl> delegates;
 
-        public CRLListLoader(String cRLConfigValue) {
+        public CRLListLoader(KeycloakSession session, String cRLConfigValue) {
             String[] delegatePaths = Constants.CFG_DELIMITER_PATTERN.split(cRLConfigValue);
             this.delegates = Arrays.stream(delegatePaths)
-                    .map(CRLFileLoader::new)
+                    .map(cRLPath -> new CRLFileLoader(session, cRLPath))
                     .collect(Collectors.toList());
         }
 
@@ -237,21 +243,25 @@ public class CertificateValidator {
 
     public static class CRLFileLoader extends CRLLoaderImpl {
 
+        private final KeycloakSession session;
         private final String cRLPath;
         private final LdapContext ldapContext;
 
-        public CRLFileLoader(String cRLPath) {
+        public CRLFileLoader(KeycloakSession session, String cRLPath) {
+            this.session = session;
             this.cRLPath = cRLPath;
             ldapContext = new LdapContext();
         }
 
-        public CRLFileLoader(String cRLPath, LdapContext ldapContext) {
+        public CRLFileLoader(KeycloakSession session, String cRLPath, LdapContext ldapContext) {
+            this.session = session;
             this.cRLPath = cRLPath;
             this.ldapContext = ldapContext;
 
             if (ldapContext == null)
                 throw new NullPointerException("Context cannot be null");
         }
+
         public Collection<X509CRL> getX509CRLs() throws GeneralSecurityException {
             CertificateFactory cf = CertificateFactory.getInstance("X.509");
             Collection<X509CRL> crlColl = null;
@@ -287,11 +297,18 @@ public class CertificateValidator {
             try {
                 logger.debugf("Loading CRL from %s", remoteURI.toString());
 
-                URLConnection conn = remoteURI.toURL().openConnection();
-                conn.setDoInput(true);
-                conn.setUseCaches(false);
-                X509CRL crl = loadFromStream(cf, conn.getInputStream());
-                return Collections.singleton(crl);
+                HttpClient httpClient = session.getProvider(HttpClientProvider.class).getHttpClient();
+                HttpGet get = new HttpGet(remoteURI);
+                get.setHeader("Pragma", "no-cache");
+                get.setHeader("Cache-Control", "no-cache, no-store");
+                HttpResponse response = httpClient.execute(get);
+                InputStream content = response.getEntity().getContent();
+                try {
+                    X509CRL crl = loadFromStream(cf, content);
+                    return Collections.singleton(crl);
+                } finally {
+                    content.close();
+                }
             }
             catch(IOException ex) {
                 logger.errorf(ex.getMessage());
@@ -584,7 +601,7 @@ public class CertificateValidator {
         }
         for (String dp : distributionPoints) {
             logger.tracef("CRL Distribution point: \"%s\"", dp);
-            checkRevocationStatusUsingCRL(certs, new CRLFileLoader(dp), session);
+            checkRevocationStatusUsingCRL(certs, new CRLFileLoader(session, dp), session);
         }
     }
 
@@ -756,7 +773,7 @@ public class CertificateValidator {
             public class GotCRLDP {
                 public GotCRLRelativePath cRLrelativePath(String value) {
                     if (value != null)
-                        _crlLoader = new CRLListLoader(value);
+                        _crlLoader = new CRLListLoader(session, value);
                     return new GotCRLRelativePath();
                 }
 
@@ -809,11 +826,11 @@ public class CertificateValidator {
 
         public CertificateValidator build(X509Certificate[] certs) {
             if (_crlLoader == null) {
-                 _crlLoader = new CRLFileLoader("");
+                 _crlLoader = new CRLFileLoader(session, "");
             }
             return new CertificateValidator(certs, _keyUsageBits, _extendedKeyUsage,
                     _crlCheckingEnabled, _crldpEnabled, _crlLoader, _ocspEnabled,
-                    new BouncyCastleOCSPChecker(_responderUri, _responderCert), session);
+                    new BouncyCastleOCSPChecker(session, _responderUri, _responderCert), session);
         }
     }
 


### PR DESCRIPTION
The preferred mechanism in Keycloak sources to execute an http request is to retrieve an `HttpClient` from `HttpClientProvider`. The `HttpClientProvider` takes care of applying the `HttpClient` settings (i.e. proxy preferences, etc) according to the standalone.xml directives.

In current sources there are just a couple of places that do not use yet the `HttpClientProvider` class and rely on the basic `UrlConnection` class instead ( https://github.com/keycloak/keycloak/search?q=urlconnection ). It is quite easy to migrate those calls to `HttpClientProvider`.

The affected code paths are only used by the X509 Authenticator for CRL and OCSP certificate validation, and tests for those features are already present. As I'm essentially swapping one implementation for another, I don't think that more tests are needed - the feature itself is already under test.

This PR extends and supersedes PR #7389 . I will now close that one.