### PR TITLE
[KEYCLOAK-17799] Add CORS headers to JSON error responses

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/AccountRestServiceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/AccountRestServiceTest.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import org.junit.Assert;
 import org.junit.Test;
 import org.keycloak.OAuth2Constants;
+import org.keycloak.OAuthErrorException;
 import org.keycloak.admin.client.resource.UserResource;
 import org.keycloak.authentication.authenticators.browser.WebAuthnAuthenticatorFactory;
 import org.keycloak.authentication.authenticators.browser.WebAuthnPasswordlessAuthenticatorFactory;
@@ -1198,7 +1199,8 @@ public class AccountRestServiceTest extends AbstractRestServiceTest {
         apiVersion = "v2-foo";
 
         SimpleHttp.Response response = SimpleHttp.doGet(getAccountUrl("credentials"), httpClient).auth(tokenUtil.getToken()).asResponse();
-        assertEquals("API version not found", response.asJson().get("error").textValue());
+        assertEquals(OAuthErrorException.INVALID_REQUEST, response.asJson().get("error").textValue());
+        assertEquals("API version not found", response.asJson().get("error_description").textValue());
         assertEquals(404, response.getStatus());
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerTest.java
@@ -6,6 +6,7 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.hamcrest.Matchers;
 import org.junit.Test;
+import org.keycloak.OAuthErrorException;
 import org.keycloak.admin.client.resource.ClientResource;
 import org.keycloak.admin.client.resource.ClientsResource;
 import org.keycloak.admin.client.resource.IdentityProviderResource;
@@ -432,7 +433,8 @@ public final class KcOidcBrokerTest extends AbstractAdvancedBrokerTest {
 
             OAuth2ErrorRepresentation error = simple.asJson(OAuth2ErrorRepresentation.class);
             assertThat(error, notNullValue());
-            assertThat(error.getError(), is("Identity Provider [" + notExistingIdP + "] not found."));
+            assertThat(error.getError(), is(OAuthErrorException.INVALID_REQUEST));
+            assertThat(error.getErrorDescription(), is("Identity Provider [" + notExistingIdP + "] not found."));
         } catch (IOException ex) {
             Assert.fail("Cannot create HTTP client. Details: " + ex.getMessage());
         }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/error/CorsErrorResponseTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/error/CorsErrorResponseTest.java
@@ -1,0 +1,161 @@
+package org.keycloak.testsuite.error;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.collection.IsMapContaining;
+import org.jboss.arquillian.drone.api.annotation.Drone;
+import org.jboss.arquillian.graphene.page.Page;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.testsuite.AbstractKeycloakTest;
+import org.keycloak.testsuite.auth.page.AuthRealm;
+import org.keycloak.testsuite.util.ContainerAssume;
+import org.keycloak.testsuite.util.JavascriptBrowser;
+import org.keycloak.testsuite.util.WaitUtils;
+import org.keycloak.testsuite.util.javascript.XMLHttpRequest;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.WebDriver;
+
+import java.net.InetAddress;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.keycloak.testsuite.util.ServerURLs.AUTH_SERVER_HOST;
+import static org.keycloak.testsuite.util.ServerURLs.AUTH_SERVER_HOST2;
+
+public class CorsErrorResponseTest extends AbstractKeycloakTest {
+
+    @Drone
+    @JavascriptBrowser
+    protected WebDriver jsDriver;
+
+    @ArquillianResource
+    @JavascriptBrowser
+    protected JavascriptExecutor jsExecutor;
+
+    @Page
+    @JavascriptBrowser
+    protected AuthRealm realmPage;
+
+    @Override
+    public void addTestRealms(List<RealmRepresentation> testRealms) {
+    }
+
+    @BeforeClass
+    public static void checkPreconditions() {
+
+        ContainerAssume.assumeAuthServerSSL();
+
+        Assume.assumeTrue("DNS resolver cannot resolve *.nip.io hosts", "127.0.0.1".equals(getAddressByName("127-0-0-1.nip.io")));
+        Assume.assumeTrue(
+                "This test requires that Auth Server is accessible from two different hostnames to simulate Cross-Origin requests",
+                !AUTH_SERVER_HOST.equals(AUTH_SERVER_HOST2) && AUTH_SERVER_HOST.endsWith(".nip.io") && AUTH_SERVER_HOST2.endsWith(".nip.io")
+        );
+
+        if ("phantomjs".equalsIgnoreCase(System.getProperty("js.browser"))) {
+            String cliArgs = System.getProperty("keycloak.phantomjs.cli.args");
+            Assume.assumeTrue("This test doesn't make sense if browser CORS features are disabled", cliArgs != null && cliArgs.contains("--web-security=true"));
+        }
+
+    }
+
+    @Before
+    public void setupTest() {
+        jsDriver.manage().timeouts().setScriptTimeout(WaitUtils.PAGELOAD_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+        // Navigate browser to secondary Auth Server hostname to simulate Cross-Origin XHR requests
+        jsDriver.get(
+                masterRealmPage
+                        .toString().replace(AUTH_SERVER_HOST, AUTH_SERVER_HOST2) +
+                        "/testing/javascript/index.html"
+        );
+    }
+
+    @Test
+    public void getExistingRealm() {
+
+        realmPage.setAuthRealm(AuthRealm.MASTER);
+
+        XMLHttpRequest req = XMLHttpRequest.create()
+                .method("GET")
+                .url(realmPage.toString())
+                .jsonResponse();
+
+        Map<String, Object> res = req.send(jsExecutor);
+        Map<String, Object> json = (Map<String, Object>) res.get("json");
+
+        MatcherAssert.assertThat(res, IsMapContaining.hasEntry("status", 200L));
+        MatcherAssert.assertThat(json, IsMapContaining.hasEntry("realm", realmPage.getAuthRealm()));
+
+    }
+
+    @Test
+    public void getExistingRealmWithCredentials() {
+
+        realmPage.setAuthRealm(AuthRealm.MASTER);
+
+        XMLHttpRequest req = XMLHttpRequest.create()
+                .method("GET")
+                .url(realmPage.toString())
+                .withCredentials()
+                .jsonResponse();
+
+        Map<String, Object> res = req.send(jsExecutor);
+        Map<String, Object> json = (Map<String, Object>) res.get("json");
+
+        MatcherAssert.assertThat(res, IsMapContaining.hasEntry("status", 200L));
+        MatcherAssert.assertThat(json, IsMapContaining.hasEntry("realm", realmPage.getAuthRealm()));
+
+    }
+
+    @Test
+    public void getInvalidRealm() {
+
+        realmPage.setAuthRealm("invalid");
+
+        XMLHttpRequest req = XMLHttpRequest.create()
+                .method("GET")
+                .url(realmPage.toString())
+                .jsonResponse();
+
+        Map<String, Object> res = req.send(jsExecutor);
+        Map<String, Object> json = (Map<String, Object>) res.get("json");
+
+        // simple request should be allowed by CORS
+        MatcherAssert.assertThat(res, IsMapContaining.hasEntry("status", 404L));
+        MatcherAssert.assertThat(json, IsMapContaining.hasEntry("error", "invalid_request"));
+        MatcherAssert.assertThat(json, IsMapContaining.hasEntry("error_description", "Realm does not exist"));
+
+    }
+
+    @Test
+    public void getInvalidRealmWithCredentials() {
+
+        realmPage.setAuthRealm("invalid");
+
+        XMLHttpRequest req = XMLHttpRequest.create()
+                .method("GET")
+                .url(realmPage.toString())
+                .withCredentials()
+                .jsonResponse();
+
+        Map<String, Object> res = req.send(jsExecutor);
+        Map<String, Object> json = (Map<String, Object>) res.get("json");
+
+        // request with credentials should be blocked by CORS
+        MatcherAssert.assertThat(res, IsMapContaining.hasEntry("status", 0L));
+
+    }
+
+    private static String getAddressByName(String hostname) {
+        try {
+            return InetAddress.getByName(hostname).getHostAddress();
+        } catch (Throwable e) {
+            return null;
+        }
+    }
+
+}


### PR DESCRIPTION
This PR adds CORS headers to **JSON** error responses the source of which is KeycloakErrorHandler exception mapper. This will improve error handling within Javascript Adapter and other 3rd party JS code, when performing Cross-Origin XHR requests to Auth Server. Without this headers Cross-Origin XHR can't access to actual error response HTTP status and JSON body. Used CORS headers will limit Cross-Origin XHR requests only to requests without credentials.

Some notes about provided test case...
To properly simulate Cross-Origin XHR requests, testsuite should be run with enabled browser security.
Also `auth.server.host` and `auth.server.host2` parameters should be configured to two different from default `localhost` origins. This can be done using nip.io. Otherwise this test case will be skipped.

Run test with default PhantomJS browser:

```
mvn -nsu -s maven-settings.xml -f testsuite/integration-arquillian/tests/base/pom.xml clean install \
        -Dtest=CorsErrorResponseTest \
        -Pauth-server-wildfly \
        -Dkeycloak.phantomjs.cli.args="--ignore-ssl-errors=true --web-security=true" \
        -Dauth.server.host=127-0-0-1.nip.io \
        -Dauth.server.host2=7f000001.nip.io
```

Or using Firefox browser:

```
mvn -nsu -s maven-settings.xml -f testsuite/integration-arquillian/tests/base/pom.xml clean install \
        -Dtest=CorsErrorResponseTest \
        -Pauth-server-wildfly \
        -Djs.browser=firefox \
        -DfirefoxHeadless=true \
        -Dwebdriver.gecko.driver=$HOME/.local/bin/geckodriver \
        -Dauth.server.host=127-0-0-1.nip.io \
        -Dauth.server.host2=7f000001.nip.io
```
