### PR TITLE
KEYCLOAK-16091: only persist webauthn-authentication count if the authhenticator increments it beyond zero

### DIFF
--- a/services/src/main/java/org/keycloak/credential/WebAuthnCredentialProvider.java
+++ b/services/src/main/java/org/keycloak/credential/WebAuthnCredentialProvider.java
@@ -195,12 +195,17 @@ public class WebAuthnCredentialProvider implements CredentialProvider<WebAuthnCr
 
                     logger.debugv("response.getAuthenticatorData().getFlags() = {0}", authenticationData.getAuthenticatorData().getFlags());
 
-                    // update authenticator counter
-                    long count = auth.getCount();
                     CredentialModel credModel = getCredentialStore().getStoredCredentialById(realm, user, auth.getCredentialDBId());
                     WebAuthnCredentialModel webAuthnCredModel = getCredentialFromModel(credModel);
-                    webAuthnCredModel.updateCounter(count + 1);
-                    getCredentialStore().updateCredential(realm, user, webAuthnCredModel);
+
+                    // update authenticator counter
+                    // counters are an optional feature of the spec - if an authenticator does not support them, it
+                    // will always send zero. MacOS/iOS does this for keys stored in the secure enclave (TouchID/FaceID)
+                    long count = auth.getCount();
+                    if (count > 0) {
+                        webAuthnCredModel.updateCounter(count + 1);
+                        getCredentialStore().updateCredential(realm, user, webAuthnCredModel);
+                    }
 
                     logger.debugf("Successfully validated WebAuthn credential for user %s", user.getUsername());
                     dumpCredentialModel(webAuthnCredModel, auth);


### PR DESCRIPTION
Fixes an issue with Apple Keys stored in the secure enclave. They dont support counters and recommend attestation instead. This is a valid design choice according to the Webauthn-Spec (counters are mentioned as SHOULD)