### PR TITLE
KEYCLOAK-14198 Client Policy - Condition : Client - Client IP

### DIFF
--- a/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientIpAddressCondition.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientIpAddressCondition.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.services.clientpolicy.condition;
+
+import org.jboss.logging.Logger;
+
+import org.keycloak.component.ComponentModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.services.clientpolicy.ClientPolicyContext;
+import org.keycloak.services.clientpolicy.ClientPolicyException;
+import org.keycloak.services.clientpolicy.ClientPolicyLogger;
+import org.keycloak.services.clientpolicy.ClientPolicyVote;
+
+public class ClientIpAddressCondition implements ClientPolicyConditionProvider {
+
+    private static final Logger logger = Logger.getLogger(ClientIpAddressCondition.class);
+
+    private final KeycloakSession session;
+    private final ComponentModel componentModel;
+
+    public ClientIpAddressCondition(KeycloakSession session, ComponentModel componentModel) {
+        this.session = session;
+        this.componentModel = componentModel;
+    }
+
+    @Override
+    public String getName() {
+        return componentModel.getName();
+    }
+
+    @Override
+    public String getProviderId() {
+        return componentModel.getProviderId();
+    }
+
+    @Override
+    public ClientPolicyVote applyPolicy(ClientPolicyContext context) throws ClientPolicyException {
+        switch (context.getEvent()) {
+            case TOKEN_REQUEST:
+            case TOKEN_REFRESH:
+            case TOKEN_REVOKE:
+            case TOKEN_INTROSPECT:
+            case USERINFO_REQUEST:
+            case LOGOUT_REQUEST:
+                if (isIpAddressMatched()) return ClientPolicyVote.YES;
+                return ClientPolicyVote.NO;
+            default:
+                return ClientPolicyVote.ABSTAIN;
+        }
+    }
+
+    private boolean isIpAddressMatched() {
+        String ipAddr = session.getContext().getConnection().getRemoteAddr();
+
+        if (logger.isTraceEnabled()) {
+            componentModel.getConfig().get(ClientIpAddressConditionFactory.IPADDR).stream().forEach(i -> ClientPolicyLogger.log(logger, "ip address expected = " + i));
+            ClientPolicyLogger.log(logger, "ip address expected = " + ipAddr);
+        }
+
+        boolean isMatched = componentModel.getConfig().get(ClientIpAddressConditionFactory.IPADDR).stream().anyMatch(i -> i.equals(ipAddr));
+        if (isMatched) {
+           ClientPolicyLogger.log(logger, "ip address matched.");
+        }  else {
+           ClientPolicyLogger.log(logger, "ip address unmatched.");
+        }
+        return isMatched;
+    }
+
+}

--- a/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientIpAddressConditionFactory.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientIpAddressConditionFactory.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.services.clientpolicy.condition;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.keycloak.Config.Scope;
+import org.keycloak.component.ComponentModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.provider.ProviderConfigProperty;
+
+public class ClientIpAddressConditionFactory  implements ClientPolicyConditionProviderFactory {
+
+    public static final String PROVIDER_ID = "client-ipaddr-condition";
+    public static final String IPADDR = "ipaddr";
+
+    private static final List<ProviderConfigProperty> configProperties = new ArrayList<ProviderConfigProperty>();
+
+    static {
+        ProviderConfigProperty property;
+        property = new ProviderConfigProperty(IPADDR, PROVIDER_ID + ".label", PROVIDER_ID + ".tooltip", ProviderConfigProperty.MULTIVALUED_STRING_TYPE, "0.0.0.0");
+        configProperties.add(property);
+    }
+
+    @Override
+    public ClientPolicyConditionProvider create(KeycloakSession session, ComponentModel model) {
+        return new ClientIpAddressCondition(session, model);
+    }
+
+    @Override
+    public void init(Scope config) {
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public String getHelpText() {
+        return "It uses the client's IP address to determine whether the policy is applied.";
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return configProperties;
+    }
+
+}

--- a/services/src/main/resources/META-INF/services/org.keycloak.services.clientpolicy.condition.ClientPolicyConditionProviderFactory
+++ b/services/src/main/resources/META-INF/services/org.keycloak.services.clientpolicy.condition.ClientPolicyConditionProviderFactory
@@ -1,2 +1,3 @@
 org.keycloak.services.clientpolicy.condition.ClientUpdateContextConditionFactory
 org.keycloak.services.clientpolicy.condition.ClientRolesConditionFactory
+org.keycloak.services.clientpolicy.condition.ClientIpAddressConditionFactory


### PR DESCRIPTION
This PR is for [KEYCLOAK-14198 Client Policy - Condition : Client - Client IP](https://issues.redhat.com/browse/KEYCLOAK-14198) in [KEYCLOAK-13933 Client Policies](https://issues.redhat.com/browse/KEYCLOAK-13933), also is the part of the project [Client Policy Official Support](https://github.com/keycloak/kc-sig-fapi/projects) of [FAPI-SIG](https://github.com/keycloak/kc-sig-fapi) activity.

Generally speaking, the aim of this PR is to support policy conditions defined in [Client Policy design document](https://github.com/keycloak/keycloak-community/blob/master/design/client-policies.md#condition--which-client)
