### PR TITLE
KEYCLOAK-17681 Client Policy - Executor : Limiting available period of Request Object with its configuration

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/AbstractClientPoliciesTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/AbstractClientPoliciesTest.java
@@ -865,8 +865,10 @@ public abstract class AbstractClientPoliciesTest extends AbstractKeycloakTest {
         return config;
     }
 
-    protected Object createSecureRequestObjectExecutorConfig() {
-        return new SecureRequestObjectExecutor.Configuration();
+    protected Object createSecureRequestObjectExecutorConfig(Integer availablePeriod) {
+        SecureRequestObjectExecutor.Configuration config = new SecureRequestObjectExecutor.Configuration();
+        if (availablePeriod != null) config.setAvailablePeriod(availablePeriod);
+        return config;
     }
 
     protected Object createSecureResponseTypeExecutorConfig() {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientPoliciesTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientPoliciesTest.java
@@ -912,11 +912,12 @@ public class ClientPoliciesTest extends AbstractClientPoliciesTest {
 
     @Test
     public void testSecureRequestObjectExecutor() throws Exception, URISyntaxException, IOException {
+        Integer availablePeriod = Integer.valueOf(SecureRequestObjectExecutor.DEFAULT_AVAILABLE_PERIOD + 400);
         // register profiles
         String json = (new ClientProfilesBuilder()).addProfile(
                 (new ClientProfileBuilder()).createProfile(PROFILE_NAME, "Prvy Profil", Boolean.FALSE, null)
                     .addExecutor(SecureRequestObjectExecutorFactory.PROVIDER_ID, 
-                        createSecureRequestObjectExecutorConfig())
+                        createSecureRequestObjectExecutorConfig(availablePeriod))
                     .toRepresentation()
                 ).toString();
         updateProfiles(json);
@@ -1000,7 +1001,7 @@ public class ClientPoliciesTest extends AbstractClientPoliciesTest {
 
         // check whether request object's available period is short
         requestObject = createValidRequestObjectForSecureRequestObjectExecutor(clientId);
-        requestObject.exp(requestObject.getNbf() + 3601);
+        requestObject.exp(requestObject.getNbf() + availablePeriod.intValue() + 1);
         registerRequestObject(requestObject, clientId, Algorithm.ES256, false);
         oauth.openLoginForm();
         assertEquals(SecureRequestObjectExecutor.INVALID_REQUEST_OBJECT, oauth.getCurrentQuery().get(OAuth2Constants.ERROR));


### PR DESCRIPTION
This PR is for [KEYCLOAK-13933 Client Policies](https://issues.redhat.com/browse/KEYCLOAK-13933), also is the part of [FAPI-SIG](https://github.com/keycloak/kc-sig-fapi) activity. 

The details can be found in its [design document](https://github.com/keycloak/keycloak-community/blob/master/design/client-policies.md) and [KEYCLOAK-17681](https://issues.redhat.com/browse/KEYCLOAK-17681) and it is the follow-up task for [KEYCLOAK-17666](https://issues.redhat.com/browse/KEYCLOAK-17666).
