### PR TITLE
Renew personal access token for installing Admin UI

### DIFF
--- a/themes/pom.xml
+++ b/themes/pom.xml
@@ -22,7 +22,7 @@
         <repository>
             <id>github</id>
             <!-- Do not decode the PAT below, as it will force Github to revoke it. -->
-            <url>https://keycloak-packages:&#103;hp_reR6QIAQBuiH7EfWSOyNopVtbvlhMM3Jqfd0@maven.pkg.github.com/keycloak/keycloak-admin-ui</url>
+            <url>https://keycloak-packages:&#103;hp_BSAWrTDzsvUequSs6YumzVxEzI7CYc4Tqgox@maven.pkg.github.com/keycloak/keycloak-admin-ui</url>
             <releases>
                 <enabled>false</enabled>
             </releases>


### PR DESCRIPTION
Fixes the broken CI when installing the Admin UI from Github packages.