### PR TITLE
KEYCLOAK-19390 admin-client: extend ResourceSopesResource by find method

### DIFF
--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/ResourceScopesResource.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/ResourceScopesResource.java
@@ -47,6 +47,14 @@ public interface ResourceScopesResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     List<ScopeRepresentation> scopes();
+    
+    @GET
+    @NoCache
+    @Produces(MediaType.APPLICATION_JSON)
+    List<ScopeRepresentation> find(@QueryParam("scopeId") String id,
+            @QueryParam("name") String name,
+            @QueryParam("first") Integer firstResult,
+            @QueryParam("max") Integer maxResult);
 
     @Path("/search")
     @GET


### PR DESCRIPTION
The find method matches the findAll in ScopeService with its available query params

https://issues.redhat.com/browse/KEYCLOAK-19390
