### PR TITLE
[KEYCLOAK-19798] - Filtering options based on the command

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/HelpFactory.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/HelpFactory.java
@@ -15,13 +15,22 @@
  * limitations under the License.
  */
 
-package org.keycloak.quarkus.runtime.cli.command;
+package org.keycloak.quarkus.runtime.cli;
 
-import picocli.CommandLine.Command;
+import picocli.CommandLine;
+import picocli.CommandLine.Help.ColorScheme;
+import picocli.CommandLine.Model.CommandSpec;
 
-@Command(name = "tools",
-        description = "%nUtilities for use and interaction with the server.",
-        subcommands = {Completion.class})
-public class Tools {
+final class HelpFactory implements CommandLine.IHelpFactory {
 
+    private Help help;
+
+    @Override
+    public CommandLine.Help create(CommandSpec commandSpec,
+            ColorScheme colorScheme) {
+        if (help == null) {
+            help = new Help(commandSpec, colorScheme);
+        }
+        return help;
+    }
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/AbstractCommand.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/AbstractCommand.java
@@ -24,17 +24,11 @@ import org.keycloak.quarkus.runtime.Environment;
 import picocli.CommandLine;
 import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Spec;
-import picocli.CommandLine.Option;
 
 public abstract class AbstractCommand {
 
     @Spec
     protected CommandSpec spec;
-
-    @Option(names = { "-h", "--help" },
-            description = "This help message.",
-            usageHelp = true)
-    boolean help;
 
     protected void devProfileNotAllowedError(String cmd) {
         executionError(spec.commandLine(), String.format("You can not '%s' the server using the '%s' configuration profile. Please re-build the server first, using './kc.sh build' for the default production profile, or using '/.kc.sh build --profile=<profile>' with a profile more suitable for production.%n", cmd, Environment.DEV_PROFILE_VALUE));

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/AbstractStartCommand.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/AbstractStartCommand.java
@@ -19,8 +19,6 @@ package org.keycloak.quarkus.runtime.cli.command;
 
 import org.keycloak.quarkus.runtime.KeycloakMain;
 
-import picocli.CommandLine;
-
 public abstract class AbstractStartCommand extends AbstractCommand implements Runnable {
 
     public static final String AUTO_BUILD_OPTION_LONG = "--auto-build";

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Build.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Build.java
@@ -28,6 +28,7 @@ import io.quarkus.bootstrap.runner.RunnerClassLoader;
 
 import io.quarkus.runtime.configuration.ProfileManager;
 import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
 
 import java.util.List;
 
@@ -59,13 +60,14 @@ import java.util.List;
                 + "      $ ${PARENT-COMMAND-FULL-NAME:-$PARENTCOMMAND} ${COMMAND-NAME} --http-relative-path=/auth%n%n"
                 + "You can also use the \"--auto-build\" option when starting the server to avoid running this command every time you change a configuration:%n%n"
                 + "    $ ${PARENT-COMMAND-FULL-NAME:-$PARENTCOMMAND} start --auto-build <OPTIONS>%n%n"
-                + "By doing that you have an additional overhead when the server is starting.",
-        abbreviateSynopsis = true,
-        optionListHeading = "Options:",
-        commandListHeading = "Commands:")
+                + "By doing that you have an additional overhead when the server is starting.%n%n"
+                + "Use '${PARENT-COMMAND-FULL-NAME:-$PARENTCOMMAND} ${COMMAND-NAME} --help-all' to list all available options, including the start options.")
 public final class Build extends AbstractCommand implements Runnable {
 
     public static final String NAME = "build";
+
+    @Mixin
+    HelpAllMixin helpAllMixin;
 
     @Override
     public void run() {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Completion.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Completion.java
@@ -22,14 +22,11 @@ import picocli.CommandLine.Command;
 
 @Command(name = "completion",
         header = "Generate bash/zsh completion script for ${ROOT-COMMAND-NAME:-the root command of this command}.",
-        optionListHeading = "Options:",
-        commandListHeading = "Commands:",
         description = {
                 "",
                 "Generate bash/zsh completion script for ${ROOT-COMMAND-NAME:-the root command of this command}.%n" +
                 "Run the following command to give `${ROOT-COMMAND-NAME:-$PARENTCOMMAND}` TAB completion in the current shell:",
                 "",
-                "  source <(${PARENT-COMMAND-FULL-NAME:-$PARENTCOMMAND} ${COMMAND-NAME})"},
-        abbreviateSynopsis = true)
+                "  source <(${PARENT-COMMAND-FULL-NAME:-$PARENTCOMMAND} ${COMMAND-NAME})"})
 public class Completion extends AutoComplete.GenerateCompletion {
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Export.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Export.java
@@ -24,11 +24,7 @@ import picocli.CommandLine.Option;
 
 @Command(name = "export",
         header = "Export data from realms to a file or directory.",
-        description = "%nExport data from realms to a file or directory.",
-        showDefaultValues = true,
-        abbreviateSynopsis = true,
-        optionListHeading = "Options:",
-        commandListHeading = "Commands:")
+        description = "%nExport data from realms to a file or directory.")
 public final class Export extends AbstractExportImportCommand implements Runnable {
 
     @Option(names = "--users",

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/HelpAllMixin.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/HelpAllMixin.java
@@ -17,11 +17,18 @@
 
 package org.keycloak.quarkus.runtime.cli.command;
 
-import picocli.CommandLine.Command;
+import org.keycloak.quarkus.runtime.cli.Help;
 
-@Command(name = "tools",
-        description = "%nUtilities for use and interaction with the server.",
-        subcommands = {Completion.class})
-public class Tools {
+import picocli.CommandLine;
 
+final class HelpAllMixin {
+
+    @CommandLine.Spec
+    private CommandLine.Model.CommandSpec spec;
+
+    @CommandLine.Option(names = { "--help-all" }, usageHelp = true, description = "This same help message but with additional options.")
+    public void setHelpAll(boolean allOptions) {
+        Help help = (Help) spec.commandLine().getHelp();
+        help.setAllOptions(true);
+    }
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Import.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Import.java
@@ -26,11 +26,7 @@ import picocli.CommandLine.Option;
 
 @Command(name = "import",
         header = "Import data from a directory or a file.",
-        description = "%nImport data from a directory or a file.",
-        showDefaultValues = true,
-        abbreviateSynopsis = true,
-        optionListHeading = "Options:",
-        commandListHeading = "Commands:")
+        description = "%nImport data from a directory or a file.")
 public final class Import extends AbstractExportImportCommand implements Runnable {
 
     @Option(names = "--override",

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Main.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Main.java
@@ -53,9 +53,6 @@ import picocli.CommandLine.Option;
             "JVM: ${java.version} (${java.vendor} ${java.vm.name} ${java.vm.version})",
             "OS: ${os.name} ${os.version} ${os.arch}"
         },
-        optionListHeading = "Options:",
-        commandListHeading = "Commands:",
-        abbreviateSynopsis = true,
         subcommands = {
                 Build.class,
                 Start.class,

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/ShowConfig.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/ShowConfig.java
@@ -42,9 +42,7 @@ import picocli.CommandLine.Parameters;
 
 @Command(name = "show-config",
         header = "Print out the current configuration.",
-        description = "%nPrint out the current configuration.",
-        abbreviateSynopsis = true,
-        optionListHeading = "Options:")
+        description = "%nPrint out the current configuration.")
 public final class ShowConfig extends AbstractCommand implements Runnable {
 
     @Parameters(

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Start.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Start.java
@@ -36,10 +36,7 @@ import java.util.Optional;
         },
         footer = "%nYou may use the \"--auto-build\" option when starting the server to avoid running the \"build\" command everytime you need to change a static property:%n%n"
                 + "      $ ${PARENT-COMMAND-FULL-NAME:-$PARENTCOMMAND} ${COMMAND-NAME} --auto-build <OPTIONS>%n%n"
-                + "By doing that you have an additional overhead when the server is starting. Run \"${PARENT-COMMAND-FULL-NAME:-$PARENTCOMMAND} build -h\" for more details.",
-        optionListHeading = "Options:",
-        commandListHeading = "Commands:",
-        abbreviateSynopsis = true)
+                + "By doing that you have an additional overhead when the server is starting. Run \"${PARENT-COMMAND-FULL-NAME:-$PARENTCOMMAND} build -h\" for more details.")
 public final class Start extends AbstractStartCommand implements Runnable {
 
     public static final String NAME = "start";

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/StartDev.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/StartDev.java
@@ -19,24 +19,26 @@ package org.keycloak.quarkus.runtime.cli.command;
 
 import org.keycloak.quarkus.runtime.Environment;
 
-import picocli.CommandLine;
 import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Option;
 
 @Command(name = StartDev.NAME,
         header = "Start the server in development mode.",
         description = {
             "%nUse this command if you want to run the server locally for development or testing purposes.",
         },
-        footer = "%nDo NOT start the server using this command when deploying to production.",
-        optionListHeading = "Options:",
-        commandListHeading = "Commands:",
-        abbreviateSynopsis = true)
+        footer = "%nDo NOT start the server using this command when deploying to production.%n%n"
+                + "Use '${PARENT-COMMAND-FULL-NAME:-$PARENTCOMMAND} ${COMMAND-NAME} --help-all' to list all available options, including build options.")
 public final class StartDev extends AbstractStartCommand implements Runnable {
 
     public static final String NAME = "start-dev";
 
-    @CommandLine.Option(names = AUTO_BUILD_OPTION_LONG, hidden = true)
+    @Option(names = AUTO_BUILD_OPTION_LONG, hidden = true)
     Boolean autoConfig;
+
+    @Mixin
+    HelpAllMixin helpAllMixin;
 
     @Override
     protected void doBeforeRun() {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMapper.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMapper.java
@@ -181,7 +181,7 @@ public class PropertyMapper {
         return null;
     }
 
-    boolean isBuildTime() {
+    public boolean isBuildTime() {
         return buildTime;
     }
 


### PR DESCRIPTION
Basically:

* Filtering options for `start`, `star-dev`, and `build` commands.
* Enabling showing additional options for the above commands using a `-ha` (is it a good short name?) or `--help-all`. Also added some hints about using the new option if supported by the command.
* Avoiding boilerplate configuration in option specs
* Removing unnecessary logic to default to start command (as per previous changes, now you need to explicitly run `start`) 