### PR TITLE
[KEYCLOAK-18447] Dynamically select attributes based on requested scopes

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/userprofile/UserProfileMetadata.java
+++ b/server-spi-private/src/main/java/org/keycloak/userprofile/UserProfileMetadata.java
@@ -19,7 +19,6 @@
 
 package org.keycloak.userprofile;
 
-import static org.keycloak.userprofile.AttributeMetadata.ALWAYS_FALSE;
 import static org.keycloak.userprofile.AttributeMetadata.ALWAYS_TRUE;
 
 import java.util.ArrayList;
@@ -73,8 +72,8 @@ public final class UserProfileMetadata implements Cloneable {
         return addAttribute(new AttributeMetadata(name).addValidator(validators));
     }
 
-    public AttributeMetadata addAttribute(String name, List<AttributeValidatorMetadata> validator, Predicate<AttributeContext> writeAllowed, Predicate<AttributeContext> required, Predicate<AttributeContext> readAllowed) {
-        return addAttribute(new AttributeMetadata(name, ALWAYS_TRUE, writeAllowed, required, readAllowed).addValidator(validator));
+    public AttributeMetadata addAttribute(String name, List<AttributeValidatorMetadata> validator, Predicate<AttributeContext> selector, Predicate<AttributeContext> writeAllowed, Predicate<AttributeContext> required, Predicate<AttributeContext> readAllowed) {
+        return addAttribute(new AttributeMetadata(name, selector, writeAllowed, required, readAllowed).addValidator(validator));
     }
 
     /**

--- a/services/src/main/java/org/keycloak/userprofile/config/UPAttribute.java
+++ b/services/src/main/java/org/keycloak/userprofile/config/UPAttribute.java
@@ -35,6 +35,8 @@ public class UPAttribute {
     private UPAttributeRequired required;
     /** null means everyone can view and edit the attribute */
     private UPAttributePermissions permissions;
+    /** null means it is always selected */
+    private UPAttributeSelector selector;
 
     public String getName() {
         return name;
@@ -83,9 +85,16 @@ public class UPAttribute {
         validations.put(validator, config);
     }
 
+    public UPAttributeSelector getSelector() {
+        return selector;
+    }
+
+    public void setSelector(UPAttributeSelector selector) {
+        this.selector = selector;
+    }
+
     @Override
     public String toString() {
-        return "UPAttribute [name=" + name + ", permissions=" + permissions + ", required=" + required + ", validations=" + validations + ", annotations="
-                + annotations + "]";
+        return "UPAttribute [name=" + name + ", permissions=" + permissions + ", selector=" + selector + ", required=" + required + ", validations=" + validations + ", annotations=" + annotations + "]";
     }
 }

--- a/services/src/main/java/org/keycloak/userprofile/config/UPAttributeSelector.java
+++ b/services/src/main/java/org/keycloak/userprofile/config/UPAttributeSelector.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.userprofile.config;
+
+import java.util.List;
+
+/**
+ * Config of the rules when attribute is selected.
+ * 
+ * @author Vlastimil Elias <velias@redhat.com>
+ *
+ */
+public class UPAttributeSelector {
+
+    private List<String> scopes;
+
+    public List<String> getScopes() {
+        return scopes;
+    }
+
+    public void setScopes(List<String> scopes) {
+        this.scopes = scopes;
+    }
+
+    @Override
+    public String toString() {
+        return "UPAttributeSelector [scopes=" + scopes + "]";
+    }
+
+}

--- a/services/src/main/java/org/keycloak/userprofile/legacy/AbstractUserProfileProvider.java
+++ b/services/src/main/java/org/keycloak/userprofile/legacy/AbstractUserProfileProvider.java
@@ -45,7 +45,6 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.services.messages.Messages;
 import org.keycloak.userprofile.AttributeContext;
-import org.keycloak.userprofile.AttributeMetadata;
 import org.keycloak.userprofile.AttributeValidatorMetadata;
 import org.keycloak.userprofile.Attributes;
 import org.keycloak.userprofile.DefaultAttributes;
@@ -283,11 +282,6 @@ public abstract class AbstractUserProfileProvider<U extends UserProfileProvider>
                 new AttributeValidatorMetadata(DuplicateUsernameValidator.ID),
                 new AttributeValidatorMetadata(UsernameMutationValidator.ID));
 
-        metadata.addAttribute(UserModel.FIRST_NAME, new AttributeValidatorMetadata(BlankAttributeValidator.ID,
-                BlankAttributeValidator.createConfig(Messages.MISSING_FIRST_NAME)));
-
-        metadata.addAttribute(UserModel.LAST_NAME, new AttributeValidatorMetadata(BlankAttributeValidator.ID, BlankAttributeValidator.createConfig(Messages.MISSING_LAST_NAME)));
-
         metadata.addAttribute(UserModel.EMAIL, new AttributeValidatorMetadata(BlankAttributeValidator.ID, BlankAttributeValidator.createConfig(Messages.MISSING_EMAIL)),
         		new AttributeValidatorMetadata(EmailValidator.ID, ValidatorConfig.builder().config(EmailValidator.IGNORE_EMPTY_VALUE, true).build()),
         		new AttributeValidatorMetadata(DuplicateEmailValidator.ID),
@@ -310,10 +304,6 @@ public abstract class AbstractUserProfileProvider<U extends UserProfileProvider>
         UserProfileMetadata metadata = new UserProfileMetadata(IDP_REVIEW);
 
         metadata.addAttribute(UserModel.USERNAME, new AttributeValidatorMetadata(BrokeringFederatedUsernameHasValueValidator.ID));
-
-        metadata.addAttribute(UserModel.FIRST_NAME,	new AttributeValidatorMetadata(BlankAttributeValidator.ID, BlankAttributeValidator.createConfig(Messages.MISSING_FIRST_NAME)));
-
-        metadata.addAttribute(UserModel.LAST_NAME, new AttributeValidatorMetadata(BlankAttributeValidator.ID, BlankAttributeValidator.createConfig(Messages.MISSING_LAST_NAME)));
 
         metadata.addAttribute(UserModel.EMAIL, new AttributeValidatorMetadata(BlankAttributeValidator.ID, BlankAttributeValidator.createConfig(Messages.MISSING_EMAIL)),
         		new AttributeValidatorMetadata(EmailValidator.ID));

--- a/services/src/main/java/org/keycloak/userprofile/legacy/DefaultUserProfileProvider.java
+++ b/services/src/main/java/org/keycloak/userprofile/legacy/DefaultUserProfileProvider.java
@@ -22,8 +22,12 @@ package org.keycloak.userprofile.legacy;
 import java.util.Map;
 
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.UserModel;
+import org.keycloak.services.messages.Messages;
+import org.keycloak.userprofile.AttributeValidatorMetadata;
 import org.keycloak.userprofile.UserProfileContext;
 import org.keycloak.userprofile.UserProfileMetadata;
+import org.keycloak.userprofile.validator.BlankAttributeValidator;
 
 /**
  * @author <a href="mailto:markus.till@bosch.io">Markus Till</a>
@@ -53,5 +57,14 @@ public class DefaultUserProfileProvider extends AbstractUserProfileProvider<Defa
     @Override
     public int order() {
         return 1;
+    }
+    
+    protected UserProfileMetadata configureUserProfile(UserProfileMetadata metadata) {
+        UserProfileContext ctx = metadata.getContext();
+        if(ctx != UserProfileContext.USER_API && ctx != UserProfileContext.REGISTRATION_USER_CREATION) {
+            metadata.addAttribute(UserModel.FIRST_NAME, new AttributeValidatorMetadata(BlankAttributeValidator.ID, BlankAttributeValidator.createConfig(Messages.MISSING_FIRST_NAME)));
+            metadata.addAttribute(UserModel.LAST_NAME, new AttributeValidatorMetadata(BlankAttributeValidator.ID, BlankAttributeValidator.createConfig(Messages.MISSING_LAST_NAME)));
+        }
+        return metadata;
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/user/profile/UserProfileTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/user/profile/UserProfileTest.java
@@ -135,7 +135,7 @@ public class UserProfileTest extends AbstractUserProfileTest {
         }
 
         assertThat(profile.getAttributes().nameSet(),
-                containsInAnyOrder(UserModel.USERNAME, UserModel.EMAIL, UserModel.FIRST_NAME, UserModel.LAST_NAME, "address"));
+                containsInAnyOrder(UserModel.USERNAME, UserModel.EMAIL, "address"));
 
         attributes.put("address", "myaddress");
 
@@ -415,7 +415,7 @@ public class UserProfileTest extends AbstractUserProfileTest {
         UserModel user = profile.create();
 
         assertThat(profile.getAttributes().nameSet(),
-                containsInAnyOrder(UserModel.USERNAME, UserModel.EMAIL, UserModel.FIRST_NAME, UserModel.LAST_NAME, "address", "department"));
+                containsInAnyOrder(UserModel.USERNAME, UserModel.EMAIL, "address", "department"));
 
         assertNull(user.getFirstAttribute("department"));
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/user/profile/config/UPConfigParserTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/user/profile/config/UPConfigParserTest.java
@@ -104,7 +104,6 @@ public class UPConfigParserTest extends AbstractTestRealmKeycloakTest {
         Assert.assertNotNull(att.getRequired().getRoles());
         Assert.assertEquals(2, att.getRequired().getRoles().size());
         
-        // permissions
         att = config.getAttributes().get(3);
         Assert.assertTrue(att.getRequired().isAlways());
         
@@ -117,6 +116,12 @@ public class UPConfigParserTest extends AbstractTestRealmKeycloakTest {
         Assert.assertEquals(2, att.getPermissions().getView().size());
         Assert.assertTrue(att.getPermissions().getView().contains("admin"));
         Assert.assertTrue(att.getPermissions().getView().contains("user"));
+        
+        //selector
+        att = config.getAttributes().get(4);
+        Assert.assertNotNull(att.getSelector().getScopes());
+        Assert.assertEquals(3, att.getSelector().getScopes().size());
+        Assert.assertTrue(att.getSelector().getScopes().contains("phone-3-sel"));
     }
 
     /**

--- a/testsuite/integration-arquillian/tests/base/src/test/resources/org/keycloak/testsuite/user/profile/config/test-OK.json
+++ b/testsuite/integration-arquillian/tests/base/src/test/resources/org/keycloak/testsuite/user/profile/config/test-OK.json
@@ -49,6 +49,9 @@
                 "scopes" : ["phone-1", "phone-2"],
                 "roles" : ["user", "admin"]
             },
+            "selector" : {
+                "scopes" : ["phone-1-sel", "phone-2-sel", "phone-3-sel"]
+            },
             "permissions": {
                 "view": ["admin", "user"], 
                 "edit": ["admin"]


### PR DESCRIPTION
@pedroigor here is it, including tests in VerifyProfileTest
BTW I have to move legacy "required" definitions for firstName and lastName attributes from abstract base provider to legacy provider, as they was used when  configured selector returned false. I think this is better approach than trying to remove them in Declarative provider (there is not even any support for removal in the SPI) as they are really only legacy definitions for legacy provider. 
