### PR TITLE
KEYCLOAK-18384 NullPointerException when fetching keys without "use" …

### DIFF
--- a/core/src/main/java/org/keycloak/util/JWKSUtils.java
+++ b/core/src/main/java/org/keycloak/util/JWKSUtils.java
@@ -37,7 +37,8 @@ public class JWKSUtils {
 
         for (JWK jwk : keySet.getKeys()) {
             JWKParser parser = JWKParser.create(jwk);
-            if (jwk.getPublicKeyUse().equals(requestedUse.asString()) && parser.isKeyTypeSupported(jwk.getKeyType())) {
+            if (jwk.getPublicKeyUse() != null && 
+                  jwk.getPublicKeyUse().equals(requestedUse.asString()) && parser.isKeyTypeSupported(jwk.getKeyType())) {
                 result.put(jwk.getKeyId(), parser.toPublicKey());
             }
         }
@@ -49,7 +50,8 @@ public class JWKSUtils {
         Map<String, KeyWrapper> result = new HashMap<>();
         for (JWK jwk : keySet.getKeys()) {
             JWKParser parser = JWKParser.create(jwk);
-            if (jwk.getPublicKeyUse().equals(requestedUse.asString()) && parser.isKeyTypeSupported(jwk.getKeyType())) {
+            if (jwk.getPublicKeyUse()!= null && 
+                  jwk.getPublicKeyUse().equals(requestedUse.asString()) && parser.isKeyTypeSupported(jwk.getKeyType())) {
                 KeyWrapper keyWrapper = new KeyWrapper();
                 keyWrapper.setKid(jwk.getKeyId());
                 if (jwk.getAlgorithm() != null) {
@@ -82,7 +84,9 @@ public class JWKSUtils {
     public static JWK getKeyForUse(JSONWebKeySet keySet, JWK.Use requestedUse) {
         for (JWK jwk : keySet.getKeys()) {
             JWKParser parser = JWKParser.create(jwk);
-            if (parser.getJwk().getPublicKeyUse().equals(requestedUse.asString()) && parser.isKeyTypeSupported(jwk.getKeyType())) {
+            JWK jwkParsed = parser.getJwk();
+            if (jwkParsed.getPublicKeyUse() != null && 
+                  jwkParsed.getPublicKeyUse().equals(requestedUse.asString()) && parser.isKeyTypeSupported(jwk.getKeyType())) {
                 return jwk;
             }
         }

--- a/core/src/test/java/org/keycloak/util/JWKSUtilsTest.java
+++ b/core/src/test/java/org/keycloak/util/JWKSUtilsTest.java
@@ -46,6 +46,7 @@ public class JWKSUtilsTest {
         String kidRsa2 = "key2";
         String kidEC1 = "key3";
         String kidEC2 = "key4";
+        String kidRsa3MissingUse = "key5";
         String jwksJson = "{" +
                 "\"keys\": [" +
                 "  {" +
@@ -80,6 +81,12 @@ public class JWKSUtilsTest {
                 "   \"x\": \"KVZ5h_W0-8fXmUrxmyRpO_9vwwI7urXfyxGdxm1hpEuhPj2hhDxivnb2BhNvtC6O\"," +
                 "   \"y\": \"1J3JVw_zR3uB3biAE7fs3V_4tJy2M1JinzWj9a4je5GSoW6zgGV4bk85OcuyUAhj\"" +
                 "  }" +
+                "  ,{" +
+                "   \"kty\": \"RSA\"," +
+                "   \"kid\": \"" + kidRsa3MissingUse + "\"," +
+                "   \"n\": \"soFDjoZ5mQ8XAA7reQAFg90inKAHk0DXMTizo4JuOsgzUbhcplIeZ7ks83hsEjm8mP8lUVaHMPMAHEIp3gu6Xxsg-s73ofx1dtt_Fo7aj8j383MFQGl8-FvixTVobNeGeC0XBBQjN8lEl-lIwOa4ZoERNAShplTej0ntDp7TQm0=\"," +
+                "   \"e\": \"AQAB\"" +
+                "  }" +
                 "] }";
         JSONWebKeySet jsonWebKeySet = JsonSerialization.readValue(jwksJson, JSONWebKeySet.class);
         Map<String, KeyWrapper> keyWrappersForUse = JWKSUtils.getKeyWrappersForUse(jsonWebKeySet, JWK.Use.SIG);
@@ -113,6 +120,5 @@ public class JWKSUtilsTest {
         assertEquals(kidEC2, key.getKid());
         assertEquals("EC", key.getType());
     }
-
 
 }


### PR DESCRIPTION
…parameter

The fix avoids those keys completely as the RFC indicates it's ok :
"Other values MAY be used.  The "use" value is a case-sensitive
   string.  Use of the "use" member is OPTIONAL, unless the application
   requires its presence."

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
