### PR TITLE
KEYCLOAK-17189 - fixed NPE during migration due to missed "account" clinet

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/migration/migrators/MigrateTo12_0_0.java
+++ b/server-spi-private/src/main/java/org/keycloak/migration/migrators/MigrateTo12_0_0.java
@@ -45,6 +45,7 @@ public class MigrateTo12_0_0 implements Migration {
         session.realms()
           .getRealmsStream()
           .map(realm -> realm.getClientByClientId(Constants.ACCOUNT_MANAGEMENT_CLIENT_ID))
+          .filter(Objects::nonNull)
           .filter(client -> Objects.isNull(client.getRole(AccountRoles.DELETE_ACCOUNT)))
           .forEach(client -> client.addRole(AccountRoles.DELETE_ACCOUNT)
           .setDescription("${role_" + AccountRoles.DELETE_ACCOUNT + "}"));


### PR DESCRIPTION
Migration fails for realms that do not contain "account client"

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
