### PR TITLE
KEYCLOAK-18052 Client Policies : Revise SecureRequestObjectExecutor to have an option for checking "nbf" claim

### DIFF
--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureRequestObjectExecutor.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureRequestObjectExecutor.java
@@ -59,8 +59,20 @@ public class SecureRequestObjectExecutor implements ClientPolicyExecutorProvider
     }
 
     @Override
-    public void setupConfiguration(Configuration config) {
-        this.configuration = config;
+    public void setupConfiguration(SecureRequestObjectExecutor.Configuration config) {
+        if (config == null) {
+            configuration = new Configuration();
+            configuration.setVerifyNbf(Boolean.TRUE);
+            configuration.setAvailablePeriod(DEFAULT_AVAILABLE_PERIOD);
+        } else {
+            configuration = config;
+            if (config.isVerifyNbf() == null) {
+                configuration.setVerifyNbf(Boolean.TRUE);
+            }
+            if (config.getAvailablePeriod() == null) {
+                configuration.setAvailablePeriod(DEFAULT_AVAILABLE_PERIOD);
+            }
+        }
     }
 
     @Override
@@ -72,6 +84,8 @@ public class SecureRequestObjectExecutor implements ClientPolicyExecutorProvider
     public static class Configuration extends ClientPolicyExecutorConfiguration {
         @JsonProperty("available-period")
         protected Integer availablePeriod;
+        @JsonProperty("verify-nbf")
+        protected Boolean verifyNbf;
 
         public Integer getAvailablePeriod() {
             return availablePeriod;
@@ -79,6 +93,14 @@ public class SecureRequestObjectExecutor implements ClientPolicyExecutorProvider
 
         public void setAvailablePeriod(Integer availablePeriod) {
             this.availablePeriod = availablePeriod;
+        }
+
+        public Boolean isVerifyNbf() {
+            return verifyNbf;
+        }
+
+        public void setVerifyNbf(Boolean verifyNbf) {
+            this.verifyNbf = verifyNbf;
         }
     }
 
@@ -150,24 +172,28 @@ public class SecureRequestObjectExecutor implements ClientPolicyExecutorProvider
             throw new ClientPolicyException(INVALID_REQUEST_OBJECT, "Request Expired");
         }
 
-        // check whether "nbf" claim exists
-        if (requestObject.get("nbf") == null) {
-            logger.trace("nbf claim not incuded.");
-            throw new ClientPolicyException(INVALID_REQUEST_OBJECT, "Missing parameter : nbf");
-        }
+        // "nbf" check is not needed for FAPI-RW ID2 security profile
+        // while needed for FAPI 1.0 Advanced security profile
+        if (Optional.ofNullable(configuration.isVerifyNbf()).orElse(Boolean.FALSE).booleanValue()) {
+            // check whether "nbf" claim exists
+            if (requestObject.get("nbf") == null) {
+                logger.trace("nbf claim not incuded.");
+                throw new ClientPolicyException(INVALID_REQUEST_OBJECT, "Missing parameter : nbf");
+            }
 
-        // check whether request object not yet being processed
-        long nbf = requestObject.get("nbf").asLong();
-        if (Time.currentTime() < nbf) { // TODO: Time.currentTime() is int while nbf is long...
-            logger.trace("request object not yet being processed.");
-            throw new ClientPolicyException(INVALID_REQUEST_OBJECT, "Request not yet being processed");
-        }
+            // check whether request object not yet being processed
+            long nbf = requestObject.get("nbf").asLong();
+            if (Time.currentTime() < nbf) { // TODO: Time.currentTime() is int while nbf is long...
+                logger.trace("request object not yet being processed.");
+                throw new ClientPolicyException(INVALID_REQUEST_OBJECT, "Request not yet being processed");
+            }
 
-        // check whether request object's available period is short
-        int availablePeriod = Optional.ofNullable(configuration.getAvailablePeriod()).orElse(DEFAULT_AVAILABLE_PERIOD).intValue();
-        if (exp - nbf > availablePeriod) {
-            logger.trace("request object's available period is long.");
-            throw new ClientPolicyException(INVALID_REQUEST_OBJECT, "Request's available period is long");
+            // check whether request object's available period is short
+            int availablePeriod = Optional.ofNullable(configuration.getAvailablePeriod()).orElse(DEFAULT_AVAILABLE_PERIOD).intValue();
+            if (exp - nbf > availablePeriod) {
+                logger.trace("request object's available period is long.");
+                throw new ClientPolicyException(INVALID_REQUEST_OBJECT, "Request's available period is long");
+            }
         }
 
         // check whether "aud" claim exists

--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureRequestObjectExecutorFactory.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureRequestObjectExecutorFactory.java
@@ -17,6 +17,8 @@
 
 package org.keycloak.services.clientpolicy.executor;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -31,6 +33,11 @@ import org.keycloak.provider.ProviderConfigProperty;
 public class SecureRequestObjectExecutorFactory implements ClientPolicyExecutorProviderFactory {
 
     public static final String PROVIDER_ID = "secure-reqobj-executor";
+
+    public static final String VERIFY_NBF = "verify-nbf";
+
+    private static final ProviderConfigProperty VERIFY_NBF_PROPERTY = new ProviderConfigProperty(
+            VERIFY_NBF, null, null, ProviderConfigProperty.BOOLEAN_TYPE, true);
 
     @Override
     public ClientPolicyExecutorProvider create(KeycloakSession session) {
@@ -61,7 +68,7 @@ public class SecureRequestObjectExecutorFactory implements ClientPolicyExecutorP
 
     @Override
     public List<ProviderConfigProperty> getConfigProperties() {
-        return Collections.emptyList();
+        return new ArrayList<>(Arrays.asList(VERIFY_NBF_PROPERTY));
     }
 
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/AbstractClientPoliciesTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/AbstractClientPoliciesTest.java
@@ -869,9 +869,10 @@ public abstract class AbstractClientPoliciesTest extends AbstractKeycloakTest {
         return config;
     }
 
-    protected Object createSecureRequestObjectExecutorConfig(Integer availablePeriod) {
+    protected Object createSecureRequestObjectExecutorConfig(Integer availablePeriod, Boolean verifyNbf) {
         SecureRequestObjectExecutor.Configuration config = new SecureRequestObjectExecutor.Configuration();
         if (availablePeriod != null) config.setAvailablePeriod(availablePeriod);
+        if (verifyNbf != null) config.setVerifyNbf(verifyNbf);
         return config;
     }
 


### PR DESCRIPTION
This PR is for [KEYCLOAK-13933 Client Policies](https://issues.redhat.com/browse/KEYCLOAK-13933), also is the part of the project [Client Policy Official Support](https://github.com/keycloak/kc-sig-fapi/projects) of [FAPI-SIG](https://github.com/keycloak/kc-sig-fapi) activity.

[KEYCLOAK-18052](https://issues.redhat.com/browse/KEYCLOAK-18052) describes it in detail.