### PR TITLE
KEYCLOAK-15437 Ensure at_hash is generated for IDTokens on token-refresh

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
@@ -365,7 +365,7 @@ public class TokenManager {
 
         String scopeParam = clientSession.getNote(OAuth2Constants.SCOPE);
         if (TokenUtil.isOIDCRequest(scopeParam)) {
-            responseBuilder.generateIDToken();
+            responseBuilder.generateIDToken().generateAccessTokenHash();
         }
 
         AccessTokenResponse res = responseBuilder.build();


### PR DESCRIPTION
Previously the at_hash claim was only present in the initial IDToken of the AccessTokenResponse and missing after a token-refresh.
We now ensure that a proper at_hash claim is generated for IDTokens on token-refresh.