### PR TITLE
KEYCLOAK-17257: Fix NPEs when user storage doesn't implement the CredentialInputValidator interface

### DIFF
--- a/services/src/main/java/org/keycloak/credential/UserCredentialStoreManager.java
+++ b/services/src/main/java/org/keycloak/credential/UserCredentialStoreManager.java
@@ -255,7 +255,7 @@ public class UserCredentialStoreManager extends AbstractStorageManager<UserStora
             if (model == null || !model.isEnabled()) return UserStorageCredentialConfigured.USER_STORAGE_DISABLED;
 
             CredentialInputValidator validator = getStorageProviderInstance(model, CredentialInputValidator.class);
-            if (validator.supportsCredentialType(type) && validator.isConfiguredFor(realm, user, type)) {
+            if (validator != null && validator.supportsCredentialType(type) && validator.isConfiguredFor(realm, user, type)) {
                 return UserStorageCredentialConfigured.CONFIGURED;
             }
         }


### PR DESCRIPTION
Hi there!


We're attempting to implement our own custom UserStorageProvider, UserQueryProvider and UserLookupProvider implementations. However, we did not implement CredentialInputValidator as well, leading to an NPE:

 
```
keycloak_1 | 02:35:04,355 ERROR [org.keycloak.services.error.KeycloakErrorHandler] (default task-5) Uncaught server error: java.lang.NullPointerException
keycloak_1 | at org.keycloak.keycloak-services@12.0.3//org.keycloak.credential.UserCredentialStoreManager.isConfiguredThroughUserStorage(UserCredentialStoreManager.java:262) keycloak_1 | at org.keycloak.keycloak-services@12.0.3//org.keycloak.credential.UserCredentialStoreManager.isConfiguredFor(UserCredentialStoreManager.java:235) keycloak_1 | at org.keycloak.keycloak-server-spi-private@12.0.3//org.keycloak.models.utils.ModelToRepresentation.toRepresentation(ModelToRepresentation.java:190)
keycloak_1 | at org.keycloak.keycloak-services@12.0.3//org.keycloak.services.resources.admin.UserResource.getUser(UserResource.java:270) keycloak_1 | at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) keycloak_1 | at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
keycloak_1 | at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethod{quote}
```

This is a small patch to add a null check guard, and avoid the internal server error.

It seems like other UserStorageProvider implementations also implement CredentialInputValidator, which is the route we've taken, but I wanted to fix this for anyone else who might be experiencing the same issue.

Thanks for Keycloak!

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
