### PR TITLE
KEYCLOAK-16693 HTTP 404 for `all.css` on the login page

### DIFF
--- a/themes/src/main/resources/theme/keycloak/login/theme.properties
+++ b/themes/src/main/resources/theme/keycloak/login/theme.properties
@@ -2,7 +2,7 @@ parent=base
 import=common/keycloak
 
 styles=css/login.css css/tile.css
-stylesCommon=web_modules/@fortawesome/fontawesome-free/css/icons/all.css web_modules/@patternfly/react-core/dist/styles/base.css web_modules/@patternfly/react-core/dist/styles/app.css node_modules/patternfly/dist/css/patternfly.min.css node_modules/patternfly/dist/css/patternfly-additions.min.css lib/pficon/pficon.css
+stylesCommon=web_modules/@patternfly/react-core/dist/styles/base.css web_modules/@patternfly/react-core/dist/styles/app.css node_modules/patternfly/dist/css/patternfly.min.css node_modules/patternfly/dist/css/patternfly-additions.min.css lib/pficon/pficon.css
 
 meta=viewport==width=device-width,initial-scale=1
 


### PR DESCRIPTION
removing reference to a nonexistent resource in the login theme
