### PR TITLE
KEYCLOAK-17345 - added possibility to use `user` in terms.ftl

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/requiredactions/TermsAndConditions.java
+++ b/services/src/main/java/org/keycloak/authentication/requiredactions/TermsAndConditions.java
@@ -73,7 +73,9 @@ public class TermsAndConditions implements RequiredActionProvider, RequiredActio
 
     @Override
     public void requiredActionChallenge(RequiredActionContext context) {
-        Response challenge = context.form().createForm("terms.ftl");
+        Response challenge = context.form()
+            .setAttribute("user", context.getAuthenticationSession().getAuthenticatedUser())
+            .createForm("terms.ftl");
         context.challenge(challenge);
     }
 


### PR DESCRIPTION
To make the terms and conditions more user specific and also show the name of the user there, we need a way to access the username, first name and last name in the `/themes/base/login/terms.ftl` file in the theme.
This will also allow us to display a user specific text depending on which user is viewing the terms and conditions.