### PR TITLE
Added missing closing div tag in login-username template

### DIFF
--- a/themes/src/main/resources/theme/base/login/login-username.ftl
+++ b/themes/src/main/resources/theme/base/login/login-username.ftl
@@ -58,6 +58,7 @@
                         </div>
                     </form>
                 </#if>
+            </div>
         </div>
 
             <#if realm.password && social.providers??>


### PR DESCRIPTION
The `login-username` template has a missing `</div>` tag.