### PR TITLE
docs: add readme file for npm publishing

### DIFF
--- a/adapters/oidc/js/README.md
+++ b/adapters/oidc/js/README.md
@@ -1,0 +1,7 @@
+## Keycloak JavaScript Adapter
+
+Keycloak JavaScript Adapter
+===========================
+
+JavaScript adapter for [Keycloak](http://www.keycloak.org/). 
+For documentation see our [Securing Clients and Applications Guide](http://www.keycloak.org/docs/latest/securing_apps/index.html#_javascript_adapter).

--- a/distribution/adapters/js-adapter-npm-zip/pom.xml
+++ b/distribution/adapters/js-adapter-npm-zip/pom.xml
@@ -53,7 +53,7 @@
                             <includeGroupIds>org.keycloak</includeGroupIds>
                             <includeArtifactIds>keycloak-js-adapter</includeArtifactIds>
                             <outputDirectory>${project.build.directory}/unpacked/js-adapter</outputDirectory>
-                            <includes>*.js,*.map,*.d.ts</includes>
+                            <includes>*.js,*.map,*.d.ts,README.md</includes>
                             <excludes>**/welcome-content/*</excludes>
                         </configuration>
                     </execution>


### PR DESCRIPTION
I cannot find how pom is published to npm. Bower repo is archived. Putting README file and looking for help on how to make it part of the npm publish process.

For context see: https://github.com/keycloak/keycloak-documentation/pull/1189