### PR TITLE
[fixes #9135] - Disables pre-loading offline sessions by default

### DIFF
--- a/quarkus/runtime/src/main/resources/META-INF/keycloak.conf
+++ b/quarkus/runtime/src/main/resources/META-INF/keycloak.conf
@@ -12,6 +12,9 @@ metrics-enabled=false
 # Do not attach route to cookies and rely on the session affinity capabilities from reverse proxy
 spi-sticky-session-encoder-infinispan-should-attach-route=false
 
+# Disables pre-loading offline sessions by default
+spi.user-sessions.infinispan.preload-offline-sessions-from-database=false
+
 # Default, and insecure, and non-production grade configuration for the development profile
 %dev.http-enabled=true
 %dev.hostname-strict=false

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/ContainerAssume.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/ContainerAssume.java
@@ -65,4 +65,9 @@ public class ContainerAssume {
         Assume.assumeFalse("Doesn't work on auth-server-quarkus",
                 AuthServerTestEnricher.AUTH_SERVER_CONTAINER.equals("auth-server-quarkus"));
     }
+
+    public static void assumeAuthServerQuarkus() {
+        Assume.assumeTrue("Only works on auth-server-quarkus",
+                AuthServerTestEnricher.AUTH_SERVER_CONTAINER.equals("auth-server-quarkus"));
+    }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/storage/ClientStorageOnQuarkusTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/storage/ClientStorageOnQuarkusTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite.federation.storage;
+
+import java.util.Arrays;
+import org.jboss.arquillian.container.spi.Container;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.junit.BeforeClass;
+import org.keycloak.testsuite.arquillian.ContainerInfo;
+import org.keycloak.testsuite.arquillian.SuiteContext;
+import org.keycloak.testsuite.arquillian.containers.KeycloakQuarkusServerDeployableContainer;
+import org.keycloak.testsuite.util.ContainerAssume;
+
+public class ClientStorageOnQuarkusTest extends ClientStorageTest {
+
+    @BeforeClass
+    public static void enabled() {
+        ContainerAssume.assumeAuthServerQuarkus();
+    }
+
+    @ArquillianResource
+    SuiteContext suiteContext;
+
+    @Override
+    public void testClientStats() throws Exception {
+        try {
+            enablePreLoadOfflineSessions();
+            super.testClientStats();
+        } finally {
+            reset();
+        }
+    }
+
+    private void enablePreLoadOfflineSessions() throws Exception {
+        KeycloakQuarkusServerDeployableContainer container = getQuarkusContainer();
+
+        container.setAdditionalBuildArgs(Arrays.asList("--spi-user-sessions-infinispan-preload-offline-sessions-from-database=true"));
+        container.restartServer();
+        reconnectAdminClient();
+    }
+
+    private void reset() {
+        KeycloakQuarkusServerDeployableContainer container = getQuarkusContainer();
+        container.resetConfiguration();
+    }
+
+    private KeycloakQuarkusServerDeployableContainer getQuarkusContainer() {
+        ContainerInfo authServerInfo = suiteContext.getAuthServerInfo();
+        Container arquillianContainer = authServerInfo.getArquillianContainer();
+        KeycloakQuarkusServerDeployableContainer container = (KeycloakQuarkusServerDeployableContainer) arquillianContainer.getDeployableContainer();
+        return container;
+    }
+}

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/storage/ClientStorageTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/storage/ClientStorageTest.java
@@ -20,6 +20,7 @@ package org.keycloak.testsuite.federation.storage;
 import org.jboss.arquillian.graphene.page.Page;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.keycloak.OAuth2Constants;
@@ -48,6 +49,7 @@ import org.keycloak.testsuite.federation.HardcodedClientStorageProviderFactory;
 import org.keycloak.testsuite.pages.AppPage;
 import org.keycloak.testsuite.pages.ErrorPage;
 import org.keycloak.testsuite.pages.LoginPage;
+import org.keycloak.testsuite.util.ContainerAssume;
 import org.keycloak.testsuite.util.OAuthClient;
 import org.keycloak.util.BasicAuthHelper;
 import org.keycloak.util.TokenUtil;
@@ -85,6 +87,12 @@ import org.keycloak.testsuite.util.AdminClientUtil;
  */
 @AuthServerContainerExclude(AuthServer.REMOTE)
 public class ClientStorageTest extends AbstractTestRealmKeycloakTest {
+
+    @BeforeClass
+    public static void enabled() {
+        ContainerAssume.assumeNotAuthServerQuarkus(); // see ClientStorageOnQuarkusTest
+    }
+
     @Rule
     public AssertEvents events = new AssertEvents(this);
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/BackchannelLogoutOnQuarkusTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/BackchannelLogoutOnQuarkusTest.java
@@ -1,0 +1,56 @@
+package org.keycloak.testsuite.oauth;
+
+import java.util.Arrays;
+import org.jboss.arquillian.container.spi.Container;
+import org.junit.BeforeClass;
+import org.keycloak.testsuite.arquillian.ContainerInfo;
+import org.keycloak.testsuite.arquillian.containers.KeycloakQuarkusServerDeployableContainer;
+import org.keycloak.testsuite.util.ContainerAssume;
+
+public class BackchannelLogoutOnQuarkusTest extends BackchannelLogoutTest {
+
+    @BeforeClass
+    public static void enabled() {
+        ContainerAssume.assumeAuthServerQuarkus();
+    }
+
+    @Override
+    public void postBackchannelLogoutNestedBrokeringRevokeOfflineSessions() throws Exception {
+        try {
+            enablePreLoadOfflineSessions();
+            super.postBackchannelLogoutNestedBrokeringRevokeOfflineSessions();
+        } finally {
+            reset();
+        }
+    }
+
+    @Override
+    public void postBackchannelLogoutNestedBrokeringRevokeOfflineSessionsWithoutActiveUserSession() throws Exception {
+        try {
+            enablePreLoadOfflineSessions();
+            super.postBackchannelLogoutNestedBrokeringRevokeOfflineSessionsWithoutActiveUserSession();
+        } finally {
+            reset();
+        }
+    }
+
+    private void enablePreLoadOfflineSessions() throws Exception {
+        KeycloakQuarkusServerDeployableContainer container = getQuarkusContainer();
+
+        container.setAdditionalBuildArgs(Arrays.asList("--spi-user-sessions-infinispan-preload-offline-sessions-from-database=true"));
+        container.restartServer();
+        reconnectAdminClient();
+    }
+
+    private void reset() {
+        KeycloakQuarkusServerDeployableContainer container = getQuarkusContainer();
+        container.resetConfiguration();
+    }
+
+    private KeycloakQuarkusServerDeployableContainer getQuarkusContainer() {
+        ContainerInfo authServerInfo = suiteContext.getAuthServerInfo();
+        Container arquillianContainer = authServerInfo.getArquillianContainer();
+        KeycloakQuarkusServerDeployableContainer container = (KeycloakQuarkusServerDeployableContainer) arquillianContainer.getDeployableContainer();
+        return container;
+    }
+}

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/BackchannelLogoutTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/BackchannelLogoutTest.java
@@ -11,6 +11,7 @@ import static org.keycloak.testsuite.broker.BrokerTestTools.getConsumerRoot;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.jboss.arquillian.drone.api.annotation.Drone;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.keycloak.OAuth2Constants;
@@ -33,6 +34,7 @@ import org.keycloak.testsuite.AssertEvents;
 import org.keycloak.testsuite.broker.AbstractNestedBrokerTest;
 import org.keycloak.testsuite.broker.NestedBrokerConfiguration;
 import org.keycloak.testsuite.broker.OidcBackchannelLogoutBrokerConfiguration;
+import org.keycloak.testsuite.util.ContainerAssume;
 import org.keycloak.testsuite.util.CredentialBuilder;
 import org.keycloak.testsuite.util.LogoutTokenUtil;
 import org.keycloak.testsuite.util.Matchers;
@@ -54,6 +56,11 @@ import java.util.stream.Collectors;
 import javax.ws.rs.core.Response;
 
 public class BackchannelLogoutTest extends AbstractNestedBrokerTest {
+
+    @BeforeClass
+    public static void enabled() {
+        ContainerAssume.assumeNotAuthServerQuarkus(); // see BackchannelLogoutOnQuarkusTest
+    }
 
     public static final String ACCOUNT_CLIENT_NAME = "account";
     public static final String BROKER_CLIENT_ID = "brokerapp";


### PR DESCRIPTION
Closes #9135

Basically:

* Disables pre-loading by default
* Specific tests for Quarkus distribution to enable pre-loading offline sessions prior to running tests that require pre-loading.