### PR TITLE
KEYCLOAK-16143 Honor forwardedErrorMessage when rendering forms

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/FormAuthenticationFlow.java
+++ b/services/src/main/java/org/keycloak/authentication/FormAuthenticationFlow.java
@@ -36,6 +36,7 @@ import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 import java.net.URI;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -276,7 +277,11 @@ public class FormAuthenticationFlow implements AuthenticationFlow {
 
     @Override
     public Response processFlow() {
-        return renderForm(null, null);
+
+        // KEYCLOAK-16143: Propagate forwarded error messages if present
+        List<FormMessage> errors = processor.forwardedErrorMessage != null ? Collections.singletonList(processor.forwardedErrorMessage) : null;
+
+        return renderForm(null, errors);
     }
 
     public Response renderForm(MultivaluedMap<String, String> formData, List<FormMessage> errors) {


### PR DESCRIPTION
Previously `org.keycloak.authentication.FormAuthenticationFlow#processFlow` did not consider `forwardedErrorMessage`'s that are associated with the current `AuthenticationProcessor` from previous failed login-actions, e.g. expired login action tokens.

If a user tried to clicked on an expired login action link like verify-email after registration, then the user would be prompted with a plain registration form without any error message.

This PR propagates forwardedErrorMessages to the form rendering, which shows the expected error message in the target page.

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
