### PR TITLE
KEYCLOAK-18552 - Grouping of attributes in user profile (step 1)

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/userprofile/AttributeGroupMetadata.java
+++ b/server-spi-private/src/main/java/org/keycloak/userprofile/AttributeGroupMetadata.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.userprofile;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Configuration of the attribute group.
+ *
+ * @author <a href="joerg.matysiak@bosch.io">Jörg Matysiak</a>
+ */
+public class AttributeGroupMetadata {
+
+    private String name;
+    private String displayHeader;
+    private String displayDescription;
+    private Map<String, Object> annotations;
+
+    public AttributeGroupMetadata(String name, String displayHeader, String displayDescription, Map<String, Object> annotations) {
+        this.name = name;
+        this.displayHeader = displayHeader;
+        this.displayDescription = displayDescription;
+        if (annotations != null) {
+            addAnnotations(annotations);
+        }
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public AttributeGroupMetadata setName(String name) {
+        this.name = name != null ? name.trim() : null;
+        return this;
+    }
+
+    public String getDisplayHeader() {
+        return displayHeader;
+    }
+
+    public AttributeGroupMetadata setDisplayHeader(String displayHeader) {
+        this.displayHeader = displayHeader;
+        return this;
+    }
+
+    public String getDisplayDescription() {
+        return displayDescription;
+    }
+
+    public AttributeGroupMetadata setDisplayDescription(String displayDescription) {
+        this.displayDescription = displayDescription;
+        return this;
+    }
+
+    public Map<String, Object> getAnnotations() {
+        return annotations;
+    }
+
+    public AttributeGroupMetadata addAnnotations(Map<String, Object> annotations) {
+        if(annotations != null) {
+            if(this.annotations == null) {
+                this.annotations = new HashMap<>();
+            }
+
+            this.annotations.putAll(annotations);
+        }
+        return this;
+    }
+
+    public AttributeGroupMetadata clone() {
+        return new AttributeGroupMetadata(name, displayHeader, displayDescription, annotations);
+    }
+}

--- a/server-spi-private/src/main/java/org/keycloak/userprofile/AttributeMetadata.java
+++ b/server-spi-private/src/main/java/org/keycloak/userprofile/AttributeMetadata.java
@@ -43,6 +43,7 @@ public final class AttributeMetadata {
 
     private final String attributeName;
     private String attributeDisplayName;
+    private AttributeGroupMetadata attributeGroupMetadata;
     private final Predicate<AttributeContext> selector;
     private final Predicate<AttributeContext> writeAllowed;
     /** Predicate to decide if attribute is required, it is handled as required if predicate is null */
@@ -112,6 +113,10 @@ public final class AttributeMetadata {
         return this;
     }
 
+    public AttributeGroupMetadata getAttributeGroupMetadata() {
+        return attributeGroupMetadata;
+    }
+    
     public boolean isSelected(AttributeContext context) {
         return selector.test(context);
     }
@@ -184,6 +189,9 @@ public final class AttributeMetadata {
             cloned.addAnnotations(annotations);
         }
         cloned.setAttributeDisplayName(attributeDisplayName);
+        if (attributeGroupMetadata != null) {
+            cloned.setAttributeGroupMetadata(attributeGroupMetadata.clone());
+        }
         return cloned;
     }
     
@@ -196,6 +204,12 @@ public final class AttributeMetadata {
     public AttributeMetadata setAttributeDisplayName(String attributeDisplayName) {
         if(attributeDisplayName != null)
             this.attributeDisplayName = attributeDisplayName;
+        return this;
+    }
+
+    public AttributeMetadata setAttributeGroupMetadata(AttributeGroupMetadata attributeGroupMetadata) {
+        if(attributeGroupMetadata != null)
+            this.attributeGroupMetadata = attributeGroupMetadata;
         return this;
     }
 

--- a/services/src/main/java/org/keycloak/forms/login/freemarker/model/AbstractUserProfileBean.java
+++ b/services/src/main/java/org/keycloak/forms/login/freemarker/model/AbstractUserProfileBean.java
@@ -44,7 +44,7 @@ public abstract class AbstractUserProfileBean {
     }
 
     /**
-     * Create UserProfile instance of the relevant type. Is called from {@link #init(KeycloakSession)}.
+     * Create UserProfile instance of the relevant type. Is called from {@link #init(KeycloakSession, boolean)}.
      * 
      * @param provider to create UserProfile from
      * @return user profile instance
@@ -156,6 +156,36 @@ public abstract class AbstractUserProfileBean {
                 return Collections.emptyMap();
             }
             return metadata.getValidators().stream().collect(Collectors.toMap(AttributeValidatorMetadata::getValidatorId, AttributeValidatorMetadata::getValidatorConfig));
+        }
+
+        public String getGroup() {
+            if (metadata.getAttributeGroupMetadata() != null) {
+                return metadata.getAttributeGroupMetadata().getName();
+            }
+            return null;
+        }
+
+        public String getGroupDisplayHeader() {
+            if (metadata.getAttributeGroupMetadata() != null) {
+                return metadata.getAttributeGroupMetadata().getDisplayHeader();
+            }
+            return null;
+        }
+
+        public String getGroupDisplayDescription() {
+            if (metadata.getAttributeGroupMetadata() != null) {
+                return metadata.getAttributeGroupMetadata().getDisplayDescription();
+            }
+            return null;
+        }
+
+        public Map<String, Object> getGroupAnnotations() {
+
+            if ((metadata.getAttributeGroupMetadata() == null) || (metadata.getAttributeGroupMetadata().getAnnotations() == null)) {
+                return Collections.emptyMap();
+            }
+            
+            return metadata.getAttributeGroupMetadata().getAnnotations();
         }
 
         @Override

--- a/services/src/main/java/org/keycloak/userprofile/AbstractUserProfileProvider.java
+++ b/services/src/main/java/org/keycloak/userprofile/AbstractUserProfileProvider.java
@@ -213,7 +213,7 @@ public abstract class AbstractUserProfileProvider<U extends UserProfileProvider>
      * Sub-types can override this method to customize how contextual profile metadata is configured at runtime.
      *
      * @param metadata the profile metadata
-     * @param metadata the current session
+     * @param session the current session
      * @return the metadata
      */
     protected UserProfileMetadata configureUserProfile(UserProfileMetadata metadata, KeycloakSession session) {

--- a/services/src/main/java/org/keycloak/userprofile/config/UPAttribute.java
+++ b/services/src/main/java/org/keycloak/userprofile/config/UPAttribute.java
@@ -38,6 +38,7 @@ public class UPAttribute {
     private UPAttributePermissions permissions;
     /** null means it is always selected */
     private UPAttributeSelector selector;
+    private String group;
 
     public String getName() {
         return name;
@@ -102,8 +103,16 @@ public class UPAttribute {
         this.displayName = displayName;
     }
 
+    public String getGroup() {
+        return group;
+    }
+
+    public void setGroup(String group) {
+        this.group = group != null ? group.trim() : null;
+    }
+
     @Override
     public String toString() {
-        return "UPAttribute [name=" + name + ", displayName=" + displayName + ", permissions=" + permissions + ", selector=" + selector + ", required=" + required + ", validations=" + validations + ", annotations=" + annotations + "]";
+        return "UPAttribute [name=" + name + ", displayName=" + displayName + ", permissions=" + permissions + ", selector=" + selector + ", required=" + required + ", validations=" + validations + ", annotations=" + annotations + ", group=" + group + "]";
     }
 }

--- a/services/src/main/java/org/keycloak/userprofile/config/UPConfig.java
+++ b/services/src/main/java/org/keycloak/userprofile/config/UPConfig.java
@@ -17,6 +17,7 @@
 package org.keycloak.userprofile.config;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -28,6 +29,7 @@ import java.util.List;
 public class UPConfig {
 
     private List<UPAttribute> attributes;
+    private List<UPGroup> groups;
 
     public List<UPAttribute> getAttributes() {
         return attributes;
@@ -47,8 +49,29 @@ public class UPConfig {
         return this;
     }
 
+    public List<UPGroup> getGroups() {
+        if (groups == null) {
+            return Collections.emptyList();
+        }
+        return groups;
+    }
+
+    public void setGroups(List<UPGroup> groups) {
+        this.groups = groups;
+    }
+
+    public UPConfig addGroup(UPGroup group) {
+        if (groups == null) {
+            groups = new ArrayList<>();
+        }
+
+        groups.add(group);
+
+        return this;
+    }
+
     @Override
     public String toString() {
-        return "UPConfig [attributes=" + attributes + "]";
+        return "UPConfig [attributes=" + attributes + ", groups=" + groups + "]";
     }
 }

--- a/services/src/main/java/org/keycloak/userprofile/config/UPGroup.java
+++ b/services/src/main/java/org/keycloak/userprofile/config/UPGroup.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.userprofile.config;
+
+import java.util.Map;
+
+/**
+ * Configuration of the attribute group.
+ *
+ * @author <a href="joerg.matysiak@bosch.io">Jörg Matysiak</a>
+ */
+public class UPGroup {
+
+    private String name;
+    private String displayHeader;
+    private String displayDescription;
+    private Map<String, Object> annotations;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name != null ? name.trim() : null;
+    }
+
+    public String getDisplayHeader() {
+        return displayHeader;
+    }
+
+    public void setDisplayHeader(String displayHeader) {
+        this.displayHeader = displayHeader;
+    }
+
+    public String getDisplayDescription() {
+        return displayDescription;
+    }
+
+    public void setDisplayDescription(String displayDescription) {
+        this.displayDescription = displayDescription;
+    }
+
+    public Map<String, Object> getAnnotations() {
+        return annotations;
+    }
+
+    public void setAnnotations(Map<String, Object> annotations) {
+        this.annotations = annotations;
+    }
+}

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/RequiredActionUpdateProfileWithUserProfileTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/RequiredActionUpdateProfileWithUserProfileTest.java
@@ -112,7 +112,71 @@ public class RequiredActionUpdateProfileWithUserProfileTest extends RequiredActi
         Assert.assertEquals("Department",updateProfilePage.getLabelForField("department"));
         
     }
-    
+
+    @Test
+    public void testAttributeGrouping() {
+
+        setUserProfileConfiguration("{\"attributes\": ["
+                + "{\"name\": \"lastName\"," + VerifyProfileTest.PERMISSIONS_ALL + "},"
+                + "{\"name\": \"username\", " + VerifyProfileTest.PERMISSIONS_ALL + "},"
+                + "{\"name\": \"firstName\"," + VerifyProfileTest.PERMISSIONS_ALL + ", \"required\": {}},"
+                + "{\"name\": \"department\", " + VerifyProfileTest.PERMISSIONS_ALL + ", \"required\":{}, \"group\": \"company\"},"
+                + "{\"name\": \"email\", " + VerifyProfileTest.PERMISSIONS_ALL + ", \"group\": \"contact\"}"
+                + "], \"groups\": ["
+                + "{\"name\": \"company\", \"displayDescription\": \"Company field desc\" },"
+                + "{\"name\": \"contact\" }"
+                + "]}");
+
+        loginPage.open();
+        loginPage.login(USERNAME1, PASSWORD);
+
+        updateProfilePage.assertCurrent();
+        String htmlFormId="kc-update-profile-form";
+
+        //assert fields and groups location in form
+        Assert.assertTrue(
+                driver.findElement(
+                        By.cssSelector("form#"+htmlFormId+" > div:nth-child(1) > div:nth-child(2) > input#lastName")
+                ).isDisplayed()
+        );
+        Assert.assertTrue(
+                driver.findElement(
+                        By.cssSelector("form#"+htmlFormId+" > div:nth-child(2) > div:nth-child(2) > input#username")
+                ).isDisplayed()
+        );
+        Assert.assertTrue(
+                driver.findElement(
+                        By.cssSelector("form#"+htmlFormId+" > div:nth-child(3) > div:nth-child(2) > input#firstName")
+                ).isDisplayed()
+        );
+        Assert.assertTrue(
+                driver.findElement(
+                        By.cssSelector("form#"+htmlFormId+" > div:nth-child(4) > div:nth-child(1) > label#header-company")
+                ).isDisplayed()
+        );
+        Assert.assertTrue(
+                driver.findElement(
+                        By.cssSelector("form#"+htmlFormId+" > div:nth-child(4) > div:nth-child(2) > label#description-company")
+                ).isDisplayed()
+        );
+        Assert.assertTrue(
+                driver.findElement(
+                        By.cssSelector("form#"+htmlFormId+" > div:nth-child(5) > div:nth-child(2) > input#department")
+                ).isDisplayed()
+        );
+        Assert.assertTrue(
+                driver.findElement(
+                        By.cssSelector("form#"+htmlFormId+" > div:nth-child(6) > div:nth-child(1) > label#header-contact")
+                ).isDisplayed()
+        );
+        Assert.assertTrue(
+                driver.findElement(
+                        By.cssSelector("form#"+htmlFormId+" > div:nth-child(7) > div:nth-child(2) > input#email")
+                ).isDisplayed()
+        );
+    }
+
+
     @Test
     public void testAttributeGuiOrder() {
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcFirstBrokerLoginWithUserProfileTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcFirstBrokerLoginWithUserProfileTest.java
@@ -71,6 +71,74 @@ public class KcOidcFirstBrokerLoginWithUserProfileTest extends KcOidcFirstBroker
         // direct value in display name
         Assert.assertEquals("Department", updateAccountInformationPage.getLabelForField("department"));
     }
+
+    @Test
+    public void testAttributeGrouping() {
+        
+        updateExecutions(AbstractBrokerTest::enableUpdateProfileOnFirstLogin);
+
+        setUserProfileConfiguration("{\"attributes\": ["
+                + "{\"name\": \"lastName\"," + VerifyProfileTest.PERMISSIONS_ALL + "},"
+                + "{\"name\": \"username\", " + VerifyProfileTest.PERMISSIONS_ALL + "},"
+                + "{\"name\": \"firstName\"," + VerifyProfileTest.PERMISSIONS_ALL + ", \"required\": {}},"
+                + "{\"name\": \"department\", " + VerifyProfileTest.PERMISSIONS_ALL + ", \"required\":{}, \"group\": \"company\"},"
+                + "{\"name\": \"email\", " + VerifyProfileTest.PERMISSIONS_ALL + ", \"group\": \"contact\"}"
+                + "], \"groups\": ["
+                + "{\"name\": \"company\", \"displayDescription\": \"Company field desc\" },"
+                + "{\"name\": \"contact\" }"
+                + "]}");
+
+        driver.navigate().to(getAccountUrl(getConsumerRoot(), bc.consumerRealmName()));
+        logInWithBroker(bc);
+
+        waitForPage(driver, "update account information", false);
+        updateAccountInformationPage.assertCurrent();
+
+        //assert fields location in form
+        String htmlFormId = "kc-idp-review-profile-form";
+        
+        //assert fields and groups location in form
+        Assert.assertTrue(
+                driver.findElement(
+                        By.cssSelector("form#"+htmlFormId+" > div:nth-child(1) > div:nth-child(2) > input#lastName")
+                ).isDisplayed()
+        );
+        Assert.assertTrue(
+                driver.findElement(
+                        By.cssSelector("form#"+htmlFormId+" > div:nth-child(2) > div:nth-child(2) > input#username")
+                ).isDisplayed()
+        );
+        Assert.assertTrue(
+                driver.findElement(
+                        By.cssSelector("form#"+htmlFormId+" > div:nth-child(3) > div:nth-child(2) > input#firstName")
+                ).isDisplayed()
+        );
+        Assert.assertTrue(
+                driver.findElement(
+                        By.cssSelector("form#"+htmlFormId+" > div:nth-child(4) > div:nth-child(1) > label#header-company")
+                ).isDisplayed()
+        );
+        Assert.assertTrue(
+                driver.findElement(
+                        By.cssSelector("form#"+htmlFormId+" > div:nth-child(4) > div:nth-child(2) > label#description-company")
+                ).isDisplayed()
+        );
+        Assert.assertTrue(
+                driver.findElement(
+                        By.cssSelector("form#"+htmlFormId+" > div:nth-child(5) > div:nth-child(2) > input#department")
+                ).isDisplayed()
+        );
+        Assert.assertTrue(
+                driver.findElement(
+                        By.cssSelector("form#"+htmlFormId+" > div:nth-child(6) > div:nth-child(1) > label#header-contact")
+                ).isDisplayed()
+        );
+        Assert.assertTrue(
+                driver.findElement(
+                        By.cssSelector("form#"+htmlFormId+" > div:nth-child(7) > div:nth-child(2) > input#email")
+                ).isDisplayed()
+        );
+    }
     
     @Test
     public void testAttributeGuiOrder() {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RegisterWithUserProfileTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RegisterWithUserProfileTest.java
@@ -295,6 +295,79 @@ public class RegisterWithUserProfileTest extends RegisterTest {
     }
 
     @Test
+    public void testAttributeGrouping() {
+
+        setUserProfileConfiguration("{\"attributes\": ["
+                + "{\"name\": \"lastName\"," + VerifyProfileTest.PERMISSIONS_ALL + "},"
+                + "{\"name\": \"username\", " + VerifyProfileTest.PERMISSIONS_ALL + "},"
+                + "{\"name\": \"firstName\"," + VerifyProfileTest.PERMISSIONS_ALL + ", \"required\": {}},"
+                + "{\"name\": \"department\", " + VerifyProfileTest.PERMISSIONS_ALL + ", \"required\":{}, \"group\": \"company\"},"
+                + "{\"name\": \"email\", " + VerifyProfileTest.PERMISSIONS_ALL + ", \"group\": \"contact\"}"
+                + "], \"groups\": ["
+                + "{\"name\": \"company\", \"displayDescription\": \"Company field desc\" },"
+                + "{\"name\": \"contact\" }"
+                + "]}");
+
+        loginPage.open();
+        loginPage.clickRegister();
+
+        registerPage.assertCurrent();
+        String htmlFormId="kc-register-form";
+        
+        //assert fields and groups location in form
+        Assert.assertTrue(
+                driver.findElement(
+                        By.cssSelector("form#"+htmlFormId+" > div:nth-child(1) > div:nth-child(2) > input#lastName")
+                ).isDisplayed()
+        );
+        Assert.assertTrue(
+                driver.findElement(
+                        By.cssSelector("form#"+htmlFormId+" > div:nth-child(2) > div:nth-child(2) > input#username")
+                ).isDisplayed()
+        );
+        Assert.assertTrue(
+                driver.findElement(
+                        By.cssSelector("form#kc-register-form > div:nth-child(3) > div:nth-child(2) > input#password")
+                ).isDisplayed()
+        );
+        Assert.assertTrue(
+                driver.findElement(
+                        By.cssSelector("form#"+htmlFormId+" > div:nth-child(4) > div:nth-child(2) > input#password-confirm")
+                ).isDisplayed()
+        );
+        Assert.assertTrue(
+                driver.findElement(
+                        By.cssSelector("form#"+htmlFormId+" > div:nth-child(5) > div:nth-child(2) > input#firstName")
+                ).isDisplayed()
+        );
+        Assert.assertTrue(
+                driver.findElement(
+                        By.cssSelector("form#"+htmlFormId+" > div:nth-child(6) > div:nth-child(1) > label#header-company")
+                ).isDisplayed()
+        );
+        Assert.assertTrue(
+                driver.findElement(
+                        By.cssSelector("form#"+htmlFormId+" > div:nth-child(6) > div:nth-child(2) > label#description-company")
+                ).isDisplayed()
+        );
+        Assert.assertTrue(
+                driver.findElement(
+                        By.cssSelector("form#"+htmlFormId+" > div:nth-child(7) > div:nth-child(2) > input#department")
+                ).isDisplayed()
+        );
+        Assert.assertTrue(
+                driver.findElement(
+                        By.cssSelector("form#"+htmlFormId+" > div:nth-child(8) > div:nth-child(1) > label#header-contact")
+                ).isDisplayed()
+        );
+        Assert.assertTrue(
+                driver.findElement(
+                        By.cssSelector("form#"+htmlFormId+" > div:nth-child(9) > div:nth-child(2) > input#email")
+                ).isDisplayed()
+        );
+    }
+
+    @Test
     public void testRegisterUserSuccess_requiredReadOnlyAttributeNotRenderedAndNotBlockingRegistration() {
 
         setUserProfileConfiguration("{\"attributes\": [" 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/VerifyProfileTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/VerifyProfileTest.java
@@ -181,6 +181,72 @@ public class VerifyProfileTest extends AbstractTestRealmKeycloakTest {
     }
     
     @Test
+    public void testAttributeGrouping() {
+
+        setUserProfileConfiguration(CONFIGURATION_FOR_USER_EDIT);
+        updateUser(user5Id, "ExistingFirst", "ExistingLast", null);
+
+        setUserProfileConfiguration("{\"attributes\": ["
+                + "{\"name\": \"lastName\"," + VerifyProfileTest.PERMISSIONS_ALL + "},"
+                + "{\"name\": \"username\", " + VerifyProfileTest.PERMISSIONS_ALL + "},"
+                + "{\"name\": \"firstName\"," + VerifyProfileTest.PERMISSIONS_ALL + ", \"required\": {}},"
+                + "{\"name\": \"department\", " + VerifyProfileTest.PERMISSIONS_ALL + ", \"required\":{}, \"group\": \"company\"},"
+                + "{\"name\": \"email\", " + VerifyProfileTest.PERMISSIONS_ALL + ", \"group\": \"contact\"}"
+                + "], \"groups\": ["
+                + "{\"name\": \"company\", \"displayDescription\": \"Company field desc\" },"
+                + "{\"name\": \"contact\" }"
+                + "]}");
+
+        loginPage.open();
+        loginPage.login("login-test5", "password");
+
+        verifyProfilePage.assertCurrent();
+        String htmlFormId="kc-update-profile-form";
+        
+        //assert fields and groups location in form
+        Assert.assertTrue(
+                driver.findElement(
+                        By.cssSelector("form#"+htmlFormId+" > div:nth-child(1) > div:nth-child(2) > input#lastName")
+                ).isDisplayed()
+        );
+        Assert.assertTrue(
+                driver.findElement(
+                        By.cssSelector("form#"+htmlFormId+" > div:nth-child(2) > div:nth-child(2) > input#username")
+                ).isDisplayed()
+        );
+        Assert.assertTrue(
+                driver.findElement(
+                        By.cssSelector("form#"+htmlFormId+" > div:nth-child(3) > div:nth-child(2) > input#firstName")
+                ).isDisplayed()
+        );
+        Assert.assertTrue(
+                driver.findElement(
+                        By.cssSelector("form#"+htmlFormId+" > div:nth-child(4) > div:nth-child(1) > label#header-company")
+                ).isDisplayed()
+        );
+        Assert.assertTrue(
+                driver.findElement(
+                        By.cssSelector("form#"+htmlFormId+" > div:nth-child(4) > div:nth-child(2) > label#description-company")
+                ).isDisplayed()
+        );
+        Assert.assertTrue(
+                driver.findElement(
+                        By.cssSelector("form#"+htmlFormId+" > div:nth-child(5) > div:nth-child(2) > input#department")
+                ).isDisplayed()
+        );
+        Assert.assertTrue(
+                driver.findElement(
+                        By.cssSelector("form#"+htmlFormId+" > div:nth-child(6) > div:nth-child(1) > label#header-contact")
+                ).isDisplayed()
+        );
+        Assert.assertTrue(
+                driver.findElement(
+                        By.cssSelector("form#"+htmlFormId+" > div:nth-child(7) > div:nth-child(2) > input#email")
+                ).isDisplayed()
+        );
+    }
+
+    @Test
     public void testAttributeGuiOrder() {
 
         setUserProfileConfiguration(CONFIGURATION_FOR_USER_EDIT);

--- a/testsuite/integration-arquillian/tests/base/src/test/resources/org/keycloak/testsuite/user/profile/config/test-OK.json
+++ b/testsuite/integration-arquillian/tests/base/src/test/resources/org/keycloak/testsuite/user/profile/config/test-OK.json
@@ -1,4 +1,14 @@
 {
+	"groups" : [
+		{
+			"name" : "contact",
+			"displayHeader" : "Contact information",
+			"displayDescription" : "Required to contact you in case of emergency",
+			"annotations" : {
+				"contactanno1" : "value1"
+			}
+		}
+	],
 	"attributes": [
 	    {
 		    "name":"username", 
@@ -46,6 +56,7 @@
 			"validations": 	{
 				"not-blank":{}
 			},
+			"group": "contact",
 			"required": {
                 "scopes" : ["phone-1", "phone-2"],
                 "roles" : ["user", "admin"]

--- a/themes/src/main/resources/theme/base/login/user-profile-commons.ftl
+++ b/themes/src/main/resources/theme/base/login/user-profile-commons.ftl
@@ -1,5 +1,35 @@
 <#macro userProfileFormFields>
+	<#assign currentGroup="">
+	
 	<#list profile.attributes as attribute>
+
+		<#assign groupName = attribute.group!"">
+		<#if groupName != currentGroup>
+			<#assign currentGroup=groupName>
+			<#if currentGroup != "" >
+				<div class="${properties.kcFormGroupClass!}">
+	
+					<#assign groupDisplayHeader=attribute.groupDisplayHeader!"">
+					<#if groupDisplayHeader != "">
+						<#assign groupHeaderText=advancedMsg(attribute.groupDisplayHeader)!groupName>
+					<#else>
+						<#assign groupHeaderText=groupName>
+					</#if>
+					<div class="${properties.kcContentWrapperClass!}">
+						<label id="header-${groupName}" class="${kcFormGroupHeader!}">${groupHeaderText}</label>
+					</div>
+	
+					<#assign groupDisplayDescription=attribute.groupDisplayDescription!"">
+					<#if groupDisplayDescription != "">
+						<#assign groupDescriptionText=advancedMsg(attribute.groupDisplayDescription)!"">
+						<div class="${properties.kcLabelWrapperClass!}">
+							<label id="description-${groupName}" class="${properties.kcLabelClass!}">${groupDescriptionText}</label>
+						</div>
+					</#if>
+				</div>
+			</#if>
+		</#if>
+
 		<#nested "beforeField" attribute>
 		<div class="${properties.kcFormGroupClass!}">
 		    <div class="${properties.kcLabelWrapperClass!}">

--- a/themes/src/main/resources/theme/keycloak/login/theme.properties
+++ b/themes/src/main/resources/theme/keycloak/login/theme.properties
@@ -68,6 +68,9 @@ kcSignUpClass=login-pf-signup
 
 kcInfoAreaClass=col-xs-12 col-sm-4 col-md-4 col-lg-5 details
 
+### user-profile grouping
+kcFormGroupHeader=pf-c-form__group
+
 ##### css classes for form buttons
 # main class used for all buttons
 kcButtonClass=pf-c-button


### PR DESCRIPTION
Group attributes in user profile dialog, show group header and an optional description.

Attributes are grouped by adding the annotation _group_ with the group name as value.

Group header and optional description are configured via realm localization using the keys
`userprofile.attributegroup.header.<groupname>` and `userprofile.attributegroup.description.<groupname>`.

See also [KEYCLOAK-18552](https://issues.redhat.com/browse/KEYCLOAK-18552).