### PR TITLE
KEYCLOAK-13644. Added healthcheck endpoints tests.

### DIFF
--- a/quarkus/deployment/src/test/java/test/org/keycloak/quarkus/services/health/KeycloakNegativeHealthCheckTest.java
+++ b/quarkus/deployment/src/test/java/test/org/keycloak/quarkus/services/health/KeycloakNegativeHealthCheckTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package test.org.keycloak.quarkus.services.health;
+
+import io.agroal.api.AgroalDataSource;
+import io.quarkus.test.QuarkusUnitTest;
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import javax.inject.Inject;
+
+import static io.restassured.RestAssured.given;
+
+public class KeycloakNegativeHealthCheckTest {
+
+    @Inject
+    AgroalDataSource agroalDataSource;
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource("application.properties", "application.properties")
+                    .addAsResource("keycloak.properties", "META-INF/keycloak.properties"));
+
+    @Test
+    public void testReadinessDown() {
+        agroalDataSource.close();
+        given()
+                .when().get("/health/ready")
+                .then()
+                .statusCode(503)
+                .body(Matchers.containsString("DOWN"));
+    }
+}

--- a/quarkus/deployment/src/test/java/test/org/keycloak/quarkus/services/health/KeycloakReadyHealthCheckTest.java
+++ b/quarkus/deployment/src/test/java/test/org/keycloak/quarkus/services/health/KeycloakReadyHealthCheckTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package test.org.keycloak.quarkus.services.health;
+
+import io.quarkus.test.QuarkusUnitTest;
+import org.hamcrest.Matchers;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.sql.SQLException;
+
+import static io.restassured.RestAssured.given;
+
+public class KeycloakReadyHealthCheckTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource("application.properties", "application.properties")
+                    .addAsResource("keycloak.properties", "META-INF/keycloak.properties"));
+
+    @Test
+    public void testLivenessUp() {
+        given()
+            .when().get("/health/live")
+            .then()
+                .statusCode(200)
+                .body(Matchers.containsString("UP"));
+    }
+
+    @Test
+    public void testReadinessUp() throws SQLException {
+        given()
+            .when().get("/health/ready")
+            .then()
+                .statusCode(200)
+                .body(Matchers.containsString("UP"));
+    }
+
+    @Test
+    public void testMetricsUp() {
+        given()
+            .when().get("/metrics")
+            .then()
+                .statusCode(200);
+    }
+}

--- a/quarkus/deployment/src/test/resources/application.properties
+++ b/quarkus/deployment/src/test/resources/application.properties
@@ -1,3 +1,3 @@
-quarkus.http.root-path=/auth
+quarkus.http.root-path=/
 quarkus.application.name=Keycloak
 quarkus.banner.enabled=false

--- a/quarkus/deployment/src/test/resources/keycloak.properties
+++ b/quarkus/deployment/src/test/resources/keycloak.properties
@@ -3,3 +3,4 @@ cluster=local
 db=h2-mem
 db.username = sa
 db.password = keycloak
+metrics.enabled=true

--- a/quarkus/runtime/pom.xml
+++ b/quarkus/runtime/pom.xml
@@ -495,6 +495,24 @@
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>${surefire-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/quarkus/runtime/src/test/java/org/keycloak/provider/quarkus/ConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/provider/quarkus/ConfigurationTest.java
@@ -184,7 +184,7 @@ public class ConfigurationTest {
         System.setProperty("kc.config.args", "--db=h2-file");
         SmallRyeConfig config = createConfig();
         assertEquals(QuarkusH2Dialect.class.getName(), config.getConfigValue("quarkus.hibernate-orm.dialect").getValue());
-        assertEquals("jdbc:h2:file:~/data/keycloakdb;;AUTO_SERVER=TRUE", config.getConfigValue("quarkus.datasource.url").getValue());
+        assertEquals("jdbc:h2:file:~/data/keycloakdb;;AUTO_SERVER=TRUE", config.getConfigValue("quarkus.datasource.jdbc.url").getValue());
 
         System.setProperty("kc.config.args", "--db=h2-mem");
         config = createConfig();

--- a/quarkus/runtime/src/test/resources/META-INF/keycloak.properties
+++ b/quarkus/runtime/src/test/resources/META-INF/keycloak.properties
@@ -2,9 +2,10 @@ spi.hostname.default.frontend-url = ${keycloak.frontendUrl:http://filepropdefaul
 %user-profile.spi.hostname.default.frontend-url = http://filepropprofile.com
 
 # Default Non-Production Grade Datasource
+quarkus.datasource.db-kind=h2
 quarkus.hibernate-orm.dialect=org.hibernate.dialect.H2Dialect
-quarkus.datasource.driver=org.h2.jdbcx.JdbcDataSource
-quarkus.datasource.url = jdbc:h2:file:${kc.home.dir:~}/data/keycloakdb;;AUTO_SERVER=TRUE
+quarkus.datasource.jdbc.driver=org.h2.jdbcx.JdbcDataSource
+quarkus.datasource.jdbc.url = jdbc:h2:file:${kc.home.dir:~}/data/keycloakdb;;AUTO_SERVER=TRUE
 quarkus.datasource.username = sa
 quarkus.datasource.password = keycloak
 quarkus.datasource.jdbc.transactions=xa


### PR DESCRIPTION
This PR includes positive tests for new healthcheck and metrics endpoints. I couldn't find a way to disable H2 database at runtime for negative cases.
