### PR TITLE
Fix Cross DC test failures caused by Keycloak not increasing failure …

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/crossdc/BruteForceCrossDCTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/crossdc/BruteForceCrossDCTest.java
@@ -91,6 +91,8 @@ public class BruteForceCrossDCTest extends AbstractAdminCrossDCTest {
                 .bruteForceProtected(true)
                 .build();
 
+        realmRep.setQuickLoginCheckMilliSeconds(0L); // This is necessary so user is not locked out for too fast consecutive login attempts; when user is locked out failure count stops increasing
+
         adminClient.realms().create(realmRep);
     }
 


### PR DESCRIPTION
…counter for blocked users

Tests for brute force detection are doing 10 login attempts and then checking that the login failures count is the same in all DCs. In the current main the number of failed attempts is only 2 because the user is blocked due to two quick login attempts that result in blocking the user and stopping increasing the failure count with all next login attempts. We need to change tests so that the user is not blocked so we can correctly count the number of failed login attempts.

Closes #9157

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
