### PR TITLE
KEYCLOAK-17734 LifespanAdapterTest fails due to header check

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/example/authorization/LifespanAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/example/authorization/LifespanAdapterTest.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.hamcrest.Matchers;
@@ -155,7 +156,15 @@ public class LifespanAdapterTest extends AbstractPhotozExampleAdapterTest {
         clientPage.viewProfile((ResponseValidator) response -> {
             Object headers = response.get("responseHeaders");
             assertThat(headers, Matchers.notNullValue());
-            assertThat(headers.toString(), Matchers.containsString("WWW-Authenticate: UMA"));
+
+            List<String> headersList = Arrays.asList(headers.toString().split("\r\n"));
+            String wwwAuthenticate = headersList.stream()
+                    .filter(s -> s.toLowerCase().startsWith("www-authenticate:"))
+                    .findFirst()
+                    .orElse(null);
+
+            assertThat(wwwAuthenticate, Matchers.notNullValue());
+            assertThat(wwwAuthenticate, Matchers.containsString("UMA"));
         });
     }
 


### PR DESCRIPTION
JIRA: [KEYCLOAK-17734](https://issues.redhat.com/browse/KEYCLOAK-17734)

With this fix, it's not failing in the adapter pipeline anymore.
https://keycloak-jenkins.com/job/universal-test-pipeline-adapters/149/testReport/