### PR TITLE
Hide Hasicorp Vault from CLI

### DIFF
--- a/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
+++ b/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
@@ -127,6 +127,7 @@ import org.keycloak.url.DefaultHostnameProviderFactory;
 import org.keycloak.url.FixedHostnameProviderFactory;
 import org.keycloak.url.RequestHostnameProviderFactory;
 import org.keycloak.util.JsonSerialization;
+import org.keycloak.vault.FilesPlainTextVaultProviderFactory;
 
 class KeycloakProcessor {
 
@@ -146,7 +147,8 @@ class KeycloakProcessor {
             LiquibaseJpaUpdaterProviderFactory.class,
             DefaultHostnameProviderFactory.class,
             FixedHostnameProviderFactory.class,
-            RequestHostnameProviderFactory.class);
+            RequestHostnameProviderFactory.class,
+            FilesPlainTextVaultProviderFactory.class);
 
     static {
         DEPLOYEABLE_SCRIPT_PROVIDERS.put(AUTHENTICATORS, KeycloakProcessor::registerScriptAuthenticator);

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/VaultPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/VaultPropertyMappers.java
@@ -8,26 +8,44 @@ final class VaultPropertyMappers {
     public static PropertyMapper[] getVaultPropertyMappers() {
         return new PropertyMapper[] {
                 builder()
-                        .from("vault-file-path")
-                        .to("kc.spi-vault-files-plaintext-dir")
-                        .description("If set, secrets can be obtained by reading the content of files within the given path.")
+                        .from("vault")
+                        .description("Enables a vault provider.")
+                        .expectedValues("file", "hashicorp")
+                        .paramLabel("provider")
+                        .isBuildTimeProperty(true)
+                        .build(),
+                builder()
+                        .from("vault-dir")
+                        .to("kc.spi-vault-file-dir")
+                        .description("If set, secrets can be obtained by reading the content of files within the given directory.")
                         .paramLabel("dir")
                         .build(),
                 builder()
-                        .from("vault-hashicorp-")
+                        .from("vault-")
                         .to("quarkus.vault.")
-                        .description("If set, secrets can be obtained from Hashicorp Vault.")
+                        .description("Maps any vault option to their corresponding properties in quarkus-vault extension.")
+                        .hidden(true)
+                        .isBuildTimeProperty(true)
                         .build(),
                 builder()
-                        .from("vault-hashicorp-paths")
-                        .to("kc.spi-vault-hashicorp-paths")
-                        .description("A set of one or more paths that should be used when looking up secrets.")
+                        .from("vault-url")
+                        .to("quarkus.vault.url")
+                        .description("The vault server url.")
                         .paramLabel("paths")
+                        .hidden(true)
+                        .isBuildTimeProperty(true)
+                        .build(),
+                builder()
+                        .from("vault-kv-paths")
+                        .to("kc.spi-vault-hashicorp-paths")
+                        .description("A set of one or more key/value paths that should be used when looking up secrets.")
+                        .paramLabel("paths")
+                        .hidden(true)
                         .build()
         };
     }
 
     private static PropertyMapper.Builder builder() {
-        return PropertyMapper.builder(ConfigCategory.VAULT).isBuildTimeProperty(true);
+        return PropertyMapper.builder(ConfigCategory.VAULT);
     }
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/vault/FilesPlainTextVaultProviderFactory.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/vault/FilesPlainTextVaultProviderFactory.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.quarkus.runtime.vault;
+
+import org.keycloak.Config;
+import org.keycloak.provider.EnvironmentDependentProviderFactory;
+import org.keycloak.quarkus.runtime.configuration.Configuration;
+
+public class FilesPlainTextVaultProviderFactory extends org.keycloak.vault.FilesPlainTextVaultProviderFactory
+    implements EnvironmentDependentProviderFactory {
+
+    public static final String ID = "file";
+
+    @Override
+    public String getId() {
+        return ID;
+    }
+
+    @Override
+    public boolean isSupported() {
+        return false;
+    }
+
+    @Override
+    public boolean isSupported(Config.Scope config) {
+        return getId().equals(Configuration.getRawValue("kc.vault"));
+    }
+}

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/vault/QuarkusVaultProviderFactory.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/vault/QuarkusVaultProviderFactory.java
@@ -21,6 +21,7 @@ import org.keycloak.Config;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.provider.EnvironmentDependentProviderFactory;
+import org.keycloak.quarkus.runtime.configuration.Configuration;
 import org.keycloak.vault.AbstractVaultProviderFactory;
 import org.keycloak.vault.VaultProvider;
 
@@ -77,7 +78,7 @@ public class QuarkusVaultProviderFactory extends AbstractVaultProviderFactory im
 
     @Override
     public boolean isSupported(Config.Scope config) {
-        return !config.getPropertyNames().isEmpty();
+        return getId().equals(Configuration.getRawValue("kc.vault"));
     }
 
     @Override

--- a/quarkus/runtime/src/main/resources/META-INF/services/org.keycloak.vault.VaultProviderFactory
+++ b/quarkus/runtime/src/main/resources/META-INF/services/org.keycloak.vault.VaultProviderFactory
@@ -1,1 +1,2 @@
+org.keycloak.quarkus.runtime.vault.FilesPlainTextVaultProviderFactory
 org.keycloak.quarkus.runtime.vault.QuarkusVaultProviderFactory

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/ConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/ConfigurationTest.java
@@ -23,7 +23,6 @@ import static org.keycloak.quarkus.runtime.configuration.ConfigArgsConfigSource.
 
 import java.io.File;
 import java.lang.reflect.Field;
-import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -45,7 +44,7 @@ import org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider;
 import io.quarkus.runtime.configuration.ConfigUtils;
 import io.smallrye.config.SmallRyeConfigProviderResolver;
 import org.keycloak.quarkus.runtime.Environment;
-import org.keycloak.vault.FilesPlainTextVaultProviderFactory;
+import org.keycloak.quarkus.runtime.vault.FilesPlainTextVaultProviderFactory;
 import org.mariadb.jdbc.MySQLDataSource;
 import org.postgresql.xa.PGXADataSource;
 
@@ -124,11 +123,11 @@ public class ConfigurationTest {
 
     @Test
     public void testEnvVarAvailableFromPropertyNames() {
-        putEnvVar("KC_VAULT_FILE_PATH", "/foo/bar");
-        Config.Scope config = initConfig("vault", FilesPlainTextVaultProviderFactory.PROVIDER_ID);
+        putEnvVar("KC_VAULT_DIR", "/foo/bar");
+        Config.Scope config = initConfig("vault", FilesPlainTextVaultProviderFactory.ID);
         assertEquals("/foo/bar", config.get("dir"));
         assertTrue(config.getPropertyNames()
-                .contains("kc.spi-vault-".concat(FilesPlainTextVaultProviderFactory.PROVIDER_ID).concat("-dir")));
+                .contains("kc.spi-vault-".concat(FilesPlainTextVaultProviderFactory.ID).concat("-dir")));
     }
 
     @Test
@@ -197,8 +196,8 @@ public class ConfigurationTest {
         assertEquals(1, config.getPropertyNames().size());
         assertEquals("http://c.jwk.url", config.get("static-jwk-url"));
 
-        System.setProperty(CLI_ARGS, "--vault-file-path=secrets");
-        config = initConfig("vault", FilesPlainTextVaultProviderFactory.PROVIDER_ID);
+        System.setProperty(CLI_ARGS, "--vault-dir=secrets");
+        config = initConfig("vault", FilesPlainTextVaultProviderFactory.ID);
         assertEquals(1, config.getPropertyNames().size());
         assertEquals("secrets", config.get("dir"));
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testBuildHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testBuildHelp.approved.txt
@@ -94,11 +94,7 @@ Metrics:
 
 Vault:
 
---vault-file-path <dir>
-                     If set, secrets can be obtained by reading the content of files within the
-                       given path.
---vault-hashicorp-paths <paths>
-                     A set of one or more paths that should be used when looking up secrets.
+--vault <provider>   Enables a vault provider.
 
 Examples:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartDevHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartDevHelp.approved.txt
@@ -95,6 +95,11 @@ Proxy:
 --proxy <mode>       The proxy address forwarding mode if the server is behind a reverse proxy.
                        Possible values are: none,edge,reencrypt,passthrough Default: none.
 
+Vault:
+
+--vault-dir <dir>    If set, secrets can be obtained by reading the content of files within the
+                       given directory.
+
 Do NOT start the server using this command when deploying to production.
 
 Use 'kc.sh start-dev --help-all' to list all available options, including build

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartDevHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartDevHelpAll.approved.txt
@@ -161,11 +161,9 @@ Proxy:
 
 Vault:
 
---vault-file-path <dir>
-                     If set, secrets can be obtained by reading the content of files within the
-                       given path.
---vault-hashicorp-paths <paths>
-                     A set of one or more paths that should be used when looking up secrets.
+--vault <provider>   Enables a vault provider.
+--vault-dir <dir>    If set, secrets can be obtained by reading the content of files within the
+                       given directory.
 
 Do NOT start the server using this command when deploying to production.
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartHelp.approved.txt
@@ -98,6 +98,11 @@ Proxy:
 --proxy <mode>       The proxy address forwarding mode if the server is behind a reverse proxy.
                        Possible values are: none,edge,reencrypt,passthrough Default: none.
 
+Vault:
+
+--vault-dir <dir>    If set, secrets can be obtained by reading the content of files within the
+                       given directory.
+
 You may use the "--auto-build" option when starting the server to avoid running
 the "build" command everytime you need to change a static property:
 

--- a/testsuite/integration-arquillian/servers/auth-server/quarkus/src/main/content/conf/keycloak.conf
+++ b/testsuite/integration-arquillian/servers/auth-server/quarkus/src/main/content/conf/keycloak.conf
@@ -45,4 +45,5 @@ spi-events-store-jpa-max-detail-length=2000
 spi-login-protocol-saml-known-protocols=http=8180,https=8543
 
 # File-Based Vault
-vault-file-path=${kc.home.dir}secrets
+vault=file
+vault-dir=${kc.home.dir}secrets


### PR DESCRIPTION
Closes #9688

* Hides hashicorp related options
* Introduces a `vault` option to choose between vault providers
* Rename some options for better naming
* Review of vault options to make sure they are in the right scope (runtime/build)

I'm not doing it now but once we add support for extensions we can have a more generic way of enabling them.