### PR TITLE
KEYCLOAK-16428 Move certificate timestamp validation configuration to CertificateValidatorBuilder

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/x509/AbstractX509ClientCertificateAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/x509/AbstractX509ClientCertificateAuthenticator.java
@@ -109,7 +109,9 @@ public abstract class AbstractX509ClientCertificateAuthenticator implements Auth
                         .cRLrelativePath(config.getCRLRelativePath())
                         .oCSPEnabled(config.getOCSPEnabled())
                         .oCSPResponseCertificate(config.getOCSPResponderCertificate())
-                        .oCSPResponderURI(config.getOCSPResponder());
+                        .oCSPResponderURI(config.getOCSPResponder())
+                    .timestampValidation()
+                        .enabled(config.isCertValidationEnabled());
         }
     }
 

--- a/services/src/main/java/org/keycloak/authentication/authenticators/x509/X509ClientCertificateAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/x509/X509ClientCertificateAuthenticator.java
@@ -85,7 +85,7 @@ public class X509ClientCertificateAuthenticator extends AbstractX509ClientCertif
                 validator.checkRevocationStatus()
                          .validateKeyUsage()
                          .validateExtendedKeyUsage()
-                         .validateTimestamps(config.isCertValidationEnabled());
+                         .validateTimestamps();
             } catch(Exception e) {
                 logger.error(e.getMessage(), e);
                 // TODO use specific locale to load error messages

--- a/services/src/test/java/org/keycloak/authentication/authenticators/x509/CertificateValidatorTest.java
+++ b/services/src/test/java/org/keycloak/authentication/authenticators/x509/CertificateValidatorTest.java
@@ -47,9 +47,12 @@ public class CertificateValidatorTest {
 
         CertificateValidator.CertificateValidatorBuilder builder =
             new CertificateValidator.CertificateValidatorBuilder();
-        CertificateValidator validator = builder.build(new X509Certificate[] { certificate });
+        CertificateValidator validator = builder
+          .timestampValidation()
+            .enabled(true)
+          .build(new X509Certificate[] { certificate });
         try {
-            validator.validateTimestamps(true);
+            validator.validateTimestamps();
         } catch (Exception ex) {
             ex.printStackTrace();
             Assert.fail(ex.getMessage());
@@ -70,9 +73,12 @@ public class CertificateValidatorTest {
 
         CertificateValidator.CertificateValidatorBuilder builder =
             new CertificateValidator.CertificateValidatorBuilder();
-        CertificateValidator validator = builder.build(new X509Certificate[] { certificate });
+        CertificateValidator validator = builder
+          .timestampValidation()
+            .enabled(true)
+          .build(new X509Certificate[] { certificate });
         try {
-            validator.validateTimestamps(true);
+            validator.validateTimestamps();
             Assert.fail("certificate validation must fail for certificate is not valid yet");
         } catch (Exception ex) {
             MatcherAssert.assertThat(ex.getMessage(), Matchers.containsString("not valid yet"));
@@ -94,9 +100,12 @@ public class CertificateValidatorTest {
 
         CertificateValidator.CertificateValidatorBuilder builder =
             new CertificateValidator.CertificateValidatorBuilder();
-        CertificateValidator validator = builder.build(new X509Certificate[] { certificate });
+        CertificateValidator validator = builder
+          .timestampValidation()
+            .enabled(true)
+          .build(new X509Certificate[] { certificate });
         try {
-            validator.validateTimestamps(true);
+            validator.validateTimestamps();
             Assert.fail("certificate validation must fail for certificate has expired");
         } catch (Exception ex) {
             MatcherAssert.assertThat(ex.getMessage(), Matchers.containsString("has expired"));


### PR DESCRIPTION
While looking at the code for the X509 Authenticator I noticed that the code for certificate timestamp validation is somewhat different from the other checks that are present: it is not activated via the CertificateValidatorBuilder class, rather by explicitly passing a parameter on the appropriate method. All other checks are configured via the CertificateValidatorBuilder class.

This pull request introduces a fluent configuration method for timestamp validation, making it more in line with the rest of the checks. There is no change in behavior or functionality.