### PR TITLE
[KEYCLOAK-19833] Fix command line completion on ZSH

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/Environment.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/Environment.java
@@ -88,9 +88,9 @@ public final class Environment {
         }
 
         if (isWindows()) {
-            return "./kc.bat";
+            return "kc.bat";
         }
-        return "./kc.sh";
+        return "kc.sh";
     }
 
     /**

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/AbstractCommand.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/AbstractCommand.java
@@ -31,7 +31,7 @@ public abstract class AbstractCommand {
     protected CommandSpec spec;
 
     protected void devProfileNotAllowedError(String cmd) {
-        executionError(spec.commandLine(), String.format("You can not '%s' the server using the '%s' configuration profile. Please re-build the server first, using './kc.sh build' for the default production profile, or using '/.kc.sh build --profile=<profile>' with a profile more suitable for production.%n", cmd, Environment.DEV_PROFILE_VALUE));
+        executionError(spec.commandLine(), String.format("You can not '%s' the server using the '%s' configuration profile. Please re-build the server first, using 'kc.sh build' for the default production profile, or using 'kc.sh build --profile=<profile>' with a profile more suitable for production.%n", cmd, Environment.DEV_PROFILE_VALUE));
     }
 
     protected void executionError(CommandLine cmd, String message) {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Main.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Main.java
@@ -33,7 +33,10 @@ import picocli.CommandLine.Option;
                 "",
                 "Find more information at: https://www.keycloak.org/docs/latest"
         },
-        description = "%nUse this command-line tool to manage your Keycloak cluster.",
+        description = {
+                "Use this command-line tool to manage your Keycloak cluster.",
+                "Make sure the command is available on your \"PATH\" or prefix it with \"./\" (e.g.: \"./${COMMAND-NAME}\") to execute from the current folder."
+        },
         footerHeading = "Examples:",
         footer = { "  Start the server in development mode for local development or testing:%n%n"
                 + "      $ ${COMMAND-NAME} start-dev%n%n"


### PR DESCRIPTION
This fix the currently broken command line completion feature on `ZSH`.
The root problem is that having `./` in the generated(by `picocli`) function names breaks the completion script.
This also better conform to `picocli` "canonical" usage.

I tested manually on `ZSH` and `bash`(to avoid regressions) and now everything looks good.

cc. @DGuhr @pedroigor 