### PR TITLE
KEYCLOAK-18846 URL param kc_locale doesn't work on info and error pages

### DIFF
--- a/services/src/main/java/org/keycloak/locale/DefaultLocaleSelectorProvider.java
+++ b/services/src/main/java/org/keycloak/locale/DefaultLocaleSelectorProvider.java
@@ -63,7 +63,12 @@ public class DefaultLocaleSelectorProvider implements LocaleSelectorProvider {
     private Locale getUserLocale(RealmModel realm, AuthenticationSessionModel session, UserModel user, HttpHeaders requestHeaders) {
         Locale locale;
 
-        locale = getUserSelectedLocale(realm, session);
+        locale = getUserSelectedLocale(realm);
+        if (locale != null) {
+            return locale;
+        }
+
+        locale = getAuthSessionLocale(realm, session);
         if (locale != null) {
             return locale;
         }
@@ -91,7 +96,16 @@ public class DefaultLocaleSelectorProvider implements LocaleSelectorProvider {
         return null;
     }
 
-    private Locale getUserSelectedLocale(RealmModel realm, AuthenticationSessionModel session) {
+    private Locale getUserSelectedLocale(RealmModel realm) {
+        String locale = this.session.getContext().getUri().getQueryParameters().getFirst(KC_LOCALE_PARAM);
+        if (locale == null) {
+            return null;
+        } else {
+            return findLocale(realm, locale);
+        }
+    }
+
+    private Locale getAuthSessionLocale(RealmModel realm, AuthenticationSessionModel session) {
         if (session == null) {
             return null;
         }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/i18n/EmailTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/i18n/EmailTest.java
@@ -133,7 +133,7 @@ public class EmailTest extends AbstractI18NTest {
         String link = MailUtils.getPasswordResetEmailLink(greenMail.getLastReceivedMessage());
 
         // Make sure kc_locale added to link doesn't set locale
-        link += "&kc_locale=de";
+        link += "&kc_locale=en";
         
         DroneUtils.getCurrentDriver().navigate().to(link);
         WaitUtils.waitForPageToLoad();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/i18n/InfoPageTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/i18n/InfoPageTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.testsuite.i18n;
+
+import org.jboss.arquillian.graphene.page.Page;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.keycloak.services.resources.LoginActionsService;
+import org.keycloak.testsuite.AssertEvents;
+import org.keycloak.testsuite.pages.AppPage;
+import org.keycloak.testsuite.pages.AppPage.RequestType;
+import org.keycloak.testsuite.pages.InfoPage;
+import org.keycloak.testsuite.pages.LoginPage;
+import org.keycloak.testsuite.util.OAuthClient;
+
+import javax.ws.rs.core.UriBuilder;
+
+public class InfoPageTest extends AbstractI18NTest {
+
+    @Rule
+    public AssertEvents events = new AssertEvents(this);
+
+    @Page
+    protected InfoPage infoPage;
+
+    @Page
+    protected LoginPage loginPage;
+
+    @Page
+    protected AppPage appPage;
+
+    //KEYCLOAK-18846
+    @Test
+    public void changeLanguage() {
+
+        loginPage.open();
+        loginPage.login("test-user@localhost", "password");
+
+        appPage.assertCurrent();
+        Assert.assertEquals(RequestType.AUTH_RESPONSE, appPage.getRequestType());
+        events.expectLogin().assertEvent();
+
+        UriBuilder baseUriBuilder = UriBuilder.fromUri(OAuthClient.AUTH_SERVER_ROOT);
+        UriBuilder loginActionsUriBuilder = LoginActionsService.loginActionsBaseUrl(baseUriBuilder);
+        UriBuilder authUriBuilder = loginActionsUriBuilder.path(LoginActionsService.AUTHENTICATE_PATH);
+        String authUrl = authUriBuilder.build(TEST_REALM_NAME).toString();
+        driver.navigate().to(authUrl);
+
+        infoPage.assertCurrent();
+        Assert.assertEquals("English", infoPage.getLanguageDropdownText());
+
+        loginPage.openLanguage("Deutsch");
+
+        infoPage.assertCurrent();
+        Assert.assertEquals("Deutsch", infoPage.getLanguageDropdownText());
+
+    }
+
+}


### PR DESCRIPTION
URL param kc_locale doesn't work on info and error pages
<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
