### PR TITLE
KEYCLOAK-13770 Check if CI fails on JsonImportTests

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/migration/AbstractMigrationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/migration/AbstractMigrationTest.java
@@ -943,7 +943,7 @@ public abstract class AbstractMigrationTest extends AbstractKeycloakTest {
             String response = SimpleHttp.doGet(url.toString(), client).asString();
             Matcher m = Pattern.compile("resources/([^/]*)/welcome").matcher(response);
             assertTrue(m.find());
-            assertTrue(m.group(1).matches("[a-zA-Z0-9_\\-.~]{5}"));
+            assertTrue(m.group(1).matches("[a-zA-Z0-9_\\-.~]{4,5}"));
         } catch (IOException e) {
             fail(e.getMessage());
         }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/migration/JsonFileImport1301MigrationClientPoliciesTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/migration/JsonFileImport1301MigrationClientPoliciesTest.java
@@ -38,7 +38,7 @@ import org.keycloak.util.JsonSerialization;
  *
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
  */
-@AuthServerContainerExclude(value = {AuthServerContainerExclude.AuthServer.REMOTE, AuthServerContainerExclude.AuthServer.QUARKUS}, details = "It works locally for Quarkus, but failing on CI for unknown reason")
+@AuthServerContainerExclude(value = {AuthServerContainerExclude.AuthServer.REMOTE})
 public class JsonFileImport1301MigrationClientPoliciesTest extends AbstractJsonFileImportMigrationTest {
 
     @Override

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/migration/JsonFileImport198MigrationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/migration/JsonFileImport198MigrationTest.java
@@ -35,7 +35,7 @@ import org.keycloak.testsuite.arquillian.annotation.AuthServerContainerExclude.A
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
  */
-@AuthServerContainerExclude(value = {AuthServer.REMOTE, AuthServer.QUARKUS}, details = "It works locally for Quarkus, but failing on CI for unknown reason")
+@AuthServerContainerExclude(value = {AuthServer.REMOTE})
 public class JsonFileImport198MigrationTest extends AbstractJsonFileImportMigrationTest {
 
     @Override

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/migration/JsonFileImport255MigrationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/migration/JsonFileImport255MigrationTest.java
@@ -37,7 +37,7 @@ import org.keycloak.testsuite.arquillian.annotation.AuthServerContainerExclude.A
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
  */
-@AuthServerContainerExclude(value = {AuthServer.REMOTE, AuthServer.QUARKUS}, details = "It works locally for Quarkus, but failing on CI for unknown reason")
+@AuthServerContainerExclude(value = {AuthServer.REMOTE})
 public class JsonFileImport255MigrationTest extends AbstractJsonFileImportMigrationTest {
 
     @Override

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/migration/JsonFileImport343MigrationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/migration/JsonFileImport343MigrationTest.java
@@ -37,7 +37,7 @@ import org.keycloak.testsuite.arquillian.annotation.AuthServerContainerExclude.A
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
  */
-@AuthServerContainerExclude(value = {AuthServer.REMOTE, AuthServer.QUARKUS}, details = "It works locally for Quarkus, but failing on CI for unknown reason")
+@AuthServerContainerExclude(value = {AuthServer.REMOTE})
 public class JsonFileImport343MigrationTest extends AbstractJsonFileImportMigrationTest {
 
     @Override

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/migration/JsonFileImport483MigrationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/migration/JsonFileImport483MigrationTest.java
@@ -33,7 +33,7 @@ import org.keycloak.testsuite.arquillian.annotation.AuthServerContainerExclude.A
 /**
  * Tests that we can import json file from previous version.  MigrationTest only tests DB.
  */
-@AuthServerContainerExclude(value = {AuthServer.REMOTE, AuthServer.QUARKUS}, details = "It works locally for Quarkus, but failing on CI for unknown reason")
+@AuthServerContainerExclude(value = {AuthServer.REMOTE})
 public class JsonFileImport483MigrationTest extends AbstractJsonFileImportMigrationTest {
 
     @Override


### PR DESCRIPTION
WIP: This Draft is to check if the GHA CI still fails on these tests, as stated in the code comments. Locally, the tests run successfully.
