### PR TITLE
KECLOAK-16009 Add a method to check if the token request has duplicat…

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
@@ -212,6 +212,7 @@ public class TokenEndpoint {
 
         if (!action.equals(Action.PERMISSION)) {
             checkClient();
+            checkParameterDuplicated();
         }
 
         switch (action) {
@@ -304,6 +305,15 @@ public class TokenEndpoint {
         }
 
         event.detail(Details.GRANT_TYPE, grantType);
+    }
+
+    private void checkParameterDuplicated() {
+        for (String key : formParams.keySet()) {
+            if (formParams.get(key).size() != 1) {
+                throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_REQUEST, "duplicated parameter",
+                    Response.Status.BAD_REQUEST);
+            }
+        }
     }
 
     public Response codeToToken() {


### PR DESCRIPTION
…e parameters

When receive a request with duplicate parameters, the token endpoint doesn't response an error message defined in the RFC6749.
The details can be found in this JIRA[1].

[1] https://issues.redhat.com/browse/KEYCLOAK-16009.

Because all the grant types supported by the token endpoint should check the duplicate parameters, I added a check method before the grant type check.

Token endpoint is different from authorization endpoint as it doesn't have a parameter parser. So I can't use the same method which used in fixing KEYCLOAK-11996 [2]. I think that looping over all params is the only way to fix this problem.
[2] https://github.com/keycloak/keycloak/pull/6467