### PR TITLE
KEYCLOAK-19864 Missing org.jboss.logging in keycloak-core modules

### DIFF
--- a/distribution/feature-packs/adapter-feature-pack/src/main/resources/modules/system/add-ons/keycloak/org/keycloak/keycloak-core/main/module.xml
+++ b/distribution/feature-packs/adapter-feature-pack/src/main/resources/modules/system/add-ons/keycloak/org/keycloak/keycloak-core/main/module.xml
@@ -30,6 +30,7 @@
         <module name="com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider"/>
         <module name="org.keycloak.keycloak-common" />
         <module name="org.bouncycastle" />
+        <module name="org.jboss.logging"/>
         <module name="javax.api"/>
         <module name="javax.activation.api"/>
         <module name="sun.jdk" optional="true" />


### PR DESCRIPTION
<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
