### PR TITLE
KEYCLOAK-17329 Allow emitting custom elements in SAML metadata extensions

### DIFF
--- a/saml-core-api/src/main/java/org/keycloak/dom/saml/v2/metadata/ExtensionsType.java
+++ b/saml-core-api/src/main/java/org/keycloak/dom/saml/v2/metadata/ExtensionsType.java
@@ -90,6 +90,18 @@ public class ExtensionsType {
         return Collections.unmodifiableList(this.any);
     }
 
+    public List<Element> getDomElements() {
+        List<Element> output = new ArrayList<Element>();
+
+        for (Object o : this.any) {
+            if (o instanceof Element) {
+                output.add((Element) o);
+            }
+        }
+
+        return Collections.unmodifiableList(output);
+    }
+
     public EntityAttributes getEntityAttributes() {
         for (Object o : this.any) {
             if (o instanceof EntityAttributes) {

--- a/saml-core/src/main/java/org/keycloak/saml/processing/core/saml/v2/writers/SAMLMetadataWriter.java
+++ b/saml-core/src/main/java/org/keycloak/saml/processing/core/saml/v2/writers/SAMLMetadataWriter.java
@@ -90,7 +90,7 @@ public class SAMLMetadataWriter extends BaseWriter {
         }
         ExtensionsType extensions = entities.getExtensions();
         if (extensions != null) {
-            StaxUtil.writeDOMElement(writer, extensions.getElement());
+            write(extensions);
         }
 
         List<Object> entityDescriptors = entities.getEntityDescriptor();
@@ -126,7 +126,7 @@ public class SAMLMetadataWriter extends BaseWriter {
         }
         ExtensionsType extensions = entityDescriptor.getExtensions();
         if (extensions != null) {
-            StaxUtil.writeDOMElement(writer, extensions.getElement());
+            write(extensions);
         }
 
         List<EntityDescriptorType.EDTChoiceType> choiceTypes = entityDescriptor.getChoiceType();
@@ -297,7 +297,7 @@ public class SAMLMetadataWriter extends BaseWriter {
         }
         ExtensionsType extensions = attributeAuthority.getExtensions();
         if (extensions != null) {
-            StaxUtil.writeDOMElement(writer, extensions.getElement());
+            write(extensions);
         }
 
         List<KeyDescriptorType> keyDescriptorList = attributeAuthority.getKeyDescriptor();
@@ -392,7 +392,7 @@ public class SAMLMetadataWriter extends BaseWriter {
 
         ExtensionsType extensions = org.getExtensions();
         if (extensions != null) {
-            StaxUtil.writeDOMElement(writer, extensions.getElement());
+            write(extensions);
         }
 
         // Write the name
@@ -434,12 +434,13 @@ public class SAMLMetadataWriter extends BaseWriter {
     public void write(ContactType contact) throws ProcessingException {
         StaxUtil.writeStartElement(writer, METADATA_PREFIX, JBossSAMLConstants.CONTACT_PERSON.get(), JBossSAMLURIConstants.METADATA_NSURI.get());
 
-        ExtensionsType extensions = contact.getExtensions();
-        if (extensions != null) {
-            StaxUtil.writeDOMElement(writer, extensions.getElement());
-        }
         ContactTypeType attribs = contact.getContactType();
         StaxUtil.writeAttribute(writer, JBossSAMLConstants.CONTACT_TYPE.get(), attribs.value());
+
+        ExtensionsType extensions = contact.getExtensions();
+        if (extensions != null) {
+            write(extensions);
+        }
 
         // Write the name
         String company = contact.getCompany();
@@ -478,6 +479,15 @@ public class SAMLMetadataWriter extends BaseWriter {
 
         StaxUtil.writeEndElement(writer);
         StaxUtil.flush(writer);
+    }
+
+    public void write(ExtensionsType extensions) throws ProcessingException {
+        StaxUtil.writeStartElement(writer, METADATA_PREFIX, JBossSAMLConstants.EXTENSIONS__METADATA.get(), JBossSAMLURIConstants.METADATA_NSURI.get());
+
+        for (Element extension : extensions.getDomElements())
+            StaxUtil.writeDOMElement(writer, extension);
+
+        StaxUtil.writeEndElement(writer);
     }
 
     public void writeKeyDescriptor(KeyDescriptorType keyDescriptor) throws ProcessingException {


### PR DESCRIPTION
SAML Metadata specs allow the definition of extension attributes in various elements of the metadata docs - for example, a federation might require additional attributes in the `ContactPerson` element, etc., i.e.:

```
<md:ContactPerson contactType="other">
<md:Extensions>
<myfederation>
<partner id="partnerId"/>
</myfederation>
</md:Extensions>
<md:EmailAddress>tech@localhost</md:EmailAddress>
</md:ContactPerson>
```

Such elements are often environment-specific XML fragments, therefore it is impossible for Keycloak to manage them via UI, but it would be really useful for custom SAML-derived providers to be able to emit the specific elements required by the federation.

The current code seems to be written as a way to read info from metadata rather than to produce them - it basically assumes that specific code for each extension has to be added in the `SAMLMetadataWriter` class, which is obviously undesirable.

I will provide a pull request that allows supplying extensions as plain Element nodes, allowing callers to create any extension they need. There are also some deprecated methods in https://github.com/keycloak/keycloak/blob/master/saml-core-api/src/main/java/org/keycloak/dom/saml/v2/metadata/ExtensionsType.java that I could remove in this context, but I'll wait on your review for that.