### PR TITLE
KEYCLOAK-19119 Added extra logging for INVALID_CLIENT_SESSION

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/AuthenticationProcessor.java
+++ b/services/src/main/java/org/keycloak/authentication/AuthenticationProcessor.java
@@ -964,7 +964,10 @@ public class AuthenticationProcessor {
         if (checkAction) {
             String action = AuthenticationSessionModel.Action.AUTHENTICATE.name();
             if (!code.isValidAction(action)) {
-                throw new AuthenticationFlowException(AuthenticationFlowError.INVALID_CLIENT_SESSION);
+                throw new AuthenticationFlowException("Action " + action +
+                        " not valid for code " + code.getClientSession().getAction() +
+                        " for authenticationSessionId " + authenticationSession.getParentSession().getId(),
+                        AuthenticationFlowError.INVALID_CLIENT_SESSION);
             }
         }
         if (!code.isActionActive(ClientSessionCode.ActionType.LOGIN)) {


### PR DESCRIPTION
<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
https://issues.redhat.com/browse/KEYCLOAK-19119

PR is about having extra logging in case of invalid_client_session to find the root cause easier.