### PR TITLE
KEYCLOAK-18249 WelcomePageTest fails on MSSQL 2019

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/helpers/DropAllServlet.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/helpers/DropAllServlet.java
@@ -94,7 +94,6 @@ public class DropAllServlet extends HttpServlet {
             "_drop_table_ AUTHENTICATOR_CONFIG _cascade_;\n" +
             "_drop_table_ AUTHENTICATOR_CONFIG_ENTRY _cascade_;\n" +
             "_drop_table_ BROKER_LINK _cascade_;\n" +
-            "alter table CLIENT nocheck constraint FK_P56CTINXXB9GSK57FO49F9TAC;\n" +
             "_drop_table_ CLIENT_ATTRIBUTES _cascade_;\n" +
             "_drop_table_ CLIENT_AUTH_FLOW_BINDINGS _cascade_;\n" +
             "_drop_table_ CLIENT_INITIAL_ACCESS _cascade_;\n" +
@@ -178,7 +177,6 @@ public class DropAllServlet extends HttpServlet {
             "_drop_table_ USER_SESSION _cascade_;\n" +
             "_drop_table_ WEB_ORIGINS _cascade_;\n" +
             "_drop_table_ CLIENT _cascade_;\n" +
-            "alter table CLIENT check constraint FK_P56CTINXXB9GSK57FO49F9TAC\n" +
             "";
 
     private void deleteAllData(Connection connection, String dropTable, String cascade, boolean executeAlterTable) throws Exception {


### PR DESCRIPTION
- removed reference to `FK_P56CTINXXB9GSK57FO49F9TAC` from the `DropAllServlet`
