### PR TITLE
KEYCLOAK-16844 Create an index to support offline sessions loading

### DIFF
--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-13.0.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-13.0.0.xml
@@ -30,4 +30,12 @@
         <dropTable tableName="CLIENT_DEFAULT_ROLES" />
     </changeSet>
 
+    <changeSet author="keycloak" id="13.0.0-KEYCLOAK-16844">
+        <createIndex tableName="OFFLINE_USER_SESSION" indexName="IDX_OFFLINE_USS_PRELOAD">
+            <column name="OFFLINE_FLAG" type="VARCHAR(4)"/>
+            <column name="CREATED_ON" type="INT"/>
+            <column name="USER_SESSION_ID" type="VARCHAR(36)"/>
+        </createIndex>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
Add the following index
CREATE INDEX IDX_OFFLINE_USS_PRELOAD ON offline_user_session(offline_flag, created_on, user_session_id);
https://issues.redhat.com/browse/KEYCLOAK-11019