### PR TITLE
Closes #9577: Always remove service account when deleting client

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmCacheSession.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmCacheSession.java
@@ -594,12 +594,10 @@ public class RealmCacheSession implements CacheRealmProvider {
             roleRemovalInvalidations(role.getId(), role.getName(), client.getId());
         });
         
-        if (client.isServiceAccountsEnabled()) {
-            UserModel serviceAccount = session.users().getServiceAccount(client);
+        UserModel serviceAccount = session.users().getServiceAccount(client);
 
-            if (serviceAccount != null) {
-                session.users().removeUser(realm, serviceAccount);
-            }
+        if (serviceAccount != null) {
+            session.users().removeUser(realm, serviceAccount);
         }
 
         return getClientDelegate().removeClient(realm, id);


### PR DESCRIPTION
Prior to this commit, the service account was removed only when the client was configured with a service account _and_ having `isServiceAccountsEnabled() == true`.

Fixes: #9577