### PR TITLE
[KEYCLOAK-17080] Fix ConcurrentModificationException in the migration…

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/migration/migrators/MigrateTo8_0_0.java
+++ b/server-spi-private/src/main/java/org/keycloak/migration/migrators/MigrateTo8_0_0.java
@@ -28,6 +28,7 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.representations.idm.RealmRepresentation;
 
 import java.util.Collections;
+import java.util.stream.Collectors;
 
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
@@ -78,11 +79,12 @@ public class MigrateTo8_0_0  implements Migration {
     }
 
     protected void migrateRealmMFA(RealmModel realm) {
-        realm.getAuthenticationFlowsStream()
+        realm.getAuthenticationFlowsStream().collect(Collectors.toList())
                 .forEach(authFlow ->
                         realm.getAuthenticationExecutionsStream(authFlow.getId())
                             .filter(exe -> exe.getRequirement() == AuthenticationExecutionModel.Requirement.CONDITIONAL)
-                            .forEachOrdered(exe -> migrateOptionalAuthenticationExecution(realm, authFlow, exe, true)));
+                            .collect(Collectors.toList())
+                            .forEach(exe -> migrateOptionalAuthenticationExecution(realm, authFlow, exe, true)));
     }
 
     public static void migrateOptionalAuthenticationExecution(RealmModel realm, AuthenticationFlowModel parentFlow, AuthenticationExecutionModel optionalExecution, boolean updateOptionalExecution) {


### PR DESCRIPTION
… to 8.0.0 that was introduced by the streamification work

NOTE: No test needs to be added, this is covered by the MigrationTest. The issue was not spotted before because it happens when migrating from a version prior to Keycloak 8.0.0 to Keycloak 12.0.x and the pipeline only runs the migration test from 9.0.3 to latest. If we run the MigrationTest using an earlier Keycloak version (e.g. 4.8.3.Final) we can see the failure.

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
