### PR TITLE
KEYCLOAK-17425 Allow integer value types in SAML messages

### DIFF
--- a/saml-core/src/main/java/org/keycloak/saml/processing/core/parsers/saml/assertion/SAMLAttributeValueParser.java
+++ b/saml-core/src/main/java/org/keycloak/saml/processing/core/parsers/saml/assertion/SAMLAttributeValueParser.java
@@ -103,6 +103,8 @@ public class SAMLAttributeValueParser implements StaxParser {
             return XMLTimeUtil.parse(StaxParserUtil.getElementText(xmlEventReader));
         } else if(typeValue.contains(":boolean")){
             return StaxParserUtil.getElementText(xmlEventReader);
+        } else if(typeValue.contains(":integer")){
+            return parseAnyTypeAsString(xmlEventReader);
         }
 
         throw logger.parserUnknownXSI(typeValue);


### PR DESCRIPTION
Added `integer` type to whitelisted value types in SAML response

[Jira ticket](https://issues.redhat.com/browse/KEYCLOAK-17425)
[Mailing list topic](https://groups.google.com/g/keycloak-dev/c/WvnDBFnIKYE/m/6hPmL9wkAwAJ)