### PR TITLE
Fix typo in ApplicationsPage.tsx

### DIFF
--- a/themes/src/main/resources/theme/keycloak.v2/account/src/app/content/applications-page/ApplicationsPage.tsx
+++ b/themes/src/main/resources/theme/keycloak.v2/account/src/app/content/applications-page/ApplicationsPage.tsx
@@ -130,7 +130,7 @@ export class ApplicationsPage extends React.Component<ApplicationsPageProps, App
               <DataListItemCells
                 dataListCells={[
                   <DataListCell key='applications-list-client-id-header' width={2}>
-                    <strong><Msg msgKey='applicaitonName' /></strong>
+                    <strong><Msg msgKey='applicationName' /></strong>
                   </DataListCell>,
                   <DataListCell key='applications-list-app-type-header' width={2}>
                     <strong><Msg msgKey='applicationType' /></strong>


### PR DESCRIPTION
Fixes a typo in the "applicationName" key in ApplicationsPage.tsx, so that the correct text is shown on the account page.

I also noticed there is no value defined for the status key in any of the messages files, but I didn't change that in here.