### PR TITLE
[KEYCLOAK-16600] - Improvements when loading many realms

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/ClientAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/ClientAdapter.java
@@ -89,7 +89,7 @@ public class ClientAdapter implements ClientModel, CachedObject {
 
     public Set<String> getWebOrigins() {
         if (isUpdated()) return updated.getWebOrigins();
-        return cached.getWebOrigins();
+        return cached.getWebOrigins(this::getClient);
     }
 
     public void setWebOrigins(Set<String> webOrigins) {
@@ -119,7 +119,7 @@ public class ClientAdapter implements ClientModel, CachedObject {
     @Override
     public Map<String, ClientScopeModel> getClientScopes(boolean defaultScope, boolean filterByProtocol) {
         if (isUpdated()) return updated.getClientScopes(defaultScope, filterByProtocol);
-        List<String> clientScopeIds = defaultScope ? cached.getDefaultClientScopesIds() : cached.getOptionalClientScopesIds();
+        List<String> clientScopeIds = defaultScope ? cached.getDefaultClientScopesIds(this::getClient) : cached.getOptionalClientScopesIds(this::getClient);
 
         // Defaults to openid-connect
         String clientProtocol = getProtocol() == null ? "openid-connect" : getProtocol();
@@ -148,7 +148,7 @@ public class ClientAdapter implements ClientModel, CachedObject {
 
     public Set<String> getRedirectUris() {
         if (isUpdated()) return updated.getRedirectUris();
-        return cached.getRedirectUris();
+        return cached.getRedirectUris(this::getClient);
     }
 
     public void setRedirectUris(Set<String> redirectUris) {
@@ -317,14 +317,14 @@ public class ClientAdapter implements ClientModel, CachedObject {
     @Override
     public String getAttribute(String name) {
         if (isUpdated()) return updated.getAttribute(name);
-        return cached.getAttributes().get(name);
+        return cached.getAttributes(this::getClient).get(name);
     }
 
     @Override
     public Map<String, String> getAttributes() {
         if (isUpdated()) return updated.getAttributes();
         Map<String, String> copy = new HashMap<>();
-        copy.putAll(cached.getAttributes());
+        copy.putAll(cached.getAttributes(this::getClient));
         return copy;
     }
 
@@ -345,21 +345,19 @@ public class ClientAdapter implements ClientModel, CachedObject {
     @Override
     public String getAuthenticationFlowBindingOverride(String name) {
         if (isUpdated()) return updated.getAuthenticationFlowBindingOverride(name);
-        return cached.getAuthFlowBindings().get(name);
+        return cached.getAuthFlowBindings(this::getClient).get(name);
     }
 
     @Override
     public Map<String, String> getAuthenticationFlowBindingOverrides() {
         if (isUpdated()) return updated.getAuthenticationFlowBindingOverrides();
-        Map<String, String> copy = new HashMap<>();
-        copy.putAll(cached.getAuthFlowBindings());
-        return copy;
+        return new HashMap<>(cached.getAuthFlowBindings(this::getClient));
     }
 
     @Override
     public Stream<ProtocolMapperModel> getProtocolMappersStream() {
         if (isUpdated()) return updated.getProtocolMappersStream();
-        return cached.getProtocolMappers().stream();
+        return cached.getProtocolMappers(this::getClient).stream();
     }
 
     @Override
@@ -384,7 +382,7 @@ public class ClientAdapter implements ClientModel, CachedObject {
 
     @Override
     public ProtocolMapperModel getProtocolMapperById(String id) {
-        for (ProtocolMapperModel mapping : cached.getProtocolMappers()) {
+        for (ProtocolMapperModel mapping : cached.getProtocolMappers(this::getClient)) {
             if (mapping.getId().equals(id)) return mapping;
         }
         return null;
@@ -392,7 +390,7 @@ public class ClientAdapter implements ClientModel, CachedObject {
 
     @Override
     public ProtocolMapperModel getProtocolMapperByName(String protocol, String name) {
-        for (ProtocolMapperModel mapping : cached.getProtocolMappers()) {
+        for (ProtocolMapperModel mapping : cached.getProtocolMappers(this::getClient)) {
             if (mapping.getProtocol().equals(protocol) && mapping.getName().equals(name)) return mapping;
         }
         return null;
@@ -629,7 +627,7 @@ public class ClientAdapter implements ClientModel, CachedObject {
     @Override
     public Map<String, Integer> getRegisteredNodes() {
         if (isUpdated()) return updated.getRegisteredNodes();
-        return cached.getRegisteredNodes();
+        return cached.getRegisteredNodes(this::getClient);
     }
 
     @Override
@@ -667,5 +665,9 @@ public class ClientAdapter implements ClientModel, CachedObject {
     @Override
     public int hashCode() {
         return getId().hashCode();
+    }
+
+    private ClientModel getClient() {
+        return cacheSession.getClientDelegate().getClientById(cachedRealm, cached.getId());
     }
 }

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/ClientScopeAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/ClientScopeAdapter.java
@@ -80,7 +80,7 @@ public class ClientScopeAdapter implements ClientScopeModel {
     @Override
     public Stream<ProtocolMapperModel> getProtocolMappersStream() {
         if (isUpdated()) return updated.getProtocolMappersStream();
-        return cached.getProtocolMappers().stream();
+        return cached.getProtocolMappers(this::getClientScope).stream();
     }
 
     @Override
@@ -105,7 +105,7 @@ public class ClientScopeAdapter implements ClientScopeModel {
 
     @Override
     public ProtocolMapperModel getProtocolMapperById(String id) {
-        for (ProtocolMapperModel mapping : cached.getProtocolMappers()) {
+        for (ProtocolMapperModel mapping : cached.getProtocolMappers(this::getClientScope)) {
             if (mapping.getId().equals(id)) return mapping;
         }
         return null;
@@ -113,7 +113,7 @@ public class ClientScopeAdapter implements ClientScopeModel {
 
     @Override
     public ProtocolMapperModel getProtocolMapperByName(String protocol, String name) {
-        for (ProtocolMapperModel mapping : cached.getProtocolMappers()) {
+        for (ProtocolMapperModel mapping : cached.getProtocolMappers(this::getClientScope)) {
             if (mapping.getProtocol().equals(protocol) && mapping.getName().equals(name)) return mapping;
         }
         return null;
@@ -201,14 +201,14 @@ public class ClientScopeAdapter implements ClientScopeModel {
     @Override
     public String getAttribute(String name) {
         if (isUpdated()) return updated.getAttribute(name);
-        return cached.getAttributes().get(name);
+        return cached.getAttributes(this::getClientScope).get(name);
     }
 
     @Override
     public Map<String, String> getAttributes() {
         if (isUpdated()) return updated.getAttributes();
         Map<String, String> copy = new HashMap<>();
-        copy.putAll(cached.getAttributes());
+        copy.putAll(cached.getAttributes(this::getClientScope));
         return copy;
     }
 
@@ -227,4 +227,7 @@ public class ClientScopeAdapter implements ClientScopeModel {
         return getId().hashCode();
     }
 
+    private ClientScopeModel getClientScope() {
+        return cacheSession.getRealmDelegate().getClientScopeById(cached.getId(), cachedRealm);
+    }
 }

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/DefaultLazyLoader.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/DefaultLazyLoader.java
@@ -28,7 +28,7 @@ import java.util.function.Supplier;
 public class DefaultLazyLoader<S, D> implements LazyLoader<S, D> {
 
     private final Function<S, D> loader;
-    private Supplier<D> fallback;
+    private final Supplier<D> fallback;
     private D data;
 
     public DefaultLazyLoader(Function<S, D> loader, Supplier<D> fallback) {
@@ -36,12 +36,24 @@ public class DefaultLazyLoader<S, D> implements LazyLoader<S, D> {
         this.fallback = fallback;
     }
 
+    public DefaultLazyLoader(Function<S, D> loader) {
+        this.loader = loader;
+        this.fallback = null;
+    }
+
     @Override
     public D get(Supplier<S> sourceSupplier) {
         if (data == null) {
             S source = sourceSupplier.get();
-            data = source == null ? fallback.get() : this.loader.apply(source);
+            data = source == null ? getDefaultValue() : this.loader.apply(source);
         }
         return data;
+    }
+
+    private D getDefaultValue() {
+        if (fallback == null) {
+            return null;
+        }
+        return fallback.get();
     }
 }

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmCacheSession.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmCacheSession.java
@@ -817,7 +817,7 @@ public class RealmCacheSession implements CacheRealmProvider {
         } else if (managedRoles.containsKey(id)) {
             return managedRoles.get(id);
         }
-        RoleAdapter adapter = new RoleAdapter(cached,this, realm);
+        RoleAdapter adapter = new RoleAdapter(cached,this, realm, session);
         managedRoles.put(id, adapter);
         return adapter;
     }

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RoleAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RoleAdapter.java
@@ -129,7 +129,6 @@ public class RoleAdapter implements RoleModel {
         if (isUpdated()) return updated.getCompositesStream();
 
         if (composites == null) {
-            composites = new HashSet<>();
             composites = cached.getComposites().stream()
                     .map(id -> {
                         RoleModel role = realm.getRoleById(id);

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/RealmAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/RealmAdapter.java
@@ -67,6 +67,13 @@ public class RealmAdapter implements RealmModel, JpaModel<RealmEntity> {
     }
 
     @Override
+    public ClientScopeModel getClientScopeByName(String clientScopeName) {
+        return getClientScopesStream()
+                .filter(clientScope -> Objects.equals(clientScopeName, clientScope.getName()))
+                .findFirst().orElse(null);
+    }
+
+    @Override
     public String getId() {
         return realm.getId();
     }

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/RoleAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/RoleAdapter.java
@@ -115,7 +115,7 @@ public class RoleAdapter implements RoleModel, JpaModel<RoleEntity> {
 
     @Override
     public boolean hasRole(RoleModel role) {
-        return this.equals(role) || KeycloakModelUtils.searchFor(role, this, new HashSet<>());
+        return this.equals(role) || KeycloakModelUtils.searchFor(role, this, new HashSet<>(), session);
     }
 
     private void persistAttributeValue(String name, String value) {

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/ClientEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/ClientEntity.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.models.jpa.entities;
 
+import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Nationalized;
 
 import javax.persistence.Access;
@@ -98,26 +99,26 @@ public class ClientEntity {
     @JoinColumn(name = "REALM_ID")
     protected RealmEntity realm;
 
-    @ElementCollection
+    @ElementCollection(fetch = FetchType.LAZY)
     @Column(name="VALUE")
     @CollectionTable(name = "WEB_ORIGINS", joinColumns={ @JoinColumn(name="CLIENT_ID") })
     protected Set<String> webOrigins;
 
-    @ElementCollection
+    @ElementCollection(fetch = FetchType.LAZY)
     @Column(name="VALUE")
     @CollectionTable(name = "REDIRECT_URIS", joinColumns={ @JoinColumn(name="CLIENT_ID") })
     protected Set<String> redirectUris;
 
-    @OneToMany(cascade ={CascadeType.REMOVE}, orphanRemoval = true, mappedBy = "client")
+    @OneToMany(cascade ={CascadeType.REMOVE}, orphanRemoval = true, mappedBy = "client", fetch = FetchType.LAZY)
     protected Collection<ClientAttributeEntity> attributes;
 
-    @ElementCollection
+    @ElementCollection(fetch = FetchType.LAZY)
     @MapKeyColumn(name="BINDING_NAME")
     @Column(name="FLOW_ID", length = 4000)
     @CollectionTable(name="CLIENT_AUTH_FLOW_BINDINGS", joinColumns={ @JoinColumn(name="CLIENT_ID") })
     protected Map<String, String> authFlowBindings;
 
-    @OneToMany(cascade ={CascadeType.REMOVE}, orphanRemoval = true, mappedBy = "client")
+    @OneToMany(cascade ={CascadeType.REMOVE}, orphanRemoval = true, mappedBy = "client", fetch = FetchType.LAZY)
     Collection<ProtocolMapperEntity> protocolMappers;
 
     @Column(name="SURROGATE_AUTH_REQUIRED")
@@ -156,9 +157,10 @@ public class ClientEntity {
     @ElementCollection
     @Column(name="ROLE_ID")
     @CollectionTable(name="SCOPE_MAPPING", joinColumns = { @JoinColumn(name="CLIENT_ID")})
+    @BatchSize(size = 20)
     private Set<String> scopeMappingIds;
 
-    @ElementCollection
+    @ElementCollection(fetch = FetchType.LAZY)
     @MapKeyColumn(name="NAME")
     @Column(name="VALUE")
     @CollectionTable(name="CLIENT_NODE_REGISTRATIONS", joinColumns={ @JoinColumn(name="CLIENT_ID") })

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/ComponentEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/ComponentEntity.java
@@ -32,6 +32,8 @@ import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
 
+import org.hibernate.annotations.BatchSize;
+
 /**
  * @author <a href="mailto:bburke@redhat.com">Bill Burke</a>
  */
@@ -64,6 +66,7 @@ public class ComponentEntity {
     protected String subType;
 
     @OneToMany(fetch = FetchType.LAZY, cascade ={ CascadeType.ALL}, orphanRemoval = true, mappedBy = "component")
+    @BatchSize(size = 20)
     Set<ComponentConfigEntity> componentConfigs;
 
     public String getId() {

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/RealmEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/RealmEntity.java
@@ -41,6 +41,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.hibernate.annotations.BatchSize;
+
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
@@ -151,7 +153,7 @@ public class RealmEntity {
     @OneToMany(fetch = FetchType.LAZY, cascade ={CascadeType.REMOVE}, orphanRemoval = true, mappedBy = "realm")
     Collection<ClientScopeEntity> clientScopes;
 
-    @ElementCollection
+    @ElementCollection(fetch = FetchType.LAZY)
     @MapKeyColumn(name="NAME")
     @Column(name="VALUE")
     @CollectionTable(name="REALM_SMTP_CONFIG", joinColumns={ @JoinColumn(name="REALM_ID") })
@@ -167,14 +169,15 @@ public class RealmEntity {
     @Column(name="EVENTS_EXPIRATION")
     protected long eventsExpiration;
 
-    @ElementCollection
+    @ElementCollection(fetch = FetchType.LAZY)
     @Column(name="VALUE")
     @CollectionTable(name="REALM_EVENTS_LISTENERS", joinColumns={ @JoinColumn(name="REALM_ID") })
     protected Set<String> eventsListeners;
     
-    @ElementCollection
+    @ElementCollection(fetch = FetchType.LAZY)
     @Column(name="VALUE")
     @CollectionTable(name="REALM_ENABLED_EVENT_TYPES", joinColumns={ @JoinColumn(name="REALM_ID") })
+    @BatchSize(size = 20)
     protected Set<String> enabledEventTypes;
     
     @Column(name="ADMIN_EVENTS_ENABLED")
@@ -190,21 +193,26 @@ public class RealmEntity {
     protected String defaultRoleId;
 
     @OneToMany(cascade ={CascadeType.REMOVE}, orphanRemoval = true, mappedBy = "realm")
+    @BatchSize(size = 20)
     protected List<IdentityProviderEntity> identityProviders;
 
-    @OneToMany(cascade ={CascadeType.REMOVE}, orphanRemoval = true, mappedBy = "realm")
+    @OneToMany(cascade ={CascadeType.REMOVE}, orphanRemoval = true, mappedBy = "realm", fetch = FetchType.LAZY)
     Collection<IdentityProviderMapperEntity> identityProviderMappers;
 
-    @OneToMany(cascade ={CascadeType.REMOVE}, orphanRemoval = true, mappedBy = "realm")
+    @OneToMany(cascade ={CascadeType.REMOVE}, orphanRemoval = true, mappedBy = "realm", fetch = FetchType.LAZY)
+    @BatchSize(size = 20)
     Collection<AuthenticatorConfigEntity> authenticators;
 
-    @OneToMany(cascade ={CascadeType.REMOVE}, orphanRemoval = true, mappedBy = "realm")
+    @OneToMany(cascade ={CascadeType.REMOVE}, orphanRemoval = true, mappedBy = "realm", fetch = FetchType.LAZY)
+    @BatchSize(size = 20)
     Collection<RequiredActionProviderEntity> requiredActionProviders;
 
-    @OneToMany(cascade ={CascadeType.REMOVE}, orphanRemoval = true, mappedBy = "realm")
+    @OneToMany(cascade ={CascadeType.REMOVE}, orphanRemoval = true, mappedBy = "realm", fetch = FetchType.LAZY)
+    @BatchSize(size = 20)
     Collection<AuthenticationFlowEntity> authenticationFlows;
 
     @OneToMany(fetch = FetchType.LAZY, cascade ={CascadeType.ALL}, orphanRemoval = true, mappedBy = "realm")
+    @BatchSize(size = 20)
     Set<ComponentEntity> components;
 
     @Column(name="BROWSER_FLOW")
@@ -229,7 +237,7 @@ public class RealmEntity {
     @Column(name="INTERNATIONALIZATION_ENABLED")
     protected boolean internationalizationEnabled;
 
-    @ElementCollection
+    @ElementCollection(fetch = FetchType.LAZY)
     @Column(name="VALUE")
     @CollectionTable(name="REALM_SUPPORTED_LOCALES", joinColumns={ @JoinColumn(name="REALM_ID") })
     protected Set<String> supportedLocales;
@@ -240,7 +248,7 @@ public class RealmEntity {
     @Column(name="ALLOW_USER_MANAGED_ACCESS")
     private boolean allowUserManagedAccess;
 
-    @OneToMany(cascade ={CascadeType.REMOVE}, orphanRemoval = true, mappedBy = "realmId")
+    @OneToMany(cascade ={CascadeType.REMOVE}, orphanRemoval = true, mappedBy = "realmId", fetch = FetchType.LAZY)
     @MapKey(name="locale")
     Map<String, RealmLocalizationTextsEntity> realmLocalizationTexts;
 

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/RequiredActionProviderEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/RequiredActionProviderEntity.java
@@ -33,6 +33,8 @@ import javax.persistence.NamedQuery;
 import javax.persistence.Table;
 import java.util.Map;
 
+import org.hibernate.annotations.BatchSize;
+
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
@@ -73,6 +75,7 @@ public class RequiredActionProviderEntity {
     @MapKeyColumn(name="NAME")
     @Column(name="VALUE")
     @CollectionTable(name="REQUIRED_ACTION_CONFIG", joinColumns={ @JoinColumn(name="REQUIRED_ACTION_ID") })
+    @BatchSize(size = 20)
     private Map<String, String> config;
 
     public String getId() {

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/RoleEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/RoleEntity.java
@@ -65,7 +65,7 @@ import java.util.Set;
         @NamedQuery(name="getRealmRoleIdByName", query="select role.id from RoleEntity role where role.clientRole = false and role.name = :name and role.realm.id = :realm"),
         @NamedQuery(name="searchForRealmRoles", query="select role from RoleEntity role where role.clientRole = false and role.realm.id = :realm and ( lower(role.name) like :search or lower(role.description) like :search ) order by role.name"),
 })
-
+@BatchSize(size = 50)
 public class RoleEntity {
     @Id
     @Column(name="ID", length = 36)
@@ -99,9 +99,10 @@ public class RoleEntity {
 
     @ManyToMany(fetch = FetchType.LAZY, cascade = {})
     @JoinTable(name = "COMPOSITE_ROLE", joinColumns = @JoinColumn(name = "COMPOSITE"), inverseJoinColumns = @JoinColumn(name = "CHILD_ROLE"))
+    @BatchSize(size = 20)
     private Set<RoleEntity> compositeRoles;
 
-    @OneToMany(cascade = CascadeType.REMOVE, orphanRemoval = true, mappedBy="role")
+    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true, mappedBy="role")
     @Fetch(FetchMode.SELECT)
     @BatchSize(size = 20)
     protected List<RoleAttributeEntity> attributes;

--- a/model/map/src/main/java/org/keycloak/models/map/role/MapRoleAdapter.java
+++ b/model/map/src/main/java/org/keycloak/models/map/role/MapRoleAdapter.java
@@ -125,7 +125,7 @@ public class MapRoleAdapter extends AbstractRoleModel<MapRoleEntity> implements 
 
     @Override
     public boolean hasRole(RoleModel role) {
-        return this.equals(role) || KeycloakModelUtils.searchFor(role, this, new HashSet<>());
+        return this.equals(role) || KeycloakModelUtils.searchFor(role, this, new HashSet<>(), session);
     }
 
     @Override

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/KeycloakModelUtils.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/KeycloakModelUtils.java
@@ -191,9 +191,7 @@ public final class KeycloakModelUtils {
             return false;
         }
 
-        Set<RoleModel> compositeRoles = composite.getCompositesStream().collect(Collectors.toSet());
-        return compositeRoles.contains(role) ||
-                        compositeRoles.stream().anyMatch(x -> x.isComposite() && searchFor(role, x, visited));
+        return composite.getCompositesStream().anyMatch(x -> role.equals(x) || (x.isComposite() && searchFor(role, x, visited)));
     }
 
     /**
@@ -601,14 +599,16 @@ public final class KeycloakModelUtils {
     }
 
     public static ClientScopeModel getClientScopeByName(RealmModel realm, String clientScopeName) {
-        return realm.getClientScopesStream()
-                .filter(clientScope -> Objects.equals(clientScopeName, clientScope.getName()))
+        ClientScopeModel clientScope = realm.getClientScopeByName(clientScopeName);
+
+        if(clientScope == null) {
+            return realm.getClientsStream()
+                .filter(c -> Objects.equals(clientScopeName, c.getClientId()))
                 .findFirst()
-                // check if we are referencing a client instead of a scope
-                .orElse(realm.getClientsStream()
-                        .filter(c -> Objects.equals(clientScopeName, c.getClientId()))
-                        .findFirst()
-                        .orElse(null));
+                .orElse(null);
+        }
+
+        return clientScope;
     }
 
     /**

--- a/server-spi/src/main/java/org/keycloak/models/RealmModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/RealmModel.java
@@ -779,6 +779,8 @@ public interface RealmModel extends RoleContainerModel {
 
     ClientScopeModel getClientScopeById(String id);
 
+    ClientScopeModel getClientScopeByName(String clientScopeName);
+
     void addDefaultClientScope(ClientScopeModel clientScope, boolean defaultScope);
     void removeDefaultClientScope(ClientScopeModel clientScope);
 

--- a/services/src/main/java/org/keycloak/services/resources/admin/permissions/MgmtPermissions.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/permissions/MgmtPermissions.java
@@ -163,6 +163,9 @@ class MgmtPermissions implements AdminPermissionEvaluator, AdminPermissionManage
         String clientId;
         RealmManager realmManager = new RealmManager(session);
         if (adminsRealm.equals(realmManager.getKeycloakAdminstrationRealm())) {
+            for (String adminRole : adminRoles) {
+                if (identity.hasClientRole(adminsRealm.getMasterAdminClient().getClientId(), adminRole)) return true;
+            }
             clientId = realm.getMasterAdminClient().getClientId();
         } else if (adminsRealm.equals(realm)) {
             clientId = realm.getClientByClientId(realmManager.getRealmAdminClientId(realm)).getClientId();

--- a/services/src/main/java/org/keycloak/storage/AbstractStorageManager.java
+++ b/services/src/main/java/org/keycloak/storage/AbstractStorageManager.java
@@ -27,6 +27,7 @@ import org.keycloak.provider.Provider;
 import org.keycloak.provider.ProviderFactory;
 import org.keycloak.utils.ServicesUtils;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -91,6 +92,14 @@ public abstract class AbstractStorageManager<ProviderType extends Provider,
      * @return enabled storage providers for realm and @{code getProviderTypeClass()}
      */
     protected <T> Stream<T> getEnabledStorageProviders(RealmModel realm, Class<T> capabilityInterface) {
+        List<ProviderFactory> factories = session.getKeycloakSessionFactory()
+                .getProviderFactories(providerTypeClass);
+
+        // there is no need iterate over the database if there is no provider
+        if (factories.isEmpty()) {
+            return Stream.empty();
+        }
+
         return getStorageProviderModels(realm, providerTypeClass)
                 .map(toStorageProviderModelTypeFunction)
                 .filter(StorageProviderModelType::isEnabled)

--- a/services/src/main/java/org/keycloak/storage/RoleStorageManager.java
+++ b/services/src/main/java/org/keycloak/storage/RoleStorageManager.java
@@ -16,8 +16,11 @@
  */
 package org.keycloak.storage;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
 import org.jboss.logging.Logger;
 import org.keycloak.common.util.reflections.Types;
 import org.keycloak.component.ComponentModel;
@@ -27,6 +30,8 @@ import org.keycloak.models.ModelException;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.RoleModel;
 import org.keycloak.models.RoleProvider;
+import org.keycloak.provider.Provider;
+import org.keycloak.provider.ProviderFactory;
 import org.keycloak.storage.role.RoleLookupProvider;
 import org.keycloak.storage.role.RoleStorageProvider;
 import org.keycloak.storage.role.RoleStorageProviderFactory;
@@ -69,6 +74,14 @@ public class RoleStorageManager implements RoleProvider {
 
 
     public static <T> Stream<RoleStorageProviderModel> getStorageProviders(RealmModel realm, KeycloakSession session, Class<T> type) {
+        List<ProviderFactory> factories = session.getKeycloakSessionFactory()
+                .getProviderFactories(RoleStorageProvider.class);
+
+        // there is no need iterate over the database if there is no role storage provider
+        if (factories.isEmpty()) {
+            return Stream.empty();
+        }
+
         return realm.getRoleStorageProvidersStream()
                 .filter(model -> {
                     RoleStorageProviderFactory factory = getRoleStorageProviderFactory(model, session);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/AdminConsolePermissionsCalculatedTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/AdminConsolePermissionsCalculatedTest.java
@@ -74,6 +74,10 @@ public class AdminConsolePermissionsCalculatedTest extends AbstractKeycloakTest 
             JsonNode jsonNode = SimpleHttp.doGet(whoAmiUrl, client).auth(accessToken.getToken()).asJson();
 
             assertTrue("Permissions for " + Config.getAdminRealm() + " realm.", jsonNode.at("/realm_access/" + Config.getAdminRealm()).isArray());
+
+            whoAmiUrl = suiteContext.getAuthServerInfo().getContextRoot().toString() + "/auth/admin/master/console/whoami/" + REALM_NAME;
+            jsonNode = SimpleHttp.doGet(whoAmiUrl, client).auth(accessToken.getToken()).asJson();
+
             assertTrue("Permissions for " + REALM_NAME + " realm.", jsonNode.at("/realm_access/" + REALM_NAME).isArray());
         }
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/FineGrainAdminUnitTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/FineGrainAdminUnitTest.java
@@ -852,17 +852,9 @@ public class FineGrainAdminUnitTest extends AbstractKeycloakTest {
             newClient.setProtocol("openid-connect");
             newClient.setPublicClient(false);
             newClient.setEnabled(true);
-            Response response = realmClient.realm("anotherRealm").clients().create(newClient);
-            Assert.assertEquals(403, response.getStatus());
-            response.close();
-
-            realmClient.close();
-            //creating new client to refresh token
-            realmClient = AdminClientUtil.createAdminClient(suiteContext.isAdapterCompatTesting(),
-                    "master", "admin", "admin", "fullScopedClient", "618268aa-51e6-4e64-93c4-3c0bc65b8171");
             assertThat(realmClient.realms().findAll().stream().map(RealmRepresentation::getRealm).collect(Collectors.toSet()),
                     hasItem("anotherRealm"));
-            response = realmClient.realm("anotherRealm").clients().create(newClient);
+            Response response = realmClient.realm("anotherRealm").clients().create(newClient);
             Assert.assertEquals(201, response.getStatus());
             response.close();
         } finally {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/PermissionsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/PermissionsTest.java
@@ -259,7 +259,7 @@ public class PermissionsTest extends AbstractKeycloakTest {
         // Check realm only contains name if missing view realm permission
         List<RealmRepresentation> realms = clients.get(AdminRoles.VIEW_USERS).realms().findAll();
         Assert.assertNames(realms, REALM_NAME);
-        assertGettersEmpty(realms.get(0));
+        assertGettersEmpty(realms.get(0), "getRealm", "getId");
 
         realms = clients.get(AdminRoles.VIEW_REALM).realms().findAll();
         Assert.assertNames(realms, REALM_NAME);
@@ -268,7 +268,7 @@ public class PermissionsTest extends AbstractKeycloakTest {
         // Check the same when access with users from 'master' realm
         realms = clients.get("master-" + AdminRoles.VIEW_USERS).realms().findAll();
         Assert.assertNames(realms, REALM_NAME);
-        assertGettersEmpty(realms.get(0));
+        assertGettersEmpty(realms.get(0), "getRealm", "getId");
 
         realms = clients.get("master-" + AdminRoles.VIEW_REALM).realms().findAll();
         Assert.assertNames(realms, REALM_NAME);

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/roles/RoleCompositeRoles.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/roles/RoleCompositeRoles.java
@@ -32,6 +32,8 @@ public class RoleCompositeRoles extends Form {
     protected Select availableRealmRolesSelect;
     @FindBy(id = "assigned")
     protected Select assignedRealmRolesSelect;
+    @FindBy(id = "realm-composite")
+    protected Select effectiveRealmRolesSelect;
 
     @FindBy(id = "clients")
     protected Select clientSelect;
@@ -163,6 +165,11 @@ public class RoleCompositeRoles extends Form {
     public boolean isAssignedClientRole(String role) {
         waitUntilElement(By.id("assigned")).is().present();
         return UIUtils.selectContainsOption(assignedClientRolesSelect, role);
+    }
+
+    public boolean isEffectiveRole(String role) {
+        waitUntilElement(By.id("realm-composite")).is().present();
+        return UIUtils.selectContainsOption(effectiveRealmRolesSelect, role);
     }
 
     public void selectClientRole(String client) {

--- a/testsuite/integration-arquillian/tests/other/console/src/test/java/org/keycloak/testsuite/console/clients/ClientClientScopesTest.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/test/java/org/keycloak/testsuite/console/clients/ClientClientScopesTest.java
@@ -155,7 +155,7 @@ public class ClientClientScopesTest extends AbstractClientTest {
         // Test roles
         evaluateForm.showRoles();
         Assert.assertNames(evaluateForm.getGrantedRealmRoles(), "offline_access");
-        Assert.assertNames(evaluateForm.getNotGrantedRealmRoles(), "uma_authorization");
+        Assert.assertNames(evaluateForm.getNotGrantedRealmRoles(), "default-roles-test", "uma_authorization");
 
         // Test access token
         evaluateForm.showToken();

--- a/testsuite/integration-arquillian/tests/other/console/src/test/java/org/keycloak/testsuite/console/roles/DefaultRolesTest.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/test/java/org/keycloak/testsuite/console/roles/DefaultRolesTest.java
@@ -57,7 +57,7 @@ public class DefaultRolesTest extends AbstractRolesTest {
         users.table().clickUser(newUser.getUsername());
 
         userPage.tabs().roleMappings();
-        assertTrue(userRolesPage.form().isAssignedRole(defaultRoleName));
+        assertTrue(userRolesPage.form().isEffectiveRole(defaultRoleName));
     }
 
     public RolesResource rolesResource() {

--- a/themes/src/main/resources/theme/base/admin/resources/js/services.js
+++ b/themes/src/main/resources/theme/base/admin/resources/js/services.js
@@ -371,6 +371,10 @@ module.factory('Realm', function($resource) {
     });
 });
 
+module.factory('Realms', function($resource) {
+    return $resource(authUrl + '/admin/realms/?briefRepresentation=true');
+});
+
 module.factory('RealmKeys', function($resource) {
     return $resource(authUrl + '/admin/realms/:id/keys', {
         id : '@realm'
@@ -1543,14 +1547,14 @@ module.factory('ClientServiceAccountUser', function($resource) {
     });
 });
 
-module.factory('Current', function(Realm, $route, $rootScope) {
+module.factory('Current', function(Realms, $route, $rootScope) {
     var current = {
         realms: {},
         realm: null
     };
 
-    $rootScope.$on('$routeChangeStart', function() {
-        current.realms = Realm.query(null, function(realms) {
+    current.refreshRealms = function() {
+        current.realms = Realms.query(function(realms) {
             var currentRealm = null;
             if ($route.current.params.realm) {
                 for (var i = 0; i < realms.length; i++) {
@@ -1561,7 +1565,7 @@ module.factory('Current', function(Realm, $route, $rootScope) {
             }
             current.realm = currentRealm;
         });
-    });
+    };
 
     return current;
 });

--- a/themes/src/main/resources/theme/base/admin/resources/partials/realm-list.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/realm-list.html
@@ -10,7 +10,7 @@
         </thead>
         <tbody>
             <tr data-ng-repeat="r in realms">
-                <td><a href="#/realms/{{r.realm}}">{{r.realm}}</a></td>
+                <td><a href="" ng-click="changeRealm(r.realm)">{{r.realm}}</a></td>
             </tr>
         </tbody>
     </table>


### PR DESCRIPTION
Running tests using a database populated with the default settings from the `keycloak-benchmark` tool. Using 1K realms.

* Delaying caching for some key properties of realm, client, and client scope
* Marking some key properties as lazy for realm, client, and client scope
* Fetching in batch some key properties that usually spans multiple queries
* Avoid fetching realms and user permissions in the `whoami` endpoint, but for a single and the current realm being managed from the admin console
* Avoid querying all realms from the admin console whenever possible
* When querying realms from admin console, return only the basic information

Expected results:

* Time to migrate should be reduced. If compared with the latest release, migration from a previous database takes forever. You should be able to migrate in less than 5 minutes. Depends on the database. The next step is to run using a production-grade DB. This is not a final solution though, but it helps a lot.
* Time to load the admin console is reduced. If compared with the latest release, the console just doesn't open. You should be able to open the admin console in a few seconds.

Next steps:

* The work done to the admin console should pave the road to other improvements to make the console more multi-realm friendly. We need to resume discussions on how we want to change it so that we avoid listing all realms, provide ways to search for realms, etc.
* Test using more realms (5k)