### PR TITLE
Add a quarkus.properties for unsupported configuration options

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/Environment.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/Environment.java
@@ -31,6 +31,7 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import io.quarkus.bootstrap.runner.RunnerClassLoader;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.configuration.ProfileManager;
 import org.apache.commons.lang3.SystemUtils;
@@ -48,7 +49,11 @@ public final class Environment {
     private Environment() {}
 
     public static Boolean isRebuild() {
-        return Boolean.getBoolean("quarkus.launch.rebuild");
+        return !isRuntimeMode();
+    }
+
+    public static Boolean isRuntimeMode() {
+        return Thread.currentThread().getContextClassLoader() instanceof RunnerClassLoader;
     }
 
     public static String getHomeDir() {
@@ -186,5 +191,9 @@ public final class Environment {
 
     public static boolean isDistribution() {
         return getHomeDir() != null;
+    }
+
+    public static boolean isRebuildCheck() {
+        return Boolean.getBoolean("kc.config.rebuild-and-exit");
     }
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/Picocli.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/Picocli.java
@@ -78,7 +78,7 @@ public final class Picocli {
     public static void parseAndRun(List<String> cliArgs) {
         CommandLine cmd = createCommandLine(cliArgs);
 
-        if (Boolean.getBoolean("kc.config.rebuild-and-exit")) {
+        if (Environment.isRebuildCheck()) {
             runReAugmentationIfNeeded(cliArgs, cmd);
             Quarkus.asyncExit(cmd.getCommandSpec().exitCodeOnSuccess());
             return;

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/KeycloakConfigSourceProvider.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/KeycloakConfigSourceProvider.java
@@ -43,6 +43,9 @@ public class KeycloakConfigSourceProvider implements ConfigSourceProvider {
 
         CONFIG_SOURCES.add(new ConfigArgsConfigSource());
         CONFIG_SOURCES.add(new KcEnvConfigSource());
+
+        CONFIG_SOURCES.addAll(new QuarkusPropertiesConfigSource().getConfigSources(Thread.currentThread().getContextClassLoader()));
+
         CONFIG_SOURCES.add(PersistedConfigSource.getInstance());
 
         CONFIG_SOURCES.addAll(new KeycloakPropertiesConfigSource.InFileSystem().getConfigSources(Thread.currentThread().getContextClassLoader()));

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/PropertyMappingInterceptor.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/PropertyMappingInterceptor.java
@@ -16,10 +16,14 @@
  */
 package org.keycloak.quarkus.runtime.configuration;
 
+import static org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider.NS_QUARKUS;
+
+import io.quarkus.runtime.configuration.AbstractRawDefaultConfigSource;
 import io.smallrye.config.ConfigSourceInterceptor;
 import io.smallrye.config.ConfigSourceInterceptorContext;
 import io.smallrye.config.ConfigValue;
 import org.keycloak.common.util.StringPropertyReplacer;
+import org.keycloak.quarkus.runtime.Environment;
 import org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper;
 import org.keycloak.quarkus.runtime.configuration.mappers.PropertyMappers;
 
@@ -35,12 +39,19 @@ import org.keycloak.quarkus.runtime.configuration.mappers.PropertyMappers;
  */
 public class PropertyMappingInterceptor implements ConfigSourceInterceptor {
 
+    private final boolean isQuarkusPropertiesEnabled = QuarkusPropertiesConfigSource.isQuarkusPropertiesEnabled();
+
     @Override
     public ConfigValue getValue(ConfigSourceInterceptorContext context, String name) {
         ConfigValue value = PropertyMappers.getValue(context, name);
         
         if (value == null || value.getValue() == null) {
             return null;
+        }
+
+        if (isPersistedOnlyProperty(value)) {
+            // quarkus properties values always resolved from persisted config source
+            return value.withValue(PersistedConfigSource.getInstance().getValue(name));
         }
 
         if (value.getValue().indexOf("${") == -1) {
@@ -58,5 +69,20 @@ public class PropertyMappingInterceptor implements ConfigSourceInterceptor {
                             
                             return prop.getValue();
                         }));
+    }
+
+    private boolean isPersistedOnlyProperty(ConfigValue value) {
+        if (isQuarkusPropertiesEnabled && value.getName().startsWith(NS_QUARKUS)) {
+            String configSourceName = value.getConfigSourceName();
+
+            return Environment.isRuntimeMode()
+                    && configSourceName != null
+                    && !configSourceName.equals(PersistedConfigSource.NAME)
+                    && !configSourceName.equals(AbstractRawDefaultConfigSource.NAME)
+                    && !configSourceName.contains("Runtime Defaults")
+                    && !configSourceName.contains("application.properties");
+        }
+
+        return false;
     }
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/QuarkusPropertiesConfigSource.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/QuarkusPropertiesConfigSource.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.quarkus.runtime.configuration;
+
+import static java.lang.Boolean.parseBoolean;
+import static org.keycloak.quarkus.runtime.configuration.Configuration.getRawPersistedProperty;
+import static org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider.NS_QUARKUS;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URL;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.eclipse.microprofile.config.spi.ConfigSource;
+import org.eclipse.microprofile.config.spi.ConfigSourceProvider;
+import org.keycloak.quarkus.runtime.Environment;
+
+import io.smallrye.config.AbstractLocationConfigSourceLoader;
+import io.smallrye.config.ConfigValue;
+import io.smallrye.config.PropertiesConfigSource;
+import io.smallrye.config.common.utils.ConfigSourceUtil;
+
+/**
+ * A configuration source for {@code quarkus.properties}.
+ */
+public final class QuarkusPropertiesConfigSource extends AbstractLocationConfigSourceLoader implements ConfigSourceProvider {
+
+    private static final String NAME = "QuarkusProperties";
+    private static final String FILE_NAME = "quarkus.properties";
+    public static final String QUARKUS_PROPERTY_ENABLED = "kc.quarkus-properties-enabled";
+
+    public static boolean isSameSource(ConfigValue value) {
+        if (value == null) {
+            return false;
+        }
+
+        return NAME.equals(value.getConfigSourceName());
+    }
+
+    public static boolean isQuarkusPropertiesEnabled() {
+        return parseBoolean(getRawPersistedProperty(QUARKUS_PROPERTY_ENABLED).orElse(Boolean.FALSE.toString()));
+    }
+
+    public static Path getConfigurationFile() {
+        String homeDir = Environment.getHomeDir();
+
+        if (homeDir != null) {
+            File file = Paths.get(homeDir, "conf", FILE_NAME).toFile();
+
+            if (file.exists()) {
+                return file.toPath();
+            }
+        }
+
+        return null;
+    }
+
+    @Override
+    protected String[] getFileExtensions() {
+        return new String[] { "properties" };
+    }
+
+    @Override
+    protected ConfigSource loadConfigSource(URL url, int ordinal) throws IOException {
+        return new PropertiesConfigSource(ConfigSourceUtil.urlToMap(url), FILE_NAME, ordinal) {
+            @Override
+            public String getName() {
+                return NAME;
+            }
+
+            @Override
+            public String getValue(String propertyName) {
+                if (propertyName.startsWith(NS_QUARKUS)) {
+                    String value = super.getValue(propertyName);
+
+                    if (value == null) {
+                        return PersistedConfigSource.getInstance().getValue(propertyName);
+                    }
+
+                    return value;
+                }
+
+                return null;
+            }
+        };
+    }
+
+    @Override
+    public List<ConfigSource> getConfigSources(final ClassLoader classLoader) {
+        List<ConfigSource> configSources = new ArrayList<>();
+
+        configSources.addAll(loadConfigSources("META-INF/services/" + FILE_NAME, 450, classLoader));
+
+        if (Environment.isRebuild() || Environment.isRebuildCheck()) {
+            Path configFile = getConfigurationFile();
+
+            if (configFile != null) {
+                configSources.addAll(loadConfigSources(configFile.toUri().toString(), 500, classLoader));
+            }
+        }
+
+        return configSources;
+    }
+
+    @Override
+    protected List<ConfigSource> tryClassPath(URI uri, int ordinal, ClassLoader classLoader) {
+        try {
+            return super.tryClassPath(uri, ordinal, classLoader);
+        } catch (RuntimeException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof NoSuchFileException) {
+                // configuration step happens before classpath is updated, and it might happen that
+                // provider JARs are still in classpath index but removed from the providers dir
+                return Collections.emptyList();
+            }
+
+            throw e;
+        }
+    }
+}

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMappers.java
@@ -49,7 +49,7 @@ public final class PropertyMappers {
     }
 
     public static boolean isBuildTimeProperty(String name) {
-        if (isFeaturesBuildTimeProperty(name) || isSpiBuildTimeProperty(name)) {
+        if (isFeaturesBuildTimeProperty(name) || isSpiBuildTimeProperty(name) || name.startsWith(MicroProfileConfigProvider.NS_QUARKUS)) {
             return true;
         }
 
@@ -123,6 +123,9 @@ public final class PropertyMappers {
     }
 
     public static PropertyMapper getMapper(String property) {
+        if (property.startsWith("%")) {
+            return MAPPERS.get(property.substring(property.indexOf('.') + 1));
+        }
         return MAPPERS.get(property);
     }
 

--- a/quarkus/runtime/src/main/resources/META-INF/keycloak.conf
+++ b/quarkus/runtime/src/main/resources/META-INF/keycloak.conf
@@ -23,8 +23,3 @@ metrics-enabled=false
 %import_export.hostname-strict=false
 %import_export.hostname-strict-https=false
 %import_export.cluster=local
-
-# Logging configuration. INFO is the default level for most of the categories
-#quarkus.log.level = DEBUG
-quarkus.log.category."org.jboss.resteasy.resteasy_jaxrs.i18n".level=WARN
-quarkus.log.category."org.infinispan.transaction.lookup.JBossStandaloneJTAManagerLookup".level=WARN

--- a/quarkus/runtime/src/main/resources/META-INF/services/quarkus.properties
+++ b/quarkus/runtime/src/main/resources/META-INF/services/quarkus.properties
@@ -1,0 +1,23 @@
+#
+# Copyright 2021 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Default options that rely on Quarkus specific options and lacking proper support in Keycloak
+
+# Logging configuration. INFO is the default level for most of the categories
+quarkus.log.level = INFO
+quarkus.log.category."org.jboss.resteasy.resteasy_jaxrs.i18n".level=WARN
+quarkus.log.category."org.infinispan.transaction.lookup.JBossStandaloneJTAManagerLookup".level=WARN

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/ConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/ConfigurationTest.java
@@ -23,7 +23,6 @@ import static org.keycloak.quarkus.runtime.configuration.ConfigArgsConfigSource.
 
 import java.io.File;
 import java.lang.reflect.Field;
-import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -390,6 +389,15 @@ public class ConfigurationTest {
         System.setProperty(CLI_ARGS, "--db-password=my_secret=");
         SmallRyeConfig config = createConfig();
         assertEquals("my_secret=", config.getConfigValue("kc.db-password").getValue());
+    }
+
+    @Test
+    public void testResolvePropertyFromDefaultProfile() {
+        Environment.setProfile("import_export");
+        assertEquals("false", createConfig().getConfigValue("kc.hostname-strict").getValue());
+
+        Environment.setProfile("prod");
+        assertEquals("true", createConfig().getConfigValue("kc.hostname-strict").getValue());
     }
 
     private Config.Scope initConfig(String... scope) {

--- a/quarkus/runtime/src/test/resources/META-INF/keycloak.conf
+++ b/quarkus/runtime/src/test/resources/META-INF/keycloak.conf
@@ -1,15 +1,2 @@
 spi-hostname-default-frontend-url = ${keycloak.frontendUrl:http://filepropdefault.unittest}
 %user-profile.spi-hostname-default-frontend-url = http://filepropprofile.unittest
-
-# Default Non-Production Grade Datasource
-quarkus.datasource.db-kind=h2
-quarkus.hibernate-orm.dialect=org.hibernate.dialect.H2Dialect
-quarkus.datasource.jdbc.driver=org.h2.jdbcx.JdbcDataSource
-quarkus.datasource.jdbc.url = jdbc:h2:file:${kc.home.dir:~}/data/keycloakdb;;AUTO_SERVER=TRUE
-quarkus.datasource.username = sa
-quarkus.datasource.password = keycloak
-quarkus.datasource.jdbc.transactions=xa
-
-# For test nested properties
-quarkus.datasource.foo = jdbc:h2:file:${kc.home.dir:${kc.db.url.path:~}}/data/keycloakdb
-quarkus.datasource.bar = foo-${kc.prop3:${kc.prop4:${kc.prop5:def}-suffix}}

--- a/quarkus/runtime/src/test/resources/META-INF/services/quarkus.properties
+++ b/quarkus/runtime/src/test/resources/META-INF/services/quarkus.properties
@@ -1,0 +1,10 @@
+# Default options that rely on Quarkus specific options and lacking proper support in Keycloak
+
+# Logging configuration. INFO is the default level for most of the categories
+quarkus.log.level = INFO
+quarkus.log.category."org.jboss.resteasy.resteasy_jaxrs.i18n".level=WARN
+quarkus.log.category."org.infinispan.transaction.lookup.JBossStandaloneJTAManagerLookup".level=WARN
+
+# For test nested properties
+quarkus.datasource.foo = jdbc:h2:file:${kc.home.dir:${kc.db.url.path:~}}/data/keycloakdb
+quarkus.datasource.bar = foo-${kc.prop3:${kc.prop4:${kc.prop5:def}-suffix}}

--- a/quarkus/tests/integration/src/main/java/org/keycloak/it/junit5/extension/BeforeStartDistribution.java
+++ b/quarkus/tests/integration/src/main/java/org/keycloak/it/junit5/extension/BeforeStartDistribution.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.it.junit5.extension;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.function.Consumer;
+import org.keycloak.it.utils.KeycloakDistribution;
+
+/**
+ * {@link BeforeStartDistribution} is used to perform additional steps prior to starting the distribution.
+ */
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface BeforeStartDistribution {
+
+    Class<? extends Consumer<KeycloakDistribution>> value();
+
+}

--- a/quarkus/tests/integration/src/main/java/org/keycloak/it/junit5/extension/CLIResult.java
+++ b/quarkus/tests/integration/src/main/java/org/keycloak/it/junit5/extension/CLIResult.java
@@ -81,4 +81,20 @@ public interface CLIResult extends LaunchResult {
     default void assertBuild() {
         assertMessage("Server configuration updated and persisted");
     }
+
+    default void assertNoBuild() {
+        assertFalse(getOutput().contains("Server configuration updated and persisted"));
+    }
+
+    default boolean isClustered() {
+        return getOutput().contains("Starting JGroups channel `ISPN`");
+    }
+
+    default void assertLocalCache() {
+        assertFalse(isClustered());
+    }
+
+    default void assertClusteredCache() {
+        assertTrue(isClustered());
+    }
 }

--- a/quarkus/tests/integration/src/main/java/org/keycloak/it/junit5/extension/CLITestExtension.java
+++ b/quarkus/tests/integration/src/main/java/org/keycloak/it/junit5/extension/CLITestExtension.java
@@ -83,6 +83,10 @@ public class CLITestExtension extends QuarkusMainTestExtension {
                 if (dist == null) {
                     dist = createDistribution(distConfig);
                 }
+
+                onBeforeStartDistribution(context.getRequiredTestClass().getAnnotation(BeforeStartDistribution.class));
+                onBeforeStartDistribution(context.getRequiredTestMethod().getAnnotation(BeforeStartDistribution.class));
+
                 dist.start(Arrays.asList(launch.value()));
             }
         } else {
@@ -91,6 +95,16 @@ public class CLITestExtension extends QuarkusMainTestExtension {
             // WORKAROUND: this intercepts the output when actually starting the server.
             QuarkusConsole.installRedirects();
             super.beforeEach(context);
+        }
+    }
+
+    private void onBeforeStartDistribution(BeforeStartDistribution annotation) {
+        if (annotation != null) {
+            try {
+                annotation.value().getDeclaredConstructor().newInstance().accept(dist);
+            } catch (Exception cause) {
+                throw new RuntimeException("Error when invoking " + annotation.value() + " instance before starting distribution", cause);
+            }
         }
     }
 

--- a/quarkus/tests/integration/src/main/java/org/keycloak/it/junit5/extension/DistributionLifecycleManager.java
+++ b/quarkus/tests/integration/src/main/java/org/keycloak/it/junit5/extension/DistributionLifecycleManager.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.it.junit5.extension;
+
+import org.keycloak.it.utils.KeycloakDistribution;
+
+public interface DistributionLifecycleManager<D extends KeycloakDistribution> {
+
+    void beforeStart(D distribution);
+}

--- a/quarkus/tests/integration/src/main/java/org/keycloak/it/utils/KeycloakDistribution.java
+++ b/quarkus/tests/integration/src/main/java/org/keycloak/it/utils/KeycloakDistribution.java
@@ -38,4 +38,16 @@ public interface KeycloakDistribution {
 
         return commands.toArray(new String[0]);
     }
+
+    default void setQuarkusProperty(String key, String value) {
+        throw new RuntimeException("Not implemented");
+    }
+
+    default void setProperty(String key, String value) {
+        throw new RuntimeException("Not implemented");
+    }
+
+    default void deleteQuarkusProperties() {
+        throw new RuntimeException("Not implemented");
+    }
 }

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ClusterConfigDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ClusterConfigDistTest.java
@@ -35,7 +35,8 @@ public class ClusterConfigDistTest {
     @Test
     @Launch({ "start-dev", "--cache=ispn" })
     void changeClusterSetting(LaunchResult result) {
-        assertTrue(isClustered(result));
+        CLIResult cliResult = (CLIResult) result;
+        cliResult.assertClusteredCache();
     }
 
     @Test
@@ -61,7 +62,7 @@ public class ClusterConfigDistTest {
     void testExplicitCacheConfigFile(LaunchResult result) {
         CLIResult cliResult = (CLIResult) result;
         cliResult.assertStartedDevMode();
-        assertTrue(isClustered(cliResult));
+        cliResult.assertClusteredCache();
     }
 
     @Test
@@ -69,7 +70,7 @@ public class ClusterConfigDistTest {
     void testStartDefaultsToClustering(LaunchResult result) {
         CLIResult cliResult = (CLIResult) result;
         cliResult.assertStarted();
-        assertTrue(isClustered(result));
+        cliResult.assertClusteredCache();
     }
 
     @Test
@@ -77,10 +78,6 @@ public class ClusterConfigDistTest {
     void testStartDevDefaultsToLocalCaches(LaunchResult result) {
         CLIResult cliResult = (CLIResult) result;
         cliResult.assertStartedDevMode();
-        assertFalse(isClustered(result));
-    }
-
-    private boolean isClustered(LaunchResult result) {
-        return result.getOutput().contains("Starting JGroups channel `ISPN`");
+        cliResult.assertLocalCache();
     }
 }

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartAutoBuildDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartAutoBuildDistTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.it.cli.dist;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.keycloak.it.junit5.extension.CLIResult;
+import org.keycloak.it.junit5.extension.DistributionTest;
+import org.keycloak.it.junit5.extension.RawDistOnly;
+
+import io.quarkus.test.junit.main.Launch;
+import io.quarkus.test.junit.main.LaunchResult;
+
+@DistributionTest(reInstall = DistributionTest.ReInstall.NEVER)
+@RawDistOnly(reason = "Containers are immutable")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class StartAutoBuildDistTest {
+
+    @Test
+    @Launch({ "start", "--auto-build", "--http-enabled=true", "--hostname-strict=false", "--cache=local" })
+    @Order(1)
+    void testStartAutoBuild(LaunchResult result) {
+        CLIResult cliResult = (CLIResult) result;
+        cliResult.assertMessage("Changes detected in configuration. Updating the server image.");
+        cliResult.assertMessage("Updating the configuration and installing your custom providers, if any. Please wait.");
+        cliResult.assertMessage("Server configuration updated and persisted. Run the following command to review the configuration:");
+        cliResult.assertMessage("kc.sh show-config");
+        cliResult.assertMessage("Next time you run the server, just run:");
+        cliResult.assertMessage("kc.sh start --http-enabled=true --hostname-strict=false");
+        assertFalse(cliResult.getOutput().contains("--cache"));
+        cliResult.assertStarted();
+    }
+
+    @Test
+    @Launch({ "start", "--auto-build", "--http-enabled=true", "--hostname-strict=false", "--cache=local" })
+    @Order(2)
+    void testShouldNotReAugIfConfigIsSame(LaunchResult result) {
+        CLIResult cliResult = (CLIResult) result;
+        cliResult.assertNoBuild();
+        cliResult.assertStarted();
+    }
+
+    @Test
+    @Launch({ "start", "--auto-build", "--db=h2-mem", "--http-enabled=true", "--hostname-strict=false", "--cache=local" })
+    @Order(3)
+    void testShouldReAugIfConfigChanged(LaunchResult result) {
+        CLIResult cliResult = (CLIResult) result;
+        cliResult.assertBuild();
+        cliResult.assertStarted();
+    }
+
+    @Test
+    @Launch({ "start", "--auto-build", "--db=h2-mem", "--http-enabled=true", "--hostname-strict=false", "--cache=local" })
+    @Order(4)
+    void testShouldNotReAugIfSameDatabase(LaunchResult result) {
+        CLIResult cliResult = (CLIResult) result;
+        cliResult.assertNoBuild();
+        cliResult.assertStarted();
+    }
+}


### PR DESCRIPTION
Closes #9682

* Adding a new config source to load quarkus specific properties. This config source is only registered when augmenting the server (build + re-augmentation)
* Quarkus properties set when running `build` are persisted
* Ignore any quarkus property at runtime if not from quarkus defaults or from persisted config sources
* Make sure quarkus properties are only resolved from persisted config source
* Make sure quarkus properties can only be set at the new properties file