### PR TITLE
Add JAVA_OPTS_APPEND option from legacy to X (resolves #9188)

### DIFF
--- a/distribution/server-x-dist/src/main/content/bin/kc.bat
+++ b/distribution/server-x-dist/src/main/content/bin/kc.bat
@@ -66,6 +66,11 @@ if not "x%JAVA_OPTS%" == "x" (
   set "JAVA_OPTS=-Xms64m -Xmx512m -XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=256m -Djava.net.preferIPv4Stack=true"
 )
 
+if not "x%JAVA_OPTS_APPEND%" == "x" (
+  echo "Appending additional Java properties to JAVA_OPTS: %JAVA_OPTS_APPEND%"
+  set "JAVA_OPTS=%JAVA_OPTS% %JAVA_OPTS_APPEND%"
+)
+
 if NOT "x%DEBUG%" == "x" (
   set "DEBUG_MODE=%DEBUG%
 )

--- a/distribution/server-x-dist/src/main/content/bin/kc.sh
+++ b/distribution/server-x-dist/src/main/content/bin/kc.sh
@@ -68,6 +68,11 @@ else
    echo "JAVA_OPTS already set in environment; overriding default settings with values: $JAVA_OPTS"
 fi
 
+if [ "x$JAVA_OPTS_APPEND" != "x" ]; then
+  echo "Appending additional Java properties to JAVA_OPTS: $JAVA_OPTS_APPEND"
+  JAVA_OPTS="$JAVA_OPTS $JAVA_OPTS_APPEND"
+fi
+
 # Set debug settings if not already set
 if [ "$DEBUG_MODE" = "true" ]; then
     DEBUG_OPT=`echo $JAVA_OPTS | $GREP "\-agentlib:jdwp"`


### PR DESCRIPTION
This adds the option to add additional, custom JAVA_OPTS to the server startup scripts, without the need to overwrite the complete defaults.

resolves #9188