### PR TITLE
KEYCLOAK-19700: Attempt to reuse denied device authorization code results in server error

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/RootAuthenticationSessionAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/RootAuthenticationSessionAdapter.java
@@ -20,6 +20,7 @@ package org.keycloak.models.sessions.infinispan;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import org.infinispan.Cache;
@@ -117,6 +118,8 @@ public class RootAuthenticationSessionAdapter implements RootAuthenticationSessi
 
     @Override
     public AuthenticationSessionModel createAuthenticationSession(ClientModel client) {
+        Objects.requireNonNull(client, "client");
+
         Map<String, AuthenticationSessionEntity> authenticationSessions = entity.getAuthenticationSessions();
         if (authenticationSessions.size() >= authSessionsLimit) {
             String tabId = authenticationSessions.entrySet().stream().min(TIMESTAMP_COMPARATOR).map(Map.Entry::getKey).orElse(null);

--- a/server-spi-private/src/main/java/org/keycloak/events/Errors.java
+++ b/server-spi-private/src/main/java/org/keycloak/events/Errors.java
@@ -109,6 +109,5 @@ public interface Errors {
     String INVALID_OAUTH2_DEVICE_CODE = "invalid_oauth2_device_code";
     String EXPIRED_OAUTH2_DEVICE_CODE = "expired_oauth2_device_code";
     String INVALID_OAUTH2_USER_CODE = "invalid_oauth2_user_code";
-    String EXPIRED_OAUTH2_USER_CODE = "expired_oauth2_user_code";
     String SLOW_DOWN = "slow_down";
 }

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/OAuth2DeviceVerificationPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/OAuth2DeviceVerificationPage.java
@@ -26,6 +26,8 @@ import org.openqa.selenium.support.FindBy;
  */
 public class OAuth2DeviceVerificationPage extends LanguageComboboxAwarePage {
 
+    private static final String CONSENT_DENIED_MESSAGE = "Consent denied for connecting the device.";
+    
     @FindBy(id = "device-user-code")
     private WebElement userCodeInput;
 
@@ -74,6 +76,11 @@ public class OAuth2DeviceVerificationPage extends LanguageComboboxAwarePage {
             isInvalidUserCodePage());
     }
 
+    public void assertExpiredUserCodePage() {
+        Assert.assertTrue("Expected expired user code page but was " + driver.getTitle() + " (" + driver.getCurrentUrl() + ")",
+                isExpiredUserCodePage());
+    }
+
     private boolean isApprovedPage() {
         if (driver.getTitle().startsWith("Sign in to ")) {
             try {
@@ -88,9 +95,8 @@ public class OAuth2DeviceVerificationPage extends LanguageComboboxAwarePage {
     private boolean isDeniedPage() {
         if (driver.getTitle().startsWith("Sign in to ")) {
             try {
-                driver.findElement(By.id("kc-page-title")).getText().equals("Device Login Failed");
-                driver.findElement(By.className("instruction")).getText().equals("Consent denied for connecting the device.");
-                return true;
+                return driver.findElement(By.id("kc-page-title")).getText().equals("Device Login Failed")
+                        && driver.findElement(By.className("instruction")).getText().equals(CONSENT_DENIED_MESSAGE);
             } catch (Throwable t) {
             }
         }
@@ -101,9 +107,20 @@ public class OAuth2DeviceVerificationPage extends LanguageComboboxAwarePage {
         if (driver.getTitle().startsWith("Sign in to ")) {
             try {
                 driver.findElement(By.id("device-user-code"));
-                driver.findElement(By.id("kc-page-title")).getText().equals("Device Login");
-                driver.findElement(By.className("kc-feedback-text")).getText().equals("Invalid code, please try again.");
-                return true;
+                return driver.findElement(By.id("kc-page-title")).getText().equals("Device Login")
+                        && driver.findElement(By.className("kc-feedback-text")).getText().equals("Invalid code, please try again.");
+            } catch (Throwable t) {
+            }
+        }
+        return false;
+    }
+
+    private boolean isExpiredUserCodePage() {
+        if (driver.getTitle().startsWith("Sign in to ")) {
+            try {
+                driver.findElement(By.id("device-user-code"));
+                return driver.findElement(By.id("kc-page-title")).getText().equals("Device Login")
+                        && driver.findElement(By.className("kc-feedback-text")).getText().equals("The code has expired. Please go back to your device and try connecting again.");
             } catch (Throwable t) {
             }
         }


### PR DESCRIPTION
https://issues.redhat.com/browse/KEYCLOAK-19700

Summary of changes...

* Check for additional device code states to prevent unintended authentication logic from being triggered (which is the source of the server error when reusing a denied device code)
  * The `!isPending()` check is hard to test for because normally you just get a null device code. There looks like a race condition though where you could get a pending device code: if device verification is submitted just after the device code is approved in another request (double submission, another browser, etc.) but before the user code is removed from the cache (perhaps the server pauses due to GC, or crashes, etc.), you might find the device code that was in pending state. Regardless, logically, I believe the check makes sense to stay. If for whatever reason a device code is found in this state, it can't be used.
  * The `isDenied()` check is what specifically fixes the NPE described in the issue.
* Guard against nulls where the NPE was occurring (perhaps controversial, I don't see this done in many places, but personally I adopted this practice long ago from Guava/Effective Java)
* The page object for device verification page assertion weren't actually really doing anything except checking for the presence of elements (not their content). The boolean checks' results were ignored. Fixing this prompted fixing another test which was not actually asserting the right page.