### PR TITLE
KEYCLOAK-18699 Brand logo is not found for product admin console

### DIFF
--- a/themes/src/main/resources-product/theme/rh-sso/admin/theme.properties
+++ b/themes/src/main/resources-product/theme/rh-sso/admin/theme.properties
@@ -1,4 +1,5 @@
 parent=keycloak
+import=common/rh-sso
 
 styles=css/styles.css
 stylesCommon=node_modules/rcue/dist/css/rcue.min.css node_modules/rcue/dist/css/rcue-additions.min.css node_modules/select2/select2.css lib/angular/treeview/css/angular.treeview.css node_modules/text-security/text-security.css


### PR DESCRIPTION
JIRA: [KEYCLOAK-18699](https://issues.redhat.com/browse/KEYCLOAK-18699)

@Pepo48 @vmuzikar @ssilvert Could you please take a look at it? Thank you very much.