### PR TITLE
KEYCLOAK-18846 URL param kc_locale doesn't work on error pages

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/i18n/EmailTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/i18n/EmailTest.java
@@ -132,17 +132,20 @@ public class EmailTest extends AbstractI18NTest {
         
         String link = MailUtils.getPasswordResetEmailLink(greenMail.getLastReceivedMessage());
 
-        // Make sure kc_locale added to link doesn't set locale
+        // Make sure kc_locale added to link sets locale
         link += "&kc_locale=de";
         
         DroneUtils.getCurrentDriver().navigate().to(link);
         WaitUtils.waitForPageToLoad();
         
         Assert.assertTrue("Expected to be on InfoPage, but it was on " + DroneUtils.getCurrentDriver().getTitle(), infoPage.isCurrent());
-        Assert.assertThat(infoPage.getLanguageDropdownText(), is(equalTo("English")));
+        Assert.assertThat(infoPage.getLanguageDropdownText(), is(equalTo("Deutsch")));
+        
+        // Make sure changing locale back and forth works
+        infoPage.openLanguage("English");
+        Assert.assertThat(DroneUtils.getCurrentDriver().getPageSource(), containsString("Update Password"));
         
         infoPage.openLanguage("Deutsch");
-
         Assert.assertThat(DroneUtils.getCurrentDriver().getPageSource(), containsString("Passwort aktualisieren"));
         
         infoPage.clickToContinueDe();


### PR DESCRIPTION
New check for kc_locale query parameter in the URI
If the kc_locale parameter is supplied it will be applied before http language headers

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
