### PR TITLE
[KEYCLOAK-16763] Upgrade to WildFly 21.0.2.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <product.rhsso.version>7.4.0.GA</product.rhsso.version>
 
         <product.build-time>${timestamp}</product.build-time>
-        <wildfly.version>21.0.1.Final</wildfly.version>
+        <wildfly.version>21.0.2.Final</wildfly.version>
         <wildfly.build-tools.version>1.2.13.Final</wildfly.build-tools.version>
         <eap.version>7.4.0.CD20-redhat-00001</eap.version>
         <wildfly.core.version>13.0.3.Final</wildfly.core.version>


### PR DESCRIPTION
    [KEYCLOAK-16763] Upgrade to WildFly 21.0.2.Final
    
    Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

Note: For those possibly wondering if this change is enough, there really doesn't seem to have been other change in [Wildfly 21.0.2.Final](https://github.com/wildfly/wildfly/releases/tag/21.0.2.Final), than just [direct fixes in Wildfly and subsequent version bump](https://github.com/wildfly/wildfly/compare/21.0.1.Final...21.0.2.Final).

Testing pipeline jobs:
- Adapters -- https://keycloak.jenkins.server.com/job/universal-test-pipeline-adapters/2000/
- Server -- https://keycloak.jenkins.server.com/job/universal-test-pipeline-server/2453/


<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
