### PR TITLE
KEYCLOAK-19038 Reload user after being updated

### DIFF
--- a/themes/src/main/resources/theme/base/admin/resources/js/controllers/users.js
+++ b/themes/src/main/resources/theme/base/admin/resources/js/controllers/users.js
@@ -385,7 +385,7 @@ module.controller('UserDetailCtrl', function($scope, realm, user, BruteForceUser
                                              Components,
                                              UserImpersonation, RequiredActions,
                                              UserStorageOperations,
-                                             $location, $http, Dialog, Notifications, $translate, Groups) {
+                                             $location, $http, Dialog, Notifications, $translate, $route, Groups) {
     $scope.realm = realm;
     $scope.create = !user.id;
     $scope.editUsername = $scope.create || $scope.realm.editUsernameAllowed;
@@ -488,10 +488,8 @@ module.controller('UserDetailCtrl', function($scope, realm, user, BruteForceUser
                 realm: realm.realm,
                 userId: $scope.user.id
             }, $scope.user, function () {
-                $scope.changed = false;
-                convertAttributeValuesToString($scope.user);
-                user = angular.copy($scope.user);
                 Notifications.success($translate.instant('user.edit.success'));
+                $route.reload();
             });
         }
     };


### PR DESCRIPTION
Make sure that user is reloaded once he is saved in the admin console.

In some cases (EG. LDAP integration), there can be attributes, which are automatically updated by the LDAP (or other 3rd party user storage provider) during user update. This is for example "modifyDate" attribute in LDAP, which tracks the time of last update of the user and is set by the LDAP server (not by Keycloak). The attribute "modifyDate" (or other similar attributes in case of 3rd party user storage providers) can contain stale time in case that user is not refreshed after he is updated in the admin console, which can cause some issues when trying to update the user.