### PR TITLE
KEYCLOAK-18737 Show sessions functionality does not work consistently

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanUserSessionProvider.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanUserSessionProvider.java
@@ -440,7 +440,7 @@ public class InfinispanUserSessionProvider implements UserSessionProvider {
 
         // return a stream that 'wraps' the infinispan cache stream so that the cache stream's elements are read one by one
         // and then filtered/mapped locally to avoid serialization issues when trying to manipulate the cache stream directly.
-        Stream<UserSessionEntity> stream = StreamSupport.stream(cache.entrySet().stream().spliterator(), true)
+        Stream<UserSessionEntity> stream = StreamSupport.stream(cache.entrySet().stream().spliterator(), false)
                 .filter(predicate)
                 .map(Mappers.userSessionEntity())
                 .sorted(Comparators.userSessionLastSessionRefresh());


### PR DESCRIPTION
### Issue
We are trying to show all the sessions in a realm by selecting Sessions->[my-client]->Show Sessions in the admin console.
This sometimes works and brings all available sessions and sometimes an error is returned

[Jira issue -KEYCLOAK-18737](https://issues.redhat.com/browse/KEYCLOAK-18737)

### Cause
It is related to parallel straem in:

org.keycloak.models.sessions.infinispan.InfinispanUserSessionProvider#getUserSessionModels

`Stream<UserSessionEntity> stream = StreamSupport.stream(cache.entrySet().stream().spliterator(), true)`

When there is bug number of sessions ( >100000) parallel straem has unexpected behavior.

### Solution

Session strem changed to single-thread.
