### PR TITLE
KEYCLOAK-16075: require user interaction (button press) for WebAuthn on Safari

### DIFF
--- a/themes/src/main/resources/theme/base/login/messages/messages_en.properties
+++ b/themes/src/main/resources/theme/base/login/messages/messages_en.properties
@@ -388,6 +388,7 @@ webauthn-login-title=Security Key login
 webauthn-registration-title=Security Key Registration
 webauthn-available-authenticators=Available authenticators
 webauthn-unsupported-browser-text=WebAuthn is not supported by this browser. Try another one or contact your administrator.
+webauthn-doAuthenticate=Sign in with Security Key
 
 # WebAuthn Error
 webauthn-error-title=Security Key Error

--- a/themes/src/main/resources/theme/base/login/webauthn-authenticate.ftl
+++ b/themes/src/main/resources/theme/base/login/webauthn-authenticate.ftl
@@ -1,5 +1,5 @@
     <#import "template.ftl" as layout>
-    <@layout.registrationLayout showAnotherWayIfPresent=false; section>
+    <@layout.registrationLayout; section>
     <#if section = "title">
      title
     <#elseif section = "header">
@@ -25,18 +25,26 @@
         </form>
     </#if>
 
+    <form class="${properties.kcFormClass!}">
+        <div class="${properties.kcFormGroupClass!}">
+            <div id="kc-form-buttons" class="${properties.kcFormButtonsClass!}">
+                <input type="button" onclick="webAuthnAuthenticate()" value="${kcSanitize(msg("webauthn-doAuthenticate"))}"
+                   class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}">
+            </div>
+        </div>
+    </form>
+
     <script type="text/javascript" src="${url.resourcesCommonPath}/node_modules/jquery/dist/jquery.min.js"></script>
     <script type="text/javascript" src="${url.resourcesPath}/js/base64url.js"></script>
     <script type="text/javascript">
-
-        window.onload = () => {
+        function webAuthnAuthenticate() {
             let isUserIdentified = ${isUserIdentified};
             if (!isUserIdentified) {
                 doAuthenticate([]);
                 return;
             }
             checkAllowCredentials();
-        };
+        }
 
         function checkAllowCredentials() {
             let allowCredentials = [];

--- a/themes/src/main/resources/theme/base/login/webauthn-register.ftl
+++ b/themes/src/main/resources/theme/base/login/webauthn-register.ftl
@@ -152,11 +152,11 @@
             }
         </script>
 
+        <input type="submit"
+               class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}"
+               id="registerWebAuthnAIA" value="${msg("doRegister")}" onclick="registerSecurityKey()"/>
+
         <#if !isSetRetry?has_content && isAppInitiatedAction?has_content>
-            <input type="submit"
-                   class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}"
-                   id="registerWebAuthnAIA" value="${msg("doRegister")}" onclick="registerSecurityKey()"
-            />
             <form action="${url.loginAction}" class="${properties.kcFormClass!}" id="kc-webauthn-settings-form"
                   method="post">
                 <button type="submit"
@@ -164,10 +164,6 @@
                         id="cancelWebAuthnAIA" name="cancel-aia" value="true"/>${msg("doCancel")}
                 </button>
             </form>
-        <#else>
-            <script>
-                registerSecurityKey();
-            </script>
         </#if>
 
     </#if>


### PR DESCRIPTION
Safari will fail to use TouchID/FaceID if it is not triggered by an explicit user interaction.
This stops the automatic webauthn prompt through `onload` and shows a button instead.