### PR TITLE
KEYCLOAK-19375 Clarify Admin UI Name of NoCookieFlowRedirectAuthenticator

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/challenge/NoCookieFlowRedirectAuthenticatorFactory.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/challenge/NoCookieFlowRedirectAuthenticatorFactory.java
@@ -82,7 +82,7 @@ public class NoCookieFlowRedirectAuthenticatorFactory implements AuthenticatorFa
 
     @Override
     public String getDisplayType() {
-        return "Browser Redirect/Refresh";
+        return "Browser Redirect for Cookie free authentication";
     }
 
     @Override

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/authentication/InitialFlowsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/authentication/InitialFlowsTest.java
@@ -195,7 +195,7 @@ public class InitialFlowsTest extends AbstractAuthenticationTest {
         addExecExport(flow, "Authentication Options", false, null, true, null, REQUIRED, 20);
 
         execs = new LinkedList<>();
-        addExecInfo(execs, "Browser Redirect/Refresh", "no-cookie-redirect", false, 0, 0, REQUIRED, null, new String[]{REQUIRED});
+        addExecInfo(execs, "Browser Redirect for Cookie free authentication", "no-cookie-redirect", false, 0, 0, REQUIRED, null, new String[]{REQUIRED});
         addExecInfo(execs, "Authentication Options", null, false, 0, 1, REQUIRED, true, new String[]{REQUIRED, ALTERNATIVE, DISABLED, CONDITIONAL});
         addExecInfo(execs, "Basic Auth Challenge", "basic-auth", false, 1, 0, REQUIRED, null, new String[]{REQUIRED, ALTERNATIVE, DISABLED});
         addExecInfo(execs, "Basic Auth Password+OTP", "basic-auth-otp", false, 1, 1, DISABLED, null, new String[]{REQUIRED, ALTERNATIVE, DISABLED});

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/authentication/ProvidersTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/authentication/ProvidersTest.java
@@ -182,7 +182,7 @@ public class ProvidersTest extends AbstractAuthenticationTest {
                 "User reviews and updates profile data retrieved from Identity Provider in the displayed form");
         addProviderInfo(result, "idp-username-password-form", "Username Password Form for identity provider reauthentication",
                 "Validates a password from login form. Username may be already known from identity provider authentication");
-        addProviderInfo(result, "no-cookie-redirect", "Browser Redirect/Refresh", "Perform a 302 redirect to get user agent's current URI on authenticate path with an auth_session_id query parameter.  This is for client's that do not support cookies.");
+        addProviderInfo(result, "no-cookie-redirect", "Browser Redirect for Cookie free authentication", "Perform a 302 redirect to get user agent's current URI on authenticate path with an auth_session_id query parameter.  This is for client's that do not support cookies.");
         addProviderInfo(result, "push-button-authenticator", "TEST: Button Login",
                 "Just press the button to login.");
         addProviderInfo(result, "reset-credential-email", "Send Reset Email", "Send email to user and wait for response.");


### PR DESCRIPTION
In the Admin UI, the NoCookieFlowRedirectAuthenticator was simply called Browser Redirect/Refresh which gives the impression that it is a generic redirector (which would be a cool Authenticator).

This Quick Fix changes the Name to "Browser Redirect for Cookie free authentication" which should bring more clarity (other suggestions appreciated).