### PR TITLE
[KEYCLOAK-17903] idp metadata describing one entity MUST have EntityDescriptor root element

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/saml/IDPMetadataDescriptor.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/IDPMetadataDescriptor.java
@@ -18,7 +18,6 @@
 package org.keycloak.protocol.saml;
 
 import org.keycloak.dom.saml.v2.metadata.EndpointType;
-import org.keycloak.dom.saml.v2.metadata.EntitiesDescriptorType;
 import org.keycloak.dom.saml.v2.metadata.EntityDescriptorType;
 import org.keycloak.dom.saml.v2.metadata.IDPSSODescriptorType;
 import org.keycloak.dom.saml.v2.metadata.IndexedEndpointType;
@@ -64,9 +63,6 @@ public class IDPMetadataDescriptor {
         XMLStreamWriter writer = StaxUtil.getXMLStreamWriter(sw);
         SAMLMetadataWriter metadataWriter = new SAMLMetadataWriter(writer);
 
-        EntitiesDescriptorType entitiesDescriptor = new EntitiesDescriptorType();
-        entitiesDescriptor.setName("urn:keycloak");
-
         EntityDescriptorType entityDescriptor = new EntityDescriptorType(entityId);
 
         IDPSSODescriptorType spIDPDescriptor = new IDPSSODescriptorType(Arrays.asList(PROTOCOL_NSURI.get()));
@@ -98,9 +94,7 @@ public class IDPMetadataDescriptor {
 
         entityDescriptor.addChoiceType(new EntityDescriptorType.EDTChoiceType(Arrays.asList(new EntityDescriptorType.EDTDescriptorChoiceType(spIDPDescriptor))));
       
-        entitiesDescriptor.addEntityDescriptor(entityDescriptor);
-
-        metadataWriter.writeEntitiesDescriptor(entitiesDescriptor);
+        metadataWriter.writeEntityDescriptor(entityDescriptor);
 
         return sw.toString();
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/url/FixedHostnameTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/url/FixedHostnameTest.java
@@ -11,7 +11,6 @@ import org.keycloak.client.registration.Auth;
 import org.keycloak.client.registration.ClientRegistration;
 import org.keycloak.client.registration.ClientRegistrationException;
 import org.keycloak.dom.saml.v2.metadata.EndpointType;
-import org.keycloak.dom.saml.v2.metadata.EntitiesDescriptorType;
 import org.keycloak.dom.saml.v2.metadata.EntityDescriptorType;
 import org.keycloak.dom.saml.v2.metadata.IDPSSODescriptorType;
 import org.keycloak.dom.saml.v2.protocol.ResponseType;
@@ -230,12 +229,9 @@ public class FixedHostnameTest extends AbstractHostnameTest {
           ) {
             entityDescriptor = EntityUtils.toString(resp.getEntity(), GeneralConstants.SAML_CHARSET);
             Object metadataO = SAMLParser.getInstance().parse(new ByteArrayInputStream(entityDescriptor.getBytes(GeneralConstants.SAML_CHARSET)));
-            assertThat(metadataO, instanceOf(EntitiesDescriptorType.class));
-            EntitiesDescriptorType metadata = (EntitiesDescriptorType) metadataO;
+            assertThat(metadataO, instanceOf(EntityDescriptorType.class));
+            EntityDescriptorType ed = (EntityDescriptorType) metadataO;
 
-            assertThat(metadata.getEntityDescriptor(), hasSize(1));
-            assertThat(metadata.getEntityDescriptor().get(0), instanceOf(EntityDescriptorType.class));
-            EntityDescriptorType ed = (EntityDescriptorType) metadata.getEntityDescriptor().get(0);
             assertThat(ed.getEntityID(), is(realmUrl));
 
             IDPSSODescriptorType idpDescriptor = ed.getChoiceType().get(0).getDescriptors().get(0).getIdpDescriptor();


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/KEYCLOAK-18049

Just removing the `EntitiesDescriptorType` because the SAML endpoint always adds only one `EntityDescriptorType`. We are following the spec now, besides this is already done this way in the [SPMetadataDescriptor counterpart](https://github.com/keycloak/keycloak/blob/13.0.0/saml-core/src/main/java/org/keycloak/saml/SPMetadataDescriptor.java#L72). Adding a check for this in the `SAMLServletAdapterTest` for both SP and IDP endpoints and modifying `FixedHostnameTest` accordingly.

@hmlnarik Take a look when you have some time and let me know if you see some improvement.