### PR TITLE
KEYCLOAK-19413 : Allow to set login_hint on "registration page" and "reset credentials" pages

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocolService.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocolService.java
@@ -119,6 +119,11 @@ public class OIDCLoginProtocolService {
         return uriBuilder.path(OIDCLoginProtocolService.class, "auth");
     }
 
+    public static UriBuilder registrationsUrl(UriBuilder baseUriBuilder) {
+        UriBuilder uriBuilder = tokenServiceBaseUrl(baseUriBuilder);
+        return uriBuilder.path(OIDCLoginProtocolService.class, "registrations");
+    }
+
     public static UriBuilder delegatedUrl(UriInfo uriInfo) {
         UriBuilder uriBuilder = tokenServiceBaseUrl(uriInfo);
         return uriBuilder.path(OIDCLoginProtocolService.class, "kcinitBrowserLoginComplete");
@@ -172,7 +177,7 @@ public class OIDCLoginProtocolService {
      * Registration endpoint
      */
     @Path("registrations")
-    public Object registerPage() {
+    public Object registrations() {
         AuthorizationEndpoint endpoint = new AuthorizationEndpoint(realm, event);
         ResteasyProviderFactory.getInstance().injectProperties(endpoint);
         return endpoint.register();

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/RegisterPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/RegisterPage.java
@@ -19,6 +19,7 @@ package org.keycloak.testsuite.pages;
 
 import org.jboss.arquillian.graphene.page.Page;
 import org.junit.Assert;
+import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.testsuite.auth.page.AccountFields;
 import org.keycloak.testsuite.auth.page.PasswordFields;
 import org.keycloak.testsuite.util.UIUtils;
@@ -232,7 +233,13 @@ public class RegisterPage extends AbstractPage {
 
     @Override
     public void open() {
-        throw new UnsupportedOperationException();
+        oauth.openRegistrationForm();
+        assertCurrent();
+    }
+
+    public void openWithLoginHint(String loginHint) {
+        oauth.addCustomParameter(OIDCLoginProtocol.LOGIN_HINT_PARAM, loginHint).openRegistrationForm();
+        assertCurrent();
     }
 
 }

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/OAuthClient.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/OAuthClient.java
@@ -1303,6 +1303,10 @@ public class OAuthClient {
         driver.navigate().to(getLoginFormUrl());
     }
 
+    public void openRegistrationForm() {
+        driver.navigate().to(getRegistrationFormUrl());
+    }
+
     public void openOAuth2DeviceVerificationForm(String verificationUri) {
         driver.navigate().to(verificationUri);
     }
@@ -1385,6 +1389,30 @@ public class OAuthClient {
         if (codeChallengeMethod != null) {
             b.queryParam(OAuth2Constants.CODE_CHALLENGE_METHOD, codeChallengeMethod);
         }
+        if (customParameters != null) {
+            customParameters.keySet().stream().forEach(i -> b.queryParam(i, customParameters.get(i)));
+        }
+
+        return b.build(realm).toString();
+    }
+
+    private String getRegistrationFormUrl() {
+        UriBuilder b = OIDCLoginProtocolService.registrationsUrl(UriBuilder.fromUri(baseUrl));
+        if (responseType != null) {
+            b.queryParam(OAuth2Constants.RESPONSE_TYPE, responseType);
+        }
+        if (clientId != null) {
+            b.queryParam(OAuth2Constants.CLIENT_ID, clientId);
+        }
+        if (redirectUri != null) {
+            b.queryParam(OAuth2Constants.REDIRECT_URI, redirectUri);
+        }
+
+        String scopeParam = openid ? TokenUtil.attachOIDCScope(scope) : scope;
+        if (scopeParam != null && !scopeParam.isEmpty()) {
+            b.queryParam(OAuth2Constants.SCOPE, scopeParam);
+        }
+
         if (customParameters != null) {
             customParameters.keySet().stream().forEach(i -> b.queryParam(i, customParameters.get(i)));
         }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RegisterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RegisterTest.java
@@ -606,6 +606,23 @@ public class RegisterTest extends AbstractTestRealmKeycloakTest {
         }
     }
 
+    @Test
+    public void registerWithLoginHint() throws IOException {
+
+        registerPage.openWithLoginHint("username_test");
+
+        assertEquals("username_test", registerPage.getUsername());
+    }
+
+    @Test
+    public void registerWithLoginHint_emailAsUsername() throws IOException {
+        try (RealmAttributeUpdater rau = configureRealmRegistrationEmailAsUsername(true).update()) {
+            registerPage.openWithLoginHint("test@test.com");
+
+            assertEquals("test@test.com", registerPage.getEmail());
+        }
+    }
+
     //KEYCLOAK-14161
     @Test
     public void customRegistrationPageFormTest() {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/ResetPasswordTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/ResetPasswordTest.java
@@ -1209,6 +1209,18 @@ public class ResetPasswordTest extends AbstractTestRealmKeycloakTest {
         assertEquals("Invalid email address.", errorPage.getError());
     }
 
+    @Test
+    public void resetPasswordWithLoginHint() throws IOException {
+        // Redirect directly to KC "forgot password" endpoint instead of "authenticate" endpoint
+        String loginUrl = oauth.getLoginFormUrl();
+        String forgotPasswordUrl = loginUrl.replace("/auth?", "/forgot-credentials?"); // Workaround, but works
+
+        driver.navigate().to(forgotPasswordUrl + "&login_hint=test");
+        resetPasswordPage.assertCurrent();
+
+        assertEquals("test", resetPasswordPage.getUsername());
+    }
+
     private void changePasswordOnUpdatePage(WebDriver driver) {
         assertThat(driver.getPageSource(), Matchers.containsString("You need to change your password."));
 


### PR DESCRIPTION
This PR allows to set login_hint in query params of "registration" page and "reset credentials" page, in order to pre-fill the username or email field.
If registrationEmailAsUsername is set, the login_hint param pre-fills on registration page the email field, else it pre-fills the username field.
