### PR TITLE
KEYCLOAK-16329 CVE-2020-1695 resteasy: Improper validation of response header

### DIFF
--- a/integration/admin-client/pom.xml
+++ b/integration/admin-client/pom.xml
@@ -31,7 +31,7 @@
     <description/>
 
     <properties>
-        <resteasy.versions>3.9.1.Final</resteasy.versions>
+        <resteasy.versions>3.13.2.Final</resteasy.versions>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Upgrade org.jboss.resteasy dependency to remediate this security vulnerability in keycloak-admin-client artifact:
https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2020-25633

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
