### PR TITLE
[KEYCLOAK-19686] - Update bat script with latest changes

### DIFF
--- a/distribution/server-x-dist/src/main/content/bin/kc.bat
+++ b/distribution/server-x-dist/src/main/content/bin/kc.bat
@@ -31,30 +31,36 @@ if "%KEY%" == "" (
     goto MAIN
 )
 if "%KEY%" == "--debug" (
-    set "DEBUG_MODE=true"
-    set "DEBUG_PORT_VAR=%~2"
-    if "%DEBUG_PORT_VAR%" == "" (
-       set DEBUG_PORT_VAR=8787
-    )
-    shift
-    shift
-    goto READ-ARGS
+  set "DEBUG_MODE=true"
+  set "DEBUG_PORT_VAR=%~2"
+  if "%DEBUG_PORT_VAR%" == "" (
+     set DEBUG_PORT_VAR=8787
+  )
+  shift
+  shift
+  goto READ-ARGS
 )
-if not "%KEY:~0,2%"=="--" if "%KEY:~0,1%"=="-" (
-    set "SERVER_OPTS=%SERVER_OPTS% %KEY%=%~2"
-    shift
+if "%KEY%" == "start-dev" (
+  set "CONFIG_ARGS=%CONFIG_ARGS% --profile=dev %KEY% --auto-build"
+  shift
+  shift
+  goto READ-ARGS
+)
+if not "%KEY:~0,2%"=="--" if "%KEY:~0,2%"=="-D" (
+  set "SERVER_OPTS=%SERVER_OPTS% %KEY%=%~2"
+  shift
 )
 if not "%KEY:~0,2%"=="--" if not "%KEY:~0,1%"=="-" (
-    set "CONFIG_ARGS=%CONFIG_ARGS% %KEY%"
+  set "CONFIG_ARGS=%CONFIG_ARGS% %KEY%"
 )
-if "%KEY:~0,2%"=="--" (
-    if "%~2"=="" (
-        set "CONFIG_ARGS=%CONFIG_ARGS% %KEY%"
-    ) else (
-        set "CONFIG_ARGS=%CONFIG_ARGS% %KEY%=%~2%"
-    )
+if "%KEY:~0,2%"=="--" if not "%KEY:~0,2%"=="-D" if "%KEY:~0,1%"=="-" (
+  if "%~2"=="" (
+    set "CONFIG_ARGS=%CONFIG_ARGS% %KEY%"
+  ) else (
+    set "CONFIG_ARGS=%CONFIG_ARGS% %KEY% %~2%"
+  )
 
-    shift
+  shift
 )
 shift
 goto READ-ARGS
@@ -103,8 +109,18 @@ if "x%JAVA_HOME%" == "x" (
   )
 )
 
-set "CLASSPATH_OPTS=%DIRNAME%..\lib\quarkus-run.jar;%DIRNAME%..\lib\lib\main\*.*"
+set "CLASSPATH_OPTS=%DIRNAME%..\lib\quarkus-run.jar"
 
-"%JAVA%" %JAVA_OPTS% -Dkc.home.dir="%DIRNAME%.." -Djboss.server.config.dir="%DIRNAME%..\conf" -Dkeycloak.theme.dir="%DIRNAME%..\themes" %SERVER_OPTS% -cp "%CLASSPATH_OPTS%" io.quarkus.bootstrap.runner.QuarkusEntryPoint %CONFIG_ARGS%
+set "JAVA_RUN_OPTS=%JAVA_OPTS% -Dkc.home.dir="%DIRNAME%.." -Djboss.server.config.dir="%DIRNAME%..\conf" -Dkeycloak.theme.dir="%DIRNAME%..\themes" %SERVER_OPTS% -cp "%CLASSPATH_OPTS%" io.quarkus.bootstrap.runner.QuarkusEntryPoint %CONFIG_ARGS%"
+
+SetLocal EnableDelayedExpansion
+
+set "AUTO_BUILD_OPTION=auto-build"
+
+if not "!CONFIG_ARGS:%AUTO_BUILD_OPTION%=!"=="!CONFIG_ARGS!" (
+  %JAVA% -Dkc.config.rebuild-and-exit=true %JAVA_RUN_OPTS%
+)
+
+"%JAVA%" %JAVA_RUN_OPTS%
 
 :END

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/Picocli.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/Picocli.java
@@ -45,6 +45,7 @@ import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 
+import io.quarkus.runtime.Quarkus;
 import org.keycloak.quarkus.runtime.cli.command.Build;
 import org.keycloak.quarkus.runtime.cli.command.Main;
 import org.keycloak.quarkus.runtime.cli.command.Start;
@@ -77,7 +78,11 @@ public final class Picocli {
     public static void parseAndRun(List<String> cliArgs) {
         CommandLine cmd = createCommandLine(cliArgs);
 
-        runReAugmentationIfNeeded(cliArgs, cmd);
+        if (Boolean.getBoolean("kc.config.rebuild-and-exit")) {
+            runReAugmentationIfNeeded(cliArgs, cmd);
+            Quarkus.asyncExit(cmd.getCommandSpec().exitCodeOnSuccess());
+            return;
+        }
 
         cmd.execute(cliArgs.toArray(new String[0]));
     }
@@ -95,10 +100,6 @@ public final class Picocli {
             if (requiresReAugmentation(cmd)) {
                 runReAugmentation(cliArgs, cmd);
             }
-        }
-
-        if (Boolean.getBoolean("kc.config.rebuild-and-exit")) {
-            System.exit(cmd.getCommandSpec().exitCodeOnSuccess());
         }
     }
 


### PR DESCRIPTION
Basically, updating `kc.bat` with latest changes to `kc.sh`:

* Allow using space when using options (e.g.: `--db postgres`)
* Support for `auto-build`
* Support for options using the short prefix (e.g.: `-pf`)

Although `auto-build` is possible, it only works when running the command for the first time. Subsequent executions should fail due to `generated-bytecode.jar` being held by another process and mess up with the distribution files. Basically, the re-augmentation steps that create jars, etc, prematurely fail.

Interestingly enough, running the `build` command multiple times work. I think something is missing when spanning/exiting the re-augmentation JVM prior to actually running the server.