### PR TITLE
[KEYCLOAK-18745] - Client JWT authentication should allow PAR endpoint as audience

### DIFF
--- a/core/src/main/java/org/keycloak/representations/JsonWebToken.java
+++ b/core/src/main/java/org/keycloak/representations/JsonWebToken.java
@@ -32,6 +32,7 @@ import org.keycloak.json.StringOrArraySerializer;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -216,6 +217,22 @@ public class JsonWebToken implements Serializable, Token {
                 return true;
             }
         }
+        return false;
+    }
+
+    public boolean hasAnyAudience(List<String> audiences) {
+        String[] auds = getAudience();
+
+        if (auds == null) {
+            return false;
+        }
+
+        for (String aud : auds) {
+            if (audiences.contains(aud)) {
+                return true;
+            }
+        }
+
         return false;
     }
 

--- a/services/src/main/java/org/keycloak/authentication/authenticators/client/JWTClientAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/client/JWTClientAuthenticator.java
@@ -46,6 +46,7 @@ import org.keycloak.models.SingleUseTokenStoreProvider;
 import org.keycloak.protocol.oidc.OIDCAdvancedConfigWrapper;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.protocol.oidc.OIDCLoginProtocolService;
+import org.keycloak.protocol.oidc.par.endpoints.ParEndpoint;
 import org.keycloak.provider.ProviderConfigProperty;
 import org.keycloak.representations.JsonWebToken;
 import org.keycloak.services.ServicesLogger;
@@ -157,10 +158,11 @@ public class JWTClientAuthenticator extends AbstractClientAuthenticator {
             }
 
             // Allow both "issuer" or "token-endpoint" as audience
-            String issuerUrl = Urls.realmIssuer(context.getUriInfo().getBaseUri(), realm.getName());
-            String tokenUrl = OIDCLoginProtocolService.tokenUrl(context.getUriInfo().getBaseUriBuilder()).build(realm.getName()).toString();
-            if (!token.hasAudience(issuerUrl) && !token.hasAudience(tokenUrl)) {
-                throw new RuntimeException("Token audience doesn't match domain. Realm issuer is '" + issuerUrl + "' but audience from token is '" + Arrays.asList(token.getAudience()).toString() + "'");
+            List<String> expectedAudiences = getExpectedAudiences(context, realm);
+
+            if (!token.hasAnyAudience(expectedAudiences)) {
+                throw new RuntimeException("Token audience doesn't match domain. Expected audiences are any of " + expectedAudiences
+                        + " but audience from token is '" + Arrays.asList(token.getAudience()) + "'");
             }
 
             if (!token.isActive()) {
@@ -266,5 +268,12 @@ public class JWTClientAuthenticator extends AbstractClientAuthenticator {
         } else {
             return Collections.emptySet();
         }
+    }
+
+    private List<String> getExpectedAudiences(ClientAuthenticationFlowContext context, RealmModel realm) {
+        String issuerUrl = Urls.realmIssuer(context.getUriInfo().getBaseUri(), realm.getName());
+        String tokenUrl = OIDCLoginProtocolService.tokenUrl(context.getUriInfo().getBaseUriBuilder()).build(realm.getName()).toString();
+        String parEndpointUrl = ParEndpoint.parUrl(context.getUriInfo().getBaseUriBuilder()).build(realm.getName()).toString();
+        return Arrays.asList(issuerUrl, tokenUrl, parEndpointUrl);
     }
 }


### PR DESCRIPTION
I'm not sure if it makes sense to have a condition to check whether the PAR feature is enabled prior to adding the endpoint to the list of expected audiences.