### PR TITLE
KEYCLOAK-17152: Updated Dutch translations login page

### DIFF
--- a/themes/src/main/resources-community/theme/base/login/messages/messages_nl.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_nl.properties
@@ -1,8 +1,8 @@
-# encoding: utf-8
 doLogIn=Inloggen
 doRegister=Registreer
 doCancel=Annuleer
 doSubmit=Verzenden
+doBack=Ga terug
 doYes=Ja
 doNo=Nee
 doContinue=Doorgaan
@@ -12,21 +12,27 @@ doDecline=Afwijzen
 doForgotPassword=Wachtwoord vergeten?
 doClickHere=Klik hier
 doImpersonate=Identiteit overnemen
+doTryAgain=Probeer het opnieuw
+doTryAnotherWay=Probeer het op een andere manier
+doConfirmDelete=Bevestig verwijderen
+errorDeletingAccount=Een fout is opgetreden bij het verwijderen van het account
+deletingAccountForbidden=U heeft onvoldoende permissies om het account te verwijderen
 kerberosNotConfigured=Kerberos is niet geconfigureerd
 kerberosNotConfiguredTitle=Kerberos is niet geconfigureerd
 bypassKerberosDetail=U bent niet ingelogd via Kerberos of uw browser kan niet met Kerberos inloggen. Klik op 'doorgaan' om via een andere manier in te loggen
 kerberosNotSetUp=Kerberos is onjuist geconfigureerd. U kunt niet inloggen.
 registerTitle=Registreer
+loginAccountTitle=Log in met uw account
 loginTitle=Log in met {0}
 loginTitleHtml={0}
 impersonateTitle={0} Identiteit overnemen
 impersonateTitleHtml=<strong>{0}</strong> Identiteit overnemen
 realmChoice=Realm
 unknownUser=Onbekende gebruiker
-loginTotpTitle=Mobile Authenticator Setup
+loginTotpTitle=Mobile Authenticator Configuratie
 loginProfileTitle=Update accountinformatie
 loginTimeout=U bent te lang bezig geweest met inloggen. Het inlogproces begint opnieuw.
-oauthGrantTitle=Verleen Toegang
+oauthGrantTitle=Verleen Toegang tot {0}
 oauthGrantTitleHtml={0}
 errorTitle=Er is een fout opgetreden...
 errorTitleHtml=Er is een fout opgetreden...
@@ -34,7 +40,7 @@ emailVerifyTitle=E-mailadres-verificatie
 emailForgotTitle=Wachtwoord vergeten?
 updatePasswordTitle=Wachtwoord updaten
 codeSuccessTitle=Succescode
-codeErrorTitle=Foutcode: {0}
+codeErrorTitle=Foutcode\: {0}
 displayUnsupported=Opgevraagde weergave type is niet ondersteund
 browserRequired=Om in te loggen is een browser vereist
 browserContinue=Om het loginproces af te ronden is een browser vereist
@@ -72,7 +78,14 @@ region=Provincie of regio
 postal_code=Postcode
 country=Land
 emailVerified=E-mailadres geverifieerd
+website=Website
+phoneNumber=Telefoonnummer
+phoneNumberVerified=Telefoonnummer is geverifieerd
+gender=Geslacht
+birthday=Geboortedatum
+zoneinfo=Tijdzone
 gssDelegationCredential=GSS delegatie Credential
+logoutOtherSessions=Log uit van andere aparaten
 
 profileScopeConsentText=Gebruikersprofiel
 emailScopeConsentText=E-mailadres
@@ -82,27 +95,44 @@ offlineAccessScopeConsentText=Offline toegang
 samlRoleListScopeConsentText=Mijn rollen
 rolesScopeConsentText=Gebruikersrollen
 
+restartLoginTooltip=Opnieuw inloggen
+
 loginTotpIntro=U bent verplicht om tweefactor-authenticatie in te stellen om dit account te kunnen gebruiken
-loginTotpStep1=Installeer een van de volgende applicaties op uw mobile telefoon
+loginTotpStep1=Installeer een van de volgende applicaties op uw mobiele telefoon
 loginTotpStep2=Open de applicatie en scan de barcode
 loginTotpStep3=Voer de eenmalige code die door de applicatie is aangeleverd in en klik op 'Verzenden' om de setup te voltooien
+loginTotpStep3DeviceName=Voer een naam van uw toestel in om makkelijk uw OTP toestellen te beheren
 loginTotpManualStep2=Open de applicatie en voer de sleutel in
 loginTotpManualStep3=Gebruik de volgende configuratiewaarden (als de applicatie dit ondersteund)
 loginTotpUnableToScan=Lukt het scannen niet?
 loginTotpScanBarcode=Scan barcode?
+loginCredential=Inloggegevens
 loginOtpOneTime=Eenmalige code
 loginTotpType=Type
 loginTotpAlgorithm=Algoritme
 loginTotpDigits=Cijfers
 loginTotpInterval=Interval
 loginTotpCounter=Teller
+loginTotpDeviceName=Toestelnaam
 
 loginTotp.totp=Time-based
 loginTotp.hotp=Counter-based
 
+loginChooseAuthenticator=Selecteer een login methode
 
 oauthGrantRequest=Wilt u deze toegangsrechten verlenen?
 inResource=in
+
+oauth2DeviceVerificationTitle=Toestel login
+verifyOAuth2DeviceUserCode=Voer de code in die door uw toestel is verstrekt en klik op Verzenden
+oauth2DeviceInvalidUserCodeMessage=Ongeldige code, probeer het alstublieft opnieuw.
+oauth2DeviceExpiredUserCodeMessage=De code is verlopen. Probeer alstublieft opnieuw in te loggen via uw toestel.
+oauth2DeviceVerificationCompleteHeader=Toestel login is gelukt
+oauth2DeviceVerificationCompleteMessage=U kan deze browservenster sluiten en verder gaan op uw toestel.
+oauth2DeviceVerificationFailedHeader=Toestel login is mislukt
+oauth2DeviceVerificationFailedMessage=U kan deze browservenster sluiten en opnieuw proberen te verbinden via uw toestel.
+oauth2DeviceConsentDeniedMessage=Toestemming is geweigerd om te verbinden met uw toestel.
+oauth2DeviceAuthorizationGrantDisabledMessage=Client mag geen OAuth 2.0 Device Authorization Grant initialiseren. Deze flow is uitgeschakeld voor de client.
 
 emailVerifyInstruction1=Een e-mail met instructies om uw e-mailadres te verifiëren is zojuist verzonden.
 emailVerifyInstruction2=Heeft u geen verificatiecode ontvangen in uw e-mail?
@@ -148,12 +178,18 @@ role_manage-account-links=Beheer accountlinks
 role_read-token=Token lezen
 role_offline-access=Offline toegang
 client_account=Account
+client_account-console=Account Console
 client_security-admin-console=Security Admin Console
 client_admin-cli=Admin CLI
 client_realm-management=Realm-beheer
 client_broker=Broker
 
+requiredFields=Vereiste velden
+
 invalidUserMessage=Ongeldige gebruikersnaam of wachtwoord.
+invalidUsernameMessage=Ongeldige gebruikersnaam.
+invalidUsernameOrEmailMessage=Ongeldige gebruikersnaam of e-mailadres.
+invalidPasswordMessage=Ongeldig wachtwoord.
 invalidEmailMessage=Ongeldig e-mailadres.
 accountDisabledMessage=Account is uitgeschakeld, neem contact op met beheer.
 accountTemporarilyDisabledMessage=Account is tijdelijk uitgeschakeld, neem contact op met beheer of probeer het later opnieuw.
@@ -168,6 +204,7 @@ missingEmailMessage=Voer uw e-mailadres in.
 missingUsernameMessage=Voer uw gebruikersnaam in.
 missingPasswordMessage=Voer uw wachtwoord in.
 missingTotpMessage=Voer uw authenticatiecode in.
+missingTotpDeviceNameMessage=Voer een toestelnaam in.
 notMatchPasswordMessage=Wachtwoorden komen niet overeen.
 
 invalidPasswordExistingMessage=Ongeldig bestaand wachtwoord.
@@ -179,14 +216,16 @@ usernameExistsMessage=Gebruikersnaam bestaat al.
 emailExistsMessage=E-mailadres bestaat al.
 
 federatedIdentityExistsMessage=Gebruiker met {0} {1} bestaat al. Log in met het beheerdersaccount om het account te koppelen.
+federatedIdentityUnavailableMessage=Gebruiker {0} kon niet worden gevonden bij de authenticeerde identity provider {1}. Neem contact op met de beheerder.
 
 confirmLinkIdpTitle=Account bestaat al
 federatedIdentityConfirmLinkMessage=Gebruiker met {0} {1} bestaat al. Hoe wilt u doorgaan?
 federatedIdentityConfirmReauthenticateMessage=Authenticeer om uw account te koppelen {0}
+nestedFirstBrokerFlowMessage=De {0} gebruiker {1} is niet meer gelinkt met een bekende gebruiker.
 confirmLinkIdpReviewProfile=Nalopen profiel
 confirmLinkIdpContinue=Voeg toe aan bestaande account
 
-configureTotpMessage=U moet de Mobile Authenticator configuren om uw account te activeren.
+configureTotpMessage=U moet een Mobile Authenticator configureren om uw account te activeren.
 updateProfileMessage=U moet uw gebruikersprofiel bijwerken om uw account te activeren.
 updatePasswordMessage=U moet uw wachtwoord wijzigen om uw account te activeren.
 resetPasswordMessage=U moet uw wachtwoord wijzigen.
@@ -212,6 +251,7 @@ invalidPasswordMinLowerCaseCharsMessage=Ongeldig wachtwoord, deze moet minstens 
 invalidPasswordMinUpperCaseCharsMessage=Ongeldig wachtwoord, deze moet minstens {0} hoofdletters bevatten.
 invalidPasswordMinSpecialCharsMessage=Ongeldig wachtwoord, deze moet minstens {0} speciale tekens bevatten.
 invalidPasswordNotUsernameMessage=Ongeldig wachtwoord, deze mag niet overeen komen met de gebruikersnaam.
+invalidPasswordNotEmailMessage=Ongeldig wachtwoord: deze mag niet overeen komen met de e-mailadres.
 invalidPasswordRegexPatternMessage=Ongeldig wachtwoord, deze komt niet overeen met opgegeven reguliere expressie(s).
 invalidPasswordHistoryMessage=Ongeldig wachtwoord, deze mag niet overeen komen met een van de laatste {0} wachtwoorden.
 invalidPasswordGenericMessage=Ongeldig wachtwoord: het nieuwe wachtwoord voldoet niet aan de opgestelde eisen.
@@ -246,10 +286,12 @@ invalidAccessCodeMessage=Ongeldige toegangscode.
 sessionNotActiveMessage=Sessie inactief.
 invalidCodeMessage=Er is een fout opgetreden, probeer nogmaals in te loggen.
 identityProviderUnexpectedErrorMessage=Onverwachte fout tijdens de authenticatie met de identity provider
+identityProviderMissingStateMessage=Ontbrekende state parameter in het respons van de identity provider.
 identityProviderNotFoundMessage=Geen identity provider gevonden met deze naam.
 identityProviderLinkSuccess=Uw account is met succes gekoppeld aan {0} account {1}.
 staleCodeMessage=Deze pagina is verlopen. Keer terug naar uw applicatie om opnieuw in te loggen.
 realmSupportsNoCredentialsMessage=Realm ondersteunt geen enkel soort aanmeldgegeven.
+credentialSetupRequired=Kan niet inloggen, aanmeldgegevens moeten worden geconfigureerd.
 identityProviderNotUniqueMessage=Realm ondersteunt meerdere identity providers. Er kon niet bepaald worden welke identity provider er gebruikt zou moeten worden tijdens de authenticatie.
 emailVerifiedMessage=Uw e-mailadres is geverifieerd.
 staleEmailVerificationLink=De link die u gebruikt is verlopen, wellicht omdat u uw e-mailadres al eerder geverifieerd heeft.
@@ -292,3 +334,57 @@ console-verify-email=U bent verplicht om uw e-mailadres te verifiëren. Een e-ma
 console-email-code=E-mail Code:
 console-accept-terms=Accepteert u de voorwaarden? [y/n]:
 console-accept=y
+
+# Openshift messages
+openshift.scope.user_info=Gebruikersinformatie
+openshift.scope.user_check-access=Gebruikerstoeganginformatie
+openshift.scope.user_full=Volledige toegang
+openshift.scope.list-projects=Lijst van projecten
+
+# SAML authentication
+saml.post-form.title=Authenticatie verwijzing
+saml.post-form.message=U wordt doorverwezen, een moment geduld alstublief.
+saml.post-form.js-disabled=JavaScript is uitgeschakeld. Wij raden het sterk aan om het in te schakelen. Klik op de onderstaande knop om door te gaan.
+
+#authenticators
+otp-display-name=Authenticator applicatie
+otp-help-text=Voer een verificatie code in die zichtbaar is in de authenticator applicatie.
+password-display-name=Wachtwoord
+password-help-text=Log in door uw wachtwoord in te voeren.
+auth-username-form-display-name=Gebruikersnaam
+auth-username-form-help-text=Log in door uw gebruikernaam in te voeren.
+auth-username-password-form-display-name=Gebruikersnaam en wachtwoord
+auth-username-password-form-help-text=Log in door uw gebruikernaam en wachtwoord in te voeren.
+
+# WebAuthn
+webauthn-display-name=Beveiligingssleutel
+webauthn-help-text=Gebruik uw beveiligingssleutel om in te loggen.
+webauthn-passwordless-display-name=Beveiligingssleutel
+webauthn-passwordless-help-text=Gebruik uw beveiligingssleutel om zonder wachtwoord in te loggen.
+webauthn-login-title=Beveiligingssleutel login
+webauthn-registration-title=Beveiligingssleutel registratie
+webauthn-available-authenticators=Beschikbare authenticators
+webauthn-unsupported-browser-text=WebAuthn wordt niet ondersteund door deze browser. Probeer een andere sleutel of neem contact op met de beheerder.
+
+# WebAuthn Error
+webauthn-error-title=Beveiligingssleutel fout
+webauthn-error-registration=Het is niet gelukt om uw beveiligingssleutel registreren.<br/> {0}
+webauthn-error-api-get=Het is niet gelukt om met uw beveiligingssleutel te authentificeren.<br/> {0}
+webauthn-error-different-user=De eerste geauthentificeerde gebruiker is niet de gebruiker die gekoppeld is aan de beveiligingssleutel.
+webauthn-error-auth-verification=Het resultaat van de authentificatie van de beveiligingssleutel is ongeldig.<br/> {0}
+webauthn-error-register-verification=Het resultaat van de registratie van de beveiligingssleutel is ongeldig.<br/> {0}
+webauthn-error-user-not-found=Een onbekende gebruiker is authentificeerd op basis van de beveiligingssleutel.
+
+# Identity provider
+identity-provider-redirector=Verbind met een andere Identity Provider
+identity-provider-login-label=Of log in met
+
+finalDeletionConfirmation=Als U uw account verwijderd kan deze niet meer worden hersteld. Om uw account te behouden, druk op annuleren.
+irreversibleAction=Deze actie kan niet meer worden teruggedraaid
+deleteAccountConfirm=Weet U zeker dat uw account wilt verwijderen?
+
+deletingImplies=Het verwijderen van uw account impleceert:
+errasingData=Het verwijderen van al uw gegevens
+loggingOutImmediately=U wordt direct uitgelogd
+accountUnusable=Het verder gebruik van de applicatie is niet meer mogelijk met dit account
+userDeletedSuccessfully=De gebruiker is succesvol verwijderd


### PR DESCRIPTION
I've noticed that the Dutch translations for the Keycloak project are out of date.
Some fields show with an message with the fallback language locale. I've translated the login pages for Keycloak in Dutch.


https://issues.redhat.com/browse/KEYCLOAK-17152