### PR TITLE
redirect URL loses query parameters

### DIFF
--- a/adapters/oidc/adapter-core/pom.xml
+++ b/adapters/oidc/adapter-core/pom.xml
@@ -106,6 +106,11 @@
             <artifactId>httpclient</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>commons-collections</groupId>
+            <artifactId>commons-collections</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/adapters/oidc/adapter-core/pom.xml
+++ b/adapters/oidc/adapter-core/pom.xml
@@ -109,6 +109,7 @@
         <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
+            <version>3.2.2</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/adapters/oidc/adapter-core/pom.xml
+++ b/adapters/oidc/adapter-core/pom.xml
@@ -109,8 +109,6 @@
         <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
-            <version>3.2.2</version>
-            <scope>provided</scope>
         </dependency>
     </dependencies>
     <build>

--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/OAuthRequestAuthenticator.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/OAuthRequestAuthenticator.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.adapters;
 
+import org.apache.commons.collections.MapUtils;
 import org.jboss.logging.Logger;
 import org.keycloak.OAuth2Constants;
 import org.keycloak.adapters.rotation.AdapterTokenVerifier;
@@ -390,9 +391,9 @@ public class OAuthRequestAuthenticator {
 
     private String rewrittenRedirectUri(String originalUri) {
         Map<String, String> rewriteRules = deployment.getRedirectRewriteRules();
-        if(rewriteRules != null && !rewriteRules.isEmpty()) {
+        if(MapUtils.isNotEmpty(rewriteRules)) {
             try {
-                Map.Entry<String, String> rule =  rewriteRules.entrySet().iterator().next();
+                Map.Entry<String, String> rule = rewriteRules.entrySet().iterator().next();
                 URI uri = new URI(originalUri);
                 return KeycloakUriBuilder.fromUri(uri)
                                          .replacePath(uri.getPath().replaceFirst(rule.getKey(), rule.getValue()))

--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/OAuthRequestAuthenticator.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/OAuthRequestAuthenticator.java
@@ -37,8 +37,8 @@ import org.keycloak.representations.IDToken;
 import org.keycloak.util.TokenUtil;
 
 import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Map;
 
 
@@ -387,22 +387,22 @@ public class OAuthRequestAuthenticator {
                 .replaceQueryParam(OAuth2Constants.SESSION_STATE, null);
         return builder.build().toString();
     }
-    
+
     private String rewrittenRedirectUri(String originalUri) {
         Map<String, String> rewriteRules = deployment.getRedirectRewriteRules();
-            if(rewriteRules != null && !rewriteRules.isEmpty()) {
+        if(rewriteRules != null && !rewriteRules.isEmpty()) {
             try {
-                URL url = new URL(originalUri);
                 Map.Entry<String, String> rule =  rewriteRules.entrySet().iterator().next();
-                StringBuilder redirectUriBuilder = new StringBuilder(url.getProtocol());
-                redirectUriBuilder.append("://"+ url.getAuthority());
-                redirectUriBuilder.append(url.getPath().replaceFirst(rule.getKey(), rule.getValue()));
-                return redirectUriBuilder.toString();
-            } catch (MalformedURLException ex) {
+                URI uri = new URI(originalUri);
+                return KeycloakUriBuilder.fromUri(uri)
+                                         .replacePath(uri.getPath().replaceFirst(rule.getKey(), rule.getValue()))
+                                         .build()
+                                         .toString();
+            } catch (URISyntaxException ex) {
                 log.error("Not a valid request url");
                 throw new RuntimeException(ex);
             }
-            }
+        }
         return originalUri;
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,7 @@
         <version.com.openshift.openshift-restclient-java>8.0.0.Final</version.com.openshift.openshift-restclient-java>
 
         <!-- Others -->
+        <commons-collections.version>3.2.2</commons-collections.version>
         <commons-lang.version>2.6</commons-lang.version>
         <commons-lang3.version>3.10</commons-lang3.version>
         <commons-io.version>2.6</commons-io.version>
@@ -1528,6 +1529,11 @@
                 <groupId>com.fasterxml.jackson.dataformat</groupId>
                 <artifactId>jackson-dataformat-cbor</artifactId>
                 <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-collections</groupId>
+                <artifactId>commons-collections</artifactId>
+                <version>${commons-collections.version}</version>
             </dependency>
             <dependency>
                 <groupId>commons-lang</groupId>


### PR DESCRIPTION
Redirect uri loses query parameters when a redirect rewrite rule is specified.

I guess the place where this happens is _OAuthRequestAuthenticator.rewrittenRedirectUri()_: If there are no rewrite rules the original uri (including query parameters) is simply passed through. But if the is a rewrite rule, a new uri is built applying the rule to the uri’s path but omitting the query parameters.