### PR TITLE
KEYCLOAK-16860 Restore redirectUri from original session on email verification

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/models/Constants.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/Constants.java
@@ -90,6 +90,7 @@ public final class Constants {
 
     public static final String SKIP_LINK = "skipLink";
     public static final String TEMPLATE_ATTR_ACTION_URI = "actionUri";
+    public static final String TEMPLATE_ATTR_REDIRECT_URI = "pageRedirectUri";
     public static final String TEMPLATE_ATTR_REQUIRED_ACTIONS = "requiredActions";
 
     // Prefix for user attributes used in various "context"data maps

--- a/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
@@ -937,7 +937,7 @@ public class AuthenticationManager {
                     .setSuccess(Messages.ACCOUNT_UPDATED);
             if (authSession.getAuthNote(SET_REDIRECT_URI_AFTER_REQUIRED_ACTIONS) != null) {
                 if (authSession.getRedirectUri() != null) {
-                    infoPage.setAttribute("pageRedirectUri", authSession.getRedirectUri());
+                    infoPage.setAttribute(Constants.TEMPLATE_ATTR_REDIRECT_URI, authSession.getRedirectUri());
                 }
 
             } else {


### PR DESCRIPTION
The registratoin endpoint has a parameter redirect_uri which is used to redirect the user back to the application/client after registration.

Given email verification is active, this also works after the user clicks the verification link from within the email. However, if the user has closed the browser in between registration and clicking the email link, the redirect does not work as expected. 

It seems the redirect_uri gets lost, because the browser deletes the session cookie. However, the action token holds all the information needed to restore it from the original auth session.


Please consider this PR to be a draft. Would like some feedback on this.