### PR TITLE
KEYCLOAK-19909: avoid NPE in LegacyAttributes when using federated st…

### DIFF
--- a/services/src/main/java/org/keycloak/userprofile/LegacyAttributes.java
+++ b/services/src/main/java/org/keycloak/userprofile/LegacyAttributes.java
@@ -40,16 +40,10 @@ public class LegacyAttributes extends DefaultAttributes {
 
     @Override
     public Map<String, List<String>> getReadable() {
-        if(user == null)
-            return null;
+        if(user == null || user.getAttributes() == null)
+            return new HashMap<>();
 
-        Map<String, List<String>> attributes = new HashMap<>(user.getAttributes());
-
-        if (attributes.isEmpty()) {
-            return null;
-        }
-
-        return attributes;
+        return new HashMap<>(user.getAttributes());
     }
 
     @Override


### PR DESCRIPTION
NPE happens for users imported from a federated storage source. Fixes: https://github.com/keycloak/keycloak/issues/15482
