### PR TITLE
[KEYCLOAK-17100] Testsuite Wildfly initialization error on Windows [KEYCLOAK-17392] Java CLASSPATH is wrongly parsed on Windows

### DIFF
--- a/testsuite/integration-arquillian/tests/pom.xml
+++ b/testsuite/integration-arquillian/tests/pom.xml
@@ -659,7 +659,7 @@
                               ~ Used for Wildfly Elytron 1.13.0.CR3+ RESTEasy client SSL truststore configuration.
                               ~ See KEYCLOAK-15692, ELY-1891 issues & PRs of EAP7-1219 issue for details.
                               -->
-                            <wildfly.config.url>${project.build.directory}/dependency/wildfly-config.xml</wildfly.config.url>
+                            <wildfly-client.config.path>${project.build.directory}${file.separator}dependency${file.separator}wildfly-config.xml</wildfly-client.config.path>
                         </systemPropertyVariables>
                         <properties>
                             <property>


### PR DESCRIPTION
    [KEYCLOAK-17100] Testsuite Wildfly initialization error on Windows
    [KEYCLOAK-17392] Java CLASSPATH is wrongly parsed on Windows
    
    Signed-off-by:  Jan Lieskovsky <jlieskov@redhat.com>
    Co-Authored-By: Peter Zaoral <pzaoral@redhat.com>

Note: Fix the Wildfly initialization error on Windows by removing the support for `-Dwildfly.config.url` parsing in `setJsseSecurityProviderForOutboundSslConnectionsOfElytronClient()` routine. Currently `-Dwildfly.config.url` is / was reused for both the Wildfly initialization, and also for that routine.

But wildfly-client-config performs additional processing of the specified `wildfly.config.url` value (in the `propertyUrlToUri()` routine below):
* https://github.com/wildfly/wildfly-client-config/blob/master/src/main/java/org/wildfly/client/config/ClientConfiguration.java#L225
* https://github.com/wildfly/wildfly-client-config/blob/master/src/main/java/org/wildfly/client/config/ClientConfiguration.java#L227
* https://github.com/wildfly/wildfly-client-config/blob/bce7116e594a8b816bdfea4be67060a56d19a0ad/src/main/java/org/wildfly/client/config/ClientConfiguration.java#L268

Therefore (without the additional processing done in `setJsseSecurityProviderForOutboundSslConnectionsOfElytronClient()`) it wasn't possible to specify a `wildfly.config.url` value (file system path to `wildfly-config.xml`) that would work correctly for both use-cases. And adding that additional processing to `setJsseSecurityProviderForOutboundSslConnectionsOfElytronClient()` isn't an option due to a need of introducing a testsuite dependency on `org.wildfly.client:wildfly-client-config` artifact, which is a no-go option. Another option would be to implement / copy that additional parsing from `wildfly-client-config` code above - but its wrong approach due to code duplication.

Thus fix this by simply dropping the support for `-Dwildfly.config.url` property (which was introduced for ability to override the default `wildfly-config.xml` with custom path) in `AuthServerTestEnricher.java`. With this change the particular location of `wildfly-config.xml` will be identified by scanning the class path like Wildfly does:
  * https://docs.wildfly.org/21/Client_Guide.html#wildfly-config-xml-discovery

Thanks to @Pepo48 for identifying additional [issues](https://issues.redhat.com/browse/KEYCLOAK-17392), suggesting fixes & additional help with the testing the changes on Windows platform.

@pskopek @miquelsi @pdrozd PTAL once got a chance

Thanks, Jan

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
