### PR TITLE
KEYCLOAK-16112 don't remove username attribute

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/UserAttributeLDAPStorageMapper.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/UserAttributeLDAPStorageMapper.java
@@ -212,8 +212,11 @@ public class UserAttributeLDAPStorageMapper extends AbstractLDAPStorageMapper {
 
                 @Override
                 public void removeAttribute(String name) {
-                    if (setLDAPAttribute(name, null)) {
-                        super.removeAttribute(name);
+                    if(!UserModel.USERNAME.equals(name)){
+                        //do not remove username
+                        if (setLDAPAttribute(name, null)) {
+                            super.removeAttribute(name);
+                        }
                     }
                 }
 


### PR DESCRIPTION
The fix is specific to the User ldap attribute mapper, to avoid too much impact, but I'm not too sure if it is the best way.