### PR TITLE
KEYCLOAK-18044 Client Policy: UI tests (old Admin Console)

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/console/page/fragment/DataTable.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/console/page/fragment/DataTable.java
@@ -19,6 +19,7 @@ package org.keycloak.testsuite.console.page.fragment;
 
 import org.jboss.arquillian.drone.api.annotation.Drone;
 import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
@@ -26,8 +27,10 @@ import org.openqa.selenium.support.FindBy;
 import java.util.List;
 
 import static org.keycloak.testsuite.util.UIUtils.clickLink;
+import static org.keycloak.testsuite.util.UIUtils.getTextFromElement;
 import static org.keycloak.testsuite.util.WaitUtils.pause;
 import static org.keycloak.testsuite.util.WaitUtils.waitForPageToLoad;
+import static org.openqa.selenium.By.tagName;
 import static org.openqa.selenium.By.xpath;
 
 /**
@@ -48,14 +51,11 @@ public class DataTable {
     private WebElement header;
     @FindBy(css = "tbody")
     private WebElement body;
-    @FindBy(xpath = "(//table)[1]/tbody/tr[@class='ng-scope']")
+    @FindBy(xpath = "tbody/tr[@class='ng-scope']")
     private List<WebElement> rows;
 
     @FindBy(tagName = "tfoot")
     private WebElement footer;
-    
-    @FindBy
-    private WebElement infoRow;
 
     public void search(String pattern) {
         searchInput.sendKeys(pattern);
@@ -94,8 +94,46 @@ public class DataTable {
         clickLink(body.findElement(By.xpath(".//tr/td/a[text()='" + text + "']")));
     }
 
+    public WebElement getActionButton(WebElement row, String buttonText) {
+        return row.findElement(xpath(".//td[contains(@class, 'kc-action-cell') and text()='" + buttonText + "']"));
+    }
+
+    public WebElement getActionButton(String rowLinkText, String buttonText) {
+        return getActionButton(getRowByLinkText(rowLinkText), buttonText);
+    }
+
+    public boolean isActionButtonVisible(String rowLinkText, String buttonText) {
+        try {
+            return getActionButton(rowLinkText, buttonText).isDisplayed();
+        }
+        catch (NoSuchElementException e) {
+            return false;
+        }
+    }
+
     public void clickRowActionButton(WebElement row, String buttonText) {
-        clickLink(row.findElement(xpath(".//td[contains(@class, 'kc-action-cell') and text()='" + buttonText + "']")));
+        clickLink(getActionButton(row, buttonText));
+    }
+
+    public void clickRowActionButton(String rowLinkText, String buttonText) {
+        clickLink(getActionButton(rowLinkText, buttonText));
+    }
+
+    public String getColumnText(WebElement row, int colIndex) {
+        return getTextFromElement(row.findElements(tagName("td")).get(colIndex));
+    }
+
+    public String getColumnText(String rowLinkText, int colIndex) {
+        return getColumnText(getRowByLinkText(rowLinkText), colIndex);
+    }
+
+    public boolean isRowPresent(String rowLinkText) {
+        try {
+            return getRowByLinkText(rowLinkText).isDisplayed();
+        }
+        catch (NoSuchElementException e) {
+            return false;
+        }
     }
     
 }

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/page/Form.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/page/Form.java
@@ -46,7 +46,7 @@ public class Form {
     private WebElement cancel;
 
     public void save() {
-        clickLink(save);
+        clickLink(saveBtn());
         try {
             AbstractPatternFlyAlert.waitUntilDisplayed();
         }
@@ -56,7 +56,7 @@ public class Form {
     }
 
     public void cancel() {
-        guardAjax(cancel).click();
+        guardAjax(cancelBtn()).click();
     }
 
     public WebElement saveBtn() {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientPoliciesImportExportTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientPoliciesImportExportTest.java
@@ -17,13 +17,6 @@
 
 package org.keycloak.testsuite.client;
 
-import static org.keycloak.testsuite.admin.AbstractAdminTest.loadJson;
-import static org.keycloak.testsuite.arquillian.annotation.AuthServerContainerExclude.AuthServer.REMOTE;
-
-import java.io.File;
-import java.util.Arrays;
-import java.util.List;
-
 import org.junit.Test;
 import org.keycloak.exportimport.ExportImportConfig;
 import org.keycloak.exportimport.singlefile.SingleFileExportProviderFactory;
@@ -34,6 +27,13 @@ import org.keycloak.representations.idm.ClientProfilesRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.testsuite.Assert;
 import org.keycloak.testsuite.arquillian.annotation.AuthServerContainerExclude;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.keycloak.testsuite.admin.AbstractAdminTest.loadJson;
+import static org.keycloak.testsuite.arquillian.annotation.AuthServerContainerExclude.AuthServer.REMOTE;
 
 /**
  * @author <a href="mailto:takashi.norimatsu.ws@hitachi.com">Takashi Norimatsu</a>

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientPoliciesLoadUpdateTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientPoliciesLoadUpdateTest.java
@@ -17,16 +17,6 @@
 
 package org.keycloak.testsuite.client;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-import static org.keycloak.testsuite.admin.AbstractAdminTest.loadJson;
-import static org.keycloak.testsuite.arquillian.annotation.AuthServerContainerExclude.AuthServer.REMOTE;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-
 import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.keycloak.admin.client.resource.RealmResource;
@@ -39,18 +29,36 @@ import org.keycloak.representations.idm.ClientPolicyRepresentation;
 import org.keycloak.representations.idm.ClientProfileRepresentation;
 import org.keycloak.representations.idm.ClientProfilesRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
-import org.keycloak.services.clientpolicy.ClientPolicyException;
 import org.keycloak.services.clientpolicy.ClientPoliciesUtil;
+import org.keycloak.services.clientpolicy.ClientPolicyException;
 import org.keycloak.services.clientpolicy.condition.ClientAccessTypeConditionFactory;
 import org.keycloak.services.clientpolicy.condition.ClientRolesConditionFactory;
+import org.keycloak.services.clientpolicy.executor.ConsentRequiredExecutorFactory;
 import org.keycloak.services.clientpolicy.executor.FullScopeDisabledExecutorFactory;
 import org.keycloak.services.clientpolicy.executor.PKCEEnforcerExecutorFactory;
 import org.keycloak.services.clientpolicy.executor.SecureClientAuthenticatorExecutorFactory;
-import org.keycloak.services.clientpolicy.executor.ConsentRequiredExecutorFactory;
 import org.keycloak.services.clientpolicy.executor.SecureClientUrisExecutorFactory;
 import org.keycloak.services.clientpolicy.executor.SecureSessionEnforceExecutorFactory;
 import org.keycloak.testsuite.Assert;
 import org.keycloak.testsuite.arquillian.annotation.AuthServerContainerExclude;
+import org.keycloak.testsuite.util.ClientPoliciesUtil.ClientPoliciesBuilder;
+import org.keycloak.testsuite.util.ClientPoliciesUtil.ClientPolicyBuilder;
+import org.keycloak.testsuite.util.ClientPoliciesUtil.ClientProfileBuilder;
+import org.keycloak.testsuite.util.ClientPoliciesUtil.ClientProfilesBuilder;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.keycloak.testsuite.admin.AbstractAdminTest.loadJson;
+import static org.keycloak.testsuite.arquillian.annotation.AuthServerContainerExclude.AuthServer.REMOTE;
+import static org.keycloak.testsuite.util.ClientPoliciesUtil.createClientAccessTypeConditionConfig;
+import static org.keycloak.testsuite.util.ClientPoliciesUtil.createClientRolesConditionConfig;
+import static org.keycloak.testsuite.util.ClientPoliciesUtil.createPKCEEnforceExecutorConfig;
+import static org.keycloak.testsuite.util.ClientPoliciesUtil.createSecureClientAuthenticatorExecutorConfig;
 
 /**
  * @author <a href="mailto:takashi.norimatsu.ws@hitachi.com">Takashi Norimatsu</a>

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientPoliciesTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientPoliciesTest.java
@@ -17,24 +17,6 @@
 
 package org.keycloak.testsuite.client;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-import static org.keycloak.testsuite.admin.AbstractAdminTest.loadJson;
-import static org.keycloak.testsuite.admin.ApiUtil.findUserByUsername;
-
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.security.KeyPair;
-import java.security.PrivateKey;
-import java.security.PublicKey;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -90,12 +72,12 @@ import org.keycloak.services.clientpolicy.executor.HolderOfKeyEnforcerExecutorFa
 import org.keycloak.services.clientpolicy.executor.PKCEEnforcerExecutorFactory;
 import org.keycloak.services.clientpolicy.executor.SecureClientAuthenticatorExecutorFactory;
 import org.keycloak.services.clientpolicy.executor.SecureClientUrisExecutorFactory;
+import org.keycloak.services.clientpolicy.executor.SecureRequestObjectExecutor;
 import org.keycloak.services.clientpolicy.executor.SecureRequestObjectExecutorFactory;
 import org.keycloak.services.clientpolicy.executor.SecureResponseTypeExecutorFactory;
 import org.keycloak.services.clientpolicy.executor.SecureSessionEnforceExecutorFactory;
 import org.keycloak.services.clientpolicy.executor.SecureSigningAlgorithmExecutorFactory;
 import org.keycloak.services.clientpolicy.executor.SecureSigningAlgorithmForSignedJwtExecutorFactory;
-import org.keycloak.services.clientpolicy.executor.SecureRequestObjectExecutor;
 import org.keycloak.testsuite.admin.ApiUtil;
 import org.keycloak.testsuite.arquillian.annotation.AuthServerContainerExclude;
 import org.keycloak.testsuite.arquillian.annotation.AuthServerContainerExclude.AuthServer;
@@ -109,6 +91,45 @@ import org.keycloak.testsuite.util.OAuthClient;
 import org.keycloak.testsuite.util.RoleBuilder;
 import org.keycloak.testsuite.util.ServerURLs;
 import org.keycloak.util.JsonSerialization;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.security.KeyPair;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.keycloak.testsuite.admin.AbstractAdminTest.loadJson;
+import static org.keycloak.testsuite.admin.ApiUtil.findUserByUsername;
+import static org.keycloak.testsuite.util.ClientPoliciesUtil.ClientPoliciesBuilder;
+import static org.keycloak.testsuite.util.ClientPoliciesUtil.ClientPolicyBuilder;
+import static org.keycloak.testsuite.util.ClientPoliciesUtil.ClientProfileBuilder;
+import static org.keycloak.testsuite.util.ClientPoliciesUtil.ClientProfilesBuilder;
+import static org.keycloak.testsuite.util.ClientPoliciesUtil.createAnyClientConditionConfig;
+import static org.keycloak.testsuite.util.ClientPoliciesUtil.createClientAccessTypeConditionConfig;
+import static org.keycloak.testsuite.util.ClientPoliciesUtil.createClientRolesConditionConfig;
+import static org.keycloak.testsuite.util.ClientPoliciesUtil.createClientScopesConditionConfig;
+import static org.keycloak.testsuite.util.ClientPoliciesUtil.createClientUpdateContextConditionConfig;
+import static org.keycloak.testsuite.util.ClientPoliciesUtil.createClientUpdateSourceGroupsConditionConfig;
+import static org.keycloak.testsuite.util.ClientPoliciesUtil.createClientUpdateSourceHostsConditionConfig;
+import static org.keycloak.testsuite.util.ClientPoliciesUtil.createClientUpdateSourceRolesConditionConfig;
+import static org.keycloak.testsuite.util.ClientPoliciesUtil.createHolderOfKeyEnforceExecutorConfig;
+import static org.keycloak.testsuite.util.ClientPoliciesUtil.createPKCEEnforceExecutorConfig;
+import static org.keycloak.testsuite.util.ClientPoliciesUtil.createSecureClientAuthenticatorExecutorConfig;
+import static org.keycloak.testsuite.util.ClientPoliciesUtil.createSecureRequestObjectExecutorConfig;
+import static org.keycloak.testsuite.util.ClientPoliciesUtil.createSecureResponseTypeExecutor;
+import static org.keycloak.testsuite.util.ClientPoliciesUtil.createSecureSigningAlgorithmEnforceExecutorConfig;
+import static org.keycloak.testsuite.util.ClientPoliciesUtil.createSecureSigningAlgorithmForSignedJwtEnforceExecutorConfig;
+import static org.keycloak.testsuite.util.ClientPoliciesUtil.createTestRaiseExeptionConditionConfig;
+import static org.keycloak.testsuite.util.ClientPoliciesUtil.createFullScopeDisabledExecutorConfig;
 
 /**
  * @author <a href="mailto:takashi.norimatsu.ws@hitachi.com">Takashi Norimatsu</a>

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/FAPI1Test.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/FAPI1Test.java
@@ -18,18 +18,6 @@
 
 package org.keycloak.testsuite.client;
 
-import java.security.KeyPair;
-import java.security.PrivateKey;
-import java.security.PublicKey;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Function;
-import java.util.function.Supplier;
-
 import org.apache.http.NameValuePair;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -87,9 +75,24 @@ import org.keycloak.testsuite.util.MutualTLSUtils;
 import org.keycloak.testsuite.util.OAuthClient;
 import org.keycloak.testsuite.util.ServerURLs;
 
+import java.security.KeyPair;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.keycloak.testsuite.admin.AbstractAdminTest.loadJson;
+import static org.keycloak.testsuite.util.ClientPoliciesUtil.ClientPoliciesBuilder;
+import static org.keycloak.testsuite.util.ClientPoliciesUtil.ClientPolicyBuilder;
+import static org.keycloak.testsuite.util.ClientPoliciesUtil.createAnyClientConditionConfig;
 
 /**
  * Test for the FAPI 1 specifications:

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/util/ClientPoliciesUtil.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/util/ClientPoliciesUtil.java
@@ -1,0 +1,334 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.keycloak.representations.idm.ClientPoliciesRepresentation;
+import org.keycloak.representations.idm.ClientPolicyConditionConfigurationRepresentation;
+import org.keycloak.representations.idm.ClientPolicyConditionRepresentation;
+import org.keycloak.representations.idm.ClientPolicyExecutorConfigurationRepresentation;
+import org.keycloak.representations.idm.ClientPolicyExecutorRepresentation;
+import org.keycloak.representations.idm.ClientPolicyRepresentation;
+import org.keycloak.representations.idm.ClientProfileRepresentation;
+import org.keycloak.representations.idm.ClientProfilesRepresentation;
+import org.keycloak.services.clientpolicy.condition.ClientAccessTypeCondition;
+import org.keycloak.services.clientpolicy.condition.ClientRolesCondition;
+import org.keycloak.services.clientpolicy.condition.ClientScopesCondition;
+import org.keycloak.services.clientpolicy.condition.ClientUpdaterContextCondition;
+import org.keycloak.services.clientpolicy.condition.ClientUpdaterSourceGroupsCondition;
+import org.keycloak.services.clientpolicy.condition.ClientUpdaterSourceHostsCondition;
+import org.keycloak.services.clientpolicy.condition.ClientUpdaterSourceRolesCondition;
+import org.keycloak.services.clientpolicy.executor.FullScopeDisabledExecutor;
+import org.keycloak.services.clientpolicy.executor.HolderOfKeyEnforcerExecutor;
+import org.keycloak.services.clientpolicy.executor.PKCEEnforcerExecutor;
+import org.keycloak.services.clientpolicy.executor.SecureClientAuthenticatorExecutor;
+import org.keycloak.services.clientpolicy.executor.SecureRequestObjectExecutor;
+import org.keycloak.services.clientpolicy.executor.SecureResponseTypeExecutor;
+import org.keycloak.services.clientpolicy.executor.SecureSigningAlgorithmExecutor;
+import org.keycloak.services.clientpolicy.executor.SecureSigningAlgorithmForSignedJwtExecutor;
+import org.keycloak.testsuite.services.clientpolicy.condition.TestRaiseExeptionCondition;
+import org.keycloak.util.JsonSerialization;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.fail;
+
+public final class ClientPoliciesUtil {
+
+    public static final ObjectMapper objectMapper = new ObjectMapper();
+
+    // Client Profiles CRUD Operations
+
+    public static class ClientProfilesBuilder {
+        private final ClientProfilesRepresentation profilesRep;
+
+        public ClientProfilesBuilder() {
+            profilesRep = new ClientProfilesRepresentation();
+            profilesRep.setProfiles(new ArrayList<>());
+        }
+
+        // Create client profile from existing representation
+        public ClientProfilesBuilder(ClientProfilesRepresentation existingRep) {
+            this.profilesRep = existingRep;
+        }
+
+        public ClientProfilesBuilder addProfile(ClientProfileRepresentation rep) {
+            profilesRep.getProfiles().add(rep);
+            return this;
+        }
+
+        public ClientProfilesRepresentation toRepresentation() {
+            return profilesRep;
+        }
+
+        public String toString() {
+            String profilesJson = null;
+            try {
+                profilesJson = objectMapper.writeValueAsString(profilesRep);
+            } catch (JsonProcessingException e) {
+                e.printStackTrace();
+                fail();
+            }
+            return profilesJson;
+        }
+    }
+
+    public static class ClientProfileBuilder {
+
+        private final ClientProfileRepresentation profileRep;
+
+        public ClientProfileBuilder() {
+            profileRep = new ClientProfileRepresentation();
+        }
+
+        public ClientProfileBuilder createProfile(String name, String description) {
+            if (name != null) {
+                profileRep.setName(name);
+            }
+            if (description != null) {
+                profileRep.setDescription(description);
+            }
+            profileRep.setExecutors(new ArrayList<>());
+
+            return this;
+        }
+
+        public ClientProfileBuilder addExecutor(String providerId, ClientPolicyExecutorConfigurationRepresentation config) throws Exception {
+            if (config == null) {
+                config = new ClientPolicyExecutorConfigurationRepresentation();
+            }
+            ClientPolicyExecutorRepresentation executor = new ClientPolicyExecutorRepresentation();
+            executor.setExecutorProviderId(providerId);
+            executor.setConfiguration(JsonSerialization.mapper.readValue(JsonSerialization.mapper.writeValueAsBytes(config), JsonNode.class));
+            profileRep.getExecutors().add(executor);
+            return this;
+        }
+
+        public ClientProfileRepresentation toRepresentation() {
+            return profileRep;
+        }
+
+        public String toString() {
+            String profileJson = null;
+            try {
+                profileJson = objectMapper.writeValueAsString(profileRep);
+            } catch (JsonProcessingException e) {
+                e.printStackTrace();
+                fail();
+            }
+            return profileJson;
+        }
+    }
+
+    // Client Profiles - Executor CRUD Operations
+
+    public static HolderOfKeyEnforcerExecutor.Configuration createHolderOfKeyEnforceExecutorConfig(Boolean autoConfigure) {
+        HolderOfKeyEnforcerExecutor.Configuration config = new HolderOfKeyEnforcerExecutor.Configuration();
+        config.setAutoConfigure(autoConfigure);
+        return config;
+    }
+
+    public static PKCEEnforcerExecutor.Configuration createPKCEEnforceExecutorConfig(Boolean autoConfigure) {
+        PKCEEnforcerExecutor.Configuration config = new PKCEEnforcerExecutor.Configuration();
+        config.setAutoConfigure(autoConfigure);
+        return config;
+    }
+
+    public static FullScopeDisabledExecutor.Configuration createFullScopeDisabledExecutorConfig(Boolean autoConfigure) {
+        FullScopeDisabledExecutor.Configuration config = new FullScopeDisabledExecutor.Configuration();
+        config.setAutoConfigure(autoConfigure);
+        return config;
+    }
+
+    public static SecureClientAuthenticatorExecutor.Configuration createSecureClientAuthenticatorExecutorConfig(List<String> allowedClientAuthenticators, String defaultClientAuthenticator) {
+        SecureClientAuthenticatorExecutor.Configuration config = new SecureClientAuthenticatorExecutor.Configuration();
+        config.setAllowedClientAuthenticators(allowedClientAuthenticators);
+        config.setDefaultClientAuthenticator(defaultClientAuthenticator);
+        return config;
+    }
+
+    public static SecureRequestObjectExecutor.Configuration createSecureRequestObjectExecutorConfig(Integer availablePeriod, Boolean verifyNbf) {
+        SecureRequestObjectExecutor.Configuration config = new SecureRequestObjectExecutor.Configuration();
+        if (availablePeriod != null) config.setAvailablePeriod(availablePeriod);
+        if (verifyNbf != null) config.setVerifyNbf(verifyNbf);
+        return config;
+    }
+
+    public static SecureResponseTypeExecutor.Configuration createSecureResponseTypeExecutor(Boolean autoConfigure, Boolean allowTokenResponseType) {
+        SecureResponseTypeExecutor.Configuration config = new SecureResponseTypeExecutor.Configuration();
+        if (autoConfigure != null) config.setAutoConfigure(autoConfigure);
+        if (allowTokenResponseType != null) config.setAllowTokenResponseType(allowTokenResponseType);
+        return config;
+    }
+
+    public static SecureSigningAlgorithmForSignedJwtExecutor.Configuration createSecureSigningAlgorithmForSignedJwtEnforceExecutorConfig(Boolean requireClientAssertion) {
+        SecureSigningAlgorithmForSignedJwtExecutor.Configuration config = new SecureSigningAlgorithmForSignedJwtExecutor.Configuration();
+        config.setRequireClientAssertion(requireClientAssertion);
+        return config;
+    }
+
+    public static SecureSigningAlgorithmExecutor.Configuration createSecureSigningAlgorithmEnforceExecutorConfig(String defaultAlgorithm) {
+        SecureSigningAlgorithmExecutor.Configuration config = new SecureSigningAlgorithmExecutor.Configuration();
+        config.setDefaultAlgorithm(defaultAlgorithm);
+        return config;
+    }
+
+    public static class ClientPoliciesBuilder {
+        private final ClientPoliciesRepresentation policiesRep;
+
+        public ClientPoliciesBuilder() {
+            policiesRep = new ClientPoliciesRepresentation();
+            policiesRep.setPolicies(new ArrayList<>());
+        }
+
+        public ClientPoliciesBuilder addPolicy(ClientPolicyRepresentation rep) {
+            policiesRep.getPolicies().add(rep);
+            return this;
+        }
+
+        public ClientPoliciesRepresentation toRepresentation() {
+            return policiesRep;
+        }
+
+        public String toString() {
+            String policiesJson = null;
+            try {
+                policiesJson = objectMapper.writeValueAsString(policiesRep);
+            } catch (JsonProcessingException e) {
+                e.printStackTrace();
+                fail();
+            }
+            return policiesJson;
+        }
+    }
+
+    public static class ClientPolicyBuilder {
+
+        private final ClientPolicyRepresentation policyRep;
+
+        public ClientPolicyBuilder() {
+            policyRep = new ClientPolicyRepresentation();
+        }
+
+        public ClientPolicyBuilder createPolicy(String name, String description, Boolean isEnabled) {
+            policyRep.setName(name);
+            if (description != null) {
+                policyRep.setDescription(description);
+            }
+            if (isEnabled != null) {
+                policyRep.setEnabled(isEnabled);
+            } else {
+                policyRep.setEnabled(Boolean.FALSE);
+            }
+
+            policyRep.setConditions(new ArrayList<>());
+            policyRep.setProfiles(new ArrayList<>());
+
+            return this;
+        }
+
+        public ClientPolicyBuilder addCondition(String providerId, ClientPolicyConditionConfigurationRepresentation config) throws Exception {
+            ClientPolicyConditionRepresentation condition = new ClientPolicyConditionRepresentation();
+            condition.setConditionProviderId(providerId);
+            condition.setConfiguration(JsonSerialization.mapper.readValue(JsonSerialization.mapper.writeValueAsBytes(config), JsonNode.class));
+            policyRep.getConditions().add(condition);
+            return this;
+        }
+
+        public ClientPolicyBuilder addProfile(String profileName) {
+            policyRep.getProfiles().add(profileName);
+            return this;
+        }
+
+        public ClientPolicyRepresentation toRepresentation() {
+            return policyRep;
+        }
+
+        public String toString() {
+            String policyJson = null;
+            try {
+                policyJson = objectMapper.writeValueAsString(policyRep);
+            } catch (JsonProcessingException e) {
+                fail();
+            }
+            return policyJson;
+        }
+    }
+
+    // Client Policies - Condition CRUD Operations
+
+    public static TestRaiseExeptionCondition.Configuration createTestRaiseExeptionConditionConfig() {
+        return new TestRaiseExeptionCondition.Configuration();
+    }
+
+    public static ClientPolicyConditionConfigurationRepresentation createAnyClientConditionConfig() {
+        return new ClientPolicyConditionConfigurationRepresentation();
+    }
+
+    public static ClientPolicyConditionConfigurationRepresentation createAnyClientConditionConfig(Boolean isNegativeLogic) {
+        ClientPolicyConditionConfigurationRepresentation config = new ClientPolicyConditionConfigurationRepresentation();
+        config.setNegativeLogic(isNegativeLogic);
+        return config;
+    }
+
+    public static ClientAccessTypeCondition.Configuration createClientAccessTypeConditionConfig(List<String> types) {
+        ClientAccessTypeCondition.Configuration config = new ClientAccessTypeCondition.Configuration();
+        config.setType(types);
+        return config;
+    }
+
+    public static ClientRolesCondition.Configuration createClientRolesConditionConfig(List<String> roles) {
+        ClientRolesCondition.Configuration config = new ClientRolesCondition.Configuration();
+        config.setRoles(roles);
+        return config;
+    }
+
+    public static ClientScopesCondition.Configuration createClientScopesConditionConfig(String type, List<String> scopes) {
+        ClientScopesCondition.Configuration config = new ClientScopesCondition.Configuration();
+        config.setType(type);
+        config.setScope(scopes);
+        return config;
+    }
+
+    public static ClientUpdaterContextCondition.Configuration createClientUpdateContextConditionConfig(List<String> updateClientSource) {
+        ClientUpdaterContextCondition.Configuration config = new ClientUpdaterContextCondition.Configuration();
+        config.setUpdateClientSource(updateClientSource);
+        return config;
+    }
+
+    public static ClientUpdaterSourceGroupsCondition.Configuration createClientUpdateSourceGroupsConditionConfig(List<String> groups) {
+        ClientUpdaterSourceGroupsCondition.Configuration config = new ClientUpdaterSourceGroupsCondition.Configuration();
+        config.setGroups(groups);
+        return config;
+    }
+
+    public static ClientUpdaterSourceHostsCondition.Configuration createClientUpdateSourceHostsConditionConfig(List<String> trustedHosts) {
+        ClientUpdaterSourceHostsCondition.Configuration config = new ClientUpdaterSourceHostsCondition.Configuration();
+        config.setTrustedHosts(trustedHosts);
+        return config;
+    }
+
+    public static ClientUpdaterSourceRolesCondition.Configuration createClientUpdateSourceRolesConditionConfig(List<String> roles) {
+        ClientUpdaterSourceRolesCondition.Configuration config = new ClientUpdaterSourceRolesCondition.Configuration();
+        config.setRoles(roles);
+        return config;
+    }
+}

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/realm/clientpolicies/BaseClientPoliciesPage.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/realm/clientpolicies/BaseClientPoliciesPage.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite.console.page.realm.clientpolicies;
+
+import org.keycloak.testsuite.console.page.realm.RealmSettings;
+
+/**
+ * @author Vaclav Muzikar <vmuzikar@redhat.com>
+ */
+public abstract class BaseClientPoliciesPage extends RealmSettings {
+    @Override
+    public String getUriFragment() {
+        return super.getUriFragment() + "/client-policies";
+    }
+}

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/realm/clientpolicies/ClientPolicies.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/realm/clientpolicies/ClientPolicies.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite.console.page.realm.clientpolicies;
+
+import org.keycloak.testsuite.console.page.fragment.DataTable;
+import org.openqa.selenium.support.FindBy;
+
+/**
+ * @author Vaclav Muzikar <vmuzikar@redhat.com>
+ */
+public class ClientPolicies extends BaseClientPoliciesPage {
+    @FindBy(tagName = "table")
+    private PoliciesTable policiesTable;
+
+    @Override
+    public String getUriFragment() {
+        return super.getUriFragment() + "/policies";
+    }
+
+    public PoliciesTable policiesTable() {
+        return policiesTable;
+    }
+
+    public static class PoliciesTable extends DataTable {
+        public void clickCreatePolicy() {
+            clickHeaderLink("Create");
+        }
+
+        public void clickEditPolicy(String policyName) {
+            clickRowActionButton(policyName, "Edit");
+        }
+
+        public void clickDeletePolicy(String policyName) {
+            clickRowActionButton(policyName, "Delete");
+        }
+
+        public String getDescription(String policyName) {
+            return getColumnText(policyName, 1);
+        }
+
+        public boolean isEnabled(String policyName) {
+            return Boolean.parseBoolean(getColumnText(policyName, 2));
+        }
+    }
+}

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/realm/clientpolicies/ClientPoliciesJson.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/realm/clientpolicies/ClientPoliciesJson.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite.console.page.realm.clientpolicies;
+
+import org.keycloak.representations.idm.ClientPoliciesRepresentation;
+import org.keycloak.testsuite.page.Form;
+import org.keycloak.util.JsonSerialization;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+import java.io.IOException;
+
+import static org.keycloak.testsuite.util.UIUtils.getTextInputValue;
+import static org.keycloak.testsuite.util.UIUtils.setTextInputValue;
+
+/**
+ * @author Vaclav Muzikar <vmuzikar@redhat.com>
+ */
+public class ClientPoliciesJson extends BaseClientPoliciesPage {
+    @FindBy(tagName = "form")
+    private JsonForm form;
+
+    @Override
+    public String getUriFragment() {
+        return super.getUriFragment() + "/policies-json";
+    }
+
+    public JsonForm form() {
+        return form;
+    }
+
+    public static class JsonForm extends Form {
+        @FindBy(id = "clientPoliciesConfig")
+        private WebElement textarea;
+
+        @FindBy(xpath = ".//button[text()='Save']")
+        private WebElement saveBtn;
+
+        public ClientPoliciesRepresentation getPolicies() {
+            try {
+                return JsonSerialization.readValue(getPoliciesAsString(), ClientPoliciesRepresentation.class);
+            }
+            catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        public String getPoliciesAsString() {
+            return getTextInputValue(textarea);
+        }
+
+        public void setPolicies(ClientPoliciesRepresentation policies) {
+            try {
+                setPoliciesAsString(JsonSerialization.writeValueAsPrettyString(policies));
+            }
+            catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        public void setPoliciesAsString(String policies) {
+            setTextInputValue(textarea, policies);
+        }
+
+        @Override
+        public WebElement saveBtn() {
+            return saveBtn;
+        }
+    }
+}

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/realm/clientpolicies/ClientPolicy.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/realm/clientpolicies/ClientPolicy.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite.console.page.realm.clientpolicies;
+
+import org.keycloak.testsuite.console.page.fragment.DataTable;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.ui.Select;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * @author Vaclav Muzikar <vmuzikar@redhat.com>
+ */
+public class ClientPolicy extends BaseClientPoliciesPage {
+    private static final String NAME = "name";
+
+    @FindBy(tagName = "form")
+    private ClientPolicyForm form;
+
+    @FindBy(xpath = "(.//table)[1]")
+    private ConditionsTable conditionsTable;
+
+    @FindBy(xpath = "(.//table)[2]")
+    private ProfilesTable profilesTable;
+
+    @Override
+    public String getUriFragment() {
+        return super.getUriFragment() + "/policies-update/{" + NAME + "}";
+    }
+
+    public void setPolicyName(String name) {
+        setUriParameter(NAME, name);
+    }
+
+    public String getPolicyName() {
+        return getUriParameter(NAME).toString();
+    }
+
+    public ClientPolicyForm form() {
+        return form;
+    }
+
+    public ConditionsTable conditionsTable() {
+        return conditionsTable;
+    }
+
+    public ProfilesTable profilesTable() {
+        return profilesTable;
+    }
+
+    public static class ConditionsTable extends DataTable {
+        public void clickCreateCondition() {
+            clickHeaderLink("Create");
+        }
+
+        public void clickEditCondition(String conditionType) {
+            clickRowActionButton(conditionType, "Edit");
+        }
+
+        public void clickDeleteCondition(String conditionType) {
+            clickRowActionButton(conditionType, "Delete");
+        }
+    }
+
+    public static class ProfilesTable extends DataTable {
+        @FindBy(tagName = "select")
+        private Select addProfileSelect;
+
+        public List<String> getProfiles() {
+            return rows().stream().map(r -> getColumnText(r, 0)).collect(Collectors.toList());
+        }
+
+        public void clickProfile(String profileName) {
+            clickRowByLinkText(profileName);
+        }
+
+        public void clickDeleteProfile(String profileName) {
+            clickRowActionButton(profileName, "Delete");
+        }
+
+        public void addProfile(String profileName) {
+            addProfileSelect.selectByVisibleText(profileName);
+        }
+    }
+}

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/realm/clientpolicies/ClientPolicyForm.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/realm/clientpolicies/ClientPolicyForm.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite.console.page.realm.clientpolicies;
+
+import org.keycloak.testsuite.console.page.fragment.OnOffSwitch;
+import org.keycloak.testsuite.page.Form;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+import static org.keycloak.testsuite.util.UIUtils.getTextInputValue;
+import static org.keycloak.testsuite.util.UIUtils.setTextInputValue;
+
+/**
+ * @author Vaclav Muzikar <vmuzikar@redhat.com>
+ */
+public class ClientPolicyForm extends Form {
+    @FindBy(id = "clientPolicyName")
+    private WebElement policyNameInput;
+
+    @FindBy(id = "description")
+    private WebElement descriptionInput;
+
+    @FindBy(xpath = ".//div[contains(@class,'onoffswitch') and ./input[@id='enabled']]")
+    private OnOffSwitch enabledSwitch;
+
+    public String getPolicyName() {
+        return getTextInputValue(policyNameInput);
+    }
+
+    public void setPolicyName(String policyName) {
+        setTextInputValue(policyNameInput, policyName);
+    }
+
+    public String getDescription() {
+        return getTextInputValue(descriptionInput);
+    }
+
+    public void setDescription(String description) {
+        setTextInputValue(descriptionInput, description);
+    }
+
+    public boolean isEnabled() {
+        return enabledSwitch.isOn();
+    }
+
+    public void setEnabled(boolean enabled) {
+        enabledSwitch.setOn(enabled);
+    }
+}

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/realm/clientpolicies/ClientProfile.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/realm/clientpolicies/ClientProfile.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite.console.page.realm.clientpolicies;
+
+import org.keycloak.testsuite.console.page.fragment.DataTable;
+import org.openqa.selenium.support.FindBy;
+
+/**
+ * @author Vaclav Muzikar <vmuzikar@redhat.com>
+ */
+public class ClientProfile extends BaseClientPoliciesPage {
+    private static final String NAME = "name";
+
+    @FindBy(tagName = "form")
+    private ClientProfileForm form;
+
+    @FindBy(tagName = "table")
+    private ExecutorsTable executorsTable;
+
+    @Override
+    public String getUriFragment() {
+        return super.getUriFragment() + "/profiles-update/{" + NAME + "}";
+    }
+
+    public void setProfileName(String name) {
+        setUriParameter(NAME, name);
+    }
+
+    public String getProfileName() {
+        return getUriParameter(NAME).toString();
+    }
+
+    public ClientProfileForm form() {
+        return form;
+    }
+
+    public ExecutorsTable executorsTable() {
+        return executorsTable;
+    }
+
+    public static class ExecutorsTable extends DataTable {
+        public void clickCreateExecutor() {
+            clickHeaderLink("Create");
+        }
+
+        public void clickEditExecutor(String executorType) {
+            clickRowActionButton(executorType, "Edit");
+        }
+
+        public void clickDeleteExecutor(String executorType) {
+            clickRowActionButton(executorType, "Delete");
+        }
+
+        public boolean isDeleteBtnPresent(String executorType) {
+            return isActionButtonVisible(executorType, "Delete");
+        }
+    }
+}

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/realm/clientpolicies/ClientProfileForm.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/realm/clientpolicies/ClientProfileForm.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite.console.page.realm.clientpolicies;
+
+import org.keycloak.testsuite.page.Form;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+import static org.keycloak.testsuite.util.UIUtils.getTextInputValue;
+import static org.keycloak.testsuite.util.UIUtils.isElementDisabled;
+import static org.keycloak.testsuite.util.UIUtils.setTextInputValue;
+
+/**
+ * @author Vaclav Muzikar <vmuzikar@redhat.com>
+ */
+public class ClientProfileForm extends Form {
+    @FindBy(id = "clientProfileName")
+    private WebElement profileNameInput;
+
+    @FindBy(id = "description")
+    private WebElement descriptionInput;
+
+    public String getProfileName() {
+        return getTextInputValue(profileNameInput);
+    }
+
+    public void setProfileName(String profileName) {
+        setTextInputValue(profileNameInput, profileName);
+    }
+
+    public String getDescription() {
+        return getTextInputValue(descriptionInput);
+    }
+
+    public void setDescription(String description) {
+        setTextInputValue(descriptionInput, description);
+    }
+
+    public boolean isInputDisabled() {
+        return isElementDisabled(profileNameInput) && isElementDisabled(descriptionInput);
+    }
+}

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/realm/clientpolicies/ClientProfiles.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/realm/clientpolicies/ClientProfiles.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite.console.page.realm.clientpolicies;
+
+import org.keycloak.testsuite.console.page.fragment.DataTable;
+import org.openqa.selenium.support.FindBy;
+
+/**
+ * @author Vaclav Muzikar <vmuzikar@redhat.com>
+ */
+public class ClientProfiles extends BaseClientPoliciesPage {
+    @FindBy(tagName = "table")
+    private ProfilesTable profilesTable;
+
+    @Override
+    public String getUriFragment() {
+        return super.getUriFragment() + "/profiles";
+    }
+
+    public ProfilesTable profilesTable() {
+        return profilesTable;
+    }
+
+    public static class ProfilesTable extends DataTable {
+        public void clickCreateProfile() {
+            clickHeaderLink("Create");
+        }
+
+        public void clickEditProfile(String profileName) {
+            clickRowActionButton(profileName, "Edit");
+        }
+
+        public void clickDeleteProfile(String profileName) {
+            clickRowActionButton(profileName, "Delete");
+        }
+
+        public boolean isDeleteBtnPresent(String profileName) {
+            return isActionButtonVisible(profileName, "Delete");
+        }
+
+        public String getDescription(String profileName) {
+            return getColumnText(profileName, 1);
+        }
+
+        public boolean isGlobal(String profileName) {
+            return Boolean.parseBoolean(getColumnText(profileName, 2));
+        }
+    }
+}

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/realm/clientpolicies/ClientProfilesJson.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/realm/clientpolicies/ClientProfilesJson.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite.console.page.realm.clientpolicies;
+
+import org.keycloak.representations.idm.ClientProfilesRepresentation;
+import org.keycloak.testsuite.page.Form;
+import org.keycloak.util.JsonSerialization;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+import java.io.IOException;
+
+import static org.keycloak.testsuite.util.UIUtils.getTextInputValue;
+import static org.keycloak.testsuite.util.UIUtils.setTextInputValue;
+
+/**
+ * @author Vaclav Muzikar <vmuzikar@redhat.com>
+ */
+public class ClientProfilesJson extends BaseClientPoliciesPage {
+    @FindBy(tagName = "form")
+    private JsonForm form;
+
+    @Override
+    public String getUriFragment() {
+        return super.getUriFragment() + "/profiles-json";
+    }
+
+    public JsonForm form() {
+        return form;
+    }
+
+    public static class JsonForm extends Form {
+        @FindBy(id = "clientProfilesConfig")
+        private WebElement textarea;
+
+        @FindBy(xpath = ".//button[text()='Save']")
+        private WebElement saveBtn;
+
+        public ClientProfilesRepresentation getProfiles() {
+            try {
+                return JsonSerialization.readValue(getProfilesAsString(), ClientProfilesRepresentation.class);
+            }
+            catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        public String getProfilesAsString() {
+            return getTextInputValue(textarea);
+        }
+
+        public void setProfiles(ClientProfilesRepresentation profiles) {
+            try {
+                setProfilesAsString(JsonSerialization.writeValueAsPrettyString(profiles));
+            }
+            catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        public void setProfilesAsString(String profiles) {
+            setTextInputValue(textarea, profiles);
+        }
+
+        @Override
+        public WebElement saveBtn() {
+            return saveBtn;
+        }
+    }
+}

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/realm/clientpolicies/Condition.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/realm/clientpolicies/Condition.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite.console.page.realm.clientpolicies;
+
+import org.jboss.arquillian.graphene.page.Page;
+
+/**
+ * @author Vaclav Muzikar <vmuzikar@redhat.com>
+ */
+public class Condition extends BaseClientPoliciesPage {
+    private static final String POLICY_NAME = "policyName";
+    private static final String CONDITION_INDEX = "conditionIndex";
+
+    @Page
+    private ConditionForm form;
+
+    @Override
+    public String getUriFragment() {
+        return super.getUriFragment() + "/policies-update/{" + POLICY_NAME + "}/update-condition/{" + CONDITION_INDEX + "}";
+    }
+
+    public void setUriParameters(String policyName, Integer conditionIndex) {
+        setUriParameter(POLICY_NAME, policyName);
+        setUriParameter(CONDITION_INDEX, conditionIndex.toString());
+    }
+
+    public ConditionForm form() {
+        return form;
+    }
+}

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/realm/clientpolicies/ConditionForm.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/realm/clientpolicies/ConditionForm.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite.console.page.realm.clientpolicies;
+
+import org.keycloak.testsuite.console.page.fragment.MultipleStringSelect2;
+import org.keycloak.testsuite.page.Form;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.ui.Select;
+
+import java.util.Set;
+
+/**
+ * @author Vaclav Muzikar <vmuzikar@redhat.com>
+ */
+public class ConditionForm extends Form {
+    @FindBy(xpath = ".//select[starts-with(@id, 'conditionType')]")
+    private Select conditionTypeSelect;
+
+    @FindBy(xpath = ".//*[starts-with(@id, 's2id_autogen')]")
+    private MultipleStringSelect2 select2;
+
+    public String getConditionType() {
+        return conditionTypeSelect.getFirstSelectedOption().getText();
+    }
+
+    public void setConditionType(String conditionType) {
+        conditionTypeSelect.selectByVisibleText(conditionType);
+    }
+
+    public Set<String> getSelect2SelectedItems() {
+        return select2.getSelected();
+    }
+
+    public void selectSelect2Item(String item) {
+        select2.select(item);
+    }
+}

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/realm/clientpolicies/CreateClientPolicy.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/realm/clientpolicies/CreateClientPolicy.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite.console.page.realm.clientpolicies;
+
+import org.openqa.selenium.support.FindBy;
+
+/**
+ * @author Vaclav Muzikar <vmuzikar@redhat.com>
+ */
+public class CreateClientPolicy extends BaseClientPoliciesPage {
+    @FindBy(tagName = "form")
+    private ClientPolicyForm form;
+
+    @Override
+    public String getUriFragment() {
+        return super.getUriFragment() + "/policy-create";
+    }
+
+    public ClientPolicyForm form() {
+        return form;
+    }
+}

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/realm/clientpolicies/CreateClientProfile.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/realm/clientpolicies/CreateClientProfile.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite.console.page.realm.clientpolicies;
+
+import org.openqa.selenium.support.FindBy;
+
+/**
+ * @author Vaclav Muzikar <vmuzikar@redhat.com>
+ */
+public class CreateClientProfile extends BaseClientPoliciesPage {
+    @FindBy(tagName = "form")
+    private ClientProfileForm form;
+
+    @Override
+    public String getUriFragment() {
+        return super.getUriFragment() + "/profiles-create";
+    }
+
+    public ClientProfileForm form() {
+        return form;
+    }
+}

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/realm/clientpolicies/CreateCondition.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/realm/clientpolicies/CreateCondition.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite.console.page.realm.clientpolicies;
+
+import org.jboss.arquillian.graphene.page.Page;
+
+/**
+ * @author Vaclav Muzikar <vmuzikar@redhat.com>
+ */
+public class CreateCondition extends BaseClientPoliciesPage {
+    private static final String POLICY_NAME = "policyName";
+
+    @Page
+    private ConditionForm form;
+
+    @Override
+    public String getUriFragment() {
+        return super.getUriFragment() + "/policies-update/{" + POLICY_NAME + "}/create-condition";
+    }
+
+    public void setPolicyName(String name) {
+        setUriParameter(POLICY_NAME, name);
+    }
+
+    public String getPolicyName() {
+        return getUriParameter(POLICY_NAME).toString();
+    }
+
+    public ConditionForm form() {
+        return form;
+    }
+}

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/realm/clientpolicies/CreateExecutor.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/realm/clientpolicies/CreateExecutor.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite.console.page.realm.clientpolicies;
+
+import org.jboss.arquillian.graphene.page.Page;
+
+/**
+ * @author Vaclav Muzikar <vmuzikar@redhat.com>
+ */
+public class CreateExecutor extends BaseClientPoliciesPage {
+    private static final String PROFILE_NAME = "profileName";
+
+    @Page
+    private ExecutorForm form;
+
+    @Override
+    public String getUriFragment() {
+        return super.getUriFragment() + "/profiles-update/{" + PROFILE_NAME + "}/create-executor";
+    }
+
+    public void setProfileName(String name) {
+        setUriParameter(PROFILE_NAME, name);
+    }
+
+    public String getProfileName() {
+        return getUriParameter(PROFILE_NAME).toString();
+    }
+
+    public ExecutorForm form() {
+        return form;
+    }
+}

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/realm/clientpolicies/Executor.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/realm/clientpolicies/Executor.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite.console.page.realm.clientpolicies;
+
+import org.jboss.arquillian.graphene.page.Page;
+
+/**
+ * @author Vaclav Muzikar <vmuzikar@redhat.com>
+ */
+public class Executor extends BaseClientPoliciesPage {
+    private static final String PROFILE_NAME = "profileName";
+    private static final String EXECUTOR_INDEX = "executorIndex";
+
+    @Page
+    private ExecutorForm form;
+
+    @Override
+    public String getUriFragment() {
+        return super.getUriFragment() + "/profiles-update/{" + PROFILE_NAME + "}/update-executor/{" + EXECUTOR_INDEX + "}";
+    }
+
+    public void setUriParameters(String profileName, Integer executorIndex) {
+        setUriParameter(PROFILE_NAME, profileName);
+        setUriParameter(EXECUTOR_INDEX, executorIndex.toString());
+    }
+
+    public ExecutorForm form() {
+        return form;
+    }
+}

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/realm/clientpolicies/ExecutorForm.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/realm/clientpolicies/ExecutorForm.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite.console.page.realm.clientpolicies;
+
+import org.keycloak.testsuite.console.page.fragment.MultipleStringSelect2;
+import org.keycloak.testsuite.console.page.fragment.OnOffSwitch;
+import org.keycloak.testsuite.page.Form;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.ui.Select;
+
+import java.util.Set;
+
+/**
+ * @author Vaclav Muzikar <vmuzikar@redhat.com>
+ */
+public class ExecutorForm extends Form {
+    @FindBy(xpath = ".//select[starts-with(@id, 'executorType')]")
+    private Select executorTypeSelect;
+
+    @FindBy(xpath = ".//div[contains(@class,'onoffswitch') and ./input[@id='kcauto-configure']]")
+    private OnOffSwitch autoConfigureSwitch;
+
+    @FindBy(xpath = ".//*[starts-with(@id, 's2id_autogen')]")
+    private MultipleStringSelect2 select2;
+
+    public String getExecutorType() {
+        return executorTypeSelect.getFirstSelectedOption().getText();
+    }
+
+    public void setExecutorType(String executorType) {
+        executorTypeSelect.selectByVisibleText(executorType);
+    }
+
+    public boolean isAutoConfigure() {
+        return autoConfigureSwitch.isOn();
+    }
+
+    public boolean isAutoConfigureVisible() {
+        return autoConfigureSwitch.isVisible();
+    }
+
+    public void setAutoConfigure(boolean autoConfigure) {
+        autoConfigureSwitch.setOn(autoConfigure);
+    }
+
+    public Set<String> getSelect2SelectedItems() {
+        return select2.getSelected();
+    }
+
+    public void selectSelect2Item(String item) {
+        select2.select(item);
+    }
+}

--- a/testsuite/integration-arquillian/tests/other/console/src/test/java/org/keycloak/testsuite/console/realm/ClientPoliciesTest.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/test/java/org/keycloak/testsuite/console/realm/ClientPoliciesTest.java
@@ -1,0 +1,393 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite.console.realm;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.jboss.arquillian.graphene.page.Page;
+import org.junit.After;
+import org.junit.Test;
+import org.keycloak.authentication.authenticators.client.ClientIdAndSecretAuthenticator;
+import org.keycloak.authentication.authenticators.client.JWTClientAuthenticator;
+import org.keycloak.representations.idm.ClientPoliciesRepresentation;
+import org.keycloak.representations.idm.ClientProfilesRepresentation;
+import org.keycloak.services.clientpolicy.condition.ClientAccessTypeConditionFactory;
+import org.keycloak.services.clientpolicy.executor.HolderOfKeyEnforcerExecutorFactory;
+import org.keycloak.services.clientpolicy.executor.SecureClientAuthenticatorExecutorFactory;
+import org.keycloak.testsuite.console.page.realm.clientpolicies.ClientPolicies;
+import org.keycloak.testsuite.console.page.realm.clientpolicies.ClientPoliciesJson;
+import org.keycloak.testsuite.console.page.realm.clientpolicies.ClientPolicy;
+import org.keycloak.testsuite.console.page.realm.clientpolicies.ClientProfile;
+import org.keycloak.testsuite.console.page.realm.clientpolicies.ClientProfiles;
+import org.keycloak.testsuite.console.page.realm.clientpolicies.ClientProfilesJson;
+import org.keycloak.testsuite.console.page.realm.clientpolicies.Condition;
+import org.keycloak.testsuite.console.page.realm.clientpolicies.CreateClientPolicy;
+import org.keycloak.testsuite.console.page.realm.clientpolicies.CreateClientProfile;
+import org.keycloak.testsuite.console.page.realm.clientpolicies.CreateCondition;
+import org.keycloak.testsuite.console.page.realm.clientpolicies.CreateExecutor;
+import org.keycloak.testsuite.console.page.realm.clientpolicies.Executor;
+import org.keycloak.testsuite.util.ClientPoliciesUtil.ClientPoliciesBuilder;
+import org.keycloak.testsuite.util.ClientPoliciesUtil.ClientPolicyBuilder;
+import org.keycloak.testsuite.util.ClientPoliciesUtil.ClientProfileBuilder;
+import org.keycloak.testsuite.util.ClientPoliciesUtil.ClientProfilesBuilder;
+import org.keycloak.util.JsonSerialization;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.keycloak.testsuite.util.ClientPoliciesUtil.createClientAccessTypeConditionConfig;
+import static org.keycloak.testsuite.util.ClientPoliciesUtil.createHolderOfKeyEnforceExecutorConfig;
+import static org.keycloak.testsuite.util.ClientPoliciesUtil.createSecureClientAuthenticatorExecutorConfig;
+import static org.keycloak.testsuite.util.UIUtils.refreshPageAndWaitForLoad;
+
+/**
+ * @author Vaclav Muzikar <vmuzikar@redhat.com>
+ */
+public class ClientPoliciesTest extends AbstractRealmTest {
+    private static final String GLOBAL_PROFILE = "fapi-1-baseline";
+    private static final String GLOBAL_EXECUTOR = "secure-session";
+
+    @Page
+    private ClientPolicies clientPoliciesPage;
+
+    @Page
+    private ClientPoliciesJson clientPoliciesJsonPage;
+
+    @Page
+    private ClientPolicy clientPolicyPage;
+
+    @Page
+    private ClientProfiles clientProfilesPage;
+
+    @Page
+    private ClientProfilesJson clientProfilesJsonPage;
+
+    @Page
+    private ClientProfile clientProfilePage;
+
+    @Page
+    private Condition conditionPage;
+
+    @Page
+    private Executor executorPage;
+
+    @Page
+    private CreateClientPolicy createClientPolicyPage;
+
+    @Page
+    private CreateClientProfile createClientProfilePage;
+
+    @Page
+    private CreateCondition createConditionPage;
+
+    @Page
+    private CreateExecutor createExecutorPage;
+
+    @After
+    public void cleanup() {
+        testRealmResource().clientPoliciesPoliciesResource().updatePolicies(new ClientPoliciesRepresentation());
+        testRealmResource().clientPoliciesProfilesResource().updateProfiles(new ClientProfilesRepresentation());
+    }
+
+    @Test
+    public void testGlobalProfiles() {
+        clientProfilesPage.navigateTo();
+        clientProfilesPage.assertCurrent();
+
+        assertTrue(clientProfilesPage.profilesTable().isGlobal(GLOBAL_PROFILE));
+        assertFalse(clientProfilesPage.profilesTable().isDeleteBtnPresent(GLOBAL_PROFILE));
+
+        clientProfilesPage.profilesTable().clickEditProfile(GLOBAL_PROFILE);
+
+        clientProfilePage.setProfileName(GLOBAL_PROFILE);
+        clientProfilePage.assertCurrent();
+        assertTrue(clientProfilePage.form().isInputDisabled());
+        assertFalse(clientProfilePage.executorsTable().isDeleteBtnPresent(GLOBAL_EXECUTOR));
+
+        clientProfilePage.executorsTable().clickEditExecutor(GLOBAL_EXECUTOR);
+
+        executorPage.setUriParameters(GLOBAL_PROFILE, 0);
+        executorPage.assertCurrent();
+    }
+
+    @Test
+    public void testProfilesFormView() throws Exception {
+        final String profileName = "mega-profile";
+        final String profileName2 = "mega-profile^2";
+        final String profileDesc = "mega-desc";
+
+        clientProfilesPage.navigateTo();
+        clientProfilesPage.assertCurrent();
+
+        clientProfilesPage.profilesTable().clickCreateProfile();
+        createClientProfilePage.assertCurrent();
+
+        // create profile
+        createClientProfilePage.form().setProfileName(profileName);
+        createClientProfilePage.form().setDescription(profileDesc);
+        createClientProfilePage.form().save();
+        assertAlertSuccess();
+
+        clientProfilePage.setProfileName(profileName);
+        clientProfilePage.assertCurrent();
+
+        assertEquals(profileName, clientProfilePage.form().getProfileName());
+        clientProfilePage.executorsTable().clickCreateExecutor();
+
+        // create executors
+        createExecutorPage.setProfileName(profileName);
+        createExecutorPage.assertCurrent();
+        createExecutorPage.form().setExecutorType(SecureClientAuthenticatorExecutorFactory.PROVIDER_ID);
+        assertTrue(createExecutorPage.form().getSelect2SelectedItems().isEmpty());
+        createExecutorPage.form().selectSelect2Item(JWTClientAuthenticator.PROVIDER_ID);
+        createExecutorPage.form().selectSelect2Item(ClientIdAndSecretAuthenticator.PROVIDER_ID);
+        createExecutorPage.form().save();
+        assertAlertSuccess();
+
+        clientProfilePage.assertCurrent();
+        clientProfilePage.executorsTable().clickEditExecutor(SecureClientAuthenticatorExecutorFactory.PROVIDER_ID);
+        executorPage.setUriParameters(profileName, 0);
+        executorPage.assertCurrent();
+        assertEquals(Stream.of(JWTClientAuthenticator.PROVIDER_ID, ClientIdAndSecretAuthenticator.PROVIDER_ID).collect(Collectors.toSet()), executorPage.form().getSelect2SelectedItems());
+
+        createExecutorPage.navigateTo();
+        createExecutorPage.form().setExecutorType(HolderOfKeyEnforcerExecutorFactory.PROVIDER_ID);
+        assertFalse(createExecutorPage.form().isAutoConfigure());
+        createExecutorPage.form().setAutoConfigure(true);
+        createExecutorPage.form().save();
+
+        clientProfilePage.executorsTable().clickEditExecutor(HolderOfKeyEnforcerExecutorFactory.PROVIDER_ID);
+        executorPage.setUriParameters(profileName, 1);
+        executorPage.assertCurrent();
+        assertTrue(executorPage.form().isAutoConfigure());
+
+        // assert JSON
+        ClientProfilesRepresentation expected = new ClientProfilesBuilder()
+                .addProfile(new ClientProfileBuilder()
+                        .createProfile(profileName, profileDesc)
+                        .addExecutor(SecureClientAuthenticatorExecutorFactory.PROVIDER_ID,
+                                createSecureClientAuthenticatorExecutorConfig(Arrays.asList(JWTClientAuthenticator.PROVIDER_ID, ClientIdAndSecretAuthenticator.PROVIDER_ID), JWTClientAuthenticator.PROVIDER_ID))
+                        .addExecutor(HolderOfKeyEnforcerExecutorFactory.PROVIDER_ID,
+                                createHolderOfKeyEnforceExecutorConfig(true))
+                        .toRepresentation())
+                .toRepresentation();
+
+        assertClientProfile(expected, false);
+
+        // remove executor
+        clientProfilePage.navigateTo();
+        clientProfilePage.executorsTable().clickDeleteExecutor(SecureClientAuthenticatorExecutorFactory.PROVIDER_ID);
+        modalDialog.confirmDeletion();
+        assertAlertSuccess();
+        expected.getProfiles().get(0).getExecutors().remove(0);
+        assertClientProfile(expected, false);
+        assertFalse(clientProfilePage.executorsTable().isRowPresent(SecureClientAuthenticatorExecutorFactory.PROVIDER_ID));
+
+        // edit executor
+        clientProfilePage.executorsTable().clickEditExecutor(HolderOfKeyEnforcerExecutorFactory.PROVIDER_ID);
+        executorPage.form().setAutoConfigure(false);
+        executorPage.form().save();
+        expected.getProfiles().get(0).getExecutors().get(0).setConfiguration(JsonSerialization.mapper.readValue(JsonSerialization.mapper.writeValueAsBytes(createHolderOfKeyEnforceExecutorConfig(false)), JsonNode.class));
+        assertClientProfile(expected, false);
+
+        // edit profile
+        clientProfilePage.form().setProfileName(profileName2);
+        clientProfilePage.form().save();
+        assertAlertSuccess();
+        clientProfilesPage.navigateTo();
+        assertEquals(profileDesc, clientProfilesPage.profilesTable().getDescription(profileName2));
+
+        // remove profile
+        clientProfilesPage.profilesTable().clickDeleteProfile(profileName2);
+        modalDialog.confirmDeletion();
+        assertAlertSuccess();
+        assertClientProfile(new ClientProfilesRepresentation(), false);
+        assertFalse(clientProfilesPage.profilesTable().isRowPresent(profileName2));
+    }
+
+    @Test
+    public void testProfilesJsonView() throws Exception {
+        clientProfilesJsonPage.navigateTo();
+
+        ClientProfilesRepresentation profiles = testRealmResource().clientPoliciesProfilesResource().getProfiles(true);
+        assertEquals(profiles, clientProfilesJsonPage.form().getProfiles());
+
+        profiles.getProfiles().add(new ClientProfileBuilder()
+                .createProfile("prof", "desc")
+                .addExecutor(HolderOfKeyEnforcerExecutorFactory.PROVIDER_ID,
+                        createHolderOfKeyEnforceExecutorConfig(true))
+                .toRepresentation());
+
+        testRealmResource().clientPoliciesProfilesResource().updateProfiles(profiles);
+        refreshPageAndWaitForLoad();
+        assertEquals(profiles, clientProfilesJsonPage.form().getProfiles());
+
+        profiles.getProfiles().add(new ClientProfileBuilder().createProfile("prof2", "desc2").toRepresentation());
+        clientProfilesJsonPage.form().setProfiles(profiles);
+        clientProfilesJsonPage.form().save();
+        assertAlertSuccess();
+        assertClientProfile(profiles, true);
+
+        clientProfilesJsonPage.form().setProfilesAsString("aaa");
+        clientProfilesJsonPage.form().save();
+        assertAlertDanger();
+    }
+
+    @Test
+    public void testPoliciesFormView() throws Exception {
+        final String profileName = "mega-profile";
+        final String policyName = "mega-policy";
+        final String policyName2 = "mega-policy^2";
+        final String policyDesc = "mega-desc";
+
+        clientPoliciesPage.navigateTo();
+        clientPoliciesPage.assertCurrent();
+
+        clientPoliciesPage.policiesTable().clickCreatePolicy();
+        createClientPolicyPage.assertCurrent();
+
+        // create policy
+        createClientPolicyPage.form().setPolicyName(policyName);
+        createClientPolicyPage.form().setDescription(policyDesc);
+        assertTrue(createClientPolicyPage.form().isEnabled());
+        createClientPolicyPage.form().save();
+        assertAlertSuccess();
+
+        clientPolicyPage.setPolicyName(policyName);
+        clientPolicyPage.assertCurrent();
+
+        assertEquals(policyName, clientPolicyPage.form().getPolicyName());
+        clientPolicyPage.conditionsTable().clickCreateCondition();
+
+        // create condition
+        createConditionPage.setPolicyName(policyName);
+        createConditionPage.assertCurrent();
+        createConditionPage.form().setConditionType(ClientAccessTypeConditionFactory.PROVIDER_ID);
+        assertEquals(Stream.of(ClientAccessTypeConditionFactory.TYPE_CONFIDENTIAL).collect(Collectors.toSet()), conditionPage.form().getSelect2SelectedItems());
+        createConditionPage.form().selectSelect2Item(ClientAccessTypeConditionFactory.TYPE_BEARERONLY);
+        createConditionPage.form().save();
+        assertAlertSuccess();
+
+        // edit condition
+        clientPolicyPage.assertCurrent();
+        clientPolicyPage.conditionsTable().clickEditCondition(ClientAccessTypeConditionFactory.PROVIDER_ID);
+        conditionPage.setUriParameters(policyName, 0);
+        conditionPage.assertCurrent();
+        assertEquals(Stream.of(ClientAccessTypeConditionFactory.TYPE_CONFIDENTIAL, ClientAccessTypeConditionFactory.TYPE_BEARERONLY).collect(Collectors.toSet()), conditionPage.form().getSelect2SelectedItems());
+        createConditionPage.form().selectSelect2Item(ClientAccessTypeConditionFactory.TYPE_PUBLIC);
+        createConditionPage.form().save();
+
+        // create profile via REST
+        ClientProfilesRepresentation profiles = new ClientProfilesBuilder()
+        .addProfile(new ClientProfileBuilder()
+                .createProfile(profileName, "desc")
+                .addExecutor(HolderOfKeyEnforcerExecutorFactory.PROVIDER_ID,
+                        createHolderOfKeyEnforceExecutorConfig(true))
+                .toRepresentation())
+        .toRepresentation();
+        testRealmResource().clientPoliciesProfilesResource().updateProfiles(profiles);
+        refreshPageAndWaitForLoad();
+
+        // add profile to policy
+        clientPolicyPage.profilesTable().addProfile(GLOBAL_PROFILE);
+        clientPolicyPage.profilesTable().addProfile(profileName);
+        assertEquals(Arrays.asList(GLOBAL_PROFILE, profileName), clientPolicyPage.profilesTable().getProfiles());
+
+        // remove profile
+        clientPolicyPage.profilesTable().clickDeleteProfile(GLOBAL_PROFILE);
+        assertAlertSuccess();
+
+        // assert JSON
+        ClientPoliciesRepresentation expected = new ClientPoliciesBuilder()
+            .addPolicy(new ClientPolicyBuilder()
+                .createPolicy(policyName, policyDesc, true)
+                .addCondition(ClientAccessTypeConditionFactory.PROVIDER_ID,
+                        createClientAccessTypeConditionConfig(Arrays.asList(ClientAccessTypeConditionFactory.TYPE_CONFIDENTIAL, ClientAccessTypeConditionFactory.TYPE_BEARERONLY, ClientAccessTypeConditionFactory.TYPE_PUBLIC)))
+                .addProfile(profileName)
+                .toRepresentation())
+            .toRepresentation();
+
+        assertClientPolicy(expected);
+
+        // remove condition
+        clientPolicyPage.navigateTo();
+        clientPolicyPage.conditionsTable().clickDeleteCondition(ClientAccessTypeConditionFactory.PROVIDER_ID);
+        modalDialog.confirmDeletion();
+        assertAlertSuccess();
+        expected.getPolicies().get(0).getConditions().remove(0);
+        assertClientPolicy(expected);
+        assertFalse(clientPolicyPage.conditionsTable().isRowPresent(ClientAccessTypeConditionFactory.PROVIDER_ID));
+
+        // edit policy
+        clientPolicyPage.form().setPolicyName(policyName2);
+        clientPolicyPage.form().setEnabled(false);
+        clientPolicyPage.form().save();
+        assertAlertSuccess();
+        clientPoliciesPage.navigateTo();
+        assertEquals(policyDesc, clientPoliciesPage.policiesTable().getDescription(policyName2));
+        assertFalse(clientPoliciesPage.policiesTable().isEnabled(policyName2));
+
+        // remove policy
+        clientPoliciesPage.policiesTable().clickDeletePolicy(policyName2);
+        modalDialog.confirmDeletion();
+        assertAlertSuccess();
+        assertClientPolicy(new ClientPoliciesRepresentation());
+        assertFalse(clientPoliciesPage.policiesTable().isRowPresent(policyName2));
+    }
+
+    @Test
+    public void testPoliciesJsonView() throws Exception {
+        clientPoliciesJsonPage.navigateTo();
+        assertEquals(new ClientPoliciesRepresentation(), clientPoliciesJsonPage.form().getPolicies());
+
+        ClientPoliciesRepresentation policies = new ClientPoliciesBuilder()
+                .addPolicy(new ClientPolicyBuilder()
+                        .createPolicy("prof", "desc", false)
+                        .addCondition(ClientAccessTypeConditionFactory.PROVIDER_ID,
+                                createClientAccessTypeConditionConfig(Arrays.asList(ClientAccessTypeConditionFactory.TYPE_CONFIDENTIAL, ClientAccessTypeConditionFactory.TYPE_BEARERONLY, ClientAccessTypeConditionFactory.TYPE_PUBLIC)))
+                        .toRepresentation())
+                .toRepresentation();
+
+        testRealmResource().clientPoliciesPoliciesResource().updatePolicies(policies);
+        refreshPageAndWaitForLoad();
+        assertEquals(policies, clientPoliciesJsonPage.form().getPolicies());
+
+        policies.getPolicies().add(new ClientPolicyBuilder().createPolicy("prof2", "desc2", true).toRepresentation());
+        clientPoliciesJsonPage.form().setPolicies(policies);
+        clientPoliciesJsonPage.form().save();
+        assertAlertSuccess();
+        assertClientPolicy(policies);
+
+        clientPoliciesJsonPage.form().setPoliciesAsString("aaa");
+        clientPoliciesJsonPage.form().save();
+        assertAlertDanger();
+    }
+
+    private void assertClientProfile(ClientProfilesRepresentation expected, boolean includeGlobalProfiles) {
+        ClientProfilesRepresentation actual = testRealmResource().clientPoliciesProfilesResource().getProfiles(includeGlobalProfiles);
+        assertEquals(expected, actual);
+    }
+
+    private void assertClientPolicy(ClientPoliciesRepresentation expected) {
+        ClientPoliciesRepresentation actual = testRealmResource().clientPoliciesPoliciesResource().getPolicies();
+        assertEquals(expected, actual);
+    }
+}


### PR DESCRIPTION
**This must NOT be merged before #8093!**

This also fixes a few UI issues I found during writing the tests. Mainly default values for select2 inputs.

The tests provide at least basic coverage, and they could've been written better for sure (more generalization etc.). But given our timeframe and also the fact that the old console will be deprecated soon, I think it'll do.

Will add a link to a pipeline run once I have it.