### PR TITLE
KEYCLOAK-11019 Initial support for lazy offline user-session loading

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanUserSessionProvider.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanUserSessionProvider.java
@@ -352,7 +352,7 @@ public class InfinispanUserSessionProvider implements UserSessionProvider {
             // fetch the offline user-sessions from the persistence provider
             UserSessionPersisterProvider persister = session.getProvider(UserSessionPersisterProvider.class);
 
-            UserModel user = session.users().getUserById(realm, predicate.getUser());
+            UserModel user = session.users().getUserById(realm, predicate.getUserId());
             if (user != null) {
                 return persister.loadUserSessionsStream(realm, user, offline, 0, null);
             }
@@ -360,13 +360,13 @@ public class InfinispanUserSessionProvider implements UserSessionProvider {
             if (predicate.getBrokerSessionId() != null) {
                 // TODO add support for offline user-session lookup by brokerSessionId
                 // currently it is not possible to access the brokerSessionId in offline user-session in a database agnostic way
-                throw new ModelException("Dynamic database lookup for offline user-sessions by brokerSessionId is currently not supported.");
+                throw new ModelException("Dynamic database lookup for offline user-sessions by brokerSessionId is currently only supported for preloaded sessions.");
             }
 
             if (predicate.getBrokerUserId() != null) {
                 // TODO add support for offline user-session lookup by brokerUserId
                 // currently it is not possible to access the brokerUserId in offline user-session in a database agnostic way
-                throw new ModelException("Dynamic database lookup for offline user-sessions by brokerUserId is currently not supported.");
+                throw new ModelException("Dynamic database lookup for offline user-sessions by brokerUserId is currently only supported for preloaded sessions.");
             }
 
         }

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanUserSessionProvider.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanUserSessionProvider.java
@@ -30,6 +30,7 @@ import org.keycloak.device.DeviceActivityManager;
 import org.keycloak.models.AuthenticatedClientSessionModel;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.ModelException;
 import org.keycloak.models.OfflineUserSessionModel;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserLoginFailureModel;
@@ -65,9 +66,11 @@ import org.keycloak.models.sessions.infinispan.util.SessionTimeouts;
 
 import java.io.Serializable;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -112,6 +115,8 @@ public class InfinispanUserSessionProvider implements UserSessionProvider {
     protected final RemoteCacheInvoker remoteCacheInvoker;
     protected final InfinispanKeyGenerator keyGenerator;
 
+    protected final boolean loadOfflineSessionsStatsFromDatabase;
+
     public InfinispanUserSessionProvider(KeycloakSession session,
                                          RemoteCacheInvoker remoteCacheInvoker,
                                          CrossDCLastSessionRefreshStore lastSessionRefreshStore,
@@ -122,7 +127,8 @@ public class InfinispanUserSessionProvider implements UserSessionProvider {
                                          Cache<String, SessionEntityWrapper<UserSessionEntity>> offlineSessionCache,
                                          Cache<UUID, SessionEntityWrapper<AuthenticatedClientSessionEntity>> clientSessionCache,
                                          Cache<UUID, SessionEntityWrapper<AuthenticatedClientSessionEntity>> offlineClientSessionCache,
-                                         Cache<LoginFailureKey, SessionEntityWrapper<LoginFailureEntity>> loginFailureCache) {
+                                         Cache<LoginFailureKey, SessionEntityWrapper<LoginFailureEntity>> loginFailureCache,
+                                         boolean loadOfflineSessionsStatsFromDatabase) {
         this.session = session;
 
         this.sessionCache = sessionCache;
@@ -145,6 +151,7 @@ public class InfinispanUserSessionProvider implements UserSessionProvider {
         this.persisterLastSessionRefreshStore = persisterLastSessionRefreshStore;
         this.remoteCacheInvoker = remoteCacheInvoker;
         this.keyGenerator = keyGenerator;
+        this.loadOfflineSessionsStatsFromDatabase = loadOfflineSessionsStatsFromDatabase;
 
         session.getTransactionManager().enlistAfterCompletion(clusterEventsSenderTx);
         session.getTransactionManager().enlistAfterCompletion(sessionTx);
@@ -246,10 +253,7 @@ public class InfinispanUserSessionProvider implements UserSessionProvider {
 
         entity.setStarted(currentTime);
         entity.setLastSessionRefresh(currentTime);
-
-
     }
-
 
     @Override
     public UserSessionModel getUserSession(RealmModel realm, String id) {
@@ -257,8 +261,70 @@ public class InfinispanUserSessionProvider implements UserSessionProvider {
     }
 
     protected UserSessionAdapter getUserSession(RealmModel realm, String id, boolean offline) {
-        UserSessionEntity entity = getUserSessionEntity(realm, id, offline);
-        return wrap(realm, entity, offline);
+
+        UserSessionEntity userSessionEntityFromCache = getUserSessionEntity(realm, id, offline);
+        if (userSessionEntityFromCache != null) {
+            return wrap(realm, userSessionEntityFromCache, offline);
+        }
+
+        if (!offline) {
+            return null;
+        }
+
+        // Try to recover from potentially lost offline-sessions by attempting to fetch and re-import
+        // the offline session information from the PersistenceProvider.
+        UserSessionEntity userSessionEntityFromPersistenceProvider = getUserSessionEntityFromPersistenceProvider(realm, id, offline);
+        if (userSessionEntityFromPersistenceProvider != null) {
+            // we successfully recovered the offline session!
+            return wrap(realm, userSessionEntityFromPersistenceProvider, offline);
+        }
+
+        // no luck, the session is really not there anymore
+        return null;
+    }
+
+    private UserSessionEntity getUserSessionEntityFromPersistenceProvider(RealmModel realm, String sessionId, boolean offline) {
+
+        log.debugf("Offline user-session not found in infinispan, attempting UserSessionPersisterProvider lookup for sessionId=%s", sessionId);
+        UserSessionPersisterProvider persister = session.getProvider(UserSessionPersisterProvider.class);
+        UserSessionModel persistentUserSession = persister.loadUserSession(realm, sessionId, offline);
+
+        if (persistentUserSession == null) {
+            log.debugf("Offline user-session not found in UserSessionPersisterProvider for sessionId=%s", sessionId);
+            return null;
+        }
+
+        return importUserSession(realm, offline, persistentUserSession);
+    }
+
+    private UserSessionEntity getUserSessionEntityFromCacheOrImportIfNecessary(RealmModel realm, boolean offline, UserSessionModel persistentUserSession) {
+
+        UserSessionEntity userSessionEntity = getUserSessionEntity(realm, persistentUserSession.getId(), offline);
+        if (userSessionEntity != null) {
+            // user session present in cache, return existing session
+            return userSessionEntity;
+        }
+
+        return importUserSession(realm, offline, persistentUserSession);
+    }
+
+    private UserSessionEntity importUserSession(RealmModel realm, boolean offline, UserSessionModel persistentUserSession) {
+
+        String sessionId = persistentUserSession.getId();
+
+        log.debugf("Attempting to import user-session for sessionId=%s offline=%s", sessionId, offline);
+        session.sessions().importUserSessions(Collections.singleton(persistentUserSession), offline);
+        log.debugf("user-session imported, trying another lookup for sessionId=%s offline=%s", sessionId, offline);
+
+        UserSessionEntity ispnUserSessionEntity = getUserSessionEntity(realm, sessionId, offline);
+
+        if (ispnUserSessionEntity != null) {
+            log.debugf("user-session found after import for sessionId=%s offline=%s", sessionId, offline);
+            return ispnUserSessionEntity;
+        }
+
+        log.debugf("user-session could not be found after import for sessionId=%s offline=%s", sessionId, offline);
+        return null;
     }
 
     private UserSessionEntity getUserSessionEntity(RealmModel realm, String id, boolean offline) {
@@ -270,8 +336,41 @@ public class InfinispanUserSessionProvider implements UserSessionProvider {
         return entity;
     }
 
+    private Stream<UserSessionModel> getUserSessionsFromPersistenceProviderStream(RealmModel realm, UserModel user, boolean offline) {
+        UserSessionPersisterProvider persister = session.getProvider(UserSessionPersisterProvider.class);
+        return persister.loadUserSessionsStream(realm, user, offline, 0, null)
+                .map(persistentUserSession -> getUserSessionEntityFromCacheOrImportIfNecessary(realm, offline, persistentUserSession))
+                .filter(Objects::nonNull)
+                .map(userSessionEntity -> wrap(realm, userSessionEntity, offline));
+    }
 
-    protected Stream<UserSessionModel> getUserSessionsStream(RealmModel realm, Predicate<Map.Entry<String, SessionEntityWrapper<UserSessionEntity>>> predicate, boolean offline) {
+
+    protected Stream<UserSessionModel> getUserSessionsStream(RealmModel realm, UserSessionPredicate predicate, boolean offline) {
+
+        if (offline && loadOfflineSessionsStatsFromDatabase) {
+
+            // fetch the offline user-sessions from the persistence provider
+            UserSessionPersisterProvider persister = session.getProvider(UserSessionPersisterProvider.class);
+
+            UserModel user = session.users().getUserById(realm, predicate.getUser());
+            if (user != null) {
+                return persister.loadUserSessionsStream(realm, user, offline, 0, null);
+            }
+
+            if (predicate.getBrokerSessionId() != null) {
+                // TODO add support for offline user-session lookup by brokerSessionId
+                // currently it is not possible to access the brokerSessionId in offline user-session in a database agnostic way
+                throw new ModelException("Dynamic database lookup for offline user-sessions by brokerSessionId is currently not supported.");
+            }
+
+            if (predicate.getBrokerUserId() != null) {
+                // TODO add support for offline user-session lookup by brokerUserId
+                // currently it is not possible to access the brokerUserId in offline user-session in a database agnostic way
+                throw new ModelException("Dynamic database lookup for offline user-sessions by brokerUserId is currently not supported.");
+            }
+
+        }
+
         Cache<String, SessionEntityWrapper<UserSessionEntity>> cache = getCache(offline);
         cache = CacheDecorators.skipCacheLoaders(cache);
 
@@ -323,6 +422,13 @@ public class InfinispanUserSessionProvider implements UserSessionProvider {
     }
 
     protected Stream<UserSessionModel> getUserSessionsStream(final RealmModel realm, ClientModel client, Integer firstResult, Integer maxResults, final boolean offline) {
+
+        if (offline && loadOfflineSessionsStatsFromDatabase) {
+            // fetch the actual offline user session count from the database
+            UserSessionPersisterProvider persister = session.getProvider(UserSessionPersisterProvider.class);
+            return persister.loadUserSessionsStream(realm, client, offline, firstResult, maxResults);
+        }
+
         final String clientUuid = client.getId();
         UserSessionPredicate predicate = UserSessionPredicate.create(realm.getId()).client(clientUuid);
 
@@ -412,6 +518,12 @@ public class InfinispanUserSessionProvider implements UserSessionProvider {
 
     @Override
     public Map<String, Long> getActiveClientSessionStats(RealmModel realm, boolean offline) {
+
+        if (offline && loadOfflineSessionsStatsFromDatabase) {
+            UserSessionPersisterProvider persister = session.getProvider(UserSessionPersisterProvider.class);
+            return persister.getUserSessionsCountsByClients(realm, offline);
+        }
+
         Cache<String, SessionEntityWrapper<UserSessionEntity>> cache = getCache(offline);
         cache = CacheDecorators.skipCacheLoaders(cache);
         return cache.entrySet().stream()
@@ -426,6 +538,13 @@ public class InfinispanUserSessionProvider implements UserSessionProvider {
     }
 
      protected long getUserSessionsCount(RealmModel realm, ClientModel client, boolean offline) {
+
+        if (offline && loadOfflineSessionsStatsFromDatabase) {
+            // fetch the actual offline user session count from the database
+            UserSessionPersisterProvider persister = session.getProvider(UserSessionPersisterProvider.class);
+            return persister.getUserSessionsCount(realm, client, offline);
+        }
+
         Cache<String, SessionEntityWrapper<UserSessionEntity>> cache = getCache(offline);
         cache = CacheDecorators.skipCacheLoaders(cache);
 
@@ -741,7 +860,12 @@ public class InfinispanUserSessionProvider implements UserSessionProvider {
 
     @Override
     public Stream<UserSessionModel> getOfflineUserSessionsStream(RealmModel realm, UserModel user) {
-        return this.getUserSessionsStream(realm, UserSessionPredicate.create(realm.getId()).user(user.getId()), true);
+
+        if (loadOfflineSessionsStatsFromDatabase) {
+            return getUserSessionsFromPersistenceProviderStream(realm, user, true);
+        }
+
+        return getUserSessionsStream(realm, UserSessionPredicate.create(realm.getId()).user(user.getId()), true);
     }
 
     @Override

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanUserSessionProviderFactory.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanUserSessionProviderFactory.java
@@ -100,9 +100,11 @@ public class InfinispanUserSessionProviderFactory implements UserSessionProvider
         Cache<UUID, SessionEntityWrapper<AuthenticatedClientSessionEntity>> offlineClientSessionsCache = connections.getCache(InfinispanConnectionProvider.OFFLINE_CLIENT_SESSION_CACHE_NAME);
         Cache<LoginFailureKey, SessionEntityWrapper<LoginFailureEntity>> loginFailures = connections.getCache(InfinispanConnectionProvider.LOGIN_FAILURE_CACHE_NAME);
 
+        boolean loadOfflineSessionsStatsFromDatabase = !isPreloadingOfflineSessionsFromDatabaseEnabled();
+
         return new InfinispanUserSessionProvider(session, remoteCacheInvoker, lastSessionRefreshStore, offlineLastSessionRefreshStore,
                 persisterLastSessionRefreshStore, keyGenerator,
-          cache, offlineSessionsCache, clientSessionCache, offlineClientSessionsCache, loginFailures);
+          cache, offlineSessionsCache, clientSessionCache, offlineClientSessionsCache, loginFailures, loadOfflineSessionsStatsFromDatabase);
     }
 
     @Override
@@ -152,6 +154,10 @@ public class InfinispanUserSessionProviderFactory implements UserSessionProvider
         });
     }
 
+    private boolean isPreloadingOfflineSessionsFromDatabaseEnabled() {
+        return config.getBoolean("preloadOfflineSessionsFromDatabase", true);
+    }
+
     // Max count of worker errors. Initialization will end with exception when this number is reached
     private int getMaxErrors() {
         return config.getInt("maxErrors", 20);
@@ -170,23 +176,32 @@ public class InfinispanUserSessionProviderFactory implements UserSessionProvider
 
     @Override
     public void loadPersistentSessions(final KeycloakSessionFactory sessionFactory, final int maxErrors, final int sessionsPerSegment) {
-        log.debug("Start pre-loading userSessions from persistent storage");
 
         KeycloakModelUtils.runJobInTransaction(sessionFactory, new KeycloakSessionTask() {
 
             @Override
             public void run(KeycloakSession session) {
-                InfinispanConnectionProvider connections = session.getProvider(InfinispanConnectionProvider.class);
-                Cache<String, Serializable> workCache = connections.getCache(InfinispanConnectionProvider.WORK_CACHE_NAME);
 
-                InfinispanCacheInitializer ispnInitializer = new InfinispanCacheInitializer(sessionFactory, workCache,
-                        new OfflinePersistentUserSessionLoader(sessionsPerSegment), "offlineUserSessions", sessionsPerSegment, maxErrors);
+                if (isPreloadingOfflineSessionsFromDatabaseEnabled()) {
+                    // only preload offline-sessions if necessary
+                    log.debug("Start pre-loading userSessions from persistent storage");
 
-                // DB-lock to ensure that persistent sessions are loaded from DB just on one DC. The other DCs will load them from remote cache.
-                CacheInitializer initializer = new DBLockBasedCacheInitializer(session, ispnInitializer);
+                    InfinispanConnectionProvider connections = session.getProvider(InfinispanConnectionProvider.class);
+                    Cache<String, Serializable> workCache = connections.getCache(InfinispanConnectionProvider.WORK_CACHE_NAME);
 
-                initializer.initCache();
-                initializer.loadSessions();
+                    InfinispanCacheInitializer ispnInitializer = new InfinispanCacheInitializer(sessionFactory, workCache,
+                            new OfflinePersistentUserSessionLoader(sessionsPerSegment), "offlineUserSessions", sessionsPerSegment, maxErrors);
+
+                    // DB-lock to ensure that persistent sessions are loaded from DB just on one DC. The other DCs will load them from remote cache.
+                    CacheInitializer initializer = new DBLockBasedCacheInitializer(session, ispnInitializer);
+
+                    initializer.initCache();
+                    initializer.loadSessions();
+
+                    log.debug("Pre-loading userSessions from persistent storage finished");
+                } else {
+                    log.debug("Skipping pre-loading of userSessions from persistent storage");
+                }
 
                 // Initialize persister for periodically doing bulk DB updates of lastSessionRefresh timestamps of refreshed sessions
                 persisterLastSessionRefreshStore = new PersisterLastSessionRefreshStoreFactory().createAndInit(session, true);
@@ -194,7 +209,7 @@ public class InfinispanUserSessionProviderFactory implements UserSessionProvider
 
         });
 
-        log.debug("Pre-loading userSessions from persistent storage finished");
+
     }
 
 

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/stream/UserSessionPredicate.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/stream/UserSessionPredicate.java
@@ -112,7 +112,7 @@ public class UserSessionPredicate implements Predicate<Map.Entry<String, Session
      * Returns the user id.
      * @return
      */
-    public String getUser() {
+    public String getUserId() {
         return user;
     }
 

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/stream/UserSessionPredicate.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/stream/UserSessionPredicate.java
@@ -108,6 +108,22 @@ public class UserSessionPredicate implements Predicate<Map.Entry<String, Session
         return this;
     }
 
+    /**
+     * Returns the user id.
+     * @return
+     */
+    public String getUser() {
+        return user;
+    }
+
+    public String getBrokerSessionId() {
+        return brokerSessionId;
+    }
+
+    public String getBrokerUserId() {
+        return brokerUserId;
+    }
+
     @Override
     public boolean test(Map.Entry<String, SessionEntityWrapper<UserSessionEntity>> entry) {
         UserSessionEntity entity = entry.getValue().getEntity();

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/session/JpaUserSessionPersisterProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/session/JpaUserSessionPersisterProvider.java
@@ -38,6 +38,7 @@ import javax.persistence.Query;
 import javax.persistence.TypedQuery;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -126,6 +127,17 @@ public class JpaUserSessionPersisterProvider implements UserSessionPersisterProv
     }
 
     @Override
+    public int removeUserSessions(RealmModel realm, Boolean offline) {
+
+        String offlineStr = offline == null ? null : offlineToString(offline);
+
+        return em.createNamedQuery("deleteUserSessionsByRealm")
+                .setParameter("realmId", realm.getId())
+                .setParameter("offline", offlineStr)
+                .executeUpdate();
+    }
+
+    @Override
     public void removeClientSession(String userSessionId, String clientUUID, boolean offline) {
         String offlineStr = offlineToString(offline);
         StorageId clientStorageId = new StorageId(clientUUID);
@@ -170,8 +182,15 @@ public class JpaUserSessionPersisterProvider implements UserSessionPersisterProv
 
     @Override
     public void onRealmRemoved(RealmModel realm) {
-        int num = em.createNamedQuery("deleteClientSessionsByRealm").setParameter("realmId", realm.getId()).executeUpdate();
-        num = em.createNamedQuery("deleteUserSessionsByRealm").setParameter("realmId", realm.getId()).executeUpdate();
+        int deletedClientSessions = em.createNamedQuery("deleteClientSessionsByRealm")
+                .setParameter("realmId", realm.getId())
+                .setParameter("offline", null)
+                .executeUpdate();
+
+        int deletedUserSessions = em.createNamedQuery("deleteUserSessionsByRealm")
+                .setParameter("realmId", realm.getId())
+                .setParameter("offline", null)
+                .executeUpdate();
     }
 
     @Override
@@ -242,20 +261,122 @@ public class JpaUserSessionPersisterProvider implements UserSessionPersisterProv
     }
 
     @Override
-    public Stream<UserSessionModel> loadUserSessionsStream(Integer firstResult, Integer maxResults, boolean offline,
-                                                           Integer lastCreatedOn, String lastUserSessionId) {
+    public Map<String, Long> getUserSessionsCountsByClients(RealmModel realm, boolean offline) {
+
         String offlineStr = offlineToString(offline);
 
-        TypedQuery<PersistentUserSessionEntity> query = em.createNamedQuery("findUserSessions", PersistentUserSessionEntity.class);
+        Query query = em.createNamedQuery("findUserSessionsCountsByClientId");
+
+        query.setParameter("offline", offlineStr);
+        query.setParameter("realmId", realm.getId());
+        query.setParameter("clientId", null);
+
+        Map<String, Long> offlineSessionsByClient = new HashMap<>();
+
+        closing(query.getResultStream()).forEach(record -> {
+
+            Object[] row = (Object[]) record;
+
+            String clientId = String.valueOf(row[0]);
+            Long count = ((Number)row[1]).longValue();
+
+            offlineSessionsByClient.put(clientId, count);
+        });
+
+        return offlineSessionsByClient;
+    }
+
+    @Override
+    public UserSessionModel loadUserSession(RealmModel realm, String userSessionId, boolean offline) {
+
+        String offlineStr = offlineToString(offline);
+
+        TypedQuery<PersistentUserSessionEntity> userSessionQuery = em.createNamedQuery("findUserSession", PersistentUserSessionEntity.class);
+        userSessionQuery.setParameter("realmId", realm.getId());
+        userSessionQuery.setParameter("offline", offlineStr);
+        userSessionQuery.setParameter("userSessionId", userSessionId);
+        userSessionQuery.setMaxResults(1);
+
+        Stream<PersistentUserSessionAdapter> persistentUserSessions = closing(userSessionQuery.getResultStream().map(this::toAdapter));
+
+        return persistentUserSessions.findAny().map(userSession -> {
+
+            TypedQuery<PersistentClientSessionEntity> clientSessionQuery = em.createNamedQuery("findClientSessionsByUserSessions", PersistentClientSessionEntity.class);
+            clientSessionQuery.setParameter("userSessionIds", Collections.singleton(userSessionId));
+            clientSessionQuery.setParameter("offline", offlineStr);
+
+            Set<String> removedClientUUIDs = new HashSet<>();
+
+            clientSessionQuery.getResultStream().forEach(clientSession -> {
+                        boolean added = addClientSessionToAuthenticatedClientSessionsIfPresent(userSession, clientSession);
+                        if (!added) {
+                            // client was removed in the meantime
+                            removedClientUUIDs.add(clientSession.getClientId());
+                        }
+                    }
+            );
+
+            removedClientUUIDs.forEach(this::onClientRemoved);
+
+            return userSession;
+        }).orElse(null);
+    }
+
+    @Override
+    public Stream<UserSessionModel> loadUserSessionsStream(RealmModel realm, ClientModel client, boolean offline, Integer firstResult, Integer maxResults) {
+
+        String offlineStr = offlineToString(offline);
+
+        TypedQuery<PersistentUserSessionEntity> query = paginateQuery(
+                em.createNamedQuery("findUserSessionsByClientId", PersistentUserSessionEntity.class),
+                firstResult, maxResults);
+
+        query.setParameter("offline", offlineStr);
+        query.setParameter("realmId", realm.getId());
+        query.setParameter("clientId", client.getId());
+
+        return loadUserSessionsWithClientSessions(query, offlineStr);
+    }
+
+    @Override
+    public Stream<UserSessionModel> loadUserSessionsStream(RealmModel realm, UserModel user, boolean offline, Integer firstResult, Integer maxResults) {
+
+        String offlineStr = offlineToString(offline);
+
+        TypedQuery<PersistentUserSessionEntity> query = paginateQuery(
+                em.createNamedQuery("findUserSessionsByUserId", PersistentUserSessionEntity.class),
+                firstResult, maxResults);
+
+        query.setParameter("offline", offlineStr);
+        query.setParameter("realmId", realm.getId());
+        query.setParameter("userId", user.getId());
+
+        return loadUserSessionsWithClientSessions(query, offlineStr);
+    }
+
+    public Stream<UserSessionModel> loadUserSessionsStream(Integer firstResult, Integer maxResults, boolean offline,
+                                                           Integer lastCreatedOn, String lastUserSessionId) {
+
+        String offlineStr = offlineToString(offline);
+
+        TypedQuery<PersistentUserSessionEntity> query = paginateQuery(
+                em.createNamedQuery("findUserSessions", PersistentUserSessionEntity.class),
+                firstResult, maxResults);
+
         query.setParameter("offline", offlineStr);
         query.setParameter("lastCreatedOn", lastCreatedOn);
         query.setParameter("lastSessionId", lastUserSessionId);
 
-        List<PersistentUserSessionAdapter> result = closing(paginateQuery(query, firstResult, maxResults).getResultStream()
+        return loadUserSessionsWithClientSessions(query, offlineStr);
+    }
+
+    private Stream<UserSessionModel> loadUserSessionsWithClientSessions(TypedQuery<PersistentUserSessionEntity> query, String offlineStr) {
+
+        List<PersistentUserSessionAdapter> userSessions = closing(query.getResultStream()
                 .map(this::toAdapter))
                 .collect(Collectors.toList());
 
-        Map<String, PersistentUserSessionAdapter> sessionsById = result.stream()
+        Map<String, PersistentUserSessionAdapter> sessionsById = userSessions.stream()
                 .collect(Collectors.toMap(UserSessionModel::getId, Function.identity()));
 
         Set<String> userSessionIds = sessionsById.keySet();
@@ -268,15 +389,10 @@ public class JpaUserSessionPersisterProvider implements UserSessionPersisterProv
             query2.setParameter("offline", offlineStr);
             closing(query2.getResultStream()).forEach(clientSession -> {
                 PersistentUserSessionAdapter userSession = sessionsById.get(clientSession.getUserSessionId());
-
-                PersistentAuthenticatedClientSessionAdapter clientSessAdapter = toAdapter(userSession.getRealm(), userSession, clientSession);
-                Map<String, AuthenticatedClientSessionModel> currentClientSessions = userSession.getAuthenticatedClientSessions();
-
-                // Case when client was removed in the meantime
-                if (clientSessAdapter.getClient() == null) {
+                boolean added = addClientSessionToAuthenticatedClientSessionsIfPresent(userSession, clientSession);
+                if (!added) {
+                    // client was removed in the meantime
                     removedClientUUIDs.add(clientSession.getClientId());
-                } else {
-                    currentClientSessions.put(clientSession.getClientId(), clientSessAdapter);
                 }
             });
         }
@@ -285,7 +401,19 @@ public class JpaUserSessionPersisterProvider implements UserSessionPersisterProv
             onClientRemoved(clientUUID);
         }
 
-        return result.stream().map(UserSessionModel.class::cast);
+        return userSessions.stream().map(UserSessionModel.class::cast);
+    }
+
+    private boolean addClientSessionToAuthenticatedClientSessionsIfPresent(PersistentUserSessionAdapter userSession, PersistentClientSessionEntity clientSessionEntity) {
+
+        PersistentAuthenticatedClientSessionAdapter clientSessAdapter = toAdapter(userSession.getRealm(), userSession, clientSessionEntity);
+
+        if (clientSessAdapter.getClient() == null) {
+            return false;
+        }
+
+        userSession.getAuthenticatedClientSessions().put(clientSessionEntity.getClientId(), clientSessAdapter);
+        return true;
     }
 
     private PersistentUserSessionAdapter toAdapter(PersistentUserSessionEntity entity) {
@@ -322,18 +450,33 @@ public class JpaUserSessionPersisterProvider implements UserSessionPersisterProv
     }
 
     @Override
-    public int getUserSessionsCount(boolean offline) {
+    public int getUserSessionsCount(RealmModel realm, boolean offline) {
         String offlineStr = offlineToString(offline);
+        String realmId = realm != null ? realm.getId() : null;
 
         Query query = em.createNamedQuery("findUserSessionsCount");
+        query.setParameter("realmId", realmId);
         query.setParameter("offline", offlineStr);
         Number n = (Number) query.getSingleResult();
         return n.intValue();
     }
 
     @Override
-    public void close() {
+    public int getUserSessionsCount(RealmModel realm, ClientModel clientModel, boolean offline) {
 
+        String offlineStr = offlineToString(offline);
+
+        Query query = em.createNamedQuery("findClientSessionsCountByClient");
+        // Note, that realm is unused here, since the clientModel id already determines the offline user-sessions bound to a owning realm.
+        query.setParameter("offline", offlineStr);
+        query.setParameter("clientId", clientModel.getId());
+        Number n = (Number) query.getSingleResult();
+        return n.intValue();
+    }
+
+    @Override
+    public void close() {
+        // NOOP
     }
 
     private String offlineToString(boolean offline) {

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/session/PersistentClientSessionEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/session/PersistentClientSessionEntity.java
@@ -30,7 +30,7 @@ import java.io.Serializable;
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
  */
 @NamedQueries({
-        @NamedQuery(name="deleteClientSessionsByRealm", query="delete from PersistentClientSessionEntity sess where sess.userSessionId IN (select u.userSessionId from PersistentUserSessionEntity u where u.realmId = :realmId)"),
+        @NamedQuery(name="deleteClientSessionsByRealm", query="delete from PersistentClientSessionEntity sess where sess.userSessionId IN (select u.userSessionId from PersistentUserSessionEntity u where u.realmId = :realmId) and sess.offline = coalesce(:offline, sess.offline) "),
         @NamedQuery(name="deleteClientSessionsByClient", query="delete from PersistentClientSessionEntity sess where sess.clientId = :clientId"),
         @NamedQuery(name="deleteClientSessionsByExternalClient", query="delete from PersistentClientSessionEntity sess where sess.clientStorageProvider = :clientStorageProvider and sess.externalClientId = :externalClientId"),
         @NamedQuery(name="deleteClientSessionsByClientStorageProvider", query="delete from PersistentClientSessionEntity sess where sess.clientStorageProvider = :clientStorageProvider"),
@@ -38,7 +38,8 @@ import java.io.Serializable;
         @NamedQuery(name="deleteClientSessionsByUserSession", query="delete from PersistentClientSessionEntity sess where sess.userSessionId = :userSessionId and sess.offline = :offline"),
         @NamedQuery(name="deleteExpiredClientSessions", query="delete from PersistentClientSessionEntity sess where sess.userSessionId IN (select u.userSessionId from PersistentUserSessionEntity u where u.realmId = :realmId AND u.offline = :offline AND u.lastSessionRefresh < :lastSessionRefresh)"),
         @NamedQuery(name="findClientSessionsByUserSession", query="select sess from PersistentClientSessionEntity sess where sess.userSessionId=:userSessionId and sess.offline = :offline"),
-        @NamedQuery(name="findClientSessionsByUserSessions", query="select sess from PersistentClientSessionEntity sess where sess.offline = :offline and sess.userSessionId IN (:userSessionIds) order by sess.userSessionId")
+        @NamedQuery(name="findClientSessionsByUserSessions", query="select sess from PersistentClientSessionEntity sess where sess.offline = :offline and sess.userSessionId IN (:userSessionIds) order by sess.userSessionId"),
+        @NamedQuery(name="findClientSessionsCountByClient", query="select count(sess) from PersistentClientSessionEntity sess where sess.offline = :offline and sess.clientId = :clientId")
 })
 @Table(name="OFFLINE_CLIENT_SESSION")
 @Entity

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/session/PersistentClientSessionEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/session/PersistentClientSessionEntity.java
@@ -30,7 +30,7 @@ import java.io.Serializable;
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
  */
 @NamedQueries({
-        @NamedQuery(name="deleteClientSessionsByRealm", query="delete from PersistentClientSessionEntity sess where sess.userSessionId IN (select u.userSessionId from PersistentUserSessionEntity u where u.realmId = :realmId) and sess.offline = coalesce(:offline, sess.offline) "),
+        @NamedQuery(name="deleteClientSessionsByRealm", query="delete from PersistentClientSessionEntity sess where sess.userSessionId IN (select u.userSessionId from PersistentUserSessionEntity u where u.realmId = :realmId) and sess.offline = coalesce(cast(:offline as text), sess.offline)"),
         @NamedQuery(name="deleteClientSessionsByClient", query="delete from PersistentClientSessionEntity sess where sess.clientId = :clientId"),
         @NamedQuery(name="deleteClientSessionsByExternalClient", query="delete from PersistentClientSessionEntity sess where sess.clientStorageProvider = :clientStorageProvider and sess.externalClientId = :externalClientId"),
         @NamedQuery(name="deleteClientSessionsByClientStorageProvider", query="delete from PersistentClientSessionEntity sess where sess.clientStorageProvider = :clientStorageProvider"),

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/session/PersistentUserSessionEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/session/PersistentUserSessionEntity.java
@@ -32,16 +32,32 @@ import java.io.Serializable;
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
  */
 @NamedQueries({
-        @NamedQuery(name="deleteUserSessionsByRealm", query="delete from PersistentUserSessionEntity sess where sess.realmId = :realmId"),
+        @NamedQuery(name="deleteUserSessionsByRealm", query="delete from PersistentUserSessionEntity sess where sess.realmId = :realmId and sess.offline = coalesce(:offline, sess.offline) "),
         @NamedQuery(name="deleteUserSessionsByUser", query="delete from PersistentUserSessionEntity sess where sess.userId = :userId"),
         @NamedQuery(name="deleteExpiredUserSessions", query="delete from PersistentUserSessionEntity sess where sess.realmId = :realmId AND sess.offline = :offline AND sess.lastSessionRefresh < :lastSessionRefresh"),
         @NamedQuery(name="updateUserSessionLastSessionRefresh", query="update PersistentUserSessionEntity sess set lastSessionRefresh = :lastSessionRefresh where sess.realmId = :realmId" +
                 " AND sess.offline = :offline AND sess.userSessionId IN (:userSessionIds)"),
-        @NamedQuery(name="findUserSessionsCount", query="select count(sess) from PersistentUserSessionEntity sess where sess.offline = :offline"),
+        @NamedQuery(name="findUserSessionsCount", query="select count(sess) from PersistentUserSessionEntity sess where sess.offline = :offline and sess.realmId = coalesce(:realmId, sess.realmId)"),
         @NamedQuery(name="findUserSessions", query="select sess from PersistentUserSessionEntity sess where sess.offline = :offline" +
                 " AND (sess.createdOn > :lastCreatedOn OR (sess.createdOn = :lastCreatedOn AND sess.userSessionId > :lastSessionId))" +
-                " order by sess.createdOn,sess.userSessionId")
-
+                " order by sess.createdOn,sess.userSessionId"),
+        @NamedQuery(name="findUserSession", query="select sess from PersistentUserSessionEntity sess where sess.offline = :offline" +
+                " AND sess.userSessionId = :userSessionId AND sess.realmId = :realmId"),
+        @NamedQuery(name="findUserSessionsByUserId", query="select sess from PersistentUserSessionEntity sess where sess.offline = :offline" +
+                " AND sess.realmId = :realmId AND sess.userId = :userId"),
+        @NamedQuery(name="findUserSessionsByClientId", query="SELECT sess FROM PersistentUserSessionEntity sess INNER JOIN PersistentClientSessionEntity clientSess " +
+                " ON sess.userSessionId = clientSess.userSessionId AND clientSess.clientId = :clientId WHERE sess.offline = :offline " +
+                " AND sess.userSessionId = clientSess.userSessionId AND sess.realmId = :realmId AND clientSess.clientId = :clientId"),
+        @NamedQuery(name="findUserSessionsCountsByClientId", query="SELECT clientSess.clientId, count(clientSess) " +
+                " FROM PersistentUserSessionEntity sess INNER JOIN PersistentClientSessionEntity clientSess " +
+                " ON sess.userSessionId = clientSess.userSessionId " +
+                // find all available offline user-session for all or specific clients in a realm
+                " AND clientSess.clientId = coalesce(:clientId, clientSess.clientId) " +
+                " WHERE sess.offline = :offline " +
+                " AND sess.userSessionId = clientSess.userSessionId AND sess.realmId = :realmId " +
+                // find all available offline user-session for all or specific clients in a realm
+                " AND clientSess.clientId = coalesce(:clientId, clientSess.clientId) " +
+                " GROUP BY clientSess.clientId")
 })
 @Table(name="OFFLINE_USER_SESSION")
 @Entity

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/session/PersistentUserSessionEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/session/PersistentUserSessionEntity.java
@@ -32,12 +32,12 @@ import java.io.Serializable;
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
  */
 @NamedQueries({
-        @NamedQuery(name="deleteUserSessionsByRealm", query="delete from PersistentUserSessionEntity sess where sess.realmId = :realmId and sess.offline = coalesce(:offline, sess.offline) "),
+        @NamedQuery(name="deleteUserSessionsByRealm", query="delete from PersistentUserSessionEntity sess where sess.realmId = :realmId and sess.offline = coalesce(cast(:offline as text), sess.offline)"),
         @NamedQuery(name="deleteUserSessionsByUser", query="delete from PersistentUserSessionEntity sess where sess.userId = :userId"),
         @NamedQuery(name="deleteExpiredUserSessions", query="delete from PersistentUserSessionEntity sess where sess.realmId = :realmId AND sess.offline = :offline AND sess.lastSessionRefresh < :lastSessionRefresh"),
         @NamedQuery(name="updateUserSessionLastSessionRefresh", query="update PersistentUserSessionEntity sess set lastSessionRefresh = :lastSessionRefresh where sess.realmId = :realmId" +
                 " AND sess.offline = :offline AND sess.userSessionId IN (:userSessionIds)"),
-        @NamedQuery(name="findUserSessionsCount", query="select count(sess) from PersistentUserSessionEntity sess where sess.offline = :offline and sess.realmId = coalesce(:realmId, sess.realmId)"),
+        @NamedQuery(name="findUserSessionsCount", query="select count(sess) from PersistentUserSessionEntity sess where sess.offline = :offline and sess.realmId = coalesce(cast(:realmId AS text), sess.realmId)"),
         @NamedQuery(name="findUserSessions", query="select sess from PersistentUserSessionEntity sess where sess.offline = :offline" +
                 " AND (sess.createdOn > :lastCreatedOn OR (sess.createdOn = :lastCreatedOn AND sess.userSessionId > :lastSessionId))" +
                 " order by sess.createdOn,sess.userSessionId"),
@@ -47,16 +47,15 @@ import java.io.Serializable;
                 " AND sess.realmId = :realmId AND sess.userId = :userId"),
         @NamedQuery(name="findUserSessionsByClientId", query="SELECT sess FROM PersistentUserSessionEntity sess INNER JOIN PersistentClientSessionEntity clientSess " +
                 " ON sess.userSessionId = clientSess.userSessionId AND clientSess.clientId = :clientId WHERE sess.offline = :offline " +
-                " AND sess.userSessionId = clientSess.userSessionId AND sess.realmId = :realmId AND clientSess.clientId = :clientId"),
+                " AND sess.userSessionId = clientSess.userSessionId AND sess.realmId = :realmId"),
         @NamedQuery(name="findUserSessionsCountsByClientId", query="SELECT clientSess.clientId, count(clientSess) " +
                 " FROM PersistentUserSessionEntity sess INNER JOIN PersistentClientSessionEntity clientSess " +
                 " ON sess.userSessionId = clientSess.userSessionId " +
                 // find all available offline user-session for all or specific clients in a realm
-                " AND clientSess.clientId = coalesce(:clientId, clientSess.clientId) " +
+                // cast(... as text) is required here to support null values
+                " AND clientSess.clientId = coalesce(CAST(:clientId as text), clientSess.clientId) " +
                 " WHERE sess.offline = :offline " +
                 " AND sess.userSessionId = clientSess.userSessionId AND sess.realmId = :realmId " +
-                // find all available offline user-session for all or specific clients in a realm
-                " AND clientSess.clientId = coalesce(:clientId, clientSess.clientId) " +
                 " GROUP BY clientSess.clientId")
 })
 @Table(name="OFFLINE_USER_SESSION")

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-13.0.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-13.0.0.xml
@@ -51,4 +51,24 @@
         <modifyDataType newDataType="VARCHAR(255)" tableName="CLIENT_SCOPE_CLIENT" columnName="CLIENT_ID"/>
         <modifyDataType newDataType="VARCHAR(255)" tableName="CLIENT_SCOPE_CLIENT" columnName="SCOPE_ID"/>
     </changeSet>
+
+    <changeSet author="keycloak" id="13.0.0-KEYCLOAK-11019">
+        <createIndex tableName="OFFLINE_CLIENT_SESSION" indexName="IDX_OFFLINE_CSS_PRELOAD">
+            <column name="OFFLINE_FLAG" type="VARCHAR(4)"/>
+            <column name="CLIENT_ID" type="VARCHAR(36)"/>
+        </createIndex>
+
+        <createIndex tableName="OFFLINE_USER_SESSION" indexName="IDX_OFFLINE_USS_BY_USER">
+            <column name="OFFLINE_FLAG" type="VARCHAR(4)"/>
+            <column name="REALM_ID" type="VARCHAR(36)"/>
+            <column name="USER_ID" type="VARCHAR(36)"/>
+        </createIndex>
+
+        <createIndex tableName="OFFLINE_USER_SESSION" indexName="IDX_OFFLINE_USS_BY_USERSESS">
+            <column name="OFFLINE_FLAG" type="VARCHAR(4)"/>
+            <column name="REALM_ID" type="VARCHAR(36)"/>
+            <column name="USER_SESSION_ID" type="VARCHAR(36)"/>
+        </createIndex>
+    </changeSet>
+
 </databaseChangeLog>

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-13.0.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-13.0.0.xml
@@ -54,19 +54,19 @@
 
     <changeSet author="keycloak" id="13.0.0-KEYCLOAK-11019">
         <createIndex tableName="OFFLINE_CLIENT_SESSION" indexName="IDX_OFFLINE_CSS_PRELOAD">
-            <column name="OFFLINE_FLAG" type="VARCHAR(4)"/>
             <column name="CLIENT_ID" type="VARCHAR(36)"/>
+            <column name="OFFLINE_FLAG" type="VARCHAR(4)"/>
         </createIndex>
 
         <createIndex tableName="OFFLINE_USER_SESSION" indexName="IDX_OFFLINE_USS_BY_USER">
-            <column name="OFFLINE_FLAG" type="VARCHAR(4)"/>
-            <column name="REALM_ID" type="VARCHAR(36)"/>
             <column name="USER_ID" type="VARCHAR(36)"/>
+            <column name="REALM_ID" type="VARCHAR(36)"/>
+            <column name="OFFLINE_FLAG" type="VARCHAR(4)"/>
         </createIndex>
 
         <createIndex tableName="OFFLINE_USER_SESSION" indexName="IDX_OFFLINE_USS_BY_USERSESS">
-            <column name="OFFLINE_FLAG" type="VARCHAR(4)"/>
             <column name="REALM_ID" type="VARCHAR(36)"/>
+            <column name="OFFLINE_FLAG" type="VARCHAR(4)"/>
             <column name="USER_SESSION_ID" type="VARCHAR(36)"/>
         </createIndex>
     </changeSet>

--- a/server-spi-private/src/main/java/org/keycloak/models/session/DisabledUserSessionPersisterProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/session/DisabledUserSessionPersisterProvider.java
@@ -27,6 +27,8 @@ import org.keycloak.models.UserModel;
 import org.keycloak.models.UserSessionModel;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
 import java.util.stream.Stream;
 
 /**
@@ -85,6 +87,11 @@ public class DisabledUserSessionPersisterProvider implements UserSessionPersiste
     }
 
     @Override
+    public int removeUserSessions(RealmModel realm, Boolean offline) {
+        return 0;
+    }
+
+    @Override
     public void onRealmRemoved(RealmModel realm) {
 
     }
@@ -109,6 +116,20 @@ public class DisabledUserSessionPersisterProvider implements UserSessionPersiste
 
     }
 
+    public UserSessionModel loadUserSession(RealmModel realm, String userSessionId, boolean offline) {
+        return null;
+    }
+
+    @Override
+    public Stream<UserSessionModel> loadUserSessionsStream(RealmModel realm, ClientModel client, boolean offline, Integer firstResult, Integer maxResults) {
+        return Stream.empty();
+    }
+
+    @Override
+    public Stream<UserSessionModel> loadUserSessionsStream(RealmModel realm, UserModel user, boolean offline, Integer firstResult, Integer maxResults) {
+        return Stream.empty();
+    }
+
     @Override
     public Stream<UserSessionModel> loadUserSessionsStream(Integer firstResult, Integer maxResults, boolean offline,
                                                            Integer lastCreatedOn, String lastUserSessionId) {
@@ -116,7 +137,17 @@ public class DisabledUserSessionPersisterProvider implements UserSessionPersiste
     }
 
     @Override
-    public int getUserSessionsCount(boolean offline) {
+    public int getUserSessionsCount(RealmModel realm, boolean offline) {
         return 0;
+    }
+
+    @Override
+    public int getUserSessionsCount(RealmModel realm, ClientModel clientModel, boolean offline) {
+        return 0;
+    }
+
+    @Override
+    public Map<String, Long> getUserSessionsCountsByClients(RealmModel realm, boolean offline) {
+        return Collections.emptyMap();
     }
 }

--- a/server-spi-private/src/main/java/org/keycloak/models/session/UserSessionPersisterProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/session/UserSessionPersisterProvider.java
@@ -26,6 +26,7 @@ import org.keycloak.provider.Provider;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -57,6 +58,37 @@ public interface UserSessionPersisterProvider extends Provider {
     void removeExpired(RealmModel realm);
 
     /**
+     * Loads the user session with the given userSessionId.
+     * @param userSessionId
+     * @param offline
+     * @return
+     */
+    UserSessionModel loadUserSession(RealmModel realm, String userSessionId, boolean offline);
+
+    /**
+     * Loads the user sessions for the given {@link UserModel} in the given {@link RealmModel} if present.
+     * @param realm
+     * @param user
+     * @param offline
+     * @param firstResult
+     * @param maxResults
+     * @return
+     */
+    Stream<UserSessionModel> loadUserSessionsStream(RealmModel realm, UserModel user, boolean offline, Integer firstResult, Integer maxResults);
+
+    /**
+     * Loads the user sessions for the given {@link ClientModel} in the given {@link RealmModel} if present.
+     *
+     * @param realm
+     * @param client
+     * @param offline
+     * @param firstResult
+     * @param maxResults
+     * @return
+     */
+    Stream<UserSessionModel> loadUserSessionsStream(RealmModel realm, ClientModel client, boolean offline, Integer firstResult, Integer maxResults);
+
+    /**
      * Called during startup. For each userSession, it loads also clientSessions
      * @deprecated Use {@link #loadUserSessionsStream(Integer, Integer, boolean, Integer, String) loadUserSessionsStream} instead.
      */
@@ -78,6 +110,53 @@ public interface UserSessionPersisterProvider extends Provider {
     Stream<UserSessionModel> loadUserSessionsStream(Integer firstResult, Integer maxResults, boolean offline,
                                                     Integer lastCreatedOn, String lastUserSessionId);
 
-    int getUserSessionsCount(boolean offline);
+    /**
+     * Retrieves the count of user sessions for a given realm.
+     *
+     * If {@code realm} is {@literal null}, then all sessions are counted.
+     *
+     * @param realm
+     * @param offline
+     * @return
+     */
+    int getUserSessionsCount(RealmModel realm, boolean offline);
 
+    /**
+     * Retrieves the count of user sessions for all realms.
+     *
+     * @param offline
+     * @return
+     * 
+     * @see #getUserSessionsCount(RealmModel, boolean)
+     */
+    default int getUserSessionsCount(boolean offline) {
+        return getUserSessionsCount(null, offline);
+    }
+
+    /**
+     * Retrieves the count of user client-sessions for the given client
+     *
+     * @param realm
+     * @param clientModel
+     * @param offline
+     * @return
+     */
+    int getUserSessionsCount(RealmModel realm, ClientModel clientModel, boolean offline);
+
+    /**
+     * Returns a {@link Map} containing the number of user-sessions aggregated by client id for the given realm.
+     * @param realm
+     * @param offline
+     * @return the count {@link Map} with clientId as key and session count as value
+     */
+    Map<String, Long> getUserSessionsCountsByClients(RealmModel realm, boolean offline);
+
+
+    /**
+     * Removes the sessions from the given realm.
+     * @param realm
+     * @param offline
+     * @return
+     */
+    int removeUserSessions(RealmModel realm, Boolean offline);
 }


### PR DESCRIPTION
This PR introduces initial support for lazy-loading of offline user-sessions.
See the discussion on the [keycloak-dev group](https://groups.google.com/g/keycloak-dev/c/ef0P_pj8ndI/m/ObBrtCjCDAAJ)

As a start, we allow to disable the pre-loading of offline sessions from the database. At a later stage we can also disable the pre-loading from a remote-cache storage.

If an offline user-session is missing from the infinispan sessions or clientSession cache, we try to find the offline user-session in the database. If the session is found, we dynamically import it into the appropriate infinispan cache.

Additionally we now allow to disable loading of offline user-sessions during startup via the new `preloadOfflineSessionsFromDatabase` property of the `infinispan userSessions` provider.

patch-standalone-ha.cli:
```bash
embed-server --server-config=standalone-ha.xml --std-out=echo

/subsystem=logging/console-handler=CONSOLE:write-attribute(name=level,value=DEBUG)

if (outcome == failed) of /subsystem=logging/logger=org.keycloak.models.sessions.infinispan/:read-resource
  /subsystem=logging/logger=org.keycloak.models.sessions.infinispan:add(level=DEBUG)
end-if

echo SETUP: Customize Keycloak UserSessions SPI configuration
# Add dedicated userSession config element to allow configuring elements.
if (outcome == failed) of /subsystem=keycloak-server/spi=userSessions/:read-resource
  echo SETUP: Add missing userSessions SPI
  /subsystem=keycloak-server/spi=userSessions:add()
  echo
end-if

echo SETUP: Configure built-in "infinispan"  UserSessions loader
if (outcome == failed) of /subsystem=keycloak-server/spi=userSessions/provider=infinispan/:read-resource
  echo SETUP: Add missing "infinispan" provider
  /subsystem=keycloak-server/spi=userSessions/provider=infinispan:add(enabled=true)
  /subsystem=keycloak-server/spi=userSessions/provider=infinispan:write-attribute(name=properties.preloadOfflineSessionsFromDatabase,value=${env.KEYCLOAK_INFINISPAN_SESSIONS_PRELOAD_DATABASE:false})
  /subsystem=keycloak-server/spi=userSessions:write-attribute(name=default-provider,value=infinispan)
  echo
end-if
```

build the keycloak distribution from source:
```
mvn -Pdistribution -pl distribution/server-dist -am -Dmaven.test.skip clean install
```
once this is finished, you can find your Keycloak distribution in `distribution/server-dist/target` as .zip or .tar.gz.

Apply `patch-standalone-ha.cli` to `standalone-ha.xml`
```
echo "yes" | bin/jboss-cli.sh --file patch-standalone-ha.cli
```

Start Keycloak:
```
bin/standalone.sh -c standalone-ha.xml --debug -Dwildfly.statistics-enabled=true
```

You should now see a DEBUG log message like:
```
...
13:09:30,850 DEBUG [org.keycloak.models.sessions.infinispan.InfinispanUserSessionProviderFactory] (ServerService Thread Pool -- 65) Skipping pre-loading of userSessions from persistent storage
...
```

If you try to obtain a new access token for a given (offline) refresh-token you should see the following in the log:
```
...
13:09:37,538 DEBUG [org.keycloak.models.sessions.infinispan.InfinispanUserSessionProvider] (default task-1) Offline user-session not found in infinispan, attempting UserSessionPersisterProvider lookup for sessionId=9c5aa5fa-1611-4c70-a4ec-10bb0edf5690
13:09:37,555 DEBUG [org.keycloak.models.sessions.infinispan.InfinispanUserSessionProvider] (default task-1) Offline user-session found in UserSessionPersisterProvider, attempting to reimport user-session for sessionId=9c5aa5fa-1611-4c70-a4ec-10bb0edf5690
13:09:37,573 DEBUG [org.keycloak.models.sessions.infinispan.InfinispanUserSessionProvider] (default task-1) Offline user-session imported, trying another lookup for sessionId=9c5aa5fa-1611-4c70-a4ec-10bb0edf5690
13:09:37,574 DEBUG [org.keycloak.models.sessions.infinispan.InfinispanUserSessionProvider] (default task-1) Offline user-session found after import for sessionId=9c5aa5fa-1611-4c70-a4ec-10bb0edf5690
...
```