### PR TITLE
KEYCLOAK-16566 Display Id Provider DisplayName instead of Alias on login-idp-link-*.ftl

### DIFF
--- a/services/src/main/java/org/keycloak/forms/login/freemarker/FreeMarkerLoginFormsProvider.java
+++ b/services/src/main/java/org/keycloak/forms/login/freemarker/FreeMarkerLoginFormsProvider.java
@@ -209,9 +209,14 @@ public class FreeMarkerLoginFormsProvider implements LoginFormsProvider {
                 BrokeredIdentityContext brokerContext = (BrokeredIdentityContext) this.attributes.get(IDENTITY_PROVIDER_BROKER_CONTEXT);
                 String idpAlias = brokerContext.getIdpConfig().getAlias();
                 idpAlias = ObjectUtil.capitalize(idpAlias);
+                String displayName = idpAlias;
+                if (!ObjectUtil.isBlank(brokerContext.getIdpConfig().getDisplayName())) {
+                    displayName = brokerContext.getIdpConfig().getDisplayName();
+                }
 
                 attributes.put("brokerContext", brokerContext);
                 attributes.put("idpAlias", idpAlias);
+                attributes.put("idpDisplayName", displayName);
                 break;
             case LOGIN_TOTP:
                 attributes.put("otpLogin", new TotpLoginBean(session, realm, user, (String) this.attributes.get(OTPFormAuthenticator.SELECTED_OTP_CREDENTIAL_ID)));
@@ -542,7 +547,12 @@ public class FreeMarkerLoginFormsProvider implements LoginFormsProvider {
         BrokeredIdentityContext brokerContext = (BrokeredIdentityContext) this.attributes.get(IDENTITY_PROVIDER_BROKER_CONTEXT);
         String idpAlias = brokerContext.getIdpConfig().getAlias();
         idpAlias = ObjectUtil.capitalize(idpAlias);
-        setMessage(MessageType.WARNING, Messages.LINK_IDP, idpAlias);
+        String displayName = idpAlias;
+        if (!ObjectUtil.isBlank(brokerContext.getIdpConfig().getDisplayName())) {
+            displayName = brokerContext.getIdpConfig().getDisplayName();
+        }
+
+        setMessage(MessageType.WARNING, Messages.LINK_IDP, displayName);
 
         return createResponse(LoginFormsPages.LOGIN_IDP_LINK_EMAIL);
     }

--- a/themes/src/main/resources/theme/base/login/login-idp-link-confirm.ftl
+++ b/themes/src/main/resources/theme/base/login/login-idp-link-confirm.ftl
@@ -6,7 +6,7 @@
         <form id="kc-register-form" action="${url.loginAction}" method="post">
             <div class="${properties.kcFormGroupClass!}">
                 <button type="submit" class="${properties.kcButtonClass!} ${properties.kcButtonDefaultClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}" name="submitAction" id="updateProfile" value="updateProfile">${msg("confirmLinkIdpReviewProfile")}</button>
-                <button type="submit" class="${properties.kcButtonClass!} ${properties.kcButtonDefaultClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}" name="submitAction" id="linkAccount" value="linkAccount">${msg("confirmLinkIdpContinue", idpAlias)}</button>
+                <button type="submit" class="${properties.kcButtonClass!} ${properties.kcButtonDefaultClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}" name="submitAction" id="linkAccount" value="linkAccount">${msg("confirmLinkIdpContinue", idpDisplayName)}</button>
             </div>
         </form>
     </#if>

--- a/themes/src/main/resources/theme/base/login/login-idp-link-email.ftl
+++ b/themes/src/main/resources/theme/base/login/login-idp-link-email.ftl
@@ -1,10 +1,10 @@
 <#import "template.ftl" as layout>
 <@layout.registrationLayout; section>
     <#if section = "header">
-        ${msg("emailLinkIdpTitle", idpAlias)}
+        ${msg("emailLinkIdpTitle", idpDisplayName)}
     <#elseif section = "form">
         <p id="instruction1" class="instruction">
-            ${msg("emailLinkIdp1", idpAlias, brokerContext.username, realm.displayName)}
+            ${msg("emailLinkIdp1", idpDisplayName, brokerContext.username, realm.displayName)}
         </p>
         <p id="instruction2" class="instruction">
             ${msg("emailLinkIdp2")} <a href="${url.loginAction}">${msg("doClickHere")}</a> ${msg("emailLinkIdp3")}


### PR DESCRIPTION
The login-idp-link-confirm.ftl and login-idp-link-email.ftl page shows idpAlias as Title. It should be possible to show the user friendly DisplayName of IdentityProviders.
