### PR TITLE
KEYCLOAK-16456 X509 Auth: add option for OCSP fail-open behavior

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/x509/AbstractX509ClientCertificateAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/x509/AbstractX509ClientCertificateAuthenticator.java
@@ -59,6 +59,7 @@ public abstract class AbstractX509ClientCertificateAuthenticator implements Auth
     public static final String REGULAR_EXPRESSION = "x509-cert-auth.regular-expression";
     public static final String ENABLE_CRL = "x509-cert-auth.crl-checking-enabled";
     public static final String ENABLE_OCSP = "x509-cert-auth.ocsp-checking-enabled";
+    public static final String OCSP_FAIL_OPEN = "x509-cert-auth.ocsp-fail-open";
     public static final String ENABLE_CRLDP = "x509-cert-auth.crldp-checking-enabled";
     public static final String CANONICAL_DN = "x509-cert-auth.canonical-dn-enabled";
     public static final String TIMESTAMP_VALIDATION = "x509-cert-auth.timestamp-validation-enabled";
@@ -116,6 +117,7 @@ public abstract class AbstractX509ClientCertificateAuthenticator implements Auth
                         .cRLDPEnabled(config.getCRLDistributionPointEnabled())
                         .cRLrelativePath(config.getCRLRelativePath())
                         .oCSPEnabled(config.getOCSPEnabled())
+                        .oCSPFailOpen(config.getOCSPFailOpen())
                         .oCSPResponseCertificate(config.getOCSPResponderCertificate())
                         .oCSPResponderURI(config.getOCSPResponder())
                     .trustValidation()

--- a/services/src/main/java/org/keycloak/authentication/authenticators/x509/AbstractX509ClientCertificateAuthenticatorFactory.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/x509/AbstractX509ClientCertificateAuthenticatorFactory.java
@@ -182,6 +182,13 @@ public abstract class AbstractX509ClientCertificateAuthenticatorFactory implemen
         oCspCheckingEnabled.setHelpText("Enable Certificate Revocation Checking using OCSP");
         oCspCheckingEnabled.setLabel("OCSP Checking Enabled");
 
+        ProviderConfigProperty ocspFailOpen = new ProviderConfigProperty();
+        ocspFailOpen.setType(BOOLEAN_TYPE);
+        ocspFailOpen.setName(OCSP_FAIL_OPEN);
+        ocspFailOpen.setDefaultValue(Boolean.toString(false));
+        ocspFailOpen.setHelpText("Whether to allow or deny authentication for client certificates that have missing/invalid/inconclusive OCSP endpoints. By default a successful OCSP response is required.");
+        ocspFailOpen.setLabel("OCSP Fail-Open Behavior");
+
         ProviderConfigProperty ocspResponderUri = new ProviderConfigProperty();
         ocspResponderUri.setType(STRING_TYPE);
         ocspResponderUri.setName(OCSPRESPONDER_URI);
@@ -245,6 +252,7 @@ public abstract class AbstractX509ClientCertificateAuthenticatorFactory implemen
                 crlDPEnabled,
                 cRLRelativePath,
                 oCspCheckingEnabled,
+                ocspFailOpen,
                 ocspResponderUri,
                 ocspResponderCert,
                 keyUsage,

--- a/services/src/main/java/org/keycloak/authentication/authenticators/x509/X509AuthenticatorConfigModel.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/x509/X509AuthenticatorConfigModel.java
@@ -130,6 +130,15 @@ public class X509AuthenticatorConfigModel extends AuthenticatorConfigModel {
         return this;
     }
 
+    public boolean getOCSPFailOpen() {
+        return Boolean.parseBoolean(getConfig().getOrDefault(OCSP_FAIL_OPEN, Boolean.toString(false)));
+    }
+
+    public X509AuthenticatorConfigModel setOCSPFailOpen(boolean value) {
+        getConfig().put(OCSP_FAIL_OPEN, Boolean.toString(value));
+        return this;
+    }
+
     public boolean getCRLDistributionPointEnabled() {
         return Boolean.parseBoolean(getConfig().get(ENABLE_CRLDP));
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/x509/X509OCSPResponderFailOpenTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/x509/X509OCSPResponderFailOpenTest.java
@@ -1,0 +1,111 @@
+package org.keycloak.testsuite.x509;
+
+import com.google.common.base.Charsets;
+
+import io.undertow.Undertow;
+import io.undertow.server.handlers.BlockingHandler;
+
+import java.nio.file.Paths;
+import java.util.function.Supplier;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.jboss.arquillian.drone.api.annotation.Drone;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.keycloak.testsuite.util.PhantomJSBrowser;
+import org.keycloak.authentication.authenticators.x509.X509AuthenticatorConfigModel;
+import org.keycloak.representations.idm.AuthenticatorConfigRepresentation;
+import org.keycloak.testsuite.util.OAuthClient;
+import org.openqa.selenium.WebDriver;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.keycloak.authentication.authenticators.x509.X509AuthenticatorConfigModel.IdentityMapperType.USERNAME_EMAIL;
+import static org.keycloak.authentication.authenticators.x509.X509AuthenticatorConfigModel.MappingSourceType.SUBJECTDN_EMAIL;
+
+public class X509OCSPResponderFailOpenTest extends AbstractX509AuthenticationTest {
+
+    private static final String OCSP_RESPONDER_HOST = "localhost";
+
+    private static final int OCSP_RESPONDER_PORT = 8888;
+
+    private Undertow ocspResponder;
+
+    @Drone
+    @PhantomJSBrowser
+    private WebDriver phantomJS;
+
+    @Before
+    public void replaceTheDefaultDriver() {
+        replaceDefaultWebDriver(phantomJS);
+    }
+
+    @Test
+    public void ocspFailCloseLoginFailed() throws Exception {
+        // Test of OCSP failure (invalid OCSP responder host) when OCSP Fail-Open is set to OFF
+        // If test is successful, it should return an auth error
+
+        X509AuthenticatorConfigModel config = new X509AuthenticatorConfigModel()
+                .setOCSPEnabled(true)
+                .setOCSPResponder("http://" + OCSP_RESPONDER_HOST + ".invalid.host:" + OCSP_RESPONDER_PORT + "/oscp")
+                .setOCSPFailOpen(false)
+                .setMappingSourceType(SUBJECTDN_EMAIL)
+                .setUserIdentityMapperType(USERNAME_EMAIL);
+        AuthenticatorConfigRepresentation cfg = newConfig("x509-directgrant-config", config.getConfig());
+        String cfgId = createConfig(directGrantExecution.getId(), cfg);
+        Assert.assertNotNull(cfgId);
+
+        oauth.clientId("resource-owner");
+        OAuthClient.AccessTokenResponse response = oauth.doGrantAccessTokenRequest("secret", "", "", null);
+
+        assertEquals(Response.Status.UNAUTHORIZED.getStatusCode(), response.getStatusCode());
+        assertEquals("invalid_request", response.getError());
+
+        // Make sure we got the right error
+        Assert.assertThat(response.getErrorDescription(), containsString("OCSP check failed"));
+    }
+
+    @Test
+    public void ocspFailOpenLoginSuccess() throws Exception {
+        // Test of OCSP failure (invalid OCSP responder host) when OCSP Fail-Open is set to ON
+        // If test is successful, it should continue the login
+
+        X509AuthenticatorConfigModel config =
+                new X509AuthenticatorConfigModel()
+                        .setOCSPEnabled(true)
+                        .setOCSPFailOpen(true)
+                        .setMappingSourceType(SUBJECTDN_EMAIL)
+                        .setOCSPResponder("http://" + OCSP_RESPONDER_HOST + ".invalid.host:" + OCSP_RESPONDER_PORT + "/oscp")
+                        .setOCSPResponderCertificate(
+                                IOUtils.toString(this.getClass().getResourceAsStream(OcspHandler.OCSP_RESPONDER_CERT_PATH), Charsets.UTF_8)
+                                        .replace("-----BEGIN CERTIFICATE-----", "")
+                                        .replace("-----END CERTIFICATE-----", ""))
+                        .setUserIdentityMapperType(USERNAME_EMAIL);
+        AuthenticatorConfigRepresentation cfg = newConfig("x509-directgrant-config", config.getConfig());
+        String cfgId = createConfig(directGrantExecution.getId(), cfg);
+        Assert.assertNotNull(cfgId);
+
+        String keyStorePath = Paths.get(System.getProperty("client.certificate.keystore"))
+                .getParent().resolve("client-ca.jks").toString();
+        String keyStorePassword = System.getProperty("client.certificate.keystore.passphrase");
+        String trustStorePath = System.getProperty("client.truststore");
+        String trustStorePassword = System.getProperty("client.truststore.passphrase");
+        Supplier<CloseableHttpClient> previous = oauth.getHttpClient();
+        try {
+            oauth.clientId("resource-owner");
+            oauth.httpClient(() -> OAuthClient.newCloseableHttpClientSSL(keyStorePath, keyStorePassword, trustStorePath, trustStorePassword));
+            OAuthClient.AccessTokenResponse response = oauth.doGrantAccessTokenRequest("secret", "", "", null);
+
+            // Make sure authentication is allowed
+            assertEquals(Response.Status.OK.getStatusCode(), response.getStatusCode());
+        } finally {
+            oauth.httpClient(previous);
+        }
+    }
+
+}


### PR DESCRIPTION
In our scenario, the OCSP server used for X509 revocation information is notoriously unreliable (connectivity issues, overloads, timeouts, etc). This PR adds an option to enable a Fail-Open behavior for OCSP requests, i.e. if the OCSP server is missing, invalid or does not return a valid response, it lets the authentication continue as if the response was positive. This new option is off by default.

![immagine](https://user-images.githubusercontent.com/16761934/100215681-9a068480-2f11-11eb-817a-7c98a1726d3d.png)