### PR TITLE
KEYCLOAK-18467 support unicode for realm localization texts

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/RealmLocalizationTextsEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/RealmLocalizationTextsEntity.java
@@ -27,6 +27,8 @@ import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.IdClass;
 import javax.persistence.Table;
+
+import org.hibernate.annotations.Nationalized;
 import org.keycloak.models.jpa.converter.MapStringConverter;
 
 @Entity
@@ -81,6 +83,7 @@ public class RealmLocalizationTextsEntity {
     @Column(name = "LOCALE")
     private String locale;
 
+    @Nationalized
     @Column(name = "TEXTS")
     private String texts;
     // TODO: The @Convert does not work as expected on quarkus. It doesn't update the "texts" in case that updated map has same keys (but different values) as old map had

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-15.0.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-15.0.0.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  ~ * Copyright 2020 Red Hat, Inc. and/or its affiliates
+  ~ * and other contributors as indicated by the @author tags.
+  ~ *
+  ~ * Licensed under the Apache License, Version 2.0 (the "License");
+  ~ * you may not use this file except in compliance with the License.
+  ~ * You may obtain a copy of the License at
+  ~ *
+  ~ * http://www.apache.org/licenses/LICENSE-2.0
+  ~ *
+  ~ * Unless required by applicable law or agreed to in writing, software
+  ~ * distributed under the License is distributed on an "AS IS" BASIS,
+  ~ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ * See the License for the specific language governing permissions and
+  ~ * limitations under the License.
+  -->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <!-- change datatype of field REALM_LOCALIZATIONS.TEXTS to NCLOB (instead of CLOB) -->
+    <changeSet author="keycloak" id="15.0.0-KEYCLOAK-18467">
+        <addColumn tableName="REALM_LOCALIZATIONS">
+            <column name="TEXTS_NEW" type="NCLOB">
+                <!-- not-null constraint has to be added at the end, when data has been copied -->
+                <!--<constraints nullable="false"/>-->
+            </column>
+        </addColumn>
+        <update tableName="REALM_LOCALIZATIONS">
+            <column name="TEXTS_NEW" valueComputed="TEXTS"/>
+        </update>
+        <dropColumn tableName="REALM_LOCALIZATIONS" columnName="TEXTS"/>
+        <renameColumn tableName="REALM_LOCALIZATIONS" oldColumnName="TEXTS_NEW" newColumnName="TEXTS" columnDataType="NCLOB"/>
+        <addNotNullConstraint tableName="REALM_LOCALIZATIONS" columnName="TEXTS" columnDataType="NCLOB" />
+    </changeSet>
+
+</databaseChangeLog>

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-master.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-master.xml
@@ -70,5 +70,6 @@
     <include file="META-INF/jpa-changelog-12.0.0.xml"/>
     <include file="META-INF/jpa-changelog-13.0.0.xml"/>
     <include file="META-INF/jpa-changelog-14.0.0.xml"/>
+    <include file="META-INF/jpa-changelog-15.0.0.xml"/>
 
 </databaseChangeLog>

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/i18n/RealmLocalizationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/i18n/RealmLocalizationTest.java
@@ -1,0 +1,29 @@
+package org.keycloak.testsuite.i18n;
+
+import org.junit.Test;
+import org.keycloak.admin.client.resource.RealmLocalizationResource;
+
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasEntry;
+
+public class RealmLocalizationTest extends AbstractI18NTest {
+
+    /**
+     * Make sure that realm localization texts support unicode ().
+     */
+    @Test
+    public void realmLocalizationTextsSupportUnicode() {
+        String locale = "en";
+        String key = "Äǜṳǚǘǖ";
+        String text = "Öṏṏ";
+        RealmLocalizationResource localizationResource = testRealm().localization();
+        localizationResource.saveRealmLocalizationText(locale, key, text);
+
+        Map<String, String> localizationTexts = localizationResource.getRealmLocalizationTexts(locale);
+
+        assertThat(localizationTexts, hasEntry(key, text));
+    }
+
+}


### PR DESCRIPTION
This PR adds unicode support for realm localization texts (see KEYCLOAK-18467):
- it changes the datatype of the database column REALM_LOCALIZATIONS.TEXTS to NCLOB (instead of CLOB)
- adds the Hibernate @Nationalized annotation to the corresponding java entity field

Related documentation PR: https://github.com/keycloak/keycloak-documentation/pull/1222