### PR TITLE
KEYCLOAK-18450 Add basic tests for the Identity Provider Redirector Default IdP feature

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/IdentityProviderAuthenticatorFactory.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/IdentityProviderAuthenticatorFactory.java
@@ -37,12 +37,12 @@ import static org.keycloak.provider.ProviderConfigProperty.STRING_TYPE;
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
  */
 public class IdentityProviderAuthenticatorFactory implements AuthenticatorFactory, DisplayTypeAuthenticatorFactory {
-
     protected static final AuthenticationExecutionModel.Requirement[] REQUIREMENT_CHOICES = {
             AuthenticationExecutionModel.Requirement.REQUIRED, AuthenticationExecutionModel.Requirement.ALTERNATIVE, AuthenticationExecutionModel.Requirement.DISABLED
     };
 
-    protected static final String DEFAULT_PROVIDER = "defaultProvider";
+    public static final String PROVIDER_ID = "identity-provider-redirector";
+    public static final String DEFAULT_PROVIDER = "defaultProvider";
 
     @Override
     public String getDisplayType() {
@@ -106,7 +106,7 @@ public class IdentityProviderAuthenticatorFactory implements AuthenticatorFactor
 
     @Override
     public String getId() {
-        return "identity-provider-redirector";
+        return PROVIDER_ID;
     }
 
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcSamlDefaultIdpTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcSamlDefaultIdpTest.java
@@ -1,0 +1,110 @@
+package org.keycloak.testsuite.broker;
+
+import org.junit.Test;
+import org.keycloak.authentication.authenticators.browser.IdentityProviderAuthenticatorFactory;
+import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.AuthenticationExecutionModel.Requirement;
+import org.keycloak.models.AuthenticatorConfigModel;
+import org.keycloak.testsuite.Assert;
+import org.keycloak.testsuite.util.FlowUtil;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.keycloak.testsuite.broker.BrokerTestTools.getConsumerRoot;
+import static org.keycloak.testsuite.broker.BrokerTestTools.waitForPage;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import java.util.UUID;
+
+/**
+ * Test of various scenarios related to the use of default IdP option
+ * in the Identity Provider Redirector authenticator
+ */
+public class KcSamlDefaultIdpTest extends AbstractInitializedBaseBrokerTest {
+
+    @Test
+    public void testDefaultIdpNotSet() {
+        // Set the Default Identity Provider option for the Identity Provider Redirector to null
+        configureFlow(null);
+
+        // Navigate to the auth page
+        driver.navigate().to(getAccountUrl(getConsumerRoot(), bc.consumerRealmName()));
+        waitForPage(driver, "sign in to", true);
+
+        Assert.assertTrue("Driver should be on the initial page and nothing should have happened",
+                driver.getCurrentUrl().contains("/auth/realms/" + bc.consumerRealmName() + "/"));
+    }
+
+    @Test
+    public void testDefaultIdpSet() {
+        // Set the Default Identity Provider option to the remote IdP name
+        configureFlow("kc-saml-idp");
+
+        String username = "all-info-set@localhost.com";
+        createUser(bc.providerRealmName(), username, "password", "FirstName");
+
+        // Navigate to the auth page
+        driver.navigate().to(getAccountUrl(getConsumerRoot(), bc.consumerRealmName()));
+        waitForPage(driver, "sign in to", true);
+
+        // Make sure we got redirected to the remote IdP automatically
+        Assert.assertTrue("Driver should be on the provider realm page right now",
+                driver.getCurrentUrl().contains("/auth/realms/" + bc.providerRealmName() + "/"));
+    }
+
+    private void configureFlow(String defaultIdpValue)
+    {
+        String newFlowAlias;
+
+        HashMap<String, String> defaultIdpConfig = new HashMap<String, String>();
+        if (defaultIdpValue != null && !defaultIdpValue.isEmpty())
+        {
+            defaultIdpConfig.put(IdentityProviderAuthenticatorFactory.DEFAULT_PROVIDER, defaultIdpValue);
+            newFlowAlias = "Browser - Default IdP " + defaultIdpValue;
+        }
+        else
+            newFlowAlias = "Browser - Default IdP OFF";
+
+        testingClient.server("consumer").run(session -> FlowUtil.inCurrentRealm(session).copyBrowserFlow(newFlowAlias));
+        testingClient.server("consumer").run(session ->
+            {
+                List<AuthenticationExecutionModel> executions = FlowUtil.inCurrentRealm(session)
+                    .selectFlow(newFlowAlias)
+                    .getExecutions();
+
+                int index = IntStream.range(0, executions.size())
+                    .filter(t -> IdentityProviderAuthenticatorFactory.PROVIDER_ID.equals(executions.get(t).getAuthenticator()))
+                    .findFirst()
+                    .orElse(-1);
+
+                assertTrue("Identity Provider Redirector execution not found", index >= 0);
+
+                FlowUtil.inCurrentRealm(session)
+                    .selectFlow(newFlowAlias)
+                    .updateExecution(index,
+                        config -> {
+                            AuthenticatorConfigModel authConfig = new AuthenticatorConfigModel();
+                            authConfig.setId(UUID.randomUUID().toString());
+                            authConfig.setAlias("cfg" + authConfig.getId().hashCode());
+                            authConfig.setConfig(defaultIdpConfig);
+
+                            session.getContext().getRealm().addAuthenticatorConfig(authConfig);
+
+                            config.setAuthenticatorConfig(authConfig.getId());
+                        }
+                    )
+                .defineAsBrowserFlow();
+            }
+        );
+    }
+
+    @Override
+    protected BrokerConfiguration getBrokerConfiguration() {
+        return new KcSamlBrokerConfiguration();
+    }
+}

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/util/FlowUtil.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/util/FlowUtil.java
@@ -236,7 +236,7 @@ public class FlowUtil {
         return this;
     }
 
-    private List<AuthenticationExecutionModel> getExecutions() {
+    public List<AuthenticationExecutionModel> getExecutions() {
         if (executions == null) {
             executions = realm.getAuthenticationExecutionsStream(currentFlow.getId()).collect(Collectors.toList());
         }


### PR DESCRIPTION
While investigating issue https://github.com/keycloak/keycloak/pull/7838 I noticed there are currently no tests for the Default IdP feature in the Identity Provider redirector.

This pull request adds a couple of very simple tests to make sure the feature is working as expected. I also introduced a constant in the IdentityProviderAuthenticatorFactory to align it to the other auth providers.