### PR TITLE
KEYCLOAK-19815 Implement online token introspection

### DIFF
--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/AdapterDeploymentContext.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/AdapterDeploymentContext.java
@@ -169,6 +169,11 @@ public class AdapterDeploymentContext {
         }
 
         @Override
+        public String getTokenIntrospectionUrl() {
+            return (this.tokenIntrospectionUrl != null) ? this.tokenIntrospectionUrl : delegate.getTokenIntrospectionUrl();
+        }
+
+        @Override
         public String getResourceName() {
             return delegate.getResourceName();
         }
@@ -413,6 +418,17 @@ public class AdapterDeploymentContext {
         public void setAlwaysRefreshToken(boolean alwaysRefreshToken) {
             delegate.setAlwaysRefreshToken(alwaysRefreshToken);
         }
+
+        @Override
+        public boolean isOnlineTokenIntrospection() {
+            return delegate.isOnlineTokenIntrospection();
+        }
+
+        @Override
+        public void setOnlineTokenIntrospection(boolean onlineTokenIntrospection) {
+            delegate.setOnlineTokenIntrospection(onlineTokenIntrospection);
+        }
+
 
         @Override
         public int getRegisterNodePeriod() {

--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/KeycloakDeployment.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/KeycloakDeployment.java
@@ -61,6 +61,7 @@ public class KeycloakDeployment {
     protected String registerNodeUrl;
     protected String unregisterNodeUrl;
     protected String jwksUrl;
+    protected String tokenIntrospectionUrl;
     protected String principalAttribute = "sub";
 
     protected String resourceName;
@@ -86,6 +87,8 @@ public class KeycloakDeployment {
     protected String corsExposedHeaders;
     protected boolean exposeToken;
     protected boolean alwaysRefreshToken;
+    // https://tools.ietf.org/html/rfc7662
+    protected boolean onlineTokenIntrospection;
     protected boolean registerNodeAtStartup;
     protected int registerNodePeriod;
     protected boolean turnOffChangeSessionIdOnLogin;
@@ -150,6 +153,7 @@ public class KeycloakDeployment {
         registerNodeUrl = null;
         unregisterNodeUrl = null;
         jwksUrl = null;
+        tokenIntrospectionUrl = null;
 
         URI authServerUri = URI.create(authServerBaseUrl);
 
@@ -195,6 +199,7 @@ public class KeycloakDeployment {
                             .path(ServiceUrlConstants.CLIENTS_MANAGEMENT_UNREGISTER_NODE_PATH)
                             .build(getRealm()).toString();
                         jwksUrl = config.getJwksUri();
+                        tokenIntrospectionUrl = config.getIntrospectionEndpoint();
 
                         log.infov("Loaded URLs from {0}", discoveryUrl);
                     } catch (Exception e) {
@@ -220,6 +225,7 @@ public class KeycloakDeployment {
         registerNodeUrl = authUrlBuilder.clone().path(ServiceUrlConstants.CLIENTS_MANAGEMENT_REGISTER_NODE_PATH).build(getRealm()).toString();
         unregisterNodeUrl = authUrlBuilder.clone().path(ServiceUrlConstants.CLIENTS_MANAGEMENT_UNREGISTER_NODE_PATH).build(getRealm()).toString();
         jwksUrl = authUrlBuilder.clone().path(ServiceUrlConstants.JWKS_URL).build(getRealm()).toString();
+        tokenIntrospectionUrl = authUrlBuilder.clone().path(ServiceUrlConstants.TOKEN_INTROSPECT_PATH).build(getRealm()).toString();
     }
 
     protected OIDCConfigurationRepresentation getOidcConfiguration(String discoveryUrl) throws Exception {
@@ -280,6 +286,11 @@ public class KeycloakDeployment {
     public String getJwksUrl() {
         resolveUrls();
         return jwksUrl;
+    }
+
+    public String getTokenIntrospectionUrl() {
+        resolveUrls();
+        return tokenIntrospectionUrl;
     }
 
     public void setResourceName(String resourceName) {
@@ -481,6 +492,14 @@ public class KeycloakDeployment {
 
     public void setAlwaysRefreshToken(boolean alwaysRefreshToken) {
         this.alwaysRefreshToken = alwaysRefreshToken;
+    }
+
+    public boolean isOnlineTokenIntrospection() {
+        return onlineTokenIntrospection;
+    }
+
+    public void setOnlineTokenIntrospection(boolean onlineTokenIntrospection) {
+        this.onlineTokenIntrospection = onlineTokenIntrospection;
     }
 
     public boolean isRegisterNodeAtStartup() {

--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/KeycloakDeploymentBuilder.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/KeycloakDeploymentBuilder.java
@@ -120,6 +120,7 @@ public class KeycloakDeploymentBuilder {
         deployment.setAutodetectBearerOnly(adapterConfig.isAutodetectBearerOnly());
         deployment.setEnableBasicAuth(adapterConfig.isEnableBasicAuth());
         deployment.setAlwaysRefreshToken(adapterConfig.isAlwaysRefreshToken());
+        deployment.setOnlineTokenIntrospection(adapterConfig.isOnlineTokenIntrospection());
         deployment.setRegisterNodeAtStartup(adapterConfig.isRegisterNodeAtStartup());
         deployment.setRegisterNodePeriod(adapterConfig.getRegisterNodePeriod());
         deployment.setTokenMinimumTimeToLive(adapterConfig.getTokenMinimumTimeToLive());

--- a/adapters/oidc/adapter-core/src/test/java/org/keycloak/adapters/KeycloakDeploymentBuilderTest.java
+++ b/adapters/oidc/adapter-core/src/test/java/org/keycloak/adapters/KeycloakDeploymentBuilderTest.java
@@ -72,6 +72,7 @@ public class KeycloakDeploymentBuilderTest {
         assertEquals(20, ((ThreadSafeClientConnManager) deployment.getClient().getConnectionManager()).getMaxTotal());
         assertEquals(RelativeUrlsUsed.NEVER, deployment.getRelativeUrls());
         assertTrue(deployment.isAlwaysRefreshToken());
+        assertTrue(deployment.isOnlineTokenIntrospection());
         assertTrue(deployment.isRegisterNodeAtStartup());
         assertEquals(1000, deployment.getRegisterNodePeriod());
         assertEquals(TokenStore.COOKIE, deployment.getTokenStore());

--- a/adapters/oidc/adapter-core/src/test/resources/keycloak.json
+++ b/adapters/oidc/adapter-core/src/test/resources/keycloak.json
@@ -26,6 +26,7 @@
     "client-keystore-password": "storepass",
     "client-key-password": "keypass",
     "always-refresh-token": true,
+    "online-token-introspection": true,
     "register-node-at-startup": true,
     "register-node-period": 1000,
     "token-store": "cookie",

--- a/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/filter/KeycloakSecurityContextRequestFilter.java
+++ b/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/filter/KeycloakSecurityContextRequestFilter.java
@@ -86,6 +86,14 @@ public class KeycloakSecurityContextRequestFilter extends GenericFilterBean impl
                 }
             }
 
+            if (deployment.isOnlineTokenIntrospection()) {
+                if (refreshableSecurityContext.introspectRelyingPartyToken()) {
+                    request.setAttribute(KeycloakSecurityContext.class.getName(), refreshableSecurityContext);
+                } else {
+                    clearAuthenticationContext();
+                }
+            }
+
             request.setAttribute(KeycloakSecurityContext.class.getName(), keycloakSecurityContext);
         }
 
@@ -101,6 +109,7 @@ public class KeycloakSecurityContextRequestFilter extends GenericFilterBean impl
     public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
         this.applicationContext = applicationContext;
     }
+
 
     private KeycloakSecurityContext getKeycloakSecurityContext() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();

--- a/authz/client/src/main/java/org/keycloak/authorization/client/resource/ProtectionResource.java
+++ b/authz/client/src/main/java/org/keycloak/authorization/client/resource/ProtectionResource.java
@@ -19,7 +19,7 @@ package org.keycloak.authorization.client.resource;
 
 import org.keycloak.authorization.client.Configuration;
 import org.keycloak.authorization.client.representation.ServerConfiguration;
-import org.keycloak.authorization.client.representation.TokenIntrospectionResponse;
+import org.keycloak.representations.TokenIntrospectionResponse;
 import org.keycloak.authorization.client.util.Http;
 import org.keycloak.authorization.client.util.TokenCallable;
 

--- a/authz/client/src/main/java/org/keycloak/authorization/client/util/Throwables.java
+++ b/authz/client/src/main/java/org/keycloak/authorization/client/util/Throwables.java
@@ -19,7 +19,7 @@ package org.keycloak.authorization.client.util;
 import java.util.concurrent.Callable;
 
 import org.keycloak.authorization.client.AuthorizationDeniedException;
-import org.keycloak.authorization.client.representation.TokenIntrospectionResponse;
+import org.keycloak.representations.TokenIntrospectionResponse;
 
 /**
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>

--- a/core/src/main/java/org/keycloak/OAuth2Constants.java
+++ b/core/src/main/java/org/keycloak/OAuth2Constants.java
@@ -50,6 +50,8 @@ public interface OAuth2Constants {
 
     String TOKEN_TYPE = "token_type";
 
+    String TOKEN_TYPE_HINT = "token_type_hint";
+
     String EXPIRES_IN = "expires_in";
 
     String ID_TOKEN = "id_token";
@@ -57,6 +59,8 @@ public interface OAuth2Constants {
     String REFRESH_TOKEN = "refresh_token";
 
     String LOGOUT_TOKEN = "logout_token";
+
+    String REQUESTING_PARTY_TOKEN = "requesting_party_token";
 
     String AUTHORIZATION_CODE = "authorization_code";
 

--- a/core/src/main/java/org/keycloak/constants/ServiceUrlConstants.java
+++ b/core/src/main/java/org/keycloak/constants/ServiceUrlConstants.java
@@ -31,6 +31,7 @@ public interface ServiceUrlConstants {
     public static final String CLIENTS_MANAGEMENT_REGISTER_NODE_PATH = "/realms/{realm-name}/clients-managements/register-node";
     public static final String CLIENTS_MANAGEMENT_UNREGISTER_NODE_PATH = "/realms/{realm-name}/clients-managements/unregister-node";
     public static final String JWKS_URL = "/realms/{realm-name}/protocol/openid-connect/certs";
+    public static final String TOKEN_INTROSPECT_PATH = "/realms/{realm-name}/protocol/openid-connect/token/introspect";
     public static final String DISCOVERY_URL = "/realms/{realm-name}/.well-known/openid-configuration";
     String AUTHZ_DISCOVERY_URL = "/realms/{realm-name}/.well-known/uma2-configuration";
 

--- a/core/src/main/java/org/keycloak/representations/TokenIntrospectionResponse.java
+++ b/core/src/main/java/org/keycloak/representations/TokenIntrospectionResponse.java
@@ -15,7 +15,7 @@
  *  limitations under the License.
  *
  */
-package org.keycloak.authorization.client.representation;
+package org.keycloak.representations;
 
 import java.util.List;
 

--- a/core/src/main/java/org/keycloak/representations/adapters/config/AdapterConfig.java
+++ b/core/src/main/java/org/keycloak/representations/adapters/config/AdapterConfig.java
@@ -36,7 +36,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
         "connection-pool-size", "socket-timeout-millis", "connection-ttl-millis", "connection-timeout-millis",
         "allow-any-hostname", "disable-trust-manager", "truststore", "truststore-password",
         "client-keystore", "client-keystore-password", "client-key-password",
-        "always-refresh-token",
+        "always-refresh-token","online-token-introspection",
         "register-node-at-startup", "register-node-period", "token-store", "adapter-state-cookie-path", "principal-attribute",
         "proxy-url", "turn-off-change-session-id-on-login", "token-minimum-time-to-live",
         "min-time-between-jwks-requests", "public-key-cache-ttl",
@@ -62,6 +62,8 @@ public class AdapterConfig extends BaseAdapterConfig implements AdapterHttpClien
     protected int connectionPoolSize = 20;
     @JsonProperty("always-refresh-token")
     protected boolean alwaysRefreshToken = false;
+    @JsonProperty("online-token-introspection")
+    protected boolean onlineTokenIntrospection = false;
     @JsonProperty("register-node-at-startup")
     protected boolean registerNodeAtStartup = false;
     @JsonProperty("register-node-period")
@@ -180,6 +182,14 @@ public class AdapterConfig extends BaseAdapterConfig implements AdapterHttpClien
 
     public void setAlwaysRefreshToken(boolean alwaysRefreshToken) {
         this.alwaysRefreshToken = alwaysRefreshToken;
+    }
+
+    public boolean isOnlineTokenIntrospection() {
+        return onlineTokenIntrospection;
+    }
+
+    public void setOnlineTokenIntrospection(boolean onlineTokenIntrospection) {
+        this.onlineTokenIntrospection = onlineTokenIntrospection;
     }
 
     public boolean isRegisterNodeAtStartup() {


### PR DESCRIPTION
We would like to run multiple Spring Applications, each providing their own Spring Session and their own server-side rendered UI. When a logout occurs on Application A, the corresponding session discards its access and refresh tokens. When the user now accesses Application B the underlying session of B still has a valid access token and therefore the user is still logged in in B. From UX perspective both applications should appear to the user as one application. Now the user is confused that they are still signed in to Application B for the remainder of the lifespan of the access token, even after they clicked the logout button.

OAuth 2.0 Token Introspection RFC tackles this issue in Section 4 where it says:

"If the token can be revoked after it was issued, the authorization server MUST determine whether or not such a revocation has taken place."

In this pull request I implemented a possible solution to opt-in online token introspection for Spring Security adapter.