### PR TITLE
KEYCLOAK-18123 Client Policy - Executor : Enforce Backchannel Authentication Request satisfying high security level

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/ciba/clientpolicy/context/BackchannelAuthenticationRequestContext.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/ciba/clientpolicy/context/BackchannelAuthenticationRequestContext.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.keycloak.services.clientpolicy.context;
+package org.keycloak.protocol.oidc.grants.ciba.clientpolicy.context;
 
 import javax.ws.rs.core.MultivaluedMap;
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/ciba/clientpolicy/executor/SecureCibaSessionEnforceExecutor.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/ciba/clientpolicy/executor/SecureCibaSessionEnforceExecutor.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.protocol.oidc.grants.ciba.clientpolicy.executor;
+
+import javax.ws.rs.core.MultivaluedMap;
+
+import org.jboss.logging.Logger;
+import org.keycloak.OAuthErrorException;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.protocol.oidc.grants.ciba.clientpolicy.context.BackchannelAuthenticationRequestContext;
+import org.keycloak.protocol.oidc.grants.ciba.endpoints.request.BackchannelAuthenticationEndpointRequest;
+import org.keycloak.representations.idm.ClientPolicyExecutorConfigurationRepresentation;
+import org.keycloak.services.clientpolicy.ClientPolicyContext;
+import org.keycloak.services.clientpolicy.ClientPolicyException;
+import org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProvider;
+
+/**
+ * @author <a href="mailto:takashi.norimatsu.ws@hitachi.com">Takashi Norimatsu</a>
+ */
+public class SecureCibaSessionEnforceExecutor implements ClientPolicyExecutorProvider<ClientPolicyExecutorConfigurationRepresentation> {
+
+    private static final Logger logger = Logger.getLogger(SecureCibaSessionEnforceExecutor.class);
+
+    private final KeycloakSession session;
+
+    public SecureCibaSessionEnforceExecutor(KeycloakSession session) {
+        this.session = session;
+    }
+
+    @Override
+    public String getProviderId() {
+        return SecureCibaSessionEnforceExecutorFactory.PROVIDER_ID;
+    }
+
+    @Override
+    public void executeOnEvent(ClientPolicyContext context) throws ClientPolicyException {
+        switch (context.getEvent()) {
+            case BACKCHANNEL_AUTHENTICATION_REQUEST:
+                BackchannelAuthenticationRequestContext backchannelAuthenticationRequestContext = (BackchannelAuthenticationRequestContext)context;
+                executeOnBackchannelAuthenticationRequest(backchannelAuthenticationRequestContext.getRequest(),
+                    backchannelAuthenticationRequestContext.getRequestParameters());
+                return;
+            default:
+                return;
+        }
+    }
+
+    private void executeOnBackchannelAuthenticationRequest(
+            BackchannelAuthenticationEndpointRequest request,
+            MultivaluedMap<String, String> requestParameters) throws ClientPolicyException {
+        logger.trace("Backchannel Authentication Endpoint - authn request");
+        if (request.getBindingMessage() == null) {
+            logger.trace("Missing parameter: binding_message");
+            throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST, "Missing parameter: binding_message");
+        }
+        logger.trace("Passed.");
+    }
+}

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/ciba/clientpolicy/executor/SecureCibaSessionEnforceExecutorFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/ciba/clientpolicy/executor/SecureCibaSessionEnforceExecutorFactory.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.protocol.oidc.grants.ciba.clientpolicy.executor;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.keycloak.Config.Scope;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProvider;
+import org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProviderFactory;
+
+/**
+ * @author <a href="mailto:takashi.norimatsu.ws@hitachi.com">Takashi Norimatsu</a>
+ */
+public class SecureCibaSessionEnforceExecutorFactory implements ClientPolicyExecutorProviderFactory {
+
+    public static final String PROVIDER_ID = "secure-ciba-session";
+
+    @Override
+    public ClientPolicyExecutorProvider create(KeycloakSession session) {
+        return new SecureCibaSessionEnforceExecutor(session);
+    }
+
+    @Override
+    public void init(Scope config) {
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public String getHelpText() {
+        return "To distinguish which authentication belongs to which CIBA flow, it refuses backchannel authentication request which lacks 'binding_message' parameter.";
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return Collections.emptyList();
+    }
+
+}

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/ciba/clientpolicy/executor/SecureCibaSignedAuthenticationRequestExecutor.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/ciba/clientpolicy/executor/SecureCibaSignedAuthenticationRequestExecutor.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.protocol.oidc.grants.ciba.clientpolicy.executor;
+
+import java.util.Optional;
+
+import javax.ws.rs.core.MultivaluedMap;
+
+import org.jboss.logging.Logger;
+import org.keycloak.OAuthErrorException;
+import org.keycloak.common.util.Time;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.protocol.oidc.OIDCLoginProtocol;
+import org.keycloak.protocol.oidc.grants.ciba.clientpolicy.context.BackchannelAuthenticationRequestContext;
+import org.keycloak.protocol.oidc.grants.ciba.endpoints.request.BackchannelAuthenticationEndpointRequest;
+import org.keycloak.protocol.oidc.grants.ciba.endpoints.request.BackchannelAuthenticationEndpointRequestParser;
+import org.keycloak.representations.idm.ClientPolicyExecutorConfigurationRepresentation;
+import org.keycloak.services.clientpolicy.ClientPolicyContext;
+import org.keycloak.services.clientpolicy.ClientPolicyException;
+import org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProvider;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * @author <a href="mailto:takashi.norimatsu.ws@hitachi.com">Takashi Norimatsu</a>
+ */
+public class SecureCibaSignedAuthenticationRequestExecutor implements ClientPolicyExecutorProvider<SecureCibaSignedAuthenticationRequestExecutor.Configuration> {
+
+    private static final Logger logger = Logger.getLogger(SecureCibaSignedAuthenticationRequestExecutor.class);
+
+    public static final String INVALID_REQUEST_OBJECT = "invalid_request_object";
+    public static final Integer DEFAULT_AVAILABLE_PERIOD = Integer.valueOf(3600); // (sec) from FAPI-CIBA requirement
+
+    private final KeycloakSession session;
+    private Configuration configuration;
+
+    public SecureCibaSignedAuthenticationRequestExecutor(KeycloakSession session) {
+        this.session = session;
+    }
+
+    @Override
+    public void setupConfiguration(SecureCibaSignedAuthenticationRequestExecutor.Configuration config) {
+        if (config == null) {
+            configuration = new Configuration();
+            configuration.setAvailablePeriod(DEFAULT_AVAILABLE_PERIOD);
+        } else {
+            configuration = config;
+            if (config.getAvailablePeriod() == null) {
+                configuration.setAvailablePeriod(DEFAULT_AVAILABLE_PERIOD);
+            }
+        }
+    }
+
+    @Override
+    public Class<Configuration> getExecutorConfigurationClass() {
+        return Configuration.class;
+    }
+
+    public static class Configuration extends ClientPolicyExecutorConfigurationRepresentation {
+        @JsonProperty("available-period")
+        protected Integer availablePeriod;
+
+        public Integer getAvailablePeriod() {
+            return availablePeriod;
+        }
+
+        public void setAvailablePeriod(Integer availablePeriod) {
+            this.availablePeriod = availablePeriod;
+        }
+
+    }
+
+    @Override
+    public String getProviderId() {
+        return SecureCibaSignedAuthenticationRequestExecutorFactory.PROVIDER_ID;
+    }
+
+    @Override
+    public void executeOnEvent(ClientPolicyContext context) throws ClientPolicyException {
+        switch (context.getEvent()) {
+            case BACKCHANNEL_AUTHENTICATION_REQUEST:
+                BackchannelAuthenticationRequestContext backchannelAuthenticationRequestContext = (BackchannelAuthenticationRequestContext)context;
+                executeOnBackchannelAuthenticationRequest(backchannelAuthenticationRequestContext.getRequest(),
+                    backchannelAuthenticationRequestContext.getRequestParameters());
+                return;
+            default:
+                return;
+        }
+    }
+
+    private void executeOnBackchannelAuthenticationRequest(
+            BackchannelAuthenticationEndpointRequest request,
+            MultivaluedMap<String, String> params) throws ClientPolicyException {
+        logger.trace("Backchannel Authentication Endpoint - authn request");
+
+        if (params == null) {
+            logger.trace("request parameter not exist.");
+            throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST, "Missing parameters");
+        }
+
+        String requestParam = params.getFirst(OIDCLoginProtocol.REQUEST_PARAM);
+        String requestUriParam = params.getFirst(OIDCLoginProtocol.REQUEST_URI_PARAM);
+
+        if (requestParam == null && requestUriParam == null) {
+            logger.trace("signed authentication request not exist.");
+            throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST, "Missing parameter: 'request' or 'request_uri'");
+        }
+
+        JsonNode signedAuthReq = (JsonNode)session.getAttribute(BackchannelAuthenticationEndpointRequestParser.CIBA_SIGNED_AUTHENTICATION_REQUEST);
+
+        // check whether signed authentication request exists
+        if (signedAuthReq == null || signedAuthReq.isEmpty()) {
+            logger.trace("signed authentication request not exist.");
+            throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST, "Invalid parameter: : 'request' or 'request_uri'");
+        }
+
+        // check whether "exp" claim exists
+        if (signedAuthReq.get("exp") == null) {
+            logger.trace("exp claim not incuded.");
+            throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST, "Missing parameter in the signed authentication request: exp");
+        }
+
+        // check whether signed authentication request not expired
+        long exp = signedAuthReq.get("exp").asLong();
+        if (Time.currentTime() > exp) { // TODO: Time.currentTime() is int while exp is long...
+            logger.trace("request object expired.");
+            throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST, "Request Expired");
+        }
+
+        // check whether "nbf" claim exists
+        if (signedAuthReq.get("nbf") == null) {
+            logger.trace("nbf claim not incuded.");
+            throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST, "Missing parameter in the signed authentication request: nbf");
+        }
+
+        // check whether signed authentication request not yet being processed
+        long nbf = signedAuthReq.get("nbf").asLong();
+        if (Time.currentTime() < nbf) { // TODO: Time.currentTime() is int while nbf is long...
+            logger.trace("request object not yet being processed.");
+            throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST, "Request not yet being processed");
+        }
+
+        // check whether signed authentication request's available period is short
+        int availablePeriod = Optional.ofNullable(configuration.getAvailablePeriod()).orElse(DEFAULT_AVAILABLE_PERIOD).intValue();
+        if (exp - nbf > availablePeriod) {
+            logger.trace("signed authentication request's available period is long.");
+            throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST, "signed authentication request's available period is long");
+        }
+
+        logger.trace("Passed.");
+    }
+
+}

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/ciba/clientpolicy/executor/SecureCibaSignedAuthenticationRequestExecutorFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/ciba/clientpolicy/executor/SecureCibaSignedAuthenticationRequestExecutorFactory.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.protocol.oidc.grants.ciba.clientpolicy.executor;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.keycloak.Config.Scope;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProvider;
+import org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProviderFactory;
+
+/**
+ * @author <a href="mailto:takashi.norimatsu.ws@hitachi.com">Takashi Norimatsu</a>
+ */
+public class SecureCibaSignedAuthenticationRequestExecutorFactory implements ClientPolicyExecutorProviderFactory {
+
+    public static final String PROVIDER_ID = "secure-ciba-signed-authn-req";
+
+    public static final String AVAILABLE_PERIOD = "available-period";
+
+    private static final ProviderConfigProperty AVAILABLE_PERIOD_PROPERTY = new ProviderConfigProperty(
+            AVAILABLE_PERIOD, "Available Period", "The maximum period in seconds for which the 'request' signed authentication request used in CIBA backchannel authentication request is considered valid.",
+            ProviderConfigProperty.STRING_TYPE, "3600");
+
+    @Override
+    public ClientPolicyExecutorProvider create(KeycloakSession session) {
+        return new SecureCibaSignedAuthenticationRequestExecutor(session);
+    }
+
+    @Override
+    public void init(Scope config) {
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public String getHelpText() {
+        return "The executor checks whether the client treats the signed authentication request in its CIBA backchannel authentication request by following Financial-grade API CIBA Security Profile.";
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return new ArrayList<>(Arrays.asList(AVAILABLE_PERIOD_PROPERTY));
+    }
+
+}

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/ciba/endpoints/BackchannelAuthenticationEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/ciba/endpoints/BackchannelAuthenticationEndpoint.java
@@ -34,12 +34,12 @@ import org.keycloak.models.UserModel;
 import org.keycloak.protocol.oidc.grants.ciba.CibaGrantType;
 import org.keycloak.protocol.oidc.grants.ciba.channel.AuthenticationChannelProvider;
 import org.keycloak.protocol.oidc.grants.ciba.channel.CIBAAuthenticationRequest;
+import org.keycloak.protocol.oidc.grants.ciba.clientpolicy.context.BackchannelAuthenticationRequestContext;
 import org.keycloak.protocol.oidc.grants.ciba.endpoints.request.BackchannelAuthenticationEndpointRequest;
 import org.keycloak.protocol.oidc.grants.ciba.endpoints.request.BackchannelAuthenticationEndpointRequestParserProcessor;
 import org.keycloak.protocol.oidc.grants.ciba.resolvers.CIBALoginUserResolver;
 import org.keycloak.services.ErrorResponseException;
 import org.keycloak.services.clientpolicy.ClientPolicyException;
-import org.keycloak.services.clientpolicy.context.BackchannelAuthenticationRequestContext;
 import org.keycloak.util.JsonSerialization;
 
 import javax.ws.rs.Consumes;

--- a/services/src/main/resources/META-INF/services/org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProviderFactory
+++ b/services/src/main/resources/META-INF/services/org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProviderFactory
@@ -10,3 +10,5 @@ org.keycloak.services.clientpolicy.executor.HolderOfKeyEnforcerExecutorFactory
 org.keycloak.services.clientpolicy.executor.ConfidentialClientAcceptExecutorFactory
 org.keycloak.services.clientpolicy.executor.ConsentRequiredExecutorFactory
 org.keycloak.services.clientpolicy.executor.FullScopeDisabledExecutorFactory
+org.keycloak.protocol.oidc.grants.ciba.clientpolicy.executor.SecureCibaSessionEnforceExecutorFactory
+org.keycloak.protocol.oidc.grants.ciba.clientpolicy.executor.SecureCibaSignedAuthenticationRequestExecutorFactory

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/rest/resource/TestingOIDCEndpointsApplicationResource.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/rest/resource/TestingOIDCEndpointsApplicationResource.java
@@ -662,9 +662,13 @@ public class TestingOIDCEndpointsApplicationResource {
 
         // optional
         // for testing purpose
-        if (request.getBindingMessage() != null && request.getBindingMessage().equals("GODOWN")) throw new BadRequestException("intentional error : GODOWN");
+        String bindingMessage = request.getBindingMessage();
+        if (bindingMessage != null && bindingMessage.equals("GODOWN")) throw new BadRequestException("intentional error : GODOWN");
 
-        authenticationChannelRequests.put(request.getBindingMessage(), new TestAuthenticationChannelRequest(request, rawBearerToken));
+        // binding_message is optional so that it can be null .
+        // only one CIBA flow without binding_message can be accepted per test method by this test mechanism.
+        if (bindingMessage == null) bindingMessage = ChannelRequestDummyKey;
+        authenticationChannelRequests.put(bindingMessage, new TestAuthenticationChannelRequest(request, rawBearerToken));
 
         return Response.status(Status.CREATED).build();
     }
@@ -674,6 +678,9 @@ public class TestingOIDCEndpointsApplicationResource {
     @Produces(MediaType.APPLICATION_JSON)
     @NoCache
     public TestAuthenticationChannelRequest getAuthenticationChannel(@QueryParam("bindingMessage") String bindingMessage) {
+        if (bindingMessage == null) bindingMessage = ChannelRequestDummyKey;
         return authenticationChannelRequests.get(bindingMessage);
     }
+
+    private static final String ChannelRequestDummyKey = "channel_request_dummy_key";
 }


### PR DESCRIPTION
This PR is for [KEYCLOAK-18457 FAPI CIBA Support](https://issues.redhat.com/browse/KEYCLOAK-18457), also is the part of the project [FAPI-CIBA(poll mode)](https://github.com/keycloak/kc-sig-fapi/projects) of [FAPI-SIG](https://github.com/keycloak/kc-sig-fapi) activity.

This PR is needed to satisfy requirements by [Financial-grade API: Client Initiated Backchannel Authentication Profile](https://bitbucket.org/openid/fapi/src/master/Financial_API_WD_CIBA.md#markdown-header-522-authorization-server).
[KEYCLOAK-18123](https://issues.redhat.com/browse/KEYCLOAK-18123) describes it more.