### PR TITLE
KEYCLOAK-17522 fixed bug that keycloak instance not recognized by Safari

### DIFF
--- a/themes/src/main/resources/theme/keycloak.v2/account/index.ftl
+++ b/themes/src/main/resources/theme/keycloak.v2/account/index.ftl
@@ -118,7 +118,7 @@
     <body>
 
         <script>
-            const keycloak = Keycloak({
+            var keycloak = Keycloak({
                 authServerUrl: authUrl,
                 realm: realm,
                 clientId: 'account-console'


### PR DESCRIPTION
<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
keycloak.v2 theme reports the following error and gets stuck when logging into the account console using Safari.

![image](https://user-images.githubusercontent.com/15964179/112203671-051a4c00-8bd0-11eb-9cdf-bf8a2191e229.png)