### PR TITLE
KEYCLOAK-12988 Deprecate getUsers methods from UserProvider and UserQueryProvider

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/UserCacheSession.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/UserCacheSession.java
@@ -545,14 +545,10 @@ public class UserCacheSession implements UserCache.Streams, OnCreateComponent, O
     }
 
     @Override
-    public Stream<UserModel> getUsersStream(RealmModel realm, boolean includeServiceAccounts) {
-        return getDelegate().getUsersStream(realm, includeServiceAccounts);
-    }
-
-    @Override
     public CredentialValidationOutput getUserByCredential(RealmModel realm, CredentialInput input) {
         return getDelegate().getUserByCredential(realm, input);
     }
+
     @Override
     public int getUsersCount(RealmModel realm, boolean includeServiceAccount) {
         return getDelegate().getUsersCount(realm, includeServiceAccount);
@@ -581,21 +577,6 @@ public class UserCacheSession implements UserCache.Streams, OnCreateComponent, O
     @Override
     public int getUsersCount(RealmModel realm, Map<String, String> params, Set<String> groupIds) {
         return getDelegate().getUsersCount(realm, params, groupIds);
-    }
-
-    @Override
-    public Stream<UserModel> getUsersStream(RealmModel realm, Integer firstResult, Integer maxResults, boolean includeServiceAccounts) {
-        return getDelegate().getUsersStream(realm, firstResult, maxResults, includeServiceAccounts);
-    }
-
-    @Override
-    public Stream<UserModel> getUsersStream(RealmModel realm) {
-        return getUsersStream(realm, false);
-    }
-
-    @Override
-    public Stream<UserModel> getUsersStream(RealmModel realm, Integer firstResult, Integer maxResults) {
-         return getUsersStream(realm, firstResult, maxResults, false);
     }
 
     @Override

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/UserEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/UserEntity.java
@@ -42,8 +42,6 @@ import java.util.LinkedList;
  * @version $Revision: 1 $
  */
 @NamedQueries({
-        @NamedQuery(name="getAllUsersByRealm", query="select u from UserEntity u where u.realmId = :realmId order by u.username"),
-        @NamedQuery(name="getAllUsersByRealmExcludeServiceAccount", query="select u from UserEntity u where u.realmId = :realmId and (u.serviceAccountClientLink is null) order by u.username"),
         @NamedQuery(name="getRealmUserByUsername", query="select u from UserEntity u where u.username = :username and u.realmId = :realmId"),
         @NamedQuery(name="getRealmUserByEmail", query="select u from UserEntity u where u.email = :email and u.realmId = :realmId"),
         @NamedQuery(name="getRealmUserByLastName", query="select u from UserEntity u where u.lastName = :lastName and u.realmId = :realmId"),

--- a/model/legacy-private/src/main/java/org/keycloak/migration/migrators/MigrateTo1_4_0.java
+++ b/model/legacy-private/src/main/java/org/keycloak/migration/migrators/MigrateTo1_4_0.java
@@ -24,6 +24,7 @@ import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.LDAPConstants;
 import org.keycloak.models.LegacyRealmModel;
 import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
 import org.keycloak.models.cache.UserCache;
 import org.keycloak.models.utils.DefaultAuthenticationFlows;
 import org.keycloak.models.utils.DefaultRequiredActions;
@@ -33,7 +34,9 @@ import org.keycloak.storage.UserStoragePrivateUtil;
 import org.keycloak.storage.UserStorageUtil;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -81,7 +84,10 @@ public class MigrateTo1_4_0 implements Migration {
     }
 
     private void migrateUsers(KeycloakSession session, RealmModel realm) {
-        UserStoragePrivateUtil.userLocalStorage(session).getUsersStream(realm, false)
+        Map<String, String> searchAttributes = new HashMap<>(1);
+        searchAttributes.put(UserModel.INCLUDE_SERVICE_ACCOUNT, Boolean.FALSE.toString());
+
+        UserStoragePrivateUtil.userLocalStorage(session).searchForUserStream(realm, searchAttributes)
                 .forEach(user -> {
                     String email = KeycloakModelUtils.toLowerCaseSafe(user.getEmail());
                     if (email != null && !email.equals(user.getEmail())) {

--- a/model/legacy-private/src/main/java/org/keycloak/storage/UserStorageManager.java
+++ b/model/legacy-private/src/main/java/org/keycloak/storage/UserStorageManager.java
@@ -379,31 +379,6 @@ public class UserStorageManager extends AbstractStorageManager<UserStorageProvid
         return importValidation(realm, results);
     }
 
-
-    @Override
-    public Stream<UserModel> getUsersStream(RealmModel realm) {
-        return getUsersStream(realm, null, null, false);
-    }
-
-    @Override
-    public Stream<UserModel> getUsersStream(RealmModel realm, Integer firstResult, Integer maxResults) {
-        return getUsersStream(realm, firstResult, maxResults, false);
-    }
-
-    @Override
-    public Stream<UserModel> getUsersStream(final RealmModel realm, Integer firstResult, Integer maxResults, final boolean includeServiceAccounts) {
-        Stream<UserModel> results =  query((provider, firstResultInQuery, maxResultsInQuery) -> {
-            if (provider instanceof UserProvider) { // it is local storage
-                return ((UserProvider) provider).getUsersStream(realm, firstResultInQuery, maxResultsInQuery, includeServiceAccounts);
-            } else if (provider instanceof UserQueryProvider) {
-                return ((UserQueryProvider)provider).getUsersStream(realm);
-            }
-            return Stream.empty();
-        }
-        , realm, firstResult, maxResults);
-        return importValidation(realm, results);
-    }
-
     @Override
     public int getUsersCount(RealmModel realm, boolean includeServiceAccount) {
         int localStorageUsersCount = localStorage().getUsersCount(realm, includeServiceAccount);

--- a/model/legacy-services/src/main/java/org/keycloak/exportimport/util/MultipleStepsExportProvider.java
+++ b/model/legacy-services/src/main/java/org/keycloak/exportimport/util/MultipleStepsExportProvider.java
@@ -31,6 +31,7 @@ import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.storage.UserStorageUtil;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -114,7 +115,7 @@ public abstract class MultipleStepsExportProvider implements ExportProvider {
                     protected void runExportImportTask(KeycloakSession session) throws IOException {
                         RealmModel realm = session.realms().getRealmByName(realmName);
                         usersHolder.users = session.users()
-                                .getUsersStream(realm, usersHolder.currentPageStart, usersHolder.currentPageEnd - usersHolder.currentPageStart, true)
+                                .searchForUserStream(realm, Collections.emptyMap(), usersHolder.currentPageStart, usersHolder.currentPageEnd - usersHolder.currentPageStart)
                                 .collect(Collectors.toList());
 
                         writeUsers(realmName + "-users-" + (usersHolder.currentPageStart / countPerPage) + ".json", session, realm, usersHolder.users);

--- a/services/src/main/java/org/keycloak/exportimport/util/ExportUtils.java
+++ b/services/src/main/java/org/keycloak/exportimport/util/ExportUtils.java
@@ -65,6 +65,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -227,7 +228,7 @@ public class ExportUtils {
 
         // Finally users if needed
         if (options.isUsersIncluded()) {
-            List<UserRepresentation> users = session.users().getUsersStream(realm, true)
+            List<UserRepresentation> users = session.users().searchForUserStream(realm, Collections.emptyMap())
                     .map(user -> exportUser(session, realm, user, options, internal))
                     .collect(Collectors.toList());
 

--- a/services/src/main/java/org/keycloak/services/resources/admin/IdentityProviderResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/IdentityProviderResource.java
@@ -61,6 +61,8 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
@@ -191,7 +193,7 @@ public class IdentityProviderResource {
             // Admin changed the ID (alias) of identity provider. We must update all clients and users
             logger.debug("Changing providerId in all clients and linked users. oldProviderId=" + oldProviderId + ", newProviderId=" + newProviderId);
 
-            updateUsersAfterProviderAliasChange(session.users().getUsersStream(realm, false),
+            updateUsersAfterProviderAliasChange(session.users().searchForUserStream(realm, Collections.singletonMap(UserModel.INCLUDE_SERVICE_ACCOUNT, Boolean.FALSE.toString())),
                     oldProviderId, newProviderId, realm, session);
         }
     }

--- a/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
@@ -433,7 +433,7 @@ public class UsersResource {
     }
 
     private Stream<UserRepresentation> searchForUser(Map<String, String> attributes, RealmModel realm, UserPermissionEvaluator usersEvaluator, Boolean briefRepresentation, Integer firstResult, Integer maxResults, Boolean includeServiceAccounts) {
-        session.setAttribute(UserModel.INCLUDE_SERVICE_ACCOUNT, includeServiceAccounts);
+        attributes.put(UserModel.INCLUDE_SERVICE_ACCOUNT, includeServiceAccounts.toString());
 
         if (!auth.users().canView()) {
             Set<String> groupModels = auth.groups().getGroupsWithViewPermission();

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/ProfileAssume.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/ProfileAssume.java
@@ -58,7 +58,7 @@ public class ProfileAssume {
     }
 
     public static void assumeFeatureDisabled(Profile.Feature feature) {
-        Assume.assumeTrue("Ignoring test as feature " + feature.name() + " is disabled", !isFeatureEnabled(feature));
+        Assume.assumeTrue("Ignoring test as feature " + feature.name() + " is enabled", !isFeatureEnabled(feature));
     }
 
     public static void assumePreview() {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPSyncTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPSyncTest.java
@@ -307,7 +307,8 @@ public class LDAPSyncTest extends AbstractLDAPTest {
             LDAPTestContext ctx = LDAPTestContext.init(session);
 
             // Remove all users from model
-            UserStoragePrivateUtil.userLocalStorage(session).getUsersStream(ctx.getRealm(), true)
+            UserStoragePrivateUtil.userLocalStorage(session)
+                    .searchForUserStream(ctx.getRealm(), Collections.emptyMap())
                     .collect(Collectors.toList())
                     .forEach(user -> UserStoragePrivateUtil.userLocalStorage(session).removeUser(ctx.getRealm(), user));
 
@@ -356,7 +357,8 @@ public class LDAPSyncTest extends AbstractLDAPTest {
             LDAPTestContext ctx = LDAPTestContext.init(session);
 
             // Remove all users from model
-            UserStoragePrivateUtil.userLocalStorage(session).getUsersStream(ctx.getRealm(), true)
+            UserStoragePrivateUtil.userLocalStorage(session)
+                    .searchForUserStream(ctx.getRealm(), Collections.emptyMap())
                     .peek(user -> System.out.println("trying to delete user: " + user.getUsername()))
                     .collect(Collectors.toList())
                     .forEach(user -> {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/storage/UserStorageFailureTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/storage/UserStorageFailureTest.java
@@ -56,6 +56,7 @@ import org.keycloak.testsuite.pages.AppPage;
 import org.keycloak.testsuite.pages.LoginPage;
 import org.keycloak.testsuite.util.OAuthClient;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -345,7 +346,7 @@ public class UserStorageFailureTest extends AbstractTestRealmKeycloakTest {
             Assert.assertEquals(1, result.count());
 
             // we run a terminal operation on the stream to make sure it is consumed.
-            session.users().getUsersStream(realm).count();
+            session.users().searchForUserStream(realm, Collections.emptyMap()).count();
             session.users().getUsersCount(realm);
 
             UserModel user = session.users().getUserByUsername(realm, FailableHardcodedStorageProvider.username);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/model/UserModelTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/model/UserModelTest.java
@@ -479,11 +479,11 @@ public class UserModelTest extends AbstractTestRealmKeycloakTest {
             Assert.assertThat(users, hasSize(1));
             Assert.assertThat(users, contains(user2));
 
-            users = currentSession.users().getUsersStream(realm, false).collect(Collectors.toList());
+            users = currentSession.users().searchForUserStream(realm, Collections.singletonMap(UserModel.INCLUDE_SERVICE_ACCOUNT, Boolean.FALSE.toString())).collect(Collectors.toList());
             Assert.assertThat(users, hasSize(1));
             Assert.assertThat(users, contains(user2));
 
-            users = currentSession.users().getUsersStream(realm, true).collect(Collectors.toList());
+            users = currentSession.users().searchForUserStream(realm, Collections.emptyMap()).collect(Collectors.toList());
             Assert.assertThat(users, hasSize(2));
             Assert.assertThat(users, containsInAnyOrder(user1, user2));
 

--- a/testsuite/utils/src/main/java/org/keycloak/testsuite/util/cli/TestCacheUtils.java
+++ b/testsuite/utils/src/main/java/org/keycloak/testsuite/util/cli/TestCacheUtils.java
@@ -24,6 +24,8 @@ import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.RoleContainerModel;
 
+import java.util.Collections;
+
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
  */
@@ -45,7 +47,7 @@ public class TestCacheUtils {
 
         realm.getClientScopesStream().map(ClientScopeModel::getId).forEach(realm::getClientScopeById);
 
-        session.users().getUsersStream(realm).forEach(user -> {
+        session.users().searchForUserStream(realm, Collections.emptyMap()).forEach(user -> {
             session.users().getUserById(realm, user.getId());
             if (user.getEmail() != null) {
                 session.users().getUserByEmail(realm, user.getEmail());


### PR DESCRIPTION
Closes #14018
This PR deprecates all methods starting with `getUsers*` in all user interfaces. These methods were used only in a few places, that are replaced by `searchUser*` variants of methods. 

The only difference I found is, that `search` variants of methods in current JPA are using `getUserById` at the end of method so that found users are cached and also import validation is done. While `getUsers` methods didn't do that. This was causing some failures in LDAP tests that are fixed in separate commit. When approved I will squash.