### PR TITLE
[KEYCLOAK-17315] [KEYCLOAK-17326] Fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,7 +189,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Check whether this phase should run
-        run: echo "GIT_DIFF=$( git diff --name-only HEAD^ | egrep -ic 'crossdc|infinispan' )" >> $GITHUB_ENV
+        run: echo "GIT_DIFF=$[ $( git diff --name-only HEAD^ | egrep -ic 'crossdc|infinispan' ) + $( git diff HEAD^ pom.xml | egrep -ic '\+\s+<wildfly.version>' ) ]" >> $GITHUB_ENV
 
       - name: Cache Maven packages
         if: ${{ github.event_name != 'pull_request' || env.GIT_DIFF != 0 }}
@@ -245,7 +245,7 @@ jobs:
           fetch-depth: 2
 
       - name: Check whether this phase should run
-        run: echo "GIT_DIFF=$( git diff --name-only HEAD^ | egrep -ic 'crossdc|infinispan' )" >> $GITHUB_ENV
+        run: echo "GIT_DIFF=$[ $( git diff --name-only HEAD^ | egrep -ic 'crossdc|infinispan' ) + $( git diff HEAD^ pom.xml | egrep -ic '\+\s+<wildfly.version>' ) ]" >> $GITHUB_ENV
 
       - uses: actions/setup-java@v1
         if: ${{ github.event_name != 'pull_request' || env.GIT_DIFF != 0 }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
 
       - name: Check whether this phase should run
         run: echo "GIT_DIFF=$[ $( git diff --name-only HEAD^ | egrep -ic 'crossdc|infinispan' ) + $( git diff HEAD^ pom.xml | egrep -ic '\+\s+<wildfly.version>' ) ]" >> $GITHUB_ENV


### PR DESCRIPTION
<hr/>

    [KEYCLOAK-17315] Enable run of clustering and Cross-DC tests on Wildfly
    within GitHub actions also for changes upgrading Keycloak to next
    Wildfly version
    
    Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

_Note:_ Would be helpful to get this one reviewed / merged yet before the https://github.com/keycloak/keycloak/pull/7705 one, so it's not necessary to manually re-run clustering / Cross-DC tests on each rebase of the `Upgrade to Wildlfy 22` one.

<hr/>

    [KEYCLOAK-17326] Fix:
    
    $ git diff --name-only HEAD^
    fatal: ambiguous argument 'HEAD^': unknown revision or path not in the working tree.
    Use '--' to separate paths from revisions, like this:
    'git <command> [<revision>...] -- [<file>...]'
    
    GHA failure on 'Test Clustering on Wildfly' phase. See e.g. recent:
      https://github.com/keycloak/keycloak/pull/7705/checks?check_run_id=2023996258
    
    Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

<hr/>

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
