### PR TITLE
KEYCLOAK-17947 Propagate security domain to ejb

### DIFF
--- a/distribution/adapters/wildfly-adapter/cli/adapter-elytron-install-offline.cli
+++ b/distribution/adapters/wildfly-adapter/cli/adapter-elytron-install-offline.cli
@@ -57,3 +57,9 @@ if (outcome != success) of /subsystem=undertow/application-security-domain=other
 else
     echo Undertow already configured with Keycloak
 end-if
+
+if (outcome != success) of /subsystem=ejb3/application-security-domain=other:read-resource
+    /subsystem=ejb3/application-security-domain=other:add(security-domain=KeycloakDomain)
+else
+    echo EJB already configured with Keycloak
+end-if


### PR DESCRIPTION
same fix as in https://github.com/keycloak/keycloak/pull/5977 just for the offline installer

See https://issues.redhat.com/browse/KEYCLOAK-17947