### PR TITLE
[Adapter - JavaScript] createLogoutUrl with parameter initiating_idp

### DIFF
--- a/adapters/oidc/js/src/main/resources/keycloak.js
+++ b/adapters/oidc/js/src/main/resources/keycloak.js
@@ -510,6 +510,10 @@
             var url = kc.endpoints.logout()
                 + '?redirect_uri=' + encodeURIComponent(adapter.redirectUri(options, false));
 
+            if (options && options.initiatingIdp) {
+                url += '&initiating_idp=' + encodeURIComponent(options.initiatingIdp);
+            }
+
             return url;
         }
 


### PR DESCRIPTION
Include parameter _initiating_idp_ to the function _createLogoutUrl_ in the Javascript Adapter. The parameter is described in the documentation on [https://www.keycloak.org/docs/latest/securing_apps/index.html#logout](https://www.keycloak.org/docs/latest/securing_apps/index.html#logout)