### PR TITLE
Fix TimeUnit function and TimeUnit2 function

### DIFF
--- a/themes/src/main/resources/theme/base/admin/resources/js/services.js
+++ b/themes/src/main/resources/theme/base/admin/resources/js/services.js
@@ -1589,15 +1589,15 @@ module.factory('TimeUnit', function() {
         if (time % 60 == 0) {
             unit = 'Minutes';
             time  = time / 60;
+            if (time % 60 == 0) {
+                unit = 'Hours';
+                time = time / 60;
+                if (time % 24 == 0) {
+                    unit = 'Days';
+                }
+            }
         }
-        if (time % 60 == 0) {
-            unit = 'Hours';
-            time = time / 60;
-        }
-        if (time % 24 == 0) {
-            unit = 'Days'
-            time = time / 24;
-        }
+
         return unit;
     }
 
@@ -1642,14 +1642,14 @@ module.factory('TimeUnit2', function() {
                 if (time % 60 == 0) {
                     unit = 'Minutes';
                     time = time / 60;
-                }
-                if (time % 60 == 0) {
-                    unit = 'Hours';
-                    time = time / 60;
-                }
-                if (time % 24 == 0) {
-                    unit = 'Days'
-                    time = time / 24;
+                    if (time % 60 == 0) {
+                        unit = 'Hours';
+                        time = time / 60;
+                        if (time % 24 == 0) {
+                            unit = 'Days';
+                            time = time / 24;
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
Closes #9488

I fixed the following behavior.
- When we set multiple of 24 to timeout of minutes, the admin console converts it and displays the timeout of days.

The TimeUnit2 function is for almost all timeouts, and the TimeUnit function is for example for brute force protection.