### PR TITLE
KEYCLOAK-13847 fix offline token refresh date

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/UserResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UserResource.java
@@ -954,7 +954,7 @@ public class UserResource {
         if (clientSession == null) {
             return null;
         }
-        rep.setLastAccess(clientSession.getTimestamp());
+        rep.setLastAccess(Time.toMillis(clientSession.getTimestamp()));
         return rep;
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/ClientTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/ClientTest.java
@@ -19,8 +19,11 @@ package org.keycloak.testsuite.admin;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -536,6 +539,8 @@ public class ClientTest extends AbstractAdminTest {
         List<UserSessionRepresentation> offlineUserSessions = realm.clients().get(id).getOfflineUserSessions(0, 100);
         assertEquals(1, offlineUserSessions.size());
         assertEquals("testuser", offlineUserSessions.get(0).getUsername());
+        org.hamcrest.MatcherAssert.assertThat(offlineUserSessions.get(0).getLastAccess(),
+            allOf(greaterThan(Time.currentTimeMillis() - 10000L), lessThan(Time.currentTimeMillis())));
 
         userSessions = realm.users().get(userId).getOfflineSessions(id);
         assertEquals("There should be one offline session", 1, userSessions.size());


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/KEYCLOAK-13847

Changed `UserResource` `getOfflineSessions` API to return `lastAccess` with milli seconds.
By changing so, "Last refresh" in the Offline token view shows the correct value like the following.

![KEYCLOAK-13847](https://user-images.githubusercontent.com/34849594/143403467-25b15c13-2d00-4acd-86d2-8edf348c3af2.PNG)

