### PR TITLE
KEYCLOAK-19286 Use client storage provider id to construct client Sto…

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/models/jpa/session/JpaUserSessionPersisterProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/session/JpaUserSessionPersisterProvider.java
@@ -434,7 +434,7 @@ public class JpaUserSessionPersisterProvider implements UserSessionPersisterProv
     private PersistentAuthenticatedClientSessionAdapter toAdapter(RealmModel realm, PersistentUserSessionAdapter userSession, PersistentClientSessionEntity entity) {
         String clientId = entity.getClientId();
         if (!entity.getExternalClientId().equals("local")) {
-            clientId = new StorageId(entity.getClientId(), entity.getExternalClientId()).getId();
+            clientId = new StorageId(entity.getClientStorageProvider(), entity.getExternalClientId()).getId();
         }
         ClientModel client = realm.getClientById(clientId);
 


### PR DESCRIPTION
[KEYCLOAK-19286](https://issues.redhat.com/browse/KEYCLOAK-19286) Use client storage provider id to construct client StorageId, so that a valid 'external' client id will be generated.
