### PR TITLE
Issue #8793: Unable to find default UserProfile provider with multiple implementations

### DIFF
--- a/services/src/main/java/org/keycloak/userprofile/DeclarativeUserProfileProvider.java
+++ b/services/src/main/java/org/keycloak/userprofile/DeclarativeUserProfileProvider.java
@@ -74,6 +74,7 @@ public class DeclarativeUserProfileProvider extends AbstractUserProfileProvider<
         implements AmphibianProviderFactory<UserProfileProvider> {
 
     public static final String ID = "declarative-user-profile";
+    public static final int PROVIDER_PRIORITY = 1;
     public static final String UP_PIECES_COUNT_COMPONENT_CONFIG_KEY = "config-pieces-count";
     public static final String REALM_USER_PROFILE_ENABLED = "userProfileEnabled";
     private static final String PARSED_CONFIG_COMPONENT_KEY = "kc.user.profile.metadata";
@@ -246,6 +247,11 @@ public class DeclarativeUserProfileProvider extends AbstractUserProfileProvider<
     public void init(Config.Scope config) {
         super.init(config);
         isDeclarativeConfigurationEnabled = Profile.isFeatureEnabled(Profile.Feature.DECLARATIVE_USER_PROFILE);
+    }
+
+    @Override
+    public int order() {
+        return PROVIDER_PRIORITY;
     }
 
     public ComponentModel getComponentModel() {

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/user/profile/CustomUserProfileProvider.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/user/profile/CustomUserProfileProvider.java
@@ -50,4 +50,8 @@ public class CustomUserProfileProvider extends DeclarativeUserProfileProvider {
         return this.create(context, attributes, (UserModel) null);
     }
 
+    @Override
+    public int order() {
+        return super.order() - 1;
+    }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/resources/META-INF/keycloak-server.json
+++ b/testsuite/integration-arquillian/tests/base/src/test/resources/META-INF/keycloak-server.json
@@ -282,7 +282,7 @@
     },
 
     "userProfile": {
-        "provider": "${keycloak.userProfile.provider:declarative-user-profile}",
+        "provider": "${keycloak.userProfile.provider:}",
         "declarative-user-profile": {
             "read-only-attributes": [ "deniedFoo", "deniedBar*", "deniedSome/thing", "deniedsome*thing" ],
             "admin-read-only-attributes": [ "deniedSomeAdmin" ]


### PR DESCRIPTION
Recently, there was a PR with a new implementation of UserProfile provider in testsuite and GH actions were executed successfully. However, our remote tests have started to fail. As described in attached GH issue, it was caused by the wrong setting of default provider for UserProfile. We didn't catch the bug in GH actions, because in testsuite, there's a file `keycloak-server.json`, where the default provider is set up. However, for remote auth-server, the file is not provided there and we were not able to execute those tests, because when we called `session.getProvider(UserProfileProvider.class)`, we didn't know about the default provider for UserProfile.

Closes #8793 
It also resolves [KEYCLOAK-19704](https://issues.redhat.com/browse/KEYCLOAK-19704)

@pedroigor @miquelsi Could you please take a look at it? Thank you.
I'll execute the remote tests.