### PR TITLE
KEYCLOAK-18041 Client Policy UI Improvements: Action column for built-in profile

### DIFF
--- a/themes/src/main/resources/theme/base/admin/resources/js/app.js
+++ b/themes/src/main/resources/theme/base/admin/resources/js/app.js
@@ -214,8 +214,8 @@ module.config([ '$routeProvider', function($routeProvider) {
                 realm : function(RealmLoader) {
                     return RealmLoader();
                 },
-                serverInfo : function(ServerInfo) {
-                    return ServerInfo.delay;
+                serverInfo : function(ServerInfoLoader) {
+                    return ServerInfoLoader();
                 }
             },
             controller : 'RealmLoginSettingsCtrl'

--- a/themes/src/main/resources/theme/base/admin/resources/partials/client-policies-list.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/client-policies-list.html
@@ -40,10 +40,10 @@
         <fieldset>
             <table class="table table-striped table-bordered">
                 <thead>
-                <tr>
+                <tr data-ng-show="access.manageRealm">
                     <th class="kc-table-actions" colspan="6">
                         <div class="form-inline">
-                            <div class="pull-right" data-ng-show="access.manageRealm">
+                            <div class="pull-right">
                                 <a href="#/realms/{{realm.realm}}/client-policies/policy-create" class="btn btn-default">{{:: 'create' | translate}}</a>
                             </div>
                         </div>
@@ -61,8 +61,8 @@
                     <td><a href="#/realms/{{realm.realm}}/client-policies/policies-update/{{clientPolicy.name}}">{{clientPolicy.name}}</a></td>
                     <td>{{clientPolicy.description}}</td>
                     <td translate="{{clientPolicy.enabled}}"></td>
-                    <td class="kc-action-cell" data-ng-hide="clientPolicy.builtin" kc-open="/realms/{{realm.realm}}/client-policies/policies-update/{{clientPolicy.name}}">{{:: 'edit' | translate}}</td>
-                    <td class="kc-action-cell" data-ng-hide="clientPolicy.builtin" data-ng-click="removeClientPolicy(clientPolicy)">{{:: 'delete' | translate}}</td>
+                    <td class="kc-action-cell" kc-open="/realms/{{realm.realm}}/client-policies/policies-update/{{clientPolicy.name}}">{{:: 'edit' | translate}}</td>
+                    <td class="kc-action-cell" data-ng-click="removeClientPolicy(clientPolicy)" data-ng-show="access.manageRealm">{{:: 'delete' | translate}}</td>
                 </tr>
                 </tbody>
             </table>

--- a/themes/src/main/resources/theme/base/admin/resources/partials/client-policies-policy-edit.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/client-policies-policy-edit.html
@@ -97,7 +97,7 @@
                 <tbody>
                 <tr ng-repeat="condition in editedPolicy.conditions">
                     <td><a href="#/realms/{{realm.realm}}/client-policies/policies-update/{{editedPolicy.name}}/update-condition/{{$index}}">{{condition.condition}}</a></td>
-                    <td class="kc-action-cell" data-ng-hide="isReadOnly()" kc-open="/realms/{{realm.realm}}/client-policies/policies-update/{{editedPolicy.name}}/update-condition/{{$index}}">{{:: 'edit' | translate}}</td>
+                    <td class="kc-action-cell" kc-open="/realms/{{realm.realm}}/client-policies/policies-update/{{editedPolicy.name}}/update-condition/{{$index}}">{{:: 'edit' | translate}}</td>
                     <td class="kc-action-cell" data-ng-hide="isReadOnly()" data-ng-click="removeCondition($index)">{{:: 'delete' | translate}}</td>
                 </tr>
                 <tr data-ng-show="!editedPolicy.conditions || editedPolicy.conditions.length == 0">
@@ -127,7 +127,7 @@
                 </tr>
                 <tr data-ng-show="editedPolicy.profiles && editedPolicy.profiles.length > 0">
                     <th>{{:: 'name' | translate}}</th>
-                    <th>{{:: 'actions' | translate}}</th>
+                    <th data-ng-hide="isReadOnly()">{{:: 'actions' | translate}}</th>
                 </tr>
                 </thead>
                 <tbody>

--- a/themes/src/main/resources/theme/base/admin/resources/partials/client-policies-profiles-edit.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/client-policies-profiles-edit.html
@@ -88,7 +88,7 @@
                     <tbody>
                         <tr ng-repeat="executor in editedProfile.executors">
                             <td><a href="#/realms/{{realm.realm}}/client-policies/profiles-update/{{editedProfile.name}}/update-executor/{{$index}}">{{executor.executor}}</a></td>
-                            <td class="kc-action-cell" data-ng-hide="isReadOnly()" kc-open="/realms/{{realm.realm}}/client-policies/profiles-update/{{editedProfile.name}}/update-executor/{{$index}}">{{:: 'edit' | translate}}</td>
+                            <td class="kc-action-cell" kc-open="/realms/{{realm.realm}}/client-policies/profiles-update/{{editedProfile.name}}/update-executor/{{$index}}">{{:: 'edit' | translate}}</td>
                             <td class="kc-action-cell" data-ng-hide="isReadOnly()" data-ng-click="removeExecutor($index)">{{:: 'delete' | translate}}</td>
                         </tr>
                         <tr data-ng-show="!editedProfile.executors || editedProfile.executors.length == 0">

--- a/themes/src/main/resources/theme/base/admin/resources/partials/client-policies-profiles-list.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/client-policies-profiles-list.html
@@ -40,10 +40,10 @@
         <fieldset>
             <table class="table table-striped table-bordered">
                 <thead>
-                    <tr>
+                    <tr data-ng-show="access.manageRealm">
                         <th class="kc-table-actions" colspan="6">
                             <div class="form-inline">
-                                <div class="pull-right" data-ng-show="access.manageRealm">
+                                <div class="pull-right">
                                     <a href="#/realms/{{realm.realm}}/client-policies/profiles-create" class="btn btn-default">{{:: 'create' | translate}}</a>
                                 </div>
                             </div>
@@ -61,15 +61,14 @@
                         <td><a href="#/realms/{{realm.realm}}/client-policies/profiles-update/{{clientProfile.name}}">{{clientProfile.name}}</a></td>
                         <td>{{clientProfile.description}}</td>
                         <td>{{:: 'true' | translate}}</td>
-                        <td></td>
-                        <td></td>
+                        <td colspan="2" class="kc-action-cell" kc-open="/realms/{{realm.realm}}/client-policies/profiles-update/{{clientProfile.name}}">{{:: 'edit' | translate}}</td>
                     </tr>
                     <tr ng-repeat="clientProfile in clientProfiles.profiles">
                         <td><a href="#/realms/{{realm.realm}}/client-policies/profiles-update/{{clientProfile.name}}">{{clientProfile.name}}</a></td>
                         <td>{{clientProfile.description}}</td>
                         <td>{{:: 'false' | translate}}</td>
                         <td class="kc-action-cell" kc-open="/realms/{{realm.realm}}/client-policies/profiles-update/{{clientProfile.name}}">{{:: 'edit' | translate}}</td>
-                        <td class="kc-action-cell" data-ng-click="removeClientProfile(clientProfile)">{{:: 'delete' | translate}}</td>
+                        <td class="kc-action-cell" data-ng-click="removeClientProfile(clientProfile)" data-ng-show="access.manageRealm">{{:: 'delete' | translate}}</td>
                     </tr>
                 </tbody>
             </table>


### PR DESCRIPTION
Tweaks the behavior specifying when the action buttons are displayed. Also fixes a few issues related to it (like a visible Delete button for user with view-only permissions).

The main change is that the Edit button is now displayed regardless the `readOnly` flag, similarly to e.g. Users, Clients, etc. It should be ok as the edit form is read only.