### PR TITLE
KEYCLOAK-14196 Client Policy - Condition : Client - Client Scope

### DIFF
--- a/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientScopesCondition.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientScopesCondition.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.services.clientpolicy.condition;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.jboss.logging.Logger;
+import org.keycloak.OAuth2Constants;
+import org.keycloak.component.ComponentModel;
+import org.keycloak.models.AuthenticatedClientSessionModel;
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.protocol.oidc.endpoints.request.AuthorizationEndpointRequest;
+import org.keycloak.services.clientpolicy.AuthorizationRequestContext;
+import org.keycloak.services.clientpolicy.ClientPolicyContext;
+import org.keycloak.services.clientpolicy.ClientPolicyException;
+import org.keycloak.services.clientpolicy.ClientPolicyLogger;
+import org.keycloak.services.clientpolicy.ClientPolicyVote;
+import org.keycloak.services.clientpolicy.TokenRequestContext;
+
+public class ClientScopesCondition implements ClientPolicyConditionProvider {
+
+    private static final Logger logger = Logger.getLogger(ClientScopesCondition.class);
+
+    private final KeycloakSession session;
+    private final ComponentModel componentModel;
+
+    public ClientScopesCondition(KeycloakSession session, ComponentModel componentModel) {
+        this.session = session;
+        this.componentModel = componentModel;
+    }
+
+    @Override
+    public ClientPolicyVote applyPolicy(ClientPolicyContext context) throws ClientPolicyException {
+        switch (context.getEvent()) {
+            case AUTHORIZATION_REQUEST:
+                if (isScopeMatched(((AuthorizationRequestContext)context).getAuthorizationEndpointRequest())) return ClientPolicyVote.YES;
+                return ClientPolicyVote.NO;
+            case TOKEN_REQUEST:
+                if (isScopeMatched(((TokenRequestContext)context).getParseResult().getClientSession())) return ClientPolicyVote.YES;
+                return ClientPolicyVote.NO;
+            default:
+                return ClientPolicyVote.ABSTAIN;
+        }
+    }
+
+    @Override
+    public String getName() {
+        return componentModel.getName();
+    }
+
+    @Override
+    public String getProviderId() {
+        return componentModel.getProviderId();
+    }
+
+    private boolean isScopeMatched(AuthenticatedClientSessionModel clientSession) {
+        if (clientSession == null) return false;
+        return isScopeMatched(clientSession.getNote(OAuth2Constants.SCOPE), clientSession.getClient());
+    }
+
+    private boolean isScopeMatched(AuthorizationEndpointRequest request) {
+        if (request == null) return false;
+        return isScopeMatched(request.getScope(), session.getContext().getRealm().getClientByClientId(request.getClientId()));
+    }
+
+    private boolean isScopeMatched(String explicitScopes, ClientModel client) {
+        Collection<String> explicitSpecifiedScopes = new HashSet<>(Arrays.asList(explicitScopes.split(" ")));
+        Set<String> defaultScopes = client.getClientScopes(true, true).keySet();
+        Set<String> optionalScopes = client.getClientScopes(false, true).keySet();
+        List<String> expectedScopes = componentModel.getConfig().get(ClientScopesConditionFactory.SCOPES);
+
+        if (logger.isTraceEnabled()) {
+            explicitSpecifiedScopes.stream().forEach(i -> ClientPolicyLogger.log(logger, " explicit specified client scope = " + i));
+            defaultScopes.stream().forEach(i -> ClientPolicyLogger.log(logger, " default client scope = " + i));
+            optionalScopes.stream().forEach(i -> ClientPolicyLogger.log(logger, " optional client scope = " + i));
+            expectedScopes.stream().forEach(i -> ClientPolicyLogger.log(logger, " expected scope = " + i));
+        }
+
+        boolean isDefaultScope = ClientScopesConditionFactory.DEFAULT.equals(componentModel.getConfig().getFirst(ClientScopesConditionFactory.TYPE));
+
+        if (isDefaultScope) {
+            expectedScopes.retainAll(defaultScopes);
+            return expectedScopes.isEmpty() ? false : true;
+        } else {
+            explicitSpecifiedScopes.retainAll(expectedScopes);
+            explicitSpecifiedScopes.retainAll(optionalScopes);
+            if (!explicitSpecifiedScopes.isEmpty()) {
+                explicitSpecifiedScopes.stream().forEach(i->{ClientPolicyLogger.log(logger, " matched scope = " + i);});
+                return true;
+            }
+        }
+        return false;
+    }
+
+}

--- a/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientScopesConditionFactory.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientScopesConditionFactory.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.services.clientpolicy.condition;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.keycloak.Config.Scope;
+import org.keycloak.component.ComponentModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.provider.ProviderConfigProperty;
+
+public class ClientScopesConditionFactory implements ClientPolicyConditionProviderFactory {
+
+    public static final String PROVIDER_ID = "clientscopes-condition";
+    public static final String SCOPES = "scopes";
+    public static final String TYPE = "type";
+    public static final String DEFAULT = "Default";
+    public static final String OPTIONAL = "Optional";
+
+    private static final List<ProviderConfigProperty> configProperties = new ArrayList<ProviderConfigProperty>();
+
+    static {
+        ProviderConfigProperty property;
+        property = new ProviderConfigProperty(SCOPES, PROVIDER_ID + ".label", PROVIDER_ID + ".tooltip", ProviderConfigProperty.MULTIVALUED_STRING_TYPE, "offline_access");
+        configProperties.add(property);
+        property = new ProviderConfigProperty(TYPE, "Scope Type", "Default or Optional", ProviderConfigProperty.LIST_TYPE, OPTIONAL);
+        configProperties.add(property);
+    }
+
+    @Override
+    public ClientPolicyConditionProvider create(KeycloakSession session, ComponentModel model) {
+        return new ClientScopesCondition(session, model);
+    }
+
+    @Override
+    public void init(Scope config) {
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public String getHelpText() {
+        return "It uses the scopes requested or assigned in advance to the client to determine whether the policy is applied to this client.";
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return configProperties;
+    }
+
+}

--- a/services/src/main/resources/META-INF/services/org.keycloak.services.clientpolicy.condition.ClientPolicyConditionProviderFactory
+++ b/services/src/main/resources/META-INF/services/org.keycloak.services.clientpolicy.condition.ClientPolicyConditionProviderFactory
@@ -1,3 +1,4 @@
 org.keycloak.services.clientpolicy.condition.ClientUpdateContextConditionFactory
 org.keycloak.services.clientpolicy.condition.ClientRolesConditionFactory
 org.keycloak.services.clientpolicy.condition.ClientIpAddressConditionFactory
+org.keycloak.services.clientpolicy.condition.ClientScopesConditionFactory


### PR DESCRIPTION
This PR is for [KEYCLOAK-14196 Client Policy - Condition : Client - Client Scope](https://issues.redhat.com/browse/KEYCLOAK-14196) in [KEYCLOAK-13933 Client Policies](https://issues.redhat.com/browse/KEYCLOAK-13933), also is the part of the project [Client Policy Official Support](https://github.com/keycloak/kc-sig-fapi/projects) of [FAPI-SIG](https://github.com/keycloak/kc-sig-fapi) activity.

Generally speaking, the aim of this PR is to support policy conditions defined in [Client Policy design document](https://github.com/keycloak/keycloak-community/blob/master/design/client-policies.md#condition--which-client)