### PR TITLE
KEYCLOAK-16808 Client Policy : Implement existing ConsentRequiredClientRegistrationPolicy as Client Policies' executor

### DIFF
--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/ConsentRequiredExecutor.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/ConsentRequiredExecutor.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.services.clientpolicy.executor;
+
+import org.keycloak.events.Errors;
+import org.keycloak.models.ClientModel;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.services.clientpolicy.ClientPolicyContext;
+import org.keycloak.services.clientpolicy.ClientPolicyException;
+import org.keycloak.services.clientpolicy.context.ClientCRUDContext;
+
+/**
+ * @author <a href="mailto:takashi.norimatsu.ws@hitachi.com">Takashi Norimatsu</a>
+ */
+public class ConsentRequiredExecutor implements ClientPolicyExecutorProvider<ClientPolicyExecutorConfiguration> {
+
+    @Override
+    public void executeOnEvent(ClientPolicyContext context) throws ClientPolicyException {
+        ClientCRUDContext clientUpdateContext = null;
+        switch (context.getEvent()) {
+            case REGISTERED:
+                clientUpdateContext = (ClientCRUDContext)context;
+                afterRegister(clientUpdateContext.getTargetClient());
+                break;
+            case UPDATE:
+                clientUpdateContext = (ClientCRUDContext)context;
+                beforeUpdate(clientUpdateContext.getTargetClient(), clientUpdateContext.getProposedClientRepresentation());
+                break;
+            default:
+                return;
+        }
+    }
+
+    @Override
+    public String getProviderId() {
+        return ConsentRequiredExecutorFactory.PROVIDER_ID;
+    }
+
+    private void afterRegister(ClientModel clientModel) {
+        clientModel.setConsentRequired(true);
+    }
+
+    public void beforeUpdate(ClientModel clientToBeUpdated, ClientRepresentation proposedClient) throws ClientPolicyException {
+        if (proposedClient.isConsentRequired() == null) {
+            return;
+        }
+        if (clientToBeUpdated == null) {
+            return;
+        }
+
+        boolean isConsentRequired = clientToBeUpdated.isConsentRequired();
+        boolean newConsentRequired = proposedClient.isConsentRequired();
+
+        if (isConsentRequired && !newConsentRequired) {
+            throw new ClientPolicyException(Errors.INVALID_REGISTRATION, "Not permitted to update consentRequired to false");
+        }
+    }
+
+}

--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/ConsentRequiredExecutorFactory.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/ConsentRequiredExecutorFactory.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.services.clientpolicy.executor;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.keycloak.Config.Scope;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.provider.ProviderConfigProperty;
+
+/**
+ * @author <a href="mailto:takashi.norimatsu.ws@hitachi.com">Takashi Norimatsu</a>
+ */
+public class ConsentRequiredExecutorFactory implements ClientPolicyExecutorProviderFactory {
+
+    public static final String PROVIDER_ID = "consent-required-executor";
+
+    @Override
+    public ClientPolicyExecutorProvider create(KeycloakSession session) {
+        return new ConsentRequiredExecutor();
+    }
+
+    @Override
+    public void init(Scope config) {
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public String getHelpText() {
+        return "When present, then newly registered client will always have 'consentRequired' switch enabled";
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return Collections.emptyList();
+    }
+
+}

--- a/services/src/main/resources/META-INF/services/org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProviderFactory
+++ b/services/src/main/resources/META-INF/services/org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProviderFactory
@@ -8,3 +8,4 @@ org.keycloak.services.clientpolicy.executor.SecureRedirectUriEnforceExecutorFact
 org.keycloak.services.clientpolicy.executor.SecureSigningAlgorithmForSignedJwtEnforceExecutorFactory
 org.keycloak.services.clientpolicy.executor.HolderOfKeyEnforceExecutorFactory
 org.keycloak.services.clientpolicy.executor.ConfidentialClientAcceptExecutorFactory
+org.keycloak.services.clientpolicy.executor.ConsentRequiredExecutorFactory


### PR DESCRIPTION
This PR is for [KEYCLOAK-13933 Client Policies](https://issues.redhat.com/browse/KEYCLOAK-13933), also is the part of the project [Client Policy Official Support](https://github.com/keycloak/kc-sig-fapi/projects) of [FAPI-SIG](https://github.com/keycloak/kc-sig-fapi) activity.

[KEYCLOAK-16808](https://issues.redhat.com/browse/KEYCLOAK-16808) describes it in detail.

This PR has been written with the contribution by @andriimurashkin as FAPI-SIG activities.