### PR TITLE
KEYCLOAK-16583 Ignore tests which directly use WebAuthn Chrome test

### DIFF
--- a/testsuite/integration-arquillian/HOW-TO-RUN.md
+++ b/testsuite/integration-arquillian/HOW-TO-RUN.md
@@ -506,6 +506,8 @@ which simulate hardware authentication device. For automated WebAuthN testing, t
 To enabling the feature you have to add flag to _chromeArguments_. In each WebAuthN test should be method with ``@Before`` annotation
 to verify the browser properties.
 
+**Note:** The testing feature is only available for Chrome version 68-80.
+
 #### Example of verifying the browser properties
 ```
 @Before

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/WebAuthnAssume.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/WebAuthnAssume.java
@@ -12,6 +12,7 @@ public class WebAuthnAssume {
 
     public static final String CHROME_NAME = BrowserType.CHROME;
     public static final int CHROME_MIN_VERSION = 68;
+    public static final int CHROME_MAX_VERSION = 80;
 
     public static void assumeChrome() {
         assumeChrome(getCurrentDriver());
@@ -28,6 +29,7 @@ public class WebAuthnAssume {
         int version = Integer.parseInt(cap.getVersion().substring(0, cap.getVersion().indexOf(".")));
 
         Assume.assumeTrue("Browser must be Chrome !", browserName.equals(CHROME_NAME));
-        Assume.assumeTrue("Version of chrome must be higher than or equal to " + CHROME_MIN_VERSION, version >= CHROME_MIN_VERSION);
+        Assume.assumeTrue("Version of Chrome must be higher than or equal to " + CHROME_MIN_VERSION, version >= CHROME_MIN_VERSION);
+        Assume.assumeTrue("Version of Chrome must be lower than or equal to " + CHROME_MAX_VERSION, version <= CHROME_MAX_VERSION);
     }
 }


### PR DESCRIPTION
Ignore tests which directly use WebAuthn Chrome testing feature

JIRA: [KEYCLOAK-16583](https://issues.redhat.com/browse/KEYCLOAK-16583)

At this moment, feature for testing the WebAuthn was removed from more recent Chrome versions and it's not possible to test it right now. Most likely, there will be used Selenium virtual authenticators for that, but it's not completed yet.