### PR TITLE
[KEYCLOAK-19310] - Oracle Support

### DIFF
--- a/quarkus/deployment/pom.xml
+++ b/quarkus/deployment/pom.xml
@@ -64,6 +64,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jdbc-oracle-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-bootstrap-core</artifactId>
         </dependency>
         <dependency>

--- a/quarkus/runtime/pom.xml
+++ b/quarkus/runtime/pom.xml
@@ -65,6 +65,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jdbc-oracle</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-core</artifactId>
         </dependency>
         <dependency>

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/KcEnvConfigSource.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/KcEnvConfigSource.java
@@ -17,46 +17,34 @@
 
 package org.keycloak.quarkus.runtime.configuration;
 
+import static io.smallrye.config.common.utils.StringUtil.replaceNonAlphanumericByUnderscores;
 import static org.keycloak.quarkus.runtime.configuration.Configuration.getMappedPropertyName;
 
+import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
-import java.util.TreeMap;
-import org.eclipse.microprofile.config.spi.ConfigSource;
 
-public class EnvConfigSource implements ConfigSource {
+import io.smallrye.config.EnvConfigSource;
 
-    private final Map<String, String> properties = new TreeMap<>();
+public class KcEnvConfigSource extends EnvConfigSource {
 
-    public EnvConfigSource() {
+    private static Map<String, String> buildProperties() {
+        Map<String, String> properties = new HashMap<>();
+
         for (Map.Entry<String, String> entry : System.getenv().entrySet()) {
             String key = entry.getKey();
-            if (key.startsWith(MicroProfileConfigProvider.NS_KEYCLOAK_PREFIX.toUpperCase().replace('.', '_'))) {
+            if (key.startsWith(replaceNonAlphanumericByUnderscores(MicroProfileConfigProvider.NS_KEYCLOAK_PREFIX.toUpperCase()))) {
                 properties.put(getMappedPropertyName(key), entry.getValue());
             }
         }
-    }
 
-    @Override
-    public Map<String, String> getProperties() {
         return properties;
     }
 
-    @Override
-    public Set<String> getPropertyNames() {
-        return properties.keySet();
-    }
-
-    public String getValue(final String propertyName) {
-        return System.getProperty(propertyName);
+    public KcEnvConfigSource() {
+        super(buildProperties(), 350);
     }
 
     public String getName() {
         return "KcEnvVarConfigSource";
-    }
-
-    @Override
-    public int getOrdinal() {
-        return 350;
     }
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/KeycloakConfigSourceProvider.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/KeycloakConfigSourceProvider.java
@@ -53,7 +53,7 @@ public class KeycloakConfigSourceProvider implements ConfigSourceProvider {
 
         CONFIG_SOURCES.add(new ConfigArgsConfigSource());
         CONFIG_SOURCES.add(new SysPropConfigSource());
-        CONFIG_SOURCES.add(new EnvConfigSource());
+        CONFIG_SOURCES.add(new KcEnvConfigSource());
         PERSISTED_CONFIG_SOURCE = new PersistedConfigSource(getPersistedConfigFile());
         CONFIG_SOURCES.add(PERSISTED_CONFIG_SOURCE);
 

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/database/Database.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/database/Database.java
@@ -154,6 +154,12 @@ public final class Database {
                 "jdbc:sqlserver://${kc.db.url.host:localhost}:1433;databaseName=${kc.db.url.database:keycloak}${kc.db.url.properties:}",
                 asList("org.keycloak.quarkus.runtime.storage.database.liquibase.database.CustomMSSQLDatabase"),
                 "mssql", "mssql-2012"
+        ),
+        ORACLE("oracle",
+                "oracle.jdbc.xa.client.OracleXADataSource",
+                "org.hibernate.dialect.Oracle12cDialect",
+                "jdbc:oracle:thin:@//${kc.db.url.host:localhost}:1521/${kc.db.url.database:keycloak}",
+                asList("liquibase.database.core.OracleDatabase")
         );
 
         final String databaseKind;

--- a/quarkus/runtime/src/test/java/org/keycloak/provider/quarkus/ConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/provider/quarkus/ConfigurationTest.java
@@ -18,6 +18,7 @@
 package org.keycloak.provider.quarkus;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.keycloak.quarkus.runtime.Environment.CLI_ARGS;
 
 import java.io.File;
@@ -115,6 +116,15 @@ public class ConfigurationTest {
     public void testEnvVarPriorityOverPropertiesFile() {
         putEnvVar("KC_SPI_HOSTNAME_DEFAULT_FRONTEND_URL", "http://envvar.unittest");
         assertEquals("http://envvar.unittest", initConfig("hostname", "default").get("frontendUrl"));
+    }
+
+    @Test
+    public void testEnvVarAvailableFromPropertyNames() {
+        putEnvVar("KC_VAULT_FILE_PATH", "/foo/bar");
+        Config.Scope config = initConfig("vault", FilesPlainTextVaultProviderFactory.PROVIDER_ID);
+        assertEquals("/foo/bar", config.get("dir"));
+        assertTrue(config.getPropertyNames()
+                .contains("kc.spi.vault.".concat(FilesPlainTextVaultProviderFactory.PROVIDER_ID).concat(".dir")));
     }
 
     @Test


### PR DESCRIPTION
@DGuhr @stianst We are now very strict about some key database settings such as Hibernate dialect, JDBC Driver, etc.

The versions we are enabling are pretty much based on our list of supported configurations (RH-SSO). I see that as a good thing because we are now more opinionated.

But yeah, people using databases that need different settings might be impacted.