### PR TITLE
KEYCLOAK-16928 Fix typo in authenticatorFlow representation

### DIFF
--- a/core/src/main/java/org/keycloak/representations/idm/AbstractAuthenticationExecutionRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/idm/AbstractAuthenticationExecutionRepresentation.java
@@ -67,11 +67,27 @@ public class AbstractAuthenticationExecutionRepresentation implements Serializab
      *
      * @return
      */
+    @Deprecated
     public boolean isAutheticatorFlow() {
         return authenticatorFlow;
     }
 
+    @Deprecated
     public void setAutheticatorFlow(boolean autheticatorFlow) {
         this.authenticatorFlow = autheticatorFlow;
     }
+
+    /**
+     * Is the referenced authenticator a flow?
+     *
+     * @return
+     */
+    public boolean isAuthenticatorFlow() {
+        return authenticatorFlow;
+    }
+
+    public void setAuthenticatorFlow(boolean authenticatorFlow) {
+        this.authenticatorFlow = authenticatorFlow;
+    }
+
 }

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
@@ -735,7 +735,7 @@ public class ModelToRepresentation {
             rep.setAuthenticatorConfig(config.getAlias());
         }
         rep.setAuthenticator(model.getAuthenticator());
-        rep.setAutheticatorFlow(model.isAuthenticatorFlow());
+        rep.setAuthenticatorFlow(model.isAuthenticatorFlow());
         if (model.getFlowId() != null) {
             AuthenticationFlowModel flow = realm.getAuthenticationFlowById(model.getFlowId());
             rep.setFlowAlias(flow.getAlias());

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
@@ -2085,7 +2085,7 @@ public class RepresentationToModel {
             model.setAuthenticatorConfig(config.getId());
         }
         model.setAuthenticator(rep.getAuthenticator());
-        model.setAuthenticatorFlow(rep.isAutheticatorFlow());
+        model.setAuthenticatorFlow(rep.isAuthenticatorFlow());
         if (rep.getFlowAlias() != null) {
             AuthenticationFlowModel flow = realm.getFlowByAlias(rep.getFlowAlias());
             model.setFlowId(flow.getId());
@@ -2111,7 +2111,7 @@ public class RepresentationToModel {
         model.setAuthenticator(rep.getAuthenticator());
         model.setPriority(rep.getPriority());
         model.setParentFlow(rep.getParentFlow());
-        model.setAuthenticatorFlow(rep.isAutheticatorFlow());
+        model.setAuthenticatorFlow(rep.isAuthenticatorFlow());
         model.setRequirement(AuthenticationExecutionModel.Requirement.valueOf(rep.getRequirement()));
 
         if (rep.getAuthenticatorConfig() != null) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/authentication/AbstractAuthenticationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/authentication/AbstractAuthenticationTest.java
@@ -107,7 +107,7 @@ public abstract class AbstractAuthenticationTest extends AbstractKeycloakTest {
         Assert.assertEquals("Execution flowAlias - " + actual.getFlowAlias(), expected.getFlowAlias(), actual.getFlowAlias());
         Assert.assertEquals("Execution authenticator - " + actual.getAuthenticator(), expected.getAuthenticator(), actual.getAuthenticator());
         Assert.assertEquals("Execution userSetupAllowed - " + actual.getAuthenticator(), expected.isUserSetupAllowed(), actual.isUserSetupAllowed());
-        Assert.assertEquals("Execution authenticatorFlow - " + actual.getAuthenticator(), expected.isAutheticatorFlow(), actual.isAutheticatorFlow());
+        Assert.assertEquals("Execution authenticatorFlow - " + actual.getAuthenticator(), expected.isAuthenticatorFlow(), actual.isAuthenticatorFlow());
         Assert.assertEquals("Execution authenticatorConfig - " + actual.getAuthenticator(), expected.getAuthenticatorConfig(), actual.getAuthenticatorConfig());
         Assert.assertEquals("Execution priority - " + actual.getAuthenticator(), expected.getPriority(), actual.getPriority());
         Assert.assertEquals("Execution requirement - " + actual.getAuthenticator(), expected.getRequirement(), actual.getRequirement());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/authentication/FlowTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/authentication/FlowTest.java
@@ -185,7 +185,7 @@ public class FlowTest extends AbstractAuthenticationTest {
         AuthenticationExecutionExportRepresentation expected = new AuthenticationExecutionExportRepresentation();
         expected.setFlowAlias("SomeFlow");
         expected.setUserSetupAllowed(false);
-        expected.setAutheticatorFlow(true);
+        expected.setAuthenticatorFlow(true);
         expected.setRequirement("DISABLED");
         expected.setPriority(0);
         compareExecution(expected, execs.get(0));
@@ -194,7 +194,7 @@ public class FlowTest extends AbstractAuthenticationTest {
         expected.setFlowAlias("SomeFlow2");
         expected.setUserSetupAllowed(false);
         expected.setAuthenticator("registration-page-form");
-        expected.setAutheticatorFlow(true);
+        expected.setAuthenticatorFlow(true);
         expected.setRequirement("DISABLED");
         expected.setPriority(1);
         compareExecution(expected, execs.get(1));

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/authentication/InitialFlowsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/authentication/InitialFlowsTest.java
@@ -251,7 +251,7 @@ public class InitialFlowsTest extends AbstractAuthenticationTest {
         rep.setFlowAlias(flowAlias);
         rep.setUserSetupAllowed(userSetupAllowed);
         rep.setAuthenticator(authenticator);
-        rep.setAutheticatorFlow(authenticatorFlow);
+        rep.setAuthenticatorFlow(authenticatorFlow);
         rep.setAuthenticatorConfig(authenticatorConfig);
         rep.setRequirement(requirement);
         rep.setPriority(priority);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/util/ExecutionBuilder.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/util/ExecutionBuilder.java
@@ -60,7 +60,7 @@ public class ExecutionBuilder {
     }
 
     public ExecutionBuilder authenticatorFlow(boolean authenticatorFlow) {
-        rep.setAutheticatorFlow(authenticatorFlow);
+        rep.setAuthenticatorFlow(authenticatorFlow);
         return this;
     }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/KEYCLOAK-16928

Fixing the issue in representation only. Old methods with typo are still present and deprecated, so it is backwards compatible.
No changes in migration files.