### PR TITLE
Check permissions before partially importing

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/RealmAdminResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RealmAdminResource.java
@@ -1099,6 +1099,22 @@ public class RealmAdminResource {
     @Operation( summary = "Partial import from a JSON file to an existing realm.")
     public Response partialImport(InputStream requestBody) {
         auth.realm().requireManageRealm();
+        if (rep.hasClients() || rep.hasClientRoles()) {
+            auth.clients().requireManage();
+        }
+        if (rep.hasGroups()) {
+            auth.groups().requireManage();
+        }
+        if (rep.hasUsers()) {
+            auth.users().requireManage();
+        }
+        if (rep.hasRealmRoles()) {
+            auth.realm().requireManageRealm();
+        }
+        if (rep.hasIdps()) {
+            auth.realm().requireManageIdentityProviders();
+        }
+
         try {
             return Response.ok(
                     KeycloakModelUtils.runJobInTransactionWithResult(session.getKeycloakSessionFactory(), kcSession -> {


### PR DESCRIPTION
This does extra checks to see if the user is actually authorized to do the importing of e.g. clients, clientroles, users, ...

This solves issue: https://github.com/keycloak/keycloak/issues/9387