### PR TITLE
[KEYCLOAK-9841] use LDAPUser UUID as an identifier instead of username

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProvider.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProvider.java
@@ -486,8 +486,11 @@ public class LDAPStorageProvider implements UserStorageProvider,
             return existing;
         }
 
-        LDAPObject ldapUser = loadLDAPUserByUsername(realm, local.getUsername());
-        if (ldapUser == null) {
+        String uuidLdapAttribute = local.getFirstAttribute(LDAPConstants.LDAP_ID);
+
+        LDAPObject ldapUser = loadLDAPUserByUuid(realm, uuidLdapAttribute);
+
+        if(ldapUser == null){
             return null;
         }
         LDAPUtils.checkUuid(ldapUser, ldapIdentityStore.getConfig());
@@ -516,7 +519,17 @@ public class LDAPStorageProvider implements UserStorageProvider,
 
         UserModel imported = null;
         if (model.isImportEnabled()) {
-            imported = session.userLocalStorage().addUser(realm, ldapUsername);
+            // Search if there is already an existing user, which means the username might have changed in LDAP without Keycloak knowing about it
+            UserModel existingLocalUser = session.userLocalStorage()
+                    .searchForUserByUserAttributeStream(realm, LDAPConstants.LDAP_ID, ldapUser.getUuid()).findFirst().orElse(null);
+            if(existingLocalUser != null){
+                imported = existingLocalUser;
+                // Need to evict the existing user from cache
+                session.userCache().evict(realm, existingLocalUser);
+            } else {
+                imported = session.userLocalStorage().addUser(realm, ldapUsername);
+            }
+
         } else {
             InMemoryUserAdapter adapter = new InMemoryUserAdapter(session, realm, new StorageId(model.getId(), ldapUsername).getId());
             adapter.addDefaults();
@@ -803,5 +816,19 @@ public class LDAPStorageProvider implements UserStorageProvider,
         }
     }
 
+    public LDAPObject loadLDAPUserByUuid(RealmModel realm, String uuid) {
+        if(uuid == null){
+            return null;
+        }
+        try (LDAPQuery ldapQuery = LDAPUtils.createQueryForUserSearch(this, realm)) {
+            LDAPQueryConditionsBuilder conditionsBuilder = new LDAPQueryConditionsBuilder();
+
+            String uuidLDAPAttributeName = this.ldapIdentityStore.getConfig().getUuidLDAPAttributeName();
+            Condition usernameCondition = conditionsBuilder.equal(uuidLDAPAttributeName, uuid, EscapeStrategy.DEFAULT);
+            ldapQuery.addWhereCondition(usernameCondition);
+
+            return ldapQuery.getFirstResult();
+        }
+    }
 
 }

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProviderFactory.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProviderFactory.java
@@ -64,6 +64,7 @@ import org.keycloak.utils.CredentialHelper;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -593,16 +594,18 @@ public class LDAPStorageProviderFactory implements UserStorageProviderFactory<LD
                         String username = LDAPUtils.getUsername(ldapUser, ldapFedProvider.getLdapIdentityStore().getConfig());
                         exists.value = true;
                         LDAPUtils.checkUuid(ldapUser, ldapFedProvider.getLdapIdentityStore().getConfig());
-                        UserModel currentUser = session.userLocalStorage().getUserByUsername(currentRealm, username);
-
-                        if (currentUser == null) {
-
+                        UserModel currentUserLocal = session.userLocalStorage().getUserByUsername(currentRealm, username);
+                        Optional<UserModel> userModelOptional = session.userLocalStorage()
+                                .searchForUserByUserAttributeStream(currentRealm, LDAPConstants.LDAP_ID, ldapUser.getUuid())
+                                .findFirst();
+                        if (!userModelOptional.isPresent() && currentUserLocal == null) {
                             // Add new user to Keycloak
                             exists.value = false;
                             ldapFedProvider.importUserFromLDAP(session, currentRealm, ldapUser);
                             syncResult.increaseAdded();
 
                         } else {
+                            UserModel currentUser = userModelOptional.isPresent() ? userModelOptional.get() : currentUserLocal;
                             if ((fedModel.getId().equals(currentUser.getFederationLink())) && (ldapUser.getUuid().equals(currentUser.getFirstAttribute(LDAPConstants.LDAP_ID)))) {
 
                                 // Update keycloak user
@@ -621,7 +624,7 @@ public class LDAPStorageProviderFactory implements UserStorageProviderFactory<LD
                                 logger.debugf("Updated user from LDAP: %s", currentUser.getUsername());
                                 syncResult.increaseUpdated();
                             } else {
-                                logger.warnf("User '%s' is not updated during sync as he already exists in Keycloak database but is not linked to federation provider '%s'", username, fedModel.getName());
+                                logger.warnf("User with ID '%s' is not updated during sync as he already exists in Keycloak database but is not linked to federation provider '%s'", ldapUser.getUuid(), fedModel.getName());
                                 syncResult.increaseFailed();
                             }
                         }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/noimport/LDAPProvidersIntegrationNoImportTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/noimport/LDAPProvidersIntegrationNoImportTest.java
@@ -334,4 +334,10 @@ public class LDAPProvidersIntegrationNoImportTest extends LDAPProvidersIntegrati
         }
     }
 
+    // No need to test this in no-import mode. There won't be any users in localStorage.
+    @Test
+    @Ignore
+    @Override
+    public void updateLDAPUsernameTest() {
+    }
 }


### PR DESCRIPTION
Implementation and Test added according the description in KEYCLOAK-9841 to load LDAPUser by UUID and prevent orphan users in localstorage