### PR TITLE
Remove keycloak-wildfly-adapter-dist from adapter bom

### DIFF
--- a/boms/adapter/pom.xml
+++ b/boms/adapter/pom.xml
@@ -51,11 +51,6 @@
             </dependency>
             <dependency>
                 <groupId>org.keycloak</groupId>
-                <artifactId>keycloak-wildfly-adapter-dist</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.keycloak</groupId>
                 <artifactId>keycloak-saml-adapter-core</artifactId>
                 <version>${project.version}</version>
             </dependency>


### PR DESCRIPTION
The artifact is a zip-file. The definition in the bom doesn't set the
type, so it defaults to jar which doesn't work.

Fixes #9339