### PR TITLE
KEYCLOAK-19021 LDAPOperationManager.getFilterById is causing additional call to AD

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPOperationManager.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPOperationManager.java
@@ -365,33 +365,10 @@ public class LDAPOperationManager {
         String filter = null;
 
         if (this.config.isObjectGUID()) {
-            final String strObjectGUID = "<GUID=" + id + ">";
+            byte[] objectGUID = LDAPUtil.encodeObjectGUID(id);
 
-            try {
-                Attributes attributes = execute(new LdapOperation<Attributes>() {
+            filter = "(&(objectClass=*)(" + getUuidAttributeName() + LDAPConstants.EQUAL + LDAPUtil.convertObjectGUIDToByteString(objectGUID) + "))";
 
-                    @Override
-                    public Attributes execute(LdapContext context) throws NamingException {
-                        return context.getAttributes(strObjectGUID);
-                    }
-
-
-                    @Override
-                    public String toString() {
-                        return new StringBuilder("LdapOperation: GUIDResolve\n")
-                                .append(" strObjectGUID: ").append(strObjectGUID)
-                                .toString();
-                    }
-
-
-                });
-
-                byte[] objectGUID = (byte[]) attributes.get(LDAPConstants.OBJECT_GUID).get();
-
-                filter = "(&(objectClass=*)(" + getUuidAttributeName() + LDAPConstants.EQUAL + LDAPUtil.convertObjectGUIDToByteString(objectGUID) + "))";
-            } catch (NamingException ne) {
-                filter = null;
-            }
         } else if (this.config.isEdirectoryGUID()) {
             filter = "(&(objectClass=*)(" + getUuidAttributeName().toUpperCase() + LDAPConstants.EQUAL + LDAPUtil.convertGUIDToEdirectoryHexString(id) + "))";
         }

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPUtil.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPUtil.java
@@ -130,6 +130,57 @@ public class LDAPUtil {
     }
 
     /**
+     * <p>Encode a string representing the display value of the <code>objectGUID</code> attribute retrieved from Active
+     * Directory.</p>
+     *
+     * @param displayString A string representing the decoded value in the form of [3][2][1][0]-[5][4]-[7][6]-[8][9]-[10][11][12][13][14][15].
+     *
+     * @return A raw byte array representing the value of the <code>objectGUID</code> attribute retrieved from
+     * Active Directory.
+     */
+    public static byte[] encodeObjectGUID(String displayString) {
+        byte [] objectGUID = new byte[16];
+        // [3][2][1][0]
+        objectGUID[0] = (byte) ((Character.digit(displayString.charAt(6), 16) << 4)
+                + Character.digit(displayString.charAt(7), 16));
+        objectGUID[1] = (byte) ((Character.digit(displayString.charAt(4), 16) << 4)
+                + Character.digit(displayString.charAt(5), 16));
+        objectGUID[2] = (byte) ((Character.digit(displayString.charAt(2), 16) << 4)
+                + Character.digit(displayString.charAt(3), 16));
+        objectGUID[3] = (byte) ((Character.digit(displayString.charAt(0), 16) << 4)
+                + Character.digit(displayString.charAt(1), 16));
+        // [5][4]
+        objectGUID[4] = (byte) ((Character.digit(displayString.charAt(11), 16) << 4)
+                + Character.digit(displayString.charAt(12), 16));
+        objectGUID[5] = (byte) ((Character.digit(displayString.charAt(9), 16) << 4)
+                + Character.digit(displayString.charAt(10), 16));
+        // [7][6]
+        objectGUID[6] = (byte) ((Character.digit(displayString.charAt(16), 16) << 4)
+                + Character.digit(displayString.charAt(17), 16));
+        objectGUID[7] = (byte) ((Character.digit(displayString.charAt(14), 16) << 4)
+                + Character.digit(displayString.charAt(15), 16));
+        // [8][9]
+        objectGUID[8] = (byte) ((Character.digit(displayString.charAt(19), 16) << 4)
+                + Character.digit(displayString.charAt(20), 16));
+        objectGUID[9] = (byte) ((Character.digit(displayString.charAt(21), 16) << 4)
+                + Character.digit(displayString.charAt(22), 16));
+        // [10][11][12][13][14][15]
+        objectGUID[10] = (byte) ((Character.digit(displayString.charAt(24), 16) << 4)
+                + Character.digit(displayString.charAt(25), 16));
+        objectGUID[11] = (byte) ((Character.digit(displayString.charAt(26), 16) << 4)
+                + Character.digit(displayString.charAt(27), 16));
+        objectGUID[12] = (byte) ((Character.digit(displayString.charAt(28), 16) << 4)
+                + Character.digit(displayString.charAt(29), 16));
+        objectGUID[13] = (byte) ((Character.digit(displayString.charAt(30), 16) << 4)
+                + Character.digit(displayString.charAt(31), 16));
+        objectGUID[14] = (byte) ((Character.digit(displayString.charAt(32), 16) << 4)
+                + Character.digit(displayString.charAt(33), 16));
+        objectGUID[15] = (byte) ((Character.digit(displayString.charAt(34), 16) << 4)
+                + Character.digit(displayString.charAt(35), 16));
+        return objectGUID;
+    }
+
+    /**
      * <p>Decode a raw byte array representing the value of the <code>objectGUID</code> attribute retrieved from Active
      * Directory.</p>
      *

--- a/federation/ldap/src/test/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPUtilTest.java
+++ b/federation/ldap/src/test/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPUtilTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.keycloak.storage.ldap.idm.store.ldap;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class LDAPUtilTest {
+
+    @Test
+    public void testEncodeDecodeGUID() {
+        String displayGUID = "2f419d1c-6495-479f-b340-9cb419eb9ae7";
+        byte[] bytes = LDAPUtil.encodeObjectGUID(displayGUID);
+        String decodeObjectGUID = LDAPUtil.decodeObjectGUID(bytes);
+        Assert.assertEquals(displayGUID, decodeObjectGUID);
+    }
+}


### PR DESCRIPTION
LDAPOperationManager.getFilterById is causing additional call to AD.

Since [KEYCLOAK-9841](https://issues.redhat.com/browse/KEYCLOAK-9841) use LDAPUser UUID as an identifier instead of username, LDAPOperationManager.getFilterById will called more often.

For converting the GUID to a byte array the code is calling AD. I think the call should be avoided. See attached image of an allocation recording. 

![Ldap-call-in-getFilterById-for-ad](https://user-images.githubusercontent.com/18034775/128866993-39fffdb0-ff55-49ce-8918-e441036de853.png)


