### PR TITLE
[KEYCLOAK-19847] - Optimizations and refactoring for better/stable startup time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -414,7 +414,7 @@ jobs:
 
       - name: Run Quarkus Tests in Docker
         run: |
-          mvn clean install -nsu -B -f quarkus/tests/pom.xml -Dkc.quarkus.tests.dist=docker | misc/log/trimmer.sh
+          mvn clean install -nsu -B -f quarkus/tests/pom.xml -Dkc.quarkus.tests.dist=docker -Dtest=StartDevCommandTest | misc/log/trimmer.sh
           TEST_RESULT=${PIPESTATUS[0]}
           exit $TEST_RESULT
 

--- a/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/CLusteringBuildSteps.java
+++ b/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/CLusteringBuildSteps.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.quarkus.deployment;
+
+import static org.keycloak.quarkus.runtime.configuration.Configuration.getConfigValue;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.stream.Collectors;
+import javax.enterprise.context.ApplicationScoped;
+import org.infinispan.commons.util.FileLookupFactory;
+import org.keycloak.quarkus.runtime.Environment;
+import org.keycloak.quarkus.runtime.KeycloakRecorder;
+import org.keycloak.quarkus.runtime.storage.infinispan.CacheInitializer;
+
+import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Record;
+
+public class CLusteringBuildSteps {
+
+    @Record(ExecutionTime.RUNTIME_INIT)
+    @BuildStep
+    void configureInfinispan(KeycloakRecorder recorder, BuildProducer<SyntheticBeanBuildItem> syntheticBeanBuildItems) {
+        String pathPrefix;
+        String homeDir = Environment.getHomeDir();
+
+        if (homeDir == null) {
+            pathPrefix = "";
+        } else {
+            pathPrefix = homeDir + "/conf/";
+        }
+
+        String configFile = getConfigValue("kc.spi.connections-infinispan.quarkus.config-file").getValue();
+
+        if (configFile != null) {
+            Path configPath = Paths.get(pathPrefix + configFile);
+            String path;
+
+            if (configPath.toFile().exists()) {
+                path = configPath.toFile().getAbsolutePath();
+            } else {
+                path = configPath.getFileName().toString();
+            }
+
+            InputStream url = FileLookupFactory.newInstance().lookupFile(path, KeycloakProcessor.class.getClassLoader());
+
+            if (url == null) {
+                throw new IllegalArgumentException("Could not load cluster configuration file at [" + configPath + "]");
+            }
+
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(url))) {
+                String config = reader.lines().collect(Collectors.joining("\n"));
+
+                syntheticBeanBuildItems.produce(SyntheticBeanBuildItem.configure(CacheInitializer.class)
+                        .scope(ApplicationScoped.class)
+                        .unremovable()
+                        .setRuntimeInit()
+                        .runtimeValue(recorder.createCacheInitializer(config)).done());
+            } catch (Exception cause) {
+                throw new RuntimeException("Failed to read clustering configuration from [" + url + "]", cause);
+            }
+        } else {
+            throw new IllegalArgumentException("Option 'configFile' needs to be specified");
+        }
+    }
+
+}

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/Environment.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/Environment.java
@@ -17,13 +17,16 @@
 
 package org.keycloak.quarkus.runtime;
 
-import static org.keycloak.quarkus.runtime.configuration.Configuration.getBuiltTimeProperty;
+import static org.keycloak.quarkus.runtime.configuration.Configuration.getBuildTimeProperty;
 
 import java.io.File;
 import java.io.FilenameFilter;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -34,13 +37,11 @@ import org.apache.commons.lang3.SystemUtils;
 public final class Environment {
 
     public static final String IMPORT_EXPORT_MODE = "import_export";
-    public static final String CLI_ARGS = "kc.config.args";
     public static final String PROFILE ="kc.profile";
     public static final String ENV_PROFILE ="KC_PROFILE";
     public static final String DATA_PATH = "/data";
     public static final String DEFAULT_THEMES_PATH = "/themes";
     public static final String DEV_PROFILE_VALUE = "dev";
-    public static final String USER_INVOKED_CLI_COMMAND = "picocli.invoked.command";
     public static final String LAUNCH_MODE = "kc.launch.mode";
 
     private Environment() {}
@@ -95,33 +96,6 @@ public final class Environment {
         return "kc.sh";
     }
 
-    /**
-     * Sets the originally invoked cli args. Useful to verify the originally invoked command
-     * when calling another cli command internally (e.g. start-dev calls build internally)
-     */
-    public static void setUserInvokedCliArgs(List<String> cliArgs) {
-        System.setProperty(USER_INVOKED_CLI_COMMAND, String.join(",", cliArgs));
-    }
-
-    /**
-     * Reads the previously set system property for the originally command.
-     * Use the System variable, when you trigger other command executions internally, but need a reference to the
-     * actually invoked command.
-     *
-     * @return the invoked command from the CLI, or empty List if not set.
-     */
-    public static List<String> getUserInvokedCliArgs() {
-        if(System.getProperty(USER_INVOKED_CLI_COMMAND) == null) {
-            return Collections.emptyList();
-        }
-
-        return List.of(System.getProperty(USER_INVOKED_CLI_COMMAND).split(","));
-    }
-
-    public static String getConfigArgs() {
-        return System.getProperty(CLI_ARGS, "");
-    }
-
     public static String getProfile() {
         String profile = System.getProperty(PROFILE);
         
@@ -156,7 +130,7 @@ public final class Environment {
             return true;
         }
 
-        return DEV_PROFILE_VALUE.equals(getBuiltTimeProperty(PROFILE).orElse(null));
+        return DEV_PROFILE_VALUE.equals(getBuildTimeProperty(PROFILE).orElse(null));
     }
 
     public static boolean isDevProfile(){

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakMain.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakMain.java
@@ -21,7 +21,9 @@ import static org.keycloak.quarkus.runtime.Environment.isDevProfile;
 import static org.keycloak.quarkus.runtime.Environment.getProfileOrDefault;
 import static org.keycloak.quarkus.runtime.Environment.isTestLaunchMode;
 import static org.keycloak.quarkus.runtime.cli.Picocli.parseAndRun;
+import static org.keycloak.quarkus.runtime.cli.command.Start.isDevProfileNotAllowed;
 
+import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -35,10 +37,10 @@ import org.jboss.logging.Logger;
 import org.keycloak.quarkus.runtime.cli.ExecutionExceptionHandler;
 import org.keycloak.quarkus.runtime.cli.Picocli;
 import org.keycloak.common.Version;
+import org.keycloak.quarkus.runtime.cli.command.Start;
 
 import io.quarkus.runtime.QuarkusApplication;
 import io.quarkus.runtime.annotations.QuarkusMain;
-import picocli.CommandLine;
 
 /**
  * <p>The main entry point, responsible for initialize and run the CLI as well as start the server.
@@ -51,25 +53,36 @@ public class KeycloakMain implements QuarkusApplication {
 
     public static void main(String[] args) {
         System.setProperty("kc.version", Version.VERSION_KEYCLOAK);
-        List<String> cliArgs = new ArrayList<>(Arrays.asList(args));
-        System.setProperty(Environment.CLI_ARGS, Picocli.parseConfigArgs(cliArgs));
+        List<String> cliArgs = Picocli.parseArgs(args);
 
         if (cliArgs.isEmpty()) {
+            cliArgs = new ArrayList<>(cliArgs);
             // default to show help message
             cliArgs.add("-h");
+        } else if (cliArgs.contains(Start.NAME) && cliArgs.size() == 1) {
+            // fast path for starting the server without bootstrapping CLI
+            ExecutionExceptionHandler errorHandler = new ExecutionExceptionHandler();
+            PrintWriter errStream = new PrintWriter(System.err, true);
+
+            if (isDevProfileNotAllowed(Arrays.asList(args))) {
+                errorHandler.error(errStream, Messages.devProfileNotAllowedError(Start.NAME), null);
+                return;
+            }
+
+            start(errorHandler, errStream);
+
+            return;
         }
 
         // parse arguments and execute any of the configured commands
         parseAndRun(cliArgs);
     }
 
-    public static void start(CommandLine cmd) {
+    public static void start(ExecutionExceptionHandler errorHandler, PrintWriter errStream) {
         try {
             Quarkus.run(KeycloakMain.class, (exitCode, cause) -> {
                 if (cause != null) {
-                    ExecutionExceptionHandler exceptionHandler = (ExecutionExceptionHandler) cmd.getExecutionExceptionHandler();
-
-                    exceptionHandler.error(cmd.getErr(),
+                    errorHandler.error(errStream,
                             String.format("Failed to start server using profile (%s)", getProfileOrDefault("prod")),
                             cause.getCause());
                 }
@@ -81,9 +94,7 @@ public class KeycloakMain implements QuarkusApplication {
                 }
             });
         } catch (Throwable cause) {
-            ExecutionExceptionHandler exceptionHandler = (ExecutionExceptionHandler) cmd.getExecutionExceptionHandler();
-
-            exceptionHandler.error(cmd.getErr(),
+            errorHandler.error(errStream,
                     String.format("Unexpected error when starting the server using profile (%s)", getProfileOrDefault("prod")),
                     cause.getCause());
         }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakRecorder.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakRecorder.java
@@ -17,7 +17,7 @@
 
 package org.keycloak.quarkus.runtime;
 
-import static org.keycloak.quarkus.runtime.configuration.Configuration.getBuiltTimeProperty;
+import static org.keycloak.quarkus.runtime.configuration.Configuration.getBuildTimeProperty;
 
 import java.util.List;
 import java.util.Map;
@@ -85,10 +85,10 @@ public class KeycloakRecorder {
                     feature = "kc.features";
                 }
 
-                Optional<String> value = getBuiltTimeProperty(feature);
+                Optional<String> value = getBuildTimeProperty(feature);
 
                 if (value.isEmpty()) {
-                    value = getBuiltTimeProperty(feature.replaceAll("\\.features\\.", "\\.features-"));
+                    value = getBuildTimeProperty(feature.replaceAll("\\.features\\.", "\\.features-"));
                 }
                 
                 if (value.isPresent()) {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/Messages.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/Messages.java
@@ -45,4 +45,8 @@ public final class Messages {
     public static void cliExecutionError(CommandLine cmd, String message, Throwable cause) {
         throw new CommandLine.ExecutionException(cmd, message, cause);
     }
+
+    public static String devProfileNotAllowedError(String cmd) {
+        return String.format("You can not '%s' the server using the '%s' configuration profile. Please re-build the server first, using 'kc.sh build' for the default production profile, or using 'kc.sh build --profile=<profile>' with a profile more suitable for production.%n", cmd, Environment.DEV_PROFILE_VALUE);
+    }
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/DefaultFactory.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/DefaultFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,24 +15,15 @@
  * limitations under the License.
  */
 
-package org.keycloak.quarkus.runtime.cli.command;
+package org.keycloak.quarkus.runtime.cli;
 
-import static org.keycloak.quarkus.runtime.Messages.cliExecutionError;
+import picocli.CommandLine.IFactory;
 
-import picocli.CommandLine;
-import picocli.CommandLine.Model.CommandSpec;
-import picocli.CommandLine.Spec;
+public class DefaultFactory implements IFactory {
 
-public abstract class AbstractCommand {
-
-    @Spec
-    protected CommandSpec spec;
-
-    protected void executionError(CommandLine cmd, String message) {
-        executionError(cmd, message, null);
-    }
-
-    protected void executionError(CommandLine cmd, String message, Throwable cause) {
-        cliExecutionError(cmd, message, cause);
+    @Override
+    public <K> K create(Class<K> cls) throws Exception {
+        // picocli tries different approaches for creating instances, this is what we need
+        return cls.getDeclaredConstructor().newInstance();
     }
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/ExecutionExceptionHandler.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/ExecutionExceptionHandler.java
@@ -38,7 +38,7 @@ public final class ExecutionExceptionHandler implements CommandLine.IExecutionEx
     private Logger logger;
     private boolean verbose;
 
-    ExecutionExceptionHandler() {}
+    public ExecutionExceptionHandler() {}
 
     @Override
     public int handleExecutionException(Exception cause, CommandLine cmd, ParseResult parseResult) {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/AbstractStartCommand.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/AbstractStartCommand.java
@@ -18,6 +18,9 @@
 package org.keycloak.quarkus.runtime.cli.command;
 
 import org.keycloak.quarkus.runtime.KeycloakMain;
+import org.keycloak.quarkus.runtime.cli.ExecutionExceptionHandler;
+
+import picocli.CommandLine;
 
 public abstract class AbstractStartCommand extends AbstractCommand implements Runnable {
 
@@ -27,7 +30,8 @@ public abstract class AbstractStartCommand extends AbstractCommand implements Ru
     @Override
     public void run() {
         doBeforeRun();
-        KeycloakMain.start(spec.commandLine());
+        CommandLine cmd = spec.commandLine();
+        KeycloakMain.start((ExecutionExceptionHandler) cmd.getExecutionExceptionHandler(), cmd.getErr());
     }
 
     protected void doBeforeRun() {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Build.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Build.java
@@ -20,8 +20,10 @@ package org.keycloak.quarkus.runtime.cli.command;
 import static org.keycloak.quarkus.runtime.Environment.getHomePath;
 import static org.keycloak.quarkus.runtime.Environment.isDevMode;
 import static org.keycloak.quarkus.runtime.cli.Picocli.println;
+import static org.keycloak.quarkus.runtime.configuration.ConfigArgsConfigSource.getAllCliArgs;
 
 import org.keycloak.quarkus.runtime.Environment;
+import org.keycloak.quarkus.runtime.Messages;
 
 import io.quarkus.bootstrap.runner.QuarkusEntryPoint;
 import io.quarkus.bootstrap.runner.RunnerClassLoader;
@@ -29,10 +31,6 @@ import io.quarkus.bootstrap.runner.RunnerClassLoader;
 import io.quarkus.runtime.configuration.ProfileManager;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
-
-import java.io.IOException;
-import java.nio.file.Files;
-import java.util.List;
 
 @Command(name = Build.NAME,
         header = "Creates a new and optimized server image.",
@@ -94,9 +92,8 @@ public final class Build extends AbstractCommand implements Runnable {
     }
 
     private void exitWithErrorIfDevProfileIsSetAndNotStartDev() {
-        List<String> userInvokedCliArgs = Environment.getUserInvokedCliArgs();
-        if(Environment.isDevProfile() && !userInvokedCliArgs.contains(StartDev.NAME)) {
-            devProfileNotAllowedError(Build.NAME);
+        if (Environment.isDevProfile() && !getAllCliArgs().contains(StartDev.NAME)) {
+            executionError(spec.commandLine(), Messages.devProfileNotAllowedError(NAME));
         }
     }
 
@@ -117,11 +114,7 @@ public final class Build extends AbstractCommand implements Runnable {
     private void cleanTempResources() {
         if (!ProfileManager.getLaunchMode().isDevOrTest()) {
             // only needed for dev/testing purposes
-            try {
-                Files.delete(getHomePath().resolve("quarkus-artifact.properties"));
-            } catch (IOException cause) {
-                throw new RuntimeException("Failed to delete temporary resources", cause);
-            }
+            getHomePath().resolve("quarkus-artifact.properties").toFile().delete();
         }
     }
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/HelpAllMixin.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/HelpAllMixin.java
@@ -21,7 +21,7 @@ import org.keycloak.quarkus.runtime.cli.Help;
 
 import picocli.CommandLine;
 
-final class HelpAllMixin {
+public final class HelpAllMixin {
 
     @CommandLine.Spec
     private CommandLine.Model.CommandSpec spec;

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Main.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Main.java
@@ -68,6 +68,9 @@ import picocli.CommandLine.Option;
         })
 public final class Main {
 
+    public static final String PROFILE_SHORT_NAME = "-pf";
+    public static final String PROFILE_LONG_NAME = "--profile";
+
     @CommandLine.Spec
     CommandLine.Model.CommandSpec spec;
 
@@ -94,7 +97,7 @@ public final class Main {
         exceptionHandler.setVerbose(verbose);
     }
 
-    @Option(names = {"-pf", "--profile"},
+    @Option(names = { PROFILE_SHORT_NAME, PROFILE_LONG_NAME },
             description = "Set the profile. Use 'dev' profile to enable development mode.")
     public void setProfile(String profile) {
         Environment.setProfile(profile);

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/ShowConfig.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/ShowConfig.java
@@ -17,8 +17,7 @@
 
 package org.keycloak.quarkus.runtime.cli.command;
 
-import static java.lang.Boolean.parseBoolean;
-import static org.keycloak.quarkus.runtime.configuration.Configuration.getBuiltTimeProperty;
+import static org.keycloak.quarkus.runtime.configuration.Configuration.getBuildTimeProperty;
 import static org.keycloak.quarkus.runtime.configuration.Configuration.getConfigValue;
 import static org.keycloak.quarkus.runtime.configuration.Configuration.getPropertyNames;
 import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMappers.canonicalFormat;
@@ -119,7 +118,7 @@ public final class ShowConfig extends AbstractCommand implements Runnable {
         String profile = Environment.getProfile();
 
         if (profile == null) {
-            return getBuiltTimeProperty("quarkus.profile").orElse(null);
+            return getBuildTimeProperty("quarkus.profile").orElse(null);
         }
 
         return profile;

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/Configuration.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/Configuration.java
@@ -52,24 +52,28 @@ public final class Configuration {
         return CONFIG;
     }
 
-    public static Optional<String> getBuiltTimeProperty(String name) {
-        String value = KeycloakConfigSourceProvider.PERSISTED_CONFIG_SOURCE.getValue(name);
+    public static Optional<String> getBuildTimeProperty(String name) {
+        Optional<String> value = getRawPersistedProperty(name);
 
-        if (value == null) {
-            value = KeycloakConfigSourceProvider.PERSISTED_CONFIG_SOURCE.getValue(getMappedPropertyName(name));
+        if (value.isEmpty()) {
+            value = getRawPersistedProperty(getMappedPropertyName(name));
         }
 
-        if (value == null) {
+        if (value.isEmpty()) {
             String profile = Environment.getProfile();
 
             if (profile == null) {
                 profile = getConfig().getRawValue(Environment.PROFILE);
             }
 
-            value = KeycloakConfigSourceProvider.PERSISTED_CONFIG_SOURCE.getValue("%" + profile + "." + name);
+            value = getRawPersistedProperty("%" + profile + "." + name);
         }
 
-        return Optional.ofNullable(value);
+        return value;
+    }
+
+    public static Optional<String> getRawPersistedProperty(String name) {
+        return Optional.ofNullable(PersistedConfigSource.getInstance().getValue(name));
     }
 
     public static String getRawValue(String propertyName) {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/KeycloakConfigSourceProvider.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/KeycloakConfigSourceProvider.java
@@ -18,22 +18,16 @@
 package org.keycloak.quarkus.runtime.configuration;
 
 
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.microprofile.config.spi.ConfigSource;
 import org.eclipse.microprofile.config.spi.ConfigSourceProvider;
-import org.jboss.logging.Logger;
 import org.keycloak.quarkus.runtime.Environment;
 
 public class KeycloakConfigSourceProvider implements ConfigSourceProvider {
 
-    private static final Logger log = Logger.getLogger(KeycloakConfigSourceProvider.class);
-
     private static final List<ConfigSource> CONFIG_SOURCES = new ArrayList<>();
-    public static PersistedConfigSource PERSISTED_CONFIG_SOURCE;
 
     // we initialize in a static block to avoid discovering the config sources multiple times when starting the application
     static {
@@ -50,8 +44,7 @@ public class KeycloakConfigSourceProvider implements ConfigSourceProvider {
         CONFIG_SOURCES.add(new ConfigArgsConfigSource());
         CONFIG_SOURCES.add(new SysPropConfigSource());
         CONFIG_SOURCES.add(new KcEnvConfigSource());
-        PERSISTED_CONFIG_SOURCE = new PersistedConfigSource(getPersistedConfigFile());
-        CONFIG_SOURCES.add(PERSISTED_CONFIG_SOURCE);
+        CONFIG_SOURCES.add(PersistedConfigSource.getInstance());
 
         CONFIG_SOURCES.addAll(new KeycloakPropertiesConfigSource.InFileSystem().getConfigSources(Thread.currentThread().getContextClassLoader()));
 
@@ -66,20 +59,6 @@ public class KeycloakConfigSourceProvider implements ConfigSourceProvider {
     public static void reload() {
         CONFIG_SOURCES.clear();
         initializeSources();
-    }
-
-    public static Path getPersistedConfigFile() {
-        String homeDir = Environment.getHomeDir();
-
-        if (homeDir == null) {
-            return Paths.get(System.getProperty("java.io.tmpdir"), PersistedConfigSource.KEYCLOAK_PROPERTIES);
-        }
-
-        Path generatedPath = Paths.get(homeDir, "data", "generated");
-
-        generatedPath.toFile().mkdirs();
-
-        return generatedPath.resolve(PersistedConfigSource.KEYCLOAK_PROPERTIES);
     }
 
     @Override

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/HttpPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/HttpPropertyMappers.java
@@ -133,7 +133,7 @@ final class HttpPropertyMappers {
             ConfigValue proceed = context.proceed("kc.https.certificate.file");
 
             if (proceed == null || proceed.getValue() == null) {
-                proceed = getMapper("quarkus.http.ssl.certificate.key-store-file").getOrDefault(context, null);
+                proceed = getMapper("quarkus.http.ssl.certificate.key-store-file").getConfigValue(context);
             }
 
             if (proceed == null || proceed.getValue() == null) {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMappers.java
@@ -3,6 +3,7 @@ package org.keycloak.quarkus.runtime.configuration.mappers;
 import io.smallrye.config.ConfigSourceInterceptorContext;
 import io.smallrye.config.ConfigValue;
 import org.keycloak.quarkus.runtime.Environment;
+import org.keycloak.quarkus.runtime.configuration.ConfigArgsConfigSource;
 import org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider;
 
 import java.util.Collection;
@@ -32,14 +33,13 @@ public final class PropertyMappers {
 
     public static ConfigValue getValue(ConfigSourceInterceptorContext context, String name) {
         PropertyMapper mapper = MAPPERS.getOrDefault(name, PropertyMapper.IDENTITY);
-        ConfigValue configValue = mapper
-                .getOrDefault(name, context, context.proceed(name));
+        ConfigValue configValue = mapper.getConfigValue(name, context);
 
         if (configValue == null) {
             Optional<String> prefixedMapper = getPrefixedMapper(name);
 
             if (prefixedMapper.isPresent()) {
-                return MAPPERS.get(prefixedMapper.get()).getOrDefault(name, context, configValue);
+                return MAPPERS.get(prefixedMapper.get()).getConfigValue(name, context);
             }
         } else {
             configValue.withName(mapper.getTo());
@@ -76,7 +76,7 @@ public final class PropertyMappers {
 
         return isBuildTimeProperty
                 && !"kc.version".equals(name)
-                && !Environment.CLI_ARGS.equals(name)
+                && !ConfigArgsConfigSource.CLI_ARGS.equals(name)
                 && !"kc.home.dir".equals(name)
                 && !"kc.config.file".equals(name)
                 && !Environment.PROFILE.equals(name)

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/integration/QuarkusPlatform.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/integration/QuarkusPlatform.java
@@ -65,18 +65,6 @@ public class QuarkusPlatform implements PlatformProvider {
         }
     }
 
-    /**
-     * Similar behavior as per {@code #exitOnError} but convenient to throw a {@link InitializationException} with a single
-     * {@code cause}
-     * 
-     * @param cause the cause
-     * @throws InitializationException the initialization exception with the given {@code cause}.
-     */
-    public static void exitOnError(Throwable cause) throws InitializationException{
-        addInitializationException(cause);
-        exitOnError();
-    }
-
     Runnable startupHook;
     Runnable shutdownHook;
 
@@ -155,7 +143,7 @@ public class QuarkusPlatform implements PlatformProvider {
             } else {
                 String dataDir = Environment.getDataDir();
                 tmpDir = new File(dataDir, "tmp");
-                tmpDir.mkdir();
+                tmpDir.mkdirs();
             }
 
             if (tmpDir.isDirectory()) {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/integration/jaxrs/QuarkusKeycloakApplication.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/integration/jaxrs/QuarkusKeycloakApplication.java
@@ -25,15 +25,23 @@ import javax.inject.Inject;
 import javax.persistence.EntityManagerFactory;
 import javax.ws.rs.ApplicationPath;
 
+import org.keycloak.Config;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.models.KeycloakTransactionManager;
 import org.keycloak.models.utils.PostMigrationEvent;
 import org.keycloak.quarkus.runtime.integration.QuarkusKeycloakSessionFactory;
-import org.keycloak.quarkus.runtime.integration.QuarkusPlatform;
+import org.keycloak.services.ServicesLogger;
+import org.keycloak.services.managers.ApplianceBootstrap;
 import org.keycloak.services.resources.KeycloakApplication;
 import org.keycloak.quarkus.runtime.services.resources.QuarkusWelcomeResource;
 import org.keycloak.services.resources.WelcomeResource;
 
 @ApplicationPath("/")
 public class QuarkusKeycloakApplication extends KeycloakApplication {
+
+    private static final String KEYCLOAK_ADMIN_ENV_VAR = "KEYCLOAK_ADMIN";
+    private static final String KEYCLOAK_ADMIN_PASSWORD_ENV_VAR = "KEYCLOAK_ADMIN_PASSWORD";
 
     private static boolean filterSingletons(Object o) {
         return !WelcomeResource.class.isInstance(o);
@@ -44,13 +52,10 @@ public class QuarkusKeycloakApplication extends KeycloakApplication {
 
     @Override
     protected void startup() {
-        try {
-            forceEntityManagerInitialization();
-            initializeKeycloakSessionFactory();
-            setupScheduledTasks(sessionFactory);
-        } catch (Throwable cause) {
-            QuarkusPlatform.exitOnError(cause);
-        }
+        forceEntityManagerInitialization();
+        initializeKeycloakSessionFactory();
+        setupScheduledTasks(sessionFactory);
+        createAdminUser();
     }
 
     @Override
@@ -59,7 +64,6 @@ public class QuarkusKeycloakApplication extends KeycloakApplication {
                 .filter(QuarkusKeycloakApplication::filterSingletons)
                 .collect(Collectors.toSet());
 
-        singletons.add(new QuarkusWelcomeResource());
         singletons.add(new QuarkusWelcomeResource());
 
         return singletons;
@@ -76,5 +80,36 @@ public class QuarkusKeycloakApplication extends KeycloakApplication {
         // also forces an initialization of the entity manager so that providers don't need to wait for any initialization logic
         // when first creating an entity manager
         entityManagerFactory.get().createEntityManager().close();
+    }
+
+    private void createAdminUser() {
+        String adminUserName = System.getenv(KEYCLOAK_ADMIN_ENV_VAR);
+        String adminPassword = System.getenv(KEYCLOAK_ADMIN_PASSWORD_ENV_VAR);
+
+        if ((adminUserName == null || adminUserName.trim().length() == 0)
+                || (adminPassword == null || adminPassword.trim().length() == 0)) {
+            return;
+        }
+
+        KeycloakSessionFactory sessionFactory = KeycloakApplication.getSessionFactory();
+        KeycloakSession session = sessionFactory.create();
+        KeycloakTransactionManager transaction = session.getTransactionManager();
+
+        try {
+            transaction.begin();
+
+            new ApplianceBootstrap(session).createMasterRealmUser(adminUserName, adminPassword);
+            ServicesLogger.LOGGER.addUserSuccess(adminUserName, Config.getAdminRealm());
+
+            transaction.commit();
+        } catch (IllegalStateException e) {
+            session.getTransactionManager().rollback();
+            ServicesLogger.LOGGER.addUserFailedUserExists(adminUserName, Config.getAdminRealm());
+        } catch (Throwable t) {
+            session.getTransactionManager().rollback();
+            ServicesLogger.LOGGER.addUserFailed(t, adminUserName, Config.getAdminRealm());
+        } finally {
+            session.close();
+        }
     }
 }

--- a/quarkus/runtime/src/main/resources/cluster-default.xml
+++ b/quarkus/runtime/src/main/resources/cluster-default.xml
@@ -28,42 +28,42 @@
                 <key media-type="application/x-java-object"/>
                 <value media-type="application/x-java-object"/>
             </encoding>
-            <memory storage="HEAP" max-count="10000"/>
+            <memory max-count="10000"/>
         </local-cache>
         <local-cache name="users">
             <encoding>
                 <key media-type="application/x-java-object"/>
                 <value media-type="application/x-java-object"/>
             </encoding>
-            <memory storage="HEAP" max-count="10000"/>
+            <memory max-count="10000"/>
         </local-cache>
-        <distributed-cache name="sessions" owners="1">
-            <expiration lifespan="900000000000000000"/>
+        <distributed-cache name="sessions" owners="2">
+            <expiration lifespan="-1"/>
         </distributed-cache>
-        <distributed-cache name="authenticationSessions" owners="1">
-            <expiration lifespan="900000000000000000"/>
+        <distributed-cache name="authenticationSessions" owners="2">
+            <expiration lifespan="-1"/>
         </distributed-cache>
-        <distributed-cache name="offlineSessions" owners="1">
-            <expiration lifespan="900000000000000000"/>
+        <distributed-cache name="offlineSessions" owners="2">
+            <expiration lifespan="-1"/>
         </distributed-cache>
-        <distributed-cache name="clientSessions" owners="1">
-            <expiration lifespan="900000000000000000"/>
+        <distributed-cache name="clientSessions" owners="2">
+            <expiration lifespan="-1"/>
         </distributed-cache>
-        <distributed-cache name="offlineClientSessions" owners="1">
-            <expiration lifespan="900000000000000000"/>
+        <distributed-cache name="offlineClientSessions" owners="2">
+            <expiration lifespan="-1"/>
         </distributed-cache>
-        <distributed-cache name="loginFailures" owners="1">
-            <expiration lifespan="900000000000000000"/>
+        <distributed-cache name="loginFailures" owners="2">
+            <expiration lifespan="-1"/>
         </distributed-cache>
         <local-cache name="authorization">
             <encoding>
                 <key media-type="application/x-java-object"/>
                 <value media-type="application/x-java-object"/>
             </encoding>
-            <memory storage="HEAP" max-count="10000"/>
+            <memory max-count="10000"/>
         </local-cache>
         <replicated-cache name="work">
-            <expiration lifespan="900000000000000000"/>
+            <expiration lifespan="-1"/>
         </replicated-cache>
         <local-cache name="keys">
             <encoding>
@@ -71,15 +71,15 @@
                 <value media-type="application/x-java-object"/>
             </encoding>
             <expiration max-idle="3600000"/>
-            <memory storage="HEAP" max-count="1000"/>
+            <memory max-count="1000"/>
         </local-cache>
         <distributed-cache name="actionTokens" owners="2">
             <encoding>
                 <key media-type="application/x-java-object"/>
                 <value media-type="application/x-java-object"/>
             </encoding>
-            <expiration max-idle="-1" lifespan="900000000000000000" interval="300000"/>
-            <memory storage="HEAP" max-count="-1"/>
+            <expiration max-idle="-1" lifespan="-1" interval="300000"/>
+            <memory max-count="-1"/>
         </distributed-cache>
     </cache-container>
 </infinispan>

--- a/quarkus/runtime/src/main/resources/cluster-local.xml
+++ b/quarkus/runtime/src/main/resources/cluster-local.xml
@@ -30,28 +30,42 @@
                 <key media-type="application/x-java-object"/>
                 <value media-type="application/x-java-object"/>
             </encoding>
-            <memory storage="HEAP" max-count="10000"/>
+            <memory max-count="10000"/>
         </local-cache>
         <local-cache name="users">
             <encoding>
                 <key media-type="application/x-java-object"/>
                 <value media-type="application/x-java-object"/>
             </encoding>
-            <memory storage="HEAP" max-count="10000"/>
+            <memory max-count="10000"/>
         </local-cache>
-        <local-cache name="sessions"/>
-        <local-cache name="authenticationSessions"/>
-        <local-cache name="offlineSessions"/>
-        <local-cache name="clientSessions"/>
-        <local-cache name="offlineClientSessions"/>
-        <local-cache name="loginFailures"/>
-        <local-cache name="work"/>
+        <local-cache name="sessions">
+            <expiration lifespan="-1"/>
+        </local-cache>
+        <local-cache name="authenticationSessions">
+            <expiration lifespan="-1"/>
+        </local-cache>
+        <local-cache name="offlineSessions">
+            <expiration lifespan="-1"/>
+        </local-cache>
+        <local-cache name="clientSessions">
+            <expiration lifespan="-1"/>
+        </local-cache>
+        <local-cache name="offlineClientSessions">
+            <expiration lifespan="-1"/>
+        </local-cache>
+        <local-cache name="loginFailures">
+            <expiration lifespan="-1"/>
+        </local-cache>
         <local-cache name="authorization">
             <encoding>
                 <key media-type="application/x-java-object"/>
                 <value media-type="application/x-java-object"/>
             </encoding>
-            <memory storage="HEAP" max-count="10000"/>
+            <memory max-count="10000"/>
+        </local-cache>
+        <local-cache name="work">
+            <expiration lifespan="-1"/>
         </local-cache>
         <local-cache name="keys">
             <encoding>
@@ -59,15 +73,15 @@
                 <value media-type="application/x-java-object"/>
             </encoding>
             <expiration max-idle="3600000"/>
-            <memory storage="HEAP" max-count="10000"/>
+            <memory max-count="1000"/>
         </local-cache>
         <local-cache name="actionTokens">
             <encoding>
                 <key media-type="application/x-java-object"/>
                 <value media-type="application/x-java-object"/>
             </encoding>
-            <expiration max-idle="-1" interval="300000"/>
-            <memory storage="HEAP" max-count="-1"/>
+            <expiration max-idle="-1" lifespan="-1" interval="300000"/>
+            <memory max-count="-1"/>
         </local-cache>
     </cache-container>
 </infinispan>

--- a/quarkus/runtime/src/test/java/org/keycloak/provider/quarkus/ConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/provider/quarkus/ConfigurationTest.java
@@ -19,7 +19,7 @@ package org.keycloak.provider.quarkus;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.keycloak.quarkus.runtime.Environment.CLI_ARGS;
+import static org.keycloak.quarkus.runtime.configuration.ConfigArgsConfigSource.CLI_ARGS;
 
 import java.io.File;
 import java.lang.reflect.Field;

--- a/quarkus/tests/integration/src/main/java/org/keycloak/it/junit5/extension/CLITestExtension.java
+++ b/quarkus/tests/integration/src/main/java/org/keycloak/it/junit5/extension/CLITestExtension.java
@@ -18,6 +18,7 @@
 package org.keycloak.it.junit5.extension;
 
 import static org.keycloak.it.junit5.extension.DistributionTest.ReInstall.BEFORE_ALL;
+import static org.keycloak.it.junit5.extension.DistributionType.RAW;
 import static org.keycloak.quarkus.runtime.Environment.forceTestLaunchMode;
 
 import java.util.Arrays;
@@ -27,8 +28,6 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.keycloak.it.utils.KeycloakDistribution;
-import org.keycloak.it.utils.DockerKeycloakDistribution;
-import org.keycloak.it.utils.RawKeycloakDistribution;
 import org.keycloak.quarkus.runtime.Environment;
 import org.keycloak.quarkus.runtime.cli.command.Start;
 import org.keycloak.quarkus.runtime.cli.command.StartDev;
@@ -83,26 +82,7 @@ public class CLITestExtension extends QuarkusMainTestExtension {
     }
 
     private KeycloakDistribution createDistribution(DistributionTest config) {
-        KeycloakDistribution distribution = null;
-
-        switch (System.getProperty("kc.quarkus.tests.dist", "raw")) {
-            case "docker":
-                distribution = new DockerKeycloakDistribution(
-                        config.debug(),
-                        config.keepAlive(),
-                        !DistributionTest.ReInstall.NEVER.equals(config.reInstall())
-                );
-                break;
-            case "raw":
-            default:
-                distribution = new RawKeycloakDistribution(
-                    config.debug(),
-                    config.keepAlive(),
-                    !DistributionTest.ReInstall.NEVER.equals(config.reInstall())
-                );
-        }
-
-        return distribution;
+        return DistributionType.getCurrent().orElse(RAW).newInstance(config);
     }
 
     @Override

--- a/quarkus/tests/integration/src/main/java/org/keycloak/it/junit5/extension/DistributionType.java
+++ b/quarkus/tests/integration/src/main/java/org/keycloak/it/junit5/extension/DistributionType.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.it.junit5.extension;
+
+import java.util.Optional;
+import java.util.function.Function;
+import org.keycloak.it.utils.DockerKeycloakDistribution;
+import org.keycloak.it.utils.KeycloakDistribution;
+import org.keycloak.it.utils.RawKeycloakDistribution;
+import org.keycloak.utils.StringUtil;
+
+public enum DistributionType {
+
+    RAW(DistributionType::createRawDistribution),
+    DOCKER(DistributionType::createDockerDistribution);
+
+    private static KeycloakDistribution createDockerDistribution(DistributionTest config) {
+        return new DockerKeycloakDistribution(
+                config.debug(),
+                config.keepAlive(),
+                !DistributionTest.ReInstall.NEVER.equals(config.reInstall()));
+    }
+
+    private static KeycloakDistribution createRawDistribution(DistributionTest config) {
+        return new RawKeycloakDistribution(
+                config.debug(),
+                config.keepAlive(),
+                !DistributionTest.ReInstall.NEVER.equals(config.reInstall()));
+    }
+
+    private final Function<DistributionTest, KeycloakDistribution> factory;
+
+    DistributionType(Function<DistributionTest, KeycloakDistribution> factory) {
+        this.factory = factory;
+    }
+
+    public static Optional<DistributionType> getCurrent() {
+        String distributionType = System.getProperty("kc.quarkus.tests.dist");
+
+        if (StringUtil.isBlank(distributionType)) {
+            return Optional.empty();
+        }
+
+        try {
+            return Optional.of(valueOf(distributionType.toUpperCase()));
+        } catch (IllegalStateException cause) {
+            throw new RuntimeException("Invalid distribution type: " + distributionType);
+        }
+    }
+
+    public KeycloakDistribution newInstance(DistributionTest config) {
+        return factory.apply(config);
+    }
+}

--- a/quarkus/tests/integration/src/main/java/org/keycloak/it/junit5/extension/RawDistOnly.java
+++ b/quarkus/tests/integration/src/main/java/org/keycloak/it/junit5/extension/RawDistOnly.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.it.junit5.extension;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * {@link RawDistOnly} is used to signal that the annotated tests class is only enabled when running tests using the {@link DistributionType#RAW}.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@EnabledIfSystemProperty(named = "kc.quarkus.tests.dist", matches = "^$|raw")
+public @interface RawDistOnly {
+
+    /**
+     * The reason why the test is disabled.
+     */
+    String reason();
+}

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/HelpCommandTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/HelpCommandTest.java
@@ -30,6 +30,13 @@ import io.quarkus.test.junit.main.LaunchResult;
 public class HelpCommandTest {
 
     @Test
+    @Launch({})
+    void testDefaultToHelp(LaunchResult result) {
+        CLIResult cliResult = (CLIResult) result;
+        cliResult.assertHelp("kc.sh");
+    }
+
+    @Test
     @Launch({ "--help" })
     void testHelpCommand(LaunchResult result) {
         CLIResult cliResult = (CLIResult) result;

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/BuildAndStartDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/BuildAndStartDistTest.java
@@ -17,24 +17,38 @@
 
 package org.keycloak.it.cli.dist;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
-import org.keycloak.it.cli.StartCommandTest;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.condition.DisabledIf;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.keycloak.it.junit5.extension.CLIResult;
 import org.keycloak.it.junit5.extension.DistributionTest;
+import org.keycloak.it.junit5.extension.RawDistOnly;
 
 import io.quarkus.test.junit.main.Launch;
 import io.quarkus.test.junit.main.LaunchResult;
 
-@DistributionTest
-public class StartCommandDistTest extends StartCommandTest {
+@DistributionTest(reInstall = DistributionTest.ReInstall.NEVER)
+@RawDistOnly(reason = "Containers are immutable")
+@TestMethodOrder(OrderAnnotation.class)
+public class BuildAndStartDistTest {
 
     @Test
-    @Launch({ "-pf=dev", "start", "--auto-build", "--http-enabled=true", "--hostname-strict=false" })
-    void failIfAutoBuildUsingDevProfile(LaunchResult result) {
-        assertTrue(result.getErrorOutput().contains("ERROR: You can not 'start' the server using the 'dev' configuration profile. Please re-build the server first, using 'kc.sh build' for the default production profile, or using 'kc.sh build --profile=<profile>' with a profile more suitable for production."),
-                () -> "The Output:\n" + result.getErrorOutput() + "doesn't contains the expected string.");
-        assertEquals(4, result.getErrorStream().size());
+    @Launch({ "build", "--http-enabled=true", "--hostname-strict=false", "--cluster=local" })
+    @Order(1)
+    void firstYouBuild(LaunchResult result) {
+    }
+
+    @Test
+    @Launch({ "start" })
+    @Order(2)
+    void thenYouStart(LaunchResult result) {
+        CLIResult cliResult = (CLIResult) result;
+        cliResult.assertStarted();
     }
 }

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/BuildCommandDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/BuildCommandDistTest.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.it.cli.dist;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
@@ -50,5 +51,6 @@ class BuildCommandDistTest {
                 () -> "The Error Output:\n" + result.getErrorOutput() + "doesn't contains the expected string.");
         assertTrue(result.getErrorOutput().contains("For more details run the same command passing the '--verbose' option. Also you can use '--help' to see the details about the usage of the particular command."),
                 () -> "The Error Output:\n" + result.getErrorOutput() + "doesn't contains the expected string.");
+        assertEquals(4, result.getErrorStream().size());
     }
 }

--- a/testsuite/integration-arquillian/servers/auth-server/quarkus/src/main/content/conf/keycloak.properties
+++ b/testsuite/integration-arquillian/servers/auth-server/quarkus/src/main/content/conf/keycloak.properties
@@ -28,6 +28,7 @@ spi.truststore.file.file=${kc.home.dir}/conf/keycloak.truststore
 spi.truststore.file.password=secret
 
 # Declarative User Profile
+spi.user-profile.provider=declarative-user-profile
 spi.user-profile.declarative-user-profile.read-only-attributes=deniedFoo,deniedBar*,deniedSome/thing,deniedsome*thing
 spi.user-profile.declarative-user-profile.admin-read-only-attributes=deniedSomeAdmin
 

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/containers/KeycloakQuarkusServerDeployableContainer.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/containers/KeycloakQuarkusServerDeployableContainer.java
@@ -46,9 +46,6 @@ import org.keycloak.testsuite.arquillian.SuiteContext;
 public class KeycloakQuarkusServerDeployableContainer implements DeployableContainer<KeycloakQuarkusConfiguration> {
 
     private static final Logger log = Logger.getLogger(KeycloakQuarkusServerDeployableContainer.class);
-    public static final String CONF_PERSISTED_PROPERTIES_FILENAME = "data/generated/persisted.properties";
-    public static final String SPI_PROVIDER_PROPERTY_PREFIX = "kc.spi-";
-    public static final String SPI_PROVIDER_PROPERTY_SUFFIX = "-provider";
 
     private KeycloakQuarkusConfiguration configuration;
     private Process container;
@@ -127,23 +124,6 @@ public class KeycloakQuarkusServerDeployableContainer implements DeployableConta
     @Override
     public void undeploy(Descriptor descriptor) throws DeploymentException {
 
-    }
-
-    /**
-     * Get the currently configured default provider for the passed spi.
-     * 
-     * @param spi the spi to get the current default provider for (dash-cased)
-     * @return the current configured provider or null if not configured
-     */
-    public String getCurrentlyConfiguredSpiProviderFor(String spi) {
-        try {
-            File persistedPropertiesFile = configuration.getProvidersPath().resolve(CONF_PERSISTED_PROPERTIES_FILENAME).toFile();
-            Properties props = new Properties();
-            props.load(new FileInputStream(persistedPropertiesFile));
-            return props.get(SPI_PROVIDER_PROPERTY_PREFIX + spi + SPI_PROVIDER_PROPERTY_SUFFIX).toString().trim();
-        } catch (IOException e) {
-            return null;
-        }
     }
 
     private Process startContainer() throws IOException {


### PR DESCRIPTION
Basically:

* There is no change to UX but internal/implementation changes
* Persisted properties are no longer within the distribution but generated as part of build steps and included in the artifacts generated by Quarkus during re-augmentation. There are several benefits here, such as avoiding breaking the server if you mess up the configuration, no need to run `build` if you replace the classpath in the distribution, and we can potentially make our default `conf/keycloak.properties` even simpler by just having there the production settings.
* Properties file config source is now able to load multiple files from classpath. Properties files loaded from file system (e.g.: running the distribution) have a higher priority. This is somewhat related to #1 above.
* Moving clustering build steps to a specific class. We should try to break a bit `KeycloakProcessor` so that we have steps better grouped on a per-area basis. It should also help make it easier to optimize re-augmentation as build steps are run in parallel.
* Removing unnecessary code paths in CLI. 
* Creates a fast-path for starting the server when the `start` command is executed without any option. This is the main usage people should consider for better startup time. We are basically avoiding running unnecessary code related to CLI args parsing and Picocli bootstrapping. It should also simplify the Picocli related code.
*  Moving CLI arg processing to the CLI config source instead of having it spread everywhere.
* Avoid static init on `KeycloakConfigSourceProvider` when looking up persisted properties before the server is starting (e.g.: still processing CLI commands/options before starting the server). This is mainly important when re-augmenting the server because re-augmentatoin runs in a different classloader.
* Moving bootstrap code from lifecycle observer to close the other bootstrap methods within `QuarkusKeycloakApplication`.
* Removing unnecessary step when running the main testsuite that was causing re-augmentation to happen everytime the server is started (e.g.: just because the user profile provider was being set).
* More tests and improvements to Dist.X testsuite
* Running a single/smoke tests using containers. The tests are a bit unstable and fail from time to time due to timeout. Also having issues running locally in a stable fashion.