### PR TITLE
KEYCLOAK-18849 Client Policy - Condition : ClientRolesCondition needs to be evaluated on PAR endpoint

### DIFF
--- a/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientRolesCondition.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientRolesCondition.java
@@ -77,6 +77,7 @@ public class ClientRolesCondition extends AbstractClientPolicyConditionProvider<
             case LOGOUT_REQUEST:
             case BACKCHANNEL_AUTHENTICATION_REQUEST:
             case BACKCHANNEL_TOKEN_REQUEST:
+            case PUSHED_AUTHORIZATION_REQUEST:
                 if (isRolesMatched(session.getContext().getClient())) return ClientPolicyVote.YES;
                 return ClientPolicyVote.NO;
             default:


### PR DESCRIPTION
This PR is for [KEYCLOAK-18629 OpenBanking Brazil support
](https://issues.redhat.com/browse/KEYCLOAK-18629), also is the part of the project [FAPI-CIBA(poll mode)](https://github.com/keycloak/kc-sig-fapi/projects) of [FAPI-SIG](https://github.com/keycloak/kc-sig-fapi) activity.

This PR is needed to to use client policies for PAR request.