### PR TITLE
KEYCLOAK-19080 Simplify the RHSSO setup in an OpenShift Disconnected cluster

### DIFF
--- a/services/src/main/java/org/keycloak/connections/httpclient/DefaultHttpClientFactory.java
+++ b/services/src/main/java/org/keycloak/connections/httpclient/DefaultHttpClientFactory.java
@@ -35,6 +35,7 @@ import org.keycloak.truststore.TruststoreProvider;
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.KeyStore;
+import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.util.EntityUtils;
@@ -62,6 +63,10 @@ public class DefaultHttpClientFactory implements HttpClientFactory {
 
     private static final Logger logger = Logger.getLogger(DefaultHttpClientFactory.class);
     private static final String configScope = "keycloak.connectionsHttpClient.default.";
+
+    private static final String HTTPS_PROXY = "https_proxy";
+    private static final String HTTP_PROXY = "http_proxy";
+    private static final String NO_PROXY = "no_proxy";
 
     private volatile CloseableHttpClient httpClient;
     private Config.Scope config;
@@ -145,11 +150,26 @@ public class DefaultHttpClientFactory implements HttpClientFactory {
                     String clientKeystore = config.get("client-keystore");
                     String clientKeystorePassword = config.get("client-keystore-password");
                     String clientPrivateKeyPassword = config.get("client-key-password");
-                    String[] proxyMappings = config.getArray("proxy-mappings");
                     boolean disableTrustManager = config.getBoolean("disable-trust-manager", false);
 
                     boolean expectContinueEnabled = getBooleanConfigWithSysPropFallback("expect-continue-enabled", false);
                     boolean resuseConnections = getBooleanConfigWithSysPropFallback("reuse-connections", true);
+
+                    // optionally configure proxy mappings
+                    // direct SPI config (e.g. via standalone.xml) takes precedence over env vars
+                    // lower case env vars take precedence over upper case env vars
+                    ProxyMappings proxyMappings = ProxyMappings.valueOf(config.getArray("proxy-mappings"));
+                    if (proxyMappings == null || proxyMappings.isEmpty()) {
+                        logger.debug("Trying to use proxy mapping from env vars");
+                        String httpProxy = getEnvVarValue(HTTPS_PROXY);
+                        if (httpProxy == null || httpProxy.isEmpty()) {
+                            httpProxy = getEnvVarValue(HTTP_PROXY);
+                        }
+                        String noProxy = getEnvVarValue(NO_PROXY);
+
+                        logger.debugf("httpProxy: %s, noProxy: %s", httpProxy, noProxy);
+                        proxyMappings = ProxyMappings.valueOf(httpProxy, noProxy);
+                    }
 
                     HttpClientBuilder builder = new HttpClientBuilder();
 
@@ -161,7 +181,7 @@ public class DefaultHttpClientFactory implements HttpClientFactory {
                             .connectionTTL(connectionTTL, TimeUnit.MILLISECONDS)
                             .maxConnectionIdleTime(maxConnectionIdleTime, TimeUnit.MILLISECONDS)
                             .disableCookies(disableCookies)
-                            .proxyMappings(ProxyMappings.valueOf(proxyMappings))
+                            .proxyMappings(proxyMappings)
                             .expectContinueEnabled(expectContinueEnabled)
                             .reuseConnections(resuseConnections);
 
@@ -213,6 +233,14 @@ public class DefaultHttpClientFactory implements HttpClientFactory {
             }
         }
         return value != null ? value : defaultValue;
+    }
+
+    private String getEnvVarValue(String name) {
+        String value = System.getenv(name.toLowerCase());
+        if (value == null || value.isEmpty()) {
+            value = System.getenv(name.toUpperCase());
+        }
+        return value;
     }
 
 }

--- a/services/src/main/java/org/keycloak/connections/httpclient/DefaultHttpClientFactory.java
+++ b/services/src/main/java/org/keycloak/connections/httpclient/DefaultHttpClientFactory.java
@@ -35,10 +35,11 @@ import org.keycloak.truststore.TruststoreProvider;
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.KeyStore;
-import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.util.EntityUtils;
+
+import static org.keycloak.utils.StringUtil.isBlank;
 
 /**
  * The default {@link HttpClientFactory} for {@link HttpClientProvider HttpClientProvider's} used by Keycloak for outbound HTTP calls.
@@ -162,13 +163,13 @@ public class DefaultHttpClientFactory implements HttpClientFactory {
                     if (proxyMappings == null || proxyMappings.isEmpty()) {
                         logger.debug("Trying to use proxy mapping from env vars");
                         String httpProxy = getEnvVarValue(HTTPS_PROXY);
-                        if (httpProxy == null || httpProxy.isEmpty()) {
+                        if (isBlank(httpProxy)) {
                             httpProxy = getEnvVarValue(HTTP_PROXY);
                         }
                         String noProxy = getEnvVarValue(NO_PROXY);
 
                         logger.debugf("httpProxy: %s, noProxy: %s", httpProxy, noProxy);
-                        proxyMappings = ProxyMappings.valueOf(httpProxy, noProxy);
+                        proxyMappings = ProxyMappings.withFixedProxyMapping(httpProxy, noProxy);
                     }
 
                     HttpClientBuilder builder = new HttpClientBuilder();
@@ -237,7 +238,7 @@ public class DefaultHttpClientFactory implements HttpClientFactory {
 
     private String getEnvVarValue(String name) {
         String value = System.getenv(name.toLowerCase());
-        if (value == null || value.isEmpty()) {
+        if (isBlank(value)) {
             value = System.getenv(name.toUpperCase());
         }
         return value;

--- a/services/src/main/java/org/keycloak/connections/httpclient/ProxyMappings.java
+++ b/services/src/main/java/org/keycloak/connections/httpclient/ProxyMappings.java
@@ -21,6 +21,7 @@ import org.apache.http.auth.UsernamePasswordCredentials;
 import org.jboss.logging.Logger;
 
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -44,9 +45,11 @@ public class ProxyMappings {
 
   private static final ProxyMappings EMPTY_MAPPING = valueOf(Collections.emptyList());
 
+  private static final String NO_PROXY_DELIMITER = ",";
+
   private final List<ProxyMapping> entries;
 
-  private static Map<String, ProxyMapping> hostnameToProxyCache = new ConcurrentHashMap<>();
+  private static final Map<String, ProxyMapping> hostnameToProxyCache = new ConcurrentHashMap<>();
 
   /**
    * Creates a {@link ProxyMappings} from the provided {@link ProxyMapping Entries}.
@@ -91,6 +94,34 @@ public class ProxyMappings {
     }
 
     return valueOf(Arrays.asList(proxyMappings));
+  }
+
+  /**
+   * Creates a new {@link ProxyMappings} from provided parameters representing the established {@code HTTP(S)_PROXY}
+   * and {@code NO_PROXY} environment variables.
+   *
+   * @param httpProxy a proxy used for all hosts except the ones specified in {@code noProxy}
+   * @param noProxy a list of hosts (separated by comma) that should not use proxy;
+   *                all suffixes are matched too (e.g. redhat.com will also match access.redhat.com)
+   * @return
+   * @see <a href="https://about.gitlab.com/blog/2021/01/27/we-need-to-talk-no-proxy/">https://about.gitlab.com/blog/2021/01/27/we-need-to-talk-no-proxy/</a>
+   */
+  public static ProxyMappings valueOf(String httpProxy, String noProxy) {
+    List<ProxyMapping> proxyMappings = new ArrayList<>();
+
+    if (httpProxy != null && !httpProxy.isEmpty()) {
+      // noProxy must be first as it's more specific than .*
+      if (noProxy != null && !noProxy.isEmpty()) {
+        for (String host : noProxy.split(NO_PROXY_DELIMITER)) {
+          // do not support regex in no_proxy
+          proxyMappings.add(new ProxyMapping(Pattern.compile("(?:.+\\.)?" + Pattern.quote(host)), null, null));
+        }
+      }
+
+      proxyMappings.add(ProxyMapping.valueOf(".*" + ProxyMapping.DELIMITER + httpProxy));
+    }
+
+    return proxyMappings.isEmpty() ? EMPTY_MAPPING : new ProxyMappings(proxyMappings);
   }
 
 

--- a/services/src/main/java/org/keycloak/connections/httpclient/ProxyMappings.java
+++ b/services/src/main/java/org/keycloak/connections/httpclient/ProxyMappings.java
@@ -31,6 +31,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import static org.keycloak.utils.StringUtil.isBlank;
+
 /**
  * {@link ProxyMappings} describes an ordered mapping for hostname regex patterns to a {@link HttpHost} proxy.
  * <p>
@@ -106,12 +108,12 @@ public class ProxyMappings {
    * @return
    * @see <a href="https://about.gitlab.com/blog/2021/01/27/we-need-to-talk-no-proxy/">https://about.gitlab.com/blog/2021/01/27/we-need-to-talk-no-proxy/</a>
    */
-  public static ProxyMappings valueOf(String httpProxy, String noProxy) {
+  public static ProxyMappings withFixedProxyMapping(String httpProxy, String noProxy) {
     List<ProxyMapping> proxyMappings = new ArrayList<>();
 
-    if (httpProxy != null && !httpProxy.isEmpty()) {
+    if (!isBlank(httpProxy)) {
       // noProxy must be first as it's more specific than .*
-      if (noProxy != null && !noProxy.isEmpty()) {
+      if (!isBlank(noProxy)) {
         for (String host : noProxy.split(NO_PROXY_DELIMITER)) {
           // do not support regex in no_proxy
           proxyMappings.add(new ProxyMapping(Pattern.compile("(?:.+\\.)?" + Pattern.quote(host)), null, null));

--- a/services/src/test/java/org/keycloak/connections/httpclient/ProxyMappingsTest.java
+++ b/services/src/test/java/org/keycloak/connections/httpclient/ProxyMappingsTest.java
@@ -32,7 +32,6 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Tests for {@link ProxyMappings}.
@@ -209,7 +208,7 @@ public class ProxyMappingsTest {
 
   @Test
   public void shouldReturnMappingForHttpProxy() {
-    ProxyMappings proxyMappings = ProxyMappings.valueOf("https://some-proxy.redhat.com:8080", null);
+    ProxyMappings proxyMappings = ProxyMappings.withFixedProxyMapping("https://some-proxy.redhat.com:8080", null);
 
     ProxyMapping forGoogle = proxyMappings.getProxyFor("login.google.com");
     assertEquals("some-proxy.redhat.com", forGoogle.getProxyHost().getHostName());
@@ -217,7 +216,7 @@ public class ProxyMappingsTest {
 
   @Test
   public void shouldReturnMappingForHttpProxyWithNoProxy() {
-    ProxyMappings proxyMappings = ProxyMappings.valueOf("https://some-proxy.redhat.com:8080", "login.facebook.com");
+    ProxyMappings proxyMappings = ProxyMappings.withFixedProxyMapping("https://some-proxy.redhat.com:8080", "login.facebook.com");
 
     assertEquals("some-proxy.redhat.com", proxyMappings.getProxyFor("login.google.com").getProxyHost().getHostName());
     assertEquals("some-proxy.redhat.com", proxyMappings.getProxyFor("facebook.com").getProxyHost().getHostName());
@@ -228,7 +227,7 @@ public class ProxyMappingsTest {
 
   @Test
   public void shouldReturnMappingForHttpProxyWithMultipleNoProxy() {
-    ProxyMappings proxyMappings = ProxyMappings.valueOf("https://some-proxy.redhat.com:8080", "login.facebook.com,corp.com");
+    ProxyMappings proxyMappings = ProxyMappings.withFixedProxyMapping("https://some-proxy.redhat.com:8080", "login.facebook.com,corp.com");
 
     assertEquals("some-proxy.redhat.com", proxyMappings.getProxyFor("login.google.com").getProxyHost().getHostName());
     assertEquals("some-proxy.redhat.com", proxyMappings.getProxyFor("facebook.com").getProxyHost().getHostName());
@@ -240,7 +239,7 @@ public class ProxyMappingsTest {
 
   @Test
   public void shouldReturnMappingForNoProxyWithInvalidChars() {
-    ProxyMappings proxyMappings = ProxyMappings.valueOf("https://some-proxy.redhat.com:8080", "[lj]ogin.facebook.com");
+    ProxyMappings proxyMappings = ProxyMappings.withFixedProxyMapping("https://some-proxy.redhat.com:8080", "[lj]ogin.facebook.com");
 
     assertEquals("some-proxy.redhat.com", proxyMappings.getProxyFor("login.facebook.com").getProxyHost().getHostName());
     assertEquals("some-proxy.redhat.com", proxyMappings.getProxyFor("jogin.facebook.com").getProxyHost().getHostName());
@@ -248,6 +247,6 @@ public class ProxyMappingsTest {
 
   @Test
   public void shouldReturnEmptyMappingForEmptyHttpProxy() {
-    assertNull(ProxyMappings.valueOf(null, "facebook.com"));
+    assertNull(ProxyMappings.withFixedProxyMapping(null, "facebook.com"));
   }
 }

--- a/services/src/test/java/org/keycloak/connections/httpclient/ProxyMappingsTest.java
+++ b/services/src/test/java/org/keycloak/connections/httpclient/ProxyMappingsTest.java
@@ -29,7 +29,10 @@ import java.util.List;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests for {@link ProxyMappings}.
@@ -202,5 +205,49 @@ public class ProxyMappingsTest {
 
     ProxyMapping forSalesForce = proxyMappingsWithProxyAuthen.getProxyFor("login.salesforce.com");
     assertThat(forSalesForce.getProxyHost().getHostName(), is("fallback"));
+  }
+
+  @Test
+  public void shouldReturnMappingForHttpProxy() {
+    ProxyMappings proxyMappings = ProxyMappings.valueOf("https://some-proxy.redhat.com:8080", null);
+
+    ProxyMapping forGoogle = proxyMappings.getProxyFor("login.google.com");
+    assertEquals("some-proxy.redhat.com", forGoogle.getProxyHost().getHostName());
+  }
+
+  @Test
+  public void shouldReturnMappingForHttpProxyWithNoProxy() {
+    ProxyMappings proxyMappings = ProxyMappings.valueOf("https://some-proxy.redhat.com:8080", "login.facebook.com");
+
+    assertEquals("some-proxy.redhat.com", proxyMappings.getProxyFor("login.google.com").getProxyHost().getHostName());
+    assertEquals("some-proxy.redhat.com", proxyMappings.getProxyFor("facebook.com").getProxyHost().getHostName());
+
+    assertNull(proxyMappings.getProxyFor("login.facebook.com").getProxyHost());
+    assertNull(proxyMappings.getProxyFor("auth.login.facebook.com").getProxyHost());
+  }
+
+  @Test
+  public void shouldReturnMappingForHttpProxyWithMultipleNoProxy() {
+    ProxyMappings proxyMappings = ProxyMappings.valueOf("https://some-proxy.redhat.com:8080", "login.facebook.com,corp.com");
+
+    assertEquals("some-proxy.redhat.com", proxyMappings.getProxyFor("login.google.com").getProxyHost().getHostName());
+    assertEquals("some-proxy.redhat.com", proxyMappings.getProxyFor("facebook.com").getProxyHost().getHostName());
+
+    assertNull(proxyMappings.getProxyFor("login.facebook.com").getProxyHost());
+    assertNull(proxyMappings.getProxyFor("auth.login.facebook.com").getProxyHost());
+    assertNull(proxyMappings.getProxyFor("myapp.acme.corp.com").getProxyHost());
+  }
+
+  @Test
+  public void shouldReturnMappingForNoProxyWithInvalidChars() {
+    ProxyMappings proxyMappings = ProxyMappings.valueOf("https://some-proxy.redhat.com:8080", "[lj]ogin.facebook.com");
+
+    assertEquals("some-proxy.redhat.com", proxyMappings.getProxyFor("login.facebook.com").getProxyHost().getHostName());
+    assertEquals("some-proxy.redhat.com", proxyMappings.getProxyFor("jogin.facebook.com").getProxyHost().getHostName());
+  }
+
+  @Test
+  public void shouldReturnEmptyMappingForEmptyHttpProxy() {
+    assertNull(ProxyMappings.valueOf(null, "facebook.com"));
   }
 }


### PR DESCRIPTION
Docs PR: https://github.com/keycloak/keycloak-documentation/pull/1269.

I have not implemented any integration tests as there are none for the proxy functionality in general. It was [agreed](https://github.com/keycloak/keycloak/pull/4543#issuecomment-360384986) in the original PR that it will be done as a [follow-up task](https://issues.redhat.com/browse/KEYCLOAK-6347). Therefore it is out of scope of this PR to add tests for proxy.