### PR TITLE
KEYCLOAK-18834 Client Policies : ClientScopesCondition needs to be evaluated on CIBA backchannel authentication request and token request

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/ciba/CibaGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/ciba/CibaGrantType.java
@@ -152,6 +152,7 @@ public class CibaGrantType {
             throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_GRANT, "Invalid Auth Req ID", Response.Status.BAD_REQUEST);
         }
 
+        request.setClient(client);
         try {
             session.clientPolicy().triggerOnEvent(new BackchannelTokenRequestContext(request, formParams));
         } catch (ClientPolicyException cpe) {

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/ciba/channel/CIBAAuthenticationRequest.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/ciba/channel/CIBAAuthenticationRequest.java
@@ -19,11 +19,7 @@ package org.keycloak.protocol.oidc.grants.ciba.channel;
 
 import javax.crypto.SecretKey;
 import java.io.UnsupportedEncodingException;
-import java.util.HashMap;
-import java.util.Map;
 
-import com.fasterxml.jackson.annotation.JsonAnyGetter;
-import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.keycloak.OAuth2Constants;
 import org.keycloak.crypto.Algorithm;

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/ciba/clientpolicy/context/BackchannelAuthenticationRequestContext.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/ciba/clientpolicy/context/BackchannelAuthenticationRequestContext.java
@@ -19,6 +19,7 @@ package org.keycloak.protocol.oidc.grants.ciba.clientpolicy.context;
 
 import javax.ws.rs.core.MultivaluedMap;
 
+import org.keycloak.protocol.oidc.grants.ciba.channel.CIBAAuthenticationRequest;
 import org.keycloak.protocol.oidc.grants.ciba.endpoints.request.BackchannelAuthenticationEndpointRequest;
 import org.keycloak.services.clientpolicy.ClientPolicyContext;
 import org.keycloak.services.clientpolicy.ClientPolicyEvent;
@@ -29,11 +30,14 @@ import org.keycloak.services.clientpolicy.ClientPolicyEvent;
 public class BackchannelAuthenticationRequestContext implements ClientPolicyContext {
 
     private final BackchannelAuthenticationEndpointRequest request;
+    private final CIBAAuthenticationRequest parsedRequest;
     private final MultivaluedMap<String, String> requestParameters;
 
     public BackchannelAuthenticationRequestContext(BackchannelAuthenticationEndpointRequest request,
+            CIBAAuthenticationRequest parsedRequest,
             MultivaluedMap<String, String> requestParameters) {
         this.request = request;
+        this.parsedRequest = parsedRequest;
         this.requestParameters = requestParameters;
     }
 
@@ -44,6 +48,10 @@ public class BackchannelAuthenticationRequestContext implements ClientPolicyCont
 
     public BackchannelAuthenticationEndpointRequest getRequest() {
         return request;
+    }
+
+    public CIBAAuthenticationRequest getParsedRequest() {
+        return parsedRequest;
     }
 
     public MultivaluedMap<String, String> getRequestParameters() {

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/ciba/clientpolicy/context/BackchannelTokenRequestContext.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/ciba/clientpolicy/context/BackchannelTokenRequestContext.java
@@ -28,12 +28,12 @@ import org.keycloak.services.clientpolicy.ClientPolicyEvent;
  */
 public class BackchannelTokenRequestContext implements ClientPolicyContext {
 
-    private final CIBAAuthenticationRequest request;
+    private final CIBAAuthenticationRequest parsedRequest;
     private final MultivaluedMap<String, String> requestParameters;
 
-    public BackchannelTokenRequestContext(CIBAAuthenticationRequest request,
+    public BackchannelTokenRequestContext(CIBAAuthenticationRequest parsedRequest,
             MultivaluedMap<String, String> requestParameters) {
-        this.request = request;
+        this.parsedRequest = parsedRequest;
         this.requestParameters = requestParameters;
     }
 
@@ -42,8 +42,8 @@ public class BackchannelTokenRequestContext implements ClientPolicyContext {
         return ClientPolicyEvent.BACKCHANNEL_TOKEN_REQUEST;
     }
 
-    public CIBAAuthenticationRequest getRequest() {
-        return request;
+    public CIBAAuthenticationRequest getParsedRequest() {
+        return parsedRequest;
     }
 
     public MultivaluedMap<String, String> getRequestParameters() {

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/ciba/endpoints/BackchannelAuthenticationEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/ciba/endpoints/BackchannelAuthenticationEndpoint.java
@@ -196,7 +196,7 @@ public class BackchannelAuthenticationEndpoint extends AbstractCibaEndpoint {
         extractAdditionalParams(endpointRequest, request);
 
         try {
-            session.clientPolicy().triggerOnEvent(new BackchannelAuthenticationRequestContext(endpointRequest, params));
+            session.clientPolicy().triggerOnEvent(new BackchannelAuthenticationRequestContext(endpointRequest, request, params));
         } catch (ClientPolicyException cpe) {
             throw new ErrorResponseException(cpe.getError(), cpe.getErrorDetail(), Response.Status.BAD_REQUEST);
         }

--- a/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientScopesCondition.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientScopesCondition.java
@@ -29,6 +29,9 @@ import org.keycloak.models.AuthenticatedClientSessionModel;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.protocol.oidc.endpoints.request.AuthorizationEndpointRequest;
+import org.keycloak.protocol.oidc.grants.ciba.channel.CIBAAuthenticationRequest;
+import org.keycloak.protocol.oidc.grants.ciba.clientpolicy.context.BackchannelAuthenticationRequestContext;
+import org.keycloak.protocol.oidc.grants.ciba.clientpolicy.context.BackchannelTokenRequestContext;
 import org.keycloak.representations.idm.ClientPolicyConditionConfigurationRepresentation;
 import org.keycloak.services.clientpolicy.ClientPolicyContext;
 import org.keycloak.services.clientpolicy.ClientPolicyException;
@@ -88,6 +91,12 @@ public class ClientScopesCondition extends AbstractClientPolicyConditionProvider
             case TOKEN_REQUEST:
                 if (isScopeMatched(((TokenRequestContext)context).getParseResult().getClientSession())) return ClientPolicyVote.YES;
                 return ClientPolicyVote.NO;
+            case BACKCHANNEL_AUTHENTICATION_REQUEST:
+                if (isScopeMatched(((BackchannelAuthenticationRequestContext)context).getParsedRequest())) return ClientPolicyVote.YES;
+                return ClientPolicyVote.NO;
+            case BACKCHANNEL_TOKEN_REQUEST:
+                if (isScopeMatched(((BackchannelTokenRequestContext)context).getParsedRequest())) return ClientPolicyVote.YES;
+                return ClientPolicyVote.NO;
             default:
                 return ClientPolicyVote.ABSTAIN;
         }
@@ -101,6 +110,11 @@ public class ClientScopesCondition extends AbstractClientPolicyConditionProvider
     private boolean isScopeMatched(AuthorizationEndpointRequest request) {
         if (request == null) return false;
         return isScopeMatched(request.getScope(), session.getContext().getRealm().getClientByClientId(request.getClientId()));
+    }
+
+    private boolean isScopeMatched(CIBAAuthenticationRequest request) {
+        if (request == null || request.getClient() == null) return false;
+        return isScopeMatched(request.getScope(), session.getContext().getRealm().getClientByClientId(request.getClient().getClientId()));
     }
 
     private boolean isScopeMatched(String explicitScopes, ClientModel client) {


### PR DESCRIPTION
This PR is for [KEYCLOAK-18457 FAPI CIBA Support](https://issues.redhat.com/browse/KEYCLOAK-18457), also is the part of the project [FAPI-CIBA(poll mode)](https://github.com/keycloak/kc-sig-fapi/projects) of [FAPI-SIG](https://github.com/keycloak/kc-sig-fapi) activity.

This PR is needed to satisfy requirements by [Financial-grade API: Client Initiated Backchannel Authentication Profile](https://bitbucket.org/openid/fapi/src/master/Financial_API_WD_CIBA.md#markdown-header-522-authorization-server).
[KEYCLOAK-18834](https://issues.redhat.com/browse/KEYCLOAK-18834) describes it more.