### PR TITLE
KEYCLOAK-18260 ClientSearchTest.testQuerySearch failure on MSSQL2019

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/ClientSearchTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/ClientSearchTest.java
@@ -57,7 +57,7 @@ public class ClientSearchTest extends AbstractClientTest {
     private String client3Id;
 
     private static final String ATTR_ORG_NAME = "org";
-    private static final String ATTR_ORG_VAL = "Přísná_\"organizace\"";
+    private static final String ATTR_ORG_VAL = "Test_\"organisation\"";
     private static final String ATTR_URL_NAME = "url";
     private static final String ATTR_URL_VAL = "https://foo.bar/clflds";
     private static final String ATTR_QUOTES_NAME = "test \"123\"";


### PR DESCRIPTION
- removed Central European characters from the test
