### PR TITLE
KEYCLOAK-18311 fix creation of roles during client registration

### DIFF
--- a/server-spi/src/main/java/org/keycloak/models/RoleContainerModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/RoleContainerModel.java
@@ -20,6 +20,7 @@ package org.keycloak.models;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import org.keycloak.provider.ProviderEvent;
 
@@ -98,14 +99,21 @@ public interface RoleContainerModel {
 
     /**
      * @deprecated Default roles are now managed by {@link org.keycloak.models.RealmModel#getDefaultRole()}. This method will be removed.
+     * @return List of default roles names or empty list if there are none. Never returns {@code null}.
      */
     @Deprecated
     default List<String> getDefaultRoles() {
-        return getDefaultRolesStream().collect(Collectors.toList());
+        Stream<String> defaultRolesStream = getDefaultRolesStream();
+        if (defaultRolesStream != null) {
+            return defaultRolesStream.collect(Collectors.toList());
+        } else {
+            return Collections.emptyList();
+        }
     }
 
     /**
      * @deprecated Default roles are now managed by {@link org.keycloak.models.RealmModel#getDefaultRole()}. This method will be removed.
+     * @return Stream of default roles names or empty stream if there are none. Never returns {@code null}.
      */
     @Deprecated
     Stream<String> getDefaultRolesStream();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientRegistrationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientRegistrationTest.java
@@ -17,7 +17,7 @@
 
 package org.keycloak.testsuite.client;
 
-import org.junit.Assert;
+import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.keycloak.client.registration.Auth;
 import org.keycloak.client.registration.ClientRegistration;
@@ -26,7 +26,6 @@ import org.keycloak.client.registration.HttpErrorException;
 import org.keycloak.models.Constants;
 import org.keycloak.protocol.oidc.OIDCAdvancedConfigWrapper;
 import org.keycloak.representations.idm.ClientRepresentation;
-import org.keycloak.representations.idm.ClientScopeRepresentation;
 import org.keycloak.representations.idm.OAuth2ErrorRepresentation;
 import org.keycloak.representations.idm.ProtocolMapperRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
@@ -46,13 +45,13 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
@@ -90,7 +89,7 @@ public class ClientRegistrationTest extends AbstractClientRegistrationTest {
         // Remove this client after test
         getCleanup().addClientUuid(createdClient.getId());
 
-        return client;
+        return createdClient;
     }
 
     @Test
@@ -172,6 +171,24 @@ public class ClientRegistrationTest extends AbstractClientRegistrationTest {
     	
     	ClientRepresentation createdClient = registerClient(client);
     	assertEquals(name, createdClient.getName());
+    }
+
+    @Test
+    public void clientWithDefaultRoles() throws ClientRegistrationException {
+        authCreateClients();
+        ClientRepresentation client = buildClient();
+        client.setDefaultRoles(new String[]{"test-default-role"});
+
+        ClientRepresentation createdClient = registerClient(client);
+        assertThat(createdClient.getDefaultRoles(), Matchers.arrayContaining("test-default-role"));
+
+        authManageClients();
+        ClientRepresentation obtainedClient = reg.get(CLIENT_ID);
+        assertThat(obtainedClient.getDefaultRoles(), Matchers.arrayContaining("test-default-role"));
+
+        client.setDefaultRoles(new String[]{"test-default-role1","test-default-role2"});
+        ClientRepresentation updatedClient = reg.update(client);
+        assertThat(updatedClient.getDefaultRoles(), Matchers.arrayContainingInAnyOrder("test-default-role1","test-default-role2"));
     }
 
     @Test


### PR DESCRIPTION
The PR adds back the possibility to use `ClientRepresentation.defaultRoles` for creating the roles during client registration. It will make it backwards compatible, but the concept of using default roles for creating the roles seems to be a bit misusage. 

Alternatively there can be added different field into `ClientRepresentation` (something like `clientRolesNames`) which will be used only for client-registration-api (not for import or admin console) and also the fallback to default roles could be added for backwards compatibility.