### PR TITLE
KEYCLOAK-19250 Use system path separator in Quarkus ConfigurationTest

### DIFF
--- a/quarkus/runtime/src/test/java/org/keycloak/provider/quarkus/ConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/provider/quarkus/ConfigurationTest.java
@@ -192,7 +192,7 @@ public class ConfigurationTest {
         System.setProperty("kc.config.args", "--db=h2-file");
         SmallRyeConfig config = createConfig();
         assertEquals(QuarkusH2Dialect.class.getName(), config.getConfigValue("quarkus.hibernate-orm.dialect").getValue());
-        assertEquals("jdbc:h2:file:~/data/keycloakdb;;AUTO_SERVER=TRUE", config.getConfigValue("quarkus.datasource.jdbc.url").getValue());
+        assertEquals("jdbc:h2:file:~" + File.separator + "data" + File.separator + "keycloakdb;;AUTO_SERVER=TRUE", config.getConfigValue("quarkus.datasource.jdbc.url").getValue());
 
         System.setProperty("kc.config.args", "--db=h2-mem");
         config = createConfig();


### PR DESCRIPTION
The test was not able to run under Windows because it expected to find forward slashes in the path.
