### PR TITLE
KEYCLOAK-18826 FAPI-CIBA-ID1 conformance test : ID Token needs to include auth_time claim

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/ciba/CibaGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/ciba/CibaGrantType.java
@@ -26,6 +26,7 @@ import org.jboss.logging.Logger;
 import org.keycloak.OAuthErrorException;
 import org.keycloak.authentication.AuthenticationProcessor;
 import org.keycloak.common.Profile;
+import org.keycloak.common.util.Time;
 import org.keycloak.events.Details;
 import org.keycloak.events.Errors;
 import org.keycloak.events.EventBuilder;
@@ -211,6 +212,9 @@ public class CibaGrantType {
 
         ClientSessionContext clientSessionCtx = DefaultClientSessionContext
                 .fromClientSessionAndClientScopes(userSession.getAuthenticatedClientSessionByClient(client.getId()), TokenManager.getRequestedClientScopes(scopeParam, client), session);
+
+        int authTime = Time.currentTime();
+        userSession.setNote(AuthenticationManager.AUTH_TIME, String.valueOf(authTime));
 
         return tokenEndpoint.createTokenResponse(user, userSession, clientSessionCtx, scopeParam, true);
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/CIBATest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/CIBATest.java
@@ -27,6 +27,7 @@ import org.apache.http.client.methods.CloseableHttpResponse;
 
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.keycloak.protocol.oidc.grants.ciba.channel.AuthenticationChannelResponse.Status.CANCELLED;
 import static org.keycloak.protocol.oidc.grants.ciba.channel.AuthenticationChannelResponse.Status.SUCCEED;
@@ -1947,6 +1948,8 @@ public class CIBATest extends AbstractClientPoliciesTest {
             prepareCIBASettings(clientResource, clientRep);
             if (isOfflineAccess) oauth.scope(OAuth2Constants.OFFLINE_ACCESS);
 
+            long startTime = Time.currentTime();
+
             // user Backchannel Authentication Request
             AuthenticationRequestAcknowledgement response = doBackchannelAuthenticationRequest(TEST_CLIENT_NAME, TEST_CLIENT_PASSWORD, username, bindingMessage, additionalParameters);
 
@@ -1966,6 +1969,11 @@ public class CIBATest extends AbstractClientPoliciesTest {
 
             // user Token Request
             OAuthClient.AccessTokenResponse tokenRes = doBackchannelAuthenticationTokenRequest(username, response.getAuthReqId());
+            IDToken idToken = oauth.verifyIDToken(tokenRes.getIdToken());
+            long currentTime = Time.currentTime();
+            long authTime = idToken.getAuth_time().longValue();
+            assertTrue(startTime -5 <= authTime);
+            assertTrue(authTime <= currentTime + 5);
 
             // token introspection
             String tokenResponse = doIntrospectAccessTokenWithClientCredential(tokenRes, username);


### PR DESCRIPTION
This PR is for [KEYCLOAK-18457 FAPI CIBA Support](https://issues.redhat.com/browse/KEYCLOAK-18457), also is the part of the project [FAPI-CIBA(poll mode)](https://github.com/keycloak/kc-sig-fapi/projects) of [FAPI-SIG](https://github.com/keycloak/kc-sig-fapi) activity.

This PR is needed to satisfy requirements by [Financial-grade API: Client Initiated Backchannel Authentication Profile](https://bitbucket.org/openid/fapi/src/master/Financial_API_WD_CIBA.md#markdown-header-522-authorization-server).
[KEYCLOAK-18826](https://issues.redhat.com/browse/KEYCLOAK-18826) describes it more.