### PR TITLE
Remove whitespace from hostname-force-backend-url-to-frontend-url option

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/configuration/PropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/configuration/PropertyMappers.java
@@ -149,7 +149,7 @@ public final class PropertyMappers {
     private static void configureHostnameProviderMappers() {
         create("hostname-frontend-url", "kc.spi.hostname.default.frontend-url", "The URL that should be used to serve frontend requests that are usually sent through the a public domain.");
         create("hostname-admin-url", "kc.spi.hostname.default.admin-url", "The URL that should be used to expose the admin endpoints and console.");
-        create("hostname-force-backend-url-to-frontend-url ", "kc.spi.hostname.default.force-backend-url-to-frontend-url", "Forces backend requests to go through the URL defined as the frontend-url. Defaults to false. Possible values are true or false.");
+        create("hostname-force-backend-url-to-frontend-url", "kc.spi.hostname.default.force-backend-url-to-frontend-url", "Forces backend requests to go through the URL defined as the frontend-url. Defaults to false. Possible values are true or false.");
     }
 
     private static void configureMetrics() {


### PR DESCRIPTION
Should fix the following error running kc.sh config, but wasn't verified, because I didn't want to find out how to build keycloak from source:

> Unknown option: '--hostname-force-backend-url-to-frontend-url=true'
---
I understand that this PR does not follow your contribution guidelines, but they are a little bit too complicated for a trivial drive-by patch like this one. Please refrain from asking me to open an account and a ticket on your JIRA or to subscribe to your mailing list. I won't claim any copyright on the removed whitespace character.

No offense, have a nice day, and thank you for your nice piece of software!