### PR TITLE
Use tools icon instead of lock for build options on all-config guide

### DIFF
--- a/docs/guides/src/main/server/all-config.adoc
+++ b/docs/guides/src/main/server/all-config.adoc
@@ -3,8 +3,7 @@
 
 <@template.guide
 title="All configuration"
-summary="All the configuration you will ever need and want">
-
+summary="Complete list of all build options and configuration for Keycloak">
 
 <#list ctx.options.categories as category>
 <#assign categoryOptions=ctx.options.getValues(category)>

--- a/docs/guides/src/main/templates/options.adoc
+++ b/docs/guides/src/main/templates/options.adoc
@@ -25,7 +25,7 @@
 
 |<#if option.defaultValue?has_content>[.options-default]#${option.defaultValue!}#</#if>
 
-|<#if option.build>icon:lock[role=options-build]</#if>
+|<#if option.build>icon:tools[role=options-build]</#if>
 </#list>
 
 |===


### PR DESCRIPTION
Lock icon gives the impression that it's locked (not changeable), while the tools icon more implies that it's building something, so should be a better icon for "build option".