### PR TITLE
KEYCLOAK-18496 NPE in LDAPStorageProvider.importUserFromLDAP

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProvider.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProvider.java
@@ -525,7 +525,9 @@ public class LDAPStorageProvider implements UserStorageProvider,
             if(existingLocalUser != null){
                 imported = existingLocalUser;
                 // Need to evict the existing user from cache
-                session.userCache().evict(realm, existingLocalUser);
+                if (session.userCache() != null) {
+                    session.userCache().evict(realm, existingLocalUser);			
+                }
             } else {
                 imported = session.userLocalStorage().addUser(realm, ldapUsername);
             }


### PR DESCRIPTION
NullPointerException when existing user from LDAP is found (same LDAP_ID, but with changed username) and session.userCache() is null.

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
