### PR TITLE
WIP KEYCLOAK-17774 Implement equals method for work cache events

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/cluster/infinispan/WrapperClusterEvent.java
+++ b/model/infinispan/src/main/java/org/keycloak/cluster/infinispan/WrapperClusterEvent.java
@@ -21,6 +21,8 @@ import org.keycloak.cluster.ClusterEvent;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.util.Objects;
+
 import org.infinispan.commons.marshall.Externalizer;
 import org.infinispan.commons.marshall.MarshallUtil;
 import org.infinispan.commons.marshall.SerializeWith;
@@ -84,6 +86,19 @@ public class WrapperClusterEvent implements ClusterEvent {
 
     public void setDelegateEvent(ClusterEvent delegateEvent) {
         this.delegateEvent = delegateEvent;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        WrapperClusterEvent that = (WrapperClusterEvent) o;
+        return ignoreSender == that.ignoreSender && ignoreSenderSite == that.ignoreSenderSite && Objects.equals(eventKey, that.eventKey) && Objects.equals(sender, that.sender) && Objects.equals(senderSite, that.senderSite) && Objects.equals(delegateEvent, that.delegateEvent);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(eventKey, sender, senderSite, ignoreSender, ignoreSenderSite, delegateEvent);
     }
 
     @Override

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/events/ClientAddedEvent.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/events/ClientAddedEvent.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.models.cache.infinispan.events;
 
+import java.util.Objects;
 import java.util.Set;
 
 import org.keycloak.models.cache.infinispan.RealmCacheManager;
@@ -58,6 +59,20 @@ public class ClientAddedEvent extends InvalidationEvent implements RealmCacheInv
     @Override
     public void addInvalidations(RealmCacheManager realmCache, Set<String> invalidations) {
         realmCache.clientAdded(realmId, clientUuid, clientId, invalidations);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        ClientAddedEvent that = (ClientAddedEvent) o;
+        return Objects.equals(clientUuid, that.clientUuid) && Objects.equals(clientId, that.clientId) && Objects.equals(realmId, that.realmId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), clientUuid, clientId, realmId);
     }
 
     public static class ExternalizerImpl implements Externalizer<ClientAddedEvent> {

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/events/ClientRemovedEvent.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/events/ClientRemovedEvent.java
@@ -18,8 +18,10 @@
 package org.keycloak.models.cache.infinispan.events;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
+import org.jboss.logging.Logger;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.RoleModel;
 import org.keycloak.models.cache.infinispan.RealmCacheManager;
@@ -45,8 +47,11 @@ public class ClientRemovedEvent extends InvalidationEvent implements RealmCacheI
     private String realmId;
     // roleId -> roleName
     private Map<String, String> clientRoles;
+    private static final Logger log = Logger.getLogger(ClientRemovedEvent.class);
 
     public static ClientRemovedEvent create(ClientModel client) {
+        log.infov("Created; clientId={0}", client.getClientId());
+
         ClientRemovedEvent event = new ClientRemovedEvent();
 
         event.realmId = client.getRealm().getId();
@@ -55,6 +60,12 @@ public class ClientRemovedEvent extends InvalidationEvent implements RealmCacheI
         event.clientRoles = client.getRolesStream().collect(Collectors.toMap(RoleModel::getId, RoleModel::getName));
 
         return event;
+    }
+
+    @Override
+    protected void finalize() throws Throwable {
+        log.infov("Finalized; clientId={0}", clientId);
+        super.finalize();
     }
 
     @Override
@@ -79,6 +90,25 @@ public class ClientRemovedEvent extends InvalidationEvent implements RealmCacheI
         }
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        ClientRemovedEvent that = (ClientRemovedEvent) o;
+        boolean equals = Objects.equals(clientUuid, that.clientUuid) &&
+                Objects.equals(clientId, that.clientId) &&
+                Objects.equals(realmId, that.realmId) &&
+                Objects.equals(clientRoles, that.clientRoles);
+        log.infov("Equals; clientId={0}, equals={1}", clientId, equals);
+        return equals;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), clientUuid, clientId, realmId, clientRoles);
+    }
+
     public static class ExternalizerImpl implements Externalizer<ClientRemovedEvent> {
 
         private static final int VERSION_1 = 1;
@@ -91,6 +121,8 @@ public class ClientRemovedEvent extends InvalidationEvent implements RealmCacheI
             MarshallUtil.marshallString(obj.clientId, output);
             MarshallUtil.marshallString(obj.realmId, output);
             KeycloakMarshallUtil.writeMap(obj.clientRoles, KeycloakMarshallUtil.STRING_EXT, KeycloakMarshallUtil.STRING_EXT, output);
+
+            log.infov("Write; clientId={0}", obj.clientId);
         }
 
         @Override
@@ -110,6 +142,8 @@ public class ClientRemovedEvent extends InvalidationEvent implements RealmCacheI
             res.realmId = MarshallUtil.unmarshallString(input);
             res.clientRoles = KeycloakMarshallUtil.readMap(input, KeycloakMarshallUtil.STRING_EXT, KeycloakMarshallUtil.STRING_EXT,
               size -> new ConcurrentHashMap<>(size));
+
+            log.infov("Read; clientId={0}", res.clientId);
 
             return res;
         }

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/events/ClientTemplateEvent.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/events/ClientTemplateEvent.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.models.cache.infinispan.events;
 
+import java.util.Objects;
 import java.util.Set;
 
 import org.keycloak.models.cache.infinispan.RealmCacheManager;
@@ -58,6 +59,20 @@ public class ClientTemplateEvent extends InvalidationEvent implements RealmCache
     @Override
     public void addInvalidations(RealmCacheManager realmCache, Set<String> invalidations) {
         // Nothing. ID was already invalidated
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        ClientTemplateEvent that = (ClientTemplateEvent) o;
+        return Objects.equals(clientTemplateId, that.clientTemplateId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), clientTemplateId);
     }
 
     public static class ExternalizerImpl implements Externalizer<ClientTemplateEvent> {

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/events/ClientUpdatedEvent.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/events/ClientUpdatedEvent.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.models.cache.infinispan.events;
 
+import java.util.Objects;
 import java.util.Set;
 
 import org.keycloak.models.cache.infinispan.RealmCacheManager;
@@ -58,6 +59,20 @@ public class ClientUpdatedEvent extends InvalidationEvent implements RealmCacheI
     @Override
     public void addInvalidations(RealmCacheManager realmCache, Set<String> invalidations) {
         realmCache.clientUpdated(realmId, clientUuid, clientId, invalidations);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        ClientUpdatedEvent that = (ClientUpdatedEvent) o;
+        return Objects.equals(clientUuid, that.clientUuid) && Objects.equals(clientId, that.clientId) && Objects.equals(realmId, that.realmId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), clientUuid, clientId, realmId);
     }
 
     public static class ExternalizerImpl implements Externalizer<ClientUpdatedEvent> {

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/events/GroupAddedEvent.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/events/GroupAddedEvent.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.models.cache.infinispan.events;
 
+import java.util.Objects;
 import java.util.Set;
 
 import org.keycloak.models.cache.infinispan.RealmCacheManager;
@@ -62,6 +63,20 @@ public class GroupAddedEvent extends InvalidationEvent implements RealmCacheInva
         if (parentId != null) {
             invalidations.add(parentId);
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        GroupAddedEvent that = (GroupAddedEvent) o;
+        return Objects.equals(groupId, that.groupId) && Objects.equals(realmId, that.realmId) && Objects.equals(parentId, that.parentId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), groupId, realmId, parentId);
     }
 
     public static class ExternalizerImpl implements Externalizer<GroupAddedEvent> {

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/events/GroupMovedEvent.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/events/GroupMovedEvent.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.models.cache.infinispan.events;
 
+import java.util.Objects;
 import java.util.Set;
 
 import org.keycloak.models.GroupModel;
@@ -67,6 +68,20 @@ public class GroupMovedEvent extends InvalidationEvent implements RealmCacheInva
         if (oldParentId != null) {
             invalidations.add(oldParentId);
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        GroupMovedEvent that = (GroupMovedEvent) o;
+        return Objects.equals(groupId, that.groupId) && Objects.equals(newParentId, that.newParentId) && Objects.equals(oldParentId, that.oldParentId) && Objects.equals(realmId, that.realmId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), groupId, newParentId, oldParentId, realmId);
     }
 
     public static class ExternalizerImpl implements Externalizer<GroupMovedEvent> {

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/events/GroupRemovedEvent.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/events/GroupRemovedEvent.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.models.cache.infinispan.events;
 
+import java.util.Objects;
 import java.util.Set;
 
 import org.keycloak.models.GroupModel;
@@ -62,6 +63,20 @@ public class GroupRemovedEvent extends InvalidationEvent implements RealmCacheIn
         if (parentId != null) {
             invalidations.add(parentId);
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        GroupRemovedEvent that = (GroupRemovedEvent) o;
+        return Objects.equals(groupId, that.groupId) && Objects.equals(parentId, that.parentId) && Objects.equals(realmId, that.realmId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), groupId, parentId, realmId);
     }
 
     public static class ExternalizerImpl implements Externalizer<GroupRemovedEvent> {

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/events/GroupUpdatedEvent.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/events/GroupUpdatedEvent.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.models.cache.infinispan.events;
 
+import java.util.Objects;
 import java.util.Set;
 
 import org.keycloak.models.cache.infinispan.RealmCacheManager;
@@ -55,6 +56,20 @@ public class GroupUpdatedEvent extends InvalidationEvent implements RealmCacheIn
     @Override
     public void addInvalidations(RealmCacheManager realmCache, Set<String> invalidations) {
         // Nothing. ID already invalidated
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        GroupUpdatedEvent that = (GroupUpdatedEvent) o;
+        return Objects.equals(groupId, that.groupId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), groupId);
     }
 
     public static class ExternalizerImpl implements Externalizer<GroupUpdatedEvent> {

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/events/InvalidationEvent.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/events/InvalidationEvent.java
@@ -17,12 +17,15 @@
 
 package org.keycloak.models.cache.infinispan.events;
 
+import org.jboss.logging.Logger;
 import org.keycloak.cluster.ClusterEvent;
 
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
  */
 public abstract class InvalidationEvent implements ClusterEvent {
+
+    private static final Logger log = Logger.getLogger(InvalidationEvent.class);
 
     public abstract String getId();
 
@@ -39,5 +42,10 @@ public abstract class InvalidationEvent implements ClusterEvent {
         InvalidationEvent that = (InvalidationEvent) obj;
         if (!that.getId().equals(getId())) return false;
         return true;
+    }
+
+    @Override
+    protected void finalize() throws Throwable {
+        super.finalize();
     }
 }

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/events/RealmRemovedEvent.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/events/RealmRemovedEvent.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.models.cache.infinispan.events;
 
+import java.util.Objects;
 import java.util.Set;
 
 import org.keycloak.models.cache.infinispan.RealmCacheManager;
@@ -56,6 +57,20 @@ public class RealmRemovedEvent extends InvalidationEvent implements RealmCacheIn
     @Override
     public void addInvalidations(RealmCacheManager realmCache, Set<String> invalidations) {
         realmCache.realmRemoval(realmId, realmName, invalidations);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        RealmRemovedEvent that = (RealmRemovedEvent) o;
+        return Objects.equals(realmId, that.realmId) && Objects.equals(realmName, that.realmName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), realmId, realmName);
     }
 
     public static class ExternalizerImpl implements Externalizer<RealmRemovedEvent> {

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/events/RealmUpdatedEvent.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/events/RealmUpdatedEvent.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.models.cache.infinispan.events;
 
+import java.util.Objects;
 import java.util.Set;
 
 import org.keycloak.models.cache.infinispan.RealmCacheManager;
@@ -56,6 +57,20 @@ public class RealmUpdatedEvent extends InvalidationEvent implements RealmCacheIn
     @Override
     public void addInvalidations(RealmCacheManager realmCache, Set<String> invalidations) {
         realmCache.realmUpdated(realmId, realmName, invalidations);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        RealmUpdatedEvent that = (RealmUpdatedEvent) o;
+        return Objects.equals(realmId, that.realmId) && Objects.equals(realmName, that.realmName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), realmId, realmName);
     }
 
     public static class ExternalizerImpl implements Externalizer<RealmUpdatedEvent> {

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/events/RoleAddedEvent.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/events/RoleAddedEvent.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.models.cache.infinispan.events;
 
+import java.util.Objects;
 import java.util.Set;
 
 import org.keycloak.models.cache.infinispan.RealmCacheManager;
@@ -56,6 +57,20 @@ public class RoleAddedEvent extends InvalidationEvent implements RealmCacheInval
     @Override
     public void addInvalidations(RealmCacheManager realmCache, Set<String> invalidations) {
         realmCache.roleAdded(containerId, invalidations);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        RoleAddedEvent that = (RoleAddedEvent) o;
+        return Objects.equals(roleId, that.roleId) && Objects.equals(containerId, that.containerId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), roleId, containerId);
     }
 
     public static class ExternalizerImpl implements Externalizer<RoleAddedEvent> {

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/events/RoleRemovedEvent.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/events/RoleRemovedEvent.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.models.cache.infinispan.events;
 
+import java.util.Objects;
 import java.util.Set;
 
 import org.keycloak.models.cache.infinispan.RealmCacheManager;
@@ -58,6 +59,20 @@ public class RoleRemovedEvent extends InvalidationEvent implements RealmCacheInv
     @Override
     public void addInvalidations(RealmCacheManager realmCache, Set<String> invalidations) {
         realmCache.roleRemoval(roleId, roleName, containerId, invalidations);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        RoleRemovedEvent that = (RoleRemovedEvent) o;
+        return Objects.equals(roleId, that.roleId) && Objects.equals(roleName, that.roleName) && Objects.equals(containerId, that.containerId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), roleId, roleName, containerId);
     }
 
     public static class ExternalizerImpl implements Externalizer<RoleRemovedEvent> {

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/events/RoleUpdatedEvent.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/events/RoleUpdatedEvent.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.models.cache.infinispan.events;
 
+import java.util.Objects;
 import java.util.Set;
 
 import org.keycloak.models.cache.infinispan.RealmCacheManager;
@@ -58,6 +59,20 @@ public class RoleUpdatedEvent extends InvalidationEvent implements RealmCacheInv
     @Override
     public void addInvalidations(RealmCacheManager realmCache, Set<String> invalidations) {
         realmCache.roleUpdated(containerId, roleName, invalidations);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        RoleUpdatedEvent that = (RoleUpdatedEvent) o;
+        return Objects.equals(roleId, that.roleId) && Objects.equals(roleName, that.roleName) && Objects.equals(containerId, that.containerId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), roleId, roleName, containerId);
     }
 
     public static class ExternalizerImpl implements Externalizer<RoleUpdatedEvent> {

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/events/UserCacheRealmInvalidationEvent.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/events/UserCacheRealmInvalidationEvent.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.models.cache.infinispan.events;
 
+import java.util.Objects;
 import java.util.Set;
 
 import org.keycloak.models.cache.infinispan.UserCacheManager;
@@ -54,6 +55,20 @@ public class UserCacheRealmInvalidationEvent  extends InvalidationEvent implemen
     @Override
     public void addInvalidations(UserCacheManager userCache, Set<String> invalidations) {
         userCache.invalidateRealmUsers(realmId, invalidations);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        UserCacheRealmInvalidationEvent that = (UserCacheRealmInvalidationEvent) o;
+        return Objects.equals(realmId, that.realmId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), realmId);
     }
 
     public static class ExternalizerImpl implements Externalizer<UserCacheRealmInvalidationEvent> {

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/events/UserConsentsUpdatedEvent.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/events/UserConsentsUpdatedEvent.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.models.cache.infinispan.events;
 
+import java.util.Objects;
 import java.util.Set;
 
 import org.keycloak.models.cache.infinispan.UserCacheManager;
@@ -54,6 +55,20 @@ public class UserConsentsUpdatedEvent extends InvalidationEvent implements UserC
     @Override
     public void addInvalidations(UserCacheManager userCache, Set<String> invalidations) {
         userCache.consentInvalidation(userId, invalidations);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        UserConsentsUpdatedEvent that = (UserConsentsUpdatedEvent) o;
+        return Objects.equals(userId, that.userId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), userId);
     }
 
     public static class ExternalizerImpl implements Externalizer<UserConsentsUpdatedEvent> {

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/events/UserFederationLinkRemovedEvent.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/events/UserFederationLinkRemovedEvent.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.models.cache.infinispan.events;
 
+import java.util.Objects;
 import java.util.Set;
 
 import org.keycloak.models.FederatedIdentityModel;
@@ -75,6 +76,20 @@ public class UserFederationLinkRemovedEvent extends InvalidationEvent implements
     @Override
     public void addInvalidations(UserCacheManager userCache, Set<String> invalidations) {
         userCache.federatedIdentityLinkRemovedInvalidation(userId, realmId, identityProviderId, socialUserId, invalidations);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        UserFederationLinkRemovedEvent that = (UserFederationLinkRemovedEvent) o;
+        return Objects.equals(userId, that.userId) && Objects.equals(realmId, that.realmId) && Objects.equals(identityProviderId, that.identityProviderId) && Objects.equals(socialUserId, that.socialUserId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), userId, realmId, identityProviderId, socialUserId);
     }
 
     public static class ExternalizerImpl implements Externalizer<UserFederationLinkRemovedEvent> {

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/events/UserFederationLinkUpdatedEvent.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/events/UserFederationLinkUpdatedEvent.java
@@ -16,6 +16,7 @@
  */
 package org.keycloak.models.cache.infinispan.events;
 
+import java.util.Objects;
 import java.util.Set;
 
 import org.keycloak.models.cache.infinispan.UserCacheManager;
@@ -53,6 +54,20 @@ public class UserFederationLinkUpdatedEvent extends InvalidationEvent implements
     @Override
     public void addInvalidations(UserCacheManager userCache, Set<String> invalidations) {
         userCache.federatedIdentityLinkUpdatedInvalidation(userId, invalidations);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        UserFederationLinkUpdatedEvent that = (UserFederationLinkUpdatedEvent) o;
+        return Objects.equals(userId, that.userId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), userId);
     }
 
     public static class ExternalizerImpl implements Externalizer<UserFederationLinkUpdatedEvent> {

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/events/UserFullInvalidationEvent.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/events/UserFullInvalidationEvent.java
@@ -20,6 +20,7 @@ package org.keycloak.models.cache.infinispan.events;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import org.keycloak.models.FederatedIdentityModel;
@@ -83,6 +84,20 @@ public class UserFullInvalidationEvent extends InvalidationEvent implements User
     @Override
     public void addInvalidations(UserCacheManager userCache, Set<String> invalidations) {
         userCache.fullUserInvalidation(userId, username, email, realmId, identityFederationEnabled, federatedIdentities, invalidations);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        UserFullInvalidationEvent that = (UserFullInvalidationEvent) o;
+        return identityFederationEnabled == that.identityFederationEnabled && Objects.equals(userId, that.userId) && Objects.equals(username, that.username) && Objects.equals(email, that.email) && Objects.equals(realmId, that.realmId) && Objects.equals(federatedIdentities, that.federatedIdentities);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), userId, username, email, realmId, identityFederationEnabled, federatedIdentities);
     }
 
     public static class ExternalizerImpl implements Externalizer<UserFullInvalidationEvent> {

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/events/UserUpdatedEvent.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/events/UserUpdatedEvent.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.models.cache.infinispan.events;
 
+import java.util.Objects;
 import java.util.Set;
 
 import org.keycloak.models.cache.infinispan.UserCacheManager;
@@ -60,6 +61,20 @@ public class UserUpdatedEvent extends InvalidationEvent implements UserCacheInva
     @Override
     public void addInvalidations(UserCacheManager userCache, Set<String> invalidations) {
         userCache.userUpdatedInvalidations(userId, username, email, realmId, invalidations);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        UserUpdatedEvent that = (UserUpdatedEvent) o;
+        return Objects.equals(userId, that.userId) && Objects.equals(username, that.username) && Objects.equals(email, that.email) && Objects.equals(realmId, that.realmId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), userId, username, email, realmId);
     }
 
     public static class ExternalizerImpl implements Externalizer<UserUpdatedEvent> {


### PR DESCRIPTION
TBD:
- [ ] Tests if possible
- [ ] `equals` for events added during map storage
- [ ] Check that all events that could go via `work` cache are covered
<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
