### PR TITLE
Fix logout-all enpoint return json format

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/RealmAdminResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RealmAdminResource.java
@@ -583,6 +583,7 @@ public class RealmAdminResource {
      */
     @Path("logout-all")
     @POST
+    @Produces(MediaType.APPLICATION_JSON)
     public GlobalRequestResult logoutAll() {
         auth.users().requireManage();
 


### PR DESCRIPTION
When i call API to logout-all endpoint . Keycloak server return 500 status.
In a log, i found an error:
ERROR [org.keycloak.services.error.KeycloakErrorHandler] (default task-23) Uncaught server error: `org.jboss.resteasy.core.NoMessageBodyWriterFoundFailure: Could not find MessageBodyWriter for response object of type: org.keycloak.representations.adapters.action.GlobalRequestResult of media type: application/octet-stream`

- I found the same error in [this pull request](https://github.com/keycloak/keycloak/pull/3571)
- I fixed it just like that

![image](https://user-images.githubusercontent.com/38358493/137768737-4e8228bf-d158-47b8-9835-3b2c015f4515.png)
