### PR TITLE
KEYCLOAK-17342 Make the default value of default signature algorithm …

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/models/Constants.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/Constants.java
@@ -62,6 +62,7 @@ public final class Constants {
     // KEYCLOAK-7688 Offline Session Max for Offline Token
     // 60 days
     public static final int DEFAULT_OFFLINE_SESSION_MAX_LIFESPAN = 5184000;
+    public static final String DEFAULT_SIGNATURE_ALGORITHM = Algorithm.RS256;
 
     public static final String DEFAULT_WEBAUTHN_POLICY_SIGNATURE_ALGORITHMS = Algorithm.ES256;
     public static final String DEFAULT_WEBAUTHN_POLICY_RP_ENTITY_NAME = "keycloak";

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
@@ -187,6 +187,7 @@ public class RepresentationToModel {
         if (rep.getNotBefore() != null) newRealm.setNotBefore(rep.getNotBefore());
 
         if (rep.getDefaultSignatureAlgorithm() != null) newRealm.setDefaultSignatureAlgorithm(rep.getDefaultSignatureAlgorithm());
+        else newRealm.setDefaultSignatureAlgorithm(Constants.DEFAULT_SIGNATURE_ALGORITHM);
 
         if (rep.getRevokeRefreshToken() != null) newRealm.setRevokeRefreshToken(rep.getRevokeRefreshToken());
         else newRealm.setRevokeRefreshToken(false);

--- a/services/src/main/java/org/keycloak/jose/jws/DefaultTokenManager.java
+++ b/services/src/main/java/org/keycloak/jose/jws/DefaultTokenManager.java
@@ -34,6 +34,7 @@ import org.keycloak.jose.jwk.JWK;
 import org.keycloak.keys.loader.PublicKeyStorageManager;
 import org.keycloak.models.AuthenticatedClientSessionModel;
 import org.keycloak.models.ClientModel;
+import org.keycloak.models.Constants;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.TokenManager;
@@ -52,8 +53,6 @@ import java.security.Key;
 public class DefaultTokenManager implements TokenManager {
 
     private static final Logger logger = Logger.getLogger(DefaultTokenManager.class);
-
-    private static String DEFAULT_ALGORITHM_NAME = Algorithm.RS256;
 
     private final KeycloakSession session;
 
@@ -159,7 +158,7 @@ public class DefaultTokenManager implements TokenManager {
             return algorithm;
         }
 
-        return DEFAULT_ALGORITHM_NAME;
+        return Constants.DEFAULT_SIGNATURE_ALGORITHM;
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/services/managers/ApplianceBootstrap.java
+++ b/services/src/main/java/org/keycloak/services/managers/ApplianceBootstrap.java
@@ -70,6 +70,7 @@ public class ApplianceBootstrap {
         realm.setDisplayNameHtml(Version.NAME_HTML);
         realm.setEnabled(true);
         realm.addRequiredCredential(CredentialRepresentation.PASSWORD);
+        realm.setDefaultSignatureAlgorithm(Constants.DEFAULT_SIGNATURE_ALGORITHM);
         realm.setSsoSessionIdleTimeout(1800);
         realm.setAccessTokenLifespan(60);
         realm.setAccessTokenLifespanForImplicitFlow(Constants.DEFAULT_ACCESS_TOKEN_LIFESPAN_FOR_IMPLICIT_FLOW_TIMEOUT);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/AdminSignatureAlgorithmTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/AdminSignatureAlgorithmTest.java
@@ -47,6 +47,8 @@ public class AdminSignatureAlgorithmTest extends AbstractKeycloakTest {
 
     @Test
     public void changeRealmTokenAlgorithm() throws Exception {
+        String defaultSignatureAlgorithm = adminClient.realm("master").toRepresentation().getDefaultSignatureAlgorithm();
+
         TokenSignatureUtil.changeRealmTokenSignatureProvider("master", adminClient, Algorithm.ES256);
 
         try (Keycloak adminClient = AdminClientUtil.createAdminClient(suiteContext.isAdapterCompatTesting(), suiteContext.getAuthServerInfo().getContextRoot().toString())) {
@@ -61,6 +63,8 @@ public class AdminSignatureAlgorithmTest extends AbstractKeycloakTest {
             JsonNode jsonNode = SimpleHttp.doGet(whoAmiUrl, client).auth(accessToken.getToken()).asJson();
             assertNotNull(jsonNode.get("realm"));
             assertNotNull(jsonNode.get("userId"));
+        } finally {
+            TokenSignatureUtil.changeRealmTokenSignatureProvider("master", adminClient, defaultSignatureAlgorithm);
         }
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/realm/RealmTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/realm/RealmTest.java
@@ -814,6 +814,22 @@ public class RealmTest extends AbstractAdminTest {
         assertEquals(0, sessionStats.size());
     }
 
+    @Test
+    // KEYCLOAK-17342
+    public void testDefaultSignatureAlgorithm() {
+        RealmRepresentation rep = new RealmRepresentation();
+        rep.setRealm("new-realm");
+
+        try {
+            adminClient.realms().create(rep);
+
+            assertEquals(Constants.DEFAULT_SIGNATURE_ALGORITHM, adminClient.realm("master").toRepresentation().getDefaultSignatureAlgorithm());
+            assertEquals(Constants.DEFAULT_SIGNATURE_ALGORITHM, adminClient.realm("new-realm").toRepresentation().getDefaultSignatureAlgorithm());
+        } finally {
+            adminClient.realms().realm(rep.getRealm()).remove();
+        }
+    }
+
     private void setupTestAppAndUser() {
         testingClient.testApp().clearAdminActions();
 


### PR DESCRIPTION
…show up in the admin console

There is no value showed up in Realm settings -> Token -> Default Signature Algorithm in Keycloak's admin console and I fixed it in this PR. The details can be found in this [JIRA](https://issues.redhat.com/projects/KEYCLOAK/issues/KEYCLOAK-17342?filter=allopenissues).