### PR TITLE
KEYCLOAK-18534 Fix js tests timeout failure

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/javascript/JavascriptAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/javascript/JavascriptAdapterTest.java
@@ -832,7 +832,7 @@ public class JavascriptAdapterTest extends AbstractJavascriptTest {
                 .add("realm", "invalid-realm-name")
                 .add("clientId", CLIENT_ID);
 
-        JSObjectBuilder initOptions = defaultArguments();
+        JSObjectBuilder initOptions = defaultArguments().add("messageReceiveTimeout", 5000);
 
         testExecutor
                 .configure(keycloakConfig)
@@ -850,7 +850,7 @@ public class JavascriptAdapterTest extends AbstractJavascriptTest {
                 .add("realm", REALM_NAME)
                 .add("clientId", CLIENT_ID);
 
-        JSObjectBuilder initOptions = defaultArguments();
+        JSObjectBuilder initOptions = defaultArguments().add("messageReceiveTimeout", 5000);
 
         testExecutor
                 .configure(keycloakConfig)


### PR DESCRIPTION
The failures were caused by following:
1. https://github.com/keycloak/keycloak/pull/8161 added a timeouts for waiting for a message from Keycloak server which default value was set to 10s
2. There were also tests added that are checking whether the adapter reports errors
3. The problem is, that there is also a drone timeout for JS scripts to be finished in 10s

This means that the failure was caused because the adapter didn't report the error within the drone timeout. This can be fixed in two ways, either we can increase the drone timeout to more than 10s, or we can decrease the adapter timeout waiting for messages from Keycloak.

Disadvantage of the first approach is that tests takes little longer, however we are testing with default values. The disadvantage of the later is that we are not testing the default values. 

I consider the later a better option but I can change this PR to the first approach if you think it is better.