### PR TITLE
Draft PR: KEYCLOAK-18607 add lastUpdatedTimestamp to user

### DIFF
--- a/core/src/main/java/org/keycloak/representations/idm/UserRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/idm/UserRepresentation.java
@@ -38,6 +38,7 @@ public class UserRepresentation {
     protected String id;
     protected String origin;
     protected Long createdTimestamp;
+    protected Long attributesUpdatedTimestamp;
     protected String username;
     protected Boolean enabled;
     protected Boolean totp;
@@ -89,6 +90,14 @@ public class UserRepresentation {
 
     public void setCreatedTimestamp(Long createdTimestamp) {
         this.createdTimestamp = createdTimestamp;
+    }
+
+    public Long getAttributesUpdatedTimestamp() {
+        return attributesUpdatedTimestamp;
+    }
+
+    public void setAttributesUpdatedTimestamp(Long attributesUpdatedTimestamp) {
+        this.attributesUpdatedTimestamp = attributesUpdatedTimestamp;
     }
 
     public String getFirstName() {

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/UserAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/UserAdapter.java
@@ -157,6 +157,18 @@ public class UserAdapter implements CachedUserModel.Streams {
     }
 
     @Override
+    public Long getAttributesUpdatedTimestamp() {
+        if (updated != null) return updated.getAttributesUpdatedTimestamp();
+        return cached.getAttributesUpdatedTimestamp();
+    }
+
+    @Override
+    public void setAttributesUpdatedTimestamp(Long timestamp) {
+        getDelegateForUpdate();
+        updated.setAttributesUpdatedTimestamp(timestamp);
+    }
+
+    @Override
     public boolean isEnabled() {
         if (updated != null) return updated.isEnabled();
         return cached.isEnabled();

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/entities/CachedUser.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/entities/CachedUser.java
@@ -40,6 +40,7 @@ public class CachedUser extends AbstractExtendableRevisioned implements InRealm 
     private final String realm;
     private final String username;
     private final Long createdTimestamp;
+    private final Long attributesUpdatedTimestamp;
     private final String email;
     private final boolean emailVerified;
     private final boolean enabled;
@@ -56,6 +57,7 @@ public class CachedUser extends AbstractExtendableRevisioned implements InRealm 
         this.realm = realm.getId();
         this.username = user.getUsername();
         this.createdTimestamp = user.getCreatedTimestamp();
+        this.attributesUpdatedTimestamp = user.getAttributesUpdatedTimestamp();
         this.email = user.getEmail();
         this.emailVerified = user.isEmailVerified();
         this.enabled = user.isEnabled();
@@ -78,6 +80,10 @@ public class CachedUser extends AbstractExtendableRevisioned implements InRealm 
 
     public Long getCreatedTimestamp() {
         return createdTimestamp;
+    }
+
+    public Long getAttributesUpdatedTimestamp() {
+        return attributesUpdatedTimestamp;
     }
 
     public String getEmail() {

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserProvider.java
@@ -105,7 +105,9 @@ public class JpaUserProvider implements UserProvider.Streams, UserCredentialStor
 
         UserEntity entity = new UserEntity();
         entity.setId(id);
-        entity.setCreatedTimestamp(System.currentTimeMillis());
+        long now = Time.currentTimeMillis();
+        entity.setCreatedTimestamp(now);
+        entity.setAttributesUpdatedTimestamp(now);
         entity.setUsername(username.toLowerCase());
         entity.setRealmId(realm.getId());
         em.persist(entity);

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/UserAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/UserAdapter.java
@@ -100,6 +100,16 @@ public class UserAdapter implements UserModel.Streams, JpaModel<UserEntity> {
     }
 
     @Override
+    public Long getAttributesUpdatedTimestamp() {
+        return user.getAttributesUpdatedTimestamp();
+    }
+
+    @Override
+    public void setAttributesUpdatedTimestamp(Long timestamp) {
+        user.setAttributesUpdatedTimestamp(timestamp);
+    }
+
+    @Override
     public boolean isEnabled() {
         return user.isEnabled();
     }

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/UserEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/UserEntity.java
@@ -78,6 +78,8 @@ public class UserEntity {
     protected String firstName;
     @Column(name = "CREATED_TIMESTAMP")
     protected Long createdTimestamp;
+    @Column(name = "ATTRIBUTES_UPDATED_TIMESTAMP")
+    protected Long attributesUpdatedTimestamp;
     @Nationalized
     @Column(name = "LAST_NAME")
     protected String lastName;
@@ -146,6 +148,14 @@ public class UserEntity {
 
     public void setCreatedTimestamp(Long timestamp) {
         createdTimestamp = timestamp;
+    }
+
+    public Long getAttributesUpdatedTimestamp() {
+        return attributesUpdatedTimestamp;
+    }
+
+    public void setAttributesUpdatedTimestamp(Long timestamp) {
+        this.attributesUpdatedTimestamp = timestamp;
     }
 
     public String getFirstName() {

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-16.0.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-16.0.0.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  ~ * Copyright 2020 Red Hat, Inc. and/or its affiliates
+  ~ * and other contributors as indicated by the @author tags.
+  ~ *
+  ~ * Licensed under the Apache License, Version 2.0 (the "License");
+  ~ * you may not use this file except in compliance with the License.
+  ~ * You may obtain a copy of the License at
+  ~ *
+  ~ * http://www.apache.org/licenses/LICENSE-2.0
+  ~ *
+  ~ * Unless required by applicable law or agreed to in writing, software
+  ~ * distributed under the License is distributed on an "AS IS" BASIS,
+  ~ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ * See the License for the specific language governing permissions and
+  ~ * limitations under the License.
+  -->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet author="keycloak" id="16.0.0-KEYCLOAK-18607">
+        <addColumn tableName="USER_ENTITY">
+            <column name="ATTRIBUTES_UPDATED_TIMESTAMP" type="BIGINT"/>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-master.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-master.xml
@@ -71,5 +71,6 @@
     <include file="META-INF/jpa-changelog-13.0.0.xml"/>
     <include file="META-INF/jpa-changelog-14.0.0.xml"/>
     <include file="META-INF/jpa-changelog-15.0.0.xml"/>
+    <include file="META-INF/jpa-changelog-16.0.0.xml"/>
 
 </databaseChangeLog>

--- a/model/map/src/main/java/org/keycloak/models/map/user/MapUserAdapter.java
+++ b/model/map/src/main/java/org/keycloak/models/map/user/MapUserAdapter.java
@@ -75,6 +75,16 @@ public abstract class MapUserAdapter extends AbstractUserModel<MapUserEntity> {
     }
 
     @Override
+    public Long getAttributesUpdatedTimestamp() {
+        return entity.getAttributesUpdatedTimestamp();
+    }
+
+    @Override
+    public void setAttributesUpdatedTimestamp(Long timestamp) {
+        entity.setAttributesUpdatedTimestamp(timestamp);
+    }
+
+    @Override
     public boolean isEnabled() {
         return entity.isEnabled();
     }

--- a/model/map/src/main/java/org/keycloak/models/map/user/MapUserEntity.java
+++ b/model/map/src/main/java/org/keycloak/models/map/user/MapUserEntity.java
@@ -24,7 +24,6 @@ import org.keycloak.models.utils.KeycloakModelUtils;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -48,6 +47,7 @@ public class MapUserEntity implements AbstractEntity, UpdatableEntity {
     private String username;
     private String firstName;
     private Long createdTimestamp;
+    private Long attributesUpdatedTimestamp;
     private String lastName;
     private String email;
     private boolean enabled;
@@ -125,6 +125,15 @@ public class MapUserEntity implements AbstractEntity, UpdatableEntity {
     public void setCreatedTimestamp(Long createdTimestamp) {
         this.updated |= !Objects.equals(this.createdTimestamp, createdTimestamp);
         this.createdTimestamp = createdTimestamp;
+    }
+
+    public Long getAttributesUpdatedTimestamp() {
+        return attributesUpdatedTimestamp;
+    }
+
+    public void setAttributesUpdatedTimestamp(Long attributesUpdatedTimestamp) {
+        this.updated |= !Objects.equals(this.attributesUpdatedTimestamp, attributesUpdatedTimestamp);
+        this.attributesUpdatedTimestamp = attributesUpdatedTimestamp;
     }
 
     public String getLastName() {

--- a/model/map/src/main/java/org/keycloak/models/map/user/MapUserProvider.java
+++ b/model/map/src/main/java/org/keycloak/models/map/user/MapUserProvider.java
@@ -316,7 +316,9 @@ public class MapUserProvider implements UserProvider.Streams, UserCredentialStor
 
         MapUserEntity entity = new MapUserEntity(id, realm.getId());
         entity.setUsername(username.toLowerCase());
-        entity.setCreatedTimestamp(Time.currentTimeMillis());
+        long now = Time.currentTimeMillis();
+        entity.setCreatedTimestamp(now);
+        entity.setAttributesUpdatedTimestamp(now);
 
         entity = tx.create(entity);
         final UserModel userModel = entityToAdapterFunc(realm).apply(entity);

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
@@ -203,6 +203,7 @@ public class ModelToRepresentation {
         rep.setOrigin(providerId);
         rep.setUsername(user.getUsername());
         rep.setCreatedTimestamp(user.getCreatedTimestamp());
+        rep.setAttributesUpdatedTimestamp(user.getAttributesUpdatedTimestamp());
         rep.setLastName(user.getLastName());
         rep.setFirstName(user.getFirstName());
         rep.setEmail(user.getEmail());
@@ -238,6 +239,7 @@ public class ModelToRepresentation {
         rep.setId(user.getId());
         rep.setUsername(user.getUsername());
         rep.setCreatedTimestamp(user.getCreatedTimestamp());
+        rep.setAttributesUpdatedTimestamp(user.getAttributesUpdatedTimestamp());
         rep.setLastName(user.getLastName());
         rep.setFirstName(user.getFirstName());
         rep.setEmail(user.getEmail());

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
@@ -1831,6 +1831,7 @@ public class RepresentationToModel {
         UserModel user = session.userLocalStorage().addUser(newRealm, userRep.getId(), userRep.getUsername(), false, false);
         user.setEnabled(userRep.isEnabled() != null && userRep.isEnabled());
         user.setCreatedTimestamp(userRep.getCreatedTimestamp());
+        user.setAttributesUpdatedTimestamp(userRep.getAttributesUpdatedTimestamp());
         user.setEmail(userRep.getEmail());
         if (userRep.isEmailVerified() != null) user.setEmailVerified(userRep.isEmailVerified());
         user.setFirstName(userRep.getFirstName());

--- a/server-spi-private/src/main/java/org/keycloak/storage/adapter/InMemoryUserAdapter.java
+++ b/server-spi-private/src/main/java/org/keycloak/storage/adapter/InMemoryUserAdapter.java
@@ -41,6 +41,7 @@ import java.util.stream.Stream;
  */
 public class InMemoryUserAdapter extends UserModelDefaultMethods.Streams {
     private Long createdTimestamp = Time.currentTimeMillis();
+    private Long attributesUpdatedTimestamp = createdTimestamp;
     private boolean emailVerified;
     private boolean enabled;
 
@@ -102,6 +103,17 @@ public class InMemoryUserAdapter extends UserModelDefaultMethods.Streams {
     public void setCreatedTimestamp(Long timestamp) {
         checkReadonly();
         this.createdTimestamp = timestamp;
+    }
+
+    @Override
+    public Long getAttributesUpdatedTimestamp() {
+        return attributesUpdatedTimestamp;
+    }
+
+    @Override
+    public void setAttributesUpdatedTimestamp(Long timestamp) {
+        checkReadonly();
+        this.attributesUpdatedTimestamp = timestamp;
     }
 
     @Override

--- a/server-spi-private/src/main/java/org/keycloak/userprofile/DefaultAttributeChangeListener.java
+++ b/server-spi-private/src/main/java/org/keycloak/userprofile/DefaultAttributeChangeListener.java
@@ -1,0 +1,37 @@
+package org.keycloak.userprofile;
+
+import org.keycloak.common.util.Time;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.UserModel;
+
+import java.util.List;
+
+/**
+ * A default listener implementation setting "attributesUpdatedTimestamp" in case of any attribute changes.
+ *
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ * @author <a href="mailto:daniel.fesenmeyer@bosch.io">Daniel Fesenmeyer</a>
+ */
+public class DefaultAttributeChangeListener implements AttributeChangeListener {
+
+    private static final String ATTRIBUTES_UPDATED_TIMESTAMP_SET = "org.keycloak.user.attributesUpdatedTimestampSet";
+
+    private final KeycloakSession session;
+
+    public DefaultAttributeChangeListener(KeycloakSession session) {
+        this.session = session;
+    }
+
+    @Override
+    public void onChange(String name, UserModel user, List<String> oldValue) {
+        setAttributesUpdatedTimestamp(user);
+    }
+
+    private void setAttributesUpdatedTimestamp(UserModel userModel) {
+        if (!session.getAttributeOrDefault(ATTRIBUTES_UPDATED_TIMESTAMP_SET, Boolean.FALSE)) {
+            userModel.setAttributesUpdatedTimestamp(Time.currentTimeMillis());
+            session.setAttribute(ATTRIBUTES_UPDATED_TIMESTAMP_SET, Boolean.TRUE);
+        }
+    }
+
+}

--- a/server-spi/src/main/java/org/keycloak/models/UserModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/UserModel.java
@@ -121,6 +121,15 @@ public interface UserModel extends RoleMapperModel {
     
     void setCreatedTimestamp(Long timestamp);
 
+    /**
+     * Get timestamp of last update to attributes. In case of new users, it will return the timestamp of creation.
+     *
+     * <p>May be null for old users last updated before this feature introduction.</p>
+     */
+    Long getAttributesUpdatedTimestamp();
+
+    void setAttributesUpdatedTimestamp(Long timestamp);
+
     boolean isEnabled();
 
     void setEnabled(boolean enabled);

--- a/server-spi/src/main/java/org/keycloak/models/utils/UserModelDelegate.java
+++ b/server-spi/src/main/java/org/keycloak/models/utils/UserModelDelegate.java
@@ -224,6 +224,16 @@ public class UserModelDelegate implements UserModel.Streams {
     }
 
     @Override
+    public Long getAttributesUpdatedTimestamp() {
+        return delegate.getAttributesUpdatedTimestamp();
+    }
+
+    @Override
+    public void setAttributesUpdatedTimestamp(Long timestamp) {
+        delegate.setAttributesUpdatedTimestamp(timestamp);
+    }
+
+    @Override
     public Stream<GroupModel> getGroupsStream() {
         return delegate.getGroupsStream();
     }

--- a/server-spi/src/main/java/org/keycloak/storage/adapter/AbstractUserAdapter.java
+++ b/server-spi/src/main/java/org/keycloak/storage/adapter/AbstractUserAdapter.java
@@ -68,25 +68,25 @@ public abstract class AbstractUserAdapter extends UserModelDefaultMethods {
 
     @Override
     public void addRequiredAction(String action) {
-        throw new ReadOnlyException("user is read only for this update");
+        throwReadOnly();
 
     }
 
     @Override
     public void removeRequiredAction(String action) {
-        throw new ReadOnlyException("user is read only for this update");
+        throwReadOnly();
 
     }
 
     @Override
     public void addRequiredAction(RequiredAction action) {
-        throw new ReadOnlyException("user is read only for this update");
+        throwReadOnly();
 
     }
 
     @Override
     public void removeRequiredAction(RequiredAction action) {
-        throw new ReadOnlyException("user is read only for this update");
+        throwReadOnly();
     }
 
     /**
@@ -119,13 +119,13 @@ public abstract class AbstractUserAdapter extends UserModelDefaultMethods {
 
     @Override
     public void joinGroup(GroupModel group) {
-        throw new ReadOnlyException("user is read only for this update");
+        throwReadOnly();
 
     }
 
     @Override
     public void leaveGroup(GroupModel group) {
-        throw new ReadOnlyException("user is read only for this update");
+        throwReadOnly();
 
     }
 
@@ -152,7 +152,7 @@ public abstract class AbstractUserAdapter extends UserModelDefaultMethods {
 
     @Override
     public void grantRole(RoleModel role) {
-        throw new ReadOnlyException("user is read only for this update");
+        throwReadOnly();
 
     }
 
@@ -182,7 +182,7 @@ public abstract class AbstractUserAdapter extends UserModelDefaultMethods {
 
     @Override
     public void deleteRoleMapping(RoleModel role) {
-        throw new ReadOnlyException("user is read only for this update");
+        throwReadOnly();
 
     }
 
@@ -193,7 +193,7 @@ public abstract class AbstractUserAdapter extends UserModelDefaultMethods {
 
     @Override
     public void setEnabled(boolean enabled) {
-        throw new ReadOnlyException("user is read only for this update");
+        throwReadOnly();
     }
 
     /**
@@ -213,7 +213,7 @@ public abstract class AbstractUserAdapter extends UserModelDefaultMethods {
      */
     @Override
     public void setFederationLink(String link) {
-        throw new ReadOnlyException("user is read only for this update");
+        throwReadOnly();
 
     }
 
@@ -234,7 +234,7 @@ public abstract class AbstractUserAdapter extends UserModelDefaultMethods {
      */
     @Override
     public void setServiceAccountClientLink(String clientInternalId) {
-        throw new ReadOnlyException("user is read only for this update");
+        throwReadOnly();
 
     }
 
@@ -255,6 +255,11 @@ public abstract class AbstractUserAdapter extends UserModelDefaultMethods {
 
     @Override
     public void setUsername(String username) {
+        throwReadOnly();
+
+    }
+
+    private void throwReadOnly() {
         throw new ReadOnlyException("user is read only for this update");
     }
 
@@ -267,25 +272,35 @@ public abstract class AbstractUserAdapter extends UserModelDefaultMethods {
 
     @Override
     public void setCreatedTimestamp(Long timestamp) {
-        throw new ReadOnlyException("user is read only for this update");
+        throwReadOnly();
 
     }
 
     @Override
+    public Long getAttributesUpdatedTimestamp() {
+        return created;
+    }
+
+    @Override
+    public void setAttributesUpdatedTimestamp(Long timestamp) {
+        throwReadOnly();
+    }
+
+    @Override
     public void setSingleAttribute(String name, String value) {
-        throw new ReadOnlyException("user is read only for this update");
+        throwReadOnly();
 
     }
 
     @Override
     public void removeAttribute(String name) {
-        throw new ReadOnlyException("user is read only for this update");
+        throwReadOnly();
 
     }
 
     @Override
     public void setAttribute(String name, List<String> values) {
-        throw new ReadOnlyException("user is read only for this update");
+        throwReadOnly();
 
     }
 
@@ -319,7 +334,7 @@ public abstract class AbstractUserAdapter extends UserModelDefaultMethods {
 
     @Override
     public void setFirstName(String firstName) {
-        throw new ReadOnlyException("user is read only for this update");
+        throwReadOnly();
 
     }
 
@@ -330,7 +345,7 @@ public abstract class AbstractUserAdapter extends UserModelDefaultMethods {
 
     @Override
     public void setLastName(String lastName) {
-        throw new ReadOnlyException("user is read only for this update");
+        throwReadOnly();
 
     }
 
@@ -341,7 +356,7 @@ public abstract class AbstractUserAdapter extends UserModelDefaultMethods {
 
     @Override
     public void setEmail(String email) {
-        throw new ReadOnlyException("user is read only for this update");
+        throwReadOnly();
 
     }
 
@@ -352,7 +367,7 @@ public abstract class AbstractUserAdapter extends UserModelDefaultMethods {
 
     @Override
     public void setEmailVerified(boolean verified) {
-        throw new ReadOnlyException("user is read only for this update");
+        throwReadOnly();
 
     }
 

--- a/server-spi/src/main/java/org/keycloak/storage/adapter/AbstractUserAdapterFederatedStorage.java
+++ b/server-spi/src/main/java/org/keycloak/storage/adapter/AbstractUserAdapterFederatedStorage.java
@@ -53,6 +53,7 @@ public abstract class AbstractUserAdapterFederatedStorage extends UserModelDefau
     public static String EMAIL_ATTRIBUTE = "EMAIL";
     public static String EMAIL_VERIFIED_ATTRIBUTE = "EMAIL_VERIFIED";
     public static String CREATED_TIMESTAMP_ATTRIBUTE = "CREATED_TIMESTAMP";
+    public static String ATTRIBUTES_UPDATED_TIMESTAMP_ATTRIBUTE = "ATTRIBUTES_UPDATED_TIMESTAMP";
     public static String ENABLED_ATTRIBUTE = "ENABLED";
 
 
@@ -311,6 +312,18 @@ public abstract class AbstractUserAdapterFederatedStorage extends UserModelDefau
             setSingleAttribute(CREATED_TIMESTAMP_ATTRIBUTE, Long.toString(timestamp));
         }
 
+    }
+
+    @Override
+    public Long getAttributesUpdatedTimestamp() {
+        String val = getFirstAttribute(ATTRIBUTES_UPDATED_TIMESTAMP_ATTRIBUTE);
+        return val == null ? null : Long.valueOf(val);
+    }
+
+    @Override
+    public void setAttributesUpdatedTimestamp(Long timestamp) {
+        String val = timestamp == null ? null : Long.toString(timestamp);
+        setSingleAttribute(ATTRIBUTES_UPDATED_TIMESTAMP_ATTRIBUTE, val);
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/authentication/authenticators/broker/IdpReviewProfileAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/broker/IdpReviewProfileAuthenticator.java
@@ -34,16 +34,17 @@ import org.keycloak.models.utils.FormMessage;
 import org.keycloak.models.utils.UserModelDelegate;
 import org.keycloak.representations.idm.IdentityProviderRepresentation;
 import org.keycloak.services.validation.Validation;
-import org.keycloak.userprofile.UserProfileContext;
-import org.keycloak.userprofile.ValidationException;
 import org.keycloak.userprofile.UserProfile;
+import org.keycloak.userprofile.UserProfileContext;
 import org.keycloak.userprofile.UserProfileProvider;
+import org.keycloak.userprofile.ValidationException;
 
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.Response;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
+
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
 
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
@@ -120,6 +121,14 @@ public class IdpReviewProfileAuthenticator extends AbstractIdpAuthenticator {
             @Override
             public Map<String, List<String>> getAttributes() {
                 return userCtx.getAttributes();
+            }
+
+            @Override
+            public void setAttributesUpdatedTimestamp(Long timestamp) {
+                /*
+                 * overwrite this method with empty implementation to prevent NPE (tracking attribute changes is not
+                 * necessary, because this authenticator is only relevant for user creation, not for update)
+                 */
             }
 
             @Override

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/AccountFormServiceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/AccountFormServiceTest.java
@@ -91,6 +91,7 @@ import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertEquals;
@@ -776,7 +777,34 @@ public class AccountFormServiceTest extends AbstractTestRealmKeycloakTest {
     }
 
     @Test
-    public void changeProfileEmailChangeSetsEmailVerified() throws Exception {
+    public void changeProfileSetsAttributesUpdatedTimestamp() {
+        UserResource userResource = testRealm().users().get(userId);
+        UserRepresentation user = userResource.toRepresentation();
+        Long attributesUpdatedTimestampBeforeUpdate = user.getAttributesUpdatedTimestamp();
+        assertNotNull(attributesUpdatedTimestampBeforeUpdate);
+
+        profilePage.open();
+        loginPage.login("test-user@localhost", "password");
+
+        events.expectLogin().client("account").detail(Details.REDIRECT_URI, getAccountRedirectUrl()).assertEvent();
+
+        // email not changed so flag no reset
+        profilePage.updateProfile(profilePage.getFirstName(), "New last", profilePage.getEmail());
+
+        events.expectAccount(EventType.UPDATE_PROFILE).detail(Details.UPDATED_LAST_NAME, "New last").detail(Details.PREVIOUS_LAST_NAME, "Brady").assertEvent();
+
+        user = userResource.toRepresentation();
+        Long attributesUpdatedTimestampAfterUpdate = user.getAttributesUpdatedTimestamp();
+        assertNotNull(attributesUpdatedTimestampAfterUpdate);
+        assertThat(attributesUpdatedTimestampAfterUpdate, greaterThan(attributesUpdatedTimestampBeforeUpdate));
+
+        // reset user for other tests
+        profilePage.updateProfile("Tom", "Brady", "test-user@localhost");
+        events.clear();
+    }
+
+    @Test
+    public void changeProfileEmailChangeSetsEmailVerified() {
         setEditUsernameAllowed(false);
         setRegistrationEmailAsUsername(false);
 
@@ -794,9 +822,9 @@ public class AccountFormServiceTest extends AbstractTestRealmKeycloakTest {
         profilePage.updateProfile(profilePage.getFirstName(), "New last", profilePage.getEmail());
         user = userResource.toRepresentation();
         assertTrue(user.isEmailVerified());
-        
+
         events.expectAccount(EventType.UPDATE_PROFILE).detail(Details.UPDATED_LAST_NAME, "New last").detail(Details.PREVIOUS_LAST_NAME, "Brady").assertEvent();
-        
+
         //email changed, flag must be reeset
         profilePage.updateProfile(profilePage.getFirstName(), profilePage.getLastName(), "new@email.com");
         Assert.assertEquals("new@email.com", profilePage.getEmail());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/AccountRestServiceWithUserProfileTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/AccountRestServiceWithUserProfileTest.java
@@ -43,7 +43,6 @@ import org.keycloak.testsuite.arquillian.annotation.AuthServerContainerExclude;
 import org.keycloak.testsuite.arquillian.annotation.EnableFeature;
 import org.keycloak.testsuite.forms.VerifyProfileTest;
 import org.keycloak.userprofile.UserProfileContext;
-import org.keycloak.userprofile.EventAuditingAttributeChangeListener;
 
 /**
  * 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/RequiredActionUpdateProfileTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/RequiredActionUpdateProfileTest.java
@@ -40,7 +40,10 @@ import org.keycloak.testsuite.pages.LoginUpdateProfileEditUsernameAllowedPage;
 import org.keycloak.testsuite.util.UserBuilder;
 import org.keycloak.userprofile.UserProfileContext;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -100,6 +103,10 @@ public class RequiredActionUpdateProfileTest extends AbstractTestRealmKeycloakTe
 
     @Test
     public void updateProfile() {
+        UserRepresentation user = ActionUtil.findUserWithAdminClient(adminClient, "test-user@localhost");
+        Long attributesUpdatedTimestampBeforeUpdate = user.getAttributesUpdatedTimestamp();
+        assertNotNull(attributesUpdatedTimestampBeforeUpdate);
+
         loginPage.open();
 
         loginPage.login("test-user@localhost", "password");
@@ -118,13 +125,15 @@ public class RequiredActionUpdateProfileTest extends AbstractTestRealmKeycloakTe
         events.expectLogin().assertEvent();
 
         // assert user is really updated in persistent store
-        UserRepresentation user = ActionUtil.findUserWithAdminClient(adminClient, "test-user@localhost");
+        user = ActionUtil.findUserWithAdminClient(adminClient, "test-user@localhost");
         Assert.assertEquals("New first", user.getFirstName());
         Assert.assertEquals("New last", user.getLastName());
         Assert.assertEquals("new@email.com", user.getEmail());
         Assert.assertEquals("test-user@localhost", user.getUsername());
         // email changed so verify that emailVerified flag is reset
         Assert.assertEquals(false, user.isEmailVerified());
+        // attributesUpdatedTimestamp should have been updated
+        assertThat(user.getAttributesUpdatedTimestamp(), greaterThan(attributesUpdatedTimestampBeforeUpdate));
     }
 
     @Test

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/exportimport/ExportImportUtil.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/exportimport/ExportImportUtil.java
@@ -61,7 +61,6 @@ import org.keycloak.storage.ldap.mappers.LDAPStorageMapper;
 import org.keycloak.testsuite.ProfileAssume;
 import org.keycloak.testsuite.admin.ApiUtil;
 import org.keycloak.testsuite.client.KeycloakTestingClient;
-import org.keycloak.testsuite.util.RealmRepUtil;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -159,8 +158,9 @@ public class ExportImportUtil {
 
         // Test role mappings
         UserRepresentation admin = findByUsername(realmRsc, "admin");
-        // user without creation timestamp in import
+        // user without timestamps in import
         Assert.assertNull(admin.getCreatedTimestamp());
+        Assert.assertNull(admin.getAttributesUpdatedTimestamp());
         Set<RoleRepresentation> allRoles = allRoles(realmRsc, admin);
         Assert.assertEquals(3, allRoles.size());
         Assert.assertTrue(containsRole(allRoles, findRealmRole(realmRsc, "admin")));
@@ -168,8 +168,9 @@ public class ExportImportUtil {
         Assert.assertTrue(containsRole(allRoles, findClientRole(realmRsc, otherApp.getId(), "otherapp-admin")));
 
         UserRepresentation wburke = findByUsername(realmRsc, "wburke");
-        // user with creation timestamp in import
+        // user with timestamps in import
         Assert.assertEquals(new Long(123654), wburke.getCreatedTimestamp());
+        Assert.assertEquals(new Long(123754), wburke.getAttributesUpdatedTimestamp());
         allRoles = allRoles(realmRsc, wburke);
         Assert.assertEquals(2, allRoles.size());
         Assert.assertFalse(containsRole(allRoles, findRealmRole(realmRsc, "admin")));
@@ -181,9 +182,9 @@ public class ExportImportUtil {
         Assert.assertEquals((Object) 159, wburke.getNotBefore());
 
         UserRepresentation loginclient = findByUsername(realmRsc, "loginclient");
-        // user with creation timestamp as string in import
+        // user with timestamps as string in import
         Assert.assertEquals(new Long(123655), loginclient.getCreatedTimestamp());
-
+        Assert.assertEquals(new Long(123755), loginclient.getAttributesUpdatedTimestamp());
         UserRepresentation hashedPasswordUser = findByUsername(realmRsc, "hashedpassworduser");
         CredentialRepresentation password = realmRsc.users().get(hashedPasswordUser.getId()).credentials().stream()
                 .filter(credential -> PasswordCredentialModel.TYPE.equals(credential.getType()))

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RegisterWithUserProfileTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RegisterWithUserProfileTest.java
@@ -105,6 +105,8 @@ public class RegisterWithUserProfileTest extends RegisterTest {
         assertEquals(RequestType.AUTH_RESPONSE, appPage.getRequestType());
 
         String userId = events.expectRegister("registerUserSuccessLastNameOptional", "registerUserSuccessLastNameOptional@email").assertEvent().getUserId();
+
+        assertLoginEvent(userId, "registerUserSuccessLastNameOptional");
         assertUserRegistered(userId, "registerUserSuccessLastNameOptional", "registerusersuccesslastnameoptional@email", "firstName", "");
     }
 
@@ -126,6 +128,7 @@ public class RegisterWithUserProfileTest extends RegisterTest {
         assertEquals(RequestType.AUTH_RESPONSE, appPage.getRequestType());
 
         String userId = events.expectRegister("registerUserSuccessLastNameRequiredForScope_notRequested", "registerUserSuccessLastNameRequiredForScope_notRequested@email").assertEvent().getUserId();
+        assertLoginEvent(userId, "registerUserSuccessLastNameRequiredForScope_notRequested");
         assertUserRegistered(userId, "registerUserSuccessLastNameRequiredForScope_notRequested", "registerusersuccesslastnamerequiredforscope_notrequested@email", "firstName", "");
     }
 
@@ -199,6 +202,7 @@ public class RegisterWithUserProfileTest extends RegisterTest {
         assertEquals(RequestType.AUTH_RESPONSE, appPage.getRequestType());
 
         String userId = events.expectRegister("registerUserSuccessLastNameLengthValidation", "registerUserSuccessLastNameLengthValidation@email").assertEvent().getUserId();
+        assertLoginEvent(userId, "registerUserSuccessLastNameLengthValidation");
         assertUserRegistered(userId, "registerUserSuccessLastNameLengthValidation", "registerusersuccesslastnamelengthvalidation@email", "firstName", "last");
     }
 
@@ -598,22 +602,6 @@ public class RegisterWithUserProfileTest extends RegisterTest {
         assertEquals("FirstAA", user.getFirstName());
         assertEquals("LastAA", user.getLastName());
         assertEquals(null, user.firstAttribute(ATTRIBUTE_DEPARTMENT));
-    }
-
-
-    private void assertUserRegistered(String userId, String username, String email, String firstName, String lastName) {
-        events.expectLogin().detail("username", username.toLowerCase()).user(userId).assertEvent();
-
-        UserRepresentation user = getUser(userId);
-        Assert.assertNotNull(user);
-        Assert.assertNotNull(user.getCreatedTimestamp());
-        // test that timestamp is current with 10s tollerance
-        Assert.assertTrue((System.currentTimeMillis() - user.getCreatedTimestamp()) < 10000);
-        // test user info is set from form
-        assertEquals(username.toLowerCase(), user.getUsername());
-        assertEquals(email.toLowerCase(), user.getEmail());
-        assertEquals(firstName, user.getFirstName());
-        assertEquals(lastName, user.getLastName());
     }
     
     protected void setUserProfileConfiguration(String configuration) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/model/UserModelTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/model/UserModelTest.java
@@ -49,7 +49,10 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.keycloak.testsuite.util.DateTimeAssert.assertTimestampIsCloseToNow;
+
 import org.keycloak.testsuite.arquillian.annotation.AuthServerContainerExclude.AuthServer;
 
 /**
@@ -83,8 +86,10 @@ public class UserModelTest extends AbstractTestRealmKeycloakTest {
             user.setLastName("last-name");
             user.setEmail("email");
             assertNotNull(user.getCreatedTimestamp());
-            // test that timestamp is current with 10s tollerance
-            Assert.assertTrue((System.currentTimeMillis() - user.getCreatedTimestamp()) < 10000);
+            assertNotNull(user.getAttributesUpdatedTimestamp());
+            assertTimestampIsCloseToNow(user.getCreatedTimestamp());
+            assertTimestampIsCloseToNow(user.getAttributesUpdatedTimestamp());
+            assertEquals(user.getCreatedTimestamp(), user.getAttributesUpdatedTimestamp());
 
             user.addRequiredAction(RequiredAction.CONFIGURE_TOTP);
             user.addRequiredAction(RequiredAction.UPDATE_PASSWORD);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/util/DateTimeAssert.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/util/DateTimeAssert.java
@@ -1,0 +1,34 @@
+package org.keycloak.testsuite.util;
+
+import org.keycloak.common.util.Time;
+
+import static org.junit.Assert.fail;
+
+public final class DateTimeAssert {
+
+    private static final long DEFAULT_TOLERANCE_MS = 10_000;
+
+    private DateTimeAssert() {
+        // nothing to do
+    }
+
+    public static void assertTimestampIsCloseToNow(long timestamp) {
+        assertTimestampIsCloseToNow(timestamp, DEFAULT_TOLERANCE_MS);
+    }
+
+    public static void assertTimestampIsCloseToNow(long timestamp, long toleranceMs) {
+        if (toleranceMs < 0) {
+            throw new IllegalArgumentException();
+        }
+
+        long now = Time.currentTimeMillis();
+        long difference = now - timestamp;
+
+        if (Math.abs(difference) > toleranceMs) {
+            String errorMessage = String.format(
+                    "Difference between now <%d> and timestamp <%d> is <%d>, which exceeds the absolute tolerance of <%d>.",
+                    now, timestamp, difference, toleranceMs);
+            fail(errorMessage);
+        }
+    }
+}

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/webauthn/WebAuthnRegisterAndLoginTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/webauthn/WebAuthnRegisterAndLoginTest.java
@@ -56,6 +56,8 @@ import java.util.List;
 
 import org.junit.Assume;
 import org.junit.BeforeClass;
+
+import static org.keycloak.testsuite.util.DateTimeAssert.assertTimestampIsCloseToNow;
 import static org.keycloak.testsuite.util.ServerURLs.AUTH_SERVER_SSL_REQUIRED;
 
 @EnableFeature(value = Profile.Feature.WEB_AUTHN, skipRestart = true, onlyForProduct = true)
@@ -293,8 +295,7 @@ public class WebAuthnRegisterAndLoginTest extends AbstractTestRealmKeycloakTest 
         UserRepresentation user = getUser(userId);
         Assert.assertNotNull(user);
         Assert.assertNotNull(user.getCreatedTimestamp());
-        // test that timestamp is current with 60s tollerance
-        Assert.assertTrue((System.currentTimeMillis() - user.getCreatedTimestamp()) < 60000);
+        assertTimestampIsCloseToNow(user.getCreatedTimestamp(), 60_000);
         // test user info is set from form
         assertEquals(username.toLowerCase(), user.getUsername());
         assertEquals(email.toLowerCase(), user.getEmail());

--- a/testsuite/integration-arquillian/tests/base/src/test/resources/model/testrealm.json
+++ b/testsuite/integration-arquillian/tests/base/src/test/resources/model/testrealm.json
@@ -128,7 +128,8 @@
         {
             "username": "wburke",
             "enabled": true,
-            "createdTimestamp" : 123654,
+            "createdTimestamp": 123654,
+            "attributesUpdatedTimestamp": 123754,
             "notBefore": 159,
             "attributes": {
                 "old-email": "bburke@redhat.com"
@@ -147,6 +148,7 @@
         {
             "username": "loginclient",
             "createdTimestamp" : "123655",
+            "attributesUpdatedTimestamp" : "123755",
             "enabled": true,
             "credentials": [
                 {

--- a/testsuite/integration-arquillian/tests/base/src/test/resources/testrealm.json
+++ b/testsuite/integration-arquillian/tests/base/src/test/resources/testrealm.json
@@ -38,7 +38,9 @@
       "clientRoles": {
         "test-app": [ "customer-user" ],
         "account": [ "view-profile", "manage-account" ]
-      }
+      },
+      "createdTimestamp": 1183784827,
+      "attributesUpdatedTimestamp": 1183784828
     },
     {
       "username" : "john-doh@localhost",

--- a/themes/src/main/resources/theme/base/admin/messages/admin-messages_en.properties
+++ b/themes/src/main/resources/theme/base/admin/messages/admin-messages_en.properties
@@ -1506,6 +1506,7 @@ send-email=Send email
 credentials.reset-actions-email.tooltip=Sends an email to user with an embedded link. Clicking the link enables the user to execute the reset actions without first logging in. For example, set the action to update password, click this button, and the user can change the password without logging in.
 add-user=Add user
 created-at=Created At
+attributes-updated-at=Attributes Last Updated At
 user-enabled=User Enabled
 user-enabled.tooltip=A disabled user cannot login.
 user-temporarily-locked=User Temporarily Locked

--- a/themes/src/main/resources/theme/base/admin/resources/partials/user-detail.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/user-detail.html
@@ -11,21 +11,28 @@
 
         <fieldset class="border-top">
             <div class="form-group">
-                <label class="col-md-2 control-label"for="id">{{:: 'id' | translate}}</label>
+                <label class="col-md-2 control-label" for="id">{{:: 'id' | translate}}</label>
                 <div class="col-md-6">
                     <input class="form-control" type="text" id="id" name="id" data-ng-model="user.id" autofocus data-ng-readonly="true">
                 </div>
             </div>
             
             <div class="form-group">
-                <label class="col-md-2 control-label"for="id">{{:: 'created-at' | translate}}</label>
+                <label class="col-md-2 control-label">{{:: 'created-at' | translate}}</label>
                 <div class="col-md-6">
                     {{user.createdTimestamp|date:('dateFormat' | translate)}}&nbsp;{{user.createdTimestamp|date:('timeFormat' | translate)}}
                 </div>
             </div>
 
+            <div class="form-group">
+                <label class="col-md-2 control-label">{{:: 'attributes-updated-at' | translate}}</label>
+                <div class="col-md-6">
+                    {{user.attributesUpdatedTimestamp|date:('dateFormat' | translate)}}&nbsp;{{user.attributesUpdatedTimestamp|date:('timeFormat' | translate)}}
+                </div>
+            </div>
+
             <div class="form-group" data-ng-hide="emailAsUsername">
-                <label class="col-md-2 control-label"for="username">{{:: 'username' | translate}} <span class="required" data-ng-show="create">*</span></label>
+                <label class="col-md-2 control-label" for="username">{{:: 'username' | translate}} <span class="required" data-ng-show="create">*</span></label>
                 <div class="col-md-6">
                     <!-- Characters >,<,/,\ are forbidden in username -->
                     <input class="form-control" type="text" id="username" name="username" data-ng-model="user.username" autofocus


### PR DESCRIPTION
This Draft PR adds a lastUpdatedTimestamp to the user (according to KEYCLOAK-18607).

It is currently implemented the following way:
- lastUpdatedTimestamp is set to the same value as the createdTimestamp, when a user is created (Event REGISTER, Admin Event CREATE)
- lastUpdatedTimestamp is updated whenever user profile or email-verified is changed (Events UPDATE_PROFILE and VERIFY_EMAIL, Admin Event UPDATE)
- on import, lastUpdatedTimestamp is handled the same way as createdTimestamp: if specified, it will be copied to the target user, otherwise it will be null
- lastUpdatedTimestamp is NOT updated when:
  - other user-related data is changed like required actions, credentials, consent or federated identities
  - user data (profile) is updated by IDP-/LDAP-Mappers (currently there is no means to figure out if user data actually changed by the mappers and there also is no event for such updates)
- in the Admin Console User Detail View, the lastUpdatedTimestamp is displayed directly below createdTimestamp
 
For our use case, the current implementation would be sufficient, with one exception: We need to get notified when user data is changed by an IDP mapper (and lastUpdatedTimestamp should also be changed in this case).
Currently there is no way to find out whether the UserModel was changed by the IDP Mapper or not. We noticed that MapUserEntity has an isUpdated() method, maybe it makes sense to provide something similar in UserModel?
Or perhaps there is a better way to track the changes?

One additional question: With the current implementation, lastUpdatedTimestamp will be null for users which have been created before the introduction of this timestamp. What do you think about a migration step which sets LAST_UPDATED_TIMESTAMP to CREATED_TIMESTAMP for all users?
Or should this be rather part of a custom migration step?

We appreciate your feedback.