### PR TITLE
fix: race condition in checkSsoSilently

### DIFF
--- a/adapters/oidc/js/src/main/resources/keycloak.js
+++ b/adapters/oidc/js/src/main/resources/keycloak.js
@@ -242,7 +242,6 @@
                     ifrm.setAttribute("src", src);
                     ifrm.setAttribute("title", "keycloak-silent-check-sso");
                     ifrm.style.display = "none";
-                    document.body.appendChild(ifrm);
 
                     var messageCallback = function(event) {
                         if (event.origin !== window.location.origin || ifrm.contentWindow !== event.source) {
@@ -257,6 +256,7 @@
                     };
 
                     window.addEventListener("message", messageCallback);
+                    document.body.appendChild(ifrm);
                 };
 
                 var options = {};


### PR DESCRIPTION
Fixes https://github.com/keycloak/keycloak/issues/9360

Removes ambiguity of loading the iFrame before addEventlistener is attached

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
