### PR TITLE
KEYCLOAK-16325 Forgot the NameQualifier property in SAML2NameIDBuilder

### DIFF
--- a/saml-core/src/main/java/org/keycloak/saml/SAML2NameIDBuilder.java
+++ b/saml-core/src/main/java/org/keycloak/saml/SAML2NameIDBuilder.java
@@ -23,6 +23,7 @@ import java.net.URI;
 public class SAML2NameIDBuilder {
     private final NameIDType nameIdType;
     private String format;
+    private String nameQualifier;
     private String spNameQualifier;
 
     private SAML2NameIDBuilder(String value) {
@@ -39,6 +40,11 @@ public class SAML2NameIDBuilder {
         return this;
     }
 
+    public SAML2NameIDBuilder setNameQualifier(String nameQualifier) {
+        this.nameQualifier = nameQualifier;
+        return this;
+    }
+
     public SAML2NameIDBuilder setSPNameQualifier(String spNameQualifier) {
         this.spNameQualifier = spNameQualifier;
         return this;
@@ -47,6 +53,9 @@ public class SAML2NameIDBuilder {
     public NameIDType build() {
         if (this.format != null)
             this.nameIdType.setFormat(URI.create(this.format));
+
+        if (this.nameQualifier != null)
+            this.nameIdType.setNameQualifier(this.nameQualifier);
 
         if (this.spNameQualifier != null)
             this.nameIdType.setSPNameQualifier(this.spNameQualifier);


### PR DESCRIPTION
Sorry, I just noticed that in recently merged PR #7614 I forgot to add the NameQualifier property to the SAML2NameIDBuilder class.
I apologize for the inconvenience.