### PR TITLE
KEYCLOAK-16863 Compute additional hashes for Github releases tab

### DIFF
--- a/distribution/downloads/pom.xml
+++ b/distribution/downloads/pom.xml
@@ -67,6 +67,44 @@
                             </execution>
                         </executions>
                     </plugin>
+                    <plugin>
+                        <groupId>net.nicoulaj.maven.plugins</groupId>
+                        <artifactId>checksum-maven-plugin</artifactId>
+                        <version>1.10</version>
+                        <executions>
+                            <execution>
+                                <id>extra-checksums</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>files</goal>
+                                </goals>
+                                <configuration>
+                                    <fileSets>
+                                        <fileSet>
+                                            <directory>${project.build.directory}/${project.version}</directory>
+                                            <excludes>
+                                                <exclude>*.md5</exclude>
+                                                <exclude>*.sha1</exclude>
+                                            </excludes>
+                                        </fileSet>
+                                    </fileSets>
+                                    <individualFiles>false</individualFiles>
+                                    <csvSummary>true</csvSummary>
+                                    <csvSummaryFile>${project.version}/checksums.csv</csvSummaryFile>
+                                    <xmlSummary>true</xmlSummary>
+                                    <xmlSummaryFile>${project.version}/checksums.xml</xmlSummaryFile>
+                                    <algorithms>
+                                        <algorithm>MD5</algorithm>
+                                        <algorithm>SHA-1</algorithm>
+                                        <algorithm>SHA-256</algorithm>
+                                        <algorithm>SHA-512</algorithm>
+                                        <algorithm>SHA3-256</algorithm>
+                                        <algorithm>SHA3-512</algorithm>
+                                    </algorithms>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
                 </plugins>
             </build>
         </profile>


### PR DESCRIPTION
A selection of hashes are calculated for every file that will be uploaded
to Github, and the hashes are written into two files that will also be
uploaded: checksums.csv and checksums.xml

The individual .md5 and .sha1 files are not removed by this, but could
be elmininated for brevity if desired, since the csv and xml also
contain these algorithms.

It takes approximately 2 minutes to compute the hashes on my laptop.

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
