### PR TITLE
KEYCLOAK-17074 Infinite loop logging as an user or impersonating an user as admin

### DIFF
--- a/testsuite/integration-arquillian/tests/other/base-ui/src/test/java/org/keycloak/testsuite/ui/account2/PermissionsTest.java
+++ b/testsuite/integration-arquillian/tests/other/base-ui/src/test/java/org/keycloak/testsuite/ui/account2/PermissionsTest.java
@@ -18,8 +18,8 @@
 package org.keycloak.testsuite.ui.account2;
 
 import org.jboss.arquillian.graphene.page.Page;
-import org.junit.Ignore;
 import org.junit.Test;
+import org.keycloak.admin.client.resource.RoleScopeResource;
 import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.testsuite.ui.account2.page.ForbiddenPage;
 import org.keycloak.testsuite.ui.account2.page.PersonalInfoPage;
@@ -27,16 +27,13 @@ import org.keycloak.testsuite.ui.account2.page.SigningInPage;
 import org.keycloak.testsuite.ui.account2.page.WelcomeScreen;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
-import static org.keycloak.models.AccountRoles.MANAGE_ACCOUNT;
 import static org.keycloak.models.Constants.ACCOUNT_MANAGEMENT_CLIENT_ID;
 import static org.keycloak.testsuite.auth.page.AuthRealm.TEST;
 
 /**
  * @author Vaclav Muzikar <vmuzikar@redhat.com>
  */
-@Ignore // TODO Remove when KEYCLOAK-17366 is fixed
 public class PermissionsTest extends AbstractAccountTest {
     @Page
     private WelcomeScreen welcomeScreen;
@@ -53,17 +50,15 @@ public class PermissionsTest extends AbstractAccountTest {
     private static final String DEFAULT_ROLE_NAME = "default-roles-" + TEST;
 
     @Test
-    public void manageAccountRoleRequired() {
-        // remove the default role from test user ACCOUNT_MANAGEMENT_CLIENT_ID
+    public void manageAccountRoleRequired() throws Exception {
+        // remove realm level roles (no "default-roles-test") and any roles in the account client
+        testUserResource().roles().realmLevel().remove(testUserResource().roles().realmLevel().listAll());
         String accountClientId = testRealmResource().clients().findByClientId(ACCOUNT_MANAGEMENT_CLIENT_ID).get(0).getId();
-
-        List<RoleRepresentation> rolesToRemove = testRealmResource().roles()
-                .get(DEFAULT_ROLE_NAME)
-                .getClientRoleComposites(accountClientId).stream()
-                .filter(role -> role.getName().equals(MANAGE_ACCOUNT))
-                .collect(Collectors.toList());
-
-        testRealmResource().roles().get(DEFAULT_ROLE_NAME).deleteComposites(rolesToRemove);
+        RoleScopeResource roleScopes = testUserResource().roles().clientLevel(accountClientId);
+        List<RoleRepresentation> roles = roleScopes.listAll();
+        if (!roles.isEmpty()) {
+            roleScopes.remove(roles);
+        }
 
         welcomeScreen.header().clickLoginBtn();
         loginToAccount();
@@ -80,8 +75,5 @@ public class PermissionsTest extends AbstractAccountTest {
         welcomeScreen.assertCurrent();
         welcomeScreen.header().assertLoginBtnVisible(true);
         welcomeScreen.header().assertLogoutBtnVisible(false);
-
-        // Revert role changes
-        getCleanup().addCleanup((Runnable) () -> testRealmResource().roles().get(DEFAULT_ROLE_NAME).addComposites(rolesToRemove));
     }
 }

--- a/themes/src/main/resources/theme/keycloak.v2/account/src/app/account-service/account.service.ts
+++ b/themes/src/main/resources/theme/keycloak.v2/account/src/app/account-service/account.service.ts
@@ -91,12 +91,17 @@ export class AccountServiceClient {
 
     private handleError(response: HttpResponse): void {
         if (response !== null && response.status === 401) {
-            // session timed out?
-            this.kcSvc.login();
+            if (this.kcSvc.authenticated() && !this.kcSvc.audiencePresent()) {
+                // authenticated and the audience is not present => not allowed
+                window.location.href = baseUrl + '#/forbidden';
+            } else {
+                // session timed out?
+                this.kcSvc.login();
+            }
         }
 
         if (response !== null && response.status === 403) {
-            window.location.href = baseUrl + '/#/forbidden';
+            window.location.href = baseUrl + '#/forbidden';
         }
 
         if (response !== null && response.data != null) {

--- a/themes/src/main/resources/theme/keycloak.v2/account/src/app/keycloak-service/keycloak.service.ts
+++ b/themes/src/main/resources/theme/keycloak.v2/account/src/app/keycloak-service/keycloak.service.ts
@@ -30,6 +30,14 @@ export class KeycloakService {
         return this.keycloakAuth.authenticated ? this.keycloakAuth.authenticated : false;
     }
 
+    public audiencePresent(): boolean {
+        if (this.keycloakAuth.tokenParsed) {
+            const audience = this.keycloakAuth.tokenParsed['aud'];
+            return audience === 'account' || (Array.isArray(audience) && audience.indexOf('account') >= 0);
+        }
+        return false;
+    }
+
     public login(options?: KeycloakLoginOptions): void {
         this.keycloakAuth.login(options);
     }


### PR DESCRIPTION
Fix for issue: https://issues.redhat.com/browse/KEYCLOAK-17074

I have also modified the `PermissionsTest` that tested this. It did not work before because the default realm role was not removed from the user in the test, so it can access the v2 app perfectly. Now realm and account roles are removed from the user and the loop is avoided.
