### PR TITLE
KEYCLOAK-16552: Build mail subject using templates

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/email/EmailTemplateProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/email/EmailTemplateProvider.java
@@ -32,7 +32,7 @@ import java.util.Map;
 public interface EmailTemplateProvider extends Provider {
 
     String IDENTITY_PROVIDER_BROKER_CONTEXT = "identityProviderBrokerCtx";
-    
+
     EmailTemplateProvider setAuthenticationSession(AuthenticationSessionModel authenticationSession);
 
     EmailTemplateProvider setRealm(RealmModel realm);

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/resources/META-INF/keycloak-themes.json
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/resources/META-INF/keycloak-themes.json
@@ -2,5 +2,9 @@
   "themes": [{
     "name" : "address",
     "types": [ "admin", "account", "login" ]
+  },
+  {
+    "name" : "test",
+    "types": [ "email" ]
   }]
 }

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/resources/theme/test/email/html/executeActions.ftl
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/resources/theme/test/email/html/executeActions.ftl
@@ -1,0 +1,9 @@
+<#outputformat "plainText">
+<#assign requiredActionsText><#if requiredActions??><#list requiredActions><#items as reqActionItem>${msg("requiredAction.${reqActionItem}")}<#sep>, </#sep></#items></#list></#if></#assign>
+</#outputformat>
+
+<html>
+<body>
+${kcSanitize(msg("executeActionsBodyHtml",link, linkExpiration, realmName, requiredActionsText, linkExpirationFormatter(linkExpiration)))?no_esc}
+</body>
+</html>

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/resources/theme/test/email/html/password-reset.ftl
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/resources/theme/test/email/html/password-reset.ftl
@@ -1,0 +1,5 @@
+<html>
+<body>
+${kcSanitize(msg("passwordResetBodyHtml",link, linkExpiration, realmName, linkExpirationFormatter(linkExpiration)))?no_esc}
+</body>
+</html>

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/resources/theme/test/email/messages/messages_en.properties
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/resources/theme/test/email/messages/messages_en.properties
@@ -1,0 +1,7 @@
+passwordResetSubject={0}, please reset your password
+passwordResetBody=Someone just requested to change your {2} account''s credentials. If this was you, click on the link below to reset them.\n\n{0}\n\nThis link and code will expire within {3}.\n\nIf you don''t want to reset your credentials, just ignore this message and nothing will be changed.
+passwordResetBodyHtml=<p>Someone just requested to change your {2} account''s credentials. If this was you, click on the link below to reset them.</p><p><a href="{0}">Link to reset credentials</a></p><p>This link will expire within {3}.</p><p>If you don''t want to reset your credentials, just ignore this message and nothing will be changed.</p>
+executeActionsSubject=Update Your Account (NO_TEMPLATE)
+executeActionsTemplateSubject=Update Your Account (TEMPLATE)
+executeActionsBody=Your administrator has just requested that you update your {2} account by performing the following action(s): {3}. Click on the link below to start this process.\n\n{0}\n\nThis link will expire within {4}.\n\nIf you are unaware that your administrator has requested this, just ignore this message and nothing will be changed.
+executeActionsBodyHtml=<p>Your administrator has just requested that you update your {2} account by performing the following action(s): {3}. Click on the link below to start this process.</p><p><a href="{0}">Link to account update</a></p><p>This link will expire within {4}.</p><p>If you are unaware that your administrator has requested this, just ignore this message and nothing will be changed.</p>

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/resources/theme/test/email/text/executeActions-subject.ftl
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/resources/theme/test/email/text/executeActions-subject.ftl
@@ -1,0 +1,3 @@
+<#-- Template contains a typo to trigger fallback to legacy subject construction -->
+<#ftl output_format="plainText">
+${msg("executeActionsTemplateSubject")

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/resources/theme/test/email/text/executeActions.ftl
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/resources/theme/test/email/text/executeActions.ftl
@@ -1,0 +1,4 @@
+<#ftl output_format="plainText">
+<#assign requiredActionsText><#if requiredActions??><#list requiredActions><#items as reqActionItem>${msg("requiredAction.${reqActionItem}")}<#sep>, </#items></#list><#else></#if></#assign>
+
+${msg("executeActionsBody",link, linkExpiration, realmName, requiredActionsText, linkExpirationFormatter(linkExpiration))}

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/resources/theme/test/email/text/password-reset-subject.ftl
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/resources/theme/test/email/text/password-reset-subject.ftl
@@ -1,0 +1,2 @@
+<#ftl output_format="plainText">
+${msg("passwordResetSubject", user.username)} [TEMPLATE]

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/resources/theme/test/email/text/password-reset.ftl
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/resources/theme/test/email/text/password-reset.ftl
@@ -1,0 +1,2 @@
+<#ftl output_format="plainText">
+${msg("passwordResetBody",link, linkExpiration, realmName, linkExpirationFormatter(linkExpiration))}

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/theme/AbstractEmailSubjectTemplateTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/theme/AbstractEmailSubjectTemplateTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2016 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.keycloak.testsuite.theme;
+
+import org.junit.After;
+import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.testsuite.AbstractTestRealmKeycloakTest;
+import org.keycloak.testsuite.util.RealmBuilder;
+import org.keycloak.testsuite.util.UserBuilder;
+
+import java.util.List;
+
+/**
+ * @author Stan Silvert ssilvert@redhat.com (C) 2016 Red Hat Inc.
+ */
+public abstract class AbstractEmailSubjectTemplateTest extends AbstractTestRealmKeycloakTest {
+
+    public String testUserUsername = "mail-subject-test";
+    public String testUserEmail = "mail-subject-test@test.com";
+    public String testUserPassword = "password";
+
+    public String adminUsername = "admin";
+    public String adminEmail = "admin@localhost";
+
+    @Override
+    public void configureTestRealm(RealmRepresentation testRealm) {
+        UserBuilder user = UserBuilder.create()
+                .username(testUserUsername)
+                .enabled(true)
+                .email(testUserEmail)
+                .role("account", "manage-account")
+                .password(testUserPassword);
+        RealmBuilder.edit(testRealm).user(user);
+
+        RealmResource realm = adminClient.realm("master");
+        List<UserRepresentation> adminUser = realm.users().search(adminUsername, 0, 1);
+        UserRepresentation adminRep = UserBuilder.edit(adminUser.get(0)).email(adminEmail).build();
+        realm.users().get(adminRep.getId()).update(adminRep);
+    }
+
+    /**
+     * Remove cookies at the end so that the next test will start out
+     * using the default locale.
+     */
+    @After
+    public void deleteCookies() {
+        driver.manage().deleteAllCookies();
+    }
+}

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/theme/EmailSubjectTemplateTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/theme/EmailSubjectTemplateTest.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.testsuite.theme;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeMessage;
+import javax.ws.rs.core.Response;
+import java.io.IOException;
+import java.util.*;
+
+import org.jboss.arquillian.graphene.page.Page;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.admin.client.resource.UserResource;
+import org.keycloak.models.UserModel;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.testsuite.ProfileAssume;
+import org.keycloak.testsuite.admin.ApiUtil;
+import org.keycloak.testsuite.arquillian.annotation.AuthServerContainerExclude;
+import org.keycloak.testsuite.arquillian.annotation.AuthServerContainerExclude.AuthServer;
+import org.keycloak.testsuite.pages.InfoPage;
+import org.keycloak.testsuite.pages.LoginPage;
+import org.keycloak.testsuite.pages.LoginPasswordResetPage;
+import org.keycloak.testsuite.pages.LoginPasswordUpdatePage;
+import org.keycloak.testsuite.util.*;
+import org.keycloak.theme.Theme;
+
+/**
+ * @author <a href="mailto:gerbermichi@me.com">Michael Gerber</a>
+ * @author Stan Silvert ssilvert@redhat.com (C) 2016 Red Hat Inc.
+ */
+@AuthServerContainerExclude(AuthServer.REMOTE)
+public class EmailSubjectTemplateTest extends AbstractEmailSubjectTemplateTest {
+
+    @Rule
+    public GreenMailRule greenMail = new GreenMailRule();
+
+    @Page
+    protected LoginPage loginPage;
+
+    @Page
+    protected LoginPasswordResetPage resetPasswordPage;
+
+    @Page
+    private InfoPage infoPage;
+
+    @Page
+    private LoginPasswordUpdatePage loginPasswordUpdatePage;
+
+    private String testTheme = "test";
+
+    private void changeUserLocale(String locale) {
+        UserRepresentation user = findUser(testUserUsername);
+        user.singleAttribute(UserModel.LOCALE, locale);
+        ApiUtil.findUserByUsernameId(testRealm(), testUserUsername).update(user);
+    }
+
+    private Map<String, String> getSMTPConfig() {
+        Map<String, String> smtpConfig = new HashMap<>();
+        smtpConfig.put("host", "127.0.0.1");
+        smtpConfig.put("port", "3025");
+        smtpConfig.put("from", "auto@keycloak.org");
+        smtpConfig.put("auth", null);
+        smtpConfig.put("ssl", null);
+        smtpConfig.put("starttls", null);
+        smtpConfig.put("user", null);
+        smtpConfig.put("password", null);
+        smtpConfig.put("replyTo", null);
+        smtpConfig.put("envelopeFrom", null);
+        return smtpConfig;
+    }
+
+    private void setTheme(String realmName, String themeName, Theme.Type themeType)
+    {
+        RealmResource realm = adminClient.realm(realmName);
+        RealmRepresentation realmRep = realm.toRepresentation();
+        switch (themeType) {
+            case EMAIL:
+                realmRep.setEmailTheme(themeName);
+                realm.update(realmRep);
+                RealmResource verifyRealm = adminClient.realm(realmName);
+                Assert.assertEquals(themeName, verifyRealm.toRepresentation().getEmailTheme());
+                break;
+            default:
+                Assert.fail("Only EMAIL type is supported");
+        }
+    }
+
+    private void afterEmailSubjectTemplateTest()
+    {
+        setTheme(TEST_REALM_NAME, "base", Theme.Type.EMAIL);
+    }
+
+    private void assertThemeTemplate(String themeName, Theme.Type themeType, String templatePath, Boolean presence) {
+
+        testingClient.server().run(session -> {
+            try {
+                Theme theme = session.theme().getTheme(themeName, themeType);
+                if (presence)
+                    Assert.assertNotNull(theme.getTemplate(templatePath));
+                else
+                    Assert.assertNull(theme.getTemplate(templatePath));
+            } catch (IOException e) {
+                Assert.fail(e.getMessage());
+            }
+        });
+    }
+
+    // Send a mail for which a subject template doesn't exist (should send properly)
+    @Test
+    public void checkTestEmailSubject() throws MessagingException, InterruptedException {
+        ProfileAssume.assumeCommunity();
+
+        setTheme("master", "base", Theme.Type.EMAIL);
+
+        // Subject construction should be handled by base theme message.properties file, not a template
+        assertThemeTemplate("base", Theme.Type.EMAIL, "text/email-test-subject.ftl", false);
+        assertThemeTemplate("base", Theme.Type.EMAIL, "text/email-test.ftl", true);
+        assertThemeTemplate(testTheme, Theme.Type.EMAIL, "text/email-test-subject.ftl", false);
+        assertThemeTemplate(testTheme, Theme.Type.EMAIL, "text/email-test.ftl", false);
+
+        RealmResource realm = adminClient.realm("master");
+        Response response = realm.testSMTPConnection(getSMTPConfig());
+        Assert.assertEquals(
+                String.format("Send mail request status expected [%s] but [%s] was received", 204, response.getStatus()),
+                204,
+                response.getStatus());
+
+        if (!greenMail.waitForIncomingEmail(1)) {
+            Assert.fail("Test email not received");
+        }
+
+        MimeMessage message = greenMail.getLastReceivedMessage();
+        Assert.assertEquals(adminEmail, message.getAllRecipients()[0].toString());
+
+        Assert.assertEquals("[KEYCLOAK] - SMTP test message", message.getSubject());
+
+        afterEmailSubjectTemplateTest();
+    }
+
+
+    // Send a mail for which a subect template exists but contains a syntax error
+    // Should send with fallback (backwards compatibility) and log the error
+    @Test
+    public void checkUpdatePasswordEmailSubject() throws MessagingException, InterruptedException {
+
+        setTheme(TEST_REALM_NAME, testTheme, Theme.Type.EMAIL);
+
+        UserResource searchUser = ApiUtil.findUserByUsernameId(testRealm(), testUserUsername);
+        searchUser.executeActionsEmail(Arrays.asList(UserModel.RequiredAction.UPDATE_PASSWORD.toString()));
+
+        if (!greenMail.waitForIncomingEmail(1)) {
+            Assert.fail("Error when receiving email");
+        }
+        MimeMessage message = greenMail.getLastReceivedMessage();
+        Assert.assertEquals(testUserEmail,message.getAllRecipients()[0].toString());
+
+        String updatePwdSubject = message.getSubject();
+        Assert.assertNotEquals("Update Your Account (TEMPLATE)", updatePwdSubject);
+        Assert.assertEquals("Update Your Account (NO_TEMPLATE)", updatePwdSubject);
+
+        afterEmailSubjectTemplateTest();
+    }
+
+    // Send a mail for which a valid subject template exists
+    @Test
+    public void checkResetPasswordEmailSubject() throws MessagingException, InterruptedException {
+
+        setTheme(TEST_REALM_NAME, testTheme, Theme.Type.EMAIL);
+
+        changeUserLocale("en");
+
+        loginPage.open();
+        loginPage.resetPassword();
+        resetPasswordPage.changePassword(testUserUsername);
+
+        if (!greenMail.waitForIncomingEmail(1)) {
+            Assert.fail("Error when receiving email");
+        }
+        MimeMessage message = greenMail.getLastReceivedMessage();
+        Assert.assertEquals(testUserEmail,message.getAllRecipients()[0].toString());
+
+        String expectedSubject = String.format("%s, please reset your password [TEMPLATE]", testUserUsername);
+        Assert.assertEquals(expectedSubject, message.getSubject());
+
+        afterEmailSubjectTemplateTest();
+    }
+
+}

--- a/themes/src/main/resources/theme/base/email/text/email-verification-subject.ftl
+++ b/themes/src/main/resources/theme/base/email/text/email-verification-subject.ftl
@@ -1,0 +1,2 @@
+<#ftl output_format="plainText">
+${msg("emailVerificationSubject")}

--- a/themes/src/main/resources/theme/base/email/text/email-verification-with-code-subject.ftl
+++ b/themes/src/main/resources/theme/base/email/text/email-verification-with-code-subject.ftl
@@ -1,0 +1,2 @@
+<#ftl output_format="plainText">
+${msg("emailVerificationSubject")}

--- a/themes/src/main/resources/theme/base/email/text/event-login_error-subject.ftl
+++ b/themes/src/main/resources/theme/base/email/text/event-login_error-subject.ftl
@@ -1,0 +1,2 @@
+<#ftl output_format="plainText">
+${msg("eventLoginErrorSubject")}

--- a/themes/src/main/resources/theme/base/email/text/event-remove_totp-subject.ftl
+++ b/themes/src/main/resources/theme/base/email/text/event-remove_totp-subject.ftl
@@ -1,0 +1,2 @@
+<#ftl output_format="plainText">
+${msg("eventRemoveTotpSubject")}

--- a/themes/src/main/resources/theme/base/email/text/event-update_password-subject.ftl
+++ b/themes/src/main/resources/theme/base/email/text/event-update_password-subject.ftl
@@ -1,0 +1,2 @@
+<#ftl output_format="plainText">
+${msg("eventUpdatePasswordSubject")}

--- a/themes/src/main/resources/theme/base/email/text/event-update_totp-subject.ftl
+++ b/themes/src/main/resources/theme/base/email/text/event-update_totp-subject.ftl
@@ -1,0 +1,2 @@
+<#ftl output_format="plainText">
+${msg("eventUpdateTotpSubject")}

--- a/themes/src/main/resources/theme/base/email/text/executeActions-subject.ftl
+++ b/themes/src/main/resources/theme/base/email/text/executeActions-subject.ftl
@@ -1,0 +1,2 @@
+<#ftl output_format="plainText">
+${msg("executeActionsSubject"))}

--- a/themes/src/main/resources/theme/base/email/text/identity-provider-link-subject.ftl
+++ b/themes/src/main/resources/theme/base/email/text/identity-provider-link-subject.ftl
@@ -1,0 +1,2 @@
+<#ftl output_format="plainText">
+${msg("identityProviderLinkSubject", identityProviderAlias)}

--- a/themes/src/main/resources/theme/base/email/text/password-reset-subject.ftl
+++ b/themes/src/main/resources/theme/base/email/text/password-reset-subject.ftl
@@ -1,0 +1,2 @@
+<#ftl output_format="plainText">
+${msg("passwordResetSubject")}


### PR DESCRIPTION
Emails sent by Keycloak (eg. password update emails, account linking emails,...) cannot have their subject built through templates just like the mail body. The subject construction occurs by retrieving the subject text from message.properties using a key.
Using a template mechanism like the one featured in this PR would allow the following advantages:

- Add the possibility to customize the subject with user or realm properties. Currently email subjects can only be a static string with the exception of the idp-link email subject that allows a single (static) parameter (idpalias)
- Configure "action specific" subjects. Currently all required actions share the same "Update your account" phishing like subject located behind the executeActionsSubject key in message.properties.

It could be completely backwards compatible