### PR TITLE
KEYCLOAK-12747 JWKTest.publicEs256 sometimes failing

### DIFF
--- a/core/src/main/java/org/keycloak/jose/jwk/JWKBuilder.java
+++ b/core/src/main/java/org/keycloak/jose/jwk/JWKBuilder.java
@@ -26,12 +26,13 @@ import org.keycloak.crypto.Algorithm;
 import org.keycloak.crypto.KeyType;
 import org.keycloak.crypto.KeyUse;
 
-import java.math.BigInteger;
 import java.security.Key;
 import java.security.PublicKey;
 import java.security.cert.X509Certificate;
 import java.security.interfaces.ECPublicKey;
 import java.security.interfaces.RSAPublicKey;
+
+import static org.keycloak.jose.jwk.JWKUtil.toIntegerBytes;
 
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
@@ -113,8 +114,6 @@ public class JWKBuilder {
 
         String kid = this.kid != null ? this.kid : KeyUtils.createKeyId(key);
         int fieldSize = ecKey.getParams().getCurve().getField().getFieldSize();
-        BigInteger affineX = ecKey.getW().getAffineX();
-        BigInteger affineY = ecKey.getW().getAffineY();
 
         k.setKeyId(kid);
         k.setKeyType(KeyType.EC);
@@ -126,32 +125,4 @@ public class JWKBuilder {
         
         return k;
     }
-
-    /**
-     * Copied from org.apache.commons.codec.binary.Base64
-     */
-    private static byte[] toIntegerBytes(final BigInteger bigInt) {
-        int bitlen = bigInt.bitLength();
-        // round bitlen
-        bitlen = ((bitlen + 7) >> 3) << 3;
-        final byte[] bigBytes = bigInt.toByteArray();
-
-        if (((bigInt.bitLength() % 8) != 0) && (((bigInt.bitLength() / 8) + 1) == (bitlen / 8))) {
-            return bigBytes;
-        }
-        // set up params for copying everything but sign bit
-        int startSrc = 0;
-        int len = bigBytes.length;
-
-        // if bigInt is exactly byte-aligned, just skip signbit in copy
-        if ((bigInt.bitLength() % 8) == 0) {
-            startSrc = 1;
-            len--;
-        }
-        final int startDst = bitlen / 8 - len; // to pad w/ nulls as per spec
-        final byte[] resizedBytes = new byte[bitlen / 8];
-        System.arraycopy(bigBytes, startSrc, resizedBytes, startDst, len);
-        return resizedBytes;
-    }
-
 }

--- a/core/src/main/java/org/keycloak/jose/jwk/JWKUtil.java
+++ b/core/src/main/java/org/keycloak/jose/jwk/JWKUtil.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.jose.jwk;
+
+import java.math.BigInteger;
+
+public class JWKUtil {
+
+    /**
+     * Convert BigInteger to 64-byte integer array
+     *
+     * Copied from org.apache.commons.codec.binary.Base64
+     */
+    public static byte[] toIntegerBytes(final BigInteger bigInt) {
+        int bitlen = bigInt.bitLength();
+        // round bitlen
+        bitlen = ((bitlen + 7) >> 3) << 3;
+        final byte[] bigBytes = bigInt.toByteArray();
+
+        if (((bigInt.bitLength() % 8) != 0) && (((bigInt.bitLength() / 8) + 1) == (bitlen / 8))) {
+            return bigBytes;
+        }
+        // set up params for copying everything but sign bit
+        int startSrc = 0;
+        int len = bigBytes.length;
+
+        // if bigInt is exactly byte-aligned, just skip signbit in copy
+        if ((bigInt.bitLength() % 8) == 0) {
+            startSrc = 1;
+            len--;
+        }
+        final int startDst = bitlen / 8 - len; // to pad w/ nulls as per spec
+        final byte[] resizedBytes = new byte[bitlen / 8];
+        System.arraycopy(bigBytes, startSrc, resizedBytes, startDst, len);
+        return resizedBytes;
+    }
+}

--- a/core/src/test/java/org/keycloak/jose/jwk/JWKTest.java
+++ b/core/src/test/java/org/keycloak/jose/jwk/JWKTest.java
@@ -35,10 +35,15 @@ import java.security.SecureRandom;
 import java.security.Security;
 import java.security.Signature;
 import java.security.cert.X509Certificate;
+import java.security.interfaces.ECPublicKey;
 import java.security.spec.ECGenParameterSpec;
+import java.security.spec.ECPoint;
 
-import static org.junit.Assert.*;
-import static org.keycloak.common.util.CertificateUtils.*;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.keycloak.common.util.CertificateUtils.generateV1SelfSignedCertificate;
 
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
@@ -150,8 +155,15 @@ public class JWKTest {
         byte[] xBytes = Base64Url.decode(ecJwk.getX());
         byte[] yBytes = Base64Url.decode(ecJwk.getY());
 
-        assertEquals(256/8, xBytes.length);
-        assertEquals(256/8, yBytes.length);
+        assertTrue(publicKey instanceof ECPublicKey);
+        ECPoint ecPoint = ((ECPublicKey) publicKey).getW();
+        assertNotNull(ecPoint);
+
+        int lengthAffineX = JWKUtil.toIntegerBytes(ecPoint.getAffineX()).length;
+        int lengthAffineY = JWKUtil.toIntegerBytes(ecPoint.getAffineY()).length;
+
+        assertEquals(lengthAffineX, xBytes.length);
+        assertEquals(lengthAffineY, yBytes.length);
 
         String jwkJson = JsonSerialization.writeValueAsString(jwk);
 


### PR DESCRIPTION
JIRA: [KEYCLOAK-12747](https://issues.redhat.com/browse/KEYCLOAK-12747)

For the Elliptic curve the affine X,Y coordinates slightly differ, and the integer division with fixed values causes inaccurrency in the test.