### PR TITLE
KEYCLOAK-18383 Update Group: don't check siblings if the name doesn't…

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/GroupResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/GroupResource.java
@@ -106,10 +106,12 @@ public class GroupResource {
             return ErrorResponse.error("Group name is missing", Response.Status.BAD_REQUEST);
         }
 
-        boolean exists = siblings().filter(s -> !Objects.equals(s.getId(), group.getId()))
-                .anyMatch(s -> Objects.equals(s.getName(), groupName));
-        if (exists) {
-            return ErrorResponse.exists("Sibling group named '" + groupName + "' already exists.");
+        if (!Objects.equals(groupName, group.getName())) {
+            boolean exists = siblings().filter(s -> !Objects.equals(s.getId(), group.getId()))
+                    .anyMatch(s -> Objects.equals(s.getName(), groupName));
+            if (exists) {
+                return ErrorResponse.exists("Sibling group named '" + groupName + "' already exists.");
+            }
         }
         
         updateGroup(rep, group);


### PR DESCRIPTION
We noticed that the "Update group, ignores subgroups. API: PUT /{realm}/groups/{id}" is very slow with a "large" number of groups (~43k). It takes about 32 seconds to complete a single update.
 
By using the postgres backend with the `pg_stat_statements` extension we noticed it’s running the same query (with different parameters) N times, where N is ~ the number of groups.
Looking at the code we see that it’s checking the uniqueness of the group name by extracting all the sibling groups from the DB.

https://issues.redhat.com/browse/KEYCLOAK-18383