### PR TITLE
KEYCLOAK-17682 Client Policy - Executor : remove inner config class for executor without any config

### DIFF
--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureRedirectUriEnforceExecutor.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureRedirectUriEnforceExecutor.java
@@ -32,8 +32,6 @@ import org.keycloak.services.clientpolicy.context.ClientCRUDContext;
 import org.keycloak.services.clientpolicy.context.DynamicClientRegisterContext;
 import org.keycloak.services.clientpolicy.context.DynamicClientUpdateContext;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-
 /**
  * @author <a href="mailto:takashi.norimatsu.ws@hitachi.com">Takashi Norimatsu</a>
  */
@@ -45,10 +43,6 @@ public class SecureRedirectUriEnforceExecutor implements ClientPolicyExecutorPro
 
     public SecureRedirectUriEnforceExecutor(KeycloakSession session) {
         this.session = session;
-    }
-
-    @JsonIgnoreProperties(ignoreUnknown = true)
-    public static class Configuration {
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureResponseTypeExecutor.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureResponseTypeExecutor.java
@@ -26,8 +26,6 @@ import org.keycloak.services.clientpolicy.ClientPolicyContext;
 import org.keycloak.services.clientpolicy.ClientPolicyException;
 import org.keycloak.services.clientpolicy.context.AuthorizationRequestContext;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-
 /**
  * @author <a href="mailto:takashi.norimatsu.ws@hitachi.com">Takashi Norimatsu</a>
  */
@@ -39,10 +37,6 @@ public class SecureResponseTypeExecutor implements ClientPolicyExecutorProvider<
 
     public SecureResponseTypeExecutor(KeycloakSession session) {
         this.session = session;
-    }
-
-    @JsonIgnoreProperties(ignoreUnknown = true)
-    public static class Configuration {
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureSessionEnforceExecutor.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureSessionEnforceExecutor.java
@@ -27,8 +27,6 @@ import org.keycloak.services.clientpolicy.ClientPolicyException;
 import org.keycloak.services.clientpolicy.context.AuthorizationRequestContext;
 import org.keycloak.util.TokenUtil;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-
 /**
  * @author <a href="mailto:takashi.norimatsu.ws@hitachi.com">Takashi Norimatsu</a>
  */
@@ -40,10 +38,6 @@ public class SecureSessionEnforceExecutor implements ClientPolicyExecutorProvide
 
     public SecureSessionEnforceExecutor(KeycloakSession session) {
         this.session = session;
-    }
-
-    @JsonIgnoreProperties(ignoreUnknown = true)
-    public static class Configuration {
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureSigningAlgorithmEnforceExecutor.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureSigningAlgorithmEnforceExecutor.java
@@ -34,8 +34,6 @@ import org.keycloak.services.clientpolicy.context.AdminClientUpdateContext;
 import org.keycloak.services.clientpolicy.context.DynamicClientRegisterContext;
 import org.keycloak.services.clientpolicy.context.DynamicClientUpdateContext;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-
 /**
  * @author <a href="mailto:takashi.norimatsu.ws@hitachi.com">Takashi Norimatsu</a>
  */
@@ -56,10 +54,6 @@ public class SecureSigningAlgorithmEnforceExecutor implements ClientPolicyExecut
 
     public SecureSigningAlgorithmEnforceExecutor(KeycloakSession session) {
         this.session = session;
-    }
-
-    @JsonIgnoreProperties(ignoreUnknown = true)
-    public static class Configuration {
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureSigningAlgorithmForSignedJwtEnforceExecutor.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureSigningAlgorithmForSignedJwtEnforceExecutor.java
@@ -28,8 +28,6 @@ import org.keycloak.models.KeycloakSession;
 import org.keycloak.services.clientpolicy.ClientPolicyContext;
 import org.keycloak.services.clientpolicy.ClientPolicyException;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-
 public class SecureSigningAlgorithmForSignedJwtEnforceExecutor implements ClientPolicyExecutorProvider<ClientPolicyExecutorConfiguration> {
 
     private static final Logger logger = Logger.getLogger(SecureSigningAlgorithmForSignedJwtEnforceExecutor.class);
@@ -38,10 +36,6 @@ public class SecureSigningAlgorithmForSignedJwtEnforceExecutor implements Client
 
     public SecureSigningAlgorithmForSignedJwtEnforceExecutor(KeycloakSession session) {
         this.session = session;
-    }
-
-    @JsonIgnoreProperties(ignoreUnknown = true)
-    public static class Configuration {
     }
 
     @Override

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/AbstractClientPoliciesTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/AbstractClientPoliciesTest.java
@@ -869,26 +869,6 @@ public abstract class AbstractClientPoliciesTest extends AbstractKeycloakTest {
         return new SecureRequestObjectExecutor.Configuration();
     }
 
-    protected Object createSecureResponseTypeExecutorConfig() {
-        return new SecureResponseTypeExecutor.Configuration();
-    }
-
-    protected Object createSecureRedirectUriEnforceExecutorConfig() {
-        return new SecureRedirectUriEnforceExecutor.Configuration();
-    }
-
-    protected Object createSecureSessionEnforceExecutorConfig() {
-        return new SecureSessionEnforceExecutor.Configuration();
-    }
-
-    protected Object createSecureSigningAlgorithmEnforceExecutorConfig() {
-        return new SecureSigningAlgorithmEnforceExecutor.Configuration();
-    }
-
-    protected Object createSecureSigningAlgorithmForSignedJwtEnforceExecutorConfig() {
-        return new SecureSigningAlgorithmForSignedJwtEnforceExecutor.Configuration();
-    }
-
     // Client Policies CRUD Operation
 
     protected static class ClientPoliciesBuilder {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientPoliciesTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientPoliciesTest.java
@@ -541,8 +541,7 @@ public class ClientPoliciesTest extends AbstractClientPoliciesTest {
         // register profiles
         String json = (new ClientProfilesBuilder()).addProfile(
                 (new ClientProfileBuilder()).createProfile(PROFILE_NAME, "Le Premier Profil", Boolean.FALSE, null)
-                    .addExecutor(SecureSessionEnforceExecutorFactory.PROVIDER_ID, 
-                        createSecureSessionEnforceExecutorConfig())
+                    .addExecutor(SecureSessionEnforceExecutorFactory.PROVIDER_ID, null)
                     .toRepresentation()
                 ).toString();
         updateProfiles(json);
@@ -808,8 +807,7 @@ public class ClientPoliciesTest extends AbstractClientPoliciesTest {
         // register profiles
         String json = (new ClientProfilesBuilder()).addProfile(
                 (new ClientProfileBuilder()).createProfile(PROFILE_NAME, "El Primer Perfil", Boolean.FALSE, null)
-                    .addExecutor(SecureSessionEnforceExecutorFactory.PROVIDER_ID, 
-                        createSecureSessionEnforceExecutorConfig())
+                    .addExecutor(SecureSessionEnforceExecutorFactory.PROVIDER_ID, null)
                     .toRepresentation()
                 ).toString();
         updateProfiles(json);
@@ -848,8 +846,7 @@ public class ClientPoliciesTest extends AbstractClientPoliciesTest {
         // register profiles
         String json = (new ClientProfilesBuilder()).addProfile(
                 (new ClientProfileBuilder()).createProfile(PROFILE_NAME, "O Primeiro Perfil", Boolean.FALSE, null)
-                    .addExecutor(SecureResponseTypeExecutorFactory.PROVIDER_ID, 
-                        createSecureResponseTypeExecutorConfig())
+                    .addExecutor(SecureResponseTypeExecutorFactory.PROVIDER_ID, null)
                     .toRepresentation()
                 ).toString();
         updateProfiles(json);
@@ -1043,8 +1040,7 @@ public class ClientPoliciesTest extends AbstractClientPoliciesTest {
         // register profiles
         String json = (new ClientProfilesBuilder()).addProfile(
                 (new ClientProfileBuilder()).createProfile(PROFILE_NAME, "Den Forste Profilen", Boolean.FALSE, null)
-                    .addExecutor(SecureSessionEnforceExecutorFactory.PROVIDER_ID, 
-                        createSecureSessionEnforceExecutorConfig())
+                    .addExecutor(SecureSessionEnforceExecutorFactory.PROVIDER_ID, null)
                     .toRepresentation()
                 ).toString();
         updateProfiles(json);
@@ -1099,8 +1095,7 @@ public class ClientPoliciesTest extends AbstractClientPoliciesTest {
         // register profiles
         String json = (new ClientProfilesBuilder()).addProfile(
                 (new ClientProfileBuilder()).createProfile(PROFILE_NAME, "Den Forsta Profilen", Boolean.FALSE, null)
-                    .addExecutor(SecureSigningAlgorithmEnforceExecutorFactory.PROVIDER_ID, 
-                        createSecureSigningAlgorithmEnforceExecutorConfig())
+                    .addExecutor(SecureSigningAlgorithmEnforceExecutorFactory.PROVIDER_ID, null)
                     .toRepresentation()
                 ).toString();
         updateProfiles(json);
@@ -1206,8 +1201,7 @@ public class ClientPoliciesTest extends AbstractClientPoliciesTest {
         // register profiles
         String json = (new ClientProfilesBuilder()).addProfile(
                 (new ClientProfileBuilder()).createProfile(PROFILE_NAME, "Ensimmainen Profiili", Boolean.FALSE, null)
-                    .addExecutor(SecureRedirectUriEnforceExecutorFactory.PROVIDER_ID, 
-                        createSecureRedirectUriEnforceExecutorConfig())
+                    .addExecutor(SecureRedirectUriEnforceExecutorFactory.PROVIDER_ID, null)
                     .toRepresentation()
                 ).toString();
         updateProfiles(json);
@@ -1258,8 +1252,7 @@ public class ClientPoliciesTest extends AbstractClientPoliciesTest {
         // register profiles
         String json = (new ClientProfilesBuilder()).addProfile(
                 (new ClientProfileBuilder()).createProfile(PROFILE_NAME, "Ensimmainen Profiili", Boolean.FALSE, null)
-                    .addExecutor(SecureSigningAlgorithmForSignedJwtEnforceExecutorFactory.PROVIDER_ID, 
-                        createSecureSigningAlgorithmForSignedJwtEnforceExecutorConfig())
+                    .addExecutor(SecureSigningAlgorithmForSignedJwtEnforceExecutorFactory.PROVIDER_ID, null)
                     .toRepresentation()
                 ).toString();
         updateProfiles(json);
@@ -1382,7 +1375,7 @@ public class ClientPoliciesTest extends AbstractClientPoliciesTest {
         // register profiles
         String json = (new ClientProfilesBuilder()).addProfile(
                 (new ClientProfileBuilder()).createProfile(PROFILE_NAME, "Den Forste Profilen", Boolean.FALSE, null)
-                    .addExecutor(SecureSessionEnforceExecutorFactory.PROVIDER_ID, createSecureSessionEnforceExecutorConfig())
+                    .addExecutor(SecureSessionEnforceExecutorFactory.PROVIDER_ID, null)
                     .toRepresentation()
                 ).toString();
         updateProfiles(json);


### PR DESCRIPTION
This PR is for [KEYCLOAK-13933 Client Policies](https://issues.redhat.com/browse/KEYCLOAK-13933), also is the part of [FAPI-SIG](https://github.com/keycloak/kc-sig-fapi) activity. 

The details can be found in [KEYCLOAK-17682](https://issues.redhat.com/browse/KEYCLOAK-17682).

