### PR TITLE
KEYCLOAK-18880 TimeBasedOTP should use look-around to mitigate clock skew

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/models/utils/TimeBasedOTP.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/TimeBasedOTP.java
@@ -42,10 +42,10 @@ public class TimeBasedOTP extends HmacOTP {
      * @param algorithm the encryption algorithm
      * @param numberDigits the number of digits for tokens
      * @param timeIntervalInSeconds the number of seconds a token is valid
-     * @param lookAheadWindow the number of previous intervals that should be used to validate tokens.
+     * @param lookAroundWindow the number of previous and following intervals that should be used to validate tokens.
      */
-    public TimeBasedOTP(String algorithm, int numberDigits, int timeIntervalInSeconds, int lookAheadWindow) {
-        super(numberDigits, algorithm, lookAheadWindow);
+    public TimeBasedOTP(String algorithm, int numberDigits, int timeIntervalInSeconds, int lookAroundWindow) {
+        super(numberDigits, algorithm, lookAroundWindow);
         this.clock = new Clock(timeIntervalInSeconds);
     }
 
@@ -60,8 +60,9 @@ public class TimeBasedOTP extends HmacOTP {
         String steps = Long.toHexString(T).toUpperCase();
 
         // Just get a 16 digit string
-        while (steps.length() < 16)
+        while (steps.length() < 16) {
             steps = "0" + steps;
+        }
 
         return generateOTP(secretKey, steps, this.numberDigits, this.algorithm);
     }
@@ -71,17 +72,21 @@ public class TimeBasedOTP extends HmacOTP {
      *
      * @param token  OTP string to validate
      * @param secret Shared secret
-     * @return
+     * @return true of the token is valid
      */
     public boolean validateTOTP(String token, byte[] secret) {
         long currentInterval = this.clock.getCurrentInterval();
 
-        for (int i = this.lookAheadWindow; i >= 0; --i) {
-            String steps = Long.toHexString(currentInterval - i).toUpperCase();
+        for (int i = 0; i <= (lookAheadWindow * 2); i++) {
+            long delta = clockSkewIndexToDelta(i);
+            long adjustedInterval = currentInterval + delta;
+
+            String steps = Long.toHexString(adjustedInterval).toUpperCase();
 
             // Just get a 16 digit string
-            while (steps.length() < 16)
+            while (steps.length() < 16) {
                 steps = "0" + steps;
+            }
 
             String candidate = generateOTP(new String(secret), steps, this.numberDigits, this.algorithm);
 
@@ -91,6 +96,13 @@ public class TimeBasedOTP extends HmacOTP {
         }
 
         return false;
+    }
+
+    /**
+     * maps 0, 1, 2, 3, 4, 5, 6, 7, ... to 0, -1, 1, -2, 2, -3, 3, ...
+     */
+    public static long clockSkewIndexToDelta(int idx) {
+        return (idx + 1) / 2 * (1 - (idx % 2) * 2);
     }
 
     public void setCalendar(Calendar calendar) {

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/TimeBasedOTP.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/TimeBasedOTP.java
@@ -101,7 +101,7 @@ public class TimeBasedOTP extends HmacOTP {
     /**
      * maps 0, 1, 2, 3, 4, 5, 6, 7, ... to 0, -1, 1, -2, 2, -3, 3, ...
      */
-    public static long clockSkewIndexToDelta(int idx) {
+    private long clockSkewIndexToDelta(int idx) {
         return (idx + 1) / 2 * (1 - (idx % 2) * 2);
     }
 

--- a/server-spi-private/src/test/java/org/keycloak/models/TotpTest.java
+++ b/server-spi-private/src/test/java/org/keycloak/models/TotpTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.models;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.keycloak.models.utils.TimeBasedOTP;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Calendar;
+
+public class TotpTest {
+
+    @Test
+    public void testTotp() {
+
+        TimeBasedOTP totp = new TimeBasedOTP("HmacSHA1", 8, 30, 1);
+        String secret = "dSdmuHLQhkm54oIm0A0S";
+        String otp = totp.generateTOTP(secret);
+
+        Assert.assertTrue(totp.validateTOTP(otp, secret.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    /**
+     * KEYCLOAK-18880
+     */
+    @Test
+    public void testTotpLookAround() {
+
+        int lookAroundWindow = 2;
+        TimeBasedOTP totp = new TimeBasedOTP("HmacSHA1", 8, 60, lookAroundWindow);
+        String secret = "dSdmuHLQhkm54oIm0A0S";
+        String otp = totp.generateTOTP(secret);
+
+        for (int i = -lookAroundWindow; i <= lookAroundWindow; i++) {
+
+            Calendar calendar = Calendar.getInstance();
+            calendar.add(Calendar.MINUTE, i);
+            totp.setCalendar(calendar);
+
+            Assert.assertTrue("Should accept code with skew offset " + i,totp.validateTOTP(otp, secret.getBytes(StandardCharsets.UTF_8)));
+        }
+    }
+}


### PR DESCRIPTION
Previously the TimeBasedOTP only looked behind to mitigate clock skew.
We now look around (look ahead + look behind) to better accommodate clock skew.

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
