### PR TITLE
KEYCLOAK-17282 Add sessionId to events in admin UI and enable filteri…

### DIFF
--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/RealmResource.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/RealmResource.java
@@ -124,8 +124,8 @@ public interface RealmResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     List<EventRepresentation> getEvents(@QueryParam("type") List<String> types, @QueryParam("client") String client,
-            @QueryParam("user") String user, @QueryParam("dateFrom") String dateFrom, @QueryParam("dateTo") String dateTo,
-            @QueryParam("ipAddress") String ipAddress, @QueryParam("first") Integer firstResult,
+            @QueryParam("user") String user, @QueryParam("sessionId") String sessionId, @QueryParam("dateFrom") String dateFrom,
+            @QueryParam("dateTo") String dateTo, @QueryParam("ipAddress") String ipAddress, @QueryParam("first") Integer firstResult,
             @QueryParam("max") Integer maxResults);
 
     @DELETE

--- a/model/jpa/src/main/java/org/keycloak/events/jpa/JpaEventQuery.java
+++ b/model/jpa/src/main/java/org/keycloak/events/jpa/JpaEventQuery.java
@@ -86,6 +86,12 @@ public class JpaEventQuery implements EventQuery {
         return this;
     }
 
+	@Override
+	public EventQuery sessionId(String sessionId) {
+		predicates.add(cb.equal(root.get("sessionId"), sessionId));
+		return this;
+	}
+
     @Override
     public EventQuery fromDate(Date fromDate) {
         predicates.add(cb.greaterThanOrEqualTo(root.<Long>get("time"), fromDate.getTime()));

--- a/server-spi-private/src/main/java/org/keycloak/events/EventQuery.java
+++ b/server-spi-private/src/main/java/org/keycloak/events/EventQuery.java
@@ -35,6 +35,8 @@ public interface EventQuery {
 
     EventQuery user(String userId);
 
+    EventQuery sessionId(String sessionId);
+
     EventQuery fromDate(Date fromDate);
 
     EventQuery toDate(Date toDate);

--- a/services/src/main/java/org/keycloak/services/resources/admin/RealmAdminResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RealmAdminResource.java
@@ -716,6 +716,7 @@ public class RealmAdminResource {
      * @param types The types of events to return
      * @param client App or oauth client name
      * @param user User id
+     * @param sessionId Session ID
      * @param ipAddress IP address
      * @param dateTo To date
      * @param dateFrom From date
@@ -728,7 +729,8 @@ public class RealmAdminResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     public Stream<EventRepresentation> getEvents(@QueryParam("type") List<String> types, @QueryParam("client") String client,
-                                               @QueryParam("user") String user, @QueryParam("dateFrom") String dateFrom, @QueryParam("dateTo") String dateTo,
+                                               @QueryParam("user") String user, @QueryParam("sessionId") String sessionId,
+                                               @QueryParam("dateFrom") String dateFrom, @QueryParam("dateTo") String dateTo,
                                                @QueryParam("ipAddress") String ipAddress, @QueryParam("first") Integer firstResult,
                                                @QueryParam("max") Integer maxResults) {
         auth.realm().requireViewEvents();
@@ -750,6 +752,10 @@ public class RealmAdminResource {
 
         if (user != null) {
             query.user(user);
+        }
+
+        if (sessionId != null) {
+            query.sessionId(sessionId);
         }
 
         if(dateFrom != null) {

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/rest/TestingResourceProvider.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/rest/TestingResourceProvider.java
@@ -318,6 +318,7 @@ public class TestingResourceProvider implements RealmResourceProvider {
      * @param types       The types of events to return
      * @param client      App or oauth client name
      * @param user        User id
+     * @param sessionId   Session ID
      * @param dateFrom    From date
      * @param dateTo      To date
      * @param ipAddress   IP address
@@ -330,8 +331,8 @@ public class TestingResourceProvider implements RealmResourceProvider {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     public Stream<EventRepresentation> queryEvents(@QueryParam("realmId") String realmId, @QueryParam("type") List<String> types, @QueryParam("client") String client,
-                                                   @QueryParam("user") String user, @QueryParam("dateFrom") String dateFrom, @QueryParam("dateTo") String dateTo,
-                                                   @QueryParam("ipAddress") String ipAddress, @QueryParam("first") Integer firstResult,
+                                                   @QueryParam("user") String user, @QueryParam("sessionId") String sessionId, @QueryParam("dateFrom") String dateFrom,
+                                                   @QueryParam("dateTo") String dateTo, @QueryParam("ipAddress") String ipAddress, @QueryParam("first") Integer firstResult,
                                                    @QueryParam("max") Integer maxResults) {
 
         EventStoreProvider eventStore = session.getProvider(EventStoreProvider.class);
@@ -356,6 +357,10 @@ public class TestingResourceProvider implements RealmResourceProvider {
 
         if (user != null) {
             query.user(user);
+        }
+
+        if (sessionId != null) {
+            query.sessionId(sessionId);
         }
 
         if (dateFrom != null) {

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/client/resources/TestingResource.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/client/resources/TestingResource.java
@@ -103,6 +103,7 @@ public interface TestingResource {
      * @param types       The types of events to return
      * @param client      App or oauth client name
      * @param user        User id
+     * @param sessionId   Session ID
      * @param dateFrom    From date
      * @param dateTo      To date
      * @param ipAddress   IP address
@@ -115,7 +116,7 @@ public interface TestingResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     public List<EventRepresentation> queryEvents(@QueryParam("realmId") String realmId, @QueryParam("type") List<String> types, @QueryParam("client") String client,
-            @QueryParam("user") String user, @QueryParam("dateFrom") String dateFrom, @QueryParam("dateTo") String dateTo,
+            @QueryParam("user") String user, @QueryParam("sessionId") String sessionId, @QueryParam("dateFrom") String dateFrom, @QueryParam("dateTo") String dateTo,
             @QueryParam("ipAddress") String ipAddress, @QueryParam("first") Integer firstResult,
             @QueryParam("max") Integer maxResults);
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/event/LoginEventsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/event/LoginEventsTest.java
@@ -129,10 +129,10 @@ public class LoginEventsTest extends AbstractEventTest {
         badLogin();
         assertEquals(2, events().size());
 
-        List<EventRepresentation> filteredEvents = testRealmResource().getEvents(Arrays.asList("REVOKE_GRANT"), null, null, null, null, null, null, null);
+        List<EventRepresentation> filteredEvents = testRealmResource().getEvents(Arrays.asList("REVOKE_GRANT"), null, null, null, null, null, null, null, null);
         assertEquals(0, filteredEvents.size());
 
-        filteredEvents = testRealmResource().getEvents(Arrays.asList("LOGIN_ERROR"), null, null, null, null, null, null, null);
+        filteredEvents = testRealmResource().getEvents(Arrays.asList("LOGIN_ERROR"), null, null, null, null, null, null, null, null);
         assertEquals(2, filteredEvents.size());
     }
 
@@ -147,9 +147,9 @@ public class LoginEventsTest extends AbstractEventTest {
             testingClient.testing("test").onEvent(event);
         }
 
-        assertEquals(100, realm.getEvents(null, null, null, null, null, null, null, null).size());
-        assertEquals(105, realm.getEvents(null, null, null, null, null, null, 0, 105).size());
-        assertTrue(realm.getEvents(null, null, null, null, null, null, 0, 1000).size() >= 110);
+        assertEquals(100, realm.getEvents(null, null, null, null, null, null, null, null, null).size());
+        assertEquals(105, realm.getEvents(null, null, null, null, null, null, null, 0, 105).size());
+        assertTrue(realm.getEvents(null, null, null, null, null, null, null, 0, 1000).size() >= 110);
     }
 
     /*

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/EntitlementAPITest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/EntitlementAPITest.java
@@ -2143,7 +2143,7 @@ public class EntitlementAPITest extends AbstractAuthzTest {
         }
 
         List<EventRepresentation> events = getRealm()
-                .getEvents(Arrays.asList(EventType.PERMISSION_TOKEN_ERROR.name()), null, null, null, null, null, null, null);
+                .getEvents(Arrays.asList(EventType.PERMISSION_TOKEN_ERROR.name()), null, null, null, null, null, null, null, null);
         assertEquals(1, events.size());
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/events/EventStoreProviderTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/events/EventStoreProviderTest.java
@@ -67,7 +67,7 @@ public class EventStoreProviderTest extends AbstractEventsTest {
 
     @Test
     public void save() {
-        testing().onEvent(create(EventType.LOGIN, "realmId", "clientId", "userId", "127.0.0.1", "error"));
+        testing().onEvent(create(EventType.LOGIN, "realmId", "clientId", "userId", "sessionId", "127.0.0.1", "error"));
     }
 
     @Test
@@ -76,31 +76,32 @@ public class EventStoreProviderTest extends AbstractEventsTest {
         long oldest = System.currentTimeMillis() - 30000;
         long newest = System.currentTimeMillis() + 30000;
 
-        testing().onEvent(create(EventType.LOGIN, "realmId", "clientId", "userId", "127.0.0.1", "error"));
-        testing().onEvent(create(newest, EventType.REGISTER, "realmId", "clientId", "userId", "127.0.0.1", "error"));
-        testing().onEvent(create(newest, EventType.REGISTER, "realmId", "clientId", "userId2", "127.0.0.1", "error"));
-        testing().onEvent(create(EventType.LOGIN, "realmId2", "clientId", "userId", "127.0.0.1", "error"));
-        testing().onEvent(create(oldest, EventType.LOGIN, "realmId", "clientId2", "userId", "127.0.0.1", "error"));
-        testing().onEvent(create(EventType.LOGIN, "realmId", "clientId", "userId2", "127.0.0.1", "error"));
+        testing().onEvent(create(EventType.LOGIN, "realmId", "clientId", "userId", "sessionId", "127.0.0.1", "error"));
+        testing().onEvent(create(newest, EventType.REGISTER, "realmId", "clientId", "userId", "sessionId", "127.0.0.1", "error"));
+        testing().onEvent(create(newest, EventType.REGISTER, "realmId", "clientId", "userId2", "sessionId2", "127.0.0.1", "error"));
+        testing().onEvent(create(EventType.LOGIN, "realmId2", "clientId", "userId", "sessionId", "127.0.0.1", "error"));
+        testing().onEvent(create(oldest, EventType.LOGIN, "realmId", "clientId2", "userId", "sessionId", "127.0.0.1", "error"));
+        testing().onEvent(create(EventType.LOGIN, "realmId", "clientId", "userId2", "sessionId2", "127.0.0.1", "error"));
 
-        Assert.assertEquals(5, testing().queryEvents(null, null, "clientId", null, null, null, null, null, null).size());
-        Assert.assertEquals(5, testing().queryEvents("realmId", null, null, null, null, null, null, null, null).size());
-        Assert.assertEquals(4, testing().queryEvents(null, toList(EventType.LOGIN), null, null, null, null, null, null, null).size());
-        Assert.assertEquals(6, testing().queryEvents(null, toList(EventType.LOGIN, EventType.REGISTER), null, null, null, null, null, null, null).size());
-        Assert.assertEquals(4, testing().queryEvents(null, null, null, "userId", null, null, null, null, null).size());
+        Assert.assertEquals(5, testing().queryEvents(null, null, "clientId", null, null, null, null, null, null, null).size());
+        Assert.assertEquals(5, testing().queryEvents("realmId", null, null, null, null, null, null, null, null, null).size());
+        Assert.assertEquals(4, testing().queryEvents(null, toList(EventType.LOGIN), null, null, null, null, null, null, null, null).size());
+        Assert.assertEquals(6, testing().queryEvents(null, toList(EventType.LOGIN, EventType.REGISTER), null, null, null, null, null, null, null, null).size());
+        Assert.assertEquals(4, testing().queryEvents(null, null, null, "userId", null, null, null, null, null, null).size());
+        Assert.assertEquals(4, testing().queryEvents(null, null, null, null, "sessionId", null, null, null, null, null).size());
 
-        Assert.assertEquals(1, testing().queryEvents(null, toList(EventType.REGISTER), null, "userId", null, null, null, null, null).size());
+        Assert.assertEquals(1, testing().queryEvents(null, toList(EventType.REGISTER), null, "userId", null, null, null, null, null, null).size());
 
-        Assert.assertEquals(2, testing().queryEvents(null, null, null, null, null, null, null, null, 2).size());
-        Assert.assertEquals(1, testing().queryEvents(null, null, null, null, null, null, null, 5, null).size());
+        Assert.assertEquals(2, testing().queryEvents(null, null, null, null, null, null, null, null, null, 2).size());
+        Assert.assertEquals(1, testing().queryEvents(null, null, null, null, null, null, null, null, 5, null).size());
 
-        Assert.assertEquals(newest, testing().queryEvents(null, null, null, null, null, null, null, null, 1).get(0).getTime());
-        Assert.assertEquals(oldest, testing().queryEvents(null, null, null, null, null, null, null, 5, 1).get(0).getTime());
+        Assert.assertEquals(newest, testing().queryEvents(null, null, null, null, null, null, null, null, null, 1).get(0).getTime());
+        Assert.assertEquals(oldest, testing().queryEvents(null, null, null, null, null, null, null, null, 5, 1).get(0).getTime());
 
         testing().clearEventStore("realmId");
         testing().clearEventStore("realmId2");
 
-        Assert.assertEquals(0, testing().queryEvents(null, null, null, null, null, null, null, null, null).size());
+        Assert.assertEquals(0, testing().queryEvents(null, null, null, null, null, null, null, null, null, null).size());
 
         String d1 = "2015-03-04";
         String d2 = "2015-03-05";
@@ -124,84 +125,84 @@ public class EventStoreProviderTest extends AbstractEventsTest {
             e.printStackTrace();
         }
 
-        testing().onEvent(create(date1, EventType.LOGIN, "realmId", "clientId", "userId", "127.0.0.1", "error"));
-        testing().onEvent(create(date1, EventType.LOGIN, "realmId", "clientId", "userId", "127.0.0.1", "error"));
-        testing().onEvent(create(date2, EventType.REGISTER, "realmId", "clientId", "userId", "127.0.0.1", "error"));
-        testing().onEvent(create(date2, EventType.REGISTER, "realmId", "clientId", "userId", "127.0.0.1", "error"));
-        testing().onEvent(create(date3, EventType.CODE_TO_TOKEN, "realmId", "clientId", "userId2", "127.0.0.1", "error"));
-        testing().onEvent(create(date3, EventType.LOGOUT, "realmId", "clientId", "userId2", "127.0.0.1", "error"));
-        testing().onEvent(create(date4, EventType.UPDATE_PROFILE, "realmId2", "clientId2", "userId2", "127.0.0.1", "error"));
-        testing().onEvent(create(date4, EventType.UPDATE_EMAIL, "realmId2", "clientId2", "userId2", "127.0.0.1", "error"));
+        testing().onEvent(create(date1, EventType.LOGIN, "realmId", "clientId", "userId", "sessionId", "127.0.0.1", "error"));
+        testing().onEvent(create(date1, EventType.LOGIN, "realmId", "clientId", "userId", "sessionId", "127.0.0.1", "error"));
+        testing().onEvent(create(date2, EventType.REGISTER, "realmId", "clientId", "userId", "sessionId", "127.0.0.1", "error"));
+        testing().onEvent(create(date2, EventType.REGISTER, "realmId", "clientId", "userId", "sessionId", "127.0.0.1", "error"));
+        testing().onEvent(create(date3, EventType.CODE_TO_TOKEN, "realmId", "clientId", "userId2", "sessionId2", "127.0.0.1", "error"));
+        testing().onEvent(create(date3, EventType.LOGOUT, "realmId", "clientId", "userId2", "sessionId2", "127.0.0.1", "error"));
+        testing().onEvent(create(date4, EventType.UPDATE_PROFILE, "realmId2", "clientId2", "userId2", "sessionId2", "127.0.0.1", "error"));
+        testing().onEvent(create(date4, EventType.UPDATE_EMAIL, "realmId2", "clientId2", "userId2", "sessionId2", "127.0.0.1", "error"));
 
-        Assert.assertEquals(6, testing().queryEvents(null, null, "clientId", null, null, null, null, null, null).size());
-        Assert.assertEquals(2, testing().queryEvents(null, null, "clientId2", null, null, null, null, null, null).size());
+        Assert.assertEquals(6, testing().queryEvents(null, null, "clientId", null, null, null, null, null, null, null).size());
+        Assert.assertEquals(2, testing().queryEvents(null, null, "clientId2", null, null, null, null, null, null, null).size());
 
-        Assert.assertEquals(6, testing().queryEvents("realmId", null, null, null, null, null, null, null, null).size());
-        Assert.assertEquals(2, testing().queryEvents("realmId2", null, null, null, null, null, null, null, null).size());
+        Assert.assertEquals(6, testing().queryEvents("realmId", null, null, null, null, null, null, null, null, null).size());
+        Assert.assertEquals(2, testing().queryEvents("realmId2", null, null, null, null, null, null, null, null, null).size());
 
-        Assert.assertEquals(4, testing().queryEvents(null, null, null, "userId", null, null, null, null, null).size());
-        Assert.assertEquals(4, testing().queryEvents(null, null, null, "userId2", null, null, null, null, null).size());
+        Assert.assertEquals(4, testing().queryEvents(null, null, null, "userId", null, null, null, null, null, null).size());
+        Assert.assertEquals(4, testing().queryEvents(null, null, null, "userId2", null, null, null, null, null, null).size());
 
-        Assert.assertEquals(2, testing().queryEvents(null, toList(EventType.LOGIN), null, null, null, null, null, null, null).size());
-        Assert.assertEquals(2, testing().queryEvents(null, toList(EventType.REGISTER), null, null, null, null, null, null, null).size());
-        Assert.assertEquals(4, testing().queryEvents(null, toList(EventType.LOGIN, EventType.REGISTER), null, null, null, null, null, null, null).size());
-        Assert.assertEquals(1, testing().queryEvents(null, toList(EventType.CODE_TO_TOKEN), null, null, null, null, null, null, null).size());
-        Assert.assertEquals(1, testing().queryEvents(null, toList(EventType.LOGOUT), null, null, null, null, null, null, null).size());
-        Assert.assertEquals(1, testing().queryEvents(null, toList(EventType.UPDATE_PROFILE), null, null, null, null, null, null, null).size());
-        Assert.assertEquals(1, testing().queryEvents(null, toList(EventType.UPDATE_EMAIL), null, null, null, null, null, null, null).size());
+        Assert.assertEquals(2, testing().queryEvents(null, toList(EventType.LOGIN), null, null, null, null, null, null, null, null).size());
+        Assert.assertEquals(2, testing().queryEvents(null, toList(EventType.REGISTER), null, null, null, null, null, null, null, null).size());
+        Assert.assertEquals(4, testing().queryEvents(null, toList(EventType.LOGIN, EventType.REGISTER), null, null, null, null, null, null, null, null).size());
+        Assert.assertEquals(1, testing().queryEvents(null, toList(EventType.CODE_TO_TOKEN), null, null, null, null, null, null, null, null).size());
+        Assert.assertEquals(1, testing().queryEvents(null, toList(EventType.LOGOUT), null, null, null, null, null, null, null, null).size());
+        Assert.assertEquals(1, testing().queryEvents(null, toList(EventType.UPDATE_PROFILE), null, null, null, null, null, null, null, null).size());
+        Assert.assertEquals(1, testing().queryEvents(null, toList(EventType.UPDATE_EMAIL), null, null, null, null, null, null, null, null).size());
 
-        Assert.assertEquals(8, testing().queryEvents(null, null, null, null, d1, null, null, null, null).size());
-        Assert.assertEquals(8, testing().queryEvents(null, null, null, null, null, d4, null, null, null).size());
+        Assert.assertEquals(8, testing().queryEvents(null, null, null, null, null, d1, null,  null,null, null).size());
+        Assert.assertEquals(8, testing().queryEvents(null, null, null, null, null, null, d4, null, null, null).size());
 
-        Assert.assertEquals(4, testing().queryEvents(null, null, null, null, d3, null, null, null, null).size());
-        Assert.assertEquals(4, testing().queryEvents(null, null, null, null, null, d2, null, null, null).size());
+        Assert.assertEquals(4, testing().queryEvents(null, null, null, null, null, d3, null, null, null, null).size());
+        Assert.assertEquals(4, testing().queryEvents(null, null, null, null, null, null, d2, null, null, null).size());
 
-        Assert.assertEquals(0, testing().queryEvents(null, null, null, null, d7, null, null, null, null).size());
-        Assert.assertEquals(0, testing().queryEvents(null, null, null, null, null, d6, null, null, null).size());
+        Assert.assertEquals(0, testing().queryEvents(null, null, null, null, null, d7, null, null, null, null).size());
+        Assert.assertEquals(0, testing().queryEvents(null, null, null, null, null, null, d6, null, null, null).size());
 
-        Assert.assertEquals(8, testing().queryEvents(null, null, null, null, d1, d4, null, null, null).size());
-        Assert.assertEquals(6, testing().queryEvents(null, null, null, null, d2, d4, null, null, null).size());
-        Assert.assertEquals(4, testing().queryEvents(null, null, null, null, d1, d2, null, null, null).size());
-        Assert.assertEquals(4, testing().queryEvents(null, null, null, null, d3, d4, null, null, null).size());
+        Assert.assertEquals(8, testing().queryEvents(null, null, null, null, null, d1, d4, null, null, null).size());
+        Assert.assertEquals(6, testing().queryEvents(null, null, null, null, null, d2, d4, null, null, null).size());
+        Assert.assertEquals(4, testing().queryEvents(null, null, null, null, null, d1, d2, null, null, null).size());
+        Assert.assertEquals(4, testing().queryEvents(null, null, null, null, null, d3, d4, null, null, null).size());
 
-        Assert.assertEquals(0, testing().queryEvents(null, null, null, null, d5, d6, null, null, null).size());
-        Assert.assertEquals(0, testing().queryEvents(null, null, null, null, d7, d8, null, null, null).size());
+        Assert.assertEquals(0, testing().queryEvents(null, null, null, null, null, d5, d6, null, null, null).size());
+        Assert.assertEquals(0, testing().queryEvents(null, null, null, null, null, d7, d8, null, null, null).size());
     }
 
     @Test
     public void clear() {
-        testing().onEvent(create(System.currentTimeMillis() - 30000, EventType.LOGIN, "realmId", "clientId", "userId", "127.0.0.1", "error"));
-        testing().onEvent(create(System.currentTimeMillis() - 20000, EventType.LOGIN, "realmId", "clientId", "userId", "127.0.0.1", "error"));
-        testing().onEvent(create(System.currentTimeMillis(), EventType.LOGIN, "realmId", "clientId", "userId", "127.0.0.1", "error"));
-        testing().onEvent(create(System.currentTimeMillis(), EventType.LOGIN, "realmId", "clientId", "userId", "127.0.0.1", "error"));
-        testing().onEvent(create(System.currentTimeMillis() - 30000, EventType.LOGIN, "realmId2", "clientId", "userId", "127.0.0.1", "error"));
+        testing().onEvent(create(System.currentTimeMillis() - 30000, EventType.LOGIN, "realmId", "clientId", "userId", "sessionId", "127.0.0.1", "error"));
+        testing().onEvent(create(System.currentTimeMillis() - 20000, EventType.LOGIN, "realmId", "clientId", "userId", "sessionId",  "127.0.0.1", "error"));
+        testing().onEvent(create(System.currentTimeMillis(), EventType.LOGIN, "realmId", "clientId", "userId", "sessionId",  "127.0.0.1", "error"));
+        testing().onEvent(create(System.currentTimeMillis(), EventType.LOGIN, "realmId", "clientId", "userId", "sessionId",  "127.0.0.1", "error"));
+        testing().onEvent(create(System.currentTimeMillis() - 30000, EventType.LOGIN, "realmId2", "clientId", "userId", "sessionId",  "127.0.0.1", "error"));
 
         testing().clearEventStore("realmId");
 
-        Assert.assertEquals(1, testing().queryEvents(null, null, null, null, null, null, null, null, null).size());
+        Assert.assertEquals(1, testing().queryEvents(null, null, null, null, null, null, null, null, null, null).size());
     }
 
     @Test
     public void lengthExceedLimit(){
-        testing().onEvent(create(System.currentTimeMillis() - 30000, EventType.LOGIN, "realmId", StringUtils.repeat("clientId", 100), "userId", "127.0.0.1", "error"));
-        testing().onEvent(create(System.currentTimeMillis() - 30000, EventType.LOGIN, StringUtils.repeat("realmId", 100), "clientId", "userId", "127.0.0.1", "error"));
-        testing().onEvent(create(System.currentTimeMillis() - 30000, EventType.LOGIN, "realmId", "clientId", StringUtils.repeat("userId", 100), "127.0.0.1", "error"));
+        testing().onEvent(create(System.currentTimeMillis() - 30000, EventType.LOGIN, "realmId", StringUtils.repeat("clientId", 100), "userId", "sessionId", "127.0.0.1", "error"));
+        testing().onEvent(create(System.currentTimeMillis() - 30000, EventType.LOGIN, StringUtils.repeat("realmId", 100), "clientId", "userId", "sessionId", "127.0.0.1", "error"));
+        testing().onEvent(create(System.currentTimeMillis() - 30000, EventType.LOGIN, "realmId", "clientId", StringUtils.repeat("userId", 100), "sessionId", "127.0.0.1", "error"));
 
     }
 
     @Test
     public void maxLengthWithNull(){
-        testing().onEvent(create(System.currentTimeMillis() - 30000, EventType.LOGIN, null, null, null, "127.0.0.1", "error"));
+        testing().onEvent(create(System.currentTimeMillis() - 30000, EventType.LOGIN, null, null, null, null, "127.0.0.1", "error"));
     }
 
     @Test
     public void clearOld() {
-        testing().onEvent(create(System.currentTimeMillis() - 300000, EventType.LOGIN, "realmId", "clientId", "userId", "127.0.0.1", "error"));
-        testing().onEvent(create(System.currentTimeMillis() - 200000, EventType.LOGIN, "realmId", "clientId", "userId", "127.0.0.1", "error"));
-        testing().onEvent(create(System.currentTimeMillis(), EventType.LOGIN, "realmId", "clientId", "userId", "127.0.0.1", "error"));
-        testing().onEvent(create(System.currentTimeMillis(), EventType.LOGIN, "realmId", "clientId", "userId", "127.0.0.1", "error"));
-        testing().onEvent(create(System.currentTimeMillis() - 300000, EventType.LOGIN, "realmId2", "clientId", "userId", "127.0.0.1", "error"));
-        testing().onEvent(create(System.currentTimeMillis(), EventType.LOGIN, "realmId2", "clientId", "userId", "127.0.0.1", "error"));
+        testing().onEvent(create(System.currentTimeMillis() - 300000, EventType.LOGIN, "realmId", "clientId", "userId", "sessionId", "127.0.0.1", "error"));
+        testing().onEvent(create(System.currentTimeMillis() - 200000, EventType.LOGIN, "realmId", "clientId", "userId", "sessionId", "127.0.0.1", "error"));
+        testing().onEvent(create(System.currentTimeMillis(), EventType.LOGIN, "realmId", "clientId", "userId", "sessionId", "127.0.0.1", "error"));
+        testing().onEvent(create(System.currentTimeMillis(), EventType.LOGIN, "realmId", "clientId", "userId", "sessionId", "127.0.0.1", "error"));
+        testing().onEvent(create(System.currentTimeMillis() - 300000, EventType.LOGIN, "realmId2", "clientId", "userId", "sessionId", "127.0.0.1", "error"));
+        testing().onEvent(create(System.currentTimeMillis(), EventType.LOGIN, "realmId2", "clientId", "userId", "sessionId", "127.0.0.1", "error"));
 
         // Set expiration of events for "realmId" .
         RealmRepresentation realm = realmsResouce().realm("realmId").toRepresentation();
@@ -210,7 +211,7 @@ public class EventStoreProviderTest extends AbstractEventsTest {
 
         // The first 2 events from realmId will be deleted
         testing().clearExpiredEvents();
-        Assert.assertEquals(4, testing().queryEvents(null, null, null, null, null, null, null, null, null).size());
+        Assert.assertEquals(4, testing().queryEvents(null, null, null, null, null, null, null, null, null, null).size());
 
         // Set expiration of events for realmId2 as well
         RealmRepresentation realm2 = realmsResouce().realm("realmId2").toRepresentation();
@@ -219,12 +220,12 @@ public class EventStoreProviderTest extends AbstractEventsTest {
 
         // The first event from "realmId2" will be deleted now
         testing().clearExpiredEvents();
-        Assert.assertEquals(3, testing().queryEvents(null, null, null, null, null, null, null, null, null).size());
+        Assert.assertEquals(3, testing().queryEvents(null, null, null, null, null, null, null, null, null, null).size());
 
         // set time offset to the future. The remaining 2 events from "realmId" and 1 event from "realmId2" should be expired now
         setTimeOffset(150);
         testing().clearExpiredEvents();
-        Assert.assertEquals(0, testing().queryEvents(null, null, null, null, null, null, null, null, null).size());
+        Assert.assertEquals(0, testing().queryEvents(null, null, null, null, null, null, null, null, null, null).size());
 
         // Revert expirations
         realm.setEventsExpiration(0);
@@ -233,21 +234,22 @@ public class EventStoreProviderTest extends AbstractEventsTest {
         realmsResouce().realm("realmId2").update(realm2);
     }
 
-    private EventRepresentation create(EventType event, String realmId, String clientId, String userId, String ipAddress, String error) {
-        return create(System.currentTimeMillis(), event, realmId, clientId, userId, ipAddress, error);
+    private EventRepresentation create(EventType event, String realmId, String clientId, String userId, String sessionId, String ipAddress, String error) {
+        return create(System.currentTimeMillis(), event, realmId, clientId, userId, sessionId, ipAddress, error);
     }
 
-    private EventRepresentation create(Date date, EventType event, String realmId, String clientId, String userId, String ipAddress, String error) {
-        return create(date.getTime(), event, realmId, clientId, userId, ipAddress, error);
+    private EventRepresentation create(Date date, EventType event, String realmId, String clientId, String userId, String sessionId, String ipAddress, String error) {
+        return create(date.getTime(), event, realmId, clientId, userId, sessionId, ipAddress, error);
     }
 
-    private EventRepresentation create(long time, EventType event, String realmId, String clientId, String userId, String ipAddress, String error) {
+    private EventRepresentation create(long time, EventType event, String realmId, String clientId, String userId, String sessionId, String ipAddress, String error) {
         EventRepresentation e = new EventRepresentation();
         e.setTime(time);
         e.setType(event.toString());
         e.setRealmId(realmId);
         e.setClientId(clientId);
         e.setUserId(userId);
+        e.setSessionId(sessionId);
         e.setIpAddress(ipAddress);
         e.setError(error);
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/LogoutTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/LogoutTest.java
@@ -313,7 +313,7 @@ public class LogoutTest extends AbstractSamlTest {
 
     private void assertLogoutEvent(String clientId) {
         List<EventRepresentation> logoutEvents = adminClient.realm(REALM_NAME)
-                .getEvents(Arrays.asList(EventType.LOGOUT.name()), clientId, null, null, null, null, null, null);
+                .getEvents(Arrays.asList(EventType.LOGOUT.name()), clientId, null, null, null, null, null, null, null);
 
         assertFalse(logoutEvents.isEmpty());
         assertEquals(1, logoutEvents.size());

--- a/themes/src/main/resources/theme/base/admin/messages/admin-messages_en.properties
+++ b/themes/src/main/resources/theme/base/admin/messages/admin-messages_en.properties
@@ -1368,6 +1368,7 @@ date-(from)=Date (From)
 date-(to)=Date (To)
 authentication-details=Authentication Details
 ip-address=IP Address
+session-id=Session ID
 time=Time
 operation-type=Operation Type
 resource-type=Resource Type

--- a/themes/src/main/resources/theme/base/admin/resources/js/controllers/realm.js
+++ b/themes/src/main/resources/theme/base/admin/resources/js/controllers/realm.js
@@ -2352,6 +2352,7 @@ module.controller('RealmEventsCtrl', function($scope, RealmEvents, realm, server
     	$scope.query.type = '';
     	$scope.query.client = '';
     	$scope.query.user = '';
+    	$scope.query.sessionId = '';
     	$scope.query.dateFrom = '';
     	$scope.query.dateTo = '';
     	

--- a/themes/src/main/resources/theme/base/admin/resources/partials/realm-events.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/realm-events.html
@@ -47,6 +47,12 @@
                             <input class="form-control" type="text" id="user" name="user" data-ng-model="query.user">
                         </div>
                     </div>
+                    <div class="form-group" data-ng-show="filter">
+                        <label class="col-md-2 control-label" for="sessionId">{{:: 'session-id' | translate}}</label>
+                        <div class="col-md-6">
+                            <input class="form-control" type="text" id="sessionId" name="sessionId" data-ng-model="query.sessionId">
+                        </div>
+                    </div>
 
                     <div class="form-group" data-ng-show="filter">
                         <label class="col-md-2 control-label" for="dateFrom">{{:: 'date-(from)' | translate}}</label>
@@ -88,6 +94,7 @@
                         <tr><td width="100px">{{:: 'client' | translate}}</td><td>{{event.clientId}}</td></tr>
                         <tr><td>{{:: 'user' | translate}}</td><td>{{event.userId}}</td></tr>
                         <tr><td>{{:: 'ip-address' | translate}}</td><td>{{event.ipAddress}}</td></tr>
+                        <tr><td>{{:: 'session-id' | translate}}</td><td>{{event.sessionId}}</td></tr>
                         <tr data-ng-show="event.error"><td>{{:: 'error' | translate}}</td><td>{{event.error}}</td></tr>
                         <tr>
                             <td>{{:: 'details' | translate}}</td>


### PR DESCRIPTION
KEYCLOAK-17282 Add sessionId to events in admin UI and enable filtering based on the sessionId

Reviewed-by: Georg Romstorfer <georg.romstorfer@cryptas.com>

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
