### PR TITLE
Fix unmatched braces in error log formatter

### DIFF
--- a/services/src/main/java/org/keycloak/keys/DefaultKeyManager.java
+++ b/services/src/main/java/org/keycloak/keys/DefaultKeyManager.java
@@ -81,7 +81,7 @@ public class DefaultKeyManager implements KeyManager {
             }
         }
 
-        logger.errorv("Failed to create fallback key for realm: realm={0} algorithm={1} use={2", realm.getName(), algorithm, use.name());
+        logger.errorv("Failed to create fallback key for realm: realm={0} algorithm={1} use={2}", realm.getName(), algorithm, use.name());
         throw new RuntimeException("Failed to find key: realm=" + realm.getName() + " algorithm=" + algorithm + " use=" + use.name());
     }
 


### PR DESCRIPTION
Fixes the following error:
> LogManager error of type FORMAT_FAILURE: Formatting error
> java.lang.IllegalArgumentException: Unmatched braces in the pattern.
>         at java.base/java.text.MessageFormat.applyPattern(MessageFormat.java:520)
>         at java.base/java.text.MessageFormat.<init>(MessageFormat.java:370)
>         at java.base/java.text.MessageFormat.format(MessageFormat.java:859)
>         ....
> ERROR [org.keycloak.services.error.KeycloakErrorHandler] (default task-1) Uncaught server error: java.lang.RuntimeException: Failed to find key: realm=master algorithm=RS256 use=SIG
>         at org.keycloak.keycloak-services@11.0.3//org.keycloak.keys.DefaultKeyManager.getActiveKey(DefaultKeyManager.java:79)
>         at org.keycloak.keycloak-services@11.0.3//org.keycloak.crypto.ServerAsymmetricSignatureSignerContext.getKey(ServerAsymmetricSignatureSignerContext.java:28)
>         at org.keycloak.keycloak-services@11.0.3//org.keycloak.crypto.ServerAsymmetricSignatureSignerContext.<init>(ServerAsymmetricSignatureSignerContext.java:24)

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
