### PR TITLE
KEYCLOAK-18247 LifespanAdapterTest fails due to validation error on EAP

### DIFF
--- a/testsuite/integration-arquillian/test-apps/photoz/keycloak-cache-lifespan-authz-service.json
+++ b/testsuite/integration-arquillian/test-apps/photoz/keycloak-cache-lifespan-authz-service.json
@@ -19,7 +19,7 @@
     "enforcement-mode": "PERMISSIVE",
     "user-managed-access": {},
     "path-cache": {
-      "lifespan": 10000
+      "lifespan": 25000
     },
     "paths": [
       {

--- a/testsuite/integration-arquillian/test-apps/photoz/photoz-html5-client/src/main/webapp/META-INF/jboss-deployment-structure.xml
+++ b/testsuite/integration-arquillian/test-apps/photoz/photoz-html5-client/src/main/webapp/META-INF/jboss-deployment-structure.xml
@@ -1,0 +1,25 @@
+<!--
+  ~  Copyright 2021 Red Hat, Inc. and/or its affiliates
+  ~  and other contributors as indicated by the @author tags.
+  ~
+  ~  Licensed under the Apache License, Version 2.0 (the "License");
+  ~  you may not use this file except in compliance with the License.
+  ~  You may obtain a copy of the License at
+  ~
+  ~  http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing, software
+  ~  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~  See the License for the specific language governing permissions and
+  ~  limitations under the License.
+  ~
+  -->
+
+<jboss-deployment-structure>
+    <deployment>
+        <dependencies>
+            <module name="org.keycloak.keycloak-common" services="import"/>
+        </dependencies>
+    </deployment>
+</jboss-deployment-structure>

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/example/authorization/AbstractBasePhotozExampleAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/example/authorization/AbstractBasePhotozExampleAdapterTest.java
@@ -49,24 +49,17 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Test;
 import org.keycloak.admin.client.resource.AuthorizationResource;
 import org.keycloak.admin.client.resource.ClientResource;
 import org.keycloak.admin.client.resource.ClientScopesResource;
 import org.keycloak.admin.client.resource.ClientsResource;
-import org.keycloak.admin.client.resource.PoliciesResource;
 import org.keycloak.admin.client.resource.RealmResource;
-import org.keycloak.admin.client.resource.ResourcesResource;
-import org.keycloak.admin.client.resource.RoleResource;
-import org.keycloak.admin.client.resource.UserResource;
-import org.keycloak.admin.client.resource.UsersResource;
 import org.keycloak.protocol.ProtocolMapperUtils;
 import org.keycloak.protocol.oidc.mappers.UserClientRoleMappingMapper;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.ClientScopeRepresentation;
 import org.keycloak.representations.idm.ProtocolMapperRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
-import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.representations.idm.authorization.PolicyRepresentation;
 import org.keycloak.representations.idm.authorization.ResourceRepresentation;
@@ -76,13 +69,10 @@ import org.keycloak.testsuite.adapter.page.PhotozClientAuthzTestApp;
 import org.keycloak.testsuite.admin.ApiUtil;
 import org.keycloak.testsuite.arquillian.AppServerTestEnricher;
 import org.keycloak.testsuite.arquillian.annotation.EnableFeature;
-import org.keycloak.testsuite.arquillian.annotation.UncaughtServerErrorExpected;
 import org.keycloak.testsuite.auth.page.login.OAuthGrant;
 import org.keycloak.testsuite.util.DroneUtils;
 import org.keycloak.testsuite.util.JavascriptBrowser;
-import org.keycloak.testsuite.util.Matchers;
 import org.keycloak.testsuite.util.javascript.JavascriptTestExecutorWithAuthorization;
-import org.keycloak.util.JsonSerialization;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -235,7 +225,7 @@ public abstract class AbstractBasePhotozExampleAdapterTest extends AbstractPhoto
     }
 
     protected void loginToClientPage(UserRepresentation user, String... scopes) throws InterruptedException {
-        log.debugf("--logging in as {0} with password: {1}; scopes: {2}", user.getUsername(), user.getCredentials().get(0).getValue(), Arrays.toString(scopes));
+        log.debugf("--logging in as '%s' with password: '%s'; scopes: %s", user.getUsername(), user.getCredentials().get(0).getValue(), Arrays.toString(scopes));
 
         if (testExecutor.isLoggedIn()) {
             testExecutor.logout(this::assertOnTestAppUrl);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/example/authorization/LifespanAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/example/authorization/LifespanAdapterTest.java
@@ -17,15 +17,18 @@
 package org.keycloak.testsuite.adapter.example.authorization;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.keycloak.testsuite.utils.io.IOUtil.loadRealm;
 
 import javax.ws.rs.core.Response;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -33,6 +36,7 @@ import org.junit.Test;
 import org.keycloak.admin.client.resource.AuthorizationResource;
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.admin.client.resource.UserResource;
+import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.representations.idm.authorization.PolicyRepresentation;
 import org.keycloak.representations.idm.authorization.ResourceRepresentation;
@@ -64,6 +68,13 @@ public class LifespanAdapterTest extends AbstractPhotozExampleAdapterTest {
               webArchive -> webArchive.addAsWebInfResource(new File(TEST_APPS_HOME_DIR + "/photoz/keycloak-cache-lifespan-authz-service.json"), "keycloak.json"));
     }
 
+    @Override
+    public void addAdapterTestRealms(List<RealmRepresentation> testRealms) {
+        RealmRepresentation realm = loadRealm(new File(TEST_APPS_HOME_DIR + "/photoz/photoz-realm.json"));
+        realm.setAccessTokenLifespan(70); // must increase lifespan of access token in order to use bigger offset in test cases
+        testRealms.add(realm);
+    }
+
     @Test
     public void testPathConfigInvalidation() throws Exception {
         loginToClientPage(aliceUser);
@@ -73,20 +84,14 @@ public class LifespanAdapterTest extends AbstractPhotozExampleAdapterTest {
         AuthorizationResource authorizationResource = getAuthorizationResource();
 
         authorizationResource.resources().resource(resource.getId()).remove();
+        assertThat(getAuthorizationResource().resources().findByName("Profile Resource").isEmpty(), Matchers.is(true));
 
         loginToClientPage(aliceUser);
 
         // should throw an error because the resource was removed and cache entry did not expire yet
-        clientPage.viewProfile(new ResponseValidator() {
-            @Override
-            public void validate(Map<String, Object> response) {
-                Object res = response.get("res");
-                assertThat(res, Matchers.notNullValue());
-                assertThat(res.toString(), Matchers.not(Matchers.containsString("userName")));
-            }
-        });
+        assertFailure();
 
-        setTimeOffsetOfAdapter(20);
+        setTimeOffsetOfAdapter(40);
 
         loginToClientPage(aliceUser);
         assertSuccess();
@@ -117,8 +122,8 @@ public class LifespanAdapterTest extends AbstractPhotozExampleAdapterTest {
 
             Map<String, String> config = new HashMap<>();
 
-            config.put("resources", JsonSerialization.writeValueAsString(Arrays.asList(resource.getId())));
-            config.put("applyPolicies", JsonSerialization.writeValueAsString(Arrays.asList("Only From @keycloak.org or Admin")));
+            config.put("resources", JsonSerialization.writeValueAsString(Collections.singletonList(resource.getId())));
+            config.put("applyPolicies", JsonSerialization.writeValueAsString(Collections.singletonList("Only From @keycloak.org or Admin")));
 
             resourceInstancePermission.setConfig(config);
             authorizationResource.policies().create(resourceInstancePermission);
@@ -128,14 +133,7 @@ public class LifespanAdapterTest extends AbstractPhotozExampleAdapterTest {
 
         loginToClientPage(aliceUser);
         // should throw an error because the resource was removed and cache entry did not expire yet
-        clientPage.viewProfile(new ResponseValidator() {
-            @Override
-            public void validate(Map<String, Object> response) {
-                Object res = response.get("res");
-                assertThat(res, Matchers.notNullValue());
-                assertThat(res.toString(), Matchers.not(Matchers.containsString("userName")));
-            }
-        });
+        assertFailure();
 
         userRepresentation.setEmail("alice@keycloak.org");
 
@@ -145,10 +143,19 @@ public class LifespanAdapterTest extends AbstractPhotozExampleAdapterTest {
     }
 
     private void assertSuccess() {
+        assertState(true);
+    }
+
+    private void assertFailure() {
+        assertState(false);
+    }
+
+    private void assertState(boolean state) {
         clientPage.viewProfile((ResponseValidator) response -> {
             Object res = response.get("res");
             assertThat(res, Matchers.notNullValue());
-            assertThat(res.toString(), Matchers.containsString("userName"));
+            Matcher<String> matcher = Matchers.containsString("userName");
+            assertThat(res.toString(), state ? matcher : Matchers.not(matcher));
         });
     }
 
@@ -169,6 +176,6 @@ public class LifespanAdapterTest extends AbstractPhotozExampleAdapterTest {
     }
 
     public void setTimeOffsetOfAdapter(int offset) {
-        this.driver.navigate().to(clientPage.getInjectedUrl() + "/timeOffset.jsp?offset=" + String.valueOf(offset));
+        this.driver.navigate().to(clientPage.getInjectedUrl() + "timeOffset.jsp?offset=" + offset);
     }
 }


### PR DESCRIPTION
JIRA: [KEYCLOAK-18247](https://issues.redhat.com/browse/KEYCLOAK-18247)

Sometimes the execution time for login is bigger than lifespan of the config path stored in cache and it caused an error.
The pipeline results will be shared after finishing the pipeline job.