### PR TITLE
Solves Issue [#9186] Update to 2.5.3 and small typo fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <quarkus.version>2.5.2.Final</quarkus.version>
+        <quarkus.version>2.5.3.Final</quarkus.version>
 
         <!--
         Performing a Wildfly upgrade? Run the:

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Tools.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Tools.java
@@ -20,7 +20,7 @@ package org.keycloak.quarkus.runtime.cli.command;
 import picocli.CommandLine.Command;
 
 @Command(name = "tools",
-        description = "%nUtilities for use and interaction with the server.",
+        description = "Utilities for use and interaction with the server.",
         subcommands = {Completion.class})
 public class Tools {
 

--- a/quarkus/tests/integration/src/main/java/org/keycloak/it/junit5/extension/CLIResult.java
+++ b/quarkus/tests/integration/src/main/java/org/keycloak/it/junit5/extension/CLIResult.java
@@ -53,12 +53,12 @@ public interface CLIResult extends LaunchResult {
 
     default void assertNotDevMode() {
         assertFalse(getOutput().contains("Running the server in dev mode."),
-                () -> "The standard output:\n" + getOutput() + "does include the Start Dev output");
+                () -> "The standard output:\n" + getOutput() + "\ndoes include the Start Dev output");
     }
 
     default void assertStartedDevMode() {
         assertTrue(getOutput().contains("Running the server in dev mode."),
-                () -> "The standard output:\n" + getOutput() + "doesn't include the Start Dev output");
+                () -> "The standard output:\n" + getOutput() + "\ndoesn't include the Start Dev output");
     }
 
     default void assertError(String msg) {

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testDefaultToHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testDefaultToHelp.approved.txt
@@ -31,7 +31,7 @@ Commands:
   export                  Export data from realms to a file or directory.
   import                  Import data from a directory or a file.
   show-config             Print out the current configuration.
-  tools                   %nUtilities for use and interaction with the server.
+  tools                   Utilities for use and interaction with the server.
     completion            Generate bash/zsh completion script for kc.sh.
 
 Examples:

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testHelp.approved.txt
@@ -31,7 +31,7 @@ Commands:
   export                  Export data from realms to a file or directory.
   import                  Import data from a directory or a file.
   show-config             Print out the current configuration.
-  tools                   %nUtilities for use and interaction with the server.
+  tools                   Utilities for use and interaction with the server.
     completion            Generate bash/zsh completion script for kc.sh.
 
 Examples:

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testHelpShort.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testHelpShort.approved.txt
@@ -31,7 +31,7 @@ Commands:
   export                  Export data from realms to a file or directory.
   import                  Import data from a directory or a file.
   show-config             Print out the current configuration.
-  tools                   %nUtilities for use and interaction with the server.
+  tools                   Utilities for use and interaction with the server.
     completion            Generate bash/zsh completion script for kc.sh.
 
 Examples:


### PR DESCRIPTION
Apart from the update (which is also a maintenance release, so not much changed and testing locally worked fine), also fixed a small typo I observed while testing locally. Fixed in the help and the according tests ("tools" description printed a %n).

I can for sure create a different issue/PR for that second one, just tell me.
