### PR TITLE
KEYCLOAK-16858 Client Policy - Improper retainAll operation in Client Scope Condition and other minor bugs

### DIFF
--- a/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientScopesCondition.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientScopesCondition.java
@@ -17,7 +17,6 @@
 
 package org.keycloak.services.clientpolicy.condition;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
@@ -89,8 +88,8 @@ public class ClientScopesCondition implements ClientPolicyConditionProvider {
         Collection<String> explicitSpecifiedScopes = new HashSet<>(Arrays.asList(explicitScopes.split(" ")));
         Set<String> defaultScopes = client.getClientScopes(true, true).keySet();
         Set<String> optionalScopes = client.getClientScopes(false, true).keySet();
-        List<String> expectedScopes = componentModel.getConfig().get(ClientScopesConditionFactory.SCOPES);
-        if (expectedScopes == null) expectedScopes = new ArrayList<>();
+        Set<String> expectedScopes = getScopesForMatching();
+        if (expectedScopes == null) expectedScopes = new HashSet<>();
 
         if (logger.isTraceEnabled()) {
             explicitSpecifiedScopes.stream().forEach(i -> ClientPolicyLogger.log(logger, " explicit specified client scope = " + i));
@@ -115,4 +114,10 @@ public class ClientScopesCondition implements ClientPolicyConditionProvider {
         return false;
     }
 
+    private Set<String> getScopesForMatching() {
+        if (componentModel.getConfig() == null) return null;
+        List<String> scopes = componentModel.getConfig().get(ClientScopesConditionFactory.SCOPES);
+        if (scopes == null) return null;
+        return new HashSet<>(scopes);
+    }
 }

--- a/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientUpdateSourceGroupsCondition.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientUpdateSourceGroupsCondition.java
@@ -109,7 +109,7 @@ public class ClientUpdateSourceGroupsCondition implements ClientPolicyConditionP
         Set<String> expectedGroups = instantiateGroupsForMatching();
         if (expectedGroups == null) return false;
 
-        // user.getRolesStream() never returns null according to {@link UserModel.getGroupsStream}
+        // user.getGroupsStream() never returns null according to {@link UserModel.getGroupsStream}
         Set<String> groups = user.getGroupsStream().map(GroupModel::getName).collect(Collectors.toSet());
 
         if (logger.isTraceEnabled()) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientPolicyBasicsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientPolicyBasicsTest.java
@@ -891,6 +891,9 @@ public class ClientPolicyBasicsTest extends AbstractKeycloakTest {
             oauth.scope("microprofile-jwt" + " " + "profile");
             failLoginByNotFollowingPKCE(clientAlphaId);
 
+            oauth.scope("microprofile-jwt" + " " + "profile");
+            failLoginByNotFollowingPKCE(clientAlphaId);
+
             successfulLoginAndLogoutWithPKCE(clientAlphaId, clientAlphaSecret, "test-user@localhost", "password");
         } catch (Exception e) {
             fail();
@@ -1112,6 +1115,7 @@ public class ClientPolicyBasicsTest extends AbstractKeycloakTest {
     }
 
     @AuthServerContainerExclude(AuthServer.REMOTE)
+    @Test
     public void testClientUpdateSourceHostsCondition() throws ClientRegistrationException, ClientPolicyException {
         String policyName = "MyPolicy";
         createPolicy(policyName, DefaultClientPolicyProviderFactory.PROVIDER_ID, null, null, null);


### PR DESCRIPTION
This PR is for [KEYCLOAK-13933 Client Policies](https://issues.redhat.com/browse/KEYCLOAK-13933), also is the part of the project [Client Policy Official Support](https://github.com/keycloak/kc-sig-fapi/projects) of [FAPI-SIG](https://github.com/keycloak/kc-sig-fapi) activity.

As mentioned in [KEYCLOAK-16858](https://issues.redhat.com/browse/KEYCLOAK-16858) some minor bugs have been fixed.
