### PR TITLE
KEYCLOAK-17192 Add jaxb module dependency required by JAXBUtil class

### DIFF
--- a/distribution/feature-packs/server-feature-pack/src/main/resources/modules/system/layers/keycloak/org/keycloak/keycloak-saml-core/main/module.xml
+++ b/distribution/feature-packs/server-feature-pack/src/main/resources/modules/system/layers/keycloak/org/keycloak/keycloak-saml-core/main/module.xml
@@ -35,5 +35,6 @@
             </imports>
         </module>
         <module name="javax.api"/>
+        <module name="javax.xml.bind.api"/>
     </dependencies>
 </module>

--- a/distribution/saml-adapters/as7-eap6-adapter/as7-modules/src/main/resources/modules/org/keycloak/keycloak-saml-core/main/module.xml
+++ b/distribution/saml-adapters/as7-eap6-adapter/as7-modules/src/main/resources/modules/org/keycloak/keycloak-saml-core/main/module.xml
@@ -36,6 +36,7 @@
             </imports>
         </module>
         <module name="javax.api"/>
+        <module name="javax.xml.bind.api" optional="true" />
         <module name="org.apache.httpcomponents"/>
     </dependencies>
 

--- a/distribution/saml-adapters/wildfly-adapter/wildfly-modules/src/main/resources/modules/org/keycloak/keycloak-saml-core/main/module.xml
+++ b/distribution/saml-adapters/wildfly-adapter/wildfly-modules/src/main/resources/modules/org/keycloak/keycloak-saml-core/main/module.xml
@@ -36,6 +36,7 @@
             </imports>
         </module>
         <module name="javax.api"/>
+        <module name="javax.xml.bind.api"/>
         <module name="org.apache.httpcomponents"/>
     </dependencies>
 


### PR DESCRIPTION
The JAXBUtil class requires classes that have been removed from JDK11. These are already imported with the appropriate POMs during compilation, but they aren't declared in the module dependencies and are therefore unavailable at runtime.

This PR adds the appropriate dependency to the module.