### PR TITLE
KEYCLOAK-15985 Brute Force Detection Lockout Event

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/events/EventBuilder.java
+++ b/server-spi-private/src/main/java/org/keycloak/events/EventBuilder.java
@@ -45,6 +45,10 @@ public class EventBuilder {
     private Event event;
 
     public EventBuilder(RealmModel realm, KeycloakSession session, ClientConnection clientConnection) {
+        this(realm, session, clientConnection.getRemoteAddr());
+    }
+
+    public EventBuilder(RealmModel realm, KeycloakSession session, String ip) {
         this.realm = realm;
 
         event = new Event();
@@ -73,7 +77,7 @@ public class EventBuilder {
                 .collect(Collectors.toList());
 
         realm(realm);
-        ipAddress(clientConnection.getRemoteAddr());
+        ipAddress(ip);
     }
 
     private EventBuilder(EventStoreProvider store, List<EventListenerProvider> listeners, RealmModel realm, Event event) {

--- a/server-spi-private/src/main/java/org/keycloak/events/EventType.java
+++ b/server-spi-private/src/main/java/org/keycloak/events/EventType.java
@@ -135,7 +135,9 @@ public enum EventType {
     PERMISSION_TOKEN_ERROR(false),
 
     DELETE_ACCOUNT(true),
-    DELETE_ACCOUNT_ERROR(true);
+    DELETE_ACCOUNT_ERROR(true),
+
+    USER_LOCKED(true);
 
     private boolean saveByDefault;
 

--- a/services/src/main/java/org/keycloak/services/managers/DefaultBruteForceProtector.java
+++ b/services/src/main/java/org/keycloak/services/managers/DefaultBruteForceProtector.java
@@ -20,6 +20,9 @@ package org.keycloak.services.managers;
 import org.jboss.logging.Logger;
 import org.keycloak.common.ClientConnection;
 import org.keycloak.common.util.Time;
+import org.keycloak.events.Details;
+import org.keycloak.events.EventBuilder;
+import org.keycloak.events.EventType;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.models.RealmModel;
@@ -128,6 +131,11 @@ public class DefaultBruteForceProtector implements Runnable, BruteForceProtector
             if(userLoginFailure.getNumFailures() == realm.getFailureFactor()) {
                 logger.debugv("user {0} locked permanently due to too many login attempts", user.getUsername());
                 user.setEnabled(false);
+                new EventBuilder(realm, session, event.ip)
+                    .event(EventType.USER_LOCKED)
+                    .detail(Details.REASON, "brute_force_protection")
+                    .user(user)
+                    .success();
                 return;
             }
 


### PR DESCRIPTION
A new "USER_LOCKED" event is introduced that is fired whenever the DefaultBruteForceDetector locks a user.

Please review the PR and tell me where I can provide unit/integration tests. So far I could not find any tests that are related to the brute-force detector.