### PR TITLE
[KEYCLOAK-18857] - Do not force default to RS256 when verifying tokens sent by clients and JWK does not hold an algorithm

### DIFF
--- a/core/src/main/java/org/keycloak/crypto/AsymmetricSignatureSignerContext.java
+++ b/core/src/main/java/org/keycloak/crypto/AsymmetricSignatureSignerContext.java
@@ -34,18 +34,18 @@ public class AsymmetricSignatureSignerContext implements SignatureSignerContext 
 
     @Override
     public String getAlgorithm() {
-        return key.getAlgorithm();
+        return key.getAlgorithmOrDefault();
     }
 
     @Override
     public String getHashAlgorithm() {
-        return JavaAlgorithm.getJavaAlgorithmForHash(key.getAlgorithm());
+        return JavaAlgorithm.getJavaAlgorithmForHash(key.getAlgorithmOrDefault());
     }
 
     @Override
     public byte[] sign(byte[] data) throws SignatureException {
         try {
-            Signature signature = Signature.getInstance(JavaAlgorithm.getJavaAlgorithm(key.getAlgorithm()));
+            Signature signature = Signature.getInstance(JavaAlgorithm.getJavaAlgorithm(key.getAlgorithmOrDefault()));
             signature.initSign((PrivateKey) key.getPrivateKey());
             signature.update(data);
             return signature.sign();

--- a/core/src/main/java/org/keycloak/crypto/AsymmetricSignatureVerifierContext.java
+++ b/core/src/main/java/org/keycloak/crypto/AsymmetricSignatureVerifierContext.java
@@ -36,13 +36,13 @@ public class AsymmetricSignatureVerifierContext implements SignatureVerifierCont
 
     @Override
     public String getAlgorithm() {
-        return key.getAlgorithm();
+        return key.getAlgorithmOrDefault();
     }
 
     @Override
     public boolean verify(byte[] data, byte[] signature) throws VerificationException {
         try {
-            Signature verifier = Signature.getInstance(JavaAlgorithm.getJavaAlgorithm(key.getAlgorithm()));
+            Signature verifier = Signature.getInstance(JavaAlgorithm.getJavaAlgorithm(key.getAlgorithmOrDefault()));
             verifier.initVerify((PublicKey) key.getPublicKey());
             verifier.update(data);
             return verifier.verify(signature);

--- a/core/src/main/java/org/keycloak/crypto/KeyWrapper.java
+++ b/core/src/main/java/org/keycloak/crypto/KeyWrapper.java
@@ -16,12 +16,24 @@
  */
 package org.keycloak.crypto;
 
+import java.util.HashMap;
 import java.util.List;
 import javax.crypto.SecretKey;
 import java.security.Key;
 import java.security.cert.X509Certificate;
+import java.util.Map;
 
 public class KeyWrapper {
+
+    /**
+     * A repository for the default algorithms by key type.
+     */
+    private static final Map<String, String> DEFAULT_ALGORITHM_BY_TYPE = new HashMap<>();
+
+    static {
+        //backwards compatibility: RSA keys without "alg" field set are considered RS256
+        DEFAULT_ALGORITHM_BY_TYPE.put(KeyType.RSA, Algorithm.RS256);
+    }
 
     private String providerId;
     private long providerPriority;
@@ -60,7 +72,29 @@ public class KeyWrapper {
         this.kid = kid;
     }
 
+    /**
+     * <p>Returns the value of the optional {@code alg} claim.
+     *
+     * @return the algorithm value
+     */
     public String getAlgorithm() {
+        return algorithm;
+    }
+
+    /**
+     * <p>Returns the value of the optional {@code alg} claim. If not defined, a default is returned depending on the
+     * key type as per {@code kty} claim.
+     *
+     * <p>For keys of type {@link KeyType#RSA}, the default algorithm is {@link Algorithm#RS256} as this is the default
+     * algorithm recommended by OIDC specs.
+     *
+     *
+     * @return the algorithm set or a default based on the key type.
+     */
+    public String getAlgorithmOrDefault() {
+        if (algorithm == null) {
+            return DEFAULT_ALGORITHM_BY_TYPE.get(type);
+        }
         return algorithm;
     }
 

--- a/core/src/main/java/org/keycloak/crypto/MacSignatureSignerContext.java
+++ b/core/src/main/java/org/keycloak/crypto/MacSignatureSignerContext.java
@@ -33,18 +33,18 @@ public class MacSignatureSignerContext implements SignatureSignerContext {
 
     @Override
     public String getAlgorithm() {
-        return key.getAlgorithm();
+        return key.getAlgorithmOrDefault();
     }
 
     @Override
     public String getHashAlgorithm() {
-        return JavaAlgorithm.getJavaAlgorithmForHash(key.getAlgorithm());
+        return JavaAlgorithm.getJavaAlgorithmForHash(key.getAlgorithmOrDefault());
     }
 
     @Override
     public byte[] sign(byte[] data) throws SignatureException {
         try {
-            Mac mac = Mac.getInstance(JavaAlgorithm.getJavaAlgorithm(key.getAlgorithm()));
+            Mac mac = Mac.getInstance(JavaAlgorithm.getJavaAlgorithm(key.getAlgorithmOrDefault()));
             mac.init(key.getSecretKey());
             mac.update(data);
             return mac.doFinal();

--- a/core/src/main/java/org/keycloak/crypto/MacSignatureVerifierContext.java
+++ b/core/src/main/java/org/keycloak/crypto/MacSignatureVerifierContext.java
@@ -36,13 +36,13 @@ public class MacSignatureVerifierContext implements SignatureVerifierContext {
 
     @Override
     public String getAlgorithm() {
-        return key.getAlgorithm();
+        return key.getAlgorithmOrDefault();
     }
 
     @Override
     public boolean verify(byte[] data, byte[] signature) throws VerificationException {
         try {
-            Mac mac = Mac.getInstance(JavaAlgorithm.getJavaAlgorithm(key.getAlgorithm()));
+            Mac mac = Mac.getInstance(JavaAlgorithm.getJavaAlgorithm(key.getAlgorithmOrDefault()));
             mac.init(key.getSecretKey());
             mac.update(data);
             byte[] verificationSignature = mac.doFinal();

--- a/core/src/main/java/org/keycloak/util/JWKSUtils.java
+++ b/core/src/main/java/org/keycloak/util/JWKSUtils.java
@@ -63,10 +63,6 @@ public class JWKSUtils {
                 if (jwk.getAlgorithm() != null) {
                     keyWrapper.setAlgorithm(jwk.getAlgorithm());
                 }
-                else if (jwk.getKeyType().equalsIgnoreCase("RSA")){
-                    //backwards compatibility: RSA keys without "alg" field set are considered RS256
-                    keyWrapper.setAlgorithm("RS256");
-                }
                 keyWrapper.setType(jwk.getKeyType());
                 keyWrapper.setUse(getKeyUse(jwk.getPublicKeyUse()));
                 keyWrapper.setPublicKey(parser.toPublicKey());

--- a/core/src/test/java/org/keycloak/util/JWKSUtilsTest.java
+++ b/core/src/test/java/org/keycloak/util/JWKSUtilsTest.java
@@ -94,28 +94,28 @@ public class JWKSUtilsTest {
 
         KeyWrapper key = keyWrappersForUse.get(kidRsa1);
         assertNotNull(key);
-        assertEquals("RS256", key.getAlgorithm());
+        assertEquals("RS256", key.getAlgorithmOrDefault());
         assertEquals(KeyUse.SIG, key.getUse());
         assertEquals(kidRsa1, key.getKid());
         assertEquals("RSA", key.getType());
 
          key = keyWrappersForUse.get(kidRsa2);
         assertNotNull(key);
-        assertEquals("RS256", key.getAlgorithm());
+        assertEquals("RS256", key.getAlgorithmOrDefault());
         assertEquals(KeyUse.SIG, key.getUse());
         assertEquals(kidRsa2, key.getKid());
         assertEquals("RSA", key.getType());
 
         key = keyWrappersForUse.get(kidEC1);
         assertNotNull(key);
-        assertEquals("ES384", key.getAlgorithm());
+        assertEquals("ES384", key.getAlgorithmOrDefault());
         assertEquals(KeyUse.SIG, key.getUse());
         assertEquals(kidEC1, key.getKid());
         assertEquals("EC", key.getType());
 
         key = keyWrappersForUse.get(kidEC2);
         assertNotNull(key);
-        assertNull(key.getAlgorithm());
+        assertNull(key.getAlgorithmOrDefault());
         assertEquals(KeyUse.SIG, key.getUse());
         assertEquals(kidEC2, key.getKid());
         assertEquals("EC", key.getType());

--- a/model/infinispan/src/main/java/org/keycloak/keys/infinispan/InfinispanPublicKeyStorageProvider.java
+++ b/model/infinispan/src/main/java/org/keycloak/keys/infinispan/InfinispanPublicKeyStorageProvider.java
@@ -203,7 +203,7 @@ public class InfinispanPublicKeyStorageProvider implements PublicKeyStorageProvi
     private KeyWrapper getPublicKeyByAlg(Map<String, KeyWrapper> publicKeys, String algorithm) {
         if (algorithm == null) return null;
         for(KeyWrapper keyWrapper : publicKeys.values())
-            if (algorithm.equals(keyWrapper.getAlgorithm())) return keyWrapper;
+            if (algorithm.equals(keyWrapper.getAlgorithmOrDefault())) return keyWrapper;
         return null;
     }
 

--- a/services/src/main/java/org/keycloak/crypto/ClientAsymmetricSignatureVerifierContext.java
+++ b/services/src/main/java/org/keycloak/crypto/ClientAsymmetricSignatureVerifierContext.java
@@ -33,6 +33,12 @@ public class ClientAsymmetricSignatureVerifierContext extends AsymmetricSignatur
         if (key == null) {
             throw new VerificationException("Key not found");
         }
+        if (key.getAlgorithm() == null) {
+            // defaults to the algorithm set to the JWS
+            // validations should be performed prior to verifying signature in case there are restrictions on the algorithms
+            // that can used for signing
+            key.setAlgorithm(input.getHeader().getRawAlgorithm());
+        }
         return key;
     }
 }

--- a/services/src/main/java/org/keycloak/keys/DefaultKeyManager.java
+++ b/services/src/main/java/org/keycloak/keys/DefaultKeyManager.java
@@ -244,7 +244,7 @@ public class DefaultKeyManager implements KeyManager {
     }
 
     private boolean matches(KeyWrapper key, KeyUse use, String algorithm) {
-        return use.equals(key.getUse()) && key.getAlgorithm().equals(algorithm);
+        return use.equals(key.getUse()) && key.getAlgorithmOrDefault().equals(algorithm);
     }
 
     private List<KeyProvider> getProviders(RealmModel realm) {

--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocolService.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocolService.java
@@ -229,7 +229,7 @@ public class OIDCLoginProtocolService {
         JWK[] jwks = session.keys().getKeysStream(realm)
                 .filter(k -> k.getStatus().isEnabled() && k.getPublicKey() != null)
                 .map(k -> {
-                    JWKBuilder b = JWKBuilder.create().kid(k.getKid()).algorithm(k.getAlgorithm());
+                    JWKBuilder b = JWKBuilder.create().kid(k.getKid()).algorithm(k.getAlgorithmOrDefault());
                     List<X509Certificate> certificates = Optional.ofNullable(k.getCertificateChain())
                         .filter(certs -> !certs.isEmpty())
                         .orElseGet(() -> Collections.singletonList(k.getCertificate()));

--- a/services/src/main/java/org/keycloak/services/resources/admin/KeyResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/KeyResource.java
@@ -60,8 +60,8 @@ public class KeyResource {
         List<KeysMetadataRepresentation.KeyMetadataRepresentation> realmKeys = session.keys().getKeysStream(realm)
                 .map(key -> {
                     if (key.getStatus().isActive()) {
-                        if (!keys.getActive().containsKey(key.getAlgorithm())) {
-                            keys.getActive().put(key.getAlgorithm(), key.getKid());
+                        if (!keys.getActive().containsKey(key.getAlgorithmOrDefault())) {
+                            keys.getActive().put(key.getAlgorithmOrDefault(), key.getKid());
                         }
                     }
                     return toKeyMetadataRepresentation(key);
@@ -79,7 +79,7 @@ public class KeyResource {
         r.setKid(key.getKid());
         r.setStatus(key.getStatus() != null ? key.getStatus().name() : null);
         r.setType(key.getType());
-        r.setAlgorithm(key.getAlgorithm());
+        r.setAlgorithm(key.getAlgorithmOrDefault());
         r.setPublicKey(key.getPublicKey() != null ? PemUtils.encodeKey(key.getPublicKey()) : null);
         r.setCertificate(key.getCertificate() != null ? PemUtils.encodeCertificate(key.getCertificate()) : null);
         r.setUse(key.getUse());

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/rest/TestApplicationResourceProviderFactory.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/rest/TestApplicationResourceProviderFactory.java
@@ -86,7 +86,7 @@ public class TestApplicationResourceProviderFactory implements RealmResourceProv
         private String oidcRequest;
         private List<String> sectorIdentifierRedirectUris;
         private String keyType = KeyType.RSA;
-        private String keyAlgorithm = Algorithm.RS256;
+        private String keyAlgorithm;
         private KeyUse keyUse = KeyUse.SIG;
 
         public KeyPair getSigningKeyPair() {

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/rest/resource/TestingOIDCEndpointsApplicationResource.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/rest/resource/TestingOIDCEndpointsApplicationResource.java
@@ -111,7 +111,8 @@ public class TestingOIDCEndpointsApplicationResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/generate-keys")
     @NoCache
-    public Map<String, String> generateKeys(@QueryParam("jwaAlgorithm") String jwaAlgorithm) {
+    public Map<String, String> generateKeys(@QueryParam("jwaAlgorithm") String jwaAlgorithm,
+            @QueryParam("advertiseJWKAlgorithm") Boolean advertiseJWKAlgorithm) {
         try {
             KeyPair keyPair = null;
             KeyUse keyUse = KeyUse.SIG;
@@ -154,7 +155,11 @@ public class TestingOIDCEndpointsApplicationResource {
 
             clientData.setKeyPair(keyPair);
             clientData.setKeyType(keyType);
-            clientData.setKeyAlgorithm(jwaAlgorithm);
+            if (advertiseJWKAlgorithm == null || Boolean.TRUE.equals(advertiseJWKAlgorithm)) {
+                clientData.setKeyAlgorithm(jwaAlgorithm);
+            } else {
+                clientData.setKeyAlgorithm(null);
+            }
             clientData.setKeyUse(keyUse);
         } catch (Exception e) {
             throw new BadRequestException("Error generating signing keypair", e);
@@ -209,7 +214,7 @@ public class TestingOIDCEndpointsApplicationResource {
         String keyType = clientData.getKeyType();
         KeyUse keyUse = clientData.getKeyUse();
 
-        if (keyPair == null || !isSupportedAlgorithm(keyAlgorithm)) {
+        if (keyPair == null) {
             keySet.setKeys(new JWK[] {});
         } else if (KeyType.RSA.equals(keyType)) {
             keySet.setKeys(new JWK[] { JWKBuilder.create().algorithm(keyAlgorithm).rsa(keyPair.getPublic(), keyUse) });

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/client/resources/TestOIDCEndpointsApplicationResource.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/client/resources/TestOIDCEndpointsApplicationResource.java
@@ -46,6 +46,12 @@ public interface TestOIDCEndpointsApplicationResource {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
+    @Path("/generate-keys")
+    Map<String, String> generateKeys(@QueryParam("jwaAlgorithm") String jwaAlgorithm,
+            @QueryParam("advertiseJWKAlgorithm") Boolean advertiseJWKAlgorithm);
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("/get-keys-as-pem")
     Map<String, String> getKeysAsPem();
 


### PR DESCRIPTION
In order to support clients exposing JWKs without the optional `alg` claim set, this PR is enabling verifying the signature of tokens sent by clients based on the algorithm set in the JWS.

As a general rule, prior to verifying the signature validations happens to make sure the algorithm set in the JWS matches the client requirements. These changes only touch signature verifications for tokens sent by clients using asymmetric keys. 
