### PR TITLE
[KEYCLOAK-19102] Replace usages of deprecated setAllowNull(boolean) c…

### DIFF
--- a/adapters/saml/wildfly/wildfly-subsystem/src/main/java/org/keycloak/subsystem/adapter/saml/extension/IdentityProviderDefinition.java
+++ b/adapters/saml/wildfly/wildfly-subsystem/src/main/java/org/keycloak/subsystem/adapter/saml/extension/IdentityProviderDefinition.java
@@ -60,25 +60,25 @@ public class IdentityProviderDefinition extends SimpleResourceDefinition {
     private static final ObjectTypeAttributeDefinition SINGLE_SIGN_ON =
             ObjectTypeAttributeDefinition.Builder.of(Constants.Model.SINGLE_SIGN_ON,
                     SingleSignOnDefinition.ATTRIBUTES)
-                    .setAllowNull(false)
+                    .setRequired(true)
                     .build();
 
     private static final ObjectTypeAttributeDefinition SINGLE_LOGOUT =
             ObjectTypeAttributeDefinition.Builder.of(Constants.Model.SINGLE_LOGOUT,
                     SingleLogoutDefinition.ATTRIBUTES)
-                    .setAllowNull(false)
+                    .setRequired(true)
                     .build();
 
     private static final ObjectTypeAttributeDefinition ALLOWED_CLOCK_SKEW =
             ObjectTypeAttributeDefinition.Builder.of(Constants.Model.ALLOWED_CLOCK_SKEW,
                     AllowedClockSkew.ATTRIBUTES)
-                    .setAllowNull(true)
+                    .setRequired(false)
                     .build();
 
     private static final ObjectTypeAttributeDefinition HTTP_CLIENT =
             ObjectTypeAttributeDefinition.Builder.of(Constants.Model.HTTP_CLIENT,
                     HttpClientDefinition.ATTRIBUTES)
-                    .setAllowNull(true)
+                    .setRequired(false)
                     .build();
 
     static final SimpleAttributeDefinition[] ATTRIBUTES = {SIGNATURES_REQUIRED, SIGNATURE_ALGORITHM, SIGNATURE_CANONICALIZATION_METHOD, METADATA_URL};

--- a/adapters/saml/wildfly/wildfly-subsystem/src/main/java/org/keycloak/subsystem/adapter/saml/extension/KeyDefinition.java
+++ b/adapters/saml/wildfly/wildfly-subsystem/src/main/java/org/keycloak/subsystem/adapter/saml/extension/KeyDefinition.java
@@ -64,7 +64,7 @@ public class KeyDefinition extends SimpleResourceDefinition {
     static final ObjectTypeAttributeDefinition KEY_STORE =
             ObjectTypeAttributeDefinition.Builder.of(Constants.Model.KEY_STORE,
                     KeyStoreDefinition.ALL_ATTRIBUTES)
-                    .setAllowNull(true)
+                    .setRequired(false)
                     .build();
 
     static final SimpleAttributeDefinition[] ATTRIBUTES = {SIGNING, ENCRYPTION};

--- a/adapters/saml/wildfly/wildfly-subsystem/src/main/java/org/keycloak/subsystem/adapter/saml/extension/ServiceProviderDefinition.java
+++ b/adapters/saml/wildfly/wildfly-subsystem/src/main/java/org/keycloak/subsystem/adapter/saml/extension/ServiceProviderDefinition.java
@@ -93,7 +93,7 @@ public class ServiceProviderDefinition extends SimpleResourceDefinition {
 
     static final ListAttributeDefinition ROLE_ATTRIBUTES =
             new StringListAttributeDefinition.Builder(Constants.Model.ROLE_ATTRIBUTES)
-                    .setAllowNull(true)
+                    .setRequired(false)
                     .build();
 
     static final SimpleAttributeDefinition ROLE_MAPPINGS_PROVIDER_ID =

--- a/wildfly/server-subsystem/src/main/java/org/keycloak/subsystem/server/attributes/ModulesListAttributeBuilder.java
+++ b/wildfly/server-subsystem/src/main/java/org/keycloak/subsystem/server/attributes/ModulesListAttributeBuilder.java
@@ -27,6 +27,6 @@ public class ModulesListAttributeBuilder extends StringListAttributeDefinition.B
     public ModulesListAttributeBuilder() {
         super("modules");
         setAllowExpression(true);
-        setAllowNull(true);
+        setRequired(false);
     }
 }

--- a/wildfly/server-subsystem/src/main/java/org/keycloak/subsystem/server/attributes/ProvidersListAttributeBuilder.java
+++ b/wildfly/server-subsystem/src/main/java/org/keycloak/subsystem/server/attributes/ProvidersListAttributeBuilder.java
@@ -31,7 +31,7 @@ public class ProvidersListAttributeBuilder extends StringListAttributeDefinition
         provider.add("classpath:${jboss.home.dir}/providers/*");
         this.defaultValue = provider;
         setAllowExpression(true);
-        setAllowNull(true);
+        setRequired(false);
     }
     
 }

--- a/wildfly/server-subsystem/src/main/java/org/keycloak/subsystem/server/extension/ProviderResourceDefinition.java
+++ b/wildfly/server-subsystem/src/main/java/org/keycloak/subsystem/server/extension/ProviderResourceDefinition.java
@@ -39,7 +39,7 @@ public class ProviderResourceDefinition extends SimpleResourceDefinition {
             new SimpleAttributeDefinitionBuilder("enabled", ModelType.BOOLEAN, true)
                     .setAllowExpression(true)
                     .setDefaultValue(new ModelNode(true))
-                    .setAllowNull(false)
+                    .setRequired(true)
                     .setRestartAllServices()
                     .build();
     

--- a/wildfly/server-subsystem/src/main/java/org/keycloak/subsystem/server/extension/ThemeResourceDefinition.java
+++ b/wildfly/server-subsystem/src/main/java/org/keycloak/subsystem/server/extension/ThemeResourceDefinition.java
@@ -58,7 +58,7 @@ public class ThemeResourceDefinition extends SimpleResourceDefinition {
         new SimpleAttributeDefinitionBuilder("cacheThemes", ModelType.BOOLEAN, true)
                 .setAllowExpression(true)
                 .setDefaultValue(new ModelNode(true))
-                .setAllowNull(false)
+                .setRequired(true)
                 .setRestartAllServices()
                 .build();
     
@@ -66,7 +66,7 @@ public class ThemeResourceDefinition extends SimpleResourceDefinition {
         new SimpleAttributeDefinitionBuilder("cacheTemplates", ModelType.BOOLEAN, true)
                 .setAllowExpression(true)
                 .setDefaultValue(new ModelNode(true))
-                .setAllowNull(false)
+                .setRequired(true)
                 .setRestartAllServices()
                 .build();
     


### PR DESCRIPTION
…alls in the adapters subsystems with setRequired(boolean)

 - WildFly will remove deprecated APIs, code needs to be changed before the next WildFly upgrade.

JIra link: https://issues.redhat.com/browse/KEYCLOAK-19102

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
