### PR TITLE
KEYCLOAK-17581 Prevent empty group names via Admin API

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/GroupResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/GroupResource.java
@@ -19,6 +19,7 @@ package org.keycloak.services.resources.admin;
 import org.jboss.resteasy.annotations.cache.NoCache;
 import javax.ws.rs.NotFoundException;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
+import org.keycloak.common.util.ObjectUtil;
 import org.keycloak.events.admin.OperationType;
 import org.keycloak.events.admin.ResourceType;
 import org.keycloak.models.Constants;
@@ -100,10 +101,15 @@ public class GroupResource {
     public Response updateGroup(GroupRepresentation rep) {
         this.auth.groups().requireManage(group);
 
+        String groupName = rep.getName();
+        if (ObjectUtil.isBlank(groupName)) {
+            return ErrorResponse.error("Group name is missing", Response.Status.BAD_REQUEST);
+        }
+
         boolean exists = siblings().filter(s -> !Objects.equals(s.getId(), group.getId()))
-                .anyMatch(s -> Objects.equals(s.getName(), rep.getName()));
+                .anyMatch(s -> Objects.equals(s.getName(), groupName));
         if (exists) {
-            return ErrorResponse.exists("Sibling group named '" + rep.getName() + "' already exists.");
+            return ErrorResponse.exists("Sibling group named '" + groupName + "' already exists.");
         }
         
         updateGroup(rep, group);
@@ -143,6 +149,11 @@ public class GroupResource {
     public Response addChild(GroupRepresentation rep) {
         this.auth.groups().requireManage(group);
 
+        String groupName = rep.getName();
+        if (ObjectUtil.isBlank(groupName)) {
+            return ErrorResponse.error("Group name is missing", Response.Status.BAD_REQUEST);
+        }
+
         Response.ResponseBuilder builder = Response.status(204);
         GroupModel child = null;
         if (rep.getId() != null) {
@@ -153,7 +164,7 @@ public class GroupResource {
             realm.moveGroup(child, group);
             adminEvent.operation(OperationType.UPDATE);
         } else {
-            child = realm.createGroup(rep.getName(), group);
+            child = realm.createGroup(groupName, group);
             updateGroup(rep, child);
             URI uri = session.getContext().getUri().getBaseUriBuilder()
                                            .path(session.getContext().getUri().getMatchedURIs().get(2))

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/group/GroupTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/group/GroupTest.java
@@ -300,6 +300,64 @@ public class GroupTest extends AbstractGroupTest {
         });
     }
 
+
+    // KEYCLOAK-17581
+    @Test
+    public void createGroupWithEmptyNameShouldFail() {
+
+        RealmResource realm = adminClient.realms().realm("test");
+
+        GroupRepresentation group = new GroupRepresentation();
+        group.setName("");
+        try (Response response = realm.groups().add(group)){
+            if (response.getStatus() != 400) {
+                Assert.fail("Creating a group with empty name should fail");
+            }
+        } catch (Exception expected) {
+            Assert.assertNotNull(expected);
+        }
+
+        group.setName(null);
+        try (Response response = realm.groups().add(group)){
+            if (response.getStatus() != 400) {
+                Assert.fail("Creating a group with null name should fail");
+            }
+        } catch (Exception expected) {
+            Assert.assertNotNull(expected);
+        }
+    }
+
+    // KEYCLOAK-17581
+    @Test
+    public void updatingGroupWithEmptyNameShouldFail() {
+
+        RealmResource realm = adminClient.realms().realm("test");
+
+        GroupRepresentation group = new GroupRepresentation();
+        group.setName("groupWithName");
+
+        String groupId = null;
+        try (Response response = realm.groups().add(group)) {
+            groupId = ApiUtil.getCreatedId(response);
+        }
+
+        try {
+            group.setName("");
+            realm.groups().group(groupId).update(group);
+            Assert.fail("Updating a group with empty name should fail");
+        } catch(Exception expected) {
+            Assert.assertNotNull(expected);
+        }
+
+        try {
+            group.setName(null);
+            realm.groups().group(groupId).update(group);
+            Assert.fail("Updating a group with null name should fail");
+        } catch(Exception expected) {
+            Assert.assertNotNull(expected);
+        }
+    }
+
     @Test
     public void createAndTestGroups() throws Exception {
         RealmResource realm = adminClient.realms().realm("test");


### PR DESCRIPTION
Create / Update operations in `GroupResource ` and `GroupsResource#addTopLevelGroup`
did not validate the given group name. This allowed the creation of groups with empty names.

We now prevent the creation of groups with empty names.

Although the admin-console UI prevents empty groups from being created, this should also be enforced on the server-side. This PR fixes the Admin API side, but there are still other ways where groups with empty groupNames might sneak in, e.g. user federation (mappers).

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
