### PR TITLE
KEYCLOAK-18981 Infinispan: prevent fetching all sessions from remotes

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanUserSessionProvider.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanUserSessionProvider.java
@@ -369,9 +369,8 @@ public class InfinispanUserSessionProvider implements UserSessionProvider {
         cache = CacheDecorators.skipCacheLoaders(cache);
 
         // return a stream that 'wraps' the infinispan cache stream so that the cache stream's elements are read one by one
-        // and then filtered/mapped locally to avoid serialization issues when trying to manipulate the cache stream directly.
-        return StreamSupport.stream(cache.entrySet().stream().spliterator(), true)
-                .filter(predicate)
+        // and then mapped locally to avoid serialization issues when trying to manipulate the cache stream directly.
+        return StreamSupport.stream(cache.entrySet().stream().filter(predicate).spliterator(), true)
                 .map(Mappers.userSessionEntity())
                 .map(entity -> this.wrap(realm, entity, offline));
     }


### PR DESCRIPTION
Move the filter to the inner stream to prevent fetching all sessions, particularly sessions stored on remote cache nodes, for filtering.