### PR TITLE
KEYCLOAK-17367 Unix filepath separator is used in the path to the wil…

### DIFF
--- a/testsuite/integration-arquillian/tests/pom.xml
+++ b/testsuite/integration-arquillian/tests/pom.xml
@@ -658,7 +658,7 @@
                               ~ Used for Wildfly Elytron 1.13.0.CR3+ RESTEasy client SSL truststore configuration.
                               ~ See KEYCLOAK-15692, ELY-1891 issues & PRs of EAP7-1219 issue for details.
                               -->
-                            <wildfly.config.url>${project.build.directory}/dependency/wildfly-config.xml</wildfly.config.url>
+                            <wildfly.config.url>${project.build.directory}${file.separator}dependency${file.separator}wildfly-config.xml</wildfly.config.url>
                         </systemPropertyVariables>
                         <properties>
                             <property>


### PR DESCRIPTION
…dfly-config.xml file on Windows

* ${file.separator} used instead of forward slash in pom.xml

Signed-off-by: Peter Zaoral <pzaoral@redhat.com>
