### PR TITLE
KEYCLOAK-11570 SocketTimeoutException in windows adapter tests

### DIFF
--- a/adapters/saml/core/src/main/java/org/keycloak/adapters/cloned/HttpClientBuilder.java
+++ b/adapters/saml/core/src/main/java/org/keycloak/adapters/cloned/HttpClientBuilder.java
@@ -36,6 +36,7 @@ import org.apache.http.impl.conn.SingleClientConnManager;
 import org.apache.http.impl.conn.tsccm.ThreadSafeClientConnManager;
 import org.apache.http.params.BasicHttpParams;
 import org.apache.http.params.HttpConnectionParams;
+import org.jboss.logging.Logger;
 import org.keycloak.common.util.EnvUtil;
 import org.keycloak.common.util.KeystoreUtil;
 
@@ -66,7 +67,7 @@ import org.apache.http.client.params.CookiePolicy;
  * @version $Revision: 1 $
  */
 public class HttpClientBuilder {
-    public static enum HostnameVerificationPolicy {
+    public enum HostnameVerificationPolicy {
         /**
          * Hostname verification is not done on the server's certificate
          */
@@ -81,6 +82,10 @@ public class HttpClientBuilder {
         STRICT
     }
 
+    private static final Logger log = Logger.getLogger(HttpClientBuilder.class);
+
+    public static final String SOCKET_TIMEOUT_PROPERTY = "adapters.http.client.socket.timeout";
+    public static final String CONNECTION_TIMEOUT_PROPERTY = "adapters.http.client.connection.timeout";
 
     /**
      * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -298,11 +303,22 @@ public class HttpClientBuilder {
 
             if (socketTimeout > -1) {
                 HttpConnectionParams.setSoTimeout(params, (int) socketTimeoutUnits.toMillis(socketTimeout));
-
+            } else {
+                Long socketTimeoutProperty = getLongSystemProperty(SOCKET_TIMEOUT_PROPERTY);
+                if (socketTimeoutProperty != null) {
+                    HttpConnectionParams.setSoTimeout(params, socketTimeoutProperty.intValue());
+                }
             }
+
             if (establishConnectionTimeout > -1) {
                 HttpConnectionParams.setConnectionTimeout(params, (int) establishConnectionTimeoutUnits.toMillis(establishConnectionTimeout));
+            } else {
+                Long connTimeoutProperty = getLongSystemProperty(CONNECTION_TIMEOUT_PROPERTY);
+                if (connTimeoutProperty != null) {
+                    HttpConnectionParams.setConnectionTimeout(params, connTimeoutProperty.intValue());
+                }
             }
+
             DefaultHttpClient client = new DefaultHttpClient(cm, params);
 
             if (disableCookieCache) {
@@ -395,5 +411,24 @@ public class HttpClientBuilder {
 
         URI uri = URI.create(adapterConfig.getProxyUrl());
         this.proxyHost = new HttpHost(uri.getHost(), uri.getPort(), uri.getScheme());
+    }
+
+    /**
+     * Get <code>Long</code> value from system property
+     *
+     * @param propertyName name of system property
+     */
+    private Long getLongSystemProperty(String propertyName) {
+        String property = System.getProperty(propertyName, "");
+        if (!property.equals("")) {
+            try {
+                return Long.parseLong(property);
+            } catch (NumberFormatException e) {
+                log.warnf("System property '%s' is present, but cannot be parsed.", propertyName);
+                return null;
+            }
+        }
+        log.warnf("Cannot find system property '%s'", propertyName);
+        return null;
     }
 }


### PR DESCRIPTION
JIRA: [KEYCLOAK-11570](https://issues.redhat.com/browse/KEYCLOAK-11570)

PR for pipeline: https://KEYCLOAK-GITLAB.com/keycloak/keycloak-pipeline/-/merge_requests/48
Pipeline tests passed: https://master-jenkins.com/job/universal-test-pipeline-adapters/473/

The HTTP client builder is the same for OIDC and SAML adapters, but those modules are separated, therefore the duplicate code is present. It'd be great to find another way, how to do it, but it's out of scope of this PR.

@miquelsi @pdrozd @mhajas  Could you please review it? Thanks.
