### PR TITLE
KEYCLOAK-19054 make form buttons consistent

### DIFF
--- a/themes/src/main/resources/theme/keycloak/account/theme.properties
+++ b/themes/src/main/resources/theme/keycloak/account/theme.properties
@@ -8,7 +8,7 @@ stylesCommon=node_modules/patternfly/dist/css/patternfly.min.css node_modules/pa
 # main class used for all buttons
 kcButtonClass=btn
 # classes defining priority of the button - primary or default (there is typically only one priority button for the form)
-kcButtonPrimaryClass=btn-primary
+kcButtonPrimaryClass=pf-m-primary
 kcButtonDefaultClass=btn-default
 # classes defining size of the button
 kcButtonLargeClass=btn-lg


### PR DESCRIPTION
https://issues.redhat.com/browse/KEYCLOAK-19054

This PR fixes the button class inconsistency between login theme and account theme: 

https://github.com/keycloak/keycloak/blob/afa6e31d367ed90912a01dae279b0261ae737a74/themes/src/main/resources/theme/keycloak/login/theme.properties#L78

https://github.com/keycloak/keycloak/blob/afa6e31d367ed90912a01dae279b0261ae737a74/themes/src/main/resources/theme/keycloak/account/theme.properties#L11