### PR TITLE
KEYCLOAK-15975 NPE in DefaultThemeManager.loadTheme() if theme directory is absent

### DIFF
--- a/services/src/main/java/org/keycloak/theme/DefaultThemeManager.java
+++ b/services/src/main/java/org/keycloak/theme/DefaultThemeManager.java
@@ -123,6 +123,10 @@ public class DefaultThemeManager implements ThemeManager {
 
     private Theme loadTheme(String name, Theme.Type type) {
         Theme theme = findTheme(name, type);
+        if (theme == null) {
+            return null;
+        }
+
         List<Theme> themes = new LinkedList<>();
         themes.add(theme);
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/ThemeSelectorTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/ThemeSelectorTest.java
@@ -28,14 +28,24 @@ public class ThemeSelectorTest extends AbstractTestRealmKeycloakTest {
         assertEquals("keycloak", detectTheme());
 
         ClientRepresentation rep = testRealm().clients().findByClientId("test-app").get(0);
-        rep.getAttributes().put("login_theme", "base");
-        testRealm().clients().get(rep.getId()).update(rep);
 
-        loginPage.open();
-        assertEquals("base", detectTheme());
+        try {
+            rep.getAttributes().put("login_theme", "base");
+            testRealm().clients().get(rep.getId()).update(rep);
 
-        rep.getAttributes().put("login_theme", "");
-        testRealm().clients().get(rep.getId()).update(rep);
+            loginPage.open();
+            assertEquals("base", detectTheme());
+
+            // assign a theme that does not exist, should use the default keycloak
+            rep.getAttributes().put("login_theme", "unavailable-theme");
+            testRealm().clients().get(rep.getId()).update(rep);
+
+            loginPage.open();
+            assertEquals("keycloak", detectTheme());
+        } finally {
+            rep.getAttributes().put("login_theme", "");
+            testRealm().clients().get(rep.getId()).update(rep);
+        }
     }
 
     private String detectTheme() {


### PR DESCRIPTION
Fix for: https://issues.redhat.com/browse/KEYCLOAK-15975

Just the comparison for null and adding a check in `ThemeSelectorTest` in order to set a unavailable theme and check the default keycloak theme is selected (no NPE is thrown).