### PR TITLE
KEYCLOAK-18695 Support user lookup by ID with Novell eDirectory

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPOperationManager.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPOperationManager.java
@@ -392,6 +392,8 @@ public class LDAPOperationManager {
             } catch (NamingException ne) {
                 filter = null;
             }
+        } else if (this.config.isEdirectoryGUID()) {
+            filter = "(&(objectClass=*)(" + getUuidAttributeName().toUpperCase() + LDAPConstants.EQUAL + LDAPUtil.convertGUIDToEdirectoryHexString(id) + "))";
         }
 
         if (filter == null) {

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPUtil.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPUtil.java
@@ -110,6 +110,26 @@ public class LDAPUtil {
     }
 
     /**
+     * see http://support.novell.com/docs/Tids/Solutions/10096551.html
+     *
+     * @param guid A GUID in the form of a dashed String as the result of (@see LDAPUtil#convertToDashedString)
+     *
+     * @return A String representation in the form of \[0][1]\[2][3]\[4][5]\[6][7]\[8][9]\[10][11]\[12][13]\[14][15]
+     */
+    public static String convertGUIDToEdirectoryHexString(String guid) {
+        String withoutDash = guid.replace("-", "");
+        StringBuilder result = new StringBuilder();
+
+        for (int i = 0; i < withoutDash.length(); i++) {
+            result.append("\\");
+            result.append(withoutDash.charAt(i));
+            result.append(withoutDash.charAt(++i));
+        }
+
+        return result.toString().toUpperCase();
+    }
+
+    /**
      * <p>Decode a raw byte array representing the value of the <code>objectGUID</code> attribute retrieved from Active
      * Directory.</p>
      *


### PR DESCRIPTION
The LDAPOperationManager does not encode GUID correctly when looking up federated users from Novell eDirectory.

The correct encoding can be found at https://support.novell.com/docs/Tids/Solutions/10096551.html

See also:
* KEYCLOAK-9841 - #7834
* KEYCLOAK-10942 - #6251