### PR TITLE
KEYCLOAK-18932 Fix url sanitization in email templates

### DIFF
--- a/services/src/main/java/org/keycloak/theme/KeycloakSanitizerMethod.java
+++ b/services/src/main/java/org/keycloak/theme/KeycloakSanitizerMethod.java
@@ -50,10 +50,8 @@ public class KeycloakSanitizerMethod implements TemplateMethodModelEx {
     private String fixURLs(String msg) {
         Pattern hrefs = Pattern.compile("href=\"([^\"]*)\"");
         Matcher matcher = hrefs.matcher(msg);
-        int count = 0;
         while(matcher.find()) {
-            count++;
-            String original = matcher.group(count);
+            String original = matcher.group();
             String href = original.replaceAll("&#61;", "=")
                     .replaceAll("\\.\\.", ".")
                     .replaceAll("&amp;", "&");


### PR DESCRIPTION
If an email message contains more than one <a> tag with href attribute, the sanitizer method fails with error "java.lang.IndexOutOfBoundsException: No group 2".

Fixes a bug that was introduced by https://github.com/keycloak/keycloak/pull/8116.
