### PR TITLE
KEYCLOAK-19510 Nested JWT JOSE header needs to set JWT to cty field

### DIFF
--- a/core/src/main/java/org/keycloak/jose/jwe/JWEHeader.java
+++ b/core/src/main/java/org/keycloak/jose/jwe/JWEHeader.java
@@ -67,6 +67,14 @@ public class JWEHeader implements JOSEHeader {
         this.keyId = keyId;
     }
 
+    public JWEHeader(String algorithm, String encryptionAlgorithm, String compressionAlgorithm, String keyId, String contentType) {
+        this.algorithm = algorithm;
+        this.encryptionAlgorithm = encryptionAlgorithm;
+        this.compressionAlgorithm = compressionAlgorithm;
+        this.keyId = keyId;
+        this.contentType = contentType;
+    }
+
     public String getAlgorithm() {
         return algorithm;
     }

--- a/core/src/main/java/org/keycloak/util/TokenUtil.java
+++ b/core/src/main/java/org/keycloak/util/TokenUtil.java
@@ -154,7 +154,7 @@ public class TokenUtil {
     }
 
     public static String jweKeyEncryptionEncode(Key encryptionKEK, byte[] contentBytes, String algAlgorithm, String encAlgorithm, String kid, JWEAlgorithmProvider jweAlgorithmProvider, JWEEncryptionProvider jweEncryptionProvider) throws JWEException {
-        JWEHeader jweHeader = new JWEHeader(algAlgorithm, encAlgorithm, null, kid);
+        JWEHeader jweHeader = new JWEHeader(algAlgorithm, encAlgorithm, null, kid, "JWT");
         return jweKeyEncryptionEncode(encryptionKEK, contentBytes, jweHeader, jweAlgorithmProvider, jweEncryptionProvider);
     }
 


### PR DESCRIPTION
JIRA ticket is the following.
https://issues.jboss.org/browse/KEYCLOAK-19510

According to [RFC 7519 JWT section 5.2](https://datatracker.ietf.org/doc/html/rfc7519#section-5.2), a nested JWT (signed and encrypted JWT) needs to set "JWT" to its JOSE Header's "cty" field. The current keycloak does not follow it.

The current keycloak generates a signed and encrypted JWT for the following tokens :

- ID Token
- JARM authorization response

Keycloak need to follow it if these are signed and encrypted.

The current keycloak receives a signed and encrypted JWT for the following tokens :

- Request Object (created by a client)

Keycloak needs not to check "cty" field because some of the existing client may send this nested JWT Request Object without "cty" field and keycloak accepts it. If keycloak checked it, such these client's nested JWT Request Object would not be accepted.