### PR TITLE
[KEYCLOAK-14696] Unable to fetch list of members from a group through keycloak admin console.

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/membership/MembershipType.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/membership/MembershipType.java
@@ -110,8 +110,10 @@ public enum MembershipType {
                 query.addWhereCondition(orCondition);
                 List<LDAPObject> ldapUsers = query.getResultList();
                 for (LDAPObject ldapUser : ldapUsers) {
-                    String username = LDAPUtils.getUsername(ldapUser, ldapConfig);
-                    usernames.add(username);
+                    if (dns.contains(ldapUser.getDn())) {
+                        String username = LDAPUtils.getUsername(ldapUser, ldapConfig);
+                        usernames.add(username);
+                    }
                 }
             }
 

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/util/LDAPTestUtils.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/util/LDAPTestUtils.java
@@ -30,6 +30,7 @@ import org.keycloak.storage.ldap.LDAPStorageProvider;
 import org.keycloak.storage.ldap.LDAPConfig;
 import org.keycloak.storage.ldap.LDAPStorageProviderFactory;
 import org.keycloak.storage.ldap.LDAPUtils;
+import org.keycloak.storage.ldap.idm.model.LDAPDn;
 import org.keycloak.storage.ldap.idm.model.LDAPObject;
 import org.keycloak.storage.ldap.idm.query.internal.LDAPQuery;
 import org.keycloak.storage.ldap.idm.store.ldap.LDAPIdentityStore;
@@ -139,6 +140,18 @@ public class LDAPTestUtils {
             }
         };
         return LDAPUtils.addUserToLDAP(ldapProvider, realm, helperUser);
+    }
+
+    public static LDAPObject addLdapOU(LDAPStorageProvider ldapProvider, String name) {
+        LDAPObject ldapObject = new LDAPObject();
+        ldapObject.setRdnAttributeName("ou");
+        ldapObject.setObjectClasses(Collections.singletonList("organizationalUnit"));
+        ldapObject.setSingleAttribute("ou", name);
+        LDAPDn dn = LDAPDn.fromString(ldapProvider.getLdapIdentityStore().getConfig().getUsersDn());
+        dn.addFirst("ou", name);
+        ldapObject.setDn(dn);
+        ldapProvider.getLdapIdentityStore().add(ldapObject);
+        return ldapObject;
     }
 
     public static void updateLDAPPassword(LDAPStorageProvider ldapProvider, LDAPObject ldapUser, String password) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPSyncTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPSyncTest.java
@@ -17,6 +17,10 @@
 
 package org.keycloak.testsuite.federation.ldap;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.hamcrest.Matchers;
@@ -40,7 +44,9 @@ import org.keycloak.services.managers.UserStorageSyncManager;
 import org.keycloak.storage.ldap.LDAPStorageProvider;
 import org.keycloak.storage.ldap.LDAPStorageProviderFactory;
 import org.keycloak.storage.ldap.LDAPUtils;
+import org.keycloak.storage.ldap.idm.model.LDAPDn;
 import org.keycloak.storage.ldap.idm.model.LDAPObject;
+import org.keycloak.storage.ldap.mappers.UserAttributeLDAPStorageMapper;
 import org.keycloak.storage.ldap.mappers.membership.LDAPGroupMapperMode;
 import org.keycloak.storage.ldap.mappers.membership.MembershipType;
 import org.keycloak.storage.ldap.mappers.membership.group.GroupLDAPStorageMapper;
@@ -490,6 +496,127 @@ public class LDAPSyncTest extends AbstractLDAPTest {
             String descriptionAttrName = LDAPTestUtils.getGroupDescriptionLDAPAttrName(ctx.getLdapProvider());
 
             Assert.assertEquals("group5 - description", kcGroup5.getFirstAttribute(descriptionAttrName));
+        });
+    }
+
+    // KEYCLOAK-14696
+    @Test
+    public void test09MembershipUsingDifferentAttributes() throws Exception {
+        final Map<String, String> previousConf = testingClient.server().fetch(session -> {
+            LDAPTestContext ctx = LDAPTestContext.init(session);
+            RealmModel appRealm = ctx.getRealm();
+
+            // Remove all users from model
+            session.userLocalStorage().getUsersStream(ctx.getRealm(), true)
+                    .peek(user -> System.out.println("trying to delete user: " + user.getUsername()))
+                    .collect(Collectors.toList())
+                    .forEach(user -> {
+                        UserCache userCache = session.userCache();
+                        if (userCache != null) {
+                            userCache.evict(ctx.getRealm(), user);
+                        }
+                        session.userLocalStorage().removeUser(ctx.getRealm(), user);
+                    });
+
+            Map<String, String> orig = new HashMap<>();
+            orig.put(LDAPConstants.RDN_LDAP_ATTRIBUTE, ctx.getLdapModel().getConfig().getFirst(LDAPConstants.RDN_LDAP_ATTRIBUTE));
+            orig.put(LDAPConstants.USERS_DN, ctx.getLdapModel().getConfig().getFirst(LDAPConstants.USERS_DN));
+            orig.put(LDAPConstants.USERNAME_LDAP_ATTRIBUTE, ctx.getLdapModel().getConfig().getFirst(LDAPConstants.USERNAME_LDAP_ATTRIBUTE));
+
+            // create an OU and this test will work below it, set RDN to CN and username to uid/samaccountname
+            LDAPTestUtils.addLdapOU(ctx.getLdapProvider(), "KC14696");
+            ctx.getLdapModel().getConfig().putSingle(LDAPConstants.USERS_DN, "ou=KC14696," + orig.get(LDAPConstants.USERS_DN));
+            ctx.getLdapModel().getConfig().putSingle(LDAPConstants.RDN_LDAP_ATTRIBUTE, LDAPConstants.CN);
+            ctx.getLdapModel().getConfig().putSingle(LDAPConstants.USERNAME_LDAP_ATTRIBUTE,
+                    ctx.getLdapProvider().getLdapIdentityStore().getConfig().isActiveDirectory()? LDAPConstants.SAM_ACCOUNT_NAME : LDAPConstants.UID);
+
+            ctx.getRealm().updateComponent(ctx.getLdapModel());
+
+            ComponentModel mapperModel = LDAPTestUtils.getSubcomponentByName(appRealm, ctx.getLdapModel(), "username");
+            mapperModel.getConfig().putSingle(UserAttributeLDAPStorageMapper.LDAP_ATTRIBUTE,
+                    ctx.getLdapProvider().getLdapIdentityStore().getConfig().isActiveDirectory()? LDAPConstants.SAM_ACCOUNT_NAME : LDAPConstants.UID);
+            ctx.getRealm().updateComponent(mapperModel);
+
+            LDAPTestUtils.addUserAttributeMapper(appRealm, LDAPTestUtils.getLdapProviderModel(appRealm), "cnMapper", "firstName", LDAPConstants.CN);
+
+            return orig;
+        }, Map.class);
+
+        testingClient.server().run(session -> {
+            LDAPTestContext ctx = LDAPTestContext.init(session);
+            RealmModel appRealm = ctx.getRealm();
+
+            // create a user8 inside the usersDn
+            LDAPObject user8 = LDAPTestUtils.addLDAPUser(ctx.getLdapProvider(), ctx.getRealm(), "user8", "User8FN", "User8LN", "user8@email.org", "user8street", "126");
+
+            // create a sample ou inside usersDn
+            LDAPTestUtils.addLdapOU(ctx.getLdapProvider(), "sample-org");
+
+            // create a user below the sample org with the same common-name but different username
+            String usersDn = ctx.getLdapModel().get(LDAPConstants.USERS_DN);
+            ctx.getLdapModel().getConfig().putSingle(LDAPConstants.USERS_DN, "ou=sample-org," + usersDn);
+            ctx.getRealm().updateComponent(ctx.getLdapModel());
+            LDAPTestUtils.addLDAPUser(ctx.getLdapProvider(), ctx.getRealm(), "user8bis", "User8FN", "User8LN", "user8bis@email.org", "user8street", "126");
+
+            // get back to parent usersDn
+            ctx.getLdapModel().getConfig().putSingle(LDAPConstants.USERS_DN, usersDn);
+            ctx.getRealm().updateComponent(ctx.getLdapModel());
+
+            // create a group with user8 as a member
+            String descriptionAttrName = LDAPTestUtils.getGroupDescriptionLDAPAttrName(ctx.getLdapProvider());
+            LDAPObject user8Group = LDAPTestUtils.createLDAPGroup(session, appRealm, ctx.getLdapModel(), "user8group", descriptionAttrName, "user8group - description");
+            LDAPUtils.addMember(ctx.getLdapProvider(), MembershipType.DN, LDAPConstants.MEMBER, "not-used", user8Group, user8);
+        });
+
+        testingClient.server().run(session -> {
+            LDAPTestContext ctx = LDAPTestContext.init(session);
+            RealmModel appRealm = ctx.getRealm();
+
+            KeycloakSessionFactory sessionFactory = session.getKeycloakSessionFactory();
+            SynchronizationResult syncResult = new UserStorageSyncManager().syncAllUsers(sessionFactory, "test", ctx.getLdapModel());
+            Assert.assertEquals(2, syncResult.getAdded());
+
+            GroupModel user8Group = KeycloakModelUtils.findGroupByPath(appRealm, "/user8group");
+            Assert.assertNotNull(user8Group);
+            UserModel user8 = session.users().getUserByUsername(appRealm, "user8");
+            Assert.assertNotNull(user8);
+            UserModel user8Bis = session.users().getUserByUsername(appRealm, "user8bis");
+            Assert.assertNotNull(user8Bis);
+            Assert.assertTrue("User user8 contains the group", user8.getGroupsStream().collect(Collectors.toSet()).contains(user8Group));
+            Assert.assertFalse("User user8bis does not contain the group", user8Bis.getGroupsStream().collect(Collectors.toSet()).contains(user8Group));
+            List<String> members = session.users().getGroupMembersStream(appRealm, user8Group).map(u -> u.getUsername()).collect(Collectors.toList());
+            Assert.assertEquals("Group contains only user8", members, Collections.singletonList("user8"));
+        });
+
+        // revert changes
+        testingClient.server().run(session -> {
+            LDAPTestContext ctx = LDAPTestContext.init(session);
+            RealmModel appRealm = ctx.getRealm();
+
+            session.users().removeImportedUsers(appRealm, ldapModelId);
+            LDAPTestUtils.removeLDAPUserByUsername(ctx.getLdapProvider(), appRealm, ctx.getLdapProvider().getLdapIdentityStore().getConfig(), "user8");
+            LDAPTestUtils.removeLDAPUserByUsername(ctx.getLdapProvider(), appRealm, ctx.getLdapProvider().getLdapIdentityStore().getConfig(), "user8bis");
+            LDAPObject ou = new LDAPObject();
+            ou.setDn(LDAPDn.fromString("ou=sample-org,ou=KC14696," + previousConf.get(LDAPConstants.USERS_DN)));
+            ctx.getLdapProvider().getLdapIdentityStore().remove(ou);
+            ou.setDn(LDAPDn.fromString("ou=KC14696," + previousConf.get(LDAPConstants.USERS_DN)));
+            ctx.getLdapProvider().getLdapIdentityStore().remove(ou);
+
+            for (Map.Entry<String, String> e : previousConf.entrySet()) {
+                if (e.getValue() == null) {
+                    ctx.getLdapModel().getConfig().remove(e.getKey());
+                } else {
+                    ctx.getLdapModel().getConfig().putSingle(e.getKey(), e.getValue());
+                }
+            }
+            ctx.getRealm().updateComponent(ctx.getLdapModel());
+
+            ComponentModel cnMapper = LDAPTestUtils.getSubcomponentByName(ctx.getRealm(), ctx.getLdapModel(), "cnMapper");
+            ctx.getRealm().removeComponent(cnMapper);
+
+            ComponentModel mapperModel = LDAPTestUtils.getSubcomponentByName(appRealm, ctx.getLdapModel(), "username");
+            mapperModel.getConfig().putSingle(UserAttributeLDAPStorageMapper.LDAP_ATTRIBUTE, ctx.getLdapProvider().getLdapIdentityStore().getConfig().getUsernameLdapAttribute());
+            ctx.getRealm().updateComponent(mapperModel);
         });
     }
 }


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/KEYCLOAK-14696

Instead of using the attribute in the RDN to search members of a group the full DN is used, because the RDN attribute is not necessarily unique.

@mposolda IMO the fix for the issue is OK but I don't know if I went too far with the test. The test creates two users with the same `cn` (used for the `rdn` too) and different `uid` but one is below an `ou` to have a different `dn`. It works with apache-ds but using AD I'm not sure (it depends on how you really test this with AD). I have changed my mind a lot of times. I can add an assume to skip AD, I can even remove the test because the general functionality is already tested... So I just do whatever you think is better. :-)