### PR TITLE
[KEYCLOAK-17602] Email account verification link is wrongly encoded

### DIFF
--- a/services/src/main/java/org/keycloak/theme/KeycloakSanitizerMethod.java
+++ b/services/src/main/java/org/keycloak/theme/KeycloakSanitizerMethod.java
@@ -21,6 +21,9 @@ import freemarker.template.TemplateMethodModelEx;
 import freemarker.template.TemplateModelException;
 
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import org.owasp.html.PolicyFactory;
 
 /**
@@ -41,7 +44,22 @@ public class KeycloakSanitizerMethod implements TemplateMethodModelEx {
         String html = list.get(0).toString();
         String sanitized = KEYCLOAK_POLICY.sanitize(html);
         
-        return sanitized;
+        return fixURLs(sanitized);
+    }
+
+    private String fixURLs(String msg) {
+        Pattern hrefs = Pattern.compile("href=\"([^\"]*)\"");
+        Matcher matcher = hrefs.matcher(msg);
+        int count = 0;
+        while(matcher.find()) {
+            count++;
+            String original = matcher.group(count);
+            String href = original.replaceAll("&#61;", "=")
+                    .replaceAll("\\.\\.", ".")
+                    .replaceAll("&amp;", "&");
+            msg = msg.replace(original, href);
+        }
+        return msg;
     }
     
 }

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/MailUtils.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/MailUtils.java
@@ -61,11 +61,6 @@ public class MailUtils {
         final String textChangePwdUrl = getLink(body.getText());
         String htmlChangePwdUrl = getLink(body.getHtml());
         
-        // undo changes that may have been made by html sanitizer
-        htmlChangePwdUrl = htmlChangePwdUrl.replace("&#61;", "=");
-        htmlChangePwdUrl = htmlChangePwdUrl.replace("..", ".");
-        htmlChangePwdUrl = htmlChangePwdUrl.replace("&amp;", "&");
-        
         assertEquals(htmlChangePwdUrl, textChangePwdUrl);
 
         return htmlChangePwdUrl;


### PR DESCRIPTION
There doesn't seem to be a way to prevent the sanitizer from sanitizing the URLs. So this PR fixes the URLs after sanitizing.
