### PR TITLE
[KEYCLOAK-16792] Pass realm instead of ID to Get Realm Localization Texts method

### DIFF
--- a/themes/src/main/resources/theme/base/admin/resources/js/controllers/realm.js
+++ b/themes/src/main/resources/theme/base/admin/resources/js/controllers/realm.js
@@ -101,8 +101,8 @@ module.controller('GlobalCtrl', function($scope, $http, Auth, Current, $location
     $scope.$watch(function() {
         return Current.realm;
     }, function() {
-        if(Current.realm !== null && currentRealm !== Current.realm.id) {
-            currentRealm = Current.realm.id;
+        if(Current.realm !== null && currentRealm !== Current.realm.realm) {
+            currentRealm = Current.realm.realm;
             translateProvider.translations(locale, resourceBundle);
             RealmSpecificLocalizationTexts.get({id: currentRealm, locale: locale}, function (localizationTexts) {
                 translateProvider.translations(locale, localizationTexts.toJSON());


### PR DESCRIPTION
The realm controller within the UI for the security admin console is incorrectly sending through the `id` of the realm, rather than the `realm` attribute, when calling the "Get Realm Localization Texts" API method on the admin REST API.

This is causing 404 errors in cases where there is a realm with an `id` that is different to the `realm`.

Here is the documentation for Get Realm Localization Texts: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_getrealmlocalizationtexts