### PR TITLE
[KEYCLOAK-14366] - Missing check for iss claim in JWT validation on Client Authentication (Token Endpoint)

### DIFF
--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/authentication/JWTClientSecretCredentialsProvider.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/authentication/JWTClientSecretCredentialsProvider.java
@@ -121,7 +121,7 @@ public class JWTClientSecretCredentialsProvider implements ClientCredentialsProv
         return signedRequestToken;
     }
 
-    private JsonWebToken createRequestToken(String clientId, String realmInfoUrl) {
+    protected JsonWebToken createRequestToken(String clientId, String realmInfoUrl) {
         // According to <a href="http://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication">OIDC's client authentication spec</a>,
         // JWT claims is the same as one by private_key_jwt
 

--- a/services/src/main/java/org/keycloak/authentication/authenticators/client/JWTClientAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/client/JWTClientAuthenticator.java
@@ -102,7 +102,11 @@ public class JWTClientAuthenticator extends AbstractClientAuthenticator {
             RealmModel realm = context.getRealm();
             String clientId = token.getSubject();
             if (clientId == null) {
-                throw new RuntimeException("Can't identify client. Issuer missing on JWT token");
+                throw new RuntimeException("Can't identify client. Subject missing on JWT token");
+            }
+
+            if (!clientId.equals(token.getIssuer())) {
+                throw new RuntimeException("Issuer mismatch. The issuer should match the subject");
             }
 
             context.getEvent().client(clientId);

--- a/services/src/main/java/org/keycloak/authentication/authenticators/client/JWTClientSecretAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/client/JWTClientSecretAuthenticator.java
@@ -95,7 +95,11 @@ public class JWTClientSecretAuthenticator extends AbstractClientAuthenticator {
             RealmModel realm = context.getRealm();
             String clientId = token.getSubject();
             if (clientId == null) {
-                throw new RuntimeException("Can't identify client. Issuer missing on JWT token");
+                throw new RuntimeException("Can't identify client. Subject missing on JWT token");
+            }
+
+            if (!clientId.equals(token.getIssuer())) {
+                throw new RuntimeException("Issuer mismatch. The issuer should match the subject");
             }
 
             context.getEvent().client(clientId);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ClientAuthSignedJWTTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ClientAuthSignedJWTTest.java
@@ -836,7 +836,7 @@ public class ClientAuthSignedJWTTest extends AbstractKeycloakTest {
     @Test
     public void testMissingIssuerClaim() throws Exception {
         OAuthClient.AccessTokenResponse response = testMissingClaim("issuer");
-        assertSuccess(response, app1.getClientId(), serviceAccountUser.getId(), serviceAccountUser.getUsername());
+        assertError(response, null, OAuthErrorException.INVALID_CLIENT, Errors.INVALID_CLIENT_CREDENTIALS);
     }
 
     @Test


### PR DESCRIPTION
We could probably refactor JWT authenticators to share most of the code?