### PR TITLE
Add profile to include new admin console

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -9,7 +9,7 @@ echo "--------------------------------------------------------------------------
 echo "Building:"
 echo ""
 
-mvn -Pjboss-release,distribution-downloads,nexus-staging -DskipTests -DskipTestsuite -DretryFailedDeploymentCount=10 -DautoReleaseAfterClose=true clean deploy
+mvn -Padmin-preview,jboss-release,distribution-downloads,nexus-staging -DskipTests -DskipTestsuite -DretryFailedDeploymentCount=10 -DautoReleaseAfterClose=true clean deploy
 
 
 echo "------------------------------------------------------------------------------------------------------------"

--- a/themes/pom.xml
+++ b/themes/pom.xml
@@ -18,21 +18,6 @@
         <args.npm.install>ci --no-optional --ignore-scripts</args.npm.install>
     </properties>
 
-    <repositories>
-        <repository>
-            <id>github</id>
-            <!-- Do not decode the PAT below, as it will force Github to revoke it. -->
-            <url>https://keycloak-packages:&#103;hp_7fUnUsoBeXc6xOUw7qsMU9RH3uhEvJ1QF7lo@maven.pkg.github.com/keycloak/keycloak-admin-ui</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-                <updatePolicy>always</updatePolicy>
-            </snapshots>
-        </repository>
-    </repositories>
-
     <build>
         <plugins>
             <plugin>
@@ -147,12 +132,7 @@
 
     <profiles>
         <profile>
-            <id>community</id>
-            <activation>
-                <property>
-                    <name>!product</name>
-                </property>
-            </activation>
+            <id>admin-preview</id>
             <dependencies>
                 <dependency>
                     <groupId>org.keycloak</groupId>
@@ -160,11 +140,6 @@
                 </dependency>
             </dependencies>
             <build>
-                <resources>
-                    <resource>
-                        <directory>src/main/resources-community</directory>
-                    </resource>
-                </resources>
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
@@ -191,6 +166,22 @@
                         </executions>
                     </plugin>
                 </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>community</id>
+            <activation>
+                <property>
+                    <name>!product</name>
+                </property>
+            </activation>
+            <build>
+                <resources>
+                    <resource>
+                        <directory>src/main/resources-community</directory>
+                    </resource>
+                </resources>
             </build>
         </profile>
         <profile>


### PR DESCRIPTION
The PAT used to download the admin-ui keeps getting revoked and we need a short term fix for this solution.

This PR removes the GitHub packages repository, and wraps the new admin console in a profile. For those that want the latest and greatest admin console in a locally built Keycloak they will for now have to build the admin-ui locally. For releases we build the admin-ui first already, and I've enabled this profile in the release script.