### PR TITLE
[KEYCLOAK-8730] Ensure role mappers don't remove roles already grante…

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/broker/provider/BrokeredIdentityContext.java
+++ b/server-spi-private/src/main/java/org/keycloak/broker/provider/BrokeredIdentityContext.java
@@ -22,8 +22,10 @@ import org.keycloak.sessions.AuthenticationSessionModel;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * <p>Represents all identity information obtained from an {@link org.keycloak.broker.provider.IdentityProvider} after a
@@ -206,6 +208,39 @@ public class BrokeredIdentityContext {
 
     public void setAuthenticationSession(AuthenticationSessionModel authenticationSession) {
         this.authenticationSession = authenticationSession;
+    }
+
+    /**
+     * Obtains the set of roles that were granted by mappers.
+     *
+     * @return a {@link Set} containing the roles.
+     */
+    private Set<String> getMapperGrantedRoles() {
+        Set<String> roles = (Set<String>) this.contextData.get(Constants.MAPPER_GRANTED_ROLES);
+        if (roles == null) {
+            roles = new HashSet<>();
+            this.contextData.put(Constants.MAPPER_GRANTED_ROLES, roles);
+        }
+        return roles;
+    }
+
+    /**
+     * Verifies if a mapper has already granted the specified role.
+     *
+     * @param roleName the name of the role.
+     * @return {@code true} if a mapper has already granted the role; {@code false} otherwise.
+     */
+    public boolean hasMapperGrantedRole(final String roleName) {
+        return this.getMapperGrantedRoles().contains(roleName);
+    }
+
+    /**
+     * Adds the specified role to the set of roles granted by mappers.
+     *
+     * @param roleName the name of the role.
+     */
+    public void addMapperGrantedRole(final String roleName) {
+        this.getMapperGrantedRoles().add(roleName);
     }
 
     /**

--- a/server-spi-private/src/main/java/org/keycloak/models/Constants.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/Constants.java
@@ -96,6 +96,9 @@ public final class Constants {
     // Prefix for user attributes used in various "context"data maps
     public static final String USER_ATTRIBUTES_PREFIX = "user.attributes.";
 
+    // Roles already granted by a mapper when updating brokered users.
+    public static final String MAPPER_GRANTED_ROLES = "MAPPER_GRANTED_ROLES";
+
     // Indication to admin-rest-endpoint that realm keys should be re-generated
     public static final String GENERATE = "GENERATE";
 

--- a/services/src/main/java/org/keycloak/broker/oidc/mappers/AbstractClaimToRoleMapper.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/mappers/AbstractClaimToRoleMapper.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.broker.oidc.mappers;
+
+import org.keycloak.broker.provider.BrokeredIdentityContext;
+import org.keycloak.broker.provider.ConfigConstants;
+import org.keycloak.broker.provider.IdentityBrokerException;
+import org.keycloak.models.IdentityProviderMapperModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.RoleModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.utils.KeycloakModelUtils;
+
+/**
+ * Abstract class that handles the logic for importing and updating brokered users for all mappers that map an OIDC
+ * claim into a {@code Keycloak} role.
+ *
+ * @author <a href="mailto:sguilhen@redhat.com">Stefan Guilhen</a>
+ */
+public abstract class AbstractClaimToRoleMapper extends AbstractClaimMapper {
+
+    @Override
+    public void importNewUser(KeycloakSession session, RealmModel realm, UserModel user, IdentityProviderMapperModel mapperModel, BrokeredIdentityContext context) {
+        RoleModel role = this.getRole(realm, mapperModel);
+        if (applies(mapperModel, context)) {
+            user.grantRole(role);
+        }
+    }
+
+    @Override
+    public void updateBrokeredUserLegacy(KeycloakSession session, RealmModel realm, UserModel user, IdentityProviderMapperModel mapperModel, BrokeredIdentityContext context) {
+        RoleModel role = this.getRole(realm, mapperModel);
+        if (!applies(mapperModel, context)) {
+            user.deleteRoleMapping(role);
+        }
+    }
+
+    @Override
+    public void updateBrokeredUser(KeycloakSession session, RealmModel realm, UserModel user, IdentityProviderMapperModel mapperModel, BrokeredIdentityContext context) {
+        RoleModel role = this.getRole(realm, mapperModel);
+        String roleName = mapperModel.getConfig().get(ConfigConstants.ROLE);
+        // KEYCLOAK-8730 if a previous mapper has already granted the same role, skip the checks so we don't accidentally remove a valid role.
+        if (!context.hasMapperGrantedRole(roleName)) {
+            if (applies(mapperModel, context)) {
+                context.addMapperGrantedRole(roleName);
+                user.grantRole(role);
+            } else {
+                user.deleteRoleMapping(role);
+            }
+        }
+    }
+
+
+    /**
+     * This method must be implemented by subclasses and they must return {@code true} if their mapping can be applied
+     * (i.e. user has the OIDC claim that should be mapped) or {@code false} otherwise.
+     *
+     * @param mapperModel a reference to the {@link IdentityProviderMapperModel}.
+     * @param context a reference to the {@link BrokeredIdentityContext}.
+     * @return {@code true} if the mapping can be applied or {@code false} otherwise.*
+     */
+    protected abstract boolean applies(final IdentityProviderMapperModel mapperModel, final BrokeredIdentityContext context);
+
+    /**
+     * Obtains the {@link RoleModel} corresponding the role configured in the specified {@link IdentityProviderMapperModel}.
+     * If the role doesn't correspond to one of the realm's client roles or to one of the realm's roles, this method throws
+     * an {@link IdentityBrokerException} to convey that an invalid role was configured.
+     *
+     * @param realm a reference to the realm.
+     * @param mapperModel a reference to the {@link IdentityProviderMapperModel} containing the configured role.
+     * @return the {@link RoleModel} that corresponds to the mapper model role.
+     * @throws IdentityBrokerException if the role name doesn't correspond to one of the realm's client roles or to one
+     * of the realm's roles.
+     */
+    private RoleModel getRole(final RealmModel realm, final IdentityProviderMapperModel mapperModel) {
+        String roleName = mapperModel.getConfig().get(ConfigConstants.ROLE);
+        RoleModel role = KeycloakModelUtils.getRoleFromString(realm, roleName);
+        if (role == null) {
+            throw new IdentityBrokerException("Unable to find role: " + roleName);
+        }
+        return role;
+    }
+}

--- a/services/src/main/java/org/keycloak/broker/oidc/mappers/AdvancedClaimToRoleMapper.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/mappers/AdvancedClaimToRoleMapper.java
@@ -21,14 +21,8 @@ import org.keycloak.broker.oidc.KeycloakOIDCIdentityProviderFactory;
 import org.keycloak.broker.oidc.OIDCIdentityProviderFactory;
 import org.keycloak.broker.provider.BrokeredIdentityContext;
 import org.keycloak.broker.provider.ConfigConstants;
-import org.keycloak.broker.provider.IdentityBrokerException;
 import org.keycloak.models.IdentityProviderMapperModel;
 import org.keycloak.models.IdentityProviderSyncMode;
-import org.keycloak.models.KeycloakSession;
-import org.keycloak.models.RealmModel;
-import org.keycloak.models.RoleModel;
-import org.keycloak.models.UserModel;
-import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.provider.ProviderConfigProperty;
 
 import java.util.ArrayList;
@@ -44,7 +38,7 @@ import static org.keycloak.utils.RegexUtils.valueMatchesRegex;
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke, Benjamin Weimer</a>
  * @version $Revision: 1 $
  */
-public class AdvancedClaimToRoleMapper extends AbstractClaimMapper {
+public class AdvancedClaimToRoleMapper extends AbstractClaimToRoleMapper {
 
     public static final String CLAIM_PROPERTY_NAME = "claims";
     public static final String ARE_CLAIM_VALUES_REGEX_PROPERTY_NAME = "are.claim.values.regex";
@@ -108,51 +102,12 @@ public class AdvancedClaimToRoleMapper extends AbstractClaimMapper {
     }
 
     @Override
-    public void importNewUser(KeycloakSession session, RealmModel realm, UserModel user, IdentityProviderMapperModel mapperModel, BrokeredIdentityContext context) {
-        String roleName = mapperModel.getConfig().get(ConfigConstants.ROLE);
-        RoleModel role = getRoleModel(realm, roleName);
-
-        if (hasAllClaimValues(mapperModel, context)) {
-            user.grantRole(role);
-        }
-    }
-
-    @Override
-    public void updateBrokeredUserLegacy(KeycloakSession session, RealmModel realm, UserModel user, IdentityProviderMapperModel mapperModel, BrokeredIdentityContext context) {
-        String roleName = mapperModel.getConfig().get(ConfigConstants.ROLE);
-        RoleModel role = getRoleModel(realm, roleName);
-
-        if (!hasAllClaimValues(mapperModel, context)) {
-            user.deleteRoleMapping(role);
-        }
-
-    }
-
-    @Override
-    public void updateBrokeredUser(KeycloakSession session, RealmModel realm, UserModel user, IdentityProviderMapperModel mapperModel, BrokeredIdentityContext context) {
-        String roleName = mapperModel.getConfig().get(ConfigConstants.ROLE);
-        RoleModel role = getRoleModel(realm, roleName);
-        if (hasAllClaimValues(mapperModel, context)) {
-            user.grantRole(role);
-        } else {
-            user.deleteRoleMapping(role);
-        }
-    }
-
-    private RoleModel getRoleModel(RealmModel realm, String roleName) {
-        RoleModel role = KeycloakModelUtils.getRoleFromString(realm, roleName);
-        if (role == null) {
-            throw new IdentityBrokerException("Unable to find role: " + roleName);
-        }
-        return role;
-    }
-
-    @Override
     public String getHelpText() {
         return "If all claims exists, grant the user the specified realm or client role.";
     }
 
-    protected boolean hasAllClaimValues(IdentityProviderMapperModel mapperModel, BrokeredIdentityContext context) {
+    @Override
+    protected boolean applies(IdentityProviderMapperModel mapperModel, BrokeredIdentityContext context) {
         Map<String, String> claims = mapperModel.getConfigMap(CLAIM_PROPERTY_NAME);
         boolean areClaimValuesRegex = Boolean.parseBoolean(mapperModel.getConfig().get(ARE_CLAIM_VALUES_REGEX_PROPERTY_NAME));
 

--- a/services/src/main/java/org/keycloak/broker/oidc/mappers/ClaimToRoleMapper.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/mappers/ClaimToRoleMapper.java
@@ -21,14 +21,8 @@ import org.keycloak.broker.oidc.KeycloakOIDCIdentityProviderFactory;
 import org.keycloak.broker.oidc.OIDCIdentityProviderFactory;
 import org.keycloak.broker.provider.BrokeredIdentityContext;
 import org.keycloak.broker.provider.ConfigConstants;
-import org.keycloak.broker.provider.IdentityBrokerException;
 import org.keycloak.models.IdentityProviderMapperModel;
 import org.keycloak.models.IdentityProviderSyncMode;
-import org.keycloak.models.KeycloakSession;
-import org.keycloak.models.RealmModel;
-import org.keycloak.models.RoleModel;
-import org.keycloak.models.UserModel;
-import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.provider.ProviderConfigProperty;
 
 import java.util.ArrayList;
@@ -41,7 +35,7 @@ import java.util.Set;
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
  */
-public class ClaimToRoleMapper extends AbstractClaimMapper {
+public class ClaimToRoleMapper extends AbstractClaimToRoleMapper {
 
     public static final String[] COMPATIBLE_PROVIDERS = {KeycloakOIDCIdentityProviderFactory.PROVIDER_ID, OIDCIdentityProviderFactory.PROVIDER_ID};
 
@@ -104,38 +98,8 @@ public class ClaimToRoleMapper extends AbstractClaimMapper {
     }
 
     @Override
-    public void importNewUser(KeycloakSession session, RealmModel realm, UserModel user, IdentityProviderMapperModel mapperModel, BrokeredIdentityContext context) {
-        String roleName = mapperModel.getConfig().get(ConfigConstants.ROLE);
-        if (hasClaimValue(mapperModel, context)) {
-            RoleModel role = KeycloakModelUtils.getRoleFromString(realm, roleName);
-            if (role == null) throw new IdentityBrokerException("Unable to find role: " + roleName);
-            user.grantRole(role);
-        }
-    }
-
-    @Override
-    public void updateBrokeredUserLegacy(KeycloakSession session, RealmModel realm, UserModel user, IdentityProviderMapperModel mapperModel, BrokeredIdentityContext context) {
-        String roleName = mapperModel.getConfig().get(ConfigConstants.ROLE);
-        if (!hasClaimValue(mapperModel, context)) {
-            RoleModel role = KeycloakModelUtils.getRoleFromString(realm, roleName);
-            if (role == null) throw new IdentityBrokerException("Unable to find role: " + roleName);
-            user.deleteRoleMapping(role);
-        }
-
-    }
-
-    @Override
-    public void updateBrokeredUser(KeycloakSession session, RealmModel realm, UserModel user, IdentityProviderMapperModel mapperModel, BrokeredIdentityContext context) {
-        String roleName = mapperModel.getConfig().get(ConfigConstants.ROLE);
-        RoleModel role = KeycloakModelUtils.getRoleFromString(realm, roleName);
-        if (role == null) {
-            throw new IdentityBrokerException("Unable to find role: " + roleName);
-        }
-        if (!hasClaimValue(mapperModel, context)) {
-            user.deleteRoleMapping(role);
-        } else {
-            user.grantRole(role);
-        }
+    protected boolean applies(IdentityProviderMapperModel mapperModel, BrokeredIdentityContext context) {
+        return super.hasClaimValue(mapperModel, context);
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/broker/saml/mappers/AbstractAttributeToRoleMapper.java
+++ b/services/src/main/java/org/keycloak/broker/saml/mappers/AbstractAttributeToRoleMapper.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.broker.saml.mappers;
+
+import org.keycloak.broker.provider.AbstractIdentityProviderMapper;
+import org.keycloak.broker.provider.BrokeredIdentityContext;
+import org.keycloak.broker.provider.ConfigConstants;
+import org.keycloak.broker.provider.IdentityBrokerException;
+import org.keycloak.models.IdentityProviderMapperModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.RoleModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.utils.KeycloakModelUtils;
+
+/**
+ * Abstract class that handles the logic for importing and updating brokered users for all mappers that map a SAML
+ * attribute into a {@code Keycloak} role.
+ *
+ * @author <a href="mailto:sguilhen@redhat.com">Stefan Guilhen</a>
+ */
+public abstract class AbstractAttributeToRoleMapper extends AbstractIdentityProviderMapper {
+
+    @Override
+    public void importNewUser(KeycloakSession session, RealmModel realm, UserModel user, IdentityProviderMapperModel mapperModel, BrokeredIdentityContext context) {
+        RoleModel role = this.getRole(realm, mapperModel);
+        if (this.applies(mapperModel, context)) {
+            user.grantRole(role);
+        }
+    }
+
+    @Override
+    public void updateBrokeredUser(KeycloakSession session, RealmModel realm, UserModel user, IdentityProviderMapperModel mapperModel, BrokeredIdentityContext context) {
+        RoleModel role = this.getRole(realm, mapperModel);
+        String roleName = mapperModel.getConfig().get(ConfigConstants.ROLE);
+        // KEYCLOAK-8730 if a previous mapper has already granted the same role, skip the checks so we don't accidentally remove a valid role.
+        if (!context.hasMapperGrantedRole(roleName)) {
+            if (this.applies(mapperModel, context)) {
+                context.addMapperGrantedRole(roleName);
+                user.grantRole(role);
+            } else {
+                user.deleteRoleMapping(role);
+            }
+        }
+    }
+
+    /**
+     * This method must be implemented by subclasses and they must return {@code true} if their mapping can be applied
+     * (i.e. user has the SAML attribute that should be mapped) or {@code false} otherwise.
+     *
+     * @param mapperModel a reference to the {@link IdentityProviderMapperModel}.
+     * @param context a reference to the {@link BrokeredIdentityContext}.
+     * @return {@code true} if the mapping can be applied or {@code false} otherwise.
+     */
+    protected abstract boolean applies(final IdentityProviderMapperModel mapperModel, final BrokeredIdentityContext context);
+
+    /**
+     * Obtains the {@link RoleModel} corresponding the role configured in the specified {@link IdentityProviderMapperModel}.
+     * If the role doesn't correspond to one of the realm's client roles or to one of the realm's roles, this method throws
+     * an {@link IdentityBrokerException} to convey that an invalid role was configured.
+     *
+     * @param realm a reference to the realm.
+     * @param mapperModel a reference to the {@link IdentityProviderMapperModel} containing the configured role.
+     * @return the {@link RoleModel} that corresponds to the mapper model role.
+     * @throws IdentityBrokerException if the role name doesn't correspond to one of the realm's client roles or to one
+     * of the realm's roles.
+     */
+    private RoleModel getRole(final RealmModel realm, final IdentityProviderMapperModel mapperModel) {
+        String roleName = mapperModel.getConfig().get(ConfigConstants.ROLE);
+        RoleModel role = KeycloakModelUtils.getRoleFromString(realm, roleName);
+        if (role == null) {
+            throw new IdentityBrokerException("Unable to find role: " + roleName);
+        }
+        return role;
+    }
+}

--- a/services/src/main/java/org/keycloak/broker/saml/mappers/AdvancedAttributeToRoleMapper.java
+++ b/services/src/main/java/org/keycloak/broker/saml/mappers/AdvancedAttributeToRoleMapper.java
@@ -18,21 +18,14 @@
 package org.keycloak.broker.saml.mappers;
 
 
-import org.keycloak.broker.provider.AbstractIdentityProviderMapper;
 import org.keycloak.broker.provider.BrokeredIdentityContext;
 import org.keycloak.broker.provider.ConfigConstants;
-import org.keycloak.broker.provider.IdentityBrokerException;
 import org.keycloak.broker.saml.SAMLEndpoint;
 import org.keycloak.broker.saml.SAMLIdentityProviderFactory;
 import org.keycloak.dom.saml.v2.assertion.AssertionType;
 import org.keycloak.dom.saml.v2.assertion.AttributeStatementType;
 import org.keycloak.models.IdentityProviderMapperModel;
 import org.keycloak.models.IdentityProviderSyncMode;
-import org.keycloak.models.KeycloakSession;
-import org.keycloak.models.RealmModel;
-import org.keycloak.models.RoleModel;
-import org.keycloak.models.UserModel;
-import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.provider.ProviderConfigProperty;
 
 import java.util.ArrayList;
@@ -49,7 +42,7 @@ import static org.keycloak.utils.RegexUtils.valueMatchesRegex;
  * <a href="mailto:external.benjamin.weimer@bosch.io">Benjamin Weimer</a>,
  * <a href="mailto:external.martin.idel@bosch.io">Martin Idel</a>,
  */
-public class AdvancedAttributeToRoleMapper extends AbstractIdentityProviderMapper {
+public class AdvancedAttributeToRoleMapper extends AbstractAttributeToRoleMapper {
 
     public static final String PROVIDER_ID = "saml-advanced-role-idp-mapper";
     public static final String ATTRIBUTE_PROPERTY_NAME = "attributes";
@@ -125,40 +118,11 @@ public class AdvancedAttributeToRoleMapper extends AbstractIdentityProviderMappe
     }
 
     @Override
-    public void importNewUser(KeycloakSession session, RealmModel realm, UserModel user, IdentityProviderMapperModel mapperModel, BrokeredIdentityContext context) {
-        String roleName = mapperModel.getConfig().get(ConfigConstants.ROLE);
-        RoleModel role = getRoleModel(realm, roleName);
-
-        if (hasAllValues(mapperModel, context)) {
-            user.grantRole(role);
-        }
-    }
-
-    @Override
-    public void updateBrokeredUser(KeycloakSession session, RealmModel realm, UserModel user, IdentityProviderMapperModel mapperModel, BrokeredIdentityContext context) {
-        String roleName = mapperModel.getConfig().get(ConfigConstants.ROLE);
-        RoleModel role = getRoleModel(realm, roleName);
-        if (hasAllValues(mapperModel, context)) {
-            user.grantRole(role);
-        } else {
-            user.deleteRoleMapping(role);
-        }
-    }
-
-    @Override
     public String getHelpText() {
         return "If the set of attributes exists and can be matched, grant the user the specified realm or client role.";
     }
 
-    static RoleModel getRoleModel(RealmModel realm, String roleName) {
-        RoleModel role = KeycloakModelUtils.getRoleFromString(realm, roleName);
-        if (role == null) {
-            throw new IdentityBrokerException("Unable to find role: " + roleName);
-        }
-        return role;
-    }
-
-    boolean hasAllValues(IdentityProviderMapperModel mapperModel, BrokeredIdentityContext context) {
+    protected boolean applies(final IdentityProviderMapperModel mapperModel, final BrokeredIdentityContext context) {
         Map<String, String> attributes = mapperModel.getConfigMap(ATTRIBUTE_PROPERTY_NAME);
         boolean areAttributeValuesRegexes = Boolean.parseBoolean(mapperModel.getConfig().get(ARE_ATTRIBUTE_VALUES_REGEX_PROPERTY_NAME));
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcSamlMultipleAttributeToRoleMappersTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcSamlMultipleAttributeToRoleMappersTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.testsuite.broker;
+
+import com.google.common.collect.ImmutableMap;
+import org.keycloak.admin.client.resource.IdentityProviderResource;
+import org.keycloak.broker.provider.ConfigConstants;
+import org.keycloak.broker.saml.mappers.AdvancedAttributeToRoleMapper;
+import org.keycloak.broker.saml.mappers.AttributeToRoleMapper;
+import org.keycloak.broker.saml.mappers.UserAttributeMapper;
+import org.keycloak.models.IdentityProviderMapperModel;
+import org.keycloak.models.IdentityProviderMapperSyncMode;
+import org.keycloak.representations.idm.IdentityProviderMapperRepresentation;
+import org.keycloak.representations.idm.IdentityProviderRepresentation;
+
+/**
+ * Runs the same tests as {@link AttributeToRoleMapperTest} but using multiple SAML mappers that map different IDP attributes
+ * to the same {@code Keycloak} role.
+ * <p/>
+ * This class aims to test the fix for {@code KEYCLOAK-8730}. When configuring two or more mappers that map different IDP
+ * attributes to the same {@code Keycloak} role, the user would sometimes not be granted the expected {@code Keycloak} role
+ * depending on the order in which the mappers would run. For example, consider a scenario where mapper A maps IDP role 'x'
+ * to the role 'keycloak' and mapper B maps IDP role 'y' to the same role 'keycloak'. The user only has role 'x' in the IDP,
+ * so when updating the brokered user the following could happen:
+ * <ul>
+ *     <li>mapper A runs, checks user has role 'x', therefore role 'keycloak' is granted to user</li>
+ *     <li>mapper B runs, checks users doesn't have role 'y', so it removes role 'keycloak' from user even if the previous
+ *     mapper has already verified that the role should have been granted.</li>
+ * </ul>
+ * This test configures three different SAML attribute mappers that all map to the same {@code Keycloak} role. Only the first
+ * mapper actually succeeds in applying the mapping, the other two do nothing as the test user doesn't have the necessary
+ * role/attribute(s). The test then verifies that the user still contains the mapped role after all mappers run.
+ *
+ * @author <a href="mailto:sguilhen@redhat.com">Stefan Guilhen</a>
+ */
+public class KcSamlMultipleAttributeToRoleMappersTest extends AttributeToRoleMapperTest {
+
+    private static final String ATTRIBUTES_TO_MATCH = "[\n" +
+            "  {\n" +
+            "    \"key\": \"test attribute\",\n" +
+            "    \"value\": \"test value\"\n" +
+            "  }\n" +
+            "]";
+
+    @Override
+    protected void createMapperInIdp(IdentityProviderRepresentation idp, IdentityProviderMapperSyncMode syncMode) {
+        // first mapper that maps a role the test user has - it should perform the mapping.
+        IdentityProviderMapperRepresentation firstSamlAttributeToRoleMapper = new IdentityProviderMapperRepresentation();
+        firstSamlAttributeToRoleMapper.setName("first-role-mapper");
+        firstSamlAttributeToRoleMapper.setIdentityProviderMapper(AttributeToRoleMapper.PROVIDER_ID);
+        firstSamlAttributeToRoleMapper.setConfig(ImmutableMap.<String,String>builder()
+                .put(IdentityProviderMapperModel.SYNC_MODE, syncMode.toString())
+                .put(UserAttributeMapper.ATTRIBUTE_NAME, "Role")
+                .put(ATTRIBUTE_VALUE, ROLE_USER)
+                .put(ConfigConstants.ROLE, CLIENT_ROLE_MAPPER_REPRESENTATION)
+                .build());
+
+        IdentityProviderResource idpResource = realm.identityProviders().get(idp.getAlias());
+        firstSamlAttributeToRoleMapper.setIdentityProviderAlias(bc.getIDPAlias());
+        idpResource.addMapper(firstSamlAttributeToRoleMapper).close();
+
+        // second mapper that maps a role the test user doesn't have - it would normally end up removing the mapped role but
+        // it should now check if a previous mapper has already granted the same mapped role.
+        IdentityProviderMapperRepresentation secondSamlAttributeToRoleMapper = new IdentityProviderMapperRepresentation();
+        secondSamlAttributeToRoleMapper.setName("second-role-mapper");
+        secondSamlAttributeToRoleMapper.setIdentityProviderMapper(AttributeToRoleMapper.PROVIDER_ID);
+        secondSamlAttributeToRoleMapper.setConfig(ImmutableMap.<String,String>builder()
+                .put(IdentityProviderMapperModel.SYNC_MODE, syncMode.toString())
+                .put(UserAttributeMapper.ATTRIBUTE_NAME, "Role")
+                .put(ATTRIBUTE_VALUE, "missing-role")
+                .put(ConfigConstants.ROLE, CLIENT_ROLE_MAPPER_REPRESENTATION)
+                .build());
+
+        secondSamlAttributeToRoleMapper.setIdentityProviderAlias(bc.getIDPAlias());
+        idpResource.addMapper(secondSamlAttributeToRoleMapper).close();
+
+        // third mapper (advanced) that maps an attribute the test user doesn't have - it would normally end up removing the
+        // mapped role but it should now check if a previous mapper has already granted the same role.
+        IdentityProviderMapperRepresentation thirdSamlAttributeToRoleMapper = new IdentityProviderMapperRepresentation();
+        thirdSamlAttributeToRoleMapper.setName("advanced-role-mapper");
+        thirdSamlAttributeToRoleMapper.setIdentityProviderMapper(AdvancedAttributeToRoleMapper.PROVIDER_ID);
+        thirdSamlAttributeToRoleMapper.setConfig(ImmutableMap.<String, String>builder()
+                .put(IdentityProviderMapperModel.SYNC_MODE, syncMode.toString())
+                .put(AdvancedAttributeToRoleMapper.ATTRIBUTE_PROPERTY_NAME, ATTRIBUTES_TO_MATCH)
+                .put(AdvancedAttributeToRoleMapper.ARE_ATTRIBUTE_VALUES_REGEX_PROPERTY_NAME, Boolean.FALSE.toString())
+                .put(ConfigConstants.ROLE, CLIENT_ROLE_MAPPER_REPRESENTATION)
+                .build());
+        thirdSamlAttributeToRoleMapper.setIdentityProviderAlias(bc.getIDPAlias());
+        idpResource.addMapper(thirdSamlAttributeToRoleMapper).close();
+    }
+}

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/OidcClaimToRoleMapperTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/OidcClaimToRoleMapperTest.java
@@ -24,8 +24,8 @@ import com.google.common.collect.ImmutableMap;
  */
 public class OidcClaimToRoleMapperTest extends AbstractRoleMapperTest {
 
-    private static final String CLAIM = KcOidcBrokerConfiguration.ATTRIBUTE_TO_MAP_NAME;
-    private static final String CLAIM_VALUE = "value 1";
+    protected static final String CLAIM = KcOidcBrokerConfiguration.ATTRIBUTE_TO_MAP_NAME;
+    protected static final String CLAIM_VALUE = "value 1";
     private String claimOnSecondLogin = "";
 
     @Override
@@ -131,7 +131,7 @@ public class OidcClaimToRoleMapperTest extends AbstractRoleMapperTest {
         adminClient.realm(bc.providerRealmName()).users().get(user.getId()).update(user);
     }
 
-    private void createClaimToRoleMapper(IdentityProviderRepresentation idp, String claimValue, IdentityProviderMapperSyncMode syncMode) {
+    protected void createClaimToRoleMapper(IdentityProviderRepresentation idp, String claimValue, IdentityProviderMapperSyncMode syncMode) {
         IdentityProviderMapperRepresentation claimToRoleMapper = new IdentityProviderMapperRepresentation();
         claimToRoleMapper.setName("claim-to-role-mapper");
         claimToRoleMapper.setIdentityProviderMapper(ClaimToRoleMapper.PROVIDER_ID);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/OidcMultipleClaimToRoleMappersTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/OidcMultipleClaimToRoleMappersTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.testsuite.broker;
+
+import com.google.common.collect.ImmutableMap;
+import org.keycloak.admin.client.resource.IdentityProviderResource;
+import org.keycloak.broker.oidc.mappers.AdvancedClaimToRoleMapper;
+import org.keycloak.broker.oidc.mappers.ClaimToRoleMapper;
+import org.keycloak.broker.oidc.mappers.ExternalKeycloakRoleToRoleMapper;
+import org.keycloak.broker.provider.ConfigConstants;
+import org.keycloak.models.IdentityProviderMapperModel;
+import org.keycloak.models.IdentityProviderMapperSyncMode;
+import org.keycloak.representations.idm.IdentityProviderMapperRepresentation;
+import org.keycloak.representations.idm.IdentityProviderRepresentation;
+
+/**
+ * Runs the same tests as {@link OidcClaimToRoleMapperTest} but using multiple OIDC mappers that map different IDP claims
+ * to the same {@code Keycloak} role.
+ * <p/>
+ * This class aims to test the fix for {@code KEYCLOAK-8730}. When configuring two or more mappers that map different IDP
+ * attributes to the same {@code Keycloak} role, the user would sometimes not be granted the expected {@code Keycloak} role
+ * depending on the order in which the mappers would run. For example, consider a scenario where mapper A maps IDP role 'x'
+ * to the role 'keycloak' and mapper B maps IDP role 'y' to the same role 'keycloak'. The user only has role 'x' in the IDP,
+ * so when updating the brokered user the following could happen:
+ * <ul>
+ *     <li>mapper A runs, checks user has role 'x', therefore role 'keycloak' is granted to user</li>
+ *     <li>mapper B runs, checks users doesn't have role 'y', so it removes role 'keycloak' from user even if the previous
+ *     mapper has already verified that the role should have been granted.</li>
+ * </ul>
+ * This test configures three different OIDC claim mappers that all map to the same {@code Keycloak} role. Only the first
+ * mapper actually succeeds in applying the mapping, the other two do nothing as the test user doesn't have the necessary
+ * role/attribute(s). The test then verifies that the user still contains the mapped role after all mappers run.
+ *
+ * @author <a href="mailto:sguilhen@redhat.com">Stefan Guilhen</a>
+ */
+public class OidcMultipleClaimToRoleMappersTest extends OidcClaimToRoleMapperTest {
+
+    private static final String CLAIMS_OR_ATTRIBUTES = "[\n" +
+            "  {\n" +
+            "    \"key\": \"test attribute\",\n" +
+            "    \"value\": \"test value*\"\n" +
+            "  }\n" +
+            "]";
+
+    @Override
+    protected void createClaimToRoleMapper(IdentityProviderRepresentation idp, String claimValue, IdentityProviderMapperSyncMode syncMode) {
+        // first mapper that maps attributes the user has - it should perform the mapping to the expected role.
+        IdentityProviderMapperRepresentation firstOidcClaimToRoleMapper = new IdentityProviderMapperRepresentation();
+        firstOidcClaimToRoleMapper.setName("claim-to-role-mapper");
+        firstOidcClaimToRoleMapper.setIdentityProviderMapper(ClaimToRoleMapper.PROVIDER_ID);
+        firstOidcClaimToRoleMapper.setConfig(ImmutableMap.<String, String>builder()
+                .put(IdentityProviderMapperModel.SYNC_MODE, syncMode.toString())
+                .put(ClaimToRoleMapper.CLAIM, OidcClaimToRoleMapperTest.CLAIM)
+                .put(ClaimToRoleMapper.CLAIM_VALUE, claimValue)
+                .put(ConfigConstants.ROLE, CLIENT_ROLE_MAPPER_REPRESENTATION)
+                .build());
+
+        IdentityProviderResource idpResource = realm.identityProviders().get(idp.getAlias());
+        firstOidcClaimToRoleMapper.setIdentityProviderAlias(bc.getIDPAlias());
+        idpResource.addMapper(firstOidcClaimToRoleMapper).close();
+
+        // second mapper that maps an external role claim the test user doesn't have - it would normally end up removing the
+        // mapped role but it should now check if a previous mapper has already granted the same role.
+        IdentityProviderMapperRepresentation secondOidcClaimToRoleMapper = new IdentityProviderMapperRepresentation();
+        secondOidcClaimToRoleMapper.setName("external-keycloak-role-mapper");
+        secondOidcClaimToRoleMapper.setIdentityProviderMapper(ExternalKeycloakRoleToRoleMapper.PROVIDER_ID);
+        secondOidcClaimToRoleMapper.setConfig(ImmutableMap.<String,String>builder()
+                .put(IdentityProviderMapperModel.SYNC_MODE, syncMode.toString())
+                .put("external.role", "missing-role")
+                .put("role", CLIENT_ROLE_MAPPER_REPRESENTATION)
+                .build());
+        secondOidcClaimToRoleMapper.setIdentityProviderAlias(bc.getIDPAlias());
+        idpResource.addMapper(secondOidcClaimToRoleMapper).close();
+
+        // third mapper (advanced) that maps a claim the test user doesn't have - it would normally end up removing the
+        // mapped role but it should now check if a previous mapper has already granted the same role.
+        IdentityProviderMapperRepresentation thirdOidcClaimToRoleMapper = new IdentityProviderMapperRepresentation();
+        thirdOidcClaimToRoleMapper.setName("advanced-claim-to-role-mapper");
+        thirdOidcClaimToRoleMapper.setIdentityProviderMapper(AdvancedClaimToRoleMapper.PROVIDER_ID);
+        thirdOidcClaimToRoleMapper.setConfig(ImmutableMap.<String, String>builder()
+                .put(IdentityProviderMapperModel.SYNC_MODE, syncMode.toString())
+                .put(AdvancedClaimToRoleMapper.CLAIM_PROPERTY_NAME, CLAIMS_OR_ATTRIBUTES)
+                .put(AdvancedClaimToRoleMapper.ARE_CLAIM_VALUES_REGEX_PROPERTY_NAME, Boolean.TRUE.toString())
+                .put(ConfigConstants.ROLE, CLIENT_ROLE_MAPPER_REPRESENTATION)
+                .build());
+
+        thirdOidcClaimToRoleMapper.setIdentityProviderAlias(bc.getIDPAlias());
+        idpResource.addMapper(thirdOidcClaimToRoleMapper).close();
+    }
+}


### PR DESCRIPTION
…d by another mapper when updating a brokered user

This allows the configuration of multiple mappers that map different attributes to the same keycloak role, fixing an issue in which a mapper that verifies its mapping can't be applied (i.e. user doesn't have the specific attribute/role to be mapped) ends up removing the role that was previously granted to the user by another mapper.

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
