### PR TITLE
[Enhancement] Tweaks client export/import

### DIFF
--- a/core/src/main/java/org/keycloak/representations/idm/ClientRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/idm/ClientRepresentation.java
@@ -21,6 +21,7 @@ import org.keycloak.representations.idm.authorization.ResourceServerRepresentati
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -80,6 +81,7 @@ public class ClientRepresentation {
     private ResourceServerRepresentation authorizationSettings;
     private Map<String, Boolean> access;
     protected String origin;
+    private Set<RoleRepresentation> roles;
 
 
     public String getId() {
@@ -424,6 +426,14 @@ public class ClientRepresentation {
 
     public void setOrigin(String origin) {
         this.origin = origin;
+    }
+
+    public Set<RoleRepresentation> getRoles() {
+        return roles;
+    }
+
+    public void setRoles(Set<RoleRepresentation> roles) {
+        this.roles = roles;
     }
 
 }


### PR DESCRIPTION
This will make single client exports include their roles and each role's attributes (if any). The single client import will take that into account. Now, when a single client is exported, the `json` file will contain that client's roles. When you import that file to another instance or realm, the import action will read client's roles and fill in accordingly.