### PR TITLE
KEYCLOAK-18551 Fixed the adapter to use dynamic openid-configuration.

### DIFF
--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/BasicAuthRequestAuthenticator.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/BasicAuthRequestAuthenticator.java
@@ -89,9 +89,7 @@ public class BasicAuthRequestAuthenticator extends BearerTokenRequestAuthenticat
     	AccessTokenResponse tokenResponse=null;
     	HttpClient client = deployment.getClient();
 
-        HttpPost post = new HttpPost(
-                KeycloakUriBuilder.fromUri(deployment.getAuthServerBaseUrl())
-                .path(ServiceUrlConstants.TOKEN_PATH).build(deployment.getRealm()));
+        HttpPost post = new HttpPost(deployment.getTokenUrl());
         java.util.List <NameValuePair> formparams = new java.util.ArrayList <NameValuePair>();
         formparams.add(new BasicNameValuePair(OAuth2Constants.GRANT_TYPE, OAuth2Constants.PASSWORD));
         formparams.add(new BasicNameValuePair("username", username));

--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/jaas/DirectAccessGrantsLoginModule.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/jaas/DirectAccessGrantsLoginModule.java
@@ -86,9 +86,7 @@ public class DirectAccessGrantsLoginModule extends AbstractKeycloakLoginModule {
 
     protected Auth directGrantAuth(String username, String password) throws IOException, VerificationException {
         String authServerBaseUrl = deployment.getAuthServerBaseUrl();
-        URI directGrantUri = KeycloakUriBuilder.fromUri(authServerBaseUrl).path(ServiceUrlConstants.TOKEN_PATH).build(deployment.getRealm());
-        HttpPost post = new HttpPost(directGrantUri);
-
+        HttpPost post = new HttpPost(deployment.getTokenUrl());
         List<NameValuePair> formparams = new ArrayList<NameValuePair>();
         formparams.add(new BasicNameValuePair(OAuth2Constants.GRANT_TYPE, OAuth2Constants.PASSWORD));
         formparams.add(new BasicNameValuePair("username", username));


### PR DESCRIPTION
Fixed the adapter to use dynamic openid-configuration instead of building the tokenUrl by itself.

Description of bug:
https://issues.redhat.com/browse/KEYCLOAK-18551
