### PR TITLE
KEYCLOAK-17666 Client Policy - Executor : Limiting available period of Request Object

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/AbstractClientPoliciesTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/AbstractClientPoliciesTest.java
@@ -520,7 +520,7 @@ public abstract class AbstractClientPoliciesTest extends AbstractKeycloakTest {
         requestObject.id(KeycloakModelUtils.generateId());
         requestObject.iat(Long.valueOf(Time.currentTime()));
         requestObject.exp(requestObject.getIat() + Long.valueOf(300));
-        requestObject.nbf(Long.valueOf(0));
+        requestObject.nbf(requestObject.getIat());
         requestObject.setClientId(clientId);
         requestObject.setResponseType("code");
         requestObject.setRedirectUriParam(oauth.getRedirectUri());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientPoliciesTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientPoliciesTest.java
@@ -982,6 +982,30 @@ public class ClientPoliciesTest extends AbstractClientPoliciesTest {
         assertEquals(SecureRequestObjectExecutor.INVALID_REQUEST_OBJECT, oauth.getCurrentQuery().get(OAuth2Constants.ERROR));
         assertEquals("Request Expired", oauth.getCurrentQuery().get(OAuth2Constants.ERROR_DESCRIPTION));
 
+        // check whether "nbf" claim exists
+        requestObject = createValidRequestObjectForSecureRequestObjectExecutor(clientId);
+        requestObject.nbf(null);
+        registerRequestObject(requestObject, clientId, Algorithm.ES256, false);
+        oauth.openLoginForm();
+        assertEquals(SecureRequestObjectExecutor.INVALID_REQUEST_OBJECT, oauth.getCurrentQuery().get(OAuth2Constants.ERROR));
+        assertEquals("Missing parameter : nbf", oauth.getCurrentQuery().get(OAuth2Constants.ERROR_DESCRIPTION));
+
+        // check whether request object not yet being processed
+        requestObject = createValidRequestObjectForSecureRequestObjectExecutor(clientId);
+        requestObject.nbf(requestObject.getNbf() + 600);
+        registerRequestObject(requestObject, clientId, Algorithm.ES256, false);
+        oauth.openLoginForm();
+        assertEquals(SecureRequestObjectExecutor.INVALID_REQUEST_OBJECT, oauth.getCurrentQuery().get(OAuth2Constants.ERROR));
+        assertEquals("Request not yet being processed", oauth.getCurrentQuery().get(OAuth2Constants.ERROR_DESCRIPTION));
+
+        // check whether request object's available period is short
+        requestObject = createValidRequestObjectForSecureRequestObjectExecutor(clientId);
+        requestObject.exp(requestObject.getNbf() + 3601);
+        registerRequestObject(requestObject, clientId, Algorithm.ES256, false);
+        oauth.openLoginForm();
+        assertEquals(SecureRequestObjectExecutor.INVALID_REQUEST_OBJECT, oauth.getCurrentQuery().get(OAuth2Constants.ERROR));
+        assertEquals("Request's available period is long", oauth.getCurrentQuery().get(OAuth2Constants.ERROR_DESCRIPTION));
+
         // check whether "aud" claim exists
         requestObject = createValidRequestObjectForSecureRequestObjectExecutor(clientId);
         requestObject.audience((String)null);


### PR DESCRIPTION
This PR is for [KEYCLOAK-13933 Client Policies](https://issues.redhat.com/browse/KEYCLOAK-13933), also is the part of [FAPI-SIG](https://github.com/keycloak/kc-sig-fapi) activity. 

The details can be found in its [design document](https://github.com/keycloak/keycloak-community/blob/master/design/client-policies.md) and [KEYCLOAK-17666](https://issues.redhat.com/browse/KEYCLOAK-17666).
