### PR TITLE
KEYCLOAK-16656 Only set execution authenticator for form flows.

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/AuthenticationManagementResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/AuthenticationManagementResource.java
@@ -428,7 +428,9 @@ public class AuthenticationManagementResource {
         execution.setFlowId(newFlow.getId());
         execution.setRequirement(AuthenticationExecutionModel.Requirement.DISABLED);
         execution.setAuthenticatorFlow(true);
-        execution.setAuthenticator(provider);
+        if (type.equals("form-flow")) {
+            execution.setAuthenticator(provider);
+        }
         execution.setPriority(getNextPriority(parentFlow));
         execution = realm.addAuthenticatorExecution(execution);
 


### PR DESCRIPTION
Hi there, this is to fix https://issues.redhat.com/browse/KEYCLOAK-16656

I am rather new to keycloak, so could someone please tell me how such a functional test would look like? Would it be okay if it created a flow and then tried login in (this is how I noticed the issue in the first place). Where would this test go?

@mposolda Since you commented on the original ticket that a PR might be welcome; do you think you could point me towards the right direction?