### PR TITLE
KEYCLOAK-19723 Existing ECDSA key provider's key pair is not regenerated when its curve is changed on Admin Console

### DIFF
--- a/services/src/main/java/org/keycloak/keys/GeneratedEcdsaKeyProviderFactory.java
+++ b/services/src/main/java/org/keycloak/keys/GeneratedEcdsaKeyProviderFactory.java
@@ -28,7 +28,10 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.provider.ConfigurationValidationHelper;
 import org.keycloak.provider.ProviderConfigProperty;
 
+import java.security.KeyFactory;
 import java.security.KeyPair;
+import java.security.interfaces.ECPublicKey;
+import java.security.spec.X509EncodedKeySpec;
 import java.util.List;
 
 public class GeneratedEcdsaKeyProviderFactory extends AbstractEcdsaKeyProviderFactory {
@@ -103,7 +106,7 @@ public class GeneratedEcdsaKeyProviderFactory extends AbstractEcdsaKeyProviderFa
             generateKeys(model, ecInNistRep);
             logger.debugv("Generated keys for {0}", realm.getName());
         } else {
-            String currentEc = model.get(ECDSA_ELLIPTIC_CURVE_KEY);
+            String currentEc = getCurveFromPublicKey(model.getConfig().getFirst(GeneratedEcdsaKeyProviderFactory.ECDSA_PUBLIC_KEY_KEY));
             if (!ecInNistRep.equals(currentEc)) {
                 generateKeys(model, ecInNistRep);
                 logger.debugv("Elliptic Curve changed, generating new keys for {0}", realm.getName());
@@ -123,4 +126,14 @@ public class GeneratedEcdsaKeyProviderFactory extends AbstractEcdsaKeyProviderFa
         }
     }
 
+    private String getCurveFromPublicKey(String publicEcdsaKeyBase64Encoded) {
+        try {
+            KeyFactory kf = KeyFactory.getInstance("EC");
+            X509EncodedKeySpec publicKeySpec = new X509EncodedKeySpec(Base64.decode(publicEcdsaKeyBase64Encoded));
+            ECPublicKey ecKey = (ECPublicKey) kf.generatePublic(publicKeySpec);
+            return "P-" + ecKey.getParams().getCurve().getField().getFieldSize();
+        } catch (Throwable t) {
+            throw new ComponentValidationException("Failed to get EC from its public key", t);
+        }
+    }
 }


### PR DESCRIPTION
This PR is for fixing a bug reported by [KEYCLOAK-19723](https://issues.redhat.com/browse/KEYCLOAK-19723) that describes it in detail.
