### PR TITLE
KEYCLOAK-19571 Add indices to HotRodClientEntity fields

### DIFF
--- a/model/map-hot-rod/src/main/java/org/keycloak/models/map/storage/hotRod/HotRodMapStorage.java
+++ b/model/map-hot-rod/src/main/java/org/keycloak/models/map/storage/hotRod/HotRodMapStorage.java
@@ -132,6 +132,7 @@ public class HotRodMapStorage<K, E extends AbstractHotRodEntity, V extends HotRo
         CloseableIterator<E> iterator = query.iterator();
         return closing(StreamSupport.stream(Spliterators.spliteratorUnknownSize(iterator, 0), false))
                 .onClose(iterator::close)
+                .filter(Objects::nonNull) // see https://github.com/keycloak/keycloak/issues/9271
                 .map(this.delegateProducer);
     }
 

--- a/model/map-hot-rod/src/main/java/org/keycloak/models/map/storage/hotRod/client/HotRodClientEntity.java
+++ b/model/map-hot-rod/src/main/java/org/keycloak/models/map/storage/hotRod/client/HotRodClientEntity.java
@@ -17,9 +17,11 @@
 
 package org.keycloak.models.map.storage.hotRod.client;
 
+import org.infinispan.protostream.annotations.ProtoDoc;
 import org.infinispan.protostream.annotations.ProtoField;
 import org.keycloak.models.map.annotations.GenerateHotRodEntityImplementation;
 import org.keycloak.models.map.storage.hotRod.common.AbstractHotRodEntity;
+import org.keycloak.models.map.storage.hotRod.common.HotRodAttributeEntity;
 import org.keycloak.models.map.storage.hotRod.common.HotRodEntityDelegate;
 import org.keycloak.models.map.storage.hotRod.common.HotRodPair;
 import org.keycloak.models.map.client.MapClientEntity;
@@ -37,111 +39,125 @@ import java.util.stream.Stream;
         implementInterface = "org.keycloak.models.map.client.MapClientEntity",
         inherits = "org.keycloak.models.map.storage.hotRod.client.HotRodClientEntity.AbstractHotRodClientEntityDelegate"
 )
+@ProtoDoc("@Indexed")
 public class HotRodClientEntity implements AbstractHotRodEntity {
 
     @ProtoField(number = 1, required = true)
     public int entityVersion = 1;
 
+    @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")
     @ProtoField(number = 2, required = true)
     public String id;
 
+    @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")
     @ProtoField(number = 3)
     public String realmId;
 
+    @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")
     @ProtoField(number = 4)
     public String clientId;
 
+    /**
+     * Lowercase interpretation of {@link #clientId} field. Infinispan doesn't support case-insensitive LIKE for non-analyzed fields.
+     * Search on analyzed fields can be case-insensitive (based on used analyzer) but doesn't support ORDER BY analyzed field.
+     */
+    @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")
     @ProtoField(number = 5)
-    public String name;
+    public String clientIdLowercase;
 
     @ProtoField(number = 6)
-    public String description;
+    public String name;
 
     @ProtoField(number = 7)
-    public Set<String> redirectUris;
+    public String description;
 
     @ProtoField(number = 8)
-    public Boolean enabled;
+    public Set<String> redirectUris;
 
     @ProtoField(number = 9)
+    public Boolean enabled;
+    
+    @ProtoField(number = 10)
     public Boolean alwaysDisplayInConsole;
 
-    @ProtoField(number = 10)
+    @ProtoField(number = 11)
     public String clientAuthenticatorType;
 
-    @ProtoField(number = 11)
+    @ProtoField(number = 12)
     public String secret;
 
-    @ProtoField(number = 12)
+    @ProtoField(number = 13)
     public String registrationToken;
 
-    @ProtoField(number = 13)
+    @ProtoField(number = 14)
     public String protocol;
 
-    @ProtoField(number = 14)
+    @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")
+    @ProtoField(number = 15)
     public Set<HotRodAttributeEntity> attributes;
 
-    @ProtoField(number = 15)
+    @ProtoField(number = 16)
     public Set<HotRodPair<String, String>> authenticationFlowBindingOverrides;
 
-    @ProtoField(number = 16)
+    @ProtoField(number = 17)
     public Boolean publicClient;
 
-    @ProtoField(number = 17)
+    @ProtoField(number = 18)
     public Boolean fullScopeAllowed;
 
-    @ProtoField(number = 18)
+    @ProtoField(number = 19)
     public Boolean frontchannelLogout;
 
-    @ProtoField(number = 19)
+    @ProtoField(number = 20)
     public Integer notBefore;
 
-    @ProtoField(number = 20)
+    @ProtoField(number = 21)
     public Set<String> scope;
 
-    @ProtoField(number = 21)
+    @ProtoField(number = 22)
     public Set<String> webOrigins;
 
-    @ProtoField(number = 22)
+    @ProtoField(number = 23)
     public Set<HotRodProtocolMapperEntity> protocolMappers;
 
-    @ProtoField(number = 23)
+    @ProtoField(number = 24)
     public Set<HotRodPair<String, Boolean>> clientScopes;
 
-    @ProtoField(number = 24, collectionImplementation = LinkedList.class)
+    @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")
+    @ProtoField(number = 25, collectionImplementation = LinkedList.class)
     public Collection<String> scopeMappings;
 
-    @ProtoField(number = 25)
+    @ProtoField(number = 26)
     public Boolean surrogateAuthRequired;
 
-    @ProtoField(number = 26)
+    @ProtoField(number = 27)
     public String managementUrl;
 
-    @ProtoField(number = 27)
+    @ProtoField(number = 28)
     public String baseUrl;
 
-    @ProtoField(number = 28)
+    @ProtoField(number = 29)
     public Boolean bearerOnly;
 
-    @ProtoField(number = 29)
+    @ProtoField(number = 30)
     public Boolean consentRequired;
 
-    @ProtoField(number = 30)
+    @ProtoField(number = 31)
     public String rootUrl;
 
-    @ProtoField(number = 31)
+    @ProtoField(number = 32)
     public Boolean standardFlowEnabled;
 
-    @ProtoField(number = 32)
+    @ProtoField(number = 33)
     public Boolean implicitFlowEnabled;
 
-    @ProtoField(number = 33)
+    @ProtoField(number = 34)
     public Boolean directAccessGrantsEnabled;
 
-    @ProtoField(number = 34)
+    @ProtoField(number = 35)
     public Boolean serviceAccountsEnabled;
 
-    @ProtoField(number = 35)
+    @ProtoField(number = 36)
     public Integer nodeReRegistrationTimeout;
 
     public static abstract class AbstractHotRodClientEntityDelegate extends UpdatableEntity.Impl implements HotRodEntityDelegate<HotRodClientEntity>, MapClientEntity {
@@ -157,6 +173,14 @@ public class HotRodClientEntity implements AbstractHotRodEntity {
             if (entity.id != null) throw new IllegalStateException("Id cannot be changed");
             entity.id = id;
             this.updated |= id != null;
+        }
+
+        @Override
+        public void setClientId(String clientId) {
+            HotRodClientEntity entity = getHotRodEntity();
+            this.updated |= ! Objects.equals(entity.clientId, clientId);
+            entity.clientId = clientId;
+            entity.clientIdLowercase = clientId == null ? null : clientId.toLowerCase();
         }
 
         @Override

--- a/model/map-hot-rod/src/main/java/org/keycloak/models/map/storage/hotRod/common/HotRodAttributeEntity.java
+++ b/model/map-hot-rod/src/main/java/org/keycloak/models/map/storage/hotRod/common/HotRodAttributeEntity.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.models.map.storage.hotRod.common;
+
+import org.infinispan.protostream.annotations.ProtoDoc;
+import org.infinispan.protostream.annotations.ProtoField;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+
+@ProtoDoc("@Indexed")
+public class HotRodAttributeEntity {
+    @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")
+    @ProtoField(number = 1)
+    public String name;
+
+    @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")
+    @ProtoField(number = 2)
+    public List<String> values = new LinkedList<>();
+
+    public HotRodAttributeEntity() {
+    }
+
+    public HotRodAttributeEntity(String name, List<String> values) {
+        this.name = name;
+        this.values.addAll(values);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public List<String> getValues() {
+        return values;
+    }
+
+    public void setValues(List<String> values) {
+        this.values = values;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        HotRodAttributeEntity that = (HotRodAttributeEntity) o;
+        return Objects.equals(name, that.name) && Objects.equals(values, that.values);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, values);
+    }
+}

--- a/model/map-hot-rod/src/main/java/org/keycloak/models/map/storage/hotRod/common/HotRodAttributeEntityNonIndexed.java
+++ b/model/map-hot-rod/src/main/java/org/keycloak/models/map/storage/hotRod/common/HotRodAttributeEntityNonIndexed.java
@@ -15,25 +15,27 @@
  * limitations under the License.
  */
 
-package org.keycloak.models.map.storage.hotRod.client;
+package org.keycloak.models.map.storage.hotRod.common;
 
+import org.infinispan.protostream.annotations.ProtoDoc;
 import org.infinispan.protostream.annotations.ProtoField;
 
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
 
-public class HotRodAttributeEntity {
+
+public class HotRodAttributeEntityNonIndexed {
     @ProtoField(number = 1)
     public String name;
 
     @ProtoField(number = 2)
     public List<String> values = new LinkedList<>();
 
-    public HotRodAttributeEntity() {
+    public HotRodAttributeEntityNonIndexed() {
     }
 
-    public HotRodAttributeEntity(String name, List<String> values) {
+    public HotRodAttributeEntityNonIndexed(String name, List<String> values) {
         this.name = name;
         this.values.addAll(values);
     }
@@ -58,7 +60,7 @@ public class HotRodAttributeEntity {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        HotRodAttributeEntity that = (HotRodAttributeEntity) o;
+        HotRodAttributeEntityNonIndexed that = (HotRodAttributeEntityNonIndexed) o;
         return Objects.equals(name, that.name) && Objects.equals(values, that.values);
     }
 

--- a/model/map-hot-rod/src/main/java/org/keycloak/models/map/storage/hotRod/common/HotRodTypesUtils.java
+++ b/model/map-hot-rod/src/main/java/org/keycloak/models/map/storage/hotRod/common/HotRodTypesUtils.java
@@ -18,7 +18,6 @@
 package org.keycloak.models.map.storage.hotRod.common;
 
 import org.keycloak.models.map.common.AbstractEntity;
-import org.keycloak.models.map.storage.hotRod.client.HotRodAttributeEntity;
 
 import java.util.List;
 import java.util.Map;
@@ -48,6 +47,10 @@ public class HotRodTypesUtils {
         return new HotRodAttributeEntity(entry.getKey(), entry.getValue());
     }
 
+    public static HotRodAttributeEntityNonIndexed createHotRodAttributeEntityNonIndexedFromMapEntry(Map.Entry<String, List<String>> entry) {
+        return new HotRodAttributeEntityNonIndexed(entry.getKey(), entry.getValue());
+    }
+
     public static <SetType, KeyType> boolean removeFromSetByMapKey(Set<SetType> set, KeyType key, Function<SetType, KeyType> keyGetter) {
         if (set == null || set.isEmpty()) { return false; }
         return set.stream()
@@ -73,7 +76,15 @@ public class HotRodTypesUtils {
         return attributeEntity.name;
     }
 
+    public static String getKey(HotRodAttributeEntityNonIndexed attributeEntity) {
+        return attributeEntity.name;
+    }
+
     public static List<String> getValue(HotRodAttributeEntity attributeEntity) {
+        return attributeEntity.values;
+    }
+
+    public static List<String> getValue(HotRodAttributeEntityNonIndexed attributeEntity) {
         return attributeEntity.values;
     }
 

--- a/model/map-hot-rod/src/main/java/org/keycloak/models/map/storage/hotRod/common/ProtoSchemaInitializer.java
+++ b/model/map-hot-rod/src/main/java/org/keycloak/models/map/storage/hotRod/common/ProtoSchemaInitializer.java
@@ -19,7 +19,6 @@ package org.keycloak.models.map.storage.hotRod.common;
 
 import org.infinispan.protostream.GeneratedSchema;
 import org.infinispan.protostream.annotations.AutoProtoSchemaBuilder;
-import org.keycloak.models.map.storage.hotRod.client.HotRodAttributeEntity;
 import org.keycloak.models.map.storage.hotRod.client.HotRodClientEntity;
 import org.keycloak.models.map.storage.hotRod.client.HotRodProtocolMapperEntity;
 import org.keycloak.models.map.storage.hotRod.group.HotRodGroupEntity;
@@ -31,14 +30,15 @@ import org.keycloak.models.map.storage.hotRod.group.HotRodGroupEntity;
         includeClasses = {
                 // Clients
                 HotRodClientEntity.class,
-                HotRodAttributeEntity.class,
                 HotRodProtocolMapperEntity.class,
 
                 // Groups
                 HotRodGroupEntity.class,
 
                 // Common
-                HotRodPair.class
+                HotRodPair.class,
+                HotRodAttributeEntity.class,
+                HotRodAttributeEntityNonIndexed.class
         },
         schemaFileName = "KeycloakHotRodMapStorage.proto",
         schemaFilePath = "proto/",

--- a/model/map-hot-rod/src/main/java/org/keycloak/models/map/storage/hotRod/group/HotRodGroupEntity.java
+++ b/model/map-hot-rod/src/main/java/org/keycloak/models/map/storage/hotRod/group/HotRodGroupEntity.java
@@ -17,20 +17,23 @@
 
 package org.keycloak.models.map.storage.hotRod.group;
 
+import org.infinispan.protostream.annotations.ProtoDoc;
 import org.infinispan.protostream.annotations.ProtoField;
 import org.keycloak.models.map.annotations.GenerateHotRodEntityImplementation;
 import org.keycloak.models.map.common.UpdatableEntity;
 import org.keycloak.models.map.group.MapGroupEntity;
-import org.keycloak.models.map.storage.hotRod.client.HotRodAttributeEntity;
 import org.keycloak.models.map.storage.hotRod.common.AbstractHotRodEntity;
+import org.keycloak.models.map.storage.hotRod.common.HotRodAttributeEntityNonIndexed;
 import org.keycloak.models.map.storage.hotRod.common.HotRodEntityDelegate;
 
+import java.util.Objects;
 import java.util.Set;
 
 @GenerateHotRodEntityImplementation(
         implementInterface = "org.keycloak.models.map.group.MapGroupEntity",
         inherits = "org.keycloak.models.map.storage.hotRod.group.HotRodGroupEntity.AbstractHotRodGroupEntityDelegate"
 )
+@ProtoDoc("@Indexed")
 public class HotRodGroupEntity implements AbstractHotRodEntity {
 
     public static abstract class AbstractHotRodGroupEntityDelegate extends UpdatableEntity.Impl implements HotRodEntityDelegate<HotRodGroupEntity>, MapGroupEntity {
@@ -47,26 +50,47 @@ public class HotRodGroupEntity implements AbstractHotRodEntity {
             entity.id = id;
             this.updated |= id != null;
         }
+
+        @Override
+        public void setName(String name) {
+            HotRodGroupEntity entity = getHotRodEntity();
+            updated |= ! Objects.equals(entity.name, name);
+            entity.name = name;
+            entity.nameLowercase = name == null ? null : name.toLowerCase();
+        }
     }
 
     @ProtoField(number = 1, required = true)
     public int entityVersion = 1;
 
+    @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")
     @ProtoField(number = 2, required = true)
     public String id;
 
+    @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")
     @ProtoField(number = 3)
     public String realmId;
 
+    @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")
     @ProtoField(number = 4)
     public String name;
 
+    /**
+     * Lowercase interpretation of {@link #name} field. Infinispan doesn't support case-insensitive LIKE for non-analyzed fields.
+     * Search on analyzed fields can be case-insensitive (based on used analyzer) but doesn't support ORDER BY analyzed field.
+     */
+    @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")
     @ProtoField(number = 5)
+    public String nameLowercase;
+
+    @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")
+    @ProtoField(number = 6)
     public String parentId;
 
-    @ProtoField(number = 6)
-    public Set<HotRodAttributeEntity> attributes;
-
     @ProtoField(number = 7)
+    public Set<HotRodAttributeEntityNonIndexed> attributes;
+
+    @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")
+    @ProtoField(number = 8)
     public Set<String> grantedRoles;
 }

--- a/model/map-hot-rod/src/main/resources/config/cacheConfig.xml
+++ b/model/map-hot-rod/src/main/resources/config/cacheConfig.xml
@@ -4,9 +4,20 @@
     <cache-container>
        <!-- Specify all remote caches that should be created on the Infinispan server. -->
         <distributed-cache name="clients" mode="SYNC">
+            <indexing>
+                <indexed-entities>
+                    <indexed-entity>kc.HotRodClientEntity</indexed-entity>
+                    <indexed-entity>kc.HotRodAttributeEntity</indexed-entity>
+                </indexed-entities>
+            </indexing>
             <encoding media-type="application/x-protostream"/>
         </distributed-cache>
         <distributed-cache name="groups" mode="SYNC">
+            <indexing>
+                <indexed-entities>
+                    <indexed-entity>kc.HotRodGroupEntity</indexed-entity>
+                </indexed-entities>
+            </indexing>
             <encoding media-type="application/x-protostream"/>
         </distributed-cache>
     </cache-container>

--- a/model/map-hot-rod/src/main/resources/config/infinispan.xml
+++ b/model/map-hot-rod/src/main/resources/config/infinispan.xml
@@ -6,9 +6,20 @@
 
         <!-- Specify all remote caches that should be created on the embedded Infinispan server. -->
         <distributed-cache name="clients" mode="SYNC">
+            <indexing>
+                <indexed-entities>
+                    <indexed-entity>kc.HotRodClientEntity</indexed-entity>
+                    <indexed-entity>kc.HotRodAttributeEntity</indexed-entity>
+                </indexed-entities>
+            </indexing>
             <encoding media-type="application/x-protostream"/>
         </distributed-cache>
         <distributed-cache name="groups" mode="SYNC">
+            <indexing>
+                <indexed-entities>
+                    <indexed-entity>kc.HotRodGroupEntity</indexed-entity>
+                </indexed-entities>
+            </indexing>
             <encoding media-type="application/x-protostream"/>
         </distributed-cache>
     </cache-container>

--- a/model/map/src/main/java/org/keycloak/models/map/group/MapGroupProvider.java
+++ b/model/map/src/main/java/org/keycloak/models/map/group/MapGroupProvider.java
@@ -32,6 +32,8 @@ import org.keycloak.models.map.storage.ModelCriteriaBuilder.Operator;
 import org.keycloak.models.map.storage.QueryParameters;
 
 import org.keycloak.models.map.storage.criteria.DefaultModelCriteria;
+
+import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;

--- a/testsuite/integration-arquillian/tests/base/src/test/resources/META-INF/keycloak-server.json
+++ b/testsuite/integration-arquillian/tests/base/src/test/resources/META-INF/keycloak-server.json
@@ -259,7 +259,8 @@
             "configureRemoteCaches": "${keycloak.connectionsHotRod.configureRemoteCaches:true}",
             "username": "${keycloak.connectionsHotRod.username:myuser}",
             "password": "${keycloak.connectionsHotRod.password:qwer1234!}",
-            "enableSecurity": "${keycloak.connectionsHotRod.enableSecurity:true}"
+            "enableSecurity": "${keycloak.connectionsHotRod.enableSecurity:true}",
+            "reindexCaches": "${keycloak.connectionsHotRod.reindexCaches:clients,groups}"
         }
     },
 

--- a/testsuite/model/src/main/resources/hotrod/infinispan.xml
+++ b/testsuite/model/src/main/resources/hotrod/infinispan.xml
@@ -2,9 +2,20 @@
     <cache-container>
         <transport stack="udp"/>
         <distributed-cache name="clients" mode="SYNC">
+            <indexing>
+                <indexed-entities>
+                    <indexed-entity>kc.HotRodClientEntity</indexed-entity>
+                    <indexed-entity>kc.HotRodAttributeEntity</indexed-entity>
+                </indexed-entities>
+            </indexing>
             <encoding media-type="application/x-protostream"/>
         </distributed-cache>
         <distributed-cache name="groups" mode="SYNC">
+            <indexing>
+                <indexed-entities>
+                    <indexed-entity>kc.HotRodGroupEntity</indexed-entity>
+                </indexed-entities>
+            </indexing>
             <encoding media-type="application/x-protostream"/>
         </distributed-cache>
     </cache-container>


### PR DESCRIPTION
This PR adds indices on `HotRodClientEntity` fields. It also bumps Infinispan version to 12 because of Infinispan 12 is able to define an index in cache declaration without the need to put proto schema into metadata cache first. Therefore we should first merge https://github.com/keycloak/keycloak/pull/9037 which also bumps the Infinispan version. 

Closes https://issues.redhat.com/browse/KEYCLOAK-19571
Closes https://github.com/keycloak/keycloak/issues/9240