### PR TITLE
KEYCLOAK-19484 Unignore BasicSamlTest testNoPortInDestination for Keycloak.X

### DIFF
--- a/testsuite/integration-arquillian/servers/auth-server/quarkus/src/main/content/conf/keycloak.properties
+++ b/testsuite/integration-arquillian/servers/auth-server/quarkus/src/main/content/conf/keycloak.properties
@@ -38,3 +38,6 @@ spi.connections-http-client.default.reuse-connections=false
 
 # set max-length of event representation stored so the db can handle it
 spi.events-store.jpa.max-detail-length=2000
+
+# set known protocol ports for basicsamltest
+spi.login-protocol.saml.known-protocols=http=${auth.server.http.port:},https=${auth.server.https.port:}

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/containers/KeycloakQuarkusServerDeployableContainer.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/containers/KeycloakQuarkusServerDeployableContainer.java
@@ -180,9 +180,12 @@ public class KeycloakQuarkusServerDeployableContainer implements DeployableConta
             commands.add("--debug");
             commands.add(System.getProperty("auth.server.debug.port", "5005"));
         }
-
         commands.add("--http-port=" + configuration.getBindHttpPort());
         commands.add("--https-port=" + configuration.getBindHttpsPort());
+
+        //for setting the spi.login-protocol.saml.known-protocols values correctly in keycloak.properties
+        commands.add("-Dauth.server.http.port=" + configuration.getBindHttpPort());
+        commands.add("-Dauth.server.https.port=" + configuration.getBindHttpsPort());
 
         if (configuration.getRoute() != null) {
             commands.add("-Djboss.node.name=" + configuration.getRoute());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/BasicSamlTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/BasicSamlTest.java
@@ -49,7 +49,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.saml.common.constants.JBossSAMLURIConstants.NAMEID_FORMAT_TRANSIENT;
 import static org.keycloak.saml.common.constants.JBossSAMLURIConstants.PROTOCOL_NSURI;
 import static org.keycloak.testsuite.util.ServerURLs.AUTH_SERVER_PORT;
@@ -167,7 +167,7 @@ public class BasicSamlTest extends AbstractSamlTest {
     }
 
     @Test
-    @AuthServerContainerExclude({AuthServer.REMOTE, AuthServer.QUARKUS})
+    @AuthServerContainerExclude({AuthServer.REMOTE})
     public void testNoPortInDestination() throws Exception {
         // note that this test relies on settings of the login-protocol.saml.knownProtocols configuration option
         testWithOverriddenPort(-1, Response.Status.OK, containsString("login"));


### PR DESCRIPTION
Draft: See if PKIX error comes from local setup.
