### PR TITLE
KEYCLOAK-19106: keycloak-authz-js cannot fetch RPT when using strict mode

### DIFF
--- a/adapters/oidc/js/src/main/resources/keycloak-authz.js
+++ b/adapters/oidc/js/src/main/resources/keycloak-authz.js
@@ -176,13 +176,13 @@
                     permissions = [];
                 }
 
-                for (i = 0; i < permissions.length; i++) {
+                for (let i = 0; i < permissions.length; i++) {
                     var resource = permissions[i];
                     var permission = resource.id;
 
                     if (resource.scopes && resource.scopes.length > 0) {
                         permission += "#";
-                        for (j = 0; j < resource.scopes.length; j++) {
+                        for (let j = 0; j < resource.scopes.length; j++) {
                             var scope = resource.scopes[j];
                             if (permission.indexOf('#') != permission.length - 1) {
                                 permission += ",";


### PR DESCRIPTION
Strict mode prevents the execution of the for loop, without declaring the i & j variables first, resulting in the error "ERROR ReferenceError: i is not defined" when attempting to fetch an RPT token