### PR TITLE
[KEYCLOAK-16455][Adapter - JavaScript] Check if Keycloak realm available before proceed to Keycloak instance initialization + propagate errors where possible

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/javascript/JavascriptTestExecutor.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/javascript/JavascriptTestExecutor.java
@@ -183,8 +183,8 @@ public class JavascriptTestExecutor {
         String script = "var callback = arguments[arguments.length - 1];" +
                 "   window.keycloak.init(" + arguments + ").then(function (authenticated) {" +
                 "       callback(\"Init Success (\" + (authenticated ? \"Authenticated\" : \"Not Authenticated\") + \")\");" +
-                "   }).catch(function () {" +
-                "       callback(\"Init Error\");" +
+                "   }).catch(function (error) {" +
+                "       callback(error);" +
                 "   });";
 
         Object output;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/javascript/AbstractJavascriptTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/javascript/AbstractJavascriptTest.java
@@ -30,6 +30,7 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.collection.IsMapContaining.hasEntry;
@@ -214,4 +215,11 @@ public abstract class AbstractJavascriptTest extends AbstractAuthTest {
     public JavascriptStateValidator assertEventsDoesntContain(String text) {
         return buildFunction(this::assertEventsWebElementDoesntContain, text);
     }
+
+    public void assertErrorResponse(WebDriver drv, Object output, WebElement evt) {
+        Assert.assertNotNull("Empty error response", output);
+        Assert.assertTrue("Invalid error response type", output instanceof Map);
+        Assert.assertTrue("Invalid error response format", ((Map<?, ?>) output).containsKey("error"));
+    }
+
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/javascript/JavascriptAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/javascript/JavascriptAdapterTest.java
@@ -822,6 +822,42 @@ public class JavascriptAdapterTest extends AbstractJavascriptTest {
                 .init(defaultArguments(), this::assertInitNotAuth);
     }
 
+    // In case of incorrect/unavailable realm provided in KeycloakConfig,
+    // JavaScript Adapter init() should fail-fast and reject Promise with KeycloakError.
+    @Test
+    public void checkInitWithInvalidRealm() {
+
+        JSObjectBuilder keycloakConfig = JSObjectBuilder.create()
+                .add("url", authServerContextRootPage + "/auth")
+                .add("realm", "invalid-realm-name")
+                .add("clientId", CLIENT_ID);
+
+        JSObjectBuilder initOptions = defaultArguments();
+
+        testExecutor
+                .configure(keycloakConfig)
+                .init(initOptions, this::assertErrorResponse);
+
+    }
+
+    // In case of unavailable Authorization Server due to network or other kind of problems,
+    // JavaScript Adapter init() should fail-fast and reject Promise with KeycloakError.
+    @Test
+    public void checkInitWithUnavailableAuthServer() {
+
+        JSObjectBuilder keycloakConfig = JSObjectBuilder.create()
+                .add("url", "https://localhost:12345/auth")
+                .add("realm", REALM_NAME)
+                .add("clientId", CLIENT_ID);
+
+        JSObjectBuilder initOptions = defaultArguments();
+
+        testExecutor
+                .configure(keycloakConfig)
+                .init(initOptions, this::assertErrorResponse);
+
+    }
+
     protected void assertAdapterIsLoggedIn(WebDriver driver1, Object output, WebElement events) {
         assertTrue(testExecutor.isLoggedIn());
     }


### PR DESCRIPTION
The motivation for this is in case of Keycloak server realm is not available due to network error or Keycloak server down, the Promise returned from Keycloak.init({ onLoad: 'check-sso' }) is never being settled. So when using this JavaScript Adapter as recommended in documentation/tutorials with Vue.js or [keycloak-anagular](https://github.com/mauriciovigolo/keycloak-angular), the application is never being initialized and displays empty page.