### PR TITLE
KEYCLOAK-18291: Danger button for removing ldap users

### DIFF
--- a/themes/src/main/resources/theme/base/admin/resources/js/controllers/users.js
+++ b/themes/src/main/resources/theme/base/admin/resources/js/controllers/users.js
@@ -1799,21 +1799,25 @@ module.controller('LDAPUserStorageCtrl', function($scope, $location, Notificatio
         });
     }
     $scope.removeImportedUsers = function() {
-        UserStorageOperations.removeImportedUsers.save({ realm: $scope.realm.realm, componentId: $scope.instance.id }, {}, function(syncResult) {
-            $route.reload();
-            Notifications.success("Remove imported users finished successfully. ");
-        }, function() {
-            $route.reload();
-            Notifications.error("Error during remove");
+        Dialog.confirmDelete('users', 'imported', function () {
+            UserStorageOperations.removeImportedUsers.save({ realm: $scope.realm.realm, componentId: $scope.instance.id }, {}, function(syncResult) {
+                $route.reload();
+                Notifications.success("Remove imported users finished successfully. ");
+            }, function() {
+                $route.reload();
+                Notifications.error("Error during remove");
+            });
         });
     };
     $scope.unlinkUsers = function() {
-        UserStorageOperations.unlinkUsers.save({ realm: $scope.realm.realm, componentId: $scope.instance.id }, {}, function(syncResult) {
-            $route.reload();
-            Notifications.success("Unlink of users finished successfully. ");
-        }, function() {
-            $route.reload();
-            Notifications.error("Error during unlink");
+        Dialog.confirmDelete('users', 'linked', function () {
+            UserStorageOperations.unlinkUsers.save({ realm: $scope.realm.realm, componentId: $scope.instance.id }, {}, function(syncResult) {
+                $route.reload();
+                Notifications.success("Unlink of users finished successfully. ");
+            }, function() {
+                $route.reload();
+                Notifications.error("Error during unlink");
+            });
         });
     };
 

--- a/themes/src/main/resources/theme/base/admin/resources/partials/user-storage-ldap.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/user-storage-ldap.html
@@ -557,8 +557,8 @@
                 <button kc-reset data-ng-disabled="!changed">{{:: 'cancel' | translate}}</button>
                 <button class="btn btn-primary" data-ng-click="triggerChangedUsersSync()" data-ng-hide="changed">{{:: 'synchronize-changed-users' | translate}}</button>
                 <button class="btn btn-primary" data-ng-click="triggerFullSync()" data-ng-hide="changed">{{:: 'synchronize-all-users' | translate}}</button>
-                <button class="btn btn-primary" data-ng-click="removeImportedUsers()" data-ng-hide="changed">{{:: 'remove-imported-users' | translate}}</button>
-                <button class="btn btn-primary" data-ng-click="unlinkUsers()" data-ng-hide="changed">{{:: 'unlink-users' | translate}}</button>
+                <button class="btn btn-danger" data-ng-click="removeImportedUsers()" data-ng-hide="changed">{{:: 'remove-imported-users' | translate}}</button>
+                <button class="btn btn-danger" data-ng-click="unlinkUsers()" data-ng-hide="changed">{{:: 'unlink-users' | translate}}</button>
             </div>
         </div>
     </form>


### PR DESCRIPTION
Accidentially deleting LDAP users causes them to be recreated without MFA and with new IDs.
To make sure this is not accidentially clicked this change makes the buttons red and adds a confirmation dialog.

Co-authored-by: Christian Dickel <dickelchris@googlemail.com>
Co-authored-by: Niklas Fassbender <niklas.fassbender@aoe.com>