### PR TITLE
KEYCLOAK-17689 - Add the same defaultValue property loading mechanism of client mappers to IdP mappers (console UI)

### DIFF
--- a/themes/src/main/resources/theme/base/admin/resources/js/controllers/realm.js
+++ b/themes/src/main/resources/theme/base/admin/resources/js/controllers/realm.js
@@ -2756,7 +2756,27 @@ module.controller('IdentityProviderMapperCreateCtrl', function ($scope, realm, i
         $scope.path = $location.path().substring(1).split("/");
     });
 
-    $scope.save = function () {
+    // apply default configurations on change for selected protocolmapper type.
+    $scope.$watch('mapperType', function() {
+
+        var currentMapperType = $scope.mapperType;
+        var defaultConfig = {};
+
+        if (currentMapperType && Array.isArray(currentMapperType.properties)) {
+            for (var i = 0; i < currentMapperType.properties.length; i++) {
+                var property = currentMapperType.properties[i];
+                if (property && property.name && property.defaultValue) {
+                    defaultConfig[property.name] = property.defaultValue;
+                }
+            }
+        }
+
+        $scope.mapper.config = defaultConfig;
+        $scope.mapper.config.syncMode = 'INHERIT';
+    }, true);
+
+
+    $scope.save = function() {
         $scope.mapper.identityProviderMapper = $scope.mapperType.id;
         let copyMapper = angular.copy($scope.mapper);
         ComponentUtils.convertAllListValuesToMultivaluedString($scope.mapperType.properties, copyMapper.config);


### PR DESCRIPTION
The mappers have a  ProviderConfigProperty which defines their additional properties (for both UI and backend). One of the parameters this class has is the "defaultValue". This  can be set for both the client and the identity provider mapper config properties. The "defaultValue" is intended to be used as the default value of the property, whenever the keycloak admin tries to create a new mapper of that kind. 
For the client mappers there is some angular.js code to load the default value of the properties of the selected mapper, but  that doesn't happen for the Identity Provider mappers. The code just ignores the fact that someone might have set a defaultValue for the property.
We added the exact same logic for IdP mapper default values, borrowed from the client mappers and we are contributing this to the community.