### PR TITLE
[Services] clean code in AbstractUsernameFormAuthenticator class

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/AbstractUsernameFormAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/AbstractUsernameFormAuthenticator.java
@@ -208,7 +208,7 @@ public abstract class AbstractUsernameFormAuthenticator extends AbstractFormAuth
         if (isDisabledByBruteForce(context, user)) {
             return false;
         }
-        if (context.getSession().userCredentialManager().isValid(context.getRealm(), user, UserCredentialModel.password(password))) {
+        if (user.credentialManager().isValid(UserCredentialModel.password(password))) {
             return true;
         }
         return badPasswordHandler(context, user, clearUser,false);


### PR DESCRIPTION
Signed-off-by: Ulrich VACHON <uvachon@gmail.com>

In this PR I made a bit clean of code for **AbstractUsernameFormAuthenticator** by :

- Removing unused logger
- Removing redundant else/return
- Removing redundant if statements