### PR TITLE
keycloak-js : loadUserProfile and loadUserInfo causes CORS error

### DIFF
--- a/adapters/oidc/js/src/main/resources/keycloak.js
+++ b/adapters/oidc/js/src/main/resources/keycloak.js
@@ -553,6 +553,7 @@
             req.open('GET', url, true);
             req.setRequestHeader('Accept', 'application/json');
             req.setRequestHeader('Authorization', 'bearer ' + kc.token);
+            req.withCredentials = true;
 
             var promise = createPromise();
 
@@ -578,6 +579,7 @@
             req.open('GET', url, true);
             req.setRequestHeader('Accept', 'application/json');
             req.setRequestHeader('Authorization', 'bearer ' + kc.token);
+            req.withCredentials = true;
 
             var promise = createPromise();
 


### PR DESCRIPTION
I just add withCredentials to XMLHTTPRequest  to avoid 403 on OPTIONS
preflight requests which causes CORS error.

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
