### PR TITLE
[KEYCLOAK-19837] use no bean for spring security filters

### DIFF
--- a/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/filter/KeycloakAuthenticatedActionsFilter.java
+++ b/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/filter/KeycloakAuthenticatedActionsFilter.java
@@ -18,10 +18,7 @@ package org.keycloak.adapters.springsecurity.filter;
 
 import java.io.IOException;
 
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
+import javax.servlet.*;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -44,12 +41,15 @@ import org.springframework.web.filter.GenericFilterBean;
 /**
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
  */
-public class KeycloakAuthenticatedActionsFilter extends GenericFilterBean implements ApplicationContextAware {
+public class KeycloakAuthenticatedActionsFilter implements Filter {
 
     private static final String FILTER_APPLIED = KeycloakAuthenticatedActionsFilter.class.getPackage().getName() + ".authenticated-actions";
 
-    private ApplicationContext applicationContext;
     private AdapterDeploymentContext deploymentContext;
+
+    public KeycloakAuthenticatedActionsFilter(AdapterDeploymentContext deploymentContext) {
+        this.deploymentContext = deploymentContext;
+    }
 
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain filterChain) throws IOException, ServletException {
@@ -72,16 +72,6 @@ public class KeycloakAuthenticatedActionsFilter extends GenericFilterBean implem
         }
 
         filterChain.doFilter(request, response);
-    }
-
-    @Override
-    protected void initFilterBean() {
-        deploymentContext = applicationContext.getBean(AdapterDeploymentContext.class);
-    }
-
-    @Override
-    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
-        this.applicationContext = applicationContext;
     }
 
     private KeycloakSecurityContext getKeycloakPrincipal() {

--- a/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/filter/KeycloakSecurityContextRequestFilter.java
+++ b/adapters/oidc/spring-security/src/main/java/org/keycloak/adapters/springsecurity/filter/KeycloakSecurityContextRequestFilter.java
@@ -18,10 +18,7 @@ package org.keycloak.adapters.springsecurity.filter;
 
 import java.io.IOException;
 
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
+import javax.servlet.*;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -36,24 +33,23 @@ import org.keycloak.adapters.springsecurity.token.AdapterTokenStoreFactory;
 import org.keycloak.adapters.springsecurity.token.SpringSecurityAdapterTokenStoreFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.BeansException;
-import org.springframework.context.ApplicationContext;
-import org.springframework.context.ApplicationContextAware;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.web.filter.GenericFilterBean;
 
 /**
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
  */
-public class KeycloakSecurityContextRequestFilter extends GenericFilterBean implements ApplicationContextAware {
+public class KeycloakSecurityContextRequestFilter implements Filter {
     private static final Logger log = LoggerFactory.getLogger(KeycloakSecurityContextRequestFilter.class);
 
     private static final String FILTER_APPLIED = KeycloakSecurityContext.class.getPackage().getName() + ".token-refreshed";
     private final AdapterTokenStoreFactory adapterTokenStoreFactory = new SpringSecurityAdapterTokenStoreFactory();
 
-    private ApplicationContext applicationContext;
-    private AdapterDeploymentContext deploymentContext;
+    private final AdapterDeploymentContext deploymentContext;
+
+    public KeycloakSecurityContextRequestFilter(AdapterDeploymentContext deploymentContext) {
+        this.deploymentContext = deploymentContext;
+    }
 
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain filterChain) throws IOException, ServletException {
@@ -90,16 +86,6 @@ public class KeycloakSecurityContextRequestFilter extends GenericFilterBean impl
         }
 
         filterChain.doFilter(request, response);
-    }
-
-    @Override
-    protected void initFilterBean() {
-        deploymentContext = applicationContext.getBean(AdapterDeploymentContext.class);
-    }
-
-    @Override
-    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
-        this.applicationContext = applicationContext;
     }
 
     private KeycloakSecurityContext getKeycloakSecurityContext() {

--- a/adapters/oidc/spring-security/src/test/java/org/keycloak/adapters/springsecurity/filter/KeycloakAuthenticationProcessingFilterTest.java
+++ b/adapters/oidc/spring-security/src/test/java/org/keycloak/adapters/springsecurity/filter/KeycloakAuthenticationProcessingFilterTest.java
@@ -107,10 +107,9 @@ public class KeycloakAuthenticationProcessingFilterTest {
         MockitoAnnotations.initMocks(this);
         request = spy(new MockHttpServletRequest());
         request.setRequestURI("http://host");
-        filter = new KeycloakAuthenticationProcessingFilter(authenticationManager);
+        filter = new KeycloakAuthenticationProcessingFilter(authenticationManager, adapterDeploymentContext);
         keycloakFailureHandler = new KeycloakAuthenticationFailureHandler();
 
-        filter.setApplicationContext(applicationContext);
         filter.setAuthenticationSuccessHandler(successHandler);
         filter.setAuthenticationFailureHandler(failureHandler);
 

--- a/adapters/oidc/spring-security/src/test/java/org/keycloak/adapters/springsecurity/filter/KeycloakPreAuthActionsFilterTest.java
+++ b/adapters/oidc/spring-security/src/test/java/org/keycloak/adapters/springsecurity/filter/KeycloakPreAuthActionsFilterTest.java
@@ -52,15 +52,13 @@ public class KeycloakPreAuthActionsFilterTest {
     @Before
     public void setUp() throws Exception {
         initMocks(this);
-        filter = new KeycloakPreAuthActionsFilter(userSessionManagement);
+        filter = new KeycloakPreAuthActionsFilter(deploymentContext);
         filter.setNodesRegistrationManagement(nodesRegistrationManagement);
-        filter.setApplicationContext(applicationContext);
         filter.setPreAuthActionsHandlerFactory(preAuthActionsHandlerFactory);
         when(applicationContext.getBean(AdapterDeploymentContext.class)).thenReturn(deploymentContext);
         when(deploymentContext.resolveDeployment(any(HttpFacade.class))).thenReturn(deployment);
         when(preAuthActionsHandlerFactory.createPreAuthActionsHandler(any(HttpFacade.class))).thenReturn(preAuthActionsHandler);
         when(deployment.isConfigured()).thenReturn(true);
-        filter.initFilterBean();
     }
     
     @Test


### PR DESCRIPTION
This PR fixes the the double registration of Keycloak Spring Security filters. See the [corresponding bug on RedHat Jira](https://issues.redhat.com/browse/KEYCLOAK-19837) for more information.

I've noticed a bug with the Keycloak Spring Boot Adapter while debugging my application.
The four Keycloak security filters (namely KeycloakPreAuthActionsFilter, KeycloakAuthenticationProcessingFilter, KeycloakSecurityContextRequestFilter, KeycloakAuthenticatedActionsFilter) will be added twice to the Spring FilterChain.

To prevent this from happening you should not provide the filters as a bean and at the same time adding them via the "addFilterBefore"/"addFilterAfter" methods to the HttpSecurity object (see KeycloakWebSecurityConfigurerAdapter).