### PR TITLE
KEYCLOAK-14206 Client Policy - Executor : Enforce more secure state and nonce treatment for preventing CSRF

### DIFF
--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureSessionEnforceExecutor.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureSessionEnforceExecutor.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.services.clientpolicy.executor;
+
+import org.jboss.logging.Logger;
+import org.keycloak.OAuthErrorException;
+import org.keycloak.component.ComponentModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.protocol.oidc.endpoints.request.AuthorizationEndpointRequest;
+import org.keycloak.protocol.oidc.utils.OIDCResponseType;
+import org.keycloak.services.clientpolicy.AuthorizationRequestContext;
+import org.keycloak.services.clientpolicy.ClientPolicyContext;
+import org.keycloak.services.clientpolicy.ClientPolicyException;
+import org.keycloak.services.clientpolicy.ClientPolicyLogger;
+import org.keycloak.util.TokenUtil;
+
+public class SecureSessionEnforceExecutor implements ClientPolicyExecutorProvider {
+
+    private static final Logger logger = Logger.getLogger(SecureSessionEnforceExecutor.class);
+
+    private final KeycloakSession session;
+    private final ComponentModel componentModel;
+
+    public SecureSessionEnforceExecutor(KeycloakSession session, ComponentModel componentModel) {
+        this.session = session;
+        this.componentModel = componentModel;
+    }
+
+    @Override
+    public String getName() {
+        return componentModel.getName();
+    }
+
+    @Override
+    public String getProviderId() {
+        return componentModel.getProviderId();
+    }
+
+    @Override
+    public void executeOnEvent(ClientPolicyContext context) throws ClientPolicyException {
+        switch (context.getEvent()) {
+            case AUTHORIZATION_REQUEST:
+                AuthorizationRequestContext authorizationRequestContext = (AuthorizationRequestContext)context;
+                executeOnAuthorizationRequest(authorizationRequestContext.getparsedResponseType(),
+                    authorizationRequestContext.getAuthorizationEndpointRequest(),
+                    authorizationRequestContext.getRedirectUri());
+                return;
+            default:
+                return;
+        }
+    }
+
+    private void executeOnAuthorizationRequest(
+            OIDCResponseType parsedResponseType,
+            AuthorizationEndpointRequest request,
+            String redirectUri) throws ClientPolicyException {
+        ClientPolicyLogger.log(logger, "Authz Endpoint - authz request");
+        if (TokenUtil.isOIDCRequest(request.getScope())) {
+            if(request.getNonce() == null) {
+                ClientPolicyLogger.log(logger, "Missing parameter: nonce");
+                throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST, "Missing parameter: nonce");
+            }
+        } else {
+            if(request.getState() == null) {
+                ClientPolicyLogger.log(logger, "Missing parameter: state");
+                throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST, "Missing parameter: state");
+            }
+        }
+        ClientPolicyLogger.log(logger, "Passed.");
+    }
+
+}

--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureSessionEnforceExecutorFactory.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureSessionEnforceExecutorFactory.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.services.clientpolicy.executor;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.keycloak.Config.Scope;
+import org.keycloak.component.ComponentModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.provider.ProviderConfigProperty;
+
+public class SecureSessionEnforceExecutorFactory implements ClientPolicyExecutorProviderFactory {
+
+    public static final String PROVIDER_ID = "secure-session-enforce-executor";
+
+    @Override
+    public ClientPolicyExecutorProvider create(KeycloakSession session, ComponentModel model) {
+        return new SecureSessionEnforceExecutor(session, model);
+    }
+
+    @Override
+    public void init(Scope config) {
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public String getHelpText() {
+        return "To prevent CSRF, it refuses the client's authorization request which lacks nonce in OIDC flow or state in OAuth2 grant.";
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return Collections.emptyList();
+    }
+
+}

--- a/services/src/main/resources/META-INF/services/org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProviderFactory
+++ b/services/src/main/resources/META-INF/services/org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProviderFactory
@@ -2,3 +2,4 @@ org.keycloak.services.clientpolicy.executor.SecureResponseTypeExecutorFactory
 org.keycloak.services.clientpolicy.executor.SecureRequestObjectExecutorFactory
 org.keycloak.services.clientpolicy.executor.SecureClientAuthEnforceExecutorFactory
 org.keycloak.services.clientpolicy.executor.PKCEEnforceExecutorFactory
+org.keycloak.services.clientpolicy.executor.SecureSessionEnforceExecutorFactory


### PR DESCRIPTION
This PR is for [KEYCLOAK-14206 Client Policy - Executor : Enforce more secure state and nonce treatment for preventing CSRF](https://issues.redhat.com/browse/KEYCLOAK-14206) in [KEYCLOAK-13933 Client Policies](https://issues.redhat.com/browse/KEYCLOAK-13933), also is the part of the project [Client Policy Official Support](https://github.com/keycloak/kc-sig-fapi/projects) of [FAPI-SIG](https://github.com/keycloak/kc-sig-fapi) activity.

Generally speaking, the aim of this PR is to support policy conditions defined in [Client Policy design document](https://github.com/keycloak/keycloak-community/blob/master/design/client-policies.md##executor--what-action)
