### PR TITLE
[KEYCLOAK-18250] LDAPSyncTest.test09MembershipUsingDifferentAttributes fails on MySQL 8 and MariaDB 10.3

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPSyncTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPSyncTest.java
@@ -570,11 +570,15 @@ public class LDAPSyncTest extends AbstractLDAPTest {
 
         testingClient.server().run(session -> {
             LDAPTestContext ctx = LDAPTestContext.init(session);
-            RealmModel appRealm = ctx.getRealm();
 
             KeycloakSessionFactory sessionFactory = session.getKeycloakSessionFactory();
             SynchronizationResult syncResult = new UserStorageSyncManager().syncAllUsers(sessionFactory, "test", ctx.getLdapModel());
             Assert.assertEquals(2, syncResult.getAdded());
+        });
+
+        testingClient.server().run(session -> {
+            LDAPTestContext ctx = LDAPTestContext.init(session);
+            RealmModel appRealm = ctx.getRealm();
 
             GroupModel user8Group = KeycloakModelUtils.findGroupByPath(appRealm, "/user8group");
             Assert.assertNotNull(user8Group);


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/KEYCLOAK-18250

Just moving the synchronization to its own request (like in a normal rest customer request). It seems that doing the asserts immediately after the synch gave issues in mariadb/mysql.

@tkyjovsk Please test if now it works with mariadb and mysql. Tested with H2, mariadb, mysql and postgresql here and it works for me.