### PR TITLE
Exclude some folders from our SAST analysis

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,6 +11,9 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [master]
+    paths-ignore:
+      - 'testsuite/**'
+      - 'examples/**'    
   schedule:
     - cron: '0 9 * * 2'
 


### PR DESCRIPTION
Currently, the CodeQL scanner has been analyzing the whole
codebase,including folders like testsuite, or examples. Those folders
are not relevant from the security standpoint, considering that they do
not expose our users and customers to any risks. They are only relevant
in the context of our pipelines, but never used in production.

Closes #9631

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
