### PR TITLE
KEYCLOAK-17503: Optimise offline session load on startup

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/initializer/OfflinePersistentWorkerContext.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/initializer/OfflinePersistentWorkerContext.java
@@ -22,18 +22,11 @@ package org.keycloak.models.sessions.infinispan.initializer;
  */
 public class OfflinePersistentWorkerContext extends SessionLoader.WorkerContext {
 
-    private final int lastCreatedOn;
     private final String lastSessionId;
 
-    public OfflinePersistentWorkerContext(int segment, int workerId, int lastCreatedOn, String lastSessionId) {
+    public OfflinePersistentWorkerContext(int segment, int workerId, String lastSessionId) {
         super(segment, workerId);
-        this.lastCreatedOn = lastCreatedOn;
         this.lastSessionId = lastSessionId;
-    }
-
-
-    public int getLastCreatedOn() {
-        return lastCreatedOn;
     }
 
     public String getLastSessionId() {

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/initializer/OfflinePersistentWorkerResult.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/initializer/OfflinePersistentWorkerResult.java
@@ -22,21 +22,13 @@ package org.keycloak.models.sessions.infinispan.initializer;
  */
 public class OfflinePersistentWorkerResult extends SessionLoader.WorkerResult {
 
-    private final int lastCreatedOn;
     private final String lastSessionId;
 
 
-    public OfflinePersistentWorkerResult(boolean success, int segment, int workerId, int lastCreatedOn, String lastSessionId) {
+    public OfflinePersistentWorkerResult(boolean success, int segment, int workerId, String lastSessionId) {
         super(success, segment, workerId);
-        this.lastCreatedOn = lastCreatedOn;
         this.lastSessionId = lastSessionId;
     }
-
-
-    public int getLastCreatedOn() {
-        return lastCreatedOn;
-    }
-
 
     public String getLastSessionId() {
         return lastSessionId;

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/session/JpaUserSessionPersisterProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/session/JpaUserSessionPersisterProvider.java
@@ -37,12 +37,7 @@ import javax.persistence.EntityManager;
 import javax.persistence.Query;
 import javax.persistence.TypedQuery;
 
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -243,30 +238,32 @@ public class JpaUserSessionPersisterProvider implements UserSessionPersisterProv
 
     @Override
     public Stream<UserSessionModel> loadUserSessionsStream(Integer firstResult, Integer maxResults, boolean offline,
-                                                           Integer lastCreatedOn, String lastUserSessionId) {
+                                                           String lastUserSessionId) {
         String offlineStr = offlineToString(offline);
 
-        TypedQuery<PersistentUserSessionEntity> query = em.createNamedQuery("findUserSessions", PersistentUserSessionEntity.class);
-        query.setParameter("offline", offlineStr);
-        query.setParameter("lastCreatedOn", lastCreatedOn);
-        query.setParameter("lastSessionId", lastUserSessionId);
+        TypedQuery<PersistentUserSessionEntity> queryUserSessions = em.createNamedQuery("findUserSessionsOrderedById", PersistentUserSessionEntity.class);
+        queryUserSessions.setParameter("offline", offlineStr);
+        queryUserSessions.setParameter("lastSessionId", lastUserSessionId);
 
-        List<PersistentUserSessionAdapter> result = closing(paginateQuery(query, firstResult, maxResults).getResultStream()
+        List<PersistentUserSessionAdapter> userSessionAdapters = closing(paginateQuery(queryUserSessions, firstResult, maxResults).getResultStream()
                 .map(this::toAdapter))
                 .collect(Collectors.toList());
 
-        Map<String, PersistentUserSessionAdapter> sessionsById = result.stream()
+        Map<String, PersistentUserSessionAdapter> sessionsById = userSessionAdapters.stream()
                 .collect(Collectors.toMap(UserSessionModel::getId, Function.identity()));
-
-        Set<String> userSessionIds = sessionsById.keySet();
 
         Set<String> removedClientUUIDs = new HashSet<>();
 
-        if (!userSessionIds.isEmpty()) {
-            TypedQuery<PersistentClientSessionEntity> query2 = em.createNamedQuery("findClientSessionsByUserSessions", PersistentClientSessionEntity.class);
-            query2.setParameter("userSessionIds", userSessionIds);
-            query2.setParameter("offline", offlineStr);
-            closing(query2.getResultStream()).forEach(clientSession -> {
+        if (!sessionsById.isEmpty()) {
+            String fromUserSessionId = userSessionAdapters.get(0).getId();
+            String toUserSessionId = userSessionAdapters.get(userSessionAdapters.size() - 1).getId();
+
+            TypedQuery<PersistentClientSessionEntity> queryClientSessions = em.createNamedQuery("findClientSessionsOrderedById", PersistentClientSessionEntity.class);
+            queryClientSessions.setParameter("offline", offlineStr);
+            queryClientSessions.setParameter("fromSessionId", fromUserSessionId);
+            queryClientSessions.setParameter("toSessionId", toUserSessionId);
+
+            closing(queryClientSessions.getResultStream()).forEach(clientSession -> {
                 PersistentUserSessionAdapter userSession = sessionsById.get(clientSession.getUserSessionId());
 
                 PersistentAuthenticatedClientSessionAdapter clientSessAdapter = toAdapter(userSession.getRealm(), userSession, clientSession);
@@ -285,7 +282,7 @@ public class JpaUserSessionPersisterProvider implements UserSessionPersisterProv
             onClientRemoved(clientUUID);
         }
 
-        return result.stream().map(UserSessionModel.class::cast);
+        return userSessionAdapters.stream().map(UserSessionModel.class::cast);
     }
 
     private PersistentUserSessionAdapter toAdapter(PersistentUserSessionEntity entity) {

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/session/PersistentClientSessionEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/session/PersistentClientSessionEntity.java
@@ -38,7 +38,7 @@ import java.io.Serializable;
         @NamedQuery(name="deleteClientSessionsByUserSession", query="delete from PersistentClientSessionEntity sess where sess.userSessionId = :userSessionId and sess.offline = :offline"),
         @NamedQuery(name="deleteExpiredClientSessions", query="delete from PersistentClientSessionEntity sess where sess.userSessionId IN (select u.userSessionId from PersistentUserSessionEntity u where u.realmId = :realmId AND u.offline = :offline AND u.lastSessionRefresh < :lastSessionRefresh)"),
         @NamedQuery(name="findClientSessionsByUserSession", query="select sess from PersistentClientSessionEntity sess where sess.userSessionId=:userSessionId and sess.offline = :offline"),
-        @NamedQuery(name="findClientSessionsByUserSessions", query="select sess from PersistentClientSessionEntity sess where sess.offline = :offline and sess.userSessionId IN (:userSessionIds) order by sess.userSessionId")
+        @NamedQuery(name="findClientSessionsOrderedById", query="select sess from PersistentClientSessionEntity sess where sess.offline = :offline and sess.userSessionId >= :fromSessionId and sess.userSessionId <= :toSessionId order by sess.userSessionId")
 })
 @Table(name="OFFLINE_CLIENT_SESSION")
 @Entity

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/session/PersistentUserSessionEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/session/PersistentUserSessionEntity.java
@@ -38,9 +38,9 @@ import java.io.Serializable;
         @NamedQuery(name="updateUserSessionLastSessionRefresh", query="update PersistentUserSessionEntity sess set lastSessionRefresh = :lastSessionRefresh where sess.realmId = :realmId" +
                 " AND sess.offline = :offline AND sess.userSessionId IN (:userSessionIds)"),
         @NamedQuery(name="findUserSessionsCount", query="select count(sess) from PersistentUserSessionEntity sess where sess.offline = :offline"),
-        @NamedQuery(name="findUserSessions", query="select sess from PersistentUserSessionEntity sess where sess.offline = :offline" +
-                " AND (sess.createdOn > :lastCreatedOn OR (sess.createdOn = :lastCreatedOn AND sess.userSessionId > :lastSessionId))" +
-                " order by sess.createdOn,sess.userSessionId")
+        @NamedQuery(name="findUserSessionsOrderedById", query="select sess from PersistentUserSessionEntity sess where sess.offline = :offline" +
+                " AND sess.userSessionId > :lastSessionId" +
+                " order by sess.userSessionId")
 
 })
 @Table(name="OFFLINE_USER_SESSION")

--- a/server-spi-private/src/main/java/org/keycloak/models/session/DisabledUserSessionPersisterProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/session/DisabledUserSessionPersisterProvider.java
@@ -111,7 +111,7 @@ public class DisabledUserSessionPersisterProvider implements UserSessionPersiste
 
     @Override
     public Stream<UserSessionModel> loadUserSessionsStream(Integer firstResult, Integer maxResults, boolean offline,
-                                                           Integer lastCreatedOn, String lastUserSessionId) {
+                                                           String lastUserSessionId) {
         return Stream.empty();
     }
 

--- a/server-spi-private/src/main/java/org/keycloak/models/session/UserSessionPersisterProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/session/UserSessionPersisterProvider.java
@@ -58,11 +58,11 @@ public interface UserSessionPersisterProvider extends Provider {
 
     /**
      * Called during startup. For each userSession, it loads also clientSessions
-     * @deprecated Use {@link #loadUserSessionsStream(Integer, Integer, boolean, Integer, String) loadUserSessionsStream} instead.
+     * @deprecated Use {@link #loadUserSessionsStream(Integer, Integer, boolean, String) loadUserSessionsStream} instead.
      */
     @Deprecated
     default List<UserSessionModel> loadUserSessions(int firstResult, int maxResults, boolean offline, int lastCreatedOn, String lastUserSessionId) {
-        return loadUserSessionsStream(firstResult, maxResults, offline, lastCreatedOn, lastUserSessionId).collect(Collectors.toList());
+        return loadUserSessionsStream(firstResult, maxResults, offline, lastUserSessionId).collect(Collectors.toList());
     }
 
     /**
@@ -70,13 +70,12 @@ public interface UserSessionPersisterProvider extends Provider {
      * @param firstResult {@code Integer} Index of the first desired user session. Ignored if negative or {@code null}.
      * @param maxResults {@code Integer} Maximum number of returned user sessions. Ignored if negative or {@code null}.
      * @param offline {@code boolean} Flag to include offline sessions.
-     * @param lastCreatedOn {@code Integer} Timestamp when the user session was created. It will return only user sessions created later.
-     * @param lastUserSessionId {@code String} Id of the user session. In case of equal {@code lastCreatedOn}
+     * @param lastUserSessionId {@code String} Id of the user session. It will return only user sessions with id's lexicographically greater than this.
      * it will compare the id in dictionary order and takes only those created later.
      * @return Stream of {@link UserSessionModel}. Never returns {@code null}.
      */
     Stream<UserSessionModel> loadUserSessionsStream(Integer firstResult, Integer maxResults, boolean offline,
-                                                    Integer lastCreatedOn, String lastUserSessionId);
+                                                    String lastUserSessionId);
 
     int getUserSessionsCount(boolean offline);
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/model/UserSessionPersisterProviderTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/model/UserSessionPersisterProviderTest.java
@@ -413,7 +413,7 @@ public class UserSessionPersisterProviderTest extends AbstractTestRealmKeycloakT
     public void testNoSessions(KeycloakSession session) {
         KeycloakModelUtils.runJobInTransaction(session.getKeycloakSessionFactory(), (KeycloakSession sessionNS) -> {
             UserSessionPersisterProvider persister = sessionNS.getProvider(UserSessionPersisterProvider.class);
-            Stream<UserSessionModel> sessions = persister.loadUserSessionsStream(0, 1, true, 0, "abc");
+            Stream<UserSessionModel> sessions = persister.loadUserSessionsStream(0, 1, true, "00000000-0000-0000-0000-000000000000");
             Assert.assertEquals(0, sessions.count());
         });
     }
@@ -576,12 +576,10 @@ public class UserSessionPersisterProviderTest extends AbstractTestRealmKeycloakT
         int pageCount = 0;
         boolean next = true;
         List<UserSessionModel> result = new ArrayList<>();
-        int lastCreatedOn = 0;
-        String lastSessionId = "abc";
-
+        String lastSessionId = "00000000-0000-0000-0000-000000000000";
         while (next) {
             List<UserSessionModel> sess = persister
-                    .loadUserSessionsStream(0, sessionsPerPage, offline, lastCreatedOn, lastSessionId)
+                    .loadUserSessionsStream(0, sessionsPerPage, offline, lastSessionId)
                     .collect(Collectors.toList());
 
             if (sess.size() < sessionsPerPage) {
@@ -595,7 +593,6 @@ public class UserSessionPersisterProviderTest extends AbstractTestRealmKeycloakT
                 pageCount++;
 
                 UserSessionModel lastSession = sess.get(sess.size() - 1);
-                lastCreatedOn = lastSession.getStarted();
                 lastSessionId = lastSession.getId();
             }
 


### PR DESCRIPTION
This PR contains optimisation startup time with a large number of offline sessions.

The reason that loading of offline sessions is quite slow, is an ineffetive "in memory" join between offline_user_session and offline_client_session. The current implementation generates a set of user_session_id's from a segment of loaded offline_user_sessions, and parses this set as a comma seperated string to the query for offline_client_sessions.

My proposed implementation instead sorts both offline_user_session and offline_client_sessions on user_client_id, which makes a more effective "join" possible.

Since the "lastCreatedOn" is no longer needed for segmentation, I have removed it (primarily in tests)

Also the "abc" used for lowest possible user_session_id have been replaced with "00000000-0000-0000-0000-000000000000".