### PR TITLE
KEYCLOAK-18691 CIBATest wrong expiration

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/Assert.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/Assert.java
@@ -48,6 +48,8 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
  */
 public class Assert extends org.junit.Assert {
 
+    public static final Long DEFAULT_NUMBER_DEVIATION = 20L;
+
     public static <T> void assertNames(Set<T> actual, String... expected) {
         Arrays.sort(expected);
         String[] actualNames = names(new LinkedList<Object>(actual));
@@ -150,7 +152,11 @@ public class Assert extends org.junit.Assert {
     }
 
     public static void assertExpiration(long actual, long expected) {
-        MatcherAssert.assertThat(actual, allOf(greaterThanOrEqualTo(expected - 50), lessThanOrEqualTo(expected)));
+        assertExpiration(actual, expected, DEFAULT_NUMBER_DEVIATION);
+    }
+
+    public static void assertExpiration(long actual, long expected, long deviation) {
+        MatcherAssert.assertThat(actual, allOf(greaterThanOrEqualTo(expected - deviation), lessThanOrEqualTo(expected + deviation)));
     }
 
     public static void assertRoleAttributes(Map<String, List<String>> expected, Map<String, List<String>> actual) {


### PR DESCRIPTION
[KEYCLOAK-18691 CIBATest.testTokenRequestAfterIntervalButNotYetAuthenticated wrong expiration](https://issues.redhat.com/browse/KEYCLOAK-18691)

Pipeline base tests passed: https://keycloak-jenkins.com/blue/organizations/jenkins/universal-test-pipeline-server/detail/universal-test-pipeline-server/647/pipeline

@miquelsi Could you please take a look at it? Thank you
