### PR TITLE
KEYCLOAK-17404: LDAPS connection not working when protocol prefix set in upper case

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/models/LDAPConstants.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/LDAPConstants.java
@@ -163,7 +163,7 @@ public class LDAPConstants {
         } else if (useTruststoreSpi != null && useTruststoreSpi.equals(LDAPConstants.USE_TRUSTSTORE_NEVER)) {
             shouldSetTruststore = false;
         } else {
-            shouldSetTruststore = (url != null && url.startsWith("ldaps"));
+            shouldSetTruststore = (url != null && url.toLowerCase().startsWith("ldaps"));
         }
 
         if (shouldSetTruststore) {


### PR DESCRIPTION
When configuring LDAP user federation if the following 2 conditions are met the connection to the LDAP backend will fail:
- Connection URL starts with the upper case string "LDAPS"
- Use truststore SPI is set to "Only for ldaps"

This PR ensures that both "ldaps" and "LDAPS" can be used in the connection URL

