### PR TITLE
KEYCLOAK-19500 Upgrade Apache Santuario to 2.1.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
         <jetty93.version>9.3.29.v20201019</jetty93.version>
         <jetty94.version>9.4.40.v20210413</jetty94.version>
         <woodstox.version>6.0.3</woodstox.version>
-        <xmlsec.version>2.1.6</xmlsec.version>
+        <xmlsec.version>2.1.7</xmlsec.version>
         <glassfish.json.version>1.1.6</glassfish.json.version>
         <wildfly.common.version>1.5.4.Final</wildfly.common.version>
         <ua-parser.version>1.4.3</ua-parser.version>


### PR DESCRIPTION
Bump up xmlsec version to 2.1.7 to mitigate CVE-2021-40690

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
