### PR TITLE
[KEYCLOAK-15634] Prevent federated user removal with new account console

### DIFF
--- a/testsuite/integration-arquillian/tests/other/base-ui/src/test/java/org/keycloak/testsuite/ui/account2/PersonalInfoTest.java
+++ b/testsuite/integration-arquillian/tests/other/base-ui/src/test/java/org/keycloak/testsuite/ui/account2/PersonalInfoTest.java
@@ -20,14 +20,20 @@ package org.keycloak.testsuite.ui.account2;
 import org.jboss.arquillian.graphene.page.Page;
 import org.junit.Before;
 import org.junit.Test;
+import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.testsuite.admin.ApiUtil;
 import org.keycloak.testsuite.ui.account2.page.AbstractLoggedInPage;
 import org.keycloak.testsuite.ui.account2.page.PersonalInfoPage;
+import org.keycloak.testsuite.util.UserBuilder;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
 import static org.keycloak.testsuite.admin.Users.setPasswordFor;
 import static org.keycloak.testsuite.util.UIUtils.refreshPageAndWaitForLoad;
 
@@ -190,5 +196,58 @@ public class PersonalInfoTest extends BaseAccountPageTest {
         realm.setEditUsernameAllowed(value);
         testRealmResource().update(realm);
         refreshPageAndWaitForLoad();
+    }
+
+    private void addUser(String username, String email) {
+        UserRepresentation user = UserBuilder.create()
+                .username(username)
+                .enabled(true)
+                .email(email)
+                .firstName("first")
+                .lastName("last")
+                .build();
+        RealmResource testRealm = adminClient.realm("test");
+        ApiUtil.createUserAndResetPasswordWithAdminClient(testRealm, user, "password");
+    }
+
+    // KEYCLOAK-15634
+    @Test
+    public void updateProfileWithAttributePresent() {
+
+        RealmResource testRealm = adminClient.realm("test");
+        assertEquals("keycloak.v2", testRealm.toRepresentation().getAccountTheme());
+
+        // Add a user and set a test attribute
+        addUser("keycloak-15634","keycloak-15634@test.local");
+        UserRepresentation userRepBefore = ApiUtil.findUserByUsername(testRealm,"keycloak-15634");
+        Map<String, List<String>> userAttributes = new HashMap<>();
+        userAttributes.put("testAttribute", Collections.singletonList("testValue"));
+        userRepBefore.setAttributes(userAttributes);
+        testRealm.users().get(userRepBefore.getId()).update(userRepBefore);
+
+        // Check our test user is ok before updating profile with account v2
+        UserRepresentation updatedUserRep = ApiUtil.findUserByUsername(testRealm,"keycloak-15634");
+        assertEquals("keycloak-15634@test.local", updatedUserRep.getEmail());
+        assertEquals("testAttribute should be set", "testValue", updatedUserRep.getAttributes().get("testAttribute").get(0));
+        assertFalse("locale attribute should not be set", updatedUserRep.getAttributes().containsKey("locale"));
+
+        personalInfoPage.assertCurrent();
+        personalInfoPage.header().clickLogoutBtn();
+        personalInfoPage.navigateTo();
+        loginPage.assertCurrent();
+        loginPage.form().login("keycloak-15634","password");
+        personalInfoPage.assertCurrent();
+
+        // Trigger the JS involved in KEYCLOAK-15634
+        assertEquals("keycloak-15634@test.local", personalInfoPage.getEmail());
+        personalInfoPage.setEmail("keycloak-15634@domain.local");
+        personalInfoPage.clickSave();
+
+        // Check if updateProfile went well and if testAttribute is still there
+        UserRepresentation userRepAfter = ApiUtil.findUserByUsername(testRealm,"keycloak-15634");
+        assertEquals("keycloak-15634@domain.local", userRepAfter.getEmail());
+        assertEquals("testAttribute should still be there","testValue", userRepAfter.getAttributes().get("testAttribute").get(0));
+
+        ApiUtil.removeUserByUsername(testRealm, "keycloak-15634");
     }
 }

--- a/themes/src/main/resources/theme/keycloak.v2/account/src/app/content/account-page/AccountPage.tsx
+++ b/themes/src/main/resources/theme/keycloak.v2/account/src/app/content/account-page/AccountPage.tsx
@@ -85,8 +85,11 @@ export class AccountPage extends React.Component<AccountPageProps, AccountPageSt
             .then((response: HttpResponse<FormFields>) => {
                 this.setState(this.DEFAULT_STATE);
                 const formFields = response.data;
-                if (!formFields!.attributes || !formFields!.attributes.locale) {
+                if (!formFields!.attributes) {
                     formFields!.attributes = { locale: [locale] };
+                }
+                else if (!formFields!.attributes.locale) {
+                    formFields!.attributes.locale = [locale];
                 }
 
                 this.setState({...{ formFields: formFields as FormFields }});


### PR DESCRIPTION
A quick and dirty fix to trigger a discussion around #KEYCLOAK-15634
The new account console deletes federated user stored in Keycloak local storage by removing system attributes from these users
