### PR TITLE
KEYCLOAK-18296 RefreshTokenRequest returns incorrect error code during failed HoK request

### DIFF
--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/HolderOfKeyEnforcerExecutor.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/HolderOfKeyEnforcerExecutor.java
@@ -180,7 +180,7 @@ public class HolderOfKeyEnforcerExecutor implements ClientPolicyExecutorProvider
         }
 
         if (!MtlsHoKTokenUtil.verifyTokenBindingWithClientCertificate(refreshToken, request, session)) {
-            throw new ClientPolicyException(Errors.NOT_ALLOWED, MtlsHoKTokenUtil.CERT_VERIFY_ERROR_DESC, Response.Status.UNAUTHORIZED);
+            throw new ClientPolicyException(OAuthErrorException.INVALID_GRANT, MtlsHoKTokenUtil.CERT_VERIFY_ERROR_DESC, Response.Status.BAD_REQUEST);
         }
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientPoliciesTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientPoliciesTest.java
@@ -2226,8 +2226,8 @@ public class ClientPoliciesTest extends AbstractClientPoliciesTest {
         }  catch (IOException ioe) {
             throw new RuntimeException(ioe);
         }
-        assertEquals(401, accessTokenResponseRefreshed.getStatusCode());
-        assertEquals(Errors.NOT_ALLOWED, accessTokenResponseRefreshed.getError());
+        assertEquals(400, accessTokenResponseRefreshed.getStatusCode());
+        assertEquals(OAuthErrorException.INVALID_GRANT, accessTokenResponseRefreshed.getError());
 
         // Check token revoke with other certificate
         try (CloseableHttpClient client = MutualTLSUtils.newCloseableHttpClientWithOtherKeyStoreAndTrustStore()) {


### PR DESCRIPTION
This PR is for [KEYCLOAK-13933 Client Policies](https://issues.redhat.com/browse/KEYCLOAK-13933), also is the part of the project [Client Policy Official Support](https://github.com/keycloak/kc-sig-fapi/projects) of [FAPI-SIG](https://github.com/keycloak/kc-sig-fapi) activity.

[KEYCLOAK-18296](https://issues.redhat.com/browse/KEYCLOAK-18296) describes it in detail.