### PR TITLE
KEYCLOAK-18042 Client Policy UI Improvements: Add delete confirmation modal dialog

### DIFF
--- a/themes/src/main/resources/theme/base/admin/resources/js/controllers/realm.js
+++ b/themes/src/main/resources/theme/base/admin/resources/js/controllers/realm.js
@@ -2972,23 +2972,25 @@ module.controller('ClientPoliciesProfilesListCtrl', function($scope, realm, clie
     $scope.clientProfiles = clientProfiles;
 
     $scope.removeClientProfile = function(clientProfile) {
-        console.log("Deleting client profile from the JSON: " + clientProfile.name);
+        Dialog.confirmDelete(clientProfile.name, 'client profile', function() {
+            console.log("Deleting client profile from the JSON: " + clientProfile.name);
 
-        for (var i=0 ; i < $scope.clientProfiles.profiles.length ; i++) {
-            var currentProfile = $scope.clientProfiles.profiles[i];
-            if (currentProfile.name === clientProfile.name) {
-                $scope.clientProfiles.profiles.splice(i, 1);
-                break;
+            for (var i = 0; i < $scope.clientProfiles.profiles.length; i++) {
+                var currentProfile = $scope.clientProfiles.profiles[i];
+                if (currentProfile.name === clientProfile.name) {
+                    $scope.clientProfiles.profiles.splice(i, 1);
+                    break;
+                }
             }
-        }
 
-        ClientPoliciesProfiles.update({
-            realm: realm.realm,
-        }, $scope.clientProfiles,  function () {
-            $route.reload();
-            Notifications.success("The client profile was deleted.");
-        }, function(errorResponse) {
-            Notifications.error('Failed to delete client profile. Check server log for the details');
+            ClientPoliciesProfiles.update({
+                realm: realm.realm,
+            }, $scope.clientProfiles, function () {
+                $route.reload();
+                Notifications.success("The client profile was deleted.");
+            }, function (errorResponse) {
+                Notifications.error('Failed to delete client profile. Check server log for the details');
+            });
         });
     };
 
@@ -3070,20 +3072,25 @@ module.controller('ClientPoliciesProfilesEditCtrl', function($scope, realm, clie
         }
     }
 
-    $scope.readOnly = !$scope.access.manageRealm || globalProfile;
+    // needs to be a function because when this controller runs, the permissions might not be loaded yet
+    $scope.isReadOnly = function() {
+        return !$scope.access.manageRealm || globalProfile;
+    }
 
     $scope.removeExecutor = function(executorIndex) {
-        console.log("remove executor of index " + executorIndex);
+        Dialog.confirmDelete($scope.editedProfile.executors[executorIndex].executor, 'executor', function() {
+            console.log("remove executor of index " + executorIndex);
 
-        // Delete executor
-        $scope.editedProfile.executors.splice(executorIndex, 1);
+            // Delete executor
+            $scope.editedProfile.executors.splice(executorIndex, 1);
 
-        ClientPoliciesProfiles.update({
-            realm: realm.realm,
-        }, clientProfiles,  function () {
-            Notifications.success("The executor was deleted.");
-        }, function(errorResponse) {
-            Notifications.error('Failed to delete executor. Check server log for the details');
+            ClientPoliciesProfiles.update({
+                realm: realm.realm,
+            }, clientProfiles, function () {
+                Notifications.success("The executor was deleted.");
+            }, function (errorResponse) {
+                Notifications.error('Failed to delete executor. Check server log for the details');
+            });
         });
     }
 
@@ -3154,7 +3161,10 @@ module.controller('ClientPoliciesProfilesEditExecutorCtrl', function($scope, rea
         throw 'Client profile of specified name not found';
     }
 
-    $scope.readOnly = !$scope.access.manageRealm || globalProfile;
+    // needs to be a function because when this controller runs, the permissions might not be loaded yet
+    $scope.isReadOnly = function() {
+        return !$scope.access.manageRealm || globalProfile;
+    }
 
     $scope.executorTypes = serverInfo.componentTypes['org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProvider'];
 
@@ -3283,23 +3293,25 @@ module.controller('ClientPoliciesListCtrl', function($scope, realm, clientPolici
     $scope.clientPolicies = clientPolicies;
 
     $scope.removeClientPolicy = function(clientPolicy) {
-        console.log("Deleting client policy from the JSON: " + clientPolicy.name);
+        Dialog.confirmDelete(clientPolicy.name, 'client policy', function() {
+            console.log("Deleting client policy from the JSON: " + clientPolicy.name);
 
-        for (var i=0 ; i < $scope.clientPolicies.policies.length ; i++) {
-            var currentPolicy = $scope.clientPolicies.policies[i];
-            if (currentPolicy.name === clientPolicy.name) {
-                $scope.clientPolicies.policies.splice(i, 1);
-                break;
+            for (var i = 0; i < $scope.clientPolicies.policies.length; i++) {
+                var currentPolicy = $scope.clientPolicies.policies[i];
+                if (currentPolicy.name === clientPolicy.name) {
+                    $scope.clientPolicies.policies.splice(i, 1);
+                    break;
+                }
             }
-        }
 
-        ClientPolicies.update({
-            realm: realm.realm,
-        }, $scope.clientPolicies,  function () {
-            $route.reload();
-            Notifications.success("The client policy was deleted.");
-        }, function(errorResponse) {
-            Notifications.error('Failed to delete client policy. Check server log for the details');
+            ClientPolicies.update({
+                realm: realm.realm,
+            }, $scope.clientPolicies, function () {
+                $route.reload();
+                Notifications.success("The client policy was deleted.");
+            }, function (errorResponse) {
+                Notifications.error('Failed to delete client policy. Check server log for the details');
+            });
         });
     };
 
@@ -3375,7 +3387,10 @@ module.controller('ClientPoliciesEditCtrl', function($scope, realm, clientProfil
         }
     }
 
-    $scope.readOnly = !$scope.access.manageRealm;
+    // needs to be a function because when this controller runs, the permissions might not be loaded yet
+    $scope.isReadOnly = function() {
+        return !$scope.access.manageRealm;
+    }
 
     $scope.availableProfiles = [];
     var allClientProfiles = clientProfiles.profiles;
@@ -3390,17 +3405,19 @@ module.controller('ClientPoliciesEditCtrl', function($scope, realm, clientProfil
     }
 
     $scope.removeCondition = function(conditionIndex) {
-        console.log("remove condition of index " + conditionIndex);
+        Dialog.confirmDelete($scope.editedPolicy.conditions[conditionIndex].condition, 'condition', function() {
+            console.log("remove condition of index " + conditionIndex);
 
-        // Delete condition
-        $scope.editedPolicy.conditions.splice(conditionIndex, 1);
+            // Delete condition
+            $scope.editedPolicy.conditions.splice(conditionIndex, 1);
 
-        ClientPolicies.update({
-            realm: realm.realm,
-        }, $scope.clientPolicies,  function () {
-            Notifications.success("The condition was deleted.");
-        }, function(errorResponse) {
-            Notifications.error('Failed to delete condition. Check server log for the details');
+            ClientPolicies.update({
+                realm: realm.realm,
+            }, $scope.clientPolicies, function () {
+                Notifications.success("The condition was deleted.");
+            }, function (errorResponse) {
+                Notifications.error('Failed to delete condition. Check server log for the details');
+            });
         });
     }
 
@@ -3492,7 +3509,10 @@ module.controller('ClientPoliciesEditConditionCtrl', function($scope, realm, ser
         throw 'Client policy of specified name not found';
     }
 
-    $scope.readOnly = !$scope.access.manageRealm;
+    // needs to be a function because when this controller runs, the permissions might not be loaded yet
+    $scope.isReadOnly = function() {
+        return !$scope.access.manageRealm;
+    }
 
     $scope.conditionTypes = serverInfo.componentTypes['org.keycloak.services.clientpolicy.condition.ClientPolicyConditionProvider'];
 

--- a/themes/src/main/resources/theme/base/admin/resources/partials/client-policies-policy-edit-condition.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/client-policies-policy-edit-condition.html
@@ -21,7 +21,7 @@
     <h1 data-ng-hide="createNew">{{conditionType.id|capitalize}}</h1>
     <h1 data-ng-show="createNew">{{:: 'create-condition' | translate}}</h1>
 
-    <form class="form-horizontal" name="realmForm" novalidate kc-read-only="readOnly">
+    <form class="form-horizontal" name="realmForm" novalidate kc-read-only="isReadOnly()">
         <fieldset>
             <div class="form-group" data-ng-show="createNew">
                 <label class="col-md-2 control-label" for="conditionTypeCreate">{{:: 'condition-type' | translate}}</label>
@@ -45,7 +45,7 @@
             <kc-provider-config config="condition.config" properties="conditionType.properties" realm="realm"></kc-provider-config>
         </fieldset>
 
-        <div class="form-group" data-ng-hide="readOnly">
+        <div class="form-group" data-ng-hide="isReadOnly()">
             <div class="col-md-10 col-md-offset-2">
                 <button kc-save>{{:: 'save' | translate}}</button>
                 <button kc-cancel data-ng-click="cancel()">{{:: 'cancel' | translate}}</button>

--- a/themes/src/main/resources/theme/base/admin/resources/partials/client-policies-policy-edit.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/client-policies-policy-edit.html
@@ -37,7 +37,7 @@
 
     <form class="form-horizontal" name="realmForm" novalidate>
 
-        <fieldset class="border-top" kc-read-only="readOnly">
+        <fieldset class="border-top" kc-read-only="isReadOnly()">
 
             <div class="form-group">
                 <label class="col-md-2 control-label" for="clientPolicyName">{{:: 'name' | translate}} <span class="required">*</span></label>
@@ -64,7 +64,7 @@
 
         </fieldset>
 
-        <fieldset data-ng-hide="readOnly">
+        <fieldset data-ng-hide="isReadOnly()">
 
             <div class="form-group">
                 <div class="col-md-10 col-md-offset-2">
@@ -80,7 +80,7 @@
             <legend><span class="text">{{:: 'conditions' | translate}}</span>  <kc-tooltip>{{:: 'client-policy-conditions.tooltip' | translate}}</kc-tooltip></legend>
             <table class="table table-striped table-bordered">
                 <thead>
-                <tr data-ng-hide="readOnly">
+                <tr data-ng-hide="isReadOnly()">
                     <th class="kc-table-actions" colspan="3">
                         <div class="form-inline">
                             <div class="pull-right">
@@ -97,8 +97,8 @@
                 <tbody>
                 <tr ng-repeat="condition in editedPolicy.conditions">
                     <td><a href="#/realms/{{realm.realm}}/client-policies/policies-update/{{editedPolicy.name}}/update-condition/{{$index}}">{{condition.condition}}</a></td>
-                    <td class="kc-action-cell" data-ng-hide="readOnly" kc-open="/realms/{{realm.realm}}/client-policies/policies-update/{{editedPolicy.name}}/update-condition/{{$index}}">{{:: 'edit' | translate}}</td>
-                    <td class="kc-action-cell" data-ng-hide="readOnly" data-ng-click="removeCondition($index)">{{:: 'delete' | translate}}</td>
+                    <td class="kc-action-cell" data-ng-hide="isReadOnly()" kc-open="/realms/{{realm.realm}}/client-policies/policies-update/{{editedPolicy.name}}/update-condition/{{$index}}">{{:: 'edit' | translate}}</td>
+                    <td class="kc-action-cell" data-ng-hide="isReadOnly()" data-ng-click="removeCondition($index)">{{:: 'delete' | translate}}</td>
                 </tr>
                 <tr data-ng-show="!editedPolicy.conditions || editedPolicy.conditions.length == 0">
                     <td>{{:: 'no-conditions-available' | translate}}</td>
@@ -112,7 +112,7 @@
             <legend><span class="text">{{:: 'client-profiles' | translate}}</span></legend><kc-tooltip>{{:: 'client-profiles.tooltip' | translate}}</kc-tooltip>
             <table class="table table-striped table-bordered">
                 <thead>
-                <tr data-ng-hide="readOnly || availableProfiles.length == 0">
+                <tr data-ng-hide="isReadOnly() || availableProfiles.length == 0">
                     <th colspan="5" class="kc-table-actions">
                         <div class="pull-right">
                             <div>
@@ -133,7 +133,7 @@
                 <tbody>
                 <tr ng-repeat="profileName in editedPolicy.profiles">
                     <td><a href="#/realms/{{realm.realm}}/client-policies/profiles-update/{{profileName}}">{{profileName}}</a></td>
-                    <td class="kc-action-cell" data-ng-hide="readOnly" data-ng-click="removeProfile(profileName)">{{:: 'delete' | translate}}</td>
+                    <td class="kc-action-cell" data-ng-hide="isReadOnly()" data-ng-click="removeProfile(profileName)">{{:: 'delete' | translate}}</td>
                 </tr>
                 <tr data-ng-show="!editedPolicy.profiles || editedPolicy.profiles.length == 0">
                     <td class="text-muted">{{:: 'no-client-profiles-configured' | translate}}</td>

--- a/themes/src/main/resources/theme/base/admin/resources/partials/client-policies-profiles-edit-executor.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/client-policies-profiles-edit-executor.html
@@ -21,7 +21,7 @@
     <h1 data-ng-hide="createNew">{{executorType.id|capitalize}}</h1>
     <h1 data-ng-show="createNew">{{:: 'create-executor' | translate}}</h1>
 
-    <form class="form-horizontal" name="realmForm" novalidate kc-read-only="readOnly">
+    <form class="form-horizontal" name="realmForm" novalidate kc-read-only="isReadOnly()">
         <fieldset>
             <div class="form-group" data-ng-show="createNew">
                 <label class="col-md-2 control-label" for="executorTypeCreate">{{:: 'executor-type' | translate}}</label>
@@ -45,7 +45,7 @@
             <kc-provider-config config="executor.config" properties="executorType.properties" realm="realm"></kc-provider-config>
         </fieldset>
 
-        <div class="form-group" data-ng-hide="readOnly">
+        <div class="form-group" data-ng-hide="isReadOnly()">
             <div class="col-md-10 col-md-offset-2">
                 <button kc-save>{{:: 'save' | translate}}</button>
                 <button kc-cancel data-ng-click="cancel()">{{:: 'cancel' | translate}}</button>

--- a/themes/src/main/resources/theme/base/admin/resources/partials/client-policies-profiles-edit.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/client-policies-profiles-edit.html
@@ -35,7 +35,7 @@
         <li><a href="#/realms/{{realm.realm}}/client-policies/profiles-json">{{:: 'client-profiles-json-editor' | translate}}</a></li>
     </ul>
 
-    <form class="form-horizontal" name="realmForm" novalidate kc-read-only="readOnly">
+    <form class="form-horizontal" name="realmForm" novalidate kc-read-only="isReadOnly()">
 
             <fieldset class="border-top">
 
@@ -71,7 +71,7 @@
                 <legend><span class="text">{{:: 'executors' | translate}}</span>  <kc-tooltip>{{:: 'client-profile-executors.tooltip' | translate}}</kc-tooltip></legend>
                 <table class="table table-striped table-bordered">
                     <thead>
-                        <tr data-ng-hide="readOnly">
+                        <tr data-ng-hide="isReadOnly()">
                             <th class="kc-table-actions" colspan="3">
                                 <div class="form-inline">
                                     <div class="pull-right">
@@ -88,8 +88,8 @@
                     <tbody>
                         <tr ng-repeat="executor in editedProfile.executors">
                             <td><a href="#/realms/{{realm.realm}}/client-policies/profiles-update/{{editedProfile.name}}/update-executor/{{$index}}">{{executor.executor}}</a></td>
-                            <td class="kc-action-cell" data-ng-hide="readOnly" kc-open="/realms/{{realm.realm}}/client-policies/profiles-update/{{editedProfile.name}}/update-executor/{{$index}}">{{:: 'edit' | translate}}</td>
-                            <td class="kc-action-cell" data-ng-hide="readOnly" data-ng-click="removeExecutor($index)">{{:: 'delete' | translate}}</td>
+                            <td class="kc-action-cell" data-ng-hide="isReadOnly()" kc-open="/realms/{{realm.realm}}/client-policies/profiles-update/{{editedProfile.name}}/update-executor/{{$index}}">{{:: 'edit' | translate}}</td>
+                            <td class="kc-action-cell" data-ng-hide="isReadOnly()" data-ng-click="removeExecutor($index)">{{:: 'delete' | translate}}</td>
                         </tr>
                         <tr data-ng-show="!editedProfile.executors || editedProfile.executors.length == 0">
                             <td>{{:: 'no-executors-available' | translate}}</td>


### PR DESCRIPTION
This also fixes one untracked issue. When a page is refreshed at the profile or policy detail screen, all executors/conditions are  read only. Not sure if my solution is correct but it works.