### PR TITLE
KEYCLOAK-18889 Add support for AWS SecretsManager vault

### DIFF
--- a/distribution/feature-packs/server-feature-pack-dependencies/pom.xml
+++ b/distribution/feature-packs/server-feature-pack-dependencies/pom.xml
@@ -411,6 +411,26 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-secretsmanager</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-core</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
 </project>

--- a/distribution/feature-packs/server-feature-pack/src/main/resources/modules/system/layers/keycloak/com/amazonaws/aws-java-sdk-core/main/module.xml
+++ b/distribution/feature-packs/server-feature-pack/src/main/resources/modules/system/layers/keycloak/com/amazonaws/aws-java-sdk-core/main/module.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module xmlns="urn:jboss:module:1.3" name="com.amazonaws.aws-java-sdk-core">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <resources>
+        <artifact name="${com.amazonaws:aws-java-sdk-core}"/>
+    </resources>
+
+    <dependencies>
+        <module name="javax.api"/>
+        <module name="javax.xml.stream.api"/>
+        <module name="javax.xml.bind.api"/>
+        <module name="org.joda.time"/>
+        <module name="org.apache.commons.logging"/>
+        <module name="org.apache.httpcomponents.core.httpclient"/>
+        <module name="org.apache.httpcomponents.core.httpcore"/>
+        <module name="com.fasterxml.jackson.core.jackson-core"/>
+        <module name="com.fasterxml.jackson.core.jackson-annotations"/>
+        <module name="com.fasterxml.jackson.core.jackson-databind"/>
+    </dependencies>
+
+</module>

--- a/distribution/feature-packs/server-feature-pack/src/main/resources/modules/system/layers/keycloak/com/amazonaws/aws-java-sdk-secretsmanager/main/module.xml
+++ b/distribution/feature-packs/server-feature-pack/src/main/resources/modules/system/layers/keycloak/com/amazonaws/aws-java-sdk-secretsmanager/main/module.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module xmlns="urn:jboss:module:1.3" name="com.amazonaws.aws-java-sdk-secretsmanager">
+    <resources>
+        <artifact name="${com.amazonaws:aws-java-sdk-secretsmanager}"/>
+    </resources>
+
+    <dependencies>
+        <module name="com.amazonaws.aws-java-sdk-core" />
+        <module name="javax.xml.stream.api"/>
+    </dependencies></module>

--- a/distribution/feature-packs/server-feature-pack/src/main/resources/modules/system/layers/keycloak/org/keycloak/keycloak-services/main/module.xml
+++ b/distribution/feature-packs/server-feature-pack/src/main/resources/modules/system/layers/keycloak/org/keycloak/keycloak-services/main/module.xml
@@ -77,5 +77,7 @@
         <module name="com.webauthn4j.webauthn4j-core"/>
         <module name="com.webauthn4j.webauthn4j-util"/>
         <module name="javax.persistence.api"/>
+        <module name="com.amazonaws.aws-java-sdk-secretsmanager"/>
+        <module name="com.amazonaws.aws-java-sdk-core"/>
     </dependencies>
 </module>

--- a/distribution/galleon-feature-packs/server-galleon-pack/src/main/resources/modules/system/layers/keycloak/com/amazonaws/aws-java-sdk-core/main/module.xml
+++ b/distribution/galleon-feature-packs/server-galleon-pack/src/main/resources/modules/system/layers/keycloak/com/amazonaws/aws-java-sdk-core/main/module.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module xmlns="urn:jboss:module:1.3" name="com.amazonaws.aws-java-sdk-core">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <resources>
+        <artifact name="${com.amazonaws:aws-java-sdk-core}"/>
+    </resources>
+
+    <dependencies>
+        <module name="javax.api"/>
+        <module name="javax.xml.stream.api"/>
+        <module name="javax.xml.bind.api"/>
+        <module name="org.joda.time"/>
+        <module name="org.apache.commons.logging"/>
+        <module name="org.apache.httpcomponents.core.httpclient"/>
+        <module name="org.apache.httpcomponents.core.httpcore"/>
+        <module name="com.fasterxml.jackson.core.jackson-core"/>
+        <module name="com.fasterxml.jackson.core.jackson-annotations"/>
+        <module name="com.fasterxml.jackson.core.jackson-databind"/>
+    </dependencies>
+
+</module>

--- a/distribution/galleon-feature-packs/server-galleon-pack/src/main/resources/modules/system/layers/keycloak/com/amazonaws/aws-java-sdk-secretsmanager/main/module.xml
+++ b/distribution/galleon-feature-packs/server-galleon-pack/src/main/resources/modules/system/layers/keycloak/com/amazonaws/aws-java-sdk-secretsmanager/main/module.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module xmlns="urn:jboss:module:1.3" name="com.amazonaws.aws-java-sdk-secretsmanager">
+    <resources>
+        <artifact name="${com.amazonaws:aws-java-sdk-secretsmanager}"/>
+    </resources>
+
+    <dependencies>
+        <module name="com.amazonaws.aws-java-sdk-core" />
+        <module name="javax.xml.stream.api"/>
+    </dependencies></module>

--- a/distribution/galleon-feature-packs/server-galleon-pack/src/main/resources/modules/system/layers/keycloak/org/keycloak/keycloak-services/main/module.xml
+++ b/distribution/galleon-feature-packs/server-galleon-pack/src/main/resources/modules/system/layers/keycloak/org/keycloak/keycloak-services/main/module.xml
@@ -77,5 +77,7 @@
         <module name="com.webauthn4j.webauthn4j-core"/>
         <module name="com.webauthn4j.webauthn4j-util"/>
         <module name="javax.persistence.api"/>
+        <module name="com.amazonaws.aws-java-sdk-secretsmanager"/>
+        <module name="com.amazonaws.aws-java-sdk-core"/>
     </dependencies>
 </module>

--- a/pom.xml
+++ b/pom.xml
@@ -126,6 +126,7 @@
         <apacheds.codec.version>2.0.0</apacheds.codec.version>
         <google.zxing.version>3.4.0</google.zxing.version>
         <freemarker.version>2.3.31</freemarker.version>
+        <awssecretsmanager.version>1.12.23</awssecretsmanager.version>
 
         <jetty9.version>${jetty92.version}</jetty9.version>
         <liquibase.version>3.5.5</liquibase.version>
@@ -1702,6 +1703,18 @@
                         <artifactId>*</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+
+            <!-- Amazon AWS Secrets Manager for vault -->
+            <dependency>
+                <groupId>com.amazonaws</groupId>
+                <artifactId>aws-java-sdk-secretsmanager</artifactId>
+                <version>${awssecretsmanager.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.amazonaws</groupId>
+                <artifactId>aws-java-sdk-core</artifactId>
+                <version>${awssecretsmanager.version}</version>
             </dependency>
 
         </dependencies>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -185,7 +185,17 @@
             <groupId>com.webauthn4j</groupId>
             <artifactId>webauthn4j-core</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-secretsmanager</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-core</artifactId>
+        </dependency>
     </dependencies>
+
     <build>
         <plugins>
             <plugin>

--- a/services/src/main/java/org/keycloak/vault/AWSSecretsMgrProvider.java
+++ b/services/src/main/java/org/keycloak/vault/AWSSecretsMgrProvider.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright 2021 OutSystems and/or its affiliates and other
+ * contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.vault;
+
+import com.amazonaws.services.secretsmanager.AWSSecretsManager;
+import com.amazonaws.services.secretsmanager.AWSSecretsManagerClientBuilder;
+import com.amazonaws.services.secretsmanager.model.GetSecretValueRequest;
+import com.amazonaws.services.secretsmanager.model.GetSecretValueResult;
+import org.jboss.logging.Logger;
+
+import java.lang.invoke.MethodHandles;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.List;
+import java.util.Optional;
+
+public class AWSSecretsMgrProvider extends AbstractVaultProvider {
+
+    private static final Logger logger = Logger.getLogger(MethodHandles.lookup().lookupClass());
+
+    protected AWSSecretsManager client;
+
+    /**
+     * Creates an instance of {@code AbstractVaultProvider} with the specified realm and list of key resolvers.
+     *
+     * @param realm the name of the keycloak realm.
+     * @param resolvers a {@link List} containing the configured key resolvers.
+     * @param region a {@link String} containing the AWS region, e.g. us-west-2.
+     */
+    public AWSSecretsMgrProvider(String realm, List<VaultKeyResolver> resolvers, String region) {
+        super(realm, resolvers);
+
+        client = AWSSecretsManagerClientBuilder.standard()
+                .withRegion(region)
+                .build();
+    }
+
+    @Override
+    protected VaultRawSecret obtainSecretInternal(String vaultKey) {
+        final GetSecretValueResult secretValue;
+        try {
+            secretValue = client.getSecretValue(new GetSecretValueRequest().withSecretId(vaultKey));
+        } catch (Exception e) {
+            logger.error("Failed to retrieve secret " + vaultKey, e);
+            throw e;
+        }
+
+        return new VaultRawSecret() {
+            @Override
+            public Optional<ByteBuffer> get() {
+                if (secretValue.getSecretString() != null) {
+                    return Optional.of(ByteBuffer.wrap(secretValue.getSecretString().getBytes(StandardCharsets.UTF_8)));
+                } else if (secretValue.getSecretBinary() != null) {
+                    return Optional.of(Base64.getDecoder().decode(secretValue.getSecretBinary()));
+                }
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<byte[]> getAsArray() {
+                if (secretValue.getSecretString() != null) {
+                    return Optional.of(secretValue.getSecretString().getBytes(StandardCharsets.UTF_8));
+                } else if (secretValue.getSecretBinary() != null) {
+                    return Optional.of(Base64.getDecoder().decode(secretValue.getSecretBinary()).array());
+                }
+                return Optional.empty();
+            }
+
+            @Override
+            public void close() {
+                // Overwrite secret with garbage
+                byte[] array = new byte[128];
+                new SecureRandom().nextBytes(array);
+                secretValue.setSecretString(new String(array, StandardCharsets.UTF_8));
+            }
+        };
+    }
+
+    @Override
+    public void close() {
+        client.shutdown();
+    }
+}

--- a/services/src/main/java/org/keycloak/vault/AWSSecretsMgrProviderFactory.java
+++ b/services/src/main/java/org/keycloak/vault/AWSSecretsMgrProviderFactory.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2021 OutSystems and/or its affiliates and other
+ * contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.vault;
+
+import org.jboss.logging.Logger;
+import org.keycloak.Config;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+
+import java.lang.invoke.MethodHandles;
+
+public class AWSSecretsMgrProviderFactory extends AbstractVaultProviderFactory {
+
+    private static final Logger logger = Logger.getLogger(MethodHandles.lookup().lookupClass());
+
+    private static final String PROVIDER_ID = "awssecretsmgr";
+
+    static final String AWS_DEFAULT_REGION = "defaultRegion";
+    static final String ENV_AWS_REGION = "KEYCLOAK_AWSSM_REGION";
+
+    private String region;
+
+    @Override
+    public VaultProvider create(KeycloakSession session) {
+        if (region == null) {
+            logger.debug("Can not create an AWS SecretsManager vault provider since it's not initialized correctly");
+            return null;
+        }
+
+        return new AWSSecretsMgrProvider(getRealmName(session), super.keyResolvers, region);
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+        super.init(config);
+
+        this.region = System.getenv(ENV_AWS_REGION);
+        if (this.region == null) {
+            this.region = config.get(AWS_DEFAULT_REGION);
+        }
+        if (this.region == null) {
+            logger.debug("AWSSecretsMgrProviderFactory not properly configured - missing region");
+        }
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+}

--- a/services/src/main/resources/META-INF/services/org.keycloak.vault.VaultProviderFactory
+++ b/services/src/main/resources/META-INF/services/org.keycloak.vault.VaultProviderFactory
@@ -1,1 +1,2 @@
 org.keycloak.vault.FilesPlainTextVaultProviderFactory
+org.keycloak.vault.AWSSecretsMgrProviderFactory

--- a/services/src/test/java/org/keycloak/vault/AWSSecretsMgrProviderFactoryTest.java
+++ b/services/src/test/java/org/keycloak/vault/AWSSecretsMgrProviderFactoryTest.java
@@ -1,0 +1,112 @@
+package org.keycloak.vault;
+
+import org.junit.Test;
+import org.keycloak.Config;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.services.DefaultKeycloakSession;
+import org.keycloak.services.DefaultKeycloakSessionFactory;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Tests for {@link AWSSecretsMgrProviderFactory}.
+ */
+public class AWSSecretsMgrProviderFactoryTest {
+
+    @Test
+    public void shouldInitializeVaultCorrectly() {
+        //given
+        VaultConfig config = new VaultConfig("region");
+        KeycloakSession session = new DefaultKeycloakSession(new DefaultKeycloakSessionFactory());
+        AWSSecretsMgrProviderFactory factory = new AWSSecretsMgrProviderFactory() {
+            @Override
+            protected String getRealmName(KeycloakSession session) {
+                return "test";
+            }
+        };
+
+        //when
+        factory.init(config);
+        VaultProvider provider = factory.create(session);
+
+        //then
+        assertNotNull(provider);
+    }
+
+    @Test
+    public void shouldReturnNullWhenWithNullDirectory() {
+        //given
+        VaultConfig config = new VaultConfig(null);
+        AWSSecretsMgrProviderFactory factory = new AWSSecretsMgrProviderFactory();
+
+        //when
+        factory.init(config);
+        VaultProvider provider = factory.create(null);
+
+        //then
+        assertNull(provider);
+    }
+
+    /**
+     * A whitebox implementation of the config. Please use only for testing {@link AWSSecretsMgrProviderFactory}.
+     */
+    private static class VaultConfig implements Config.Scope {
+
+        private String defaultRegion;
+
+        public VaultConfig(String defaultRegion) {
+            this.defaultRegion = defaultRegion;
+        }
+
+        @Override
+        public String get(String key) {
+            return "defaultRegion".equals(key) ? defaultRegion : null;
+        }
+
+        @Override
+        public String get(String key, String defaultValue) {
+            return get(key) != null ? get(key) : defaultValue;
+        }
+
+        @Override
+        public String[] getArray(String key) {
+            throw new UnsupportedOperationException("not implemented");
+        }
+
+        @Override
+        public Integer getInt(String key) {
+            throw new UnsupportedOperationException("not implemented");
+        }
+
+        @Override
+        public Integer getInt(String key, Integer defaultValue) {
+            throw new UnsupportedOperationException("not implemented");
+        }
+
+        @Override
+        public Long getLong(String key) {
+            throw new UnsupportedOperationException("not implemented");
+        }
+
+        @Override
+        public Long getLong(String key, Long defaultValue) {
+            throw new UnsupportedOperationException("not implemented");
+        }
+
+        @Override
+        public Boolean getBoolean(String key) {
+            throw new UnsupportedOperationException("not implemented");
+        }
+
+        @Override
+        public Boolean getBoolean(String key, Boolean defaultValue) {
+            throw new UnsupportedOperationException("not implemented");
+        }
+
+        @Override
+        public Config.Scope scope(String... scope) {
+            throw new UnsupportedOperationException("not implemented");
+        }
+    }
+}


### PR DESCRIPTION
# AWS SecretsManager extension for Keycloak

This extension provides support for Amazon's AWS SecretsManager as a vault implementation for Keycloak. 
It will currently work with any single AWS region provided via the execution environment as `KEYCLOAK_AWSSM_REGION` (defaults to SPI configured region).

Like any org.keycloak.vault implementation, secrets are configured in keycloak in the format `${vault.<SECRET_NAME>}`.
In AWS SecretsManager the secret must be configured as raw, plain text -- no JSON formatting -- with the name in the format `<KEYCLOAK_REALM>_<SECRET_NAME>`.

## Usage

1. Setup your AWS credentials, e.g. in your ENV, in ~/.aws/credentials, etc.

2. Add the following to Keycloak configuration, e.g. standalone.xml, in the `urn:jboss:domain:keycloak-server` subsystem to enable this vault provider:
```
<spi name="vault">
    <default-provider>awssecretsmgr</default-provider>
    <provider name="awssecretsmgr" enabled="true">
        <properties>
            <property name="defaultRegion" value="<AWS_REGION>"/>
        </properties>
    </provider>
</spi>
```

3. (Optional) Set the AWS region in the local environment variable `KEYCLOAK_AWSSM_REGION` to override the value in the config above.

Secrets configured in Keycloak will now be pulled from AWS SecretsManager.


Documentation PR: https://github.com/keycloak/keycloak-documentation/pull/1233
