### PR TITLE
KEYCLOAK-16606 add default value to mandatory LDAP attributes

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/UserAttributeLDAPStorageMapper.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/UserAttributeLDAPStorageMapper.java
@@ -60,6 +60,7 @@ public class UserAttributeLDAPStorageMapper extends AbstractLDAPStorageMapper {
     public static final String ALWAYS_READ_VALUE_FROM_LDAP = "always.read.value.from.ldap";
     public static final String IS_MANDATORY_IN_LDAP = "is.mandatory.in.ldap";
     public static final String IS_BINARY_ATTRIBUTE = "is.binary.attribute";
+    public static final String ATTRIBUTE_DEFAULT_VALUE = "attribute.default.value";
 
     public UserAttributeLDAPStorageMapper(ComponentModel mapperModel, LDAPStorageProvider ldapProvider) {
         super(mapperModel, ldapProvider);
@@ -102,6 +103,7 @@ public class UserAttributeLDAPStorageMapper extends AbstractLDAPStorageMapper {
         String userModelAttrName = getUserModelAttribute();
         String ldapAttrName = getLdapAttributeName();
         boolean isMandatoryInLdap = parseBooleanParameter(mapperModel, IS_MANDATORY_IN_LDAP);
+        String attributeDefaultValue = getAttributeDefaultValue();
 
         Property<Object> userModelProperty = userModelProperties.get(userModelAttrName.toLowerCase());
 
@@ -112,7 +114,7 @@ public class UserAttributeLDAPStorageMapper extends AbstractLDAPStorageMapper {
 
             if (attrValue == null) {
                 if (isMandatoryInLdap) {
-                    ldapUser.setSingleAttribute(ldapAttrName, LDAPConstants.EMPTY_ATTRIBUTE_VALUE);
+                    ldapUser.setSingleAttribute(ldapAttrName, attributeDefaultValue);
                 } else {
                     ldapUser.setAttribute(ldapAttrName, new LinkedHashSet<String>());
                 }
@@ -126,7 +128,7 @@ public class UserAttributeLDAPStorageMapper extends AbstractLDAPStorageMapper {
 
             if (attrValues.isEmpty()) {
                 if (isMandatoryInLdap) {
-                    ldapUser.setSingleAttribute(ldapAttrName, LDAPConstants.EMPTY_ATTRIBUTE_VALUE);
+                    ldapUser.setSingleAttribute(ldapAttrName, attributeDefaultValue);
                 } else {
                     ldapUser.setAttribute(ldapAttrName, new LinkedHashSet<>());
                 }
@@ -423,6 +425,11 @@ public class UserAttributeLDAPStorageMapper extends AbstractLDAPStorageMapper {
                 condition.setBinary(isBinaryAttribute());
             }
         }
+    }
+
+    private String getAttributeDefaultValue() {
+        String attributeDefaultValue = mapperModel.getConfig().getFirst(ATTRIBUTE_DEFAULT_VALUE);
+        return (attributeDefaultValue == null || attributeDefaultValue.trim().isEmpty()) ? LDAPConstants.EMPTY_ATTRIBUTE_VALUE : attributeDefaultValue;
     }
 
     private String getUserModelAttribute() {

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/UserAttributeLDAPStorageMapperFactory.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/UserAttributeLDAPStorageMapperFactory.java
@@ -72,9 +72,13 @@ public class UserAttributeLDAPStorageMapperFactory extends AbstractLDAPStorageMa
                     .type(ProviderConfigProperty.BOOLEAN_TYPE).defaultValue("false").add();
         }
         config.property().name(UserAttributeLDAPStorageMapper.IS_MANDATORY_IN_LDAP).label("Is Mandatory In LDAP")
-                .helpText("If true, attribute is mandatory in LDAP. Hence if there is no value in Keycloak DB, the empty value will be set to be propagated to LDAP")
+                .helpText("If true, attribute is mandatory in LDAP. Hence if there is no value in Keycloak DB, the default or empty value will be set to be propagated to LDAP")
                 .type(ProviderConfigProperty.BOOLEAN_TYPE)
                 .defaultValue("false").add()
+                .property().name(UserAttributeLDAPStorageMapper.ATTRIBUTE_DEFAULT_VALUE).label("Attribute default value")
+                .helpText("If there is no value in Keycloak DB and attribute is mandatory in LDAP, this value will be propagated to LDAP")
+                .type(ProviderConfigProperty.STRING_TYPE)
+                .defaultValue("").add()
                 .property().name(UserAttributeLDAPStorageMapper.IS_BINARY_ATTRIBUTE).label("Is Binary Attribute")
                 .helpText("Should be true for binary LDAP attributes")
                 .type(ProviderConfigProperty.BOOLEAN_TYPE)


### PR DESCRIPTION
<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->

The default empty value of " " does not always meet LDAP attribute syntax requierements.
This is the case for for example posixAccount uidNumber and gidNumber attributes.

This patch adds ability to set default value for attribute