### PR TITLE
KEYCLOAK-19582 Quarkus update to 2.4.0.CR1

### DIFF
--- a/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
+++ b/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
@@ -126,6 +126,12 @@ class KeycloakProcessor {
     private static final Map<String, Function<ScriptProviderMetadata, ProviderFactory>> DEPLOYEABLE_SCRIPT_PROVIDERS = new HashMap<>();
     private static final String KEYCLOAK_SCRIPTS_JSON_PATH = "META-INF/keycloak-scripts.json";
 
+    private static final List<Class<? extends ProviderFactory>> IGNORED_PROVIDER_FACTORY = Arrays.asList(
+            JBossJtaTransactionManagerLookup.class,
+            DefaultJpaConnectionProviderFactory.class,
+            DefaultLiquibaseConnectionProvider.class,
+            LiquibaseJpaUpdaterProviderFactory.class);
+
     static {
         DEPLOYEABLE_SCRIPT_PROVIDERS.put(AUTHENTICATORS, KeycloakProcessor::registerScriptAuthenticator);
         DEPLOYEABLE_SCRIPT_PROVIDERS.put(POLICIES, KeycloakProcessor::registerScriptPolicy);
@@ -387,11 +393,7 @@ class KeycloakProcessor {
             preConfiguredProviders.putAll(deployedScriptProviders);
 
             for (ProviderFactory factory : loadedFactories) {
-                if (Arrays.asList(
-                        JBossJtaTransactionManagerLookup.class,
-                        DefaultJpaConnectionProviderFactory.class,
-                        DefaultLiquibaseConnectionProvider.class,
-                        LiquibaseJpaUpdaterProviderFactory.class).contains(factory.getClass())) {
+                if (IGNORED_PROVIDER_FACTORY.contains(factory.getClass())) {
                     continue;
                 }
 

--- a/quarkus/pom.xml
+++ b/quarkus/pom.xml
@@ -32,18 +32,20 @@
 
     <properties>
         <!-- Quarkus version -->
-        <quarkus.version>2.3.0.Final</quarkus.version>
+        <quarkus.version>2.4.0.CR1</quarkus.version>
 
         <!--
             Override versions based on Quarkus dependencies.
             Make sure to update these dependencies when Quarkus version changes.
+            See https://github.com/quarkusio/quarkus/blob/<versionTag>/bom/application/pom.xml
+            for reference
         -->
         <resteasy.version>4.7.0.Final</resteasy.version>
         <jackson.version>2.12.5</jackson.version>
         <jackson.databind.version>${jackson.version}</jackson.databind.version>
-        <hibernate.core.version>5.6.0.Beta2</hibernate.core.version>
+        <hibernate.core.version>5.6.0.CR1</hibernate.core.version>
         <mysql.driver.version>8.0.26</mysql.driver.version>
-        <postgresql.version>42.2.23</postgresql.version>
+        <postgresql.version>42.2.24</postgresql.version>
         <microprofile-metrics-api.version>3.0</microprofile-metrics-api.version>
         <wildfly.common.version>1.5.4.Final-format-001</wildfly.common.version>
 

--- a/quarkus/runtime/pom.xml
+++ b/quarkus/runtime/pom.xml
@@ -484,6 +484,12 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- logging wrapper for log4j-->
+        <dependency>
+            <groupId>org.jboss.logmanager</groupId>
+            <artifactId>log4j-jboss-logmanager</artifactId>
+        </dependency>
+
         <!-- twitter api -->
         <dependency>
             <groupId>org.twitter4j</groupId>
@@ -496,6 +502,10 @@
             <artifactId>openshift-restclient-java</artifactId>
             <version>${version.com.openshift.openshift-restclient-java}</version>
             <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>


### PR DESCRIPTION
... also added a small bugfix to exclude log4j transitive dependency from openshift restclient according to https://quarkus.io/guides/logging#what-about-apache-log4j to prevent a warning about a missing log appender when doing the first request to keycloak.x.
