### PR TITLE
KEYCLOAK-19410 Compile issues in IntelliJ due to imports of sun packages

### DIFF
--- a/common/src/main/java/org/keycloak/common/util/PemUtils.java
+++ b/common/src/main/java/org/keycloak/common/util/PemUtils.java
@@ -35,6 +35,9 @@ import java.security.cert.X509Certificate;
  */
 public final class PemUtils {
 
+    public static final String BEGIN_CERT = "-----BEGIN CERTIFICATE-----";
+    public static final String END_CERT = "-----END CERTIFICATE-----";
+
     static {
         BouncyIntegration.init();
     }

--- a/saml-core/src/main/java/org/keycloak/saml/processing/core/util/XMLSignatureUtil.java
+++ b/saml-core/src/main/java/org/keycloak/saml/processing/core/util/XMLSignatureUtil.java
@@ -16,6 +16,7 @@
  */
 package org.keycloak.saml.processing.core.util;
 
+import org.keycloak.common.util.PemUtils;
 import org.keycloak.dom.xmlsec.w3.xmldsig.DSAKeyValueType;
 import org.keycloak.dom.xmlsec.w3.xmldsig.KeyValueType;
 import org.keycloak.dom.xmlsec.w3.xmldsig.RSAKeyValueType;
@@ -577,7 +578,7 @@ public class XMLSignatureUtil {
     public static X509Certificate getX509CertificateFromKeyInfoString(String certificateString) throws ProcessingException {
         X509Certificate cert = null;
         StringBuilder builder = new StringBuilder();
-        builder.append("-----BEGIN CERTIFICATE-----\n").append(certificateString).append("\n-----END CERTIFICATE-----");
+        builder.append(PemUtils.BEGIN_CERT + "\n").append(certificateString).append("\n" + PemUtils.END_CERT);
 
         String derFormattedString = builder.toString();
 

--- a/services/src/main/java/org/keycloak/protocol/docker/installation/compose/DockerCertFileUtils.java
+++ b/services/src/main/java/org/keycloak/protocol/docker/installation/compose/DockerCertFileUtils.java
@@ -1,5 +1,7 @@
 package org.keycloak.protocol.docker.installation.compose;
 
+import org.keycloak.common.util.PemUtils;
+
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.cert.Certificate;
@@ -7,8 +9,8 @@ import java.security.cert.CertificateEncodingException;
 import java.util.Base64;
 
 public final class DockerCertFileUtils {
-    public static final String BEGIN_CERT = "-----BEGIN CERTIFICATE-----";
-    public static final String END_CERT = "-----END CERTIFICATE-----";
+    public static final String BEGIN_CERT = PemUtils.BEGIN_CERT;
+    public static final String END_CERT = PemUtils.END_CERT;
     public static final String BEGIN_PRIVATE_KEY = "-----BEGIN PRIVATE KEY-----";
     public static final String END_PRIVATE_KEY = "-----END PRIVATE KEY-----";
     public static final String LINE_SEPERATOR = System.getProperty("line.separator");

--- a/services/src/main/java/org/keycloak/services/x509/ApacheProxySslClientCertificateLookup.java
+++ b/services/src/main/java/org/keycloak/services/x509/ApacheProxySslClientCertificateLookup.java
@@ -41,8 +41,8 @@ public class ApacheProxySslClientCertificateLookup extends AbstractClientCertifi
     }
 
     private static String removeBeginEnd(String pem) {
-        pem = pem.replace("-----BEGIN CERTIFICATE-----", "");
-        pem = pem.replace("-----END CERTIFICATE-----", "");
+        pem = pem.replace(PemUtils.BEGIN_CERT, "");
+        pem = pem.replace(PemUtils.END_CERT, "");
         pem = pem.replace("\r\n", "");
         pem = pem.replace("\n", "");
         return pem.trim();
@@ -53,7 +53,7 @@ public class ApacheProxySslClientCertificateLookup extends AbstractClientCertifi
         if (pem == null) {
             return null;
         }
-        if (pem.startsWith("-----BEGIN CERTIFICATE-----")) {
+        if (pem.startsWith(PemUtils.BEGIN_CERT)) {
             pem = removeBeginEnd(pem);
         }
         return PemUtils.decodeCertificate(pem);

--- a/services/src/main/java/org/keycloak/services/x509/NginxProxySslClientCertificateLookup.java
+++ b/services/src/main/java/org/keycloak/services/x509/NginxProxySslClientCertificateLookup.java
@@ -87,8 +87,8 @@ public class NginxProxySslClientCertificateLookup extends AbstractClientCertific
      * @return
      */
     private static String removeBeginEnd(String pem) {
-        pem = pem.replace("-----BEGIN CERTIFICATE-----", "");
-        pem = pem.replace("-----END CERTIFICATE-----", "");
+        pem = pem.replace(PemUtils.BEGIN_CERT, "");
+        pem = pem.replace(PemUtils.END_CERT, "");
         pem = pem.replace("\r\n", "");
         pem = pem.replace("\n", "");
         return pem.trim();
@@ -110,7 +110,7 @@ public class NginxProxySslClientCertificateLookup extends AbstractClientCertific
             log.error("Cannot URL decode the end user TLS Certificate : " + pem,e);
         }
 
-        if (pem.startsWith("-----BEGIN CERTIFICATE-----")) {
+        if (pem.startsWith(PemUtils.BEGIN_CERT)) {
             pem = removeBeginEnd(pem);
         }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/CredentialsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/CredentialsTest.java
@@ -22,6 +22,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.keycloak.admin.client.resource.ClientAttributeCertificateResource;
 import org.keycloak.admin.client.resource.ClientResource;
+import org.keycloak.common.util.PemUtils;
 import org.keycloak.events.admin.OperationType;
 import org.keycloak.events.admin.ResourceType;
 import org.keycloak.models.utils.KeycloakModelUtils;
@@ -170,7 +171,7 @@ public class CredentialsTest extends AbstractClientTest {
         form = new MultipartFormDataOutput();
         form.addFormData("keystoreFormat", "Certificate PEM", MediaType.TEXT_PLAIN_TYPE);
 
-        String certificate2WithHeaders = "-----BEGIN CERTIFICATE-----\n" + certificate2 + "\n-----END CERTIFICATE-----";
+        String certificate2WithHeaders = PemUtils.BEGIN_CERT + "\n" + certificate2 + "\n" + PemUtils.END_CERT;
 
         form.addFormData("file", certificate2WithHeaders.getBytes(Charset.forName("ASCII")), MediaType.APPLICATION_OCTET_STREAM_TYPE);
         cert = certRsc.uploadJks(form);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/docker/DockerClientTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/docker/DockerClientTest.java
@@ -4,6 +4,7 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.keycloak.common.Profile;
+import org.keycloak.common.util.PemUtils;
 import org.keycloak.representations.idm.KeysMetadataRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.testsuite.AbstractKeycloakTest;
@@ -13,7 +14,6 @@ import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.Container;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
-import sun.security.provider.X509Factory;
 
 import java.io.File;
 import java.io.PrintWriter;
@@ -28,6 +28,7 @@ import static org.junit.Assume.assumeTrue;
 import static org.keycloak.testsuite.util.ServerURLs.AUTH_SERVER_PORT;
 import org.keycloak.testsuite.arquillian.annotation.AuthServerContainerExclude;
 import org.keycloak.testsuite.arquillian.annotation.AuthServerContainerExclude.AuthServer;
+
 import static org.keycloak.testsuite.util.WaitUtils.pause;
 
 @AuthServerContainerExclude(AuthServer.REMOTE)
@@ -97,9 +98,9 @@ public class DockerClientTest extends AbstractKeycloakTest {
         File tmpCertFile = File.createTempFile("keycloak-docker-realm-cert-", ".pem");
         tmpCertFile.deleteOnExit();
         PrintWriter tmpCertWriter = new PrintWriter(tmpCertFile);
-        tmpCertWriter.println(X509Factory.BEGIN_CERT);
+        tmpCertWriter.println(PemUtils.BEGIN_CERT);
         tmpCertWriter.println(realmCert);
-        tmpCertWriter.println(X509Factory.END_CERT);
+        tmpCertWriter.println(PemUtils.END_CERT);
         tmpCertWriter.close();
 
         final Map<String, String> environment = new HashMap<>();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/x509/X509OCSPResponderTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/x509/X509OCSPResponderTest.java
@@ -25,6 +25,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.keycloak.authentication.authenticators.x509.X509AuthenticatorConfigModel;
+import org.keycloak.common.util.PemUtils;
 import org.keycloak.representations.idm.AuthenticatorConfigRepresentation;
 import org.keycloak.testsuite.util.OAuthClient;
 
@@ -164,8 +165,8 @@ public class X509OCSPResponderTest extends AbstractX509AuthenticationTest {
                         .setOCSPResponder("http://" + OCSP_RESPONDER_HOST + ":" + OCSP_RESPONDER_PORT + "/oscp")
                         .setOCSPResponderCertificate(
                                 IOUtils.toString(this.getClass().getResourceAsStream(OcspHandler.OCSP_RESPONDER_CERT_PATH), Charsets.UTF_8)
-                                        .replace("-----BEGIN CERTIFICATE-----", "")
-                                        .replace("-----END CERTIFICATE-----", ""))
+                                        .replace(PemUtils.BEGIN_CERT, "")
+                                        .replace(PemUtils.END_CERT, ""))
                         .setUserIdentityMapperType(USERNAME_EMAIL);
         AuthenticatorConfigRepresentation cfg = newConfig("x509-directgrant-config", config.getConfig());
         String cfgId = createConfig(directGrantExecution.getId(), cfg);

--- a/testsuite/integration-arquillian/util/src/main/java/org/keycloak/testsuite/utils/arquillian/DeploymentArchiveProcessorUtils.java
+++ b/testsuite/integration-arquillian/util/src/main/java/org/keycloak/testsuite/utils/arquillian/DeploymentArchiveProcessorUtils.java
@@ -39,7 +39,6 @@ import org.w3c.dom.DOMException;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
-import sun.applet.AppletSecurity;
 
 import static org.keycloak.testsuite.utils.io.IOUtil.modifyDocElementAttribute;
 import static org.keycloak.testsuite.util.ServerURLs.getAppServerContextRoot;


### PR DESCRIPTION
Fixes issues with DeploymentArchiveProcessorUtils and DockerClientTest not compiling in IntelliJ with Java 11 due to importing sun packages.

While removing use of X509Factory.BEGIN_CERT in DockerClientTest I added BEGIN_CERT and END_CERT to PemUtils, and refactored part of the code base that defines these strings to use the constants from PemUtils instead. Not strictly needed to fix the issue, but a small cleanup with minimum risk.