### PR TITLE
KEYCLOAK-18831 FAPI-CIBA-ID1 conformance test : need to return 400 if user authentication is not successfully completed

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/ciba/CibaGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/ciba/CibaGrantType.java
@@ -178,7 +178,7 @@ public class CibaGrantType {
 
         if (deviceCode.isDenied()) {
             logDebug("denied.", request);
-            throw new CorsErrorResponseException(cors, OAuthErrorException.ACCESS_DENIED, "not authorized", Response.Status.FORBIDDEN);
+            throw new CorsErrorResponseException(cors, OAuthErrorException.ACCESS_DENIED, "not authorized", Response.Status.BAD_REQUEST);
         }
 
         // get corresponding Authentication Channel Result entry

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/CIBATest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/CIBATest.java
@@ -1046,12 +1046,12 @@ public class CIBATest extends AbstractClientPoliciesTest {
 
     @Test
     public void testAuthenticationChannelUnauthorized() throws Exception {
-        testAuthenticationChannelErrorCase(Status.OK, Status.FORBIDDEN, UNAUTHORIZED, OAuthErrorException.ACCESS_DENIED, Errors.CONSENT_DENIED);
+        testAuthenticationChannelErrorCase(Status.OK, Status.BAD_REQUEST, UNAUTHORIZED, OAuthErrorException.ACCESS_DENIED, Errors.CONSENT_DENIED);
     }
 
     @Test
     public void testAuthenticationChannelCancelled() throws Exception {
-        testAuthenticationChannelErrorCase(Status.OK, Status.FORBIDDEN, CANCELLED, OAuthErrorException.ACCESS_DENIED, Errors.NOT_ALLOWED);
+        testAuthenticationChannelErrorCase(Status.OK, Status.BAD_REQUEST, CANCELLED, OAuthErrorException.ACCESS_DENIED, Errors.NOT_ALLOWED);
     }
 
     @Test


### PR DESCRIPTION
This PR is for [KEYCLOAK-18457 FAPI CIBA Support](https://issues.redhat.com/browse/KEYCLOAK-18457), also is the part of the project [FAPI-CIBA(poll mode)](https://github.com/keycloak/kc-sig-fapi/projects) of [FAPI-SIG](https://github.com/keycloak/kc-sig-fapi) activity.

This PR is needed to satisfy requirements by [Financial-grade API: Client Initiated Backchannel Authentication Profile](https://bitbucket.org/openid/fapi/src/master/Financial_API_WD_CIBA.md#markdown-header-522-authorization-server).
[KEYCLOAK-18831](https://issues.redhat.com/browse/KEYCLOAK-18831) describes it more.