### PR TITLE
8901 TimeProvider should support scheduling with explicit delay

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/timer/TimerProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/timer/TimerProvider.java
@@ -24,9 +24,45 @@ import org.keycloak.provider.Provider;
  */
 public interface TimerProvider extends Provider {
 
-    public void schedule(Runnable runnable, long intervalMillis, String taskName);
+    /**
+     * Schedules the execution of the given {@code runnable}. The first execution happens after {@code intervalMillis} millis
+     * and repeats every {@code intervalMillis} millis.
+     *
+     * @param runnable
+     * @param intervalMillis
+     * @param taskName
+     */
+    void schedule(Runnable runnable, long intervalMillis, String taskName);
 
-    public void scheduleTask(ScheduledTask scheduledTask, long intervalMillis, String taskName);
+    /**
+     * Schedules the execution of the given {@code runnable}. The first execution happens after {@code delayMillis} millis
+     * and repeats every {@code intervalMillis} millis.
+     *
+     * @param runnable
+     * @param intervalMillis
+     * @param taskName
+     */
+    void schedule(Runnable runnable, long delayMillis, long intervalMillis, String taskName);
+
+    /**
+     * Schedules the execution of the given {@code scheduledTask}. The first execution happens after {@code intervalMillis} millis
+     * and repeats every {@code intervalMillis} millis.
+     *
+     * @param scheduledTask
+     * @param intervalMillis
+     * @param taskName
+     */
+    void scheduleTask(ScheduledTask scheduledTask, long intervalMillis, String taskName);
+
+    /**
+     * Schedules the execution of the given {@code scheduledTask}. The first execution happens after {@code delayMillis} millis
+     * and repeats every {@code intervalMillis} millis.
+     *
+     * @param scheduledTask
+     * @param intervalMillis
+     * @param taskName
+     */
+    void scheduleTask(ScheduledTask scheduledTask, long delayMillis, long intervalMillis, String taskName);
 
 
     /**
@@ -35,7 +71,7 @@ public interface TimerProvider extends Provider {
      * @param taskName
      * @return existing task or null if task under this name doesn't exist
      */
-    public TimerTaskContext cancelTask(String taskName);
+    TimerTaskContext cancelTask(String taskName);
 
 
     interface TimerTaskContext {

--- a/services/src/main/java/org/keycloak/timer/basic/BasicTimerProvider.java
+++ b/services/src/main/java/org/keycloak/timer/basic/BasicTimerProvider.java
@@ -46,7 +46,12 @@ public class BasicTimerProvider implements TimerProvider {
     }
 
     @Override
-    public void schedule(final Runnable runnable, final long intervalMillis, String taskName) {
+    public void schedule(Runnable runnable, long intervalMillis, String taskName) {
+        schedule(runnable, intervalMillis, intervalMillis, taskName);
+    }
+
+    @Override
+    public void schedule(Runnable runnable, long delayMillis, long intervalMillis, String taskName) {
         TimerTask task = new TimerTask() {
             @Override
             public void run() {
@@ -61,14 +66,19 @@ public class BasicTimerProvider implements TimerProvider {
             existingTask.timerTask.cancel();
         }
 
-        logger.debugf("Starting task '%s' with interval '%d'", taskName, intervalMillis);
-        timer.schedule(task, intervalMillis, intervalMillis);
+        logger.debugf("Starting task '%s' with delay '%d' and interval '%d'", taskName, intervalMillis, delayMillis);
+        timer.schedule(task, delayMillis, intervalMillis);
     }
 
     @Override
     public void scheduleTask(ScheduledTask scheduledTask, long intervalMillis, String taskName) {
+        scheduleTask(scheduledTask, intervalMillis, intervalMillis, taskName);
+    }
+
+    @Override
+    public void scheduleTask(ScheduledTask scheduledTask, long delayMillis, long intervalMillis, String taskName) {
         ScheduledTaskRunner scheduledTaskRunner = new ScheduledTaskRunner(session.getKeycloakSessionFactory(), scheduledTask, transactionTimeout);
-        this.schedule(scheduledTaskRunner, intervalMillis, taskName);
+        this.schedule(scheduledTaskRunner, delayMillis, intervalMillis, taskName);
     }
 
     @Override
@@ -78,7 +88,6 @@ public class BasicTimerProvider implements TimerProvider {
             logger.debugf("Cancelling task '%s'", taskName);
             existingTask.timerTask.cancel();
         }
-
         return existingTask;
     }
 


### PR DESCRIPTION
8901 Added new schedule methods to TimeProvider which allow
to pass an explicit delay value.
Adapted the BasicTimerProvider accordingly.

Fixes #8901

Signed-off-by: Thomas Darimont <thomas.darimont@googlemail.com>

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
