### PR TITLE
KEYCLOAK-18587 CIBA signed request: Client must configure the algorithm

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/ciba/endpoints/request/BackchannelAuthenticationEndpointSignedRequestParser.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/ciba/endpoints/request/BackchannelAuthenticationEndpointSignedRequestParser.java
@@ -60,8 +60,8 @@ class BackchannelAuthenticationEndpointSignedRequestParser extends BackchannelAu
         if (!signatureProvider.isAsymmetricAlgorithm()) {
             throw new RuntimeException("Signed algorithm is not allowed");
         }
-        if (requestedSignatureAlgorithm != null && requestedSignatureAlgorithm != headerAlgorithm) {
-            throw new RuntimeException("Signed with different algorithm than client requested algorithm");
+        if (requestedSignatureAlgorithm == null || requestedSignatureAlgorithm != headerAlgorithm) {
+            throw new RuntimeException("Client requested algorithm not registered in advance or request signed with different algorithm other than client requested algorithm");
         }
 
         this.requestParams = session.tokens().decodeClientJWT(signedAuthReq, client, JsonNode.class);


### PR DESCRIPTION
This PR is for [KEYCLOAK-18457 FAPI CIBA Support](https://issues.redhat.com/browse/KEYCLOAK-18457), also is the part of the project [FAPI-CIBA(poll mode)](https://github.com/keycloak/kc-sig-fapi/projects) of [FAPI-SIG](https://github.com/keycloak/kc-sig-fapi) activity.

[KEYCLOAK-18587](https://issues.redhat.com/browse/KEYCLOAK-18587) describes it more.