### PR TITLE
8942 - port in location header is -1 when doing SAML global logout

### DIFF
--- a/adapters/saml/wildfly-elytron/src/main/java/org/keycloak/adapters/saml/elytron/KeycloakHttpServerAuthenticationMechanism.java
+++ b/adapters/saml/wildfly-elytron/src/main/java/org/keycloak/adapters/saml/elytron/KeycloakHttpServerAuthenticationMechanism.java
@@ -173,7 +173,13 @@ class KeycloakHttpServerAuthenticationMechanism implements HttpServerAuthenticat
             String path = uri.getPath();
             String relativePath = exchange.getRequest().getRelativePath();
             String contextPath = path.substring(0, path.indexOf(relativePath));
-            String loc = exchange.getURI().getScheme() + "://" + exchange.getURI().getHost() + ":" + exchange.getURI().getPort() + contextPath + location;
+            String loc;
+            int port = uri.getPort();
+            if (port == -1) {
+                loc = uri.getScheme() + "://" + uri.getHost() + contextPath + location;
+            } else {
+                loc = uri.getScheme() + "://" + uri.getHost() + ":" + port + contextPath + location;
+            }
             exchange.getResponse().setHeader("Location", loc);
         }
         exchange.getResponse().setStatus(HttpServletResponse.SC_FOUND);


### PR DESCRIPTION
Fix #8942 