### PR TITLE
KEYCLOAK-17897 Parse CLI arguments with multiple =

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/configuration/ConfigArgsConfigSource.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/configuration/ConfigArgsConfigSource.java
@@ -98,11 +98,14 @@ public class ConfigArgsConfigSource extends PropertiesConfigSource {
             
             String value;
             
-            if (keyValue.length == 2) {
+            if (keyValue.length == 1) {
+                continue;
+            } else if (keyValue.length == 2) {
                 // the argument has a simple value. Eg.: key=pair
                 value = keyValue[1];
             } else {
-                continue;
+                // to support cases like --db-url=jdbc:mariadb://localhost/kc?a=1
+                value = arg.substring(key.length() + 1);
             }
             
             key = NS_KEYCLOAK_PREFIX + key.substring(2);

--- a/quarkus/runtime/src/test/java/org/keycloak/provider/quarkus/ConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/provider/quarkus/ConfigurationTest.java
@@ -180,6 +180,14 @@ public class ConfigurationTest {
     }
 
     @Test
+    public void testDatabaseUrlProperties() {
+        System.setProperty("kc.config.args", "--db=mariadb,--db-url=jdbc:mariadb:aurora://foo/bar?a=1&b=2");
+        SmallRyeConfig config = createConfig();
+        assertEquals(MariaDBDialect.class.getName(), config.getConfigValue("quarkus.hibernate-orm.dialect").getValue());
+        assertEquals("jdbc:mariadb:aurora://foo/bar?a=1&b=2", config.getConfigValue("quarkus.datasource.jdbc.url").getValue());
+    }
+
+    @Test
     public void testDatabaseDefaults() {
         System.setProperty("kc.config.args", "--db=h2-file");
         SmallRyeConfig config = createConfig();


### PR DESCRIPTION
See https://issues.redhat.com/browse/KEYCLOAK-17897

Parse Quarkus CLI arguments with multiple equal-signs '=', to support cases like `--db-url=jdbc:mariadb://localhost/kc?a=1`.
Reverts a part of commit 04415d34eab5ed577c472802df4ca11fbafabc7e #7449.

I added a unit test to show the problem, it fails with this error message without the patch:

```log
[ERROR] testDatabaseUrlProperties(org.keycloak.provider.quarkus.ConfigurationTest)  Time elapsed: 0.038 s  <<< FAILURE!
org.junit.ComparisonFailure: expected:<jdbc:mariadb:[aurora://foo/bar?a=1&b=2]> but was:<jdbc:mariadb:[//localhost/keycloak]>
```

But with this patch, the unit tests succeeds.