### PR TITLE
KEYCLOAK-17784: URL encode Keycloak's remember-me cookie to allow non-ascii usernames.

### DIFF
--- a/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
@@ -88,7 +88,10 @@ import javax.ws.rs.core.NewCookie;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
+import java.io.UnsupportedEncodingException;
 import java.net.URI;
+import java.net.URLEncoder;
+import java.net.URLDecoder;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
@@ -698,7 +701,11 @@ public class AuthenticationManager {
         boolean secureOnly = realm.getSslRequired().isRequired(connection);
         // remember me cookie should be persistent (hardcoded to 365 days for now)
         //NewCookie cookie = new NewCookie(KEYCLOAK_REMEMBER_ME, "true", path, null, null, realm.getCentralLoginLifespan(), secureOnly);// todo httponly , true);
-        CookieHelper.addCookie(KEYCLOAK_REMEMBER_ME, "username:" + username, path, null, null, 31536000, secureOnly, true);
+        try {
+            CookieHelper.addCookie(KEYCLOAK_REMEMBER_ME, "username:" + URLEncoder.encode(username, "UTF-8"), path, null, null, 31536000, secureOnly, true);
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException("Failed to urlencode", e);
+        }
     }
 
     public static String getRememberMeUsername(RealmModel realm, HttpHeaders headers) {
@@ -708,7 +715,11 @@ public class AuthenticationManager {
                 String value = cookie.getValue();
                 String[] s = value.split(":");
                 if (s[0].equals("username") && s.length == 2) {
-                    return s[1];
+                    try {
+                        return URLDecoder.decode(s[1], "UTF-8");
+                    } catch (UnsupportedEncodingException e) {
+                        throw new RuntimeException("Failed to urldecode", e);
+                    }
                 }
             }
         }

--- a/testsuite/integration-arquillian/tests/other/console/src/test/java/org/keycloak/testsuite/console/realm/LoginSettingsTest.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/test/java/org/keycloak/testsuite/console/realm/LoginSettingsTest.java
@@ -232,6 +232,44 @@ public class LoginSettingsTest extends AbstractRealmTest {
         
     }
     
+    @Test
+    public void rememberMeWithUtf8Username() {
+        log.info("creating username with non-ASCII username");
+        UserRepresentation utf8TestUser = createUserRepresentation("täst", "test-utf8@email.test", "utf8", "test", true);
+        setPasswordFor(utf8TestUser, PASSWORD);
+
+        log.info("enabling remember me");
+        loginSettingsPage.form().setRememberMeAllowed(true);
+        assertTrue(loginSettingsPage.form().isRememberMeAllowed());
+        loginSettingsPage.form().save();
+        assertAlertSuccess();
+        log.debug("enabled");
+
+        log.info("login with remember me checked");
+        testAccountPage.navigateTo();
+        testRealmLoginPage.form().rememberMe(true);
+        testRealmLoginPage.form().login(utf8TestUser);
+        assertCurrentUrlStartsWith(testAccountPage);
+
+        assertTrue("Cookie KEYCLOAK_REMEMBER_ME should be present.", getCookieNames().contains("KEYCLOAK_REMEMBER_ME"));
+
+        log.info("verified remember me is enabled");
+
+        log.info("disabling remember me");
+        loginSettingsPage.navigateTo();
+        loginSettingsPage.form().setRememberMeAllowed(false);
+        assertFalse(loginSettingsPage.form().isRememberMeAllowed());
+        loginSettingsPage.form().save();
+        assertAlertSuccess();
+        log.debug("disabled");
+
+        testAccountPage.navigateTo();
+        testAccountPage.signOut();
+        assertTrue(testRealmLoginPage.form().isLoginButtonPresent());
+        assertFalse(testRealmLoginPage.form().isRememberMePresent());
+        log.info("verified remember me is disabled");
+    }
+
     @Test 
     public void verifyEmail() {
 

--- a/testsuite/integration-arquillian/tests/other/console/src/test/java/org/keycloak/testsuite/console/realm/LoginSettingsTest.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/test/java/org/keycloak/testsuite/console/realm/LoginSettingsTest.java
@@ -40,7 +40,9 @@ import java.util.Set;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNotNull;
 import static org.keycloak.representations.idm.CredentialRepresentation.PASSWORD;
+import static org.keycloak.testsuite.admin.ApiUtil.createUserWithAdminClient;
 import static org.keycloak.testsuite.admin.ApiUtil.createUserAndResetPasswordWithAdminClient;
 import static org.keycloak.testsuite.admin.Users.setPasswordFor;
 import static org.keycloak.testsuite.util.ServerURLs.AUTH_SERVER_PORT;
@@ -237,6 +239,9 @@ public class LoginSettingsTest extends AbstractRealmTest {
         log.info("creating username with non-ASCII username");
         UserRepresentation utf8TestUser = createUserRepresentation("täst", "test-utf8@email.test", "utf8", "test", true);
         setPasswordFor(utf8TestUser, PASSWORD);
+
+        String id = createUserWithAdminClient(testRealmResource(), utf8TestUser);
+        assertNotNull(id);
 
         log.info("enabling remember me");
         loginSettingsPage.form().setRememberMeAllowed(true);


### PR DESCRIPTION
International users using non-ascii symbols such as the german `äöü`
will make Keycloak set the KEYCLOAK_REMEMBER_ME cookie without URL
encoding. This will trigger an java.lang.IllegalArgumentException:
UT000173 exception in undertow's cookie parser which does not
allow non-ascii characters.

Co-authored-by: Fabian Freyer <mail@fabianfreyer.de>