### PR TITLE
KEYCLOAK-14203 Client Policy - Executor : Enforce HTTPS URIs

### DIFF
--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureRedirectUriEnforceExecutor.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureRedirectUriEnforceExecutor.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.services.clientpolicy.executor;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.jboss.logging.Logger;
+import org.keycloak.OAuthErrorException;
+import org.keycloak.component.ComponentModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.services.clientpolicy.AdminClientRegisterContext;
+import org.keycloak.services.clientpolicy.AdminClientUpdateContext;
+import org.keycloak.services.clientpolicy.AuthorizationRequestContext;
+import org.keycloak.services.clientpolicy.ClientPolicyContext;
+import org.keycloak.services.clientpolicy.ClientPolicyException;
+import org.keycloak.services.clientpolicy.ClientPolicyLogger;
+import org.keycloak.services.clientpolicy.ClientUpdateContext;
+import org.keycloak.services.clientpolicy.DynamicClientRegisterContext;
+import org.keycloak.services.clientpolicy.DynamicClientUpdateContext;
+
+public class SecureRedirectUriEnforceExecutor implements ClientPolicyExecutorProvider {
+
+    private static final Logger logger = Logger.getLogger(SecureRedirectUriEnforceExecutor.class);
+
+    private final KeycloakSession session;
+    private final ComponentModel componentModel;
+
+    public SecureRedirectUriEnforceExecutor(KeycloakSession session, ComponentModel componentModel) {
+        this.session = session;
+        this.componentModel = componentModel;
+    }
+
+    @Override
+    public String getName() {
+        return componentModel.getName();
+    }
+
+    @Override
+    public String getProviderId() {
+        return componentModel.getProviderId();
+    }
+
+    @Override
+    public void executeOnEvent(ClientPolicyContext context) throws ClientPolicyException {
+        switch (context.getEvent()) {
+            case REGISTER:
+                if (context instanceof AdminClientRegisterContext || context instanceof DynamicClientRegisterContext) {
+                    confirmSecureRedirectUris(((ClientUpdateContext)context).getProposedClientRepresentation().getRedirectUris());
+                } else {
+                    throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST, "not allowed input format.");
+                }
+                return;
+            case UPDATE:
+                if (context instanceof AdminClientUpdateContext || context instanceof DynamicClientUpdateContext) {
+                    confirmSecureRedirectUris(((ClientUpdateContext)context).getProposedClientRepresentation().getRedirectUris());
+                } else {
+                    throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST, "not allowed input format.");
+                }
+                return;
+            case AUTHORIZATION_REQUEST:
+                confirmSecureRedirectUris(Arrays.asList(((AuthorizationRequestContext)context).getRedirectUri()));
+                return;
+            default:
+                return;
+        }
+    }
+
+    private void confirmSecureRedirectUris(List<String> redirectUris) throws ClientPolicyException {
+        if (redirectUris == null || redirectUris.isEmpty()) {
+            throw new ClientPolicyException(OAuthErrorException.INVALID_CLIENT_METADATA, "Invalid client metadata: redirect_uris");
+        }
+
+        for(String redirectUri : redirectUris) {
+            ClientPolicyLogger.log(logger, "Redirect URI = " + redirectUri);
+            if (redirectUri.startsWith("http://") || redirectUri.contains("*")) {
+                throw new ClientPolicyException(OAuthErrorException.INVALID_CLIENT_METADATA, "Invalid client metadata: redirect_uris");
+            }
+        }
+    }
+}

--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureRedirectUriEnforceExecutorFactory.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureRedirectUriEnforceExecutorFactory.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.services.clientpolicy.executor;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.keycloak.Config.Scope;
+import org.keycloak.component.ComponentModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.provider.ProviderConfigProperty;
+
+public class SecureRedirectUriEnforceExecutorFactory implements ClientPolicyExecutorProviderFactory {
+
+    public static final String PROVIDER_ID = "secure-redirecturi-enforce-executor";
+
+    @Override
+    public ClientPolicyExecutorProvider create(KeycloakSession session, ComponentModel model) {
+        return new SecureRedirectUriEnforceExecutor(session, model);
+    }
+
+    @Override
+    public void init(Scope config) {
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public String getHelpText() {
+        return "It prohibits the client registering/specifying http scheme URI.";
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return Collections.emptyList();
+    }
+
+}

--- a/services/src/main/resources/META-INF/services/org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProviderFactory
+++ b/services/src/main/resources/META-INF/services/org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProviderFactory
@@ -4,3 +4,4 @@ org.keycloak.services.clientpolicy.executor.SecureClientAuthEnforceExecutorFacto
 org.keycloak.services.clientpolicy.executor.PKCEEnforceExecutorFactory
 org.keycloak.services.clientpolicy.executor.SecureSessionEnforceExecutorFactory
 org.keycloak.services.clientpolicy.executor.SecureSigningAlgorithmEnforceExecutorFactory
+org.keycloak.services.clientpolicy.executor.SecureRedirectUriEnforceExecutorFactory


### PR DESCRIPTION
This PR is for [KEYCLOAK-14203 Client Policy - Executor : Enforce HTTPS URIs](https://issues.redhat.com/browse/KEYCLOAK-14203) in [KEYCLOAK-13933 Client Policies](https://issues.redhat.com/browse/KEYCLOAK-13933), also is the part of the project [Client Policy Official Support](https://github.com/keycloak/kc-sig-fapi/projects) of [FAPI-SIG](https://github.com/keycloak/kc-sig-fapi) activity.

Generally speaking, the aim of this PR is to support policy conditions defined in [Client Policy design document](https://github.com/keycloak/keycloak-community/blob/master/design/client-policies.md#condition--which-client)

It behavior has been specified in [the JIRA ticket](https://issues.redhat.com/browse/KEYCLOAK-14203).