### PR TITLE
[KEYCLOAK-15440] Fixed PasswordForm usage with LDAP users.

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/PasswordForm.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/PasswordForm.java
@@ -44,8 +44,7 @@ public class PasswordForm extends UsernamePasswordForm implements CredentialVali
 
     @Override
     public boolean configuredFor(KeycloakSession session, RealmModel realm, UserModel user) {
-        // never called
-        return getCredentialProvider(session).isConfiguredFor(realm, user, getType(session));
+        return session.userCredentialManager().isConfiguredFor(realm, user, getCredentialProvider(session).getType());
     }
 
     @Override


### PR DESCRIPTION
Adjusted PasswordCredentialProvider to properly check if LDAP/Kerberos has a credential configured.