### PR TITLE
Change how WebAuthn credential signature counter is updated

### DIFF
--- a/services/src/main/java/org/keycloak/credential/WebAuthnCredentialProvider.java
+++ b/services/src/main/java/org/keycloak/credential/WebAuthnCredentialProvider.java
@@ -199,7 +199,7 @@ public class WebAuthnCredentialProvider implements CredentialProvider<WebAuthnCr
                     long count = auth.getCount();
                     CredentialModel credModel = getCredentialStore().getStoredCredentialById(realm, user, auth.getCredentialDBId());
                     WebAuthnCredentialModel webAuthnCredModel = getCredentialFromModel(credModel);
-                    webAuthnCredModel.updateCounter(count + 1);
+                    webAuthnCredModel.updateCounter(count);
                     getCredentialStore().updateCredential(realm, user, webAuthnCredModel);
 
                     logger.debugf("Successfully validated WebAuthn credential for user %s", user.getUsername());


### PR DESCRIPTION
The WebAuthn spec says that authenticator "SHOULD" implement a signature counter, to aid in detection of cloned authenticators. But this is not a MUST. In the case of some authenticators, e.g. iOS FaceID/TouchID, this signature counter is always zero, which is allowed by the specification. If Keycloak's stored signature counter is incremented by one, such authenticators will not function properly. In this proposed change, the signature counter is updated to the last value of the signature counter provided by the authenticator, which makes it possible to function with zero-signature-counter authenticator, while still being fully compatible with the specification. 

Reference: https://www.w3.org/TR/webauthn-2/#sctn-sign-counter

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
