### PR TITLE
KEYCLOAK-15773 Enable admin endpoints and admin-console via Feature flags

### DIFF
--- a/common/src/main/java/org/keycloak/common/Profile.java
+++ b/common/src/main/java/org/keycloak/common/Profile.java
@@ -22,6 +22,7 @@ import static org.keycloak.common.Profile.Type.DEPRECATED;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
@@ -89,6 +90,11 @@ public class Profile {
                     break;
             }
         }
+
+        if ((!disabledFeatures.contains(Feature.ADMIN2) || !disabledFeatures.contains(Feature.ADMIN)) && disabledFeatures.contains(Feature.ADMIN_API)) {
+                throw new RuntimeException(String.format("Invalid value for feature: %s needs to be enabled because it is required by feature %s.",
+                        Feature.ADMIN_API, Arrays.asList(Feature.ADMIN, Feature.ADMIN2)));
+        }
     }
 
     private static Profile getInstance() {
@@ -153,6 +159,22 @@ public class Profile {
         ACCOUNT2("New Account Management Console", Type.DEFAULT),
         ACCOUNT_API("Account Management REST API", Type.DEFAULT),
         ADMIN_FINE_GRAINED_AUTHZ("Fine-Grained Admin Permissions", Type.PREVIEW),
+        /**
+         * Controls the availability of the Admin REST-API.
+         */
+        ADMIN_API("Admin API", Type.DEFAULT),
+
+        /**
+         * Controls the availability of the legacy admin-console.
+         * Note that the admin-console requires the {@link #ADMIN_API} feature.
+         */
+        @Deprecated
+        ADMIN("Legacy Admin Console", Type.DEPRECATED),
+
+        /**
+         * Controls the availability of the admin-console.
+         * Note that the admin-console requires the {@link #ADMIN_API} feature.
+         */
         ADMIN2("New Admin Console", Type.DEFAULT),
         DOCKER("Docker Registry protocol", Type.DISABLED_BY_DEFAULT),
         IMPERSONATION("Ability for admins to impersonate users", Type.DEFAULT),

--- a/common/src/test/java/org/keycloak/common/ProfileTest.java
+++ b/common/src/test/java/org/keycloak/common/ProfileTest.java
@@ -24,7 +24,7 @@ public class ProfileTest {
     @Test
     public void checkDefaultsKeycloak() {
         Assert.assertEquals("community", Profile.getName());
-        assertEquals(Profile.getDisabledFeatures(), Profile.Feature.ADMIN_FINE_GRAINED_AUTHZ, Profile.Feature.DYNAMIC_SCOPES, Profile.Feature.DOCKER, Profile.Feature.RECOVERY_CODES, Profile.Feature.SCRIPTS, Profile.Feature.TOKEN_EXCHANGE, Profile.Feature.OPENSHIFT_INTEGRATION, Profile.Feature.MAP_STORAGE, Profile.Feature.DECLARATIVE_USER_PROFILE, Feature.CLIENT_SECRET_ROTATION, Feature.UPDATE_EMAIL);
+        assertEquals(Profile.getDisabledFeatures(), Profile.Feature.ADMIN, Profile.Feature.ADMIN_FINE_GRAINED_AUTHZ, Profile.Feature.DYNAMIC_SCOPES, Profile.Feature.DOCKER, Profile.Feature.RECOVERY_CODES, Profile.Feature.SCRIPTS, Profile.Feature.TOKEN_EXCHANGE, Profile.Feature.OPENSHIFT_INTEGRATION, Profile.Feature.MAP_STORAGE, Profile.Feature.DECLARATIVE_USER_PROFILE, Feature.CLIENT_SECRET_ROTATION, Feature.UPDATE_EMAIL);
         assertEquals(Profile.getPreviewFeatures(), Profile.Feature.ADMIN_FINE_GRAINED_AUTHZ, Profile.Feature.RECOVERY_CODES, Profile.Feature.SCRIPTS, Profile.Feature.TOKEN_EXCHANGE, Profile.Feature.OPENSHIFT_INTEGRATION, Profile.Feature.DECLARATIVE_USER_PROFILE, Feature.CLIENT_SECRET_ROTATION, Feature.UPDATE_EMAIL);
     }
 
@@ -36,7 +36,7 @@ public class ProfileTest {
         Profile.init();
 
         Assert.assertEquals("product", Profile.getName());
-        assertEquals(Profile.getDisabledFeatures(), Profile.Feature.ADMIN_FINE_GRAINED_AUTHZ, Profile.Feature.DYNAMIC_SCOPES, Profile.Feature.DOCKER,  Profile.Feature.RECOVERY_CODES, Profile.Feature.SCRIPTS, Profile.Feature.TOKEN_EXCHANGE, Profile.Feature.OPENSHIFT_INTEGRATION, Profile.Feature.MAP_STORAGE, Profile.Feature.DECLARATIVE_USER_PROFILE, Feature.CLIENT_SECRET_ROTATION, Feature.UPDATE_EMAIL);
+        assertEquals(Profile.getDisabledFeatures(), Profile.Feature.ADMIN, Profile.Feature.ADMIN_FINE_GRAINED_AUTHZ, Profile.Feature.DYNAMIC_SCOPES, Profile.Feature.DOCKER,  Profile.Feature.RECOVERY_CODES, Profile.Feature.SCRIPTS, Profile.Feature.TOKEN_EXCHANGE, Profile.Feature.OPENSHIFT_INTEGRATION, Profile.Feature.MAP_STORAGE, Profile.Feature.DECLARATIVE_USER_PROFILE, Feature.CLIENT_SECRET_ROTATION, Feature.UPDATE_EMAIL);
         assertEquals(Profile.getPreviewFeatures(), Profile.Feature.ADMIN_FINE_GRAINED_AUTHZ, Profile.Feature.RECOVERY_CODES, Profile.Feature.SCRIPTS, Profile.Feature.TOKEN_EXCHANGE, Profile.Feature.OPENSHIFT_INTEGRATION, Profile.Feature.DECLARATIVE_USER_PROFILE, Feature.CLIENT_SECRET_ROTATION, Feature.UPDATE_EMAIL);
 
         System.setProperty("keycloak.profile", "community");

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/services/resources/QuarkusWelcomeResource.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/services/resources/QuarkusWelcomeResource.java
@@ -19,6 +19,7 @@ package org.keycloak.quarkus.runtime.services.resources;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.spi.HttpRequest;
 import org.keycloak.common.ClientConnection;
+import org.keycloak.common.Profile;
 import org.keycloak.common.Version;
 import org.keycloak.common.util.Base64Url;
 import org.keycloak.common.util.MimeTypeUtil;
@@ -173,6 +174,7 @@ public class QuarkusWelcomeResource {
 
             Map<String, Object> map = new HashMap<>();
 
+            map.put("adminConsoleEnabled", isAdminConsoleEnabled());
             map.put("productName", Version.NAME);
             map.put("productNameFull", Version.NAME_FULL);
 
@@ -248,6 +250,10 @@ public class QuarkusWelcomeResource {
             }
         }
         return shouldBootstrap.get();
+    }
+
+    private static boolean isAdminConsoleEnabled() {
+        return Profile.isFeatureEnabled(Profile.Feature.ADMIN2) || Profile.isFeatureEnabled(Profile.Feature.ADMIN);
     }
 
     private boolean isLocal() {

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testBuildHelp.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testBuildHelp.unix.approved.txt
@@ -44,18 +44,18 @@ Transaction:
 Feature:
 
 --features <feature> Enables a set of one or more features. Possible values are: authorization,
-                       account2, account-api, admin-fine-grained-authz, admin2, docker,
-                       impersonation, openshift-integration, scripts, token-exchange, web-authn,
-                       client-policies, ciba, map-storage, par, declarative-user-profile,
-                       dynamic-scopes, client-secret-rotation, step-up-authentication,
-                       recovery-codes, update-email, preview.
+                       account2, account-api, admin-fine-grained-authz, admin-api, admin, admin2,
+                       docker, impersonation, openshift-integration, scripts, token-exchange,
+                       web-authn, client-policies, ciba, map-storage, par,
+                       declarative-user-profile, dynamic-scopes, client-secret-rotation,
+                       step-up-authentication, recovery-codes, update-email, preview.
 --features-disabled <feature>
                      Disables a set of one or more features. Possible values are: authorization,
-                       account2, account-api, admin-fine-grained-authz, admin2, docker,
-                       impersonation, openshift-integration, scripts, token-exchange, web-authn,
-                       client-policies, ciba, map-storage, par, declarative-user-profile,
-                       dynamic-scopes, client-secret-rotation, step-up-authentication,
-                       recovery-codes, update-email, preview.
+                       account2, account-api, admin-fine-grained-authz, admin-api, admin, admin2,
+                       docker, impersonation, openshift-integration, scripts, token-exchange,
+                       web-authn, client-policies, ciba, map-storage, par,
+                       declarative-user-profile, dynamic-scopes, client-secret-rotation,
+                       step-up-authentication, recovery-codes, update-email, preview.
 
 HTTP/TLS:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartDevHelp.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartDevHelp.unix.approved.txt
@@ -67,18 +67,18 @@ Transaction:
 Feature:
 
 --features <feature> Enables a set of one or more features. Possible values are: authorization,
-                       account2, account-api, admin-fine-grained-authz, admin2, docker,
-                       impersonation, openshift-integration, scripts, token-exchange, web-authn,
-                       client-policies, ciba, map-storage, par, declarative-user-profile,
-                       dynamic-scopes, client-secret-rotation, step-up-authentication,
-                       recovery-codes, update-email, preview.
+                       account2, account-api, admin-fine-grained-authz, admin-api, admin, admin2,
+                       docker, impersonation, openshift-integration, scripts, token-exchange,
+                       web-authn, client-policies, ciba, map-storage, par,
+                       declarative-user-profile, dynamic-scopes, client-secret-rotation,
+                       step-up-authentication, recovery-codes, update-email, preview.
 --features-disabled <feature>
                      Disables a set of one or more features. Possible values are: authorization,
-                       account2, account-api, admin-fine-grained-authz, admin2, docker,
-                       impersonation, openshift-integration, scripts, token-exchange, web-authn,
-                       client-policies, ciba, map-storage, par, declarative-user-profile,
-                       dynamic-scopes, client-secret-rotation, step-up-authentication,
-                       recovery-codes, update-email, preview.
+                       account2, account-api, admin-fine-grained-authz, admin-api, admin, admin2,
+                       docker, impersonation, openshift-integration, scripts, token-exchange,
+                       web-authn, client-policies, ciba, map-storage, par,
+                       declarative-user-profile, dynamic-scopes, client-secret-rotation,
+                       step-up-authentication, recovery-codes, update-email, preview.
 
 Hostname:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartDevHelpAll.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartDevHelpAll.unix.approved.txt
@@ -128,18 +128,18 @@ Transaction:
 Feature:
 
 --features <feature> Enables a set of one or more features. Possible values are: authorization,
-                       account2, account-api, admin-fine-grained-authz, admin2, docker,
-                       impersonation, openshift-integration, scripts, token-exchange, web-authn,
-                       client-policies, ciba, map-storage, par, declarative-user-profile,
-                       dynamic-scopes, client-secret-rotation, step-up-authentication,
-                       recovery-codes, update-email, preview.
+                       account2, account-api, admin-fine-grained-authz, admin-api, admin, admin2,
+                       docker, impersonation, openshift-integration, scripts, token-exchange,
+                       web-authn, client-policies, ciba, map-storage, par,
+                       declarative-user-profile, dynamic-scopes, client-secret-rotation,
+                       step-up-authentication, recovery-codes, update-email, preview.
 --features-disabled <feature>
                      Disables a set of one or more features. Possible values are: authorization,
-                       account2, account-api, admin-fine-grained-authz, admin2, docker,
-                       impersonation, openshift-integration, scripts, token-exchange, web-authn,
-                       client-policies, ciba, map-storage, par, declarative-user-profile,
-                       dynamic-scopes, client-secret-rotation, step-up-authentication,
-                       recovery-codes, update-email, preview.
+                       account2, account-api, admin-fine-grained-authz, admin-api, admin, admin2,
+                       docker, impersonation, openshift-integration, scripts, token-exchange,
+                       web-authn, client-policies, ciba, map-storage, par,
+                       declarative-user-profile, dynamic-scopes, client-secret-rotation,
+                       step-up-authentication, recovery-codes, update-email, preview.
 
 Hostname:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartHelp.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartHelp.unix.approved.txt
@@ -73,18 +73,18 @@ Transaction:
 Feature:
 
 --features <feature> Enables a set of one or more features. Possible values are: authorization,
-                       account2, account-api, admin-fine-grained-authz, admin2, docker,
-                       impersonation, openshift-integration, scripts, token-exchange, web-authn,
-                       client-policies, ciba, map-storage, par, declarative-user-profile,
-                       dynamic-scopes, client-secret-rotation, step-up-authentication,
-                       recovery-codes, update-email, preview.
+                       account2, account-api, admin-fine-grained-authz, admin-api, admin, admin2,
+                       docker, impersonation, openshift-integration, scripts, token-exchange,
+                       web-authn, client-policies, ciba, map-storage, par,
+                       declarative-user-profile, dynamic-scopes, client-secret-rotation,
+                       step-up-authentication, recovery-codes, update-email, preview.
 --features-disabled <feature>
                      Disables a set of one or more features. Possible values are: authorization,
-                       account2, account-api, admin-fine-grained-authz, admin2, docker,
-                       impersonation, openshift-integration, scripts, token-exchange, web-authn,
-                       client-policies, ciba, map-storage, par, declarative-user-profile,
-                       dynamic-scopes, client-secret-rotation, step-up-authentication,
-                       recovery-codes, update-email, preview.
+                       account2, account-api, admin-fine-grained-authz, admin-api, admin, admin2,
+                       docker, impersonation, openshift-integration, scripts, token-exchange,
+                       web-authn, client-policies, ciba, map-storage, par,
+                       declarative-user-profile, dynamic-scopes, client-secret-rotation,
+                       step-up-authentication, recovery-codes, update-email, preview.
 
 Hostname:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartHelpAll.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartHelpAll.unix.approved.txt
@@ -134,18 +134,18 @@ Transaction:
 Feature:
 
 --features <feature> Enables a set of one or more features. Possible values are: authorization,
-                       account2, account-api, admin-fine-grained-authz, admin2, docker,
-                       impersonation, openshift-integration, scripts, token-exchange, web-authn,
-                       client-policies, ciba, map-storage, par, declarative-user-profile,
-                       dynamic-scopes, client-secret-rotation, step-up-authentication,
-                       recovery-codes, update-email, preview.
+                       account2, account-api, admin-fine-grained-authz, admin-api, admin, admin2,
+                       docker, impersonation, openshift-integration, scripts, token-exchange,
+                       web-authn, client-policies, ciba, map-storage, par,
+                       declarative-user-profile, dynamic-scopes, client-secret-rotation,
+                       step-up-authentication, recovery-codes, update-email, preview.
 --features-disabled <feature>
                      Disables a set of one or more features. Possible values are: authorization,
-                       account2, account-api, admin-fine-grained-authz, admin2, docker,
-                       impersonation, openshift-integration, scripts, token-exchange, web-authn,
-                       client-policies, ciba, map-storage, par, declarative-user-profile,
-                       dynamic-scopes, client-secret-rotation, step-up-authentication,
-                       recovery-codes, update-email, preview.
+                       account2, account-api, admin-fine-grained-authz, admin-api, admin, admin2,
+                       docker, impersonation, openshift-integration, scripts, token-exchange,
+                       web-authn, client-policies, ciba, map-storage, par,
+                       declarative-user-profile, dynamic-scopes, client-secret-rotation,
+                       step-up-authentication, recovery-codes, update-email, preview.
 
 Hostname:
 

--- a/services/src/main/java/org/keycloak/services/resources/KeycloakApplication.java
+++ b/services/src/main/java/org/keycloak/services/resources/KeycloakApplication.java
@@ -19,8 +19,8 @@ package org.keycloak.services.resources;
 import com.fasterxml.jackson.core.type.TypeReference;
 import org.jboss.logging.Logger;
 import org.keycloak.Config;
+import org.keycloak.common.Profile;
 import org.keycloak.common.crypto.CryptoIntegration;
-import org.keycloak.common.util.BouncyIntegration;
 import org.keycloak.common.util.Resteasy;
 import org.keycloak.common.util.StringPropertyReplacer;
 import org.keycloak.config.ConfigProviderFactory;
@@ -101,7 +101,9 @@ public class KeycloakApplication extends Application {
 
             singletons.add(new RobotsResource());
             singletons.add(new RealmsResource());
-            singletons.add(new AdminRoot());
+            if (Profile.isFeatureEnabled(Profile.Feature.ADMIN_API)) {
+                singletons.add(new AdminRoot());
+            }
             classes.add(ThemeResource.class);
             classes.add(JsResource.class);
 

--- a/services/src/main/java/org/keycloak/services/resources/WelcomeResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/WelcomeResource.java
@@ -18,6 +18,7 @@ package org.keycloak.services.resources;
 
 import org.jboss.logging.Logger;
 import org.keycloak.common.ClientConnection;
+import org.keycloak.common.Profile;
 import org.keycloak.common.Version;
 import org.keycloak.common.util.Base64Url;
 import org.keycloak.common.util.MimeTypeUtil;
@@ -176,6 +177,7 @@ public class WelcomeResource {
 
             Map<String, Object> map = new HashMap<>();
 
+            map.put("adminConsoleEnabled", isAdminConsoleEnabled());
             map.put("productName", Version.NAME);
             map.put("productNameFull", Version.NAME_FULL);
 
@@ -213,6 +215,10 @@ public class WelcomeResource {
         } catch (Exception e) {
             throw new WebApplicationException(Response.Status.INTERNAL_SERVER_ERROR);
         }
+    }
+
+    private static boolean isAdminConsoleEnabled() {
+        return Profile.isFeatureEnabled(Profile.Feature.ADMIN2) || Profile.isFeatureEnabled(Profile.Feature.ADMIN);
     }
 
     private Theme getTheme() {

--- a/themes/src/main/resources/theme/keycloak/welcome/index.ftl
+++ b/themes/src/main/resources/theme/keycloak/welcome/index.ftl
@@ -52,6 +52,7 @@
         <h1>Welcome to <strong>${productNameFull}</strong></h1>
       </div>
       <div class="row">
+        <#if adminConsoleEnabled>
         <div class="col-xs-12 col-sm-4">
           <div class="card-pf h-l">
             <#if successMessage?has_content>
@@ -93,6 +94,7 @@
                     <button id="create-button" type="submit" class="btn btn-primary">Create</button>
                 </form>
             </#if>
+
             <div class="welcome-primary-link">
               <h3><a href="${adminUrl}"><img src="welcome-content/user.png">Administration Console <i class="fa fa-angle-right link" aria-hidden="true"></i></a></h3>
               <div class="description">
@@ -101,6 +103,7 @@
             </div>
           </div>
         </div>
+        </#if> <#-- adminConsoleEnabled -->
         <div class="col-xs-12 col-sm-4">
           <div class="card-pf h-l">
             <h3><a href="${properties.documentationUrl}"><img class="doc-img" src="welcome-content/admin-console.png">Documentation <i class="fa fa-angle-right link" aria-hidden="true"></i></a></h3>


### PR DESCRIPTION
This PR adds the ability to control the availability of the admin-api endpoints and admin-console via feature flags.
This enables administrators to configure the `/admin` endpoint's availability, including the admin REST API and the admin-console per instance.
This allows admins to have public-facing `worker` instances and internal `admin` instances, which reduces the attack surface for the public-facing Keycloak instances.

New feature flags:
- ADMIN_API
Controls whether the `AdminRoot` JAX-RS resource are served via the /admin path

- ADMIN
Controls whether the legacy `admin-console` endpoints are served. 
This flag is marked as deprecated and will be removed once the legacy admin-console is removed.

Note that the existing ADMIN2 feature flag can also be used to control the availability of the "new" admin-console.

To run a Keycloak instance without admin-api and admin-console use:
```
bin/kc.sh --features-disabled=admin-api,admin,admin2
```

To run a Keycloak instance without admin-console use:

```
bin/kc.sh --features-disabled=admin,admin2
```