### PR TITLE
KEYCLOAK-17812 extend building.md

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -5,7 +5,25 @@ Ensure you have JDK 8 (or newer), Maven 3.5.4 (or newer) and Git installed
     java -version
     mvn -version
     git --version
-    
+
+**NOTE**
+
+For users of _Maven 3.8.1_ or newer: 
+Please add the following mirror to your local _~/.m2/settings.xml_ to avoid build errors:
+```
+<mirrors>
+  <mirror>
+    <id>jboss-public-repository-group-https</id>
+    <mirrorOf>jboss-public-repository-group</mirrorOf>
+    <name>Jboss public https</name>
+    <url>https://repository.jboss.org/nexus/content/groups/public/</url>
+  </mirror>
+</mirrors>
+```
+See this [Jira-Ticket](https://issues.redhat.com/browse/KEYCLOAK-17812) for more details.
+
+---
+
 First clone the Keycloak repository:
     
     git clone https://github.com/keycloak/keycloak.git

--- a/docs/building.md
+++ b/docs/building.md
@@ -8,8 +8,8 @@ Ensure you have JDK 8 (or newer), Maven 3.5.4 (or newer) and Git installed
 
 **NOTE**
 
-For users of _Maven 3.8.1_ or newer: 
-Please add the following mirror to your local _~/.m2/settings.xml_ to avoid build errors:
+If you use Maven 3.8.1 or newer, please add the following mirror to your local 
+`~/.m2/settings.xml` to avoid build errors:
 ```
 <mirrors>
   <mirror>
@@ -20,7 +20,7 @@ Please add the following mirror to your local _~/.m2/settings.xml_ to avoid buil
   </mirror>
 </mirrors>
 ```
-See this [Jira-Ticket](https://issues.redhat.com/browse/KEYCLOAK-17812) for more details.
+See [KEYCLOAK-17812](https://issues.redhat.com/browse/KEYCLOAK-17812) for more details.
 
 ---
 


### PR DESCRIPTION
Added a note describing how to build keycloak from source without errors when using maven 3.8.1 or newer, with link to corresponding jira ticket.