### PR TITLE
KEYCLOAK-18527 IdentityProviderTest failure

### DIFF
--- a/testsuite/integration-arquillian/tests/other/console/src/test/java/org/keycloak/testsuite/console/idp/IdentityProviderTest.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/test/java/org/keycloak/testsuite/console/idp/IdentityProviderTest.java
@@ -176,7 +176,7 @@ public class IdentityProviderTest extends AbstractConsoleTest {
         assertThat(multiStringPropertyForm.getItem(1), is("third"));
 
         createIdentityProviderMapperPage.form().save();
-        assertAlertSuccess();
+        refreshPageAndWaitForLoad();
 
         // add empty item
         assertThat(multiStringPropertyForm.getItems().size(), is(3));


### PR DESCRIPTION
JIRA: [KEYCLOAK-18527](https://issues.redhat.com/browse/KEYCLOAK-18527)

For verifying the functionality is sufficient to only reload page instead of catching alert box, which is sometimes unstable in pipeline. 