### PR TITLE
KEYCLOAK-11733 Add endpoint to get parents of a role

### DIFF
--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/RoleResource.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/RoleResource.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.admin.client.resource;
 
+import org.jboss.resteasy.annotations.cache.NoCache;
 import org.keycloak.representations.idm.GroupRepresentation;
 import org.keycloak.representations.idm.ManagementPermissionReference;
 import org.keycloak.representations.idm.ManagementPermissionRepresentation;
@@ -25,6 +26,7 @@ import org.keycloak.representations.idm.UserRepresentation;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
@@ -90,6 +92,16 @@ public interface RoleResource {
     @Path("composites/clients/{clientUuid}")
     @Produces(MediaType.APPLICATION_JSON)
     Set<RoleRepresentation> getClientRoleComposites(@PathParam("clientUuid") String clientUuid);
+    
+    @GET
+    @Path("parents")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Set<RoleRepresentation> getParentsRoles();
+    
+    @GET
+    @Path("parents")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Set<RoleRepresentation> getParentsRoles(@QueryParam("briefRepresentation") @DefaultValue("true") boolean briefRepresentation);
 
     @POST
     @Path("composites")

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmCacheSession.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmCacheSession.java
@@ -251,13 +251,24 @@ public class RealmCacheSession implements CacheRealmProvider {
         }
     }
 
-
+    private void invalidateRoleAndComposite(String id) {
+        invalidations.add(id);
+        RoleAdapter adapter = managedRoles.get(id);
+        
+        if (adapter != null) {
+            adapter.invalidate();
+            adapter.invalidateComposites();
+        }
+    }
 
 
     private void invalidateRole(String id) {
         invalidations.add(id);
         RoleAdapter adapter = managedRoles.get(id);
-        if (adapter != null) adapter.invalidate();
+        
+        if (adapter != null) {
+            adapter.invalidate();
+        }
     }
 
     private void addedRole(String roleId, String roleContainerId) {
@@ -801,7 +812,7 @@ public class RealmCacheSession implements CacheRealmProvider {
     public boolean removeRole(RoleModel role) {
         listInvalidations.add(role.getContainer().getId());
 
-        invalidateRole(role.getId());
+        invalidateRoleAndComposite(role.getId());
         invalidationEvents.add(RoleRemovedEvent.create(role.getId(), role.getName(), role.getContainer().getId()));
         roleRemovalInvalidations(role.getId(), role.getName(), role.getContainer().getId());
 

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/entities/CachedRole.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/entities/CachedRole.java
@@ -38,7 +38,8 @@ public class CachedRole extends AbstractRevisioned implements InRealm {
     final protected String realm;
     final protected String description;
     final protected boolean composite;
-    final protected Set<String> composites = new HashSet<>();
+    final protected Set<String> composites = new HashSet<String>();
+    final protected Set<String> parents = new HashSet<String>();
     private final LazyLoader<RoleModel, MultivaluedHashMap<String, String>> attributes;
 
     public CachedRole(Long revision, RoleModel model, RealmModel realm) {
@@ -50,6 +51,10 @@ public class CachedRole extends AbstractRevisioned implements InRealm {
         if (composite) {
             composites.addAll(model.getCompositesStream().map(RoleModel::getId).collect(Collectors.toSet()));
         }
+        
+        parents.addAll(model.getParentsStream().map(RoleModel::getId).collect(Collectors.toSet()));
+
+        
         attributes = new DefaultLazyLoader<>(roleModel -> new MultivaluedHashMap<>(roleModel.getAttributes()), MultivaluedHashMap::new);
     }
 
@@ -71,6 +76,10 @@ public class CachedRole extends AbstractRevisioned implements InRealm {
 
     public Set<String> getComposites() {
         return composites;
+    }
+    
+    public Set<String> getParents() {
+        return parents;
     }
 
     public MultivaluedHashMap<String, String> getAttributes(Supplier<RoleModel> roleModel) {

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/RoleAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/RoleAdapter.java
@@ -17,16 +17,6 @@
 
 package org.keycloak.models.jpa;
 
-import org.keycloak.models.KeycloakSession;
-import org.keycloak.models.RealmModel;
-import org.keycloak.models.RoleContainerModel;
-import org.keycloak.models.RoleModel;
-import org.keycloak.models.jpa.entities.RoleAttributeEntity;
-import org.keycloak.models.jpa.entities.RoleEntity;
-import org.keycloak.models.utils.KeycloakModelUtils;
-
-import javax.persistence.EntityManager;
-import javax.persistence.Query;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -35,6 +25,17 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Stream;
+
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
+
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.RoleContainerModel;
+import org.keycloak.models.RoleModel;
+import org.keycloak.models.jpa.entities.RoleAttributeEntity;
+import org.keycloak.models.jpa.entities.RoleEntity;
+import org.keycloak.models.utils.KeycloakModelUtils;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -118,6 +119,21 @@ public class RoleAdapter implements RoleModel, JpaModel<RoleEntity> {
         return session.roles().getRolesStream(realm,
                 getEntity().getCompositeRoles().stream().map(RoleEntity::getId),
                 search, first, max);
+    }
+    
+    @Override
+    public void addParentRole(RoleModel role) {
+        RoleEntity entity = toRoleEntity(role);
+        for (RoleEntity parent : getEntity().getParentRoles()) {
+            if (parent.equals(entity)) return;
+        }
+        getEntity().getParentRoles().add(entity);
+    }
+    
+    @Override
+    public Stream<RoleModel> getParentsStream() {
+        Stream<RoleModel> composites = getEntity().getParentRoles().stream().map(c -> new RoleAdapter(session, realm, em, c));
+        return composites.filter(Objects::nonNull);
     }
 
     @Override

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/RoleEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/RoleEntity.java
@@ -96,7 +96,10 @@ public class RoleEntity {
 
     @ManyToMany(fetch = FetchType.LAZY, cascade = {})
     @JoinTable(name = "COMPOSITE_ROLE", joinColumns = @JoinColumn(name = "COMPOSITE"), inverseJoinColumns = @JoinColumn(name = "CHILD_ROLE"))
-    private Set<RoleEntity> compositeRoles;
+    private Set<RoleEntity> compositeRoles = new HashSet<>();
+    
+    @ManyToMany(fetch = FetchType.LAZY, cascade = {}, mappedBy = "compositeRoles")
+    private Set<RoleEntity> parentRoles = new HashSet<>();
 
     @OneToMany(cascade = CascadeType.REMOVE, orphanRemoval = true, mappedBy="role")
     @Fetch(FetchMode.SELECT)
@@ -156,6 +159,14 @@ public class RoleEntity {
 
     public void setCompositeRoles(Set<RoleEntity> compositeRoles) {
         this.compositeRoles = compositeRoles;
+    }
+    
+    public Set<RoleEntity> getParentRoles() {
+        return parentRoles;
+    }
+
+    public void setParentRoles(Set<RoleEntity> parentRoles) {
+        this.parentRoles = parentRoles;
     }
 
     public boolean isClientRole() {

--- a/model/map-hot-rod/src/main/java/org/keycloak/models/map/storage/hotRod/role/HotRodRoleEntity.java
+++ b/model/map-hot-rod/src/main/java/org/keycloak/models/map/storage/hotRod/role/HotRodRoleEntity.java
@@ -124,9 +124,14 @@ public class HotRodRoleEntity extends AbstractHotRodEntity {
     @Basic(sortable = true)
     @ProtoField(number = 8)
     public Set<String> compositeRoles;
-
+    
     @ProtoField(number = 9)
     public Set<HotRodAttributeEntityNonIndexed> attributes;
+    
+    @Basic(sortable = true)
+    @ProtoField(number = 10)
+    public Set<String> parentRoles;
+
 
     @Override
     public boolean equals(Object o) {

--- a/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/role/delegate/JpaMapRoleEntityDelegate.java
+++ b/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/role/delegate/JpaMapRoleEntityDelegate.java
@@ -24,8 +24,12 @@ import org.keycloak.models.map.storage.jpa.role.entity.JpaRoleCompositeEntityKey
 import org.keycloak.models.map.storage.jpa.role.entity.JpaRoleEntity;
 
 import javax.persistence.EntityManager;
+import javax.persistence.FetchType;
+import javax.persistence.ManyToMany;
 import javax.persistence.Query;
 import javax.persistence.TypedQuery;
+
+import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -44,6 +48,7 @@ public class JpaMapRoleEntityDelegate extends MapRoleEntityDelegate {
     private final JpaRoleEntity original;
 
     private Set<String> compositeRoles;
+    private Set<String> parentRoles;
 
     @Override
     public void setId(String id) {
@@ -112,6 +117,24 @@ public class JpaMapRoleEntityDelegate extends MapRoleEntityDelegate {
         if (compositeRoles != null) {
             compositeRoles.remove(roleId);
         }
+    }
+    
+    @Override
+    public Set<String> getParentRoles() {
+        return new HashSet<String>();
+    }
+
+    @Override
+    public void setParentRoles(Set<String> parentRoles) {
+    }
+
+    @Override
+    public void addParentRole(String roleId) {
+    }
+
+    @Override
+    public void removeParentRole(String roleId) {
+        
     }
 
 }

--- a/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/role/entity/JpaRoleEntity.java
+++ b/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/role/entity/JpaRoleEntity.java
@@ -278,4 +278,24 @@ public class JpaRoleEntity extends AbstractRoleEntity implements JpaRootVersione
         return Objects.equals(getId(), ((JpaRoleEntity) obj).getId());
     }
 
+    @Override
+    public Set<String> getParentRoles() {
+        return metadata.getParentRoles();
+    }
+
+    @Override
+    public void setParentRoles(Set<String> parentRoles) {
+        metadata.setParentRoles(parentRoles);
+    }
+
+    @Override
+    public void addParentRole(String roleId) {
+        metadata.addParentRole(roleId);
+    }
+
+    @Override
+    public void removeParentRole(String roleId) {
+        metadata.removeParentRole(roleId);
+    }
+
 }

--- a/model/map/src/main/java/org/keycloak/models/map/role/MapRoleAdapter.java
+++ b/model/map/src/main/java/org/keycloak/models/map/role/MapRoleAdapter.java
@@ -96,6 +96,22 @@ public class MapRoleAdapter extends AbstractRoleModel<MapRoleEntity> implements 
         LOG.tracef("(%s).removeCompositeRole(%s(%s))%s", this, role.getName(), role.getId(), getShortStackTrace());
         entity.removeCompositeRole(role.getId());
     }
+    
+    @Override
+    public Stream<RoleModel> getParentsStream() {
+        Set<String> parentRoles = entity.getParentRoles() == null ? Collections.emptySet() : entity.getParentRoles();
+        LOG.tracef("%% %s(%s).getParentsStream():%d - %s", entity.getName(), entity.getId(), parentRoles.size(), getShortStackTrace());
+        return parentRoles.stream()
+                .map(uuid -> session.roles().getRoleById(realm, uuid))
+                .filter(Objects::nonNull);
+    }
+
+    @Override
+    public void addParentRole(RoleModel role) {
+        LOG.tracef("(%s).addParentRole(%s(%s))%s", this, role.getName(), role.getId(), getShortStackTrace());
+        entity.addParentRole(role.getId());
+        
+    }
 
     @Override
     public boolean isClientRole() {

--- a/model/map/src/main/java/org/keycloak/models/map/role/MapRoleEntity.java
+++ b/model/map/src/main/java/org/keycloak/models/map/role/MapRoleEntity.java
@@ -66,4 +66,9 @@ public interface MapRoleEntity extends AbstractEntity, UpdatableEntity, EntityWi
     void setCompositeRoles(Set<String> compositeRoles);
     void addCompositeRole(String roleId);
     void removeCompositeRole(String roleId);
+    
+    public Set<String> getParentRoles();
+    public void setParentRoles(Set<String> parentRoles);
+    public void addParentRole(String roleId);
+    public void removeParentRole(String roleId);
 }

--- a/server-spi/src/main/java/org/keycloak/models/RoleModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/RoleModel.java
@@ -117,4 +117,8 @@ public interface RoleModel {
     Stream<String> getAttributeStream(String name);
 
     Map<String, List<String>> getAttributes();
+
+    void addParentRole(RoleModel role);
+
+    Stream<RoleModel> getParentsStream();
 }

--- a/services/src/main/java/org/keycloak/services/resources/admin/RoleByIdResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RoleByIdResource.java
@@ -36,6 +36,7 @@ import org.keycloak.services.resources.admin.permissions.AdminPermissions;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
@@ -46,6 +47,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Stream;
 
 /**
@@ -244,6 +246,29 @@ public class RoleByIdResource extends RoleResource {
         RoleModel role = getRoleModel(id);
         auth.roles().requireManage(role);
         deleteComposites(adminEvent, session.getContext().getUri(), roles, role);
+    }
+    
+    /**
+     * Get parents of the roles, thoses which have the given role as composite
+     *
+     * @param id Role id
+     * @param briefRepresentation if false, return a full representation of the roles with their attributes
+     * @return parents of the roles
+     */
+    @Path("{role-id}/parents")
+    @GET
+    @NoCache
+    @Produces(MediaType.APPLICATION_JSON)
+    public Set<RoleRepresentation> getParentsRoles(final @PathParam("role-id") String id,
+                                                   final @QueryParam("briefRepresentation") @DefaultValue("true") boolean briefRepresentation) {
+        RoleModel role = getRoleModel(id);
+        auth.roles().requireManage(role);
+
+        if (role == null) {
+            throw new NotFoundException("Could not find role");
+        }
+        
+        return getParentsRoles(role, briefRepresentation);
     }
 
     /**

--- a/services/src/main/java/org/keycloak/services/resources/admin/RoleContainerResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RoleContainerResource.java
@@ -23,13 +23,12 @@ import org.keycloak.events.admin.OperationType;
 import org.keycloak.events.admin.ResourceType;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.Constants;
+import org.keycloak.models.GroupModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.ModelDuplicateException;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.RoleContainerModel;
 import org.keycloak.models.RoleModel;
-import org.keycloak.models.UserModel;
-import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.models.utils.ModelToRepresentation;
 import org.keycloak.models.utils.RoleUtils;
 import org.keycloak.representations.idm.GroupRepresentation;
@@ -61,7 +60,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.keycloak.services.ErrorResponseException;
 
@@ -321,7 +319,29 @@ public class RoleContainerResource extends RoleResource {
         }
         return role.getCompositesStream().map(ModelToRepresentation::toBriefRepresentation);
     }
-
+    
+    /**
+     * Get parents of the roles, thoses which have the given role as composite
+     *
+     * @param roleName role's name (not id!)
+     * @param briefRepresentation if false, return a full representation of the roles with their attributes
+     * @return parents of the roles
+     */
+    @Path("{role-name}/parents")
+    @GET
+    @NoCache
+    @Produces(MediaType.APPLICATION_JSON)
+    public Set<RoleRepresentation> getParentsRoles(final @PathParam("role-name") String roleName,
+                                                   final @QueryParam("briefRepresentation") @DefaultValue("true") boolean briefRepresentation) {
+        auth.roles().requireView(roleContainer);
+        RoleModel role = roleContainer.getRole(roleName);
+        if (role == null) {
+            throw new NotFoundException("Could not find role");
+        }
+        
+        return getParentsRoles(role, briefRepresentation);
+    }
+    
     /**
      * Get realm-level roles of the role's composite
      *
@@ -500,7 +520,8 @@ public class RoleContainerResource extends RoleResource {
             throw new NotFoundException("Could not find role");
         }
         
-        return session.groups().getGroupsByRoleStream(realm, role, firstResult, maxResults)
-                .map(g -> ModelToRepresentation.toRepresentation(g, !briefRepresentation));
+        Stream<GroupModel> groupsModel = session.groups().getGroupsByRoleStream(realm, role, firstResult, maxResults);
+
+        return groupsModel.map(g -> ModelToRepresentation.toRepresentation(g, !briefRepresentation));
     }   
 }

--- a/services/src/main/java/org/keycloak/services/resources/admin/RoleResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RoleResource.java
@@ -36,6 +36,9 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Stream;
 
+import java.util.Collections;
+import java.util.stream.Collectors;
+
 /**
  * @resource Roles
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -121,6 +124,7 @@ public abstract class RoleResource {
                 throw new NotFoundException("Could not find composite role");
             }
             auth.roles().requireMapComposite(composite);
+            composite.addParentRole(role);
             role.addCompositeRole(composite);
         }
 
@@ -161,5 +165,13 @@ public abstract class RoleResource {
         }
 
         adminEvent.operation(OperationType.DELETE).resourcePath(uriInfo).representation(roles).success();
+    }
+    
+    protected Set<RoleRepresentation> getParentsRoles(RoleModel role, boolean briefRepresentation) {
+        if(briefRepresentation) {
+            return role.getParentsStream().map(r-> ModelToRepresentation.toBriefRepresentation(r)).collect(Collectors.toSet());
+        }
+
+        return role.getParentsStream().map(r-> ModelToRepresentation.toRepresentation(r)).collect(Collectors.toSet());
     }
 }

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/federation/HardcodedRoleStorageProvider.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/federation/HardcodedRoleStorageProvider.java
@@ -187,6 +187,16 @@ public class HardcodedRoleStorageProvider implements RoleStorageProvider {
         public void removeAttribute(String name) {
             throw new ReadOnlyException("role is read only");
         }
+
+        @Override
+        public void addParentRole(RoleModel role) {
+            throw new ReadOnlyException("role is read only");
+        }
+
+        @Override
+        public Stream<RoleModel> getParentsStream() {
+            return Stream.empty();
+        }
     }
 
 


### PR DESCRIPTION
Following https://github.com/keycloak/keycloak/pull/6383 which was closed, I don't know how to reopen it ?

I rebased it on main

https://issues.jboss.org/browse/KEYCLOAK-11733

**Note**

 accordingly to changes on CompositesRoles I turned the getParentRoles into a stream. I did implement the new function in JpaRoleEntity.java because it was required by compiler but I'm not sure of what does theses `return metadata.getParentRoles();`  `JpaRoleMetadata extends MapRoleEntityImpl ` and I can't found any occurence of `MapRoleEntityImpl` it sound a bit magic to me
 
Last comment from @stianst one previous PR was `A simpler and perhaps better idea might be to just not cache the parent roles at all and just allow fetching/querying them from admin APIs.`

It's not done yet, I will try. If someone think he can do it quickly he can finish the request.

