### PR TITLE
KEYCLOAK-19894 Working with case-insensitivity on user_entity.username

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserProvider.java
@@ -813,6 +813,12 @@ public class JpaUserProvider implements UserProvider.Streams, UserCredentialStor
                     }
                     break;
                 case USERNAME:
+                    if (Boolean.valueOf(attributes.getOrDefault(UserModel.EXACT, Boolean.FALSE.toString()))) {
+                        predicates.add(builder.equal(root.get(key), value.toLowerCase()));
+                    } else {
+                        predicates.add(builder.like(root.get(key), "%" + value.toLowerCase() + "%"));
+                    }
+                    break;
                 case FIRST_NAME:
                 case LAST_NAME:
                 case EMAIL:

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserProvider.java
@@ -669,7 +669,7 @@ public class JpaUserProvider implements UserProvider.Streams, UserCredentialStor
 
             switch (key) {
                 case UserModel.USERNAME:
-                    restrictions.add(qb.like(from.get("username"), "%" + value + "%"));
+                    restrictions.add(qb.like(from.get("username"), "%" + value.toLowerCase() + "%"));
                     break;
                 case UserModel.FIRST_NAME:
                     restrictions.add(qb.like(from.get("firstName"), "%" + value + "%"));
@@ -718,7 +718,7 @@ public class JpaUserProvider implements UserProvider.Streams, UserCredentialStor
 
             switch (key) {
                 case UserModel.USERNAME:
-                    restrictions.add(qb.like(from.get("user").get("username"), "%" + value + "%"));
+                    restrictions.add(qb.like(from.get("user").get("username"), "%" + value.toLowerCase() + "%"));
                     break;
                 case UserModel.FIRST_NAME:
                     restrictions.add(qb.like(from.get("user").get("firstName"), "%" + value + "%"));


### PR DESCRIPTION
Values in the `username` column of the `user_entity` database table are stored there as lower-case values.

When querying those values, the database-stored values should not be transformed to lower-case (by wrapping them in `lower()`), because they already are lower-case. Converting them again prevents database indices from being used during execution of the query.

Conversely, search query input values _should_ be transformed to lower-case. Otherwise, the query is sure to _not_ return any data if the input contains anything that isn't lower-case.

More context for this PR is provided in https://keycloak.discourse.group/t/code-change-suggestion-to-improve-performance-for-user-entity-lookups/ and https://issues.redhat.com/projects/KEYCLOAK/issues/KEYCLOAK-19894