### PR TITLE
KEYCLOAK-16918 Set custom user attribute to Name ID Format for a SAML client

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/saml/mappers/NameIdMapperHelper.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/mappers/NameIdMapperHelper.java
@@ -1,0 +1,36 @@
+package org.keycloak.protocol.saml.mappers;
+
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.saml.common.constants.JBossSAMLURIConstants;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class NameIdMapperHelper {
+
+    public static final String NAMEID_MAPPER_CATEGORY = "NameID Mapper";
+
+    // The Class implemented NameIDMapper needs the following attributes.
+    public static final String MAPPER_NAMEID_FORMAT = "mapper.nameid.format";
+    public static final String MAPPER_NAMEID_FORMAT_LABEL = "name-id-format";
+    public static final String MAPPER_NAMEID_FORMAT_HELP_TEXT = "mapper.nameid.format.tooltip";
+
+    public static void setConfigProperties(List<ProviderConfigProperty> configProperties) {
+        ProviderConfigProperty property = new ProviderConfigProperty();
+        property.setName(NameIdMapperHelper.MAPPER_NAMEID_FORMAT);
+        property.setLabel(NameIdMapperHelper.MAPPER_NAMEID_FORMAT_LABEL);
+        property.setHelpText(NameIdMapperHelper.MAPPER_NAMEID_FORMAT_HELP_TEXT);
+        List<String> types = new ArrayList<String>();
+        types.add(JBossSAMLURIConstants.NAMEID_FORMAT_UNSPECIFIED.get());
+        types.add(JBossSAMLURIConstants.NAMEID_FORMAT_EMAIL.get());
+        types.add(JBossSAMLURIConstants.NAMEID_FORMAT_X509SUBJECTNAME.get());
+        types.add(JBossSAMLURIConstants.NAMEID_FORMAT_WINDOWS_DOMAIN_NAME.get());
+        types.add(JBossSAMLURIConstants.NAMEID_FORMAT_KERBEROS.get());
+        types.add(JBossSAMLURIConstants.NAMEID_FORMAT_ENTITY.get());
+        types.add(JBossSAMLURIConstants.NAMEID_FORMAT_PERSISTENT.get());
+        types.add(JBossSAMLURIConstants.NAMEID_FORMAT_TRANSIENT.get());
+        property.setType(ProviderConfigProperty.LIST_TYPE);
+        property.setOptions(types);
+        configProperties.add(property);
+    }
+}

--- a/services/src/main/java/org/keycloak/protocol/saml/mappers/SAMLNameIdMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/mappers/SAMLNameIdMapper.java
@@ -1,0 +1,13 @@
+package org.keycloak.protocol.saml.mappers;
+
+import org.keycloak.models.AuthenticatedClientSessionModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.ProtocolMapperModel;
+import org.keycloak.models.UserSessionModel;
+
+public interface SAMLNameIdMapper {
+
+    String mapperNameId(String nameIdFormat, ProtocolMapperModel mappingModel, KeycloakSession session,
+                                        UserSessionModel userSession, AuthenticatedClientSessionModel clientSession);
+
+}

--- a/services/src/main/java/org/keycloak/protocol/saml/mappers/UserAttributeNameIdMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/mappers/UserAttributeNameIdMapper.java
@@ -1,0 +1,58 @@
+package org.keycloak.protocol.saml.mappers;
+
+import org.keycloak.models.AuthenticatedClientSessionModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.ProtocolMapperModel;
+import org.keycloak.models.UserSessionModel;
+import org.keycloak.protocol.ProtocolMapperUtils;
+import org.keycloak.provider.ProviderConfigProperty;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class UserAttributeNameIdMapper extends AbstractSAMLProtocolMapper implements SAMLNameIdMapper {
+
+    private static final List<ProviderConfigProperty> configProperties = new ArrayList<ProviderConfigProperty>();
+
+    static {
+        NameIdMapperHelper.setConfigProperties(configProperties);
+        ProviderConfigProperty property;
+        property = new ProviderConfigProperty();
+        property.setName(ProtocolMapperUtils.USER_ATTRIBUTE);
+        property.setLabel(ProtocolMapperUtils.USER_MODEL_ATTRIBUTE_LABEL);
+        property.setHelpText(ProtocolMapperUtils.USER_MODEL_ATTRIBUTE_HELP_TEXT);
+        configProperties.add(property);
+    }
+
+    public static final String PROVIDER_ID = "saml-user-attribute-nameid-mapper";
+
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return configProperties;
+    }
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public String getDisplayType() {
+        return "User Attribute Mapper For NameID";
+    }
+
+    @Override
+    public String getDisplayCategory() {
+        return "NameID Mapper";
+    }
+
+    @Override
+    public String getHelpText() {
+        return "Map user attribute to SAML NameID value.";
+    }
+
+    @Override
+    public String mapperNameId(String nameIdFormat, ProtocolMapperModel mappingModel, KeycloakSession session,
+            UserSessionModel userSession, AuthenticatedClientSessionModel clientSession) {
+        return userSession.getUser().getFirstAttribute(mappingModel.getConfig().get(ProtocolMapperUtils.USER_ATTRIBUTE));
+    }
+
+}

--- a/services/src/main/resources/META-INF/services/org.keycloak.protocol.ProtocolMapper
+++ b/services/src/main/resources/META-INF/services/org.keycloak.protocol.ProtocolMapper
@@ -44,3 +44,4 @@ org.keycloak.protocol.oidc.mappers.ScriptBasedOIDCProtocolMapper
 org.keycloak.protocol.saml.mappers.SAMLAudienceProtocolMapper
 org.keycloak.protocol.saml.mappers.SAMLAudienceResolveProtocolMapper
 org.keycloak.protocol.oidc.mappers.ClaimsParameterTokenMapper
+org.keycloak.protocol.saml.mappers.UserAttributeNameIdMapper

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/NameIdMapperTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/NameIdMapperTest.java
@@ -1,0 +1,95 @@
+package org.keycloak.testsuite.saml;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.keycloak.dom.saml.v2.assertion.NameIDType;
+import org.keycloak.dom.saml.v2.protocol.ResponseType;
+import org.keycloak.protocol.ProtocolMapperUtils;
+import org.keycloak.protocol.saml.SamlConfigAttributes;
+import org.keycloak.protocol.saml.mappers.NameIdMapperHelper;
+import org.keycloak.protocol.saml.mappers.UserAttributeNameIdMapper;
+import org.keycloak.saml.common.constants.JBossSAMLURIConstants;
+import org.keycloak.saml.processing.core.saml.v2.common.SAMLDocumentHolder;
+import org.keycloak.testsuite.updaters.ClientAttributeUpdater;
+import org.keycloak.testsuite.updaters.ProtocolMappersUpdater;
+import org.keycloak.testsuite.util.SamlClientBuilder;
+import org.keycloak.testsuite.util.SamlClient.Binding;
+
+import static org.junit.Assert.assertEquals;
+import static org.keycloak.testsuite.saml.RoleMapperTest.createSamlProtocolMapper;
+import static org.keycloak.testsuite.util.ServerURLs.AUTH_SERVER_PORT;
+import static org.keycloak.testsuite.util.ServerURLs.AUTH_SERVER_SCHEME;
+import static org.keycloak.testsuite.util.ServerURLs.AUTH_SERVER_SSL_REQUIRED;
+
+import java.io.IOException;
+
+public class NameIdMapperTest extends AbstractSamlTest {
+
+    public static final String SAML_ASSERTION_CONSUMER_URL_EMPLOYEE_2 = AUTH_SERVER_SCHEME + "://localhost:"
+            + (AUTH_SERVER_SSL_REQUIRED ? AUTH_SERVER_PORT : 8080) + "/employee2/";
+
+    private ClientAttributeUpdater cau;
+    private ProtocolMappersUpdater pmu;
+
+    @Before
+    public void setNameIdConfigAndCleanMappers() {
+        this.cau = ClientAttributeUpdater.forClient(adminClient, REALM_NAME, SAML_CLIENT_ID_EMPLOYEE_2)
+                        .setAttribute(SamlConfigAttributes.SAML_NAME_ID_FORMAT_ATTRIBUTE, "username")
+                        .setAttribute(SamlConfigAttributes.SAML_FORCE_NAME_ID_FORMAT_ATTRIBUTE, "true").update();
+        this.pmu = cau.protocolMappers().clear().update();
+    }
+
+    @After
+    public void revertCleanMappersAndScopes() throws IOException {
+            this.pmu.close();
+            this.cau.close();
+    }
+
+    @Test
+    public void testNameIdMapper() {
+        pmu.add(createSamlProtocolMapper(UserAttributeNameIdMapper.PROVIDER_ID, 
+                NameIdMapperHelper.MAPPER_NAMEID_FORMAT, JBossSAMLURIConstants.NAMEID_FORMAT_UNSPECIFIED.get(),
+                ProtocolMapperUtils.USER_ATTRIBUTE,"email"))
+                .update();
+        testExpectedNameId(bburkeUser.getEmail());
+    }
+
+    @Test
+    public void testNameIdMapperNotFound() {
+        pmu.add(createSamlProtocolMapper(UserAttributeNameIdMapper.PROVIDER_ID,
+                NameIdMapperHelper.MAPPER_NAMEID_FORMAT, JBossSAMLURIConstants.NAMEID_FORMAT_EMAIL.get(),
+                ProtocolMapperUtils.USER_ATTRIBUTE, "email"))
+                .update();
+        testExpectedNameId(bburkeUser.getUsername());
+    }
+
+    @Test
+    public void testNameIdMapperValueIsNull() {
+        pmu.add(createSamlProtocolMapper(UserAttributeNameIdMapper.PROVIDER_ID, 
+                NameIdMapperHelper.MAPPER_NAMEID_FORMAT, JBossSAMLURIConstants.NAMEID_FORMAT_UNSPECIFIED.get(),
+                ProtocolMapperUtils.USER_ATTRIBUTE,"keycloak"))
+                .update();
+        testExpectedStatusCode(JBossSAMLURIConstants.STATUS_INVALID_NAMEIDPOLICY.get());
+    }
+
+    private void testExpectedNameId(String expectedNameId) {
+        ResponseType rt = getSamlResponseObject();
+        NameIDType nameId = (NameIDType) rt.getAssertions().get(0).getAssertion().getSubject().getSubType().getBaseID();
+        assertEquals(expectedNameId,nameId.getValue());
+        assertEquals(JBossSAMLURIConstants.STATUS_SUCCESS.get(),rt.getStatus().getStatusCode().getValue().toString());
+    }
+
+    private void testExpectedStatusCode(String expectedStatusCode) {
+        assertEquals(expectedStatusCode, 
+                        getSamlResponseObject().getStatus().getStatusCode().getStatusCode().getValue().toString());
+    }
+
+    private ResponseType getSamlResponseObject(){
+        SAMLDocumentHolder document = new SamlClientBuilder()
+                .authnRequest(getAuthServerSamlEndpoint(REALM_NAME), SAML_CLIENT_ID_EMPLOYEE_2,
+                        SAML_ASSERTION_CONSUMER_URL_EMPLOYEE_2, Binding.POST)
+                .build().login().user(bburkeUser).build().getSamlResponse(Binding.POST);
+        return (ResponseType) document.getSamlObject();
+    }
+}

--- a/themes/src/main/resources-community/theme/base/admin/messages/admin-messages_ja.properties
+++ b/themes/src/main/resources-community/theme/base/admin/messages/admin-messages_ja.properties
@@ -343,6 +343,7 @@ force-name-id-format=Name IDフォーマットを強制
 force-name-id-format.tooltip=要求されたNameIDサブジェクト・フォーマットを無視し、管理コンソールで設定された物を使用します。
 name-id-format=Name IDフォーマット
 name-id-format.tooltip=サブジェクトに使用するName IDフォーマットを設定します。
+mapper.nameid.format.tooltip=マッパーを適用するName IDフォーマット
 root-url=ルートURL
 root-url.tooltip=相対URLに追加するルートURLを設定します。
 valid-redirect-uris=有効なリダイレクトURI

--- a/themes/src/main/resources/theme/base/admin/messages/admin-messages_en.properties
+++ b/themes/src/main/resources/theme/base/admin/messages/admin-messages_en.properties
@@ -359,6 +359,7 @@ force-name-id-format=Force Name ID Format
 force-name-id-format.tooltip=Ignore requested NameID subject format and use admin console configured one.
 name-id-format=Name ID Format
 name-id-format.tooltip=The name ID format to use for the subject.
+mapper.nameid.format.tooltip=Name ID Format using Mapper
 root-url=Root URL
 root-url.tooltip=Root URL appended to relative URLs
 valid-redirect-uris=Valid Redirect URIs


### PR DESCRIPTION
https://issues.redhat.com/projects/KEYCLOAK/issues/KEYCLOAK-16918
https://groups.google.com/g/keycloak-dev/c/4ExUdT9rc2g

### SAMLNameIdMapper interface
I created SAMLNameIdMapper interface so that we can add Script mapper etc. in the future.

### SAML Metadata
I do not change NameID Format  in SAML 2.0 Identity Provider Metadata.
I think it is unclear whether NameID will be the expected value.

Docs PR : https://github.com/keycloak/keycloak-documentation/pull/1149