### PR TITLE
[DRAFT] Allow shortening of access tokens and introspection of full token content

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/models/Constants.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/Constants.java
@@ -130,4 +130,6 @@ public final class Constants {
     public static final String CLIENT_PROFILES = "client-policies.profiles";
     public static final String CLIENT_POLICIES = "client-policies.policies";
 
+    public static final String INTROSPECTABLE_CLAIMS_CLAIM_NAME = "isc";
+    public static final String SKIP_ACCESS_TOKEN_SHORTENER_SESSION_ATTRIBUTE = "skipAccessTokenShortener";
 }

--- a/services/src/main/java/org/keycloak/protocol/ProtocolMapperUtils.java
+++ b/services/src/main/java/org/keycloak/protocol/ProtocolMapperUtils.java
@@ -80,8 +80,11 @@ public class ProtocolMapperUtils {
     // Add roles to tokens finally
     public static final int PRIORITY_ROLE_MAPPER = 40;
 
-    // Script mapper goes last, so it can access the roles in the token
+    // Script mapper goes after roles, so it can access the roles in the token
     public static final int PRIORITY_SCRIPT_MAPPER = 50;
+
+    // Shortener mapper goes last, so it can access all token content
+    public static final int PRIORITY_ACCESS_TOKEN_SHORTENER = 60;
 
     public static String getUserModelValue(UserModel user, String propertyName) {
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/AccessTokenShortenerMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/AccessTokenShortenerMapper.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.protocol.oidc.mappers;
+
+import org.keycloak.models.ClientSessionContext;
+import org.keycloak.models.Constants;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.ProtocolMapperModel;
+import org.keycloak.models.UserSessionModel;
+import org.keycloak.protocol.ProtocolMapperUtils;
+import org.keycloak.protocol.oidc.OIDCLoginProtocol;
+import org.keycloak.protocol.oidc.utils.OIDCTokenChangeUtils;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.representations.AccessToken;
+import org.keycloak.util.JsonSerialization;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Mapper which is used to shorten an access token. The full token can still be retrieved with token introspection.
+ *
+ * @author <a href="mailto:daniel.fesenmeyer@bosch.io">Daniel Fesenmeyer</a>
+ * @version $Revision: 1 $
+ */
+public class AccessTokenShortenerMapper extends AbstractOIDCProtocolMapper implements OIDCAccessTokenMapper {
+
+    public static final String PROVIDER_ID = "oidc-shorten-token";
+
+    private static final String INTROSPECTABLE_CLAIMS_PROPERTY_NAME = "introspectable-claims";
+    private static final List<String> DEFAULT_INTROSPECTABLE_CLAIMS =
+            Collections.unmodifiableList(Arrays.asList("aud", "realm_access.roles", "resource_access"));
+    private static final String DEFAULT_INTROSPECTABLE_CLAIMS_STR = String.join(",", DEFAULT_INTROSPECTABLE_CLAIMS);
+
+    private static final List<ProviderConfigProperty> CONFIG_PROPERTIES = createConfigProperties();
+
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return CONFIG_PROPERTIES;
+    }
+
+    @Override
+    public int getPriority() {
+        return ProtocolMapperUtils.PRIORITY_ACCESS_TOKEN_SHORTENER;
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public String getDisplayType() {
+        return "Shorten access token";
+    }
+
+    @Override
+    public String getDisplayCategory() {
+        return TOKEN_MAPPER_CATEGORY;
+    }
+
+    @Override
+    public String getHelpText() {
+        return "Shorten the access token by removing configurable claims - full token can be retrieved with introspection.";
+    }
+
+    public AccessToken transformAccessToken(AccessToken token, ProtocolMapperModel mappingModel,
+            KeycloakSession keycloakSession,
+            UserSessionModel userSession, ClientSessionContext clientSessionCtx) {
+        boolean skip =
+                keycloakSession.getAttributeOrDefault(Constants.SKIP_ACCESS_TOKEN_SHORTENER_SESSION_ATTRIBUTE, false);
+        if (skip) {
+            return token;
+        }
+
+        String claimsStr = mappingModel.getConfig().get(INTROSPECTABLE_CLAIMS_PROPERTY_NAME);
+        Set<String> claims = stringToClaims(claimsStr);
+
+        if (claims.isEmpty()) {
+            return token;
+        }
+
+        ObjectNode accessTokenObject;
+        try {
+            accessTokenObject = JsonSerialization.createObjectNode(token);
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+        Set<String> removedClaims = OIDCTokenChangeUtils.removeClaims(accessTokenObject, claims);
+
+        if (removedClaims.isEmpty()) {
+            return token;
+        } else {
+            AccessToken resultToken;
+            try {
+                resultToken = JsonSerialization.mapper.readerFor(AccessToken.class).readValue(accessTokenObject);
+            } catch (IOException e) {
+                throw new IllegalStateException(e);
+            }
+            resultToken.setOtherClaims(Constants.INTROSPECTABLE_CLAIMS_CLAIM_NAME, removedClaims);
+
+            return resultToken;
+        }
+    }
+
+    private static List<ProviderConfigProperty> createConfigProperties() {
+        ProviderConfigProperty property = new ProviderConfigProperty();
+        property.setName(INTROSPECTABLE_CLAIMS_PROPERTY_NAME);
+        // TODO@dfr i18n
+        property.setLabel("Introspectable claims");
+        property.setType(ProviderConfigProperty.STRING_TYPE);
+        // TODO@dfr i18n
+        property.setHelpText(
+                "Comma-separated list of Claims that will be removed from the access token, but can be retrieved via Token Introspection. Claims can be fully qualified names like 'address.street'. To prevent nesting and use dot literally, escape the dot with backslash (\\.).");
+        property.setDefaultValue(DEFAULT_INTROSPECTABLE_CLAIMS_STR);
+
+        return Collections.singletonList(property);
+    }
+
+    public static ProtocolMapperModel create(final String name) {
+        ProtocolMapperModel mapper = new ProtocolMapperModel();
+        mapper.setName(name);
+        mapper.setProtocolMapper(PROVIDER_ID);
+        mapper.setProtocol(OIDCLoginProtocol.LOGIN_PROTOCOL);
+        Map<String, String> config =
+                Collections.singletonMap(INTROSPECTABLE_CLAIMS_PROPERTY_NAME, DEFAULT_INTROSPECTABLE_CLAIMS_STR);
+        mapper.setConfig(config);
+        return mapper;
+    }
+
+    private static Set<String> stringToClaims(final String claimsStr) {
+        if (claimsStr == null) {
+            return Collections.emptySet();
+        }
+
+        return Stream.of(claimsStr.split(",")).collect(Collectors.toSet());
+    }
+
+}

--- a/services/src/main/java/org/keycloak/protocol/oidc/utils/OIDCTokenChangeUtils.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/utils/OIDCTokenChangeUtils.java
@@ -1,0 +1,154 @@
+package org.keycloak.protocol.oidc.utils;
+
+import org.keycloak.protocol.oidc.mappers.OIDCAttributeMapperHelper;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * Utils to change the content of tokens.
+ *
+ * @author <a href="mailto:daniel.fesenmeyer@bosch.io">Daniel Fesenmeyer</a>
+ * @version $Revision: 1 $
+ */
+public final class OIDCTokenChangeUtils {
+
+    private OIDCTokenChangeUtils() {
+        throw new AssertionError();
+    }
+
+    // TODO@dfr: make sure that certain claims cannot be removed
+    public static Set<String> removeClaims(ObjectNode token, Collection<String> claimsToRemove) {
+        final Set<String> removedClaims = new TreeSet<>();
+
+        for (String claimToRemove : claimsToRemove) {
+            boolean removed = removeClaim(token, claimToRemove);
+            if (removed) {
+                removedClaims.add(claimToRemove);
+            }
+        }
+
+        return removedClaims;
+    }
+
+    private static boolean removeClaim(ObjectNode token, String claimToRemove) {
+        List<String> claimComponents = splitClaimPath(claimToRemove);
+        if (claimComponents.isEmpty()) {
+            return false;
+        }
+
+        boolean removed = false;
+
+        final int length = claimComponents.size();
+        int i = 0;
+
+        ObjectNode currentObject = token;
+        for (String component : claimComponents) {
+            i++;
+            if (i == length) {
+                JsonNode removedObj = currentObject.remove(component);
+                removed = removedObj != null;
+            } else {
+                JsonNode nested = currentObject.get(component);
+
+                if (!(nested instanceof ObjectNode)) {
+                    return false;
+                }
+
+                currentObject = (ObjectNode) nested;
+            }
+        }
+
+        return removed;
+    }
+
+    // TODO@dfr: make sure that certain claims cannot be copied
+    public static void copyClaims(ObjectNode srcToken, ObjectNode targetToken, Collection<String> claimsToCopy) {
+        claimsToCopy.forEach(claimToCopy -> {
+            copyClaim(srcToken, targetToken, claimToCopy);
+        });
+
+    }
+
+    private static void copyClaim(ObjectNode srcToken, ObjectNode targetToken, String claimToCopy) {
+        JsonNode srcValue = getClaim(srcToken, claimToCopy);
+
+        if (srcValue != null) {
+            setClaim(targetToken, claimToCopy, srcValue);
+        }
+    }
+
+    private static JsonNode getClaim(ObjectNode token, String claimToGet) {
+        List<String> claimComponents = splitClaimPath(claimToGet);
+        if (claimComponents.isEmpty()) {
+            return null;
+        }
+
+        JsonNode found = null;
+
+        final int length = claimComponents.size();
+        int i = 0;
+        ObjectNode currentObject = token;
+        for (String component : claimComponents) {
+            i++;
+            if (i == length) {
+                found = currentObject.get(component);
+            } else {
+                JsonNode nested = currentObject.get(component);
+
+                if (nested == null) {
+                    return null;
+                } else if (!(nested instanceof ObjectNode)) {
+                    // TODO@dfr: logging
+                    return null;
+                }
+
+                currentObject = (ObjectNode) nested;
+            }
+        }
+
+        return found;
+    }
+
+    private static void setClaim(ObjectNode token, String claimToSet, JsonNode attributeValue) {
+        if (attributeValue == null) {
+            return;
+        }
+
+        List<String> claimComponents = splitClaimPath(claimToSet);
+        if (claimComponents.isEmpty()) {
+            return;
+        }
+
+        final int length = claimComponents.size();
+        int i = 0;
+        ObjectNode currentObject = token;
+        for (String component : claimComponents) {
+            i++;
+            if (i == length) {
+                currentObject.set(component, attributeValue);
+            } else {
+                JsonNode nested = currentObject.get(component);
+
+                if (nested == null) {
+                    nested = currentObject.objectNode();
+                    currentObject.set(component, nested);
+                } else if (!(nested instanceof ObjectNode)) {
+                    // TODO@dfr: logging
+                    return;
+                }
+
+                currentObject = (ObjectNode) nested;
+            }
+        }
+    }
+
+    private static List<String> splitClaimPath(String claimPath) {
+        return OIDCAttributeMapperHelper.splitClaimPath(claimPath);
+    }
+}

--- a/services/src/main/resources/META-INF/services/org.keycloak.protocol.ProtocolMapper
+++ b/services/src/main/resources/META-INF/services/org.keycloak.protocol.ProtocolMapper
@@ -18,6 +18,7 @@
 org.keycloak.protocol.oidc.mappers.UserAttributeMapper
 org.keycloak.protocol.oidc.mappers.FullNameMapper
 org.keycloak.protocol.oidc.mappers.UserPropertyMapper
+org.keycloak.protocol.oidc.mappers.AccessTokenShortenerMapper
 org.keycloak.protocol.oidc.mappers.AddressMapper
 org.keycloak.protocol.oidc.mappers.HardcodedClaim
 org.keycloak.protocol.oidc.mappers.HardcodedRole


### PR DESCRIPTION
This is an implementation DRAFT based on discussion #8599. I would like to get feedback from the community, whether the implemented approach makes sense, how it can be improved, or if someone suggests a better alternative.

## Current Implementation

This DRAFT PR implements a mapper named AccessTokenShortenerMapper, which can be configured with a list of "Introspectable claims", which will be excluded from the resulting access token - the default value for those claims is "aud,realm_access.roles,resource_access". Instead of those claims, the token contains a special claim "isc" (short for introspectable claims), which contains the claims which have been excluded.
The "Introspectable claims" are configurable, in order to make it possible to also exclude groups or custom claims, which may become large.

The token introspection endpoint has been extended to evaluate the "isc" claim and extending the existing token with the missing claims. The missing claims are created based on a newly created access token. This access token is created based on user info, client info and scope from the existing token, skipping AccessTokenShortenerMapper.

The KeycloakIdentity class, which is used in the Admin API and several other places, has been adjusted to support reloading the missing claims (with "internal token introspection"), when an access token contains the "isc" claim.
This way, the Admin API can be used with any full-scope client with configured AccessTokenShortenerMapper - even when the full token is quite large - for example, when authorizing as an admin of many realms.

## Implications of the current implementation

The current implementation of the token introspection (both the "actual" and the "internal" token introspection) extends the token with the missing claims based on the current state, not the state when the token was created. This should be fine, because the current state should be the relevant one for most use cases.
On the other hand, for performance reasons, it COULD make sense to cache a full token - then the token introspection would not necessarily reflect the current state.

## Considered alternatives

### Special admin-client flag on the client

This should be quite easy to implement. When this flag would be set, the Admin API would just load the roles from the persistence (see UserModelIdentity), as it is already done for the special clients admin-cli and security-admin-console.

But this approach has the drawback that it is only usable when accessing Keycloak internal API. It does not help to integrate external clients which require a large amount of authorization data.

### Add a flag to mappers

Add a flag to the mappers, which defines whether this mapper's result should be excluded from a access token and only be available via token introspection. For users, it would be more intuitive to have this configuration directly at the affected mapper, but it also would be more implementation effort - not only once, but also for new mappers.
Furthermore, the client configuration would be much more complicated, because the aud, realm_access and resource_access claims are created by mappers configured for the "roles" client scope, which is a default client scope. In order to have different mappers configured for the admin clients, another "introspectable-roles" scope would have to be created and added as default scope to the client, instead of the "roles" scope. Additionally, the three mappers would have to be added to the client with appropriate configuration. And users might be confused that there are now two OIDC scopes "roles" and "introspectable-roles", for essentially the same data.

## Open issues

### Denylist for certain claims

It should be made sure that certain claims such as alg, typ, iss cannot be excluded from the token, in a similar way as it is already done in OIDCAttributeMapperHelper.

### Support "Internal token introspection" for complete Keycloak API

For a final implementation, it has to be considered that there are several other places using bearer authentication. They probably should also be extended to support the "internal token introspection" functionality:

- IdentityBrokerService: uses AccessToken directly
- AccountLoader: instantiates an Auth class based on the AccessToken
- ClientRegistrationAuth: checks the roles in a similar way as done in KeycloakIdentity, but with completely different code

Maybe there are even more places?

### Migration of existing clients admin-cli and security-admin-console?

Currently, in case of the special admin clients, all (role-based) authorization is done based on the roles currently assigned to the user, regardless of whether they are contained in the token or even in the scope of the client (see UserModelIdentity).
To get rid of the UserModelIdentity and similar classes, the clients admin-cli and security-admin-console would need to be re-configured in the following way:

- Change their scope to "Full Scope Allowed" (For admin clients - especially those for managing multiple realms - it is impractical to explicitly manage client roles)
- Add the AccessTokenShortenerMapper to the clients, with the default configuration of "Introspectable claims": "aud,realm_access.roles,resource_access". 







