### PR TITLE
Closes #9562: Add DB index for UserEntity getRealmUserByServiceAccount

### DIFF
--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-17.0.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-17.0.0.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  ~ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+  ~ * and other contributors as indicated by the @author tags.
+  ~ *
+  ~ * Licensed under the Apache License, Version 2.0 (the "License");
+  ~ * you may not use this file except in compliance with the License.
+  ~ * You may obtain a copy of the License at
+  ~ *
+  ~ * http://www.apache.org/licenses/LICENSE-2.0
+  ~ *
+  ~ * Unless required by applicable law or agreed to in writing, software
+  ~ * distributed under the License is distributed on an "AS IS" BASIS,
+  ~ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ * See the License for the specific language governing permissions and
+  ~ * limitations under the License.
+  -->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet author="keycloak" id="17.0.0-9562">
+        <createIndex indexName="IDX_USER_SERVICE_ACCOUNT" tableName="USER_ENTITY">
+            <column name="REALM_ID" type="VARCHAR(255)"/>
+            <column name="SERVICE_ACCOUNT_CLIENT_LINK" type="VARCHAR(36)"/>
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-master.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-master.xml
@@ -71,5 +71,6 @@
     <include file="META-INF/jpa-changelog-13.0.0.xml"/>
     <include file="META-INF/jpa-changelog-14.0.0.xml"/>
     <include file="META-INF/jpa-changelog-15.0.0.xml"/>
+    <include file="META-INF/jpa-changelog-17.0.0.xml"/>
 
 </databaseChangeLog>


### PR DESCRIPTION
As described in #9562, the absence of this index can be rather painful on larger instances.