### PR TITLE
KEYCLOAK-18454 Reset password : wrong email instructions when duplica…

### DIFF
--- a/services/src/main/java/org/keycloak/forms/login/freemarker/model/RealmBean.java
+++ b/services/src/main/java/org/keycloak/forms/login/freemarker/model/RealmBean.java
@@ -74,6 +74,10 @@ public class RealmBean {
         return realm.isLoginWithEmailAllowed();
     }
 
+    public boolean isDuplicateEmailsAllowed() {
+        return realm.isDuplicateEmailsAllowed();
+    }
+
     public boolean isResetPasswordAllowed() {
         return realm.isResetPasswordAllowed();
     }

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/LoginPasswordResetPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/LoginPasswordResetPage.java
@@ -44,6 +44,9 @@ public class LoginPasswordResetPage extends LanguageComboboxAwarePage {
     @FindBy(partialLinkText = "Back to Login")
     private WebElement backToLogin;
 
+    @FindBy(id = "kc-info-wrapper")
+    private WebElement infoWrapper;
+
     public void changePassword() {
         submitButton.click();
     }
@@ -91,4 +94,11 @@ public class LoginPasswordResetPage extends LanguageComboboxAwarePage {
         backToLogin.click();
     }
 
+    public String getInfoMessage() {
+        try {
+            return UIUtils.getTextFromElement(infoWrapper);
+        } catch (NoSuchElementException e) {
+            return null;
+        }
+    }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/ResetPasswordTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/ResetPasswordTest.java
@@ -1157,6 +1157,38 @@ public class ResetPasswordTest extends AbstractTestRealmKeycloakTest {
         }
     }
 
+    @Test
+    public void resetPasswordInfoMessageWithDuplicateEmailsAllowed() throws IOException {
+        RealmRepresentation realmRep = testRealm().toRepresentation();
+        Boolean originalLoginWithEmailAllowed = realmRep.isLoginWithEmailAllowed();
+        Boolean originalDuplicateEmailsAllowed = realmRep.isDuplicateEmailsAllowed();
+
+        try {
+            loginPage.open();
+            loginPage.resetPassword();
+
+            resetPasswordPage.assertCurrent();
+
+            assertEquals("Enter your username or email address and we will send you instructions on how to create a new password.", resetPasswordPage.getInfoMessage());
+
+            realmRep.setLoginWithEmailAllowed(false);
+            realmRep.setDuplicateEmailsAllowed(true);
+            testRealm().update(realmRep);
+
+            loginPage.open();
+            loginPage.resetPassword();
+
+            resetPasswordPage.assertCurrent();
+
+            assertEquals("Enter your username and we will send you instructions on how to create a new password.", resetPasswordPage.getInfoMessage());
+        } finally {
+            realmRep.setLoginWithEmailAllowed(originalLoginWithEmailAllowed);
+            realmRep.setDuplicateEmailsAllowed(originalDuplicateEmailsAllowed);
+            testRealm().update(realmRep);
+        }
+
+    }
+
     // KEYCLOAK-15170
     @Test
     public void changeEmailAddressAfterSendingEmail() throws IOException {

--- a/themes/src/main/resources/theme/base/login/login-reset-password.ftl
+++ b/themes/src/main/resources/theme/base/login/login-reset-password.ftl
@@ -30,6 +30,10 @@
             </div>
         </form>
     <#elseif section = "info" >
-        ${msg("emailInstruction")}
+        <#if realm.duplicateEmailsAllowed>
+            ${msg("emailInstructionUsername")}
+        <#else>
+            ${msg("emailInstruction")}
+        </#if>
     </#if>
 </@layout.registrationLayout>

--- a/themes/src/main/resources/theme/base/login/messages/messages_en.properties
+++ b/themes/src/main/resources/theme/base/login/messages/messages_en.properties
@@ -149,6 +149,7 @@ emailLinkIdp5=to continue.
 backToLogin=&laquo; Back to Login
 
 emailInstruction=Enter your username or email address and we will send you instructions on how to create a new password.
+emailInstructionUsername=Enter your username and we will send you instructions on how to create a new password.
 
 copyCodeInstruction=Please copy this code and paste it into your application:
 


### PR DESCRIPTION
KEYCLOAK-18454 : Reset password : wrong email instructions when duplicates email is allowed

If login with email id disabled and duplicate emails is allowed, the reset password instructions should not tell user to enter its email. Only the username is allowed.

