### PR TITLE
KEYCLOAK-17057 Add support for JSON Logging in Keycloak.X

### DIFF
--- a/quarkus/deployment/pom.xml
+++ b/quarkus/deployment/pom.xml
@@ -68,6 +68,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-logging-json-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-health-deployment</artifactId>
         </dependency>
         <dependency>

--- a/quarkus/runtime/pom.xml
+++ b/quarkus/runtime/pom.xml
@@ -45,6 +45,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-logging-json</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jdbc-h2</artifactId>
         </dependency>
         <dependency>

--- a/quarkus/server/src/main/resources/META-INF/keycloak.properties
+++ b/quarkus/server/src/main/resources/META-INF/keycloak.properties
@@ -6,6 +6,7 @@ db=h2-file
 %dev.db.username = sa
 %dev.db.password = keycloak
 %dev.cluster=local
+%dev.quarkus.log.console.json=false
 
 # Metrics and healthcheck are disabled by default
 metrics.enabled=false


### PR DESCRIPTION
We now support JSON as the default log-format in non-dev environments.

JSON logging can be disabled via `-Dquarkus.log.console.json=false`

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
