### PR TITLE
Set order of LiquibaseDBLockProviderFactory to 1

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/connections/jpa/updater/liquibase/lock/LiquibaseDBLockProviderFactory.java
+++ b/model/jpa/src/main/java/org/keycloak/connections/jpa/updater/liquibase/lock/LiquibaseDBLockProviderFactory.java
@@ -30,6 +30,7 @@ import org.keycloak.models.dblock.DBLockProviderFactory;
 public class LiquibaseDBLockProviderFactory implements DBLockProviderFactory {
 
     private static final Logger logger = Logger.getLogger(LiquibaseDBLockProviderFactory.class);
+    public static final int PROVIDER_PRIORITY = 1;
 
     private long lockWaitTimeoutMillis;
 
@@ -67,5 +68,10 @@ public class LiquibaseDBLockProviderFactory implements DBLockProviderFactory {
     @Override
     public String getId() {
         return "jpa";
+    }
+
+    @Override
+    public int order() {
+        return PROVIDER_PRIORITY;
     }
 }


### PR DESCRIPTION
- makes it the default provider when no provider is explicitly configured
- avoid NPE at server startup when other providers are present and none is set as default

#Closes #9479

With this fix, the Keycloak server is able to start without throwing a `NPE` when the `MAP_STORAGE` feature is enabled. To test, simply start keycloak with the `-Dkeycloak.profile.feature.map_storage=enabled` flag.
<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
