### PR TITLE
Fix the download of keycloak-admin-ui in case of missing maven cache

### DIFF
--- a/.github/settings.xml
+++ b/.github/settings.xml
@@ -2,13 +2,54 @@
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
                       https://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+  <activeProfiles>
+    <activeProfile>github</activeProfile>
+  </activeProfiles>
+
+  <profiles>
+    <profile>
+      <id>github</id>
+      <repositories>
+        <repository>
+          <id>central</id>
+          <url>https://repo1.maven.org/maven2</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </repository>
+        <repository>
+          <id>github</id>
+          <url>https://maven.pkg.github.com/keycloak/keycloak-admin-ui</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </repository>
+      </repositories>
+    </profile>
+  </profiles>
+
+  <servers>
+    <server>
+      <id>github</id>
+      <username>$GITHUB_ACTOR</username>
+      <password>$GITHUB_TOKEN</password>
+    </server>
+  </servers>
+
   <mirrors>
     <mirror>
-     <id>jboss-public-repository-group-https</id>
-     <mirrorOf>jboss-public-repository-group</mirrorOf>
-     <name>Jboss public https</name>
-     <url>https://repository.jboss.org/nexus/content/groups/public/</url>
-     </mirror>
-   </mirrors>
+    <id>jboss-public-repository-group-https</id>
+    <mirrorOf>jboss-public-repository-group</mirrorOf>
+    <name>Jboss public https</name>
+    <url>https://repository.jboss.org/nexus/content/groups/public/</url>
+    </mirror>
+  </mirrors>
   
 </settings>

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,10 @@ jobs:
         with:
           java-version: ${{ env.DEFAULT_JDK_VERSION }}
       - name: Update maven settings
-        run: mkdir -p ~/.m2 ; cp .github/settings.xml ~/.m2/
+        env:
+          GITHUB_ACTOR: ${{ secrets.GITHUB_ACTOR }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: mkdir -p ~/.m2 ; envsubst < .github/settings.xml > ~/.m2/settings.xml
       - name: Cache Maven packages
         id: cache
         uses: actions/cache@v2


### PR DESCRIPTION
Currently, all of the builds from `main` that are not hitting a maven cache are failing:

https://github.com/keycloak/keycloak/runs/4209302684?check_suite_focus=true#step:6:4414

this PR fixes the download from GH packages in case of missing caches as demonstrated here:
https://github.com/andreaTP/keycloak/actions/runs/1462103095

restoring the `Build` step functionality.