### PR TITLE
[KEYCLOAK-18630] - Request object encryption support

### DIFF
--- a/core/src/main/java/org/keycloak/jose/JOSE.java
+++ b/core/src/main/java/org/keycloak/jose/JOSE.java
@@ -1,0 +1,16 @@
+package org.keycloak.jose;
+
+/**
+ * An interface to represent signed (JWS) and encrypted (JWE) JWTs.
+ *
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public interface JOSE {
+
+    /**
+     * Returns the JWT header.
+     *
+     * @return the JWT header
+     */
+    <H extends JOSEHeader> H getHeader();
+}

--- a/core/src/main/java/org/keycloak/jose/JOSEHeader.java
+++ b/core/src/main/java/org/keycloak/jose/JOSEHeader.java
@@ -1,0 +1,22 @@
+package org.keycloak.jose;
+
+import java.io.Serializable;
+
+import org.keycloak.jose.jws.Algorithm;
+
+/**
+ * This interface represents a JOSE header.
+ *
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public interface JOSEHeader extends Serializable {
+
+    /**
+     * Returns the algorithm used to sign or encrypt the JWT from the JOSE header.
+     *
+     * @return the algorithm from the JOSE header
+     */
+    String getRawAlgorithm();
+
+    String getKeyId();
+}

--- a/core/src/main/java/org/keycloak/jose/JOSEParser.java
+++ b/core/src/main/java/org/keycloak/jose/JOSEParser.java
@@ -1,0 +1,49 @@
+package org.keycloak.jose;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.keycloak.common.util.Base64Url;
+import org.keycloak.jose.jwe.JWE;
+import org.keycloak.jose.jws.JWSInput;
+import org.keycloak.jose.jws.JWSInputException;
+import org.keycloak.util.JsonSerialization;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public class JOSEParser {
+
+    /**
+     * Parses the given encoded {@code jwt} and returns either a {@link JWSInput} or {@link JWE}
+     * depending on the JOSE header configuration.
+     *
+     * @param jwt the encoded JWT
+     * @return a {@link JOSE}
+     */
+    public static JOSE parse(String jwt) {
+        String[] parts = jwt.split("\\.");
+
+        if (parts.length == 0) {
+            throw new RuntimeException("Could not infer header from JWT");
+        }
+
+        JsonNode header;
+
+        try {
+            header = JsonSerialization.readValue(Base64Url.decode(parts[0]), JsonNode.class);
+        } catch (IOException cause) {
+            throw new RuntimeException("Failed to parse JWT header", cause);
+        }
+
+        if (header.has("enc")) {
+            return new JWE(jwt);
+        }
+
+        try {
+            return new JWSInput(jwt);
+        } catch (JWSInputException cause) {
+            throw new RuntimeException("Failed to build JWS", cause);
+        }
+    }
+}

--- a/core/src/main/java/org/keycloak/jose/jwe/JWEHeader.java
+++ b/core/src/main/java/org/keycloak/jose/jwe/JWEHeader.java
@@ -18,18 +18,19 @@
 package org.keycloak.jose.jwe;
 
 import java.io.IOException;
-import java.io.Serializable;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.keycloak.jose.JOSEHeader;
 
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class JWEHeader implements Serializable {
+public class JWEHeader implements JOSEHeader {
 
     @JsonProperty("alg")
     private String algorithm;
@@ -68,6 +69,12 @@ public class JWEHeader implements Serializable {
 
     public String getAlgorithm() {
         return algorithm;
+    }
+
+    @JsonIgnore
+    @Override
+    public String getRawAlgorithm() {
+        return getAlgorithm();
     }
 
     public String getEncryptionAlgorithm() {

--- a/core/src/main/java/org/keycloak/jose/jwe/JWERegistry.java
+++ b/core/src/main/java/org/keycloak/jose/jwe/JWERegistry.java
@@ -23,7 +23,10 @@ import java.util.Map;
 import org.keycloak.jose.jwe.alg.AesKeyWrapAlgorithmProvider;
 import org.keycloak.jose.jwe.alg.DirectAlgorithmProvider;
 import org.keycloak.jose.jwe.alg.JWEAlgorithmProvider;
+import org.keycloak.jose.jwe.alg.RsaKeyEncryption256JWEAlgorithmProvider;
+import org.keycloak.jose.jwe.alg.RsaKeyEncryptionJWEAlgorithmProvider;
 import org.keycloak.jose.jwe.enc.AesCbcHmacShaEncryptionProvider;
+import org.keycloak.jose.jwe.enc.AesGcmJWEEncryptionProvider;
 import org.keycloak.jose.jwe.enc.JWEEncryptionProvider;
 
 /**
@@ -45,8 +48,11 @@ class JWERegistry {
         // Provider 'dir' just directly uses encryption keys for encrypt/decrypt content.
         ALG_PROVIDERS.put(JWEConstants.DIR, new DirectAlgorithmProvider());
         ALG_PROVIDERS.put(JWEConstants.A128KW, new AesKeyWrapAlgorithmProvider());
+        ALG_PROVIDERS.put(JWEConstants.RSA_OAEP, new RsaKeyEncryptionJWEAlgorithmProvider("RSA/ECB/OAEPWithSHA-1AndMGF1Padding"));
+        ALG_PROVIDERS.put(JWEConstants.RSA_OAEP_256, new RsaKeyEncryption256JWEAlgorithmProvider("RSA/ECB/OAEPWithSHA-256AndMGF1Padding"));
 
 
+        ENC_PROVIDERS.put(JWEConstants.A256GCM, new AesGcmJWEEncryptionProvider(JWEConstants.A256GCM));
         ENC_PROVIDERS.put(JWEConstants.A128CBC_HS256, new AesCbcHmacShaEncryptionProvider.Aes128CbcHmacSha256Provider());
         ENC_PROVIDERS.put(JWEConstants.A192CBC_HS384, new AesCbcHmacShaEncryptionProvider.Aes192CbcHmacSha384Provider());
         ENC_PROVIDERS.put(JWEConstants.A256CBC_HS512, new AesCbcHmacShaEncryptionProvider.Aes256CbcHmacSha512Provider());

--- a/core/src/main/java/org/keycloak/jose/jwk/JWKBuilder.java
+++ b/core/src/main/java/org/keycloak/jose/jwk/JWKBuilder.java
@@ -44,7 +44,7 @@ public class JWKBuilder {
     private String kid;
 
     private String algorithm;
-    
+
     private JWKBuilder() {
     }
 
@@ -68,14 +68,18 @@ public class JWKBuilder {
     }
 
     public JWK rsa(Key key) {
-        return rsa(key, (List<X509Certificate>) null);
+        return rsa(key, null, KeyUse.SIG);
     }
     
     public JWK rsa(Key key, X509Certificate certificate) {
-        return rsa(key, Collections.singletonList(certificate));
+        return rsa(key, Collections.singletonList(certificate), KeyUse.SIG);
     }
 
     public JWK rsa(Key key, List<X509Certificate> certificates) {
+        return rsa(key, certificates, null);
+    }
+
+    public JWK rsa(Key key, List<X509Certificate> certificates, KeyUse keyUse) {
         RSAPublicKey rsaKey = (RSAPublicKey) key;
 
         RSAPublicJWK k = new RSAPublicJWK();
@@ -84,7 +88,7 @@ public class JWKBuilder {
         k.setKeyId(kid);
         k.setKeyType(KeyType.RSA);
         k.setAlgorithm(algorithm);
-        k.setPublicKeyUse(DEFAULT_PUBLIC_KEY_USE);
+        k.setPublicKeyUse(keyUse == null ? KeyUse.SIG.getSpecName() : keyUse.getSpecName());
         k.setModulus(Base64Url.encode(toIntegerBytes(rsaKey.getModulus())));
         k.setPublicExponent(Base64Url.encode(toIntegerBytes(rsaKey.getPublicExponent())));
 

--- a/core/src/main/java/org/keycloak/jose/jws/JWSHeader.java
+++ b/core/src/main/java/org/keycloak/jose/jws/JWSHeader.java
@@ -17,20 +17,21 @@
 
 package org.keycloak.jose.jws;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.keycloak.jose.JOSEHeader;
 
 import java.io.IOException;
-import java.io.Serializable;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class JWSHeader implements Serializable {
+public class JWSHeader implements JOSEHeader {
     @JsonProperty("alg")
     private Algorithm algorithm;
 
@@ -60,6 +61,12 @@ public class JWSHeader implements Serializable {
 
     public Algorithm getAlgorithm() {
         return algorithm;
+    }
+
+    @JsonIgnore
+    @Override
+    public String getRawAlgorithm() {
+        return getAlgorithm().name();
     }
 
     public String getType() {

--- a/core/src/main/java/org/keycloak/jose/jws/JWSInput.java
+++ b/core/src/main/java/org/keycloak/jose/jws/JWSInput.java
@@ -18,6 +18,7 @@
 package org.keycloak.jose.jws;
 
 import org.keycloak.common.util.Base64Url;
+import org.keycloak.jose.JOSE;
 import org.keycloak.util.JsonSerialization;
 
 import java.io.IOException;
@@ -27,7 +28,7 @@ import java.nio.charset.StandardCharsets;
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
  */
-public class JWSInput {
+public class JWSInput implements JOSE {
     String wireString;
     String encodedHeader;
     String encodedContent;
@@ -88,13 +89,6 @@ public class JWSInput {
 
     public byte[] getSignature() {
         return signature;
-    }
-
-    public boolean verify(String key) {
-        if (header.getAlgorithm().getProvider() == null) {
-            throw new RuntimeException("signing algorithm not supported");
-        }
-        return header.getAlgorithm().getProvider().verify(this, key);
     }
 
     public <T> T readJsonContent(Class<T> type) throws JWSInputException {

--- a/core/src/main/java/org/keycloak/protocol/oidc/representations/OIDCConfigurationRepresentation.java
+++ b/core/src/main/java/org/keycloak/protocol/oidc/representations/OIDCConfigurationRepresentation.java
@@ -79,6 +79,12 @@ public class OIDCConfigurationRepresentation {
     @JsonProperty("request_object_signing_alg_values_supported")
     private List<String> requestObjectSigningAlgValuesSupported;
 
+    @JsonProperty("request_object_encryption_alg_values_supported")
+    private List<String> requestObjectEncryptionAlgValuesSupported;
+
+    @JsonProperty("request_object_encryption_enc_values_supported")
+    private List<String> requestObjectEncryptionEncValuesSupported;
+
     @JsonProperty("response_modes_supported")
     private List<String> responseModesSupported;
 
@@ -282,6 +288,22 @@ public class OIDCConfigurationRepresentation {
 
     public void setRequestObjectSigningAlgValuesSupported(List<String> requestObjectSigningAlgValuesSupported) {
         this.requestObjectSigningAlgValuesSupported = requestObjectSigningAlgValuesSupported;
+    }
+
+    public List<String> getRequestObjectEncryptionAlgValuesSupported() {
+        return requestObjectEncryptionAlgValuesSupported;
+    }
+
+    public void setRequestObjectEncryptionAlgValuesSupported(List<String> requestObjectEncryptionAlgValuesSupported) {
+        this.requestObjectEncryptionAlgValuesSupported = requestObjectEncryptionAlgValuesSupported;
+    }
+
+    public List<String> getRequestObjectEncryptionEncValuesSupported() {
+        return requestObjectEncryptionEncValuesSupported;
+    }
+
+    public void setRequestObjectEncryptionEncValuesSupported(List<String> requestObjectEncryptionEncValuesSupported) {
+        this.requestObjectEncryptionEncValuesSupported = requestObjectEncryptionEncValuesSupported;
     }
 
     public List<String> getResponseModesSupported() {

--- a/core/src/main/java/org/keycloak/representations/idm/KeysMetadataRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/idm/KeysMetadataRepresentation.java
@@ -20,6 +20,8 @@ package org.keycloak.representations.idm;
 import java.util.List;
 import java.util.Map;
 
+import org.keycloak.crypto.KeyUse;
+
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
  */
@@ -58,6 +60,7 @@ public class KeysMetadataRepresentation {
 
         private String publicKey;
         private String certificate;
+        private KeyUse use;
 
         public String getProviderId() {
             return providerId;
@@ -121,6 +124,14 @@ public class KeysMetadataRepresentation {
 
         public void setCertificate(String certificate) {
             this.certificate = certificate;
+        }
+
+        public KeyUse getUse() {
+            return use;
+        }
+
+        public void setUse(KeyUse use) {
+            this.use = use;
         }
     }
 }

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/DefaultKeyProviders.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/DefaultKeyProviders.java
@@ -20,6 +20,7 @@ package org.keycloak.models.utils;
 import org.keycloak.common.util.MultivaluedHashMap;
 import org.keycloak.component.ComponentModel;
 import org.keycloak.crypto.Algorithm;
+import org.keycloak.crypto.KeyUse;
 import org.keycloak.keys.KeyProvider;
 import org.keycloak.models.RealmModel;
 
@@ -32,21 +33,27 @@ public class DefaultKeyProviders {
 
     public static void createProviders(RealmModel realm) {
         if (!hasProvider(realm, "rsa-generated")) {
-            ComponentModel generated = new ComponentModel();
-            generated.setName("rsa-generated");
-            generated.setParentId(realm.getId());
-            generated.setProviderId("rsa-generated");
-            generated.setProviderType(KeyProvider.class.getName());
-
-            MultivaluedHashMap<String, String> config = new MultivaluedHashMap<>();
-            config.putSingle("priority", "100");
-            generated.setConfig(config);
-
-            realm.addComponentModel(generated);
+            createRsaKeyProvider("rsa-generated", KeyUse.SIG, realm);
+            createRsaKeyProvider("rsa-enc-generated", KeyUse.ENC, realm);
         }
 
         createSecretProvider(realm);
         createAesProvider(realm);
+    }
+
+    private static void createRsaKeyProvider(String name, KeyUse keyUse, RealmModel realm) {
+        ComponentModel generated = new ComponentModel();
+        generated.setName(name);
+        generated.setParentId(realm.getId());
+        generated.setProviderId("rsa-generated");
+        generated.setProviderType(KeyProvider.class.getName());
+
+        MultivaluedHashMap<String, String> config = new MultivaluedHashMap<>();
+        config.putSingle("priority", "100");
+        config.putSingle("keyUse", keyUse.getSpecName());
+        generated.setConfig(config);
+
+        realm.addComponentModel(generated);
     }
 
     public static void createSecretProvider(RealmModel realm) {

--- a/server-spi/src/main/java/org/keycloak/models/TokenManager.java
+++ b/server-spi/src/main/java/org/keycloak/models/TokenManager.java
@@ -16,11 +16,23 @@
  */
 package org.keycloak.models;
 
+import java.util.function.BiConsumer;
+
 import org.keycloak.Token;
 import org.keycloak.TokenCategory;
+import org.keycloak.jose.JOSE;
+import org.keycloak.jose.jws.Algorithm;
 import org.keycloak.representations.LogoutToken;
 
 public interface TokenManager {
+
+    BiConsumer<JOSE, ClientModel> DEFAULT_VALIDATOR = (jwt, client) -> {
+        String rawAlgorithm = jwt.getHeader().getRawAlgorithm();
+
+        if (rawAlgorithm.equalsIgnoreCase(Algorithm.none.name())) {
+            throw new RuntimeException("Algorithm none not supported");
+        }
+    };
 
     /**
      * Encodes the supplied token
@@ -42,7 +54,21 @@ public interface TokenManager {
 
     String signatureAlgorithm(TokenCategory category);
 
-    <T> T decodeClientJWT(String token, ClientModel client, Class<T> clazz);
+    /**
+     *
+     *
+     * @param token
+     * @param client
+     * @param clazz
+     * @param <T>
+     * @return
+     */
+    default <T> T decodeClientJWT(String token, ClientModel client, Class<T> clazz) {
+        return decodeClientJWT(token, client, DEFAULT_VALIDATOR, clazz);
+    }
+
+    <T> T decodeClientJWT(String token, ClientModel client, BiConsumer<JOSE, ClientModel> jwtValidator,
+            Class<T> clazz);
 
     String encodeAndEncrypt(Token token);
     String cekManagementAlgorithm(TokenCategory category);

--- a/services/src/main/java/org/keycloak/jose/jws/DefaultTokenManager.java
+++ b/services/src/main/java/org/keycloak/jose/jws/DefaultTokenManager.java
@@ -27,6 +27,9 @@ import org.keycloak.crypto.KeyUse;
 import org.keycloak.crypto.KeyWrapper;
 import org.keycloak.crypto.SignatureProvider;
 import org.keycloak.crypto.SignatureSignerContext;
+import org.keycloak.jose.JOSEParser;
+import org.keycloak.jose.JOSE;
+import org.keycloak.jose.jwe.JWE;
 import org.keycloak.jose.jwe.JWEException;
 import org.keycloak.jose.jwe.alg.JWEAlgorithmProvider;
 import org.keycloak.jose.jwe.enc.JWEEncryptionProvider;
@@ -47,8 +50,17 @@ import org.keycloak.representations.LogoutToken;
 import org.keycloak.util.JsonSerialization;
 import org.keycloak.util.TokenUtil;
 
+import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.security.Key;
+import java.security.PrivateKey;
+import java.util.Comparator;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 public class DefaultTokenManager implements TokenManager {
 
@@ -103,17 +115,69 @@ public class DefaultTokenManager implements TokenManager {
     }
 
     @Override
-    public <T> T decodeClientJWT(String token, ClientModel client, Class<T> clazz) {
-        if (token == null) {
+    public <T> T decodeClientJWT(String jwt, ClientModel client, BiConsumer<JOSE, ClientModel> jwtValidator, Class<T> clazz) {
+        if (jwt == null) {
             return null;
         }
+
+        JOSE joseToken = JOSEParser.parse(jwt);
+
+        jwtValidator.accept(joseToken, client);
+
+        if (joseToken instanceof JWE) {
+            try {
+                Optional<KeyWrapper> activeKey;
+                String kid = joseToken.getHeader().getKeyId();
+                Stream<KeyWrapper> keys = session.keys().getKeysStream(session.getContext().getRealm());
+
+                if (kid == null) {
+                    activeKey = keys.filter(k -> KeyUse.ENC.equals(k.getUse()) && k.getPublicKey() != null)
+                            .sorted(Comparator.comparingLong(KeyWrapper::getProviderPriority).reversed())
+                            .findFirst();
+                } else {
+                    activeKey = keys
+                            .filter(k -> KeyUse.ENC.equals(k.getUse()) && k.getKid().equals(kid)).findAny();
+                }
+
+                JWE jwe = JWE.class.cast(joseToken);
+                Key privateKey = activeKey.map(KeyWrapper::getPrivateKey)
+                        .orElseThrow(() -> new RuntimeException("Could not find private key for decrypting token"));
+
+                jwe.getKeyStorage().setDecryptionKey(privateKey);
+
+                byte[] content = jwe.verifyAndDecodeJwe().getContent();
+
+                try {
+                    JOSE jws = JOSEParser.parse(new String(content));
+
+                    if (jws instanceof JWSInput) {
+                        jwtValidator.accept(jws, client);
+                        return verifyJWS(client, clazz, (JWSInput) jws);
+                    }
+                } catch (Exception ignore) {
+                    // try to decrypt content as is
+                }
+
+                return JsonSerialization.readValue(content, clazz);
+            } catch (IOException cause) {
+                throw new RuntimeException("Failed to deserialize JWT", cause);
+            } catch (JWEException cause) {
+                throw new RuntimeException("Failed to decrypt JWT", cause);
+            }
+        }
+
+        return verifyJWS(client, clazz, (JWSInput) joseToken);
+    }
+
+    private <T> T verifyJWS(ClientModel client, Class<T> clazz, JWSInput jws) {
         try {
-            JWSInput jws = new JWSInput(token);
-
             String signatureAlgorithm = jws.getHeader().getAlgorithm().name();
-
             ClientSignatureVerifierProvider signatureProvider = session.getProvider(ClientSignatureVerifierProvider.class, signatureAlgorithm);
+
             if (signatureProvider == null) {
+                if (jws.getHeader().getAlgorithm().equals(org.keycloak.jose.jws.Algorithm.none)) {
+                    return jws.readJsonContent(clazz);
+                }
                 return null;
             }
 

--- a/services/src/main/java/org/keycloak/keys/AbstractRsaKeyProvider.java
+++ b/services/src/main/java/org/keycloak/keys/AbstractRsaKeyProvider.java
@@ -61,18 +61,19 @@ public abstract class AbstractRsaKeyProvider implements KeyProvider {
         return Stream.of(key);
     }
 
-    protected KeyWrapper createKeyWrapper(KeyPair keyPair, X509Certificate certificate) {
-        return createKeyWrapper(keyPair, certificate, Collections.emptyList());
+    protected KeyWrapper createKeyWrapper(KeyPair keyPair, X509Certificate certificate, KeyUse keyUse) {
+        return createKeyWrapper(keyPair, certificate, Collections.emptyList(), keyUse);
     }
 
-    protected KeyWrapper createKeyWrapper(KeyPair keyPair, X509Certificate certificate, List<X509Certificate> certificateChain) {
+    protected KeyWrapper createKeyWrapper(KeyPair keyPair, X509Certificate certificate, List<X509Certificate> certificateChain,
+        KeyUse keyUse) {
         KeyWrapper key = new KeyWrapper();
 
         key.setProviderId(model.getId());
         key.setProviderPriority(model.get("priority", 0l));
 
         key.setKid(KeyUtils.createKeyId(keyPair.getPublic()));
-        key.setUse(KeyUse.SIG);
+        key.setUse(keyUse == null ? KeyUse.SIG : keyUse);
         key.setType(KeyType.RSA);
         key.setAlgorithm(algorithm);
         key.setStatus(status);

--- a/services/src/main/java/org/keycloak/keys/Attributes.java
+++ b/services/src/main/java/org/keycloak/keys/Attributes.java
@@ -18,6 +18,7 @@
 package org.keycloak.keys;
 
 import org.keycloak.crypto.Algorithm;
+import org.keycloak.crypto.KeyUse;
 import org.keycloak.provider.ProviderConfigProperty;
 
 import static org.keycloak.provider.ProviderConfigProperty.*;
@@ -44,6 +45,10 @@ public interface Attributes {
 
     String KEY_SIZE_KEY = "keySize";
     ProviderConfigProperty KEY_SIZE_PROPERTY = new ProviderConfigProperty(KEY_SIZE_KEY, "Key size", "Size for the generated keys", LIST_TYPE, "2048", "1024", "2048", "4096");
+
+    String KEY_USE = "keyUse";
+    ProviderConfigProperty KEY_USE_PROPERTY = new ProviderConfigProperty(KEY_USE, "Key use", "Whether the key should be used for signing or encryption.", LIST_TYPE,
+            KeyUse.SIG.getSpecName(), KeyUse.SIG.getSpecName(), KeyUse.ENC.getSpecName());
 
     String KID_KEY = "kid";
 

--- a/services/src/main/java/org/keycloak/keys/GeneratedRsaKeyProviderFactory.java
+++ b/services/src/main/java/org/keycloak/keys/GeneratedRsaKeyProviderFactory.java
@@ -50,6 +50,7 @@ public class GeneratedRsaKeyProviderFactory extends AbstractRsaKeyProviderFactor
 
     private static final List<ProviderConfigProperty> CONFIG_PROPERTIES = AbstractRsaKeyProviderFactory.configurationBuilder()
             .property(Attributes.KEY_SIZE_PROPERTY)
+            .property(Attributes.KEY_USE_PROPERTY)
             .build();
 
     @Override

--- a/services/src/main/java/org/keycloak/keys/ImportedRsaKeyProvider.java
+++ b/services/src/main/java/org/keycloak/keys/ImportedRsaKeyProvider.java
@@ -20,6 +20,7 @@ package org.keycloak.keys;
 import org.keycloak.common.util.KeyUtils;
 import org.keycloak.common.util.PemUtils;
 import org.keycloak.component.ComponentModel;
+import org.keycloak.crypto.KeyUse;
 import org.keycloak.crypto.KeyWrapper;
 import org.keycloak.models.RealmModel;
 
@@ -48,7 +49,9 @@ public class ImportedRsaKeyProvider extends AbstractRsaKeyProvider {
         KeyPair keyPair = new KeyPair(publicKey, privateKey);
         X509Certificate certificate = PemUtils.decodeCertificate(certificatePem);
 
-        return createKeyWrapper(keyPair, certificate);
+        KeyUse keyUse = KeyUse.valueOf(model.get(Attributes.KEY_USE, KeyUse.SIG.name()).toUpperCase());
+
+        return createKeyWrapper(keyPair, certificate, keyUse);
     }
 
 }

--- a/services/src/main/java/org/keycloak/keys/JavaKeystoreKeyProvider.java
+++ b/services/src/main/java/org/keycloak/keys/JavaKeystoreKeyProvider.java
@@ -20,10 +20,10 @@ package org.keycloak.keys;
 import org.keycloak.common.util.CertificateUtils;
 import org.keycloak.common.util.KeyUtils;
 import org.keycloak.component.ComponentModel;
+import org.keycloak.crypto.KeyUse;
 import org.keycloak.crypto.KeyWrapper;
 import org.keycloak.models.RealmModel;
 
-import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -76,7 +76,9 @@ public class JavaKeystoreKeyProvider extends AbstractRsaKeyProvider {
                 certificate = CertificateUtils.generateV1SelfSignedCertificate(keyPair, realm.getName());
             }
 
-            return createKeyWrapper(keyPair, certificate, loadCertificateChain(keyStore, keyAlias));
+            KeyUse keyUse = KeyUse.valueOf(model.get(Attributes.KEY_USE, KeyUse.SIG.getSpecName()).toUpperCase());
+
+            return createKeyWrapper(keyPair, certificate, loadCertificateChain(keyStore, keyAlias), keyUse);
         } catch (KeyStoreException kse) {
             throw new RuntimeException("KeyStore error on server. " + kse.getMessage(), kse);
         } catch (FileNotFoundException fnfe) {

--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocolService.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocolService.java
@@ -227,14 +227,14 @@ public class OIDCLoginProtocolService {
         checkSsl();
 
         JWK[] jwks = session.keys().getKeysStream(realm)
-                .filter(k -> k.getStatus().isEnabled() && Objects.equals(k.getUse(), KeyUse.SIG) && k.getPublicKey() != null)
+                .filter(k -> k.getStatus().isEnabled() && k.getPublicKey() != null)
                 .map(k -> {
                     JWKBuilder b = JWKBuilder.create().kid(k.getKid()).algorithm(k.getAlgorithm());
                     List<X509Certificate> certificates = Optional.ofNullable(k.getCertificateChain())
                         .filter(certs -> !certs.isEmpty())
                         .orElseGet(() -> Collections.singletonList(k.getCertificate()));
                     if (k.getType().equals(KeyType.RSA)) {
-                        return b.rsa(k.getPublicKey(), certificates);
+                        return b.rsa(k.getPublicKey(), certificates, k.getUse());
                     } else if (k.getType().equals(KeyType.EC)) {
                         return b.ec(k.getPublicKey());
                     }

--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCWellKnownProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCWellKnownProvider.java
@@ -130,6 +130,8 @@ public class OIDCWellKnownProvider implements WellKnownProvider {
         config.setIdTokenEncryptionEncValuesSupported(getSupportedIdTokenEncryptionEnc(false));
         config.setUserInfoSigningAlgValuesSupported(getSupportedSigningAlgorithms(true));
         config.setRequestObjectSigningAlgValuesSupported(getSupportedClientSigningAlgorithms(true));
+        config.setRequestObjectEncryptionAlgValuesSupported(getSupportedEncryptionAlgorithms());
+        config.setRequestObjectEncryptionEncValuesSupported(getSupportedContentEncryptionAlgorithms());
         config.setResponseTypesSupported(DEFAULT_RESPONSE_TYPES_SUPPORTED);
         config.setSubjectTypesSupported(DEFAULT_SUBJECT_TYPES_SUPPORTED);
         config.setResponseModesSupported(DEFAULT_RESPONSE_MODES_SUPPORTED);
@@ -222,6 +224,14 @@ public class OIDCWellKnownProvider implements WellKnownProvider {
 
     private List<String> getSupportedClientSigningAlgorithms(boolean includeNone) {
         return getSupportedAlgorithms(ClientSignatureVerifierProvider.class, includeNone);
+    }
+
+    private List<String> getSupportedContentEncryptionAlgorithms() {
+        return getSupportedAlgorithms(ContentEncryptionProvider.class, false);
+    }
+
+    private List<String> getSupportedEncryptionAlgorithms() {
+        return getSupportedAlgorithms(CekManagementProvider.class, false);
     }
 
     private List<String> getSupportedBackchannelAuthenticationRequestSigningAlgorithms() {

--- a/services/src/main/java/org/keycloak/services/resources/admin/KeyResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/KeyResource.java
@@ -82,6 +82,7 @@ public class KeyResource {
         r.setAlgorithm(key.getAlgorithm());
         r.setPublicKey(key.getPublicKey() != null ? PemUtils.encodeKey(key.getPublicKey()) : null);
         r.setCertificate(key.getCertificate() != null ? PemUtils.encodeCertificate(key.getCertificate()) : null);
+        r.setUse(key.getUse());
         return r;
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/admin/ApiUtil.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/admin/ApiUtil.java
@@ -24,6 +24,8 @@ import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.admin.client.resource.RoleResource;
 import org.keycloak.admin.client.resource.UserResource;
 import org.keycloak.crypto.Algorithm;
+import org.keycloak.crypto.KeyStatus;
+import org.keycloak.crypto.KeyUse;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.ClientScopeRepresentation;
 import org.keycloak.representations.idm.CredentialRepresentation;
@@ -268,11 +270,10 @@ public class ApiUtil {
         return null;
     }
 
-    public static KeysMetadataRepresentation.KeyMetadataRepresentation findActiveKey(RealmResource realm) {
+    public static KeysMetadataRepresentation.KeyMetadataRepresentation findActiveSigningKey(RealmResource realm) {
         KeysMetadataRepresentation keyMetadata = realm.keys().getKeyMetadata();
-        String activeKid = keyMetadata.getActive().get(Algorithm.RS256);
         for (KeysMetadataRepresentation.KeyMetadataRepresentation rep : keyMetadata.getKeys()) {
-            if (rep.getKid().equals(activeKid)) {
+            if (rep.getPublicKey() != null && KeyStatus.valueOf(rep.getStatus()).isActive() && KeyUse.SIG.equals(rep.getUse())) {
                 return rep;
             }
         }

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/KeyUtils.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/KeyUtils.java
@@ -1,6 +1,8 @@
 package org.keycloak.testsuite.util;
 
 import org.keycloak.common.util.BouncyIntegration;
+import org.keycloak.crypto.KeyStatus;
+import org.keycloak.crypto.KeyUse;
 import org.keycloak.representations.idm.KeysMetadataRepresentation;
 
 import java.security.KeyFactory;
@@ -41,10 +43,18 @@ public class KeyUtils {
         }
     }
 
-    public static KeysMetadataRepresentation.KeyMetadataRepresentation getActiveKey(KeysMetadataRepresentation keys, String algorithm) {
-        String kid = keys.getActive().get(algorithm);
+    public static KeysMetadataRepresentation.KeyMetadataRepresentation getActiveSigningKey(KeysMetadataRepresentation keys, String algorithm) {
         for (KeysMetadataRepresentation.KeyMetadataRepresentation k : keys.getKeys()) {
-            if (k.getKid().equals(kid)) {
+            if (k.getAlgorithm().equals(algorithm) && KeyStatus.valueOf(k.getStatus()).isActive() && KeyUse.SIG.equals(k.getUse())) {
+                return k;
+            }
+        }
+        throw new RuntimeException("Active key not found");
+    }
+
+    public static KeysMetadataRepresentation.KeyMetadataRepresentation getActiveEncKey(KeysMetadataRepresentation keys, String algorithm) {
+        for (KeysMetadataRepresentation.KeyMetadataRepresentation k : keys.getKeys()) {
+            if (k.getAlgorithm().equals(algorithm) && KeyStatus.valueOf(k.getStatus()).isActive() && KeyUse.ENC.equals(k.getUse())) {
                 return k;
             }
         }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/InstallationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/InstallationTest.java
@@ -26,7 +26,6 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.keycloak.admin.client.resource.ClientResource;
 import org.keycloak.events.admin.OperationType;
@@ -168,7 +167,7 @@ public class InstallationTest extends AbstractClientTest {
 
     private void assertOidcInstallationConfig(String config) {
         assertThat(config, containsString("test"));
-        assertThat(config, not(containsString(ApiUtil.findActiveKey(testRealmResource()).getPublicKey())));
+        assertThat(config, not(containsString(ApiUtil.findActiveSigningKey(testRealmResource()).getPublicKey())));
         assertThat(config, containsString(authServerUrl()));
     }
 
@@ -182,7 +181,7 @@ public class InstallationTest extends AbstractClientTest {
         String xml = samlClient.getInstallationProvider("keycloak-saml");
         assertThat(xml, containsString("<keycloak-saml-adapter>"));
         assertThat(xml, containsString("SPECIFY YOUR entityID!"));
-        assertThat(xml, not(containsString(ApiUtil.findActiveKey(testRealmResource()).getCertificate())));
+        assertThat(xml, not(containsString(ApiUtil.findActiveSigningKey(testRealmResource()).getCertificate())));
         assertThat(xml, containsString(samlUrl()));
     }
 
@@ -191,7 +190,7 @@ public class InstallationTest extends AbstractClientTest {
         String cli = samlClient.getInstallationProvider("keycloak-saml-subsystem-cli");
         assertThat(cli, containsString("/subsystem=keycloak-saml/secure-deployment=YOUR-WAR.war/"));
         assertThat(cli, containsString("SPECIFY YOUR entityID!"));
-        assertThat(cli, not(containsString(ApiUtil.findActiveKey(testRealmResource()).getCertificate())));
+        assertThat(cli, not(containsString(ApiUtil.findActiveSigningKey(testRealmResource()).getCertificate())));
         assertThat(cli, containsString(samlUrl()));
     }
 
@@ -209,7 +208,7 @@ public class InstallationTest extends AbstractClientTest {
         String xml = samlClient.getInstallationProvider("keycloak-saml-subsystem");
         assertThat(xml, containsString("<secure-deployment"));
         assertThat(xml, containsString("SPECIFY YOUR entityID!"));
-        assertThat(xml, not(containsString(ApiUtil.findActiveKey(testRealmResource()).getCertificate())));
+        assertThat(xml, not(containsString(ApiUtil.findActiveSigningKey(testRealmResource()).getCertificate())));
         assertThat(xml, containsString(samlUrl()));
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/group/AbstractGroupTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/group/AbstractGroupTest.java
@@ -55,7 +55,7 @@ public abstract class AbstractGroupTest extends AbstractKeycloakTest {
         String accessToken = tokenResponse.getAccessToken();
         String refreshToken = tokenResponse.getRefreshToken();
 
-        PublicKey publicKey = PemUtils.decodePublicKey(ApiUtil.findActiveKey(adminClient.realm("test")).getPublicKey());
+        PublicKey publicKey = PemUtils.decodePublicKey(ApiUtil.findActiveSigningKey(adminClient.realm("test")).getPublicKey());
 
         AccessToken accessTokenRepresentation = RSATokenVerifier.verifyToken(accessToken, publicKey, getAuthServerContextRoot() + "/auth/realms/test");
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOIDCBrokerWithSignatureTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOIDCBrokerWithSignatureTest.java
@@ -137,7 +137,7 @@ public class KcOIDCBrokerWithSignatureTest extends AbstractBaseBrokerTest {
         cfg.setValidateSignature(true);
         cfg.setUseJwksUrl(false);
 
-        KeysMetadataRepresentation.KeyMetadataRepresentation key = ApiUtil.findActiveKey(providerRealm());
+        KeysMetadataRepresentation.KeyMetadataRepresentation key = ApiUtil.findActiveSigningKey(providerRealm());
         cfg.setPublicKeySignatureVerifier(key.getPublicKey());
         updateIdentityProvider(idpRep);
 
@@ -171,7 +171,7 @@ public class KcOIDCBrokerWithSignatureTest extends AbstractBaseBrokerTest {
         cfg.setValidateSignature(true);
         cfg.setUseJwksUrl(false);
 
-        KeysMetadataRepresentation.KeyMetadataRepresentation key = ApiUtil.findActiveKey(providerRealm());
+        KeysMetadataRepresentation.KeyMetadataRepresentation key = ApiUtil.findActiveSigningKey(providerRealm());
         String pemData = key.getPublicKey();
         cfg.setPublicKeySignatureVerifier(pemData);
         String expectedKeyId = KeyUtils.createKeyId(PemUtils.decodePublicKey(pemData));

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerPrivateKeyJwtTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerPrivateKeyJwtTest.java
@@ -46,7 +46,7 @@ public class KcOidcBrokerPrivateKeyJwtTest extends AbstractBrokerTest {
         public List<ClientRepresentation> createProviderClients() {
             List<ClientRepresentation> clientsRepList = super.createProviderClients();
             log.info("Update provider clients to accept JWT authentication");
-            KeyMetadataRepresentation keyRep = KeyUtils.getActiveKey(adminClient.realm(consumerRealmName()).keys().getKeyMetadata(), Algorithm.RS256);
+            KeyMetadataRepresentation keyRep = KeyUtils.getActiveSigningKey(adminClient.realm(consumerRealmName()).keys().getKeyMetadata(), Algorithm.RS256);
             for (ClientRepresentation client: clientsRepList) {
                 client.setClientAuthenticatorType(JWTClientAuthenticator.PROVIDER_ID);
                 if (client.getAttributes() == null) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcSamlSignedBrokerTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcSamlSignedBrokerTest.java
@@ -64,10 +64,10 @@ public class KcSamlSignedBrokerTest extends AbstractBrokerTest {
     private static final String PUBLIC_KEY = "MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALOOiAmD0SJJq/HYhApsk+fXAoU1iBIl2AWN0+ji5WaxfKH1Qs2xHqFDpoa7R4o8cbikqKi1j+JzTrd6yDbUDQUCAwEAAQ==";
 
     public void withSignedEncryptedAssertions(Runnable testBody, boolean signedDocument, boolean signedAssertion, boolean encryptedAssertion) throws Exception {
-        String providerCert = KeyUtils.getActiveKey(adminClient.realm(bc.providerRealmName()).keys().getKeyMetadata(), Algorithm.RS256).getCertificate();
+        String providerCert = KeyUtils.getActiveSigningKey(adminClient.realm(bc.providerRealmName()).keys().getKeyMetadata(), Algorithm.RS256).getCertificate();
         Assert.assertThat(providerCert, Matchers.notNullValue());
 
-        String consumerCert = KeyUtils.getActiveKey(adminClient.realm(bc.consumerRealmName()).keys().getKeyMetadata(), Algorithm.RS256).getCertificate();
+        String consumerCert = KeyUtils.getActiveSigningKey(adminClient.realm(bc.consumerRealmName()).keys().getKeyMetadata(), Algorithm.RS256).getCertificate();
         Assert.assertThat(consumerCert, Matchers.notNullValue());
 
         try (Closeable idpUpdater = new IdentityProviderAttributeUpdater(identityProviderResource)
@@ -271,7 +271,7 @@ public class KcSamlSignedBrokerTest extends AbstractBrokerTest {
         public List<ClientRepresentation> createProviderClients() {
             List<ClientRepresentation> clientRepresentationList = super.createProviderClients();
 
-            String consumerCert = KeyUtils.getActiveKey(adminClient.realm(consumerRealmName()).keys().getKeyMetadata(), Algorithm.RS256).getCertificate();
+            String consumerCert = KeyUtils.getActiveSigningKey(adminClient.realm(consumerRealmName()).keys().getKeyMetadata(), Algorithm.RS256).getCertificate();
             Assert.assertThat(consumerCert, Matchers.notNullValue());
 
             for (ClientRepresentation client : clientRepresentationList) {
@@ -298,7 +298,7 @@ public class KcSamlSignedBrokerTest extends AbstractBrokerTest {
         public IdentityProviderRepresentation setUpIdentityProvider(IdentityProviderSyncMode syncMode) {
             IdentityProviderRepresentation result = super.setUpIdentityProvider(syncMode);
 
-            String providerCert = KeyUtils.getActiveKey(adminClient.realm(providerRealmName()).keys().getKeyMetadata(), Algorithm.RS256).getCertificate();
+            String providerCert = KeyUtils.getActiveSigningKey(adminClient.realm(providerRealmName()).keys().getKeyMetadata(), Algorithm.RS256).getCertificate();
             Assert.assertThat(providerCert, Matchers.notNullValue());
 
             Map<String, String> config = result.getConfig();
@@ -452,10 +452,10 @@ public class KcSamlSignedBrokerTest extends AbstractBrokerTest {
     public void testSignatureDataWhenWantsRequestsSigned() throws Exception {
         // Verifies that an AuthnRequest contains the KeyInfo/X509Data element when
         // client AuthnRequest signature is requested
-        String providerCert = KeyUtils.getActiveKey(adminClient.realm(bc.providerRealmName()).keys().getKeyMetadata(), Algorithm.RS256).getCertificate();
+        String providerCert = KeyUtils.getActiveSigningKey(adminClient.realm(bc.providerRealmName()).keys().getKeyMetadata(), Algorithm.RS256).getCertificate();
         Assert.assertThat(providerCert, Matchers.notNullValue());
 
-        String consumerCert = KeyUtils.getActiveKey(adminClient.realm(bc.consumerRealmName()).keys().getKeyMetadata(), Algorithm.RS256).getCertificate();
+        String consumerCert = KeyUtils.getActiveSigningKey(adminClient.realm(bc.consumerRealmName()).keys().getKeyMetadata(), Algorithm.RS256).getCertificate();
         Assert.assertThat(consumerCert, Matchers.notNullValue());
 
         try (Closeable idpUpdater = new IdentityProviderAttributeUpdater(identityProviderResource)

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/OIDCWellKnownProviderTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/OIDCWellKnownProviderTest.java
@@ -133,6 +133,10 @@ public class OIDCWellKnownProviderTest extends AbstractKeycloakTest {
             Assert.assertNames(oidcConfig.getUserInfoSigningAlgValuesSupported(), "none", Algorithm.PS256, Algorithm.PS384, Algorithm.PS512, Algorithm.RS256, Algorithm.RS384, Algorithm.RS512, Algorithm.ES256, Algorithm.ES384, Algorithm.ES512, Algorithm.HS256, Algorithm.HS384, Algorithm.HS512);
             Assert.assertNames(oidcConfig.getRequestObjectSigningAlgValuesSupported(), "none", Algorithm.PS256, Algorithm.PS384, Algorithm.PS512, Algorithm.RS256, Algorithm.RS384, Algorithm.RS512, Algorithm.ES256, Algorithm.ES384, Algorithm.ES512, Algorithm.HS256, Algorithm.HS384, Algorithm.HS512);
 
+            // request object encryption algorithms
+            Assert.assertNames(oidcConfig.getRequestObjectEncryptionAlgValuesSupported(), JWEConstants.RSA_OAEP, JWEConstants.RSA_OAEP_256, JWEConstants.RSA1_5);
+            Assert.assertNames(oidcConfig.getRequestObjectEncryptionEncValuesSupported(), JWEConstants.A256GCM, JWEConstants.A192GCM, JWEConstants.A128GCM, JWEConstants.A128CBC_HS256, JWEConstants.A192CBC_HS384, JWEConstants.A256CBC_HS512);
+
             // Encryption algorithms
             Assert.assertNames(oidcConfig.getIdTokenEncryptionAlgValuesSupported(), JWEConstants.RSA1_5, JWEConstants.RSA_OAEP, JWEConstants.RSA_OAEP_256);
             Assert.assertNames(oidcConfig.getIdTokenEncryptionEncValuesSupported(), JWEConstants.A128CBC_HS256, JWEConstants.A128GCM, JWEConstants.A192CBC_HS384, JWEConstants.A192GCM, JWEConstants.A256CBC_HS512, JWEConstants.A256GCM);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/UserInfoTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/UserInfoTest.java
@@ -265,7 +265,7 @@ public class UserInfoTest extends AbstractKeycloakTest {
                     .assertEvent();
 
             // Check signature and content
-            PublicKey publicKey = PemUtils.decodePublicKey(ApiUtil.findActiveKey(adminClient.realm("test")).getPublicKey());
+            PublicKey publicKey = PemUtils.decodePublicKey(ApiUtil.findActiveSigningKey(adminClient.realm("test")).getPublicKey());
 
             Assert.assertEquals(200, response.getStatus());
             Assert.assertEquals(response.getHeaderString(HttpHeaders.CONTENT_TYPE), MediaType.APPLICATION_JWT);

--- a/themes/src/main/resources/theme/base/admin/messages/admin-messages_en.properties
+++ b/themes/src/main/resources/theme/base/admin/messages/admin-messages_en.properties
@@ -1924,3 +1924,4 @@ user.profile.attribute.validation.add.validator=Add Validator
 user.profile.attribute.validation.add.validator.tooltip=Select a validator to enforce specific constraints to the attribute value.
 user.profile.attribute.validation.no.validators=No validators.
 user.profile.attribute.annotation=Annotation
+use=Use

--- a/themes/src/main/resources/theme/base/admin/resources/partials/realm-keys.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/realm-keys.html
@@ -28,7 +28,7 @@
     <table class="table table-striped table-bordered">
         <thead>
         <tr>
-            <th class="kc-table-actions" colspan="7">
+            <th class="kc-table-actions" colspan="8">
                 <div class="form-inline">
                     <div class="form-group">
                         <div class="input-group">
@@ -45,6 +45,7 @@
             <th>{{:: 'algorithm' | translate}}</th>
             <th>{{:: 'type' | translate}}</th>
             <th>{{:: 'kid' | translate}}</th>
+            <th>{{:: 'use' | translate}}</th>
             <th>{{:: 'priority' | translate}}</th>
             <th>{{:: 'provider' | translate}}</th>
             <th colspan="2">{{:: 'publicKeys' | translate}}</th>
@@ -55,6 +56,7 @@
             <td>{{key.algorithm}}</td>
             <td>{{key.type}}</td>
             <td>{{key.kid}}</td>
+            <td>{{key.use}}</td>
             <td>{{key.providerPriority}}</td>
             <td><a href="#/realms/{{realm.realm}}/keys/providers/{{key.provider.providerId}}/{{key.provider.id}}">{{key.provider.name}}</a></td>
 


### PR DESCRIPTION
Basically:

* Enable request object encryption using asymmetric keys (only RSA for now) based on realm active keys intended for encryption use
* When decrypting, key selection is based on either the `kid` or on the priority set for keys in case multiple `ENC` keys exist and no `kid` was set
* Exposes keys for encryption use in JWKS
* Enables both `RSA-OAEP` and `RSA-OAEP-256` algorithms. As well as content encryption using `A256GCM`.
* Changes `TokenManager` to deal with both `JWS` and `JWE`. It should make it easier to support encryption in other places where clients might send JWS/JWE.
* Supports JWE and JWS+JWE.

I did not include yet any config option for clients like to force encryption for request objects or even force a specific alg/enc. 