### PR TITLE
KEYCLOAK-16426 add attributes to keycloak.d.ts

### DIFF
--- a/adapters/oidc/js/src/main/resources/keycloak.d.ts
+++ b/adapters/oidc/js/src/main/resources/keycloak.d.ts
@@ -292,23 +292,19 @@ declare namespace Keycloak {
 	}
 
 	interface KeycloakTokenParsed {
-		acr?: string;
+		iss?: string;
+		sub?: string;
 		aud?: string;
-		auth_time?: number;
-		azp?: string;
-		email_varified?: boolean;
 		exp?: number;
 		iat?: number;
-		iss?: string;
-		jti?: string;
+		auth_time?: number;
 		nonce?: string;
-		preferred_username?: string;
+		acr?: string;
+		amr?: string;
+		azp?: string;
+		session_state?: string;
 		realm_access?: KeycloakRoles;
 		resource_access?: KeycloakResourceAccess;
-		scope?: string;
-		session_state?: string;
-		sub?: string;
-		typ?: string;
 	}
 
 	interface KeycloakResourceAccess {

--- a/adapters/oidc/js/src/main/resources/keycloak.d.ts
+++ b/adapters/oidc/js/src/main/resources/keycloak.d.ts
@@ -305,6 +305,7 @@ declare namespace Keycloak {
 		session_state?: string;
 		realm_access?: KeycloakRoles;
 		resource_access?: KeycloakResourceAccess;
+		[key: string]: any; // Add other attributes here.
 	}
 
 	interface KeycloakResourceAccess {

--- a/adapters/oidc/js/src/main/resources/keycloak.d.ts
+++ b/adapters/oidc/js/src/main/resources/keycloak.d.ts
@@ -292,13 +292,23 @@ declare namespace Keycloak {
 	}
 
 	interface KeycloakTokenParsed {
+		acr?: string;
+		aud?: string;
+		auth_time?: number;
+		azp?: string;
+		email_varified?: boolean;
 		exp?: number;
 		iat?: number;
+		iss?: string;
+		jti?: string;
 		nonce?: string;
-		sub?: string;
-		session_state?: string;
+		preferred_username?: string;
 		realm_access?: KeycloakRoles;
 		resource_access?: KeycloakResourceAccess;
+		scope?: string;
+		session_state?: string;
+		sub?: string;
+		typ?: string;
 	}
 
 	interface KeycloakResourceAccess {


### PR DESCRIPTION
<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
recreated PR from https://github.com/keycloak/keycloak/pull/7502
I am using keycloak adaptor in TypeScript App.
I noticed some attributes of the "KeycloakTokenParsed" is missing in the keycloak.d.ts.

![image](https://user-images.githubusercontent.com/49754654/99808291-fbca9580-2b83-11eb-9a5b-885f29a8c392.png)
