### PR TITLE
KEYCLOAK-14766 - Removed setting default password for LDAPRule config

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/LDAPRule.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/LDAPRule.java
@@ -227,9 +227,6 @@ public class LDAPRule extends ExternalResource {
             case VAULT_EXPRESSION:
                 config.put(LDAPConstants.BIND_CREDENTIAL, VAULT_EXPRESSION);
                 break;
-            default:
-                // Default to secret as the bind credential
-                config.put(LDAPConstants.BIND_CREDENTIAL, "secret");
         }
         switch (defaultProperties.getProperty(LDAPEmbeddedServer.PROPERTY_ENABLE_ANONYMOUS_ACCESS)) {
             case "true":


### PR DESCRIPTION
Causing authentication failures in not default providers

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
