### PR TITLE
KEYCLOAK-19371 - fix for UI crash when user has limited Keycloak roles and multiple realms

### DIFF
--- a/themes/src/main/resources/theme/base/admin/resources/js/controllers/realm.js
+++ b/themes/src/main/resources/theme/base/admin/resources/js/controllers/realm.js
@@ -280,7 +280,10 @@ module.controller('RealmDetailCtrl', function($scope, Current, Realm, realm, ser
         }
     }
     $scope.realm = angular.copy(realm);
-    $scope.realm.attributes['userProfileEnabled'] = $scope.realm.attributes['userProfileEnabled'] == 'true';
+    
+    if ($scope.realm.attributes != null) {
+    	$scope.realm.attributes['userProfileEnabled'] = $scope.realm.attributes['userProfileEnabled'] == 'true';
+    }
 
     var oldCopy = angular.copy($scope.realm);
     $scope.realmCopy = oldCopy;


### PR DESCRIPTION
For example user create in master realm with `view-users` role across multiple other realms (which does not allow to see realm details). Crash was
happening on switching the realm during rendering the realm form.

fixes KEYCLOAK-19371
<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
