### PR TITLE
KEYCLOAK-18991 Server-config-migration testsuite failing on a bad galleon version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -775,7 +775,7 @@
             <dependency>
                 <groupId>${ee.maven.groupId}</groupId>
                 <artifactId>wildfly-ee-galleon-pack</artifactId>
-                <version>${wildfly.version}</version>
+                <version>${ee.maven.version}</version>
                 <type>zip</type>
             </dependency>
             <dependency>


### PR DESCRIPTION
JIRA: [KEYCLOAK-18991](https://issues.redhat.com/browse/KEYCLOAK-18991)

@drichtarik @pskopek Could you please take a look at it? Thanks.