### PR TITLE
KEYCLOAK-17141: Keycloak replaces port to 80 in redirect URL if custom schema is set

### DIFF
--- a/common/src/main/java/org/keycloak/common/util/KeycloakUriBuilder.java
+++ b/common/src/main/java/org/keycloak/common/util/KeycloakUriBuilder.java
@@ -429,7 +429,7 @@ public class KeycloakUriBuilder {
                 if ("".equals(host)) throw new RuntimeException("empty host name");
                 replaceParameter(paramMap, fromEncodedMap, isTemplate, host, buffer, encodeSlash);
             }
-            if (port != -1 && (scheme == null || (scheme.equals("http") && port != 80) || (scheme.equals("https") && port != 443)) ) {
+            if (port != -1 && !(("http".equals(scheme) && port == 80) || ("https".equals(scheme) && port == 443))) {
                 buffer.append(":").append(Integer.toString(port));
             }
         } else if (authority != null) {

--- a/common/src/test/java/org/keycloak/common/util/KeycloakUriBuilderTest.java
+++ b/common/src/test/java/org/keycloak/common/util/KeycloakUriBuilderTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.keycloak.common.util;
+
+import java.util.Collections;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author rmartinc
+ */
+public class KeycloakUriBuilderTest {
+
+    @Test
+    public void test() {
+        Assert.assertEquals("http://localhost:8080/path?attr1=value1&attr2=value2",
+                KeycloakUriBuilder.fromUri("http://localhost:8080/path?attr1=value1&attr2=value2")
+                        .build().toString());
+
+        Assert.assertEquals("http://localhost/path?attr1=value1&attr2=value2",
+                KeycloakUriBuilder.fromUri("http://localhost:80")
+                        .path("path")
+                        .queryParam("attr1", "value1")
+                        .queryParam("attr2", "value2")
+                        .build().toString());
+
+        Assert.assertEquals("unknown://localhost:9000/path",
+                KeycloakUriBuilder.fromUri("unknown://localhost:9000/path").build().toString());
+
+        Assert.assertEquals("https://localhost/path?attr1=value1",
+                KeycloakUriBuilder.fromUri("https://{hostname}:443/path?attr1={value}")
+                        .build("localhost", "value1").toString());
+
+        Assert.assertEquals("https://localhost:8443/path?attr1=value1",
+                KeycloakUriBuilder.fromUri("https://localhost:8443/path?attr1={value}")
+                        .buildFromMap(Collections.singletonMap("value", "value1")).toString());
+    }
+}


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/KEYCLOAK-17141

Easy win in the KeycloakUriBuilder. Right now the port is omitted if the scheme is not http or https. I think this is an oversight trying to avoid a NPE because I don't see any reason to not use the port for other schemes. This is very important for mobile apps that use custom URLs to register the client (right now the port is not included in the final URL).

I have just created a little direct test over the KeycloakUriBuilder in the common folder. It tests some use-cases, probably not complete but it tests this scenario.