### PR TITLE
KEYCLOAK-19127 Removed duplicated slash in realm/issuer for Docker registry config f…

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/docker/installation/DockerRegistryConfigFileInstallationProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/docker/installation/DockerRegistryConfigFileInstallationProvider.java
@@ -43,9 +43,9 @@ public class DockerRegistryConfigFileInstallationProvider implements ClientInsta
     public Response generateInstallation(final KeycloakSession session, final RealmModel realm, final ClientModel client, final URI serverBaseUri) {
         final StringBuilder responseString = new StringBuilder("auth:\n")
                 .append("  token:\n")
-                .append("    realm: ").append(serverBaseUri).append("/realms/").append(realm.getName()).append("/protocol/").append(DockerAuthV2Protocol.LOGIN_PROTOCOL).append("/auth\n")
+                .append("    realm: ").append(serverBaseUri).append("realms/").append(realm.getName()).append("/protocol/").append(DockerAuthV2Protocol.LOGIN_PROTOCOL).append("/auth\n")
                 .append("    service: ").append(client.getClientId()).append("\n")
-                .append("    issuer: ").append(serverBaseUri).append("/realms/").append(realm.getName()).append("\n");
+                .append("    issuer: ").append(serverBaseUri).append("realms/").append(realm.getName()).append("\n");
         return Response.ok(responseString.toString(), MediaType.TEXT_PLAIN_TYPE).build();
     }
 

--- a/services/src/main/java/org/keycloak/protocol/docker/installation/DockerVariableOverrideInstallationProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/docker/installation/DockerVariableOverrideInstallationProvider.java
@@ -42,10 +42,10 @@ public class DockerVariableOverrideInstallationProvider implements ClientInstall
     // TODO "auth" is not guaranteed to be the endpoint, fix it
     @Override
     public Response generateInstallation(final KeycloakSession session, final RealmModel realm, final ClientModel client, final URI serverBaseUri) {
-        final StringBuilder builder = new StringBuilder()
-                .append("-e REGISTRY_AUTH_TOKEN_REALM=").append(serverBaseUri).append("/realms/").append(realm.getName()).append("/protocol/").append(DockerAuthV2Protocol.LOGIN_PROTOCOL).append("/auth \\\n")
+        final StringBuilder builder = new StringBuilder()session.getContext().getUri().getBaseUri().toURL()
+                .append("-e REGISTRY_AUTH_TOKEN_REALM=").append(serverBaseUri).append("realms/").append(realm.getName()).append("/protocol/").append(DockerAuthV2Protocol.LOGIN_PROTOCOL).append("/auth \\\n")
                 .append("-e REGISTRY_AUTH_TOKEN_SERVICE=").append(client.getClientId()).append(" \\\n")
-                .append("-e REGISTRY_AUTH_TOKEN_ISSUER=").append(serverBaseUri).append("/realms/").append(realm.getName()).append(" \\\n");
+                .append("-e REGISTRY_AUTH_TOKEN_ISSUER=").append(serverBaseUri).append("realms/").append(realm.getName()).append(" \\\n");
         return Response.ok(builder.toString(), MediaType.TEXT_PLAIN_TYPE).build();
     }
 


### PR DESCRIPTION
The docker-v2 protocol supports three installation methods (in the installation tab). While the `DockerComposeYamlInstallationProvider.java` works fine the `DockerRegistryConfigFileInstallationProvider.java` and `DockerVariableOverrideInstallationProvider.java` have an issue: They append "/realms/" to the serverBaseUri which leads to a duplicated slash - `https://login.hapconnect.de/auth//realms/master/protocol/docker-v2/auth` instead of `https://login.hapconnect.de/auth/realms/master/protocol/docker-v2/auth`. This leads to a 404 when accessing the URL and the whole login process failing. 

The DockerComposeYamlFile only appends "realms/" so I guess that is correct:
REGISTRY_AUTH_TOKEN_REALM: " + authServerUrl + "realms/" + realmName + "/protocol/docker-v2/auth*\n*");

Just as an aside: The DockerComposeYamlInstallationProvider.java uses `session.getContext().getUri().getBaseUri().toURL()`instead of `serverBaseUri`which looks fishy to me. Maybe someone with a better understanding of the code base can look into this.
