### PR TITLE
KEYCLOAK-18725 Honor pairwise subject identifier for LogoutToken in backchannel logouts

### DIFF
--- a/services/src/main/java/org/keycloak/jose/jws/DefaultTokenManager.java
+++ b/services/src/main/java/org/keycloak/jose/jws/DefaultTokenManager.java
@@ -39,13 +39,16 @@ import org.keycloak.models.AuthenticatedClientSessionModel;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.Constants;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.ProtocolMapperModel;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.TokenManager;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.utils.KeycloakModelUtils;
+import org.keycloak.protocol.ProtocolMapperUtils;
 import org.keycloak.protocol.oidc.OIDCAdvancedConfigWrapper;
 import org.keycloak.protocol.oidc.OIDCConfigAttributes;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
+import org.keycloak.protocol.oidc.mappers.AbstractPairwiseSubMapper;
 import org.keycloak.representations.LogoutToken;
 import org.keycloak.util.JsonSerialization;
 import org.keycloak.util.TokenUtil;
@@ -332,8 +335,21 @@ public class DefaultTokenManager implements TokenManager {
         if (oidcAdvancedConfigWrapper.getBackchannelLogoutRevokeOfflineTokens()){
             token.putEvents(TokenUtil.TOKEN_BACKCHANNEL_LOGOUT_EVENT_REVOKE_OFFLINE_TOKENS, true);
         }
-        token.setSubject(user.getId());
+
+        String localSub = user.getId();
+        token.setSubject(localSub);
+
+        // adjust the subject in the logout token in case we have an PairwiseSubMapper
+        ProtocolMapperUtils.getSortedProtocolMappers(session, client)
+                .filter(mapperEntry -> mapperEntry.getValue() instanceof AbstractPairwiseSubMapper)
+                .forEach(mapperEntry -> {
+                    AbstractPairwiseSubMapper mapper = (AbstractPairwiseSubMapper) mapperEntry.getValue();
+                    ProtocolMapperModel model = mapperEntry.getKey();
+                    String sectorIdentifier = mapper.getSectorIdentifier(client, model);
+                    token.setSubject(mapper.generateSub(model,sectorIdentifier, localSub));
+                });
 
         return token;
     }
+
 }

--- a/services/src/main/java/org/keycloak/protocol/ProtocolMapperUtils.java
+++ b/services/src/main/java/org/keycloak/protocol/ProtocolMapperUtils.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.protocol;
 
+import org.keycloak.models.ClientModel;
 import org.keycloak.models.ClientSessionContext;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
@@ -26,6 +27,7 @@ import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.protocol.oidc.OIDCLoginProtocolFactory;
 
 import java.lang.reflect.Method;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
@@ -131,6 +133,20 @@ public class ProtocolMapperUtils {
                     Map<ProtocolMapperModel, ProtocolMapper> protocolMapperMap = new HashMap<>();
                     protocolMapperMap.put(mapperModel, mapper);
                     return protocolMapperMap.entrySet().stream();
+                })
+                .filter(Objects::nonNull)
+                .sorted(Comparator.comparing(ProtocolMapperUtils::compare));
+    }
+
+    public static Stream<Entry<ProtocolMapperModel, ProtocolMapper>> getSortedProtocolMappers(KeycloakSession session, ClientModel client) {
+        KeycloakSessionFactory sessionFactory = session.getKeycloakSessionFactory();
+        return client.getProtocolMappersStream()
+                .flatMap(mapperModel -> {
+                    ProtocolMapper mapper = (ProtocolMapper) sessionFactory.getProviderFactory(ProtocolMapper.class, mapperModel.getProtocolMapper());
+                    if (mapper == null) {
+                        return null;
+                    }
+                    return Collections.singletonMap(mapperModel, mapper).entrySet().stream();
                 })
                 .filter(Objects::nonNull)
                 .sorted(Comparator.comparing(ProtocolMapperUtils::compare));

--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/AbstractPairwiseSubMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/AbstractPairwiseSubMapper.java
@@ -101,7 +101,7 @@ public abstract class AbstractPairwiseSubMapper extends AbstractOIDCProtocolMapp
         return configProperties;
     }
 
-    private String getSectorIdentifier(ClientModel client, ProtocolMapperModel mappingModel) {
+    public String getSectorIdentifier(ClientModel client, ProtocolMapperModel mappingModel) {
         String sectorIdentifierUri = PairwiseSubMapperHelper.getSectorIdentifierUri(mappingModel);
         if (sectorIdentifierUri != null && !sectorIdentifierUri.isEmpty()) {
             return PairwiseSubMapperUtils.resolveValidSectorIdentifier(sectorIdentifierUri);

--- a/services/src/main/java/org/keycloak/services/managers/ResourceAdminManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/ResourceAdminManager.java
@@ -197,14 +197,15 @@ public class ResourceAdminManager {
         return StringPropertyReplacer.replaceProperties(absoluteURI);
     }
 
-    protected Response sendBackChannelLogoutRequestToClientUri(ClientModel resource,
+    protected Response sendBackChannelLogoutRequestToClientUri(ClientModel client,
                                                               AuthenticatedClientSessionModel clientSessionModel, String managementUrl) {
         UserModel user = clientSessionModel.getUserSession().getUser();
 
-        LogoutToken logoutToken = session.tokens().initLogoutToken(resource, user, clientSessionModel);
+        LogoutToken logoutToken = session.tokens().initLogoutToken(client, user, clientSessionModel);
+
         String token = session.tokens().encode(logoutToken);
         if (logger.isDebugEnabled())
-            logger.debugv("logout resource {0} url: {1} sessionIds: ", resource.getClientId(), managementUrl);
+            logger.debugv("logout client {0} url: {1} sessionIds: ", client.getClientId(), managementUrl);
         HttpPost post = null;
         try {
             post = new HttpPost(managementUrl);
@@ -228,7 +229,7 @@ public class ResourceAdminManager {
                 }
             }
         } catch (IOException e) {
-            ServicesLogger.LOGGER.logoutFailed(e, resource.getClientId());
+            ServicesLogger.LOGGER.logoutFailed(e, client.getClientId());
             return Response.serverError().build();
         } finally {
             if (post != null) {


### PR DESCRIPTION
Previously LogoutTokens did contain the original subject identifier, even if
a pairwise subject identifier was configured for the client.
We now honor configured pairwise subject identifiers for backchannel logouts.

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
