### PR TITLE
KEYCLOAK-18980 Keycloak locale dropdown is active over whole form

### DIFF
--- a/themes/src/main/resources/theme/keycloak/login/resources/css/login.css
+++ b/themes/src/main/resources/theme/keycloak/login/resources/css/login.css
@@ -172,8 +172,12 @@ h1#kc-page-title {
     padding: 0;
 }
 
-#kc-locale:hover ul {
-    display: block;
+#kc-locale-dropdown{
+    display: inline-block;
+}
+
+#kc-locale-dropdown:hover ul {
+    display:block;
 }
 
 /* IE compatibility */


### PR DESCRIPTION
JIRA: [KEYCLOAK-18980](https://issues.redhat.com/browse/KEYCLOAK-18980)

Old behaviour:
<img src="https://user-images.githubusercontent.com/38039883/137099675-cde3340b-62f9-4b10-88f6-de6c0a974772.png" width="400" />

With changes in this PR it works as expected:
<img src="https://user-images.githubusercontent.com/38039883/137099742-b822b9e9-05a2-420b-a907-e3c22f1de1ac.png" width="400" />

<img src="https://user-images.githubusercontent.com/38039883/137099752-6686ab06-8a70-4d6d-871d-3d8c055712c9.png" width="400" />

@ssilvert @Pepo48 Could you please take a look at it? Thank you.