### PR TITLE
KEYCLOAK-17888 Add default cert bootstrap provisioning under feature flag

### DIFF
--- a/services/src/main/java/org/keycloak/services/managers/ApplianceBootstrap.java
+++ b/services/src/main/java/org/keycloak/services/managers/ApplianceBootstrap.java
@@ -26,6 +26,7 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.RoleModel;
 import org.keycloak.models.UserCredentialModel;
 import org.keycloak.models.UserModel;
+import org.keycloak.models.utils.DefaultKeyProviders;
 import org.keycloak.representations.idm.CredentialRepresentation;
 import org.keycloak.services.ServicesLogger;
 
@@ -86,6 +87,7 @@ public class ApplianceBootstrap {
         realm.setRegistrationEmailAsUsername(false);
 
         session.getContext().setRealm(realm);
+        DefaultKeyProviders.createProviders(realm);
 
         return true;
     }


### PR DESCRIPTION
This is a proposal to restore [previous functionality](https://github.com/keycloak/keycloak/pull/7108) back under a default-off feature flag as a workaround for [KEYCLOAK-17888](https://issues.redhat.com/browse/KEYCLOAK-17888)

This would enable KC bootstrap to once again provision the master realm certificates prior to servicing requests from consumers. Rather than provisioning them on-demand upon /auth/admin login. 

It results in the keys being generated as such:

<img width="1487" alt="image" src="https://user-images.githubusercontent.com/24445283/116347888-687f4580-a830-11eb-9b81-dad675f8424a.png">


The flag introduced: `-Dkeycloak.profile.feature.bootstrap_default_key=enabled`

I was not entirely sure this fits under KC's [profile feature flags](https://www.keycloak.org/docs/latest/server_installation/#profiles), happy to move the configuration elsewhere if this PR approach is endorsed. 

Ideally this PR / feature flag is not necessary and either the original bootstrap provisioning could be re-introduced (if the original changes performance gains were minimal), or the Fallback cert provisioning could be changed to ensure that only 1 set of certs are provisioned despite potentially some load during initial configuration.
