### PR TITLE
[KEYCLOAK-11698] - Change context path of Keycloak to / for Keycloak.X

### DIFF
--- a/quarkus/server/src/main/resources/application.properties
+++ b/quarkus/server/src/main/resources/application.properties
@@ -5,6 +5,6 @@ quarkus.package.output-directory=lib
 quarkus.package.user-providers-directory=../providers
 quarkus.package.main-class=keycloak
 
-quarkus.http.root-path=/auth
+quarkus.http.root-path=/
 quarkus.application.name=Keycloak
 quarkus.banner.enabled=false

--- a/testsuite/integration-arquillian/servers/auth-server/quarkus/ant/configure.xml
+++ b/testsuite/integration-arquillian/servers/auth-server/quarkus/ant/configure.xml
@@ -5,6 +5,7 @@
         <echo>Re-augmenting...</echo>
         <exec osfamily="unix" dir="${auth.server.home}/bin" executable="./kc.sh" failonerror="true">
             <arg value="config"/>
+            <arg value="-Dquarkus.http.root-path=/auth"/>
         </exec>
     </target>
 


### PR DESCRIPTION
<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
