### PR TITLE
[KEYCLOAK-19310] - MSSQL Support

### DIFF
--- a/quarkus/deployment/pom.xml
+++ b/quarkus/deployment/pom.xml
@@ -60,6 +60,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jdbc-mssql-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-bootstrap-core</artifactId>
         </dependency>
         <dependency>

--- a/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/LiquibaseProcessor.java
+++ b/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/LiquibaseProcessor.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import io.quarkus.agroal.spi.JdbcDataSourceBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.ClassInfo;
@@ -35,11 +36,12 @@ class LiquibaseProcessor {
 
     @Record(ExecutionTime.STATIC_INIT)
     @BuildStep
-    void configure(KeycloakRecorder recorder, CombinedIndexBuildItem indexBuildItem) {
+    void configure(KeycloakRecorder recorder, List<JdbcDataSourceBuildItem> jdbcDataSources, CombinedIndexBuildItem indexBuildItem) {
         DotName liquibaseServiceName = DotName.createSimple(LiquibaseService.class.getName());
         Map<String, List<String>> services = new HashMap<>();
-
         IndexView index = indexBuildItem.getIndex();
+        JdbcDataSourceBuildItem dataSourceBuildItem = jdbcDataSources.get(0);
+        String dbKind = dataSourceBuildItem.getDbKind();
 
         for (Class<?> c : Arrays.asList(liquibase.diff.compare.DatabaseObjectComparator.class,
                 liquibase.parser.NamespaceDetails.class,
@@ -61,7 +63,7 @@ class LiquibaseProcessor {
             } else {
                 classes.addAll(index.getAllKnownSubclasses(DotName.createSimple(c.getName())));
             }
-            filterImplementations(c, classes);
+            filterImplementations(c, dbKind, classes);
             for (ClassInfo found : classes) {
                 if (Modifier.isAbstract(found.flags()) ||
                         Modifier.isInterface(found.flags()) ||
@@ -85,10 +87,10 @@ class LiquibaseProcessor {
         recorder.configureLiquibase(services);
     }
 
-    private void filterImplementations(Class<?> types, Set<ClassInfo> classes) {
+    private void filterImplementations(Class<?> types, String dbKind, Set<ClassInfo> classes) {
         if (Database.class.equals(types)) {
             // removes unsupported databases
-            classes.removeIf(classInfo -> !org.keycloak.quarkus.runtime.storage.database.Database.isSupported(classInfo.name().toString()));
+            classes.removeIf(classInfo -> !org.keycloak.quarkus.runtime.storage.database.Database.isLiquibaseDatabaseSupported(classInfo.name().toString(), dbKind));
         }
     }
 }

--- a/quarkus/runtime/pom.xml
+++ b/quarkus/runtime/pom.xml
@@ -61,6 +61,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jdbc-mssql</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-core</artifactId>
         </dependency>
         <dependency>

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakRecorder.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakRecorder.java
@@ -42,8 +42,6 @@ import liquibase.servicelocator.ServiceLocator;
 @Recorder
 public class KeycloakRecorder {
 
-    private static final Logger LOGGER = Logger.getLogger(KeycloakRecorder.class);
-
     public void configureLiquibase(Map<String, List<String>> services) {
         LogFactory.setInstance(new LogFactory() {
             final KeycloakLogger logger = new KeycloakLogger();

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/OptionRenderer.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/OptionRenderer.java
@@ -52,7 +52,7 @@ public class OptionRenderer implements CommandLine.Help.IOptionRenderer {
             throw new CommandLine.PicocliException("Option[" + option + "] description should have a single line.");
         }
 
-        Text description = scheme.text(descriptions[0]);
+        Text description = formatDescription(descriptions, option, scheme);
 
         if (EMPTY_TEXT.equals(shortName)) {
             result[0] = new Text[] { longName, description };
@@ -61,6 +61,17 @@ public class OptionRenderer implements CommandLine.Help.IOptionRenderer {
         }
 
         return result;
+    }
+
+    private Text formatDescription(String[] descriptions, OptionSpec option, ColorScheme scheme) {
+        String description = descriptions[0];
+        String defaultValue = option.defaultValue();
+
+        if (defaultValue != null) {
+            description = description + " Default: " + defaultValue + ".";
+        }
+
+        return scheme.text(description);
     }
 
     private Text createLongName(OptionSpec option, ColorScheme scheme) {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/Picocli.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/Picocli.java
@@ -67,6 +67,7 @@ public final class Picocli {
 
     private static final String ARG_SEPARATOR = ";;";
     public static final String ARG_PREFIX = "--";
+    public static final String ARG_SHORT_PREFIX = "-";
     public static final String ARG_PART_SEPARATOR = "-";
     public static final char ARG_KEY_VALUE_SEPARATOR = '=';
     public static final Pattern ARG_SPLIT = Pattern.compile(";;");
@@ -342,6 +343,7 @@ public final class Picocli {
                 .description("Enables a group of features. Possible values are: " + String.join(",", featuresExpectedValues))
                 .paramLabel("feature")
                 .completionCandidates(featuresExpectedValues)
+                .parameterConsumer(PropertyMapperParameterConsumer.INSTANCE)
                 .type(String.class)
                 .build());
 
@@ -352,6 +354,7 @@ public final class Picocli {
                     .description("Enables the " + feature.name() + " feature.")
                     .paramLabel(String.join("|", expectedValues))
                     .type(String.class)
+                    .parameterConsumer(PropertyMapperParameterConsumer.INSTANCE)
                     .completionCandidates(expectedValues)
                     .build());
         }
@@ -385,12 +388,14 @@ public final class Picocli {
                 }
 
                 String defaultValue = mapper.getDefaultValue();
+                Iterable<String> expectedValues = mapper.getExpectedValues();
 
                 argGroupBuilder.addArg(OptionSpec.builder(name)
                         .defaultValue(defaultValue)
-                        .description(description + (defaultValue == null ? "" : " Default: ${DEFAULT-VALUE}."))
+                        .description(description)
                         .paramLabel(mapper.getParamLabel())
-                        .completionCandidates(mapper.getExpectedValues())
+                        .completionCandidates(expectedValues)
+                        .parameterConsumer(PropertyMapperParameterConsumer.INSTANCE)
                         .type(String.class)
                         .build());
             }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/PropertyMapperParameterConsumer.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/PropertyMapperParameterConsumer.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.quarkus.runtime.cli;
+
+import static org.keycloak.quarkus.runtime.cli.Picocli.ARG_PREFIX;
+
+import java.util.Iterator;
+import java.util.Stack;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Model.ArgSpec;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Model.OptionSpec;
+import picocli.CommandLine.ParameterException;
+
+public final class PropertyMapperParameterConsumer implements CommandLine.IParameterConsumer {
+
+    static final CommandLine.IParameterConsumer INSTANCE = new PropertyMapperParameterConsumer();
+
+    private PropertyMapperParameterConsumer() {
+        // singleton
+    }
+
+    @Override
+    public void consumeParameters(Stack<String> args, ArgSpec argSpec,
+            CommandSpec commandSpec) {
+        if (argSpec instanceof OptionSpec) {
+            validateOption(args, argSpec, commandSpec);
+        }
+    }
+
+    private void validateOption(Stack<String> args, ArgSpec argSpec, CommandSpec commandSpec) {
+        OptionSpec option = (OptionSpec) argSpec;
+        String name = String.join(", ", option.names());
+        CommandLine commandLine = commandSpec.commandLine();
+
+        if (args.isEmpty() || !isOptionValue(args.peek())) {
+            throw new ParameterException(
+                    commandLine, "Missing required value for option '" + name + "' (" + argSpec.paramLabel() + ")." + getExpectedValuesMessage(argSpec, option));
+        }
+
+        // consumes the value
+        String value = args.pop();
+
+        if (!args.isEmpty() && isOptionValue(args.peek())) {
+            throw new ParameterException(
+                    commandLine, "Option '" + name + "' expects a single value (" + argSpec.paramLabel() + ")" + getExpectedValuesMessage(argSpec, option));
+        }
+
+        if (isExpectedValue(option, value)) {
+            return;
+        }
+
+        throw new ParameterException(
+                commandLine, "Invalid value for option '" + name + "': " + value + "." + getExpectedValuesMessage(argSpec, option));
+    }
+
+    private boolean isOptionValue(String arg) {
+        return !(arg.startsWith(ARG_PREFIX) || arg.startsWith(Picocli.ARG_SHORT_PREFIX));
+    }
+
+    private String getExpectedValuesMessage(ArgSpec argSpec, OptionSpec option) {
+        return option.completionCandidates().iterator().hasNext() ? " Expected values are: " + String.join(", ", argSpec.completionCandidates()) : "";
+    }
+
+    private boolean isExpectedValue(OptionSpec option, String value) {
+        Iterator<String> expectedValues = option.completionCandidates().iterator();
+
+        if (!expectedValues.hasNext()) {
+            // accept any
+            return true;
+        }
+
+        while (expectedValues.hasNext()) {
+            String expectedValue = expectedValues.next();
+
+            if (expectedValue.equals(value)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Start.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Start.java
@@ -19,8 +19,6 @@ package org.keycloak.quarkus.runtime.cli.command;
 
 import static org.keycloak.quarkus.runtime.cli.Picocli.NO_PARAM_LABEL;
 
-import org.keycloak.quarkus.runtime.cli.Picocli;
-
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/ConfigArgsConfigSource.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/ConfigArgsConfigSource.java
@@ -26,7 +26,6 @@ import static org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvi
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.regex.Pattern;
 
 import org.jboss.logging.Logger;
 

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/ClusteringPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/ClusteringPropertyMappers.java
@@ -19,7 +19,6 @@ final class ClusteringPropertyMappers {
                                 "Value 'default' enables clustering for infinispan caches.")
                         .paramLabel("mode")
                         .isBuildTimeProperty(true)
-                        .expectedValues(Arrays.asList("local", "default"))
                         .build(),
                 builder().from("cluster-stack")
                         .to("kc.spi.connections-infinispan.quarkus.stack")

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/integration/QuarkusKeycloakSessionFactory.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/integration/QuarkusKeycloakSessionFactory.java
@@ -32,8 +32,6 @@ import org.keycloak.services.resources.admin.permissions.AdminPermissions;
 
 public final class QuarkusKeycloakSessionFactory extends DefaultKeycloakSessionFactory {
 
-    private static final Logger logger = Logger.getLogger(QuarkusKeycloakSessionFactory.class);
-
     public static QuarkusKeycloakSessionFactory getInstance() {
         if (INSTANCE == null) {
             INSTANCE = new QuarkusKeycloakSessionFactory();

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/integration/web/QuarkusRequestFilter.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/integration/web/QuarkusRequestFilter.java
@@ -46,7 +46,7 @@ public class QuarkusRequestFilter extends AbstractRequestFilter implements Handl
         context.vertx().executeBlocking(promise -> {
             ClientConnection connection = createClientConnection(context.request());
 
-            filter(connection, (session) -> {
+            filter(connection, session -> {
                 try {
                     configureContextualData(context, connection, session);
 

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/database/jpa/QuarkusJpaConnectionProviderFactory.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/database/jpa/QuarkusJpaConnectionProviderFactory.java
@@ -45,7 +45,6 @@ import javax.transaction.Transaction;
 import com.fasterxml.jackson.core.type.TypeReference;
 import io.quarkus.runtime.Quarkus;
 
-import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.internal.SessionFactoryImpl;
 import org.jboss.logging.Logger;
 import org.keycloak.Config;
@@ -117,7 +116,6 @@ public final class QuarkusJpaConnectionProviderFactory implements JpaConnectionP
     }
 
     private void addSpecificNamedQueries(KeycloakSession session, Connection connection) {
-        SessionFactoryImplementor sfi = emf.unwrap(SessionFactoryImplementor.class);
         EntityManager em = createEntityManager(session);
 
         try {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/database/liquibase/FastServiceLocator.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/database/liquibase/FastServiceLocator.java
@@ -79,6 +79,15 @@ public class FastServiceLocator extends ServiceLocator {
         getPackages().remove("liquibase.parser.core.json");
         getPackages().remove("liquibase.serializer.core.json");
 
+        // register only the implementations related to the chosen db
+        for (String databaseImpl : services.get(Database.class.getName())) {
+            try {
+                register((Database) getClass().getClassLoader().loadClass(databaseImpl).getDeclaredConstructor().newInstance());
+            } catch (Exception cause) {
+                throw new RuntimeException("Failed to load database implementation", cause);
+            }
+        }
+
         this.services = services;
     }
 

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/database/liquibase/KeycloakLogger.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/database/liquibase/KeycloakLogger.java
@@ -24,7 +24,7 @@ import liquibase.logging.Logger;
 
 public class KeycloakLogger implements Logger {
 
-    private static final org.jboss.logging.Logger logger = org.jboss.logging.Logger.getLogger(QuarkusLiquibaseConnectionProvider.class);
+    private static final org.jboss.logging.Logger logger = org.jboss.logging.Logger.getLogger(KeycloakLogger.class);
     
     @Override
     public void setName(String name) {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/database/liquibase/QuarkusLiquibaseConnectionProvider.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/database/liquibase/QuarkusLiquibaseConnectionProvider.java
@@ -29,9 +29,6 @@ import org.keycloak.Config;
 import org.keycloak.connections.jpa.JpaConnectionProvider;
 import org.keycloak.connections.jpa.JpaConnectionProviderFactory;
 import org.keycloak.connections.jpa.updater.liquibase.MySQL8VarcharType;
-import org.keycloak.connections.jpa.updater.liquibase.PostgresPlusDatabase;
-import org.keycloak.connections.jpa.updater.liquibase.UpdatedMariaDBDatabase;
-import org.keycloak.connections.jpa.updater.liquibase.UpdatedMySqlDatabase;
 import org.keycloak.connections.jpa.updater.liquibase.conn.CustomChangeLogHistoryService;
 import org.keycloak.connections.jpa.updater.liquibase.conn.LiquibaseConnectionProvider;
 import org.keycloak.connections.jpa.updater.liquibase.conn.LiquibaseConnectionProviderFactory;
@@ -79,11 +76,6 @@ public class QuarkusLiquibaseConnectionProvider implements LiquibaseConnectionPr
         JpaConnectionProviderFactory jpaConnectionProvider = (JpaConnectionProviderFactory) session
                 .getKeycloakSessionFactory().getProviderFactory(JpaConnectionProvider.class);
 
-        // register our custom databases
-        locator.register(new PostgresPlusDatabase());
-        locator.register(new UpdatedMySqlDatabase());
-        locator.register(new UpdatedMariaDBDatabase());
-        
         // registers only the database we are using
         try (Connection connection = jpaConnectionProvider.getConnection()) {
             Database database = DatabaseFactory.getInstance()

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/database/liquibase/database/CustomMSSQLDatabase.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/database/liquibase/database/CustomMSSQLDatabase.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.quarkus.runtime.storage.database.liquibase.database;
+
+import liquibase.database.core.MSSQLDatabase;
+
+public class CustomMSSQLDatabase extends MSSQLDatabase {
+
+    private static String ENGINE_EDITION;
+
+    @Override
+    public String getEngineEdition() {
+        // no need to query engine edition every time
+        // it should be safe to update without any synchronization code as liquibase runs from a single thread
+        if (ENGINE_EDITION == null) {
+            return ENGINE_EDITION = super.getEngineEdition();
+        }
+        return ENGINE_EDITION;
+    }
+}

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/infinispan/CacheInitializer.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/infinispan/CacheInitializer.java
@@ -26,8 +26,6 @@ import org.keycloak.Config;
 
 public class CacheInitializer {
 
-    private static final Logger log = Logger.getLogger(CacheInitializer.class);
-
     private final String config;
 
     public CacheInitializer(String config) {

--- a/quarkus/runtime/src/test/java/org/keycloak/provider/quarkus/ConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/provider/quarkus/ConfigurationTest.java
@@ -235,7 +235,7 @@ public class ConfigurationTest {
 
     @Test
     public void testDatabaseKindProperties() {
-        System.setProperty(CLI_ARGS, "--db=postgres-10" + ARG_SEPARATOR + "--db-url=jdbc:postgresql://localhost/keycloak");
+        System.setProperty(CLI_ARGS, "--db=postgres" + ARG_SEPARATOR + "--db-url=jdbc:postgresql://localhost/keycloak");
         SmallRyeConfig config = createConfig();
         assertEquals("io.quarkus.hibernate.orm.runtime.dialect.QuarkusPostgreSQL10Dialect",
             config.getConfigValue("quarkus.hibernate-orm.dialect").getValue());


### PR DESCRIPTION
Basically:

* Support for MSSQL database. For now, we have support for 2012 and the latest dialects (based on Quarkus default).
* Added validation to database options that should also help to provide a more meaningful feedback for users
* Changed Liquibase to only include the database selected when building the server (we were still iterating over all liquibase impls)
* Minor improvements to code 