### PR TITLE
LDAP attribute default value templating support

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/UserAttributeLDAPStorageMapper.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/UserAttributeLDAPStorageMapper.java
@@ -103,8 +103,7 @@ public class UserAttributeLDAPStorageMapper extends AbstractLDAPStorageMapper {
         String userModelAttrName = getUserModelAttribute();
         String ldapAttrName = getLdapAttributeName();
         boolean isMandatoryInLdap = parseBooleanParameter(mapperModel, IS_MANDATORY_IN_LDAP);
-        String attributeDefaultValue = getAttributeDefaultValue();
-
+        String attributeDefaultValue = getAttributeDefaultValue(localUser);
         Property<Object> userModelProperty = userModelProperties.get(userModelAttrName.toLowerCase());
 
         if (userModelProperty != null) {
@@ -457,8 +456,12 @@ public class UserAttributeLDAPStorageMapper extends AbstractLDAPStorageMapper {
         }
     }
 
-    private String getAttributeDefaultValue() {
+    private String getAttributeDefaultValue(UserModel localUser) {
         String attributeDefaultValue = mapperModel.getConfig().getFirst(ATTRIBUTE_DEFAULT_VALUE);
+        if(attributeDefaultValue != null){
+            attributeDefaultValue = UserAttributeTranscriber.getTemplatedString(attributeDefaultValue, localUser);
+        }
+
         return (attributeDefaultValue == null || attributeDefaultValue.trim().isEmpty()) ? LDAPConstants.EMPTY_ATTRIBUTE_VALUE : attributeDefaultValue;
     }
 

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/UserAttributeTranscriber.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/UserAttributeTranscriber.java
@@ -1,0 +1,44 @@
+package org.keycloak.storage.ldap.mappers;
+
+import org.keycloak.models.UserModel;
+import org.keycloak.storage.ldap.LDAPUtils;
+import org.keycloak.models.utils.reflection.Property;
+
+import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
+
+public class UserAttributeTranscriber {
+    private static final Pattern pattern = Pattern.compile("\\$\\{attr\\.(.+?)}");
+    private static final Map<String, Property<Object>> userModelProperties = LDAPUtils.getUserModelProperties();
+
+    public static String getTemplatedString(final String value, UserModel user) {
+        if (value != null) {
+            String retVal = value;
+            Matcher matcher = pattern.matcher(value);
+            while(matcher.find()){
+                String attrName = matcher.group(1);
+                if(attrName == null || attrName.trim().length() == 0)
+                    continue;
+                String subVal = subAttr(attrName, user);
+
+                if(subVal != null){
+                    retVal = retVal.replace("${attr." + attrName + "}", subVal);
+                }
+            }
+            return retVal;
+        }
+        return value;
+    }
+
+    private static String subAttr(String attrName, UserModel user){
+        Property<Object> userModelProperty = userModelProperties.get(attrName.toLowerCase());
+        if(userModelProperty != null){
+            Object attrValue = userModelProperty.getValue(user);
+            if(attrValue != null){
+                return attrValue.toString();
+            }
+        }
+        return user.getFirstAttribute(attrName);
+    }
+}


### PR DESCRIPTION
Allow for templating of default value when using LDAP attribute mappers. This is useful when creating LDAP accounts with attributes such as `homeDirectory` which can, depending on the use case, be derived from the username using a template such as `/home/${attr.username}`. This templating mechanism uses a similar format to that used in the Vault SPI and allows for usage of any already defined user-attribute as part of an LDAP default value string.