### PR TITLE
[KEYCLOAK-18559] Fix SAML adapters so they allow unescaped characters…

### DIFF
--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/OAuthRequestAuthenticator.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/OAuthRequestAuthenticator.java
@@ -151,7 +151,7 @@ public class OAuthRequestAuthenticator {
             }
             KeycloakUriBuilder secureUrl = KeycloakUriBuilder.fromUri(url).scheme("https").port(-1);
             if (port != 443) secureUrl.port(port);
-            url = secureUrl.build().toString();
+            url = secureUrl.buildAsString();
         }
 
         String loginHint = getQueryParamValue("login_hint");
@@ -197,7 +197,7 @@ public class OAuthRequestAuthenticator {
         scope = TokenUtil.attachOIDCScope(scope);
         redirectUriBuilder.queryParam(OAuth2Constants.SCOPE, scope);
 
-        return redirectUriBuilder.build().toString();
+        return redirectUriBuilder.buildAsString();
     }
 
     protected int sslRedirectPort() {
@@ -385,7 +385,7 @@ public class OAuthRequestAuthenticator {
                 .replaceQueryParam(OAuth2Constants.CODE, null)
                 .replaceQueryParam(OAuth2Constants.STATE, null)
                 .replaceQueryParam(OAuth2Constants.SESSION_STATE, null);
-        return builder.build().toString();
+        return builder.buildAsString();
     }
     
     private String rewrittenRedirectUri(String originalUri) {

--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/ServerRequest.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/ServerRequest.java
@@ -292,7 +292,7 @@ public class ServerRequest {
         KeycloakUriBuilder builder = KeycloakUriBuilder.fromUri(uri)
                 .replaceQueryParam(OAuth2Constants.CODE, null)
                 .replaceQueryParam(OAuth2Constants.STATE, null);
-        return builder.build().toString();
+        return builder.buildAsString();
     }
 
 

--- a/adapters/saml/undertow/src/main/java/org/keycloak/adapters/saml/undertow/ServletSamlSessionStore.java
+++ b/adapters/saml/undertow/src/main/java/org/keycloak/adapters/saml/undertow/ServletSamlSessionStore.java
@@ -230,7 +230,7 @@ public class ServletSamlSessionStore implements SamlSessionStore {
         KeycloakUriBuilder uriBuilder = KeycloakUriBuilder.fromUri(exchange.getRequestURI())
                 .replaceQuery(exchange.getQueryString());
         if (!exchange.isHostIncludedInRequestURI()) uriBuilder.scheme(exchange.getRequestScheme()).host(exchange.getHostAndPort());
-        String uri = uriBuilder.build().toString();
+        String uri = uriBuilder.buildAsString();
 
         session.setAttribute(SAML_REDIRECT_URI, uri);
 

--- a/adapters/saml/wildfly-elytron/src/main/java/org/keycloak/adapters/saml/elytron/ElytronSamlSessionStore.java
+++ b/adapters/saml/wildfly-elytron/src/main/java/org/keycloak/adapters/saml/elytron/ElytronSamlSessionStore.java
@@ -212,11 +212,7 @@ public class ElytronSamlSessionStore implements SamlSessionStore, ElytronTokeSto
         if (!scope.exists()) {
             scope.create();
         }
-
-        KeycloakUriBuilder uriBuilder = KeycloakUriBuilder.fromUri(exchange.getURI()).replaceQuery(exchange.getURI().getQuery());
-        String uri = uriBuilder.build().toString();
-
-        scope.setAttachment(SAML_REDIRECT_URI, uri);
+        scope.setAttachment(SAML_REDIRECT_URI, exchange.getRequest().getURI());
     }
 
     @Override

--- a/adapters/spi/undertow-adapter-spi/src/main/java/org/keycloak/adapters/undertow/UndertowHttpFacade.java
+++ b/adapters/spi/undertow-adapter-spi/src/main/java/org/keycloak/adapters/undertow/UndertowHttpFacade.java
@@ -96,7 +96,7 @@ public class UndertowHttpFacade implements HttpFacade {
             KeycloakUriBuilder uriBuilder = KeycloakUriBuilder.fromUri(exchange.getRequestURI())
                     .replaceQuery(exchange.getQueryString());
             if (!exchange.isHostIncludedInRequestURI()) uriBuilder.scheme(exchange.getRequestScheme()).host(exchange.getHostAndPort());
-            return uriBuilder.build().toString();
+            return uriBuilder.buildAsString();
         }
 
         @Override

--- a/common/src/main/java/org/keycloak/common/util/KeycloakUriBuilder.java
+++ b/common/src/main/java/org/keycloak/common/util/KeycloakUriBuilder.java
@@ -571,28 +571,33 @@ public class KeycloakUriBuilder {
         return buildFromValues(true, false, values);
     }
 
+    public String buildAsString(Object... values) throws IllegalArgumentException {
+        if (values == null) throw new IllegalArgumentException("values parameter is null");
+        return buildFromValuesAsString(true, false, values);
+    }
+
     protected URI buildFromValues(boolean encodeSlash, boolean encoded, Object... values) {
+        String buf = buildFromValuesAsString(encodeSlash, encoded, values);
+        try {
+            return new URI(buf);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to create URI: " + buf, e);
+        }
+    }
+
+    protected String buildFromValuesAsString(boolean encodeSlash, boolean encoded, Object... values) {
         List<String> params = getPathParamNamesInDeclarationOrder();
         if (values.length < params.size())
             throw new IllegalArgumentException("You did not supply enough values to fill path parameters");
 
         Map<String, Object> pathParams = new HashMap<String, Object>();
-
-
         for (int i = 0; i < params.size(); i++) {
             String pathParam = params.get(i);
             Object val = values[i];
             if (val == null) throw new IllegalArgumentException("A value was null");
             pathParams.put(pathParam, val.toString());
         }
-        String buf = null;
-        try {
-            buf = buildString(pathParams, encoded, false, encodeSlash);
-            return new URI(buf);
-            //return URI.create(buf);
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to create URI: " + buf, e);
-        }
+        return buildString(pathParams, encoded, false, encodeSlash);
     }
 
     public KeycloakUriBuilder matrixParam(String name, Object... values) throws IllegalArgumentException {

--- a/core/src/main/java/org/keycloak/AbstractOAuthClient.java
+++ b/core/src/main/java/org/keycloak/AbstractOAuthClient.java
@@ -130,7 +130,7 @@ public class AbstractOAuthClient {
         KeycloakUriBuilder builder = KeycloakUriBuilder.fromUri(uri)
                 .replaceQueryParam(OAuth2Constants.CODE, null)
                 .replaceQueryParam(OAuth2Constants.STATE, null);
-        return builder.build().toString();
+        return builder.buildAsString();
     }
 
 }


### PR DESCRIPTION
… in URIs

- Makes adapters bahavior consistent with containers that allow unescaped characters in URIs

As discussed with @pdrozd this PR doesn't include automated tests as all libraries used in the testsuite (and others I've experimented with) to send HTTP requests automatically encode the URLs, which makes it impossible to send an unencoded URL to the app server. So testing for this PR was done manually by using curl to send HTTP GET requests to the app server without encoding the test URLs.

When using WildFly as the app server, one has to first enable the 'allow-unescaped-characters-in-url' propery in the undertow subsystem:

    /subsystem=undertow/server=default-server/http-listener=default:write-attribute(name=allow-unescaped-characters-in-url,value=true)

Then, with the SAML adapter correctly installed and a sample app, send a request with unencoded curly braces. Example:

curl -v -L -g 'http://localhost:8280/employee2/x?jsonp={"firstName":"a","lastName":"1123"}'

Without this fix, the request above fails with a java.net.URISyntaxException: Illegal character in query at index 54: http://localhost:8080/test/TestCase02942127.jsp?jsonp={%22firstName%22:%22a%22,%22lastName%22:%221123%22}

When the fix is in place, the URL is correctly handled by the adapter code. Same thing happens when Undertow is used as the app server.

In Undertow the property that allows unencoded URLs can be set when booting the server. For example:

        UndertowJaxrsServer undertow = new UndertowJaxrsServer();
        undertow.start(Undertow.builder()
            .addHttpListener(configuration.getBindHttpPort(), configuration.getBindAddress())
            .setServerOption(UndertowOptions.ALLOW_UNESCAPED_CHARACTERS_IN_URL, Boolean.TRUE));

Then after setting up the adapter and deploying the sample app one can test the issue using the same curl command as shown above to see the exception being thrown when the fix is not applied.

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
