### PR TITLE
Add ability to set default authenticator

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/account/AccountCredentialResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountCredentialResource.java
@@ -296,25 +296,13 @@ public class AccountCredentialResource {
     }
 
     /**
-     * Move a credential to a position behind another credential
+     * Set  a credential as default (first position)
      * @param credentialId The credential to move
      */
-    @Path("{credentialId}/moveToFirst")
+    @Path("{credentialId}/setDefault")
     @POST
-    public void moveToFirst(final @PathParam("credentialId") String credentialId){
-        moveCredentialAfter(credentialId, null);
-    }
-
-    /**
-     * Move a credential to a position behind another credential
-     * @param credentialId The credential to move
-     * @param newPreviousCredentialId The credential that will be the previous element in the list. If set to null, the moved credential will be the first element in the list.
-     */
-    @Path("{credentialId}/moveAfter/{newPreviousCredentialId}")
-    @POST
-    public void moveCredentialAfter(final @PathParam("credentialId") String credentialId, final @PathParam("newPreviousCredentialId") String newPreviousCredentialId){
+    public void setDefault(final @PathParam("credentialId") String credentialId){
         auth.require(AccountRoles.MANAGE_ACCOUNT);
-        session.userCredentialManager().moveCredentialTo(realm, user, credentialId, newPreviousCredentialId);
+        session.userCredentialManager().moveCredentialTo(realm, user, credentialId, null);
     }
-
 }

--- a/services/src/main/java/org/keycloak/services/resources/account/AccountCredentialResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountCredentialResource.java
@@ -29,6 +29,7 @@ import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.NotFoundException;
+import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -294,27 +295,26 @@ public class AccountCredentialResource {
         }
     }
 
-    // TODO: This is kept here for now and commented.
-//    /**
-//     * Move a credential to a position behind another credential
-//     * @param credentialId The credential to move
-//     */
-//    @Path("{credentialId}/moveToFirst")
-//    @POST
-//    public void moveToFirst(final @PathParam("credentialId") String credentialId){
-//        moveCredentialAfter(credentialId, null);
-//    }
-//
-//    /**
-//     * Move a credential to a position behind another credential
-//     * @param credentialId The credential to move
-//     * @param newPreviousCredentialId The credential that will be the previous element in the list. If set to null, the moved credential will be the first element in the list.
-//     */
-//    @Path("{credentialId}/moveAfter/{newPreviousCredentialId}")
-//    @POST
-//    public void moveCredentialAfter(final @PathParam("credentialId") String credentialId, final @PathParam("newPreviousCredentialId") String newPreviousCredentialId){
-//        auth.require(AccountRoles.MANAGE_ACCOUNT);
-//        session.userCredentialManager().moveCredentialTo(realm, user, credentialId, newPreviousCredentialId);
-//    }
+    /**
+     * Move a credential to a position behind another credential
+     * @param credentialId The credential to move
+     */
+    @Path("{credentialId}/moveToFirst")
+    @POST
+    public void moveToFirst(final @PathParam("credentialId") String credentialId){
+        moveCredentialAfter(credentialId, null);
+    }
+
+    /**
+     * Move a credential to a position behind another credential
+     * @param credentialId The credential to move
+     * @param newPreviousCredentialId The credential that will be the previous element in the list. If set to null, the moved credential will be the first element in the list.
+     */
+    @Path("{credentialId}/moveAfter/{newPreviousCredentialId}")
+    @POST
+    public void moveCredentialAfter(final @PathParam("credentialId") String credentialId, final @PathParam("newPreviousCredentialId") String newPreviousCredentialId){
+        auth.require(AccountRoles.MANAGE_ACCOUNT);
+        session.userCredentialManager().moveCredentialTo(realm, user, credentialId, newPreviousCredentialId);
+    }
 
 }

--- a/themes/src/main/resources/theme/keycloak.v2/account/messages/messages_en.properties
+++ b/themes/src/main/resources/theme/keycloak.v2/account/messages/messages_en.properties
@@ -12,6 +12,7 @@ done=Done
 cancel=Cancel
 remove=Remove
 update=Update
+setDefault=Set default
 loadingMessage=Account Console loading ...
 unknownUser=Anonymous
 fullName={0} {1}
@@ -95,6 +96,9 @@ webauthn-passwordless-display-name=Security Key
 webauthn-passwordless-help-text=Use your security key for passwordless log in.
 basic-authentication=Basic Authentication
 invalidRequestMessage=Invalid Request
+successSetDefaultMessage={0} was set as default.
+setDefaultCredTitle=Set {0} as default
+setDefaultCred=Set {0} as default authenticator application?
 
 # Applications page
 applicationsPageTitle=Applications

--- a/themes/src/main/resources/theme/keycloak.v2/account/src/app/content/signingin-page/SigningInPage.tsx
+++ b/themes/src/main/resources/theme/keycloak.v2/account/src/app/content/signingin-page/SigningInPage.tsx
@@ -136,7 +136,7 @@ class SigningInPage extends React.Component<SigningInPageProps, SigningInPageSta
     }
 
     private handleSetDefault = (credentialId: string, userLabel: string) => {
-      this.context!.doPost("/credentials/" + credentialId + "/moveToFirst", {})
+      this.context!.doPost("/credentials/" + credentialId + "/setDefault", {})
         .then(() => {
             this.getCredentialContainers();
             ContentAlert.success('successSetDefaultMessage', [userLabel]);


### PR DESCRIPTION
This implements the ability to set the "default" authenticator application simply by calling the `moveToFirst` API call.

Authenticator application details page changes, adding a "set default" button.
![image](https://user-images.githubusercontent.com/67428/131123871-8ca481df-7713-409e-8cd5-338e5aaa8ee9.png)

Set default dialog
![image](https://user-images.githubusercontent.com/67428/131123969-b64b300c-1db4-4e43-a007-93932ef6d8f8.png)

Is this behaviour acceptable? I saw there is a requirement for adding tests, but I couldn't find tests for the remove action to base my tests on? 

I've just looked at:
```
testsuite/integration-arquillian/tests/other/base-ui/src/test/java/org/keycloak/testsuite/ui/account2/SigningInTest.java
```