### PR TITLE
KEYCLOAK-19262 Login/Register UI: Keycloak Background Image Does Not Cover Page

### DIFF
--- a/themes/src/main/resources/theme/keycloak/login/resources/css/login.css
+++ b/themes/src/main/resources/theme/keycloak/login/resources/css/login.css
@@ -1,3 +1,10 @@
+/* Patternfly CSS places a "bg-login.jpg" as the background on this ".login-pf" class.
+   This clashes with the "keycloak-bg.png' background defined on the body below.
+   Therefore the Patternfly background must be set to none. */
+.login-pf {
+    background: none;
+}
+
 .login-pf body {
     background: url("../img/keycloak-bg.png") no-repeat center center fixed;
     background-size: cover;


### PR DESCRIPTION
## Issue

OS: Mac OS X

Browsers: Chrome and Firefox

https://issues.redhat.com/browse/KEYCLOAK-19262

## Problem

On the login and register pages, Keycloak background image stops before the bottom of the page, revealing another background image underneath. To see this you must resize the browser window to have less space vertically, to show the scroll bar. Then scroll down to the bottom of the page.

See screenshot:

<img width="889" alt="Screenshot 2021-09-09 at 11 57 06 am" src="https://user-images.githubusercontent.com/1764083/132673882-35e2d0ca-3135-4748-97b2-d3045b9f2070.png">

<img width="981" alt="Screenshot 2021-09-09 at 12 18 32 pm" src="https://user-images.githubusercontent.com/1764083/132676680-7d5d962d-7693-4ad4-886a-46641a2b901b.png">

## Cause

The Patternfly CSS file:

```
/keycloak/node_modules/patternfly/dist/css/patternfly-additions.min.css
```

Defines a CSS background image:

https://github.com/keycloak/keycloak/blob/master/themes/src/main/resources/theme/keycloak/common/resources/node_modules/patternfly/dist/css/patternfly-additions.css#L5713

However, Keycloak's CSS also defines a background image:

https://github.com/keycloak/keycloak/blob/master/themes/src/main/resources/theme/keycloak/login/resources/css/login.css#L2

The Patternfly background image styles are conflicting with Keycloak's causing the Patternfly background to be shown at the bottom of the page.

## Solution

As Patternfly is a third party package, I've disabled its background image from Keycloak's login.css in this PR. This ensures only the Keycloak background is shown, covering the whole page.
