### PR TITLE
KEYCLOAK-19076 Performance Tests Docker Entrypoint Script not executable

### DIFF
--- a/testsuite/performance/keycloak/src/main/scripts/Dockerfile
+++ b/testsuite/performance/keycloak/src/main/scripts/Dockerfile
@@ -19,7 +19,7 @@ ADD *.sh /usr/local/bin/
 
 USER root
 RUN chown -R jboss .; chgrp -R jboss .; chmod -R -v ug+x bin/*.sh ; \
-    chmod -R -v ug+x /usr/local/bin/ 
+    chmod -R -v +x /usr/local/bin/ 
 
 USER jboss
 


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/KEYCLOAK-19076

Entrypoint of Keycloak Docker Image that's used in performance tests is not executable for jboss user