### PR TITLE
WIP Shorter and cleaner IDs

### DIFF
--- a/common/src/main/java/org/keycloak/common/util/Base62.java
+++ b/common/src/main/java/org/keycloak/common/util/Base62.java
@@ -1,0 +1,176 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2017 Sebastian Ruhleder
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.keycloak.common.util;
+
+import java.io.ByteArrayOutputStream;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+
+/*
+ * Base62 encoding/decoding (based on https://github.com/seruco/base62)
+ */
+public class Base62 {
+
+    private static final int STANDARD_BASE = 256;
+
+    private static final int TARGET_BASE = 62;
+
+    private static final byte[] alphabet = {
+            (byte) '0', (byte) '1', (byte) '2', (byte) '3', (byte) '4', (byte) '5', (byte) '6', (byte) '7',
+            (byte) '8', (byte) '9', (byte) 'A', (byte) 'B', (byte) 'C', (byte) 'D', (byte) 'E', (byte) 'F',
+            (byte) 'G', (byte) 'H', (byte) 'I', (byte) 'J', (byte) 'K', (byte) 'L', (byte) 'M', (byte) 'N',
+            (byte) 'O', (byte) 'P', (byte) 'Q', (byte) 'R', (byte) 'S', (byte) 'T', (byte) 'U', (byte) 'V',
+            (byte) 'W', (byte) 'X', (byte) 'Y', (byte) 'Z', (byte) 'a', (byte) 'b', (byte) 'c', (byte) 'd',
+            (byte) 'e', (byte) 'f', (byte) 'g', (byte) 'h', (byte) 'i', (byte) 'j', (byte) 'k', (byte) 'l',
+            (byte) 'm', (byte) 'n', (byte) 'o', (byte) 'p', (byte) 'q', (byte) 'r', (byte) 's', (byte) 't',
+            (byte) 'u', (byte) 'v', (byte) 'w', (byte) 'x', (byte) 'y', (byte) 'z'
+    };
+
+    private static final byte[] lookup = createLookupTable();
+
+    /**
+     * Encodes a sequence of bytes in Base62 encoding.
+     *
+     * @param message a byte sequence.
+     * @return a sequence of Base62-encoded bytes.
+     */
+    public static byte[] encode(final byte[] message) {
+        final byte[] indices = convert(message, STANDARD_BASE, TARGET_BASE);
+
+        return translate(indices, alphabet);
+    }
+
+    public static String encodeToString(final byte[] message) {
+        byte[] encoded = encode(message);
+        return new String(encoded, UTF_8);
+    }
+
+    public static byte[] decode(final String encoded) {
+        return decode(encoded.getBytes(UTF_8));
+    }
+
+    /**
+     * Decodes a sequence of Base62-encoded bytes.
+     *
+     * @param encoded a sequence of Base62-encoded bytes.
+     * @return a byte sequence.
+     * @throws IllegalArgumentException when {@code encoded} is not encoded over the Base62 alphabet.
+     */
+    public static byte[] decode(final byte[] encoded) {
+        final byte[] prepared = translate(encoded, lookup);
+
+        return convert(prepared, TARGET_BASE, STANDARD_BASE);
+    }
+
+    /**
+     * Uses the elements of a byte array as indices to a dictionary and returns the corresponding values
+     * in form of a byte array.
+     */
+    private static byte[] translate(final byte[] indices, final byte[] dictionary) {
+        final byte[] translation = new byte[indices.length];
+
+        for (int i = 0; i < indices.length; i++) {
+            translation[i] = dictionary[indices[i]];
+        }
+
+        return translation;
+    }
+
+    /**
+     * Converts a byte array from a source base to a target base using the alphabet.
+     */
+    private static byte[] convert(final byte[] message, final int sourceBase, final int targetBase) {
+        /* This algorithm is inspired by: http://codegolf.stackexchange.com/a/21672 */
+
+        final int estimatedLength = estimateOutputLength(message.length, sourceBase, targetBase);
+
+        final ByteArrayOutputStream out = new ByteArrayOutputStream(estimatedLength);
+
+        byte[] source = message;
+
+        while (source.length > 0) {
+            final ByteArrayOutputStream quotient = new ByteArrayOutputStream(source.length);
+
+            int remainder = 0;
+
+            for (byte b : source) {
+                final int accumulator = (b & 0xFF) + remainder * sourceBase;
+                final int digit = (accumulator - (accumulator % targetBase)) / targetBase;
+
+                remainder = accumulator % targetBase;
+
+                if (quotient.size() > 0 || digit > 0) {
+                    quotient.write(digit);
+                }
+            }
+
+            out.write(remainder);
+
+            source = quotient.toByteArray();
+        }
+
+        // pad output with zeroes corresponding to the number of leading zeroes in the message
+        for (int i = 0; i < message.length - 1 && message[i] == 0; i++) {
+            out.write(0);
+        }
+
+        return reverse(out.toByteArray());
+    }
+
+    /**
+     * Estimates the length of the output in bytes.
+     */
+    private static int estimateOutputLength(int inputLength, int sourceBase, int targetBase) {
+        return (int) Math.ceil((Math.log(sourceBase) / Math.log(targetBase)) * inputLength);
+    }
+
+    /**
+     * Reverses a byte array.
+     */
+    private static byte[] reverse(final byte[] arr) {
+        final int length = arr.length;
+
+        final byte[] reversed = new byte[length];
+
+        for (int i = 0; i < length; i++) {
+            reversed[length - i - 1] = arr[i];
+        }
+
+        return reversed;
+    }
+
+    /**
+     * Creates the lookup table from character to index of character in character set.
+     */
+    private static byte[] createLookupTable() {
+        byte[] lookup = new byte[256];
+
+        for (int i = 0; i < alphabet.length; i++) {
+            lookup[alphabet[i]] = (byte) (i & 0xFF);
+        }
+        return lookup;
+    }
+
+}

--- a/common/src/main/java/org/keycloak/common/util/PrettyUUID.java
+++ b/common/src/main/java/org/keycloak/common/util/PrettyUUID.java
@@ -1,0 +1,67 @@
+package org.keycloak.common.util;
+
+import java.nio.ByteBuffer;
+import java.util.UUID;
+
+public class PrettyUUID {
+
+    private final UUID uuid;
+    private byte[] signature;
+
+    public static String create() {
+        return encode(UUID.randomUUID());
+    }
+
+    public static String encode(UUID uuid) {
+        return encode(uuid, null);
+    }
+
+    public static String encode(UUID uuid, byte[] signature) {
+        boolean signed = signature != null;
+        ByteBuffer uuidBuffer = ByteBuffer.allocate(signed ? 48 : 16);
+        uuidBuffer.putLong(uuid.getMostSignificantBits());
+        uuidBuffer.putLong(uuid.getLeastSignificantBits());
+        if (signed) {
+            uuidBuffer.put(signature);
+        }
+        return Base62.encodeToString(uuidBuffer.array());
+    }
+
+    public static PrettyUUID decode(String encoded) {
+        boolean signed = encoded.length() > 26;
+
+        byte[] decode = Base62.decode(encoded);
+        ByteBuffer wrap = ByteBuffer.wrap(decode);
+
+        UUID uuid = new UUID(wrap.getLong(), wrap.getLong());
+        PrettyUUID prettyUUID = new PrettyUUID(uuid);
+
+        if (signed) {
+            prettyUUID.signature = new byte[32];
+            wrap.get(prettyUUID.signature);
+        }
+
+        return prettyUUID;
+    }
+
+    private PrettyUUID(UUID uuid) {
+        this.uuid = uuid;
+    }
+
+    public UUID getUuid() {
+        return uuid;
+    }
+
+    public boolean isSigned() {
+        return signature != null;
+    }
+
+    public byte[] getSignature() {
+        return signature;
+    }
+
+    public void sign(byte[] signature) {
+        this.signature = signature;
+    }
+
+}

--- a/common/src/main/java/org/keycloak/common/util/SecretGenerator.java
+++ b/common/src/main/java/org/keycloak/common/util/SecretGenerator.java
@@ -1,0 +1,19 @@
+package org.keycloak.common.util;
+
+import java.security.SecureRandom;
+
+public class SecretGenerator {
+
+    public static final int DEFAULT_BYTES = 32;
+
+    public static String generate() {
+        return generate(DEFAULT_BYTES);
+    }
+
+    public static String generate(int bytes) {
+        byte[] buf = new byte[bytes];
+        new SecureRandom().nextBytes(buf);
+        return Base62.encodeToString(buf);
+    }
+
+}

--- a/common/src/test/java/org/keycloak/common/util/Base62Test.java
+++ b/common/src/test/java/org/keycloak/common/util/Base62Test.java
@@ -1,0 +1,26 @@
+package org.keycloak.common.util;
+
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+
+public class Base62Test {
+
+    @Test
+    public void encode() {
+        assertEncode("s");
+        assertEncode("sdsfge4rg09u4309tudpoigjsndrgoji3409uer0gr90ued0r90goi");
+        assertEncode("sdfoijdsfg9dfo9034dfig sa-d0fsdfj0-j32423");
+        assertEncode("sdfoijds£Q()*%$£()*$£)(*FSIHFNSOAIN£*()*£\"()\\$*\")(fg9dfo9034dfig sa-d0fsdfj0-j32423");
+    }
+
+    void assertEncode(String original) {
+        byte[] bytes = original.getBytes(StandardCharsets.UTF_8);
+        String encoded = Base62.encodeToString(bytes);
+        byte[] decoded = Base62.decode(encoded);
+        assertEquals("Encoded/decoded string does not match", original, new String(decoded, StandardCharsets.UTF_8));
+    }
+
+}

--- a/common/src/test/java/org/keycloak/common/util/PrettyUUIDTest.java
+++ b/common/src/test/java/org/keycloak/common/util/PrettyUUIDTest.java
@@ -1,0 +1,65 @@
+package org.keycloak.common.util;
+
+import org.junit.Test;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.UUID;
+
+import static org.junit.Assert.*;
+
+public class PrettyUUIDTest {
+
+    @Test
+    public void unsigned() {
+        UUID uuid = UUID.randomUUID();
+        String encoded = PrettyUUID.encode(uuid);
+        assertTrue(encoded.length() <= 22);
+
+        PrettyUUID decoded = PrettyUUID.decode(encoded);
+        assertEquals(uuid, decoded.getUuid());
+        assertFalse(decoded.isSigned());
+    }
+
+    @Test
+    public void signed() throws InvalidKeyException, NoSuchAlgorithmException {
+        UUID uuid = UUID.randomUUID();
+        byte[] secret = new byte[32];
+        new SecureRandom().nextBytes(secret);
+        byte[] signature = sign(secret, uuid.toString(), "something else");
+
+        String encoded = PrettyUUID.encode(uuid, signature);
+        assertTrue(encoded.length() >= 60);
+
+        PrettyUUID decoded = PrettyUUID.decode(encoded);
+        assertEquals(uuid, decoded.getUuid());
+        assertTrue(decoded.isSigned());
+        assertTrue(verify(secret, decoded.getSignature(), decoded.getUuid().toString(), "something else"));
+    }
+
+    private static byte[] sign(byte[] secret, String... parts) throws NoSuchAlgorithmException, InvalidKeyException {
+        Mac mac = Mac.getInstance("HMACSHA256");
+        mac.init(new SecretKeySpec(secret, mac.getAlgorithm()));
+        for (String s : parts) {
+            mac.update(s.getBytes(StandardCharsets.UTF_8));
+        }
+
+        byte[] signature = mac.doFinal();
+        return signature;
+    }
+
+    private static boolean verify(byte[] secret, byte[] signature, String... parts) throws NoSuchAlgorithmException, InvalidKeyException {
+        Mac mac = Mac.getInstance("HMACSHA256");
+        mac.init(new SecretKeySpec(secret, mac.getAlgorithm()));
+        for (String s : parts) {
+            mac.update(s.getBytes(StandardCharsets.UTF_8));
+        }
+        return MessageDigest.isEqual(signature, mac.doFinal());
+    }
+
+}

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanAuthenticationSessionProvider.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanAuthenticationSessionProvider.java
@@ -25,6 +25,7 @@ import java.util.concurrent.TimeUnit;
 import org.infinispan.Cache;
 import org.jboss.logging.Logger;
 import org.keycloak.common.util.Base64Url;
+import org.keycloak.common.util.SecretGenerator;
 import org.keycloak.common.util.Time;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
@@ -183,6 +184,6 @@ public class InfinispanAuthenticationSessionProvider implements AuthenticationSe
 
 
     protected String generateTabId() {
-        return Base64Url.encode(KeycloakModelUtils.generateSecret(8));
+        return SecretGenerator.generate(8);
     }
 }

--- a/model/map/src/main/java/org/keycloak/models/map/authSession/MapRootAuthenticationSessionAdapter.java
+++ b/model/map/src/main/java/org/keycloak/models/map/authSession/MapRootAuthenticationSessionAdapter.java
@@ -17,6 +17,7 @@
 package org.keycloak.models.map.authSession;
 
 import org.keycloak.common.util.Base64Url;
+import org.keycloak.common.util.SecretGenerator;
 import org.keycloak.common.util.Time;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
@@ -122,6 +123,6 @@ public class MapRootAuthenticationSessionAdapter extends AbstractRootAuthenticat
     }
 
     private String generateTabId() {
-        return Base64Url.encode(KeycloakModelUtils.generateSecret(8));
+        return SecretGenerator.generate(8);
     }
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/services/resources/QuarkusWelcomeResource.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/services/resources/QuarkusWelcomeResource.java
@@ -22,6 +22,7 @@ import org.keycloak.common.ClientConnection;
 import org.keycloak.common.Version;
 import org.keycloak.common.util.Base64Url;
 import org.keycloak.common.util.MimeTypeUtil;
+import org.keycloak.common.util.SecretGenerator;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.services.ForbiddenException;
@@ -251,7 +252,7 @@ public class QuarkusWelcomeResource {
     }
 
     private String setCsrfCookie() {
-        String stateChecker = Base64Url.encode(KeycloakModelUtils.generateSecret());
+        String stateChecker = SecretGenerator.generate();
         String cookiePath = session.getContext().getUri().getPath();
         boolean secureOnly = session.getContext().getUri().getRequestUri().getScheme().equalsIgnoreCase("https");
         CookieHelper.addCookie(KEYCLOAK_STATE_CHECKER, stateChecker, cookiePath, null, null, 300, secureOnly, true);

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/KeycloakModelUtils.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/KeycloakModelUtils.java
@@ -22,6 +22,7 @@ import org.keycloak.broker.social.SocialIdentityProviderFactory;
 import org.keycloak.common.util.CertificateUtils;
 import org.keycloak.common.util.KeyUtils;
 import org.keycloak.common.util.PemUtils;
+import org.keycloak.common.util.PrettyUUID;
 import org.keycloak.component.ComponentModel;
 import org.keycloak.models.AuthenticationExecutionModel;
 import org.keycloak.models.AuthenticationFlowModel;
@@ -77,16 +78,6 @@ public final class KeycloakModelUtils {
 
     public static String generateId() {
         return UUID.randomUUID().toString();
-    }
-
-    public static byte[] generateSecret() {
-        return generateSecret(32);
-    }
-
-    public static byte[] generateSecret(int bytes) {
-        byte[] buf = new byte[bytes];
-        new SecureRandom().nextBytes(buf);
-        return buf;
     }
 
     public static PublicKey getPublicKey(String publicKeyPem) {

--- a/server-spi/src/main/java/org/keycloak/models/UserCredentialModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/UserCredentialModel.java
@@ -17,12 +17,15 @@
 
 package org.keycloak.models;
 
+import org.keycloak.common.util.Base62;
+import org.keycloak.common.util.SecretGenerator;
 import org.keycloak.credential.CredentialInput;
 import org.keycloak.credential.CredentialModel;
 import org.keycloak.models.credential.OTPCredentialModel;
 import org.keycloak.models.credential.PasswordCredentialModel;
 import org.keycloak.models.credential.PasswordUserCredentialModel;
 
+import java.security.SecureRandom;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -123,7 +126,7 @@ public class UserCredentialModel implements CredentialInput {
     }
 
     public static UserCredentialModel generateSecret() {
-        return new UserCredentialModel("", SECRET, UUID.randomUUID().toString());
+        return new UserCredentialModel("", SECRET, SecretGenerator.generate());
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/broker/oidc/OIDCIdentityProvider.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/OIDCIdentityProvider.java
@@ -28,6 +28,7 @@ import org.keycloak.broker.provider.ExchangeExternalToken;
 import org.keycloak.broker.provider.IdentityBrokerException;
 import org.keycloak.broker.provider.util.SimpleHttp;
 import org.keycloak.common.util.Base64Url;
+import org.keycloak.common.util.SecretGenerator;
 import org.keycloak.common.util.Time;
 import org.keycloak.events.Details;
 import org.keycloak.events.Errors;
@@ -776,7 +777,7 @@ public class OIDCIdentityProvider extends AbstractOAuth2IdentityProvider<OIDCIde
     @Override
     protected UriBuilder createAuthorizationUrl(AuthenticationRequest request) {
         UriBuilder uriBuilder = super.createAuthorizationUrl(request);
-        String nonce = Base64Url.encode(KeycloakModelUtils.generateSecret(16));
+        String nonce = SecretGenerator.generate(16);
         AuthenticationSessionModel authenticationSession = request.getAuthenticationSession();
 
         authenticationSession.setClientNote(BROKER_NONCE_PARAM, nonce);

--- a/services/src/main/java/org/keycloak/keys/AbstractGeneratedSecretKeyProviderFactory.java
+++ b/services/src/main/java/org/keycloak/keys/AbstractGeneratedSecretKeyProviderFactory.java
@@ -19,6 +19,7 @@ package org.keycloak.keys;
 
 import org.jboss.logging.Logger;
 import org.keycloak.common.util.Base64Url;
+import org.keycloak.common.util.SecretGenerator;
 import org.keycloak.component.ComponentModel;
 import org.keycloak.component.ComponentValidationException;
 import org.keycloak.models.KeycloakSession;
@@ -52,8 +53,8 @@ public abstract class AbstractGeneratedSecretKeyProviderFactory<T extends KeyPro
 
     private void generateSecret(ComponentModel model, int size) {
         try {
-            byte[] secret = KeycloakModelUtils.generateSecret(size);
-            model.put(Attributes.SECRET_KEY, Base64Url.encode(secret));
+            String secret = SecretGenerator.generate(size);
+            model.put(Attributes.SECRET_KEY, secret);
 
             String kid = KeycloakModelUtils.generateId();
             model.put(Attributes.KID_KEY, kid);

--- a/services/src/main/java/org/keycloak/protocol/oidc/utils/PkceUtils.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/utils/PkceUtils.java
@@ -2,6 +2,7 @@ package org.keycloak.protocol.oidc.utils;
 
 import org.keycloak.OAuth2Constants;
 import org.keycloak.common.util.Base64Url;
+import org.keycloak.common.util.SecretGenerator;
 import org.keycloak.models.utils.KeycloakModelUtils;
 
 import java.nio.charset.StandardCharsets;
@@ -10,7 +11,7 @@ import java.security.MessageDigest;
 public class PkceUtils {
 
     public static String generateCodeVerifier() {
-        return Base64Url.encode(KeycloakModelUtils.generateSecret(64));
+        return SecretGenerator.generate(64);
     }
 
     public static String encodeCodeChallenge(String codeVerifier, String codeChallengeMethod) {

--- a/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
@@ -38,6 +38,7 @@ import org.keycloak.broker.provider.IdentityProvider;
 import org.keycloak.common.ClientConnection;
 import org.keycloak.common.VerificationException;
 import org.keycloak.common.util.Base64Url;
+import org.keycloak.common.util.SecretGenerator;
 import org.keycloak.common.util.Time;
 import org.keycloak.crypto.SignatureProvider;
 import org.keycloak.crypto.SignatureVerifierContext;
@@ -660,7 +661,7 @@ public class AuthenticationManager {
 
         String stateChecker = (String) keycloakSession.getAttribute("state_checker");
         if (stateChecker == null) {
-            stateChecker = Base64Url.encode(KeycloakModelUtils.generateSecret());
+            stateChecker = SecretGenerator.generate();
             keycloakSession.setAttribute("state_checker", stateChecker);
         }
         token.getOtherClaims().put("state_checker", stateChecker);

--- a/services/src/main/java/org/keycloak/services/managers/CodeGenerateUtil.java
+++ b/services/src/main/java/org/keycloak/services/managers/CodeGenerateUtil.java
@@ -19,6 +19,7 @@ package org.keycloak.services.managers;
 
 import org.jboss.logging.Logger;
 import org.keycloak.common.util.Base64Url;
+import org.keycloak.common.util.SecretGenerator;
 import org.keycloak.events.EventBuilder;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
@@ -99,7 +100,7 @@ class CodeGenerateUtil {
         public String retrieveCode(KeycloakSession session, AuthenticationSessionModel authSession) {
             String nextCode = authSession.getAuthNote(ACTIVE_CODE);
             if (nextCode == null) {
-                String actionId = Base64Url.encode(KeycloakModelUtils.generateSecret());
+                String actionId = SecretGenerator.generate();
                 authSession.setAuthNote(ACTIVE_CODE, actionId);
 
                 // We need to set the active code to the authSession in the separate sub-transaction as well

--- a/services/src/main/java/org/keycloak/services/resources/WelcomeResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/WelcomeResource.java
@@ -21,6 +21,7 @@ import org.keycloak.common.ClientConnection;
 import org.keycloak.common.Version;
 import org.keycloak.common.util.Base64Url;
 import org.keycloak.common.util.MimeTypeUtil;
+import org.keycloak.common.util.SecretGenerator;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.services.ForbiddenException;
@@ -256,7 +257,7 @@ public class WelcomeResource {
     }
 
     private String setCsrfCookie() {
-        String stateChecker = Base64Url.encode(KeycloakModelUtils.generateSecret());
+        String stateChecker = SecretGenerator.generate();
         String cookiePath = session.getContext().getUri().getPath();
         boolean secureOnly = session.getContext().getUri().getRequestUri().getScheme().equalsIgnoreCase("https");
         CookieHelper.addCookie(KEYCLOAK_STATE_CHECKER, stateChecker, cookiePath, null, null, 300, secureOnly, true);


### PR DESCRIPTION
Add support for short IDs that can be used in personal access tokens where the length matters. Also has support to include a signature in a single relatively short string without any delimiters.

An example of a token ref looks like:
7Z8hIjtUZUroApWlZF1uqRFdFxkDDyHOhboSjrYfQO6UkgFV7yJkT3A0DfrWHQPnd

With this token ref we can get the original UUID, as well as a signature that can be used to verify the integrity of the token ref.

Initially I also thought it would be a good idea to use these new types of IDs for all IDs, but realised that was a bad idea and removed that from the PR. I left the changes to secrets though as I think the new format here is a better way to generate secrets than what we did before.

See JIRA for full description:
https://issues.redhat.com/browse/KEYCLOAK-17222