### PR TITLE
KEYCLOAK-19476: Unignore LoginTest.loginWithLongRedirectUri by adding…

### DIFF
--- a/testsuite/integration-arquillian/servers/auth-server/quarkus/src/main/content/conf/keycloak.properties
+++ b/testsuite/integration-arquillian/servers/auth-server/quarkus/src/main/content/conf/keycloak.properties
@@ -35,3 +35,6 @@ spi.password-policy.password-blacklist.blacklists-path=${kc.home.dir:}/dependenc
 
 # http client connection reuse settings
 spi.connections-http-client.default.reuse-connections=false
+
+# set max-length of event representation stored so the db can handle it
+spi.events-store.jpa.max-detail-length=2000

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/LoginTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/LoginTest.java
@@ -220,7 +220,7 @@ public class LoginTest extends AbstractTestRealmKeycloakTest {
         client.close();
     }
 
-    @AuthServerContainerExclude(value = {AuthServerContainerExclude.AuthServer.QUARKUS, AuthServerContainerExclude.AuthServer.REMOTE}, details = "Unstable for Quarkus, review later. Remote testsuite: max-detail-length is set to zero in standalone.xml, proposed fix - KEYCLOAK-17659")
+    @AuthServerContainerExclude(value = {AuthServerContainerExclude.AuthServer.REMOTE}, details = "Remote testsuite: max-detail-length is set to zero in standalone.xml, proposed fix - KEYCLOAK-17659")
     @Test
     public void loginWithLongRedirectUri() throws Exception {
         try (AutoCloseable c = new RealmAttributeUpdater(adminClient.realm("test"))


### PR DESCRIPTION
… property spi.events-store.jpa.max-detail-length to authserver-quarkus' keycloak.properties

