### PR TITLE
Enable tar support for large GIDs in build

### DIFF
--- a/distribution/server-dist/pom.xml
+++ b/distribution/server-dist/pom.xml
@@ -265,7 +265,7 @@
                             <appendAssemblyId>false</appendAssemblyId>
                             <outputDirectory>${project.build.directory}</outputDirectory>
                             <workDirectory>${project.build.directory}/assembly/work</workDirectory>
-                            <tarLongFileMode>gnu</tarLongFileMode>
+                            <tarLongFileMode>posix</tarLongFileMode>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
Closes #8926.
