### PR TITLE
Solves #9102 - Update to Quarkus 2.5.2.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <quarkus.version>2.5.1.Final</quarkus.version>
+        <quarkus.version>2.5.2.Final</quarkus.version>
 
         <!--
         Performing a Wildfly upgrade? Run the:


### PR DESCRIPTION
Only a maintenance release, so no other dependencies need upgrade.

Local, manually successful tests:
- run via IDELauncher w/ h2
- run dist w/ postgres docker, + smoke tests (create realm/client/user, delete, add, search)
- run start with local SSL cert 
- login to a client (keycloak.org/app )
- serving assets, pressing f5 xx times / min
- run quarkus testsuite
- started run of arquillian testsuite, but let's check that on gha. 
