### PR TITLE
KEYCLOAK-18500: Prevent security flaw using passwordless authentication

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/WebAuthnPasswordlessAuthenticatorFactory.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/WebAuthnPasswordlessAuthenticatorFactory.java
@@ -53,4 +53,10 @@ public class WebAuthnPasswordlessAuthenticatorFactory extends WebAuthnAuthentica
     public String getId() {
         return PROVIDER_ID;
     }
+
+    @Override
+    public boolean isUserSetupAllowed() {
+        return false;
+    }
+
 }


### PR DESCRIPTION
If you register without an password or delete your last token your account can be hijacked. This is can be done by simply trying to login in that moment where the account is without a token. You get the "normal" registration dialog and can capture the complete account.
