### PR TITLE
KEYCLOAK-18727 Improve user search query

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/UserEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/UserEntity.java
@@ -44,8 +44,6 @@ import java.util.LinkedList;
 @NamedQueries({
         @NamedQuery(name="getAllUsersByRealm", query="select u from UserEntity u where u.realmId = :realmId order by u.username"),
         @NamedQuery(name="getAllUsersByRealmExcludeServiceAccount", query="select u from UserEntity u where u.realmId = :realmId and (u.serviceAccountClientLink is null) order by u.username"),
-        @NamedQuery(name="searchForUserCount", query="select count(u) from UserEntity u where u.realmId = :realmId and (u.serviceAccountClientLink is null) and " +
-                "( lower(u.username) like :search or lower(concat(coalesce(u.firstName, ''), ' ', coalesce(u.lastName, ''))) like :search or u.email like :search )"),
         @NamedQuery(name="getRealmUserByUsername", query="select u from UserEntity u where u.username = :username and u.realmId = :realmId"),
         @NamedQuery(name="getRealmUserByEmail", query="select u from UserEntity u where u.email = :email and u.realmId = :realmId"),
         @NamedQuery(name="getRealmUserByLastName", query="select u from UserEntity u where u.lastName = :lastName and u.realmId = :realmId"),

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/UserGroupMembershipEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/UserGroupMembershipEntity.java
@@ -41,8 +41,6 @@ import java.io.Serializable;
         @NamedQuery(name="deleteUserGroupMembershipsByRealmAndLink", query="delete from  UserGroupMembershipEntity mapping where mapping.user IN (select u from UserEntity u where u.realmId=:realmId and u.federationLink=:link)"),
         @NamedQuery(name="deleteUserGroupMembershipsByGroup", query="delete from UserGroupMembershipEntity m where m.groupId = :groupId"),
         @NamedQuery(name="deleteUserGroupMembershipsByUser", query="delete from UserGroupMembershipEntity m where m.user = :user"),
-        @NamedQuery(name="searchForUserCountInGroups", query="select count(m.user) from UserGroupMembershipEntity m where m.user.realmId = :realmId and (m.user.serviceAccountClientLink is null) and " +
-                "( lower(m.user.username) like :search or lower(concat(m.user.firstName, ' ', m.user.lastName)) like :search or m.user.email like :search ) and m.groupId in :groupIds"),
         @NamedQuery(name="userCountInGroups", query="select count(m.user) from UserGroupMembershipEntity m where m.user.realmId = :realmId and m.groupId in :groupIds")
 })
 @Table(name="USER_GROUP_MEMBERSHIP")

--- a/model/map/src/main/java/org/keycloak/models/map/storage/chm/CriteriaOperator.java
+++ b/model/map/src/main/java/org/keycloak/models/map/storage/chm/CriteriaOperator.java
@@ -44,6 +44,7 @@ class CriteriaOperator {
     private static final Logger LOG = Logger.getLogger(CriteriaOperator.class.getSimpleName());
 
     private static final Predicate<Object> ALWAYS_FALSE = o -> false;
+    private static final Predicate<Object> ALWAYS_TRUE = o -> true;
 
     static {
         OPERATORS.put(Operator.EQ, CriteriaOperator::eq);
@@ -190,6 +191,11 @@ class CriteriaOperator {
         Object value0 = getFirstArrayElement(value);
         if (value0 instanceof String) {
             String sValue = (String) value0;
+
+            if(Pattern.matches("^%+$", sValue)) {
+                return ALWAYS_TRUE;
+            }
+
             boolean anyBeginning = sValue.startsWith("%");
             boolean anyEnd = sValue.endsWith("%");
 
@@ -210,6 +216,11 @@ class CriteriaOperator {
         Object value0 = getFirstArrayElement(value);
         if (value0 instanceof String) {
             String sValue = (String) value0;
+
+            if(Pattern.matches("^%+$", sValue)) {
+                return ALWAYS_TRUE;
+            }
+
             boolean anyBeginning = sValue.startsWith("%");
             boolean anyEnd = sValue.endsWith("%");
 


### PR DESCRIPTION
The purpose of this PR is to improve the performance of the user search (specifically when you search for a user in the UI),
since customers were facing bad performance on systems with a large amount of users. The implementation is following
a suggestion from @hmlnarik . You can find the full discussion here: https://groups.google.com/g/keycloak-dev/c/jn5Yy9Y4Lw4 .

TL;DR :
You can now search for a user in 3 different ways:
1. Prefix, e.g : foo or foo* (new default)
2. Exact, e.g : "foo"
3. Infix, e.g : \*foo\* (old default)

However, we would like to make the following remarks and like to hear your feedback:

1. Changing the default behavior of the user search endpoint is technically breaking the API. One might also consider making a new endpoint and let the UI use it instead.
   
2. For consistency, we also changed the user count (if a search string is part of the input) to work similarly to the user search.

3. We only adjusted the JpaUserProvider and MapUserProvider because we wanted to hear your feedback on whether it is also necessary to adjust the LdapStorageProvider.

4. While adjusting the JpaUserProvider and MapUserProvider, we decided that it would be consistent to unify their queries. This means the JpaUserProvider now searches for the search string on both the FIRST_NAME and LAST_NAME columns separately instead of concatenating them with coalesc. Also the search string gets split on both providers now.
