### PR TITLE
KEYCLOAK-17013 Brute force protection: Successfully logged in user should not have to wait up to 5 seconds for event processing

### DIFF
--- a/services/src/main/java/org/keycloak/services/managers/DefaultBruteForceProtector.java
+++ b/services/src/main/java/org/keycloak/services/managers/DefaultBruteForceProtector.java
@@ -291,13 +291,8 @@ public class DefaultBruteForceProtector implements Runnable, BruteForceProtector
 
     @Override
     public void successfulLogin(final RealmModel realm, final UserModel user, final ClientConnection clientConnection) {
-        try {
-            SuccessfulLogin event = new SuccessfulLogin(realm.getId(), user.getId(), clientConnection.getRemoteAddr());
-            queue.offer(event);
-
-            event.latch.await(5, TimeUnit.SECONDS);
-        } catch (InterruptedException e) {
-        }
+        SuccessfulLogin event = new SuccessfulLogin(realm.getId(), user.getId(), clientConnection.getRemoteAddr());
+        queue.offer(event);
         logger.trace("sent success event");
     }
 


### PR DESCRIPTION
Fix #11695