### PR TITLE
KEYCLOAK-16392 Client Policy - Condition : NPE without any initial configuration

### DIFF
--- a/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientAccessTypeCondition.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientAccessTypeCondition.java
@@ -17,6 +17,9 @@
 
 package org.keycloak.services.clientpolicy.condition;
 
+import java.util.Collections;
+import java.util.List;
+
 import org.jboss.logging.Logger;
 import org.keycloak.component.ComponentModel;
 import org.keycloak.models.ClientModel;
@@ -76,11 +79,16 @@ public class ClientAccessTypeCondition implements ClientPolicyConditionProvider 
 
     private boolean isClientAccessTypeMatched() {
         final String accessType = getClientAccessType();
-        if (logger.isTraceEnabled() ) {
+
+        List<String> expectedAccessTypes = componentModel.getConfig().get(ClientAccessTypeConditionFactory.TYPE);
+        if (expectedAccessTypes == null) expectedAccessTypes = Collections.emptyList();
+
+        if (logger.isTraceEnabled()) {
             ClientPolicyLogger.log(logger, "client access type = " + accessType);
-            componentModel.getConfig().get(ClientAccessTypeConditionFactory.TYPE).stream().forEach(i -> ClientPolicyLogger.log(logger, "client access type expected = " + i));
+            expectedAccessTypes.stream().forEach(i -> ClientPolicyLogger.log(logger, "client access type expected = " + i));
         }
-        boolean isMatched = componentModel.getConfig().get(ClientAccessTypeConditionFactory.TYPE).stream().anyMatch(i -> i.equals(accessType));
+
+        boolean isMatched = expectedAccessTypes.stream().anyMatch(i -> i.equals(accessType));
         if (isMatched) {
             ClientPolicyLogger.log(logger, "client access type matched.");
         } else {

--- a/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientIpAddressCondition.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientIpAddressCondition.java
@@ -17,6 +17,9 @@
 
 package org.keycloak.services.clientpolicy.condition;
 
+import java.util.Collections;
+import java.util.List;
+
 import org.jboss.logging.Logger;
 
 import org.keycloak.component.ComponentModel;
@@ -67,12 +70,15 @@ public class ClientIpAddressCondition implements ClientPolicyConditionProvider {
     private boolean isIpAddressMatched() {
         String ipAddr = session.getContext().getConnection().getRemoteAddr();
 
+        List<String> expectedIpAddresses = componentModel.getConfig().get(ClientIpAddressConditionFactory.IPADDR);
+        if (expectedIpAddresses == null) expectedIpAddresses = Collections.emptyList();
+
         if (logger.isTraceEnabled()) {
-            componentModel.getConfig().get(ClientIpAddressConditionFactory.IPADDR).stream().forEach(i -> ClientPolicyLogger.log(logger, "ip address expected = " + i));
-            ClientPolicyLogger.log(logger, "ip address expected = " + ipAddr);
+            ClientPolicyLogger.log(logger, "ip address = " + ipAddr);
+            expectedIpAddresses.stream().forEach(i -> ClientPolicyLogger.log(logger, "ip address expected = " + i));
         }
 
-        boolean isMatched = componentModel.getConfig().get(ClientIpAddressConditionFactory.IPADDR).stream().anyMatch(i -> i.equals(ipAddr));
+        boolean isMatched = expectedIpAddresses.stream().anyMatch(i -> i.equals(ipAddr));
         if (isMatched) {
            ClientPolicyLogger.log(logger, "ip address matched.");
         }  else {

--- a/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientScopesCondition.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientScopesCondition.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.services.clientpolicy.condition;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
@@ -84,10 +85,12 @@ public class ClientScopesCondition implements ClientPolicyConditionProvider {
     }
 
     private boolean isScopeMatched(String explicitScopes, ClientModel client) {
+        if (explicitScopes == null) explicitScopes = "";
         Collection<String> explicitSpecifiedScopes = new HashSet<>(Arrays.asList(explicitScopes.split(" ")));
         Set<String> defaultScopes = client.getClientScopes(true, true).keySet();
         Set<String> optionalScopes = client.getClientScopes(false, true).keySet();
         List<String> expectedScopes = componentModel.getConfig().get(ClientScopesConditionFactory.SCOPES);
+        if (expectedScopes == null) expectedScopes = new ArrayList<>();
 
         if (logger.isTraceEnabled()) {
             explicitSpecifiedScopes.stream().forEach(i -> ClientPolicyLogger.log(logger, " explicit specified client scope = " + i));

--- a/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientUpdateContextCondition.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientUpdateContextCondition.java
@@ -17,6 +17,9 @@
 
 package org.keycloak.services.clientpolicy.condition;
 
+import java.util.Collections;
+import java.util.List;
+
 import org.jboss.logging.Logger;
 import org.keycloak.component.ComponentModel;
 import org.keycloak.models.KeycloakSession;
@@ -57,10 +60,15 @@ public class ClientUpdateContextCondition implements ClientPolicyConditionProvid
     private boolean isAuthMethodMatched(String authMethod) {
         if (authMethod == null) return false;
 
-        ClientPolicyLogger.log(logger, "auth method = " + authMethod);
-        componentModel.getConfig().get(ClientUpdateContextConditionFactory.UPDATE_CLIENT_SOURCE).stream().forEach(i -> ClientPolicyLogger.log(logger, "auth method expected = " + i));
+        List<String> expectedAuthMethods = componentModel.getConfig().get(ClientUpdateContextConditionFactory.UPDATE_CLIENT_SOURCE);
+        if (expectedAuthMethods == null) expectedAuthMethods = Collections.emptyList();
 
-        boolean isMatched = componentModel.getConfig().get(ClientUpdateContextConditionFactory.UPDATE_CLIENT_SOURCE).stream().anyMatch(i -> i.equals(authMethod));
+        if (logger.isTraceEnabled()) {
+            ClientPolicyLogger.log(logger, "auth method = " + authMethod);
+            expectedAuthMethods.stream().forEach(i -> ClientPolicyLogger.log(logger, "auth method expected = " + i));
+        }
+
+        boolean isMatched = expectedAuthMethods.stream().anyMatch(i -> i.equals(authMethod));
         if (isMatched) {
             ClientPolicyLogger.log(logger, "auth method matched.");
         } else {

--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureRequestObjectExecutor.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureRequestObjectExecutor.java
@@ -17,42 +17,26 @@
 
 package org.keycloak.services.clientpolicy.executor;
 
-import java.io.IOException;
-import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import javax.ws.rs.core.MultivaluedMap;
 
 import org.jboss.logging.Logger;
-import org.keycloak.OAuth2Constants;
 import org.keycloak.OAuthErrorException;
-import org.keycloak.common.util.StreamUtil;
 import org.keycloak.common.util.Time;
 import org.keycloak.component.ComponentModel;
-import org.keycloak.connections.httpclient.HttpClientProvider;
-import org.keycloak.constants.AdapterConstants;
-import org.keycloak.jose.jws.JWSInput;
-import org.keycloak.jose.jws.JWSInputException;
-import org.keycloak.models.Constants;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.protocol.oidc.endpoints.request.AuthorizationEndpointRequest;
 import org.keycloak.protocol.oidc.endpoints.request.AuthzEndpointRequestParser;
 import org.keycloak.protocol.oidc.utils.OIDCResponseType;
-import org.keycloak.representations.JsonWebToken;
 import org.keycloak.services.Urls;
 import org.keycloak.services.clientpolicy.AuthorizationRequestContext;
 import org.keycloak.services.clientpolicy.ClientPolicyContext;
 import org.keycloak.services.clientpolicy.ClientPolicyException;
 import org.keycloak.services.clientpolicy.ClientPolicyLogger;
-import org.keycloak.util.JsonSerialization;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 
 public class SecureRequestObjectExecutor implements ClientPolicyExecutorProvider {

--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureSigningAlgorithmEnforceExecutor.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureSigningAlgorithmEnforceExecutor.java
@@ -17,12 +17,9 @@
 
 package org.keycloak.services.clientpolicy.executor;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Set;
 
-import org.apache.commons.compress.utils.Sets;
 import org.jboss.logging.Logger;
 
 import org.keycloak.OAuthErrorException;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientPolicyBasicsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientPolicyBasicsTest.java
@@ -1021,6 +1021,63 @@ public class ClientPolicyBasicsTest extends AbstractKeycloakTest {
         }
     }
 
+    @Test
+    public void testConditionWithoutNoConfiguration() throws ClientRegistrationException, ClientPolicyException {
+        String policyName = "MyPolicy-ClientAccessTypeCondition";
+        createPolicy(policyName, DefaultClientPolicyProviderFactory.PROVIDER_ID, null, null, null);
+        logger.info("... Created Policy : " + policyName);
+        createCondition("ClientAccessTypeCondition", ClientAccessTypeConditionFactory.PROVIDER_ID, null, (ComponentRepresentation provider) -> {
+        });
+        registerCondition("ClientAccessTypeCondition", policyName);
+        logger.info("... Registered Condition : ClientAccessTypeCondition");
+
+        policyName = "MyPolicy-ClientIpAddressCondition";
+        createPolicy(policyName, DefaultClientPolicyProviderFactory.PROVIDER_ID, null, null, null);
+        logger.info("... Created Policy : " + policyName);
+        createCondition("ClientIpAddressCondition", ClientIpAddressConditionFactory.PROVIDER_ID, null, (ComponentRepresentation provider) -> {
+        });
+        registerCondition("ClientIpAddressCondition", policyName);
+        logger.info("... Registered Condition : ClientIpAddressCondition");
+
+        policyName = "MyPolicy-ClientScopesCondition";
+        createPolicy(policyName, DefaultClientPolicyProviderFactory.PROVIDER_ID, null, null, null);
+        logger.info("... Created Policy : " + policyName);
+        createCondition("ClientScopesCondition", ClientScopesConditionFactory.PROVIDER_ID, null, (ComponentRepresentation provider) -> {
+        });
+        registerCondition("ClientScopesCondition", policyName);
+        logger.info("... Registered Condition : ClientScopesCondition");
+
+        policyName = "MyPolicy-ClientUpdateContextCondition";
+        createPolicy(policyName, DefaultClientPolicyProviderFactory.PROVIDER_ID, null, null, null);
+        logger.info("... Created Policy : " + policyName);
+        createCondition("ClientUpdateContextCondition", ClientUpdateContextConditionFactory.PROVIDER_ID, null, (ComponentRepresentation provider) -> {
+        });
+        registerCondition("ClientUpdateContextCondition", policyName);
+        logger.info("... Registered Condition : ClientUpdateContextCondition");
+
+        policyName = "MyPolicy-SecureSessionEnforceExecutor";
+        createPolicy(policyName, DefaultClientPolicyProviderFactory.PROVIDER_ID, null, null, null);
+        logger.info("... Created Policy : " + policyName);
+        createExecutor("SecureSessionEnforceExecutor", SecureSessionEnforceExecutorFactory.PROVIDER_ID, null, (ComponentRepresentation provider) -> {
+        });
+        registerExecutor("SecureSessionEnforceExecutor", policyName);
+        logger.info("... Registered Executor : SecureSessionEnforceExecutor");
+
+        String clientAlphaId = "Alpha-App";
+        String clientAlphaSecret = "secretAlpha";
+        String cAlphaId = createClientByAdmin(clientAlphaId, (ClientRepresentation clientRep) -> {
+            clientRep.setSecret(clientAlphaSecret);
+            clientRep.setBearerOnly(Boolean.FALSE);
+            clientRep.setPublicClient(Boolean.FALSE);
+        });
+
+        try {
+            successfulLoginAndLogout(clientAlphaId, clientAlphaSecret);
+        } finally {
+            deleteClientByAdmin(cAlphaId);
+        }
+    }
+
     private AuthorizationEndpointRequestObject createValidRequestObjectForSecureRequestObjectExecutor(String clientId) throws URISyntaxException {
         AuthorizationEndpointRequestObject requestObject = new AuthorizationEndpointRequestObject();
         requestObject.id(KeycloakModelUtils.generateId());


### PR DESCRIPTION
This PR is for [KEYCLOAK-13933 Client Policies](https://issues.redhat.com/browse/KEYCLOAK-13933), also is the part of the project [Client Policy Official Support](https://github.com/keycloak/kc-sig-fapi/projects) of [FAPI-SIG](https://github.com/keycloak/kc-sig-fapi) activity.

Potentially NPE may happen on existing conditions when no initial configuration is set to these conditions. 
