### PR TITLE
KEYCLOAK-18421 Mark empty flow as successful

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/DefaultAuthenticationFlow.java
+++ b/services/src/main/java/org/keycloak/authentication/DefaultAuthenticationFlow.java
@@ -265,7 +265,7 @@ public class DefaultAuthenticationFlow implements AuthenticationFlow {
         //Evaluate alternative elements only if there are no required elements. This may also occur if there was only condition elements
         if (requiredList.isEmpty()) {
             //check if an alternative is already successful, in case we are returning in the flow after an action
-            if (alternativeList.stream().anyMatch(alternative -> processor.isSuccessful(alternative) || isSetupRequired(alternative))) {
+            if (alternativeList.isEmpty() || alternativeList.stream().anyMatch(alternative -> processor.isSuccessful(alternative) || isSetupRequired(alternative))) {
                 successful = true;
                 return null;
             }


### PR DESCRIPTION
This is fixing the issue described in https://issues.redhat.com/browse/KEYCLOAK-18421 but I am not sure the fix is correct. I can also add some test if the fix is correct.
