### PR TITLE
KEYCLOAK-16627 detach user session on potential refresh token abuse

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
@@ -386,6 +386,9 @@ public class TokenManager {
 
             int currentCount = clientSession.getCurrentRefreshTokenUseCount();
             if (currentCount > realm.getRefreshTokenMaxReuse()) {
+                // KEYCLOAK-16627
+                // https://tools.ietf.org/html/draft-ietf-oauth-security-topics-16#section-4.13.2
+                clientSession.detachFromUserSession();
                 throw new OAuthErrorException(OAuthErrorException.INVALID_GRANT, "Maximum allowed refresh token reuse exceeded",
                         "Maximum allowed refresh token reuse exceeded");
             }


### PR DESCRIPTION
JIRA: [KEYCLOAK-16627: Potential abuse of refresh tokens does not invalidate related tokens](https://issues.redhat.com/browse/KEYCLOAK-16627)

Potential abuse of refresh tokens did not invalidate other refresh tokens, violating the OAuth 2.0 BCP and allowing an attacker to take over a session simply by immediately refreshing after illicitly obtaining a refresh token, which would work so long as the real user had not yet used that refresh token.

I've used `detachFromUserSession()` in the existing place where the potential abuse is detected to create this behavior, and updated the related tests to check for it (where previously they'd checked that the refresh tokens were still allowed).