### PR TITLE
KEYCLOAK-17684: fix TypeScript definition of createAccountUrl parameter

### DIFF
--- a/adapters/oidc/js/src/main/resources/keycloak.d.ts
+++ b/adapters/oidc/js/src/main/resources/keycloak.d.ts
@@ -248,6 +248,13 @@ declare namespace Keycloak {
 	}
 
 	interface KeycloakRegisterOptions extends Omit<KeycloakLoginOptions, 'action'> { }
+	
+	interface KeycloakAccountOptions {
+		/**
+		 * Specifies the uri to redirect to when redirecting back to the application.
+		 */
+		redirectUri?: string;	
+	}
 
 	type KeycloakPromiseCallback<T> = (result: T) => void;
 
@@ -529,8 +536,9 @@ declare namespace Keycloak {
 
 		/**
 		 * Returns the URL to the Account Management Console.
+		 * @param options The options used for creating the account URL.
 		 */
-		createAccountUrl(): string;
+		createAccountUrl(options?: KeycloakAccountOptions): string;
 
 		/**
 		 * Returns true if the token has less than `minValidity` seconds left before


### PR DESCRIPTION
<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
