### PR TITLE
KEYCLOAK-18051 Adds RegexRedirectUri validation

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpoint.java
@@ -50,6 +50,7 @@ import org.keycloak.services.clientpolicy.ClientPolicyException;
 import org.keycloak.services.clientpolicy.context.AuthorizationRequestContext;
 import org.keycloak.services.messages.Messages;
 import org.keycloak.services.resources.LoginActionsService;
+import org.keycloak.services.resources.admin.permissions.AdminPermissions;
 import org.keycloak.services.util.CacheControlUtil;
 import org.keycloak.sessions.AuthenticationSessionModel;
 import org.keycloak.util.TokenUtil;
@@ -441,9 +442,12 @@ public class AuthorizationEndpoint extends AuthorizationEndpointBase {
         boolean isOIDCRequest = TokenUtil.isOIDCRequest(request.getScope());
 
         event.detail(Details.REDIRECT_URI, redirectUriParam);
-
+        boolean allowRegexRedirectUri = AdminPermissions
+            .management(session, session.getContext().getRealm())
+            .clients().allowRegexRedirectUri(client);
+        
         // redirect_uri parameter is required per OpenID Connect, but optional per OAuth2
-        redirectUri = RedirectUtils.verifyRedirectUri(session, redirectUriParam, client, isOIDCRequest);
+        redirectUri = RedirectUtils.verifyRedirectUri(session, redirectUriParam, client, isOIDCRequest, allowRegexRedirectUri);
         if (redirectUri == null) {
             event.error(Errors.INVALID_REDIRECT_URI);
             throw new ErrorPageException(session, authenticationSession, Response.Status.BAD_REQUEST, Messages.INVALID_PARAMETER, OIDCLoginProtocol.REDIRECT_URI_PARAM);

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/request/AuthorizationEndpointRequestParserProcessor.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/request/AuthorizationEndpointRequestParserProcessor.java
@@ -30,7 +30,7 @@ import org.keycloak.protocol.oidc.utils.RedirectUtils;
 import org.keycloak.services.ErrorPageException;
 import org.keycloak.services.ServicesLogger;
 import org.keycloak.services.messages.Messages;
-
+import org.keycloak.services.resources.admin.permissions.AdminPermissions;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 import java.io.InputStream;
@@ -77,9 +77,12 @@ public class AuthorizationEndpointRequestParserProcessor {
             if (requestParam != null) {
                 new AuthzEndpointRequestObjectParser(session, requestParam, client).parseRequest(request);
             } else if (requestUriParam != null) {
+              boolean allowRegexRedirectUri = AdminPermissions
+                  .management(session, session.getContext().getRealm())
+                  .clients().allowRegexRedirectUri(client);          
                 // Validate "requestUriParam" with allowed requestUris
                 List<String> requestUris = OIDCAdvancedConfigWrapper.fromClientModel(client).getRequestUris();
-                String requestUri = RedirectUtils.verifyRedirectUri(session, client.getRootUrl(), requestUriParam, new HashSet<>(requestUris), false);
+                String requestUri = RedirectUtils.verifyRedirectUri(session, client.getRootUrl(), requestUriParam, new HashSet<>(requestUris), false, allowRegexRedirectUri);
                 if (requestUri == null) {
                     throw new RuntimeException("Specified 'request_uri' not allowed for this client.");
                 }

--- a/services/src/main/java/org/keycloak/protocol/saml/SamlService.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/SamlService.java
@@ -103,6 +103,7 @@ import org.keycloak.services.managers.RealmManager;
 import org.keycloak.services.messages.Messages;
 import org.keycloak.services.resources.RealmsResource;
 import org.keycloak.services.scheduled.ScheduledTaskRunner;
+import org.keycloak.services.resources.admin.permissions.AdminPermissions;
 import org.keycloak.services.util.CacheControlUtil;
 import org.keycloak.sessions.AuthenticationSessionModel;
 import org.keycloak.sessions.CommonClientSessionModel;
@@ -421,7 +422,11 @@ public class SamlService extends AuthorizationEndpointBase {
             String redirect;
             URI redirectUri = requestAbstractType.getAssertionConsumerServiceURL();
             if (redirectUri != null && ! "null".equals(redirectUri.toString())) { // "null" is for testing purposes
-                redirect = RedirectUtils.verifyRedirectUri(session, redirectUri.toString(), client);
+              boolean allowRegexRedirectUri = AdminPermissions
+                  .management(session, session.getContext().getRealm())
+                  .clients().allowRegexRedirectUri(client);
+              
+                redirect = RedirectUtils.verifyRedirectUri(session, redirectUri.toString(), client, allowRegexRedirectUri);
             } else {
                 if ((requestAbstractType.getProtocolBinding() != null
                         && JBossSAMLURIConstants.SAML_HTTP_ARTIFACT_BINDING.getUri()

--- a/services/src/main/java/org/keycloak/services/resources/IdentityBrokerService.java
+++ b/services/src/main/java/org/keycloak/services/resources/IdentityBrokerService.java
@@ -80,6 +80,7 @@ import org.keycloak.services.managers.BruteForceProtector;
 import org.keycloak.services.managers.ClientSessionCode;
 import org.keycloak.services.messages.Messages;
 import org.keycloak.services.resources.account.AccountFormService;
+import org.keycloak.services.resources.admin.permissions.AdminPermissions;
 import org.keycloak.services.util.AuthenticationFlowURLHelper;
 import org.keycloak.services.util.BrowserHistoryHelper;
 import org.keycloak.services.util.CacheControlUtil;
@@ -211,7 +212,11 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
         this.event.event(EventType.CLIENT_INITIATED_ACCOUNT_LINKING);
         checkRealm();
         ClientModel client = checkClient(clientId);
-        redirectUri = RedirectUtils.verifyRedirectUri(session, redirectUri, client);
+        boolean allowRegexRedirectUri = AdminPermissions
+            .management(session, session.getContext().getRealm())
+            .clients().allowRegexRedirectUri(client);
+        
+        redirectUri = RedirectUtils.verifyRedirectUri(session, redirectUri, client, allowRegexRedirectUri);
         if (redirectUri == null) {
             event.error(Errors.INVALID_REDIRECT_URI);
             throw new ErrorPageException(session, Response.Status.BAD_REQUEST, Messages.INVALID_REQUEST);

--- a/services/src/main/java/org/keycloak/services/resources/LoginActionsService.java
+++ b/services/src/main/java/org/keycloak/services/resources/LoginActionsService.java
@@ -78,6 +78,7 @@ import org.keycloak.services.managers.AuthenticationManager;
 import org.keycloak.services.managers.AuthenticationSessionManager;
 import org.keycloak.services.managers.ClientSessionCode;
 import org.keycloak.services.messages.Messages;
+import org.keycloak.services.resources.admin.permissions.AdminPermissions;
 import org.keycloak.services.resource.RealmResourceProvider;
 import org.keycloak.services.util.AuthenticationFlowURLHelper;
 import org.keycloak.services.util.BrowserHistoryHelper;
@@ -403,7 +404,11 @@ public class LoginActionsService {
             client = SystemClientUtil.getSystemClient(realm);
             redirectUri = Urls.accountBase(session.getContext().getUri().getBaseUri()).path("/").build(realm.getName()).toString();
         } else {
-            redirectUri = RedirectUtils.getFirstValidRedirectUri(session, client.getRootUrl(), client.getRedirectUris());
+          boolean allowRegexRedirectUri = AdminPermissions
+              .management(session, session.getContext().getRealm())
+              .clients().allowRegexRedirectUri(client);
+          
+            redirectUri = RedirectUtils.getFirstValidRedirectUri(session, client.getRootUrl(), client.getRedirectUris(), allowRegexRedirectUri);
         }
 
         RootAuthenticationSessionModel rootAuthSession = new AuthenticationSessionManager(session).createAuthenticationSession(realm, true);

--- a/services/src/main/java/org/keycloak/services/resources/LoginActionsServiceChecks.java
+++ b/services/src/main/java/org/keycloak/services/resources/LoginActionsServiceChecks.java
@@ -36,6 +36,7 @@ import org.keycloak.protocol.oidc.utils.RedirectUtils;
 import org.keycloak.representations.JsonWebToken;
 import org.keycloak.services.managers.AuthenticationManager;
 import org.keycloak.services.messages.Messages;
+import org.keycloak.services.resources.admin.permissions.AdminPermissions;
 import org.keycloak.sessions.AuthenticationSessionCompoundId;
 import org.keycloak.sessions.AuthenticationSessionModel;
 import org.keycloak.sessions.CommonClientSessionModel.Action;
@@ -226,8 +227,11 @@ public class LoginActionsServiceChecks {
             }
 
             ClientModel client = context.getAuthenticationSession().getClient();
-
-            if (RedirectUtils.verifyRedirectUri(context.getSession(), redirectUri, client) == null) {
+            boolean allowRegexRedirectUri = AdminPermissions
+                .management(context.getSession(), context.getRealm())
+                .clients().allowRegexRedirectUri(client);
+            
+            if (RedirectUtils.verifyRedirectUri(context.getSession(), redirectUri, client, allowRegexRedirectUri) == null) {
                 throw new ExplainedTokenVerificationException(t, Errors.INVALID_REDIRECT_URI, Messages.INVALID_REDIRECT_URI);
             }
 

--- a/services/src/main/java/org/keycloak/services/resources/account/AccountConsole.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountConsole.java
@@ -48,6 +48,7 @@ import java.util.stream.Collectors;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 import org.keycloak.services.resources.RealmsResource;
+import org.keycloak.services.resources.admin.permissions.AdminPermissions;
 
 /**
  * Created by st on 29/03/17.
@@ -208,7 +209,11 @@ public class AccountConsole {
         ClientModel referrerClient = realm.getClientByClientId(referrer);
         if (referrerClient != null) {
             if (referrerUri != null) {
-                referrerUri = RedirectUtils.verifyRedirectUri(session, referrerUri, referrerClient);
+              boolean allowRegexRedirectUri = AdminPermissions
+                  .management(session, session.getContext().getRealm())
+                  .clients().allowRegexRedirectUri(client);
+              
+                referrerUri = RedirectUtils.verifyRedirectUri(session, referrerUri, referrerClient, allowRegexRedirectUri);
             } else {
                 referrerUri = ResolveRelative.resolveRelativeUri(session, client.getRootUrl(), referrerClient.getBaseUrl());
             }
@@ -223,7 +228,11 @@ public class AccountConsole {
         } else if (referrerUri != null) {
             referrerClient = realm.getClientByClientId(referrer);
             if (client != null) {
-                referrerUri = RedirectUtils.verifyRedirectUri(session, referrerUri, referrerClient);
+                boolean allowRegexRedirectUri = AdminPermissions
+                    .management(session, session.getContext().getRealm())
+                    .clients().allowRegexRedirectUri(client);
+                
+                referrerUri = RedirectUtils.verifyRedirectUri(session, referrerUri, referrerClient, allowRegexRedirectUri);
 
                 if (referrerUri != null) {
                     return new String[]{referrer, referrer, referrerUri};

--- a/services/src/main/java/org/keycloak/services/resources/account/AccountFormService.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountFormService.java
@@ -68,6 +68,7 @@ import org.keycloak.services.managers.UserConsentManager;
 import org.keycloak.services.messages.Messages;
 import org.keycloak.services.resources.AbstractSecuredLocalService;
 import org.keycloak.services.resources.RealmsResource;
+import org.keycloak.services.resources.admin.permissions.AdminPermissions;
 import org.keycloak.services.util.ResolveRelative;
 import org.keycloak.services.validation.Validation;
 import org.keycloak.sessions.AuthenticationSessionModel;
@@ -1039,9 +1040,14 @@ public class AccountFormService extends AbstractSecuredLocalService {
         String referrerUri = session.getContext().getUri().getQueryParameters().getFirst("referrer_uri");
 
         ClientModel referrerClient = realm.getClientByClientId(referrer);
+        
+        boolean allowRegexRedirectUri = AdminPermissions
+            .management(session, session.getContext().getRealm())
+            .clients().allowRegexRedirectUri(client);
+        
         if (referrerClient != null) {
             if (referrerUri != null) {
-                referrerUri = RedirectUtils.verifyRedirectUri(session, referrerUri, referrerClient);
+              referrerUri = RedirectUtils.verifyRedirectUri(session, referrerUri, referrerClient, allowRegexRedirectUri);
             } else {
                 referrerUri = ResolveRelative.resolveRelativeUri(session, referrerClient.getRootUrl(), referrerClient.getBaseUrl());
             }
@@ -1055,8 +1061,7 @@ public class AccountFormService extends AbstractSecuredLocalService {
             }
         } else if (referrerUri != null) {
             if (client != null) {
-                referrerUri = RedirectUtils.verifyRedirectUri(session, referrerUri, client);
-
+                referrerUri = RedirectUtils.verifyRedirectUri(session, referrerUri, client, allowRegexRedirectUri);
                 if (referrerUri != null) {
                     return new String[]{referrer, referrerUri};
                 }

--- a/services/src/main/java/org/keycloak/services/resources/admin/UserResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UserResource.java
@@ -71,6 +71,7 @@ import org.keycloak.services.managers.UserSessionManager;
 import org.keycloak.services.resources.LoginActionsService;
 import org.keycloak.services.resources.account.AccountFormService;
 import org.keycloak.services.resources.admin.permissions.AdminPermissionEvaluator;
+import org.keycloak.services.resources.admin.permissions.AdminPermissions;
 import org.keycloak.services.validation.Validation;
 import org.keycloak.storage.ReadOnlyException;
 import org.keycloak.userprofile.ValidationException;
@@ -800,7 +801,11 @@ public class UserResource {
 
         String redirect;
         if (redirectUri != null) {
-            redirect = RedirectUtils.verifyRedirectUri(session, redirectUri, client);
+          boolean allowRegexRedirectUri = AdminPermissions
+              .management(session, session.getContext().getRealm())
+              .clients().allowRegexRedirectUri(client);
+          
+            redirect = RedirectUtils.verifyRedirectUri(session, redirectUri, client, allowRegexRedirectUri);
             if (redirect == null) {
                 throw new WebApplicationException(
                     ErrorResponse.error("Invalid redirect uri.", Status.BAD_REQUEST));

--- a/services/src/main/java/org/keycloak/services/resources/admin/permissions/ClientPermissionEvaluator.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/permissions/ClientPermissionEvaluator.java
@@ -79,6 +79,8 @@ public interface ClientPermissionEvaluator {
     boolean canMapCompositeRoles(ClientModel client);
 
     boolean canMapClientScopeRoles(ClientModel client);
+    
+    boolean allowRegexRedirectUri(ClientModel client);
 
     Map<String, Boolean> getAccess(ClientModel client);
 }

--- a/services/src/main/java/org/keycloak/services/resources/admin/permissions/ClientPermissionManagement.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/permissions/ClientPermissionManagement.java
@@ -32,6 +32,7 @@ public interface ClientPermissionManagement {
     public static final String MAP_ROLES_CLIENT_SCOPE = "map-roles-client-scope";
     public static final String MAP_ROLES_COMPOSITE_SCOPE = "map-roles-composite";
     public static final String CONFIGURE_SCOPE = "configure";
+    public static final String ALLOW_REGEX_REDIRECT_URI_SCOPE = "allow-regex-redirect-uri";
 
     boolean isPermissionsEnabled(ClientModel client);
 
@@ -42,6 +43,8 @@ public interface ClientPermissionManagement {
     Map<String, String> getPermissions(ClientModel client);
 
     boolean canExchangeTo(ClientModel authorizedClient, ClientModel to);
+    
+    boolean allowRegexRedirectUri(ClientModel client);
 
     Policy exchangeToPermission(ClientModel client);
 
@@ -50,6 +53,8 @@ public interface ClientPermissionManagement {
     Policy mapRolesClientScopePermission(ClientModel client);
 
     Policy mapRolesCompositePermission(ClientModel client);
+    
+    Policy allowRegexRedirectUriPermission(ClientModel client);
 
     Policy managePermission(ClientModel client);
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientRedirectTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientRedirectTest.java
@@ -17,34 +17,56 @@
 
 package org.keycloak.testsuite.client;
 
-import org.junit.Test;
 import org.junit.Rule;
+import org.junit.Test;
 import org.keycloak.OAuth2Constants;
 import org.keycloak.OAuthErrorException;
+import org.keycloak.admin.client.resource.ClientResource;
+import org.keycloak.admin.client.resource.ClientsResource;
+import org.keycloak.authorization.model.Policy;
+import org.keycloak.authorization.model.Resource;
+import org.keycloak.authorization.model.ResourceServer;
 import org.keycloak.common.Profile;
 import org.keycloak.common.util.KeycloakUriBuilder;
 import org.keycloak.constants.ServiceUrlConstants;
+import org.keycloak.events.Details;
+import org.keycloak.events.EventType;
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
+import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.representations.idm.authorization.ClientPolicyRepresentation;
+import org.keycloak.representations.idm.authorization.ResourceRepresentation;
+import org.keycloak.services.resources.admin.permissions.AdminPermissionManagement;
+import org.keycloak.services.resources.admin.permissions.AdminPermissions;
 import org.keycloak.testsuite.AbstractTestRealmKeycloakTest;
 import org.keycloak.testsuite.AssertEvents;
 import org.keycloak.testsuite.admin.ApiUtil;
-import org.keycloak.testsuite.util.AdminClientUtil;
 import org.keycloak.testsuite.arquillian.annotation.DisableFeature;
+import org.keycloak.testsuite.arquillian.annotation.EnableFeature;
+import org.keycloak.testsuite.util.AdminClientUtil;
 import org.keycloak.testsuite.util.ClientBuilder;
 import org.keycloak.testsuite.util.RealmBuilder;
 
-import java.net.URI;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Collections;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.keycloak.services.resources.admin.permissions.ClientPermissionManagement.ALLOW_REGEX_REDIRECT_URI_SCOPE;
+import static org.keycloak.testsuite.AssertEvents.isCodeId;
+import static org.keycloak.testsuite.AssertEvents.isUUID;
 import static org.keycloak.testsuite.util.Matchers.statusCodeIs;
 
 /**
@@ -127,4 +149,88 @@ public class ClientRedirectTest extends AbstractTestRealmKeycloakTest {
             adminClient.realm("test").clients().get(clientId).remove();
         }
     }
+
+    // KEYCLOAK-18051
+    @Test
+    @EnableFeature(value = Profile.Feature.ADMIN_FINE_GRAINED_AUTHZ, skipRestart = true)
+    public void testRegexRedirectURI() throws URISyntaxException, MalformedURLException {
+        String clientId = null;
+        try {
+
+            ClientsResource clientsResource = testRealm().clients();
+            testingClient.server().run(ClientRedirectTest::setupAllowRegexRedirectUriPermission);
+            clientId = clientsResource.findByClientId("regex-client").get(0).getId();
+
+            ClientResource clientResource = clientsResource.get(clientId);
+            ClientRepresentation clientRepresentation = clientResource.toRepresentation();
+
+            clientRepresentation.setRedirectUris(Collections.singletonList("http://[a-zA-Z]+\\.[a-zA-Z]+/[a-zA-Z]+"));
+            clientsResource.get(clientId).update(clientRepresentation);
+
+            URI login = KeycloakUriBuilder.fromUri(suiteContext.getAuthServerInfo().getBrowserContextRoot().toURI())
+                .path("auth" + ServiceUrlConstants.AUTH_PATH)
+                .queryParam(OIDCLoginProtocol.CLIENT_ID_PARAM, clientRepresentation.getClientId())
+                .queryParam(OIDCLoginProtocol.RESPONSE_TYPE_PARAM, "code").queryParam(OIDCLoginProtocol.SCOPE_PARAM, "openid")
+                .queryParam(OIDCLoginProtocol.REDIRECT_URI_PARAM, "http://example.org/launchpad").build("test");
+
+            driver.navigate().to(login.toURL());
+
+            oauth.fillLoginForm("test-user@localhost", "password");
+
+            events.expect(EventType.LOGIN).client(clientRepresentation.getClientId()).session(isUUID()).detail(Details.CODE_ID, isCodeId())
+                .assertEvent();
+
+            URI notAllowedRedirectUri = KeycloakUriBuilder.fromUri(suiteContext.getAuthServerInfo().getBrowserContextRoot().toURI())
+                .path("auth" + ServiceUrlConstants.AUTH_PATH)
+                .queryParam(OIDCLoginProtocol.CLIENT_ID_PARAM, clientRepresentation.getClientId())
+                .queryParam(OIDCLoginProtocol.RESPONSE_TYPE_PARAM, "code").queryParam(OIDCLoginProtocol.SCOPE_PARAM, "openid")
+                .queryParam(OIDCLoginProtocol.REDIRECT_URI_PARAM, "https://example.org/launchpad").build("test");
+
+            driver.navigate().to(notAllowedRedirectUri.toURL());
+
+            events.expect(EventType.LOGIN_ERROR).error(OAuthErrorException.INVALID_REDIRECT_URI).client((String) null).user((String) null);
+
+        } finally {
+            log.debug("removing disabled-client");
+            if (clientId != null) {
+                adminClient.realm("test").clients().get(clientId).remove();
+            }
+        }
+    }
+
+    public static void setupAllowRegexRedirectUriPermission(KeycloakSession session) {
+        
+        RealmModel realm = session.realms().getRealmByName("test");
+        ClientModel client = session.clients().getClientByClientId(realm, "regex-client");
+        // lazy init
+        if (client != null) return;
+        client = realm.addClient("regex-client");
+        client.setSecret("secret");
+        client.setPublicClient(false);
+        client.setProtocol(OIDCLoginProtocol.LOGIN_PROTOCOL);
+        client.setEnabled(true);
+        client.setDirectAccessGrantsEnabled(true);
+
+        ClientPolicyRepresentation clientPolicyRep = new ClientPolicyRepresentation();
+        clientPolicyRep.setName("client-policy");
+        clientPolicyRep.addClient(client.getId());
+
+        AdminPermissionManagement management = AdminPermissions.management(session, realm);
+        management.clients().setPermissionsEnabled(client,true);
+
+        String resourceName = "client.resource." + client.getId();
+        ResourceRepresentation resourceRepresentation = new ResourceRepresentation();
+        resourceRepresentation.setName(resourceName);
+        resourceRepresentation.addScope(ALLOW_REGEX_REDIRECT_URI_SCOPE);
+
+        ResourceServer server = management.realmResourceServer();
+        Policy clientPolicy = management.authz().getStoreFactory().getPolicyStore().create(clientPolicyRep, server);
+        Resource resource = management.authz().getStoreFactory().getResourceStore().create(resourceName, server, "realm-management");
+
+        management.clients().allowRegexRedirectUriPermission(client).addAssociatedPolicy(clientPolicy);
+        management.clients().allowRegexRedirectUriPermission(client).addResource(resource);
+        
+    }
+    
+    
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/ResetPasswordTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/ResetPasswordTest.java
@@ -1277,7 +1277,7 @@ public class ResetPasswordTest extends AbstractTestRealmKeycloakTest {
         return redirectUris.stream()
                 .map(uri -> isRootUrlValid && uri.startsWith("/") ? rootUrl + uri : uri)
                 .map(uri -> uri.startsWith("/") ? OAuthClient.AUTH_SERVER_ROOT + uri : uri)
-                .map(RedirectUtils::validateRedirectUriWildcard)
+                .map(uri -> RedirectUtils.validateRedirectUriWildcard(uri, false))
                 .findFirst()
                 .orElse(null);
     }

--- a/themes/src/main/resources/theme/base/admin/messages/admin-messages_en.properties
+++ b/themes/src/main/resources/theme/base/admin/messages/admin-messages_en.properties
@@ -1857,6 +1857,7 @@ map-roles-authz-users-scope-description=Policies that decide if administrator ca
 user-impersonated-authz-users-scope-description=Policies that decide which users can be impersonated.  These policies are applied to the user being impersonated.
 manage-membership-authz-group-scope-description=Policies that decide if an administrator can add or remove users from this group
 manage-members-authz-group-scope-description=Policies that decide if an administrator can manage the members of this group
+allow-regex-redirect-uri-authz-client-scope-description=Policies that decide if a client can configure regex as valid redirect uris
 
 # KEYCLOAK-6771 Certificate Bound Token
 # https://tools.ietf.org/html/draft-ietf-oauth-mtls-08#section-3


### PR DESCRIPTION
Add possibility to configure a client to allow to set and use regex for the valid redirect uris.


Documentation-PR: https://github.com/keycloak/keycloak-documentation/pull/1215