### PR TITLE
KEYCLOAK-16519 X509 Auth: typo in regex prevents requiring multiple extended key usages

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/x509/CertificateValidator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/x509/CertificateValidator.java
@@ -737,7 +737,7 @@ public class CertificateValidator {
                 if (extendedKeyUsage == null || extendedKeyUsage.trim().length() == 0)
                     return _parent;
 
-                String[] strs = extendedKeyUsage.split("[,;:]]");
+                String[] strs = extendedKeyUsage.split("[,;:]");
                 for (String str : strs) {
                     _extendedKeyUsage.add(str.trim());
                 }


### PR DESCRIPTION
There is a typo on https://github.com/keycloak/keycloak/blob/a51e0cc484f023e4e9e0b504ac237f1dda624152/services/src/main/java/org/keycloak/authentication/authenticators/x509/CertificateValidator.java#L740 

The line is supposed to split the Extended Key Usage parameter of X509 Certificate Auth Configuration in order to verify multiple key usage requirements, but as it stands the regex is invalid and never splits at separators.

The fix is to get rid of the extra "]" at the end of the regex.