### PR TITLE
KEYCLOAK-17827 Client Policy - Condition : Client - Client Host : Removing Option

### DIFF
--- a/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientUpdateSourceHostsCondition.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientUpdateSourceHostsCondition.java
@@ -74,8 +74,6 @@ public class ClientUpdateSourceHostsCondition implements ClientPolicyConditionPr
 
         @JsonProperty("trusted-hosts")
         protected List<String> trustedHosts;
-        @JsonProperty("host-sending-request-must-match")
-        protected List<Boolean> hostSendingRequestMustMatch;
 
         public List<String> getTrustedHosts() {
             return trustedHosts;
@@ -83,14 +81,6 @@ public class ClientUpdateSourceHostsCondition implements ClientPolicyConditionPr
 
         public void setTrustedHosts(List<String> trustedHosts) {
             this.trustedHosts = trustedHosts;
-        }
-
-        public List<Boolean> getHostSendingRequestMustMatch() {
-            return hostSendingRequestMustMatch;
-        }
-
-        public void setHostSendingRequestMustMatch(List<Boolean> hostSendingRequestMustMatch) {
-            this.hostSendingRequestMustMatch = hostSendingRequestMustMatch;
         }
     }
 
@@ -109,7 +99,6 @@ public class ClientUpdateSourceHostsCondition implements ClientPolicyConditionPr
         switch (context.getEvent()) {
         case REGISTER:
         case UPDATE:
-            if (!isHostMustMatch()) return ClientPolicyVote.ABSTAIN;
             if (isHostMatched()) return ClientPolicyVote.YES;
             return ClientPolicyVote.NO;
         default:
@@ -195,11 +184,5 @@ public class ClientUpdateSourceHostsCondition implements ClientPolicyConditionPr
         }
 
         return null;
-    }
-
-    boolean isHostMustMatch() {
-        List<Boolean> l = configuration.getHostSendingRequestMustMatch();
-        if (l != null && !l.isEmpty()) return l.get(0).booleanValue();
-        return true;
     }
 }

--- a/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientUpdateSourceHostsConditionFactory.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientUpdateSourceHostsConditionFactory.java
@@ -34,12 +34,7 @@ public class ClientUpdateSourceHostsConditionFactory implements ClientPolicyCond
 
     public static final String TRUSTED_HOSTS = "trusted-hosts";
 
-    public static final String HOST_SENDING_REQUEST_MUST_MATCH = "host-sending-request-must-match";
-
     private static final ProviderConfigProperty TRUSTED_HOSTS_PROPERTY = new ProviderConfigProperty(TRUSTED_HOSTS, "clientupdate-trusted-hosts.label", "clientupdate-trusted-hosts.tooltip", ProviderConfigProperty.MULTIVALUED_STRING_TYPE, null);
-
-    private static final ProviderConfigProperty HOST_SENDING_REGISTRATION_REQUEST_MUST_MATCH_PROPERTY = new ProviderConfigProperty(HOST_SENDING_REQUEST_MUST_MATCH, "host-sending-request-must-match.label",
-            "host-sending-request-must-match.tooltip", ProviderConfigProperty.BOOLEAN_TYPE, "true");
 
     @Override
     public ClientPolicyConditionProvider create(KeycloakSession session) {
@@ -70,7 +65,7 @@ public class ClientUpdateSourceHostsConditionFactory implements ClientPolicyCond
 
     @Override
     public List<ProviderConfigProperty> getConfigProperties() {
-        return Arrays.asList(TRUSTED_HOSTS_PROPERTY, HOST_SENDING_REGISTRATION_REQUEST_MUST_MATCH_PROPERTY);
+        return Arrays.asList(TRUSTED_HOSTS_PROPERTY);
     }
 
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/AbstractClientPoliciesTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/AbstractClientPoliciesTest.java
@@ -116,24 +116,18 @@ import org.keycloak.services.clientpolicy.condition.ClientUpdateSourceHostsCondi
 import org.keycloak.services.clientpolicy.condition.ClientUpdateSourceHostsConditionFactory;
 import org.keycloak.services.clientpolicy.condition.ClientUpdateSourceRolesCondition;
 import org.keycloak.services.clientpolicy.condition.ClientUpdateSourceRolesConditionFactory;
-import org.keycloak.services.clientpolicy.executor.ConfidentialClientAcceptExecutor;
 import org.keycloak.services.clientpolicy.executor.HolderOfKeyEnforceExecutor;
 import org.keycloak.services.clientpolicy.executor.HolderOfKeyEnforceExecutorFactory;
 import org.keycloak.services.clientpolicy.executor.PKCEEnforceExecutor;
 import org.keycloak.services.clientpolicy.executor.PKCEEnforceExecutorFactory;
 import org.keycloak.services.clientpolicy.executor.SecureClientAuthEnforceExecutor;
 import org.keycloak.services.clientpolicy.executor.SecureClientAuthEnforceExecutorFactory;
-import org.keycloak.services.clientpolicy.executor.SecureRedirectUriEnforceExecutor;
 import org.keycloak.services.clientpolicy.executor.SecureRedirectUriEnforceExecutorFactory;
 import org.keycloak.services.clientpolicy.executor.SecureRequestObjectExecutor;
 import org.keycloak.services.clientpolicy.executor.SecureRequestObjectExecutorFactory;
-import org.keycloak.services.clientpolicy.executor.SecureResponseTypeExecutor;
 import org.keycloak.services.clientpolicy.executor.SecureResponseTypeExecutorFactory;
-import org.keycloak.services.clientpolicy.executor.SecureSessionEnforceExecutor;
 import org.keycloak.services.clientpolicy.executor.SecureSessionEnforceExecutorFactory;
-import org.keycloak.services.clientpolicy.executor.SecureSigningAlgorithmEnforceExecutor;
 import org.keycloak.services.clientpolicy.executor.SecureSigningAlgorithmEnforceExecutorFactory;
-import org.keycloak.services.clientpolicy.executor.SecureSigningAlgorithmForSignedJwtEnforceExecutor;
 import org.keycloak.services.clientpolicy.executor.SecureSigningAlgorithmForSignedJwtEnforceExecutorFactory;
 import org.keycloak.testsuite.AbstractKeycloakTest;
 import org.keycloak.testsuite.AssertEvents;
@@ -255,7 +249,7 @@ public abstract class AbstractClientPoliciesTest extends AbstractKeycloakTest {
                     .addCondition(ClientUpdateSourceGroupsConditionFactory.PROVIDER_ID, 
                             createClientUpdateSourceGroupsConditionConfig(Arrays.asList("topGroup")))
                     .addCondition(ClientUpdateSourceHostsConditionFactory.PROVIDER_ID, 
-                            createClientUpdateSourceHostsConditionConfig(Arrays.asList("localhost", "127.0.0.1"), Arrays.asList(Boolean.TRUE, Boolean.TRUE)))
+                            createClientUpdateSourceHostsConditionConfig(Arrays.asList("localhost", "127.0.0.1")))
                     .addCondition(ClientUpdateSourceRolesConditionFactory.PROVIDER_ID, 
                             createClientUpdateSourceRolesConditionConfig(Arrays.asList(AdminRoles.CREATE_CLIENT)))
                     .toRepresentation();
@@ -1034,10 +1028,9 @@ public abstract class AbstractClientPoliciesTest extends AbstractKeycloakTest {
         return config;
     }
 
-    protected Object createClientUpdateSourceHostsConditionConfig(List<String> trustedHosts, List<Boolean> hostSendingRequestMustMatch) {
+    protected Object createClientUpdateSourceHostsConditionConfig(List<String> trustedHosts) {
         ClientUpdateSourceHostsCondition.Configuration config = new ClientUpdateSourceHostsCondition.Configuration();
         config.setTrustedHosts(trustedHosts);
-        config.setHostSendingRequestMustMatch(hostSendingRequestMustMatch);
         return config;
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientPoliciesTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientPoliciesTest.java
@@ -644,7 +644,7 @@ public class ClientPoliciesTest extends AbstractClientPoliciesTest {
         json = (new ClientPoliciesBuilder()).addPolicy(
                    (new ClientPolicyBuilder()).createPolicy(POLICY_NAME, "Prvni Politika", Boolean.FALSE, Boolean.TRUE, null, null)
                        .addCondition(ClientUpdateSourceHostsConditionFactory.PROVIDER_ID, 
-                            createClientUpdateSourceHostsConditionConfig(Arrays.asList("localhost", "127.0.0.1"), Arrays.asList(Boolean.TRUE, Boolean.TRUE)))
+                            createClientUpdateSourceHostsConditionConfig(Arrays.asList("localhost", "127.0.0.1")))
                        .addProfile(PROFILE_NAME)
                        .toRepresentation()
                ).toString();
@@ -665,7 +665,7 @@ public class ClientPoliciesTest extends AbstractClientPoliciesTest {
         json = (new ClientPoliciesBuilder()).addPolicy(
                    (new ClientPolicyBuilder()).createPolicy(POLICY_NAME, "Aktualizovana Prvni Politika", Boolean.FALSE, Boolean.TRUE, null, null)
                        .addCondition(ClientUpdateSourceHostsConditionFactory.PROVIDER_ID, 
-                           createClientUpdateSourceHostsConditionConfig(Arrays.asList("example.com"), Arrays.asList(Boolean.TRUE)))
+                           createClientUpdateSourceHostsConditionConfig(Arrays.asList("example.com")))
                        .addProfile(PROFILE_NAME)
                        .toRepresentation()
                 ).toString();


### PR DESCRIPTION
This PR is for [KEYCLOAK-13933 Client Policies](https://issues.redhat.com/browse/KEYCLOAK-13933), also is the part of the project [Client Policy Official Support](https://github.com/keycloak/kc-sig-fapi/projects) of [FAPI-SIG](https://github.com/keycloak/kc-sig-fapi) activity.

As mentioned in [KEYCLOAK-17827](https://issues.redhat.com/browse/KEYCLOAK-17827), it removes the unnecessary option `HOST_SETTING_REQUEST_MUST_MATCH ` in `ClientUpdateSourceHostsConditionFactory `.
