### PR TITLE
Upgrade Infinispan to 12.1.7.Final

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/connections/infinispan/DefaultInfinispanConnectionProviderFactory.java
+++ b/model/infinispan/src/main/java/org/keycloak/connections/infinispan/DefaultInfinispanConnectionProviderFactory.java
@@ -384,6 +384,10 @@ public class DefaultInfinispanConnectionProviderFactory implements InfinispanCon
         String jdgServer = config.get("remoteStoreHost", "localhost");
         Integer jdgPort = config.getInt("remoteStorePort", 11222);
 
+        // After upgrade to Infinispan 12.1.7.Final it's required that both remote store and embedded cache use
+        // the same key media type to allow segmentation. Also, the number of segments in an embedded cache needs to match number of segments in the remote store.
+        boolean segmented = config.getBoolean("segmented", false);
+
         builder.persistence()
                 .passivation(false)
                 .addStore(RemoteStoreConfigurationBuilder.class)
@@ -393,6 +397,7 @@ public class DefaultInfinispanConnectionProviderFactory implements InfinispanCon
                 .preload(false)
                 .shared(true)
                 .remoteCacheName(cacheName)
+                .segmented(segmented)
                 .rawValues(true)
                 .forceReturnValues(false)
                 .marshaller(KeycloakHotRodMarshallerFactory.class.getName())
@@ -408,6 +413,10 @@ public class DefaultInfinispanConnectionProviderFactory implements InfinispanCon
         String jdgServer = config.get("remoteStoreHost", "localhost");
         Integer jdgPort = config.getInt("remoteStorePort", 11222);
 
+        // After upgrade to Infinispan 12.1.7.Final it's required that both remote store and embedded cache use
+        // the same key media type to allow segmentation. Also, the number of segments in an embedded cache needs to match number of segments in the remote store.
+        boolean segmented = config.getBoolean("segmented", false);
+
         builder.persistence()
                 .passivation(false)
                 .addStore(RemoteStoreConfigurationBuilder.class)
@@ -417,6 +426,7 @@ public class DefaultInfinispanConnectionProviderFactory implements InfinispanCon
                     .preload(true)
                     .shared(true)
                     .remoteCacheName(InfinispanConnectionProvider.ACTION_TOKEN_CACHE)
+                    .segmented(segmented)
                     .rawValues(true)
                     .forceReturnValues(false)
                     .marshaller(KeycloakHotRodMarshallerFactory.class.getName())

--- a/pom.xml
+++ b/pom.xml
@@ -78,8 +78,8 @@
         <jakarta.persistence.version>2.2.3</jakarta.persistence.version>
         <hibernate.core.version>5.3.20.Final</hibernate.core.version>
         <hibernate.c3p0.version>5.3.20.Final</hibernate.c3p0.version>
-        <infinispan.version>11.0.9.Final</infinispan.version>
-        <infinispan.protostream.processor.version>4.3.4.Final</infinispan.protostream.processor.version>
+        <infinispan.version>12.1.7.Final</infinispan.version>
+        <infinispan.protostream.processor.version>4.4.1.Final</infinispan.protostream.processor.version>
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
         <jackson.version>2.12.1</jackson.version>
         <jackson.databind.version>${jackson.version}</jackson.databind.version>


### PR DESCRIPTION
New HotRodStorage uses indices which are defined within a cache configuration. When creating a cache, the protobuf schema is not registered within the Infinispan server yet. This caused an error during a cache creation. Since Infinispan 12 a "Lazy start SearchMapping for protobuf caches" was introduced which fix the problem.

closes #9332 
