### PR TITLE
[fix: #9213] Partial workaround for QuarkusMainTests streams spilling

### DIFF
--- a/quarkus/tests/integration/src/main/java/org/keycloak/it/utils/RawKeycloakDistribution.java
+++ b/quarkus/tests/integration/src/main/java/org/keycloak/it/utils/RawKeycloakDistribution.java
@@ -103,6 +103,15 @@ public final class RawKeycloakDistribution implements KeycloakDistribution {
             } catch (Exception cause) {
                 keycloak.destroyForcibly();
                 throw new RuntimeException("Failed to stop the server", cause);
+            } finally {
+                try {
+                    keycloak.getInputStream().close();
+                    keycloak.getOutputStream().flush();
+                    keycloak.getOutputStream().close();
+                    keycloak.getErrorStream().close();
+                } catch (IOException cause) {
+                    throw new RuntimeException("Failed to close open streams", cause);
+                }
             }
         }
 


### PR DESCRIPTION
This is a partial and temporary mitigation for #9213 
