### PR TITLE
KEYCLOAK-17327 - always use KeycloakUriBuilder

### DIFF
--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/OAuthRequestAuthenticator.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/OAuthRequestAuthenticator.java
@@ -142,17 +142,18 @@ public class OAuthRequestAuthenticator {
     protected String getRedirectUri(String state) {
         String url = getRequestUrl();
         log.debugf("callback uri: %s", url);
-      
+
+        KeycloakUriBuilder newUrl = KeycloakUriBuilder.fromUri(url);
         if (!facade.getRequest().isSecure() && deployment.getSslRequired().isRequired(facade.getRequest().getRemoteAddr())) {
             int port = sslRedirectPort();
             if (port < 0) {
                 // disabled?
                 return null;
             }
-            KeycloakUriBuilder secureUrl = KeycloakUriBuilder.fromUri(url).scheme("https").port(-1);
-            if (port != 443) secureUrl.port(port);
-            url = secureUrl.build().toString();
+            newUrl.scheme("https").port(-1);
+            if (port != 443) newUrl.port(port);
         }
+        url = newUrl.build().toString();
 
         String loginHint = getQueryParamValue("login_hint");
         url = UriUtils.stripQueryParam(url,"login_hint");


### PR DESCRIPTION
The `redirect_url` query parameter, that was generated during the
authentication redirect and the form body parameter generated when
trying to acquire an access token were handled slightly differently:

When redirecting to the authentication server the KeycloakUriBuilder
was not used, when the remote host was a local address. When trying to
acquire an access token later on, it was used in any case. This leads
in our setup to differing urls (https://host:443/... vs https://host/...)
and consequently to an error and no token being handed out.

This commit targets the redirecting behaviour and rearranges the
creation and usage of the KeycloakUriBuilder in so that it conforms to
the behaviour as seen when acquiring an access token.

Please note, that we experienced this problem in version `11.0.2`.
Please consult https://issues.redhat.com/browse/KEYCLOAK-17327 for further details.