### PR TITLE
KEYCLOAK-17685 - Add a javascript identity provider mapper

### DIFF
--- a/core/src/main/java/org/keycloak/representations/provider/ScriptProviderDescriptor.java
+++ b/core/src/main/java/org/keycloak/representations/provider/ScriptProviderDescriptor.java
@@ -32,6 +32,7 @@ public class ScriptProviderDescriptor {
     public static final String MAPPERS = "mappers";
 
     public static final String SAML_MAPPERS = "saml-mappers";
+    public static final String SAML_IDP_MAPPERS = "saml-idp-mappers";
 
     private Map<String, List<ScriptProviderMetadata>> providers = new HashMap<>();
 
@@ -61,6 +62,11 @@ public class ScriptProviderDescriptor {
         providers.put(SAML_MAPPERS, metadata);
     }
 
+    @JsonSetter(SAML_IDP_MAPPERS)
+    public void setSAMLIdPMappers(List<ScriptProviderMetadata> metadata) {
+        providers.put(SAML_IDP_MAPPERS, metadata);
+    }
+
     public void addAuthenticator(String name, String fileName) {
         addProvider(AUTHENTICATORS, name, fileName, null);
     }
@@ -86,5 +92,9 @@ public class ScriptProviderDescriptor {
 
     public void addSAMLMapper(String name, String fileName) {
         addProvider(SAML_MAPPERS, name, fileName, null);
+    }
+
+    public void addSAMLIdPMapper(String name, String fileName) {
+        addProvider(SAML_IDP_MAPPERS, name, fileName, null);
     }
 }

--- a/services/src/main/java/org/keycloak/broker/provider/DeployedIdPScriptMapper.java
+++ b/services/src/main/java/org/keycloak/broker/provider/DeployedIdPScriptMapper.java
@@ -1,0 +1,54 @@
+package org.keycloak.broker.provider;
+
+import org.keycloak.models.IdentityProviderMapperModel;
+import org.keycloak.representations.provider.ScriptProviderMetadata;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.keycloak.provider.ProviderConfigProperty;
+
+public class DeployedIdPScriptMapper extends ScriptMapper{
+    protected ScriptProviderMetadata metadata;
+
+    public DeployedIdPScriptMapper(ScriptProviderMetadata metadata) {
+        this.metadata = metadata;
+    }
+
+    public DeployedIdPScriptMapper() {
+        // for reflection
+    }
+
+    @Override
+    public String getId() {
+        return metadata.getId();
+    }
+
+    @Override
+    public String getDisplayType() {
+        return metadata.getName();
+    }
+
+    @Override
+    public String getHelpText() {
+        return metadata.getDescription();
+    }
+
+    @Override
+    protected String getScriptCode(IdentityProviderMapperModel mapperModel) {
+        return metadata.getCode();
+    }
+
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return super.getConfigProperties().stream()
+                .filter(providerConfigProperty -> !ProviderConfigProperty.SCRIPT_TYPE.equals(providerConfigProperty.getName())) // filter "script" property
+                .collect(Collectors.toList());
+    }
+
+    public void setMetadata(ScriptProviderMetadata metadata) {
+        this.metadata = metadata;
+    }
+
+    public ScriptProviderMetadata getMetadata() {
+        return metadata;
+    }
+}

--- a/services/src/main/java/org/keycloak/broker/provider/ScriptMapper.java
+++ b/services/src/main/java/org/keycloak/broker/provider/ScriptMapper.java
@@ -1,0 +1,137 @@
+package org.keycloak.broker.provider;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.jboss.logging.Logger;
+import org.keycloak.models.IdentityProviderMapperModel;
+import org.keycloak.models.IdentityProviderSyncMode;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.ScriptModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.scripting.EvaluatableScriptAdapter;
+import org.keycloak.scripting.ScriptingProvider;
+
+
+public class ScriptMapper extends AbstractIdentityProviderMapper {
+
+    private static final List<ProviderConfigProperty> configProperties;
+    public static final String PROVIDER_ID = "javascript-idp-mapper";
+    public static final String SINGLE_VALUE_ATTRIBUTE = "single";
+    private static final Logger LOGGER = Logger.getLogger(ScriptMapper.class);
+    public static final String[] COMPATIBLE_PROVIDERS = {ANY_PROVIDER};
+    private static final Set<IdentityProviderSyncMode> IDENTITY_PROVIDER_SYNC_MODES = new HashSet<>(Arrays.asList(IdentityProviderSyncMode.values()));
+
+
+    /*
+     * This static property block is used to determine the elements available to the mapper. This is determinant
+     * both for the frontend (gui elements in the mapper) and for the backend.
+     */
+    static {
+        configProperties = new ArrayList<>();
+        ProviderConfigProperty property = new ProviderConfigProperty();
+        property.setType(ProviderConfigProperty.SCRIPT_TYPE);
+        property.setLabel(ProviderConfigProperty.SCRIPT_TYPE);
+        property.setName(ProviderConfigProperty.SCRIPT_TYPE);
+        property.setHelpText(
+                "Script to compute the attribute value. \n" + //
+                        " Available variables: \n" + //
+                        " 'realm' - the current realm.\n" + //
+                        " 'brokeredIdentityContext' - the brokeredIdentityContext (contains info about idp, mapper, saml assertion, claims).\n" + //
+                        " 'keycloakSession' - the current keycloakSession.\n" + //
+                        " 'userModel' - User model.\\n\n" //
+        );
+        property.setDefaultValue("/*\n" +
+                "  Available variables: \n" +
+                "    realmModel - the current realm\n" +
+                "    brokeredIdentityContext - the brokeredIdentityContext (contains info about idp, mapper, saml assertion, claims)\n" +
+                "    keycloakSession - the current keycloakSession\n" +
+                "    userModel - the userModel, if this is not the first login of the user. If it's the first login of the user, this variable is null\n\n" +
+                "  If the userModel is null, you should set the user attribute on the brokeredIdentityContext. i.e.: \n" +
+                "    brokeredIdentityContext.setUserAttribute('my-attrib', 'attribval'); \n" +
+                "  if the userModel is not null, then it's an update on an existing user, so add the user attribute on userModel. i.e: \n" +
+                "    userModel.setSingleAttribute('my-attrib', 'newattribval') */ \n\n" +
+                "//Insert your code below... \n"
+        );
+        configProperties.add(property);
+
+        property = new ProviderConfigProperty();
+        property.setName(SINGLE_VALUE_ATTRIBUTE);
+        property.setLabel("Single Value Attribute");
+        property.setType(ProviderConfigProperty.BOOLEAN_TYPE);
+        property.setDefaultValue("true");
+        property.setHelpText("If true, all values will be stored under one attribute with multiple attribute values.");
+        configProperties.add(property);
+
+    }
+
+    @Override
+    public boolean supportsSyncMode(IdentityProviderSyncMode syncMode) {
+        return IDENTITY_PROVIDER_SYNC_MODES.contains(syncMode);
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return configProperties;
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public String[] getCompatibleProviders() {
+        return COMPATIBLE_PROVIDERS;
+    }
+
+    @Override
+    public String getDisplayCategory() {
+        return "Javascript Mapper";
+    }
+
+    @Override
+    public String getDisplayType() {
+        return "Javascript Mapper";
+    }
+
+    @Override
+    public void preprocessFederatedIdentity(KeycloakSession session, RealmModel realm, IdentityProviderMapperModel mapperModel, BrokeredIdentityContext context) {
+        updateBrokeredUser(session, realm, null, mapperModel, context);
+    }
+
+    @Override
+    public void updateBrokeredUser(KeycloakSession session, RealmModel realm, UserModel user, IdentityProviderMapperModel mapperModel, BrokeredIdentityContext context) {
+
+        String scriptSource = mapperModel.getConfig().get(ProviderConfigProperty.SCRIPT_TYPE);
+
+        ScriptingProvider scripting = session.getProvider(ScriptingProvider.class);
+        ScriptModel scriptModel = scripting.createScript(realm.getId(), ScriptModel.TEXT_JAVASCRIPT, "idp2user-attribute-mapper-script_" + mapperModel.getName(), scriptSource, null);
+
+        EvaluatableScriptAdapter script = scripting.prepareEvaluatableScript(scriptModel);
+        try {
+            script.eval(bindings -> {
+                bindings.put("realmModel", realm);
+                bindings.put("keycloakSession", session);
+                bindings.put("brokeredIdentityContext", context);
+                bindings.put("userModel", user);
+            });
+        } catch (Exception ex) {
+            LOGGER.error(String.format("Error during execution of ScriptMapper's javascript (realm: %s, idp_mapper:  %s)", realm.getName(), mapperModel.getName()), ex);
+        }
+
+    }
+
+    @Override
+    public String getHelpText() {
+        return "Write a custom script to create the desired mapper. i.e perform conditional mapping, attribute aggregations, etc";
+    }
+
+
+}
+

--- a/services/src/main/resources/META-INF/services/org.keycloak.broker.provider.IdentityProviderMapper
+++ b/services/src/main/resources/META-INF/services/org.keycloak.broker.provider.IdentityProviderMapper
@@ -19,7 +19,6 @@ org.keycloak.broker.provider.HardcodedGroupMapper
 org.keycloak.broker.provider.HardcodedRoleMapper
 org.keycloak.broker.provider.HardcodedAttributeMapper
 org.keycloak.broker.provider.HardcodedUserSessionAttributeMapper
-org.keycloak.broker.provider.ScriptMapper
 org.keycloak.broker.oidc.mappers.ClaimToRoleMapper
 org.keycloak.broker.oidc.mappers.AdvancedClaimToRoleMapper
 org.keycloak.broker.oidc.mappers.AdvancedClaimToGroupMapper

--- a/services/src/main/resources/META-INF/services/org.keycloak.broker.provider.IdentityProviderMapper
+++ b/services/src/main/resources/META-INF/services/org.keycloak.broker.provider.IdentityProviderMapper
@@ -19,6 +19,7 @@ org.keycloak.broker.provider.HardcodedGroupMapper
 org.keycloak.broker.provider.HardcodedRoleMapper
 org.keycloak.broker.provider.HardcodedAttributeMapper
 org.keycloak.broker.provider.HardcodedUserSessionAttributeMapper
+org.keycloak.broker.provider.ScriptMapper
 org.keycloak.broker.oidc.mappers.ClaimToRoleMapper
 org.keycloak.broker.oidc.mappers.AdvancedClaimToRoleMapper
 org.keycloak.broker.oidc.mappers.AdvancedClaimToGroupMapper

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/IdentityProviderTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/IdentityProviderTest.java
@@ -610,6 +610,7 @@ public class IdentityProviderTest extends AbstractAdminTest {
         expected.add("oidc-hardcoded-group-idp-mapper");
         expected.add("hardcoded-attribute-idp-mapper");
         expected.add("multi-valued-test-idp-mapper");
+        expected.add("javascript-idp-mapper");
         expected.addAll(Arrays.asList(mapperIds));
 
         Assert.assertEquals("mapperTypes", expected, mapperTypes.keySet());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/SamlJavascriptIdentityProviderMapperTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/SamlJavascriptIdentityProviderMapperTest.java
@@ -1,0 +1,90 @@
+package org.keycloak.testsuite.broker;
+
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Test;
+import org.keycloak.admin.client.resource.IdentityProviderResource;
+import org.keycloak.broker.provider.ScriptMapper;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.representations.idm.IdentityProviderMapperRepresentation;
+import org.keycloak.representations.idm.IdentityProviderRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+
+import java.util.HashMap;
+
+import static org.junit.Assert.assertTrue;
+
+public class SamlJavascriptIdentityProviderMapperTest extends AbstractIdentityProviderMapperTest {
+
+    private static String USER_ATTRIBUTE = "identifier";
+    private static String DELIMITER = "@";
+
+
+    private static String SIMPLE_SCRIPT_TEXT = "brokeredIdentityContext.setUserAttribute('custom-attr','custom-value');";
+
+    private static String COMPLEX_SCRIPT_TEXT =
+            "var idp_alias = brokeredIdentityContext.getIdpConfig().getAlias();\n" +
+            "var username = brokeredIdentityContext.getUsername();\n" +
+            "brokeredIdentityContext.setUserAttribute('"+USER_ATTRIBUTE+"', username+'"+DELIMITER+"'+idp_alias);";
+
+
+    @Test
+    public void testSimple(){
+        final IdentityProviderRepresentation idp = setupIdentityProvider();
+        final IdentityProviderMapperRepresentation idpMapper = getSimpleJavascriptMapper();
+        addIdPMapperToIdp(idp, idpMapper);
+        createUserInProviderRealm(new HashMap<>());
+        logInAsUserInIDPForFirstTime();
+        UserRepresentation user = findUser(bc.consumerRealmName(), bc.getUserLogin(), bc.getUserEmail());
+        assertTrue(user.getAttributes().get("custom-attr").contains("custom-value"));
+
+    }
+
+
+    @Test
+    public void testComplex(){
+        final IdentityProviderRepresentation idp = setupIdentityProvider();
+        final IdentityProviderMapperRepresentation idpMapper = getComplexJavascriptMapper();
+        addIdPMapperToIdp(idp, idpMapper);
+        createUserInProviderRealm(new HashMap<>());
+        logInAsUserInIDPForFirstTime();
+        UserRepresentation user = findUser(bc.consumerRealmName(), bc.getUserLogin(), bc.getUserEmail());
+        assertTrue(user.getAttributes().get(USER_ATTRIBUTE).contains(BrokerTestConstants.USER_LOGIN + DELIMITER + BrokerTestConstants.IDP_SAML_ALIAS));
+
+    }
+
+
+    private IdentityProviderMapperRepresentation getSimpleJavascriptMapper(){
+        IdentityProviderMapperRepresentation jsSamlIdPMapper = new IdentityProviderMapperRepresentation();
+        jsSamlIdPMapper.setName("javascript-saml-idp-mapper");
+        jsSamlIdPMapper.setIdentityProviderMapper(ScriptMapper.PROVIDER_ID);
+        jsSamlIdPMapper.setConfig(ImmutableMap.<String,String>builder()
+                .put(ProviderConfigProperty.SCRIPT_TYPE, SIMPLE_SCRIPT_TEXT)
+                .put(ScriptMapper.SINGLE_VALUE_ATTRIBUTE, "true")
+                .build());
+        return jsSamlIdPMapper;
+    }
+
+    private IdentityProviderMapperRepresentation getComplexJavascriptMapper(){
+        IdentityProviderMapperRepresentation jsSamlIdPMapper = new IdentityProviderMapperRepresentation();
+        jsSamlIdPMapper.setName("javascript-saml-idp-mapper");
+        jsSamlIdPMapper.setIdentityProviderMapper(ScriptMapper.PROVIDER_ID);
+        jsSamlIdPMapper.setConfig(ImmutableMap.<String,String>builder()
+                .put(ProviderConfigProperty.SCRIPT_TYPE, COMPLEX_SCRIPT_TEXT)
+                .put(ScriptMapper.SINGLE_VALUE_ATTRIBUTE, "true")
+                .build());
+        return jsSamlIdPMapper;
+    }
+
+    private void addIdPMapperToIdp(IdentityProviderRepresentation idp, IdentityProviderMapperRepresentation jsSamlIdPMapper){
+        IdentityProviderResource idpResource = realm.identityProviders().get(idp.getAlias());
+        jsSamlIdPMapper.setIdentityProviderAlias(bc.getIDPAlias());
+        idpResource.addMapper(jsSamlIdPMapper).close();
+    }
+
+    @Override
+    protected BrokerConfiguration getBrokerConfiguration() {
+        return new KcSamlBrokerConfiguration();
+    }
+
+}


### PR DESCRIPTION
Currently, keycloak has a script mapper only on the Client side. This type of mapper is very useful when you want to perform a customized mapping, not covered from the other mappings. For instance, if you want to perform a conditional mapping - if this, map using attribA, otherwise map using attribB. or want to have a mapping with perplex concatenations, etc. We have implemented the same "script mapper" for the IdentityProvider side. 
We use this mapper in our installations, with javascript code to perform such complex mapping scenarios, which cannot be done using any of the existing mapper(s).
We think it's a very handy tool and we would like to contribute this to the community.