### PR TITLE
[fixes #9224] Always show the consent screen when a dynamic scope is requested and show the requested parameter

### DIFF
--- a/core/src/main/java/org/keycloak/representations/AuthorizationDetailsJSONRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/AuthorizationDetailsJSONRepresentation.java
@@ -137,6 +137,13 @@ public class AuthorizationDetailsJSONRepresentation implements Serializable {
         return null;
     }
 
+    public String getDynamicScopeParamFromCustomData() {
+        if(this.getType().equalsIgnoreCase(DYNAMIC_SCOPE_RAR_TYPE)) {
+            return (String) this.customData.get("scope_parameter");
+        }
+        return null;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/server-spi-private/src/main/java/org/keycloak/forms/login/LoginFormsProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/forms/login/LoginFormsProvider.java
@@ -18,10 +18,10 @@
 package org.keycloak.forms.login;
 
 import org.keycloak.authentication.AuthenticationFlowContext;
-import org.keycloak.models.ClientScopeModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.utils.FormMessage;
 import org.keycloak.provider.Provider;
+import org.keycloak.rar.AuthorizationDetails;
 import org.keycloak.sessions.AuthenticationSessionModel;
 
 import javax.ws.rs.core.MultivaluedMap;
@@ -104,7 +104,7 @@ public interface LoginFormsProvider extends Provider {
 
     LoginFormsProvider setClientSessionCode(String accessCode);
 
-    LoginFormsProvider setAccessRequest(List<ClientScopeModel> clientScopesRequested);
+    LoginFormsProvider setAccessRequest(List<AuthorizationDetails> clientScopesRequested);
 
     /**
      * Set one global error message.

--- a/server-spi/src/main/java/org/keycloak/rar/AuthorizationDetails.java
+++ b/server-spi/src/main/java/org/keycloak/rar/AuthorizationDetails.java
@@ -46,6 +46,11 @@ public class AuthorizationDetails implements Serializable {
         this.authorizationDetails = authorizationDetails;
     }
 
+    public AuthorizationDetails(ClientScopeModel clientScope) {
+        this.clientScope = clientScope;
+        this.source = AuthorizationRequestSource.SCOPE;
+    }
+
     public ClientScopeModel getClientScope() {
         return clientScope;
     }
@@ -68,6 +73,25 @@ public class AuthorizationDetails implements Serializable {
 
     public void setAuthorizationDetails(AuthorizationDetailsJSONRepresentation authorizationDetails) {
         this.authorizationDetails = authorizationDetails;
+    }
+
+    /**
+     * Returns whether the current {@link AuthorizationDetails} object is a dynamic scope
+     * @return see description
+     */
+    public boolean isDynamicScope() {
+        return this.source.equals(AuthorizationRequestSource.SCOPE) && this.getClientScope().isDynamicScope();
+    }
+
+    /**
+     * Returns the Dynamic Scope parameter from the underlying {@link AuthorizationDetailsJSONRepresentation} representation
+     * @return see description
+     */
+    public String getDynamicScopeParam() {
+        if(isDynamicScope()) {
+            return this.authorizationDetails.getDynamicScopeParamFromCustomData();
+        }
+        return null;
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/forms/login/freemarker/FreeMarkerLoginFormsProvider.java
+++ b/services/src/main/java/org/keycloak/forms/login/freemarker/FreeMarkerLoginFormsProvider.java
@@ -46,7 +46,6 @@ import org.keycloak.forms.login.freemarker.model.UrlBean;
 import org.keycloak.forms.login.freemarker.model.VerifyProfileBean;
 import org.keycloak.forms.login.freemarker.model.X509ConfirmBean;
 import org.keycloak.models.ClientModel;
-import org.keycloak.models.ClientScopeModel;
 import org.keycloak.models.Constants;
 import org.keycloak.models.IdentityProviderModel;
 import org.keycloak.models.KeycloakSession;
@@ -54,6 +53,7 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.utils.FormMessage;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
+import org.keycloak.rar.AuthorizationDetails;
 import org.keycloak.services.Urls;
 import org.keycloak.services.messages.Messages;
 import org.keycloak.services.resources.LoginActionsService;
@@ -100,7 +100,7 @@ public class FreeMarkerLoginFormsProvider implements LoginFormsProvider {
     protected String accessCode;
     protected Response.Status status;
     protected javax.ws.rs.core.MediaType contentType;
-    protected List<ClientScopeModel> clientScopesRequested;
+    protected List<AuthorizationDetails> clientScopesRequested;
     protected Map<String, String> httpResponseHeaders = new HashMap<>();
     protected URI actionUri;
     protected String execution;
@@ -767,7 +767,7 @@ public class FreeMarkerLoginFormsProvider implements LoginFormsProvider {
     }
 
     @Override
-    public LoginFormsProvider setAccessRequest(List<ClientScopeModel> clientScopesRequested) {
+    public LoginFormsProvider setAccessRequest(List<AuthorizationDetails> clientScopesRequested) {
         this.clientScopesRequested = clientScopesRequested;
         return this;
     }

--- a/services/src/main/java/org/keycloak/forms/login/freemarker/model/OAuthGrantBean.java
+++ b/services/src/main/java/org/keycloak/forms/login/freemarker/model/OAuthGrantBean.java
@@ -19,6 +19,7 @@ package org.keycloak.forms.login.freemarker.model;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.ClientScopeModel;
 import org.keycloak.models.OrderedModel;
+import org.keycloak.rar.AuthorizationDetails;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -34,12 +35,13 @@ public class OAuthGrantBean {
     private String code;
     private ClientModel client;
 
-    public OAuthGrantBean(String code, ClientModel client, List<ClientScopeModel> clientScopesRequested) {
+    public OAuthGrantBean(String code, ClientModel client, List<AuthorizationDetails> clientScopesRequested) {
         this.code = code;
         this.client = client;
 
-        for (ClientScopeModel clientScope : clientScopesRequested) {
-            this.clientScopesRequested.add(new ClientScopeEntry(clientScope.getConsentScreenText(), clientScope.getGuiOrder()));
+        for (AuthorizationDetails authDetails : clientScopesRequested) {
+            ClientScopeModel clientScope = authDetails.getClientScope();
+            this.clientScopesRequested.add(new ClientScopeEntry(clientScope.getConsentScreenText(), clientScope.getGuiOrder(), authDetails));
         }
         this.clientScopesRequested.sort(COMPARATOR_INSTANCE);
     }
@@ -64,10 +66,12 @@ public class OAuthGrantBean {
 
         private final String consentScreenText;
         private final String guiOrder;
+        private final String dynamicScopeParameter;
 
-        private ClientScopeEntry(String consentScreenText, String guiOrder) {
+        public ClientScopeEntry(String consentScreenText, String guiOrder, AuthorizationDetails authorizationDetails) {
             this.consentScreenText = consentScreenText;
             this.guiOrder = guiOrder;
+            this.dynamicScopeParameter = authorizationDetails.getDynamicScopeParam();
         }
 
         public String getConsentScreenText() {
@@ -77,6 +81,10 @@ public class OAuthGrantBean {
         @Override
         public String getGuiOrder() {
             return guiOrder;
+        }
+
+        public String getDynamicScopeParameter() {
+            return dynamicScopeParameter;
         }
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
@@ -659,6 +659,11 @@ public class TokenManager {
             requestedScopes.remove(OAuth2Constants.SCOPE_OPENID);
         }
 
+        if (logger.isTraceEnabled()) {
+            logger.tracef("Rar scopes to validate requested scopes against: %1s", String.join(" ", rarScopes));
+            logger.tracef("Requested scopes: %1s", String.join(" ", requestedScopes));
+        }
+
         for (String requestedScope : requestedScopes) {
             // We keep the check to the getDynamicClientScope for the OpenshiftSAClientAdapter
             if (!rarScopes.contains(requestedScope) && client.getDynamicClientScope(requestedScope) == null) {
@@ -667,7 +672,7 @@ public class TokenManager {
         }
         return true;
     }
-    
+
     public static boolean isValidScope(String scopes, ClientModel client) {
         if (scopes == null) {
             return true;

--- a/services/src/main/java/org/keycloak/protocol/oidc/rar/parsers/ClientScopeAuthorizationRequestParser.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/rar/parsers/ClientScopeAuthorizationRequestParser.java
@@ -16,6 +16,7 @@
  */
 package org.keycloak.protocol.oidc.rar.parsers;
 
+import org.jboss.logging.Logger;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.ClientScopeModel;
 import org.keycloak.protocol.oidc.TokenManager;
@@ -45,6 +46,8 @@ import static org.keycloak.representations.AuthorizationDetailsJSONRepresentatio
  * @author <a href="mailto:dgozalob@redhat.com">Daniel Gozalo</a>
  */
 public class ClientScopeAuthorizationRequestParser implements AuthorizationRequestParserProvider {
+
+    protected static final Logger logger = Logger.getLogger(ClientScopeAuthorizationRequestParser.class);
 
     /**
      * This parser will be created on a per-request basis. When the adapter is created, the request's client is passed

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OAuthGrantTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OAuthGrantTest.java
@@ -27,7 +27,6 @@ import org.keycloak.admin.client.resource.ClientScopeResource;
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.admin.client.resource.UserResource;
 import org.keycloak.common.Profile;
-import org.keycloak.common.constants.KerberosConstants;
 import org.keycloak.events.Details;
 import org.keycloak.events.EventType;
 import org.keycloak.models.ClientScopeModel;
@@ -43,18 +42,16 @@ import org.keycloak.testsuite.AbstractKeycloakTest;
 import org.keycloak.testsuite.AssertEvents;
 import org.keycloak.testsuite.admin.ApiUtil;
 import org.keycloak.testsuite.arquillian.annotation.DisableFeature;
+import org.keycloak.testsuite.arquillian.annotation.EnableFeature;
 import org.keycloak.testsuite.pages.AccountApplicationsPage;
 import org.keycloak.testsuite.pages.AppPage;
 import org.keycloak.testsuite.pages.ErrorPage;
 import org.keycloak.testsuite.pages.OAuthGrantPage;
-import org.keycloak.testsuite.util.ClientManager;
 import org.keycloak.testsuite.util.OAuthClient;
 import org.keycloak.testsuite.util.ProtocolMapperUtil;
-import org.keycloak.testsuite.util.RoleBuilder;
 import org.openqa.selenium.By;
 
-import java.util.Arrays;
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -63,7 +60,6 @@ import javax.ws.rs.core.Response;
 import static org.junit.Assert.assertEquals;
 import static org.keycloak.testsuite.admin.AbstractAdminTest.loadJson;
 import static org.keycloak.testsuite.admin.ApiUtil.findClientByClientId;
-import static org.keycloak.testsuite.admin.ApiUtil.findUserByUsernameId;
 
 /**
  * @author <a href="mailto:vrockai@redhat.com">Viliam Rockai</a>
@@ -319,6 +315,78 @@ public class OAuthGrantTest extends AbstractKeycloakTest {
         // cleanup
         oauth.scope(null);
         thirdParty.removeOptionalClientScope(fooScopeId);
+    }
+
+    @Test
+    @EnableFeature(value = Profile.Feature.DYNAMIC_SCOPES, skipRestart = true)
+    public void oauthGrantDynamicScopeParamRequired() {
+        RealmResource appRealm = adminClient.realm(REALM_NAME);
+        ClientResource thirdParty = findClientByClientId(appRealm, THIRD_PARTY_APP);
+
+        // Create clientScope
+        ClientScopeRepresentation scope = new ClientScopeRepresentation();
+        scope.setName("foo-dynamic-scope");
+        scope.setProtocol(OIDCLoginProtocol.LOGIN_PROTOCOL);
+        scope.setAttributes(new HashMap<String, String>() {{
+            put(ClientScopeModel.IS_DYNAMIC_SCOPE, "true");
+            put(ClientScopeModel.DYNAMIC_SCOPE_REGEXP, "foo-dynamic-scope:*");
+        }});
+        Response response = appRealm.clientScopes().create(scope);
+        String dynamicFooScopeId = ApiUtil.getCreatedId(response);
+        response.close();
+        getCleanup().addClientScopeId(dynamicFooScopeId);
+
+        // Add clientScope as optional to client
+        thirdParty.addOptionalClientScope(dynamicFooScopeId);
+
+        // Assert clientScope not on grant screen when not requested
+        oauth.clientId(THIRD_PARTY_APP);
+        oauth.scope("foo-dynamic-scope:withparam");
+        oauth.doLogin("test-user@localhost", "password");
+        grantPage.assertCurrent();
+        List<String> grants = grantPage.getDisplayedGrants();
+        Assert.assertTrue(grants.contains("foo-dynamic-scope: withparam"));
+        grantPage.accept();
+
+        EventRepresentation loginEvent = events.expectLogin()
+                .client(THIRD_PARTY_APP)
+                .detail(Details.CONSENT, Details.CONSENT_VALUE_CONSENT_GRANTED)
+                .assertEvent();
+
+        String code = new OAuthClient.AuthorizationEndpointResponse(oauth).getCode();
+        OAuthClient.AccessTokenResponse res = oauth.doAccessTokenRequest(code, "password");
+
+        events.expectCodeToToken(loginEvent.getDetails().get(Details.CODE_ID), loginEvent.getSessionId())
+                .client(THIRD_PARTY_APP)
+                .assertEvent();
+
+        oauth.openLogout();
+
+        events.expectLogout(loginEvent.getSessionId()).assertEvent();
+
+        // login again to check whether the Dynamic scope and only the dynamic scope is requested again
+        oauth.scope("foo-dynamic-scope:withparam");
+        oauth.doLogin("test-user@localhost", "password");
+        grantPage.assertCurrent();
+        grants = grantPage.getDisplayedGrants();
+        Assert.assertEquals(1, grants.size());
+        Assert.assertTrue(grants.contains("foo-dynamic-scope: withparam"));
+        grantPage.accept();
+
+        events.expectLogin()
+                .client(THIRD_PARTY_APP)
+                .detail(Details.CONSENT, Details.CONSENT_VALUE_CONSENT_GRANTED)
+                .assertEvent();
+
+        // Revoke
+        accountAppsPage.open();
+        accountAppsPage.revokeGrant(THIRD_PARTY_APP);
+        events.expect(EventType.REVOKE_GRANT)
+                .client("account").detail(Details.REVOKED_CLIENT, THIRD_PARTY_APP).assertEvent();
+
+        // cleanup
+        oauth.scope(null);
+        thirdParty.removeOptionalClientScope(dynamicFooScopeId);
     }
 
 

--- a/themes/src/main/resources/theme/base/login/login-oauth-grant.ftl
+++ b/themes/src/main/resources/theme/base/login/login-oauth-grant.ftl
@@ -18,7 +18,12 @@
                 <#if oauth.clientScopesRequested??>
                     <#list oauth.clientScopesRequested as clientScope>
                         <li>
-                            <span>${advancedMsg(clientScope.consentScreenText)}</span>
+                            <span><#if !clientScope.dynamicScopeParameter??>
+                                        ${advancedMsg(clientScope.consentScreenText)}
+                                    <#else>
+                                        ${advancedMsg(clientScope.consentScreenText)}: <b>${clientScope.dynamicScopeParameter}</b>
+                                </#if>
+                            </span>
                         </li>
                     </#list>
                 </#if>


### PR DESCRIPTION
Always show the consent screen when a dynamic scope is requested and show the requested parameter

Also make sure we start using the common `AuthorizationDetails` in the code to standardize how we handle Scopes.

This is what the consent screen would look like with a dynamic scope with a parameter:

Updated image:

![Screenshot 2022-02-01 at 11 05 48](https://user-images.githubusercontent.com/48915630/151949167-4e1cce50-0874-4f6f-95ae-788cd2417262.png)

<!---

Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->


