### PR TITLE
Expose password policy in login forms to FreeMarker templates

### DIFF
--- a/services/src/main/java/org/keycloak/forms/login/freemarker/FreeMarkerLoginFormsProvider.java
+++ b/services/src/main/java/org/keycloak/forms/login/freemarker/FreeMarkerLoginFormsProvider.java
@@ -35,6 +35,7 @@ import org.keycloak.forms.login.freemarker.model.IdpReviewProfileBean;
 import org.keycloak.forms.login.freemarker.model.LoginBean;
 import org.keycloak.forms.login.freemarker.model.FrontChannelLogoutBean;
 import org.keycloak.forms.login.freemarker.model.OAuthGrantBean;
+import org.keycloak.forms.login.freemarker.model.PasswordPolicyBean;
 import org.keycloak.forms.login.freemarker.model.ProfileBean;
 import org.keycloak.forms.login.freemarker.model.RealmBean;
 import org.keycloak.forms.login.freemarker.model.RegisterBean;
@@ -455,6 +456,7 @@ public class FreeMarkerLoginFormsProvider implements LoginFormsProvider {
 
             attributes.put("url", new UrlBean(realm, theme, baseUri, this.actionUri));
             attributes.put("requiredActionUrl", new RequiredActionUrlFormatterMethod(realm, baseUri));
+            attributes.put("passwordPolicy", new PasswordPolicyBean(realm));
             attributes.put("auth", new AuthenticationContextBean(context, page));
             attributes.put(Constants.EXECUTION, execution);
 

--- a/services/src/main/java/org/keycloak/forms/login/freemarker/model/PasswordPolicyBean.java
+++ b/services/src/main/java/org/keycloak/forms/login/freemarker/model/PasswordPolicyBean.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.forms.login.freemarker.model;
+
+import java.util.Set;
+
+import org.keycloak.models.RealmModel;
+
+/**
+ * @author <a href="mailto:scherer.adi@gmail.com">Adrian Scherer</a>
+ */
+public class PasswordPolicyBean {
+
+    private final RealmModel realm;
+
+    public PasswordPolicyBean(final RealmModel realmModel) {
+
+        this.realm = realmModel;
+    }
+
+    public Set<String> getPolicies() {
+
+        return this.realm.getPasswordPolicy().getPolicies();
+    }
+
+    public <T> T getPolicyConfig(final String key) {
+
+        return (T) this.realm.getPasswordPolicy().getPolicyConfig(key);
+    }
+}


### PR DESCRIPTION
- Add the possibility to get password policy rules for a realm in the Login FreeMarker templates so that theme developers could use them to create a password tooltip.
- Resolves [#8949](https://github.com/keycloak/keycloak/issues/8949).
