### PR TITLE
KEYCLOAK-18964 MetricsRestServiceTest contains wrong health check mesage

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/metrics/MetricsRestServiceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/metrics/MetricsRestServiceTest.java
@@ -21,15 +21,14 @@ import javax.ws.rs.client.Client;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.keycloak.common.Profile;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.testsuite.AbstractKeycloakTest;
 import org.keycloak.testsuite.util.AdminClientUtil;
 import org.keycloak.testsuite.util.ContainerAssume;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.keycloak.testsuite.util.Matchers.body;
 import static org.keycloak.testsuite.util.Matchers.statusCodeIs;
@@ -53,15 +52,11 @@ public class MetricsRestServiceTest extends AbstractKeycloakTest {
     @Test
     public void testHealthEndpoint() {
         Client client = AdminClientUtil.createResteasyClient();
-        final String serverReportedRunningPerMicroProfileHealthSubsystem = "{\"status\":\"UP\",\"checks\":[{";
-        final String serverReportedRunningPerWildflyHealthSubsystem = "{\"name\" : \"server-state\", \"outcome\" : true, \"data\" : [{ \"value\" : \"running\" }]}";
-
-        // Post upgrade to Wildfly 22 expect output of Wildfly subsystem for health for community builds, and output of MicroProfile health subsystem for product builds
-        final String expectedString = Profile.getName().equals("community") ? serverReportedRunningPerWildflyHealthSubsystem : serverReportedRunningPerMicroProfileHealthSubsystem;
+        final String expectedString = "{\"name\" : \"server-state\", \"outcome\" : true, \"data\" : [{ \"value\" : \"running\" }]}";
 
         try (Response response = client.target("http://" + MGMT_HOST + ":" + MGMT_PORT + "/health").request().get()) {
-            Assert.assertThat(response, statusCodeIs(Status.OK));
-            Assert.assertThat(response, body(containsString(expectedString)));
+            assertThat(response, statusCodeIs(Status.OK));
+            assertThat(response, body(containsString(expectedString)));
         } finally {
             client.close();
         }
@@ -72,8 +67,8 @@ public class MetricsRestServiceTest extends AbstractKeycloakTest {
         Client client = AdminClientUtil.createResteasyClient();
 
         try (Response response = client.target("http://" + MGMT_HOST + ":" + MGMT_PORT + "/metrics").request().get()) {
-            Assert.assertThat(response, statusCodeIs(Status.OK));
-            Assert.assertThat(response, body(containsString("base_memory_maxHeap_bytes")));
+            assertThat(response, statusCodeIs(Status.OK));
+            assertThat(response, body(containsString("base_memory_maxHeap_bytes")));
         } finally {
             client.close();
         }


### PR DESCRIPTION
JIRA: [KEYCLOAK-18964](https://issues.redhat.com/browse/KEYCLOAK-18964)

I'll rerun the pipeline tests.

@miquelsi Could you please take a look at it? Thank you