### PR TITLE
KEYCLOAK-19565 Client Policies : Wrong SecureLogoutExecutor's provider ID

### DIFF
--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureLogoutExecutor.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureLogoutExecutor.java
@@ -65,7 +65,7 @@ public class SecureLogoutExecutor implements ClientPolicyExecutorProvider<Secure
 
     @Override
     public String getProviderId() {
-        return PKCEEnforcerExecutorFactory.PROVIDER_ID;
+        return SecureLogoutExecutorFactory.PROVIDER_ID;
     }
 
     @Override


### PR DESCRIPTION
This PR is for [KEYCLOAK-13933 Client Policies](https://issues.redhat.com/browse/KEYCLOAK-13933), also is the part of the project [Client Policy Official Support](https://github.com/keycloak/kc-sig-fapi/projects) of [FAPI-SIG](https://github.com/keycloak/kc-sig-fapi) activity.

It seems to be related to [KEYCLOAK-17653 Implement support frontchannel logout on openid-connect](https://issues.redhat.com/browse/KEYCLOAK-17653).
[KEYCLOAK-19565](https://issues.redhat.com/browse/KEYCLOAK-19565) describes it in detail.
