### PR TITLE
KEYCLOAK-17792: Expose realm attributes to templates

### DIFF
--- a/services/src/main/java/org/keycloak/forms/account/freemarker/model/RealmBean.java
+++ b/services/src/main/java/org/keycloak/forms/account/freemarker/model/RealmBean.java
@@ -18,6 +18,7 @@ package org.keycloak.forms.account.freemarker.model;
 
 import org.keycloak.models.RealmModel;
 
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -72,5 +73,9 @@ public class RealmBean {
 
     public boolean isUserManagedAccessAllowed() {
         return realm.isUserManagedAccessAllowed();
+    }
+
+    public Map<String, String> getAttributes() {
+        return realm.getAttributes();
     }
 }

--- a/services/src/main/java/org/keycloak/forms/login/freemarker/model/RealmBean.java
+++ b/services/src/main/java/org/keycloak/forms/login/freemarker/model/RealmBean.java
@@ -22,6 +22,7 @@ import org.keycloak.authentication.actiontoken.verifyemail.VerifyEmailActionToke
 import org.keycloak.models.RealmModel;
 import org.keycloak.representations.idm.CredentialRepresentation;
 
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
@@ -125,5 +126,9 @@ public class RealmBean {
      */
     public int getIdpVerifyAccountLinkActionTokenLifespanMinutes() {
         return (int)TimeUnit.SECONDS.toMinutes(realm.getActionTokenGeneratedByUserLifespan(IdpVerifyAccountLinkActionToken.TOKEN_TYPE));
+    }
+
+    public Map<String, String> getAttributes() {
+        return realm.getAttributes();
     }
 }

--- a/services/src/test/java/org/keycloak/forms/account/freemarker/model/AccountRealmBeanTest.java
+++ b/services/src/test/java/org/keycloak/forms/account/freemarker/model/AccountRealmBeanTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.forms.account.freemarker.model;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.keycloak.models.RealmModel;
+
+import java.lang.reflect.Proxy;
+import java.util.HashMap;
+import java.util.Map;
+
+public class AccountRealmBeanTest {
+
+	@Test
+	public void exposeRealmAttributesTest() {
+		Map<String, String> map = new HashMap<String, String>();
+	    RealmModel realmModel = (RealmModel) Proxy.newProxyInstance(AccountRealmBeanTest.class.getClassLoader(), new Class[]{RealmModel.class}, (proxy, method, args) -> {
+
+	        if (method.getName().matches("getAttributes")) {
+	            return map;
+	        }
+
+	        return null;
+	    });
+	    RealmBean realmBean = new RealmBean(realmModel);
+
+	    Assert.assertEquals(map,realmBean.getAttributes());
+	}
+}

--- a/services/src/test/java/org/keycloak/forms/login/freemarker/model/LoginRealmBeanTest.java
+++ b/services/src/test/java/org/keycloak/forms/login/freemarker/model/LoginRealmBeanTest.java
@@ -22,6 +22,8 @@ import org.junit.Test;
 import org.keycloak.models.RealmModel;
 
 import java.lang.reflect.Proxy;
+import java.util.HashMap;
+import java.util.Map;
 
 public class LoginRealmBeanTest {
 
@@ -43,4 +45,20 @@ public class LoginRealmBeanTest {
         Assert.assertEquals(5, realmBean.getResetCredentialsActionTokenLifespanMinutes());
         Assert.assertEquals(5, realmBean.getVerifyEmailActionTokenLifespanMinutes());
     }
+
+	@Test
+	public void exposeRealmAttributesTest() {
+		Map<String, String> map = new HashMap<String, String>();
+	    RealmModel realmModel = (RealmModel) Proxy.newProxyInstance(LoginRealmBeanTest.class.getClassLoader(), new Class[]{RealmModel.class}, (proxy, method, args) -> {
+
+	        if (method.getName().matches("getAttributes")) {
+	            return map;
+	        }
+
+	        return null;
+	    });
+	    RealmBean realmBean = new RealmBean(realmModel);
+
+	    Assert.assertEquals(map,realmBean.getAttributes());
+	}
 }


### PR DESCRIPTION
Setting a custom configuration per realm and be able to access it in the template (for instance to store a different google analytics key per realm) and expose realm attributes template

https://issues.redhat.com/browse/KEYCLOAK-17792
