### PR TITLE
KEYCLOAK-18830 FAPI-CIBA-ID1 conformance test : HolderOfKeyEnforcerExecutor needs to be executed on CIBA token request

### DIFF
--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/HolderOfKeyEnforcerExecutor.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/HolderOfKeyEnforcerExecutor.java
@@ -90,6 +90,7 @@ public class HolderOfKeyEnforcerExecutor implements ClientPolicyExecutorProvider
                 validate(clientUpdateContext.getProposedClientRepresentation());
                 break;
             case TOKEN_REQUEST:
+            case BACKCHANNEL_TOKEN_REQUEST:
                 AccessToken.CertConf certConf = MtlsHoKTokenUtil.bindTokenWithClientCertificate(request, session);
                 if (certConf == null) {
                     throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST, "Client Certification missing for MTLS HoK Token Binding");

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/OAuthClient.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/OAuthClient.java
@@ -777,25 +777,29 @@ public class OAuthClient {
 
     public AccessTokenResponse doBackchannelAuthenticationTokenRequest(String clientId, String clientSecret, String authReqId) throws Exception {
         try (CloseableHttpClient client = HttpClientBuilder.create().build()) {
-            HttpPost post = new HttpPost(getBackchannelAuthenticationTokenRequestUrl());
-
-            String authorization = BasicAuthHelper.createHeader(clientId, clientSecret);
-            post.setHeader("Authorization", authorization);
-
-            List<NameValuePair> parameters = new LinkedList<>();
-            parameters.add(new BasicNameValuePair(OAuth2Constants.GRANT_TYPE, OAuth2Constants.CIBA_GRANT_TYPE));
-            parameters.add(new BasicNameValuePair(AUTH_REQ_ID, authReqId));
-
-            UrlEncodedFormEntity formEntity;
-            try {
-                formEntity = new UrlEncodedFormEntity(parameters, "UTF-8");
-            } catch (UnsupportedEncodingException e) {
-                throw new RuntimeException(e);
-            }
-            post.setEntity(formEntity);
-
-            return new AccessTokenResponse(client.execute(post));
+            return doBackchannelAuthenticationTokenRequest(clientId, clientSecret, authReqId, client);
         }
+    }
+
+    public AccessTokenResponse doBackchannelAuthenticationTokenRequest(String clientId, String clientSecret, String authReqId, CloseableHttpClient client) throws Exception {
+        HttpPost post = new HttpPost(getBackchannelAuthenticationTokenRequestUrl());
+
+        String authorization = BasicAuthHelper.createHeader(clientId, clientSecret);
+        post.setHeader("Authorization", authorization);
+
+        List<NameValuePair> parameters = new LinkedList<>();
+        parameters.add(new BasicNameValuePair(OAuth2Constants.GRANT_TYPE, OAuth2Constants.CIBA_GRANT_TYPE));
+        parameters.add(new BasicNameValuePair(AUTH_REQ_ID, authReqId));
+
+        UrlEncodedFormEntity formEntity;
+        try {
+            formEntity = new UrlEncodedFormEntity(parameters, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
+        }
+        post.setEntity(formEntity);
+
+        return new AccessTokenResponse(client.execute(post));
     }
 
     // KEYCLOAK-6771 Certificate Bound Token


### PR DESCRIPTION
This PR is for [KEYCLOAK-18457 FAPI CIBA Support](https://issues.redhat.com/browse/KEYCLOAK-18457), also is the part of the project [FAPI-CIBA(poll mode)](https://github.com/keycloak/kc-sig-fapi/projects) of [FAPI-SIG](https://github.com/keycloak/kc-sig-fapi) activity.

This PR is needed to satisfy requirements by [Financial-grade API: Client Initiated Backchannel Authentication Profile](https://bitbucket.org/openid/fapi/src/master/Financial_API_WD_CIBA.md#markdown-header-522-authorization-server).
[KEYCLOAK-18830](https://issues.redhat.com/browse/KEYCLOAK-18830) describes it more.