### PR TITLE
KEYCLOAK-15595: update keycloak js for KEYCLOAK-15595

### DIFF
--- a/adapters/oidc/js/src/main/resources/keycloak.js
+++ b/adapters/oidc/js/src/main/resources/keycloak.js
@@ -1496,7 +1496,7 @@
                         var promise = createPromise();
 
                         var logoutUrl = kc.createLogoutUrl(options);
-                        var ref = cordovaOpenWindowWrapper(logoutUrl, '_blank', 'location=no,hidden=yes');
+                        var ref = cordovaOpenWindowWrapper(logoutUrl, '_blank', 'location=no,hidden=yes,clearcache=yes');
 
                         var error;
 


### PR DESCRIPTION
while working on cordova+angular+ios the keycloak logout is not working. as the user clicks logout the user can again see the app instead of the inappbrowser page for login.
with clearcache=yes in the inappbrowser open the issue appears no more.

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
