### PR TITLE
KEYCLOAK-19292 Add missing metadata to fix quarkus dev ui rendering

### DIFF
--- a/quarkus/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/quarkus/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,6 +1,7 @@
 ---
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
 name: "Keycloak"
+description: "Keycloak Server"
 metadata:
   keywords:
   - "keycloak"


### PR DESCRIPTION
This allows to open http://localhost:8080/q/dev/ without problems.

Previously opening the /q/dev UI resulted in an Exception being thrown.
```
io.quarkus.qute.TemplateException: Property "description" not found on the base object "java.util.LinkedHashMap" in expression {it.description} in template tags/nonActionableExtension.html on line 21
```

With this in place the quarkus dev ui works as expected.
![image](https://user-images.githubusercontent.com/314690/133146872-fc4b8a2a-d705-47a2-b4d7-c72ec51a2e48.png)


<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
