### PR TITLE
#11707 : Allow Google IDP to pass login_hint

### DIFF
--- a/themes/src/main/resources/theme/base/admin/resources/partials/realm-identity-provider-google-ext.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/realm-identity-provider-google-ext.html
@@ -1,4 +1,11 @@
 <div class="form-group">
+    <label class="col-sm-2 control-label" for="loginHint">{{:: 'loginHint' | translate}}</label>
+    <div class="col-sm-4">
+        <input ng-model="identityProvider.config.loginHint" id="loginHint" onoffswitchvalue on-text="{{:: 'onText' | translate}}" off-text="{{:: 'offText' | translate}}" />
+    </div>
+    <kc-tooltip>{{:: 'loginHint.tooltip' | translate}}</kc-tooltip>
+</div>
+<div class="form-group">
     <label class="col-md-2 control-label" for="hostedDomain">{{:: 'hostedDomain' | translate}}</label>
     <div class="col-md-6">
         <input ng-model="identityProvider.config.hostedDomain" id="hostedDomain" class="form-control" />


### PR DESCRIPTION
#11707  : Allow Google IDP to pass login_hint

This PR allow to have the "Pass Login Hint" toggle when creating a new Google IDP.
The login_hint is supported by Google : https://developers.google.com/identity/protocols/oauth2/openid-connect
