### PR TITLE
KEYCLOAK-16450 X509 Direct Grant Auth does not verify certificate timestamp validity

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/x509/ValidateX509CertificateUsername.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/x509/ValidateX509CertificateUsername.java
@@ -75,7 +75,8 @@ public class ValidateX509CertificateUsername extends AbstractX509ClientCertifica
             CertificateValidator validator = builder.build(certs);
             validator.checkRevocationStatus()
                     .validateKeyUsage()
-                    .validateExtendedKeyUsage();
+                    .validateExtendedKeyUsage()
+                    .validateTimestamps();
         } catch(Exception e) {
             logger.error(e.getMessage(), e);
             // TODO use specific locale to load error messages


### PR DESCRIPTION
PR https://github.com/keycloak/keycloak/pull/6330 missed a spot in adding the `validateTimestamps` call to the X509 Direct Grant authenticator. This PR fixes the issue and adds the related tests.