### PR TITLE
KEYCLOAK-17935 SAML Client - Validate InResponseTo attribute

### DIFF
--- a/services/src/main/java/org/keycloak/broker/saml/SAMLIdentityProvider.java
+++ b/services/src/main/java/org/keycloak/broker/saml/SAMLIdentityProvider.java
@@ -42,6 +42,7 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserSessionModel;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.protocol.saml.JaxrsSAML2BindingBuilder;
+import org.keycloak.protocol.saml.SamlProtocol;
 import org.keycloak.protocol.saml.SamlService;
 import org.keycloak.protocol.saml.SamlSessionUtils;
 import org.keycloak.protocol.saml.preprocessor.SamlAuthenticationPreprocessor;
@@ -169,6 +170,9 @@ public class SAMLIdentityProvider extends AbstractIdentityProvider<SAMLIdentityP
             if (authnRequest.getDestination() != null) {
                 destinationUrl = authnRequest.getDestination().toString();
             }
+
+            // Save the current RequestID in the Auth Session as we need to verify it against the ID returned from the IdP
+            request.getAuthenticationSession().setClientNote(SamlProtocol.SAML_REQUEST_ID, authnRequest.getID());
 
             if (postBinding) {
                 return binding.postBinding(authnRequestBuilder.toDocument()).request(destinationUrl);


### PR DESCRIPTION
In SP-initiated login, when an IDP replies to an AuthnRequest it must return the request ID generated by the SP in the InResponseTo attribute. According to the SAML spec, the SP must validate that the returned InResponseTo attribute matches the ID of the AuthnRequest it sent before. If a SubjectConfirmationData element is present, its InResponseTo attribute should be validated too.
This PR adds those missing validation checks.