### PR TITLE
KEYCLOAK-7724 User Profile sane default validations

### DIFF
--- a/services/src/main/resources/org/keycloak/userprofile/config/keycloak-default-user-profile.json
+++ b/services/src/main/resources/org/keycloak/userprofile/config/keycloak-default-user-profile.json
@@ -2,11 +2,18 @@
 	"attributes": [
 		{
 			"name": "username",
-			"displayName": "${username}"
+			"displayName": "${username}",
+			"validations": {
+				"length": { "min": 3, "max": 255 },
+				"pattern": {"pattern": "^[^<>&\"'\\s\\v\\h$%!#?,;:*~/\\\\|^=\\[\\]{}`\\p{Cntrl}]+$"}
+			}
 		},
 		{
 			"name": "email",
-			"displayName": "${email}"
+			"displayName": "${email}",
+			"validations": {
+				"length": { "min": 1, "max": 255 }
+			}
 		},
 		{
 			"name": "firstName",
@@ -15,6 +22,10 @@
 			"permissions": {
 				"view": ["admin", "user"],
 				"edit": ["admin", "user"]
+			},
+			"validations": {
+				"length": { "min": 1, "max": 255 },
+				"pattern": {"pattern": "^[^<>&\"\\s\\v\\h$%!#?,;:*~/\\\\|^=\\[\\]{}`\\p{Cntrl}]+$"}
 			}
 		},
 		{
@@ -24,6 +35,10 @@
 			"permissions": {
 				"view": ["admin", "user"],
 				"edit": ["admin", "user"]
+			},
+			"validations": {
+				"length": { "min": 1, "max": 255 },
+				"pattern": {"pattern": "^[^<>&\"\\s\\v\\h$%!#?,;:*~/\\\\|^=\\[\\]{}`\\p{Cntrl}]+$"}
 			}
 		}
 	]


### PR DESCRIPTION
Sane default validations for default user attributed added based on dicsussion at keycloak-dev list.
* length validation to prevent JPA error
* pattern validation to deny distinct nonsense or potentially malicious characters

Admin can (and always should) reconfigure validations as necessary for it's instance.
