### PR TITLE
Fix embedded theme-resources lookup in Keycloak.X

### DIFF
--- a/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
+++ b/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
@@ -421,7 +421,14 @@ class KeycloakProcessor {
             Map<String, ProviderFactory> preConfiguredProviders) {
         Config.init(new MicroProfileConfigProvider());
         ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-        ProviderManager pm = new ProviderManager(KeycloakDeploymentInfo.create().services(), classLoader);
+
+        KeycloakDeploymentInfo keycloakDeploymentInfo = KeycloakDeploymentInfo.create()
+                .name("classpath")
+                .services()
+                // .themes() // handling of .jar based themes is already supported by Keycloak.x
+                .themeResources();
+
+        ProviderManager pm = new ProviderManager(keycloakDeploymentInfo, classLoader);
         Map<Spi, Map<Class<? extends Provider>, Map<String, ProviderFactory>>> factories = new HashMap<>();
 
         for (Spi spi : pm.loadSpis()) {

--- a/server-spi-private/src/main/java/org/keycloak/provider/KeycloakDeploymentInfo.java
+++ b/server-spi-private/src/main/java/org/keycloak/provider/KeycloakDeploymentInfo.java
@@ -37,6 +37,10 @@ public class KeycloakDeploymentInfo {
         return name;
     }
 
+    /**
+     * Enables discovery of services via {@link java.util.ServiceLoader}.
+     * @return
+     */
     public KeycloakDeploymentInfo services() {
         this.services = true;
         return this;
@@ -46,6 +50,10 @@ public class KeycloakDeploymentInfo {
         return themes;
     }
 
+    /**
+     * Enables discovery embedded themes.
+     * @return
+     */
     public KeycloakDeploymentInfo themes() {
         this.themes = true;
         return this;
@@ -55,6 +63,10 @@ public class KeycloakDeploymentInfo {
         return themeResources;
     }
 
+    /**
+     * Enables discovery of embedded theme-resources.
+     * @return
+     */
     public KeycloakDeploymentInfo themeResources() {
         themeResources = true;
         return this;

--- a/services/src/main/java/org/keycloak/theme/ClasspathThemeResourceProviderFactory.java
+++ b/services/src/main/java/org/keycloak/theme/ClasspathThemeResourceProviderFactory.java
@@ -22,6 +22,10 @@ public class ClasspathThemeResourceProviderFactory implements ThemeResourceProvi
     private final String id;
     private final ClassLoader classLoader;
 
+    public ClasspathThemeResourceProviderFactory() {
+        this("classpath", Thread.currentThread().getContextClassLoader());
+    }
+
     public ClasspathThemeResourceProviderFactory(String id, ClassLoader classLoader) {
         this.id = id;
         this.classLoader = classLoader;


### PR DESCRIPTION
Previously lookups for embedded theme-resources did not work for Keycloak.X because of a missing
`ClasspathThemeResourceProvider` registration.

This PR ensures that a `ClasspathThemeResourceProvider` will be registered in Keycloak.X based deployments.

Fixes #9653

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
