### PR TITLE
KEYCLOAK-18845 Remove key type in map storage

### DIFF
--- a/model/map/pom.xml
+++ b/model/map/pom.xml
@@ -8,7 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>keycloak-model-map</artifactId>
-    <name>Keycloak Model Naive Map</name>
+    <name>Keycloak Model Map</name>
     <description/>
 
     <dependencies>

--- a/model/map/src/main/java/org/keycloak/models/map/authSession/MapRootAuthenticationSessionAdapter.java
+++ b/model/map/src/main/java/org/keycloak/models/map/authSession/MapRootAuthenticationSessionAdapter.java
@@ -31,10 +31,15 @@ import java.util.stream.Collectors;
 /**
  * @author <a href="mailto:mkanis@redhat.com">Martin Kanis</a>
  */
-public abstract class MapRootAuthenticationSessionAdapter<K> extends AbstractRootAuthenticationSessionModel<MapRootAuthenticationSessionEntity<K>> {
+public class MapRootAuthenticationSessionAdapter extends AbstractRootAuthenticationSessionModel<MapRootAuthenticationSessionEntity> {
 
-    public MapRootAuthenticationSessionAdapter(KeycloakSession session, RealmModel realm, MapRootAuthenticationSessionEntity<K> entity) {
+    public MapRootAuthenticationSessionAdapter(KeycloakSession session, RealmModel realm, MapRootAuthenticationSessionEntity entity) {
         super(session, realm, entity);
+    }
+
+    @Override
+    public String getId() {
+        return entity.getId();
     }
 
     @Override

--- a/model/map/src/main/java/org/keycloak/models/map/authSession/MapRootAuthenticationSessionEntity.java
+++ b/model/map/src/main/java/org/keycloak/models/map/authSession/MapRootAuthenticationSessionEntity.java
@@ -26,9 +26,9 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * @author <a href="mailto:mkanis@redhat.com">Martin Kanis</a>
  */
-public class MapRootAuthenticationSessionEntity<K> implements AbstractEntity<K>, UpdatableEntity {
+public class MapRootAuthenticationSessionEntity implements AbstractEntity, UpdatableEntity {
 
-    private K id;
+    private String id;
     private String realmId;
 
     /**
@@ -43,8 +43,7 @@ public class MapRootAuthenticationSessionEntity<K> implements AbstractEntity<K>,
         this.realmId = null;
     }
 
-    public MapRootAuthenticationSessionEntity(K id, String realmId) {
-        Objects.requireNonNull(id, "id");
+    public MapRootAuthenticationSessionEntity(String id, String realmId) {
         Objects.requireNonNull(realmId, "realmId");
 
         this.id = id;
@@ -52,7 +51,7 @@ public class MapRootAuthenticationSessionEntity<K> implements AbstractEntity<K>,
     }
 
     @Override
-    public K getId() {
+    public String getId() {
         return this.id;
     }
 

--- a/model/map/src/main/java/org/keycloak/models/map/authSession/MapRootAuthenticationSessionProvider.java
+++ b/model/map/src/main/java/org/keycloak/models/map/authSession/MapRootAuthenticationSessionProvider.java
@@ -44,16 +44,16 @@ import static org.keycloak.models.map.storage.QueryParameters.withCriteria;
 /**
  * @author <a href="mailto:mkanis@redhat.com">Martin Kanis</a>
  */
-public class MapRootAuthenticationSessionProvider<K> implements AuthenticationSessionProvider {
+public class MapRootAuthenticationSessionProvider implements AuthenticationSessionProvider {
 
     private static final Logger LOG = Logger.getLogger(MapRootAuthenticationSessionProvider.class);
     private final KeycloakSession session;
-    protected final MapKeycloakTransaction<K, MapRootAuthenticationSessionEntity, RootAuthenticationSessionModel> tx;
-    private final MapStorage<K, MapRootAuthenticationSessionEntity, RootAuthenticationSessionModel> sessionStore;
+    protected final MapKeycloakTransaction<MapRootAuthenticationSessionEntity, RootAuthenticationSessionModel> tx;
+    private final MapStorage<MapRootAuthenticationSessionEntity, RootAuthenticationSessionModel> sessionStore;
 
     private static final String AUTHENTICATION_SESSION_EVENTS = "AUTHENTICATION_SESSION_EVENTS";
 
-    public MapRootAuthenticationSessionProvider(KeycloakSession session, MapStorage<K, MapRootAuthenticationSessionEntity, RootAuthenticationSessionModel> sessionStore) {
+    public MapRootAuthenticationSessionProvider(KeycloakSession session, MapStorage<MapRootAuthenticationSessionEntity, RootAuthenticationSessionModel> sessionStore) {
         this.session = session;
         this.sessionStore = sessionStore;
         this.tx = sessionStore.createTransaction(session);
@@ -87,7 +87,7 @@ public class MapRootAuthenticationSessionProvider<K> implements AuthenticationSe
         LOG.tracef("createRootAuthenticationSession(%s)%s", realm.getName(), getShortStackTrace());
 
         // create map authentication session entity
-        MapRootAuthenticationSessionEntity entity = new MapRootAuthenticationSessionEntity(null, realm.getId());
+        MapRootAuthenticationSessionEntity entity = new MapRootAuthenticationSessionEntity(id, realm.getId());
         entity.setTimestamp(Time.currentTime());
 
         if (id != null && tx.read(id) != null) {

--- a/model/map/src/main/java/org/keycloak/models/map/authSession/MapRootAuthenticationSessionProvider.java
+++ b/model/map/src/main/java/org/keycloak/models/map/authSession/MapRootAuthenticationSessionProvider.java
@@ -48,12 +48,12 @@ public class MapRootAuthenticationSessionProvider<K> implements AuthenticationSe
 
     private static final Logger LOG = Logger.getLogger(MapRootAuthenticationSessionProvider.class);
     private final KeycloakSession session;
-    protected final MapKeycloakTransaction<K, MapRootAuthenticationSessionEntity<K>, RootAuthenticationSessionModel> tx;
-    private final MapStorage<K, MapRootAuthenticationSessionEntity<K>, RootAuthenticationSessionModel> sessionStore;
+    protected final MapKeycloakTransaction<K, MapRootAuthenticationSessionEntity, RootAuthenticationSessionModel> tx;
+    private final MapStorage<K, MapRootAuthenticationSessionEntity, RootAuthenticationSessionModel> sessionStore;
 
     private static final String AUTHENTICATION_SESSION_EVENTS = "AUTHENTICATION_SESSION_EVENTS";
 
-    public MapRootAuthenticationSessionProvider(KeycloakSession session, MapStorage<K, MapRootAuthenticationSessionEntity<K>, RootAuthenticationSessionModel> sessionStore) {
+    public MapRootAuthenticationSessionProvider(KeycloakSession session, MapStorage<K, MapRootAuthenticationSessionEntity, RootAuthenticationSessionModel> sessionStore) {
         this.session = session;
         this.sessionStore = sessionStore;
         this.tx = sessionStore.createTransaction(session);
@@ -61,18 +61,13 @@ public class MapRootAuthenticationSessionProvider<K> implements AuthenticationSe
         session.getTransactionManager().enlistAfterCompletion(tx);
     }
 
-    private Function<MapRootAuthenticationSessionEntity<K>, RootAuthenticationSessionModel> entityToAdapterFunc(RealmModel realm) {
+    private Function<MapRootAuthenticationSessionEntity, RootAuthenticationSessionModel> entityToAdapterFunc(RealmModel realm) {
         // Clone entity before returning back, to avoid giving away a reference to the live object to the caller
 
-        return origEntity -> new MapRootAuthenticationSessionAdapter<K>(session, realm, origEntity) {
-            @Override
-            public String getId() {
-                return sessionStore.getKeyConvertor().keyToString(entity.getId());
-            }
-        };
+        return origEntity -> new MapRootAuthenticationSessionAdapter(session, realm, origEntity);
     }
 
-    private Predicate<MapRootAuthenticationSessionEntity<K>> entityRealmFilter(String realmId) {
+    private Predicate<MapRootAuthenticationSessionEntity> entityRealmFilter(String realmId) {
         if (realmId == null) {
             return c -> false;
         }
@@ -89,16 +84,13 @@ public class MapRootAuthenticationSessionProvider<K> implements AuthenticationSe
     public RootAuthenticationSessionModel createRootAuthenticationSession(RealmModel realm, String id) {
         Objects.requireNonNull(realm, "The provided realm can't be null!");
 
-        final K entityId = id == null ? sessionStore.getKeyConvertor().yieldNewUniqueKey() : sessionStore.getKeyConvertor().fromString(id);
-
         LOG.tracef("createRootAuthenticationSession(%s)%s", realm.getName(), getShortStackTrace());
 
         // create map authentication session entity
-        MapRootAuthenticationSessionEntity<K> entity = new MapRootAuthenticationSessionEntity<>(entityId, realm.getId());
-        entity.setRealmId(realm.getId());
+        MapRootAuthenticationSessionEntity entity = new MapRootAuthenticationSessionEntity(null, realm.getId());
         entity.setTimestamp(Time.currentTime());
 
-        if (tx.read(entity.getId()) != null) {
+        if (id != null && tx.read(id) != null) {
             throw new ModelDuplicateException("Root authentication session exists: " + entity.getId());
         }
 
@@ -116,7 +108,7 @@ public class MapRootAuthenticationSessionProvider<K> implements AuthenticationSe
 
         LOG.tracef("getRootAuthenticationSession(%s, %s)%s", realm.getName(), authenticationSessionId, getShortStackTrace());
 
-        MapRootAuthenticationSessionEntity<K> entity = tx.read(sessionStore.getKeyConvertor().fromStringSafe(authenticationSessionId));
+        MapRootAuthenticationSessionEntity entity = tx.read(authenticationSessionId);
         return (entity == null || !entityRealmFilter(realm.getId()).test(entity))
                 ? null
                 : entityToAdapterFunc(realm).apply(entity);
@@ -125,7 +117,7 @@ public class MapRootAuthenticationSessionProvider<K> implements AuthenticationSe
     @Override
     public void removeRootAuthenticationSession(RealmModel realm, RootAuthenticationSessionModel authenticationSession) {
         Objects.requireNonNull(authenticationSession, "The provided root authentication session can't be null!");
-        tx.delete(sessionStore.getKeyConvertor().fromString(authenticationSession.getId()));
+        tx.delete(authenticationSession.getId());
     }
 
     @Override

--- a/model/map/src/main/java/org/keycloak/models/map/authSession/MapRootAuthenticationSessionProviderFactory.java
+++ b/model/map/src/main/java/org/keycloak/models/map/authSession/MapRootAuthenticationSessionProviderFactory.java
@@ -26,7 +26,7 @@ import org.keycloak.sessions.RootAuthenticationSessionModel;
 /**
  * @author <a href="mailto:mkanis@redhat.com">Martin Kanis</a>
  */
-public class MapRootAuthenticationSessionProviderFactory<K> extends AbstractMapProviderFactory<AuthenticationSessionProvider, K, MapRootAuthenticationSessionEntity<K>, RootAuthenticationSessionModel>
+public class MapRootAuthenticationSessionProviderFactory<K> extends AbstractMapProviderFactory<AuthenticationSessionProvider, K, MapRootAuthenticationSessionEntity, RootAuthenticationSessionModel>
         implements AuthenticationSessionProviderFactory {
 
     public MapRootAuthenticationSessionProviderFactory() {

--- a/model/map/src/main/java/org/keycloak/models/map/authSession/MapRootAuthenticationSessionProviderFactory.java
+++ b/model/map/src/main/java/org/keycloak/models/map/authSession/MapRootAuthenticationSessionProviderFactory.java
@@ -26,7 +26,7 @@ import org.keycloak.sessions.RootAuthenticationSessionModel;
 /**
  * @author <a href="mailto:mkanis@redhat.com">Martin Kanis</a>
  */
-public class MapRootAuthenticationSessionProviderFactory<K> extends AbstractMapProviderFactory<AuthenticationSessionProvider, K, MapRootAuthenticationSessionEntity, RootAuthenticationSessionModel>
+public class MapRootAuthenticationSessionProviderFactory extends AbstractMapProviderFactory<AuthenticationSessionProvider, MapRootAuthenticationSessionEntity, RootAuthenticationSessionModel>
         implements AuthenticationSessionProviderFactory {
 
     public MapRootAuthenticationSessionProviderFactory() {
@@ -35,7 +35,7 @@ public class MapRootAuthenticationSessionProviderFactory<K> extends AbstractMapP
 
     @Override
     public AuthenticationSessionProvider create(KeycloakSession session) {
-        return new MapRootAuthenticationSessionProvider<>(session, getStorage(session));
+        return new MapRootAuthenticationSessionProvider(session, getStorage(session));
     }
 
     @Override

--- a/model/map/src/main/java/org/keycloak/models/map/authorization/MapAuthorizationStoreFactory.java
+++ b/model/map/src/main/java/org/keycloak/models/map/authorization/MapAuthorizationStoreFactory.java
@@ -45,7 +45,7 @@ import static org.keycloak.models.utils.KeycloakModelUtils.getComponentFactory;
 /**
  * @author mhajas
  */
-public class MapAuthorizationStoreFactory<K> implements AmphibianProviderFactory<StoreFactory>, AuthorizationStoreFactory, EnvironmentDependentProviderFactory {
+public class MapAuthorizationStoreFactory implements AmphibianProviderFactory<StoreFactory>, AuthorizationStoreFactory, EnvironmentDependentProviderFactory {
 
     public static final String PROVIDER_ID = AbstractMapProviderFactory.PROVIDER_ID;
 

--- a/model/map/src/main/java/org/keycloak/models/map/authorization/MapPermissionTicketStore.java
+++ b/model/map/src/main/java/org/keycloak/models/map/authorization/MapPermissionTicketStore.java
@@ -48,14 +48,14 @@ import static org.keycloak.models.map.storage.QueryParameters.withCriteria;
 import static org.keycloak.utils.StreamsUtil.distinctByKey;
 import static org.keycloak.utils.StreamsUtil.paginatedStream;
 
-public class MapPermissionTicketStore<K extends Comparable<K>> implements PermissionTicketStore {
+public class MapPermissionTicketStore implements PermissionTicketStore {
 
     private static final Logger LOG = Logger.getLogger(MapPermissionTicketStore.class);
     private final AuthorizationProvider authorizationProvider;
-    final MapKeycloakTransaction<K, MapPermissionTicketEntity, PermissionTicket> tx;
-    private final MapStorage<K, MapPermissionTicketEntity, PermissionTicket> permissionTicketStore;
+    final MapKeycloakTransaction<MapPermissionTicketEntity, PermissionTicket> tx;
+    private final MapStorage<MapPermissionTicketEntity, PermissionTicket> permissionTicketStore;
 
-    public MapPermissionTicketStore(KeycloakSession session, MapStorage<K, MapPermissionTicketEntity, PermissionTicket> permissionTicketStore, AuthorizationProvider provider) {
+    public MapPermissionTicketStore(KeycloakSession session, MapStorage<MapPermissionTicketEntity, PermissionTicket> permissionTicketStore, AuthorizationProvider provider) {
         this.authorizationProvider = provider;
         this.permissionTicketStore = permissionTicketStore;
         this.tx = permissionTicketStore.createTransaction(session);

--- a/model/map/src/main/java/org/keycloak/models/map/authorization/MapPermissionTicketStore.java
+++ b/model/map/src/main/java/org/keycloak/models/map/authorization/MapPermissionTicketStore.java
@@ -52,25 +52,20 @@ public class MapPermissionTicketStore<K extends Comparable<K>> implements Permis
 
     private static final Logger LOG = Logger.getLogger(MapPermissionTicketStore.class);
     private final AuthorizationProvider authorizationProvider;
-    final MapKeycloakTransaction<K, MapPermissionTicketEntity<K>, PermissionTicket> tx;
-    private final MapStorage<K, MapPermissionTicketEntity<K>, PermissionTicket> permissionTicketStore;
+    final MapKeycloakTransaction<K, MapPermissionTicketEntity, PermissionTicket> tx;
+    private final MapStorage<K, MapPermissionTicketEntity, PermissionTicket> permissionTicketStore;
 
-    public MapPermissionTicketStore(KeycloakSession session, MapStorage<K, MapPermissionTicketEntity<K>, PermissionTicket> permissionTicketStore, AuthorizationProvider provider) {
+    public MapPermissionTicketStore(KeycloakSession session, MapStorage<K, MapPermissionTicketEntity, PermissionTicket> permissionTicketStore, AuthorizationProvider provider) {
         this.authorizationProvider = provider;
         this.permissionTicketStore = permissionTicketStore;
         this.tx = permissionTicketStore.createTransaction(session);
         session.getTransactionManager().enlist(tx);
     }
 
-    private PermissionTicket entityToAdapter(MapPermissionTicketEntity<K> origEntity) {
+    private PermissionTicket entityToAdapter(MapPermissionTicketEntity origEntity) {
         if (origEntity == null) return null;
         // Clone entity before returning back, to avoid giving away a reference to the live object to the caller
-        return new MapPermissionTicketAdapter<K>(origEntity, authorizationProvider.getStoreFactory()) {
-            @Override
-            public String getId() {
-                return permissionTicketStore.getKeyConvertor().keyToString(entity.getId());
-            }
-        };
+        return new MapPermissionTicketAdapter(origEntity, authorizationProvider.getStoreFactory());
     }
 
     private ModelCriteriaBuilder<PermissionTicket> forResourceServer(String resourceServerId) {
@@ -114,8 +109,7 @@ public class MapPermissionTicketStore<K extends Comparable<K>> implements Permis
                     + ", Resource: " + resourceId + ", owner: " + owner + ", scopeId: " + scopeId + " already exists.");
         }
 
-        final K newId = permissionTicketStore.getKeyConvertor().yieldNewUniqueKey();
-        MapPermissionTicketEntity<K> entity = new MapPermissionTicketEntity<>(newId);
+        MapPermissionTicketEntity entity = new MapPermissionTicketEntity(null);
         entity.setResourceId(resourceId);
         entity.setRequester(requester);
         entity.setCreatedTimestamp(System.currentTimeMillis());
@@ -135,7 +129,7 @@ public class MapPermissionTicketStore<K extends Comparable<K>> implements Permis
     @Override
     public void delete(String id) {
         LOG.tracef("delete(%s)%s", id, getShortStackTrace());
-        tx.delete(permissionTicketStore.getKeyConvertor().fromString(id));
+        tx.delete(id);
     }
 
     @Override
@@ -276,7 +270,7 @@ public class MapPermissionTicketStore<K extends Comparable<K>> implements Permis
                 .compare(SearchableFields.REQUESTER, Operator.EQ, requester)
                 .compare(SearchableFields.GRANTED_TIMESTAMP, Operator.EXISTS);
 
-        Function<MapPermissionTicketEntity<K>, Resource> ticketResourceMapper;
+        Function<MapPermissionTicketEntity, Resource> ticketResourceMapper;
 
         ResourceStore resourceStore = authorizationProvider.getStoreFactory().getResourceStore();
         if (name != null) {

--- a/model/map/src/main/java/org/keycloak/models/map/authorization/MapPolicyStore.java
+++ b/model/map/src/main/java/org/keycloak/models/map/authorization/MapPolicyStore.java
@@ -43,14 +43,14 @@ import java.util.stream.Collectors;
 import static org.keycloak.common.util.StackUtil.getShortStackTrace;
 import static org.keycloak.models.map.storage.QueryParameters.withCriteria;
 
-public class MapPolicyStore<K> implements PolicyStore {
+public class MapPolicyStore implements PolicyStore {
 
     private static final Logger LOG = Logger.getLogger(MapPolicyStore.class);
     private final AuthorizationProvider authorizationProvider;
-    final MapKeycloakTransaction<K, MapPolicyEntity, Policy> tx;
-    private final MapStorage<K, MapPolicyEntity, Policy> policyStore;
+    final MapKeycloakTransaction<MapPolicyEntity, Policy> tx;
+    private final MapStorage<MapPolicyEntity, Policy> policyStore;
 
-    public MapPolicyStore(KeycloakSession session, MapStorage<K, MapPolicyEntity, Policy> policyStore, AuthorizationProvider provider) {
+    public MapPolicyStore(KeycloakSession session, MapStorage<MapPolicyEntity, Policy> policyStore, AuthorizationProvider provider) {
         this.authorizationProvider = provider;
         this.policyStore = policyStore;
         this.tx = policyStore.createTransaction(session);
@@ -134,7 +134,7 @@ public class MapPolicyStore<K> implements PolicyStore {
 
     @Override
     public List<Policy> findByResourceServer(Map<Policy.FilterOption, String[]> attributes, String resourceServerId, int firstResult, int maxResult) {
-        LOG.tracef("findByResource(%s, %s, %d, %d)%s", attributes, resourceServerId, firstResult, maxResult, getShortStackTrace());
+        LOG.tracef("findByResourceServer(%s, %s, %d, %d)%s", attributes, resourceServerId, firstResult, maxResult, getShortStackTrace());
 
         ModelCriteriaBuilder<Policy> mcb = forResourceServer(resourceServerId).and(
                 attributes.entrySet().stream()

--- a/model/map/src/main/java/org/keycloak/models/map/authorization/MapResourceServerStore.java
+++ b/model/map/src/main/java/org/keycloak/models/map/authorization/MapResourceServerStore.java
@@ -40,14 +40,14 @@ import org.keycloak.storage.StorageId;
 
 import static org.keycloak.common.util.StackUtil.getShortStackTrace;
 
-public class MapResourceServerStore<K> implements ResourceServerStore {
+public class MapResourceServerStore implements ResourceServerStore {
 
     private static final Logger LOG = Logger.getLogger(MapResourceServerStore.class);
     private final AuthorizationProvider authorizationProvider;
-    final MapKeycloakTransaction<K, MapResourceServerEntity, ResourceServer> tx;
-    private final MapStorage<K, MapResourceServerEntity, ResourceServer> resourceServerStore;
+    final MapKeycloakTransaction<MapResourceServerEntity, ResourceServer> tx;
+    private final MapStorage<MapResourceServerEntity, ResourceServer> resourceServerStore;
 
-    public MapResourceServerStore(KeycloakSession session, MapStorage<K, MapResourceServerEntity, ResourceServer> resourceServerStore, AuthorizationProvider provider) {
+    public MapResourceServerStore(KeycloakSession session, MapStorage<MapResourceServerEntity, ResourceServer> resourceServerStore, AuthorizationProvider provider) {
         this.resourceServerStore = resourceServerStore;
         this.tx = resourceServerStore.createTransaction(session);
         this.authorizationProvider = provider;

--- a/model/map/src/main/java/org/keycloak/models/map/authorization/MapResourceStore.java
+++ b/model/map/src/main/java/org/keycloak/models/map/authorization/MapResourceStore.java
@@ -42,14 +42,14 @@ import java.util.stream.Collectors;
 import static org.keycloak.common.util.StackUtil.getShortStackTrace;
 import static org.keycloak.models.map.storage.QueryParameters.withCriteria;
 
-public class MapResourceStore<K extends Comparable<K>> implements ResourceStore {
+public class MapResourceStore implements ResourceStore {
 
     private static final Logger LOG = Logger.getLogger(MapResourceStore.class);
     private final AuthorizationProvider authorizationProvider;
-    final MapKeycloakTransaction<K, MapResourceEntity, Resource> tx;
-    private final MapStorage<K, MapResourceEntity, Resource> resourceStore;
+    final MapKeycloakTransaction<MapResourceEntity, Resource> tx;
+    private final MapStorage<MapResourceEntity, Resource> resourceStore;
 
-    public MapResourceStore(KeycloakSession session, MapStorage<K, MapResourceEntity, Resource> resourceStore, AuthorizationProvider provider) {
+    public MapResourceStore(KeycloakSession session, MapStorage<MapResourceEntity, Resource> resourceStore, AuthorizationProvider provider) {
         this.resourceStore = resourceStore;
         this.tx = resourceStore.createTransaction(session);
         session.getTransactionManager().enlist(tx);

--- a/model/map/src/main/java/org/keycloak/models/map/authorization/MapScopeStore.java
+++ b/model/map/src/main/java/org/keycloak/models/map/authorization/MapScopeStore.java
@@ -40,14 +40,14 @@ import java.util.stream.Collectors;
 import static org.keycloak.common.util.StackUtil.getShortStackTrace;
 import static org.keycloak.models.map.storage.QueryParameters.withCriteria;
 
-public class MapScopeStore<K> implements ScopeStore {
+public class MapScopeStore implements ScopeStore {
 
     private static final Logger LOG = Logger.getLogger(MapScopeStore.class);
     private final AuthorizationProvider authorizationProvider;
-    final MapKeycloakTransaction<K, MapScopeEntity, Scope> tx;
-    private final MapStorage<K, MapScopeEntity, Scope> scopeStore;
+    final MapKeycloakTransaction<MapScopeEntity, Scope> tx;
+    private final MapStorage<MapScopeEntity, Scope> scopeStore;
 
-    public MapScopeStore(KeycloakSession session, MapStorage<K, MapScopeEntity, Scope> scopeStore, AuthorizationProvider provider) {
+    public MapScopeStore(KeycloakSession session, MapStorage<MapScopeEntity, Scope> scopeStore, AuthorizationProvider provider) {
         this.authorizationProvider = provider;
         this.scopeStore = scopeStore;
         this.tx = scopeStore.createTransaction(session);

--- a/model/map/src/main/java/org/keycloak/models/map/authorization/adapter/AbstractPolicyModel.java
+++ b/model/map/src/main/java/org/keycloak/models/map/authorization/adapter/AbstractPolicyModel.java
@@ -24,7 +24,7 @@ import org.keycloak.models.map.common.AbstractEntity;
 
 import java.util.Objects;
 
-public abstract class AbstractPolicyModel<E extends AbstractEntity<?>> extends AbstractAuthorizationModel implements Policy {
+public abstract class AbstractPolicyModel<E extends AbstractEntity> extends AbstractAuthorizationModel implements Policy {
 
     protected final E entity;
 

--- a/model/map/src/main/java/org/keycloak/models/map/authorization/adapter/AbstractResourceModel.java
+++ b/model/map/src/main/java/org/keycloak/models/map/authorization/adapter/AbstractResourceModel.java
@@ -24,7 +24,7 @@ import org.keycloak.models.map.common.AbstractEntity;
 
 import java.util.Objects;
 
-public abstract class AbstractResourceModel<E extends AbstractEntity<?>> extends AbstractAuthorizationModel implements Resource {
+public abstract class AbstractResourceModel<E extends AbstractEntity> extends AbstractAuthorizationModel implements Resource {
 
     protected final E entity;
 

--- a/model/map/src/main/java/org/keycloak/models/map/authorization/adapter/MapPermissionTicketAdapter.java
+++ b/model/map/src/main/java/org/keycloak/models/map/authorization/adapter/MapPermissionTicketAdapter.java
@@ -28,10 +28,15 @@ import org.keycloak.authorization.store.StoreFactory;
 import org.keycloak.models.map.authorization.entity.MapPermissionTicketEntity;
 import static org.keycloak.authorization.UserManagedPermissionUtil.updatePolicy;
 
-public abstract class MapPermissionTicketAdapter<K extends Comparable<K>> extends AbstractPermissionTicketModel<MapPermissionTicketEntity<K>> {
+public class MapPermissionTicketAdapter extends AbstractPermissionTicketModel<MapPermissionTicketEntity> {
     
-    public MapPermissionTicketAdapter(MapPermissionTicketEntity<K> entity, StoreFactory storeFactory) {
+    public MapPermissionTicketAdapter(MapPermissionTicketEntity entity, StoreFactory storeFactory) {
         super(entity, storeFactory);
+    }
+
+    @Override
+    public String getId() {
+        return entity.getId();
     }
 
     @Override

--- a/model/map/src/main/java/org/keycloak/models/map/authorization/adapter/MapPolicyAdapter.java
+++ b/model/map/src/main/java/org/keycloak/models/map/authorization/adapter/MapPolicyAdapter.java
@@ -30,7 +30,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public class MapPolicyAdapter<K> extends AbstractPolicyModel<MapPolicyEntity> {
+public class MapPolicyAdapter extends AbstractPolicyModel<MapPolicyEntity> {
     
     public MapPolicyAdapter(MapPolicyEntity entity, StoreFactory storeFactory) {
         super(entity, storeFactory);

--- a/model/map/src/main/java/org/keycloak/models/map/authorization/adapter/MapPolicyAdapter.java
+++ b/model/map/src/main/java/org/keycloak/models/map/authorization/adapter/MapPolicyAdapter.java
@@ -30,10 +30,15 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public abstract class MapPolicyAdapter<K> extends AbstractPolicyModel<MapPolicyEntity<K>> {
+public class MapPolicyAdapter<K> extends AbstractPolicyModel<MapPolicyEntity> {
     
-    public MapPolicyAdapter(MapPolicyEntity<K> entity, StoreFactory storeFactory) {
+    public MapPolicyAdapter(MapPolicyEntity entity, StoreFactory storeFactory) {
         super(entity, storeFactory);
+    }
+
+    @Override
+    public String getId() {
+        return entity.getId();
     }
 
     @Override

--- a/model/map/src/main/java/org/keycloak/models/map/authorization/adapter/MapResourceAdapter.java
+++ b/model/map/src/main/java/org/keycloak/models/map/authorization/adapter/MapResourceAdapter.java
@@ -28,10 +28,15 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public abstract class MapResourceAdapter<K> extends AbstractResourceModel<MapResourceEntity<K>> {
+public class MapResourceAdapter extends AbstractResourceModel<MapResourceEntity> {
 
-    public MapResourceAdapter(MapResourceEntity<K> entity, StoreFactory storeFactory) {
+    public MapResourceAdapter(MapResourceEntity entity, StoreFactory storeFactory) {
         super(entity, storeFactory);
+    }
+
+    @Override
+    public String getId() {
+        return entity.getId();
     }
 
     @Override

--- a/model/map/src/main/java/org/keycloak/models/map/authorization/adapter/MapResourceServerAdapter.java
+++ b/model/map/src/main/java/org/keycloak/models/map/authorization/adapter/MapResourceServerAdapter.java
@@ -23,10 +23,15 @@ import org.keycloak.models.map.authorization.entity.MapResourceServerEntity;
 import org.keycloak.representations.idm.authorization.DecisionStrategy;
 import org.keycloak.representations.idm.authorization.PolicyEnforcementMode;
 
-public abstract class MapResourceServerAdapter<K> extends AbstractResourceServerModel<MapResourceServerEntity<K>> {
+public class MapResourceServerAdapter extends AbstractResourceServerModel<MapResourceServerEntity> {
 
-    public MapResourceServerAdapter(MapResourceServerEntity<K> entity, StoreFactory storeFactory) {
+    public MapResourceServerAdapter(MapResourceServerEntity entity, StoreFactory storeFactory) {
         super(entity, storeFactory);
+    }
+
+    @Override
+    public String getId() {
+        return entity.getId();
     }
 
     @Override

--- a/model/map/src/main/java/org/keycloak/models/map/authorization/adapter/MapScopeAdapter.java
+++ b/model/map/src/main/java/org/keycloak/models/map/authorization/adapter/MapScopeAdapter.java
@@ -22,10 +22,15 @@ import org.keycloak.authorization.model.ResourceServer;
 import org.keycloak.authorization.store.StoreFactory;
 import org.keycloak.models.map.authorization.entity.MapScopeEntity;
 
-public abstract class MapScopeAdapter<K> extends AbstractScopeModel<MapScopeEntity<K>> {
+public class MapScopeAdapter extends AbstractScopeModel<MapScopeEntity> {
 
-    public MapScopeAdapter(MapScopeEntity<K> entity, StoreFactory storeFactory) {
+    public MapScopeAdapter(MapScopeEntity entity, StoreFactory storeFactory) {
         super(entity, storeFactory);
+    }
+
+    @Override
+    public String getId() {
+        return entity.getId();
     }
 
     @Override

--- a/model/map/src/main/java/org/keycloak/models/map/authorization/entity/MapPermissionTicketEntity.java
+++ b/model/map/src/main/java/org/keycloak/models/map/authorization/entity/MapPermissionTicketEntity.java
@@ -22,9 +22,9 @@ import org.keycloak.models.map.common.AbstractEntity;
 import org.keycloak.models.map.common.UpdatableEntity;
 import java.util.Objects;
 
-public class MapPermissionTicketEntity<K> implements AbstractEntity<K>, UpdatableEntity {
+public class MapPermissionTicketEntity implements AbstractEntity, UpdatableEntity {
 
-    private final K id;
+    private final String id;
     private String owner;
     private String requester;
     private Long createdTimestamp;
@@ -35,7 +35,7 @@ public class MapPermissionTicketEntity<K> implements AbstractEntity<K>, Updatabl
     private String policyId;
     private boolean updated = false;
 
-    public MapPermissionTicketEntity(K id) {
+    public MapPermissionTicketEntity(String id) {
         this.id = id;
     }
 
@@ -44,7 +44,7 @@ public class MapPermissionTicketEntity<K> implements AbstractEntity<K>, Updatabl
     }
 
     @Override
-    public K getId() {
+    public String getId() {
         return id;
     }
 

--- a/model/map/src/main/java/org/keycloak/models/map/authorization/entity/MapPolicyEntity.java
+++ b/model/map/src/main/java/org/keycloak/models/map/authorization/entity/MapPolicyEntity.java
@@ -28,9 +28,9 @@ import java.util.Set;
 import java.util.Map;
 import java.util.Objects;
 
-public class MapPolicyEntity<K> implements AbstractEntity<K>, UpdatableEntity {
+public class MapPolicyEntity implements AbstractEntity, UpdatableEntity {
     
-    private final K id;
+    private final String id;
     private String name;
     private String description;
     private String type;
@@ -44,7 +44,7 @@ public class MapPolicyEntity<K> implements AbstractEntity<K>, UpdatableEntity {
     private String owner;
     private boolean updated = false;
 
-    public MapPolicyEntity(K id) {
+    public MapPolicyEntity(String id) {
         this.id = id;
     }
 
@@ -178,7 +178,7 @@ public class MapPolicyEntity<K> implements AbstractEntity<K>, UpdatableEntity {
     }
 
     @Override
-    public K getId() {
+    public String getId() {
         return id;
     }
 

--- a/model/map/src/main/java/org/keycloak/models/map/authorization/entity/MapResourceEntity.java
+++ b/model/map/src/main/java/org/keycloak/models/map/authorization/entity/MapResourceEntity.java
@@ -27,9 +27,9 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
-public class MapResourceEntity<K> implements AbstractEntity<K>, UpdatableEntity {
+public class MapResourceEntity implements AbstractEntity, UpdatableEntity {
     
-    private final K id;
+    private final String id;
     private String name;
     private String displayName;
     private final Set<String> uris = new HashSet<>();
@@ -43,7 +43,7 @@ public class MapResourceEntity<K> implements AbstractEntity<K>, UpdatableEntity 
     private final Map<String, List<String>> attributes = new HashMap<>();
     private boolean updated = false;
 
-    public MapResourceEntity(K id) {
+    public MapResourceEntity(String id) {
         this.id = id;
     }
 
@@ -52,7 +52,7 @@ public class MapResourceEntity<K> implements AbstractEntity<K>, UpdatableEntity 
     }
 
     @Override
-    public K getId() {
+    public String getId() {
         return id;
     }
 

--- a/model/map/src/main/java/org/keycloak/models/map/authorization/entity/MapResourceServerEntity.java
+++ b/model/map/src/main/java/org/keycloak/models/map/authorization/entity/MapResourceServerEntity.java
@@ -24,16 +24,16 @@ import org.keycloak.representations.idm.authorization.PolicyEnforcementMode;
 
 import java.util.Objects;
 
-public class MapResourceServerEntity<K> implements AbstractEntity<K>, UpdatableEntity {
+public class MapResourceServerEntity implements AbstractEntity, UpdatableEntity {
 
-    private final K id;
+    private final String id;
     private boolean updated = false;
 
     private boolean allowRemoteResourceManagement;
     private PolicyEnforcementMode policyEnforcementMode = PolicyEnforcementMode.ENFORCING;
     private DecisionStrategy decisionStrategy = DecisionStrategy.UNANIMOUS;
 
-    public MapResourceServerEntity(K id) {
+    public MapResourceServerEntity(String id) {
         this.id = id;
     }
 
@@ -42,7 +42,7 @@ public class MapResourceServerEntity<K> implements AbstractEntity<K>, UpdatableE
     }
 
     @Override
-    public K getId() {
+    public String getId() {
         return id;
     }
 

--- a/model/map/src/main/java/org/keycloak/models/map/authorization/entity/MapScopeEntity.java
+++ b/model/map/src/main/java/org/keycloak/models/map/authorization/entity/MapScopeEntity.java
@@ -22,16 +22,16 @@ import org.keycloak.models.map.common.AbstractEntity;
 import org.keycloak.models.map.common.UpdatableEntity;
 import java.util.Objects;
 
-public class MapScopeEntity<K> implements AbstractEntity<K>, UpdatableEntity {
+public class MapScopeEntity implements AbstractEntity, UpdatableEntity {
 
-    private final K id;
+    private final String id;
     private String name;
     private String displayName;
     private String iconUri;
     private String resourceServerId;
     private boolean updated = false;
 
-    public MapScopeEntity(K id) {
+    public MapScopeEntity(String id) {
         this.id = id;
     }
 
@@ -40,7 +40,7 @@ public class MapScopeEntity<K> implements AbstractEntity<K>, UpdatableEntity {
     }
 
     @Override
-    public K getId() {
+    public String getId() {
         return id;
     }
 

--- a/model/map/src/main/java/org/keycloak/models/map/client/MapClientAdapter.java
+++ b/model/map/src/main/java/org/keycloak/models/map/client/MapClientAdapter.java
@@ -36,10 +36,15 @@ import java.util.stream.Stream;
  *
  * @author hmlnarik
  */
-public abstract class MapClientAdapter<K> extends AbstractClientModel<MapClientEntity<K>> implements ClientModel {
+public abstract class MapClientAdapter extends AbstractClientModel<MapClientEntity> implements ClientModel {
 
-    public MapClientAdapter(KeycloakSession session, RealmModel realm, MapClientEntity<K> entity) {
+    public MapClientAdapter(KeycloakSession session, RealmModel realm, MapClientEntity entity) {
         super(session, realm, entity);
+    }
+
+    @Override
+    public String getId() {
+        return entity.getId();
     }
 
     @Override

--- a/model/map/src/main/java/org/keycloak/models/map/client/MapClientEntity.java
+++ b/model/map/src/main/java/org/keycloak/models/map/client/MapClientEntity.java
@@ -29,7 +29,7 @@ import java.util.stream.Stream;
  *
  * @author hmlnarik
  */
-public interface MapClientEntity<K> extends AbstractEntity<K>, UpdatableEntity {
+public interface MapClientEntity extends AbstractEntity, UpdatableEntity {
 
     void addClientScope(String id, Boolean defaultScope);
 

--- a/model/map/src/main/java/org/keycloak/models/map/client/MapClientEntityDelegate.java
+++ b/model/map/src/main/java/org/keycloak/models/map/client/MapClientEntityDelegate.java
@@ -20,7 +20,7 @@ package org.keycloak.models.map.client;
  *
  * @author hmlnarik
  */
-public class MapClientEntityDelegate<K> extends MapClientEntityLazyDelegate<K> {
+public class MapClientEntityDelegate extends MapClientEntityLazyDelegate {
 
     private final MapClientEntity delegate;
 

--- a/model/map/src/main/java/org/keycloak/models/map/client/MapClientEntityDelegate.java
+++ b/model/map/src/main/java/org/keycloak/models/map/client/MapClientEntityDelegate.java
@@ -22,15 +22,15 @@ package org.keycloak.models.map.client;
  */
 public class MapClientEntityDelegate<K> extends MapClientEntityLazyDelegate<K> {
 
-    private final MapClientEntity<K> delegate;
+    private final MapClientEntity delegate;
 
-    public MapClientEntityDelegate(MapClientEntity<K> delegate) {
+    public MapClientEntityDelegate(MapClientEntity delegate) {
         super(null);
         this.delegate = delegate;
     }
 
     @Override
-    protected MapClientEntity<K> getDelegate() {
+    protected MapClientEntity getDelegate() {
         return delegate;
     }
 }

--- a/model/map/src/main/java/org/keycloak/models/map/client/MapClientEntityImpl.java
+++ b/model/map/src/main/java/org/keycloak/models/map/client/MapClientEntityImpl.java
@@ -36,9 +36,9 @@ import java.util.stream.Stream;
  *
  * @author hmlnarik
  */
-public class MapClientEntityImpl<K> implements MapClientEntity<K> {
+public class MapClientEntityImpl<K> implements MapClientEntity {
 
-    private K id;
+    private String id;
     private String realmId;
 
     private String clientId;
@@ -84,8 +84,7 @@ public class MapClientEntityImpl<K> implements MapClientEntity<K> {
         this.realmId = null;
     }
 
-    public MapClientEntityImpl(K id, String realmId) {
-        Objects.requireNonNull(id, "id");
+    public MapClientEntityImpl(String id, String realmId) {
         Objects.requireNonNull(realmId, "realmId");
 
         this.id = id;
@@ -93,7 +92,7 @@ public class MapClientEntityImpl<K> implements MapClientEntity<K> {
     }
 
     @Override
-    public K getId() {
+    public String getId() {
         return this.id;
     }
 

--- a/model/map/src/main/java/org/keycloak/models/map/client/MapClientEntityImpl.java
+++ b/model/map/src/main/java/org/keycloak/models/map/client/MapClientEntityImpl.java
@@ -17,7 +17,6 @@
 package org.keycloak.models.map.client;
 
 import org.keycloak.models.ProtocolMapperModel;
-import org.keycloak.models.map.common.AbstractEntity;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -36,7 +35,7 @@ import java.util.stream.Stream;
  *
  * @author hmlnarik
  */
-public class MapClientEntityImpl<K> implements MapClientEntity {
+public class MapClientEntityImpl implements MapClientEntity {
 
     private String id;
     private String realmId;

--- a/model/map/src/main/java/org/keycloak/models/map/client/MapClientEntityLazyDelegate.java
+++ b/model/map/src/main/java/org/keycloak/models/map/client/MapClientEntityLazyDelegate.java
@@ -29,7 +29,7 @@ import java.util.stream.Stream;
  *
  * @author hmlnarik
  */
-public class MapClientEntityLazyDelegate<K> implements MapClientEntity {
+public class MapClientEntityLazyDelegate implements MapClientEntity {
 
     private final Supplier<MapClientEntity> delegateSupplier;
 

--- a/model/map/src/main/java/org/keycloak/models/map/client/MapClientEntityLazyDelegate.java
+++ b/model/map/src/main/java/org/keycloak/models/map/client/MapClientEntityLazyDelegate.java
@@ -29,21 +29,21 @@ import java.util.stream.Stream;
  *
  * @author hmlnarik
  */
-public class MapClientEntityLazyDelegate<K> implements MapClientEntity<K> {
+public class MapClientEntityLazyDelegate<K> implements MapClientEntity {
 
-    private final Supplier<MapClientEntity<K>> delegateSupplier;
+    private final Supplier<MapClientEntity> delegateSupplier;
 
-    private final AtomicMarkableReference<MapClientEntity<K>> delegate = new AtomicMarkableReference<>(null, false);
+    private final AtomicMarkableReference<MapClientEntity> delegate = new AtomicMarkableReference<>(null, false);
 
-    public MapClientEntityLazyDelegate(Supplier<MapClientEntity<K>> delegateSupplier) {
+    public MapClientEntityLazyDelegate(Supplier<MapClientEntity> delegateSupplier) {
         this.delegateSupplier = delegateSupplier;
     }
 
-    protected MapClientEntity<K> getDelegate() {
+    protected MapClientEntity getDelegate() {
         if (! delegate.isMarked()) {
             delegate.compareAndSet(null, delegateSupplier == null ? null : delegateSupplier.get(), false, true);
         }
-        MapClientEntity<K> ref = delegate.getReference();
+        MapClientEntity ref = delegate.getReference();
         if (ref == null) {
             throw new IllegalStateException("Invalid delegate obtained");
         }
@@ -456,7 +456,7 @@ public class MapClientEntityLazyDelegate<K> implements MapClientEntity<K> {
     }
 
     @Override
-    public K getId() {
+    public String getId() {
         return getDelegate().getId();
     }
 

--- a/model/map/src/main/java/org/keycloak/models/map/client/MapClientProviderFactory.java
+++ b/model/map/src/main/java/org/keycloak/models/map/client/MapClientProviderFactory.java
@@ -35,9 +35,9 @@ import java.util.concurrent.ConcurrentMap;
  *
  * @author hmlnarik
  */
-public class MapClientProviderFactory<K> extends AbstractMapProviderFactory<ClientProvider, K, MapClientEntity<K>, ClientModel> implements ClientProviderFactory, ProviderEventListener {
+public class MapClientProviderFactory<K> extends AbstractMapProviderFactory<ClientProvider, K, MapClientEntity, ClientModel> implements ClientProviderFactory, ProviderEventListener {
 
-    private final ConcurrentHashMap<K, ConcurrentMap<String, Integer>> REGISTERED_NODES_STORE = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, ConcurrentMap<String, Integer>> REGISTERED_NODES_STORE = new ConcurrentHashMap<>();
 
     private Runnable onClose;
 

--- a/model/map/src/main/java/org/keycloak/models/map/client/MapClientProviderFactory.java
+++ b/model/map/src/main/java/org/keycloak/models/map/client/MapClientProviderFactory.java
@@ -35,7 +35,7 @@ import java.util.concurrent.ConcurrentMap;
  *
  * @author hmlnarik
  */
-public class MapClientProviderFactory<K> extends AbstractMapProviderFactory<ClientProvider, K, MapClientEntity, ClientModel> implements ClientProviderFactory, ProviderEventListener {
+public class MapClientProviderFactory extends AbstractMapProviderFactory<ClientProvider, MapClientEntity, ClientModel> implements ClientProviderFactory, ProviderEventListener {
 
     private final ConcurrentHashMap<String, ConcurrentMap<String, Integer>> REGISTERED_NODES_STORE = new ConcurrentHashMap<>();
 
@@ -53,7 +53,7 @@ public class MapClientProviderFactory<K> extends AbstractMapProviderFactory<Clie
 
     @Override
     public MapClientProvider create(KeycloakSession session) {
-        return new MapClientProvider<>(session, getStorage(session), REGISTERED_NODES_STORE);
+        return new MapClientProvider(session, getStorage(session), REGISTERED_NODES_STORE);
     }
 
     @Override

--- a/model/map/src/main/java/org/keycloak/models/map/clientscope/MapClientScopeAdapter.java
+++ b/model/map/src/main/java/org/keycloak/models/map/clientscope/MapClientScopeAdapter.java
@@ -31,10 +31,15 @@ import org.keycloak.models.RoleModel;
 import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.models.utils.RoleUtils;
 
-public abstract class MapClientScopeAdapter<K> extends AbstractClientScopeModel<MapClientScopeEntity<K>> implements ClientScopeModel {
+public class MapClientScopeAdapter extends AbstractClientScopeModel<MapClientScopeEntity> implements ClientScopeModel {
 
-    public MapClientScopeAdapter(KeycloakSession session, RealmModel realm, MapClientScopeEntity<K> entity) {
+    public MapClientScopeAdapter(KeycloakSession session, RealmModel realm, MapClientScopeEntity entity) {
         super(session, realm, entity);
+    }
+
+    @Override
+    public String getId() {
+        return entity.getId();
     }
 
     @Override

--- a/model/map/src/main/java/org/keycloak/models/map/clientscope/MapClientScopeEntity.java
+++ b/model/map/src/main/java/org/keycloak/models/map/clientscope/MapClientScopeEntity.java
@@ -31,9 +31,9 @@ import org.keycloak.models.ProtocolMapperModel;
 import org.keycloak.models.map.common.AbstractEntity;
 import org.keycloak.models.map.common.UpdatableEntity;
 
-public class MapClientScopeEntity<K> implements AbstractEntity<K>, UpdatableEntity {
+public class MapClientScopeEntity implements AbstractEntity, UpdatableEntity {
 
-    private final K id;
+    private final String id;
     private final String realmId;
 
     private String name;
@@ -54,8 +54,7 @@ public class MapClientScopeEntity<K> implements AbstractEntity<K>, UpdatableEnti
         this.realmId = null;
     }
 
-    public MapClientScopeEntity(K id, String realmId) {
-        Objects.requireNonNull(id, "id");
+    public MapClientScopeEntity(String id, String realmId) {
         Objects.requireNonNull(realmId, "realmId");
 
         this.id = id;
@@ -63,7 +62,7 @@ public class MapClientScopeEntity<K> implements AbstractEntity<K>, UpdatableEnti
     }
 
     @Override
-    public K getId() {
+    public String getId() {
         return this.id;
     }
 

--- a/model/map/src/main/java/org/keycloak/models/map/clientscope/MapClientScopeProvider.java
+++ b/model/map/src/main/java/org/keycloak/models/map/clientscope/MapClientScopeProvider.java
@@ -39,14 +39,14 @@ import org.keycloak.models.utils.KeycloakModelUtils;
 import static org.keycloak.models.map.storage.QueryParameters.Order.ASCENDING;
 import static org.keycloak.models.map.storage.QueryParameters.withCriteria;
 
-public class MapClientScopeProvider<K> implements ClientScopeProvider {
+public class MapClientScopeProvider implements ClientScopeProvider {
 
     private static final Logger LOG = Logger.getLogger(MapClientScopeProvider.class);
     private final KeycloakSession session;
-    private final MapKeycloakTransaction<K, MapClientScopeEntity, ClientScopeModel> tx;
-    private final MapStorage<K, MapClientScopeEntity, ClientScopeModel> clientScopeStore;
+    private final MapKeycloakTransaction<MapClientScopeEntity, ClientScopeModel> tx;
+    private final MapStorage<MapClientScopeEntity, ClientScopeModel> clientScopeStore;
 
-    public MapClientScopeProvider(KeycloakSession session, MapStorage<K, MapClientScopeEntity, ClientScopeModel> clientScopeStore) {
+    public MapClientScopeProvider(KeycloakSession session, MapStorage<MapClientScopeEntity, ClientScopeModel> clientScopeStore) {
         this.session = session;
         this.clientScopeStore = clientScopeStore;
         this.tx = clientScopeStore.createTransaction(session);
@@ -91,7 +91,7 @@ public class MapClientScopeProvider<K> implements ClientScopeProvider {
 
         MapClientScopeEntity entity = new MapClientScopeEntity(id, realm.getId());
         entity.setName(KeycloakModelUtils.convertClientScopeName(name));
-        if (tx.read(id) != null) {
+        if (id != null && tx.read(id) != null) {
             throw new ModelDuplicateException("Client scope exists: " + id);
         }
         entity = tx.create(entity);

--- a/model/map/src/main/java/org/keycloak/models/map/clientscope/MapClientScopeProviderFactory.java
+++ b/model/map/src/main/java/org/keycloak/models/map/clientscope/MapClientScopeProviderFactory.java
@@ -22,7 +22,7 @@ import org.keycloak.models.ClientScopeProviderFactory;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.map.common.AbstractMapProviderFactory;
 
-public class MapClientScopeProviderFactory<K> extends AbstractMapProviderFactory<ClientScopeProvider, K, MapClientScopeEntity, ClientScopeModel> implements ClientScopeProviderFactory {
+public class MapClientScopeProviderFactory extends AbstractMapProviderFactory<ClientScopeProvider, MapClientScopeEntity, ClientScopeModel> implements ClientScopeProviderFactory {
 
     public MapClientScopeProviderFactory() {
         super(ClientScopeModel.class);
@@ -30,7 +30,7 @@ public class MapClientScopeProviderFactory<K> extends AbstractMapProviderFactory
 
     @Override
     public ClientScopeProvider create(KeycloakSession session) {
-        return new MapClientScopeProvider<>(session, getStorage(session));
+        return new MapClientScopeProvider(session, getStorage(session));
     }
 
     @Override

--- a/model/map/src/main/java/org/keycloak/models/map/clientscope/MapClientScopeProviderFactory.java
+++ b/model/map/src/main/java/org/keycloak/models/map/clientscope/MapClientScopeProviderFactory.java
@@ -22,7 +22,7 @@ import org.keycloak.models.ClientScopeProviderFactory;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.map.common.AbstractMapProviderFactory;
 
-public class MapClientScopeProviderFactory<K> extends AbstractMapProviderFactory<ClientScopeProvider, K, MapClientScopeEntity<K>, ClientScopeModel> implements ClientScopeProviderFactory {
+public class MapClientScopeProviderFactory<K> extends AbstractMapProviderFactory<ClientScopeProvider, K, MapClientScopeEntity, ClientScopeModel> implements ClientScopeProviderFactory {
 
     public MapClientScopeProviderFactory() {
         super(ClientScopeModel.class);

--- a/model/map/src/main/java/org/keycloak/models/map/common/AbstractEntity.java
+++ b/model/map/src/main/java/org/keycloak/models/map/common/AbstractEntity.java
@@ -20,8 +20,8 @@ package org.keycloak.models.map.common;
  *
  * @author hmlnarik
  */
-public interface AbstractEntity<K> {
+public interface AbstractEntity {
 
-    K getId();
+    String getId();
 
 }

--- a/model/map/src/main/java/org/keycloak/models/map/common/AbstractMapProviderFactory.java
+++ b/model/map/src/main/java/org/keycloak/models/map/common/AbstractMapProviderFactory.java
@@ -34,7 +34,7 @@ import static org.keycloak.models.utils.KeycloakModelUtils.getComponentFactory;
  *
  * @author hmlnarik
  */
-public abstract class AbstractMapProviderFactory<T extends Provider, K, V extends AbstractEntity<K>, M> implements AmphibianProviderFactory<T>, EnvironmentDependentProviderFactory {
+public abstract class AbstractMapProviderFactory<T extends Provider, K, V extends AbstractEntity, M> implements AmphibianProviderFactory<T>, EnvironmentDependentProviderFactory {
 
     public static final String PROVIDER_ID = "map";
 

--- a/model/map/src/main/java/org/keycloak/models/map/common/AbstractMapProviderFactory.java
+++ b/model/map/src/main/java/org/keycloak/models/map/common/AbstractMapProviderFactory.java
@@ -34,7 +34,7 @@ import static org.keycloak.models.utils.KeycloakModelUtils.getComponentFactory;
  *
  * @author hmlnarik
  */
-public abstract class AbstractMapProviderFactory<T extends Provider, K, V extends AbstractEntity, M> implements AmphibianProviderFactory<T>, EnvironmentDependentProviderFactory {
+public abstract class AbstractMapProviderFactory<T extends Provider, V extends AbstractEntity, M> implements AmphibianProviderFactory<T>, EnvironmentDependentProviderFactory {
 
     public static final String PROVIDER_ID = "map";
 
@@ -56,7 +56,7 @@ public abstract class AbstractMapProviderFactory<T extends Provider, K, V extend
         return PROVIDER_ID;
     }
 
-    protected MapStorage<K, V, M> getStorage(KeycloakSession session) {
+    protected MapStorage<V, M> getStorage(KeycloakSession session) {
         ProviderFactory<MapStorageProvider> storageProviderFactory = getComponentFactory(session.getKeycloakSessionFactory(),
           MapStorageProvider.class, storageConfigScope, MapStorageSpi.NAME);
         final MapStorageProvider factory = storageProviderFactory.create(session);

--- a/model/map/src/main/java/org/keycloak/models/map/common/StringKeyConvertor.java
+++ b/model/map/src/main/java/org/keycloak/models/map/common/StringKeyConvertor.java
@@ -113,6 +113,11 @@ public interface StringKeyConvertor<K> {
         }
 
         @Override
+        public String keyToString(Long key) {
+            return Long.toUnsignedString(key);
+        }
+
+        @Override
         public Long fromString(String key) {
             return key == null ? null : Long.parseUnsignedLong(key);
         }

--- a/model/map/src/main/java/org/keycloak/models/map/common/StringKeyConvertor.java
+++ b/model/map/src/main/java/org/keycloak/models/map/common/StringKeyConvertor.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.keycloak.models.map.storage;
+package org.keycloak.models.map.common;
 
 import java.security.SecureRandom;
 import java.util.UUID;

--- a/model/map/src/main/java/org/keycloak/models/map/group/MapGroupAdapter.java
+++ b/model/map/src/main/java/org/keycloak/models/map/group/MapGroupAdapter.java
@@ -29,9 +29,14 @@ import java.util.Map;
 import java.util.stream.Stream;
 
 
-public abstract class MapGroupAdapter<K> extends AbstractGroupModel<MapGroupEntity<K>> {
-    public MapGroupAdapter(KeycloakSession session, RealmModel realm, MapGroupEntity<K> entity) {
+public class MapGroupAdapter extends AbstractGroupModel<MapGroupEntity> {
+    public MapGroupAdapter(KeycloakSession session, RealmModel realm, MapGroupEntity entity) {
         super(session, realm, entity);
+    }
+
+    @Override
+    public String getId() {
+        return entity.getId();
     }
 
     @Override

--- a/model/map/src/main/java/org/keycloak/models/map/group/MapGroupEntity.java
+++ b/model/map/src/main/java/org/keycloak/models/map/group/MapGroupEntity.java
@@ -31,9 +31,9 @@ import java.util.Set;
  *
  * @author mhajas
  */
-public class MapGroupEntity<K> implements AbstractEntity<K>, UpdatableEntity {
+public class MapGroupEntity implements AbstractEntity, UpdatableEntity {
 
-    private final K id;
+    private final String id;
     private final String realmId;
 
     private String name;
@@ -51,8 +51,7 @@ public class MapGroupEntity<K> implements AbstractEntity<K>, UpdatableEntity {
         this.realmId = null;
     }
 
-    public MapGroupEntity(K id, String realmId) {
-        Objects.requireNonNull(id, "id");
+    public MapGroupEntity(String id, String realmId) {
         Objects.requireNonNull(realmId, "realmId");
 
         this.id = id;
@@ -60,7 +59,7 @@ public class MapGroupEntity<K> implements AbstractEntity<K>, UpdatableEntity {
     }
 
     @Override
-    public K getId() {
+    public String getId() {
         return this.id;
     }
 

--- a/model/map/src/main/java/org/keycloak/models/map/group/MapGroupEntity.java
+++ b/model/map/src/main/java/org/keycloak/models/map/group/MapGroupEntity.java
@@ -33,7 +33,7 @@ import java.util.Set;
  */
 public class MapGroupEntity implements AbstractEntity, UpdatableEntity {
 
-    private final String id;
+    private String id;
     private final String realmId;
 
     private String name;

--- a/model/map/src/main/java/org/keycloak/models/map/group/MapGroupProvider.java
+++ b/model/map/src/main/java/org/keycloak/models/map/group/MapGroupProvider.java
@@ -42,14 +42,14 @@ import static org.keycloak.common.util.StackUtil.getShortStackTrace;
 import static org.keycloak.models.map.storage.QueryParameters.Order.ASCENDING;
 import static org.keycloak.models.map.storage.QueryParameters.withCriteria;
 
-public class MapGroupProvider<K> implements GroupProvider {
+public class MapGroupProvider implements GroupProvider {
 
     private static final Logger LOG = Logger.getLogger(MapGroupProvider.class);
     private final KeycloakSession session;
-    final MapKeycloakTransaction<K, MapGroupEntity, GroupModel> tx;
-    private final MapStorage<K, MapGroupEntity, GroupModel> groupStore;
+    final MapKeycloakTransaction<MapGroupEntity, GroupModel> tx;
+    private final MapStorage<MapGroupEntity, GroupModel> groupStore;
 
-    public MapGroupProvider(KeycloakSession session, MapStorage<K, MapGroupEntity, GroupModel> groupStore) {
+    public MapGroupProvider(KeycloakSession session, MapStorage<MapGroupEntity, GroupModel> groupStore) {
         this.session = session;
         this.groupStore = groupStore;
         this.tx = groupStore.createTransaction(session);

--- a/model/map/src/main/java/org/keycloak/models/map/group/MapGroupProviderFactory.java
+++ b/model/map/src/main/java/org/keycloak/models/map/group/MapGroupProviderFactory.java
@@ -35,7 +35,7 @@ import org.keycloak.models.map.common.AbstractMapProviderFactory;
  *
  * @author mhajas
  */
-public class MapGroupProviderFactory<K> extends AbstractMapProviderFactory<GroupProvider, K, MapGroupEntity, GroupModel> implements GroupProviderFactory, ProviderEventListener {
+public class MapGroupProviderFactory extends AbstractMapProviderFactory<GroupProvider, MapGroupEntity, GroupModel> implements GroupProviderFactory, ProviderEventListener {
 
     private Runnable onClose;
 
@@ -51,7 +51,7 @@ public class MapGroupProviderFactory<K> extends AbstractMapProviderFactory<Group
 
     @Override
     public MapGroupProvider create(KeycloakSession session) {
-        return new MapGroupProvider<>(session, getStorage(session));
+        return new MapGroupProvider(session, getStorage(session));
     }
 
     @Override

--- a/model/map/src/main/java/org/keycloak/models/map/group/MapGroupProviderFactory.java
+++ b/model/map/src/main/java/org/keycloak/models/map/group/MapGroupProviderFactory.java
@@ -35,7 +35,7 @@ import org.keycloak.models.map.common.AbstractMapProviderFactory;
  *
  * @author mhajas
  */
-public class MapGroupProviderFactory<K> extends AbstractMapProviderFactory<GroupProvider, K, MapGroupEntity<K>, GroupModel> implements GroupProviderFactory, ProviderEventListener {
+public class MapGroupProviderFactory<K> extends AbstractMapProviderFactory<GroupProvider, K, MapGroupEntity, GroupModel> implements GroupProviderFactory, ProviderEventListener {
 
     private Runnable onClose;
 

--- a/model/map/src/main/java/org/keycloak/models/map/loginFailure/MapUserLoginFailureAdapter.java
+++ b/model/map/src/main/java/org/keycloak/models/map/loginFailure/MapUserLoginFailureAdapter.java
@@ -22,9 +22,14 @@ import org.keycloak.models.RealmModel;
 /**
  * @author <a href="mailto:mkanis@redhat.com">Martin Kanis</a>
  */
-public abstract class MapUserLoginFailureAdapter<K> extends AbstractUserLoginFailureModel<MapUserLoginFailureEntity<K>> {
-    public MapUserLoginFailureAdapter(KeycloakSession session, RealmModel realm, MapUserLoginFailureEntity<K> entity) {
+public class MapUserLoginFailureAdapter extends AbstractUserLoginFailureModel<MapUserLoginFailureEntity> {
+    public MapUserLoginFailureAdapter(KeycloakSession session, RealmModel realm, MapUserLoginFailureEntity entity) {
         super(session, realm, entity);
+    }
+
+    @Override
+    public String getId() {
+        return entity.getId();
     }
 
     @Override

--- a/model/map/src/main/java/org/keycloak/models/map/loginFailure/MapUserLoginFailureEntity.java
+++ b/model/map/src/main/java/org/keycloak/models/map/loginFailure/MapUserLoginFailureEntity.java
@@ -24,8 +24,8 @@ import java.util.Objects;
 /**
  * @author <a href="mailto:mkanis@redhat.com">Martin Kanis</a>
  */
-public class MapUserLoginFailureEntity<K> implements AbstractEntity<K>, UpdatableEntity {
-    private K id;
+public class MapUserLoginFailureEntity implements AbstractEntity, UpdatableEntity {
+    private String id;
     private String realmId;
     private String userId;
 
@@ -45,14 +45,14 @@ public class MapUserLoginFailureEntity<K> implements AbstractEntity<K>, Updatabl
         this.userId = null;
     }
 
-    public MapUserLoginFailureEntity(K id, String realmId, String userId) {
+    public MapUserLoginFailureEntity(String id, String realmId, String userId) {
         this.id = id;
         this.realmId = realmId;
         this.userId = userId;
     }
 
     @Override
-    public K getId() {
+    public String getId() {
         return this.id;
     }
 

--- a/model/map/src/main/java/org/keycloak/models/map/loginFailure/MapUserLoginFailureProvider.java
+++ b/model/map/src/main/java/org/keycloak/models/map/loginFailure/MapUserLoginFailureProvider.java
@@ -33,14 +33,14 @@ import static org.keycloak.models.map.storage.QueryParameters.withCriteria;
 /**
  * @author <a href="mailto:mkanis@redhat.com">Martin Kanis</a>
  */
-public class MapUserLoginFailureProvider<K> implements UserLoginFailureProvider {
+public class MapUserLoginFailureProvider implements UserLoginFailureProvider {
 
     private static final Logger LOG = Logger.getLogger(MapUserLoginFailureProvider.class);
     private final KeycloakSession session;
-    protected final MapKeycloakTransaction<K, MapUserLoginFailureEntity, UserLoginFailureModel> userLoginFailureTx;
-    private final MapStorage<K, MapUserLoginFailureEntity, UserLoginFailureModel> userLoginFailureStore;
+    protected final MapKeycloakTransaction<MapUserLoginFailureEntity, UserLoginFailureModel> userLoginFailureTx;
+    private final MapStorage<MapUserLoginFailureEntity, UserLoginFailureModel> userLoginFailureStore;
 
-    public MapUserLoginFailureProvider(KeycloakSession session, MapStorage<K, MapUserLoginFailureEntity, UserLoginFailureModel> userLoginFailureStore) {
+    public MapUserLoginFailureProvider(KeycloakSession session, MapStorage<MapUserLoginFailureEntity, UserLoginFailureModel> userLoginFailureStore) {
         this.session = session;
         this.userLoginFailureStore = userLoginFailureStore;
 

--- a/model/map/src/main/java/org/keycloak/models/map/loginFailure/MapUserLoginFailureProviderFactory.java
+++ b/model/map/src/main/java/org/keycloak/models/map/loginFailure/MapUserLoginFailureProviderFactory.java
@@ -31,7 +31,7 @@ import org.keycloak.provider.ProviderEventListener;
 /**
  * @author <a href="mailto:mkanis@redhat.com">Martin Kanis</a>
  */
-public class MapUserLoginFailureProviderFactory<K> extends AbstractMapProviderFactory<UserLoginFailureProvider, K, MapUserLoginFailureEntity<K>, UserLoginFailureModel>
+public class MapUserLoginFailureProviderFactory<K> extends AbstractMapProviderFactory<UserLoginFailureProvider, K, MapUserLoginFailureEntity, UserLoginFailureModel>
         implements UserLoginFailureProviderFactory, ProviderEventListener {
 
     private Runnable onClose;

--- a/model/map/src/main/java/org/keycloak/models/map/loginFailure/MapUserLoginFailureProviderFactory.java
+++ b/model/map/src/main/java/org/keycloak/models/map/loginFailure/MapUserLoginFailureProviderFactory.java
@@ -31,7 +31,7 @@ import org.keycloak.provider.ProviderEventListener;
 /**
  * @author <a href="mailto:mkanis@redhat.com">Martin Kanis</a>
  */
-public class MapUserLoginFailureProviderFactory<K> extends AbstractMapProviderFactory<UserLoginFailureProvider, K, MapUserLoginFailureEntity, UserLoginFailureModel>
+public class MapUserLoginFailureProviderFactory extends AbstractMapProviderFactory<UserLoginFailureProvider, MapUserLoginFailureEntity, UserLoginFailureModel>
         implements UserLoginFailureProviderFactory, ProviderEventListener {
 
     private Runnable onClose;
@@ -53,8 +53,8 @@ public class MapUserLoginFailureProviderFactory<K> extends AbstractMapProviderFa
     }
 
     @Override
-    public MapUserLoginFailureProvider<K> create(KeycloakSession session) {
-        return new MapUserLoginFailureProvider<>(session, getStorage(session));
+    public MapUserLoginFailureProvider create(KeycloakSession session) {
+        return new MapUserLoginFailureProvider(session, getStorage(session));
     }
 
     @Override

--- a/model/map/src/main/java/org/keycloak/models/map/realm/MapRealmAdapter.java
+++ b/model/map/src/main/java/org/keycloak/models/map/realm/MapRealmAdapter.java
@@ -62,7 +62,7 @@ import org.keycloak.models.map.realm.entity.MapRequiredCredentialEntity;
 import org.keycloak.models.map.realm.entity.MapWebAuthnPolicyEntity;
 import org.keycloak.models.utils.ComponentUtil;
 
-public abstract class MapRealmAdapter<K> extends AbstractRealmModel<MapRealmEntity<K>> implements RealmModel {
+public class MapRealmAdapter extends AbstractRealmModel<MapRealmEntity> implements RealmModel {
 
     private static final String ACTION_TOKEN_GENERATED_BY_USER_LIFESPAN = "actionTokenGeneratedByUserLifespan";
     private static final String DEFAULT_SIGNATURE_ALGORITHM = "defaultSignatureAlgorithm";
@@ -77,8 +77,13 @@ public abstract class MapRealmAdapter<K> extends AbstractRealmModel<MapRealmEnti
 
     private PasswordPolicy passwordPolicy;
 
-    public MapRealmAdapter(KeycloakSession session, MapRealmEntity<K> entity) {
+    public MapRealmAdapter(KeycloakSession session, MapRealmEntity entity) {
         super(session, entity);
+    }
+
+    @Override
+    public String getId() {
+        return entity.getId();
     }
 
     @Override

--- a/model/map/src/main/java/org/keycloak/models/map/realm/MapRealmEntity.java
+++ b/model/map/src/main/java/org/keycloak/models/map/realm/MapRealmEntity.java
@@ -45,7 +45,7 @@ import org.keycloak.models.map.realm.entity.MapWebAuthnPolicyEntity;
 
 public class MapRealmEntity implements AbstractEntity, UpdatableEntity {
 
-    private final String id;
+    private String id;
     private String name;
 
     private Boolean enabled = false;

--- a/model/map/src/main/java/org/keycloak/models/map/realm/MapRealmEntity.java
+++ b/model/map/src/main/java/org/keycloak/models/map/realm/MapRealmEntity.java
@@ -43,9 +43,9 @@ import org.keycloak.models.map.realm.entity.MapRequiredActionProviderEntity;
 import org.keycloak.models.map.realm.entity.MapRequiredCredentialEntity;
 import org.keycloak.models.map.realm.entity.MapWebAuthnPolicyEntity;
 
-public class MapRealmEntity<K> implements AbstractEntity<K>, UpdatableEntity {
+public class MapRealmEntity implements AbstractEntity, UpdatableEntity {
 
-    private final K id;
+    private final String id;
     private String name;
 
     private Boolean enabled = false;
@@ -134,14 +134,12 @@ public class MapRealmEntity<K> implements AbstractEntity<K>, UpdatableEntity {
         this.id = null;
     }
 
-    public MapRealmEntity(K id) {
-        Objects.requireNonNull(id, "id");
-
+    public MapRealmEntity(String id) {
         this.id = id;
     }
 
     @Override
-    public K getId() {
+    public String getId() {
         return this.id;
     }
 

--- a/model/map/src/main/java/org/keycloak/models/map/realm/MapRealmProvider.java
+++ b/model/map/src/main/java/org/keycloak/models/map/realm/MapRealmProvider.java
@@ -40,14 +40,14 @@ import org.keycloak.models.utils.KeycloakModelUtils;
 import static org.keycloak.models.map.storage.QueryParameters.Order.ASCENDING;
 import static org.keycloak.models.map.storage.QueryParameters.withCriteria;
 
-public class MapRealmProvider<K> implements RealmProvider {
+public class MapRealmProvider implements RealmProvider {
 
     private static final Logger LOG = Logger.getLogger(MapRealmProvider.class);
     private final KeycloakSession session;
-    final MapKeycloakTransaction<K, MapRealmEntity, RealmModel> tx;
-    private final MapStorage<K, MapRealmEntity, RealmModel> realmStore;
+    final MapKeycloakTransaction<MapRealmEntity, RealmModel> tx;
+    private final MapStorage<MapRealmEntity, RealmModel> realmStore;
 
-    public MapRealmProvider(KeycloakSession session, MapStorage<K, MapRealmEntity, RealmModel> realmStore) {
+    public MapRealmProvider(KeycloakSession session, MapStorage<MapRealmEntity, RealmModel> realmStore) {
         this.session = session;
         this.realmStore = realmStore;
         this.tx = realmStore.createTransaction(session);

--- a/model/map/src/main/java/org/keycloak/models/map/realm/MapRealmProviderFactory.java
+++ b/model/map/src/main/java/org/keycloak/models/map/realm/MapRealmProviderFactory.java
@@ -22,7 +22,7 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.RealmProvider;
 import org.keycloak.models.RealmProviderFactory;
 
-public class MapRealmProviderFactory<K> extends AbstractMapProviderFactory<RealmProvider, K, MapRealmEntity, RealmModel> implements RealmProviderFactory {
+public class MapRealmProviderFactory extends AbstractMapProviderFactory<RealmProvider, MapRealmEntity, RealmModel> implements RealmProviderFactory {
 
     public MapRealmProviderFactory() {
         super(RealmModel.class);
@@ -30,7 +30,7 @@ public class MapRealmProviderFactory<K> extends AbstractMapProviderFactory<Realm
 
     @Override
     public RealmProvider create(KeycloakSession session) {
-        return new MapRealmProvider<>(session, getStorage(session));
+        return new MapRealmProvider(session, getStorage(session));
     }
 
     @Override

--- a/model/map/src/main/java/org/keycloak/models/map/realm/MapRealmProviderFactory.java
+++ b/model/map/src/main/java/org/keycloak/models/map/realm/MapRealmProviderFactory.java
@@ -22,7 +22,7 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.RealmProvider;
 import org.keycloak.models.RealmProviderFactory;
 
-public class MapRealmProviderFactory<K> extends AbstractMapProviderFactory<RealmProvider, K, MapRealmEntity<K>, RealmModel> implements RealmProviderFactory {
+public class MapRealmProviderFactory<K> extends AbstractMapProviderFactory<RealmProvider, K, MapRealmEntity, RealmModel> implements RealmProviderFactory {
 
     public MapRealmProviderFactory() {
         super(RealmModel.class);

--- a/model/map/src/main/java/org/keycloak/models/map/role/MapRoleAdapter.java
+++ b/model/map/src/main/java/org/keycloak/models/map/role/MapRoleAdapter.java
@@ -70,7 +70,7 @@ public class MapRoleAdapter extends AbstractRoleModel<MapRoleEntity> implements 
 
     @Override
     public Stream<RoleModel> getCompositesStream() {
-        LOG.tracef("%% %s(%s).getCompositesStream():%d - %s", entity.getName(), entity.getId().toString(), entity.getCompositeRoles().size(), getShortStackTrace());
+        LOG.tracef("%% %s(%s).getCompositesStream():%d - %s", entity.getName(), entity.getId(), entity.getCompositeRoles().size(), getShortStackTrace());
         return entity.getCompositeRoles().stream()
                 .map(uuid -> session.roles().getRoleById(realm, uuid))
                 .filter(Objects::nonNull);
@@ -78,13 +78,13 @@ public class MapRoleAdapter extends AbstractRoleModel<MapRoleEntity> implements 
 
     @Override
     public void addCompositeRole(RoleModel role) {
-        LOG.tracef("%s(%s).addCompositeRole(%s(%s))%s", entity.getName(), entity.getId().toString(), role.getName(), role.getId(), getShortStackTrace());
+        LOG.tracef("%s(%s).addCompositeRole(%s(%s))%s", entity.getName(), entity.getId(), role.getName(), role.getId(), getShortStackTrace());
         entity.addCompositeRole(role.getId());
     }
 
     @Override
     public void removeCompositeRole(RoleModel role) {
-        LOG.tracef("%s(%s).removeCompositeRole(%s(%s))%s", entity.getName(), entity.getId().toString(), role.getName(), role.getId(), getShortStackTrace());
+        LOG.tracef("%s(%s).removeCompositeRole(%s(%s))%s", entity.getName(), entity.getId(), role.getName(), role.getId(), getShortStackTrace());
         entity.removeCompositeRole(role.getId());
     }
 

--- a/model/map/src/main/java/org/keycloak/models/map/role/MapRoleAdapter.java
+++ b/model/map/src/main/java/org/keycloak/models/map/role/MapRoleAdapter.java
@@ -30,12 +30,17 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.RoleContainerModel;
 import org.keycloak.models.utils.KeycloakModelUtils;
 
-public abstract class MapRoleAdapter<K> extends AbstractRoleModel<MapRoleEntity<K>> implements RoleModel {
+public class MapRoleAdapter extends AbstractRoleModel<MapRoleEntity> implements RoleModel {
 
     private static final Logger LOG = Logger.getLogger(MapRoleAdapter.class);
 
-    public MapRoleAdapter(KeycloakSession session, RealmModel realm, MapRoleEntity<K> entity) {
+    public MapRoleAdapter(KeycloakSession session, RealmModel realm, MapRoleEntity entity) {
         super(session, realm, entity);
+    }
+
+    @Override
+    public String getId() {
+        return entity.getId();
     }
 
     @Override

--- a/model/map/src/main/java/org/keycloak/models/map/role/MapRoleEntity.java
+++ b/model/map/src/main/java/org/keycloak/models/map/role/MapRoleEntity.java
@@ -25,9 +25,9 @@ import java.util.Set;
 import org.keycloak.models.map.common.AbstractEntity;
 import org.keycloak.models.map.common.UpdatableEntity;
 
-public class MapRoleEntity<K> implements AbstractEntity<K>, UpdatableEntity {
+public class MapRoleEntity implements AbstractEntity, UpdatableEntity {
 
-    private K id;
+    private String id;
     private String realmId;
 
     private String name;
@@ -47,8 +47,7 @@ public class MapRoleEntity<K> implements AbstractEntity<K>, UpdatableEntity {
         this.realmId = null;
     }
 
-    public MapRoleEntity(K id, String realmId) {
-        Objects.requireNonNull(id, "id");
+    public MapRoleEntity(String id, String realmId) {
         Objects.requireNonNull(realmId, "realmId");
 
         this.id = id;
@@ -56,7 +55,7 @@ public class MapRoleEntity<K> implements AbstractEntity<K>, UpdatableEntity {
     }
 
     @Override
-    public K getId() {
+    public String getId() {
         return this.id;
     }
 

--- a/model/map/src/main/java/org/keycloak/models/map/role/MapRoleProvider.java
+++ b/model/map/src/main/java/org/keycloak/models/map/role/MapRoleProvider.java
@@ -40,14 +40,14 @@ import org.keycloak.models.RoleProvider;
 import org.keycloak.models.map.storage.ModelCriteriaBuilder;
 import org.keycloak.models.map.storage.ModelCriteriaBuilder.Operator;
 
-public class MapRoleProvider<K> implements RoleProvider {
+public class MapRoleProvider implements RoleProvider {
 
     private static final Logger LOG = Logger.getLogger(MapRoleProvider.class);
     private final KeycloakSession session;
-    final MapKeycloakTransaction<K, MapRoleEntity, RoleModel> tx;
-    private final MapStorage<K, MapRoleEntity, RoleModel> roleStore;
+    final MapKeycloakTransaction<MapRoleEntity, RoleModel> tx;
+    private final MapStorage<MapRoleEntity, RoleModel> roleStore;
 
-    public MapRoleProvider(KeycloakSession session, MapStorage<K, MapRoleEntity, RoleModel> roleStore) {
+    public MapRoleProvider(KeycloakSession session, MapStorage<MapRoleEntity, RoleModel> roleStore) {
         this.session = session;
         this.roleStore = roleStore;
         this.tx = roleStore.createTransaction(session);

--- a/model/map/src/main/java/org/keycloak/models/map/role/MapRoleProviderFactory.java
+++ b/model/map/src/main/java/org/keycloak/models/map/role/MapRoleProviderFactory.java
@@ -22,7 +22,7 @@ import org.keycloak.models.RoleModel;
 import org.keycloak.models.RoleProvider;
 import org.keycloak.models.RoleProviderFactory;
 
-public class MapRoleProviderFactory<K> extends AbstractMapProviderFactory<RoleProvider, K, MapRoleEntity<K>, RoleModel> implements RoleProviderFactory {
+public class MapRoleProviderFactory<K> extends AbstractMapProviderFactory<RoleProvider, K, MapRoleEntity, RoleModel> implements RoleProviderFactory {
 
     public MapRoleProviderFactory() {
         super(RoleModel.class);

--- a/model/map/src/main/java/org/keycloak/models/map/role/MapRoleProviderFactory.java
+++ b/model/map/src/main/java/org/keycloak/models/map/role/MapRoleProviderFactory.java
@@ -22,7 +22,7 @@ import org.keycloak.models.RoleModel;
 import org.keycloak.models.RoleProvider;
 import org.keycloak.models.RoleProviderFactory;
 
-public class MapRoleProviderFactory<K> extends AbstractMapProviderFactory<RoleProvider, K, MapRoleEntity, RoleModel> implements RoleProviderFactory {
+public class MapRoleProviderFactory extends AbstractMapProviderFactory<RoleProvider, MapRoleEntity, RoleModel> implements RoleProviderFactory {
 
     public MapRoleProviderFactory() {
         super(RoleModel.class);
@@ -30,7 +30,7 @@ public class MapRoleProviderFactory<K> extends AbstractMapProviderFactory<RolePr
 
     @Override
     public RoleProvider create(KeycloakSession session) {
-        return new MapRoleProvider<>(session, getStorage(session));
+        return new MapRoleProvider(session, getStorage(session));
     }
 
     @Override

--- a/model/map/src/main/java/org/keycloak/models/map/storage/MapKeycloakTransaction.java
+++ b/model/map/src/main/java/org/keycloak/models/map/storage/MapKeycloakTransaction.java
@@ -23,7 +23,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
-public interface MapKeycloakTransaction<K, V extends AbstractEntity<K>, M> extends KeycloakTransaction {
+public interface MapKeycloakTransaction<K, V extends AbstractEntity, M> extends KeycloakTransaction {
 
     /**
      * Instructs this transaction to add a new value into the underlying store on commit.
@@ -44,7 +44,7 @@ public interface MapKeycloakTransaction<K, V extends AbstractEntity<K>, M> exten
      * @param key identifier of a value
      * @return a value associated with the given {@code key}
      */
-    V read(K key);
+    V read(String key);
 
     /**
      * Returns a stream of values from underlying storage that are updated based on the current transaction changes;
@@ -76,7 +76,7 @@ public interface MapKeycloakTransaction<K, V extends AbstractEntity<K>, M> exten
      * @return Returns {@code true} if the object has been deleted or result cannot be determined, {@code false} otherwise.
      * @param key identifier of a value
      */
-    boolean delete(K key);
+    boolean delete(String key);
 
     /**
      * Instructs this transaction to remove values (identified by {@code mcb} filter) from the underlying store on commit.

--- a/model/map/src/main/java/org/keycloak/models/map/storage/MapKeycloakTransaction.java
+++ b/model/map/src/main/java/org/keycloak/models/map/storage/MapKeycloakTransaction.java
@@ -19,11 +19,9 @@ package org.keycloak.models.map.storage;
 import org.keycloak.models.KeycloakTransaction;
 import org.keycloak.models.map.common.AbstractEntity;
 
-import java.util.function.Function;
-import java.util.function.Predicate;
 import java.util.stream.Stream;
 
-public interface MapKeycloakTransaction<K, V extends AbstractEntity, M> extends KeycloakTransaction {
+public interface MapKeycloakTransaction<V extends AbstractEntity, M> extends KeycloakTransaction {
 
     /**
      * Instructs this transaction to add a new value into the underlying store on commit.

--- a/model/map/src/main/java/org/keycloak/models/map/storage/MapStorage.java
+++ b/model/map/src/main/java/org/keycloak/models/map/storage/MapStorage.java
@@ -28,7 +28,6 @@ import java.util.stream.Stream;
  * ({@link #getCount(org.keycloak.models.map.storage.QueryParameters)}).
  *
  * @author hmlnarik
- * @param <K> Type of the primary key. Various storages can
  * @param <V> Type of the stored values that contains all the data stripped of session state. In other words, in the entities
  *            there are only IDs and mostly primitive types / {@code String}, never references to {@code *Model} instances.
  *            See the {@code Abstract*Entity} classes in this module.
@@ -36,11 +35,12 @@ import java.util.stream.Stream;
  *            filtering via model fields in {@link ModelCriteriaBuilder} which is necessary to abstract from physical
  *            layout and thus to support no-downtime upgrade.
  */
-public interface MapStorage<K, V extends AbstractEntity, M> {
+public interface MapStorage<V extends AbstractEntity, M> {
 
     /**
      * Creates an object in the store. ID of the {@code value} may be prescribed in id of the {@code value}.
-     * If the id is {@code null}, then the {@code value}'s ID will be generated and returned in the id of the return value.
+     * If the id is {@code null} or its format is not matching the store internal format for ID, then
+     * the {@code value}'s ID will be generated and returned in the id of the return value.
      * @param value Entity to create in the store
      * @throws NullPointerException if {@code value} is {@code null}
      * @see AbstractEntity#getId()
@@ -129,6 +129,6 @@ public interface MapStorage<K, V extends AbstractEntity, M> {
      *
      * @return See description. Never returns {@code null}
      */
-    MapKeycloakTransaction<K, V, M> createTransaction(KeycloakSession session);
+    MapKeycloakTransaction<V, M> createTransaction(KeycloakSession session);
 
 }

--- a/model/map/src/main/java/org/keycloak/models/map/storage/MapStorage.java
+++ b/model/map/src/main/java/org/keycloak/models/map/storage/MapStorage.java
@@ -36,7 +36,7 @@ import java.util.stream.Stream;
  *            filtering via model fields in {@link ModelCriteriaBuilder} which is necessary to abstract from physical
  *            layout and thus to support no-downtime upgrade.
  */
-public interface MapStorage<K, V extends AbstractEntity<K>, M> {
+public interface MapStorage<K, V extends AbstractEntity, M> {
 
     /**
      * Creates an object in the store. ID of the {@code value} may be prescribed in id of the {@code value}.
@@ -56,7 +56,7 @@ public interface MapStorage<K, V extends AbstractEntity<K>, M> {
      * @return See description
      * @throws NullPointerException if the {@code key} is {@code null}
      */
-    V read(K key);
+    V read(String key);
 
     /**
      * Returns stream of objects satisfying given {@code criteria} from the storage.
@@ -94,7 +94,7 @@ public interface MapStorage<K, V extends AbstractEntity<K>, M> {
      * @param key
      * @return Returns {@code true} if the object has been deleted or result cannot be determined, {@code false} otherwise.
      */
-    boolean delete(K key);
+    boolean delete(String key);
 
     /**
      * Deletes objects that match the given criteria.
@@ -130,13 +130,5 @@ public interface MapStorage<K, V extends AbstractEntity<K>, M> {
      * @return See description. Never returns {@code null}
      */
     MapKeycloakTransaction<K, V, M> createTransaction(KeycloakSession session);
-
-    /**
-     * Returns a {@link StringKeyConvertor} that is used to convert primary keys
-     * from {@link String} to internal representation and vice versa.
-     * 
-     * @return See above. Never returns {@code null}.
-     */
-    StringKeyConvertor<K> getKeyConvertor();
 
 }

--- a/model/map/src/main/java/org/keycloak/models/map/storage/MapStorageProvider.java
+++ b/model/map/src/main/java/org/keycloak/models/map/storage/MapStorageProvider.java
@@ -28,7 +28,6 @@ public interface MapStorageProvider extends Provider {
     
     /**
      * Returns a key-value storage implementation for the given types.
-     * @param <K> type of the primary key
      * @param <V> type of the value
      * @param <M> type of the corresponding model (e.g. {@code UserModel})
      * @param modelType Model type
@@ -36,5 +35,5 @@ public interface MapStorageProvider extends Provider {
      * @return
      * @throws IllegalArgumentException If some of the types is not supported by the underlying implementation.
      */
-    <K, V extends AbstractEntity, M> MapStorage<K, V, M> getStorage(Class<M> modelType, Flag... flags);
+    <V extends AbstractEntity, M> MapStorage<V, M> getStorage(Class<M> modelType, Flag... flags);
 }

--- a/model/map/src/main/java/org/keycloak/models/map/storage/MapStorageProvider.java
+++ b/model/map/src/main/java/org/keycloak/models/map/storage/MapStorageProvider.java
@@ -36,5 +36,5 @@ public interface MapStorageProvider extends Provider {
      * @return
      * @throws IllegalArgumentException If some of the types is not supported by the underlying implementation.
      */
-    <K, V extends AbstractEntity<K>, M> MapStorage<K, V, M> getStorage(Class<M> modelType, Flag... flags);
+    <K, V extends AbstractEntity, M> MapStorage<K, V, M> getStorage(Class<M> modelType, Flag... flags);
 }

--- a/model/map/src/main/java/org/keycloak/models/map/storage/chm/ConcurrentHashMapKeycloakTransaction.java
+++ b/model/map/src/main/java/org/keycloak/models/map/storage/chm/ConcurrentHashMapKeycloakTransaction.java
@@ -36,21 +36,21 @@ import org.keycloak.models.map.storage.ModelCriteriaBuilder;
 import org.keycloak.models.map.storage.QueryParameters;
 import org.keycloak.utils.StreamsUtil;
 
-public class ConcurrentHashMapKeycloakTransaction<K, V extends AbstractEntity & UpdatableEntity, M> implements MapKeycloakTransaction<K, V, M> {
+public class ConcurrentHashMapKeycloakTransaction<K, V extends AbstractEntity & UpdatableEntity, M> implements MapKeycloakTransaction<V, M> {
 
     private final static Logger log = Logger.getLogger(ConcurrentHashMapKeycloakTransaction.class);
 
     private boolean active;
     private boolean rollback;
     private final Map<String, MapTaskWithValue> tasks = new LinkedHashMap<>();
-    private final MapStorage<K, V, M> map;
+    private final MapStorage<V, M> map;
     private final StringKeyConvertor<K> keyConvertor;
 
     enum MapOperation {
         CREATE, UPDATE, DELETE,
     }
 
-    public ConcurrentHashMapKeycloakTransaction(MapStorage<K, V, M> map, StringKeyConvertor<K> keyConvertor) {
+    public ConcurrentHashMapKeycloakTransaction(MapStorage<V, M> map, StringKeyConvertor<K> keyConvertor) {
         this.map = map;
         this.keyConvertor = keyConvertor;
     }

--- a/model/map/src/main/java/org/keycloak/models/map/storage/chm/ConcurrentHashMapStorage.java
+++ b/model/map/src/main/java/org/keycloak/models/map/storage/chm/ConcurrentHashMapStorage.java
@@ -44,7 +44,7 @@ import static org.keycloak.utils.StreamsUtil.paginatedStream;
  *
  * @author hmlnarik
  */
-public class ConcurrentHashMapStorage<K, V extends AbstractEntity & UpdatableEntity, M> implements MapStorage<K, V, M> {
+public class ConcurrentHashMapStorage<K, V extends AbstractEntity & UpdatableEntity, M> implements MapStorage<V, M> {
 
     private final ConcurrentMap<K, V> store = new ConcurrentHashMap<>();
 
@@ -71,7 +71,8 @@ public class ConcurrentHashMapStorage<K, V extends AbstractEntity & UpdatableEnt
     @Override
     public V read(String key) {
         Objects.requireNonNull(key, "Key must be non-null");
-        return store.get(keyConvertor.fromString(key));
+        K k = keyConvertor.fromStringSafe(key);
+        return store.get(k);
     }
 
     @Override
@@ -126,8 +127,8 @@ public class ConcurrentHashMapStorage<K, V extends AbstractEntity & UpdatableEnt
 
     @Override
     @SuppressWarnings("unchecked")
-    public MapKeycloakTransaction<K, V, M> createTransaction(KeycloakSession session) {
-        MapKeycloakTransaction<K, V, M> sessionTransaction = session.getAttribute("map-transaction-" + hashCode(), MapKeycloakTransaction.class);
+    public MapKeycloakTransaction<V, M> createTransaction(KeycloakSession session) {
+        MapKeycloakTransaction<V, M> sessionTransaction = session.getAttribute("map-transaction-" + hashCode(), MapKeycloakTransaction.class);
         return sessionTransaction == null ? new ConcurrentHashMapKeycloakTransaction<>(this, keyConvertor) : sessionTransaction;
     }
 

--- a/model/map/src/main/java/org/keycloak/models/map/storage/chm/ConcurrentHashMapStorageProvider.java
+++ b/model/map/src/main/java/org/keycloak/models/map/storage/chm/ConcurrentHashMapStorageProvider.java
@@ -39,7 +39,7 @@ public class ConcurrentHashMapStorageProvider implements MapStorageProvider {
 
     @Override
     @SuppressWarnings("unchecked")
-    public <K, V extends AbstractEntity<K>, M> MapStorage<K, V, M> getStorage(Class<M> modelType, Flag... flags) {
+    public <K, V extends AbstractEntity, M> MapStorage<K, V, M> getStorage(Class<M> modelType, Flag... flags) {
         ConcurrentHashMapStorage storage = factory.getStorage(modelType, flags);
         return (MapStorage<K, V, M>) storage;
     }

--- a/model/map/src/main/java/org/keycloak/models/map/storage/chm/ConcurrentHashMapStorageProvider.java
+++ b/model/map/src/main/java/org/keycloak/models/map/storage/chm/ConcurrentHashMapStorageProvider.java
@@ -39,8 +39,8 @@ public class ConcurrentHashMapStorageProvider implements MapStorageProvider {
 
     @Override
     @SuppressWarnings("unchecked")
-    public <K, V extends AbstractEntity, M> MapStorage<K, V, M> getStorage(Class<M> modelType, Flag... flags) {
+    public <V extends AbstractEntity, M> MapStorage<V, M> getStorage(Class<M> modelType, Flag... flags) {
         ConcurrentHashMapStorage storage = factory.getStorage(modelType, flags);
-        return (MapStorage<K, V, M>) storage;
+        return (MapStorage<V, M>) storage;
     }
 }

--- a/model/map/src/main/java/org/keycloak/models/map/storage/chm/ConcurrentHashMapStorageProviderFactory.java
+++ b/model/map/src/main/java/org/keycloak/models/map/storage/chm/ConcurrentHashMapStorageProviderFactory.java
@@ -16,6 +16,7 @@
  */
 package org.keycloak.models.map.storage.chm;
 
+import org.keycloak.models.map.common.StringKeyConvertor;
 import org.keycloak.component.AmphibianProviderFactory;
 import org.keycloak.Config.Scope;
 import org.keycloak.authorization.model.PermissionTicket;
@@ -63,7 +64,6 @@ import org.keycloak.models.map.storage.MapStorageProvider;
 import org.keycloak.models.map.storage.MapStorageProviderFactory;
 import org.keycloak.models.map.storage.ModelCriteriaBuilder;
 import org.keycloak.models.map.userSession.MapAuthenticatedClientSessionEntity;
-import org.keycloak.models.map.storage.StringKeyConvertor;
 import org.keycloak.models.map.user.MapUserEntity;
 import org.keycloak.models.map.userSession.MapUserSessionEntity;
 import org.keycloak.provider.EnvironmentDependentProviderFactory;
@@ -241,7 +241,7 @@ public class ConcurrentHashMapStorageProviderFactory implements AmphibianProvide
         }
     }
 
-    private <K, V extends AbstractEntity<K> & UpdatableEntity, M> ConcurrentHashMapStorage<K, V, M> loadMap(String mapName,
+    private <K, V extends AbstractEntity & UpdatableEntity, M> ConcurrentHashMapStorage<K, V, M> loadMap(String mapName,
       Class<M> modelType, EnumSet<Flag> flags) {
         final StringKeyConvertor kc = keyConvertors.getOrDefault(mapName, defaultKeyConvertor);
         Class<?> valueType = MODEL_TO_VALUE_TYPE.get(modelType);
@@ -291,7 +291,7 @@ public class ConcurrentHashMapStorageProviderFactory implements AmphibianProvide
     }
 
     @SuppressWarnings("unchecked")
-    public <K, V extends AbstractEntity<K> & UpdatableEntity, M> ConcurrentHashMapStorage<K, V, M> getStorage(
+    public <K, V extends AbstractEntity & UpdatableEntity, M> ConcurrentHashMapStorage<K, V, M> getStorage(
       Class<M> modelType, Flag... flags) {
         EnumSet<Flag> f = flags == null || flags.length == 0 ? EnumSet.noneOf(Flag.class) : EnumSet.of(flags[0], flags);
         String name = MODEL_TO_NAME.getOrDefault(modelType, modelType.getSimpleName());

--- a/model/map/src/main/java/org/keycloak/models/map/storage/chm/MapFieldPredicates.java
+++ b/model/map/src/main/java/org/keycloak/models/map/storage/chm/MapFieldPredicates.java
@@ -75,21 +75,21 @@ import static org.keycloak.models.UserSessionModel.CORRESPONDING_SESSION_ID;
  */
 public class MapFieldPredicates {
 
-    public static final Map<SearchableModelField<AuthenticatedClientSessionModel>, UpdatePredicatesFunc<Object, MapAuthenticatedClientSessionEntity<Object>, AuthenticatedClientSessionModel>> CLIENT_SESSION_PREDICATES = basePredicates(AuthenticatedClientSessionModel.SearchableFields.ID);
-    public static final Map<SearchableModelField<ClientModel>, UpdatePredicatesFunc<Object, MapClientEntity<Object>, ClientModel>> CLIENT_PREDICATES = basePredicates(ClientModel.SearchableFields.ID);
-    public static final Map<SearchableModelField<ClientScopeModel>, UpdatePredicatesFunc<Object, MapClientScopeEntity<Object>, ClientScopeModel>> CLIENT_SCOPE_PREDICATES = basePredicates(ClientScopeModel.SearchableFields.ID);
-    public static final Map<SearchableModelField<GroupModel>, UpdatePredicatesFunc<Object, MapGroupEntity<Object>, GroupModel>> GROUP_PREDICATES = basePredicates(GroupModel.SearchableFields.ID);
-    public static final Map<SearchableModelField<RoleModel>, UpdatePredicatesFunc<Object, MapRoleEntity<Object>, RoleModel>> ROLE_PREDICATES = basePredicates(RoleModel.SearchableFields.ID);
-    public static final Map<SearchableModelField<RootAuthenticationSessionModel>, UpdatePredicatesFunc<Object, MapRootAuthenticationSessionEntity<Object>, RootAuthenticationSessionModel>> AUTHENTICATION_SESSION_PREDICATES = basePredicates(RootAuthenticationSessionModel.SearchableFields.ID);
-    public static final Map<SearchableModelField<RealmModel>, UpdatePredicatesFunc<Object, MapRealmEntity<Object>, RealmModel>> REALM_PREDICATES = basePredicates(RealmModel.SearchableFields.ID);
-    public static final Map<SearchableModelField<ResourceServer>, UpdatePredicatesFunc<Object, MapResourceServerEntity<Object>, ResourceServer>> AUTHZ_RESOURCE_SERVER_PREDICATES = basePredicates(ResourceServer.SearchableFields.ID);
-    public static final Map<SearchableModelField<Resource>, UpdatePredicatesFunc<Object, MapResourceEntity<Object>, Resource>> AUTHZ_RESOURCE_PREDICATES = basePredicates(Resource.SearchableFields.ID);
-    public static final Map<SearchableModelField<Scope>, UpdatePredicatesFunc<Object, MapScopeEntity<Object>, Scope>> AUTHZ_SCOPE_PREDICATES = basePredicates(Scope.SearchableFields.ID);
-    public static final Map<SearchableModelField<PermissionTicket>, UpdatePredicatesFunc<Object, MapPermissionTicketEntity<Object>, PermissionTicket>> AUTHZ_PERMISSION_TICKET_PREDICATES = basePredicates(PermissionTicket.SearchableFields.ID);
-    public static final Map<SearchableModelField<Policy>, UpdatePredicatesFunc<Object, MapPolicyEntity<Object>, Policy>> AUTHZ_POLICY_PREDICATES = basePredicates(Policy.SearchableFields.ID);
-    public static final Map<SearchableModelField<UserLoginFailureModel>, UpdatePredicatesFunc<Object, MapUserLoginFailureEntity<Object>, UserLoginFailureModel>> USER_LOGIN_FAILURE_PREDICATES = basePredicates(UserLoginFailureModel.SearchableFields.ID);
-    public static final Map<SearchableModelField<UserModel>, UpdatePredicatesFunc<Object, MapUserEntity<Object>, UserModel>> USER_PREDICATES = basePredicates(UserModel.SearchableFields.ID);
-    public static final Map<SearchableModelField<UserSessionModel>, UpdatePredicatesFunc<Object, MapUserSessionEntity<Object>, UserSessionModel>> USER_SESSION_PREDICATES = basePredicates(UserSessionModel.SearchableFields.ID);
+    public static final Map<SearchableModelField<AuthenticatedClientSessionModel>, UpdatePredicatesFunc<Object, MapAuthenticatedClientSessionEntity, AuthenticatedClientSessionModel>> CLIENT_SESSION_PREDICATES = basePredicates(AuthenticatedClientSessionModel.SearchableFields.ID);
+    public static final Map<SearchableModelField<ClientModel>, UpdatePredicatesFunc<Object, MapClientEntity, ClientModel>> CLIENT_PREDICATES = basePredicates(ClientModel.SearchableFields.ID);
+    public static final Map<SearchableModelField<ClientScopeModel>, UpdatePredicatesFunc<Object, MapClientScopeEntity, ClientScopeModel>> CLIENT_SCOPE_PREDICATES = basePredicates(ClientScopeModel.SearchableFields.ID);
+    public static final Map<SearchableModelField<GroupModel>, UpdatePredicatesFunc<Object, MapGroupEntity, GroupModel>> GROUP_PREDICATES = basePredicates(GroupModel.SearchableFields.ID);
+    public static final Map<SearchableModelField<RoleModel>, UpdatePredicatesFunc<Object, MapRoleEntity, RoleModel>> ROLE_PREDICATES = basePredicates(RoleModel.SearchableFields.ID);
+    public static final Map<SearchableModelField<RootAuthenticationSessionModel>, UpdatePredicatesFunc<Object, MapRootAuthenticationSessionEntity, RootAuthenticationSessionModel>> AUTHENTICATION_SESSION_PREDICATES = basePredicates(RootAuthenticationSessionModel.SearchableFields.ID);
+    public static final Map<SearchableModelField<RealmModel>, UpdatePredicatesFunc<Object, MapRealmEntity, RealmModel>> REALM_PREDICATES = basePredicates(RealmModel.SearchableFields.ID);
+    public static final Map<SearchableModelField<ResourceServer>, UpdatePredicatesFunc<Object, MapResourceServerEntity, ResourceServer>> AUTHZ_RESOURCE_SERVER_PREDICATES = basePredicates(ResourceServer.SearchableFields.ID);
+    public static final Map<SearchableModelField<Resource>, UpdatePredicatesFunc<Object, MapResourceEntity, Resource>> AUTHZ_RESOURCE_PREDICATES = basePredicates(Resource.SearchableFields.ID);
+    public static final Map<SearchableModelField<Scope>, UpdatePredicatesFunc<Object, MapScopeEntity, Scope>> AUTHZ_SCOPE_PREDICATES = basePredicates(Scope.SearchableFields.ID);
+    public static final Map<SearchableModelField<PermissionTicket>, UpdatePredicatesFunc<Object, MapPermissionTicketEntity, PermissionTicket>> AUTHZ_PERMISSION_TICKET_PREDICATES = basePredicates(PermissionTicket.SearchableFields.ID);
+    public static final Map<SearchableModelField<Policy>, UpdatePredicatesFunc<Object, MapPolicyEntity, Policy>> AUTHZ_POLICY_PREDICATES = basePredicates(Policy.SearchableFields.ID);
+    public static final Map<SearchableModelField<UserLoginFailureModel>, UpdatePredicatesFunc<Object, MapUserLoginFailureEntity, UserLoginFailureModel>> USER_LOGIN_FAILURE_PREDICATES = basePredicates(UserLoginFailureModel.SearchableFields.ID);
+    public static final Map<SearchableModelField<UserModel>, UpdatePredicatesFunc<Object, MapUserEntity, UserModel>> USER_PREDICATES = basePredicates(UserModel.SearchableFields.ID);
+    public static final Map<SearchableModelField<UserSessionModel>, UpdatePredicatesFunc<Object, MapUserSessionEntity, UserSessionModel>> USER_SESSION_PREDICATES = basePredicates(UserSessionModel.SearchableFields.ID);
 
     @SuppressWarnings("unchecked")
     private static final Map<Class<?>, Map> PREDICATES = new HashMap<>();
@@ -212,26 +212,26 @@ public class MapFieldPredicates {
         PREDICATES.put(UserLoginFailureModel.class,             USER_LOGIN_FAILURE_PREDICATES);
     }
 
-    private static <K, V extends AbstractEntity<K>, M, L extends Comparable<L>> void put(
+    private static <K, V extends AbstractEntity, M, L extends Comparable<L>> void put(
       Map<SearchableModelField<M>, UpdatePredicatesFunc<K, V, M>> map,
       SearchableModelField<M> field, Function<V, L> extractor) {
         COMPARATORS.put(field, Comparator.comparing(extractor));
         map.put(field, (mcb, op, values) -> mcb.fieldCompare(op, extractor, values));
     }
 
-    private static <K, V extends AbstractEntity<K>, M> void putIncomparable(
+    private static <K, V extends AbstractEntity, M> void putIncomparable(
             Map<SearchableModelField<M>, UpdatePredicatesFunc<K, V, M>> map,
             SearchableModelField<M> field, Function<V, Object> extractor) {
         map.put(field, (mcb, op, values) -> mcb.fieldCompare(op, extractor, values));
     }
 
-    private static <K, V extends AbstractEntity<K>, M> void put(
+    private static <K, V extends AbstractEntity, M> void put(
       Map<SearchableModelField<M>, UpdatePredicatesFunc<K, V, M>> map,
       SearchableModelField<M> field, UpdatePredicatesFunc<K, V, M> function) {
         map.put(field, function);
     }
 
-    private static <V extends AbstractEntity<?>> Function<V, String> predicateForKeyField(Function<V, Object> extractor) {
+    private static <V extends AbstractEntity> Function<V, String> predicateForKeyField(Function<V, Object> extractor) {
         return entity -> {
             Object o = extractor.apply(entity);
             return o == null ? null : o.toString();
@@ -258,30 +258,30 @@ public class MapFieldPredicates {
         return expectedType.cast(ob);
     }
 
-    private static MapModelCriteriaBuilder<Object, MapClientEntity<Object>, ClientModel> checkScopeMappingRole(MapModelCriteriaBuilder<Object, MapClientEntity<Object>, ClientModel> mcb, Operator op, Object[] values) {
+    private static MapModelCriteriaBuilder<Object, MapClientEntity, ClientModel> checkScopeMappingRole(MapModelCriteriaBuilder<Object, MapClientEntity, ClientModel> mcb, Operator op, Object[] values) {
         String roleIdS = ensureEqSingleValue(ClientModel.SearchableFields.SCOPE_MAPPING_ROLE, "role_id", op, values);
-        Function<MapClientEntity<Object>, ?> getter;
+        Function<MapClientEntity, ?> getter;
         getter = ce -> ce.getScopeMappings().contains(roleIdS);
         return mcb.fieldCompare(Boolean.TRUE::equals, getter);
     }
 
-    private static MapModelCriteriaBuilder<Object, MapGroupEntity<Object>, GroupModel> checkGrantedGroupRole(MapModelCriteriaBuilder<Object, MapGroupEntity<Object>, GroupModel> mcb, Operator op, Object[] values) {
+    private static MapModelCriteriaBuilder<Object, MapGroupEntity, GroupModel> checkGrantedGroupRole(MapModelCriteriaBuilder<Object, MapGroupEntity, GroupModel> mcb, Operator op, Object[] values) {
         String roleIdS = ensureEqSingleValue(GroupModel.SearchableFields.ASSIGNED_ROLE, "role_id", op, values);
-        Function<MapGroupEntity<Object>, ?> getter;
+        Function<MapGroupEntity, ?> getter;
         getter = ge -> ge.getGrantedRoles().contains(roleIdS);
         return mcb.fieldCompare(Boolean.TRUE::equals, getter);
     }
 
-    private static MapModelCriteriaBuilder<Object, MapUserEntity<Object>, UserModel> getUserConsentClientFederationLink(MapModelCriteriaBuilder<Object, MapUserEntity<Object>, UserModel> mcb, Operator op, Object[] values) {
+    private static MapModelCriteriaBuilder<Object, MapUserEntity, UserModel> getUserConsentClientFederationLink(MapModelCriteriaBuilder<Object, MapUserEntity, UserModel> mcb, Operator op, Object[] values) {
         String providerId = ensureEqSingleValue(UserModel.SearchableFields.CONSENT_CLIENT_FEDERATION_LINK, "provider_id", op, values);
         String providerIdS = new StorageId((String) providerId, "").getId();
-        Function<MapUserEntity<Object>, ?> getter;
+        Function<MapUserEntity, ?> getter;
         getter = ue -> ue.getUserConsents().map(UserConsentEntity::getClientId).anyMatch(v -> v != null && v.startsWith(providerIdS));
 
         return mcb.fieldCompare(Boolean.TRUE::equals, getter);
     }
 
-    private static MapModelCriteriaBuilder<Object, MapUserEntity<Object>, UserModel> checkUserAttributes(MapModelCriteriaBuilder<Object, MapUserEntity<Object>, UserModel> mcb, Operator op, Object[] values) {
+    private static MapModelCriteriaBuilder<Object, MapUserEntity, UserModel> checkUserAttributes(MapModelCriteriaBuilder<Object, MapUserEntity, UserModel> mcb, Operator op, Object[] values) {
         if (values == null || values.length <= 1) {
             throw new CriterionNotSupportedException(UserModel.SearchableFields.ATTRIBUTE, op, "Invalid arguments, expected (attribute_name, ...), got: " + Arrays.toString(values));
         }
@@ -291,7 +291,7 @@ public class MapFieldPredicates {
             throw new CriterionNotSupportedException(UserModel.SearchableFields.ATTRIBUTE, op, "Invalid arguments, expected (String attribute_name), got: " + Arrays.toString(values));
         }
         String attrNameS = (String) attrName;
-        Function<MapUserEntity<Object>, ?> getter;
+        Function<MapUserEntity, ?> getter;
         Object[] realValues = new Object[values.length - 1];
         System.arraycopy(values, 1, realValues, 0, values.length - 1);
         Predicate<Object> valueComparator = CriteriaOperator.predicateFor(op, realValues);
@@ -303,7 +303,7 @@ public class MapFieldPredicates {
         return mcb.fieldCompare(Boolean.TRUE::equals, getter);
     }
 
-    private static MapModelCriteriaBuilder<Object, MapClientEntity<Object>, ClientModel> checkClientAttributes(MapModelCriteriaBuilder<Object, MapClientEntity<Object>, ClientModel> mcb, Operator op, Object[] values) {
+    private static MapModelCriteriaBuilder<Object, MapClientEntity, ClientModel> checkClientAttributes(MapModelCriteriaBuilder<Object, MapClientEntity, ClientModel> mcb, Operator op, Object[] values) {
         if (values == null || values.length != 2) {
             throw new CriterionNotSupportedException(ClientModel.SearchableFields.ATTRIBUTE, op, "Invalid arguments, expected attribute_name-value pair, got: " + Arrays.toString(values));
         }
@@ -316,7 +316,7 @@ public class MapFieldPredicates {
         Object[] realValues = new Object[values.length - 1];
         System.arraycopy(values, 1, realValues, 0, values.length - 1);
         Predicate<Object> valueComparator = CriteriaOperator.predicateFor(op, realValues);
-        Function<MapClientEntity<Object>, ?> getter = ue -> {
+        Function<MapClientEntity, ?> getter = ue -> {
             final List<String> attrs = ue.getAttribute(attrNameS);
             return attrs != null && attrs.stream().anyMatch(valueComparator);
         };
@@ -324,16 +324,16 @@ public class MapFieldPredicates {
         return mcb.fieldCompare(Boolean.TRUE::equals, getter);
     }
 
-    private static MapModelCriteriaBuilder<Object, MapUserEntity<Object>, UserModel> checkGrantedUserRole(MapModelCriteriaBuilder<Object, MapUserEntity<Object>, UserModel> mcb, Operator op, Object[] values) {
+    private static MapModelCriteriaBuilder<Object, MapUserEntity, UserModel> checkGrantedUserRole(MapModelCriteriaBuilder<Object, MapUserEntity, UserModel> mcb, Operator op, Object[] values) {
         String roleIdS = ensureEqSingleValue(UserModel.SearchableFields.ASSIGNED_ROLE, "role_id", op, values);
-        Function<MapUserEntity<Object>, ?> getter;
+        Function<MapUserEntity, ?> getter;
         getter = ue -> ue.getRolesMembership().contains(roleIdS);
 
         return mcb.fieldCompare(Boolean.TRUE::equals, getter);
     }
 
-    private static MapModelCriteriaBuilder<Object, MapResourceEntity<Object>, Resource> checkResourceUri(MapModelCriteriaBuilder<Object, MapResourceEntity<Object>, Resource> mcb, Operator op, Object[] values) {
-        Function<MapResourceEntity<Object>, ?> getter;
+    private static MapModelCriteriaBuilder<Object, MapResourceEntity, Resource> checkResourceUri(MapModelCriteriaBuilder<Object, MapResourceEntity, Resource> mcb, Operator op, Object[] values) {
+        Function<MapResourceEntity, ?> getter;
 
         if (Operator.EXISTS.equals(op)) {
             getter = re -> re.getUris() != null && !re.getUris().isEmpty();
@@ -348,8 +348,8 @@ public class MapFieldPredicates {
         return mcb.fieldCompare(Boolean.TRUE::equals, getter);
     }
 
-    private static MapModelCriteriaBuilder<Object, MapResourceEntity<Object>, Resource> checkResourceScopes(MapModelCriteriaBuilder<Object, MapResourceEntity<Object>, Resource> mcb, Operator op, Object[] values) {
-        Function<MapResourceEntity<Object>, ?> getter;
+    private static MapModelCriteriaBuilder<Object, MapResourceEntity, Resource> checkResourceScopes(MapModelCriteriaBuilder<Object, MapResourceEntity, Resource> mcb, Operator op, Object[] values) {
+        Function<MapResourceEntity, ?> getter;
 
         if (op == Operator.IN && values != null && values.length == 1 && (values[0] instanceof Collection)) {
             Collection<?> c = (Collection<?>) values[0];
@@ -362,8 +362,8 @@ public class MapFieldPredicates {
         return mcb.fieldCompare(Boolean.TRUE::equals, getter);
     }
 
-    private static MapModelCriteriaBuilder<Object, MapPolicyEntity<Object>, Policy> checkPolicyResources(MapModelCriteriaBuilder<Object, MapPolicyEntity<Object>, Policy> mcb, Operator op, Object[] values) {
-        Function<MapPolicyEntity<Object>, ?> getter;
+    private static MapModelCriteriaBuilder<Object, MapPolicyEntity, Policy> checkPolicyResources(MapModelCriteriaBuilder<Object, MapPolicyEntity, Policy> mcb, Operator op, Object[] values) {
+        Function<MapPolicyEntity, ?> getter;
 
         if (op == Operator.NOT_EXISTS) {
             getter = re -> re.getResourceIds().isEmpty();
@@ -378,8 +378,8 @@ public class MapFieldPredicates {
         return mcb.fieldCompare(Boolean.TRUE::equals, getter);
     }
 
-    private static MapModelCriteriaBuilder<Object, MapPolicyEntity<Object>, Policy> checkPolicyScopes(MapModelCriteriaBuilder<Object, MapPolicyEntity<Object>, Policy> mcb, Operator op, Object[] values) {
-        Function<MapPolicyEntity<Object>, ?> getter;
+    private static MapModelCriteriaBuilder<Object, MapPolicyEntity, Policy> checkPolicyScopes(MapModelCriteriaBuilder<Object, MapPolicyEntity, Policy> mcb, Operator op, Object[] values) {
+        Function<MapPolicyEntity, ?> getter;
 
         if (op == Operator.IN && values != null && values.length == 1 && (values[0] instanceof Collection)) {
             Collection<?> c = (Collection<?>) values[0];
@@ -392,8 +392,8 @@ public class MapFieldPredicates {
         return mcb.fieldCompare(Boolean.TRUE::equals, getter);
     }
 
-    private static MapModelCriteriaBuilder<Object, MapPolicyEntity<Object>, Policy> checkPolicyConfig(MapModelCriteriaBuilder<Object, MapPolicyEntity<Object>, Policy> mcb, Operator op, Object[] values) {
-        Function<MapPolicyEntity<Object>, ?> getter;
+    private static MapModelCriteriaBuilder<Object, MapPolicyEntity, Policy> checkPolicyConfig(MapModelCriteriaBuilder<Object, MapPolicyEntity, Policy> mcb, Operator op, Object[] values) {
+        Function<MapPolicyEntity, ?> getter;
 
         final Object attrName = values[0];
         if (!(attrName instanceof String)) {
@@ -412,8 +412,8 @@ public class MapFieldPredicates {
         return mcb.fieldCompare(Boolean.TRUE::equals, getter);
     }
 
-    private static MapModelCriteriaBuilder<Object, MapPolicyEntity<Object>, Policy> checkAssociatedPolicy(MapModelCriteriaBuilder<Object, MapPolicyEntity<Object>, Policy> mcb, Operator op, Object[] values) {
-        Function<MapPolicyEntity<Object>, ?> getter;
+    private static MapModelCriteriaBuilder<Object, MapPolicyEntity, Policy> checkAssociatedPolicy(MapModelCriteriaBuilder<Object, MapPolicyEntity, Policy> mcb, Operator op, Object[] values) {
+        Function<MapPolicyEntity, ?> getter;
 
         if (op == Operator.IN && values != null && values.length == 1 && (values[0] instanceof Collection)) {
             Collection<?> c = (Collection<?>) values[0];
@@ -426,8 +426,8 @@ public class MapFieldPredicates {
         return mcb.fieldCompare(Boolean.TRUE::equals, getter);
     }
 
-    private static MapModelCriteriaBuilder<Object, MapUserEntity<Object>, UserModel> checkUserGroup(MapModelCriteriaBuilder<Object, MapUserEntity<Object>, UserModel> mcb, Operator op, Object[] values) {
-        Function<MapUserEntity<Object>, ?> getter;
+    private static MapModelCriteriaBuilder<Object, MapUserEntity, UserModel> checkUserGroup(MapModelCriteriaBuilder<Object, MapUserEntity, UserModel> mcb, Operator op, Object[] values) {
+        Function<MapUserEntity, ?> getter;
         if (op == Operator.IN && values != null && values.length == 1 && (values[0] instanceof Collection)) {
             Collection<?> c = (Collection<?>) values[0];
             getter = ue -> ue.getGroupsMembership().stream().anyMatch(c::contains);
@@ -439,23 +439,23 @@ public class MapFieldPredicates {
         return mcb.fieldCompare(Boolean.TRUE::equals, getter);
     }
 
-    private static MapModelCriteriaBuilder<Object, MapUserEntity<Object>, UserModel> checkUserClientConsent(MapModelCriteriaBuilder<Object, MapUserEntity<Object>, UserModel> mcb, Operator op, Object[] values) {
+    private static MapModelCriteriaBuilder<Object, MapUserEntity, UserModel> checkUserClientConsent(MapModelCriteriaBuilder<Object, MapUserEntity, UserModel> mcb, Operator op, Object[] values) {
         String clientIdS = ensureEqSingleValue(UserModel.SearchableFields.CONSENT_FOR_CLIENT, "client_id", op, values);
-        Function<MapUserEntity<Object>, ?> getter;
+        Function<MapUserEntity, ?> getter;
         getter = ue -> ue.getUserConsent(clientIdS);
 
         return mcb.fieldCompare(Operator.EXISTS, getter, null);
     }
 
-    private static MapModelCriteriaBuilder<Object, MapUserEntity<Object>, UserModel> checkUserConsentsWithClientScope(MapModelCriteriaBuilder<Object, MapUserEntity<Object>, UserModel> mcb, Operator op, Object[] values) {
+    private static MapModelCriteriaBuilder<Object, MapUserEntity, UserModel> checkUserConsentsWithClientScope(MapModelCriteriaBuilder<Object, MapUserEntity, UserModel> mcb, Operator op, Object[] values) {
         String clientScopeIdS = ensureEqSingleValue(UserModel.SearchableFields.CONSENT_FOR_CLIENT, "client_scope_id", op, values);
-        Function<MapUserEntity<Object>, ?> getter;
+        Function<MapUserEntity, ?> getter;
         getter = ue -> ue.getUserConsents().anyMatch(consent -> consent.getGrantedClientScopesIds().contains(clientScopeIdS));
 
         return mcb.fieldCompare(Boolean.TRUE::equals, getter);
     }
 
-    private static MapModelCriteriaBuilder<Object, MapUserEntity<Object>, UserModel> getUserIdpAliasAtIdentityProviderPredicate(MapModelCriteriaBuilder<Object, MapUserEntity<Object>, UserModel> mcb, Operator op, Object[] values) {
+    private static MapModelCriteriaBuilder<Object, MapUserEntity, UserModel> getUserIdpAliasAtIdentityProviderPredicate(MapModelCriteriaBuilder<Object, MapUserEntity, UserModel> mcb, Operator op, Object[] values) {
         if (op != Operator.EQ) {
             throw new CriterionNotSupportedException(UserModel.SearchableFields.IDP_AND_USER, op);
         }
@@ -464,7 +464,7 @@ public class MapFieldPredicates {
         }
 
         final Object idpAlias = values[0];
-        Function<MapUserEntity<Object>, ?> getter;
+        Function<MapUserEntity, ?> getter;
         if (values.length == 1) {
             getter = ue -> ue.getFederatedIdentities()
               .anyMatch(aue -> Objects.equals(idpAlias, aue.getIdentityProvider()));
@@ -481,25 +481,25 @@ public class MapFieldPredicates {
         return mcb.fieldCompare(Boolean.TRUE::equals, getter);
     }
 
-    private static MapModelCriteriaBuilder<Object, MapRealmEntity<Object>, RealmModel> checkRealmsWithComponentType(MapModelCriteriaBuilder<Object, MapRealmEntity<Object>, RealmModel> mcb, Operator op, Object[] values) {
+    private static MapModelCriteriaBuilder<Object, MapRealmEntity, RealmModel> checkRealmsWithComponentType(MapModelCriteriaBuilder<Object, MapRealmEntity, RealmModel> mcb, Operator op, Object[] values) {
         String providerType = ensureEqSingleValue(RealmModel.SearchableFields.COMPONENT_PROVIDER_TYPE, "component_provider_type", op, values);
-        Function<MapRealmEntity<Object>, ?> getter = realmEntity -> realmEntity.getComponents().anyMatch(component -> component.getProviderType().equals(providerType));
+        Function<MapRealmEntity, ?> getter = realmEntity -> realmEntity.getComponents().anyMatch(component -> component.getProviderType().equals(providerType));
         return mcb.fieldCompare(Boolean.TRUE::equals, getter);
     }
 
-    private static MapModelCriteriaBuilder<Object, MapUserSessionEntity<Object>, UserSessionModel> checkUserSessionContainsAuthenticatedClientSession(MapModelCriteriaBuilder<Object, MapUserSessionEntity<Object>, UserSessionModel> mcb, Operator op, Object[] values) {
+    private static MapModelCriteriaBuilder<Object, MapUserSessionEntity, UserSessionModel> checkUserSessionContainsAuthenticatedClientSession(MapModelCriteriaBuilder<Object, MapUserSessionEntity, UserSessionModel> mcb, Operator op, Object[] values) {
         String clientId = ensureEqSingleValue(UserSessionModel.SearchableFields.CLIENT_ID, "client_id", op, values);
-        Function<MapUserSessionEntity<Object>, ?> getter = use -> (use.getAuthenticatedClientSessions().containsKey(clientId));
+        Function<MapUserSessionEntity, ?> getter = use -> (use.getAuthenticatedClientSessions().containsKey(clientId));
         return mcb.fieldCompare(Boolean.TRUE::equals, getter);
     }
 
-    protected static <K, V extends AbstractEntity<K>, M> Map<SearchableModelField<M>, UpdatePredicatesFunc<K, V, M>> basePredicates(SearchableModelField<M> idField) {
+    protected static <K, V extends AbstractEntity, M> Map<SearchableModelField<M>, UpdatePredicatesFunc<K, V, M>> basePredicates(SearchableModelField<M> idField) {
         Map<SearchableModelField<M>, UpdatePredicatesFunc<K, V, M>> fieldPredicates = new HashMap<>();
         fieldPredicates.put(idField, MapModelCriteriaBuilder::idCompare);
         return fieldPredicates;
     }
 
-    public static <K, V extends AbstractEntity<K>, M> Comparator<V> getComparator(QueryParameters.OrderBy<M> orderBy) {
+    public static <K, V extends AbstractEntity, M> Comparator<V> getComparator(QueryParameters.OrderBy<M> orderBy) {
         SearchableModelField<M> searchableModelField = orderBy.getModelField();
         QueryParameters.Order order = orderBy.getOrder();
 
@@ -518,14 +518,14 @@ public class MapFieldPredicates {
     }
 
     @SuppressWarnings("unchecked")
-    public static <K, V extends AbstractEntity<K>, M> Comparator<V> getComparator(Stream<QueryParameters.OrderBy<M>> ordering) {
+    public static <K, V extends AbstractEntity, M> Comparator<V> getComparator(Stream<QueryParameters.OrderBy<M>> ordering) {
         return (Comparator<V>) ordering.map(MapFieldPredicates::getComparator)
                 .reduce(Comparator::thenComparing)
                 .orElseThrow(() -> new IllegalArgumentException("Cannot create comparator for " + ordering));
     }
 
     @SuppressWarnings("unchecked")
-    public static <K, V extends AbstractEntity<K>, M> Map<SearchableModelField<M>, UpdatePredicatesFunc<K, V, M>> getPredicates(Class<M> clazz) {
+    public static <K, V extends AbstractEntity, M> Map<SearchableModelField<M>, UpdatePredicatesFunc<K, V, M>> getPredicates(Class<M> clazz) {
         return PREDICATES.get(clazz);
     }
 }

--- a/model/map/src/main/java/org/keycloak/models/map/storage/chm/UserSessionConcurrentHashMapStorage.java
+++ b/model/map/src/main/java/org/keycloak/models/map/storage/chm/UserSessionConcurrentHashMapStorage.java
@@ -44,9 +44,9 @@ public class UserSessionConcurrentHashMapStorage<K> extends ConcurrentHashMapSto
 
     private class Transaction extends ConcurrentHashMapKeycloakTransaction<K, MapUserSessionEntity, UserSessionModel> {
 
-        private final MapKeycloakTransaction<K, MapAuthenticatedClientSessionEntity, AuthenticatedClientSessionModel> clientSessionTr;
+        private final MapKeycloakTransaction<MapAuthenticatedClientSessionEntity, AuthenticatedClientSessionModel> clientSessionTr;
 
-        public Transaction(MapKeycloakTransaction<K, MapAuthenticatedClientSessionEntity, AuthenticatedClientSessionModel> clientSessionTr, StringKeyConvertor<K> keyConvertor) {
+        public Transaction(MapKeycloakTransaction<MapAuthenticatedClientSessionEntity, AuthenticatedClientSessionModel> clientSessionTr, StringKeyConvertor<K> keyConvertor) {
             super(UserSessionConcurrentHashMapStorage.this, keyConvertor);
             this.clientSessionTr = clientSessionTr;
         }
@@ -77,8 +77,8 @@ public class UserSessionConcurrentHashMapStorage<K> extends ConcurrentHashMapSto
 
     @Override
     @SuppressWarnings("unchecked")
-    public MapKeycloakTransaction<K, MapUserSessionEntity, UserSessionModel> createTransaction(KeycloakSession session) {
-        MapKeycloakTransaction<K, MapUserSessionEntity, UserSessionModel> sessionTransaction = session.getAttribute("map-transaction-" + hashCode(), MapKeycloakTransaction.class);
+    public MapKeycloakTransaction<MapUserSessionEntity, UserSessionModel> createTransaction(KeycloakSession session) {
+        MapKeycloakTransaction<MapUserSessionEntity, UserSessionModel> sessionTransaction = session.getAttribute("map-transaction-" + hashCode(), MapKeycloakTransaction.class);
         return sessionTransaction == null ? new Transaction(clientSessionStore.createTransaction(session), clientSessionStore.getKeyConvertor()) : sessionTransaction;
     }
 }

--- a/model/map/src/main/java/org/keycloak/models/map/storage/chm/UserSessionConcurrentHashMapStorage.java
+++ b/model/map/src/main/java/org/keycloak/models/map/storage/chm/UserSessionConcurrentHashMapStorage.java
@@ -16,6 +16,7 @@
  */
 package org.keycloak.models.map.storage.chm;
 
+import org.keycloak.models.map.common.StringKeyConvertor;
 import org.keycloak.models.AuthenticatedClientSessionModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.UserSessionModel;
@@ -24,7 +25,6 @@ import org.keycloak.models.map.storage.MapKeycloakTransaction;
 import org.keycloak.models.map.storage.ModelCriteriaBuilder;
 import org.keycloak.models.map.storage.ModelCriteriaBuilder.Operator;
 import org.keycloak.models.map.storage.QueryParameters;
-import org.keycloak.models.map.storage.StringKeyConvertor;
 import org.keycloak.models.map.userSession.MapAuthenticatedClientSessionEntity;
 import org.keycloak.models.map.userSession.MapUserSessionEntity;
 import java.util.Set;
@@ -38,31 +38,29 @@ import static org.keycloak.models.map.storage.QueryParameters.withCriteria;
  *
  * @author hmlnarik
  */
-public class UserSessionConcurrentHashMapStorage<K> extends ConcurrentHashMapStorage<K, MapUserSessionEntity<K>, UserSessionModel> {
+public class UserSessionConcurrentHashMapStorage<K> extends ConcurrentHashMapStorage<K, MapUserSessionEntity, UserSessionModel> {
 
-    private final ConcurrentHashMapStorage<K, MapAuthenticatedClientSessionEntity<K>, AuthenticatedClientSessionModel> clientSessionStore;
+    private final ConcurrentHashMapStorage<K, MapAuthenticatedClientSessionEntity, AuthenticatedClientSessionModel> clientSessionStore;
 
-    private class Transaction extends ConcurrentHashMapKeycloakTransaction<K, MapUserSessionEntity<K>, UserSessionModel> {
+    private class Transaction extends ConcurrentHashMapKeycloakTransaction<K, MapUserSessionEntity, UserSessionModel> {
 
-        private final MapKeycloakTransaction<K, MapAuthenticatedClientSessionEntity<K>, AuthenticatedClientSessionModel> clientSessionTr;
+        private final MapKeycloakTransaction<K, MapAuthenticatedClientSessionEntity, AuthenticatedClientSessionModel> clientSessionTr;
 
-        public Transaction(MapKeycloakTransaction<K, MapAuthenticatedClientSessionEntity<K>, AuthenticatedClientSessionModel> clientSessionTr) {
-            super(UserSessionConcurrentHashMapStorage.this);
+        public Transaction(MapKeycloakTransaction<K, MapAuthenticatedClientSessionEntity, AuthenticatedClientSessionModel> clientSessionTr, StringKeyConvertor<K> keyConvertor) {
+            super(UserSessionConcurrentHashMapStorage.this, keyConvertor);
             this.clientSessionTr = clientSessionTr;
         }
 
         @Override
         public long delete(QueryParameters<UserSessionModel> queryParameters) {
-            ModelCriteriaBuilder<UserSessionModel> mcb = queryParameters.getModelCriteriaBuilder();
-
-            Set<K> ids = read(queryParameters).map(AbstractEntity::getId).collect(Collectors.toSet());
+            Set<String> ids = read(queryParameters).map(AbstractEntity::getId).collect(Collectors.toSet());
             ModelCriteriaBuilder<AuthenticatedClientSessionModel> csMcb = clientSessionStore.createCriteriaBuilder().compare(AuthenticatedClientSessionModel.SearchableFields.USER_SESSION_ID, Operator.IN, ids);
             clientSessionTr.delete(withCriteria(csMcb));
             return super.delete(queryParameters);
         }
 
         @Override
-        public boolean delete(K key) {
+        public boolean delete(String key) {
             ModelCriteriaBuilder<AuthenticatedClientSessionModel> csMcb = clientSessionStore.createCriteriaBuilder().compare(AuthenticatedClientSessionModel.SearchableFields.USER_SESSION_ID, Operator.EQ, key);
             clientSessionTr.delete(withCriteria(csMcb));
             return super.delete(key);
@@ -71,7 +69,7 @@ public class UserSessionConcurrentHashMapStorage<K> extends ConcurrentHashMapSto
     }
 
     @SuppressWarnings("unchecked")
-    public UserSessionConcurrentHashMapStorage(ConcurrentHashMapStorage<K, MapAuthenticatedClientSessionEntity<K>, AuthenticatedClientSessionModel> clientSessionStore,
+    public UserSessionConcurrentHashMapStorage(ConcurrentHashMapStorage<K, MapAuthenticatedClientSessionEntity, AuthenticatedClientSessionModel> clientSessionStore,
       StringKeyConvertor<K> keyConvertor) {
         super(UserSessionModel.class, keyConvertor);
         this.clientSessionStore = clientSessionStore;
@@ -79,8 +77,8 @@ public class UserSessionConcurrentHashMapStorage<K> extends ConcurrentHashMapSto
 
     @Override
     @SuppressWarnings("unchecked")
-    public MapKeycloakTransaction<K, MapUserSessionEntity<K>, UserSessionModel> createTransaction(KeycloakSession session) {
-        MapKeycloakTransaction<K, MapUserSessionEntity<K>, UserSessionModel> sessionTransaction = session.getAttribute("map-transaction-" + hashCode(), MapKeycloakTransaction.class);
-        return sessionTransaction == null ? new Transaction(clientSessionStore.createTransaction(session)) : sessionTransaction;
+    public MapKeycloakTransaction<K, MapUserSessionEntity, UserSessionModel> createTransaction(KeycloakSession session) {
+        MapKeycloakTransaction<K, MapUserSessionEntity, UserSessionModel> sessionTransaction = session.getAttribute("map-transaction-" + hashCode(), MapKeycloakTransaction.class);
+        return sessionTransaction == null ? new Transaction(clientSessionStore.createTransaction(session), clientSessionStore.getKeyConvertor()) : sessionTransaction;
     }
 }

--- a/model/map/src/main/java/org/keycloak/models/map/user/MapUserAdapter.java
+++ b/model/map/src/main/java/org/keycloak/models/map/user/MapUserAdapter.java
@@ -36,9 +36,14 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 
-public abstract class MapUserAdapter<K> extends AbstractUserModel<MapUserEntity<K>> {
-    public MapUserAdapter(KeycloakSession session, RealmModel realm, MapUserEntity<K> entity) {
+public abstract class MapUserAdapter extends AbstractUserModel<MapUserEntity> {
+    public MapUserAdapter(KeycloakSession session, RealmModel realm, MapUserEntity entity) {
         super(session, realm, entity);
+    }
+
+    @Override
+    public String getId() {
+        return entity.getId();
     }
 
     @Override

--- a/model/map/src/main/java/org/keycloak/models/map/user/MapUserEntity.java
+++ b/model/map/src/main/java/org/keycloak/models/map/user/MapUserEntity.java
@@ -40,9 +40,9 @@ import java.util.stream.Stream;
  *
  * @author mhajas
  */
-public class MapUserEntity<K> implements AbstractEntity<K>, UpdatableEntity {
+public class MapUserEntity implements AbstractEntity, UpdatableEntity {
 
-    private final K id;
+    private final String id;
     private final String realmId;
 
     private String username;
@@ -76,8 +76,7 @@ public class MapUserEntity<K> implements AbstractEntity<K>, UpdatableEntity {
         this.realmId = null;
     }
 
-    public MapUserEntity(K id, String realmId) {
-        Objects.requireNonNull(id, "id");
+    public MapUserEntity(String id, String realmId) {
         Objects.requireNonNull(realmId, "realmId");
 
         this.id = id;
@@ -85,7 +84,7 @@ public class MapUserEntity<K> implements AbstractEntity<K>, UpdatableEntity {
     }
 
     @Override
-    public K getId() {
+    public String getId() {
         return this.id;
     }
 

--- a/model/map/src/main/java/org/keycloak/models/map/user/MapUserProvider.java
+++ b/model/map/src/main/java/org/keycloak/models/map/user/MapUserProvider.java
@@ -72,14 +72,14 @@ import static org.keycloak.models.UserModel.USERNAME;
 import static org.keycloak.models.map.storage.QueryParameters.Order.ASCENDING;
 import static org.keycloak.models.map.storage.QueryParameters.withCriteria;
 
-public class MapUserProvider<K> implements UserProvider.Streams, UserCredentialStore.Streams {
+public class MapUserProvider implements UserProvider.Streams, UserCredentialStore.Streams {
 
     private static final Logger LOG = Logger.getLogger(MapUserProvider.class);
     private final KeycloakSession session;
-    final MapKeycloakTransaction<K, MapUserEntity, UserModel> tx;
-    private final MapStorage<K, MapUserEntity, UserModel> userStore;
+    final MapKeycloakTransaction<MapUserEntity, UserModel> tx;
+    private final MapStorage<MapUserEntity, UserModel> userStore;
 
-    public MapUserProvider(KeycloakSession session, MapStorage<K, MapUserEntity, UserModel> store) {
+    public MapUserProvider(KeycloakSession session, MapStorage<MapUserEntity, UserModel> store) {
         this.session = session;
         this.userStore = store;
         this.tx = userStore.createTransaction(session);
@@ -129,10 +129,6 @@ public class MapUserProvider<K> implements UserProvider.Streams, UserCredentialS
     private MapUserEntity getEntityByIdOrThrow(RealmModel realm, String id) {
         return getEntityById(realm, id)
                 .orElseThrow(this::userDoesntExistException);
-    }
-
-    private Optional<MapUserEntity> getRegisteredEntityById(RealmModel realm, String id) {
-        return getEntityById(realm, id);
     }
 
     @Override
@@ -314,7 +310,7 @@ public class MapUserProvider<K> implements UserProvider.Streams, UserCredentialS
             throw new ModelDuplicateException("User with username '" + username + "' in realm " + realm.getName() + " already exists" );
         }
         
-        if (tx.read(id) != null) {
+        if (id != null && tx.read(id) != null) {
             throw new ModelDuplicateException("User exists: " + id);
         }
 

--- a/model/map/src/main/java/org/keycloak/models/map/user/MapUserProviderFactory.java
+++ b/model/map/src/main/java/org/keycloak/models/map/user/MapUserProviderFactory.java
@@ -27,7 +27,7 @@ import org.keycloak.models.map.common.AbstractMapProviderFactory;
  *
  * @author mhajas
  */
-public class MapUserProviderFactory<K> extends AbstractMapProviderFactory<UserProvider, K, MapUserEntity, UserModel> implements UserProviderFactory {
+public class MapUserProviderFactory extends AbstractMapProviderFactory<UserProvider, MapUserEntity, UserModel> implements UserProviderFactory {
 
     public MapUserProviderFactory() {
         super(UserModel.class);
@@ -35,7 +35,7 @@ public class MapUserProviderFactory<K> extends AbstractMapProviderFactory<UserPr
 
     @Override
     public UserProvider create(KeycloakSession session) {
-        return new MapUserProvider<>(session, getStorage(session));
+        return new MapUserProvider(session, getStorage(session));
     }
 
     @Override

--- a/model/map/src/main/java/org/keycloak/models/map/user/MapUserProviderFactory.java
+++ b/model/map/src/main/java/org/keycloak/models/map/user/MapUserProviderFactory.java
@@ -27,7 +27,7 @@ import org.keycloak.models.map.common.AbstractMapProviderFactory;
  *
  * @author mhajas
  */
-public class MapUserProviderFactory<K> extends AbstractMapProviderFactory<UserProvider, K, MapUserEntity<K>, UserModel> implements UserProviderFactory {
+public class MapUserProviderFactory<K> extends AbstractMapProviderFactory<UserProvider, K, MapUserEntity, UserModel> implements UserProviderFactory {
 
     public MapUserProviderFactory() {
         super(UserModel.class);

--- a/model/map/src/main/java/org/keycloak/models/map/userSession/AbstractAuthenticatedClientSessionModel.java
+++ b/model/map/src/main/java/org/keycloak/models/map/userSession/AbstractAuthenticatedClientSessionModel.java
@@ -28,15 +28,15 @@ import java.util.Objects;
 /**
  * @author <a href="mailto:mkanis@redhat.com">Martin Kanis</a>
  */
-public abstract class AbstractAuthenticatedClientSessionModel<K> implements AuthenticatedClientSessionModel {
+public abstract class AbstractAuthenticatedClientSessionModel implements AuthenticatedClientSessionModel {
     protected final KeycloakSession session;
     protected final RealmModel realm;
     protected ClientModel client;
     protected UserSessionModel userSession;
-    protected final MapAuthenticatedClientSessionEntity<K> entity;
+    protected final MapAuthenticatedClientSessionEntity entity;
 
     public AbstractAuthenticatedClientSessionModel(KeycloakSession session, RealmModel realm, ClientModel client,
-                                                   UserSessionModel userSession, MapAuthenticatedClientSessionEntity<K> entity) {
+                                                   UserSessionModel userSession, MapAuthenticatedClientSessionEntity entity) {
         Objects.requireNonNull(entity, "entity");
         Objects.requireNonNull(realm, "realm");
         Objects.requireNonNull(client, "client");

--- a/model/map/src/main/java/org/keycloak/models/map/userSession/AbstractUserSessionModel.java
+++ b/model/map/src/main/java/org/keycloak/models/map/userSession/AbstractUserSessionModel.java
@@ -29,9 +29,9 @@ import java.util.Objects;
 public abstract class AbstractUserSessionModel<K> implements UserSessionModel {
     protected final KeycloakSession session;
     protected final RealmModel realm;
-    protected final MapUserSessionEntity<K> entity;
+    protected final MapUserSessionEntity entity;
 
-    public AbstractUserSessionModel(KeycloakSession session, RealmModel realm, MapUserSessionEntity<K> entity) {
+    public AbstractUserSessionModel(KeycloakSession session, RealmModel realm, MapUserSessionEntity entity) {
         Objects.requireNonNull(entity, "entity");
         Objects.requireNonNull(realm, "realm");
 

--- a/model/map/src/main/java/org/keycloak/models/map/userSession/AbstractUserSessionModel.java
+++ b/model/map/src/main/java/org/keycloak/models/map/userSession/AbstractUserSessionModel.java
@@ -19,14 +19,13 @@ package org.keycloak.models.map.userSession;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserSessionModel;
-import org.keycloak.models.map.common.AbstractEntity;
 
 import java.util.Objects;
 
 /**
  * @author <a href="mailto:mkanis@redhat.com">Martin Kanis</a>
  */
-public abstract class AbstractUserSessionModel<K> implements UserSessionModel {
+public abstract class AbstractUserSessionModel implements UserSessionModel {
     protected final KeycloakSession session;
     protected final RealmModel realm;
     protected final MapUserSessionEntity entity;

--- a/model/map/src/main/java/org/keycloak/models/map/userSession/MapAuthenticatedClientSessionAdapter.java
+++ b/model/map/src/main/java/org/keycloak/models/map/userSession/MapAuthenticatedClientSessionAdapter.java
@@ -26,11 +26,16 @@ import java.util.Map;
 /**
  * @author <a href="mailto:mkanis@redhat.com">Martin Kanis</a>
  */
-public abstract class MapAuthenticatedClientSessionAdapter<K> extends AbstractAuthenticatedClientSessionModel<K> {
+public abstract class MapAuthenticatedClientSessionAdapter extends AbstractAuthenticatedClientSessionModel {
 
     public MapAuthenticatedClientSessionAdapter(KeycloakSession session, RealmModel realm, ClientModel client,
-                                                UserSessionModel userSession, MapAuthenticatedClientSessionEntity<K> entity) {
+                                                UserSessionModel userSession, MapAuthenticatedClientSessionEntity entity) {
         super(session, realm, client, userSession, entity);
+    }
+
+    @Override
+    public String getId() {
+        return entity.getId();
     }
 
     @Override

--- a/model/map/src/main/java/org/keycloak/models/map/userSession/MapAuthenticatedClientSessionEntity.java
+++ b/model/map/src/main/java/org/keycloak/models/map/userSession/MapAuthenticatedClientSessionEntity.java
@@ -27,9 +27,9 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * @author <a href="mailto:mkanis@redhat.com">Martin Kanis</a>
  */
-public class MapAuthenticatedClientSessionEntity<K> implements AbstractEntity<K>, UpdatableEntity {
+public class MapAuthenticatedClientSessionEntity implements AbstractEntity, UpdatableEntity {
 
-    private K id;
+    private String id;
     private String userSessionId;
     private String realmId;
     private String clientId;
@@ -57,8 +57,7 @@ public class MapAuthenticatedClientSessionEntity<K> implements AbstractEntity<K>
         this.realmId = null;
     }
 
-    public MapAuthenticatedClientSessionEntity(K id, String userSessionId, String realmId, String clientId, boolean offline) {
-        Objects.requireNonNull(id, "id");
+    public MapAuthenticatedClientSessionEntity(String id, String userSessionId, String realmId, String clientId, boolean offline) {
         Objects.requireNonNull(userSessionId, "userSessionId");
         Objects.requireNonNull(realmId, "realmId");
         Objects.requireNonNull(clientId, "clientId");
@@ -72,7 +71,7 @@ public class MapAuthenticatedClientSessionEntity<K> implements AbstractEntity<K>
     }
 
     @Override
-    public K getId() {
+    public String getId() {
         return this.id;
     }
 

--- a/model/map/src/main/java/org/keycloak/models/map/userSession/MapUserSessionAdapter.java
+++ b/model/map/src/main/java/org/keycloak/models/map/userSession/MapUserSessionAdapter.java
@@ -30,16 +30,20 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * @author <a href="mailto:mkanis@redhat.com">Martin Kanis</a>
  */
-public abstract class MapUserSessionAdapter<K> extends AbstractUserSessionModel<K> {
+public abstract class MapUserSessionAdapter extends AbstractUserSessionModel {
 
-    public MapUserSessionAdapter(KeycloakSession session, RealmModel realm, MapUserSessionEntity<K> entity) {
+    public MapUserSessionAdapter(KeycloakSession session, RealmModel realm, MapUserSessionEntity entity) {
         super(session, realm, entity);
+    }
+
+    @Override
+    public String getId() {
+        return entity.getId();
     }
 
     @Override

--- a/model/map/src/main/java/org/keycloak/models/map/userSession/MapUserSessionEntity.java
+++ b/model/map/src/main/java/org/keycloak/models/map/userSession/MapUserSessionEntity.java
@@ -30,8 +30,8 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * @author <a href="mailto:mkanis@redhat.com">Martin Kanis</a>
  */
-public class MapUserSessionEntity<K> implements AbstractEntity<K>, UpdatableEntity {
-    private K id;
+public class MapUserSessionEntity implements AbstractEntity, UpdatableEntity {
+    private String id;
 
     private String realmId;
 
@@ -74,15 +74,14 @@ public class MapUserSessionEntity<K> implements AbstractEntity<K>, UpdatableEnti
         this.realmId = null;
     }
 
-    public MapUserSessionEntity(K id, String realmId) {
-        Objects.requireNonNull(id, "id");
+    public MapUserSessionEntity(String id, String realmId) {
         Objects.requireNonNull(realmId, "realmId");
 
         this.id = id;
         this.realmId = realmId;
     }
 
-    public MapUserSessionEntity(K id, RealmModel realm, UserModel user, String loginUsername, String ipAddress,
+    public MapUserSessionEntity(String id, RealmModel realm, UserModel user, String loginUsername, String ipAddress,
                                      String authMethod, boolean rememberMe, String brokerSessionId, String brokerUserId,
                                      boolean offline) {
         this.id = id;
@@ -100,7 +99,7 @@ public class MapUserSessionEntity<K> implements AbstractEntity<K>, UpdatableEnti
     }
 
     @Override
-    public K getId() {
+    public String getId() {
         return this.id;
     }
 

--- a/model/map/src/main/java/org/keycloak/models/map/userSession/MapUserSessionProviderFactory.java
+++ b/model/map/src/main/java/org/keycloak/models/map/userSession/MapUserSessionProviderFactory.java
@@ -79,7 +79,7 @@ public class MapUserSessionProviderFactory<UK, CK> implements AmphibianProviderF
     }
 
     @Override
-    public MapUserSessionProvider<UK, CK> create(KeycloakSession session) {
+    public MapUserSessionProvider create(KeycloakSession session) {
         MapStorageProviderFactory storageProviderFactoryUs = (MapStorageProviderFactory) getComponentFactory(session.getKeycloakSessionFactory(),
           MapStorageProvider.class, storageConfigScopeUserSessions, MapStorageSpi.NAME);
         final MapStorageProvider factoryUs = storageProviderFactoryUs.create(session);
@@ -90,7 +90,7 @@ public class MapUserSessionProviderFactory<UK, CK> implements AmphibianProviderF
         final MapStorageProvider factoryCs = storageProviderFactoryCs.create(session);
         MapStorage clientSessionStore = factoryCs.getStorage(AuthenticatedClientSessionModel.class);
 
-        return new MapUserSessionProvider<>(session, userSessionStore, clientSessionStore);
+        return new MapUserSessionProvider(session, userSessionStore, clientSessionStore);
     }
 
     @Override

--- a/model/map/src/main/java/org/keycloak/models/map/userSession/SessionExpiration.java
+++ b/model/map/src/main/java/org/keycloak/models/map/userSession/SessionExpiration.java
@@ -26,7 +26,7 @@ import org.keycloak.protocol.oidc.OIDCConfigAttributes;
  */
 public class SessionExpiration {
 
-    public static <K> void setClientSessionExpiration(MapAuthenticatedClientSessionEntity<K> entity, RealmModel realm, ClientModel client) {
+    public static <K> void setClientSessionExpiration(MapAuthenticatedClientSessionEntity entity, RealmModel realm, ClientModel client) {
         if (entity.isOffline()) {
             long sessionExpires = entity.getTimestamp() + realm.getOfflineSessionIdleTimeout();
             if (realm.isOfflineSessionMaxLifespanEnabled()) {
@@ -99,7 +99,7 @@ public class SessionExpiration {
         }
     }
 
-    public static <K> void setUserSessionExpiration(MapUserSessionEntity<K> entity, RealmModel realm) {
+    public static <K> void setUserSessionExpiration(MapUserSessionEntity entity, RealmModel realm) {
         if (entity.isOffline()) {
             long sessionExpires = entity.getLastSessionRefresh() + realm.getOfflineSessionIdleTimeout();
             if (realm.isOfflineSessionMaxLifespanEnabled()) {

--- a/model/map/src/main/java/org/keycloak/models/map/userSession/SessionExpiration.java
+++ b/model/map/src/main/java/org/keycloak/models/map/userSession/SessionExpiration.java
@@ -26,7 +26,7 @@ import org.keycloak.protocol.oidc.OIDCConfigAttributes;
  */
 public class SessionExpiration {
 
-    public static <K> void setClientSessionExpiration(MapAuthenticatedClientSessionEntity entity, RealmModel realm, ClientModel client) {
+    public static void setClientSessionExpiration(MapAuthenticatedClientSessionEntity entity, RealmModel realm, ClientModel client) {
         if (entity.isOffline()) {
             long sessionExpires = entity.getTimestamp() + realm.getOfflineSessionIdleTimeout();
             if (realm.isOfflineSessionMaxLifespanEnabled()) {
@@ -99,7 +99,7 @@ public class SessionExpiration {
         }
     }
 
-    public static <K> void setUserSessionExpiration(MapUserSessionEntity entity, RealmModel realm) {
+    public static void setUserSessionExpiration(MapUserSessionEntity entity, RealmModel realm) {
         if (entity.isOffline()) {
             long sessionExpires = entity.getLastSessionRefresh() + realm.getOfflineSessionIdleTimeout();
             if (realm.isOfflineSessionMaxLifespanEnabled()) {

--- a/model/map/src/test/java/org/keycloak/models/map/user/AbstractUserEntityCredentialsOrderTest.java
+++ b/model/map/src/test/java/org/keycloak/models/map/user/AbstractUserEntityCredentialsOrderTest.java
@@ -28,11 +28,11 @@ import java.util.stream.Collectors;
 
 public class AbstractUserEntityCredentialsOrderTest {
 
-    private MapUserEntity<Integer> user;
+    private MapUserEntity user;
     
     @Before
     public void init() {
-        user = new MapUserEntity<Integer>(1, "realmId") {};
+        user = new MapUserEntity("1", "realmId");
         
         for (int i = 1; i <= 5; i++) {
             UserCredentialEntity credentialModel = new UserCredentialEntity();

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/LogoutEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/LogoutEndpoint.java
@@ -142,7 +142,7 @@ public class LogoutEndpoint {
 
         if (redirect != null) {
             String validatedUri;
-            ClientModel client = (idToken == null || idToken.getIssuedFor() == null) ? null : realm.getClientById(idToken.getIssuedFor());
+            ClientModel client = (idToken == null || idToken.getIssuedFor() == null) ? null : realm.getClientByClientId(idToken.getIssuedFor());
             if (client != null) {
                 validatedUri = RedirectUtils.verifyRedirectUri(session, redirect, client);
             } else {


### PR DESCRIPTION
This PR is to simplify `MapStorage` interface by removing the key type from the generics as it should be an implementation detail. Specifically see [model/map/src/main/java/org/keycloak/models/map/storage/MapStorage.java](https://github.com/keycloak/keycloak/pull/8288/files#diff-91ca21d5c074b826e13ccf8efc1fd50ec91d2ce30c40a77ff463cd2e16d76f7b)


<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
