### PR TITLE
CIAM-1419 Test more recent versions of Spring Boot

### DIFF
--- a/adapters/oidc/spring-boot/pom.xml
+++ b/adapters/oidc/spring-boot/pom.xml
@@ -28,7 +28,7 @@
 
   <artifactId>keycloak-spring-boot-adapter</artifactId>
   <name>Keycloak Spring Boot Integration</name>
-  <description/>
+  <description>Warning: We do not support Spring Boot 1.x anymore. Please upgrade to Spring Boot 2.x</description>
 
   <properties>
     <maven.compiler.target>1.7</maven.compiler.target>

--- a/adapters/oidc/spring-boot/src/main/java/org/keycloak/adapters/springboot/KeycloakAutoConfiguration.java
+++ b/adapters/oidc/spring-boot/src/main/java/org/keycloak/adapters/springboot/KeycloakAutoConfiguration.java
@@ -40,11 +40,13 @@ import org.springframework.context.annotation.Configuration;
  *
  * @author <a href="mailto:jimmidyson@gmail.com">Jimmi Dyson</a>
  * @version $Revision: 1 $
+ * @deprecated Please upgrade to Spring Boot 2.x
  */
 @Configuration
 @ConditionalOnWebApplication
 @EnableConfigurationProperties(KeycloakSpringBootProperties.class)
 @ConditionalOnProperty(value = "keycloak.enabled", matchIfMissing = true)
+@Deprecated
 public class KeycloakAutoConfiguration extends KeycloakBaseSpringBootConfiguration  {
 
     @Bean

--- a/adapters/oidc/spring-boot/src/main/java/org/keycloak/adapters/springboot/client/KeycloakRestTemplateCustomizer.java
+++ b/adapters/oidc/spring-boot/src/main/java/org/keycloak/adapters/springboot/client/KeycloakRestTemplateCustomizer.java
@@ -3,6 +3,10 @@ package org.keycloak.adapters.springboot.client;
 import org.springframework.boot.web.client.RestTemplateCustomizer;
 import org.springframework.web.client.RestTemplate;
 
+/**
+ * @deprecated Please upgrade to Spring Boot 2.x
+ */
+@Deprecated
 public class KeycloakRestTemplateCustomizer implements RestTemplateCustomizer {
 
     private final KeycloakSecurityContextClientRequestInterceptor keycloakInterceptor;

--- a/adapters/oidc/spring-boot/src/main/java/org/keycloak/adapters/springboot/client/KeycloakSecurityContextClientRequestInterceptor.java
+++ b/adapters/oidc/spring-boot/src/main/java/org/keycloak/adapters/springboot/client/KeycloakSecurityContextClientRequestInterceptor.java
@@ -18,7 +18,9 @@ import java.security.Principal;
  *
  * @author <a href="mailto:jmcshan1@gmail.com">James McShane</a>
  * @version $Revision: 1 $
+ * @deprecated Please upgrade to Spring Boot 2.x
  */
+@Deprecated
 public class KeycloakSecurityContextClientRequestInterceptor implements ClientHttpRequestInterceptor {
 
     private static final String AUTHORIZATION_HEADER = "Authorization";

--- a/adapters/oidc/spring-boot2/pom.xml
+++ b/adapters/oidc/spring-boot2/pom.xml
@@ -31,8 +31,8 @@
   <description/>
 
   <properties>
-    <spring-boot.version>2.0.5.RELEASE</spring-boot.version>
-    <spring.version>5.0.2.RELEASE</spring.version>
+    <spring-boot.version>2.4.13</spring-boot.version>
+    <spring.version>5.3.13</spring.version>
     <mockito.version>1.9.5</mockito.version>
   </properties>
 
@@ -77,7 +77,7 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-core</artifactId>
-      <version>5.0.2.RELEASE</version>
+      <version>${spring.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/misc/scripts/upgrade-wildfly/lib/wildfly/upgrade/__init__.py
+++ b/misc/scripts/upgrade-wildfly/lib/wildfly/upgrade/__init__.py
@@ -663,10 +663,8 @@ _keycloakSpecificProperties = [
     "tomcat7.version",
     "tomcat8.version",
     "tomcat9.version",
-    "spring-boot15.version",
-    "spring-boot21.version",
-    "spring-boot22.version",
-    "spring-boot23.version",
+    "spring-boot24.version",
+    "spring-boot26.version",
     "webauthn4j.version",
     "org.apache.kerby.kerby-asn1.version",
 ]
@@ -771,7 +769,7 @@ _keycloakToWildflyProperties = {
     # Skip "frontend.plugin.version" since Keycloak specific
     # Skip "docker.maven.plugin.version" since Keycloak specific
     # Skip "tomcat7.version", "tomcat8.version", and "tomcat9.version" since Keycloak specific
-    # Skip "spring-boot15.version", "spring-boot21.version", "spring-boot22.version", and "spring-boot23.version" since Keycloak specific
+    # Skip "spring-boot24.version" and "spring-boot26.version" since Keycloak specific
     # Skip "webauthn4j.version" since Keycloak specific
     # Skip "org.apache.kerby.kerby-asn1.version" since Keycloak specific
 }

--- a/pom.xml
+++ b/pom.xml
@@ -187,10 +187,8 @@
         <tomcat9.version>9.0.16</tomcat9.version>
 
         <!-- Spring Boot versions, used for tests -->
-        <spring-boot15.version>1.5.20.RELEASE</spring-boot15.version>
-        <spring-boot21.version>2.1.3.RELEASE</spring-boot21.version>
-        <spring-boot22.version>2.2.0.RELEASE</spring-boot22.version>
-        <spring-boot23.version>2.3.0.RELEASE</spring-boot23.version>
+        <spring-boot24.version>2.4.13</spring-boot24.version>
+        <spring-boot26.version>2.6.1</spring-boot26.version>
 
         <!-- webauthn support -->
         <webauthn4j.version>0.12.0.RELEASE</webauthn4j.version>

--- a/testsuite/integration-arquillian/HOW-TO-RUN.md
+++ b/testsuite/integration-arquillian/HOW-TO-RUN.md
@@ -472,18 +472,19 @@ mvn -f testsuite/integration-arquillian/tests/other/console/pom.xml \
 
 ## Spring Boot adapter tests
 
-Currently we are testing Spring Boot with three different containers `Tomcat 8`, `Undertow` and `Jetty [9.2, 9.3, 9.4]`. We are testing two versions of Spring Boot 1.5.x and 2.1.x. All versions are specified in [root pom.xml](../../pom.xml) (see properties `spring-boot15.version` and `spring-boot21.version`).
-
-To run tests execute following command. Default version of Spring Boot is 1.5.x, to run tests with version 2.1.x add profile `-Pspringboot21`
+Currently, we are testing Spring Boot with three different containers `Tomcat 8`, `Undertow` and `Jetty 9.4`. 
+We are testing various versions of Spring Boot 2.x. All versions are specified in [root pom.xml](../../pom.xml) (i.e. see properties `spring-boot24.version` and `spring-boot26.version`).
+To run tests execute following command. Default version of Spring Boot is 2.4.x, to run tests with version 2.6.x add profile `-Pspringboot26`.
 
 ```
 mvn -f testsuite/integration-arquillian/tests/other/springboot-tests/pom.xml \
     clean test \
-    -Dadapter.container=[tomcat|undertow|jetty92|jetty93|jetty94] \
-    [-Pspringboot21]
+    -Dadapter.container=[tomcat|undertow|jetty94] \
+    [-Pspringboot26]
 ```
 
-Note: Spring Boot 21 doesn't work with jetty92 and jetty93, only jetty94 is tested.
+**Note:** We have deprecated Spring Boot 1.5.x, so please upgrade to Spring Boot 2.x. 
+However, Spring Boot 2.x doesn't work with `jetty92` and `jetty93`, only `jetty94` is tested.
 
 ## Base UI tests
 Similarly to Admin Console tests, these tests are focused on UI, specifically on the parts of the server that are accessed by an end user (like Login page, or Account Console).

--- a/testsuite/integration-arquillian/test-apps/spring-boot-adapter-app/pom.xml
+++ b/testsuite/integration-arquillian/test-apps/spring-boot-adapter-app/pom.xml
@@ -17,7 +17,7 @@
         <java.version>1.8</java.version>
         <jetty.version>${jetty94.version}</jetty.version>
 
-        <springboot-version>2.3</springboot-version>
+        <springboot-version>2.4</springboot-version>
 
         <spring-boot-adapter-jetty>false</spring-boot-adapter-jetty>
         <spring.boot.tomcat.adapter.artifactId>keycloak-tomcat-adapter</spring.boot.tomcat.adapter.artifactId>
@@ -44,431 +44,43 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-spring-boot-2-adapter</artifactId>
+        </dependency>
     </dependencies>
 
     <profiles>
         <profile>
-            <id>spring.boot.1.5</id>
+            <id>spring.boot.2.4</id>
 
             <activation>
                 <activeByDefault>true</activeByDefault>
-
                 <property>
                     <name>springboot-version</name>
-                    <value>1.5</value>
+                    <value>2.4</value>
                 </property>
             </activation>
 
             <properties>
-                <spring-boot.version>${spring-boot15.version}</spring-boot.version>
+                <spring-boot.version>${spring-boot24.version}</spring-boot.version>
             </properties>
-
-            <dependencyManagement>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.eclipse.jetty</groupId>
-                        <artifactId>apache-jsp</artifactId>
-                        <version>${jetty.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.eclipse.jetty</groupId>
-                        <artifactId>apache-jstl</artifactId>
-                        <version>${jetty.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.eclipse.jetty</groupId>
-                        <artifactId>jetty-alpn-client</artifactId>
-                        <version>${jetty.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.eclipse.jetty</groupId>
-                        <artifactId>jetty-alpn-java-client</artifactId>
-                        <version>${jetty.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.eclipse.jetty</groupId>
-                        <artifactId>jetty-alpn-java-server</artifactId>
-                        <version>${jetty.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.eclipse.jetty</groupId>
-                        <artifactId>jetty-alpn-server</artifactId>
-                        <version>${jetty.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.eclipse.jetty</groupId>
-                        <artifactId>jetty-annotations</artifactId>
-                        <version>${jetty.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.eclipse.jetty</groupId>
-                        <artifactId>jetty-ant</artifactId>
-                        <version>${jetty.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.eclipse.jetty</groupId>
-                        <artifactId>jetty-client</artifactId>
-                        <version>${jetty.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.eclipse.jetty</groupId>
-                        <artifactId>jetty-continuation</artifactId>
-                        <version>${jetty.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.eclipse.jetty</groupId>
-                        <artifactId>jetty-deploy</artifactId>
-                        <version>${jetty.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.eclipse.jetty</groupId>
-                        <artifactId>jetty-hazelcast</artifactId>
-                        <version>${jetty.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.eclipse.jetty</groupId>
-                        <artifactId>jetty-http</artifactId>
-                        <version>${jetty.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.eclipse.jetty</groupId>
-                        <artifactId>jetty-http-spi</artifactId>
-                        <version>${jetty.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.eclipse.jetty</groupId>
-                        <artifactId>jetty-infinispan</artifactId>
-                        <version>${jetty.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.eclipse.jetty</groupId>
-                        <artifactId>jetty-io</artifactId>
-                        <version>${jetty.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.eclipse.jetty</groupId>
-                        <artifactId>jetty-jaas</artifactId>
-                        <version>${jetty.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.eclipse.jetty</groupId>
-                        <artifactId>jetty-jaspi</artifactId>
-                        <version>${jetty.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.eclipse.jetty</groupId>
-                        <artifactId>jetty-jmx</artifactId>
-                        <version>${jetty.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.eclipse.jetty</groupId>
-                        <artifactId>jetty-jndi</artifactId>
-                        <version>${jetty.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.eclipse.jetty</groupId>
-                        <artifactId>jetty-nosql</artifactId>
-                        <version>${jetty.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.eclipse.jetty</groupId>
-                        <artifactId>jetty-plus</artifactId>
-                        <version>${jetty.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.eclipse.jetty</groupId>
-                        <artifactId>jetty-proxy</artifactId>
-                        <version>${jetty.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.eclipse.jetty</groupId>
-                        <artifactId>jetty-quickstart</artifactId>
-                        <version>${jetty.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.eclipse.jetty</groupId>
-                        <artifactId>jetty-rewrite</artifactId>
-                        <version>${jetty.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.eclipse.jetty</groupId>
-                        <artifactId>jetty-runner</artifactId>
-                        <version>${jetty.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.eclipse.jetty</groupId>
-                        <artifactId>jetty-security</artifactId>
-                        <version>${jetty.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.eclipse.jetty</groupId>
-                        <artifactId>jetty-server</artifactId>
-                        <version>${jetty.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.eclipse.jetty</groupId>
-                        <artifactId>jetty-servlet</artifactId>
-                        <version>${jetty.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.eclipse.jetty</groupId>
-                        <artifactId>jetty-servlets</artifactId>
-                        <version>${jetty.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.eclipse.jetty</groupId>
-                        <artifactId>jetty-spring</artifactId>
-                        <version>${jetty.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.eclipse.jetty</groupId>
-                        <artifactId>jetty-start</artifactId>
-                        <version>${jetty.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.eclipse.jetty</groupId>
-                        <artifactId>jetty-unixsocket</artifactId>
-                        <version>${jetty.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.eclipse.jetty</groupId>
-                        <artifactId>jetty-util</artifactId>
-                        <version>${jetty.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.eclipse.jetty</groupId>
-                        <artifactId>jetty-util-ajax</artifactId>
-                        <version>${jetty.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.eclipse.jetty</groupId>
-                        <artifactId>jetty-webapp</artifactId>
-                        <version>${jetty.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.eclipse.jetty</groupId>
-                        <artifactId>jetty-xml</artifactId>
-                        <version>${jetty.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.eclipse.jetty.cdi</groupId>
-                        <artifactId>cdi-core</artifactId>
-                        <version>${jetty.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.eclipse.jetty.cdi</groupId>
-                        <artifactId>cdi-servlet</artifactId>
-                        <version>${jetty.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.eclipse.jetty.fcgi</groupId>
-                        <artifactId>fcgi-client</artifactId>
-                        <version>${jetty.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.eclipse.jetty.fcgi</groupId>
-                        <artifactId>fcgi-server</artifactId>
-                        <version>${jetty.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.eclipse.jetty.gcloud</groupId>
-                        <artifactId>jetty-gcloud-session-manager</artifactId>
-                        <version>${jetty.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.eclipse.jetty.http2</groupId>
-                        <artifactId>http2-client</artifactId>
-                        <version>${jetty.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.eclipse.jetty.http2</groupId>
-                        <artifactId>http2-common</artifactId>
-                        <version>${jetty.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.eclipse.jetty.http2</groupId>
-                        <artifactId>http2-hpack</artifactId>
-                        <version>${jetty.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.eclipse.jetty.http2</groupId>
-                        <artifactId>http2-http-client-transport</artifactId>
-                        <version>${jetty.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.eclipse.jetty.http2</groupId>
-                        <artifactId>http2-server</artifactId>
-                        <version>${jetty.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.eclipse.jetty.memcached</groupId>
-                        <artifactId>jetty-memcached-sessions</artifactId>
-                        <version>${jetty.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.eclipse.jetty.osgi</groupId>
-                        <artifactId>jetty-osgi-boot</artifactId>
-                        <version>${jetty.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.eclipse.jetty.osgi</groupId>
-                        <artifactId>jetty-osgi-boot-jsp</artifactId>
-                        <version>${jetty.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.eclipse.jetty.osgi</groupId>
-                        <artifactId>jetty-osgi-boot-warurl</artifactId>
-                        <version>${jetty.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.eclipse.jetty.osgi</groupId>
-                        <artifactId>jetty-httpservice</artifactId>
-                        <version>${jetty.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.eclipse.jetty.websocket</groupId>
-                        <artifactId>javax-websocket-client-impl</artifactId>
-                        <version>${jetty.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.eclipse.jetty.websocket</groupId>
-                        <artifactId>javax-websocket-server-impl</artifactId>
-                        <version>${jetty.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.eclipse.jetty.websocket</groupId>
-                        <artifactId>websocket-api</artifactId>
-                        <version>${jetty.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.eclipse.jetty.websocket</groupId>
-                        <artifactId>websocket-client</artifactId>
-                        <version>${jetty.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.eclipse.jetty.websocket</groupId>
-                        <artifactId>websocket-common</artifactId>
-                        <version>${jetty.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.eclipse.jetty.websocket</groupId>
-                        <artifactId>websocket-server</artifactId>
-                        <version>${jetty.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.eclipse.jetty.websocket</groupId>
-                        <artifactId>websocket-servlet</artifactId>
-                        <version>${jetty.version}</version>
-                    </dependency>
-                </dependencies>
-            </dependencyManagement>
-
-            <dependencies>
-                <dependency>
-                    <groupId>org.keycloak</groupId>
-                    <artifactId>keycloak-spring-boot-adapter</artifactId>
-                </dependency>
-            </dependencies>
-
         </profile>
 
         <profile>
-            <id>spring.boot.2.1</id>
+            <id>spring.boot.2.6</id>
 
             <activation>
                 <property>
                     <name>springboot-version</name>
-                    <value>2.1</value>
+                    <value>2.6</value>
                 </property>
             </activation>
 
             <properties>
-                <spring-boot.version>${spring-boot21.version}</spring-boot.version>
+                <spring-boot.version>${spring-boot26.version}</spring-boot.version>
             </properties>
-
-            <dependencyManagement>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.eclipse.jetty</groupId>
-                        <artifactId>jetty-bom</artifactId>
-                        <version>${jetty.version}</version>
-                        <type>pom</type>
-                    </dependency>
-                </dependencies>
-            </dependencyManagement>
-
-            <dependencies>
-                <dependency>
-                    <groupId>org.keycloak</groupId>
-                    <artifactId>keycloak-spring-boot-2-adapter</artifactId>
-                </dependency>
-            </dependencies>
-        </profile>
-
-        <profile>
-            <id>spring.boot.2.2</id>
-
-            <activation>
-                <property>
-                    <name>springboot-version</name>
-                    <value>2.2</value>
-                </property>
-            </activation>
-
-            <properties>
-                <spring-boot.version>${spring-boot22.version}</spring-boot.version>
-            </properties>
-
-            <dependencyManagement>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.eclipse.jetty</groupId>
-                        <artifactId>jetty-bom</artifactId>
-                        <version>${jetty.version}</version>
-                        <type>pom</type>
-                    </dependency>
-                </dependencies>
-            </dependencyManagement>
-
-            <dependencies>
-                <dependency>
-                    <groupId>org.keycloak</groupId>
-                    <artifactId>keycloak-spring-boot-2-adapter</artifactId>
-                </dependency>
-            </dependencies>
-        </profile>
-
-        <profile>
-            <id>spring.boot.2.3</id>
-
-            <activation>
-                <property>
-                    <name>springboot-version</name>
-                    <value>2.3</value>
-                </property>
-            </activation>
-
-            <properties>
-                <spring-boot.version>${spring-boot23.version}</spring-boot.version>
-            </properties>
-
-            <dependencyManagement>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.eclipse.jetty</groupId>
-                        <artifactId>jetty-bom</artifactId>
-                        <version>${jetty.version}</version>
-                        <type>pom</type>
-                    </dependency>
-                </dependencies>
-            </dependencyManagement>
-
-            <dependencies>
-                <dependency>
-                    <groupId>org.keycloak</groupId>
-                    <artifactId>keycloak-spring-boot-2-adapter</artifactId>
-                </dependency>
-            </dependencies>
         </profile>
 
         <profile>
@@ -630,6 +242,12 @@
                 <version>${spring-boot.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-bom</artifactId>
+                <version>${jetty.version}</version>
+                <type>pom</type>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/AssertEvents.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/AssertEvents.java
@@ -39,6 +39,8 @@ import org.keycloak.util.TokenUtil;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.is;
 import static org.keycloak.testsuite.util.ServerURLs.getAuthServerContextRoot;
 
@@ -221,7 +223,7 @@ public class AssertEvents implements TestRule {
                 .user(defaultUserId())
                 .ipAddress(
                         System.getProperty("auth.server.host", "localhost").contains("localhost")
-                        ? CoreMatchers.anyOf(is(DEFAULT_IP_ADDRESS), is(DEFAULT_IP_ADDRESS_V6), is(DEFAULT_IP_ADDRESS_V6_SHORT))
+                        ? anyOf(is(DEFAULT_IP_ADDRESS), is(DEFAULT_IP_ADDRESS_V6), is(DEFAULT_IP_ADDRESS_V6_SHORT))
                         : Matchers.any(String.class))
                 .session((String) null)
                 .event(event);

--- a/testsuite/integration-arquillian/tests/other/springboot-tests/pom.xml
+++ b/testsuite/integration-arquillian/tests/other/springboot-tests/pom.xml
@@ -15,7 +15,7 @@
         <adapter.container>tomcat</adapter.container>
 
         <maven.settings.file/>
-        <springboot.version.option>1.5</springboot.version.option>
+        <springboot.version.option>2.4</springboot.version.option>
 
         <app.server.debug.port>5006</app.server.debug.port>
         <app.server.debug.suspend>n</app.server.debug.suspend>
@@ -201,24 +201,18 @@
                 </plugins>
             </build>
         </profile>
+
         <profile>
-            <id>springboot21</id>
+            <id>springboot24</id>
             <properties>
-                <springboot.version.option>2.1</springboot.version.option>
+                <springboot.version.option>2.4</springboot.version.option>
             </properties>
         </profile>
 
         <profile>
-            <id>springboot22</id>
+            <id>springboot26</id>
             <properties>
-                <springboot.version.option>2.2</springboot.version.option>
-            </properties>
-        </profile>
-
-        <profile>
-            <id>springboot23</id>
-            <properties>
-                <springboot.version.option>2.3</springboot.version.option>
+                <springboot.version.option>2.6</springboot.version.option>
             </properties>
         </profile>
 


### PR DESCRIPTION
Closes [CIAM-1419](https://issues.redhat.com/browse/CIAM-1419)

- Spring Boot version 1.5.x is deprecated and not tested anymore. However, adapter for Spring Boot 1.x is still included in a codebase and only added deprecation annotations, but it needs further discussion if it's really necessary to support it.
- Tested versions Spring Boot 2.4, and 2.6. 
- Removed 1.5.x, 2.1.x, 2.2.x, 2.3.x version
- Default version is set up to 2.4

@pdrozd @miquelsi Could you please take a look at it? Thanks.

Edit: @mhajas PTAL as well. Thank you