### PR TITLE
[KEYCLOAK-17443] Username and email form fields kept in registration form when duplicate

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/forms/RegistrationProfile.java
+++ b/services/src/main/java/org/keycloak/authentication/forms/RegistrationProfile.java
@@ -78,7 +78,6 @@ public class RegistrationProfile implements FormAction, FormActionFactory {
 
             if (pve.hasError(Messages.EMAIL_EXISTS)) {
                 context.error(Errors.EMAIL_IN_USE);
-                formData.remove("email");
             } else
                 context.error(Errors.INVALID_REGISTRATION);
 

--- a/services/src/main/java/org/keycloak/authentication/forms/RegistrationUserCreation.java
+++ b/services/src/main/java/org/keycloak/authentication/forms/RegistrationUserCreation.java
@@ -92,14 +92,10 @@ public class RegistrationUserCreation implements FormAction, FormActionFactory {
 
             if (pve.hasError(Messages.EMAIL_EXISTS)) {
                 context.error(Errors.EMAIL_IN_USE);
-                formData.remove(RegistrationPage.FIELD_EMAIL);
             } else if (pve.hasError(Messages.MISSING_EMAIL, Messages.MISSING_USERNAME, Messages.INVALID_EMAIL)) {
-                if (pve.hasError(Messages.INVALID_EMAIL))
-                    formData.remove(Validation.FIELD_EMAIL);
                 context.error(Errors.INVALID_REGISTRATION);
             } else if (pve.hasError(Messages.USERNAME_EXISTS)) {
                 context.error(Errors.USERNAME_IN_USE);
-                formData.remove(Validation.FIELD_USERNAME);
             }
 
             context.validationError(formData, errors);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RegisterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RegisterTest.java
@@ -89,7 +89,7 @@ public class RegisterTest extends AbstractTestRealmKeycloakTest {
         assertEquals("firstName", registerPage.getFirstName());
         assertEquals("lastName", registerPage.getLastName());
         assertEquals("registerExistingUser@email", registerPage.getEmail());
-        assertEquals("", registerPage.getUsername());
+        assertEquals("roleRichUser", registerPage.getUsername());
         assertEquals("", registerPage.getPassword());
         assertEquals("", registerPage.getPasswordConfirm());
 
@@ -112,7 +112,7 @@ public class RegisterTest extends AbstractTestRealmKeycloakTest {
         // assert form keeps form fields on error
         assertEquals("firstName", registerPage.getFirstName());
         assertEquals("lastName", registerPage.getLastName());
-        assertEquals("", registerPage.getEmail());
+        assertEquals("test-user@localhost", registerPage.getEmail());
         assertEquals("registerExistingUser", registerPage.getUsername());
         assertEquals("", registerPage.getPassword());
         assertEquals("", registerPage.getPasswordConfirm());


### PR DESCRIPTION
There is an UX problem in Registration form. When username or email is duplicate then registration form is reshown with relevant error message, which is OK. But username or email field is blank in this case, so user can't patch value easily but have to retype it fully.  Common practice in forms with good UX is reshowning values so user can patch them (except password fields naturally).