### PR TITLE
KEYCLOAK-16429 X509 config - Pass default boolean values as strings, as expected by the UI

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/x509/AbstractX509ClientCertificateAuthenticatorFactory.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/x509/AbstractX509ClientCertificateAuthenticatorFactory.java
@@ -103,14 +103,14 @@ public abstract class AbstractX509ClientCertificateAuthenticatorFactory implemen
         canonicalDn.setType(BOOLEAN_TYPE);
         canonicalDn.setName(CANONICAL_DN);
         canonicalDn.setLabel("Canonical DN representation enabled");
-        canonicalDn.setDefaultValue(false);
+        canonicalDn.setDefaultValue(Boolean.toString(false));
         canonicalDn.setHelpText("Use the canonical format to determine the distinguished name. This option is relevant for authenticators using a distinguished name.");
 
         ProviderConfigProperty serialnumberHex = new ProviderConfigProperty();
         serialnumberHex.setType(BOOLEAN_TYPE);
         serialnumberHex.setName(SERIALNUMBER_HEX);
         serialnumberHex.setLabel("Enable Serial Number hexadecimal representation");
-        serialnumberHex.setDefaultValue(false);
+        serialnumberHex.setDefaultValue(Boolean.toString(false));
         serialnumberHex.setHelpText("Use the hex representation of the serial number. This option is relevant for authenticators using serial number.");
 
         
@@ -144,7 +144,7 @@ public abstract class AbstractX509ClientCertificateAuthenticatorFactory implemen
         timestampValidationValue.setType(BOOLEAN_TYPE);
         timestampValidationValue.setName(TIMESTAMP_VALIDATION);
         timestampValidationValue.setLabel("Check certificate validity");
-        timestampValidationValue.setDefaultValue(true);
+        timestampValidationValue.setDefaultValue(Boolean.toString(true));
         timestampValidationValue.setHelpText("Will verify that the certificate has not expired yet and is already valid by checking the attributes 'notBefore' and 'notAfter'.");
 
         ProviderConfigProperty crlCheckingEnabled = new ProviderConfigProperty();
@@ -156,7 +156,7 @@ public abstract class AbstractX509ClientCertificateAuthenticatorFactory implemen
         ProviderConfigProperty crlDPEnabled = new ProviderConfigProperty();
         crlDPEnabled.setType(BOOLEAN_TYPE);
         crlDPEnabled.setName(ENABLE_CRLDP);
-        crlDPEnabled.setDefaultValue(false);
+        crlDPEnabled.setDefaultValue(Boolean.toString(false));
         crlDPEnabled.setLabel("Enable CRL Distribution Point to check certificate revocation status");
         crlDPEnabled.setHelpText("CRL Distribution Point is a starting point for CRL. If this is ON, then CRL checking will be done based on the CRL distribution points included" +
                 " in the checked certificates. CDP is optional, but most PKI authorities include CDP in their certificates.");


### PR DESCRIPTION
When adding a new "X509/Validate Username Form" Execution, all boolean values in the Config screen default to "Off" (false), however in the source one of them is actually meant to be set to "On" (true). 

This happens because the fields are defined as `onoffswitchstring` in kc-provider-config.html:

https://github.com/keycloak/keycloak/blob/bd4315ef373ad629ebab73c16b8222fe61f6a7f2/themes/src/main/resources/theme/base/admin/resources/templates/kc-provider-config.html#L12

so the UI expects string values in the json model, but the initialization code in AbstractX509ClientCertificateAuthenticatorFactory.java sends boolean values, not strings:

https://github.com/keycloak/keycloak/blob/b90a0307ea04c7179699511aea2862eeb50a42f7/services/src/main/java/org/keycloak/authentication/authenticators/x509/AbstractX509ClientCertificateAuthenticatorFactory.java#L147

This pull request simply converts all boolean default values to strings in the setDefaultValue calls.
