### PR TITLE
KEYCLOAK-19721: Server error (NullPointerException) when trying to view users using KeycloakServer

### DIFF
--- a/testsuite/utils/src/main/resources/META-INF/keycloak-server.json
+++ b/testsuite/utils/src/main/resources/META-INF/keycloak-server.json
@@ -149,7 +149,7 @@
     },
 
     "userProfile": {
-        "provider": "${keycloak.userProfile.provider:}",
+        "provider": "${keycloak.userProfile.provider:declarative-user-profile}",
         "declarative-user-profile": {
             "read-only-attributes": [ "deniedFoo", "deniedBar*", "deniedSome/thing", "deniedsome*thing" ],
             "admin-read-only-attributes": [ "deniedSomeAdmin" ]


### PR DESCRIPTION
The testsuite classpath has multiple implementations since #8513 but KeycloakServer's JSON config did not have a default configured, and both implementations use the default (0) order.