### PR TITLE
KEYCLOAK-17928 Determine public client based on token_endpoint_auth_method during OIDC dynamic client registration

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/OIDCClientRegistrationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/OIDCClientRegistrationTest.java
@@ -254,22 +254,27 @@ public class OIDCClientRegistrationTest extends AbstractClientRegistrationTest {
     public void createClientImplicitFlow() throws ClientRegistrationException {
         OIDCClientRepresentation clientRep = createRep();
 
-        // create implicitFlow client and assert it's public client
         clientRep.setResponseTypes(Arrays.asList("id_token token"));
         OIDCClientRepresentation response = reg.oidc().create(clientRep);
 
         String clientId = response.getClientId();
         ClientRepresentation kcClientRep = getKeycloakClient(clientId);
+        Assert.assertFalse(kcClientRep.isPublicClient());
+        Assert.assertNull(kcClientRep.getSecret());
+    }
+
+    @Test
+    public void createPublicClient() throws ClientRegistrationException {
+        OIDCClientRepresentation clientRep = createRep();
+
+        clientRep.setTokenEndpointAuthMethod("none");
+        OIDCClientRepresentation response = reg.oidc().create(clientRep);
+        Assert.assertEquals("none", response.getTokenEndpointAuthMethod());
+
+        String clientId = response.getClientId();
+        ClientRepresentation kcClientRep = getKeycloakClient(clientId);
         Assert.assertTrue(kcClientRep.isPublicClient());
         Assert.assertNull(kcClientRep.getSecret());
-
-        // Update client to hybrid and check it's not public client anymore
-        reg.auth(Auth.token(response));
-        response.setResponseTypes(Arrays.asList("id_token token", "code id_token", "code"));
-        reg.oidc().update(response);
-
-        kcClientRep = getKeycloakClient(clientId);
-        Assert.assertFalse(kcClientRep.isPublicClient());
     }
 
     // KEYCLOAK-6771 Certificate Bound Token


### PR DESCRIPTION
This PR is for [KEYCLOAK-13933 Client Policies](https://issues.redhat.com/browse/KEYCLOAK-13933), also is the part of the project [Client Policy Official Support](https://github.com/keycloak/kc-sig-fapi/projects) of [FAPI-SIG](https://github.com/keycloak/kc-sig-fapi) activity.

[KEYCLOAK-17928](https://issues.redhat.com/browse/KEYCLOAK-17928) describes it in detail.
