### PR TITLE
Fixes #9473 - change config ordinals

### DIFF
--- a/distribution/server-x-dist/assembly.xml
+++ b/distribution/server-x-dist/assembly.xml
@@ -97,10 +97,6 @@
             <source>target/keycloak-quarkus-server/cache-ispn.xml</source>
             <outputDirectory>conf</outputDirectory>
         </file>
-        <file>
-            <source>../../quarkus/runtime/src/main/resources/META-INF/keycloak.properties</source>
-            <outputDirectory>conf</outputDirectory>
-        </file>
     </files>
 
 </assembly>

--- a/distribution/server-x-dist/src/main/content/conf/keycloak.properties
+++ b/distribution/server-x-dist/src/main/content/conf/keycloak.properties
@@ -1,0 +1,14 @@
+# Basic settings for running in production. Change accordingly before deploying the server.
+# Database
+#%prod.db=postgres
+#%prod.db.username=keycloak
+#%prod.db.password=password
+#%prod.db.url=jdbc:postgresql://localhost/keycloak
+# Observability
+#%prod.metrics.enabled=true
+# HTTP
+#%prod.spi.hostname.frontend-url=https://localhost:8443
+#%prod.https.certificate.file=${kc.home.dir}conf/server.crt.pem
+#%prod.https.certificate.key-file=${kc.home.dir}conf/server.key.pem
+#%prod.proxy=reencrypt
+#%prod.hostname=myhostname

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/Environment.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/Environment.java
@@ -18,6 +18,7 @@
 package org.keycloak.quarkus.runtime;
 
 import static org.keycloak.quarkus.runtime.configuration.Configuration.getBuildTimeProperty;
+import static org.keycloak.quarkus.runtime.configuration.Configuration.getConfig;
 
 import java.io.File;
 import java.io.FilenameFilter;
@@ -107,6 +108,13 @@ public final class Environment {
             System.setProperty("mp.config.profile", profile);
             System.setProperty(ProfileManager.QUARKUS_TEST_PROFILE_PROP, profile);
         }
+    }
+    public static String getCurrentOrPersistedProfile() {
+        String profile = getProfile();
+        if(profile == null) {
+            profile = getConfig().getRawValue(PROFILE);
+        }
+        return profile;
     }
 
     public static String getProfileOrDefault(String defaultProfile) {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/ShowConfig.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/ShowConfig.java
@@ -17,7 +17,7 @@
 
 package org.keycloak.quarkus.runtime.cli.command;
 
-import static org.keycloak.quarkus.runtime.configuration.Configuration.getBuildTimeProperty;
+import static org.keycloak.quarkus.runtime.Environment.getCurrentOrPersistedProfile;
 import static org.keycloak.quarkus.runtime.configuration.Configuration.getConfigValue;
 import static org.keycloak.quarkus.runtime.configuration.Configuration.getPropertyNames;
 import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMappers.canonicalFormat;
@@ -33,7 +33,6 @@ import java.util.stream.StreamSupport;
 
 import org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider;
 import org.keycloak.quarkus.runtime.configuration.PersistedConfigSource;
-import org.keycloak.quarkus.runtime.Environment;
 
 import io.quarkus.runtime.Quarkus;
 import io.smallrye.config.ConfigValue;
@@ -59,7 +58,7 @@ public final class ShowConfig extends AbstractCommand implements Runnable {
 
         if (configArgs != null) {
             Map<String, Set<String>> properties = getPropertiesByGroup();
-            String profile = getProfile();
+            String profile = getCurrentOrPersistedProfile();
 
             printRunTimeConfig(properties, profile);
 
@@ -83,6 +82,7 @@ public final class ShowConfig extends AbstractCommand implements Runnable {
         spec.commandLine().getOut().printf("Current Profile: %s%n", profile == null ? "none" : profile);
 
         spec.commandLine().getOut().println("Runtime Configuration:");
+
         properties.get(MicroProfileConfigProvider.NS_KEYCLOAK).stream().sorted()
                 .filter(name -> {
                     String canonicalFormat = canonicalFormat(name);
@@ -113,16 +113,6 @@ public final class ShowConfig extends AbstractCommand implements Runnable {
                         properties1.stream().sorted().forEachOrdered(this::printProperty);
                     });
         }
-    }
-
-    private static String getProfile() {
-        String profile = Environment.getProfile();
-
-        if (profile == null) {
-            return getBuildTimeProperty("quarkus.profile").orElse(null);
-        }
-
-        return profile;
     }
 
     private static Map<String, Set<String>> getPropertiesByGroup() {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/ConfigArgsConfigSource.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/ConfigArgsConfigSource.java
@@ -62,8 +62,7 @@ public class ConfigArgsConfigSource extends PropertiesConfigSource {
     }
 
     protected ConfigArgsConfigSource() {
-        // higher priority over default Quarkus config sources
-        super(parseArgument(), "CliConfigSource", 500);
+        super(parseArgument(), "CliConfigSource", 600);
     }
 
     public static void setCliArgs(String[] args) {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/KcEnvConfigSource.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/KcEnvConfigSource.java
@@ -27,6 +27,10 @@ import io.smallrye.config.EnvConfigSource;
 
 public class KcEnvConfigSource extends EnvConfigSource {
 
+    public KcEnvConfigSource() {
+        super(buildProperties(), 500);
+    }
+
     private static Map<String, String> buildProperties() {
         Map<String, String> properties = new HashMap<>();
 
@@ -40,10 +44,7 @@ public class KcEnvConfigSource extends EnvConfigSource {
         return properties;
     }
 
-    public KcEnvConfigSource() {
-        super(buildProperties(), 350);
-    }
-
+    @Override
     public String getName() {
         return "KcEnvVarConfigSource";
     }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/KeycloakPropertiesConfigSource.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/KeycloakPropertiesConfigSource.java
@@ -68,7 +68,7 @@ public class KeycloakPropertiesConfigSource extends AbstractLocationConfigSource
 
         @Override
         public List<ConfigSource> getConfigSources(final ClassLoader classLoader) {
-            return loadConfigSources("META-INF/keycloak.properties", 240, classLoader);
+            return loadConfigSources("META-INF/keycloak.properties", 150, classLoader);
         }
 
         @Override
@@ -104,7 +104,7 @@ public class KeycloakPropertiesConfigSource extends AbstractLocationConfigSource
                 return Collections.emptyList();
             }
 
-            return loadConfigSources(configFile.toUri().toString(), 250, classLoader);
+            return loadConfigSources(configFile.toUri().toString(), 450, classLoader);
         }
 
         @Override

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/MicroProfileConfigProvider.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/MicroProfileConfigProvider.java
@@ -32,7 +32,6 @@ public class MicroProfileConfigProvider implements Config.ConfigProvider {
     public static final String NS_KEYCLOAK = "kc";
     public static final String NS_KEYCLOAK_PREFIX = NS_KEYCLOAK + ".";
     public static final String NS_QUARKUS = "quarkus";
-    public static final String NS_QUARKUS_PREFIX = NS_QUARKUS + ".";
 
     private final org.eclipse.microprofile.config.Config config;
 

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/PersistedConfigSource.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/PersistedConfigSource.java
@@ -44,7 +44,7 @@ public final class PersistedConfigSource extends PropertiesConfigSource {
     private static final PersistedConfigSource INSTANCE = new PersistedConfigSource();
 
     private PersistedConfigSource() {
-        super(readProperties(), "", 300);
+        super(readProperties(), "", 200);
     }
 
     public static PersistedConfigSource getInstance() {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/SysPropConfigSource.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/SysPropConfigSource.java
@@ -60,6 +60,6 @@ public class SysPropConfigSource implements ConfigSource {
 
     @Override
     public int getOrdinal() {
-        return 400;
+        return 550;
     }
 }

--- a/quarkus/runtime/src/main/resources/META-INF/keycloak.properties
+++ b/quarkus/runtime/src/main/resources/META-INF/keycloak.properties
@@ -9,21 +9,6 @@ http.enabled=false
 # Metrics and healthcheck are disabled by default
 metrics.enabled=false
 
-# Basic settings for running in production. Change accordingly before deploying the server.
-# Database
-#%prod.db=postgres
-#%prod.db.username=keycloak
-#%prod.db.password=password
-#%prod.db.url=jdbc:postgresql://localhost/keycloak
-# Observability
-#%prod.metrics.enabled=true
-# HTTP
-#%prod.spi.hostname.frontend-url=https://localhost:8443
-#%prod.https.certificate.file=${kc.home.dir}conf/server.crt.pem
-#%prod.https.certificate.key-file=${kc.home.dir}conf/server.key.pem
-#%prod.proxy=reencrypt
-#%prod.hostname=myhostname
-
 # Default, and insecure, and non-production grade configuration for the development profile
 %dev.http.enabled=true
 %dev.hostname.strict=false


### PR DESCRIPTION
This PR changes the config ordinals such that:
- Persisted configsource now has the lowest ordinal (of 200) and thus does not create unwanted sideeffects as in #9473
- Keycloak specific configsources always have precedence over quarkus internal ones
- Also fixes a small bug for the show-config command which never showed the profile from persisted.properties, but always "none".

@pedroigor Added a todo where I left the show-config off, with an explanation what to do in. feel free to look, if not i'll work on that tomorrow, should be easy, just have a matching of sorts. Also, if you think it's safe just remove the `getCurrentOrPersistedProfile` and add the check to `getProfile` instead. I'm not sure about the implications and have to leave for today. 

Closes #9473
