### PR TITLE
KEYCLOAK-15985 Add Brute Force Detection Lockout Event

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/events/EventType.java
+++ b/server-spi-private/src/main/java/org/keycloak/events/EventType.java
@@ -155,8 +155,10 @@ public enum EventType implements EnumWithStableIndex {
 
     // PAR request.
     PUSHED_AUTHORIZATION_REQUEST(51, false),
-    PUSHED_AUTHORIZATION_REQUEST_ERROR(0x10000 + PUSHED_AUTHORIZATION_REQUEST.getStableIndex(), false);
+    PUSHED_AUTHORIZATION_REQUEST_ERROR(0x10000 + PUSHED_AUTHORIZATION_REQUEST.getStableIndex(), false),
 
+    USER_DISABLED_BY_PERMANENT_LOCKOUT(52, true),
+    USER_DISABLED_BY_PERMANENT_LOCKOUT_ERROR(0x10000 + USER_DISABLED_BY_PERMANENT_LOCKOUT.getStableIndex(), false);
 
     private final int stableIndex;
     private final boolean saveByDefault;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/AssertEvents.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/AssertEvents.java
@@ -361,7 +361,7 @@ public class AssertEvents implements TestRule {
         }
 
         public EventRepresentation assertEvent(EventRepresentation actual) {
-            if (expected.getError() != null && ! expected.getType().toString().endsWith("_ERROR")) {
+            if (expected.getError() != null && ! expected.getType().endsWith("_ERROR")) {
                 expected.setType(expected.getType() + "_ERROR");
             }
             assertThat("type", actual.getType(), is(expected.getType()));

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/BruteForceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/BruteForceTest.java
@@ -30,6 +30,7 @@ import org.keycloak.events.EventType;
 import org.keycloak.models.Constants;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.utils.TimeBasedOTP;
+import org.keycloak.representations.idm.EventRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.services.managers.BruteForceProtector;
@@ -51,9 +52,7 @@ import org.keycloak.testsuite.util.UserBuilder;
 
 import jakarta.mail.internet.MimeMessage;
 import java.net.MalformedURLException;
-import java.util.Calendar;
-import java.util.Collections;
-import java.util.Map;
+import java.util.*;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
@@ -477,7 +476,7 @@ public class BruteForceTest extends AbstractTestRealmKeycloakTest {
     }
 
     @Test
-    public void testPermanentLockout() throws Exception {
+    public void testPermanentLockout() {
         RealmRepresentation realm = testRealm().toRepresentation();
 
         try {
@@ -486,8 +485,15 @@ public class BruteForceTest extends AbstractTestRealmKeycloakTest {
             testRealm().update(realm);
 
             // act
-            loginInvalidPassword();
-            loginInvalidPassword();
+            loginInvalidPassword("test-user@localhost");
+            loginInvalidPassword("test-user@localhost", false);
+
+            // As of now, there are two events: USER_DISABLED_BY_PERMANENT_LOCKOUT and LOGIN_ERROR but Order is not
+            // guarantee though since the brute force detector is running separately "in its own thread" named
+            // "Brute Force Protector".
+            List<EventRepresentation> actualEvents = Arrays.asList(events.poll(), events.poll());
+            assertIsContained(events.expect(EventType.USER_DISABLED_BY_PERMANENT_LOCKOUT).client((String) null).detail(Details.REASON, "brute_force_attack detected"), actualEvents);
+            assertIsContained(events.expect(EventType.LOGIN_ERROR).error(Errors.INVALID_USER_CREDENTIALS), actualEvents);
 
             // assert
             expectPermanentlyDisabled();
@@ -509,7 +515,7 @@ public class BruteForceTest extends AbstractTestRealmKeycloakTest {
     }
 
     @Test
-    public void testResetLoginFailureCount() throws Exception {
+    public void testResetLoginFailureCount() {
         RealmRepresentation realm = testRealm().toRepresentation();
 
         try {
@@ -608,20 +614,19 @@ public class BruteForceTest extends AbstractTestRealmKeycloakTest {
         events.clear();
     }
 
-    public void expectTemporarilyDisabled() throws Exception {
+    public void expectTemporarilyDisabled() {
         expectTemporarilyDisabled("test-user@localhost", null, "password");
     }
 
-    public void expectTemporarilyDisabled(String username, String userId) throws Exception {
+    public void expectTemporarilyDisabled(String username, String userId) {
         expectTemporarilyDisabled(username, userId, "password");
     }
 
-    public void expectTemporarilyDisabled(String username, String userId, String password) throws Exception {
+    public void expectTemporarilyDisabled(String username, String userId, String password) {
         loginPage.open();
         loginPage.login(username, password);
 
         loginPage.assertCurrent();
-        String src = driver.getPageSource();
         Assert.assertEquals("Invalid username or password.", loginPage.getInputError());
         ExpectedEvent event = events.expectLogin()
                 .session((String) null)
@@ -634,11 +639,11 @@ public class BruteForceTest extends AbstractTestRealmKeycloakTest {
         event.assertEvent();
     }
 
-    public void expectPermanentlyDisabled() throws Exception {
-        expectPermanentlyDisabled("test-user@localhost", null);
+    public void expectPermanentlyDisabled() {
+        expectPermanentlyDisabled("test-user@localhost");
     }
 
-    public void expectPermanentlyDisabled(String username, String userId) throws Exception {
+    public void expectPermanentlyDisabled(String username) {
         loginPage.open();
         loginPage.login(username, "password");
 
@@ -649,17 +654,14 @@ public class BruteForceTest extends AbstractTestRealmKeycloakTest {
             .error(Errors.USER_DISABLED)
             .detail(Details.USERNAME, username)
             .removeDetail(Details.CONSENT);
-        if (userId != null) {
-            event.user(userId);
-        }
         event.assertEvent();
     }
 
-    public void loginSuccess() throws Exception {
+    public void loginSuccess() {
         loginSuccess("test-user@localhost");
     }
 
-    public void loginSuccess(String username) throws Exception {
+    public void loginSuccess(String username) {
         loginPage.open();
         loginPage.login(username, "password");
 
@@ -676,8 +678,6 @@ public class BruteForceTest extends AbstractTestRealmKeycloakTest {
         String idTokenHint = oauth.doAccessTokenRequest(code, "password").getIdToken();
         appPage.logout(idTokenHint);
         events.clear();
-
-
     }
 
     public void loginWithTotpFailure() {
@@ -752,11 +752,15 @@ public class BruteForceTest extends AbstractTestRealmKeycloakTest {
         events.clear();
     }
 
-    public void loginInvalidPassword() throws Exception {
+    public void loginInvalidPassword() {
         loginInvalidPassword("test-user@localhost");
     }
 
-    public void loginInvalidPassword(String username) throws Exception {
+    public void loginInvalidPassword(String username) {
+        loginInvalidPassword(username, true);
+    }
+
+    public void loginInvalidPassword(String username, boolean clearEventsQueue) {
         loginPage.open();
         loginPage.login(username, "invalid");
 
@@ -764,7 +768,9 @@ public class BruteForceTest extends AbstractTestRealmKeycloakTest {
 
         Assert.assertEquals("Invalid username or password.", loginPage.getInputError());
 
-        events.clear();
+        if (clearEventsQueue) {
+            events.clear();
+        }
     }
 
     public void loginMissingPassword() {
@@ -825,5 +831,28 @@ public class BruteForceTest extends AbstractTestRealmKeycloakTest {
         for (int i = 0; i < failureFactor; ++i) {
             sendInvalidPasswordPasswordGrant();
         }
+    }
+
+    /**
+     * Verifies the given {@link ExpectedEvent} is "contained" in the collection of actual events. An
+     * {@link ExpectedEvent expectedEvent} object is considered equal to a
+     * {@link EventRepresentation eventRepresentation} object if {@code
+     * expectedEvent.assertEvent(eventRepresentation)} does not throw any {@link AssertionError}.
+     *
+     * @param expectedEvent the expected event
+     * @param actualEvents the collection of {@link EventRepresentation}
+     */
+    public void assertIsContained(ExpectedEvent expectedEvent, List<? extends EventRepresentation> actualEvents) {
+        List<String> messages = new ArrayList<>();
+        for (EventRepresentation e : actualEvents) {
+            try {
+                expectedEvent.assertEvent(e);
+                return;
+            } catch (AssertionError error) {
+                // silently fail
+                messages.add(error.getMessage());
+            }
+        }
+        Assert.fail(String.format("Expected event not found. Possible reasons are: %s", messages));
     }
 }


### PR DESCRIPTION
This PR aims to introduce a new event when a user account gets permanently locked up. Test `BruteForceTest#testPermanentLockout` has been updated accordingly. 

Fixes #8769