### PR TITLE
KEYCLOAK-16246 Revert changes from workaround made in KEYCLOAK-16244 …

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
@@ -947,9 +947,8 @@ public class JpaRealmProvider implements RealmProvider, ClientProvider, ClientSc
     public boolean updateLocalizationText(RealmModel realm, String locale, String key, String text) {
         RealmLocalizationTextsEntity entity = getRealmLocalizationTextsEntity(locale, realm.getId());
         if (entity != null && entity.getTexts() != null && entity.getTexts().containsKey(key)) {
-            Map<String, String> keys = new HashMap<>(entity.getTexts());
-            keys.put(key, text);
-            entity.setTexts(keys);
+            entity.getTexts().put(key, text);
+
             em.persist(entity);
             return true;
         } else {
@@ -966,9 +965,7 @@ public class JpaRealmProvider implements RealmProvider, ClientProvider, ClientSc
             entity.setLocale(locale);
             entity.setTexts(new HashMap<>());
         }
-        Map<String, String> keys = new HashMap<>(entity.getTexts());
-        keys.put(key, text);
-        entity.setTexts(keys);
+        entity.getTexts().put(key, text);
         em.persist(entity);
     }
 
@@ -1008,9 +1005,8 @@ public class JpaRealmProvider implements RealmProvider, ClientProvider, ClientSc
     public boolean deleteLocalizationText(RealmModel realm, String locale, String key) {
         RealmLocalizationTextsEntity entity = getRealmLocalizationTextsEntity(locale, realm.getId());
         if (entity != null && entity.getTexts() != null && entity.getTexts().containsKey(key)) {
-            Map<String, String> keys = new HashMap<>(entity.getTexts());
-            keys.remove(key);
-            entity.setTexts(keys);
+            entity.getTexts().remove(key);
+
             em.persist(entity);
             return true;
         } else {

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/RealmAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/RealmAdapter.java
@@ -2177,9 +2177,6 @@ public class RealmAdapter implements RealmModel, JpaModel<RealmEntity> {
         Map<String, RealmLocalizationTextsEntity> currentLocalizationTexts = realm.getRealmLocalizationTexts();
         if(currentLocalizationTexts.containsKey(locale)) {
             RealmLocalizationTextsEntity localizationTextsEntity = currentLocalizationTexts.get(locale);
-            Map<String, String> keys = new HashMap<>(localizationTextsEntity.getTexts());
-            keys.putAll(localizationTexts);
-            localizationTextsEntity.setTexts(keys);
             localizationTextsEntity.getTexts().putAll(localizationTexts);
 
             em.persist(localizationTextsEntity);

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/RealmLocalizationTextsEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/RealmLocalizationTextsEntity.java
@@ -18,7 +18,6 @@
 package org.keycloak.models.jpa.entities;
 
 import java.io.Serializable;
-import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import javax.persistence.Column;
@@ -35,11 +34,6 @@ import org.keycloak.models.jpa.converter.MapStringConverter;
 @IdClass(RealmLocalizationTextsEntity.RealmLocalizationTextEntityKey.class)
 @Table(name = "REALM_LOCALIZATIONS")
 public class RealmLocalizationTextsEntity {
-
-    // TODO: Remove this constant once the quarkus issue is fixed and use the @Convert annotation in the proper JPA way. Ideally see the github history and revert whole commit,
-    // which adds this "TODO" once the quarkus issue is fixed
-    private static final MapStringConverter MAP_STRING_CONVERTER = new MapStringConverter();
-
     static public class RealmLocalizationTextEntityKey implements Serializable {
         private String realmId;
         private String locale;
@@ -85,25 +79,15 @@ public class RealmLocalizationTextsEntity {
 
     @Nationalized
     @Column(name = "TEXTS")
-    private String texts;
-    // TODO: The @Convert does not work as expected on quarkus. It doesn't update the "texts" in case that updated map has same keys (but different values) as old map had
-//    @Convert(converter = MapStringConverter.class)
-//    private Map<String,String> texts;
+    @Convert(converter = MapStringConverter.class)
+    private Map<String,String> texts;
 
     public Map<String,String> getTexts() {
-        if (texts == null) {
-            return Collections.emptyMap();
-        } else {
-            return Collections.unmodifiableMap(MAP_STRING_CONVERTER.convertToEntityAttribute(texts));
-        }
+        return texts;
     }
 
     public void setTexts(Map<String,String> texts) {
-        if (texts == null) {
-            this.texts = null;
-        } else {
-            this.texts = MAP_STRING_CONVERTER.convertToDatabaseColumn(texts);
-        }
+        this.texts = texts;
     }
 
     public String getLocale() {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/RealmLocalizationResourceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/RealmLocalizationResourceTest.java
@@ -32,7 +32,7 @@ import java.util.Map;
 import javax.ws.rs.NotFoundException;
 
 
-public class RealmRealmLocalizationResourceTest extends AbstractAdminTest {
+public class RealmLocalizationResourceTest extends AbstractAdminTest {
 
     private RealmLocalizationResource resource;
 


### PR DESCRIPTION
…after upgrading to quarkus 2

Also fixed a small typo in testclasses name.
This reverts commit 9b2f2015f7a608a895217176da65031d338a31dc.