### PR TITLE
KEYCLOAK-18918 - clientSession.setTimesteamp() must NOT be executed during Introspection

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
@@ -284,11 +284,7 @@ public class TokenManager {
             }
 
             if (valid) {
-                int currentTime = Time.currentTime();
-                userSession.setLastSessionRefresh(currentTime);
-                if (clientSession != null) {
-                    clientSession.setTimestamp(currentTime);
-                }
+                userSession.setLastSessionRefresh(Time.currentTime());
             }
         }
 


### PR DESCRIPTION
KEYCLOAK-18918 - clientSession.setTimesteamp() must NOT be executed during Introspection. 
**If executed, on the next refresh, the refresh token will appear as 'stale token' and trigger error.**

Bug introduced in 13.0.0, in this commit : https://github.com/keycloak/keycloak/commit/515bfb5064fc2552e521c302507a29b9962f1d81#diff-fd8b1c47da5ec7ee42d5450d3f7b73cdeef9c08af26b825c9245e3e6052c5cdf
