### PR TITLE
KEYCLOAK-18891 Add support for searching users by attributes

### DIFF
--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/UsersResource.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/UsersResource.java
@@ -111,6 +111,20 @@ public interface UsersResource {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    List<UserRepresentation> searchByAttributes(@QueryParam("q") String searchQuery);
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    List<UserRepresentation> searchByAttributes(@QueryParam("first") Integer firstResult,
+                                                @QueryParam("max") Integer maxResults,
+                                                @QueryParam("enabled") Boolean enabled,
+                                                @QueryParam("briefRepresentation") Boolean briefRepresentation,
+                                                @QueryParam("q") String searchQuery);
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
     List<UserRepresentation> search(@QueryParam("username") String username, @QueryParam("exact") Boolean exact);
 
     /**
@@ -246,7 +260,7 @@ public interface UsersResource {
     @Path("{id}")
     @DELETE
     Response delete(@PathParam("id") String id);
-    
+
     @Path("profile")
     UserProfileResource userProfile();
 

--- a/model/map/src/main/java/org/keycloak/models/map/user/MapUserProvider.java
+++ b/model/map/src/main/java/org/keycloak/models/map/user/MapUserProvider.java
@@ -637,6 +637,11 @@ public class MapUserProvider implements UserProvider.Streams, UserCredentialStor
                     mcb = mcb.compare(SearchableFields.IDP_AND_USER, Operator.EQ, attributes.get(UserModel.IDP_ALIAS), value);
                     break;
                 }
+                case UserModel.EXACT:
+                    break;
+                default:
+                    mcb = mcb.compare(SearchableFields.ATTRIBUTE, Operator.EQ, key, value);
+                    break;
             }
         }
 

--- a/server-spi/src/main/java/org/keycloak/storage/user/UserQueryProvider.java
+++ b/server-spi/src/main/java/org/keycloak/storage/user/UserQueryProvider.java
@@ -389,6 +389,8 @@ public interface UserQueryProvider {
      *     the given userId (case sensitive string)</li>
      * </ul>
      *
+     * Any other parameters will be treated as custom user attributes.
+     *
      * This method is used by the REST API when querying users.
      *
      * @param realm a reference to the realm.


### PR DESCRIPTION
Users can now be searched by custom attributes using query parameters. Any query parameters that are not in the list of method arguments will be considered to be custom attributes. In this implementation query keys need to be unique, otherwise the first value is assumed.

Because the JAX-RS client does not support dynamic query parameters, a Map will be accepted as query parameters for custom attributes, it will be flattened to query parameter by a request filter.

