### PR TITLE
Fixes #9471: RepresentationToModel setting ServiceAccountsEnabled

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
@@ -2899,9 +2899,7 @@ public class RepresentationToModel {
         AuthorizationProvider authorization = session.getProvider(AuthorizationProvider.class);
         UserModel serviceAccount = session.users().getServiceAccount(client);
 
-        if (serviceAccount == null) {
-            client.setServiceAccountsEnabled(true);
-        }
+        client.setServiceAccountsEnabled(serviceAccount != null);
 
         if (addDefaultRoles) {
             RoleModel umaProtectionRole = client.getRole(Constants.AUTHZ_UMA_PROTECTION);


### PR DESCRIPTION
When there _is_ a service account for the client, set ServiceAccountsEnabled to `true`.

Fixes: #9471