### PR TITLE
KEYCLOAK-17214 extend user profile provider

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/userprofile/UserProfileAttributes.java
+++ b/server-spi-private/src/main/java/org/keycloak/userprofile/UserProfileAttributes.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.List;
+import org.keycloak.userprofile.validation.UserUpdateEvent;
 
 public class UserProfileAttributes extends HashMap<String, List<String>> {
 
@@ -56,7 +57,11 @@ public class UserProfileAttributes extends HashMap<String, List<String>> {
         this.remove(attr);
     }
 
-    public boolean isReadOnlyAttribute(String key) {
-        return profileProvider != null && profileProvider.isReadOnlyAttribute(key);
+    public boolean isReadOnlyAttribute(UserUpdateEvent userUpdateEvent, String key) {
+        return profileProvider != null && profileProvider.isReadOnlyAttribute(userUpdateEvent, key);
+    }
+
+    public boolean removeMissingAttribute(UserUpdateEvent userUpdateEvent, String key, boolean defaultValue) {
+        return profileProvider != null && profileProvider.removeMissingAttribute(userUpdateEvent, key, defaultValue);
     }
 }

--- a/server-spi-private/src/main/java/org/keycloak/userprofile/UserProfileProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/userprofile/UserProfileProvider.java
@@ -18,7 +18,9 @@
 package org.keycloak.userprofile;
 
 import org.keycloak.provider.Provider;
+import org.keycloak.representations.account.UserRepresentation;
 import org.keycloak.userprofile.validation.UserProfileValidationResult;
+import org.keycloak.userprofile.validation.UserUpdateEvent;
 
 /**
  * @author <a href="mailto:markus.till@bosch.io">Markus Till</a>
@@ -27,5 +29,13 @@ public interface UserProfileProvider extends Provider {
 
     UserProfileValidationResult validate(UserProfileContext updateContext, UserProfile updatedProfile);
 
-    boolean isReadOnlyAttribute(String key);
+    boolean isReadOnlyAttribute(UserUpdateEvent userUpdateEvent, String key);
+
+    default boolean removeMissingAttribute(UserUpdateEvent userUpdateEvent, String key, boolean defaultValue) {
+        return defaultValue;
+    }
+
+    default UserRepresentation filterUserRepresentation(UserRepresentation rep, UserUpdateEvent userUpdateEvent) {
+        return rep;
+    }
 }

--- a/services/src/main/java/org/keycloak/services/resources/account/AccountRestService.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountRestService.java
@@ -77,6 +77,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.keycloak.userprofile.validation.UserUpdateEvent;
 
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
@@ -145,7 +146,7 @@ public class AccountRestService {
         copiedAttributes.remove(UserModel.USERNAME);
         rep.setAttributes(copiedAttributes);
 
-        return rep;
+        return UserUpdateHelper.filterUserRepresentation(rep, UserUpdateEvent.Account, session);
     }
 
     @Path("/")

--- a/services/src/main/java/org/keycloak/userprofile/LegacyUserProfileProvider.java
+++ b/services/src/main/java/org/keycloak/userprofile/LegacyUserProfileProvider.java
@@ -27,6 +27,7 @@ import org.keycloak.models.UserModel;
 import org.keycloak.services.messages.Messages;
 import org.keycloak.userprofile.validation.StaticValidators;
 import org.keycloak.userprofile.validation.UserProfileValidationResult;
+import org.keycloak.userprofile.validation.UserUpdateEvent;
 import org.keycloak.userprofile.validation.ValidationChainBuilder;
 
 /**
@@ -78,8 +79,13 @@ public class LegacyUserProfileProvider implements UserProfileProvider {
     }
 
     @Override
-    public boolean isReadOnlyAttribute(String key) {
-        return readOnlyAttributes.matcher(key).find() || adminReadOnlyAttributes.matcher(key).find();
+    public boolean isReadOnlyAttribute(UserUpdateEvent userUpdateEvent, String key) {
+        switch (userUpdateEvent) {
+            case UserResource:
+                return adminReadOnlyAttributes.matcher(key).find();
+            default:
+                return readOnlyAttributes.matcher(key).find();
+        }
     }
 
     private void addUserCreationValidators(ValidationChainBuilder builder) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/UserTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/UserTest.java
@@ -1152,6 +1152,23 @@ public class UserTest extends AbstractAdminTest {
         assertEquals("foo", user1.getAttributes().get("usercertificate").get(0));
         assertEquals("bar", user1.getAttributes().get("saml.persistent.name.id.for.foo").get(0));
         assertFalse(user1.getAttributes().containsKey(LDAPConstants.LDAP_ID));
+
+        // Add an attribute that is read only for a regular user, but not for an admin
+        UserRepresentation user2 = new UserRepresentation();
+        user2.setUsername("user2");
+        String user2Id = createUser(user2);
+        user2 = realm.users().get(user2Id).toRepresentation();
+        user2.singleAttribute("foo", "bar");
+        user2.singleAttribute("saml.persistent.name.id.for.foo2", "bar");
+        updateUser(realm.users().get(user2Id), user2);
+        user2 = realm.users().get(user2Id).toRepresentation();
+        assertEquals("bar", user2.getAttributes().get("saml.persistent.name.id.for.foo2").get(0));
+
+        // Remove an attribute that is read only for a regular user, but not for an admin
+        user2.getAttributes().remove("saml.persistent.name.id.for.foo2");
+        updateUser(realm.users().get(user2Id), user2);
+        user2 = realm.users().get(user2Id).toRepresentation();
+        assertNull(user2.getAttributes().get("saml.persistent.name.id.for.foo2"));
     }
 
     @Test


### PR DESCRIPTION
The isReadOnlyAttribute in UserProfileProvider was missing context to decide what is read only or not (admin or regular)

Added the methods isRemoveMissingAttributes and filterUserRepresentation to UserProfileProvider
These allow implementing an account client which does not always receive all user attributes
This is especially relevant for javascript applications for which you do not always want to allow read access to all user attributes

https://issues.redhat.com/browse/KEYCLOAK-17214