### PR TITLE
KEYCLOAK-16660 Fix typo in 'applicationName'

### DIFF
--- a/themes/src/main/resources-community/theme/base/account/messages/messages_fr.properties
+++ b/themes/src/main/resources-community/theme/base/account/messages/messages_fr.properties
@@ -165,7 +165,7 @@ invalidPasswordNotUsernameMessage=Mot de passe invalide: ne doit pas \u00eatre i
 invalidPasswordRegexPatternMessage=Mot de passe invalide: ne valide pas l''expression rationnelle.
 invalidPasswordHistoryMessage=Mot de passe invalide: ne doit pas \u00eatre \u00e9gal aux {0} derniers mots de passe.
 
-applicaitonName=Nom de l''application
+applicationName=Nom de l''application
 update=Mettre \u00e0 jour
 status=Statut
 authenticatorActionSetup=Configurer


### PR DESCRIPTION
Small fix in French translation for key 'applicationName' - a twisted letters typo.