### PR TITLE
[KEYCLOAK-18541] separate template for IDP review page

### DIFF
--- a/services/src/main/java/org/keycloak/forms/login/freemarker/Templates.java
+++ b/services/src/main/java/org/keycloak/forms/login/freemarker/Templates.java
@@ -75,8 +75,9 @@ public class Templates {
             case SAML_POST_FORM:
                 return "saml-post-form.ftl";
             case UPDATE_USER_PROFILE:
-            case IDP_REVIEW_USER_PROFILE:
                 return "update-user-profile.ftl";
+            case IDP_REVIEW_USER_PROFILE:
+                return "idp-review-user-profile.ftl";
             default:
                 throw new IllegalArgumentException();
         }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcFirstBrokerLoginWithUserProfileTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcFirstBrokerLoginWithUserProfileTest.java
@@ -92,7 +92,7 @@ public class KcOidcFirstBrokerLoginWithUserProfileTest extends KcOidcFirstBroker
         updateAccountInformationPage.assertCurrent();
         
         //assert fields location in form
-        String htmlFormId = "kc-update-profile-form";
+        String htmlFormId = "kc-idp-review-profile-form";
         Assert.assertTrue(
             driver.findElement(
                 By.cssSelector("form#"+htmlFormId+" > div:nth-child(1) > div:nth-child(2) > input#lastName")

--- a/themes/src/main/resources/theme/base/login/idp-review-user-profile.ftl
+++ b/themes/src/main/resources/theme/base/login/idp-review-user-profile.ftl
@@ -1,0 +1,23 @@
+<#import "template.ftl" as layout>
+<#import "user-profile-commons.ftl" as userProfileCommons>
+<@layout.registrationLayout displayMessage=messagesPerField.exists('global') displayRequiredFields=true; section>
+    <#if section = "header">
+        ${msg("loginIdpReviewProfileTitle")}
+    <#elseif section = "form">
+        <form id="kc-idp-review-profile-form" class="${properties.kcFormClass!}" action="${url.loginAction}" method="post">
+
+            <@userProfileCommons.userProfileFormFields/>
+
+            <div class="${properties.kcFormGroupClass!}">
+                <div id="kc-form-options" class="${properties.kcFormOptionsClass!}">
+                    <div class="${properties.kcFormOptionsWrapperClass!}">
+                    </div>
+                </div>
+
+                <div id="kc-form-buttons" class="${properties.kcFormButtonsClass!}">
+                    <input class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}" type="submit" value="${msg("doSubmit")}" />
+                </div>
+            </div>
+        </form>
+    </#if>
+</@layout.registrationLayout>

--- a/themes/src/main/resources/theme/base/login/messages/messages_en.properties
+++ b/themes/src/main/resources/theme/base/login/messages/messages_en.properties
@@ -31,6 +31,7 @@ realmChoice=Realm
 unknownUser=Unknown user
 loginTotpTitle=Mobile Authenticator Setup
 loginProfileTitle=Update Account Information
+loginIdpReviewProfileTitle=Update Account Information
 loginTimeout=Your login attempt timed out.  Login will start from the beginning.
 oauthGrantTitle=Grant Access to {0}
 oauthGrantTitleHtml={0}


### PR DESCRIPTION
As being discussed in the keycloak-dev list. 
I think separate template for IDP review use case is beneficial as it is really another use case than profile update. Eg. `update-user-profile.ftl` has buttons for app initiated actions not necessary here, and we should expect that more `if`s will be added as we implement other improvements and features.