### PR TITLE
KEYCLOAK-19832 Update to Quarkus 2.5.1

### DIFF
--- a/distribution/server-x-dist/src/main/content/bin/kc.sh
+++ b/distribution/server-x-dist/src/main/content/bin/kc.sh
@@ -63,7 +63,7 @@ done
 # Specify options to pass to the Java VM.
 #
 if [ "x$JAVA_OPTS" = "x" ]; then
-   JAVA_OPTS="-Xms64m -Xmx512m -XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=256m -Djava.net.preferIPv4Stack=true -Dquarkus-log-max-startup-records=10000"
+   JAVA_OPTS="-Xms64m -Xmx512m -XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=256m -Djava.net.preferIPv4Stack=true"
 else
    echo "JAVA_OPTS already set in environment; overriding default settings with values: $JAVA_OPTS"
 fi

--- a/quarkus/pom.xml
+++ b/quarkus/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <!-- Quarkus version -->
-        <quarkus.version>2.4.2.Final</quarkus.version>
+        <quarkus.version>2.5.1.Final</quarkus.version>
 
         <!--
             Override versions based on Quarkus dependencies.
@@ -44,8 +44,8 @@
         <jackson.version>2.12.5</jackson.version>
         <jackson.databind.version>${jackson.version}</jackson.databind.version>
         <hibernate.core.version>5.6.1.Final</hibernate.core.version>
-        <mysql.driver.version>8.0.26</mysql.driver.version>
-        <postgresql.version>42.2.24</postgresql.version>
+        <mysql.driver.version>8.0.27</mysql.driver.version>
+        <postgresql.version>42.3.1</postgresql.version>
         <microprofile-metrics-api.version>3.0</microprofile-metrics-api.version>
         <wildfly.common.version>1.5.4.Final-format-001</wildfly.common.version>
         <infinispan.version>13.0.0.Final</infinispan.version>

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Build.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Build.java
@@ -49,7 +49,7 @@ import java.util.List;
         },
         footerHeading = "Examples:",
         footer = "  Optimize the server based on a profile configuration:%n%n"
-                + "      $ ${PARENT-COMMAND-FULL-NAME:-$PARENTCOMMAND} ${COMMAND-NAME} --profile=prod%n%n"
+                + "      $ ${PARENT-COMMAND-FULL-NAME:-$PARENTCOMMAND} --profile=prod ${COMMAND-NAME}%n%n"
                 + "  Change database settings:%n%n"
                 + "      $ ${PARENT-COMMAND-FULL-NAME:-$PARENTCOMMAND} ${COMMAND-NAME} --db=postgres [--db-url][--db-username][--db-password]%n%n"
                 + "  Enable a feature:%n%n"

--- a/quarkus/tests/integration/src/main/java/org/keycloak/it/junit5/extension/CLIResult.java
+++ b/quarkus/tests/integration/src/main/java/org/keycloak/it/junit5/extension/CLIResult.java
@@ -61,6 +61,7 @@ public interface CLIResult extends LaunchResult {
     boolean isDistribution();
 
     default void assertStarted() {
+        assertFalse(getOutput().contains("The delayed handler's queue was overrun and log record(s) were lost (Did you forget to configure logging?)"), () -> "The standard Output:\n" + getOutput() + "should not contain a warning about log queue overrun.");
         assertTrue(getOutput().contains("Listening on:"), () -> "The standard output:\n" + getOutput() + "does include \"Listening on:\"");
         assertNotDevMode();
     }


### PR DESCRIPTION
Quarkus 2.5.1 brings us:
- maintenance updates
- bugfix for stream handling in RESTEASY-Classic (prevented update to 2.5.0, see https://github.com/quarkusio/quarkus/issues/21602)
- Capability to use @QuarkusTest and provide CLI-Args to it, which should enable easy integration tests with testresources etc. 
- added assert to `assertStarted` to check for unwanted log msg which shouldnt show up anymore (see https://github.com/quarkusio/quarkus/pull/21473 )
