### PR TITLE
KEYCLOAK-19858 Add Tests for Help Command and refactor testing to use…

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -18,3 +18,5 @@
 *.eot binary
 *.otf binary
 *.woff binary
+# See https://github.com/approvals/ApprovalTests.Java#approved-file-artifacts (used in golden testing for help output of quarkus based dist)
+*.approved.* binary

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/Environment.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/Environment.java
@@ -83,12 +83,6 @@ public final class Environment {
     }
 
     public static String getCommand() {
-        String homeDir = getHomeDir();
-
-        if (homeDir == null) {
-            return "java -jar $KEYCLOAK_HOME/lib/quarkus-run.jar";
-        }
-
         if (isWindows()) {
             return "kc.bat";
         }
@@ -183,6 +177,6 @@ public final class Environment {
     }
 
     public static boolean isDistribution() {
-        return Environment.getCommand().startsWith("kc.");
+        return getHomeDir() != null;
     }
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Build.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Build.java
@@ -47,7 +47,7 @@ import picocli.CommandLine.Mixin;
         },
         footerHeading = "Examples:",
         footer = "  Optimize the server based on a profile configuration:%n%n"
-                + "      $ ${PARENT-COMMAND-FULL-NAME:-$PARENTCOMMAND} --profile=prod ${COMMAND-NAME}%n%n"
+                + "      $ ${PARENT-COMMAND-FULL-NAME:-$PARENTCOMMAND} --profile=prod ${COMMAND-NAME} %n%n"
                 + "  Change database settings:%n%n"
                 + "      $ ${PARENT-COMMAND-FULL-NAME:-$PARENTCOMMAND} ${COMMAND-NAME} --db=postgres [--db-url][--db-username][--db-password]%n%n"
                 + "  Enable a feature:%n%n"

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Main.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Main.java
@@ -70,6 +70,8 @@ public final class Main {
 
     public static final String PROFILE_SHORT_NAME = "-pf";
     public static final String PROFILE_LONG_NAME = "--profile";
+    public static final String CONFIG_FILE_SHORT_NAME = "-cf";
+    public static final String CONFIG_FILE_LONG_NAME = "--config-file";
 
     @CommandLine.Spec
     CommandLine.Model.CommandSpec spec;
@@ -103,7 +105,7 @@ public final class Main {
         Environment.setProfile(profile);
     }
 
-    @Option(names = { "-cf", "--config-file" },
+    @Option(names = { CONFIG_FILE_SHORT_NAME, CONFIG_FILE_LONG_NAME },
             arity = "1",
             description = "Set the path to a configuration file. By default, configuration properties are read from the \"keycloak.properties\" file in the \"conf\" directory.",
             paramLabel = "file")

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/ShowConfig.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/ShowConfig.java
@@ -45,6 +45,7 @@ import picocli.CommandLine.Parameters;
         description = "%nPrint out the current configuration.")
 public final class ShowConfig extends AbstractCommand implements Runnable {
 
+    public static final String NAME = "show-config";
     @Parameters(
             paramLabel = "filter",
             defaultValue = "none",

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/ConfigArgsConfigSource.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/ConfigArgsConfigSource.java
@@ -34,8 +34,6 @@ import java.util.function.BiConsumer;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
-import org.jboss.logging.Logger;
-
 import io.smallrye.config.PropertiesConfigSource;
 
 import org.keycloak.quarkus.runtime.cli.Picocli;
@@ -52,8 +50,6 @@ import org.keycloak.quarkus.runtime.configuration.mappers.PropertyMappers;
  * <p>Each argument is going to be mapped to its corresponding configuration property by prefixing the key with the {@link MicroProfileConfigProvider#NS_KEYCLOAK} namespace. 
  */
 public class ConfigArgsConfigSource extends PropertiesConfigSource {
-
-    private static final Logger log = Logger.getLogger(ConfigArgsConfigSource.class);
 
     public static final String CLI_ARGS = "kc.config.args";
     private static final String ARG_SEPARATOR = ";;";
@@ -120,7 +116,6 @@ public class ConfigArgsConfigSource extends PropertiesConfigSource {
         String rawArgs = getRawConfigArgs();
         
         if (rawArgs == null || "".equals(rawArgs.trim())) {
-            log.trace("No command-line arguments provided");
             return Collections.emptyMap();
         }
 
@@ -131,7 +126,6 @@ public class ConfigArgsConfigSource extends PropertiesConfigSource {
             public void accept(String key, String value) {
                 key = NS_KEYCLOAK_PREFIX + key.substring(2);
 
-                log.tracef("Adding property [%s=%s] from command-line", key, value);
                 properties.put(key, value);
 
                 String mappedPropertyName = getMappedPropertyName(key);
@@ -171,7 +165,6 @@ public class ConfigArgsConfigSource extends PropertiesConfigSource {
         String rawArgs = getRawConfigArgs();
 
         if (rawArgs == null || "".equals(rawArgs.trim())) {
-            log.trace("No command-line arguments provided");
             return;
         }
 

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/Configuration.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/Configuration.java
@@ -29,6 +29,7 @@ import io.smallrye.config.ConfigValue;
 import io.smallrye.config.SmallRyeConfig;
 import io.smallrye.config.SmallRyeConfigProviderResolver;
 
+import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
 import org.eclipse.microprofile.config.spi.ConfigSource;
 import org.keycloak.quarkus.runtime.Environment;
 import org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper;
@@ -39,17 +40,12 @@ import org.keycloak.quarkus.runtime.configuration.mappers.PropertyMappers;
  */
 public final class Configuration {
 
-    private static volatile SmallRyeConfig CONFIG;
-
     private Configuration() {
 
     }
 
     public static synchronized SmallRyeConfig getConfig() {
-        if (CONFIG == null) {
-            CONFIG = (SmallRyeConfig) SmallRyeConfigProviderResolver.instance().getConfig();
-        }
-        return CONFIG;
+        return (SmallRyeConfig) ConfigProviderResolver.instance().getConfig();
     }
 
     public static Optional<String> getBuildTimeProperty(String name) {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/KeycloakConfigSourceProvider.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/KeycloakConfigSourceProvider.java
@@ -63,6 +63,9 @@ public class KeycloakConfigSourceProvider implements ConfigSourceProvider {
 
     @Override
     public Iterable<ConfigSource> getConfigSources(ClassLoader forClassLoader) {
+        if(Environment.isTestLaunchMode()) {
+            reload();
+        }
         return CONFIG_SOURCES;
     }
 }

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/ConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/ConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.keycloak.provider.quarkus;
+package org.keycloak.quarkus.runtime.configuration.test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;

--- a/quarkus/tests/integration/pom.xml
+++ b/quarkus/tests/integration/pom.xml
@@ -27,10 +27,15 @@
         <version>16.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
-    
+
     <name>Keycloak Quarkus Server Integration tests</name>
     <artifactId>keycloak-quarkus-integration-tests</artifactId>
     <packaging>jar</packaging>
+
+    <properties>
+        <kc.quarkus.tests.dist>raw</kc.quarkus.tests.dist>
+        <approvaltests.version>12.3.2</approvaltests.version>
+    </properties>
 
     <dependencies>
         <dependency>
@@ -64,6 +69,11 @@
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.approvaltests</groupId>
+            <artifactId>approvaltests</artifactId>
+            <version>${approvaltests.version}</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -72,12 +82,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <systemProperties>
-                        <property>
-                            <name>kc.quarkus.tests.dist</name>
-                            <value>${kc.quarkus.tests.dist}</value>
-                        </property>
-                    </systemProperties>
+                    <systemPropertyVariables>
+                        <kc.quarkus.tests.dist>${kc.quarkus.tests.dist}</kc.quarkus.tests.dist>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
         </plugins>

--- a/quarkus/tests/integration/src/main/java/org/keycloak/it/junit5/extension/RawDistOnly.java
+++ b/quarkus/tests/integration/src/main/java/org/keycloak/it/junit5/extension/RawDistOnly.java
@@ -22,10 +22,11 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
- * {@link RawDistOnly} is used to signal that the annotated tests class is only enabled when running tests using the {@link DistributionType#RAW}.
+ * {@link RawDistOnly} is used to signal that the annotated test class
+ * is only enabled when running tests using the {@link DistributionType#RAW}
+ * or running tests in whitebox mode in the same jvm using {@link CLITest}
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)

--- a/quarkus/tests/integration/src/main/java/org/keycloak/it/utils/RawKeycloakDistribution.java
+++ b/quarkus/tests/integration/src/main/java/org/keycloak/it/utils/RawKeycloakDistribution.java
@@ -43,14 +43,11 @@ import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 import org.apache.commons.io.FileUtils;
-import org.jboss.logging.Logger;
 
 import io.quarkus.bootstrap.util.ZipUtils;
 import org.keycloak.common.Version;
 
 public final class RawKeycloakDistribution implements KeycloakDistribution {
-
-    private static final Logger LOGGER = Logger.getLogger(RawKeycloakDistribution.class);
 
     private Process keycloak;
     private int exitCode = -1;
@@ -164,7 +161,6 @@ public final class RawKeycloakDistribution implements KeycloakDistribution {
                 connection.connect();
 
                 if (connection.getResponseCode() == 200) {
-                    LOGGER.infof("Keycloak is ready at %s", contextRoot);
                     break;
                 }
             } catch (Exception ignore) {

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/HelpCommandTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/HelpCommandTest.java
@@ -17,14 +17,15 @@
 
 package org.keycloak.it.cli;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.keycloak.it.junit5.extension.CLIResult;
 import org.keycloak.it.junit5.extension.CLITest;
-import org.keycloak.quarkus.runtime.cli.command.Main;
+import org.keycloak.quarkus.runtime.cli.command.Build;
 
 import io.quarkus.test.junit.main.Launch;
 import io.quarkus.test.junit.main.LaunchResult;
+import org.keycloak.quarkus.runtime.cli.command.Start;
+import org.keycloak.quarkus.runtime.cli.command.StartDev;
 
 @CLITest
 public class HelpCommandTest {
@@ -33,34 +34,56 @@ public class HelpCommandTest {
     @Launch({})
     void testDefaultToHelp(LaunchResult result) {
         CLIResult cliResult = (CLIResult) result;
-        cliResult.assertHelp("kc.sh");
+        cliResult.assertHelp();
     }
 
     @Test
     @Launch({ "--help" })
-    void testHelpCommand(LaunchResult result) {
+    void testHelp(LaunchResult result) {
         CLIResult cliResult = (CLIResult) result;
-        cliResult.assertHelp("kc.sh");
+        cliResult.assertHelp();
     }
 
     @Test
-    @Launch({ "start", "--help" })
-    void testStartHelpCommand(LaunchResult result) {
+    @Launch({ "-h" })
+    void testHelpShort(LaunchResult result) {
         CLIResult cliResult = (CLIResult) result;
-        cliResult.assertHelp("start");
+        cliResult.assertHelp();
     }
 
     @Test
-    @Launch({ "start-dev", "--help" })
-    void testStartDevCommand(LaunchResult result) {
+    @Launch({ Start.NAME, "--help" })
+    void testStartHelp(LaunchResult result) {
         CLIResult cliResult = (CLIResult) result;
-        cliResult.assertHelp("start-dev");
+        cliResult.assertHelp();
     }
 
     @Test
-    @Launch({ "build", "--help" })
-    void testBuildCommand(LaunchResult result) {
+    @Launch({ StartDev.NAME, "--help" })
+    void testStartDevHelp(LaunchResult result) {
         CLIResult cliResult = (CLIResult) result;
-        cliResult.assertHelp("build");
+        cliResult.assertHelp();
     }
+
+    @Test
+    @Launch({ StartDev.NAME, "--help-all" })
+    void testStartDevHelpAll(LaunchResult result) {
+        CLIResult cliResult = (CLIResult) result;
+        cliResult.assertHelp();
+    }
+
+    @Test
+    @Launch({ Build.NAME, "--help" })
+    void testBuildHelp(LaunchResult result) {
+        CLIResult cliResult = (CLIResult) result;
+        cliResult.assertHelp();
+    }
+
+    @Test
+    @Launch({ Build.NAME, "--help-all" })
+    void testBuildHelpAll(LaunchResult result) {
+        CLIResult cliResult = (CLIResult) result;
+        cliResult.assertHelp();
+    }
+
 }

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/PackageSettings.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/PackageSettings.java
@@ -1,0 +1,17 @@
+package org.keycloak.it.cli;
+
+import org.keycloak.it.junit5.extension.CLITestExtension;
+
+/**
+ * Used to specify the output directory for the received / to-be-approved outputs of this packages tests.
+ * In our case they should be stored under resources/clitest/approvals or resources/rawdist/approvals depending
+ * on the runtype of the tests (@DistributionTest in Raw mode, or @CLITest, leading to either using "kc.sh"
+ * or "java -jar $KEYCLOAK_HOME/lib/quarkus-run.jar" as command in the usage output).
+ *
+ * Note: Creates the directories if they don't exist yet.
+ * **/
+public class PackageSettings {
+
+    public String UseApprovalSubdirectory = "approvals/cli/help";
+    public String ApprovalBaseDirectory = "../resources";
+}

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/ShowConfigCommandTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/ShowConfigCommandTest.java
@@ -23,19 +23,23 @@ import org.keycloak.it.junit5.extension.CLITest;
 
 import io.quarkus.test.junit.main.Launch;
 import io.quarkus.test.junit.main.LaunchResult;
+import org.keycloak.quarkus.runtime.cli.command.ShowConfig;
+import org.keycloak.quarkus.runtime.configuration.mappers.PropertyMappers;
+
+import static org.keycloak.quarkus.runtime.cli.command.Main.CONFIG_FILE_LONG_NAME;
 
 @CLITest
-class ShowConfigCommandTest {
+public class ShowConfigCommandTest {
 
     @Test
-    @Launch({ "show-config" })
+    @Launch({ ShowConfig.NAME })
     void testShowConfigCommandShowsRuntimeConfig(LaunchResult result) {
         Assertions.assertTrue(result.getOutput()
                 .contains("Runtime Configuration"));
     }
 
     @Test
-    @Launch({ "show-config", "all" })
+    @Launch({ ShowConfig.NAME, "all" })
     void testShowConfigCommandWithAllShowsAllProfiles(LaunchResult result) {
         Assertions.assertTrue(result.getOutput()
                 .contains("Runtime Configuration"));
@@ -43,5 +47,18 @@ class ShowConfigCommandTest {
                 .contains("Quarkus Configuration"));
         Assertions.assertTrue(result.getOutput()
                 .contains("Profile \"import_export\" Configuration"));
+    }
+
+    @Test
+    @Launch({ CONFIG_FILE_LONG_NAME+"=src/test/resources/ShowConfigCommandTest/keycloak.properties", ShowConfig.NAME, "all" })
+    void testShowConfigCommandHidesCredentialsInProfiles(LaunchResult result) {
+        String output = result.getOutput();
+        Assertions.assertFalse(output.contains("testpw1"));
+        Assertions.assertFalse(output.contains("testpw2"));
+        Assertions.assertFalse(output.contains("testpw3"));
+        Assertions.assertTrue(output.contains("kc.db.password =  " + PropertyMappers.VALUE_MASK));
+        Assertions.assertTrue(output.contains("%dev.kc.db.password =  " + PropertyMappers.VALUE_MASK));
+        Assertions.assertTrue(output.contains("%dev.kc.https.key-store.password =  " + PropertyMappers.VALUE_MASK));
+        Assertions.assertTrue(output.contains("%import_export.kc.db.password =  " + PropertyMappers.VALUE_MASK));
     }
 }

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/HelpCommandDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/HelpCommandDistTest.java
@@ -19,7 +19,9 @@ package org.keycloak.it.cli.dist;
 
 import org.keycloak.it.cli.HelpCommandTest;
 import org.keycloak.it.junit5.extension.DistributionTest;
+import org.keycloak.it.junit5.extension.RawDistOnly;
 
 @DistributionTest
+@RawDistOnly(reason = "Verifying the help message output doesn't need long spin-up of docker dist tests.")
 public class HelpCommandDistTest extends HelpCommandTest {
 }

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartCommandDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartCommandDistTest.java
@@ -22,10 +22,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 import org.keycloak.it.cli.StartCommandTest;
+import org.keycloak.it.junit5.extension.CLIResult;
 import org.keycloak.it.junit5.extension.DistributionTest;
 
 import io.quarkus.test.junit.main.Launch;
 import io.quarkus.test.junit.main.LaunchResult;
+import org.keycloak.quarkus.runtime.configuration.mappers.PropertyMappers;
 
 @DistributionTest
 public class StartCommandDistTest extends StartCommandTest {
@@ -43,5 +45,13 @@ public class StartCommandDistTest extends StartCommandTest {
     void failNoHostnameNotSet(LaunchResult result) {
         assertTrue(result.getErrorOutput().contains("ERROR: Strict hostname resolution configured but no hostname was set"),
                 () -> "The Output:\n" + result.getOutput() + "doesn't contains the expected string.");
+    }
+
+    @Test
+    @Launch({ "start", "--auto-build", "--db-password=secret", "--https-key-store-password=secret"})
+    void testStartWithAutoBuildDoesntShowCredentialsInConsole(LaunchResult result) {
+        CLIResult cliResult = (CLIResult) result;
+        assertTrue(cliResult.getOutput().contains("--db-password=" + PropertyMappers.VALUE_MASK));
+        assertTrue(cliResult.getOutput().contains("--https-key-store-password=" + PropertyMappers.VALUE_MASK));
     }
 }

--- a/quarkus/tests/integration/src/test/resources/ShowConfigCommandTest/keycloak.properties
+++ b/quarkus/tests/integration/src/test/resources/ShowConfigCommandTest/keycloak.properties
@@ -1,0 +1,48 @@
+# Default and non-production grade database vendor
+db=h2-file
+db.username = sa
+db.password = keycloak
+
+# Insecure requests are disabled by default
+http.enabled=false
+
+# Metrics and healthcheck are disabled by default
+metrics.enabled=false
+
+# Basic settings for running in production. Change accordingly before deploying the server.
+# Database
+#%prod.db=postgres
+#%prod.db.username=keycloak
+#%prod.db.password=password
+#%prod.db.url=jdbc:postgresql://localhost/keycloak
+# Observability
+#%prod.metrics.enabled=true
+# HTTP
+#%prod.spi.hostname.frontend-url=https://localhost:8443
+#%prod.https.certificate.file=${kc.home.dir}conf/server.crt.pem
+#%prod.https.certificate.key-file=${kc.home.dir}conf/server.key.pem
+#%prod.proxy=reencrypt
+#%prod.hostname=myhostname
+
+# Default, and insecure, and non-production grade configuration for the development profile
+%dev.http.enabled=true
+%dev.hostname.strict=false
+%dev.db.password=testpw1
+%dev.hostname.strict-https=false
+%dev.cluster=local
+%dev.spi.theme.cache-themes=false
+%dev.spi.theme.cache-templates=false
+%dev.spi.theme.static-max-age=-1
+%dev.https.key-store.password=testpw2
+
+# The default configuration when running in import or export mode
+%import_export.http.enabled=true
+%import_export.db.password=testpw3
+%import_export.hostname.strict=false
+%import_export.hostname.strict-https=false
+%import_export.cluster=local
+
+# Logging configuration. INFO is the default level for most of the categories
+#quarkus.log.level = DEBUG
+quarkus.log.category."org.jboss.resteasy.resteasy_jaxrs.i18n".level=WARN
+quarkus.log.category."org.infinispan.transaction.lookup.JBossStandaloneJTAManagerLookup".level=WARN

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testBuildHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testBuildHelp.approved.txt
@@ -1,0 +1,136 @@
+Creates a new and optimized server image.
+
+Usage:
+
+kc.sh build [OPTIONS]
+
+Creates a new and optimized server image based on the configuration options
+passed to this command. Once created, the configuration will be persisted and
+read during startup without having to pass them over again.
+
+Some configuration options require this command to be executed in order to
+actually change a configuration. For instance
+
+- Change database vendor
+- Enable/disable features
+- Enable/Disable providers or set a default
+
+Consider running this command before running the server in production for an
+optimal runtime.
+
+Options:
+
+-h, --help           This help message.
+--help-all           This same help message but with additional options.
+
+Cluster:
+
+--cache <type>       Defines the cache mechanism for high-availability. By default, a 'ispn' cache
+                       is used to create a cluster between multiple server nodes. A 'local' cache
+                       disables clustering and is intended for development and testing purposes.
+                       Default: ispn.
+--cache-config-file <file>
+                     Defines the file from which cache configuration should be loaded from.
+--cache-stack <stack>
+                     Define the default stack to use for cluster communication and node discovery.
+                       This option only takes effect if 'cache' is set to 'ispn'. Default: udp.
+
+Database:
+
+--db <vendor>        The database vendor. Possible values are: h2-file, h2-mem, mariadb, mssql,
+                       mssql-2012, mysql, oracle, postgres, postgres-95
+
+Feature:
+
+--features-account2 <enabled|disabled>
+                     Enables the ACCOUNT2 feature.
+--features-account_api <enabled|disabled>
+                     Enables the ACCOUNT_API feature.
+--features-admin2 <enabled|disabled>
+                     Enables the ADMIN2 feature.
+--features-admin_fine_grained_authz <enabled|disabled>
+                     Enables the ADMIN_FINE_GRAINED_AUTHZ feature.
+--features-authorization <enabled|disabled>
+                     Enables the AUTHORIZATION feature.
+--features-ciba <enabled|disabled>
+                     Enables the CIBA feature.
+--features-client_policies <enabled|disabled>
+                     Enables the CLIENT_POLICIES feature.
+--features-declarative_user_profile <enabled|disabled>
+                     Enables the DECLARATIVE_USER_PROFILE feature.
+--features-docker <enabled|disabled>
+                     Enables the DOCKER feature.
+--features-impersonation <enabled|disabled>
+                     Enables the IMPERSONATION feature.
+--features-map_storage <enabled|disabled>
+                     Enables the MAP_STORAGE feature.
+--features-openshift_integration <enabled|disabled>
+                     Enables the OPENSHIFT_INTEGRATION feature.
+--features-par <enabled|disabled>
+                     Enables the PAR feature.
+--features-scripts <enabled|disabled>
+                     Enables the SCRIPTS feature.
+--features-token_exchange <enabled|disabled>
+                     Enables the TOKEN_EXCHANGE feature.
+--features-upload_scripts <enabled|disabled>
+                     Enables the UPLOAD_SCRIPTS feature.
+--features-web_authn <enabled|disabled>
+                     Enables the WEB_AUTHN feature.
+-ft, --features <preview>
+                     Enables all tech preview features.
+
+HTTP/TLS:
+
+--http-relative-path <path>
+                     Set the path relative to '/' for serving resources. Default: /.
+
+Metrics:
+
+--metrics-enabled <true|false>
+                     If the server should expose metrics and healthcheck. If enabled, metrics are
+                       available at the '/metrics' endpoint and healthcheck at the '/health'
+                       endpoint. Default: false.
+
+Vault:
+
+--vault-file-path <dir>
+                     If set, secrets can be obtained by reading the content of files within the
+                       given path.
+--vault-hashicorp-paths <paths>
+                     A set of one or more paths that should be used when looking up secrets.
+
+Examples:
+
+  Optimize the server based on a profile configuration:
+
+      $ kc.sh --profile=prod build
+
+  Change database settings:
+
+      $ kc.sh build --db=postgres [--db-url][--db-username][--db-password]
+
+  Enable a feature:
+
+      $ kc.sh build --features-<feature_name>=[enabled|disabled]
+
+  Or alternatively, enable all tech preview features:
+
+      $ kc.sh build --features=preview
+
+  Enable metrics:
+
+      $ kc.sh build --metrics-enabled=true
+
+  Change the relative path:
+
+      $ kc.sh build --http-relative-path=/auth
+
+You can also use the "--auto-build" option when starting the server to avoid
+running this command every time you change a configuration:
+
+    $ kc.sh start --auto-build <OPTIONS>
+
+By doing that you have an additional overhead when the server is starting.
+
+Use 'kc.sh build --help-all' to list all available options, including the start
+options.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testBuildHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testBuildHelpAll.approved.txt
@@ -1,0 +1,213 @@
+Creates a new and optimized server image.
+
+Usage:
+
+kc.sh build [OPTIONS]
+
+Creates a new and optimized server image based on the configuration options
+passed to this command. Once created, the configuration will be persisted and
+read during startup without having to pass them over again.
+
+Some configuration options require this command to be executed in order to
+actually change a configuration. For instance
+
+- Change database vendor
+- Enable/disable features
+- Enable/Disable providers or set a default
+
+Consider running this command before running the server in production for an
+optimal runtime.
+
+Options:
+
+-h, --help           This help message.
+--help-all           This same help message but with additional options.
+
+Cluster:
+
+--cache <type>       Defines the cache mechanism for high-availability. By default, a 'ispn' cache
+                       is used to create a cluster between multiple server nodes. A 'local' cache
+                       disables clustering and is intended for development and testing purposes.
+                       Default: ispn.
+--cache-config-file <file>
+                     Defines the file from which cache configuration should be loaded from.
+--cache-stack <stack>
+                     Define the default stack to use for cluster communication and node discovery.
+                       This option only takes effect if 'cache' is set to 'ispn'. Default: udp.
+
+Database:
+
+--db <vendor>        The database vendor. Possible values are: h2-file, h2-mem, mariadb, mssql,
+                       mssql-2012, mysql, oracle, postgres, postgres-95
+--db-password <password>
+                     The password of the database user.
+--db-pool-initial-size <size>
+                     The initial size of the connection pool.
+--db-pool-max-size <size>
+                     The maximum size of the connection pool. Default: 100.
+--db-pool-min-size <size>
+                     The minimal size of the connection pool.
+--db-schema <schema> The database schema to be used.
+--db-url <jdbc-url>  The full database JDBC URL. If not provided, a default URL is set based on the
+                       selected database vendor. For instance, if using 'postgres', the default
+                       JDBC URL would be 'jdbc:postgresql://localhost/keycloak'.
+--db-url-database <dbname>
+                     Sets the database name of the default JDBC URL of the chosen vendor. If the
+                       `db-url` option is set, this option is ignored.
+--db-url-host <hostname>
+                     Sets the hostname of the default JDBC URL of the chosen vendor. If the
+                       `db-url` option is set, this option is ignored.
+--db-url-properties <properties>
+                     Sets the properties of the default JDBC URL of the chosen vendor. If the
+                       `db-url` option is set, this option is ignored.
+--db-username <username>
+                     The username of the database user.
+
+Feature:
+
+--features-account2 <enabled|disabled>
+                     Enables the ACCOUNT2 feature.
+--features-account_api <enabled|disabled>
+                     Enables the ACCOUNT_API feature.
+--features-admin2 <enabled|disabled>
+                     Enables the ADMIN2 feature.
+--features-admin_fine_grained_authz <enabled|disabled>
+                     Enables the ADMIN_FINE_GRAINED_AUTHZ feature.
+--features-authorization <enabled|disabled>
+                     Enables the AUTHORIZATION feature.
+--features-ciba <enabled|disabled>
+                     Enables the CIBA feature.
+--features-client_policies <enabled|disabled>
+                     Enables the CLIENT_POLICIES feature.
+--features-declarative_user_profile <enabled|disabled>
+                     Enables the DECLARATIVE_USER_PROFILE feature.
+--features-docker <enabled|disabled>
+                     Enables the DOCKER feature.
+--features-impersonation <enabled|disabled>
+                     Enables the IMPERSONATION feature.
+--features-map_storage <enabled|disabled>
+                     Enables the MAP_STORAGE feature.
+--features-openshift_integration <enabled|disabled>
+                     Enables the OPENSHIFT_INTEGRATION feature.
+--features-par <enabled|disabled>
+                     Enables the PAR feature.
+--features-scripts <enabled|disabled>
+                     Enables the SCRIPTS feature.
+--features-token_exchange <enabled|disabled>
+                     Enables the TOKEN_EXCHANGE feature.
+--features-upload_scripts <enabled|disabled>
+                     Enables the UPLOAD_SCRIPTS feature.
+--features-web_authn <enabled|disabled>
+                     Enables the WEB_AUTHN feature.
+-ft, --features <preview>
+                     Enables all tech preview features.
+
+Hostname:
+
+--hostname <hostname>
+                     Hostname for the Keycloak server.
+--hostname-admin <url>
+                     Overrides the hostname for the admin console and APIs.
+--hostname-path <path>
+                     This should be set if proxy uses a different context-path for Keycloak.
+--hostname-strict <true|false>
+                     Disables dynamically resolving the hostname from request headers. Should
+                       always be set to true in production, unless proxy verifies the Host header.
+                       Default: true.
+--hostname-strict-backchannel <true|false>
+                     By default backchannel URLs are dynamically resolved from request headers to
+                       allow internal an external applications. If all applications use the public
+                       URL this option should be enabled. Default: false.
+
+HTTP/TLS:
+
+--http-enabled <true|false>
+                     Enables the HTTP listener. Default: false.
+--http-host <host>   The used HTTP Host. Default: 0.0.0.0.
+--http-port <port>   The used HTTP port. Default: 8080.
+--http-relative-path <path>
+                     Set the path relative to '/' for serving resources. Default: /.
+--https-certificate-file <file>
+                     The file path to a server certificate or certificate chain in PEM format.
+--https-certificate-key-file <file>
+                     The file path to a private key in PEM format.
+--https-cipher-suites <ciphers>
+                     The cipher suites to use. If none is given, a reasonable default is selected.
+--https-client-auth <auth>
+                     Configures the server to require/request client authentication. Possible
+                       Values: none, request, required. Default: none.
+--https-key-store-file <file>
+                     The key store which holds the certificate information instead of specifying
+                       separate files.
+--https-key-store-password <password>
+                     The password of the key store file. Default: password.
+--https-key-store-type <type>
+                     The type of the key store file. If not given, the type is automatically
+                       detected based on the file name.
+--https-port <port>  The used HTTPS port. Default: 8443.
+--https-protocols <protocols>
+                     The list of protocols to explicitly enable.
+--https-trust-store-file <file>
+                     The trust store which holds the certificate information of the certificates to
+                       trust.
+--https-trust-store-password <password>
+                     The password of the trust store file.
+--https-trust-store-type <type>
+                     The type of the trust store file. If not given, the type is automatically
+                       detected based on the file name.
+
+Metrics:
+
+--metrics-enabled <true|false>
+                     If the server should expose metrics and healthcheck. If enabled, metrics are
+                       available at the '/metrics' endpoint and healthcheck at the '/health'
+                       endpoint. Default: false.
+
+Proxy:
+
+--proxy <mode>       The proxy address forwarding mode if the server is behind a reverse proxy.
+                       Possible values are: none,edge,reencrypt,passthrough Default: none.
+
+Vault:
+
+--vault-file-path <dir>
+                     If set, secrets can be obtained by reading the content of files within the
+                       given path.
+--vault-hashicorp-paths <paths>
+                     A set of one or more paths that should be used when looking up secrets.
+
+Examples:
+
+  Optimize the server based on a profile configuration:
+
+      $ kc.sh --profile=prod build
+
+  Change database settings:
+
+      $ kc.sh build --db=postgres [--db-url][--db-username][--db-password]
+
+  Enable a feature:
+
+      $ kc.sh build --features-<feature_name>=[enabled|disabled]
+
+  Or alternatively, enable all tech preview features:
+
+      $ kc.sh build --features=preview
+
+  Enable metrics:
+
+      $ kc.sh build --metrics-enabled=true
+
+  Change the relative path:
+
+      $ kc.sh build --http-relative-path=/auth
+
+You can also use the "--auto-build" option when starting the server to avoid
+running this command every time you change a configuration:
+
+    $ kc.sh start --auto-build <OPTIONS>
+
+By doing that you have an additional overhead when the server is starting.
+
+Use 'kc.sh build --help-all' to list all available options, including the start
+options.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testDefaultToHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testDefaultToHelp.approved.txt
@@ -1,0 +1,59 @@
+Keycloak - Open Source Identity and Access Management
+
+Find more information at: https://www.keycloak.org/docs/latest
+
+Usage:
+
+kc.sh [OPTIONS] [COMMAND]
+
+Use this command-line tool to manage your Keycloak cluster.
+Make sure the command is available on your "PATH" or prefix it with "./" (e.g.:
+"./kc.sh") to execute from the current folder.
+
+Options:
+
+-cf, --config-file <file>
+                     Set the path to a configuration file. By default, configuration properties are
+                       read from the "keycloak.properties" file in the "conf" directory.
+-D<key>=<value> <sysProps>
+                     Set a Java system property
+-h, --help           This help message.
+-pf, --profile <profile>
+                     Set the profile. Use 'dev' profile to enable development mode.
+-v, --verbose        Print out error details when running this command.
+-V, --version        Show version information
+
+Commands:
+
+  build                   Creates a new and optimized server image.
+  start                   Start the server.
+  start-dev               Start the server in development mode.
+  export                  Export data from realms to a file or directory.
+  import                  Import data from a directory or a file.
+  show-config             Print out the current configuration.
+  tools                   %nUtilities for use and interaction with the server.
+    completion            Generate bash/zsh completion script for kc.sh.
+
+Examples:
+
+  Start the server in development mode for local development or testing:
+
+      $ kc.sh start-dev
+
+  Building an optimized server runtime:
+
+      $ kc.sh build <OPTIONS>
+
+  Start the server in production mode:
+
+      $ kc.sh start <OPTIONS>
+
+  Enable auto-completion to bash/zsh:
+
+      $ source <(kc.sh tools completion)
+
+  Please, take a look at the documentation for more details before deploying in
+production.
+
+Use "kc.sh start --help" for the available options when starting the server.
+Use "kc.sh <command> --help" for more information about other commands.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testHelp.approved.txt
@@ -1,0 +1,59 @@
+Keycloak - Open Source Identity and Access Management
+
+Find more information at: https://www.keycloak.org/docs/latest
+
+Usage:
+
+kc.sh [OPTIONS] [COMMAND]
+
+Use this command-line tool to manage your Keycloak cluster.
+Make sure the command is available on your "PATH" or prefix it with "./" (e.g.:
+"./kc.sh") to execute from the current folder.
+
+Options:
+
+-cf, --config-file <file>
+                     Set the path to a configuration file. By default, configuration properties are
+                       read from the "keycloak.properties" file in the "conf" directory.
+-D<key>=<value> <sysProps>
+                     Set a Java system property
+-h, --help           This help message.
+-pf, --profile <profile>
+                     Set the profile. Use 'dev' profile to enable development mode.
+-v, --verbose        Print out error details when running this command.
+-V, --version        Show version information
+
+Commands:
+
+  build                   Creates a new and optimized server image.
+  start                   Start the server.
+  start-dev               Start the server in development mode.
+  export                  Export data from realms to a file or directory.
+  import                  Import data from a directory or a file.
+  show-config             Print out the current configuration.
+  tools                   %nUtilities for use and interaction with the server.
+    completion            Generate bash/zsh completion script for kc.sh.
+
+Examples:
+
+  Start the server in development mode for local development or testing:
+
+      $ kc.sh start-dev
+
+  Building an optimized server runtime:
+
+      $ kc.sh build <OPTIONS>
+
+  Start the server in production mode:
+
+      $ kc.sh start <OPTIONS>
+
+  Enable auto-completion to bash/zsh:
+
+      $ source <(kc.sh tools completion)
+
+  Please, take a look at the documentation for more details before deploying in
+production.
+
+Use "kc.sh start --help" for the available options when starting the server.
+Use "kc.sh <command> --help" for more information about other commands.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testHelpShort.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testHelpShort.approved.txt
@@ -1,0 +1,59 @@
+Keycloak - Open Source Identity and Access Management
+
+Find more information at: https://www.keycloak.org/docs/latest
+
+Usage:
+
+kc.sh [OPTIONS] [COMMAND]
+
+Use this command-line tool to manage your Keycloak cluster.
+Make sure the command is available on your "PATH" or prefix it with "./" (e.g.:
+"./kc.sh") to execute from the current folder.
+
+Options:
+
+-cf, --config-file <file>
+                     Set the path to a configuration file. By default, configuration properties are
+                       read from the "keycloak.properties" file in the "conf" directory.
+-D<key>=<value> <sysProps>
+                     Set a Java system property
+-h, --help           This help message.
+-pf, --profile <profile>
+                     Set the profile. Use 'dev' profile to enable development mode.
+-v, --verbose        Print out error details when running this command.
+-V, --version        Show version information
+
+Commands:
+
+  build                   Creates a new and optimized server image.
+  start                   Start the server.
+  start-dev               Start the server in development mode.
+  export                  Export data from realms to a file or directory.
+  import                  Import data from a directory or a file.
+  show-config             Print out the current configuration.
+  tools                   %nUtilities for use and interaction with the server.
+    completion            Generate bash/zsh completion script for kc.sh.
+
+Examples:
+
+  Start the server in development mode for local development or testing:
+
+      $ kc.sh start-dev
+
+  Building an optimized server runtime:
+
+      $ kc.sh build <OPTIONS>
+
+  Start the server in production mode:
+
+      $ kc.sh start <OPTIONS>
+
+  Enable auto-completion to bash/zsh:
+
+      $ source <(kc.sh tools completion)
+
+  Please, take a look at the documentation for more details before deploying in
+production.
+
+Use "kc.sh start --help" for the available options when starting the server.
+Use "kc.sh <command> --help" for more information about other commands.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartDevHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartDevHelp.approved.txt
@@ -1,0 +1,101 @@
+Start the server in development mode.
+
+Usage:
+
+kc.sh start-dev [OPTIONS]
+
+Use this command if you want to run the server locally for development or
+testing purposes.
+
+Options:
+
+-h, --help           This help message.
+--help-all           This same help message but with additional options.
+
+Database:
+
+--db-password <password>
+                     The password of the database user.
+--db-pool-initial-size <size>
+                     The initial size of the connection pool.
+--db-pool-max-size <size>
+                     The maximum size of the connection pool. Default: 100.
+--db-pool-min-size <size>
+                     The minimal size of the connection pool.
+--db-schema <schema> The database schema to be used.
+--db-url <jdbc-url>  The full database JDBC URL. If not provided, a default URL is set based on the
+                       selected database vendor. For instance, if using 'postgres', the default
+                       JDBC URL would be 'jdbc:postgresql://localhost/keycloak'.
+--db-url-database <dbname>
+                     Sets the database name of the default JDBC URL of the chosen vendor. If the
+                       `db-url` option is set, this option is ignored.
+--db-url-host <hostname>
+                     Sets the hostname of the default JDBC URL of the chosen vendor. If the
+                       `db-url` option is set, this option is ignored.
+--db-url-properties <properties>
+                     Sets the properties of the default JDBC URL of the chosen vendor. If the
+                       `db-url` option is set, this option is ignored.
+--db-username <username>
+                     The username of the database user.
+
+Hostname:
+
+--hostname <hostname>
+                     Hostname for the Keycloak server.
+--hostname-admin <url>
+                     Overrides the hostname for the admin console and APIs.
+--hostname-path <path>
+                     This should be set if proxy uses a different context-path for Keycloak.
+--hostname-strict <true|false>
+                     Disables dynamically resolving the hostname from request headers. Should
+                       always be set to true in production, unless proxy verifies the Host header.
+                       Default: true.
+--hostname-strict-backchannel <true|false>
+                     By default backchannel URLs are dynamically resolved from request headers to
+                       allow internal an external applications. If all applications use the public
+                       URL this option should be enabled. Default: false.
+
+HTTP/TLS:
+
+--http-enabled <true|false>
+                     Enables the HTTP listener. Default: false.
+--http-host <host>   The used HTTP Host. Default: 0.0.0.0.
+--http-port <port>   The used HTTP port. Default: 8080.
+--https-certificate-file <file>
+                     The file path to a server certificate or certificate chain in PEM format.
+--https-certificate-key-file <file>
+                     The file path to a private key in PEM format.
+--https-cipher-suites <ciphers>
+                     The cipher suites to use. If none is given, a reasonable default is selected.
+--https-client-auth <auth>
+                     Configures the server to require/request client authentication. Possible
+                       Values: none, request, required. Default: none.
+--https-key-store-file <file>
+                     The key store which holds the certificate information instead of specifying
+                       separate files.
+--https-key-store-password <password>
+                     The password of the key store file. Default: password.
+--https-key-store-type <type>
+                     The type of the key store file. If not given, the type is automatically
+                       detected based on the file name.
+--https-port <port>  The used HTTPS port. Default: 8443.
+--https-protocols <protocols>
+                     The list of protocols to explicitly enable.
+--https-trust-store-file <file>
+                     The trust store which holds the certificate information of the certificates to
+                       trust.
+--https-trust-store-password <password>
+                     The password of the trust store file.
+--https-trust-store-type <type>
+                     The type of the trust store file. If not given, the type is automatically
+                       detected based on the file name.
+
+Proxy:
+
+--proxy <mode>       The proxy address forwarding mode if the server is behind a reverse proxy.
+                       Possible values are: none,edge,reencrypt,passthrough Default: none.
+
+Do NOT start the server using this command when deploying to production.
+
+Use 'kc.sh start-dev --help-all' to list all available options, including build
+options.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartDevHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartDevHelpAll.approved.txt
@@ -1,0 +1,171 @@
+Start the server in development mode.
+
+Usage:
+
+kc.sh start-dev [OPTIONS]
+
+Use this command if you want to run the server locally for development or
+testing purposes.
+
+Options:
+
+-h, --help           This help message.
+--help-all           This same help message but with additional options.
+
+Cluster:
+
+--cache <type>       Defines the cache mechanism for high-availability. By default, a 'ispn' cache
+                       is used to create a cluster between multiple server nodes. A 'local' cache
+                       disables clustering and is intended for development and testing purposes.
+                       Default: ispn.
+--cache-config-file <file>
+                     Defines the file from which cache configuration should be loaded from.
+--cache-stack <stack>
+                     Define the default stack to use for cluster communication and node discovery.
+                       This option only takes effect if 'cache' is set to 'ispn'. Default: udp.
+
+Database:
+
+--db <vendor>        The database vendor. Possible values are: h2-file, h2-mem, mariadb, mssql,
+                       mssql-2012, mysql, oracle, postgres, postgres-95
+--db-password <password>
+                     The password of the database user.
+--db-pool-initial-size <size>
+                     The initial size of the connection pool.
+--db-pool-max-size <size>
+                     The maximum size of the connection pool. Default: 100.
+--db-pool-min-size <size>
+                     The minimal size of the connection pool.
+--db-schema <schema> The database schema to be used.
+--db-url <jdbc-url>  The full database JDBC URL. If not provided, a default URL is set based on the
+                       selected database vendor. For instance, if using 'postgres', the default
+                       JDBC URL would be 'jdbc:postgresql://localhost/keycloak'.
+--db-url-database <dbname>
+                     Sets the database name of the default JDBC URL of the chosen vendor. If the
+                       `db-url` option is set, this option is ignored.
+--db-url-host <hostname>
+                     Sets the hostname of the default JDBC URL of the chosen vendor. If the
+                       `db-url` option is set, this option is ignored.
+--db-url-properties <properties>
+                     Sets the properties of the default JDBC URL of the chosen vendor. If the
+                       `db-url` option is set, this option is ignored.
+--db-username <username>
+                     The username of the database user.
+
+Feature:
+
+--features-account2 <enabled|disabled>
+                     Enables the ACCOUNT2 feature.
+--features-account_api <enabled|disabled>
+                     Enables the ACCOUNT_API feature.
+--features-admin2 <enabled|disabled>
+                     Enables the ADMIN2 feature.
+--features-admin_fine_grained_authz <enabled|disabled>
+                     Enables the ADMIN_FINE_GRAINED_AUTHZ feature.
+--features-authorization <enabled|disabled>
+                     Enables the AUTHORIZATION feature.
+--features-ciba <enabled|disabled>
+                     Enables the CIBA feature.
+--features-client_policies <enabled|disabled>
+                     Enables the CLIENT_POLICIES feature.
+--features-declarative_user_profile <enabled|disabled>
+                     Enables the DECLARATIVE_USER_PROFILE feature.
+--features-docker <enabled|disabled>
+                     Enables the DOCKER feature.
+--features-impersonation <enabled|disabled>
+                     Enables the IMPERSONATION feature.
+--features-map_storage <enabled|disabled>
+                     Enables the MAP_STORAGE feature.
+--features-openshift_integration <enabled|disabled>
+                     Enables the OPENSHIFT_INTEGRATION feature.
+--features-par <enabled|disabled>
+                     Enables the PAR feature.
+--features-scripts <enabled|disabled>
+                     Enables the SCRIPTS feature.
+--features-token_exchange <enabled|disabled>
+                     Enables the TOKEN_EXCHANGE feature.
+--features-upload_scripts <enabled|disabled>
+                     Enables the UPLOAD_SCRIPTS feature.
+--features-web_authn <enabled|disabled>
+                     Enables the WEB_AUTHN feature.
+-ft, --features <preview>
+                     Enables all tech preview features.
+
+Hostname:
+
+--hostname <hostname>
+                     Hostname for the Keycloak server.
+--hostname-admin <url>
+                     Overrides the hostname for the admin console and APIs.
+--hostname-path <path>
+                     This should be set if proxy uses a different context-path for Keycloak.
+--hostname-strict <true|false>
+                     Disables dynamically resolving the hostname from request headers. Should
+                       always be set to true in production, unless proxy verifies the Host header.
+                       Default: true.
+--hostname-strict-backchannel <true|false>
+                     By default backchannel URLs are dynamically resolved from request headers to
+                       allow internal an external applications. If all applications use the public
+                       URL this option should be enabled. Default: false.
+
+HTTP/TLS:
+
+--http-enabled <true|false>
+                     Enables the HTTP listener. Default: false.
+--http-host <host>   The used HTTP Host. Default: 0.0.0.0.
+--http-port <port>   The used HTTP port. Default: 8080.
+--http-relative-path <path>
+                     Set the path relative to '/' for serving resources. Default: /.
+--https-certificate-file <file>
+                     The file path to a server certificate or certificate chain in PEM format.
+--https-certificate-key-file <file>
+                     The file path to a private key in PEM format.
+--https-cipher-suites <ciphers>
+                     The cipher suites to use. If none is given, a reasonable default is selected.
+--https-client-auth <auth>
+                     Configures the server to require/request client authentication. Possible
+                       Values: none, request, required. Default: none.
+--https-key-store-file <file>
+                     The key store which holds the certificate information instead of specifying
+                       separate files.
+--https-key-store-password <password>
+                     The password of the key store file. Default: password.
+--https-key-store-type <type>
+                     The type of the key store file. If not given, the type is automatically
+                       detected based on the file name.
+--https-port <port>  The used HTTPS port. Default: 8443.
+--https-protocols <protocols>
+                     The list of protocols to explicitly enable.
+--https-trust-store-file <file>
+                     The trust store which holds the certificate information of the certificates to
+                       trust.
+--https-trust-store-password <password>
+                     The password of the trust store file.
+--https-trust-store-type <type>
+                     The type of the trust store file. If not given, the type is automatically
+                       detected based on the file name.
+
+Metrics:
+
+--metrics-enabled <true|false>
+                     If the server should expose metrics and healthcheck. If enabled, metrics are
+                       available at the '/metrics' endpoint and healthcheck at the '/health'
+                       endpoint. Default: false.
+
+Proxy:
+
+--proxy <mode>       The proxy address forwarding mode if the server is behind a reverse proxy.
+                       Possible values are: none,edge,reencrypt,passthrough Default: none.
+
+Vault:
+
+--vault-file-path <dir>
+                     If set, secrets can be obtained by reading the content of files within the
+                       given path.
+--vault-hashicorp-paths <paths>
+                     A set of one or more paths that should be used when looking up secrets.
+
+Do NOT start the server using this command when deploying to production.
+
+Use 'kc.sh start-dev --help-all' to list all available options, including build
+options.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartHelp.approved.txt
@@ -1,0 +1,107 @@
+Start the server.
+
+Usage:
+
+kc.sh start [OPTIONS]
+
+Use this command to run the server in production.
+
+Options:
+
+-b, --auto-build     Automatically detects whether the server configuration changed and a new
+                       server image must be built prior to starting the server. This option
+                       provides an alternative to manually running the 'build' prior to starting
+                       the server. Use this configuration carefully in production as it might
+                       impact the startup time.
+-h, --help           This help message.
+
+Database:
+
+--db-password <password>
+                     The password of the database user.
+--db-pool-initial-size <size>
+                     The initial size of the connection pool.
+--db-pool-max-size <size>
+                     The maximum size of the connection pool. Default: 100.
+--db-pool-min-size <size>
+                     The minimal size of the connection pool.
+--db-schema <schema> The database schema to be used.
+--db-url <jdbc-url>  The full database JDBC URL. If not provided, a default URL is set based on the
+                       selected database vendor. For instance, if using 'postgres', the default
+                       JDBC URL would be 'jdbc:postgresql://localhost/keycloak'.
+--db-url-database <dbname>
+                     Sets the database name of the default JDBC URL of the chosen vendor. If the
+                       `db-url` option is set, this option is ignored.
+--db-url-host <hostname>
+                     Sets the hostname of the default JDBC URL of the chosen vendor. If the
+                       `db-url` option is set, this option is ignored.
+--db-url-properties <properties>
+                     Sets the properties of the default JDBC URL of the chosen vendor. If the
+                       `db-url` option is set, this option is ignored.
+--db-username <username>
+                     The username of the database user.
+
+Hostname:
+
+--hostname <hostname>
+                     Hostname for the Keycloak server.
+--hostname-admin <url>
+                     Overrides the hostname for the admin console and APIs.
+--hostname-path <path>
+                     This should be set if proxy uses a different context-path for Keycloak.
+--hostname-strict <true|false>
+                     Disables dynamically resolving the hostname from request headers. Should
+                       always be set to true in production, unless proxy verifies the Host header.
+                       Default: true.
+--hostname-strict-backchannel <true|false>
+                     By default backchannel URLs are dynamically resolved from request headers to
+                       allow internal an external applications. If all applications use the public
+                       URL this option should be enabled. Default: false.
+
+HTTP/TLS:
+
+--http-enabled <true|false>
+                     Enables the HTTP listener. Default: false.
+--http-host <host>   The used HTTP Host. Default: 0.0.0.0.
+--http-port <port>   The used HTTP port. Default: 8080.
+--https-certificate-file <file>
+                     The file path to a server certificate or certificate chain in PEM format.
+--https-certificate-key-file <file>
+                     The file path to a private key in PEM format.
+--https-cipher-suites <ciphers>
+                     The cipher suites to use. If none is given, a reasonable default is selected.
+--https-client-auth <auth>
+                     Configures the server to require/request client authentication. Possible
+                       Values: none, request, required. Default: none.
+--https-key-store-file <file>
+                     The key store which holds the certificate information instead of specifying
+                       separate files.
+--https-key-store-password <password>
+                     The password of the key store file. Default: password.
+--https-key-store-type <type>
+                     The type of the key store file. If not given, the type is automatically
+                       detected based on the file name.
+--https-port <port>  The used HTTPS port. Default: 8443.
+--https-protocols <protocols>
+                     The list of protocols to explicitly enable.
+--https-trust-store-file <file>
+                     The trust store which holds the certificate information of the certificates to
+                       trust.
+--https-trust-store-password <password>
+                     The password of the trust store file.
+--https-trust-store-type <type>
+                     The type of the trust store file. If not given, the type is automatically
+                       detected based on the file name.
+
+Proxy:
+
+--proxy <mode>       The proxy address forwarding mode if the server is behind a reverse proxy.
+                       Possible values are: none,edge,reencrypt,passthrough Default: none.
+
+You may use the "--auto-build" option when starting the server to avoid running
+the "build" command everytime you need to change a static property:
+
+      $ kc.sh start --auto-build <OPTIONS>
+
+By doing that you have an additional overhead when the server is starting. Run
+"kc.sh build -h" for more details.


### PR DESCRIPTION
… Golden Master Testing technique
See e.g. https://blog.thecodewhisperer.com/permalink/how-not-to-write-golden-master-tests for general details on Golden Master Testing.

This PR provides:
- Tests to check if credentials are leaking into CLI when using --auto-build or show-config command.
- Improvements to test extension to allow usage of --config-file and to reset profiles to other tests by using --profile.
- Support for running `@RawDistOnly` annotated test classes from the IDE by setting the System variable in the extension constructor if it's not found.
- Integration of https://approvaltests.com/ resp. https://github.com/approvals/ApprovalTests.Java 
- Workflow for approvaltests is as follows:
1. You change something w.r.t. the console help output
2. You run the test(s) locally
3. Test(s) which compare the now-changed output will fail. A file `<TestClassName>.<TestMethodName>.received.txt` will be created in the `org/keycloak/it/cli/approvals/cli/help` directory.
4. **You check the `<...>.received.txt` file and check if the output is as expected.** Then you rename the file from `<...>.received.txt` to `<...>.approved.txt`
5. You run the test again. Test will work, as the file to compare with is now "approved".
6. repeat for new changes, **re-check** and overwrite `<...>.approved.txt` with new version from `<...>.received.txt`.

- **Why Golden Master:** Help/HelpAll output is based on the currently executed command, and shows either buildtime properties, runtime properties or both. It also has some hints inside, which could have e.g. runtime properties in it even when you just run a command which shows only buildtime properties ("build --help", for example). So this made it kinda complicated to check if the current output doesn't have runtime properties in it, and so is a pretty good usecase for the golden master testing imo. That said, we should not overuse this, for it's only a good option in very specific scenarios.

- Also fixes a small bug in the build command output, where `--profile=prod` was shown in the wrong place.