### PR TITLE
KEYCLOAK-14718 Adding test case for User Client Role Mapper

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/updaters/ClientAttributeUpdater.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/updaters/ClientAttributeUpdater.java
@@ -136,4 +136,9 @@ public class ClientAttributeUpdater extends ServerResourceUpdater<ClientAttribut
         rep.getDefaultClientScopes().add(clientScope);
         return this;
     }
+
+    public ClientAttributeUpdater setDirectAccessGrantsEnabled(Boolean directAccessGranted) {
+        rep.setDirectAccessGrantsEnabled(directAccessGranted);
+        return this;
+    }
 }


### PR DESCRIPTION
JIRA: [KEYCLOAK-14718 Creating a Protocol Mapper for a Client via REST api does not fill the Client ID](https://issues.redhat.com/browse/KEYCLOAK-14718)

Original JIRA issue is not valid, but there is missing test case for roles from different clients. In order to improve the test coverage of the feature, it should be included. Attribute `clientID` is not so clear in the context of the `UserClientRoleMapper`, so it's changed to `Specific Client ID`, which should be better, because there's a bigger probability the user will read the tooltip of the attribute.
More details in JIRA.