### PR TITLE
Database configuration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -425,6 +425,13 @@ jobs:
           find . -path '*/target/surefire-reports/*.xml' | zip -q reports-quarkus-tests.zip -@
           exit $TEST_RESULT
 
+      - name: Run Quarkus Storage Tests
+        run: |
+          mvn clean install -nsu -B -f quarkus/tests/pom.xml -Ptest-database -Dtest=PostgreSQLStartDatabaseTest | misc/log/trimmer.sh
+          TEST_RESULT=${PIPESTATUS[0]}
+          find . -path '*/target/surefire-reports/*.xml' | zip -q reports-quarkus-tests.zip -@
+          exit $TEST_RESULT
+
       - name: Quarkus test reports
         uses: actions/upload-artifact@v2
         if: failure()

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/Picocli.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/Picocli.java
@@ -395,8 +395,9 @@ public final class Picocli {
         while (iterator.hasNext()) {
             String arg = iterator.next();
 
-            if (arg.startsWith("--spi")) {
+            if (arg.startsWith("--spi") || arg.startsWith("-D")) {
                 // TODO: ignore properties for providers for now, need to fetch them from the providers, otherwise CLI will complain about invalid options
+                // also ignores system properties as they are set when starting the JVM
                 // change this once we are able to obtain properties from providers
                 iterator.remove();
 

--- a/quarkus/tests/integration/pom.xml
+++ b/quarkus/tests/integration/pom.xml
@@ -90,4 +90,27 @@
         </plugins>
     </build>
 
+    <profiles>
+        <profile>
+            <id>test-database</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <argLine>-Xmx1024m -XX:MaxMetaspaceSize=512m</argLine>
+                            <systemProperties>
+                                <kc.test.storage.database>true</kc.test.storage.database>
+                            </systemProperties>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
 </project>

--- a/quarkus/tests/integration/src/main/java/org/keycloak/it/junit5/extension/WithDatabase.java
+++ b/quarkus/tests/integration/src/main/java/org/keycloak/it/junit5/extension/WithDatabase.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.it.junit5.extension;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+/**
+ * {@link WithDatabase} is used to start a database container.
+ */
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@EnabledIfSystemProperty(named = "kc.test.storage.database", matches = "true", disabledReason = "Docker takes too much time and stability depends on the environment. We should try running these tests in CI but isolated.")
+public @interface WithDatabase {
+
+    /**
+     * The database name as per database aliases.
+     *
+     * @return the database alias
+     */
+    String alias();
+}

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/storage/database/MSSQLStartDatabaseTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/storage/database/MSSQLStartDatabaseTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.it.storage.database;
+
+import org.junit.jupiter.api.Test;
+import org.keycloak.it.junit5.extension.CLIResult;
+import org.keycloak.it.junit5.extension.CLITest;
+import org.keycloak.it.junit5.extension.WithDatabase;
+
+import io.quarkus.test.junit.main.Launch;
+import io.quarkus.test.junit.main.LaunchResult;
+
+@CLITest
+@WithDatabase(alias = "mssql")
+public class MSSQLStartDatabaseTest extends AbstractStartDabataseTest {
+
+    /**
+     * It should be possible to enable XA but here we reproduce a managed environment where only nonXA transaction is supported
+     *
+     * @param result
+     */
+    @Override
+    @Test
+    @Launch({ "-Dkc.db.tx-type=enabled", "-Dkc.db.driver=com.microsoft.sqlserver.jdbc.SQLServerDriver", "start-dev" })
+    void testSuccessful(LaunchResult result) {
+        CLIResult cliResult = (CLIResult) result;
+        cliResult.assertStartedDevMode();
+    }
+
+    @Override
+    protected void assertWrongUsername(CLIResult cliResult) {
+        cliResult.assertMessage("ERROR: Login failed for user 'wrong'");
+    }
+
+    @Override
+    protected void assertWrongPassword(CLIResult cliResult) {
+        cliResult.assertMessage("Login failed for user");
+    }
+}

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/storage/database/MariaDBStartDatabaseTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/storage/database/MariaDBStartDatabaseTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.it.storage.database;
+
+import org.junit.jupiter.api.Test;
+import org.keycloak.it.junit5.extension.CLIResult;
+import org.keycloak.it.junit5.extension.CLITest;
+import org.keycloak.it.junit5.extension.WithDatabase;
+
+import io.quarkus.test.junit.main.Launch;
+import io.quarkus.test.junit.main.LaunchResult;
+
+@CLITest
+@WithDatabase(alias = "mariadb")
+public class MariaDBStartDatabaseTest extends AbstractStartDabataseTest {
+
+    @Override
+    protected void assertWrongPassword(CLIResult cliResult) {
+        cliResult.assertMessage("Access denied for user");
+    }
+
+    @Override
+    protected void assertWrongUsername(CLIResult cliResult) {
+        cliResult.assertMessage("Access denied for user 'wrong'");
+    }
+}

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/storage/database/MySQLStartDatabaseTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/storage/database/MySQLStartDatabaseTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.it.storage.database;
+
+import org.junit.jupiter.api.Test;
+import org.keycloak.it.junit5.extension.CLIResult;
+import org.keycloak.it.junit5.extension.CLITest;
+import org.keycloak.it.junit5.extension.WithDatabase;
+
+import io.quarkus.test.junit.main.Launch;
+import io.quarkus.test.junit.main.LaunchResult;
+
+@CLITest
+@WithDatabase(alias = "mysql")
+public class MySQLStartDatabaseTest extends AbstractStartDabataseTest {
+
+    @Override
+    protected void assertWrongUsername(CLIResult cliResult) {
+        cliResult.assertMessage("ERROR: Access denied for user 'wrong'");
+    }
+
+    @Override
+    protected void assertWrongPassword(CLIResult cliResult) {
+        cliResult.assertMessage("ERROR: Access denied for user");
+    }
+}

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/storage/database/OracleStartDatabaseTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/storage/database/OracleStartDatabaseTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.it.storage.database;
+
+import org.junit.jupiter.api.Test;
+import org.keycloak.it.junit5.extension.CLIResult;
+import org.keycloak.it.junit5.extension.CLITest;
+import org.keycloak.it.junit5.extension.WithDatabase;
+
+import io.quarkus.test.junit.main.Launch;
+import io.quarkus.test.junit.main.LaunchResult;
+
+@CLITest
+@WithDatabase(alias = "oracle")
+public class OracleStartDatabaseTest extends AbstractStartDabataseTest {
+
+    @Override
+    protected void assertWrongUsername(CLIResult cliResult) {
+        cliResult.assertMessage("ORA-01017: invalid username/password; logon denied");
+    }
+
+    @Override
+    protected void assertWrongPassword(CLIResult cliResult) {
+        cliResult.assertMessage("ORA-01017: invalid username/password; logon denied");
+    }
+}

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/storage/database/PostgreSQLStartDatabaseTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/storage/database/PostgreSQLStartDatabaseTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.it.storage.database;
+
+import org.junit.jupiter.api.Test;
+import org.keycloak.it.junit5.extension.CLIResult;
+import org.keycloak.it.junit5.extension.CLITest;
+import org.keycloak.it.junit5.extension.WithDatabase;
+
+import io.quarkus.test.junit.main.Launch;
+import io.quarkus.test.junit.main.LaunchResult;
+
+@CLITest
+@WithDatabase(alias = "postgres")
+public class PostgreSQLStartDatabaseTest extends AbstractStartDabataseTest {
+
+    @Override
+    protected void assertWrongUsername(CLIResult cliResult) {
+        cliResult.assertMessage("ERROR: FATAL: password authentication failed for user \"wrong\"");
+    }
+
+    @Override
+    protected void assertWrongPassword(CLIResult cliResult) {
+        cliResult.assertMessage("ERROR: FATAL: password authentication failed for user");
+    }
+}

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/storage/database/dist/CustomTransactionDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/storage/database/dist/CustomTransactionDistTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.it.storage.database.dist;
+
+import org.junit.jupiter.api.Test;
+import org.keycloak.it.junit5.extension.CLIResult;
+import org.keycloak.it.junit5.extension.DistributionTest;
+
+import io.quarkus.test.junit.main.Launch;
+import io.quarkus.test.junit.main.LaunchResult;
+
+@DistributionTest
+public class CustomTransactionDistTest {
+
+    @Test
+    @Launch({ "-Dkc.db.tx-type=enabled", "-Dkc.db.driver=org.postgresql.xa.PGXADataSource", "build", "--db=postgres" })
+    void failNoXAUsingXADriver(LaunchResult result) {
+        CLIResult cliResult = (CLIResult) result;
+        cliResult.assertError("Driver org.postgresql.xa.PGXADataSource is an XA datasource, but XA transactions have not been enabled on the default datasource");
+    }
+
+    @Test
+    @Launch({ "-Dkc.db.driver=com.microsoft.sqlserver.jdbc.SQLServerDriver", "build", "--db=mssql" })
+    void failXAUsingNonXADriver(LaunchResult result) {
+        CLIResult cliResult = (CLIResult) result;
+        cliResult.assertError("Driver is not an XA dataSource, while XA has been enabled in the configuration of the default datasource");
+    }
+
+    @Test
+    @Launch({ "-Dkc.db.tx-type=enabled", "-Dkc.db.driver=com.microsoft.sqlserver.jdbc.SQLServerDriver", "build", "--db=mssql" })
+    void testNoXa(LaunchResult result) {
+        CLIResult cliResult = (CLIResult) result;
+        cliResult.assertBuild();
+    }
+}

--- a/quarkus/tests/integration/src/test/resources/application.properties
+++ b/quarkus/tests/integration/src/test/resources/application.properties
@@ -1,0 +1,19 @@
+#
+# Copyright 2021 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+quarkus.vault.devservices.enabled=false
+quarkus.datasource.devservices.enabled=false
+quarkus.devservices.enabled=true

--- a/quarkus/tests/integration/src/test/resources/container-license-acceptance.txt
+++ b/quarkus/tests/integration/src/test/resources/container-license-acceptance.txt
@@ -1,0 +1,1 @@
+mcr.microsoft.com/mssql/server:2019-CU10-ubuntu-20.04


### PR DESCRIPTION
Closes #9293 

Basically:

* Baseline for running tests using a database leveraging Quarkus Dev Services
* Tests are mainly about checking if we can start using the different databases we support
* Adding a new step in GHA to run database tests. For now, only PostgreSQL because I'm afraid it will become a bit unstable if we add tests for all databases. Better than none ...