### PR TITLE
Let users create Dynamic Scopes in the UI and show them what the expected format would look like

### DIFF
--- a/common/src/main/java/org/keycloak/common/Profile.java
+++ b/common/src/main/java/org/keycloak/common/Profile.java
@@ -64,7 +64,8 @@ public class Profile {
         CIBA(Type.DEFAULT),
         MAP_STORAGE(Type.EXPERIMENTAL),
         PAR(Type.DEFAULT),
-        DECLARATIVE_USER_PROFILE(Type.PREVIEW);
+        DECLARATIVE_USER_PROFILE(Type.PREVIEW),
+        DYNAMIC_SCOPES(Type.EXPERIMENTAL);
 
         private final Type typeProject;
         private final Type typeProduct;

--- a/common/src/test/java/org/keycloak/common/ProfileTest.java
+++ b/common/src/test/java/org/keycloak/common/ProfileTest.java
@@ -21,7 +21,7 @@ public class ProfileTest {
     @Test
     public void checkDefaultsKeycloak() {
         Assert.assertEquals("community", Profile.getName());
-        assertEquals(Profile.getDisabledFeatures(), Profile.Feature.ADMIN_FINE_GRAINED_AUTHZ, Profile.Feature.ADMIN2, Profile.Feature.DOCKER, Profile.Feature.SCRIPTS, Profile.Feature.TOKEN_EXCHANGE, Profile.Feature.OPENSHIFT_INTEGRATION, Profile.Feature.UPLOAD_SCRIPTS, Profile.Feature.MAP_STORAGE, Profile.Feature.DECLARATIVE_USER_PROFILE);
+        assertEquals(Profile.getDisabledFeatures(), Profile.Feature.ADMIN_FINE_GRAINED_AUTHZ, Profile.Feature.DYNAMIC_SCOPES, Profile.Feature.ADMIN2, Profile.Feature.DOCKER, Profile.Feature.SCRIPTS, Profile.Feature.TOKEN_EXCHANGE, Profile.Feature.OPENSHIFT_INTEGRATION, Profile.Feature.UPLOAD_SCRIPTS, Profile.Feature.MAP_STORAGE, Profile.Feature.DECLARATIVE_USER_PROFILE);
         assertEquals(Profile.getPreviewFeatures(), Profile.Feature.ADMIN_FINE_GRAINED_AUTHZ, Profile.Feature.SCRIPTS, Profile.Feature.TOKEN_EXCHANGE, Profile.Feature.OPENSHIFT_INTEGRATION, Profile.Feature.DECLARATIVE_USER_PROFILE);
         assertEquals(Profile.getDeprecatedFeatures(), Profile.Feature.UPLOAD_SCRIPTS);
 
@@ -37,7 +37,7 @@ public class ProfileTest {
         Profile.init();
 
         Assert.assertEquals("product", Profile.getName());
-        assertEquals(Profile.getDisabledFeatures(), Profile.Feature.ADMIN_FINE_GRAINED_AUTHZ, Profile.Feature.ADMIN2, Profile.Feature.DOCKER, Profile.Feature.SCRIPTS, Profile.Feature.TOKEN_EXCHANGE, Profile.Feature.OPENSHIFT_INTEGRATION, Profile.Feature.UPLOAD_SCRIPTS, Profile.Feature.WEB_AUTHN, Profile.Feature.MAP_STORAGE, Profile.Feature.DECLARATIVE_USER_PROFILE);
+        assertEquals(Profile.getDisabledFeatures(), Profile.Feature.ADMIN_FINE_GRAINED_AUTHZ, Profile.Feature.DYNAMIC_SCOPES, Profile.Feature.ADMIN2, Profile.Feature.DOCKER, Profile.Feature.SCRIPTS, Profile.Feature.TOKEN_EXCHANGE, Profile.Feature.OPENSHIFT_INTEGRATION, Profile.Feature.UPLOAD_SCRIPTS, Profile.Feature.WEB_AUTHN, Profile.Feature.MAP_STORAGE, Profile.Feature.DECLARATIVE_USER_PROFILE);
         assertEquals(Profile.getPreviewFeatures(), Profile.Feature.ADMIN_FINE_GRAINED_AUTHZ, Profile.Feature.SCRIPTS, Profile.Feature.TOKEN_EXCHANGE, Profile.Feature.OPENSHIFT_INTEGRATION, Profile.Feature.WEB_AUTHN, Profile.Feature.DECLARATIVE_USER_PROFILE);
         assertEquals(Profile.getDeprecatedFeatures(), Profile.Feature.UPLOAD_SCRIPTS);
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testBuildHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testBuildHelp.approved.txt
@@ -60,6 +60,8 @@ Feature:
                      Enables the DECLARATIVE_USER_PROFILE feature.
 --features-docker <enabled|disabled>
                      Enables the DOCKER feature.
+--features-dynamic_scopes <enabled|disabled>
+                     Enables the DYNAMIC_SCOPES feature.
 --features-impersonation <enabled|disabled>
                      Enables the IMPERSONATION feature.
 --features-map_storage <enabled|disabled>

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testBuildHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testBuildHelpAll.approved.txt
@@ -83,6 +83,8 @@ Feature:
                      Enables the DECLARATIVE_USER_PROFILE feature.
 --features-docker <enabled|disabled>
                      Enables the DOCKER feature.
+--features-dynamic_scopes <enabled|disabled>
+                     Enables the DYNAMIC_SCOPES feature.
 --features-impersonation <enabled|disabled>
                      Enables the IMPERSONATION feature.
 --features-map_storage <enabled|disabled>

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartDevHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartDevHelpAll.approved.txt
@@ -72,6 +72,8 @@ Feature:
                      Enables the DECLARATIVE_USER_PROFILE feature.
 --features-docker <enabled|disabled>
                      Enables the DOCKER feature.
+--features-dynamic_scopes <enabled|disabled>
+                     Enables the DYNAMIC_SCOPES feature.
 --features-impersonation <enabled|disabled>
                      Enables the IMPERSONATION feature.
 --features-map_storage <enabled|disabled>

--- a/server-spi-private/src/main/java/org/keycloak/models/delegate/ClientModelLazyDelegate.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/delegate/ClientModelLazyDelegate.java
@@ -509,6 +509,21 @@ public class ClientModelLazyDelegate implements ClientModel {
     }
 
     @Override
+    public boolean isDynamicScope() {
+        return getDelegate().isDynamicScope();
+    }
+
+    @Override
+    public void setIsDynamicScope(boolean isDynamicScope) {
+        getDelegate().setIsDynamicScope(isDynamicScope);
+    }
+
+    @Override
+    public String getDynamicScopeRegexp() {
+        return getDelegate().getDynamicScopeRegexp();
+    }
+
+    @Override
     public Set<RoleModel> getScopeMappings() {
         return getDelegate().getScopeMappings();
     }

--- a/server-spi/src/main/java/org/keycloak/models/ClientScopeModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/ClientScopeModel.java
@@ -18,6 +18,7 @@
 package org.keycloak.models;
 
 import java.util.Map;
+import java.util.Optional;
 
 import org.keycloak.common.util.ObjectUtil;
 import org.keycloak.provider.ProviderEvent;
@@ -67,6 +68,8 @@ public interface ClientScopeModel extends ProtocolMapperContainerModel, ScopeCon
     String CONSENT_SCREEN_TEXT = "consent.screen.text";
     String GUI_ORDER = "gui.order";
     String INCLUDE_IN_TOKEN_SCOPE = "include.in.token.scope";
+    String IS_DYNAMIC_SCOPE = "is.dynamic.scope";
+    String DYNAMIC_SCOPE_REGEXP = "dynamic.scope.regexp";
 
     default boolean isDisplayOnConsentScreen() {
         String displayVal = getAttribute(DISPLAY_ON_CONSENT_SCREEN);
@@ -106,5 +109,17 @@ public interface ClientScopeModel extends ProtocolMapperContainerModel, ScopeCon
 
     default void setIncludeInTokenScope(boolean includeInTokenScope) {
         setAttribute(INCLUDE_IN_TOKEN_SCOPE, String.valueOf(includeInTokenScope));
+    }
+
+    default boolean isDynamicScope() {
+        return Optional.ofNullable(getAttribute(IS_DYNAMIC_SCOPE)).isPresent();
+    }
+
+    default void setIsDynamicScope(boolean isDynamicScope) {
+        setAttribute(IS_DYNAMIC_SCOPE, String.valueOf(isDynamicScope));
+    }
+
+    default String getDynamicScopeRegexp() {
+        return getAttribute(DYNAMIC_SCOPE_REGEXP);
     }
 }

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientScopesResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientScopesResource.java
@@ -94,7 +94,7 @@ public class ClientScopesResource {
     @NoCache
     public Response createClientScope(ClientScopeRepresentation rep) {
         auth.clients().requireManageClientScopes();
-
+        ClientScopeResource.validateDynamicClientScope(rep);
         try {
             ClientScopeModel clientModel = RepresentationToModel.createClientScope(session, realm, rep);
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/ClientScopeTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/ClientScopeTest.java
@@ -24,10 +24,12 @@ import org.keycloak.admin.client.resource.ClientScopesResource;
 import org.keycloak.admin.client.resource.ProtocolMappersResource;
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.admin.client.resource.RoleMappingResource;
+import org.keycloak.common.Profile;
 import org.keycloak.common.util.ObjectUtil;
 import org.keycloak.events.admin.OperationType;
 import org.keycloak.events.admin.ResourceType;
 import org.keycloak.models.AccountRoles;
+import org.keycloak.models.ClientScopeModel;
 import org.keycloak.models.Constants;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.protocol.saml.SamlProtocol;
@@ -38,15 +40,19 @@ import org.keycloak.representations.idm.MappingsRepresentation;
 import org.keycloak.representations.idm.ProtocolMapperRepresentation;
 import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.testsuite.admin.ApiUtil;
+import org.keycloak.testsuite.arquillian.annotation.DisableFeature;
+import org.keycloak.testsuite.arquillian.annotation.EnableFeature;
 import org.keycloak.testsuite.util.AdminEventPaths;
 import org.keycloak.testsuite.util.ClientBuilder;
 import org.keycloak.testsuite.util.Matchers;
 import org.keycloak.testsuite.util.RoleBuilder;
+import org.keycloak.util.JsonSerialization;
 
 import javax.ws.rs.ClientErrorException;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
+import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -58,6 +64,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.keycloak.testsuite.Assert.assertNames;
 
 /**
@@ -651,6 +658,99 @@ public class ClientScopeTest extends AbstractClientTest {
         //update client - check it passes (it used to throw ModelDuplicateException before)
         clientRep.setDescription("new_description");
         testRealmResource().clients().get(clientUuid).update(clientRep);
+    }
+
+    @Test
+    @EnableFeature(value = Profile.Feature.DYNAMIC_SCOPES, skipRestart = true)
+    public void testCreateValidDynamicScope() {
+        ClientScopeRepresentation scopeRep = new ClientScopeRepresentation();
+        scopeRep.setName("dynamic-scope-def");
+        scopeRep.setProtocol("openid-connect");
+        scopeRep.setAttributes(new HashMap<String, String>(){{
+            put(ClientScopeModel.IS_DYNAMIC_SCOPE, "true");
+            put(ClientScopeModel.DYNAMIC_SCOPE_REGEXP, "dynamic-scope-def:*");
+        }});
+        String scopeDefId = createClientScope(scopeRep);
+        getCleanup().addClientScopeId(scopeDefId);
+
+        // Assert updated attributes
+        scopeRep = clientScopes().get(scopeDefId).toRepresentation();
+        assertEquals("dynamic-scope-def", scopeRep.getName());
+        assertEquals("true", scopeRep.getAttributes().get(ClientScopeModel.IS_DYNAMIC_SCOPE));
+        assertEquals("dynamic-scope-def:*", scopeRep.getAttributes().get(ClientScopeModel.DYNAMIC_SCOPE_REGEXP));
+    }
+
+    @Test
+    @EnableFeature(value = Profile.Feature.DYNAMIC_SCOPES, skipRestart = true)
+    public void testCreateNonDynamicScopeWithFeatureEnabled() {
+        ClientScopeRepresentation scopeRep = new ClientScopeRepresentation();
+        scopeRep.setName("non-dynamic-scope-def");
+        scopeRep.setProtocol("openid-connect");
+        scopeRep.setAttributes(new HashMap<String, String>(){{
+            put(ClientScopeModel.IS_DYNAMIC_SCOPE, "false");
+            put(ClientScopeModel.DYNAMIC_SCOPE_REGEXP, "");
+        }});
+        String scopeDefId = createClientScope(scopeRep);
+        getCleanup().addClientScopeId(scopeDefId);
+
+        // Assert updated attributes
+        scopeRep = clientScopes().get(scopeDefId).toRepresentation();
+        assertEquals("non-dynamic-scope-def", scopeRep.getName());
+        assertEquals("false", scopeRep.getAttributes().get(ClientScopeModel.IS_DYNAMIC_SCOPE));
+        assertEquals("", scopeRep.getAttributes().get(ClientScopeModel.DYNAMIC_SCOPE_REGEXP));
+    }
+
+    @Test
+    @DisableFeature(value = Profile.Feature.DYNAMIC_SCOPES, skipRestart = true)
+    public void testCreateDynamicScopeWithFeatureDisabledAndIsDynamicScopeTrue() {
+        ClientScopeRepresentation scopeRep = new ClientScopeRepresentation();
+        scopeRep.setName("non-dynamic-scope-def2");
+        scopeRep.setProtocol("openid-connect");
+        scopeRep.setAttributes(new HashMap<String, String>(){{
+            put(ClientScopeModel.IS_DYNAMIC_SCOPE, "true");
+            put(ClientScopeModel.DYNAMIC_SCOPE_REGEXP, "");
+        }});
+        handleExpectedCreateFailure(scopeRep, 400, "Unexpected value \"true\" for attribute is.dynamic.scope in ClientScope");
+    }
+
+    @Test
+    @DisableFeature(value = Profile.Feature.DYNAMIC_SCOPES, skipRestart = true)
+    public void testCreateDynamicScopeWithFeatureDisabledAndNonEmptyDynamicScopeRegexp() {
+        ClientScopeRepresentation scopeRep = new ClientScopeRepresentation();
+        scopeRep.setName("non-dynamic-scope-def3");
+        scopeRep.setProtocol("openid-connect");
+        scopeRep.setAttributes(new HashMap<String, String>(){{
+            put(ClientScopeModel.IS_DYNAMIC_SCOPE, "false");
+            put(ClientScopeModel.DYNAMIC_SCOPE_REGEXP, "not-empty");
+        }});
+        handleExpectedCreateFailure(scopeRep, 400, "Unexpected value \"not-empty\" for attribute dynamic.scope.regexp in ClientScope");
+    }
+
+    @Test
+    @EnableFeature(value = Profile.Feature.DYNAMIC_SCOPES, skipRestart = true)
+    public void testCreateInvalidRegexpDynamicScope() {
+        ClientScopeRepresentation scopeRep = new ClientScopeRepresentation();
+        scopeRep.setName("dynamic-scope-def4");
+        scopeRep.setProtocol("openid-connect");
+        scopeRep.setAttributes(new HashMap<String, String>(){{
+            put(ClientScopeModel.IS_DYNAMIC_SCOPE, "true");
+            put(ClientScopeModel.DYNAMIC_SCOPE_REGEXP, "dynamic-scope-def:*:*");
+        }});
+        handleExpectedCreateFailure(scopeRep, 400, "Invalid format for the Dynamic Scope regexp dynamic-scope-def:*:*");
+    }
+
+    private void handleExpectedCreateFailure(ClientScopeRepresentation scopeRep, int expectedErrorCode, String expectedErrorMessage) {
+        try(Response resp = clientScopes().create(scopeRep)) {
+            Assert.assertEquals(expectedErrorCode, resp.getStatus());
+            String respBody = resp.readEntity(String.class);
+            Map<String, String> responseJson = null;
+            try {
+                responseJson = JsonSerialization.readValue(respBody, Map.class);
+                Assert.assertEquals(expectedErrorMessage, responseJson.get("errorMessage"));
+            } catch (IOException e) {
+                fail("Failed to extract the errorMessage from a CreateScope Response");
+            }
+        }
     }
 
     private ClientScopesResource clientScopes() {

--- a/themes/src/main/resources/theme/base/admin/messages/admin-messages_en.properties
+++ b/themes/src/main/resources/theme/base/admin/messages/admin-messages_en.properties
@@ -1163,6 +1163,10 @@ client-scope.gui-order=GUI order
 client-scope.gui-order.tooltip=Specify order of the provider in GUI (such as in Consent page) as integer
 client-scope.include-in-token-scope=Include In Token Scope
 client-scope.include-in-token-scope.tooltip=If on, the name of this client scope will be added to the access token property 'scope' as well as to the Token Introspection Endpoint response. If off, this client scope will be omitted from the token and from the Token Introspection Endpoint response.
+client-scope.is-dynamic-scope=Dynamic Scope
+client-scope.is-dynamic-scope.tooltip=If on, this scope will be considered a Dynamic Scope, which will be comprised of a static and a variable portion.
+client-scope.dynamic-scope-regexp=Dynamic Scope Format
+client-scope.dynamic-scope-regexp.tooltip=This is the regular expression that the system will use to extract the scope name and variable.
 
 add-user-federation-provider=Add user federation provider
 add-user-storage-provider=Add user storage provider

--- a/themes/src/main/resources/theme/base/admin/resources/js/controllers/clients.js
+++ b/themes/src/main/resources/theme/base/admin/resources/js/controllers/clients.js
@@ -3262,6 +3262,20 @@ module.controller('ClientScopeDetailCtrl', function($scope, realm, clientScope, 
             $scope.displayOnConsentScreen = true;
         }
 
+        if(serverInfo.featureEnabled("DYNAMIC_SCOPES")) {
+            if ($scope.clientScope.attributes["is.dynamic.scope"]) {
+                if ($scope.clientScope.attributes["is.dynamic.scope"] === "true") {
+                    $scope.isDynamicScope = true;
+                } else {
+                    $scope.isDynamicScope = false;
+                }
+            } else {
+                $scope.isDynamicScope = false;
+            }
+
+            $scope.clientScope.attributes["dynamic.scope.regexp"] = $scope.clientScope.name + ":*";
+        }
+
         if ($scope.clientScope.attributes["include.in.token.scope"]) {
             if ($scope.clientScope.attributes["include.in.token.scope"] == "true") {
                 $scope.includeInTokenScope = true;
@@ -3318,6 +3332,14 @@ module.controller('ClientScopeDetailCtrl', function($scope, realm, clientScope, 
             $scope.clientScope.attributes["display.on.consent.screen"] = "true";
         } else {
             $scope.clientScope.attributes["display.on.consent.screen"] = "false";
+        }
+
+        if(serverInfo.featureEnabled("DYNAMIC_SCOPES")) {
+            if ($scope.isDynamicScope === true) {
+                $scope.clientScope.attributes["is.dynamic.scope"] = "true";
+            } else {
+                $scope.clientScope.attributes["is.dynamic.scope"] = "false";
+            }
         }
 
         if ($scope.includeInTokenScope == true) {

--- a/themes/src/main/resources/theme/base/admin/resources/partials/client-scope-detail.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/client-scope-detail.html
@@ -17,6 +17,24 @@
                 </div>
                 <kc-tooltip>{{:: 'client-scope.name.tooltip' | translate}}</kc-tooltip>
             </div>
+            <div class="form-group clearfix block" data-ng-show="serverInfo.featureEnabled('DYNAMIC_SCOPES') && protocol === 'openid-connect'">
+                <label class="col-md-2 control-label" for="isDynamicScope">{{:: 'client-scope.is-dynamic-scope' | translate}}</label>
+                <div class="col-sm-6">
+                    <input ng-model="isDynamicScope" ng-click="switchChange()" name="isDynamicScope" id="isDynamicScope" onoffswitch on-text="{{:: 'onText' | translate}}" off-text="{{:: 'offText' | translate}}"/>
+                </div>
+                <kc-tooltip>{{:: 'client-scope.is-dynamic-scope.tooltip' | translate}}</kc-tooltip>
+            </div>
+            <div class="form-group" data-ng-show="protocol === 'openid-connect' && isDynamicScope && serverInfo.featureEnabled('DYNAMIC_SCOPES')">
+                <label class="col-md-2 control-label" for="dynamicScopeRegExp">{{:: 'client-scope.dynamic-scope-regexp' | translate}} <span class="required">*</span></label>
+                <div class="col-sm-6">
+                    <input class="form-control" ng-readonly="true" type="text"
+                           ng-value="(isDynamicScope && serverInfo.featureEnabled('DYNAMIC_SCOPES')) ? clientScope.attributes['dynamic.scope.regexp'] = clientScope.name+':*' : ''"
+                           id="dynamicScopeRegExp" name="dynamicScopeRegExp"
+                           data-ng-model="clientScope.attributes['dynamic.scope.regexp']" autofocus ng-disabled="!isDynamicScope"
+                           ng-required="isDynamicScope">
+                </div>
+                <kc-tooltip>{{:: 'client-scope.dynamic-scope-regexp.tooltip' | translate}}</kc-tooltip>
+            </div>
             <div class="form-group">
                 <label class="col-md-2 control-label" for="description">{{:: 'description' | translate}} </label>
                 <div class="col-sm-6">


### PR DESCRIPTION
<WIP>

Changes to the UI to make Dynamic Scopes configurable by users and adds some validation in the backend.
These changes will be behind a feature flag called `DYNAMIC_SCOPES` and it's the first iteration set of changes of #9225.

The new configuration has been stored in the `client_scope_attributes` table to avoid database migrations, and utility methods have been provided in the `ClientScopeModel` class to make it easier to work with them in other parts of the code.

Opened to start an early review, **do not merge yet**

closes #9222 
<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
