### PR TITLE
KEYCLOAK-18054 EAP6Fuse6HawtioAdapterTest fails due to wrong port

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/example/fuse/EAP6Fuse6HawtioAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/example/fuse/EAP6Fuse6HawtioAdapterTest.java
@@ -32,7 +32,6 @@ import org.junit.After;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import org.keycloak.representations.idm.RealmRepresentation;
@@ -48,7 +47,6 @@ import org.keycloak.testsuite.util.DroneUtils;
 import org.keycloak.testsuite.util.JavascriptBrowser;
 import org.keycloak.testsuite.util.WaitUtils;
 
-import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 
 /**
@@ -81,6 +79,7 @@ public class EAP6Fuse6HawtioAdapterTest extends AbstractExampleAdapterTest imple
     public static void enabled() {
         Assume.assumeFalse(System.getProperty("os.name").startsWith("Windows"));
         ContainerAssume.assumeNotAppServerSSL();
+        ContainerAssume.assumeAuthServerSSL();
     }
 
     @Before


### PR DESCRIPTION
KEYCLOAK-18054 EAP6Fuse6HawtioAdapterTest fails due to wrong port without TLS

The Fuse 6 app server is started in the test class and its configuration always directs to the auth server with TLS even if the TLS is not required for auth server. IMO it's sufficient to have this test in the test suite without testing TLS for Oracle and IBM JDK7 and it's not worth the effort to keep two distinct configurations for the app server.

JIRA: [KEYCLOAK-18054](https://issues.redhat.com/browse/KEYCLOAK-18054)