### PR TITLE
Remove EAP 6 and JBoss AS 7 adapters from distribution

### DIFF
--- a/distribution/downloads/src/main/resources/files
+++ b/distribution/downloads/src/main/resources/files
@@ -4,8 +4,6 @@
     keycloak-server-overlay:keycloak-overlay
     keycloak-api-docs-dist:keycloak-api-docs
 
-    keycloak-as7-adapter-dist:keycloak-oidc-as7-adapter
-    keycloak-eap6-adapter-dist:keycloak-oidc-eap6-adapter
     keycloak-jetty92-adapter-dist:keycloak-oidc-jetty92-adapter
     keycloak-jetty93-adapter-dist:keycloak-oidc-jetty93-adapter
     keycloak-jetty94-adapter-dist:keycloak-oidc-jetty94-adapter
@@ -15,8 +13,6 @@
     keycloak-wildfly-adapter-dist:keycloak-oidc-wildfly-adapter
     keycloak-fuse-adapter-dist:keycloak-oidc-fuse-adapter
 
-    keycloak-saml-as7-adapter-dist:keycloak-saml-as7-adapter
-    keycloak-saml-eap6-adapter-dist:keycloak-saml-eap6-adapter
     keycloak-saml-jetty92-adapter-dist:keycloak-saml-jetty92-adapter
     keycloak-saml-jetty93-adapter-dist:keycloak-saml-jetty93-adapter
     keycloak-saml-jetty94-adapter-dist:keycloak-saml-jetty94-adapter


### PR DESCRIPTION
Closes #9071

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
