### PR TITLE
KEYCLOAK-18560 NoClassDefFoundError: JWKSUtils 

### DIFF
--- a/core/src/main/java/org/keycloak/util/JWKSUtils.java
+++ b/core/src/main/java/org/keycloak/util/JWKSUtils.java
@@ -17,7 +17,6 @@
 
 package org.keycloak.util;
 
-import org.jboss.logging.Logger;
 import org.keycloak.crypto.KeyUse;
 import org.keycloak.crypto.KeyWrapper;
 import org.keycloak.jose.jwk.JSONWebKeySet;
@@ -27,13 +26,15 @@ import org.keycloak.jose.jwk.JWKParser;
 import java.security.PublicKey;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
  */
 public class JWKSUtils {
 
-    private static final Logger logger = Logger.getLogger(JWKSUtils.class);
+    private static final Logger logger = Logger.getLogger(JWKSUtils.class.getName());
 
     public static Map<String, PublicKey> getKeysForUse(JSONWebKeySet keySet, JWK.Use requestedUse) {
         Map<String, PublicKey> result = new HashMap<>();
@@ -41,7 +42,7 @@ public class JWKSUtils {
         for (JWK jwk : keySet.getKeys()) {
             JWKParser parser = JWKParser.create(jwk);
             if (jwk.getPublicKeyUse() == null) {
-                logger.debugf("Ignoring JWK key '%s'. Missing required field 'use'.", jwk.getKeyId());
+                logger.log(Level.FINE, "Ignoring JWK key '%s'. Missing required field 'use'.", jwk.getKeyId());
             } else if (requestedUse.asString().equals(jwk.getPublicKeyUse()) && parser.isKeyTypeSupported(jwk.getKeyType())) {
                 result.put(jwk.getKeyId(), parser.toPublicKey());
             }
@@ -55,7 +56,7 @@ public class JWKSUtils {
         for (JWK jwk : keySet.getKeys()) {
             JWKParser parser = JWKParser.create(jwk);
             if (jwk.getPublicKeyUse() == null) {
-                logger.debugf("Ignoring JWK key '%s'. Missing required field 'use'.", jwk.getKeyId());
+                logger.log(Level.FINE, "Ignoring JWK key '%s'. Missing required field 'use'.", jwk.getKeyId());
             } else if (requestedUse.asString().equals(jwk.getPublicKeyUse()) && parser.isKeyTypeSupported(jwk.getKeyType())) {
                 KeyWrapper keyWrapper = new KeyWrapper();
                 keyWrapper.setKid(jwk.getKeyId());
@@ -90,7 +91,7 @@ public class JWKSUtils {
         for (JWK jwk : keySet.getKeys()) {
             JWKParser parser = JWKParser.create(jwk);
             if (jwk.getPublicKeyUse() == null) {
-                logger.debugf("Ignoring JWK key '%s'. Missing required field 'use'.", jwk.getKeyId());
+                logger.log(Level.FINE, "Ignoring JWK key '%s'. Missing required field 'use'.", jwk.getKeyId());
             } else if (requestedUse.asString().equals(parser.getJwk().getPublicKeyUse()) && parser.isKeyTypeSupported(jwk.getKeyType())) {
                 return jwk;
             }


### PR DESCRIPTION
Could not initialize class org.keycloak.util.JWKSUtils

JIRA: [KEYCLOAK-18560](https://issues.redhat.com/browse/KEYCLOAK-18560)
The pipeline tests are working again due to including this PR into that. 
Please see https://master-jenkins.com/job/universal-test-pipeline-adapters/497/console

IMHO, in the _core_ module there should be generic dependencies instead of more specific like _JBoss_ below. For the adapters, the JBoss logging dependency is not found. It's possible to strictly include the dependency, but I'd say this is a better approach. 
I'm not 100% sure about the equality of those log levels. 
@mposolda WDYT?
