### PR TITLE
KEYCLOAK-17764 Remove all clients querying fallback

### DIFF
--- a/authz/policy/common/src/main/java/org/keycloak/authorization/policy/provider/role/RolePolicyProviderFactory.java
+++ b/authz/policy/common/src/main/java/org/keycloak/authorization/policy/provider/role/RolePolicyProviderFactory.java
@@ -173,13 +173,6 @@ public class RolePolicyProviderFactory implements PolicyProviderFactory<RolePoli
                     role = client.getRole(roleName);
                 }
 
-                // fallback to find any client role with the given name
-                if (role == null) {
-                    String finalRoleName = roleName;
-                    role = realm.getClientsStream().map(clientModel -> clientModel.getRole(finalRoleName)).filter(roleModel -> roleModel != null)
-                            .findFirst().orElse(null);
-                }
-
                 if (role == null) {
                     throw new RuntimeException("Error while updating policy [" + policy.getName()  + "]. Role [" + roleName + "] could not be found.");
                 }

--- a/testsuite/integration-arquillian/test-apps/photoz/photoz-restful-api-authz-service.json
+++ b/testsuite/integration-arquillian/test-apps/photoz/photoz-restful-api-authz-service.json
@@ -81,7 +81,7 @@
       "decisionStrategy": "UNANIMOUS",
       "config": {
         "applyPolicies": "[]",
-        "roles": "[{\"id\":\"user\"},{\"id\":\"manage-albums\",\"required\":true}]"
+        "roles": "[{\"id\":\"user\"},{\"id\":\"photoz-restful-api/manage-albums\",\"required\":true}]"
       }
     },
     {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/example/authorization/AbstractServletAuthzAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/example/authorization/AbstractServletAuthzAdapterTest.java
@@ -222,7 +222,7 @@ public abstract class AbstractServletAuthzAdapterTest extends AbstractBaseServle
 
             policy.setName("Required Role Policy");
             policy.addRole("user_premium", false);
-            policy.addRole("required-role", false);
+            policy.addRole(RESOURCE_SERVER_ID + "/required-role", false);
 
             RolePoliciesResource rolePolicy = getAuthorizationResource().policies().role();
 
@@ -237,7 +237,7 @@ public abstract class AbstractServletAuthzAdapterTest extends AbstractBaseServle
 
             policy.getRoles().clear();
             policy.addRole("user_premium", false);
-            policy.addRole("required-role", true);
+            policy.addRole(RESOURCE_SERVER_ID + "/required-role", true);
 
             rolePolicy.findById(policy.getId()).update(policy);
 
@@ -258,7 +258,7 @@ public abstract class AbstractServletAuthzAdapterTest extends AbstractBaseServle
 
             policy.getRoles().clear();
             policy.addRole("user_premium", false);
-            policy.addRole("required-role", false);
+            policy.addRole(RESOURCE_SERVER_ID + "/required-role", false);
 
             rolePolicy.findById(policy.getId()).update(policy);
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/AuthzCleanupTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/AuthzCleanupTest.java
@@ -74,8 +74,8 @@ public class AuthzCleanupTest extends AbstractKeycloakTest {
         AuthorizationProvider authz = session.getProvider(AuthorizationProvider.class);
         ClientModel myclient = realm.getClientByClientId("myclient");
         ResourceServer resourceServer = authz.getStoreFactory().getResourceServerStore().findById(myclient.getId());
-        createRolePolicy(authz, resourceServer, "client-role-1");
-        createRolePolicy(authz, resourceServer, "client-role-2");
+        createRolePolicy(authz, resourceServer, myclient.getClientId() + "/client-role-1");
+        createRolePolicy(authz, resourceServer, myclient.getClientId() + "/client-role-2");
     }
 
     private static Policy createRolePolicy(AuthorizationProvider authz, ResourceServer resourceServer, String roleName) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/authorization/RolePolicyManagementTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/authorization/RolePolicyManagementTest.java
@@ -92,7 +92,7 @@ public class RolePolicyManagementTest extends AbstractPolicyManagementTest {
 
         roles.create(new RoleRepresentation("Client Role B", "desc", false));
 
-        representation.addRole("Client Role A");
+        representation.addRole("resource-server-test/Client Role A");
         representation.addClientRole(clientRep.getClientId(), "Client Role B", true);
 
         assertCreated(authorization, representation);

--- a/testsuite/integration-arquillian/tests/base/src/test/resources/authorization-test/acme-resource-server-cleanup-test.json
+++ b/testsuite/integration-arquillian/tests/base/src/test/resources/authorization-test/acme-resource-server-cleanup-test.json
@@ -56,7 +56,7 @@
       "logic": "POSITIVE",
       "decisionStrategy": "UNANIMOUS",
       "config": {
-        "roles": "[{\"id\":\"Acme administrator\",\"required\":true}]"
+        "roles": "[{\"id\":\"myclient/Acme administrator\",\"required\":true}]"
       }
     },
     {
@@ -65,7 +65,7 @@
       "logic": "POSITIVE",
       "decisionStrategy": "UNANIMOUS",
       "config": {
-        "roles": "[{\"id\":\"Acme viewer\",\"required\":true}]"
+        "roles": "[{\"id\":\"myclient/Acme viewer\",\"required\":true}]"
       }
     },
     {
@@ -74,7 +74,7 @@
       "logic": "POSITIVE",
       "decisionStrategy": "UNANIMOUS",
       "config": {
-        "roles": "[{\"id\":\"tenant user\",\"required\":true}]"
+        "roles": "[{\"id\":\"myclient/tenant user\",\"required\":true}]"
       }
     },
     {
@@ -83,7 +83,7 @@
       "logic": "POSITIVE",
       "decisionStrategy": "UNANIMOUS",
       "config": {
-        "roles": "[{\"id\":\"tenant administrator\",\"required\":true}]"
+        "roles": "[{\"id\":\"myclient/tenant administrator\",\"required\":true}]"
       }
     },
     {
@@ -92,7 +92,7 @@
       "logic": "POSITIVE",
       "decisionStrategy": "UNANIMOUS",
       "config": {
-        "roles": "[{\"id\":\"tenant viewer\",\"required\":true}]"
+        "roles": "[{\"id\":\"myclient/tenant viewer\",\"required\":true}]"
       }
     },
     {

--- a/testsuite/integration-arquillian/tests/base/src/test/resources/authorization-test/import-authorization-unordered-settings.json
+++ b/testsuite/integration-arquillian/tests/base/src/test/resources/authorization-test/import-authorization-unordered-settings.json
@@ -68,7 +68,7 @@
       "logic": "POSITIVE",
       "decisionStrategy": "UNANIMOUS",
       "config": {
-        "roles": "[{\"id\":\"user\"},{\"id\":\"manage-albums\",\"required\":true}]"
+        "roles": "[{\"id\":\"user\"},{\"id\":\"resource-server-test/manage-albums\",\"required\":true}]"
       }
     },
     {
@@ -143,7 +143,7 @@
       "logic": "POSITIVE",
       "decisionStrategy": "UNANIMOUS",
       "config": {
-        "roles": "[{\"id\":\"admin\",\"required\":true}]"
+        "roles": "[{\"id\":\"resource-server-test/admin\",\"required\":true}]"
       }
     },
     {


### PR DESCRIPTION
I think this is redundant here. If an administrator sets a role so that it fails the previous searches it should probably throw an exception rather than trying to query all clients.
```
                if (clientId == null) {
                    role = realm.getRole(roleName);
                    if (role == null) {
                        role = realm.getRoleById(roleName);
                    }
                } else {
                    ClientModel client = realm.getClientByClientId(clientId);
                    if (client == null) {
                        throw new RuntimeException("Client with id [" + clientId + "] not found.");
                    }
                    role = client.getRole(roleName);
                }

```
