### PR TITLE
[KEYCLOAK-19427] - Upgrade to Quarkus 2.3.0.Final

### DIFF
--- a/quarkus/pom.xml
+++ b/quarkus/pom.xml
@@ -32,16 +32,16 @@
 
     <properties>
         <!-- Quarkus version -->
-        <quarkus.version>2.2.3.Final</quarkus.version>
+        <quarkus.version>2.3.0.Final</quarkus.version>
 
         <!--
             Override versions based on Quarkus dependencies.
             Make sure to update these dependencies when Quarkus version changes.
         -->
         <resteasy.version>4.7.0.Final</resteasy.version>
-        <jackson.version>2.12.4</jackson.version>
+        <jackson.version>2.12.5</jackson.version>
         <jackson.databind.version>${jackson.version}</jackson.databind.version>
-        <hibernate.core.version>5.5.7.Final</hibernate.core.version>
+        <hibernate.core.version>5.6.0.Beta2</hibernate.core.version>
         <mysql.driver.version>8.0.26</mysql.driver.version>
         <postgresql.version>42.2.23</postgresql.version>
         <microprofile-metrics-api.version>3.0</microprofile-metrics-api.version>


### PR DESCRIPTION
This release of Quarkus introduces new capabilities for testing CLI applications.We should be able now to provide better coverage for the distribution itself.