### PR TITLE
KEYCLOAK-17202 Restrict Issuance of Refresh tokens to specific clients

### DIFF
--- a/services/src/main/java/org/keycloak/authorization/authorization/AuthorizationTokenService.java
+++ b/services/src/main/java/org/keycloak/authorization/authorization/AuthorizationTokenService.java
@@ -71,6 +71,7 @@ import org.keycloak.models.UserModel;
 import org.keycloak.models.UserSessionModel;
 import org.keycloak.models.UserSessionProvider;
 import org.keycloak.models.utils.KeycloakModelUtils;
+import org.keycloak.protocol.oidc.OIDCAdvancedConfigWrapper;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.protocol.oidc.TokenManager;
 import org.keycloak.protocol.oidc.TokenManager.AccessTokenResponseBuilder;
@@ -361,11 +362,13 @@ public class AuthorizationTokenService {
             // Skip generating refresh token for accessToken without sessionState claim. This is "stateless" accessToken not pointing to any real persistent userSession
             rpt.setSessionState(null);
         } else {
-            responseBuilder.generateRefreshToken();
-            RefreshToken refreshToken = responseBuilder.getRefreshToken();
+            if (OIDCAdvancedConfigWrapper.fromClientModel(client).isUseRefreshToken()) {
+                responseBuilder.generateRefreshToken();
+                RefreshToken refreshToken = responseBuilder.getRefreshToken();
 
-            refreshToken.issuedFor(client.getClientId());
-            refreshToken.setAuthorization(authorization);
+                refreshToken.issuedFor(client.getClientId());
+                refreshToken.setAuthorization(authorization);
+            }
         }
 
         if (!rpt.hasAudience(targetClient.getClientId())) {

--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCAdvancedConfigWrapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCAdvancedConfigWrapper.java
@@ -131,6 +131,16 @@ public class OIDCAdvancedConfigWrapper {
         setAttribute(OIDCConfigAttributes.USE_MTLS_HOK_TOKEN, val);
     }
 
+    public boolean isUseRefreshToken() {
+        String useRefreshToken = getAttribute(OIDCConfigAttributes.USE_REFRESH_TOKEN, "true");
+        return Boolean.parseBoolean(useRefreshToken);
+    }
+
+    public void setUseRefreshToken(boolean useRefreshToken) {
+        String val = String.valueOf(useRefreshToken);
+        setAttribute(OIDCConfigAttributes.USE_REFRESH_TOKEN, val);
+    }
+
     /**
      * If true, then Client Credentials Grant generates refresh token and creates user session. This is not per specs, so it is false by default
      * For the details @see https://tools.ietf.org/html/rfc6749#section-4.4.3

--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCConfigAttributes.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCConfigAttributes.java
@@ -62,6 +62,8 @@ public final class OIDCConfigAttributes {
 
     public static final String USE_REFRESH_TOKEN_FOR_CLIENT_CREDENTIALS_GRANT = "client_credentials.use_refresh_token";
 
+    public static final String USE_REFRESH_TOKEN = "use.refresh.tokens";
+
     private OIDCConfigAttributes() {
     }
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
@@ -337,11 +337,14 @@ public class TokenManager {
             validation.newToken.setAuthorization(refreshToken.getAuthorization());
         }
 
-        AccessTokenResponseBuilder responseBuilder = responseBuilder(realm, authorizedClient, event, session, validation.userSession, validation.clientSessionCtx)
-                .accessToken(validation.newToken)
-                .generateRefreshToken();
+        AccessTokenResponseBuilder responseBuilder = responseBuilder(realm, authorizedClient, event, session,
+            validation.userSession, validation.clientSessionCtx).accessToken(validation.newToken);
+        if (OIDCAdvancedConfigWrapper.fromClientModel(authorizedClient).isUseRefreshToken()) {
+            responseBuilder.generateRefreshToken();
+        }
 
-        if (validation.newToken.getAuthorization() != null) {
+        if (validation.newToken.getAuthorization() != null
+            && OIDCAdvancedConfigWrapper.fromClientModel(authorizedClient).isUseRefreshToken()) {
             responseBuilder.getRefreshToken().setAuthorization(validation.newToken.getAuthorization());
         }
 
@@ -351,7 +354,9 @@ public class TokenManager {
         AccessToken.CertConf certConf = refreshToken.getCertConf();
         if (certConf != null) {
             responseBuilder.getAccessToken().setCertConf(certConf);
-            responseBuilder.getRefreshToken().setCertConf(certConf);
+            if (OIDCAdvancedConfigWrapper.fromClientModel(authorizedClient).isUseRefreshToken()) {
+                responseBuilder.getRefreshToken().setCertConf(certConf);
+            }
         }
 
         String scopeParam = clientSession.getNote(OAuth2Constants.SCOPE);

--- a/services/src/main/java/org/keycloak/services/clientregistration/oidc/DescriptionConverter.java
+++ b/services/src/main/java/org/keycloak/services/clientregistration/oidc/DescriptionConverter.java
@@ -321,7 +321,9 @@ public class DescriptionConverter {
         if (client.getAuthorizationServicesEnabled() != null && client.getAuthorizationServicesEnabled()) {
             grantTypes.add(OAuth2Constants.UMA_GRANT_TYPE);
         }
-        grantTypes.add(OAuth2Constants.REFRESH_TOKEN);
+        if (OIDCAdvancedConfigWrapper.fromClientRepresentation(client).isUseRefreshToken()) {
+            grantTypes.add(OAuth2Constants.REFRESH_TOKEN);
+        }
         return grantTypes;
     }
 

--- a/services/src/main/java/org/keycloak/services/clientregistration/oidc/OIDCClientRegistrationProvider.java
+++ b/services/src/main/java/org/keycloak/services/clientregistration/oidc/OIDCClientRegistrationProvider.java
@@ -24,6 +24,7 @@ import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.ProtocolMapperModel;
 import org.keycloak.models.utils.ModelToRepresentation;
 import org.keycloak.models.utils.RepresentationToModel;
+import org.keycloak.protocol.oidc.OIDCAdvancedConfigWrapper;
 import org.keycloak.protocol.oidc.mappers.AbstractPairwiseSubMapper;
 import org.keycloak.protocol.oidc.mappers.PairwiseSubMapperHelper;
 import org.keycloak.protocol.oidc.mappers.SHA256PairwiseSubMapper;
@@ -77,6 +78,10 @@ public class OIDCClientRegistrationProvider extends AbstractClientRegistrationPr
 
             if (grantTypes != null && grantTypes.contains(OAuth2Constants.UMA_GRANT_TYPE)) {
                 client.setAuthorizationServicesEnabled(true);
+            }
+
+            if (!(grantTypes == null || grantTypes.contains(OAuth2Constants.REFRESH_TOKEN))) {
+                OIDCAdvancedConfigWrapper.fromClientRepresentation(client).setUseRefreshToken(false);
             }
 
             OIDCClientRegistrationContext oidcContext = new OIDCClientRegistrationContext(session, client, this, clientOIDC);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/OIDCClientRegistrationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/OIDCClientRegistrationTest.java
@@ -558,4 +558,49 @@ public class OIDCClientRegistrationTest extends AbstractClientRegistrationTest {
         OIDCAdvancedConfigWrapper config = OIDCAdvancedConfigWrapper.fromClientRepresentation(kcClient);
         Assert.assertNames(config.getRequestUris(), "http://host/foo", "https://host2/bar");
     }
+
+    @Test
+    public void testClientWithoutRefreshToken() throws Exception {
+        OIDCClientRepresentation clientRep = null;
+        OIDCClientRepresentation response = null;
+
+        clientRep = createRep();
+        clientRep.setGrantTypes(Arrays.asList(OAuth2Constants.AUTHORIZATION_CODE));
+
+        response = reg.oidc().create(clientRep);
+
+        // Test Keycloak representation
+        ClientRepresentation kcClient = getClient(response.getClientId());
+        OIDCAdvancedConfigWrapper config = OIDCAdvancedConfigWrapper.fromClientRepresentation(kcClient);
+        Assert.assertFalse(config.isUseRefreshToken());
+    }
+
+    @Test
+    public void testClientWithRefreshToken() throws Exception {
+        OIDCClientRepresentation clientRep = null;
+        OIDCClientRepresentation response = null;
+
+        clientRep = createRep();
+        clientRep.setGrantTypes(Arrays.asList(OAuth2Constants.AUTHORIZATION_CODE, OAuth2Constants.REFRESH_TOKEN));
+
+        response = reg.oidc().create(clientRep);
+
+        // Test Keycloak representation
+        ClientRepresentation kcClient = getClient(response.getClientId());
+        OIDCAdvancedConfigWrapper config = OIDCAdvancedConfigWrapper.fromClientRepresentation(kcClient);
+        Assert.assertTrue(config.isUseRefreshToken());
+    }
+
+    @Test
+    public void testClientWithoutGrantTypes() throws Exception {
+        OIDCClientRepresentation response = create();
+
+        assertTrue(CollectionUtil.collectionEquals(
+            Arrays.asList(OAuth2Constants.AUTHORIZATION_CODE, OAuth2Constants.REFRESH_TOKEN), response.getGrantTypes()));
+
+        // Test Keycloak representation
+        ClientRepresentation kcClient = getClient(response.getClientId());
+        OIDCAdvancedConfigWrapper config = OIDCAdvancedConfigWrapper.fromClientRepresentation(kcClient);
+        Assert.assertTrue(config.isUseRefreshToken());
+    }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/AccessTokenTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/AccessTokenTest.java
@@ -1212,6 +1212,27 @@ public class AccessTokenTest extends AbstractKeycloakTest {
     }
 
     @Test
+    public void accessTokenRequestNoRefreshToken() {
+        ClientResource client = ApiUtil.findClientByClientId(adminClient.realm("test"), "test-app");
+        ClientRepresentation clientRepresentation = client.toRepresentation();
+        clientRepresentation.getAttributes().put(OIDCConfigAttributes.USE_REFRESH_TOKEN, "false");
+        client.update(clientRepresentation);
+
+        oauth.doLogin("test-user@localhost", "password");
+
+        String code = oauth.getCurrentQuery().get(OAuth2Constants.CODE);
+        OAuthClient.AccessTokenResponse response = oauth.doAccessTokenRequest(code, "password");
+
+        assertEquals(200, response.getStatusCode());
+
+        assertNotNull(response.getAccessToken());
+        assertNull(response.getRefreshToken());
+
+        clientRepresentation.getAttributes().put(OIDCConfigAttributes.USE_REFRESH_TOKEN, "true");
+        client.update(clientRepresentation);
+    }
+
+    @Test
     public void accessTokenRequest_ClientPS384_RealmRS256() throws Exception {
         conductAccessTokenRequest(Algorithm.HS256, Algorithm.PS384, Algorithm.RS256);
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ClientTokenExchangeTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ClientTokenExchangeTest.java
@@ -21,6 +21,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.keycloak.OAuth2Constants;
 import org.keycloak.TokenVerifier;
+import org.keycloak.admin.client.resource.ClientResource;
 import org.keycloak.authorization.model.Policy;
 import org.keycloak.authorization.model.ResourceServer;
 import org.keycloak.common.Profile;
@@ -31,10 +32,12 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.RoleModel;
 import org.keycloak.models.UserCredentialModel;
 import org.keycloak.models.UserModel;
+import org.keycloak.protocol.oidc.OIDCConfigAttributes;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.protocol.oidc.mappers.UserSessionNoteMapper;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.AccessTokenResponse;
+import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.authorization.ClientPolicyRepresentation;
 import org.keycloak.representations.idm.authorization.DecisionStrategy;
@@ -43,6 +46,7 @@ import org.keycloak.services.resources.admin.permissions.AdminPermissions;
 import org.keycloak.testsuite.AbstractKeycloakTest;
 import org.keycloak.testsuite.Assert;
 import org.keycloak.testsuite.AssertEvents;
+import org.keycloak.testsuite.admin.ApiUtil;
 import org.keycloak.testsuite.arquillian.annotation.AuthServerContainerExclude;
 import org.keycloak.testsuite.arquillian.annotation.DisableFeature;
 import org.keycloak.testsuite.arquillian.annotation.EnableFeature;
@@ -61,6 +65,7 @@ import java.util.Map;
 
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.keycloak.models.ImpersonationSessionNote.IMPERSONATOR_ID;
 import static org.keycloak.models.ImpersonationSessionNote.IMPERSONATOR_USERNAME;
 import org.keycloak.testsuite.arquillian.annotation.AuthServerContainerExclude.AuthServer;
@@ -171,12 +176,23 @@ public class ClientTokenExchangeTest extends AbstractKeycloakTest {
         directNoSecret.setProtocol(OIDCLoginProtocol.LOGIN_PROTOCOL);
         directNoSecret.setFullScopeAllowed(false);
 
+        ClientModel noRefreshToken = realm.addClient("no-refresh-token");
+        noRefreshToken.setClientId("no-refresh-token");
+        noRefreshToken.setPublicClient(false);
+        noRefreshToken.setDirectAccessGrantsEnabled(true);
+        noRefreshToken.setEnabled(true);
+        noRefreshToken.setSecret("secret");
+        noRefreshToken.setProtocol(OIDCLoginProtocol.LOGIN_PROTOCOL);
+        noRefreshToken.setFullScopeAllowed(false);
+        noRefreshToken.getAttributes().put(OIDCConfigAttributes.USE_REFRESH_TOKEN, "false");
+
         // permission for client to client exchange to "target" client
         ClientPolicyRepresentation clientRep = new ClientPolicyRepresentation();
         clientRep.setName("to");
         clientRep.addClient(clientExchanger.getId());
         clientRep.addClient(legal.getId());
         clientRep.addClient(directLegal.getId());
+        clientRep.addClient(noRefreshToken.getId());
 
         ResourceServer server = management.realmResourceServer();
         Policy clientPolicy = management.authz().getStoreFactory().getPolicyStore().create(clientRep, server);
@@ -465,6 +481,41 @@ public class ClientTokenExchangeTest extends AbstractKeycloakTest {
             Assert.assertTrue(response.getStatus() >= 400);
             response.close();
         }
+    }
+
+    @Test
+    @UncaughtServerErrorExpected
+    public void testExchangeNoRefreshToken() throws Exception {
+        testingClient.server().run(ClientTokenExchangeTest::setupRealm);
+
+        oauth.realm(TEST);
+        oauth.clientId("client-exchanger");
+
+        ClientResource client = ApiUtil.findClientByClientId(adminClient.realm(TEST), "no-refresh-token");
+        ClientRepresentation clientRepresentation = client.toRepresentation();
+        clientRepresentation.getAttributes().put(OIDCConfigAttributes.USE_REFRESH_TOKEN, "false");
+        client.update(clientRepresentation);
+
+        OAuthClient.AccessTokenResponse response = oauth.doGrantAccessTokenRequest("secret", "user", "password");
+        String accessToken = response.getAccessToken();
+
+        {
+            response = oauth.doTokenExchange(TEST, accessToken, "target", "client-exchanger", "secret");
+            String exchangedTokenString = response.getAccessToken();
+            String refreshTokenString = response.getRefreshToken();
+            assertNotNull(exchangedTokenString);
+            assertNotNull(refreshTokenString);
+        }
+
+        {
+            response = oauth.doTokenExchange(TEST, accessToken, "target", "no-refresh-token", "secret");
+            String exchangedTokenString = response.getAccessToken();
+            String refreshTokenString = response.getRefreshToken();
+            assertNotNull(exchangedTokenString);
+            assertNull(refreshTokenString);
+        }
+        clientRepresentation.getAttributes().put(OIDCConfigAttributes.USE_REFRESH_TOKEN, "true");
+        client.update(clientRepresentation);
     }
 
     private static void addDirectExchanger(KeycloakSession session) {

--- a/themes/src/main/resources/theme/base/admin/messages/admin-messages_en.properties
+++ b/themes/src/main/resources/theme/base/admin/messages/admin-messages_en.properties
@@ -413,6 +413,8 @@ oidc-compatibility-modes=OpenID Connect Compatibility Modes
 oidc-compatibility-modes.tooltip=Expand this section to configure settings for backwards compatibility with older OpenID Connect / OAuth2 adapters. It is useful especially if your client uses older version of Keycloak / RH-SSO adapter.
 exclude-session-state-from-auth-response=Exclude Session State From Authentication Response
 exclude-session-state-from-auth-response.tooltip=If this is on, the parameter 'session_state' will not be included in OpenID Connect Authentication Response. It is useful if your client uses older OIDC / OAuth2 adapter, which does not support 'session_state' parameter.
+use-refresh-tokens=Use Refresh Tokens
+use-refresh-tokens.tooltip=If this is on, a refresh_token will be created and added to the token response. If this is off then no refresh_token will be generated.
 use-refresh-token-for-client-credentials-grant=Use Refresh Tokens For Client Credentials Grant
 use-refresh-token-for-client-credentials-grant.tooltip=If this is on, a refresh_token will be created and added to the token response if the client_credentials grant is used. The OAuth 2.0 RFC6749 Section 4.4.3 states that a refresh_token should not be generated when client_credentials grant is used. If this is off then no refresh_token will be generated and the associated user session will be removed.
 

--- a/themes/src/main/resources/theme/base/admin/resources/js/controllers/clients.js
+++ b/themes/src/main/resources/theme/base/admin/resources/js/controllers/clients.js
@@ -1112,6 +1112,7 @@ module.controller('ClientDetailCtrl', function($scope, realm, client, flows, $ro
     // KEYCLOAK-6771 Certificate Bound Token
     // https://tools.ietf.org/html/draft-ietf-oauth-mtls-08#section-3
     $scope.tlsClientCertificateBoundAccessTokens = false;
+    $scope.useRefreshTokens = true;
 
     $scope.accessTokenLifespan = TimeUnit2.asUnit(client.attributes['access.token.lifespan']);
     $scope.samlAssertionLifespan = TimeUnit2.asUnit(client.attributes['saml.assertion.lifespan']);
@@ -1287,6 +1288,14 @@ module.controller('ClientDetailCtrl', function($scope, realm, client, flows, $ro
                $scope.oauth2DeviceAuthorizationGrantEnabled = true;
            } else {
                $scope.oauth2DeviceAuthorizationGrantEnabled = false;
+           }
+       }
+
+       if ($scope.client.attributes["use.refresh.tokens"]) {
+           if ($scope.client.attributes["use.refresh.tokens"] == "true") {
+               $scope.useRefreshTokens = true;
+           } else {
+               $scope.useRefreshTokens = false;
            }
        }
 
@@ -1695,6 +1704,12 @@ module.controller('ClientDetailCtrl', function($scope, realm, client, flows, $ro
             $scope.clientEdit.attributes["oauth2.device.authorization.grant.enabled"] = "true";
         } else {
             $scope.clientEdit.attributes["oauth2.device.authorization.grant.enabled"] = "false";
+        }
+
+        if ($scope.useRefreshTokens == true) {
+            $scope.clientEdit.attributes["use.refresh.tokens"] = "true";
+        } else {
+            $scope.clientEdit.attributes["use.refresh.tokens"] = "false";
         }
 
         // KEYCLOAK-6771 Certificate Bound Token

--- a/themes/src/main/resources/theme/base/admin/resources/partials/client-detail.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/client-detail.html
@@ -560,6 +560,14 @@
                 <kc-tooltip>{{:: 'exclude-session-state-from-auth-response.tooltip' | translate}}</kc-tooltip>
             </div>
             <div class="form-group clearfix block" data-ng-show="protocol == 'openid-connect'">
+                <label class="col-md-2 control-label" for="useRefreshTokens">{{:: 'use-refresh-tokens' | translate}}</label>
+                <div class="col-sm-6">
+                    <input ng-model="useRefreshTokens" ng-click="switchChange()" name="useRefreshTokens" id="useRefreshTokens"
+                        onoffswitch on-text="{{:: 'onText' | translate}}" off-text="{{:: 'offText' | translate}}" />
+                </div>
+                <kc-tooltip>{{:: 'use-refresh-tokens.tooltip' | translate}}</kc-tooltip>
+            </div>
+            <div class="form-group clearfix block" data-ng-show="protocol == 'openid-connect'">
                 <label class="col-md-2 control-label" for="useRefreshTokenForClientCredentialsGrant">{{:: 'use-refresh-token-for-client-credentials-grant' | translate}}</label>
                 <div class="col-md-6">
                     <input ng-model="useRefreshTokenForClientCredentialsGrant" ng-click="switchChange()" name="useRefreshTokenForClientCredentialsGrant" id="useRefreshTokenForClientCredentialsGrant" onoffswitch on-text="{{:: 'onText' | translate}}" off-text="{{:: 'offText' | translate}}"/>


### PR DESCRIPTION
-	Add `Use Refresh Tokens` option on top of `Use Refresh Tokens For Client Credentials Grant` at the client setting screen.
This option is displayed when openid connect is selected.

-	If `Use Refresh Tokens` is ON, Keycloak issues Refresh tokens.
`Use Refresh Tokens` is the option for Authrization Code Grant, Resource Owner Password Credentials Grant, Uma Grant, Device Authrization Grant, Token Refresh and Token Exchange.
If you use Client Credentials Grant, you use existing `Use Refresh Tokens For Client Credentials Grant` instead of this option. If Client Credentials Grant is used, the value of this option is ignored.

-	If `Use Refresh Tokens` is OFF, Keycloak does not issue Refresh tokens.
If Client Credentials Grant is used, the value of this option is ignored as above.

-	If you set `Use Refresh Tokens` to OFF after Keycloak issued Refresh tokens, you can use the Refresh tokens.
If you want to prohibit the use of the issued Refresh tokens, you use token revocation.

JIRA: https://issues.redhat.com/browse/KEYCLOAK-17202
