### PR TITLE
KEYCLOAK-13701 Fix Corrupted STDOUT warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1748,7 +1748,9 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
+                    <version>3.0.0-M5</version>
                     <configuration>
+                        <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
                         <forkMode>once</forkMode>
                         <argLine>-Djava.awt.headless=true ${surefire.memory.settings}</argLine>
                         <runOrder>alphabetical</runOrder>


### PR DESCRIPTION
Fix by updating surefire plugin to 3.0.0-M5 and adding the forkNode configuration which leads to get the stdout/stderr via TCP instead. See https://issues.apache.org/jira/browse/SUREFIRE-1788 or https://issues.apache.org/jira/browse/SUREFIRE-1881 for more details.
