### PR TITLE
[KEYCLOAK-16780] - Allow batching writes to storage when running migration

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/connections/jpa/DefaultJpaConnectionProviderFactory.java
+++ b/model/jpa/src/main/java/org/keycloak/connections/jpa/DefaultJpaConnectionProviderFactory.java
@@ -88,7 +88,7 @@ public class DefaultJpaConnectionProviderFactory implements JpaConnectionProvide
 
             em = emf.createEntityManager(SynchronizationType.SYNCHRONIZED);
         }
-        em = PersistenceExceptionConverter.create(em);
+        em = PersistenceExceptionConverter.create(session, em);
         if (!jtaEnabled) session.getTransactionManager().enlist(new JpaKeycloakTransaction(em));
         return new DefaultJpaConnectionProvider(em);
     }

--- a/model/jpa/src/main/java/org/keycloak/connections/jpa/PersistenceExceptionConverter.java
+++ b/model/jpa/src/main/java/org/keycloak/connections/jpa/PersistenceExceptionConverter.java
@@ -18,6 +18,8 @@
 package org.keycloak.connections.jpa;
 
 import org.hibernate.exception.ConstraintViolationException;
+import org.keycloak.models.Constants;
+import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.ModelDuplicateException;
 import org.keycloak.models.ModelException;
 
@@ -27,28 +29,50 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
+import java.util.Arrays;
+import java.util.Collection;
 
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
  */
 public class PersistenceExceptionConverter implements InvocationHandler {
 
-    private EntityManager em;
+    private static final Collection<String> WRITE_METHOD_NAMES = Arrays.asList("persist", "merge");
 
-    public static EntityManager create(EntityManager em) {
-        return (EntityManager) Proxy.newProxyInstance(EntityManager.class.getClassLoader(), new Class[]{EntityManager.class}, new PersistenceExceptionConverter(em));
+    private final EntityManager em;
+    private final Boolean batchEnabled;
+    private final Integer batchSize;
+    private int changeCount = 0;
+
+    public static EntityManager create(KeycloakSession session, EntityManager em) {
+        return (EntityManager) Proxy.newProxyInstance(EntityManager.class.getClassLoader(), new Class[]{EntityManager.class}, new PersistenceExceptionConverter(session, em));
     }
 
-    private PersistenceExceptionConverter(EntityManager em) {
+    private PersistenceExceptionConverter(KeycloakSession session, EntityManager em) {
+        batchEnabled = session.getAttributeOrDefault(Constants.STORAGE_BATCH_ENABLED, false);
+        batchSize = session.getAttributeOrDefault(Constants.STORAGE_BATCH_SIZE, 100);
         this.em = em;
     }
 
     @Override
     public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
         try {
+            flushInBatchIfEnabled(method);
             return method.invoke(em, args);
         } catch (InvocationTargetException e) {
             throw convert(e.getCause());
+        }
+    }
+
+    private void flushInBatchIfEnabled(Method method) {
+        if (batchEnabled) {
+            if (WRITE_METHOD_NAMES.contains(method.getName())) {
+                if (changeCount++ > batchSize) {
+                    em.flush();
+                    em.clear();
+                    changeCount = 0;
+                }
+            }
         }
     }
 

--- a/model/jpa/src/main/java/org/keycloak/connections/jpa/PersistenceExceptionConverter.java
+++ b/model/jpa/src/main/java/org/keycloak/connections/jpa/PersistenceExceptionConverter.java
@@ -29,19 +29,18 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
-import java.util.Arrays;
-import java.util.Collection;
+import java.util.regex.Pattern;
 
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
  */
 public class PersistenceExceptionConverter implements InvocationHandler {
 
-    private static final Collection<String> WRITE_METHOD_NAMES = Arrays.asList("persist", "merge");
+    private static final Pattern WRITE_METHOD_NAMES = Pattern.compile("persist|merge");
 
     private final EntityManager em;
-    private final Boolean batchEnabled;
-    private final Integer batchSize;
+    private final boolean batchEnabled;
+    private final int batchSize;
     private int changeCount = 0;
 
     public static EntityManager create(KeycloakSession session, EntityManager em) {
@@ -66,7 +65,7 @@ public class PersistenceExceptionConverter implements InvocationHandler {
 
     private void flushInBatchIfEnabled(Method method) {
         if (batchEnabled) {
-            if (WRITE_METHOD_NAMES.contains(method.getName())) {
+            if (WRITE_METHOD_NAMES.matcher(method.getName()).matches()) {
                 if (changeCount++ > batchSize) {
                     em.flush();
                     em.clear();

--- a/quarkus/runtime/src/main/java/org/keycloak/connections/jpa/QuarkusJpaConnectionProviderFactory.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/connections/jpa/QuarkusJpaConnectionProviderFactory.java
@@ -61,7 +61,6 @@ import org.keycloak.models.UserModel;
 import org.keycloak.models.UserProvider;
 import org.keycloak.models.dblock.DBLockManager;
 import org.keycloak.models.dblock.DBLockProvider;
-import org.keycloak.models.utils.DefaultKeyProviders;
 import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.models.utils.RepresentationToModel;
 import org.keycloak.provider.ServerInfoAwareProviderFactory;
@@ -113,7 +112,7 @@ public class QuarkusJpaConnectionProviderFactory implements JpaConnectionProvide
 
             em = emf.createEntityManager(SynchronizationType.SYNCHRONIZED);
         }
-        em = PersistenceExceptionConverter.create(em);
+        em = PersistenceExceptionConverter.create(session, em);
         if (!jtaEnabled) session.getTransactionManager().enlist(new JpaKeycloakTransaction(em));
         return new DefaultJpaConnectionProvider(em);
     }

--- a/server-spi-private/src/main/java/org/keycloak/migration/MigrationModelManager.java
+++ b/server-spi-private/src/main/java/org/keycloak/migration/MigrationModelManager.java
@@ -52,6 +52,7 @@ import org.keycloak.migration.migrators.MigrateTo8_0_2;
 import org.keycloak.migration.migrators.MigrateTo9_0_0;
 import org.keycloak.migration.migrators.MigrateTo9_0_4;
 import org.keycloak.migration.migrators.Migration;
+import org.keycloak.models.Constants;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.representations.idm.RealmRepresentation;
@@ -96,6 +97,8 @@ public class MigrationModelManager {
     };
 
     public static void migrate(KeycloakSession session) {
+        session.setAttribute(Constants.STORAGE_BATCH_ENABLED, Boolean.getBoolean("keycloak.migration.batch-enabled"));
+        session.setAttribute(Constants.STORAGE_BATCH_SIZE, Integer.getInteger("keycloak.migration.batch-size"));
         MigrationModel model = session.realms().getMigrationModel();
 
         ModelVersion currentVersion = new ModelVersion(Version.VERSION_KEYCLOAK);

--- a/server-spi-private/src/main/java/org/keycloak/models/Constants.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/Constants.java
@@ -108,4 +108,14 @@ public final class Constants {
     public static final Pattern CFG_DELIMITER_PATTERN = Pattern.compile("\\s*" + CFG_DELIMITER + "\\s*");
 
     public static final String OFFLINE_ACCESS_SCOPE_CONSENT_TEXT = "${offlineAccessScopeConsentText}";
+
+    /**
+     * If set as an attribute in the {@link KeycloakSession}, indicates that the storage should batch write operations.
+     */
+    public static final String STORAGE_BATCH_ENABLED = "org.keycloak.storage.batch_enabled";
+
+    /**
+     * If {@code #STORAGE_BATCH_ENABLED} is set, indicates the batch size.
+     */
+    public static final String STORAGE_BATCH_SIZE = "org.keycloak.storage.batch_size";
 }


### PR DESCRIPTION
These changes aim to:

* Allow setting whether migration changes should be done in batches
* Allow setting how many migration changes should be done in batch
* Possible useful to other scenarios where a large number of changes to storage is made

Expected result:

* Time to migrate should be drastically reduced. Tests using the latest version migrate 1K realms in `555528ms`, whereas with these changes migration happens in ` 54595ms`.

During migration, we should expect degradation due to the number of changes being made. By using a batch approach (as recommended by Hibernate, btw), we can improve performance and startup.

We should expect better results if running using https://github.com/keycloak/keycloak/pull/7712.