### PR TITLE
KEYCLOAK-14193 Client Policy - Condition : Client - Client Access Type

### DIFF
--- a/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientAccessTypeCondition.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientAccessTypeCondition.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.services.clientpolicy.condition;
+
+import org.jboss.logging.Logger;
+import org.keycloak.component.ComponentModel;
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.services.clientpolicy.ClientPolicyContext;
+import org.keycloak.services.clientpolicy.ClientPolicyException;
+import org.keycloak.services.clientpolicy.ClientPolicyLogger;
+import org.keycloak.services.clientpolicy.ClientPolicyVote;
+
+public class ClientAccessTypeCondition implements ClientPolicyConditionProvider {
+
+    private static final Logger logger = Logger.getLogger(ClientAccessTypeCondition.class);
+
+    private final KeycloakSession session;
+    private final ComponentModel componentModel;
+
+    public ClientAccessTypeCondition(KeycloakSession session, ComponentModel componentModel) {
+        this.session = session;
+        this.componentModel = componentModel;
+    }
+
+    @Override
+    public String getName() {
+        return componentModel.getName();
+    }
+
+    @Override
+    public String getProviderId() {
+        return componentModel.getProviderId();
+    }
+
+    @Override
+    public ClientPolicyVote applyPolicy(ClientPolicyContext context) throws ClientPolicyException {
+        switch (context.getEvent()) {
+            case AUTHORIZATION_REQUEST:
+            case TOKEN_REQUEST:
+            case TOKEN_REFRESH:
+            case TOKEN_REVOKE:
+            case TOKEN_INTROSPECT:
+            case USERINFO_REQUEST:
+            case LOGOUT_REQUEST:
+                if (isClientAccessTypeMatched()) return ClientPolicyVote.YES;
+                return ClientPolicyVote.NO;
+            default:
+                return ClientPolicyVote.ABSTAIN;
+        }
+    }
+
+    private String getClientAccessType() {
+        ClientModel client = session.getContext().getClient();
+        if (client == null) return null;
+
+        if (client.isPublicClient()) return ClientAccessTypeConditionFactory.TYPE_PUBLIC;
+        if (client.isBearerOnly()) return ClientAccessTypeConditionFactory.TYPE_BEARERONLY;
+        else return ClientAccessTypeConditionFactory.TYPE_CONFIDENTIAL;
+    }
+
+    private boolean isClientAccessTypeMatched() {
+        final String accessType = getClientAccessType();
+        if (logger.isTraceEnabled() ) {
+            ClientPolicyLogger.log(logger, "client access type = " + accessType);
+            componentModel.getConfig().get(ClientAccessTypeConditionFactory.TYPE).stream().forEach(i -> ClientPolicyLogger.log(logger, "client access type expected = " + i));
+        }
+        boolean isMatched = componentModel.getConfig().get(ClientAccessTypeConditionFactory.TYPE).stream().anyMatch(i -> i.equals(accessType));
+        if (isMatched) {
+            ClientPolicyLogger.log(logger, "client access type matched.");
+        } else {
+            ClientPolicyLogger.log(logger, "client access type unmatched.");
+        }
+        return isMatched;
+    }
+
+}

--- a/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientAccessTypeConditionFactory.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientAccessTypeConditionFactory.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.services.clientpolicy.condition;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.keycloak.Config.Scope;
+import org.keycloak.component.ComponentModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.provider.ProviderConfigProperty;
+
+public class ClientAccessTypeConditionFactory implements ClientPolicyConditionProviderFactory {
+
+    public static final String PROVIDER_ID = "client-accesstype-condition";
+    public static final String TYPE = "type";
+    public static final String TYPE_CONFIDENTIAL = "confidential";
+    public static final String TYPE_PUBLIC = "public";
+    public static final String TYPE_BEARERONLY = "bearer-only";
+
+    private static final List<ProviderConfigProperty> configProperties = new ArrayList<ProviderConfigProperty>();
+
+    static {
+        ProviderConfigProperty property;
+        property = new ProviderConfigProperty(TYPE, "client-accesstype.label", "client-accesstype.tooltip", ProviderConfigProperty.MULTIVALUED_LIST_TYPE, TYPE_CONFIDENTIAL);
+        List<String> updateProfileValues = Arrays.asList(TYPE_CONFIDENTIAL, TYPE_PUBLIC, TYPE_BEARERONLY);
+        property.setOptions(updateProfileValues);
+        configProperties.add(property);
+    }
+
+    @Override
+    public ClientPolicyConditionProvider create(KeycloakSession session, ComponentModel model) {
+        return new ClientAccessTypeCondition(session, model);
+    }
+
+    @Override
+    public void init(Scope config) {
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public String getHelpText() {
+        return "It uses the client's access type (confidential, public, bearer-only) to determine whether the policy is applied.";
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return configProperties;
+    }
+
+}

--- a/services/src/main/resources/META-INF/services/org.keycloak.services.clientpolicy.condition.ClientPolicyConditionProviderFactory
+++ b/services/src/main/resources/META-INF/services/org.keycloak.services.clientpolicy.condition.ClientPolicyConditionProviderFactory
@@ -2,3 +2,4 @@ org.keycloak.services.clientpolicy.condition.ClientUpdateContextConditionFactory
 org.keycloak.services.clientpolicy.condition.ClientRolesConditionFactory
 org.keycloak.services.clientpolicy.condition.ClientIpAddressConditionFactory
 org.keycloak.services.clientpolicy.condition.ClientScopesConditionFactory
+org.keycloak.services.clientpolicy.condition.ClientAccessTypeConditionFactory


### PR DESCRIPTION
This PR is for [KEYCLOAK-14193 Client Policy - Condition : Client - Client Access Type](https://issues.redhat.com/browse/KEYCLOAK-14193) in [KEYCLOAK-13933 Client Policies](https://issues.redhat.com/browse/KEYCLOAK-13933), also is the part of the project [Client Policy Official Support](https://github.com/keycloak/kc-sig-fapi/projects) of [FAPI-SIG](https://github.com/keycloak/kc-sig-fapi) activity.

Generally speaking, the aim of this PR is to support policy conditions defined in [Client Policy design document](https://github.com/keycloak/keycloak-community/blob/master/design/client-policies.md#condition--which-client)
