### PR TITLE
KEYCLOAK-19731: Make password field autofocus on login form, fixes #10027

### DIFF
--- a/themes/src/main/resources/theme/base/login/login-password.ftl
+++ b/themes/src/main/resources/theme/base/login/login-password.ftl
@@ -11,7 +11,7 @@
                         <hr/>
                         <label for="password" class="${properties.kcLabelClass!}">${msg("password")}</label>
                         <input tabindex="2" id="password" class="${properties.kcInputClass!}" name="password"
-                               type="password" autocomplete="on"
+                               type="password" autocomplete="on" autofocus
                                aria-invalid="<#if messagesPerField.existsError('password')>true</#if>"
                         />
                         <#if messagesPerField.existsError('password')>


### PR DESCRIPTION
As user I would like to be able to directly type my password in a flow where I have a username form, followed by a password form. fixes #10027