### PR TITLE
Fail authenticate if credentialInput is not of type UserCredentialModel Closes #11191

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProvider.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProvider.java
@@ -718,7 +718,7 @@ public class LDAPStorageProvider implements UserStorageProvider,
 
     @Override
     public CredentialValidationOutput authenticate(RealmModel realm, CredentialInput cred) {
-        if (!(cred instanceof UserCredentialModel)) CredentialValidationOutput.failed();
+        if (!(cred instanceof UserCredentialModel)) return CredentialValidationOutput.failed();
         UserCredentialModel credential = (UserCredentialModel)cred;
         if (credential.getType().equals(UserCredentialModel.KERBEROS)) {
             if (kerberosConfig.isAllowKerberosAuthentication()) {


### PR DESCRIPTION
The class `LDAPStorageProvider` currently has a bug in it's `authenticate`-method. If the given `CredentialInput` is not of type `UserCredentialModel`, the method won't return `CredentialValidationOutput.failed()` but will fail in the next line when trying to do a typecast.

This PR introduces the (possibly) intended way to return a `CredentialValidationOutput.failed()` if the `CredentialInput` does not have the correct type.

Closes #11191