### PR TITLE
KEYCLOAK-13633 Remove java.security.acl.Group usages from tomcat adapters

### DIFF
--- a/adapters/oidc/as7-eap6/as7-adapter-spi/src/main/java/org/keycloak/adapters/jbossweb/JBossWebPrincipalFactory.java
+++ b/adapters/oidc/as7-eap6/as7-adapter-spi/src/main/java/org/keycloak/adapters/jbossweb/JBossWebPrincipalFactory.java
@@ -27,7 +27,7 @@ import org.jboss.security.SecurityContextAssociation;
 import org.jboss.security.SimpleGroup;
 import org.jboss.security.SimplePrincipal;
 import org.keycloak.adapters.spi.KeycloakAccount;
-import org.keycloak.adapters.tomcat.GenericPrincipalFactory;
+import org.keycloak.adapters.tomcat.PrincipalFactory;
 
 import javax.security.auth.Subject;
 import java.lang.reflect.Constructor;
@@ -44,14 +44,9 @@ import java.util.Set;
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
  */
-public class JBossWebPrincipalFactory extends GenericPrincipalFactory {
+public class JBossWebPrincipalFactory implements PrincipalFactory {
 
     private static Constructor jbossWebPrincipalConstructor = findJBossGenericPrincipalConstructor();
-
-    @Override
-    protected GenericPrincipal createPrincipal(Principal userPrincipal, List<String> roles) {
-        return null;
-    }
 
     @Override
     public GenericPrincipal createPrincipal(Realm realm, final Principal identity, final Set<String> roleSet) {

--- a/adapters/oidc/as7-eap6/as7-adapter/src/main/java/org/keycloak/adapters/jbossweb/KeycloakAuthenticatorValve.java
+++ b/adapters/oidc/as7-eap6/as7-adapter/src/main/java/org/keycloak/adapters/jbossweb/KeycloakAuthenticatorValve.java
@@ -27,7 +27,7 @@ import org.apache.catalina.deploy.LoginConfig;
 import org.keycloak.adapters.AdapterDeploymentContext;
 import org.keycloak.adapters.tomcat.AbstractAuthenticatedActionsValve;
 import org.keycloak.adapters.tomcat.AbstractKeycloakAuthenticatorValve;
-import org.keycloak.adapters.tomcat.GenericPrincipalFactory;
+import org.keycloak.adapters.tomcat.PrincipalFactory;
 
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -65,7 +65,7 @@ public class KeycloakAuthenticatorValve extends AbstractKeycloakAuthenticatorVal
     }
 
     @Override
-    protected GenericPrincipalFactory createPrincipalFactory() {
+    protected PrincipalFactory createPrincipalFactory() {
         return new JBossWebPrincipalFactory();
     }
 

--- a/adapters/oidc/tomcat/tomcat-core/src/main/java/org/keycloak/adapters/tomcat/AbstractKeycloakAuthenticatorValve.java
+++ b/adapters/oidc/tomcat/tomcat-core/src/main/java/org/keycloak/adapters/tomcat/AbstractKeycloakAuthenticatorValve.java
@@ -183,7 +183,7 @@ public abstract class AbstractKeycloakAuthenticatorValve extends FormAuthenticat
         }
     }
 
-    protected abstract GenericPrincipalFactory createPrincipalFactory();
+    protected abstract PrincipalFactory createPrincipalFactory();
     protected abstract boolean forwardToErrorPageInternal(Request request, HttpServletResponse response, Object loginConfig) throws IOException;
     protected abstract AbstractAuthenticatedActionsValve createAuthenticatedActionsValve(AdapterDeploymentContext deploymentContext, Valve next, Container container);
 

--- a/adapters/oidc/tomcat/tomcat-core/src/main/java/org/keycloak/adapters/tomcat/CatalinaCookieTokenStore.java
+++ b/adapters/oidc/tomcat/tomcat-core/src/main/java/org/keycloak/adapters/tomcat/CatalinaCookieTokenStore.java
@@ -43,11 +43,11 @@ public class CatalinaCookieTokenStore implements AdapterTokenStore {
     private Request request;
     private HttpFacade facade;
     private KeycloakDeployment deployment;
-    private GenericPrincipalFactory principalFactory;
+    private PrincipalFactory principalFactory;
 
     private KeycloakPrincipal<RefreshableKeycloakSecurityContext> authenticatedPrincipal;
 
-    public CatalinaCookieTokenStore(Request request, HttpFacade facade, KeycloakDeployment deployment, GenericPrincipalFactory principalFactory) {
+    public CatalinaCookieTokenStore(Request request, HttpFacade facade, KeycloakDeployment deployment, PrincipalFactory principalFactory) {
         this.request = request;
         this.facade = facade;
         this.deployment = deployment;

--- a/adapters/oidc/tomcat/tomcat-core/src/main/java/org/keycloak/adapters/tomcat/CatalinaRequestAuthenticator.java
+++ b/adapters/oidc/tomcat/tomcat-core/src/main/java/org/keycloak/adapters/tomcat/CatalinaRequestAuthenticator.java
@@ -41,13 +41,13 @@ import java.util.logging.Logger;
 public class CatalinaRequestAuthenticator extends RequestAuthenticator {
     private static final Logger log = Logger.getLogger(""+CatalinaRequestAuthenticator.class);
     protected Request request;
-    protected GenericPrincipalFactory principalFactory;
+    protected PrincipalFactory principalFactory;
 
     public CatalinaRequestAuthenticator(KeycloakDeployment deployment,
                                         AdapterTokenStore tokenStore,
                                         CatalinaHttpFacade facade,
                                         Request request,
-                                        GenericPrincipalFactory principalFactory) {
+                                        PrincipalFactory principalFactory) {
         super(facade, deployment, tokenStore, request.getConnector().getRedirectPort());
         this.request = request;
         this.principalFactory = principalFactory;

--- a/adapters/oidc/tomcat/tomcat-core/src/main/java/org/keycloak/adapters/tomcat/CatalinaSessionTokenStore.java
+++ b/adapters/oidc/tomcat/tomcat-core/src/main/java/org/keycloak/adapters/tomcat/CatalinaSessionTokenStore.java
@@ -45,12 +45,12 @@ public class CatalinaSessionTokenStore extends CatalinaAdapterSessionStore imple
 
     private KeycloakDeployment deployment;
     private CatalinaUserSessionManagement sessionManagement;
-    protected GenericPrincipalFactory principalFactory;
+    protected PrincipalFactory principalFactory;
 
 
     public CatalinaSessionTokenStore(Request request, KeycloakDeployment deployment,
                                      CatalinaUserSessionManagement sessionManagement,
-                                     GenericPrincipalFactory principalFactory,
+                                     PrincipalFactory principalFactory,
                                      AbstractKeycloakAuthenticatorValve valve) {
         super(request, valve);
         this.deployment = deployment;

--- a/adapters/saml/as7-eap6/adapter/src/main/java/org/keycloak/adapters/saml/jbossweb/SamlAuthenticatorValve.java
+++ b/adapters/saml/as7-eap6/adapter/src/main/java/org/keycloak/adapters/saml/jbossweb/SamlAuthenticatorValve.java
@@ -26,7 +26,7 @@ import org.apache.catalina.deploy.LoginConfig;
 import org.keycloak.adapters.jbossweb.JBossWebPrincipalFactory;
 import org.keycloak.adapters.saml.*;
 import org.keycloak.adapters.spi.SessionIdMapperUpdater;
-import org.keycloak.adapters.tomcat.GenericPrincipalFactory;
+import org.keycloak.adapters.tomcat.PrincipalFactory;
 
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -69,7 +69,7 @@ public class SamlAuthenticatorValve extends AbstractSamlAuthenticatorValve {
     }
 
     @Override
-    protected GenericPrincipalFactory createPrincipalFactory() {
+    protected PrincipalFactory createPrincipalFactory() {
         return new JBossWebPrincipalFactory();
     }
 

--- a/adapters/saml/tomcat/tomcat-core/src/main/java/org/keycloak/adapters/saml/AbstractSamlAuthenticatorValve.java
+++ b/adapters/saml/tomcat/tomcat-core/src/main/java/org/keycloak/adapters/saml/AbstractSamlAuthenticatorValve.java
@@ -31,7 +31,7 @@ import org.keycloak.adapters.saml.config.parsers.ResourceLoader;
 import org.keycloak.adapters.spi.*;
 import org.keycloak.adapters.tomcat.CatalinaHttpFacade;
 import org.keycloak.adapters.tomcat.CatalinaUserSessionManagement;
-import org.keycloak.adapters.tomcat.GenericPrincipalFactory;
+import org.keycloak.adapters.tomcat.PrincipalFactory;
 import org.keycloak.saml.common.exceptions.ParsingException;
 
 import javax.servlet.RequestDispatcher;
@@ -186,7 +186,7 @@ public abstract class AbstractSamlAuthenticatorValve extends FormAuthenticator i
 
     }
 
-    protected abstract GenericPrincipalFactory createPrincipalFactory();
+    protected abstract PrincipalFactory createPrincipalFactory();
     protected abstract boolean forwardToErrorPageInternal(Request request, HttpServletResponse response, Object loginConfig) throws IOException;
     private static final Pattern PROTOCOL_PATTERN = Pattern.compile("^[a-zA-Z][a-zA-Z0-9+.-]*:");
 

--- a/adapters/saml/tomcat/tomcat-core/src/main/java/org/keycloak/adapters/saml/CatalinaSamlSessionStore.java
+++ b/adapters/saml/tomcat/tomcat-core/src/main/java/org/keycloak/adapters/saml/CatalinaSamlSessionStore.java
@@ -26,7 +26,7 @@ import org.keycloak.adapters.spi.HttpFacade;
 import org.keycloak.adapters.spi.SessionIdMapper;
 import org.keycloak.adapters.spi.SessionIdMapperUpdater;
 import org.keycloak.adapters.tomcat.CatalinaUserSessionManagement;
-import org.keycloak.adapters.tomcat.GenericPrincipalFactory;
+import org.keycloak.adapters.tomcat.PrincipalFactory;
 import org.keycloak.common.util.KeycloakUriBuilder;
 
 import javax.servlet.http.HttpSession;
@@ -44,7 +44,7 @@ public class CatalinaSamlSessionStore implements SamlSessionStore {
     public static final String SAML_REDIRECT_URI = "SAML_REDIRECT_URI";
 
     private final CatalinaUserSessionManagement sessionManagement;
-    protected final GenericPrincipalFactory principalFactory;
+    protected final PrincipalFactory principalFactory;
     private final SessionIdMapper idMapper;
     private final SessionIdMapperUpdater idMapperUpdater;
     protected final Request request;
@@ -52,7 +52,7 @@ public class CatalinaSamlSessionStore implements SamlSessionStore {
     protected final HttpFacade facade;
     protected final SamlDeployment deployment;
 
-    public CatalinaSamlSessionStore(CatalinaUserSessionManagement sessionManagement, GenericPrincipalFactory principalFactory,
+    public CatalinaSamlSessionStore(CatalinaUserSessionManagement sessionManagement, PrincipalFactory principalFactory,
                                     SessionIdMapper idMapper, SessionIdMapperUpdater idMapperUpdater,
                                     Request request, AbstractSamlAuthenticatorValve valve, HttpFacade facade,
                                     SamlDeployment deployment) {

--- a/adapters/saml/tomcat/tomcat/src/main/java/org/keycloak/adapters/saml/tomcat/TomcatSamlSessionStore.java
+++ b/adapters/saml/tomcat/tomcat/src/main/java/org/keycloak/adapters/saml/tomcat/TomcatSamlSessionStore.java
@@ -26,14 +26,14 @@ import org.keycloak.adapters.spi.HttpFacade;
 import org.keycloak.adapters.spi.SessionIdMapper;
 import org.keycloak.adapters.spi.SessionIdMapperUpdater;
 import org.keycloak.adapters.tomcat.CatalinaUserSessionManagement;
-import org.keycloak.adapters.tomcat.GenericPrincipalFactory;
+import org.keycloak.adapters.tomcat.PrincipalFactory;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
  */
 public class TomcatSamlSessionStore extends CatalinaSamlSessionStore {
-    public TomcatSamlSessionStore(CatalinaUserSessionManagement sessionManagement, GenericPrincipalFactory principalFactory, SessionIdMapper idMapper, Request request, AbstractSamlAuthenticatorValve valve, HttpFacade facade, SamlDeployment deployment) {
+    public TomcatSamlSessionStore(CatalinaUserSessionManagement sessionManagement, PrincipalFactory principalFactory, SessionIdMapper idMapper, Request request, AbstractSamlAuthenticatorValve valve, HttpFacade facade, SamlDeployment deployment) {
         super(sessionManagement, principalFactory, idMapper, SessionIdMapperUpdater.DIRECT, request, valve, facade, deployment);
     }
 

--- a/adapters/spi/jboss-adapter-core/src/main/java/org/keycloak/adapters/jboss/KeycloakLoginModule.java
+++ b/adapters/spi/jboss-adapter-core/src/main/java/org/keycloak/adapters/jboss/KeycloakLoginModule.java
@@ -30,7 +30,6 @@ import javax.security.auth.callback.UnsupportedCallbackException;
 import javax.security.auth.login.LoginException;
 import java.io.IOException;
 import java.security.Principal;
-import java.security.acl.Group;
 import java.util.Set;
 
 /**
@@ -83,10 +82,10 @@ public class KeycloakLoginModule extends AbstractServerLoginModule {
     */
 
     @Override
-    protected Group[] getRoleSets() throws LoginException {
+    protected SimpleGroup[] getRoleSets() throws LoginException {
         //log.info("getRoleSets");
         SimpleGroup roles = new SimpleGroup("Roles");
-        Group[] roleSets = {roles};
+        SimpleGroup[] roleSets = {roles};
         for (String role : roleSet) {
             //log.info("   adding role: " + role);
             roles.addMember(new SimplePrincipal(role));

--- a/adapters/spi/tomcat-adapter-spi/src/main/java/org/keycloak/adapters/tomcat/GenericPrincipalFactory.java
+++ b/adapters/spi/tomcat-adapter-spi/src/main/java/org/keycloak/adapters/tomcat/GenericPrincipalFactory.java
@@ -24,16 +24,17 @@ import javax.security.auth.Subject;
 import java.security.Principal;
 import java.util.ArrayList;
 import java.util.Enumeration;
-import java.util.List;
 import java.util.Collection;
+import java.util.List;
 import java.util.Set;
 
 /**
  * @author <a href="mailto:ungarida@gmail.com">Davide Ungari</a>
  * @version $Revision: 1 $
  */
-public abstract class GenericPrincipalFactory {
+public abstract class GenericPrincipalFactory implements PrincipalFactory {
 
+    @Override
     public GenericPrincipal createPrincipal(Realm realm, final Principal identity, final Set<String> roleSet) {
         Subject subject = new Subject();
         Set<Principal> principals = subject.getPrincipals();

--- a/adapters/spi/tomcat-adapter-spi/src/main/java/org/keycloak/adapters/tomcat/GenericPrincipalFactory.java
+++ b/adapters/spi/tomcat-adapter-spi/src/main/java/org/keycloak/adapters/tomcat/GenericPrincipalFactory.java
@@ -22,7 +22,11 @@ import org.apache.catalina.realm.GenericPrincipal;
 
 import javax.security.auth.Subject;
 import java.security.Principal;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Collection;
+import java.util.Set;
 
 /**
  * @author <a href="mailto:ungarida@gmail.com">Davide Ungari</a>

--- a/adapters/spi/tomcat-adapter-spi/src/main/java/org/keycloak/adapters/tomcat/PrincipalFactory.java
+++ b/adapters/spi/tomcat-adapter-spi/src/main/java/org/keycloak/adapters/tomcat/PrincipalFactory.java
@@ -1,0 +1,11 @@
+package org.keycloak.adapters.tomcat;
+
+import org.apache.catalina.Realm;
+import org.apache.catalina.realm.GenericPrincipal;
+
+import java.security.Principal;
+import java.util.Set;
+
+public interface PrincipalFactory {
+    GenericPrincipal createPrincipal(Realm realm, final Principal identity, final Set<String> roleSet);
+}

--- a/adapters/spi/tomcat-adapter-spi/src/main/java/org/keycloak/adapters/tomcat/SimpleGroup.java
+++ b/adapters/spi/tomcat-adapter-spi/src/main/java/org/keycloak/adapters/tomcat/SimpleGroup.java
@@ -18,13 +18,12 @@
 package org.keycloak.adapters.tomcat;
 
 import java.security.Principal;
-import java.security.acl.Group;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Set;
 
-public class SimpleGroup extends SimplePrincipal implements Group {
+public class SimpleGroup extends SimplePrincipal {
     private final Set<Principal> members = new HashSet<Principal>();
 
     /**


### PR DESCRIPTION
This PR supersedes #7533, check that for previous discussions. This PR merely changes a few abstractions around, preventing the previous changes from breaking other adapters.

I introduced the new interface `PrincipleFactory ` that is used on many places where previously `GenericPrincipleFactory` was used. `JBossWebPrincipalFactory` is not derived from `GenericPrincipleFactory` anymore. Both `JBossWebPrincipalFactory` and `GenericPrincipleFactory` implement the new `PrincipleFactory ` interface, allowing them to be used in the same way as before, just behind a different interface.

This change allows to implement `JBossWebPrincipalFactory` and `GenericPrincipleFactory` completely separate from each other. `GenericPrincipleFactory` now has no more references to `java.security.acl.Group`, instead it directly uses its own SimpleGroup class. `JBossWebPrincipalFactory` is unchanged and still uses `java.security.acl.Group`, since that seems to be required by the systems to be adapted.