### PR TITLE
KEYCLOAK-17620 - Fix ClientClientScopesTest

### DIFF
--- a/testsuite/integration-arquillian/tests/other/console/src/test/java/org/keycloak/testsuite/console/clients/ClientClientScopesTest.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/test/java/org/keycloak/testsuite/console/clients/ClientClientScopesTest.java
@@ -20,7 +20,6 @@ package org.keycloak.testsuite.console.clients;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 import java.util.Set;
 
 import org.jboss.arquillian.graphene.page.Page;
@@ -35,6 +34,8 @@ import org.keycloak.testsuite.console.page.clients.clientscopes.ClientScopesSetu
 import org.keycloak.testsuite.console.page.clients.clientscopes.ClientScopesSetupForm;
 import org.keycloak.util.JsonSerialization;
 import org.keycloak.util.TokenUtil;
+import org.hamcrest.MatcherAssert;
+import static org.hamcrest.Matchers.hasItems;
 
 import static org.junit.Assert.assertNotNull;
 import static org.keycloak.testsuite.auth.page.login.Login.OIDC;
@@ -155,7 +156,8 @@ public class ClientClientScopesTest extends AbstractClientTest {
         // Test roles
         evaluateForm.showRoles();
         Assert.assertNames(evaluateForm.getGrantedRealmRoles(), "offline_access");
-        Assert.assertNames(evaluateForm.getNotGrantedRealmRoles(), "uma_authorization");
+        MatcherAssert.assertThat(evaluateForm.getNotGrantedRealmRoles(),
+                hasItems("uma_authorization", "default-roles-test"));
 
         // Test access token
         evaluateForm.showToken();


### PR DESCRIPTION
Fix ClientClientScopesTest.testEvaluateClientScopes, it was failing due to a change on roles management