### PR TITLE
KEYCLOAK-18273 Display Id Provider DisplayName instead of Alias on identity-provider-link.ftl

### DIFF
--- a/services/src/main/java/org/keycloak/email/freemarker/FreeMarkerEmailTemplateProvider.java
+++ b/services/src/main/java/org/keycloak/email/freemarker/FreeMarkerEmailTemplateProvider.java
@@ -148,6 +148,10 @@ public class FreeMarkerEmailTemplateProvider implements EmailTemplateProvider {
         String idpAlias = brokerContext.getIdpConfig().getAlias();
         String idpDisplayName = brokerContext.getIdpConfig().getDisplayName();
         idpAlias = ObjectUtil.capitalize(idpAlias);
+        String displayName = idpAlias;
+        if (!ObjectUtil.isBlank(brokerContext.getIdpConfig().getDisplayName())) {
+            displayName = brokerContext.getIdpConfig().getDisplayName();
+        }
 
         if (idpDisplayName != null && idpDisplayName.length() > 0) {
             idpAlias = ObjectUtil.capitalize(idpDisplayName);
@@ -155,8 +159,9 @@ public class FreeMarkerEmailTemplateProvider implements EmailTemplateProvider {
 
         attributes.put("identityProviderContext", brokerContext);
         attributes.put("identityProviderAlias", idpAlias);
+        attributes.put("identityProviderDisplayName", displayName);
 
-        List<Object> subjectAttrs = Arrays.asList(idpAlias);
+        List<Object> subjectAttrs = Arrays.asList(displayName);
         send("identityProviderLinkSubject", subjectAttrs, "identity-provider-link.ftl", attributes);
     }
 

--- a/themes/src/main/resources/theme/base/email/html/identity-provider-link.ftl
+++ b/themes/src/main/resources/theme/base/email/html/identity-provider-link.ftl
@@ -1,4 +1,4 @@
 <#import "template.ftl" as layout>
 <@layout.emailLayout>
-${kcSanitize(msg("identityProviderLinkBodyHtml", identityProviderAlias, realmName, identityProviderContext.username, link, linkExpiration, linkExpirationFormatter(linkExpiration)))?no_esc}
+${kcSanitize(msg("identityProviderLinkBodyHtml", identityProviderDisplayName, realmName, identityProviderContext.username, link, linkExpiration, linkExpirationFormatter(linkExpiration)))?no_esc}
 </@layout.emailLayout>

--- a/themes/src/main/resources/theme/base/email/text/identity-provider-link.ftl
+++ b/themes/src/main/resources/theme/base/email/text/identity-provider-link.ftl
@@ -1,2 +1,2 @@
 <#ftl output_format="plainText">
-${msg("identityProviderLinkBody", identityProviderAlias, realmName, identityProviderContext.username, link, linkExpiration, linkExpirationFormatter(linkExpiration))}
+${msg("identityProviderLinkBody", identityProviderDisplayName, realmName, identityProviderContext.username, link, linkExpiration, linkExpirationFormatter(linkExpiration))}


### PR DESCRIPTION
The identity-provider-link.ftl email shows idpAlias as Identity Provider Name. It should be possible to show the user friendly DisplayName of IdentityProviders. See related issue #7669 