### PR TITLE
KEYCLOAK-17110 LDAP Connection Pool not used with org.keycloak.truststore.SSLSocketFactory

### DIFF
--- a/services/src/main/java/org/keycloak/truststore/SSLSocketFactory.java
+++ b/services/src/main/java/org/keycloak/truststore/SSLSocketFactory.java
@@ -22,6 +22,7 @@ import org.jboss.logging.Logger;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.Socket;
+import java.util.Comparator;
 
 
 /**
@@ -36,7 +37,7 @@ import java.net.Socket;
  * @author <a href="mailto:mstrukel@redhat.com">Marko Strukelj</a>
  */
 
-public class SSLSocketFactory extends javax.net.ssl.SSLSocketFactory {
+public class SSLSocketFactory extends javax.net.ssl.SSLSocketFactory implements Comparator {
 
     private static final Logger log = Logger.getLogger(SSLSocketFactory.class);
 
@@ -107,4 +108,8 @@ public class SSLSocketFactory extends javax.net.ssl.SSLSocketFactory {
         return sslsf.createSocket();
     }
 
+    @Override
+    public int compare(Object socketFactory1, Object socketFactory2) {
+        return socketFactory1.equals(socketFactory2) ? 0 : -1;
+    }
 }


### PR DESCRIPTION
LDAP Connection Pool not used with org.keycloak.truststore.SSLSocketFactory

[KEYCLOAK-17110](https://issues.redhat.com/browse/KEYCLOAK-17110)

It should be `Comparator<SocketFactory>` ref here [jndi-ldap.html#pooling](http://docs.oracle.com/javase/6/docs/technotes/guides/jndi/jndi-ldap.html#pooling)  
but it must be `Comparator<String>` ref here [pooling-ldap-connections-with-custom-socket-factory](http://stackoverflow.com/questions/23898970/pooling-ldap-connections-with-custom-socket-factory). 
Keep it untyped for now
