### PR TITLE
KEYCLOAK-14248 Keycloak should throw an error when attempt to register user to LDAP with empty RDN attribute

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPUtils.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPUtils.java
@@ -107,13 +107,17 @@ public class LDAPUtils {
     public static void computeAndSetDn(LDAPConfig config, LDAPObject ldapUser) {
         String rdnLdapAttrName = config.getRdnLdapAttribute();
         String rdnLdapAttrValue = ldapUser.getAttributeAsString(rdnLdapAttrName);
-        if (rdnLdapAttrValue == null) {
+        if (isBlank(rdnLdapAttrValue)) {
             throw new ModelException("RDN Attribute [" + rdnLdapAttrName + "] is not filled. Filled attributes: " + ldapUser.getAttributes());
         }
 
         LDAPDn dn = LDAPDn.fromString(config.getUsersDn());
         dn.addFirst(rdnLdapAttrName, rdnLdapAttrValue);
         ldapUser.setDn(dn);
+    }
+
+    public static boolean isBlank(String s) {
+        return s == null || s.trim().length() == 0;
     }
 
     public static String getUsername(LDAPObject ldapUser, LDAPConfig config) {


### PR DESCRIPTION
If "Is Mandatory in LDAP" is ON in a user-attribute-ldap-mapper of RDN attribute, an invalid LDAP entry of DN: cn=\\20,dc=... is created. This PR adds 0-length checking and white-space(s) checking of RDN value so that KC does not create an invalid LDAP entry.