### PR TITLE
KEYCLOAK-18235 Display of options about device grant when selecting

### DIFF
--- a/themes/src/main/resources/theme/base/admin/resources/partials/client-detail.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/client-detail.html
@@ -140,7 +140,7 @@
                 </div>
             </div>
             <div class="form-group"
-                data-ng-show="protocol == 'openid-connect' && !clientEdit.publicClient && !clientEdit.bearerOnly">
+                data-ng-show="protocol == 'openid-connect' && !clientEdit.bearerOnly">
                 <label class="col-md-2 control-label" for="oauth2DeviceAuthorizationGrantEnabled">{{::
                     'oauth2-device-authorization-grant-enabled' | translate}}</label>
                 <kc-tooltip>{{:: 'oauth2-device-authorization-grant-enabled.tooltip' | translate}}</kc-tooltip>
@@ -725,7 +725,7 @@
             </div>
 
             <div class="form-group"
-                data-ng-show="protocol == 'openid-connect' && !clientEdit.publicClient && !clientEdit.bearerOnly && oauth2DeviceAuthorizationGrantEnabled == true">
+                data-ng-show="protocol == 'openid-connect' && !clientEdit.bearerOnly && oauth2DeviceAuthorizationGrantEnabled == true">
                 <label class="col-md-2 control-label" for="oauth2DeviceCodeLifespan">{{:: 'oauth2-device-code-lifespan'
                     | translate}}</label>
                 <div class="col-md-6 time-selector">
@@ -743,7 +743,7 @@
             </div>
 
             <div class="form-group"
-                data-ng-show="protocol == 'openid-connect' && !clientEdit.publicClient && !clientEdit.bearerOnly && oauth2DeviceAuthorizationGrantEnabled == true">
+                data-ng-show="protocol == 'openid-connect' && !clientEdit.bearerOnly && oauth2DeviceAuthorizationGrantEnabled == true">
                 <label class="col-md-2 control-label" for="oauth2DevicePollingInterval">{{::
                     'oauth2-device-polling-interval' | translate}}</label>
                 <div class="col-md-6 time-selector">


### PR DESCRIPTION
- modify the followings.
  - "OAuth 2.0 Device Authorization Grant Enabled" is visible when selecting "public" as the access type.
  - "OAuth 2.0 Device Code Lifespan" and "OAuth 2.0 Device Polling Interval" are visible when "OAuth 2.0 Device Authorization Grant Enabled" is on and selecting "public" as the access type.
- add public client test of device grant.

JIRA: https://issues.redhat.com/browse/KEYCLOAK-18235