### PR TITLE
Add missing dependency on server-deployment

### DIFF
--- a/quarkus/server/pom.xml
+++ b/quarkus/server/pom.xml
@@ -19,6 +19,10 @@
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-quarkus-server</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-quarkus-server-deployment</artifactId>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
I usually build the server dist with:

```
mvn -Pdistribution -pl distribution/server-x-dist -am -DskipTests -f ~/dev/keycloak/pom.xml -T 4 clean package
```

This lets me build only the modules I need to get a fresh server dist, and not all the adapters, etc..

There's a problem with this as there's no dependency on `keycloak-quarkus-server-deployment` so Maven doesn't build this one. A simpler command to run is:

```
mvn -pl quarkus/server -am
```

This shows that `Keycloak Quarkus Server Deployment` isn't built as part of this even though it really should.