### PR TITLE
[fixes #9750] Make sure a Dynamic scope isn't assignable to a client as a default scope, and only show non-dynamic scopes in the available client scopes client menu

### DIFF
--- a/server-spi/src/main/java/org/keycloak/models/ClientScopeModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/ClientScopeModel.java
@@ -112,7 +112,7 @@ public interface ClientScopeModel extends ProtocolMapperContainerModel, ScopeCon
     }
 
     default boolean isDynamicScope() {
-        return Optional.ofNullable(getAttribute(IS_DYNAMIC_SCOPE)).isPresent();
+        return Boolean.parseBoolean(getAttribute(IS_DYNAMIC_SCOPE));
     }
 
     default void setIsDynamicScope(boolean isDynamicScope) {

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientResource.java
@@ -348,6 +348,9 @@ public class ClientResource {
         if (clientScope == null) {
             throw new javax.ws.rs.NotFoundException("Client scope not found");
         }
+        if (defaultScope && clientScope.isDynamicScope()) {
+            throw new ErrorResponseException("invalid_request", "Can't assign a Dynamic Scope to a Client as a Default Scope", Response.Status.BAD_REQUEST);
+        }
         client.addClientScope(clientScope, defaultScope);
 
         adminEvent.operation(OperationType.CREATE).resource(ResourceType.CLIENT_SCOPE_CLIENT_MAPPING).resourcePath(session.getContext().getUri()).success();

--- a/themes/src/main/resources/theme/base/admin/resources/partials/client-scopes-setup.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/client-scopes-setup.html
@@ -48,7 +48,7 @@
                         <select id="available" class="form-control overflow-select" multiple size="5"
                                 ng-multiple="true"
                                 ng-model="selectedDefaultClientScopes">
-                            <option ng-repeat="r in availableClientScopes | orderBy:'name'"
+                            <option ng-repeat="r in availableClientScopes | orderBy:'name' | filter: {attributes: {'is.dynamic.scope': '!true'}}"
                                     value="{{r}}" title="{{r.name}}">
                                 {{r.name}}
                             </option>


### PR DESCRIPTION
Restrict the assignment of Dynamic scopes to clients as optional scopes by:
- Validating what kind of scope is being assigned to a client as a default scope in the server side and fail.
- When updating a Client Scope and making it Dynamic, check if the scope is already assigned to any client as a default scope and fail if so.

Also, as a small UX improvement, filter out the dynamic scopes from the "available scopes" list that a client can assign as default scopes.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
