### PR TITLE
KEYCLOAK-16325 Introduce SAML2NameIDBuilder for easier creation of NameIDType elements

### DIFF
--- a/saml-core/src/main/java/org/keycloak/saml/SAML2AuthnRequestBuilder.java
+++ b/saml-core/src/main/java/org/keycloak/saml/SAML2AuthnRequestBuilder.java
@@ -21,6 +21,7 @@ import org.keycloak.dom.saml.v2.assertion.SubjectType;
 import org.keycloak.dom.saml.v2.protocol.AuthnRequestType;
 import org.keycloak.dom.saml.v2.protocol.ExtensionsType;
 import org.keycloak.dom.saml.v2.protocol.RequestedAuthnContextType;
+import org.keycloak.saml.SAML2NameIDBuilder;
 import org.keycloak.saml.processing.api.saml.v2.request.SAML2Request;
 import org.keycloak.saml.processing.core.saml.v2.common.IDGenerator;
 import org.keycloak.saml.processing.core.saml.v2.util.XMLTimeUtil;
@@ -37,7 +38,7 @@ public class SAML2AuthnRequestBuilder implements SamlProtocolExtensionsAwareBuil
 
     private final AuthnRequestType authnRequestType;
     protected String destination;
-    protected String issuer;
+    protected NameIDType issuer;
     protected final List<NodeGenerator> extensions = new LinkedList<>();
 
     public SAML2AuthnRequestBuilder destination(String destination) {
@@ -45,9 +46,13 @@ public class SAML2AuthnRequestBuilder implements SamlProtocolExtensionsAwareBuil
         return this;
     }
 
-    public SAML2AuthnRequestBuilder issuer(String issuer) {
+    public SAML2AuthnRequestBuilder issuer(NameIDType issuer) {
         this.issuer = issuer;
         return this;
+    }
+
+    public SAML2AuthnRequestBuilder issuer(String issuer) {
+        return issuer(SAML2NameIDBuilder.value(issuer).build());
     }
 
     @Override
@@ -132,11 +137,8 @@ public class SAML2AuthnRequestBuilder implements SamlProtocolExtensionsAwareBuil
 
     public AuthnRequestType createAuthnRequest() {
         AuthnRequestType res = this.authnRequestType;
-        NameIDType nameIDType = new NameIDType();
-        nameIDType.setValue(this.issuer);
 
-        res.setIssuer(nameIDType);
-
+        res.setIssuer(issuer);
         res.setDestination(URI.create(this.destination));
 
         if (! this.extensions.isEmpty()) {

--- a/saml-core/src/main/java/org/keycloak/saml/SAML2ErrorResponseBuilder.java
+++ b/saml-core/src/main/java/org/keycloak/saml/SAML2ErrorResponseBuilder.java
@@ -40,7 +40,7 @@ public class SAML2ErrorResponseBuilder implements SamlProtocolExtensionsAwareBui
 
     protected String status;
     protected String destination;
-    protected String issuer;
+    protected NameIDType issuer;
     protected final List<NodeGenerator> extensions = new LinkedList<>();
 
     public SAML2ErrorResponseBuilder status(String status) {
@@ -53,9 +53,13 @@ public class SAML2ErrorResponseBuilder implements SamlProtocolExtensionsAwareBui
         return this;
     }
 
-    public SAML2ErrorResponseBuilder issuer(String issuer) {
+    public SAML2ErrorResponseBuilder issuer(NameIDType issuer) {
         this.issuer = issuer;
         return this;
+    }
+
+    public SAML2ErrorResponseBuilder issuer(String issuer) {
+        return issuer(SAML2NameIDBuilder.value(issuer).build());
     }
 
     @Override
@@ -70,9 +74,6 @@ public class SAML2ErrorResponseBuilder implements SamlProtocolExtensionsAwareBui
             StatusResponseType statusResponse = new ResponseType(IDGenerator.create("ID_"), XMLTimeUtil.getIssueInstant());
 
             statusResponse.setStatus(JBossSAMLAuthnResponseFactory.createStatusTypeForResponder(status));
-            NameIDType issuer = new NameIDType();
-            issuer.setValue(this.issuer);
-
             statusResponse.setIssuer(issuer);
             statusResponse.setDestination(destination);
 

--- a/saml-core/src/main/java/org/keycloak/saml/SAML2LoginResponseBuilder.java
+++ b/saml-core/src/main/java/org/keycloak/saml/SAML2LoginResponseBuilder.java
@@ -21,6 +21,7 @@ import org.keycloak.dom.saml.v2.assertion.AssertionType;
 import org.keycloak.dom.saml.v2.assertion.AudienceRestrictionType;
 import org.keycloak.dom.saml.v2.assertion.AuthnStatementType;
 import org.keycloak.dom.saml.v2.assertion.ConditionsType;
+import org.keycloak.dom.saml.v2.assertion.NameIDType;
 import org.keycloak.dom.saml.v2.assertion.OneTimeUseType;
 import org.keycloak.dom.saml.v2.assertion.SubjectConfirmationDataType;
 import org.keycloak.dom.saml.v2.protocol.ExtensionsType;
@@ -31,6 +32,7 @@ import org.keycloak.saml.common.constants.JBossSAMLURIConstants;
 import org.keycloak.saml.common.exceptions.ConfigurationException;
 import org.keycloak.saml.common.exceptions.ProcessingException;
 import org.keycloak.saml.common.util.DocumentUtil;
+import org.keycloak.saml.SAML2NameIDBuilder;
 import org.keycloak.saml.processing.api.saml.v2.response.SAML2Response;
 import org.keycloak.saml.processing.core.saml.v2.common.IDGenerator;
 import org.keycloak.saml.processing.core.saml.v2.holders.IDPInfoHolder;
@@ -57,7 +59,7 @@ public class SAML2LoginResponseBuilder implements SamlProtocolExtensionsAwareBui
     protected static final PicketLinkLogger logger = PicketLinkLoggerFactory.getLogger();
 
     protected String destination;
-    protected String issuer;
+    protected NameIDType issuer;
     protected int subjectExpiration;
     protected int assertionExpiration;
     protected int sessionExpiration;
@@ -82,9 +84,13 @@ public class SAML2LoginResponseBuilder implements SamlProtocolExtensionsAwareBui
         return this;
     }
 
-    public SAML2LoginResponseBuilder issuer(String issuer) {
+    public SAML2LoginResponseBuilder issuer(NameIDType issuer) {
         this.issuer = issuer;
         return this;
+    }
+
+    public SAML2LoginResponseBuilder issuer(String issuer) {
+        return issuer(SAML2NameIDBuilder.value(issuer).build());
     }
 
     /**

--- a/saml-core/src/main/java/org/keycloak/saml/SAML2LogoutRequestBuilder.java
+++ b/saml-core/src/main/java/org/keycloak/saml/SAML2LogoutRequestBuilder.java
@@ -18,7 +18,9 @@
 package org.keycloak.saml;
 
 import org.keycloak.dom.saml.v2.assertion.NameIDType;
+import org.keycloak.dom.saml.v2.protocol.ExtensionsType;
 import org.keycloak.dom.saml.v2.protocol.LogoutRequestType;
+import org.keycloak.saml.SAML2NameIDBuilder;
 import org.keycloak.saml.common.exceptions.ConfigurationException;
 import org.keycloak.saml.common.exceptions.ParsingException;
 import org.keycloak.saml.common.exceptions.ProcessingException;
@@ -29,7 +31,6 @@ import org.w3c.dom.Document;
 import java.net.URI;
 import java.util.LinkedList;
 import java.util.List;
-import org.keycloak.dom.saml.v2.protocol.ExtensionsType;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -40,7 +41,7 @@ public class SAML2LogoutRequestBuilder implements SamlProtocolExtensionsAwareBui
     protected String sessionIndex;
     protected long assertionExpiration;
     protected String destination;
-    protected String issuer;
+    protected NameIDType issuer;
     protected final List<NodeGenerator> extensions = new LinkedList<>();
 
     public SAML2LogoutRequestBuilder destination(String destination) {
@@ -48,9 +49,13 @@ public class SAML2LogoutRequestBuilder implements SamlProtocolExtensionsAwareBui
         return this;
     }
 
-    public SAML2LogoutRequestBuilder issuer(String issuer) {
+    public SAML2LogoutRequestBuilder issuer(NameIDType issuer) {
         this.issuer = issuer;
         return this;
+    }
+
+    public SAML2LogoutRequestBuilder issuer(String issuer) {
+        return issuer(SAML2NameIDBuilder.value(issuer).build());
     }
 
     @Override
@@ -108,12 +113,8 @@ public class SAML2LogoutRequestBuilder implements SamlProtocolExtensionsAwareBui
         LogoutRequestType lort = SAML2Request.createLogoutRequest(issuer);
 
         lort.setNameID(nameId);
+        lort.setIssuer(issuer);
 
-        if (issuer != null) {
-            NameIDType issuerID = new NameIDType();
-            issuerID.setValue(issuer);
-            lort.setIssuer(issuerID);
-        }
         if (sessionIndex != null) lort.addSessionIndex(sessionIndex);
 
 

--- a/saml-core/src/main/java/org/keycloak/saml/SAML2LogoutResponseBuilder.java
+++ b/saml-core/src/main/java/org/keycloak/saml/SAML2LogoutResponseBuilder.java
@@ -21,6 +21,7 @@ import org.keycloak.dom.saml.v2.assertion.NameIDType;
 import org.keycloak.dom.saml.v2.protocol.StatusCodeType;
 import org.keycloak.dom.saml.v2.protocol.StatusResponseType;
 import org.keycloak.dom.saml.v2.protocol.StatusType;
+import org.keycloak.saml.SAML2NameIDBuilder;
 import org.keycloak.saml.common.constants.JBossSAMLURIConstants;
 import org.keycloak.saml.common.exceptions.ConfigurationException;
 import org.keycloak.saml.common.exceptions.ParsingException;
@@ -42,7 +43,7 @@ public class SAML2LogoutResponseBuilder implements SamlProtocolExtensionsAwareBu
 
     protected String logoutRequestID;
     protected String destination;
-    protected String issuer;
+    protected NameIDType issuer;
     protected final List<NodeGenerator> extensions = new LinkedList<>();
 
     public SAML2LogoutResponseBuilder logoutRequestID(String logoutRequestID) {
@@ -55,9 +56,13 @@ public class SAML2LogoutResponseBuilder implements SamlProtocolExtensionsAwareBu
         return this;
     }
 
-    public SAML2LogoutResponseBuilder issuer(String issuer) {
+    public SAML2LogoutResponseBuilder issuer(NameIDType issuer) {
         this.issuer = issuer;
         return this;
+    }
+
+    public SAML2LogoutResponseBuilder issuer(String issuer) {
+        return issuer(SAML2NameIDBuilder.value(issuer).build());
     }
 
     @Override
@@ -77,9 +82,6 @@ public class SAML2LogoutResponseBuilder implements SamlProtocolExtensionsAwareBu
 
         statusResponse.setStatus(statusType);
         statusResponse.setInResponseTo(logoutRequestID);
-        NameIDType issuer = new NameIDType();
-        issuer.setValue(this.issuer);
-
         statusResponse.setIssuer(issuer);
         statusResponse.setDestination(destination);
 

--- a/saml-core/src/main/java/org/keycloak/saml/SAML2NameIDBuilder.java
+++ b/saml-core/src/main/java/org/keycloak/saml/SAML2NameIDBuilder.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.saml;
+
+import org.keycloak.dom.saml.v2.assertion.NameIDType;
+
+import java.net.URI;
+
+public class SAML2NameIDBuilder {
+    private final NameIDType nameIdType;
+    private String format;
+    private String spNameQualifier;
+
+    private SAML2NameIDBuilder(String value) {
+        this.nameIdType = new NameIDType();
+        this.nameIdType.setValue(value);
+    }
+
+    public static SAML2NameIDBuilder value(String value) {
+        return new SAML2NameIDBuilder(value);
+    }
+
+    public SAML2NameIDBuilder setFormat(String format) {
+        this.format = format;
+        return this;
+    }
+
+    public SAML2NameIDBuilder setSPNameQualifier(String spNameQualifier) {
+        this.spNameQualifier = spNameQualifier;
+        return this;
+    }
+
+    public NameIDType build() {
+        if (this.format != null)
+            this.nameIdType.setFormat(URI.create(this.format));
+
+        if (this.spNameQualifier != null)
+            this.nameIdType.setSPNameQualifier(this.spNameQualifier);
+
+        return this.nameIdType;
+    }
+}

--- a/saml-core/src/main/java/org/keycloak/saml/processing/api/saml/v2/request/SAML2Request.java
+++ b/saml-core/src/main/java/org/keycloak/saml/processing/api/saml/v2/request/SAML2Request.java
@@ -257,14 +257,10 @@ public class SAML2Request {
      *
      * @throws ConfigurationException
      */
-    public static LogoutRequestType createLogoutRequest(String issuer) throws ConfigurationException {
+    public static LogoutRequestType createLogoutRequest(NameIDType issuer) throws ConfigurationException {
         LogoutRequestType lrt = new LogoutRequestType(IDGenerator.create("ID_"), XMLTimeUtil.getIssueInstant());
 
-        // Create an issuer
-        NameIDType issuerNameID = new NameIDType();
-        issuerNameID.setValue(issuer);
-
-        lrt.setIssuer(issuerNameID);
+        lrt.setIssuer(issuer);
 
         return lrt;
     }


### PR DESCRIPTION
Some SAML IdPs require the indication of the format attribute in the `Issuer` element of `AuthnRequests`. This is not supported by Keycloak UI, but can be implemented by customizing the source code or defining custom providers. However in many places Keycloak currently uses a simple `String` to represent the `Issuer` element instead of the proper `NameIDType` class.

This PR changes the `Issuer` attribute type in the request/response builders to the `NameIDType` class and introduces the helper class `SAML2NameIDBuilder` for easier translation from a `String` to `NameIDType`. It also keeps the existing setters as overloads that invoke the builder class as they are mostly used in tests.

The code paths are already under tests, so no additional tests are needed.