### PR TITLE
[KEYCLOAK-9841] use LDAPUser UUID as an identifier instead of username

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProvider.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProvider.java
@@ -486,7 +486,7 @@ public class LDAPStorageProvider implements UserStorageProvider,
             return existing;
         }
 
-        LDAPObject ldapUser = loadLDAPUserByUsername(realm, local.getUsername());
+        LDAPObject ldapUser = loadLDAPUserByUUID(realm, local.getFirstAttribute(LDAPConstants.LDAP_ID));
         if (ldapUser == null) {
             return null;
         }
@@ -784,6 +784,18 @@ public class LDAPStorageProvider implements UserStorageProvider,
         // Creating user to local storage
         logger.debugf("Kerberos authenticated user [%s] not in Keycloak storage. Creating him", username);
         return getUserByUsername(realm, username);
+    }
+
+    public LDAPObject loadLDAPUserByUUID(RealmModel realm, String uuid){
+        try (LDAPQuery ldapQuery = LDAPUtils.createQueryForUserSearch(this, realm)) {
+            LDAPQueryConditionsBuilder conditionsBuilder = new LDAPQueryConditionsBuilder();
+
+            String uuidMappedAttribute = this.ldapIdentityStore.getConfig().getUuidLDAPAttributeName();
+            Condition uuidCondition = conditionsBuilder.equal(uuidMappedAttribute, uuid, EscapeStrategy.DEFAULT);
+            ldapQuery.addWhereCondition(uuidCondition);
+
+            return ldapQuery.getFirstResult();
+        }
     }
 
     public LDAPObject loadLDAPUserByUsername(RealmModel realm, String username) {

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProviderFactory.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProviderFactory.java
@@ -64,6 +64,7 @@ import org.keycloak.utils.CredentialHelper;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -593,16 +594,18 @@ public class LDAPStorageProviderFactory implements UserStorageProviderFactory<LD
                         String username = LDAPUtils.getUsername(ldapUser, ldapFedProvider.getLdapIdentityStore().getConfig());
                         exists.value = true;
                         LDAPUtils.checkUuid(ldapUser, ldapFedProvider.getLdapIdentityStore().getConfig());
-                        UserModel currentUser = session.userLocalStorage().getUserByUsername(currentRealm, username);
-
-                        if (currentUser == null) {
-
+                        UserModel currentUserLocal = session.userLocalStorage().getUserByUsername(currentRealm, username);
+                        Optional<UserModel> userModelOptional = session.userLocalStorage()
+                                .searchForUserByUserAttributeStream(currentRealm, LDAPConstants.LDAP_ID, ldapUser.getUuid())
+                                .findFirst();
+                        if (!userModelOptional.isPresent() && currentUserLocal == null) {
                             // Add new user to Keycloak
                             exists.value = false;
                             ldapFedProvider.importUserFromLDAP(session, currentRealm, ldapUser);
                             syncResult.increaseAdded();
 
                         } else {
+                            UserModel currentUser = userModelOptional.isPresent() ? userModelOptional.get() : currentUserLocal;
                             if ((fedModel.getId().equals(currentUser.getFederationLink())) && (ldapUser.getUuid().equals(currentUser.getFirstAttribute(LDAPConstants.LDAP_ID)))) {
 
                                 // Update keycloak user
@@ -621,7 +624,7 @@ public class LDAPStorageProviderFactory implements UserStorageProviderFactory<LD
                                 logger.debugf("Updated user from LDAP: %s", currentUser.getUsername());
                                 syncResult.increaseUpdated();
                             } else {
-                                logger.warnf("User '%s' is not updated during sync as he already exists in Keycloak database but is not linked to federation provider '%s'", username, fedModel.getName());
+                                logger.warnf("User with ID '%s' is not updated during sync as he already exists in Keycloak database but is not linked to federation provider '%s'", ldapUser.getUuid(), fedModel.getName());
                                 syncResult.increaseFailed();
                             }
                         }


### PR DESCRIPTION
[KEYCLOAK-9841] remove uncommented lines

[KEYCLOAK-9841] load LdapUser by uuid

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
