### PR TITLE
KEYCLOAK-18750 - Set "Email Verified" to false when email changed in UserProfile Provider

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/userprofile/DefaultUserProfile.java
+++ b/server-spi-private/src/main/java/org/keycloak/userprofile/DefaultUserProfile.java
@@ -42,14 +42,16 @@ import org.keycloak.models.UserModel;
  */
 public final class DefaultUserProfile implements UserProfile {
 
+    protected final UserProfileMetadata metadata;
     private final Function<Attributes, UserModel> userSupplier;
     private final Attributes attributes;
     private final KeycloakSession session;
     private boolean validated;
     private UserModel user;
 
-    public DefaultUserProfile(Attributes attributes, Function<Attributes, UserModel> userCreator, UserModel user,
+    public DefaultUserProfile(UserProfileMetadata metadata, Attributes attributes, Function<Attributes, UserModel> userCreator, UserModel user,
             KeycloakSession session) {
+        this.metadata = metadata;
         this.userSupplier = userCreator;
         this.attributes = attributes;
         this.user = user;
@@ -113,6 +115,11 @@ public final class DefaultUserProfile implements UserProfile {
 
                 if (currentValue.size() != updatedValue.size() || !currentValue.containsAll(updatedValue)) {
                     user.setAttribute(name, updatedValue);
+                    
+                    if(UserModel.EMAIL.equals(name) && metadata.getContext().isResetEmailVerified()) {
+                        user.setEmailVerified(false);
+                    }
+                    
                     for (BiConsumer<String, UserModel> listener : changeListener) {
                         listener.accept(name, user);
                     }

--- a/server-spi-private/src/main/java/org/keycloak/userprofile/UserProfileContext.java
+++ b/server-spi-private/src/main/java/org/keycloak/userprofile/UserProfileContext.java
@@ -30,11 +30,25 @@ package org.keycloak.userprofile;
  */
 public enum UserProfileContext {
 
-    UPDATE_PROFILE,
-    USER_API,
-    ACCOUNT,
-    ACCOUNT_OLD,
-    IDP_REVIEW,
-    REGISTRATION_PROFILE,
-    REGISTRATION_USER_CREATION;
+    UPDATE_PROFILE(true),
+    USER_API(false),
+    ACCOUNT(true),
+    ACCOUNT_OLD(true),
+    IDP_REVIEW(false),
+    REGISTRATION_PROFILE(false),
+    REGISTRATION_USER_CREATION(false);
+    
+    protected boolean resetEmailVerified;
+    
+    private UserProfileContext(boolean resetEmailVerified){
+        this.resetEmailVerified = resetEmailVerified;
+    }
+    
+    /**
+     * @return true means that UserModel.emailVerified flag must be reset to false in this context when email address is updated
+     */
+    public boolean isResetEmailVerified() {
+        return resetEmailVerified;
+    }
+    
 }

--- a/services/src/main/java/org/keycloak/authentication/requiredactions/UpdateProfile.java
+++ b/services/src/main/java/org/keycloak/authentication/requiredactions/UpdateProfile.java
@@ -84,7 +84,6 @@ public class UpdateProfile implements RequiredActionProvider, RequiredActionFact
                     event.detail(Details.PREVIOUS_LAST_NAME, oldLastName).detail(Details.UPDATED_LAST_NAME, user.getLastName());
                 }
                 if (attributeName.equals(UserModel.EMAIL)) {
-                    user.setEmailVerified(false);
                     event.detail(Details.PREVIOUS_EMAIL, oldEmail).detail(Details.UPDATED_EMAIL, user.getEmail());
                 }
             });

--- a/services/src/main/java/org/keycloak/services/resources/account/AccountFormService.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountFormService.java
@@ -377,7 +377,6 @@ public class AccountFormService extends AbstractSecuredLocalService {
             // backward compatibility with old account console where attributes are not removed if missing
             profile.update(false, (attributeName, userModel) -> {
                 if (attributeName.equals(UserModel.EMAIL)) {
-                    user.setEmailVerified(false);
                     event.detail(Details.PREVIOUS_EMAIL, oldEmail).detail(Details.UPDATED_EMAIL, user.getEmail()).success();
                 }
                 if (attributeName.equals(UserModel.FIRST_NAME)) {

--- a/services/src/main/java/org/keycloak/services/resources/account/AccountRestService.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountRestService.java
@@ -135,6 +135,7 @@ public class AccountRestService {
         UserModel user = auth.getUser();
 
         UserRepresentation rep = new UserRepresentation();
+        rep.setId(user.getId());
         rep.setUsername(user.getUsername());
         rep.setFirstName(user.getFirstName());
         rep.setLastName(user.getLastName());

--- a/services/src/main/java/org/keycloak/userprofile/AbstractUserProfileProvider.java
+++ b/services/src/main/java/org/keycloak/userprofile/AbstractUserProfileProvider.java
@@ -250,7 +250,7 @@ public abstract class AbstractUserProfileProvider<U extends UserProfileProvider>
     private UserProfile createUserProfile(UserProfileContext context, Map<String, ?> attributes, UserModel user) {
         UserProfileMetadata metadata = configureUserProfile(contextualMetadataRegistry.get(context), session);
         Attributes profileAttributes = createAttributes(context, attributes, user, metadata);
-        return new DefaultUserProfile(profileAttributes, createUserFactory(), user, session);
+        return new DefaultUserProfile(metadata, profileAttributes, createUserFactory(), user, session);
     }
 
     protected Attributes createAttributes(UserProfileContext context, Map<String, ?> attributes, UserModel user,

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/VerifyProfilePage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/VerifyProfilePage.java
@@ -75,6 +75,26 @@ public class VerifyProfilePage extends AbstractPage {
 
         update(firstName, lastName);
     }
+    
+    public void updateEmail(String email, String firstName, String lastName) {
+        
+        emailInput.clear();
+        if (emailInput != null) {
+            emailInput.sendKeys(email);
+        }
+        
+        firstNameInput.clear();
+        if (firstName != null) {
+            firstNameInput.sendKeys(firstName);
+        }
+
+        lastNameInput.clear();
+        if (lastName != null) {
+            lastNameInput.sendKeys(lastName);
+        }
+
+        submitButton.click();
+    }
 
     public String getAlertError() {
         try {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/AccountFormServiceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/AccountFormServiceTest.java
@@ -772,6 +772,44 @@ public class AccountFormServiceTest extends AbstractTestRealmKeycloakTest {
     }
 
     @Test
+    public void changeProfileEmailChangeSetsEmailVerified() throws Exception {
+        setEditUsernameAllowed(false);
+        setRegistrationEmailAsUsername(false);
+
+        UserResource userResource = testRealm().users().get(userId);
+        UserRepresentation user = userResource.toRepresentation();
+        user.setEmailVerified(true);
+        userResource.update(user);
+
+        profilePage.open();
+        loginPage.login("test-user@localhost", "password");
+
+        events.expectLogin().client("account").detail(Details.REDIRECT_URI, getAccountRedirectUrl()).assertEvent();
+
+        // email not changed so flag no reset
+        profilePage.updateProfile(profilePage.getFirstName(), "New last", profilePage.getEmail());
+        user = userResource.toRepresentation();
+        assertTrue(user.isEmailVerified());
+        
+        events.expectAccount(EventType.UPDATE_PROFILE).detail(Details.UPDATED_LAST_NAME, "New last").detail(Details.PREVIOUS_LAST_NAME, "Brady").assertEvent();
+        
+        //email changed, flag must be reeset
+        profilePage.updateProfile(profilePage.getFirstName(), profilePage.getLastName(), "new@email.com");
+        Assert.assertEquals("new@email.com", profilePage.getEmail());
+        user = userResource.toRepresentation();
+        assertFalse(user.isEmailVerified());
+
+        events.expectAccount(EventType.UPDATE_PROFILE).detail(Details.PREVIOUS_EMAIL, "test-user@localhost").detail(Details.UPDATED_EMAIL, "new@email.com").assertEvent();
+
+        // reset user for other tests
+        profilePage.updateProfile("Tom", "Brady", "test-user@localhost");
+        events.clear();
+
+        // Revert
+        setEditUsernameAllowed(true);
+    }
+
+    @Test
     public void changeProfileEmailAsUsernameEnabled() throws Exception {
         setRegistrationEmailAsUsername(true);
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/RequiredActionUpdateProfileTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/RequiredActionUpdateProfileTest.java
@@ -82,6 +82,7 @@ public class RequiredActionUpdateProfileTest extends AbstractTestRealmKeycloakTe
                 .email("test-user@localhost")
                 .firstName("Tom")
                 .lastName("Brady")
+                .emailVerified(true)
                 .requiredAction(UserModel.RequiredAction.UPDATE_PROFILE.name()).build();
         ApiUtil.createUserAndResetPasswordWithAdminClient(testRealm(), user, "password");
 
@@ -91,6 +92,7 @@ public class RequiredActionUpdateProfileTest extends AbstractTestRealmKeycloakTe
                 .email("john-doh@localhost")
                 .firstName("John")
                 .lastName("Doh")
+                .emailVerified(true)
                 .requiredAction(UserModel.RequiredAction.UPDATE_PROFILE.name()).build();
         ApiUtil.createUserAndResetPasswordWithAdminClient(testRealm(), user, "password");
     }
@@ -121,6 +123,8 @@ public class RequiredActionUpdateProfileTest extends AbstractTestRealmKeycloakTe
         Assert.assertEquals("New last", user.getLastName());
         Assert.assertEquals("new@email.com", user.getEmail());
         Assert.assertEquals("test-user@localhost", user.getUsername());
+        // email changed so verify that emailVerified flag is reset
+        Assert.assertEquals(false, user.isEmailVerified());
     }
 
     @Test
@@ -150,6 +154,8 @@ public class RequiredActionUpdateProfileTest extends AbstractTestRealmKeycloakTe
         Assert.assertEquals("New last", user.getLastName());
         Assert.assertEquals("john-doh@localhost", user.getEmail());
         Assert.assertEquals("new", user.getUsername());
+        // email not changed so verify that emailVerified flag is NOT reset
+        Assert.assertEquals(true, user.isEmailVerified());
         getCleanup().addUserId(user.getId());
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/util/UserBuilder.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/util/UserBuilder.java
@@ -107,6 +107,11 @@ public class UserBuilder {
         rep.setEmail(email);
         return this;
     }
+    
+    public UserBuilder emailVerified(boolean emailVerified) {
+        rep.setEmailVerified(emailVerified);
+        return this;
+    }
 
     public UserBuilder enabled(boolean enabled) {
         rep.setEnabled(enabled);


### PR DESCRIPTION
Logic to reset emailVerified flag is now centralized in UserProfile, not spread over client code calling it. 
Added integration tests to cover this logic for:
* Update Profile Required action
* Verify Profile Required action
* Email update from old account console 
* Email update over New Account console REST API