### PR TITLE
KEYCLOAK-18879 Generate RequestedAttribute SP metadata for SAML Attribute to Role Mappers

### DIFF
--- a/services/src/main/java/org/keycloak/broker/saml/mappers/AttributeToRoleMapper.java
+++ b/services/src/main/java/org/keycloak/broker/saml/mappers/AttributeToRoleMapper.java
@@ -24,8 +24,12 @@ import org.keycloak.broker.saml.SAMLIdentityProviderFactory;
 import org.keycloak.dom.saml.v2.assertion.AssertionType;
 import org.keycloak.dom.saml.v2.assertion.AttributeStatementType;
 import org.keycloak.dom.saml.v2.assertion.AttributeType;
+import org.keycloak.dom.saml.v2.metadata.AttributeConsumingServiceType;
+import org.keycloak.dom.saml.v2.metadata.EntityDescriptorType;
+import org.keycloak.dom.saml.v2.metadata.RequestedAttributeType;
 import org.keycloak.models.IdentityProviderMapperModel;
 import org.keycloak.models.IdentityProviderSyncMode;
+import org.keycloak.protocol.saml.mappers.SamlMetadataDescriptorUpdater;
 import org.keycloak.provider.ProviderConfigProperty;
 
 import java.util.ArrayList;
@@ -35,11 +39,13 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+import static org.keycloak.saml.common.constants.JBossSAMLURIConstants.ATTRIBUTE_FORMAT_BASIC;
+
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
  */
-public class AttributeToRoleMapper extends AbstractAttributeToRoleMapper {
+public class AttributeToRoleMapper extends AbstractAttributeToRoleMapper implements SamlMetadataDescriptorUpdater {
 
     public static final String[] COMPATIBLE_PROVIDERS = {SAMLIdentityProviderFactory.PROVIDER_ID};
 
@@ -138,4 +144,33 @@ public class AttributeToRoleMapper extends AbstractAttributeToRoleMapper {
         return "If an attribute exists, grant the user the specified realm or client role.";
     }
 
+    // SamlMetadataDescriptorUpdater interface
+    @Override
+    public void updateMetadata(IdentityProviderMapperModel mapperModel, EntityDescriptorType entityDescriptor) {
+        String attributeName = mapperModel.getConfig().get(UserAttributeMapper.ATTRIBUTE_NAME);
+        String attributeFriendlyName = mapperModel.getConfig().get(AttributeToRoleMapper.ATTRIBUTE_FRIENDLY_NAME);
+
+        RequestedAttributeType requestedAttribute = new RequestedAttributeType(mapperModel.getConfig().get(AttributeToRoleMapper.ATTRIBUTE_NAME));
+        requestedAttribute.setIsRequired(null);
+        requestedAttribute.setNameFormat(ATTRIBUTE_FORMAT_BASIC.get());
+
+        if (attributeFriendlyName != null && attributeFriendlyName.length() > 0)
+            requestedAttribute.setFriendlyName(attributeFriendlyName);
+
+        // Add the requestedAttribute item to any AttributeConsumingServices
+        for (EntityDescriptorType.EDTChoiceType choiceType: entityDescriptor.getChoiceType()) {
+            List<EntityDescriptorType.EDTDescriptorChoiceType> descriptors = choiceType.getDescriptors();
+            for (EntityDescriptorType.EDTDescriptorChoiceType descriptor: descriptors) {
+                for (AttributeConsumingServiceType attributeConsumingService: descriptor.getSpDescriptor().getAttributeConsumingService())
+                {
+                    boolean alreadyPresent = attributeConsumingService.getRequestedAttribute().stream()
+                        .anyMatch(t -> (attributeName == null || attributeName.equalsIgnoreCase(t.getName())) &&
+                                       (attributeFriendlyName == null || attributeFriendlyName.equalsIgnoreCase(t.getFriendlyName())));
+
+                    if (!alreadyPresent)
+                        attributeConsumingService.addRequestedAttribute(requestedAttribute);
+                }
+            }
+        }
+    }
 }

--- a/services/src/main/java/org/keycloak/broker/saml/mappers/UserAttributeMapper.java
+++ b/services/src/main/java/org/keycloak/broker/saml/mappers/UserAttributeMapper.java
@@ -220,14 +220,16 @@ public class UserAttributeMapper extends AbstractIdentityProviderMapper implemen
         return "Import declared saml attribute if it exists in assertion into the specified user property or attribute.";
     }
 
-    // ISpMetadataAttributeProvider interface
+    // SamlMetadataDescriptorUpdater interface
     @Override
     public void updateMetadata(IdentityProviderMapperModel mapperModel, EntityDescriptorType entityDescriptor) {
-        RequestedAttributeType requestedAttribute = new RequestedAttributeType(mapperModel.getConfig().get(UserAttributeMapper.ATTRIBUTE_NAME));
+        String attributeName = mapperModel.getConfig().get(UserAttributeMapper.ATTRIBUTE_NAME);
+        String attributeFriendlyName = mapperModel.getConfig().get(UserAttributeMapper.ATTRIBUTE_FRIENDLY_NAME);
+
+        RequestedAttributeType requestedAttribute = new RequestedAttributeType(attributeName);
         requestedAttribute.setIsRequired(null);
         requestedAttribute.setNameFormat(ATTRIBUTE_FORMAT_BASIC.get());
 
-        String attributeFriendlyName = mapperModel.getConfig().get(UserAttributeMapper.ATTRIBUTE_FRIENDLY_NAME);
         if (attributeFriendlyName != null && attributeFriendlyName.length() > 0)
             requestedAttribute.setFriendlyName(attributeFriendlyName);
 
@@ -236,7 +238,12 @@ public class UserAttributeMapper extends AbstractIdentityProviderMapper implemen
             List<EntityDescriptorType.EDTDescriptorChoiceType> descriptors = choiceType.getDescriptors();
             for (EntityDescriptorType.EDTDescriptorChoiceType descriptor : descriptors) {
                 for (AttributeConsumingServiceType attributeConsumingService : descriptor.getSpDescriptor().getAttributeConsumingService()) {
-                    attributeConsumingService.addRequestedAttribute(requestedAttribute);
+                    boolean alreadyPresent = attributeConsumingService.getRequestedAttribute().stream()
+                        .anyMatch(t -> (attributeName == null || attributeName.equalsIgnoreCase(t.getName())) &&
+                                       (attributeFriendlyName == null || attributeFriendlyName.equalsIgnoreCase(t.getFriendlyName())));
+
+                    if (!alreadyPresent)
+                        attributeConsumingService.addRequestedAttribute(requestedAttribute);
                 }
             }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcSamlAttributeConsumingServiceIndexTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcSamlAttributeConsumingServiceIndexTest.java
@@ -14,9 +14,7 @@ import java.io.Closeable;
 import org.junit.Assert;
 import org.junit.Test;
 import org.w3c.dom.Document;
-import org.w3c.dom.Element;
 import org.w3c.dom.Node;
-import static org.keycloak.saml.common.constants.JBossSAMLURIConstants.ASSERTION_NSURI;
 import static org.keycloak.testsuite.broker.BrokerTestTools.getConsumerRoot;
 
 /**


### PR DESCRIPTION
Follow up to #7817 to add automatic generation of the RequestedAttribute metadata element in the SP descriptor for SAML Attribute to Role mappers.