### PR TITLE
KEYCLOAK-19461 Add dependency for openshift restclient to quarkus dis…

### DIFF
--- a/quarkus/runtime/pom.xml
+++ b/quarkus/runtime/pom.xml
@@ -13,7 +13,6 @@
     <name>Keycloak Quarkus Server Extension</name>
     <artifactId>keycloak-quarkus-server</artifactId>
     <description>Keycloak Server</description>
-
     <dependencies>
         <!-- Quarkus -->
         <dependency>
@@ -484,9 +483,24 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- twitter api -->
         <dependency>
             <groupId>org.twitter4j</groupId>
             <artifactId>twitter4j-core</artifactId>
+        </dependency>
+
+        <!-- Openshift -->
+        <dependency>
+            <groupId>com.openshift</groupId>
+            <artifactId>openshift-restclient-java</artifactId>
+            <version>${version.com.openshift.openshift-restclient-java}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/openshift/OpenshiftClientStorageTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/openshift/OpenshiftClientStorageTest.java
@@ -66,7 +66,7 @@ import static org.keycloak.testsuite.admin.ApiUtil.findUserByUsername;
  *
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
  */
-@AuthServerContainerExclude({AuthServer.REMOTE, AuthServer.QUARKUS})
+@AuthServerContainerExclude({AuthServer.REMOTE})
 @EnableFeature(value = OPENSHIFT_INTEGRATION, skipRestart = true)
 public final class OpenshiftClientStorageTest extends AbstractTestRealmKeycloakTest {
 


### PR DESCRIPTION
…t to make the OpenShiftClientStorageTest work. OpenShiftClientStorageProviderFactory needs it for the ClientBuilder call..

Short rant: We should really think about creating a base "sdk" not containing e.g. twitter4j, openshift etc. and let the ppl build their own extensions on top of it. Like Quarkus extensions, spring boot starters... etc ;)