### PR TITLE
KEYCLOAK-18034 Enforce SecureSigningAlgorithmForSignedJwtEnforceExecutor to private-key-jwt clients regardless their option

### DIFF
--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureSigningAlgorithmForSignedJwtEnforceExecutor.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureSigningAlgorithmForSignedJwtEnforceExecutor.java
@@ -17,20 +17,20 @@
 
 package org.keycloak.services.clientpolicy.executor;
 
-import java.util.List;
 import java.util.Optional;
 
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.spi.HttpRequest;
 import org.keycloak.OAuth2Constants;
 import org.keycloak.OAuthErrorException;
+import org.keycloak.authentication.authenticators.client.JWTClientAuthenticator;
+import org.keycloak.common.util.ObjectUtil;
 import org.keycloak.crypto.Algorithm;
 import org.keycloak.jose.jws.JWSInput;
 import org.keycloak.jose.jws.JWSInputException;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.services.clientpolicy.ClientPolicyContext;
 import org.keycloak.services.clientpolicy.ClientPolicyException;
-import org.keycloak.services.clientpolicy.executor.SecureClientAuthEnforceExecutor.Configuration;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -84,9 +84,12 @@ public class SecureSigningAlgorithmForSignedJwtEnforceExecutor implements Client
             case TOKEN_INTROSPECT:
             case LOGOUT_REQUEST:
                 boolean isRequireClientAssertion = Optional.ofNullable(configuration.isRequireClientAssertion()).orElse(Boolean.FALSE).booleanValue();
-                if (!isRequireClientAssertion) break;
                 HttpRequest req = session.getContext().getContextObject(HttpRequest.class);
                 String clientAssertion = req.getDecodedFormParameters().getFirst(OAuth2Constants.CLIENT_ASSERTION);
+                if (!isRequireClientAssertion && ObjectUtil.isBlank(clientAssertion)) {
+                    break;
+                }
+
                 JWSInput jws = null;
                 try {
                     jws = new JWSInput(clientAssertion);


### PR DESCRIPTION
This PR is for [KEYCLOAK-13933 Client Policies](https://issues.redhat.com/browse/KEYCLOAK-13933), also is the part of the project [Client Policy Official Support](https://github.com/keycloak/kc-sig-fapi/projects) of [FAPI-SIG](https://github.com/keycloak/kc-sig-fapi) activity.

[KEYCLOAK-18034](https://issues.redhat.com/browse/KEYCLOAK-18034) describes it in detail.
