### PR TITLE
Fixes outdated Readme

### DIFF
--- a/distribution/server-x-dist/src/main/README.md
+++ b/distribution/server-x-dist/src/main/README.md
@@ -1,13 +1,25 @@
 Keycloak.X
 ==========
 
-To run on Linux/Unix:
+To get help configuring Keycloak via the CLI, run:
+
+on Linux/Unix:
 
     $ bin/kc.sh
 
-To run on Windows:
+on Windows:
 
     $ bin\kc.bat
+
+To try Keycloak out in development mode, run: 
+
+on Linux/Unix:
+
+    $ bin/kc.sh start-dev
+
+on Windows:
+
+    $ bin\kc.bat start-dev
 
 After the server boots, open http://localhost:8080 in your web browser. The welcome page will indicate that the server is running.
 

--- a/distribution/server-x-dist/src/main/content/providers/README.md
+++ b/distribution/server-x-dist/src/main/content/providers/README.md
@@ -1,10 +1,10 @@
 Installing Custom Providers
 ===========================
 
-You should add to this directory your custom provider JAR files.
+Add your custom provider JAR files in this directory.
 
-Once you have your providers in this directory you should run the following command to complete the installation:
+Once you have your providers in this directory, run the following command to complete the installation:
 
 ```
-${kc.home.dir}/bin/kc.sh config
+${kc.home.dir}/bin/kc.sh build
 ```

--- a/distribution/server-x-dist/src/main/content/themes/README.md
+++ b/distribution/server-x-dist/src/main/content/themes/README.md
@@ -4,10 +4,10 @@ Creating Themes
 Themes are used to configure the look and feel of login pages and the account management console.
 
 Custom themes packaged in a JAR file should be deployed to the `${kc.home.dir}/providers` directory and you should run
-the `config` command to install them prior to running the server.
+the `build` command to install them prior to running the server.
 
-You should also be able to create your custom themes in this directory, directly. Themes within this directory do not require
-the `config` command to install them.
+You are also able to create your custom themes in this directory, directly. Themes within this directory do not require
+the `build` command to install them.
 
 When running the server in development mode, themes are not cached so that you can easily work on them without any need to restart
 the server when making changes.


### PR DESCRIPTION
also changes the general and themes readme, bc invoking the shell-script without arguments leads to help now instead of starting and `config`is now `build`

Closes #9501
