### PR TITLE
KEYCLOAK-18410 Unable to load protocol org.jgroups.aws.s3.NATIVE_S3_PING when using "default-jgroups-ec2.xml"

### DIFF
--- a/quarkus/pom.xml
+++ b/quarkus/pom.xml
@@ -42,6 +42,7 @@
         <snakeyaml.version>1.28</snakeyaml.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <wildfly.common.format.version>1.5.4.Final-format-001</wildfly.common.format.version>
+        <native-s3-ping.version>1.0.0.Final</native-s3-ping.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/quarkus/runtime/pom.xml
+++ b/quarkus/runtime/pom.xml
@@ -466,6 +466,11 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jgroups.aws.s3</groupId>
+            <artifactId>native-s3-ping</artifactId>
+            <version>${native-s3-ping.version}</version>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
JIRA ticket: https://issues.redhat.com/browse/KEYCLOAK-18410

Added native-s3-ping to pom.xml, then we could configure HA with S3.