### PR TITLE
KEYCLOAK-17310. Disabled test in remote environment.

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/UserTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/UserTest.java
@@ -1104,7 +1104,7 @@ public class UserTest extends AbstractAdminTest {
     }
 
     @Test
-    @AuthServerContainerExclude(QUARKUS) // TODO: Enable for quarkus
+    @AuthServerContainerExclude({REMOTE, QUARKUS}) // TODO: Enable for quarkus and remote
     public void updateUserWithReadOnlyAttributes() {
         // Admin is able to update "usercertificate" attribute
         UserRepresentation user1 = new UserRepresentation();


### PR DESCRIPTION
After discussion with @mposolda we agreed that this test should be disabled for now until a proper refactor is addressed. This is not the only test disabled for remote, it's just that it was not disabled by error previously.
