### PR TITLE
[KEYCLOAK-16536] Implement Audit Events for Authorization Services requests

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/events/Details.java
+++ b/server-spi-private/src/main/java/org/keycloak/events/Details.java
@@ -47,6 +47,7 @@ public interface Details {
     String REASON = "reason";
     String REVOKED_CLIENT = "revoked_client";
     String AUDIENCE = "audience";
+    String PERMISSION = "permission";
     String SCOPE = "scope";
     String REQUESTED_ISSUER = "requested_issuer";
     String REQUESTED_SUBJECT = "requested_subject";

--- a/server-spi-private/src/main/java/org/keycloak/events/Errors.java
+++ b/server-spi-private/src/main/java/org/keycloak/events/Errors.java
@@ -100,4 +100,7 @@ public interface Errors {
     String INVALID_SAML_DOCUMENT = "invalid_saml_document";
     String UNSUPPORTED_NAMEID_FORMAT = "unsupported_nameid_format";
 
+    String INVALID_PERMISSION_TICKET = "invalid_permission_ticket";
+    String ACCESS_DENIED = "access_denied";
+
 }

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
@@ -1244,8 +1244,10 @@ public class TokenEndpoint {
                     AccessToken invalidToken = new JWSInput(accessTokenString).readJsonContent(AccessToken.class);
                     ClientModel client = realm.getClientByClientId(invalidToken.getIssuedFor());
                     cors.allowedOrigins(session, client);
+                    event.client(client);
                 } catch (JWSInputException ignore) {
                 }
+                event.error(Errors.INVALID_TOKEN);
                 throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_GRANT, "Invalid bearer token", Status.UNAUTHORIZED);
             }
 
@@ -1254,6 +1256,7 @@ public class TokenEndpoint {
             session.getContext().setClient(client);
 
             cors.allowedOrigins(session, client);
+            event.client(client);
         }
 
         String claimToken = null;
@@ -1300,6 +1303,7 @@ public class TokenEndpoint {
         if (rpt != null) {
             AccessToken accessToken = session.tokens().decode(rpt, AccessToken.class);
             if (accessToken == null) {
+                event.error(Errors.INVALID_REQUEST);
                 throw new CorsErrorResponseException(cors, "invalid_rpt", "RPT signature is invalid", Status.FORBIDDEN);
             }
 
@@ -1307,8 +1311,11 @@ public class TokenEndpoint {
         }
 
         authorizationRequest.setScope(formParams.getFirst("scope"));
-        authorizationRequest.setAudience(formParams.getFirst("audience"));
+        String audienceParam = formParams.getFirst("audience");
+        authorizationRequest.setAudience(audienceParam);
         authorizationRequest.setSubjectToken(accessTokenString);
+
+        event.detail(Details.AUDIENCE, audienceParam);
 
         String submitRequest = formParams.getFirst("submit_request");
 
@@ -1318,6 +1325,7 @@ public class TokenEndpoint {
         List<String> permissions = formParams.get("permission");
 
         if (permissions != null) {
+            event.detail(Details.PERMISSION, String.join("|", permissions));
             for (String permission : permissions) {
                 String[] parts = permission.split("#");
                 String resource = parts[0];
@@ -1349,7 +1357,11 @@ public class TokenEndpoint {
 
         authorizationRequest.setMetadata(metadata);
 
-        return AuthorizationTokenService.instance().authorize(authorizationRequest);
+        Response authorizationResponse = AuthorizationTokenService.instance().authorize(authorizationRequest);
+
+        event.success();
+
+        return authorizationResponse;
     }
 
     // https://tools.ietf.org/html/rfc7636#section-4.1

--- a/services/src/main/java/org/keycloak/services/CorsErrorResponseException.java
+++ b/services/src/main/java/org/keycloak/services/CorsErrorResponseException.java
@@ -41,6 +41,10 @@ public class CorsErrorResponseException extends WebApplicationException {
         this.status = status;
     }
 
+    public String getErrorDescription() {
+        return errorDescription;
+    }
+
     @Override
     public Response getResponse() {
         OAuth2ErrorRepresentation errorRep = new OAuth2ErrorRepresentation(error, errorDescription);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/AbstractResourceServerTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/AbstractResourceServerTest.java
@@ -77,6 +77,7 @@ public abstract class AbstractResourceServerTest extends AbstractAuthzTest {
                 .client(ClientBuilder.create().clientId("test-app")
                         .redirectUris("http://localhost:8180/auth/realms/master/app/auth", "https://localhost:8543/auth/realms/master/app/auth")
                         .publicClient())
+                .testEventListener()
                 .build());
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/UserManagedAccessTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/UserManagedAccessTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.keycloak.testsuite.AssertEvents.isUUID;
 
 import java.util.Arrays;
 import java.util.ArrayList;
@@ -28,11 +29,13 @@ import java.util.Collection;
 import java.util.List;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.keycloak.admin.client.resource.AuthorizationResource;
 import org.keycloak.admin.client.resource.ClientResource;
 import org.keycloak.authorization.client.AuthorizationDeniedException;
 import org.keycloak.authorization.client.resource.PermissionResource;
+import org.keycloak.events.EventType;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.idm.authorization.AuthorizationRequest;
 import org.keycloak.representations.idm.authorization.AuthorizationResponse;
@@ -44,6 +47,7 @@ import org.keycloak.representations.idm.authorization.ResourcePermissionRepresen
 import org.keycloak.representations.idm.authorization.ResourceRepresentation;
 import org.keycloak.representations.idm.authorization.ResourceServerRepresentation;
 import org.keycloak.representations.idm.authorization.ScopePermissionRepresentation;
+import org.keycloak.testsuite.AssertEvents;
 import org.keycloak.testsuite.arquillian.annotation.AuthServerContainerExclude;
 import org.keycloak.testsuite.arquillian.annotation.AuthServerContainerExclude.AuthServer;
 
@@ -54,6 +58,9 @@ import org.keycloak.testsuite.arquillian.annotation.AuthServerContainerExclude.A
 public class UserManagedAccessTest extends AbstractResourceServerTest {
 
     private ResourceRepresentation resource;
+
+    @Rule
+    public AssertEvents events = new AssertEvents(this);
 
     @Before
     public void configureAuthorization() throws Exception {
@@ -281,9 +288,12 @@ public class UserManagedAccessTest extends AbstractResourceServerTest {
         permission.addResource(resource.getId());
         permission.addPolicy("Only Owner Policy");
 
-        getClient(getRealm()).authorization().permissions().resource().create(permission).close();
+        ClientResource client = getClient(getRealm());
+
+        client.authorization().permissions().resource().create(permission).close();
 
         AuthorizationResponse response = authorize("marta", "password", "Resource A", new String[] {"ScopeA", "ScopeB"});
+
         String rpt = response.getToken();
 
         assertNotNull(rpt);
@@ -300,12 +310,30 @@ public class UserManagedAccessTest extends AbstractResourceServerTest {
         assertPermissions(permissions, "Resource A", "ScopeA", "ScopeB");
         assertTrue(permissions.isEmpty());
 
+        getTestContext().getTestingClient().testing().clearEventQueue();
+
         try {
             response = authorize("kolo", "password", resource.getId(), new String[] {});
             fail("User should not have access to resource from another user");
         } catch (AuthorizationDeniedException ade) {
 
         }
+
+        String realmId = getRealm().toRepresentation().getId();
+        String clientId = client.toRepresentation().getClientId();
+        events.expectLogin().realm(realmId).client(clientId)
+                .user(isUUID())
+                .clearDetails()
+                .assertEvent();
+        events.expectLogin().realm(realmId).client(clientId)
+                .user(isUUID())
+                .clearDetails()
+                .assertEvent();
+        events.expect(EventType.PERMISSION_TOKEN_ERROR).realm(realmId).client(clientId).user(isUUID())
+                .session((String) null)
+                .error("access_denied")
+                .detail("reason", "request_submitted")
+                .assertEvent();
 
         PermissionResource permissionResource = getAuthzClient().protection().permission();
         List<PermissionTicketRepresentation> permissionTickets = permissionResource.findByResource(resource.getId());
@@ -330,6 +358,8 @@ public class UserManagedAccessTest extends AbstractResourceServerTest {
             assertTrue(ticket.isGranted());
         }
 
+        getTestContext().getTestingClient().testing().clearEventQueue();
+
         response = authorize("kolo", "password", resource.getId(), new String[] {"ScopeA", "ScopeB"});
         rpt = response.getToken();
 
@@ -346,6 +376,19 @@ public class UserManagedAccessTest extends AbstractResourceServerTest {
         assertNotNull(permissions);
         assertPermissions(permissions, resource.getName(), "ScopeA", "ScopeB");
         assertTrue(permissions.isEmpty());
+
+        events.expectLogin().realm(realmId).client(clientId)
+                .user(isUUID())
+                .clearDetails()
+                .assertEvent();
+        events.expectLogin().realm(realmId).client(clientId)
+                .user(isUUID())
+                .clearDetails()
+                .assertEvent();
+        events.expect(EventType.PERMISSION_TOKEN).realm(realmId).client(clientId).user(isUUID())
+                .session((String) null)
+                .clearDetails()
+                .assertEvent();
     }
 
     @Test


### PR DESCRIPTION
CONTRIBUTING.MD mentions that all PRs require relevant documentation. Unfortunately, I didn't find any documentation about Audit Events in [Keycloak Documentation repository](https://github.com/keycloak/keycloak-documentation).

I'm willing to add some if further instructions are provided as to where to place it and what kind of contents it should contain.

In general, this PR contains code to submit the error and success events for Authorization Services permission requests, for both successful and failed ones, including relevant data about them such as the permission request **audience** and **permission** parameters, the user linked to the request and the client used for it.

The PERMISSION_TOKEN and PERMISSION_TOKEN_ERROR events already existed, so no new event types had to be defined. This PR only includes the necessary changes to submit the success or error events when applicable, and include the necessary information to clearly identify the type of error for audit purposes.

The same applies for tests. I wasn't able to find tests for other events so it is not clear where or how these tests should be implemented. I'm also willing to add them if further instructions are provided for this particular case.