### PR TITLE
KEYCLOAK-17368 Show forwarded errors when a default remote IdP is configured

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/AuthenticationProcessor.java
+++ b/services/src/main/java/org/keycloak/authentication/AuthenticationProcessor.java
@@ -990,7 +990,12 @@ public class AuthenticationProcessor {
         Response challenge = authenticationFlow.processFlow();
         if (challenge != null) return challenge;
         if (authenticationSession.getAuthenticatedUser() == null) {
-            throw new AuthenticationFlowException(AuthenticationFlowError.UNKNOWN_USER);
+            if (this.forwardedErrorMessageStore.getForwardedMessage() != null) {
+                LoginFormsProvider forms = session.getProvider(LoginFormsProvider.class).setAuthenticationSession(authenticationSession);
+                forms.addError(this.forwardedErrorMessageStore.getForwardedMessage());
+                return forms.createErrorPage(Response.Status.BAD_REQUEST);
+            } else
+                throw new AuthenticationFlowException(AuthenticationFlowError.UNKNOWN_USER);
         }
         if (!authenticationFlow.isSuccessful()) {
             throw new AuthenticationFlowException(authenticationFlow.getFlowExceptions());

--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/IdentityProviderAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/IdentityProviderAuthenticator.java
@@ -58,6 +58,13 @@ public class IdentityProviderAuthenticator implements Authenticator {
                 redirect(context, providerId);
             }
         } else if (context.getAuthenticatorConfig() != null && context.getAuthenticatorConfig().getConfig().containsKey(IdentityProviderAuthenticatorFactory.DEFAULT_PROVIDER)) {
+            if (context.getForwardedErrorMessage() != null) {
+                LOG.infof("Should redirect to remote IdP but forwardedError has value '%s', skipping this authenticator...", context.getForwardedErrorMessage());
+                context.attempted();
+
+                return;
+            }
+
             String defaultProvider = context.getAuthenticatorConfig().getConfig().get(IdentityProviderAuthenticatorFactory.DEFAULT_PROVIDER);
             LOG.tracef("Redirecting: default provider set to %s", defaultProvider);
             redirect(context, defaultProvider);

--- a/services/src/main/java/org/keycloak/broker/saml/SAMLEndpoint.java
+++ b/services/src/main/java/org/keycloak/broker/saml/SAMLEndpoint.java
@@ -417,7 +417,7 @@ public class SAMLEndpoint {
 
                 KeyManager.ActiveRsaKey keys = session.keys().getActiveRsaKey(realm);
                 if (! isSuccessfulSamlResponse(responseType)) {
-                    String statusMessage = responseType.getStatus() == null ? Messages.IDENTITY_PROVIDER_UNEXPECTED_ERROR : responseType.getStatus().getStatusMessage();
+                    String statusMessage = responseType.getStatus() == null || responseType.getStatus().getStatusMessage() == null ? Messages.IDENTITY_PROVIDER_UNEXPECTED_ERROR : responseType.getStatus().getStatusMessage();
                     return callback.error(statusMessage);
                 }
                 if (responseType.getAssertions() == null || responseType.getAssertions().isEmpty()) {


### PR DESCRIPTION
Scenario: a remote SAML IdP is configured as a default Identity Provider in the Authentication - Identity Provider Redirector configuration. 

When a remote IdP returns a SAML error (AuthnFailed), the error status code and description are returned to the IdP and generally they are shown to the user as an explanation of what went wrong.

When a default IdP is set in the Identity Provider Redirector however, any remote failure messages are not displayed to the user and the authentication process loops, returning the user to the remote IdP over and over again with no explanation.

This PR stops the default redirect when an error is forwarded, and shows the error message to the user.