### PR TITLE
KEYCLOAK-17039 Local file in a webview fails with "Origin: null"

### DIFF
--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/PreAuthActionsHandler.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/PreAuthActionsHandler.java
@@ -104,7 +104,7 @@ public class PreAuthActionsHandler {
             return false;
         }
         String origin = facade.getRequest().getHeader(CorsHeaders.ORIGIN);
-        if (origin == null || origin.equals("null")) {
+        if (origin == null) {
             log.debug("checkCorsPreflight: no origin header");
             return false;
         }

--- a/services/src/main/java/org/keycloak/services/resources/Cors.java
+++ b/services/src/main/java/org/keycloak/services/resources/Cors.java
@@ -135,7 +135,7 @@ public class Cors {
 
     public Response build() {
         String origin = request.getHttpHeaders().getRequestHeaders().getFirst(ORIGIN_HEADER);
-        if (origin == null || origin.equals("null")) {
+        if (origin == null) {
             logger.trace("No origin header ignoring");
             return builder.build();
         }
@@ -182,7 +182,7 @@ public class Cors {
 
     public void build(HttpResponse response) {
         String origin = request.getHttpHeaders().getRequestHeaders().getFirst(ORIGIN_HEADER);
-        if (origin == null || origin.equals("null")) {
+        if (origin == null) {
             logger.trace("No origin header ignoring");
             return;
         }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/OIDCWellKnownProviderTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/OIDCWellKnownProviderTest.java
@@ -252,6 +252,13 @@ public class OIDCWellKnownProviderTest extends AbstractKeycloakTest {
         Response response = request.get();
 
         assertEquals("http://somehost", response.getHeaders().getFirst(Cors.ACCESS_CONTROL_ALLOW_ORIGIN));
+
+
+        Invocation.Builder nullRequest = oidcDiscoveryTarget.request();
+        nullRequest.header(Cors.ORIGIN_HEADER, "null");
+        Response nullResponse = nullRequest.get();
+
+        assertEquals("null", nullResponse.getHeaders().getFirst(Cors.ACCESS_CONTROL_ALLOW_ORIGIN));
     }
 
     @Test


### PR DESCRIPTION
https://issues.redhat.com/browse/KEYCLOAK-17039