### PR TITLE
KEYCLOAK-17486: an error should not be a boolean

### DIFF
--- a/adapters/oidc/js/src/main/resources/keycloak.js
+++ b/adapters/oidc/js/src/main/resources/keycloak.js
@@ -679,7 +679,7 @@
 
                                     kc.onAuthRefreshError && kc.onAuthRefreshError();
                                     for (var p = refreshQueue.pop(); p != null; p = refreshQueue.pop()) {
-                                        p.setError(true);
+                                        p.setError();
                                     }
                                 }
                             }


### PR DESCRIPTION
<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->

There are some libs around which try to access `.message` if an error is present, but they fail because of the provided `boolean`.