### PR TITLE
KEYCLOAK-19246 Always use locale en-US when executing unit tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1745,7 +1745,7 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <configuration>
                         <forkMode>once</forkMode>
-                        <argLine>-Djava.awt.headless=true ${surefire.memory.settings}</argLine>
+                        <argLine>-Djava.awt.headless=true ${surefire.memory.settings} -Duser.language=en -Duser.region=US</argLine>
                         <runOrder>alphabetical</runOrder>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
The unit test StaxParserUtilTest.testXMLBombAttack fails for non-English locales. To fix this I pinned the locale used by Surefire to "en-US".