### PR TITLE
Fix null pointer when certificate in null

### DIFF
--- a/core/src/main/java/org/keycloak/jose/jwk/JWKBuilder.java
+++ b/core/src/main/java/org/keycloak/jose/jwk/JWKBuilder.java
@@ -72,7 +72,13 @@ public class JWKBuilder {
     }
     
     public JWK rsa(Key key, X509Certificate certificate) {
-        return rsa(key, Collections.singletonList(certificate), KeyUse.SIG);
+        List<X509Certificate> certificateList;
+        if (certificate != null) {
+            certificateList = Collections.singletonList(certificate);
+        } else {
+            certificateList = Collections.EMPTY_LIST;
+        }
+        return rsa(key, certificateList, KeyUse.SIG);
     }
 
     public JWK rsa(Key key, List<X509Certificate> certificates) {


### PR DESCRIPTION
When certificate is null Collections.singletonList(certificate) has a size of 1 still, so the check on line 101 does not work on it leading to a NPE on 104.

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
