### PR TITLE
KEYCLOAK-16464 Allow to map enabled and emailVerified user model attribute to LDAP attributes

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/UserAttributeLDAPStorageMapper.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/UserAttributeLDAPStorageMapper.java
@@ -250,6 +250,12 @@ public class UserAttributeLDAPStorageMapper extends AbstractLDAPStorageMapper {
                     super.setFirstName(firstName);
                 }
 
+                @Override
+                public void setEmailVerified(boolean verified) {
+                    setLDAPAttribute(UserModel.EMAIL_VERIFIED, Boolean.toString(verified));
+                    super.setEmailVerified(verified);
+                }
+
                 protected boolean setLDAPAttribute(String modelAttrName, Object value) {
                     if (modelAttrName.equalsIgnoreCase(userModelAttrName)) {
                         if (UserAttributeLDAPStorageMapper.logger.isTraceEnabled()) {
@@ -377,6 +383,15 @@ public class UserAttributeLDAPStorageMapper extends AbstractLDAPStorageMapper {
                         return ldapUser.getAttributeAsString(ldapAttrName);
                     } else {
                         return super.getEmail();
+                    }
+                }
+
+                @Override
+                public boolean isEmailVerified() {
+                    if (UserModel.EMAIL_VERIFIED.equalsIgnoreCase(userModelAttrName)) {
+                        return Boolean.parseBoolean(ldapUser.getAttributeAsString(ldapAttrName));
+                    } else {
+                        return super.isEmailVerified();
                     }
                 }
 

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/UserAttributeLDAPStorageMapper.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/UserAttributeLDAPStorageMapper.java
@@ -239,6 +239,12 @@ public class UserAttributeLDAPStorageMapper extends AbstractLDAPStorageMapper {
                 }
 
                 @Override
+                public void setEnabled(boolean enabled) {
+                    setLDAPAttribute(UserModel.ENABLED, Boolean.toString(enabled));
+                    super.setEnabled(enabled);
+                }
+
+                @Override
                 public void setLastName(String lastName) {
                     setLDAPAttribute(UserModel.LAST_NAME, lastName);
                     super.setLastName(lastName);
@@ -383,6 +389,15 @@ public class UserAttributeLDAPStorageMapper extends AbstractLDAPStorageMapper {
                         return ldapUser.getAttributeAsString(ldapAttrName);
                     } else {
                         return super.getEmail();
+                    }
+                }
+
+                @Override
+                public boolean isEnabled() {
+                    if (UserModel.ENABLED.equalsIgnoreCase(userModelAttrName)) {
+                        return Boolean.parseBoolean(ldapUser.getAttributeAsString(ldapAttrName));
+                    } else {
+                        return super.isEnabled();
                     }
                 }
 

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/util/LDAPTestUtils.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/util/LDAPTestUtils.java
@@ -50,6 +50,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 /**
@@ -66,6 +67,18 @@ public class LDAPTestUtils {
 
         session.userCredentialManager().updateCredential(realm, user, creds);
         return user;
+    }
+
+    public static void addLdapUser(KeycloakSession session, RealmModel appRealm, LDAPStorageProvider ldapFedProvider, String username, String password, Consumer<UserModel> userCustomizer) {
+
+        UserModel user = ldapFedProvider.addUser(appRealm, username);
+
+        userCustomizer.accept(user);
+
+        if (password == null) {
+            return;
+        }
+        session.userCredentialManager().updateCredential(appRealm, user, (UserCredentialModel) UserCredentialModel.password(username));
     }
 
     public static LDAPObject addLDAPUser(LDAPStorageProvider ldapProvider, RealmModel realm, final String username,

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPUserPropertiesMappingTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPUserPropertiesMappingTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite.federation.ldap;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.keycloak.component.ComponentModel;
+import org.keycloak.models.KeycloakContext;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.storage.UserStorageProvider;
+import org.keycloak.storage.UserStorageProviderModel;
+import org.keycloak.storage.ldap.LDAPStorageProvider;
+import org.keycloak.storage.ldap.idm.model.LDAPObject;
+import org.keycloak.testsuite.Assert;
+import org.keycloak.testsuite.util.LDAPRule;
+import org.keycloak.testsuite.util.LDAPTestConfiguration;
+import org.keycloak.testsuite.util.LDAPTestUtils;
+
+public class LDAPUserPropertiesMappingTest extends AbstractLDAPTest {
+
+    public static final String USER_EMAIL_VERIFIED_LDAP_ATTRIBUTE = "l";
+    public static final String USER_ENABLED_LDAP_ATTRIBUTE = "o";
+
+    public static final String DIETMAR = "dietmar"; // enabled=true, emailVerified=true
+    public static final String STEFAN = "stefan"; // enabled=false, emailVerified=false
+
+    @ClassRule
+    public static LDAPRule ldapRule = new LDAPRule()
+            .assumeTrue(LDAPTestConfiguration::isStartEmbeddedLdapServer);
+
+    @Override
+    protected LDAPRule getLDAPRule() {
+        return ldapRule;
+    }
+
+    @Override
+    protected void afterImportTestRealm() {
+        testingClient.server().run(session -> {
+
+            LDAPTestContext ctx = LDAPTestContext.init(session);
+            RealmModel appRealm = ctx.getRealm();
+
+            ComponentModel ldapModel = appRealm.getComponentsStream(appRealm.getId(), UserStorageProvider.class.getName()).findFirst().get();
+            ldapModel.getConfig().putSingle(UserStorageProviderModel.IMPORT_ENABLED, "false");
+            appRealm.updateComponent(ldapModel);
+
+            ComponentModel emailVerifiedMapperModel = LDAPTestUtils.addUserAttributeMapper(appRealm, ldapModel, "customEmailVerifiedMapper", "emailVerified", USER_EMAIL_VERIFIED_LDAP_ATTRIBUTE);
+            appRealm.updateComponent(emailVerifiedMapperModel);
+
+            ComponentModel enabledMapperModel = LDAPTestUtils.addUserAttributeMapper(appRealm, ldapModel, "customEnabledMapper", "enabled", USER_ENABLED_LDAP_ATTRIBUTE);
+            appRealm.updateComponent(enabledMapperModel);
+
+            appRealm.getClientByClientId("test-app").setDirectAccessGrantsEnabled(true);
+
+            LDAPStorageProvider ldapFedProvider = LDAPTestUtils.getLdapProvider(session, ldapModel);
+
+            LDAPTestUtils.addLdapUser(session, appRealm, ldapFedProvider, DIETMAR, null, user -> {
+                user.setEnabled(true);
+                user.setEmailVerified(true);
+            });
+
+            LDAPTestUtils.addLdapUser(session, appRealm, ldapFedProvider, STEFAN, null, user -> {
+                user.setEnabled(false);
+                user.setEmailVerified(false);
+            });
+        });
+    }
+
+    @Test
+    public void createAndReadUser() {
+        testingClient.server(TEST_REALM_NAME).run(session -> {
+            KeycloakContext context = session.getContext();
+            RealmModel realm = context.getRealm();
+
+            UserModel test10 = session.users().getUserByUsername(DIETMAR, realm);
+            Assert.assertTrue(test10.isEnabled());
+            Assert.assertTrue(test10.isEmailVerified());
+
+            UserModel test11 = session.users().getUserByUsername(STEFAN, realm);
+            Assert.assertFalse(test11.isEnabled());
+            Assert.assertFalse(test11.isEmailVerified());
+
+            ComponentModel ldapProviderModel = LDAPTestUtils.getLdapProviderModel(realm);
+            LDAPStorageProvider ldapProvider = LDAPTestUtils.getLdapProvider(session, ldapProviderModel);
+
+            LDAPObject user10FromLdap = ldapProvider.loadLDAPUserByUsername(realm, DIETMAR);
+            Assert.assertTrue(Boolean.parseBoolean(user10FromLdap.getAttributeAsString(USER_EMAIL_VERIFIED_LDAP_ATTRIBUTE)));
+            Assert.assertTrue(Boolean.parseBoolean(user10FromLdap.getAttributeAsString(USER_ENABLED_LDAP_ATTRIBUTE)));
+
+            LDAPObject user11FromLdap = ldapProvider.loadLDAPUserByUsername(realm, STEFAN);
+            Assert.assertFalse(Boolean.parseBoolean(user11FromLdap.getAttributeAsString(USER_EMAIL_VERIFIED_LDAP_ATTRIBUTE)));
+            Assert.assertFalse(Boolean.parseBoolean(user11FromLdap.getAttributeAsString(USER_ENABLED_LDAP_ATTRIBUTE)));
+        });
+    }
+}
+


### PR DESCRIPTION
What would be the suitable place to add a test for this?

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
