### PR TITLE
KEYCLOAK-19783 Cached user's session ids for faster user sessions retrieval

### DIFF
--- a/distribution/galleon-feature-packs/server-galleon-pack/src/main/resources/feature_groups/infinispan-dist-keycloak.xml
+++ b/distribution/galleon-feature-packs/server-galleon-pack/src/main/resources/feature_groups/infinispan-dist-keycloak.xml
@@ -27,6 +27,13 @@
                 </feature>
             </feature>
             <feature spec="subsystem.infinispan.cache-container.distributed-cache">
+                <param name="distributed-cache" value="sessionIds"/>
+                <param name="owners" value="1"/>
+                <feature spec="subsystem.infinispan.cache-container.distributed-cache.component.expiration">
+                    <param name="lifespan" value="900000000000000000"/>
+                </feature>
+            </feature>
+            <feature spec="subsystem.infinispan.cache-container.distributed-cache">
                 <param name="distributed-cache" value="authenticationSessions"/>
                 <param name="owners" value="1"/>
                 <feature spec="subsystem.infinispan.cache-container.distributed-cache.component.expiration">

--- a/distribution/galleon-feature-packs/server-galleon-pack/src/main/resources/feature_groups/infinispan-local-keycloak.xml
+++ b/distribution/galleon-feature-packs/server-galleon-pack/src/main/resources/feature_groups/infinispan-local-keycloak.xml
@@ -20,6 +20,9 @@
                 <param name="local-cache" value="sessions"/>
             </feature>
             <feature spec="subsystem.infinispan.cache-container.local-cache">
+                <param name="local-cache" value="sessionIds"/>
+            </feature>
+            <feature spec="subsystem.infinispan.cache-container.local-cache">
                 <param name="local-cache" value="authenticationSessions"/>
             </feature>
             <feature spec="subsystem.infinispan.cache-container.local-cache">

--- a/distribution/server-overlay/src/main/cli/keycloak-install-base.cli
+++ b/distribution/server-overlay/src/main/cli/keycloak-install-base.cli
@@ -6,6 +6,7 @@ embed-server --server-config=standalone.xml
 /subsystem=infinispan/cache-container=keycloak/local-cache=users:add()
 /subsystem=infinispan/cache-container=keycloak/local-cache=users/memory=object:add(size=10000)
 /subsystem=infinispan/cache-container=keycloak/local-cache=sessions:add()
+/subsystem=infinispan/cache-container=keycloak/local-cache=sessionIds:add()
 /subsystem=infinispan/cache-container=keycloak/local-cache=authenticationSessions:add()
 /subsystem=infinispan/cache-container=keycloak/local-cache=offlineSessions:add()
 /subsystem=infinispan/cache-container=keycloak/local-cache=clientSessions:add()

--- a/distribution/server-overlay/src/main/cli/keycloak-install-ha-base.cli
+++ b/distribution/server-overlay/src/main/cli/keycloak-install-ha-base.cli
@@ -7,6 +7,7 @@ embed-server --server-config=standalone-ha.xml
 /subsystem=infinispan/cache-container=keycloak/local-cache=users:add()
 /subsystem=infinispan/cache-container=keycloak/local-cache=users/memory=object:add(size=10000)
 /subsystem=infinispan/cache-container=keycloak/distributed-cache=sessions:add(owners="1")
+/subsystem=infinispan/cache-container=keycloak/distributed-cache=sessionIds:add(owners="1")
 /subsystem=infinispan/cache-container=keycloak/distributed-cache=authenticationSessions:add(owners="1")
 /subsystem=infinispan/cache-container=keycloak/distributed-cache=offlineSessions:add(owners="1")
 /subsystem=infinispan/cache-container=keycloak/distributed-cache=clientSessions:add(owners="1")

--- a/model/infinispan/src/main/java/org/keycloak/connections/infinispan/DefaultInfinispanConnectionProviderFactory.java
+++ b/model/infinispan/src/main/java/org/keycloak/connections/infinispan/DefaultInfinispanConnectionProviderFactory.java
@@ -266,6 +266,14 @@ public class DefaultInfinispanConnectionProviderFactory implements InfinispanCon
         if (jdgEnabled) {
             sessionConfigBuilder = createCacheConfigurationBuilder();
             sessionConfigBuilder.read(sessionCacheConfigurationBase);
+            configureRemoteCacheStore(sessionConfigBuilder, async, InfinispanConnectionProvider.USER_SESSION_IDS_CACHE_NAME);
+        }
+        sessionCacheConfiguration = sessionConfigBuilder.build();
+        cacheManager.defineConfiguration(InfinispanConnectionProvider.USER_SESSION_IDS_CACHE_NAME, sessionCacheConfiguration);
+
+        if (jdgEnabled) {
+            sessionConfigBuilder = createCacheConfigurationBuilder();
+            sessionConfigBuilder.read(sessionCacheConfigurationBase);
             configureRemoteCacheStore(sessionConfigBuilder, async, InfinispanConnectionProvider.OFFLINE_USER_SESSION_CACHE_NAME);
         }
         sessionCacheConfiguration = sessionConfigBuilder.build();
@@ -299,6 +307,7 @@ public class DefaultInfinispanConnectionProviderFactory implements InfinispanCon
 
         // Retrieve caches to enforce rebalance
         cacheManager.getCache(InfinispanConnectionProvider.USER_SESSION_CACHE_NAME, true);
+        cacheManager.getCache(InfinispanConnectionProvider.USER_SESSION_IDS_CACHE_NAME, true);
         cacheManager.getCache(InfinispanConnectionProvider.OFFLINE_USER_SESSION_CACHE_NAME, true);
         cacheManager.getCache(InfinispanConnectionProvider.CLIENT_SESSION_CACHE_NAME, true);
         cacheManager.getCache(InfinispanConnectionProvider.OFFLINE_CLIENT_SESSION_CACHE_NAME, true);

--- a/model/infinispan/src/main/java/org/keycloak/connections/infinispan/InfinispanConnectionProvider.java
+++ b/model/infinispan/src/main/java/org/keycloak/connections/infinispan/InfinispanConnectionProvider.java
@@ -35,6 +35,7 @@ public interface InfinispanConnectionProvider extends Provider {
     int USER_REVISIONS_CACHE_DEFAULT_MAX = 100000;
 
     String USER_SESSION_CACHE_NAME = "sessions";
+    String USER_SESSION_IDS_CACHE_NAME = "sessionIds";
     String CLIENT_SESSION_CACHE_NAME = "clientSessions";
     String OFFLINE_USER_SESSION_CACHE_NAME = "offlineSessions";
     String OFFLINE_CLIENT_SESSION_CACHE_NAME = "offlineClientSessions";

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanUserSessionListener.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanUserSessionListener.java
@@ -1,0 +1,67 @@
+package org.keycloak.models.sessions.infinispan;
+
+import org.infinispan.Cache;
+import org.infinispan.notifications.Listener;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryCreated;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryRemoved;
+import org.infinispan.notifications.cachelistener.event.CacheEntryCreatedEvent;
+import org.infinispan.notifications.cachelistener.event.CacheEntryRemovedEvent;
+import org.jboss.logging.Logger;
+import org.keycloak.models.sessions.infinispan.changes.SessionEntityWrapper;
+import org.keycloak.models.sessions.infinispan.entities.UserSessionEntity;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CompletionStage;
+
+@Listener
+public class InfinispanUserSessionListener {
+
+    public static final Logger logger = Logger.getLogger(InfinispanUserSessionListener.class);
+
+    private final Cache<String, Set<String>> sessionIdsCache;
+
+    public InfinispanUserSessionListener(Cache<String, Set<String>> sessionIdsCache) {
+        this.sessionIdsCache = sessionIdsCache;
+    }
+
+    @CacheEntryCreated
+    public void listen(CacheEntryCreatedEvent<String, SessionEntityWrapper<UserSessionEntity>> event) {
+        if (event.isPre()) {
+            return;
+        }
+
+        final String userId = event.getValue().getEntity().getUser();
+        final Set<String> sessionIds = sessionIdsCache.getOrDefault(userId, new HashSet<>());
+        sessionIds.add(event.getKey());
+        sessionIdsCache.put(userId, sessionIds);
+    }
+
+    @CacheEntryRemoved
+    public CompletionStage<Void> listen(CacheEntryRemovedEvent<String, SessionEntityWrapper<UserSessionEntity>> event) {
+        if (!event.isPre()) {
+            return null;
+        }
+
+        final String userId = event.getValue().getEntity().getUser();
+        final Set<String> sessionIds = sessionIdsCache.get(userId);
+
+        if (sessionIds == null) {
+            return null;
+        }
+
+        final Set<String> newSessionIds = new HashSet<>(sessionIds);
+        newSessionIds.remove(event.getKey());
+
+        if (newSessionIds.isEmpty()) {
+            if (!sessionIdsCache.remove(userId, sessionIds)) {
+                logger.warnf("Failed to remove session ids for user '%s' in cache '%s'", userId, sessionIdsCache.getName());
+            }
+        } else if (!sessionIdsCache.replace(userId, sessionIds, newSessionIds)) {
+            logger.warnf("Failed to replace session ids for user '%s' in cache '%s'", userId, sessionIdsCache.getName());
+        }
+
+        return null;
+    }
+
+}

--- a/testsuite/integration-arquillian/servers/auth-server/jboss/common/jboss-cli/cross-dc-setup.cli
+++ b/testsuite/integration-arquillian/servers/auth-server/jboss/common/jboss-cli/cross-dc-setup.cli
@@ -43,6 +43,23 @@ echo ** Update distributed-cache sessions element **
 )
 /subsystem=infinispan/cache-container=keycloak/distributed-cache=sessions:write-attribute(name=statistics-enabled,value=true)
 
+echo ** Update distributed-cache session ids element **
+/subsystem=infinispan/cache-container=keycloak/distributed-cache=sessionIds/store=remote:add( \
+    passivation=false, \
+    fetch-state=false, \
+    purge=false, \
+    preload=false, \
+    shared=true, \
+    remote-servers=["remote-cache"], \
+    cache=sessionIds, \
+    properties={ \
+        rawValues=true, \
+        marshaller=org.keycloak.cluster.infinispan.KeycloakHotRodMarshallerFactory, \
+        protocolVersion=${keycloak.connectionsInfinispan.hotrodProtocolVersion} \
+    } \
+)
+/subsystem=infinispan/cache-container=keycloak/distributed-cache=sessionIds:write-attribute(name=statistics-enabled,value=true)
+
 echo ** Update distributed-cache offlineSessions element **
 /subsystem=infinispan/cache-container=keycloak/distributed-cache=offlineSessions/store=remote:add( \
     passivation=false, \

--- a/testsuite/performance/infinispan/src/main/scripts/jboss-cli/add-keycloak-caches.cli
+++ b/testsuite/performance/infinispan/src/main/scripts/jboss-cli/add-keycloak-caches.cli
@@ -24,6 +24,7 @@ cd replicated-cache-configuration=sessions-cfg
 cd /subsystem=datagrid-infinispan/cache-container=clustered
 ./replicated-cache=work:add(configuration=sessions-cfg)
 ./replicated-cache=sessions:add(configuration=sessions-cfg)
+./replicated-cache=sessionsIds:add(configuration=sessions-cfg)
 ./replicated-cache=clientSessions:add(configuration=sessions-cfg)
 ./replicated-cache=offlineSessions:add(configuration=sessions-cfg)
 ./replicated-cache=offlineClientSessions:add(configuration=sessions-cfg)

--- a/testsuite/performance/keycloak/src/main/scripts/jboss-cli/add-remote-cache-stores.cli
+++ b/testsuite/performance/keycloak/src/main/scripts/jboss-cli/add-remote-cache-stores.cli
@@ -9,6 +9,7 @@ cd /subsystem=infinispan/cache-container=keycloak
 
 ./replicated-cache=work/store=remote:add(cache=work,                                    fetch-state=false, passivation=false, preload=false, purge=false, remote-servers=["remote-cache"], shared=true, properties={rawValues=true, marshaller=org.keycloak.cluster.infinispan.KeycloakHotRodMarshallerFactory, protocolVersion=${env.HOTROD_VERSION:2.8}})
 ./distributed-cache=sessions/store=remote:add(cache=sessions,                           fetch-state=false, passivation=false, preload=false, purge=false, remote-servers=["remote-cache"], shared=true, properties={rawValues=true, marshaller=org.keycloak.cluster.infinispan.KeycloakHotRodMarshallerFactory, protocolVersion=${env.HOTROD_VERSION:2.8}})
+./distributed-cache=sessionIds/store=remote:add(cache=sessionIds                        fetch-state=false, passivation=false, preload=false, purge=false, remote-servers=["remote-cache"], shared=true, properties={rawValues=true, marshaller=org.keycloak.cluster.infinispan.KeycloakHotRodMarshallerFactory, protocolVersion=${env.HOTROD_VERSION:2.8}})
 ./distributed-cache=offlineSessions/store=remote:add(cache=offlineSessions,             fetch-state=false, passivation=false, preload=false, purge=false, remote-servers=["remote-cache"], shared=true, properties={rawValues=true, marshaller=org.keycloak.cluster.infinispan.KeycloakHotRodMarshallerFactory, protocolVersion=${env.HOTROD_VERSION:2.8}})
 ./distributed-cache=clientSessions/store=remote:add(cache=clientSessions,               fetch-state=false, passivation=false, preload=false, purge=false, remote-servers=["remote-cache"], shared=true, properties={rawValues=true, marshaller=org.keycloak.cluster.infinispan.KeycloakHotRodMarshallerFactory, protocolVersion=${env.HOTROD_VERSION:2.8}})
 ./distributed-cache=offlineClientSessions/store=remote:add(cache=offlineClientSessions, fetch-state=false, passivation=false, preload=false, purge=false, remote-servers=["remote-cache"], shared=true, properties={rawValues=true, marshaller=org.keycloak.cluster.infinispan.KeycloakHotRodMarshallerFactory, protocolVersion=${env.HOTROD_VERSION:2.8}})
@@ -18,6 +19,7 @@ cd /subsystem=infinispan/cache-container=keycloak
 
 ./replicated-cache=work:write-attribute                     (name=statistics-enabled, value=${env.CACHE_STATISTICS:true})
 ./distributed-cache=sessions:write-attribute                (name=statistics-enabled, value=${env.CACHE_STATISTICS:true})
+./distributed-cache=sessionIds:write-attribute              (name=statistics-enabled, value=${env.CACHE_STATISTICS:true})
 ./distributed-cache=offlineSessions:write-attribute         (name=statistics-enabled, value=${env.CACHE_STATISTICS:true})
 ./distributed-cache=clientSessions:write-attribute          (name=statistics-enabled, value=${env.CACHE_STATISTICS:true})
 ./distributed-cache=offlineClientSessions:write-attribute   (name=statistics-enabled, value=${env.CACHE_STATISTICS:true})


### PR DESCRIPTION
I noticed that the API to retrieve user sessions is getting slower as the number of active user sessions increase. After looking at InfinispanUserSessionProvider, I realized that retrieving sessions for a user ends up iterating all the sessions from the "sessions" cache.

To address this, I'm proposing to cache the user's session ids and use that cache to retrieve all the sessions of a user. The cache gets updated by listening to events from "sessions" cache. Basically, an entry for a user will be added or updated whenever a session is created or removed for a particular user.