### PR TITLE
[KEYCLOAK-17933] Upgrade Keycloak to Wildfly 23.0.2.Final

### DIFF
--- a/distribution/galleon-feature-packs/adapter-galleon-pack/pom.xml
+++ b/distribution/galleon-feature-packs/adapter-galleon-pack/pom.xml
@@ -32,7 +32,7 @@
     
     <properties>
         <feature-pack.resources.directory>${basedir}/../../feature-packs/adapter-feature-pack/src/main/resources</feature-pack.resources.directory>
-        <version.org.wildfly.galleon-plugins>5.1.0.Final</version.org.wildfly.galleon-plugins>
+        <version.org.wildfly.galleon-plugins>5.1.3.Final</version.org.wildfly.galleon-plugins>
         <xmlFileSource>${feature-pack.resources.directory}/licenses/${product.slot}/licenses.xml</xmlFileSource>
         <outputDirectory>${basedir}/target/resources/packages/licenses/content/docs/licenses-${product.slot}</outputDirectory>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <product.rhsso.version>7.4.0.GA</product.rhsso.version>
 
         <product.build-time>${timestamp}</product.build-time>
-        <wildfly.version>23.0.1.Final</wildfly.version>
+        <wildfly.version>23.0.2.Final</wildfly.version>
         <wildfly.build-tools.version>1.2.13.Final</wildfly.build-tools.version>
         <eap.version>7.4.0.CD20-redhat-00001</eap.version>
         <wildfly.core.version>15.0.1.Final</wildfly.core.version>


### PR DESCRIPTION
    [KEYCLOAK-17933] Upgrade Keycloak to Wildfly 23.0.2.Final
    
    Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
