### PR TITLE
Mark flaky tests in CI as NotThreadSafe

### DIFF
--- a/testsuite/model/pom.xml
+++ b/testsuite/model/pom.xml
@@ -100,6 +100,13 @@
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-server-core</artifactId>
         </dependency>
+        <!-- https://maven.apache.org/surefire/maven-surefire-plugin/examples/fork-options-and-parallel-execution.html -->
+        <dependency>
+            <groupId>com.github.stephenc.jcip</groupId>
+            <artifactId>jcip-annotations</artifactId>
+            <version>1.0-1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/testsuite/model/src/test/java/org/keycloak/testsuite/model/infinispan/CacheExpirationTest.java
+++ b/testsuite/model/src/test/java/org/keycloak/testsuite/model/infinispan/CacheExpirationTest.java
@@ -49,6 +49,7 @@ import static org.junit.Assume.assumeThat;
  * @author hmlnarik
  */
 @RequireProvider(InfinispanConnectionProvider.class)
+@net.jcip.annotations.NotThreadSafe
 public class CacheExpirationTest extends KeycloakModelTest {
 
     @Test

--- a/testsuite/model/src/test/java/org/keycloak/testsuite/model/session/OfflineSessionPersistenceTest.java
+++ b/testsuite/model/src/test/java/org/keycloak/testsuite/model/session/OfflineSessionPersistenceTest.java
@@ -56,6 +56,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 @RequireProvider(UserProvider.class)
 @RequireProvider(RealmProvider.class)
 @RequireProvider(UserSessionProvider.class)
+@net.jcip.annotations.NotThreadSafe
 public class OfflineSessionPersistenceTest extends KeycloakModelTest {
 
     private static final int USER_COUNT = 50;

--- a/testsuite/model/src/test/java/org/keycloak/testsuite/model/session/UserSessionInitializerTest.java
+++ b/testsuite/model/src/test/java/org/keycloak/testsuite/model/session/UserSessionInitializerTest.java
@@ -60,6 +60,7 @@ import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.U
 @RequireProvider(UserSessionProvider.class)
 @RequireProvider(UserProvider.class)
 @RequireProvider(RealmProvider.class)
+@net.jcip.annotations.NotThreadSafe
 public class UserSessionInitializerTest extends KeycloakModelTest {
 
     private String realmId;

--- a/testsuite/model/src/test/java/org/keycloak/testsuite/model/session/UserSessionPersisterProviderTest.java
+++ b/testsuite/model/src/test/java/org/keycloak/testsuite/model/session/UserSessionPersisterProviderTest.java
@@ -65,6 +65,7 @@ import java.util.LinkedList;
 @RequireProvider(value = UserSessionProvider.class, only = InfinispanUserSessionProviderFactory.PROVIDER_ID)
 @RequireProvider(UserProvider.class)
 @RequireProvider(RealmProvider.class)
+@net.jcip.annotations.NotThreadSafe
 public class UserSessionPersisterProviderTest extends KeycloakModelTest {
 
     private static final int USER_SESSION_COUNT = 2000;

--- a/testsuite/model/src/test/java/org/keycloak/testsuite/model/session/UserSessionProviderModelTest.java
+++ b/testsuite/model/src/test/java/org/keycloak/testsuite/model/session/UserSessionProviderModelTest.java
@@ -52,6 +52,7 @@ import static org.keycloak.testsuite.model.session.UserSessionPersisterProviderT
 @RequireProvider(UserSessionProvider.class)
 @RequireProvider(UserProvider.class)
 @RequireProvider(RealmProvider.class)
+@net.jcip.annotations.NotThreadSafe
 public class UserSessionProviderModelTest extends KeycloakModelTest {
 
     private String realmId;

--- a/testsuite/model/src/test/java/org/keycloak/testsuite/model/session/UserSessionProviderOfflineModelTest.java
+++ b/testsuite/model/src/test/java/org/keycloak/testsuite/model/session/UserSessionProviderOfflineModelTest.java
@@ -55,6 +55,7 @@ import org.keycloak.testsuite.model.RequireProvider;
 @RequireProvider(value=UserSessionProvider.class, only={"infinispan"})
 @RequireProvider(UserProvider.class)
 @RequireProvider(RealmProvider.class)
+@net.jcip.annotations.NotThreadSafe
 public class UserSessionProviderOfflineModelTest extends KeycloakModelTest {
 
     private String realmId;


### PR DESCRIPTION
I hope this PR doesn't increase the noise too much, feel free to close in case!

I noticed that in CI `models` tests have not been passing.
Testing locally everything was fine, it appears to be a concurrency issue, here you have a "workaround" to isolate more the execution of the critical tests.

Example of passing CI:
https://github.com/andreaTP/keycloak/actions/runs/1463970639