### PR TITLE
KEYCLOAK-14200 Client Policy - Executor : Enforce Holder-of-Key Token

### DIFF
--- a/server-spi/src/main/java/org/keycloak/services/clientpolicy/ClientPolicyException.java
+++ b/server-spi/src/main/java/org/keycloak/services/clientpolicy/ClientPolicyException.java
@@ -17,10 +17,16 @@
 
 package org.keycloak.services.clientpolicy;
 
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
+import org.keycloak.OAuthErrorException;
+
 public class ClientPolicyException extends Exception {
 
-    private String error;
+    private String error = OAuthErrorException.INVALID_REQUEST;
     private String errorDetail;
+    private Status errorStatus = Response.Status.BAD_REQUEST;
 
     public ClientPolicyException(String error, String errorDetail) {
         super(error);
@@ -28,10 +34,24 @@ public class ClientPolicyException extends Exception {
         setErrorDetail(errorDetail);
     }
 
+    public ClientPolicyException(String error, String errorDetail, Status errorStatus) {
+        super(error);
+        setError(error);
+        setErrorDetail(errorDetail);
+        setErrorStatus(errorStatus);
+    }
+
     public ClientPolicyException(String error, String errorDetail, Throwable throwable) {
         super(throwable);
         setError(error);
         setErrorDetail(errorDetail);
+    }
+
+    public ClientPolicyException(String error, String errorDetail, Status errorStatus, Throwable throwable) {
+        super(throwable);
+        setError(error);
+        setErrorDetail(errorDetail);
+        setErrorStatus(errorStatus);
     }
 
     public String getError() {
@@ -48,6 +68,14 @@ public class ClientPolicyException extends Exception {
 
     public void setErrorDetail(String errorDetail) {
         this.errorDetail = errorDetail;
+    }
+
+    public Status getErrorStatus() {
+        return errorStatus;
+    }
+
+    public void setErrorStatus(Status errorStatus) {
+        this.errorStatus = errorStatus;
     }
 
     /**

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/LogoutEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/LogoutEndpoint.java
@@ -212,7 +212,7 @@ public class LogoutEndpoint {
         try {
             session.clientPolicy().triggerOnEvent(new LogoutRequestContext(form));
         } catch (ClientPolicyException cpe) {
-            throw new ErrorResponseException(Errors.INVALID_REQUEST, cpe.getErrorDetail(), Response.Status.BAD_REQUEST);
+            throw new ErrorResponseException(cpe.getError(), cpe.getErrorDetail(), cpe.getErrorStatus());
         }
 
         RefreshToken token = null;

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
@@ -539,7 +539,7 @@ public class TokenEndpoint {
             session.clientPolicy().triggerOnEvent(new TokenRefreshContext(formParams));
         } catch (ClientPolicyException cpe) {
             event.error(cpe.getError());
-            throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_GRANT, cpe.getErrorDetail(), Response.Status.BAD_REQUEST);
+            throw new CorsErrorResponseException(cors, cpe.getError(), cpe.getErrorDetail(), cpe.getErrorStatus());
         }
 
         AccessTokenResponse res;

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenRevocationEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenRevocationEndpoint.java
@@ -52,6 +52,7 @@ import org.keycloak.services.clientpolicy.TokenRevokeContext;
 import org.keycloak.services.managers.UserSessionCrossDCManager;
 import org.keycloak.services.managers.UserSessionManager;
 import org.keycloak.services.resources.Cors;
+import org.keycloak.services.util.MtlsHoKTokenUtil;
 import org.keycloak.util.TokenUtil;
 
 /**
@@ -102,7 +103,7 @@ public class TokenRevocationEndpoint {
             session.clientPolicy().triggerOnEvent(new TokenRevokeContext(formParams));
         } catch (ClientPolicyException cpe) {
             event.error(cpe.getError());
-            throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_GRANT, cpe.getErrorDetail(), Response.Status.BAD_REQUEST);
+            throw new CorsErrorResponseException(cors, cpe.getError(), cpe.getErrorDetail(), cpe.getErrorStatus());
         }
 
         checkToken();

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/UserInfoEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/UserInfoEndpoint.java
@@ -43,6 +43,7 @@ import org.keycloak.models.UserSessionModel;
 import org.keycloak.protocol.oidc.OIDCAdvancedConfigWrapper;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.representations.AccessToken;
+import org.keycloak.services.CorsErrorResponseException;
 import org.keycloak.services.ErrorResponseException;
 import org.keycloak.services.Urls;
 import org.keycloak.services.clientpolicy.ClientPolicyException;
@@ -136,7 +137,7 @@ public class UserInfoEndpoint {
         try {
             session.clientPolicy().triggerOnEvent(new UserInfoRequestContext(tokenString));
         } catch (ClientPolicyException cpe) {
-            throw new ErrorResponseException(Errors.INVALID_REQUEST, cpe.getErrorDetail(), Response.Status.BAD_REQUEST);
+            throw new ErrorResponseException(cpe.getError(), cpe.getErrorDetail(), cpe.getErrorStatus());
         }
 
         EventBuilder event = new EventBuilder(realm, session, clientConnection)

--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/HolderOfKeyEnforceExecutor.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/HolderOfKeyEnforceExecutor.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.services.clientpolicy.executor;
+
+import org.jboss.resteasy.spi.HttpRequest;
+import org.keycloak.OAuth2Constants;
+import org.keycloak.OAuthErrorException;
+import org.keycloak.component.ComponentModel;
+import org.keycloak.events.Errors;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.protocol.oidc.OIDCAdvancedConfigWrapper;
+import org.keycloak.representations.AccessToken;
+import org.keycloak.representations.RefreshToken;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.services.clientpolicy.*;
+import org.keycloak.services.util.MtlsHoKTokenUtil;
+
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+
+public class HolderOfKeyEnforceExecutor extends AbstractAugumentingClientRegistrationPolicyExecutor {
+
+    private final KeycloakSession session;
+    private final ComponentModel componentModel;
+
+    public HolderOfKeyEnforceExecutor(KeycloakSession session, ComponentModel componentModel) {
+        super(session, componentModel);
+        this.session = session;
+        this.componentModel = componentModel;
+    }
+
+    @Override
+    public String getName() {
+        return componentModel.getName();
+    }
+
+    @Override
+    public String getProviderId() {
+        return componentModel.getProviderId();
+    }
+
+    @Override
+    protected void augment(ClientRepresentation rep) {
+        if (Boolean.parseBoolean(componentModel.getConfig().getFirst(AbstractAugumentingClientRegistrationPolicyExecutor.IS_AUGMENT))) {
+            OIDCAdvancedConfigWrapper.fromClientRepresentation(rep).setUseMtlsHoKToken(true);
+        }
+    }
+
+    @Override
+    protected void validate(ClientRepresentation rep) throws ClientPolicyException {
+        boolean useMtlsHokToken = OIDCAdvancedConfigWrapper.fromClientRepresentation(rep).isUseMtlsHokToken();
+        if (!useMtlsHokToken) {
+            throw new ClientPolicyException(OAuthErrorException.INVALID_CLIENT_METADATA, "Invalid client metadata: MTLS token in disabled");
+        }
+    }
+
+    @Override
+    public void executeOnEvent(ClientPolicyContext context) throws ClientPolicyException {
+        super.executeOnEvent(context);
+        HttpRequest request = session.getContext().getContextObject(HttpRequest.class);
+
+        switch (context.getEvent()) {
+
+            case TOKEN_REQUEST:
+                AccessToken.CertConf certConf = MtlsHoKTokenUtil.bindTokenWithClientCertificate(request, session);
+                if (certConf == null) {
+                    throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST, "Client Certification missing for MTLS HoK Token Binding");
+                }
+                break;
+
+            case TOKEN_REFRESH:
+                checkTokenRefresh((TokenRefreshContext) context, request);
+                break;
+
+            case TOKEN_REVOKE:
+                checkTokenRevoke((TokenRevokeContext) context, request);
+                break;
+
+            case USERINFO_REQUEST:
+                checkUserInfo((UserInfoRequestContext) context, request);
+                break;
+
+            case LOGOUT_REQUEST:
+                checkLogout((LogoutRequestContext) context, request);
+                break;
+        }
+    }
+
+    private void checkLogout(LogoutRequestContext context, HttpRequest request) throws ClientPolicyException {
+        MultivaluedMap<String, String> formParameters = context.getParams();
+        String encodedRefreshToken = formParameters.getFirst(OAuth2Constants.REFRESH_TOKEN);
+
+        RefreshToken refreshToken = session.tokens().decode(encodedRefreshToken, RefreshToken.class);
+        if (refreshToken == null) {
+            // this executor does not treat this error case.
+            return;
+        }
+
+        if (!MtlsHoKTokenUtil.verifyTokenBindingWithClientCertificate(refreshToken, request, session)) {
+            throw new ClientPolicyException(Errors.NOT_ALLOWED, MtlsHoKTokenUtil.CERT_VERIFY_ERROR_DESC, Response.Status.UNAUTHORIZED);
+        }
+    }
+
+    private void checkUserInfo(UserInfoRequestContext context, HttpRequest request) throws ClientPolicyException {
+        String encodedAccessToken = context.getTokenString();
+
+        AccessToken accessToken = session.tokens().decode(encodedAccessToken, AccessToken.class);
+        if (accessToken == null) {
+            // this executor does not treat this error case.
+            return;
+        }
+
+        if (!MtlsHoKTokenUtil.verifyTokenBindingWithClientCertificate(accessToken, request, session)) {
+            throw new ClientPolicyException(Errors.NOT_ALLOWED, MtlsHoKTokenUtil.CERT_VERIFY_ERROR_DESC, Response.Status.UNAUTHORIZED);
+        }
+    }
+
+    private void checkTokenRevoke(TokenRevokeContext context, HttpRequest request) throws ClientPolicyException {
+        MultivaluedMap<String, String> revokeParameters = context.getParams();
+        String encodedRevokeToken = revokeParameters.getFirst("token");
+
+        RefreshToken refreshToken = session.tokens().decode(encodedRevokeToken, RefreshToken.class);
+        if (refreshToken == null) {
+            // this executor does not treat this error case.
+            return;
+        }
+
+        if (!MtlsHoKTokenUtil.verifyTokenBindingWithClientCertificate(refreshToken, request, session)) {
+            throw new ClientPolicyException(Errors.NOT_ALLOWED, MtlsHoKTokenUtil.CERT_VERIFY_ERROR_DESC, Response.Status.UNAUTHORIZED);
+        }
+    }
+
+    private void checkTokenRefresh(TokenRefreshContext context, HttpRequest request) throws ClientPolicyException {
+        MultivaluedMap<String, String> formParameters = context.getParams();
+        String encodedRefreshToken = formParameters.getFirst(OAuth2Constants.REFRESH_TOKEN);
+
+        RefreshToken refreshToken = session.tokens().decode(encodedRefreshToken, RefreshToken.class);
+        if (refreshToken == null) {
+            // this executor does not treat this error case.
+            return;
+        }
+
+        if (!MtlsHoKTokenUtil.verifyTokenBindingWithClientCertificate(refreshToken, request, session)) {
+            throw new ClientPolicyException(Errors.NOT_ALLOWED, MtlsHoKTokenUtil.CERT_VERIFY_ERROR_DESC, Response.Status.UNAUTHORIZED);
+        }
+    }
+}

--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/HolderOfKeyEnforceExecutorFactory.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/HolderOfKeyEnforceExecutorFactory.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.services.clientpolicy.executor;
+
+import org.keycloak.Config.Scope;
+import org.keycloak.component.ComponentModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.provider.ProviderConfigProperty;
+
+import java.util.Collections;
+import java.util.List;
+
+public class HolderOfKeyEnforceExecutorFactory implements ClientPolicyExecutorProviderFactory {
+
+    public static final String PROVIDER_ID = "holder-of-key-enforce-executor";
+
+    @Override
+    public ClientPolicyExecutorProvider create(KeycloakSession session, ComponentModel model) {
+        return new HolderOfKeyEnforceExecutor(session, model);
+    }
+
+    @Override
+    public void init(Scope config) {
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public String getHelpText() {
+        return "It prohibits the client whose MTLS certificate does not match with the certificate thumbprint from the tokens.";
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return Collections.emptyList();
+    }
+
+}

--- a/services/src/main/resources/META-INF/services/org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProviderFactory
+++ b/services/src/main/resources/META-INF/services/org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProviderFactory
@@ -6,3 +6,4 @@ org.keycloak.services.clientpolicy.executor.SecureSessionEnforceExecutorFactory
 org.keycloak.services.clientpolicy.executor.SecureSigningAlgorithmEnforceExecutorFactory
 org.keycloak.services.clientpolicy.executor.SecureRedirectUriEnforceExecutorFactory
 org.keycloak.services.clientpolicy.executor.SecureSigningAlgorithmForSignedJwtEnforceExecutorFactory
+org.keycloak.services.clientpolicy.executor.HolderOfKeyEnforceExecutorFactory


### PR DESCRIPTION
This PR is for [KEYCLOAK-14200 Client Policy - Executor : Enforce Holder-of-Key Token](https://issues.redhat.com/browse/KEYCLOAK-14200) in [KEYCLOAK-13933 Client Policies](https://issues.redhat.com/browse/KEYCLOAK-13933), also is the part of the project [Client Policy Official Support](https://github.com/keycloak/kc-sig-fapi/projects) of [FAPI-SIG](https://github.com/keycloak/kc-sig-fapi) activity.

Generally speaking, the aim of this PR is to support policy conditions defined in [Client Policy design document](https://github.com/keycloak/keycloak-community/blob/master/design/client-policies.md#condition--which-client)

It behavior has been specified in [the JIRA ticket](https://issues.redhat.com/browse/KEYCLOAK-14200).

This PR has been written with the contribution by @HryhoriiHevorkian as FAPI-SIG activities..
