### PR TITLE
Bulk import of the previous operator CRDs

### DIFF
--- a/operator/pom.xml
+++ b/operator/pom.xml
@@ -106,6 +106,13 @@
             <artifactId>quarkus-kubernetes-client</artifactId>
         </dependency>
 
+        <!-- Lombok for the imported CRD -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.22</version>
+        </dependency>
+
 
         <!--  This dependency is needed only to ensure proper building order so that this module is build after the CSV extension -->
         <dependency>

--- a/operator/src/main/java/org/keycloak/operator/v2alpha1/crds/KeycloakRealm.java
+++ b/operator/src/main/java/org/keycloak/operator/v2alpha1/crds/KeycloakRealm.java
@@ -16,31 +16,16 @@
  */
 package org.keycloak.operator.v2alpha1.crds;
 
-import org.keycloak.representations.idm.RealmRepresentation;
+import io.fabric8.kubernetes.api.model.Namespaced;
+import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.model.annotation.Group;
+import io.fabric8.kubernetes.model.annotation.Plural;
+import io.fabric8.kubernetes.model.annotation.ShortNames;
+import io.fabric8.kubernetes.model.annotation.Version;
+import org.keycloak.operator.Constants;
 
-import javax.validation.constraints.NotNull;
-
-public class RealmSpec {
-
-    @NotNull
-    private String keycloakCRName;
-    @NotNull
-    private RealmRepresentation realm;
-
-    public String getKeycloakCRName() {
-        return keycloakCRName;
-    }
-
-    public void setKeycloakCRName(String keycloakCRName) {
-        this.keycloakCRName = keycloakCRName;
-    }
-
-    public RealmRepresentation getRealm() {
-        return realm;
-    }
-
-    public void setRealm(RealmRepresentation realm) {
-        this.realm = realm;
-    }
+@Group(Constants.CRDS_GROUP)
+@Version(Constants.CRDS_VERSION)
+public class KeycloakRealm extends CustomResource<KeycloakRealmSpec, Void> implements Namespaced {
 
 }

--- a/operator/src/main/java/org/keycloak/operator/v2alpha1/crds/KeycloakRealmSpec.java
+++ b/operator/src/main/java/org/keycloak/operator/v2alpha1/crds/KeycloakRealmSpec.java
@@ -16,16 +16,31 @@
  */
 package org.keycloak.operator.v2alpha1.crds;
 
-import io.fabric8.kubernetes.api.model.Namespaced;
-import io.fabric8.kubernetes.client.CustomResource;
-import io.fabric8.kubernetes.model.annotation.Group;
-import io.fabric8.kubernetes.model.annotation.Plural;
-import io.fabric8.kubernetes.model.annotation.ShortNames;
-import io.fabric8.kubernetes.model.annotation.Version;
-import org.keycloak.operator.Constants;
+import org.keycloak.representations.idm.RealmRepresentation;
 
-@Group(Constants.CRDS_GROUP)
-@Version(Constants.CRDS_VERSION)
-public class Realm extends CustomResource<RealmSpec, Void> implements Namespaced {
+import javax.validation.constraints.NotNull;
+
+public class KeycloakRealmSpec {
+
+    @NotNull
+    private String keycloakCRName;
+    @NotNull
+    private RealmRepresentation realm;
+
+    public String getKeycloakCRName() {
+        return keycloakCRName;
+    }
+
+    public void setKeycloakCRName(String keycloakCRName) {
+        this.keycloakCRName = keycloakCRName;
+    }
+
+    public RealmRepresentation getRealm() {
+        return realm;
+    }
+
+    public void setRealm(RealmRepresentation realm) {
+        this.realm = realm;
+    }
 
 }

--- a/operator/src/main/java/org/keycloak/v1alpha1/AffinitySpec.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/AffinitySpec.java
@@ -1,0 +1,60 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"nodeAffinity","podAffinity","podAntiAffinity"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class AffinitySpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("nodeAffinity")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Describes node affinity scheduling rules for the pod.")
+    private NodeAffinitySpec nodeAffinity;
+
+    public NodeAffinitySpec getNodeAffinity() {
+        return nodeAffinity;
+    }
+
+    public void setNodeAffinity(NodeAffinitySpec nodeAffinity) {
+        this.nodeAffinity = nodeAffinity;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("podAffinity")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).")
+    private PodAffinitySpec podAffinity;
+
+    public PodAffinitySpec getPodAffinity() {
+        return podAffinity;
+    }
+
+    public void setPodAffinity(PodAffinitySpec podAffinity) {
+        this.podAffinity = podAffinity;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("podAntiAffinity")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).")
+    private PodAntiAffinitySpec podAntiAffinity;
+
+    public PodAntiAffinitySpec getPodAntiAffinity() {
+        return podAntiAffinity;
+    }
+
+    public void setPodAntiAffinity(PodAntiAffinitySpec podAntiAffinity) {
+        this.podAntiAffinity = podAntiAffinity;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/AuthenticationExecutionsSpec.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/AuthenticationExecutionsSpec.java
@@ -1,0 +1,108 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"authenticator","authenticatorConfig","authenticatorFlow","flowAlias","priority","requirement","userSetupAllowed"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class AuthenticationExecutionsSpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("authenticator")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Authenticator")
+    private String authenticator;
+
+    public String getAuthenticator() {
+        return authenticator;
+    }
+
+    public void setAuthenticator(String authenticator) {
+        this.authenticator = authenticator;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("authenticatorConfig")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Authenticator Config")
+    private String authenticatorConfig;
+
+    public String getAuthenticatorConfig() {
+        return authenticatorConfig;
+    }
+
+    public void setAuthenticatorConfig(String authenticatorConfig) {
+        this.authenticatorConfig = authenticatorConfig;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("authenticatorFlow")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Authenticator flow")
+    private Boolean authenticatorFlow;
+
+    public Boolean getAuthenticatorFlow() {
+        return authenticatorFlow;
+    }
+
+    public void setAuthenticatorFlow(Boolean authenticatorFlow) {
+        this.authenticatorFlow = authenticatorFlow;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("flowAlias")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Flow Alias")
+    private String flowAlias;
+
+    public String getFlowAlias() {
+        return flowAlias;
+    }
+
+    public void setFlowAlias(String flowAlias) {
+        this.flowAlias = flowAlias;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("priority")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Priority")
+    private Integer priority;
+
+    public Integer getPriority() {
+        return priority;
+    }
+
+    public void setPriority(Integer priority) {
+        this.priority = priority;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("requirement")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Requirement [REQUIRED, OPTIONAL, ALTERNATIVE, DISABLED]")
+    private String requirement;
+
+    public String getRequirement() {
+        return requirement;
+    }
+
+    public void setRequirement(String requirement) {
+        this.requirement = requirement;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("userSetupAllowed")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("User setup allowed")
+    private Boolean userSetupAllowed;
+
+    public Boolean getUserSetupAllowed() {
+        return userSetupAllowed;
+    }
+
+    public void setUserSetupAllowed(Boolean userSetupAllowed) {
+        this.userSetupAllowed = userSetupAllowed;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/AuthenticationFlowsSpec.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/AuthenticationFlowsSpec.java
@@ -1,0 +1,98 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"alias","authenticationExecutions","builtIn","id","providerId","topLevel"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class AuthenticationFlowsSpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("alias")
+    @javax.validation.constraints.NotNull()
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Alias")
+    private String alias;
+
+    public String getAlias() {
+        return alias;
+    }
+
+    public void setAlias(String alias) {
+        this.alias = alias;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("authenticationExecutions")
+    @javax.validation.constraints.NotNull()
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Authentication executions")
+    private java.util.List<AuthenticationExecutionsSpec> authenticationExecutions;
+
+    public java.util.List<AuthenticationExecutionsSpec> getAuthenticationExecutions() {
+        return authenticationExecutions;
+    }
+
+    public void setAuthenticationExecutions(java.util.List<AuthenticationExecutionsSpec> authenticationExecutions) {
+        this.authenticationExecutions = authenticationExecutions;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("builtIn")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Built in")
+    private Boolean builtIn;
+
+    public Boolean getBuiltIn() {
+        return builtIn;
+    }
+
+    public void setBuiltIn(Boolean builtIn) {
+        this.builtIn = builtIn;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("ID")
+    private String id;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("providerId")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Provider ID")
+    private String providerId;
+
+    public String getProviderId() {
+        return providerId;
+    }
+
+    public void setProviderId(String providerId) {
+        this.providerId = providerId;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("topLevel")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Top level")
+    private Boolean topLevel;
+
+    public Boolean getTopLevel() {
+        return topLevel;
+    }
+
+    public void setTopLevel(Boolean topLevel) {
+        this.topLevel = topLevel;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/AuthenticatorConfigSpec.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/AuthenticatorConfigSpec.java
@@ -1,0 +1,61 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"alias","config","id"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class AuthenticatorConfigSpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("alias")
+    @javax.validation.constraints.NotNull()
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Alias")
+    private String alias;
+
+    public String getAlias() {
+        return alias;
+    }
+
+    public void setAlias(String alias) {
+        this.alias = alias;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("config")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Config")
+    private java.util.Map<java.lang.String, String> config;
+
+    public java.util.Map<java.lang.String, String> getConfig() {
+        return config;
+    }
+
+    public void setConfig(java.util.Map<java.lang.String, String> config) {
+        this.config = config;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("ID")
+    private String id;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/AuthorizationSettingsSpec.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/AuthorizationSettingsSpec.java
@@ -1,0 +1,132 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"allowRemoteResourceManagement","clientId","decisionStrategy","id","name","policies","policyEnforcementMode","resources","scopes"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class AuthorizationSettingsSpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("allowRemoteResourceManagement")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("True if resources should be managed remotely by the resource server.")
+    private Boolean allowRemoteResourceManagement;
+
+    public Boolean getAllowRemoteResourceManagement() {
+        return allowRemoteResourceManagement;
+    }
+
+    public void setAllowRemoteResourceManagement(Boolean allowRemoteResourceManagement) {
+        this.allowRemoteResourceManagement = allowRemoteResourceManagement;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("clientId")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Client ID.")
+    private String clientId;
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public void setClientId(String clientId) {
+        this.clientId = clientId;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("decisionStrategy")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("The decision strategy dictates how permissions are evaluated and how a final decision is obtained. 'Affirmative' means that at least one permission must evaluate to a positive decision in order to grant access to a resource and its scopes. 'Unanimous' means that all permissions must evaluate to a positive decision in order for the final decision to be also positive.")
+    private String decisionStrategy;
+
+    public String getDecisionStrategy() {
+        return decisionStrategy;
+    }
+
+    public void setDecisionStrategy(String decisionStrategy) {
+        this.decisionStrategy = decisionStrategy;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("ID.")
+    private String id;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Name.")
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("policies")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Policies.")
+    private java.util.List<PoliciesSpec> policies;
+
+    public java.util.List<PoliciesSpec> getPolicies() {
+        return policies;
+    }
+
+    public void setPolicies(java.util.List<PoliciesSpec> policies) {
+        this.policies = policies;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("policyEnforcementMode")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("The policy enforcement mode dictates how policies are enforced when evaluating authorization requests. 'Enforcing' means requests are denied by default even when there is no policy associated with a given resource. 'Permissive' means requests are allowed even when there is no policy associated with a given resource. 'Disabled' completely disables the evaluation of policies and allows access to any resource.")
+    private String policyEnforcementMode;
+
+    public String getPolicyEnforcementMode() {
+        return policyEnforcementMode;
+    }
+
+    public void setPolicyEnforcementMode(String policyEnforcementMode) {
+        this.policyEnforcementMode = policyEnforcementMode;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("resources")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Resources.")
+    private java.util.List<ResourcesSpec> resources;
+
+    public java.util.List<ResourcesSpec> getResources() {
+        return resources;
+    }
+
+    public void setResources(java.util.List<ResourcesSpec> resources) {
+        this.resources = resources;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("scopes")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Authorization Scopes.")
+    private java.util.List<ScopesSpec1> scopes;
+
+    public java.util.List<ScopesSpec1> getScopes() {
+        return scopes;
+    }
+
+    public void setScopes(java.util.List<ScopesSpec1> scopes) {
+        this.scopes = scopes;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/BackupsSpec.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/BackupsSpec.java
@@ -1,0 +1,36 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"enabled"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class BackupsSpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("enabled")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("If set to true, the operator will do database backup before doing migration")
+    private Boolean enabled;
+
+    public Boolean getEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/ClientScopeMappingsSpec.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/ClientScopeMappingsSpec.java
@@ -1,0 +1,72 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"client","clientScope","roles","self"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class ClientScopeMappingsSpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("client")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Client")
+    private String client;
+
+    public String getClient() {
+        return client;
+    }
+
+    public void setClient(String client) {
+        this.client = client;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("clientScope")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Client Scope")
+    private String clientScope;
+
+    public String getClientScope() {
+        return clientScope;
+    }
+
+    public void setClientScope(String clientScope) {
+        this.clientScope = clientScope;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("roles")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Roles")
+    private java.util.List<String> roles;
+
+    public java.util.List<String> getRoles() {
+        return roles;
+    }
+
+    public void setRoles(java.util.List<String> roles) {
+        this.roles = roles;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("self")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Self")
+    private String self;
+
+    public String getSelf() {
+        return self;
+    }
+
+    public void setSelf(String self) {
+        this.self = self;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/ClientScopesSpec.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/ClientScopesSpec.java
@@ -1,0 +1,80 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"attributes","id","name","protocol","protocolMappers"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class ClientScopesSpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("attributes")
+    private java.util.Map<java.lang.String, String> attributes;
+
+    public java.util.Map<java.lang.String, String> getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(java.util.Map<java.lang.String, String> attributes) {
+        this.attributes = attributes;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    private String id;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("protocol")
+    private String protocol;
+
+    public String getProtocol() {
+        return protocol;
+    }
+
+    public void setProtocol(String protocol) {
+        this.protocol = protocol;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("protocolMappers")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Protocol Mappers.")
+    private java.util.List<ProtocolMappersSpec> protocolMappers;
+
+    public java.util.List<ProtocolMappersSpec> getProtocolMappers() {
+        return protocolMappers;
+    }
+
+    public void setProtocolMappers(java.util.List<ProtocolMappersSpec> protocolMappers) {
+        this.protocolMappers = protocolMappers;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/ClientSpec.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/ClientSpec.java
@@ -1,0 +1,109 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"attributes","clientRole","composite","composites","containerId","id","name"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class ClientSpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("attributes")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Role Attributes")
+    private java.util.Map<java.lang.String, java.util.List<String>> attributes;
+
+    public java.util.Map<java.lang.String, java.util.List<String>> getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(java.util.Map<java.lang.String, java.util.List<String>> attributes) {
+        this.attributes = attributes;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("clientRole")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Client Role")
+    private Boolean clientRole;
+
+    public Boolean getClientRole() {
+        return clientRole;
+    }
+
+    public void setClientRole(Boolean clientRole) {
+        this.clientRole = clientRole;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("composite")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Composite")
+    private Boolean composite;
+
+    public Boolean getComposite() {
+        return composite;
+    }
+
+    public void setComposite(Boolean composite) {
+        this.composite = composite;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("composites")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Composites")
+    private CompositesSpec0 composites;
+
+    public CompositesSpec0 getComposites() {
+        return composites;
+    }
+
+    public void setComposites(CompositesSpec0 composites) {
+        this.composites = composites;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("containerId")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Container Id")
+    private String containerId;
+
+    public String getContainerId() {
+        return containerId;
+    }
+
+    public void setContainerId(String containerId) {
+        this.containerId = containerId;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Id")
+    private String id;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    @javax.validation.constraints.NotNull()
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Name")
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/ClientsSpec.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/ClientsSpec.java
@@ -1,0 +1,457 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"access","adminUrl","attributes","authenticationFlowBindingOverrides","authorizationServicesEnabled","authorizationSettings","baseUrl","bearerOnly","clientAuthenticatorType","clientId","consentRequired","defaultClientScopes","defaultRoles","directAccessGrantsEnabled","enabled","frontchannelLogout","fullScopeAllowed","id","implicitFlowEnabled","name","nodeReRegistrationTimeout","notBefore","optionalClientScopes","protocol","protocolMappers","publicClient","redirectUris","rootUrl","secret","serviceAccountsEnabled","standardFlowEnabled","surrogateAuthRequired","useTemplateConfig","useTemplateMappers","useTemplateScope","webOrigins"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class ClientsSpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("access")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Access options.")
+    private java.util.Map<java.lang.String, Boolean> access;
+
+    public java.util.Map<java.lang.String, Boolean> getAccess() {
+        return access;
+    }
+
+    public void setAccess(java.util.Map<java.lang.String, Boolean> access) {
+        this.access = access;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("adminUrl")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Application Admin URL.")
+    private String adminUrl;
+
+    public String getAdminUrl() {
+        return adminUrl;
+    }
+
+    public void setAdminUrl(String adminUrl) {
+        this.adminUrl = adminUrl;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("attributes")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Client Attributes.")
+    private java.util.Map<java.lang.String, String> attributes;
+
+    public java.util.Map<java.lang.String, String> getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(java.util.Map<java.lang.String, String> attributes) {
+        this.attributes = attributes;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("authenticationFlowBindingOverrides")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Authentication Flow Binding Overrides.")
+    private java.util.Map<java.lang.String, String> authenticationFlowBindingOverrides;
+
+    public java.util.Map<java.lang.String, String> getAuthenticationFlowBindingOverrides() {
+        return authenticationFlowBindingOverrides;
+    }
+
+    public void setAuthenticationFlowBindingOverrides(java.util.Map<java.lang.String, String> authenticationFlowBindingOverrides) {
+        this.authenticationFlowBindingOverrides = authenticationFlowBindingOverrides;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("authorizationServicesEnabled")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("True if fine-grained authorization support is enabled for this client.")
+    private Boolean authorizationServicesEnabled;
+
+    public Boolean getAuthorizationServicesEnabled() {
+        return authorizationServicesEnabled;
+    }
+
+    public void setAuthorizationServicesEnabled(Boolean authorizationServicesEnabled) {
+        this.authorizationServicesEnabled = authorizationServicesEnabled;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("authorizationSettings")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Authorization settings for this resource server.")
+    private AuthorizationSettingsSpec authorizationSettings;
+
+    public AuthorizationSettingsSpec getAuthorizationSettings() {
+        return authorizationSettings;
+    }
+
+    public void setAuthorizationSettings(AuthorizationSettingsSpec authorizationSettings) {
+        this.authorizationSettings = authorizationSettings;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("baseUrl")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Application base URL.")
+    private String baseUrl;
+
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    public void setBaseUrl(String baseUrl) {
+        this.baseUrl = baseUrl;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("bearerOnly")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("True if a client supports only Bearer Tokens.")
+    private Boolean bearerOnly;
+
+    public Boolean getBearerOnly() {
+        return bearerOnly;
+    }
+
+    public void setBearerOnly(Boolean bearerOnly) {
+        this.bearerOnly = bearerOnly;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("clientAuthenticatorType")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("What Client authentication type to use.")
+    private String clientAuthenticatorType;
+
+    public String getClientAuthenticatorType() {
+        return clientAuthenticatorType;
+    }
+
+    public void setClientAuthenticatorType(String clientAuthenticatorType) {
+        this.clientAuthenticatorType = clientAuthenticatorType;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("clientId")
+    @javax.validation.constraints.NotNull()
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Client ID.")
+    private String clientId;
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public void setClientId(String clientId) {
+        this.clientId = clientId;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("consentRequired")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("True if Consent Screen is required.")
+    private Boolean consentRequired;
+
+    public Boolean getConsentRequired() {
+        return consentRequired;
+    }
+
+    public void setConsentRequired(Boolean consentRequired) {
+        this.consentRequired = consentRequired;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("defaultClientScopes")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("A list of default client scopes. Default client scopes are always applied when issuing OpenID Connect tokens or SAML assertions for this client.")
+    private java.util.List<String> defaultClientScopes;
+
+    public java.util.List<String> getDefaultClientScopes() {
+        return defaultClientScopes;
+    }
+
+    public void setDefaultClientScopes(java.util.List<String> defaultClientScopes) {
+        this.defaultClientScopes = defaultClientScopes;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("defaultRoles")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Default Client roles.")
+    private java.util.List<String> defaultRoles;
+
+    public java.util.List<String> getDefaultRoles() {
+        return defaultRoles;
+    }
+
+    public void setDefaultRoles(java.util.List<String> defaultRoles) {
+        this.defaultRoles = defaultRoles;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("directAccessGrantsEnabled")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("True if Direct Grant is enabled.")
+    private Boolean directAccessGrantsEnabled;
+
+    public Boolean getDirectAccessGrantsEnabled() {
+        return directAccessGrantsEnabled;
+    }
+
+    public void setDirectAccessGrantsEnabled(Boolean directAccessGrantsEnabled) {
+        this.directAccessGrantsEnabled = directAccessGrantsEnabled;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("enabled")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Client enabled flag.")
+    private Boolean enabled;
+
+    public Boolean getEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("frontchannelLogout")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("True if this client supports Front Channel logout.")
+    private Boolean frontchannelLogout;
+
+    public Boolean getFrontchannelLogout() {
+        return frontchannelLogout;
+    }
+
+    public void setFrontchannelLogout(Boolean frontchannelLogout) {
+        this.frontchannelLogout = frontchannelLogout;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("fullScopeAllowed")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("True if Full Scope is allowed.")
+    private Boolean fullScopeAllowed;
+
+    public Boolean getFullScopeAllowed() {
+        return fullScopeAllowed;
+    }
+
+    public void setFullScopeAllowed(Boolean fullScopeAllowed) {
+        this.fullScopeAllowed = fullScopeAllowed;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Client ID. If not specified, automatically generated.")
+    private String id;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("implicitFlowEnabled")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("True if Implicit flow is enabled.")
+    private Boolean implicitFlowEnabled;
+
+    public Boolean getImplicitFlowEnabled() {
+        return implicitFlowEnabled;
+    }
+
+    public void setImplicitFlowEnabled(Boolean implicitFlowEnabled) {
+        this.implicitFlowEnabled = implicitFlowEnabled;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Client name.")
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("nodeReRegistrationTimeout")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Node registration timeout.")
+    private Long nodeReRegistrationTimeout;
+
+    public Long getNodeReRegistrationTimeout() {
+        return nodeReRegistrationTimeout;
+    }
+
+    public void setNodeReRegistrationTimeout(Long nodeReRegistrationTimeout) {
+        this.nodeReRegistrationTimeout = nodeReRegistrationTimeout;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("notBefore")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Not Before setting.")
+    private Long notBefore;
+
+    public Long getNotBefore() {
+        return notBefore;
+    }
+
+    public void setNotBefore(Long notBefore) {
+        this.notBefore = notBefore;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("optionalClientScopes")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("A list of optional client scopes. Optional client scopes are applied when issuing tokens for this client, but only when they are requested by the scope parameter in the OpenID Connect authorization request.")
+    private java.util.List<String> optionalClientScopes;
+
+    public java.util.List<String> getOptionalClientScopes() {
+        return optionalClientScopes;
+    }
+
+    public void setOptionalClientScopes(java.util.List<String> optionalClientScopes) {
+        this.optionalClientScopes = optionalClientScopes;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("protocol")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Protocol used for this Client.")
+    private String protocol;
+
+    public String getProtocol() {
+        return protocol;
+    }
+
+    public void setProtocol(String protocol) {
+        this.protocol = protocol;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("protocolMappers")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Protocol Mappers.")
+    private java.util.List<ProtocolMappersSpec0> protocolMappers;
+
+    public java.util.List<ProtocolMappersSpec0> getProtocolMappers() {
+        return protocolMappers;
+    }
+
+    public void setProtocolMappers(java.util.List<ProtocolMappersSpec0> protocolMappers) {
+        this.protocolMappers = protocolMappers;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("publicClient")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("True if this is a public Client.")
+    private Boolean publicClient;
+
+    public Boolean getPublicClient() {
+        return publicClient;
+    }
+
+    public void setPublicClient(Boolean publicClient) {
+        this.publicClient = publicClient;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("redirectUris")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("A list of valid Redirection URLs.")
+    private java.util.List<String> redirectUris;
+
+    public java.util.List<String> getRedirectUris() {
+        return redirectUris;
+    }
+
+    public void setRedirectUris(java.util.List<String> redirectUris) {
+        this.redirectUris = redirectUris;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("rootUrl")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Application root URL.")
+    private String rootUrl;
+
+    public String getRootUrl() {
+        return rootUrl;
+    }
+
+    public void setRootUrl(String rootUrl) {
+        this.rootUrl = rootUrl;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("secret")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Client Secret. The Operator will automatically create a Secret based on this value.")
+    private String secret;
+
+    public String getSecret() {
+        return secret;
+    }
+
+    public void setSecret(String secret) {
+        this.secret = secret;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("serviceAccountsEnabled")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("True if Service Accounts are enabled.")
+    private Boolean serviceAccountsEnabled;
+
+    public Boolean getServiceAccountsEnabled() {
+        return serviceAccountsEnabled;
+    }
+
+    public void setServiceAccountsEnabled(Boolean serviceAccountsEnabled) {
+        this.serviceAccountsEnabled = serviceAccountsEnabled;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("standardFlowEnabled")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("True if Standard flow is enabled.")
+    private Boolean standardFlowEnabled;
+
+    public Boolean getStandardFlowEnabled() {
+        return standardFlowEnabled;
+    }
+
+    public void setStandardFlowEnabled(Boolean standardFlowEnabled) {
+        this.standardFlowEnabled = standardFlowEnabled;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("surrogateAuthRequired")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Surrogate Authentication Required option.")
+    private Boolean surrogateAuthRequired;
+
+    public Boolean getSurrogateAuthRequired() {
+        return surrogateAuthRequired;
+    }
+
+    public void setSurrogateAuthRequired(Boolean surrogateAuthRequired) {
+        this.surrogateAuthRequired = surrogateAuthRequired;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("useTemplateConfig")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("True to use a Template Config.")
+    private Boolean useTemplateConfig;
+
+    public Boolean getUseTemplateConfig() {
+        return useTemplateConfig;
+    }
+
+    public void setUseTemplateConfig(Boolean useTemplateConfig) {
+        this.useTemplateConfig = useTemplateConfig;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("useTemplateMappers")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("True to use Template Mappers.")
+    private Boolean useTemplateMappers;
+
+    public Boolean getUseTemplateMappers() {
+        return useTemplateMappers;
+    }
+
+    public void setUseTemplateMappers(Boolean useTemplateMappers) {
+        this.useTemplateMappers = useTemplateMappers;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("useTemplateScope")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("True to use Template Scope.")
+    private Boolean useTemplateScope;
+
+    public Boolean getUseTemplateScope() {
+        return useTemplateScope;
+    }
+
+    public void setUseTemplateScope(Boolean useTemplateScope) {
+        this.useTemplateScope = useTemplateScope;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("webOrigins")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("A list of valid Web Origins.")
+    private java.util.List<String> webOrigins;
+
+    public java.util.List<String> getWebOrigins() {
+        return webOrigins;
+    }
+
+    public void setWebOrigins(java.util.List<String> webOrigins) {
+        this.webOrigins = webOrigins;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/CompositesSpec.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/CompositesSpec.java
@@ -1,0 +1,48 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"client","realm"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class CompositesSpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("client")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Map client => []role")
+    private java.util.Map<java.lang.String, java.util.List<String>> client;
+
+    public java.util.Map<java.lang.String, java.util.List<String>> getClient() {
+        return client;
+    }
+
+    public void setClient(java.util.Map<java.lang.String, java.util.List<String>> client) {
+        this.client = client;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("realm")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Realm roles")
+    private java.util.List<String> realm;
+
+    public java.util.List<String> getRealm() {
+        return realm;
+    }
+
+    public void setRealm(java.util.List<String> realm) {
+        this.realm = realm;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/CompositesSpec0.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/CompositesSpec0.java
@@ -1,0 +1,48 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"client","realm"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class CompositesSpec0 implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("client")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Map client => []role")
+    private java.util.Map<java.lang.String, java.util.List<String>> client;
+
+    public java.util.Map<java.lang.String, java.util.List<String>> getClient() {
+        return client;
+    }
+
+    public void setClient(java.util.Map<java.lang.String, java.util.List<String>> client) {
+        this.client = client;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("realm")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Realm roles")
+    private java.util.List<String> realm;
+
+    public java.util.List<String> getRealm() {
+        return realm;
+    }
+
+    public void setRealm(java.util.List<String> realm) {
+        this.realm = realm;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/CompositesSpec1.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/CompositesSpec1.java
@@ -1,0 +1,48 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"client","realm"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class CompositesSpec1 implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("client")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Map client => []role")
+    private java.util.Map<java.lang.String, java.util.List<String>> client;
+
+    public java.util.Map<java.lang.String, java.util.List<String>> getClient() {
+        return client;
+    }
+
+    public void setClient(java.util.Map<java.lang.String, java.util.List<String>> client) {
+        this.client = client;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("realm")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Realm roles")
+    private java.util.List<String> realm;
+
+    public java.util.List<String> getRealm() {
+        return realm;
+    }
+
+    public void setRealm(java.util.List<String> realm) {
+        this.realm = realm;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/ConfigMapKeyRefSpec.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/ConfigMapKeyRefSpec.java
@@ -1,0 +1,61 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"key","name","optional"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class ConfigMapKeyRefSpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("key")
+    @javax.validation.constraints.NotNull()
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("The key to select.")
+    private String key;
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?")
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("optional")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Specify whether the ConfigMap or its key must be defined")
+    private Boolean optional;
+
+    public Boolean getOptional() {
+        return optional;
+    }
+
+    public void setOptional(Boolean optional) {
+        this.optional = optional;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/CredentialsSpec.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/CredentialsSpec.java
@@ -1,0 +1,60 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"temporary","type","value"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class CredentialsSpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("temporary")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("True if this credential object is temporary.")
+    private Boolean temporary;
+
+    public Boolean getTemporary() {
+        return temporary;
+    }
+
+    public void setTemporary(Boolean temporary) {
+        this.temporary = temporary;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("type")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Credential Type.")
+    private String type;
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("value")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Credential Value.")
+    private String value;
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/DefaultRoleSpec.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/DefaultRoleSpec.java
@@ -1,0 +1,109 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"attributes","clientRole","composite","composites","containerId","id","name"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class DefaultRoleSpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("attributes")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Role Attributes")
+    private java.util.Map<java.lang.String, java.util.List<String>> attributes;
+
+    public java.util.Map<java.lang.String, java.util.List<String>> getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(java.util.Map<java.lang.String, java.util.List<String>> attributes) {
+        this.attributes = attributes;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("clientRole")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Client Role")
+    private Boolean clientRole;
+
+    public Boolean getClientRole() {
+        return clientRole;
+    }
+
+    public void setClientRole(Boolean clientRole) {
+        this.clientRole = clientRole;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("composite")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Composite")
+    private Boolean composite;
+
+    public Boolean getComposite() {
+        return composite;
+    }
+
+    public void setComposite(Boolean composite) {
+        this.composite = composite;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("composites")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Composites")
+    private CompositesSpec composites;
+
+    public CompositesSpec getComposites() {
+        return composites;
+    }
+
+    public void setComposites(CompositesSpec composites) {
+        this.composites = composites;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("containerId")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Container Id")
+    private String containerId;
+
+    public String getContainerId() {
+        return containerId;
+    }
+
+    public void setContainerId(String containerId) {
+        this.containerId = containerId;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Id")
+    private String id;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    @javax.validation.constraints.NotNull()
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Name")
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/EnvSpec.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/EnvSpec.java
@@ -1,0 +1,61 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"name","value","valueFrom"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class EnvSpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    @javax.validation.constraints.NotNull()
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Name of the environment variable. Must be a C_IDENTIFIER.")
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("value")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".")
+    private String value;
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("valueFrom")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Source for the environment variable's value. Cannot be used if value is not empty.")
+    private ValueFromSpec valueFrom;
+
+    public ValueFromSpec getValueFrom() {
+        return valueFrom;
+    }
+
+    public void setValueFrom(ValueFromSpec valueFrom) {
+        this.valueFrom = valueFrom;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/ExperimentalSpec.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/ExperimentalSpec.java
@@ -1,0 +1,96 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"affinity","args","command","env","serviceAccountName","volumes"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class ExperimentalSpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("affinity")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Affinity settings")
+    private AffinitySpec affinity;
+
+    public AffinitySpec getAffinity() {
+        return affinity;
+    }
+
+    public void setAffinity(AffinitySpec affinity) {
+        this.affinity = affinity;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("args")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Arguments to the entrypoint. Translates into Container CMD.")
+    private java.util.List<String> args;
+
+    public java.util.List<String> getArgs() {
+        return args;
+    }
+
+    public void setArgs(java.util.List<String> args) {
+        this.args = args;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("command")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Container command. Translates into Container ENTRYPOINT.")
+    private java.util.List<String> command;
+
+    public java.util.List<String> getCommand() {
+        return command;
+    }
+
+    public void setCommand(java.util.List<String> command) {
+        this.command = command;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("env")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("List of environment variables to set in the container.")
+    private java.util.List<EnvSpec> env;
+
+    public java.util.List<EnvSpec> getEnv() {
+        return env;
+    }
+
+    public void setEnv(java.util.List<EnvSpec> env) {
+        this.env = env;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("serviceAccountName")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("ServiceAccountName settings")
+    private String serviceAccountName;
+
+    public String getServiceAccountName() {
+        return serviceAccountName;
+    }
+
+    public void setServiceAccountName(String serviceAccountName) {
+        this.serviceAccountName = serviceAccountName;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("volumes")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Additional volume mounts")
+    private VolumesSpec volumes;
+
+    public VolumesSpec getVolumes() {
+        return volumes;
+    }
+
+    public void setVolumes(VolumesSpec volumes) {
+        this.volumes = volumes;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/ExternalAccessSpec.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/ExternalAccessSpec.java
@@ -1,0 +1,60 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"enabled","host","tlsTermination"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class ExternalAccessSpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("enabled")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("If set to true, the Operator will create an Ingress or a Route pointing to Keycloak.")
+    private Boolean enabled;
+
+    public Boolean getEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("host")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("If set, the Operator will use value of host for Ingress host instead of default value keycloak.local. Using this setting in OpenShift environment will result an error. Only users with special permissions are allowed to modify the hostname.")
+    private String host;
+
+    public String getHost() {
+        return host;
+    }
+
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("tlsTermination")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("TLS Termination type for the external access. Setting this field to \"reencrypt\" will terminate TLS on the Ingress/Route level. Setting this field to \"passthrough\" will send encrypted traffic to the Pod. If unspecified, defaults to \"reencrypt\". Note, that this setting has no effect on Ingress as Ingress TLS settings are not reconciled by this operator. In other words, Ingress TLS configuration is the same in both cases and it is up to the user to configure TLS section of the Ingress.")
+    private String tlsTermination;
+
+    public String getTlsTermination() {
+        return tlsTermination;
+    }
+
+    public void setTlsTermination(String tlsTermination) {
+        this.tlsTermination = tlsTermination;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/ExternalDatabaseSpec.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/ExternalDatabaseSpec.java
@@ -1,0 +1,36 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"enabled"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class ExternalDatabaseSpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("enabled")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("If set to true, the Operator will use an external database pointing to Keycloak. The embedded database (externalDatabase.enabled = false) is deprecated.")
+    private Boolean enabled;
+
+    public Boolean getEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/ExternalSpec.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/ExternalSpec.java
@@ -1,0 +1,48 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"enabled","url"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class ExternalSpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("enabled")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("If set to true, this Keycloak will be treated as an external instance. The unmanaged field also needs to be set to true if this field is true.")
+    private Boolean enabled;
+
+    public Boolean getEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("url")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("The URL to use for the keycloak admin API. Needs to be set if external is true.")
+    private String url;
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/FederatedIdentitiesSpec.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/FederatedIdentitiesSpec.java
@@ -1,0 +1,60 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"identityProvider","userId","userName"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class FederatedIdentitiesSpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("identityProvider")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Federated Identity Provider.")
+    private String identityProvider;
+
+    public String getIdentityProvider() {
+        return identityProvider;
+    }
+
+    public void setIdentityProvider(String identityProvider) {
+        this.identityProvider = identityProvider;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("userId")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Federated Identity User ID.")
+    private String userId;
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("userName")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Federated Identity User Name.")
+    private String userName;
+
+    public String getUserName() {
+        return userName;
+    }
+
+    public void setUserName(String userName) {
+        this.userName = userName;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/FieldRefSpec.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/FieldRefSpec.java
@@ -1,0 +1,49 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"apiVersion","fieldPath"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class FieldRefSpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("apiVersion")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Version of the schema the FieldPath is written in terms of, defaults to \"v1\".")
+    private String apiVersion;
+
+    public String getApiVersion() {
+        return apiVersion;
+    }
+
+    public void setApiVersion(String apiVersion) {
+        this.apiVersion = apiVersion;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("fieldPath")
+    @javax.validation.constraints.NotNull()
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Path of the field to select in the specified API version.")
+    private String fieldPath;
+
+    public String getFieldPath() {
+        return fieldPath;
+    }
+
+    public void setFieldPath(String fieldPath) {
+        this.fieldPath = fieldPath;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/IdentityProvidersSpec.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/IdentityProvidersSpec.java
@@ -1,0 +1,168 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"addReadTokenRoleOnCreate","alias","config","displayName","enabled","firstBrokerLoginFlowAlias","internalId","linkOnly","postBrokerLoginFlowAlias","providerId","storeToken","trustEmail"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class IdentityProvidersSpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("addReadTokenRoleOnCreate")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Adds Read Token role when creating this Identity Provider.")
+    private Boolean addReadTokenRoleOnCreate;
+
+    public Boolean getAddReadTokenRoleOnCreate() {
+        return addReadTokenRoleOnCreate;
+    }
+
+    public void setAddReadTokenRoleOnCreate(Boolean addReadTokenRoleOnCreate) {
+        this.addReadTokenRoleOnCreate = addReadTokenRoleOnCreate;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("alias")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Identity Provider Alias.")
+    private String alias;
+
+    public String getAlias() {
+        return alias;
+    }
+
+    public void setAlias(String alias) {
+        this.alias = alias;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("config")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Identity Provider config.")
+    private java.util.Map<java.lang.String, String> config;
+
+    public java.util.Map<java.lang.String, String> getConfig() {
+        return config;
+    }
+
+    public void setConfig(java.util.Map<java.lang.String, String> config) {
+        this.config = config;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Identity Provider Display Name.")
+    private String displayName;
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("enabled")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Identity Provider enabled flag.")
+    private Boolean enabled;
+
+    public Boolean getEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("firstBrokerLoginFlowAlias")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Identity Provider First Broker Login Flow Alias.")
+    private String firstBrokerLoginFlowAlias;
+
+    public String getFirstBrokerLoginFlowAlias() {
+        return firstBrokerLoginFlowAlias;
+    }
+
+    public void setFirstBrokerLoginFlowAlias(String firstBrokerLoginFlowAlias) {
+        this.firstBrokerLoginFlowAlias = firstBrokerLoginFlowAlias;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("internalId")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Identity Provider Internal ID.")
+    private String internalId;
+
+    public String getInternalId() {
+        return internalId;
+    }
+
+    public void setInternalId(String internalId) {
+        this.internalId = internalId;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("linkOnly")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Identity Provider Link Only setting.")
+    private Boolean linkOnly;
+
+    public Boolean getLinkOnly() {
+        return linkOnly;
+    }
+
+    public void setLinkOnly(Boolean linkOnly) {
+        this.linkOnly = linkOnly;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("postBrokerLoginFlowAlias")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Identity Provider Post Broker Login Flow Alias.")
+    private String postBrokerLoginFlowAlias;
+
+    public String getPostBrokerLoginFlowAlias() {
+        return postBrokerLoginFlowAlias;
+    }
+
+    public void setPostBrokerLoginFlowAlias(String postBrokerLoginFlowAlias) {
+        this.postBrokerLoginFlowAlias = postBrokerLoginFlowAlias;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("providerId")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Identity Provider ID.")
+    private String providerId;
+
+    public String getProviderId() {
+        return providerId;
+    }
+
+    public void setProviderId(String providerId) {
+        this.providerId = providerId;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("storeToken")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Identity Provider Store to Token.")
+    private Boolean storeToken;
+
+    public Boolean getStoreToken() {
+        return storeToken;
+    }
+
+    public void setStoreToken(Boolean storeToken) {
+        this.storeToken = storeToken;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("trustEmail")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Identity Provider Trust Email.")
+    private Boolean trustEmail;
+
+    public Boolean getTrustEmail() {
+        return trustEmail;
+    }
+
+    public void setTrustEmail(Boolean trustEmail) {
+        this.trustEmail = trustEmail;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/InstanceSelectorSpec.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/InstanceSelectorSpec.java
@@ -1,0 +1,48 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"matchExpressions","matchLabels"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class InstanceSelectorSpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("matchExpressions")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("matchExpressions is a list of label selector requirements. The requirements are ANDed.")
+    private java.util.List<MatchExpressionsSpec> matchExpressions;
+
+    public java.util.List<MatchExpressionsSpec> getMatchExpressions() {
+        return matchExpressions;
+    }
+
+    public void setMatchExpressions(java.util.List<MatchExpressionsSpec> matchExpressions) {
+        this.matchExpressions = matchExpressions;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("matchLabels")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.")
+    private java.util.Map<java.lang.String, String> matchLabels;
+
+    public java.util.Map<java.lang.String, String> getMatchLabels() {
+        return matchLabels;
+    }
+
+    public void setMatchLabels(java.util.Map<java.lang.String, String> matchLabels) {
+        this.matchLabels = matchLabels;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/ItemsSpec.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/ItemsSpec.java
@@ -1,0 +1,85 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"configMaps","items","mountPath","name","secrets"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class ItemsSpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("configMaps")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Allow multiple configmaps to mount to the same directory")
+    private java.util.List<String> configMaps;
+
+    public java.util.List<String> getConfigMaps() {
+        return configMaps;
+    }
+
+    public void setConfigMaps(java.util.List<String> configMaps) {
+        this.configMaps = configMaps;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("items")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Mount details")
+    private java.util.List<ItemsSpec0> items;
+
+    public java.util.List<ItemsSpec0> getItems() {
+        return items;
+    }
+
+    public void setItems(java.util.List<ItemsSpec0> items) {
+        this.items = items;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("mountPath")
+    @javax.validation.constraints.NotNull()
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("An absolute path where to mount it")
+    private String mountPath;
+
+    public String getMountPath() {
+        return mountPath;
+    }
+
+    public void setMountPath(String mountPath) {
+        this.mountPath = mountPath;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Volume name")
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("secrets")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Secret mount")
+    private java.util.List<String> secrets;
+
+    public java.util.List<String> getSecrets() {
+        return secrets;
+    }
+
+    public void setSecrets(java.util.List<String> secrets) {
+        this.secrets = secrets;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/ItemsSpec0.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/ItemsSpec0.java
@@ -1,0 +1,62 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"key","mode","path"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class ItemsSpec0 implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("key")
+    @javax.validation.constraints.NotNull()
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("The key to project.")
+    private String key;
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("mode")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.")
+    private Integer mode;
+
+    public Integer getMode() {
+        return mode;
+    }
+
+    public void setMode(Integer mode) {
+        this.mode = mode;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("path")
+    @javax.validation.constraints.NotNull()
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.")
+    private String path;
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/Keycloak.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/Keycloak.java
@@ -1,0 +1,6 @@
+package org.keycloak.v1alpha1;
+
+@io.fabric8.kubernetes.model.annotation.Version(value = "v1alpha1", storage = false, served = false)
+@io.fabric8.kubernetes.model.annotation.Group("keycloak.org")
+public class Keycloak extends io.fabric8.kubernetes.client.CustomResource<KeycloakSpec, KeycloakStatus> implements io.fabric8.kubernetes.api.model.Namespaced {
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/KeycloakDeploymentSpecSpec.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/KeycloakDeploymentSpecSpec.java
@@ -1,0 +1,60 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"experimental","podlabels","resources"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class KeycloakDeploymentSpecSpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("experimental")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Experimental section NOTE: This section might change or get removed without any notice. It may also cause the deployment to behave in an unpredictable fashion. Please use with care.")
+    private ExperimentalSpec experimental;
+
+    public ExperimentalSpec getExperimental() {
+        return experimental;
+    }
+
+    public void setExperimental(ExperimentalSpec experimental) {
+        this.experimental = experimental;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("podlabels")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("List of labels to set in the keycloak pods")
+    private java.util.Map<java.lang.String, String> podlabels;
+
+    public java.util.Map<java.lang.String, String> getPodlabels() {
+        return podlabels;
+    }
+
+    public void setPodlabels(java.util.Map<java.lang.String, String> podlabels) {
+        this.podlabels = podlabels;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("resources")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Resources (Requests and Limits) for the Pods.")
+    private ResourcesSpec resources;
+
+    public ResourcesSpec getResources() {
+        return resources;
+    }
+
+    public void setResources(ResourcesSpec resources) {
+        this.resources = resources;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/KeycloakRealm.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/KeycloakRealm.java
@@ -1,0 +1,6 @@
+package org.keycloak.v1alpha1;
+
+@io.fabric8.kubernetes.model.annotation.Version(value = "v1alpha1", storage = false, served = false)
+@io.fabric8.kubernetes.model.annotation.Group("keycloak.org")
+public class KeycloakRealm extends io.fabric8.kubernetes.client.CustomResource<KeycloakRealmSpec, KeycloakRealmStatus> implements io.fabric8.kubernetes.api.model.Namespaced {
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/KeycloakRealmSpec.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/KeycloakRealmSpec.java
@@ -1,0 +1,73 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"instanceSelector","realm","realmOverrides","unmanaged"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class KeycloakRealmSpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("instanceSelector")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Selector for looking up Keycloak Custom Resources.")
+    private InstanceSelectorSpec instanceSelector;
+
+    public InstanceSelectorSpec getInstanceSelector() {
+        return instanceSelector;
+    }
+
+    public void setInstanceSelector(InstanceSelectorSpec instanceSelector) {
+        this.instanceSelector = instanceSelector;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("realm")
+    @javax.validation.constraints.NotNull()
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Keycloak Realm REST object.")
+    private RealmSpec realm;
+
+    public RealmSpec getRealm() {
+        return realm;
+    }
+
+    public void setRealm(RealmSpec realm) {
+        this.realm = realm;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("realmOverrides")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("A list of overrides to the default Realm behavior.")
+    private java.util.List<RealmOverridesSpec> realmOverrides;
+
+    public java.util.List<RealmOverridesSpec> getRealmOverrides() {
+        return realmOverrides;
+    }
+
+    public void setRealmOverrides(java.util.List<RealmOverridesSpec> realmOverrides) {
+        this.realmOverrides = realmOverrides;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("unmanaged")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("When set to true, this KeycloakRealm will be marked as unmanaged and not be managed by this operator. It can then be used for targeting purposes.")
+    private Boolean unmanaged;
+
+    public Boolean getUnmanaged() {
+        return unmanaged;
+    }
+
+    public void setUnmanaged(Boolean unmanaged) {
+        this.unmanaged = unmanaged;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/KeycloakRealmStatus.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/KeycloakRealmStatus.java
@@ -1,0 +1,88 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"loginURL","message","phase","ready","secondaryResources"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class KeycloakRealmStatus implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("loginURL")
+    @javax.validation.constraints.NotNull()
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("TODO")
+    private String loginURL;
+
+    public String getLoginURL() {
+        return loginURL;
+    }
+
+    public void setLoginURL(String loginURL) {
+        this.loginURL = loginURL;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("message")
+    @javax.validation.constraints.NotNull()
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Human-readable message indicating details about current operator phase or error.")
+    private String message;
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("phase")
+    @javax.validation.constraints.NotNull()
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Current phase of the operator.")
+    private String phase;
+
+    public String getPhase() {
+        return phase;
+    }
+
+    public void setPhase(String phase) {
+        this.phase = phase;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("ready")
+    @javax.validation.constraints.NotNull()
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("True if all resources are in a ready state and all work is done.")
+    private Boolean ready;
+
+    public Boolean getReady() {
+        return ready;
+    }
+
+    public void setReady(Boolean ready) {
+        this.ready = ready;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("secondaryResources")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("A map of all the secondary resources types and names created for this CR. e.g \"Deployment\": [ \"DeploymentName1\", \"DeploymentName2\" ]")
+    private java.util.Map<java.lang.String, java.util.List<String>> secondaryResources;
+
+    public java.util.Map<java.lang.String, java.util.List<String>> getSecondaryResources() {
+        return secondaryResources;
+    }
+
+    public void setSecondaryResources(java.util.Map<java.lang.String, java.util.List<String>> secondaryResources) {
+        this.secondaryResources = secondaryResources;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/KeycloakSpec.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/KeycloakSpec.java
@@ -1,0 +1,180 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"extensions","external","externalAccess","externalDatabase","instances","keycloakDeploymentSpec","migration","multiAvailablityZones","podDisruptionBudget","postgresDeploymentSpec","profile","storageClassName","unmanaged"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class KeycloakSpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("extensions")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("A list of extensions, where each one is a URL to a JAR files that will be deployed in Keycloak.")
+    private java.util.List<String> extensions;
+
+    public java.util.List<String> getExtensions() {
+        return extensions;
+    }
+
+    public void setExtensions(java.util.List<String> extensions) {
+        this.extensions = extensions;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("external")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Contains configuration for external Keycloak instances. Unmanaged needs to be set to true to use this.")
+    private ExternalSpec external;
+
+    public ExternalSpec getExternal() {
+        return external;
+    }
+
+    public void setExternal(ExternalSpec external) {
+        this.external = external;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("externalAccess")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Controls external Ingress/Route settings.")
+    private ExternalAccessSpec externalAccess;
+
+    public ExternalAccessSpec getExternalAccess() {
+        return externalAccess;
+    }
+
+    public void setExternalAccess(ExternalAccessSpec externalAccess) {
+        this.externalAccess = externalAccess;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("externalDatabase")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Controls external database settings. Using an external database requires providing a secret containing credentials as well as connection details. Here's an example of such secret: \n     apiVersion: v1     kind: Secret     metadata:         name: keycloak-db-secret         namespace: keycloak     stringData:         POSTGRES_DATABASE: <Database Name>         POSTGRES_EXTERNAL_ADDRESS: <External Database IP or URL (resolvable by K8s)>         POSTGRES_EXTERNAL_PORT: <External Database Port>         # Strongly recommended to use <'Keycloak CR Name'-postgresql>         POSTGRES_HOST: <Database Service Name>         POSTGRES_PASSWORD: <Database Password>         # Required for AWS Backup functionality         POSTGRES_SUPERUSER: true         POSTGRES_USERNAME: <Database Username>      type: Opaque \n Both POSTGRES_EXTERNAL_ADDRESS and POSTGRES_EXTERNAL_PORT are specifically required for creating connection to the external database. The secret name is created using the following convention:       <Custom Resource Name>-db-secret \n For more information, please refer to the Operator documentation.")
+    private ExternalDatabaseSpec externalDatabase;
+
+    public ExternalDatabaseSpec getExternalDatabase() {
+        return externalDatabase;
+    }
+
+    public void setExternalDatabase(ExternalDatabaseSpec externalDatabase) {
+        this.externalDatabase = externalDatabase;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("instances")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Number of Keycloak instances in HA mode. Default is 1.")
+    private Long instances;
+
+    public Long getInstances() {
+        return instances;
+    }
+
+    public void setInstances(Long instances) {
+        this.instances = instances;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("keycloakDeploymentSpec")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Resources (Requests and Limits) for KeycloakDeployment.")
+    private KeycloakDeploymentSpecSpec keycloakDeploymentSpec;
+
+    public KeycloakDeploymentSpecSpec getKeycloakDeploymentSpec() {
+        return keycloakDeploymentSpec;
+    }
+
+    public void setKeycloakDeploymentSpec(KeycloakDeploymentSpecSpec keycloakDeploymentSpec) {
+        this.keycloakDeploymentSpec = keycloakDeploymentSpec;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("migration")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Specify Migration configuration")
+    private MigrationSpec migration;
+
+    public MigrationSpec getMigration() {
+        return migration;
+    }
+
+    public void setMigration(MigrationSpec migration) {
+        this.migration = migration;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("multiAvailablityZones")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Specify PodAntiAffinity settings for Keycloak deployment in Multi AZ")
+    private MultiAvailablityZonesSpec multiAvailablityZones;
+
+    public MultiAvailablityZonesSpec getMultiAvailablityZones() {
+        return multiAvailablityZones;
+    }
+
+    public void setMultiAvailablityZones(MultiAvailablityZonesSpec multiAvailablityZones) {
+        this.multiAvailablityZones = multiAvailablityZones;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("podDisruptionBudget")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Specify PodDisruptionBudget configuration.")
+    private PodDisruptionBudgetSpec podDisruptionBudget;
+
+    public PodDisruptionBudgetSpec getPodDisruptionBudget() {
+        return podDisruptionBudget;
+    }
+
+    public void setPodDisruptionBudget(PodDisruptionBudgetSpec podDisruptionBudget) {
+        this.podDisruptionBudget = podDisruptionBudget;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("postgresDeploymentSpec")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Resources (Requests and Limits) for PostgresDeployment.")
+    private PostgresDeploymentSpecSpec postgresDeploymentSpec;
+
+    public PostgresDeploymentSpecSpec getPostgresDeploymentSpec() {
+        return postgresDeploymentSpec;
+    }
+
+    public void setPostgresDeploymentSpec(PostgresDeploymentSpecSpec postgresDeploymentSpec) {
+        this.postgresDeploymentSpec = postgresDeploymentSpec;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("profile")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Profile used for controlling Operator behavior. Default is empty.")
+    private String profile;
+
+    public String getProfile() {
+        return profile;
+    }
+
+    public void setProfile(String profile) {
+        this.profile = profile;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("storageClassName")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Name of the StorageClass for Postgresql Persistent Volume Claim")
+    private String storageClassName;
+
+    public String getStorageClassName() {
+        return storageClassName;
+    }
+
+    public void setStorageClassName(String storageClassName) {
+        this.storageClassName = storageClassName;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("unmanaged")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("When set to true, this Keycloak will be marked as unmanaged and will not be managed by this operator. It can then be used for targeting purposes.")
+    private Boolean unmanaged;
+
+    public Boolean getUnmanaged() {
+        return unmanaged;
+    }
+
+    public void setUnmanaged(Boolean unmanaged) {
+        this.unmanaged = unmanaged;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/KeycloakStatus.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/KeycloakStatus.java
@@ -1,0 +1,126 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"credentialSecret","externalURL","internalURL","message","phase","ready","secondaryResources","version"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class KeycloakStatus implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("credentialSecret")
+    @javax.validation.constraints.NotNull()
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("The secret where the admin credentials are to be found.")
+    private String credentialSecret;
+
+    public String getCredentialSecret() {
+        return credentialSecret;
+    }
+
+    public void setCredentialSecret(String credentialSecret) {
+        this.credentialSecret = credentialSecret;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("externalURL")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("External URL for accessing Keycloak instance from outside the cluster. Is identical to external.URL if it's specified, otherwise is computed (e.g. from Ingress).")
+    private String externalURL;
+
+    public String getExternalURL() {
+        return externalURL;
+    }
+
+    public void setExternalURL(String externalURL) {
+        this.externalURL = externalURL;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("internalURL")
+    @javax.validation.constraints.NotNull()
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("An internal URL (service name) to be used by the admin client.")
+    private String internalURL;
+
+    public String getInternalURL() {
+        return internalURL;
+    }
+
+    public void setInternalURL(String internalURL) {
+        this.internalURL = internalURL;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("message")
+    @javax.validation.constraints.NotNull()
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Human-readable message indicating details about current operator phase or error.")
+    private String message;
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("phase")
+    @javax.validation.constraints.NotNull()
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Current phase of the operator.")
+    private String phase;
+
+    public String getPhase() {
+        return phase;
+    }
+
+    public void setPhase(String phase) {
+        this.phase = phase;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("ready")
+    @javax.validation.constraints.NotNull()
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("True if all resources are in a ready state and all work is done.")
+    private Boolean ready;
+
+    public Boolean getReady() {
+        return ready;
+    }
+
+    public void setReady(Boolean ready) {
+        this.ready = ready;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("secondaryResources")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("A map of all the secondary resources types and names created for this CR. e.g \"Deployment\": [ \"DeploymentName1\", \"DeploymentName2\" ].")
+    private java.util.Map<java.lang.String, java.util.List<String>> secondaryResources;
+
+    public java.util.Map<java.lang.String, java.util.List<String>> getSecondaryResources() {
+        return secondaryResources;
+    }
+
+    public void setSecondaryResources(java.util.Map<java.lang.String, java.util.List<String>> secondaryResources) {
+        this.secondaryResources = secondaryResources;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("version")
+    @javax.validation.constraints.NotNull()
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Version of Keycloak or RHSSO running on the cluster.")
+    private String version;
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/LabelSelectorSpec.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/LabelSelectorSpec.java
@@ -1,0 +1,48 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"matchExpressions","matchLabels"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class LabelSelectorSpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("matchExpressions")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("matchExpressions is a list of label selector requirements. The requirements are ANDed.")
+    private java.util.List<MatchExpressionsSpec1> matchExpressions;
+
+    public java.util.List<MatchExpressionsSpec1> getMatchExpressions() {
+        return matchExpressions;
+    }
+
+    public void setMatchExpressions(java.util.List<MatchExpressionsSpec1> matchExpressions) {
+        this.matchExpressions = matchExpressions;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("matchLabels")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.")
+    private java.util.Map<java.lang.String, String> matchLabels;
+
+    public java.util.Map<java.lang.String, String> getMatchLabels() {
+        return matchLabels;
+    }
+
+    public void setMatchLabels(java.util.Map<java.lang.String, String> matchLabels) {
+        this.matchLabels = matchLabels;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/LabelSelectorSpec0.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/LabelSelectorSpec0.java
@@ -1,0 +1,48 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"matchExpressions","matchLabels"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class LabelSelectorSpec0 implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("matchExpressions")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("matchExpressions is a list of label selector requirements. The requirements are ANDed.")
+    private java.util.List<MatchExpressionsSpec2> matchExpressions;
+
+    public java.util.List<MatchExpressionsSpec2> getMatchExpressions() {
+        return matchExpressions;
+    }
+
+    public void setMatchExpressions(java.util.List<MatchExpressionsSpec2> matchExpressions) {
+        this.matchExpressions = matchExpressions;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("matchLabels")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.")
+    private java.util.Map<java.lang.String, String> matchLabels;
+
+    public java.util.Map<java.lang.String, String> getMatchLabels() {
+        return matchLabels;
+    }
+
+    public void setMatchLabels(java.util.Map<java.lang.String, String> matchLabels) {
+        this.matchLabels = matchLabels;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/LabelSelectorSpec1.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/LabelSelectorSpec1.java
@@ -1,0 +1,48 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"matchExpressions","matchLabels"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class LabelSelectorSpec1 implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("matchExpressions")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("matchExpressions is a list of label selector requirements. The requirements are ANDed.")
+    private java.util.List<MatchExpressionsSpec3> matchExpressions;
+
+    public java.util.List<MatchExpressionsSpec3> getMatchExpressions() {
+        return matchExpressions;
+    }
+
+    public void setMatchExpressions(java.util.List<MatchExpressionsSpec3> matchExpressions) {
+        this.matchExpressions = matchExpressions;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("matchLabels")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.")
+    private java.util.Map<java.lang.String, String> matchLabels;
+
+    public java.util.Map<java.lang.String, String> getMatchLabels() {
+        return matchLabels;
+    }
+
+    public void setMatchLabels(java.util.Map<java.lang.String, String> matchLabels) {
+        this.matchLabels = matchLabels;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/LabelSelectorSpec2.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/LabelSelectorSpec2.java
@@ -1,0 +1,48 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"matchExpressions","matchLabels"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class LabelSelectorSpec2 implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("matchExpressions")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("matchExpressions is a list of label selector requirements. The requirements are ANDed.")
+    private java.util.List<MatchExpressionsSpec4> matchExpressions;
+
+    public java.util.List<MatchExpressionsSpec4> getMatchExpressions() {
+        return matchExpressions;
+    }
+
+    public void setMatchExpressions(java.util.List<MatchExpressionsSpec4> matchExpressions) {
+        this.matchExpressions = matchExpressions;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("matchLabels")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.")
+    private java.util.Map<java.lang.String, String> matchLabels;
+
+    public java.util.Map<java.lang.String, String> getMatchLabels() {
+        return matchLabels;
+    }
+
+    public void setMatchLabels(java.util.Map<java.lang.String, String> matchLabels) {
+        this.matchLabels = matchLabels;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/MatchExpressionsSpec.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/MatchExpressionsSpec.java
@@ -1,0 +1,62 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"key","operator","values"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class MatchExpressionsSpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("key")
+    @javax.validation.constraints.NotNull()
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("key is the label key that the selector applies to.")
+    private String key;
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("operator")
+    @javax.validation.constraints.NotNull()
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.")
+    private String operator;
+
+    public String getOperator() {
+        return operator;
+    }
+
+    public void setOperator(String operator) {
+        this.operator = operator;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("values")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.")
+    private java.util.List<String> values;
+
+    public java.util.List<String> getValues() {
+        return values;
+    }
+
+    public void setValues(java.util.List<String> values) {
+        this.values = values;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/MatchExpressionsSpec0.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/MatchExpressionsSpec0.java
@@ -1,0 +1,62 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"key","operator","values"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class MatchExpressionsSpec0 implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("key")
+    @javax.validation.constraints.NotNull()
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("The label key that the selector applies to.")
+    private String key;
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("operator")
+    @javax.validation.constraints.NotNull()
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.")
+    private String operator;
+
+    public String getOperator() {
+        return operator;
+    }
+
+    public void setOperator(String operator) {
+        this.operator = operator;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("values")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.")
+    private java.util.List<String> values;
+
+    public java.util.List<String> getValues() {
+        return values;
+    }
+
+    public void setValues(java.util.List<String> values) {
+        this.values = values;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/MatchExpressionsSpec1.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/MatchExpressionsSpec1.java
@@ -1,0 +1,62 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"key","operator","values"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class MatchExpressionsSpec1 implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("key")
+    @javax.validation.constraints.NotNull()
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("key is the label key that the selector applies to.")
+    private String key;
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("operator")
+    @javax.validation.constraints.NotNull()
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.")
+    private String operator;
+
+    public String getOperator() {
+        return operator;
+    }
+
+    public void setOperator(String operator) {
+        this.operator = operator;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("values")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.")
+    private java.util.List<String> values;
+
+    public java.util.List<String> getValues() {
+        return values;
+    }
+
+    public void setValues(java.util.List<String> values) {
+        this.values = values;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/MatchExpressionsSpec2.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/MatchExpressionsSpec2.java
@@ -1,0 +1,62 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"key","operator","values"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class MatchExpressionsSpec2 implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("key")
+    @javax.validation.constraints.NotNull()
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("key is the label key that the selector applies to.")
+    private String key;
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("operator")
+    @javax.validation.constraints.NotNull()
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.")
+    private String operator;
+
+    public String getOperator() {
+        return operator;
+    }
+
+    public void setOperator(String operator) {
+        this.operator = operator;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("values")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.")
+    private java.util.List<String> values;
+
+    public java.util.List<String> getValues() {
+        return values;
+    }
+
+    public void setValues(java.util.List<String> values) {
+        this.values = values;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/MatchExpressionsSpec3.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/MatchExpressionsSpec3.java
@@ -1,0 +1,62 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"key","operator","values"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class MatchExpressionsSpec3 implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("key")
+    @javax.validation.constraints.NotNull()
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("key is the label key that the selector applies to.")
+    private String key;
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("operator")
+    @javax.validation.constraints.NotNull()
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.")
+    private String operator;
+
+    public String getOperator() {
+        return operator;
+    }
+
+    public void setOperator(String operator) {
+        this.operator = operator;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("values")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.")
+    private java.util.List<String> values;
+
+    public java.util.List<String> getValues() {
+        return values;
+    }
+
+    public void setValues(java.util.List<String> values) {
+        this.values = values;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/MatchExpressionsSpec4.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/MatchExpressionsSpec4.java
@@ -1,0 +1,62 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"key","operator","values"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class MatchExpressionsSpec4 implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("key")
+    @javax.validation.constraints.NotNull()
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("key is the label key that the selector applies to.")
+    private String key;
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("operator")
+    @javax.validation.constraints.NotNull()
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.")
+    private String operator;
+
+    public String getOperator() {
+        return operator;
+    }
+
+    public void setOperator(String operator) {
+        this.operator = operator;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("values")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.")
+    private java.util.List<String> values;
+
+    public java.util.List<String> getValues() {
+        return values;
+    }
+
+    public void setValues(java.util.List<String> values) {
+        this.values = values;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/MatchFieldsSpec.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/MatchFieldsSpec.java
@@ -1,0 +1,62 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"key","operator","values"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class MatchFieldsSpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("key")
+    @javax.validation.constraints.NotNull()
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("The label key that the selector applies to.")
+    private String key;
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("operator")
+    @javax.validation.constraints.NotNull()
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.")
+    private String operator;
+
+    public String getOperator() {
+        return operator;
+    }
+
+    public void setOperator(String operator) {
+        this.operator = operator;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("values")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.")
+    private java.util.List<String> values;
+
+    public java.util.List<String> getValues() {
+        return values;
+    }
+
+    public void setValues(java.util.List<String> values) {
+        this.values = values;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/MatchFieldsSpec0.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/MatchFieldsSpec0.java
@@ -1,0 +1,62 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"key","operator","values"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class MatchFieldsSpec0 implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("key")
+    @javax.validation.constraints.NotNull()
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("The label key that the selector applies to.")
+    private String key;
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("operator")
+    @javax.validation.constraints.NotNull()
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.")
+    private String operator;
+
+    public String getOperator() {
+        return operator;
+    }
+
+    public void setOperator(String operator) {
+        this.operator = operator;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("values")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.")
+    private java.util.List<String> values;
+
+    public java.util.List<String> getValues() {
+        return values;
+    }
+
+    public void setValues(java.util.List<String> values) {
+        this.values = values;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/MigrationSpec.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/MigrationSpec.java
@@ -1,0 +1,48 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"backups","strategy"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class MigrationSpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("backups")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Set it to config backup policy for migration")
+    private BackupsSpec backups;
+
+    public BackupsSpec getBackups() {
+        return backups;
+    }
+
+    public void setBackups(BackupsSpec backups) {
+        this.backups = backups;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("strategy")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Specify migration strategy")
+    private String strategy;
+
+    public String getStrategy() {
+        return strategy;
+    }
+
+    public void setStrategy(String strategy) {
+        this.strategy = strategy;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/MultiAvailablityZonesSpec.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/MultiAvailablityZonesSpec.java
@@ -1,0 +1,36 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"enabled"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class MultiAvailablityZonesSpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("enabled")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("If set to true, the operator will create a podAntiAffinity settings for the Keycloak deployment.")
+    private Boolean enabled;
+
+    public Boolean getEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/NodeAffinitySpec.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/NodeAffinitySpec.java
@@ -1,0 +1,48 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"preferredDuringSchedulingIgnoredDuringExecution","requiredDuringSchedulingIgnoredDuringExecution"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class NodeAffinitySpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("preferredDuringSchedulingIgnoredDuringExecution")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.")
+    private java.util.List<PreferredDuringSchedulingIgnoredDuringExecutionSpec> preferredDuringSchedulingIgnoredDuringExecution;
+
+    public java.util.List<PreferredDuringSchedulingIgnoredDuringExecutionSpec> getPreferredDuringSchedulingIgnoredDuringExecution() {
+        return preferredDuringSchedulingIgnoredDuringExecution;
+    }
+
+    public void setPreferredDuringSchedulingIgnoredDuringExecution(java.util.List<PreferredDuringSchedulingIgnoredDuringExecutionSpec> preferredDuringSchedulingIgnoredDuringExecution) {
+        this.preferredDuringSchedulingIgnoredDuringExecution = preferredDuringSchedulingIgnoredDuringExecution;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("requiredDuringSchedulingIgnoredDuringExecution")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.")
+    private RequiredDuringSchedulingIgnoredDuringExecutionSpec requiredDuringSchedulingIgnoredDuringExecution;
+
+    public RequiredDuringSchedulingIgnoredDuringExecutionSpec getRequiredDuringSchedulingIgnoredDuringExecution() {
+        return requiredDuringSchedulingIgnoredDuringExecution;
+    }
+
+    public void setRequiredDuringSchedulingIgnoredDuringExecution(RequiredDuringSchedulingIgnoredDuringExecutionSpec requiredDuringSchedulingIgnoredDuringExecution) {
+        this.requiredDuringSchedulingIgnoredDuringExecution = requiredDuringSchedulingIgnoredDuringExecution;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/NodeSelectorTermsSpec.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/NodeSelectorTermsSpec.java
@@ -1,0 +1,48 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"matchExpressions","matchFields"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class NodeSelectorTermsSpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("matchExpressions")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("A list of node selector requirements by node's labels.")
+    private java.util.List<MatchExpressionsSpec0> matchExpressions;
+
+    public java.util.List<MatchExpressionsSpec0> getMatchExpressions() {
+        return matchExpressions;
+    }
+
+    public void setMatchExpressions(java.util.List<MatchExpressionsSpec0> matchExpressions) {
+        this.matchExpressions = matchExpressions;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("matchFields")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("A list of node selector requirements by node's fields.")
+    private java.util.List<MatchFieldsSpec0> matchFields;
+
+    public java.util.List<MatchFieldsSpec0> getMatchFields() {
+        return matchFields;
+    }
+
+    public void setMatchFields(java.util.List<MatchFieldsSpec0> matchFields) {
+        this.matchFields = matchFields;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/PodAffinitySpec.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/PodAffinitySpec.java
@@ -1,0 +1,48 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"preferredDuringSchedulingIgnoredDuringExecution","requiredDuringSchedulingIgnoredDuringExecution"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class PodAffinitySpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("preferredDuringSchedulingIgnoredDuringExecution")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.")
+    private java.util.List<PreferredDuringSchedulingIgnoredDuringExecutionSpec0> preferredDuringSchedulingIgnoredDuringExecution;
+
+    public java.util.List<PreferredDuringSchedulingIgnoredDuringExecutionSpec0> getPreferredDuringSchedulingIgnoredDuringExecution() {
+        return preferredDuringSchedulingIgnoredDuringExecution;
+    }
+
+    public void setPreferredDuringSchedulingIgnoredDuringExecution(java.util.List<PreferredDuringSchedulingIgnoredDuringExecutionSpec0> preferredDuringSchedulingIgnoredDuringExecution) {
+        this.preferredDuringSchedulingIgnoredDuringExecution = preferredDuringSchedulingIgnoredDuringExecution;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("requiredDuringSchedulingIgnoredDuringExecution")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.")
+    private java.util.List<RequiredDuringSchedulingIgnoredDuringExecutionSpec0> requiredDuringSchedulingIgnoredDuringExecution;
+
+    public java.util.List<RequiredDuringSchedulingIgnoredDuringExecutionSpec0> getRequiredDuringSchedulingIgnoredDuringExecution() {
+        return requiredDuringSchedulingIgnoredDuringExecution;
+    }
+
+    public void setRequiredDuringSchedulingIgnoredDuringExecution(java.util.List<RequiredDuringSchedulingIgnoredDuringExecutionSpec0> requiredDuringSchedulingIgnoredDuringExecution) {
+        this.requiredDuringSchedulingIgnoredDuringExecution = requiredDuringSchedulingIgnoredDuringExecution;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/PodAffinityTermSpec.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/PodAffinityTermSpec.java
@@ -1,0 +1,61 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"labelSelector","namespaces","topologyKey"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class PodAffinityTermSpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("labelSelector")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("A label query over a set of resources, in this case pods.")
+    private LabelSelectorSpec labelSelector;
+
+    public LabelSelectorSpec getLabelSelector() {
+        return labelSelector;
+    }
+
+    public void setLabelSelector(LabelSelectorSpec labelSelector) {
+        this.labelSelector = labelSelector;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("namespaces")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means \"this pod's namespace\"")
+    private java.util.List<String> namespaces;
+
+    public java.util.List<String> getNamespaces() {
+        return namespaces;
+    }
+
+    public void setNamespaces(java.util.List<String> namespaces) {
+        this.namespaces = namespaces;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("topologyKey")
+    @javax.validation.constraints.NotNull()
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.")
+    private String topologyKey;
+
+    public String getTopologyKey() {
+        return topologyKey;
+    }
+
+    public void setTopologyKey(String topologyKey) {
+        this.topologyKey = topologyKey;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/PodAffinityTermSpec0.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/PodAffinityTermSpec0.java
@@ -1,0 +1,61 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"labelSelector","namespaces","topologyKey"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class PodAffinityTermSpec0 implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("labelSelector")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("A label query over a set of resources, in this case pods.")
+    private LabelSelectorSpec1 labelSelector;
+
+    public LabelSelectorSpec1 getLabelSelector() {
+        return labelSelector;
+    }
+
+    public void setLabelSelector(LabelSelectorSpec1 labelSelector) {
+        this.labelSelector = labelSelector;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("namespaces")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means \"this pod's namespace\"")
+    private java.util.List<String> namespaces;
+
+    public java.util.List<String> getNamespaces() {
+        return namespaces;
+    }
+
+    public void setNamespaces(java.util.List<String> namespaces) {
+        this.namespaces = namespaces;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("topologyKey")
+    @javax.validation.constraints.NotNull()
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.")
+    private String topologyKey;
+
+    public String getTopologyKey() {
+        return topologyKey;
+    }
+
+    public void setTopologyKey(String topologyKey) {
+        this.topologyKey = topologyKey;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/PodAntiAffinitySpec.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/PodAntiAffinitySpec.java
@@ -1,0 +1,48 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"preferredDuringSchedulingIgnoredDuringExecution","requiredDuringSchedulingIgnoredDuringExecution"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class PodAntiAffinitySpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("preferredDuringSchedulingIgnoredDuringExecution")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.")
+    private java.util.List<PreferredDuringSchedulingIgnoredDuringExecutionSpec1> preferredDuringSchedulingIgnoredDuringExecution;
+
+    public java.util.List<PreferredDuringSchedulingIgnoredDuringExecutionSpec1> getPreferredDuringSchedulingIgnoredDuringExecution() {
+        return preferredDuringSchedulingIgnoredDuringExecution;
+    }
+
+    public void setPreferredDuringSchedulingIgnoredDuringExecution(java.util.List<PreferredDuringSchedulingIgnoredDuringExecutionSpec1> preferredDuringSchedulingIgnoredDuringExecution) {
+        this.preferredDuringSchedulingIgnoredDuringExecution = preferredDuringSchedulingIgnoredDuringExecution;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("requiredDuringSchedulingIgnoredDuringExecution")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.")
+    private java.util.List<RequiredDuringSchedulingIgnoredDuringExecutionSpec1> requiredDuringSchedulingIgnoredDuringExecution;
+
+    public java.util.List<RequiredDuringSchedulingIgnoredDuringExecutionSpec1> getRequiredDuringSchedulingIgnoredDuringExecution() {
+        return requiredDuringSchedulingIgnoredDuringExecution;
+    }
+
+    public void setRequiredDuringSchedulingIgnoredDuringExecution(java.util.List<RequiredDuringSchedulingIgnoredDuringExecutionSpec1> requiredDuringSchedulingIgnoredDuringExecution) {
+        this.requiredDuringSchedulingIgnoredDuringExecution = requiredDuringSchedulingIgnoredDuringExecution;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/PodDisruptionBudgetSpec.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/PodDisruptionBudgetSpec.java
@@ -1,0 +1,36 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"enabled"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class PodDisruptionBudgetSpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("enabled")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("If set to true, the operator will create a PodDistruptionBudget for the Keycloak deployment and set its `maxUnavailable` value to 1.")
+    private Boolean enabled;
+
+    public Boolean getEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/PoliciesSpec.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/PoliciesSpec.java
@@ -1,0 +1,168 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"config","decisionStrategy","id","logic","name","owner","policies","resources","resourcesData","scopes","scopesData","type"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class PoliciesSpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("config")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Config.")
+    private java.util.Map<java.lang.String, String> config;
+
+    public java.util.Map<java.lang.String, String> getConfig() {
+        return config;
+    }
+
+    public void setConfig(java.util.Map<java.lang.String, String> config) {
+        this.config = config;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("decisionStrategy")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("The decision strategy dictates how the policies associated with a given permission are evaluated and how a final decision is obtained. 'Affirmative' means that at least one policy must evaluate to a positive decision in order for the final decision to be also positive. 'Unanimous' means that all policies must evaluate to a positive decision in order for the final decision to be also positive. 'Consensus' means that the number of positive decisions must be greater than the number of negative decisions. If the number of positive and negative is the same, the final decision will be negative.")
+    private String decisionStrategy;
+
+    public String getDecisionStrategy() {
+        return decisionStrategy;
+    }
+
+    public void setDecisionStrategy(String decisionStrategy) {
+        this.decisionStrategy = decisionStrategy;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("ID.")
+    private String id;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("logic")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("The logic dictates how the policy decision should be made. If 'Positive', the resulting effect (permit or deny) obtained during the evaluation of this policy will be used to perform a decision. If 'Negative', the resulting effect will be negated, in other words, a permit becomes a deny and vice-versa.")
+    private String logic;
+
+    public String getLogic() {
+        return logic;
+    }
+
+    public void setLogic(String logic) {
+        this.logic = logic;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("The name of this policy.")
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("owner")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Owner.")
+    private String owner;
+
+    public String getOwner() {
+        return owner;
+    }
+
+    public void setOwner(String owner) {
+        this.owner = owner;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("policies")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Policies.")
+    private java.util.List<String> policies;
+
+    public java.util.List<String> getPolicies() {
+        return policies;
+    }
+
+    public void setPolicies(java.util.List<String> policies) {
+        this.policies = policies;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("resources")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Resources.")
+    private java.util.List<String> resources;
+
+    public java.util.List<String> getResources() {
+        return resources;
+    }
+
+    public void setResources(java.util.List<String> resources) {
+        this.resources = resources;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("resourcesData")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Resources Data.")
+    private java.util.List<ResourcesDataSpec> resourcesData;
+
+    public java.util.List<ResourcesDataSpec> getResourcesData() {
+        return resourcesData;
+    }
+
+    public void setResourcesData(java.util.List<ResourcesDataSpec> resourcesData) {
+        this.resourcesData = resourcesData;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("scopes")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Scopes.")
+    private java.util.List<String> scopes;
+
+    public java.util.List<String> getScopes() {
+        return scopes;
+    }
+
+    public void setScopes(java.util.List<String> scopes) {
+        this.scopes = scopes;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("scopesData")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Scopes Data.")
+    private java.util.List<ScopesDataSpec> scopesData;
+
+    public java.util.List<ScopesDataSpec> getScopesData() {
+        return scopesData;
+    }
+
+    public void setScopesData(java.util.List<ScopesDataSpec> scopesData) {
+        this.scopesData = scopesData;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("type")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Type.")
+    private String type;
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/PoliciesSpec0.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/PoliciesSpec0.java
@@ -1,0 +1,168 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"config","decisionStrategy","id","logic","name","owner","policies","resources","resourcesData","scopes","scopesData","type"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class PoliciesSpec0 implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("config")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Config.")
+    private java.util.Map<java.lang.String, String> config;
+
+    public java.util.Map<java.lang.String, String> getConfig() {
+        return config;
+    }
+
+    public void setConfig(java.util.Map<java.lang.String, String> config) {
+        this.config = config;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("decisionStrategy")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("The decision strategy dictates how the policies associated with a given permission are evaluated and how a final decision is obtained. 'Affirmative' means that at least one policy must evaluate to a positive decision in order for the final decision to be also positive. 'Unanimous' means that all policies must evaluate to a positive decision in order for the final decision to be also positive. 'Consensus' means that the number of positive decisions must be greater than the number of negative decisions. If the number of positive and negative is the same, the final decision will be negative.")
+    private String decisionStrategy;
+
+    public String getDecisionStrategy() {
+        return decisionStrategy;
+    }
+
+    public void setDecisionStrategy(String decisionStrategy) {
+        this.decisionStrategy = decisionStrategy;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("ID.")
+    private String id;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("logic")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("The logic dictates how the policy decision should be made. If 'Positive', the resulting effect (permit or deny) obtained during the evaluation of this policy will be used to perform a decision. If 'Negative', the resulting effect will be negated, in other words, a permit becomes a deny and vice-versa.")
+    private String logic;
+
+    public String getLogic() {
+        return logic;
+    }
+
+    public void setLogic(String logic) {
+        this.logic = logic;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("The name of this policy.")
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("owner")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Owner.")
+    private String owner;
+
+    public String getOwner() {
+        return owner;
+    }
+
+    public void setOwner(String owner) {
+        this.owner = owner;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("policies")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Policies.")
+    private java.util.List<String> policies;
+
+    public java.util.List<String> getPolicies() {
+        return policies;
+    }
+
+    public void setPolicies(java.util.List<String> policies) {
+        this.policies = policies;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("resources")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Resources.")
+    private java.util.List<String> resources;
+
+    public java.util.List<String> getResources() {
+        return resources;
+    }
+
+    public void setResources(java.util.List<String> resources) {
+        this.resources = resources;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("resourcesData")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Resources Data.")
+    private java.util.List<ResourcesDataSpec0> resourcesData;
+
+    public java.util.List<ResourcesDataSpec0> getResourcesData() {
+        return resourcesData;
+    }
+
+    public void setResourcesData(java.util.List<ResourcesDataSpec0> resourcesData) {
+        this.resourcesData = resourcesData;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("scopes")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Scopes.")
+    private java.util.List<String> scopes;
+
+    public java.util.List<String> getScopes() {
+        return scopes;
+    }
+
+    public void setScopes(java.util.List<String> scopes) {
+        this.scopes = scopes;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("scopesData")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Scopes Data.")
+    private java.util.List<ScopesDataSpec0> scopesData;
+
+    public java.util.List<ScopesDataSpec0> getScopesData() {
+        return scopesData;
+    }
+
+    public void setScopesData(java.util.List<ScopesDataSpec0> scopesData) {
+        this.scopesData = scopesData;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("type")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Type.")
+    private String type;
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/PostgresDeploymentSpecSpec.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/PostgresDeploymentSpecSpec.java
@@ -1,0 +1,36 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"resources"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class PostgresDeploymentSpecSpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("resources")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Resources (Requests and Limits) for the Pods.")
+    private ResourcesSpec0 resources;
+
+    public ResourcesSpec0 getResources() {
+        return resources;
+    }
+
+    public void setResources(ResourcesSpec0 resources) {
+        this.resources = resources;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/PreferenceSpec.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/PreferenceSpec.java
@@ -1,0 +1,48 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"matchExpressions","matchFields"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class PreferenceSpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("matchExpressions")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("A list of node selector requirements by node's labels.")
+    private java.util.List<MatchExpressionsSpec> matchExpressions;
+
+    public java.util.List<MatchExpressionsSpec> getMatchExpressions() {
+        return matchExpressions;
+    }
+
+    public void setMatchExpressions(java.util.List<MatchExpressionsSpec> matchExpressions) {
+        this.matchExpressions = matchExpressions;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("matchFields")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("A list of node selector requirements by node's fields.")
+    private java.util.List<MatchFieldsSpec> matchFields;
+
+    public java.util.List<MatchFieldsSpec> getMatchFields() {
+        return matchFields;
+    }
+
+    public void setMatchFields(java.util.List<MatchFieldsSpec> matchFields) {
+        this.matchFields = matchFields;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/PreferredDuringSchedulingIgnoredDuringExecutionSpec.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/PreferredDuringSchedulingIgnoredDuringExecutionSpec.java
@@ -1,0 +1,50 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"preference","weight"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class PreferredDuringSchedulingIgnoredDuringExecutionSpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("preference")
+    @javax.validation.constraints.NotNull()
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("A node selector term, associated with the corresponding weight.")
+    private PreferenceSpec preference;
+
+    public PreferenceSpec getPreference() {
+        return preference;
+    }
+
+    public void setPreference(PreferenceSpec preference) {
+        this.preference = preference;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("weight")
+    @javax.validation.constraints.NotNull()
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.")
+    private Integer weight;
+
+    public Integer getWeight() {
+        return weight;
+    }
+
+    public void setWeight(Integer weight) {
+        this.weight = weight;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/PreferredDuringSchedulingIgnoredDuringExecutionSpec0.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/PreferredDuringSchedulingIgnoredDuringExecutionSpec0.java
@@ -1,0 +1,50 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"podAffinityTerm","weight"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class PreferredDuringSchedulingIgnoredDuringExecutionSpec0 implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("podAffinityTerm")
+    @javax.validation.constraints.NotNull()
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Required. A pod affinity term, associated with the corresponding weight.")
+    private PodAffinityTermSpec podAffinityTerm;
+
+    public PodAffinityTermSpec getPodAffinityTerm() {
+        return podAffinityTerm;
+    }
+
+    public void setPodAffinityTerm(PodAffinityTermSpec podAffinityTerm) {
+        this.podAffinityTerm = podAffinityTerm;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("weight")
+    @javax.validation.constraints.NotNull()
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("weight associated with matching the corresponding podAffinityTerm, in the range 1-100.")
+    private Integer weight;
+
+    public Integer getWeight() {
+        return weight;
+    }
+
+    public void setWeight(Integer weight) {
+        this.weight = weight;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/PreferredDuringSchedulingIgnoredDuringExecutionSpec1.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/PreferredDuringSchedulingIgnoredDuringExecutionSpec1.java
@@ -1,0 +1,50 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"podAffinityTerm","weight"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class PreferredDuringSchedulingIgnoredDuringExecutionSpec1 implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("podAffinityTerm")
+    @javax.validation.constraints.NotNull()
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Required. A pod affinity term, associated with the corresponding weight.")
+    private PodAffinityTermSpec0 podAffinityTerm;
+
+    public PodAffinityTermSpec0 getPodAffinityTerm() {
+        return podAffinityTerm;
+    }
+
+    public void setPodAffinityTerm(PodAffinityTermSpec0 podAffinityTerm) {
+        this.podAffinityTerm = podAffinityTerm;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("weight")
+    @javax.validation.constraints.NotNull()
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("weight associated with matching the corresponding podAffinityTerm, in the range 1-100.")
+    private Integer weight;
+
+    public Integer getWeight() {
+        return weight;
+    }
+
+    public void setWeight(Integer weight) {
+        this.weight = weight;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/ProtocolMappersSpec.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/ProtocolMappersSpec.java
@@ -1,0 +1,108 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"config","consentRequired","consentText","id","name","protocol","protocolMapper"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class ProtocolMappersSpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("config")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Config options.")
+    private java.util.Map<java.lang.String, String> config;
+
+    public java.util.Map<java.lang.String, String> getConfig() {
+        return config;
+    }
+
+    public void setConfig(java.util.Map<java.lang.String, String> config) {
+        this.config = config;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("consentRequired")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("True if Consent Screen is required.")
+    private Boolean consentRequired;
+
+    public Boolean getConsentRequired() {
+        return consentRequired;
+    }
+
+    public void setConsentRequired(Boolean consentRequired) {
+        this.consentRequired = consentRequired;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("consentText")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Text to use for displaying Consent Screen.")
+    private String consentText;
+
+    public String getConsentText() {
+        return consentText;
+    }
+
+    public void setConsentText(String consentText) {
+        this.consentText = consentText;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Protocol Mapper ID.")
+    private String id;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Protocol Mapper Name.")
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("protocol")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Protocol to use.")
+    private String protocol;
+
+    public String getProtocol() {
+        return protocol;
+    }
+
+    public void setProtocol(String protocol) {
+        this.protocol = protocol;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("protocolMapper")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Protocol Mapper to use")
+    private String protocolMapper;
+
+    public String getProtocolMapper() {
+        return protocolMapper;
+    }
+
+    public void setProtocolMapper(String protocolMapper) {
+        this.protocolMapper = protocolMapper;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/ProtocolMappersSpec0.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/ProtocolMappersSpec0.java
@@ -1,0 +1,108 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"config","consentRequired","consentText","id","name","protocol","protocolMapper"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class ProtocolMappersSpec0 implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("config")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Config options.")
+    private java.util.Map<java.lang.String, String> config;
+
+    public java.util.Map<java.lang.String, String> getConfig() {
+        return config;
+    }
+
+    public void setConfig(java.util.Map<java.lang.String, String> config) {
+        this.config = config;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("consentRequired")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("True if Consent Screen is required.")
+    private Boolean consentRequired;
+
+    public Boolean getConsentRequired() {
+        return consentRequired;
+    }
+
+    public void setConsentRequired(Boolean consentRequired) {
+        this.consentRequired = consentRequired;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("consentText")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Text to use for displaying Consent Screen.")
+    private String consentText;
+
+    public String getConsentText() {
+        return consentText;
+    }
+
+    public void setConsentText(String consentText) {
+        this.consentText = consentText;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Protocol Mapper ID.")
+    private String id;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Protocol Mapper Name.")
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("protocol")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Protocol to use.")
+    private String protocol;
+
+    public String getProtocol() {
+        return protocol;
+    }
+
+    public void setProtocol(String protocol) {
+        this.protocol = protocol;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("protocolMapper")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Protocol Mapper to use")
+    private String protocolMapper;
+
+    public String getProtocolMapper() {
+        return protocolMapper;
+    }
+
+    public void setProtocolMapper(String protocolMapper) {
+        this.protocolMapper = protocolMapper;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/RealmOverridesSpec.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/RealmOverridesSpec.java
@@ -1,0 +1,49 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"forFlow","identityProvider"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class RealmOverridesSpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("forFlow")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Flow to be overridden.")
+    private String forFlow;
+
+    public String getForFlow() {
+        return forFlow;
+    }
+
+    public void setForFlow(String forFlow) {
+        this.forFlow = forFlow;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("identityProvider")
+    @javax.validation.constraints.NotNull()
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Identity Provider to be overridden.")
+    private String identityProvider;
+
+    public String getIdentityProvider() {
+        return identityProvider;
+    }
+
+    public void setIdentityProvider(String identityProvider) {
+        this.identityProvider = identityProvider;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/RealmSpec.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/RealmSpec.java
@@ -1,0 +1,636 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"accessTokenLifespan","accessTokenLifespanForImplicitFlow","accountTheme","adminEventsDetailsEnabled","adminEventsEnabled","adminTheme","authenticationFlows","authenticatorConfig","bruteForceProtected","clientScopeMappings","clientScopes","clients","defaultLocale","defaultRole","displayName","displayNameHtml","duplicateEmailsAllowed","editUsernameAllowed","emailTheme","enabled","enabledEventTypes","eventsEnabled","eventsListeners","failureFactor","id","identityProviders","internationalizationEnabled","loginTheme","loginWithEmailAllowed","maxDeltaTimeSeconds","maxFailureWaitSeconds","minimumQuickLoginWaitSeconds","passwordPolicy","permanentLockout","quickLoginCheckMilliSeconds","realm","registrationAllowed","registrationEmailAsUsername","rememberMe","resetPasswordAllowed","roles","scopeMappings","smtpServer","sslRequired","supportedLocales","userFederationMappers","userFederationProviders","userManagedAccessAllowed","users","verifyEmail","waitIncrementSeconds"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class RealmSpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("accessTokenLifespan")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Access Token Lifespan")
+    private Integer accessTokenLifespan;
+
+    public Integer getAccessTokenLifespan() {
+        return accessTokenLifespan;
+    }
+
+    public void setAccessTokenLifespan(Integer accessTokenLifespan) {
+        this.accessTokenLifespan = accessTokenLifespan;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("accessTokenLifespanForImplicitFlow")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Access Token Lifespan For Implicit Flow")
+    private Integer accessTokenLifespanForImplicitFlow;
+
+    public Integer getAccessTokenLifespanForImplicitFlow() {
+        return accessTokenLifespanForImplicitFlow;
+    }
+
+    public void setAccessTokenLifespanForImplicitFlow(Integer accessTokenLifespanForImplicitFlow) {
+        this.accessTokenLifespanForImplicitFlow = accessTokenLifespanForImplicitFlow;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("accountTheme")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Account Theme")
+    private String accountTheme;
+
+    public String getAccountTheme() {
+        return accountTheme;
+    }
+
+    public void setAccountTheme(String accountTheme) {
+        this.accountTheme = accountTheme;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("adminEventsDetailsEnabled")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Enable admin events details TODO: change to values and use kubebuilder default annotation once supported")
+    private Boolean adminEventsDetailsEnabled;
+
+    public Boolean getAdminEventsDetailsEnabled() {
+        return adminEventsDetailsEnabled;
+    }
+
+    public void setAdminEventsDetailsEnabled(Boolean adminEventsDetailsEnabled) {
+        this.adminEventsDetailsEnabled = adminEventsDetailsEnabled;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("adminEventsEnabled")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Enable events recording TODO: change to values and use kubebuilder default annotation once supported")
+    private Boolean adminEventsEnabled;
+
+    public Boolean getAdminEventsEnabled() {
+        return adminEventsEnabled;
+    }
+
+    public void setAdminEventsEnabled(Boolean adminEventsEnabled) {
+        this.adminEventsEnabled = adminEventsEnabled;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("adminTheme")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Admin Console Theme")
+    private String adminTheme;
+
+    public String getAdminTheme() {
+        return adminTheme;
+    }
+
+    public void setAdminTheme(String adminTheme) {
+        this.adminTheme = adminTheme;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("authenticationFlows")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Authentication flows")
+    private java.util.List<AuthenticationFlowsSpec> authenticationFlows;
+
+    public java.util.List<AuthenticationFlowsSpec> getAuthenticationFlows() {
+        return authenticationFlows;
+    }
+
+    public void setAuthenticationFlows(java.util.List<AuthenticationFlowsSpec> authenticationFlows) {
+        this.authenticationFlows = authenticationFlows;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("authenticatorConfig")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Authenticator config")
+    private java.util.List<AuthenticatorConfigSpec> authenticatorConfig;
+
+    public java.util.List<AuthenticatorConfigSpec> getAuthenticatorConfig() {
+        return authenticatorConfig;
+    }
+
+    public void setAuthenticatorConfig(java.util.List<AuthenticatorConfigSpec> authenticatorConfig) {
+        this.authenticatorConfig = authenticatorConfig;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("bruteForceProtected")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Brute Force Detection")
+    private Boolean bruteForceProtected;
+
+    public Boolean getBruteForceProtected() {
+        return bruteForceProtected;
+    }
+
+    public void setBruteForceProtected(Boolean bruteForceProtected) {
+        this.bruteForceProtected = bruteForceProtected;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("clientScopeMappings")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Client Scope Mappings")
+    private java.util.Map<java.lang.String, java.util.List<ClientScopeMappingsSpec>> clientScopeMappings;
+
+    public java.util.Map<java.lang.String, java.util.List<ClientScopeMappingsSpec>> getClientScopeMappings() {
+        return clientScopeMappings;
+    }
+
+    public void setClientScopeMappings(java.util.Map<java.lang.String, java.util.List<ClientScopeMappingsSpec>> clientScopeMappings) {
+        this.clientScopeMappings = clientScopeMappings;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("clientScopes")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Client scopes")
+    private java.util.List<ClientScopesSpec> clientScopes;
+
+    public java.util.List<ClientScopesSpec> getClientScopes() {
+        return clientScopes;
+    }
+
+    public void setClientScopes(java.util.List<ClientScopesSpec> clientScopes) {
+        this.clientScopes = clientScopes;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("clients")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("A set of Keycloak Clients.")
+    private java.util.List<ClientsSpec> clients;
+
+    public java.util.List<ClientsSpec> getClients() {
+        return clients;
+    }
+
+    public void setClients(java.util.List<ClientsSpec> clients) {
+        this.clients = clients;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("defaultLocale")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Default Locale")
+    private String defaultLocale;
+
+    public String getDefaultLocale() {
+        return defaultLocale;
+    }
+
+    public void setDefaultLocale(String defaultLocale) {
+        this.defaultLocale = defaultLocale;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("defaultRole")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Default role")
+    private DefaultRoleSpec defaultRole;
+
+    public DefaultRoleSpec getDefaultRole() {
+        return defaultRole;
+    }
+
+    public void setDefaultRole(DefaultRoleSpec defaultRole) {
+        this.defaultRole = defaultRole;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Realm display name.")
+    private String displayName;
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("displayNameHtml")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Realm HTML display name.")
+    private String displayNameHtml;
+
+    public String getDisplayNameHtml() {
+        return displayNameHtml;
+    }
+
+    public void setDisplayNameHtml(String displayNameHtml) {
+        this.displayNameHtml = displayNameHtml;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("duplicateEmailsAllowed")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Duplicate emails")
+    private Boolean duplicateEmailsAllowed;
+
+    public Boolean getDuplicateEmailsAllowed() {
+        return duplicateEmailsAllowed;
+    }
+
+    public void setDuplicateEmailsAllowed(Boolean duplicateEmailsAllowed) {
+        this.duplicateEmailsAllowed = duplicateEmailsAllowed;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("editUsernameAllowed")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Edit username")
+    private Boolean editUsernameAllowed;
+
+    public Boolean getEditUsernameAllowed() {
+        return editUsernameAllowed;
+    }
+
+    public void setEditUsernameAllowed(Boolean editUsernameAllowed) {
+        this.editUsernameAllowed = editUsernameAllowed;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("emailTheme")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Email Theme")
+    private String emailTheme;
+
+    public String getEmailTheme() {
+        return emailTheme;
+    }
+
+    public void setEmailTheme(String emailTheme) {
+        this.emailTheme = emailTheme;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("enabled")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Realm enabled flag.")
+    private Boolean enabled;
+
+    public Boolean getEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("enabledEventTypes")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Enabled event types")
+    private java.util.List<String> enabledEventTypes;
+
+    public java.util.List<String> getEnabledEventTypes() {
+        return enabledEventTypes;
+    }
+
+    public void setEnabledEventTypes(java.util.List<String> enabledEventTypes) {
+        this.enabledEventTypes = enabledEventTypes;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("eventsEnabled")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Enable events recording TODO: change to values and use kubebuilder default annotation once supported")
+    private Boolean eventsEnabled;
+
+    public Boolean getEventsEnabled() {
+        return eventsEnabled;
+    }
+
+    public void setEventsEnabled(Boolean eventsEnabled) {
+        this.eventsEnabled = eventsEnabled;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("eventsListeners")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("A set of Event Listeners.")
+    private java.util.List<String> eventsListeners;
+
+    public java.util.List<String> getEventsListeners() {
+        return eventsListeners;
+    }
+
+    public void setEventsListeners(java.util.List<String> eventsListeners) {
+        this.eventsListeners = eventsListeners;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("failureFactor")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Max Login Failures")
+    private Integer failureFactor;
+
+    public Integer getFailureFactor() {
+        return failureFactor;
+    }
+
+    public void setFailureFactor(Integer failureFactor) {
+        this.failureFactor = failureFactor;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    private String id;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("identityProviders")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("A set of Identity Providers.")
+    private java.util.List<IdentityProvidersSpec> identityProviders;
+
+    public java.util.List<IdentityProvidersSpec> getIdentityProviders() {
+        return identityProviders;
+    }
+
+    public void setIdentityProviders(java.util.List<IdentityProvidersSpec> identityProviders) {
+        this.identityProviders = identityProviders;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("internationalizationEnabled")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Internationalization Enabled")
+    private Boolean internationalizationEnabled;
+
+    public Boolean getInternationalizationEnabled() {
+        return internationalizationEnabled;
+    }
+
+    public void setInternationalizationEnabled(Boolean internationalizationEnabled) {
+        this.internationalizationEnabled = internationalizationEnabled;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("loginTheme")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Login Theme")
+    private String loginTheme;
+
+    public String getLoginTheme() {
+        return loginTheme;
+    }
+
+    public void setLoginTheme(String loginTheme) {
+        this.loginTheme = loginTheme;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("loginWithEmailAllowed")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Login with email")
+    private Boolean loginWithEmailAllowed;
+
+    public Boolean getLoginWithEmailAllowed() {
+        return loginWithEmailAllowed;
+    }
+
+    public void setLoginWithEmailAllowed(Boolean loginWithEmailAllowed) {
+        this.loginWithEmailAllowed = loginWithEmailAllowed;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("maxDeltaTimeSeconds")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Failure Reset Time")
+    private Integer maxDeltaTimeSeconds;
+
+    public Integer getMaxDeltaTimeSeconds() {
+        return maxDeltaTimeSeconds;
+    }
+
+    public void setMaxDeltaTimeSeconds(Integer maxDeltaTimeSeconds) {
+        this.maxDeltaTimeSeconds = maxDeltaTimeSeconds;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("maxFailureWaitSeconds")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Max Wait")
+    private Integer maxFailureWaitSeconds;
+
+    public Integer getMaxFailureWaitSeconds() {
+        return maxFailureWaitSeconds;
+    }
+
+    public void setMaxFailureWaitSeconds(Integer maxFailureWaitSeconds) {
+        this.maxFailureWaitSeconds = maxFailureWaitSeconds;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("minimumQuickLoginWaitSeconds")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Minimum Quick Login Wait")
+    private Integer minimumQuickLoginWaitSeconds;
+
+    public Integer getMinimumQuickLoginWaitSeconds() {
+        return minimumQuickLoginWaitSeconds;
+    }
+
+    public void setMinimumQuickLoginWaitSeconds(Integer minimumQuickLoginWaitSeconds) {
+        this.minimumQuickLoginWaitSeconds = minimumQuickLoginWaitSeconds;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("passwordPolicy")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Realm Password Policy")
+    private String passwordPolicy;
+
+    public String getPasswordPolicy() {
+        return passwordPolicy;
+    }
+
+    public void setPasswordPolicy(String passwordPolicy) {
+        this.passwordPolicy = passwordPolicy;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("permanentLockout")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Permanent Lockout")
+    private Boolean permanentLockout;
+
+    public Boolean getPermanentLockout() {
+        return permanentLockout;
+    }
+
+    public void setPermanentLockout(Boolean permanentLockout) {
+        this.permanentLockout = permanentLockout;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("quickLoginCheckMilliSeconds")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Quick Login Check Milli Seconds")
+    private Long quickLoginCheckMilliSeconds;
+
+    public Long getQuickLoginCheckMilliSeconds() {
+        return quickLoginCheckMilliSeconds;
+    }
+
+    public void setQuickLoginCheckMilliSeconds(Long quickLoginCheckMilliSeconds) {
+        this.quickLoginCheckMilliSeconds = quickLoginCheckMilliSeconds;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("realm")
+    @javax.validation.constraints.NotNull()
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Realm name.")
+    private String realm;
+
+    public String getRealm() {
+        return realm;
+    }
+
+    public void setRealm(String realm) {
+        this.realm = realm;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("registrationAllowed")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("User registration")
+    private Boolean registrationAllowed;
+
+    public Boolean getRegistrationAllowed() {
+        return registrationAllowed;
+    }
+
+    public void setRegistrationAllowed(Boolean registrationAllowed) {
+        this.registrationAllowed = registrationAllowed;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("registrationEmailAsUsername")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Email as username")
+    private Boolean registrationEmailAsUsername;
+
+    public Boolean getRegistrationEmailAsUsername() {
+        return registrationEmailAsUsername;
+    }
+
+    public void setRegistrationEmailAsUsername(Boolean registrationEmailAsUsername) {
+        this.registrationEmailAsUsername = registrationEmailAsUsername;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("rememberMe")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Remember me")
+    private Boolean rememberMe;
+
+    public Boolean getRememberMe() {
+        return rememberMe;
+    }
+
+    public void setRememberMe(Boolean rememberMe) {
+        this.rememberMe = rememberMe;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("resetPasswordAllowed")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Forgot password")
+    private Boolean resetPasswordAllowed;
+
+    public Boolean getResetPasswordAllowed() {
+        return resetPasswordAllowed;
+    }
+
+    public void setResetPasswordAllowed(Boolean resetPasswordAllowed) {
+        this.resetPasswordAllowed = resetPasswordAllowed;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("roles")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Roles")
+    private RolesSpec roles;
+
+    public RolesSpec getRoles() {
+        return roles;
+    }
+
+    public void setRoles(RolesSpec roles) {
+        this.roles = roles;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("scopeMappings")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Scope Mappings")
+    private java.util.List<ScopeMappingsSpec> scopeMappings;
+
+    public java.util.List<ScopeMappingsSpec> getScopeMappings() {
+        return scopeMappings;
+    }
+
+    public void setScopeMappings(java.util.List<ScopeMappingsSpec> scopeMappings) {
+        this.scopeMappings = scopeMappings;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("smtpServer")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Email")
+    private java.util.Map<java.lang.String, String> smtpServer;
+
+    public java.util.Map<java.lang.String, String> getSmtpServer() {
+        return smtpServer;
+    }
+
+    public void setSmtpServer(java.util.Map<java.lang.String, String> smtpServer) {
+        this.smtpServer = smtpServer;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("sslRequired")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Require SSL")
+    private String sslRequired;
+
+    public String getSslRequired() {
+        return sslRequired;
+    }
+
+    public void setSslRequired(String sslRequired) {
+        this.sslRequired = sslRequired;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("supportedLocales")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Supported Locales")
+    private java.util.List<String> supportedLocales;
+
+    public java.util.List<String> getSupportedLocales() {
+        return supportedLocales;
+    }
+
+    public void setSupportedLocales(java.util.List<String> supportedLocales) {
+        this.supportedLocales = supportedLocales;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("userFederationMappers")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("User federation mappers are extension points triggered by the user federation at various points.")
+    private java.util.List<UserFederationMappersSpec> userFederationMappers;
+
+    public java.util.List<UserFederationMappersSpec> getUserFederationMappers() {
+        return userFederationMappers;
+    }
+
+    public void setUserFederationMappers(java.util.List<UserFederationMappersSpec> userFederationMappers) {
+        this.userFederationMappers = userFederationMappers;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("userFederationProviders")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Point keycloak to an external user provider to validate credentials or pull in identity information.")
+    private java.util.List<UserFederationProvidersSpec> userFederationProviders;
+
+    public java.util.List<UserFederationProvidersSpec> getUserFederationProviders() {
+        return userFederationProviders;
+    }
+
+    public void setUserFederationProviders(java.util.List<UserFederationProvidersSpec> userFederationProviders) {
+        this.userFederationProviders = userFederationProviders;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("userManagedAccessAllowed")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("User Managed Access Allowed")
+    private Boolean userManagedAccessAllowed;
+
+    public Boolean getUserManagedAccessAllowed() {
+        return userManagedAccessAllowed;
+    }
+
+    public void setUserManagedAccessAllowed(Boolean userManagedAccessAllowed) {
+        this.userManagedAccessAllowed = userManagedAccessAllowed;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("users")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("A set of Keycloak Users.")
+    private java.util.List<UsersSpec> users;
+
+    public java.util.List<UsersSpec> getUsers() {
+        return users;
+    }
+
+    public void setUsers(java.util.List<UsersSpec> users) {
+        this.users = users;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("verifyEmail")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Verify email")
+    private Boolean verifyEmail;
+
+    public Boolean getVerifyEmail() {
+        return verifyEmail;
+    }
+
+    public void setVerifyEmail(Boolean verifyEmail) {
+        this.verifyEmail = verifyEmail;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("waitIncrementSeconds")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Wait Increment")
+    private Integer waitIncrementSeconds;
+
+    public Integer getWaitIncrementSeconds() {
+        return waitIncrementSeconds;
+    }
+
+    public void setWaitIncrementSeconds(Integer waitIncrementSeconds) {
+        this.waitIncrementSeconds = waitIncrementSeconds;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/RealmSpec0.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/RealmSpec0.java
@@ -1,0 +1,109 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"attributes","clientRole","composite","composites","containerId","id","name"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class RealmSpec0 implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("attributes")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Role Attributes")
+    private java.util.Map<java.lang.String, java.util.List<String>> attributes;
+
+    public java.util.Map<java.lang.String, java.util.List<String>> getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(java.util.Map<java.lang.String, java.util.List<String>> attributes) {
+        this.attributes = attributes;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("clientRole")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Client Role")
+    private Boolean clientRole;
+
+    public Boolean getClientRole() {
+        return clientRole;
+    }
+
+    public void setClientRole(Boolean clientRole) {
+        this.clientRole = clientRole;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("composite")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Composite")
+    private Boolean composite;
+
+    public Boolean getComposite() {
+        return composite;
+    }
+
+    public void setComposite(Boolean composite) {
+        this.composite = composite;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("composites")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Composites")
+    private CompositesSpec1 composites;
+
+    public CompositesSpec1 getComposites() {
+        return composites;
+    }
+
+    public void setComposites(CompositesSpec1 composites) {
+        this.composites = composites;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("containerId")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Container Id")
+    private String containerId;
+
+    public String getContainerId() {
+        return containerId;
+    }
+
+    public void setContainerId(String containerId) {
+        this.containerId = containerId;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Id")
+    private String id;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    @javax.validation.constraints.NotNull()
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Name")
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/RequiredDuringSchedulingIgnoredDuringExecutionSpec.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/RequiredDuringSchedulingIgnoredDuringExecutionSpec.java
@@ -1,0 +1,37 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"nodeSelectorTerms"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class RequiredDuringSchedulingIgnoredDuringExecutionSpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("nodeSelectorTerms")
+    @javax.validation.constraints.NotNull()
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Required. A list of node selector terms. The terms are ORed.")
+    private java.util.List<NodeSelectorTermsSpec> nodeSelectorTerms;
+
+    public java.util.List<NodeSelectorTermsSpec> getNodeSelectorTerms() {
+        return nodeSelectorTerms;
+    }
+
+    public void setNodeSelectorTerms(java.util.List<NodeSelectorTermsSpec> nodeSelectorTerms) {
+        this.nodeSelectorTerms = nodeSelectorTerms;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/RequiredDuringSchedulingIgnoredDuringExecutionSpec0.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/RequiredDuringSchedulingIgnoredDuringExecutionSpec0.java
@@ -1,0 +1,61 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"labelSelector","namespaces","topologyKey"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class RequiredDuringSchedulingIgnoredDuringExecutionSpec0 implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("labelSelector")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("A label query over a set of resources, in this case pods.")
+    private LabelSelectorSpec0 labelSelector;
+
+    public LabelSelectorSpec0 getLabelSelector() {
+        return labelSelector;
+    }
+
+    public void setLabelSelector(LabelSelectorSpec0 labelSelector) {
+        this.labelSelector = labelSelector;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("namespaces")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means \"this pod's namespace\"")
+    private java.util.List<String> namespaces;
+
+    public java.util.List<String> getNamespaces() {
+        return namespaces;
+    }
+
+    public void setNamespaces(java.util.List<String> namespaces) {
+        this.namespaces = namespaces;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("topologyKey")
+    @javax.validation.constraints.NotNull()
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.")
+    private String topologyKey;
+
+    public String getTopologyKey() {
+        return topologyKey;
+    }
+
+    public void setTopologyKey(String topologyKey) {
+        this.topologyKey = topologyKey;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/RequiredDuringSchedulingIgnoredDuringExecutionSpec1.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/RequiredDuringSchedulingIgnoredDuringExecutionSpec1.java
@@ -1,0 +1,61 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"labelSelector","namespaces","topologyKey"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class RequiredDuringSchedulingIgnoredDuringExecutionSpec1 implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("labelSelector")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("A label query over a set of resources, in this case pods.")
+    private LabelSelectorSpec2 labelSelector;
+
+    public LabelSelectorSpec2 getLabelSelector() {
+        return labelSelector;
+    }
+
+    public void setLabelSelector(LabelSelectorSpec2 labelSelector) {
+        this.labelSelector = labelSelector;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("namespaces")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means \"this pod's namespace\"")
+    private java.util.List<String> namespaces;
+
+    public java.util.List<String> getNamespaces() {
+        return namespaces;
+    }
+
+    public void setNamespaces(java.util.List<String> namespaces) {
+        this.namespaces = namespaces;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("topologyKey")
+    @javax.validation.constraints.NotNull()
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.")
+    private String topologyKey;
+
+    public String getTopologyKey() {
+        return topologyKey;
+    }
+
+    public void setTopologyKey(String topologyKey) {
+        this.topologyKey = topologyKey;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/ResourceFieldRefSpec.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/ResourceFieldRefSpec.java
@@ -1,0 +1,61 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"containerName","divisor","resource"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class ResourceFieldRefSpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("containerName")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Container name: required for volumes, optional for env vars")
+    private String containerName;
+
+    public String getContainerName() {
+        return containerName;
+    }
+
+    public void setContainerName(String containerName) {
+        this.containerName = containerName;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("divisor")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Specifies the output format of the exposed resources, defaults to \"1\"")
+    private io.fabric8.kubernetes.api.model.IntOrString divisor;
+
+    public io.fabric8.kubernetes.api.model.IntOrString getDivisor() {
+        return divisor;
+    }
+
+    public void setDivisor(io.fabric8.kubernetes.api.model.IntOrString divisor) {
+        this.divisor = divisor;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("resource")
+    @javax.validation.constraints.NotNull()
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Required: resource to select")
+    private String resource;
+
+    public String getResource() {
+        return resource;
+    }
+
+    public void setResource(String resource) {
+        this.resource = resource;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/ResourcesDataSpec.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/ResourcesDataSpec.java
@@ -1,0 +1,132 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"_id","attributes","displayName","icon_uri","name","ownerManagedAccess","scopes","type","uris"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class ResourcesDataSpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("_id")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("ID.")
+    private String _id;
+
+    public String get_id() {
+        return _id;
+    }
+
+    public void set_id(String _id) {
+        this._id = _id;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("attributes")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("The attributes associated with the resource.")
+    private java.util.Map<java.lang.String, String> attributes;
+
+    public java.util.Map<java.lang.String, String> getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(java.util.Map<java.lang.String, String> attributes) {
+        this.attributes = attributes;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.")
+    private String displayName;
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("icon_uri")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("An URI pointing to an icon.")
+    private String icon_uri;
+
+    public String getIcon_uri() {
+        return icon_uri;
+    }
+
+    public void setIcon_uri(String icon_uri) {
+        this.icon_uri = icon_uri;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.")
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("ownerManagedAccess")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("True if the access to this resource can be managed by the resource owner.")
+    private Boolean ownerManagedAccess;
+
+    public Boolean getOwnerManagedAccess() {
+        return ownerManagedAccess;
+    }
+
+    public void setOwnerManagedAccess(Boolean ownerManagedAccess) {
+        this.ownerManagedAccess = ownerManagedAccess;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("scopes")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("The scopes associated with this resource.")
+    private java.util.List<ScopesSpec> scopes;
+
+    public java.util.List<ScopesSpec> getScopes() {
+        return scopes;
+    }
+
+    public void setScopes(java.util.List<ScopesSpec> scopes) {
+        this.scopes = scopes;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("type")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("The type of this resource. It can be used to group different resource instances with the same type.")
+    private String type;
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("uris")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Set of URIs which are protected by resource.")
+    private java.util.List<String> uris;
+
+    public java.util.List<String> getUris() {
+        return uris;
+    }
+
+    public void setUris(java.util.List<String> uris) {
+        this.uris = uris;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/ResourcesDataSpec0.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/ResourcesDataSpec0.java
@@ -1,0 +1,132 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"_id","attributes","displayName","icon_uri","name","ownerManagedAccess","scopes","type","uris"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class ResourcesDataSpec0 implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("_id")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("ID.")
+    private String _id;
+
+    public String get_id() {
+        return _id;
+    }
+
+    public void set_id(String _id) {
+        this._id = _id;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("attributes")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("The attributes associated with the resource.")
+    private java.util.Map<java.lang.String, String> attributes;
+
+    public java.util.Map<java.lang.String, String> getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(java.util.Map<java.lang.String, String> attributes) {
+        this.attributes = attributes;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.")
+    private String displayName;
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("icon_uri")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("An URI pointing to an icon.")
+    private String icon_uri;
+
+    public String getIcon_uri() {
+        return icon_uri;
+    }
+
+    public void setIcon_uri(String icon_uri) {
+        this.icon_uri = icon_uri;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.")
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("ownerManagedAccess")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("True if the access to this resource can be managed by the resource owner.")
+    private Boolean ownerManagedAccess;
+
+    public Boolean getOwnerManagedAccess() {
+        return ownerManagedAccess;
+    }
+
+    public void setOwnerManagedAccess(Boolean ownerManagedAccess) {
+        this.ownerManagedAccess = ownerManagedAccess;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("scopes")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("The scopes associated with this resource.")
+    private java.util.List<ScopesSpec2> scopes;
+
+    public java.util.List<ScopesSpec2> getScopes() {
+        return scopes;
+    }
+
+    public void setScopes(java.util.List<ScopesSpec2> scopes) {
+        this.scopes = scopes;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("type")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("The type of this resource. It can be used to group different resource instances with the same type.")
+    private String type;
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("uris")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Set of URIs which are protected by resource.")
+    private java.util.List<String> uris;
+
+    public java.util.List<String> getUris() {
+        return uris;
+    }
+
+    public void setUris(java.util.List<String> uris) {
+        this.uris = uris;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/ResourcesSpec.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/ResourcesSpec.java
@@ -1,0 +1,132 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"_id","attributes","displayName","icon_uri","name","ownerManagedAccess","scopes","type","uris"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class ResourcesSpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("_id")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("ID.")
+    private String _id;
+
+    public String get_id() {
+        return _id;
+    }
+
+    public void set_id(String _id) {
+        this._id = _id;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("attributes")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("The attributes associated with the resource.")
+    private java.util.Map<java.lang.String, String> attributes;
+
+    public java.util.Map<java.lang.String, String> getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(java.util.Map<java.lang.String, String> attributes) {
+        this.attributes = attributes;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.")
+    private String displayName;
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("icon_uri")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("An URI pointing to an icon.")
+    private String icon_uri;
+
+    public String getIcon_uri() {
+        return icon_uri;
+    }
+
+    public void setIcon_uri(String icon_uri) {
+        this.icon_uri = icon_uri;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.")
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("ownerManagedAccess")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("True if the access to this resource can be managed by the resource owner.")
+    private Boolean ownerManagedAccess;
+
+    public Boolean getOwnerManagedAccess() {
+        return ownerManagedAccess;
+    }
+
+    public void setOwnerManagedAccess(Boolean ownerManagedAccess) {
+        this.ownerManagedAccess = ownerManagedAccess;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("scopes")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("The scopes associated with this resource.")
+    private java.util.List<ScopesSpec0> scopes;
+
+    public java.util.List<ScopesSpec0> getScopes() {
+        return scopes;
+    }
+
+    public void setScopes(java.util.List<ScopesSpec0> scopes) {
+        this.scopes = scopes;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("type")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("The type of this resource. It can be used to group different resource instances with the same type.")
+    private String type;
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("uris")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Set of URIs which are protected by resource.")
+    private java.util.List<String> uris;
+
+    public java.util.List<String> getUris() {
+        return uris;
+    }
+
+    public void setUris(java.util.List<String> uris) {
+        this.uris = uris;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/ResourcesSpec0.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/ResourcesSpec0.java
@@ -1,0 +1,132 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"_id","attributes","displayName","icon_uri","name","ownerManagedAccess","scopes","type","uris"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class ResourcesSpec0 implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("_id")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("ID.")
+    private String _id;
+
+    public String get_id() {
+        return _id;
+    }
+
+    public void set_id(String _id) {
+        this._id = _id;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("attributes")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("The attributes associated with the resource.")
+    private java.util.Map<java.lang.String, String> attributes;
+
+    public java.util.Map<java.lang.String, String> getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(java.util.Map<java.lang.String, String> attributes) {
+        this.attributes = attributes;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.")
+    private String displayName;
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("icon_uri")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("An URI pointing to an icon.")
+    private String icon_uri;
+
+    public String getIcon_uri() {
+        return icon_uri;
+    }
+
+    public void setIcon_uri(String icon_uri) {
+        this.icon_uri = icon_uri;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.")
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("ownerManagedAccess")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("True if the access to this resource can be managed by the resource owner.")
+    private Boolean ownerManagedAccess;
+
+    public Boolean getOwnerManagedAccess() {
+        return ownerManagedAccess;
+    }
+
+    public void setOwnerManagedAccess(Boolean ownerManagedAccess) {
+        this.ownerManagedAccess = ownerManagedAccess;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("scopes")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("The scopes associated with this resource.")
+    private java.util.List<ScopesSpec3> scopes;
+
+    public java.util.List<ScopesSpec3> getScopes() {
+        return scopes;
+    }
+
+    public void setScopes(java.util.List<ScopesSpec3> scopes) {
+        this.scopes = scopes;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("type")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("The type of this resource. It can be used to group different resource instances with the same type.")
+    private String type;
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("uris")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Set of URIs which are protected by resource.")
+    private java.util.List<String> uris;
+
+    public java.util.List<String> getUris() {
+        return uris;
+    }
+
+    public void setUris(java.util.List<String> uris) {
+        this.uris = uris;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/RolesSpec.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/RolesSpec.java
@@ -1,0 +1,48 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"client","realm"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class RolesSpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("client")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Client Roles")
+    private java.util.Map<java.lang.String, java.util.List<ClientSpec>> client;
+
+    public java.util.Map<java.lang.String, java.util.List<ClientSpec>> getClient() {
+        return client;
+    }
+
+    public void setClient(java.util.Map<java.lang.String, java.util.List<ClientSpec>> client) {
+        this.client = client;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("realm")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Realm Roles")
+    private java.util.List<RealmSpec0> realm;
+
+    public java.util.List<RealmSpec0> getRealm() {
+        return realm;
+    }
+
+    public void setRealm(java.util.List<RealmSpec0> realm) {
+        this.realm = realm;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/ScopeMappingsSpec.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/ScopeMappingsSpec.java
@@ -1,0 +1,72 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"client","clientScope","roles","self"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class ScopeMappingsSpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("client")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Client")
+    private String client;
+
+    public String getClient() {
+        return client;
+    }
+
+    public void setClient(String client) {
+        this.client = client;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("clientScope")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Client Scope")
+    private String clientScope;
+
+    public String getClientScope() {
+        return clientScope;
+    }
+
+    public void setClientScope(String clientScope) {
+        this.clientScope = clientScope;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("roles")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Roles")
+    private java.util.List<String> roles;
+
+    public java.util.List<String> getRoles() {
+        return roles;
+    }
+
+    public void setRoles(java.util.List<String> roles) {
+        this.roles = roles;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("self")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Self")
+    private String self;
+
+    public String getSelf() {
+        return self;
+    }
+
+    public void setSelf(String self) {
+        this.self = self;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/ScopesDataSpec.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/ScopesDataSpec.java
@@ -1,0 +1,37 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class ScopesDataSpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonIgnore()
+    private java.util.Map<String, Object> additionalProperties = new java.util.HashMap<String, Object>();
+
+    @com.fasterxml.jackson.annotation.JsonAnyGetter()
+    public java.util.Map<String, Object> getAdditionalProperties() {
+        return additionalProperties;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonAnySetter()
+    public void setAdditionalProperties(java.util.Map<String, Object> additionalProperties) {
+        this.additionalProperties = additionalProperties;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/ScopesDataSpec0.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/ScopesDataSpec0.java
@@ -1,0 +1,37 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class ScopesDataSpec0 implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonIgnore()
+    private java.util.Map<String, Object> additionalProperties = new java.util.HashMap<String, Object>();
+
+    @com.fasterxml.jackson.annotation.JsonAnyGetter()
+    public java.util.Map<String, Object> getAdditionalProperties() {
+        return additionalProperties;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonAnySetter()
+    public void setAdditionalProperties(java.util.Map<String, Object> additionalProperties) {
+        this.additionalProperties = additionalProperties;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/ScopesSpec.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/ScopesSpec.java
@@ -1,0 +1,37 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class ScopesSpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonIgnore()
+    private java.util.Map<String, Object> additionalProperties = new java.util.HashMap<String, Object>();
+
+    @com.fasterxml.jackson.annotation.JsonAnyGetter()
+    public java.util.Map<String, Object> getAdditionalProperties() {
+        return additionalProperties;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonAnySetter()
+    public void setAdditionalProperties(java.util.Map<String, Object> additionalProperties) {
+        this.additionalProperties = additionalProperties;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/ScopesSpec0.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/ScopesSpec0.java
@@ -1,0 +1,37 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class ScopesSpec0 implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonIgnore()
+    private java.util.Map<String, Object> additionalProperties = new java.util.HashMap<String, Object>();
+
+    @com.fasterxml.jackson.annotation.JsonAnyGetter()
+    public java.util.Map<String, Object> getAdditionalProperties() {
+        return additionalProperties;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonAnySetter()
+    public void setAdditionalProperties(java.util.Map<String, Object> additionalProperties) {
+        this.additionalProperties = additionalProperties;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/ScopesSpec1.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/ScopesSpec1.java
@@ -1,0 +1,96 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"displayName","iconUri","id","name","policies","resources"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class ScopesSpec1 implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("A unique name for this scope. The name can be used to uniquely identify a scope, useful when querying for a specific scope.")
+    private String displayName;
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("iconUri")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("An URI pointing to an icon.")
+    private String iconUri;
+
+    public String getIconUri() {
+        return iconUri;
+    }
+
+    public void setIconUri(String iconUri) {
+        this.iconUri = iconUri;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("ID.")
+    private String id;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("A unique name for this scope. The name can be used to uniquely identify a scope, useful when querying for a specific scope.")
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("policies")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Policies.")
+    private java.util.List<PoliciesSpec0> policies;
+
+    public java.util.List<PoliciesSpec0> getPolicies() {
+        return policies;
+    }
+
+    public void setPolicies(java.util.List<PoliciesSpec0> policies) {
+        this.policies = policies;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("resources")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Resources.")
+    private java.util.List<ResourcesSpec0> resources;
+
+    public java.util.List<ResourcesSpec0> getResources() {
+        return resources;
+    }
+
+    public void setResources(java.util.List<ResourcesSpec0> resources) {
+        this.resources = resources;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/ScopesSpec2.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/ScopesSpec2.java
@@ -1,0 +1,37 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class ScopesSpec2 implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonIgnore()
+    private java.util.Map<String, Object> additionalProperties = new java.util.HashMap<String, Object>();
+
+    @com.fasterxml.jackson.annotation.JsonAnyGetter()
+    public java.util.Map<String, Object> getAdditionalProperties() {
+        return additionalProperties;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonAnySetter()
+    public void setAdditionalProperties(java.util.Map<String, Object> additionalProperties) {
+        this.additionalProperties = additionalProperties;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/ScopesSpec3.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/ScopesSpec3.java
@@ -1,0 +1,37 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class ScopesSpec3 implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonIgnore()
+    private java.util.Map<String, Object> additionalProperties = new java.util.HashMap<String, Object>();
+
+    @com.fasterxml.jackson.annotation.JsonAnyGetter()
+    public java.util.Map<String, Object> getAdditionalProperties() {
+        return additionalProperties;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonAnySetter()
+    public void setAdditionalProperties(java.util.Map<String, Object> additionalProperties) {
+        this.additionalProperties = additionalProperties;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/SecretKeyRefSpec.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/SecretKeyRefSpec.java
@@ -1,0 +1,61 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"key","name","optional"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class SecretKeyRefSpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("key")
+    @javax.validation.constraints.NotNull()
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("The key of the secret to select from.  Must be a valid secret key.")
+    private String key;
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?")
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("optional")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Specify whether the Secret or its key must be defined")
+    private Boolean optional;
+
+    public Boolean getOptional() {
+        return optional;
+    }
+
+    public void setOptional(Boolean optional) {
+        this.optional = optional;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/UserFederationMappersSpec.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/UserFederationMappersSpec.java
@@ -1,0 +1,81 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"config","federationMapperType","federationProviderDisplayName","id","name"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class UserFederationMappersSpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("config")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("User federation mapper config.")
+    private java.util.Map<java.lang.String, String> config;
+
+    public java.util.Map<java.lang.String, String> getConfig() {
+        return config;
+    }
+
+    public void setConfig(java.util.Map<java.lang.String, String> config) {
+        this.config = config;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("federationMapperType")
+    private String federationMapperType;
+
+    public String getFederationMapperType() {
+        return federationMapperType;
+    }
+
+    public void setFederationMapperType(String federationMapperType) {
+        this.federationMapperType = federationMapperType;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("federationProviderDisplayName")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("The displayName for the user federation provider this mapper applies to.")
+    private String federationProviderDisplayName;
+
+    public String getFederationProviderDisplayName() {
+        return federationProviderDisplayName;
+    }
+
+    public void setFederationProviderDisplayName(String federationProviderDisplayName) {
+        this.federationProviderDisplayName = federationProviderDisplayName;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    private String id;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/UserFederationProvidersSpec.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/UserFederationProvidersSpec.java
@@ -1,0 +1,95 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"config","displayName","fullSyncPeriod","id","priority","providerName"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class UserFederationProvidersSpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("config")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("User federation provider config.")
+    private java.util.Map<java.lang.String, String> config;
+
+    public java.util.Map<java.lang.String, String> getConfig() {
+        return config;
+    }
+
+    public void setConfig(java.util.Map<java.lang.String, String> config) {
+        this.config = config;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("displayName")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("The display name of this provider instance.")
+    private String displayName;
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("fullSyncPeriod")
+    private Integer fullSyncPeriod;
+
+    public Integer getFullSyncPeriod() {
+        return fullSyncPeriod;
+    }
+
+    public void setFullSyncPeriod(Integer fullSyncPeriod) {
+        this.fullSyncPeriod = fullSyncPeriod;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("The ID of this provider")
+    private String id;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("priority")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("The priority of this provider when looking up users or adding a user.")
+    private Integer priority;
+
+    public Integer getPriority() {
+        return priority;
+    }
+
+    public void setPriority(Integer priority) {
+        this.priority = priority;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("providerName")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("The name of the user provider, such as \"ldap\", \"kerberos\" or a custom SPI.")
+    private String providerName;
+
+    public String getProviderName() {
+        return providerName;
+    }
+
+    public void setProviderName(String providerName) {
+        this.providerName = providerName;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/UsersSpec.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/UsersSpec.java
@@ -1,0 +1,192 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"attributes","clientRoles","credentials","email","emailVerified","enabled","federatedIdentities","firstName","groups","id","lastName","realmRoles","requiredActions","username"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class UsersSpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("attributes")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("A set of Attributes.")
+    private java.util.Map<java.lang.String, java.util.List<String>> attributes;
+
+    public java.util.Map<java.lang.String, java.util.List<String>> getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(java.util.Map<java.lang.String, java.util.List<String>> attributes) {
+        this.attributes = attributes;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("clientRoles")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("A set of Client Roles.")
+    private java.util.Map<java.lang.String, java.util.List<String>> clientRoles;
+
+    public java.util.Map<java.lang.String, java.util.List<String>> getClientRoles() {
+        return clientRoles;
+    }
+
+    public void setClientRoles(java.util.Map<java.lang.String, java.util.List<String>> clientRoles) {
+        this.clientRoles = clientRoles;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("credentials")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("A set of Credentials.")
+    private java.util.List<CredentialsSpec> credentials;
+
+    public java.util.List<CredentialsSpec> getCredentials() {
+        return credentials;
+    }
+
+    public void setCredentials(java.util.List<CredentialsSpec> credentials) {
+        this.credentials = credentials;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("email")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Email.")
+    private String email;
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("emailVerified")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("True if email has already been verified.")
+    private Boolean emailVerified;
+
+    public Boolean getEmailVerified() {
+        return emailVerified;
+    }
+
+    public void setEmailVerified(Boolean emailVerified) {
+        this.emailVerified = emailVerified;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("enabled")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("User enabled flag.")
+    private Boolean enabled;
+
+    public Boolean getEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("federatedIdentities")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("A set of Federated Identities.")
+    private java.util.List<FederatedIdentitiesSpec> federatedIdentities;
+
+    public java.util.List<FederatedIdentitiesSpec> getFederatedIdentities() {
+        return federatedIdentities;
+    }
+
+    public void setFederatedIdentities(java.util.List<FederatedIdentitiesSpec> federatedIdentities) {
+        this.federatedIdentities = federatedIdentities;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("firstName")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("First Name.")
+    private String firstName;
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("groups")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("A set of Groups.")
+    private java.util.List<String> groups;
+
+    public java.util.List<String> getGroups() {
+        return groups;
+    }
+
+    public void setGroups(java.util.List<String> groups) {
+        this.groups = groups;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("id")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("User ID.")
+    private String id;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("lastName")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Last Name.")
+    private String lastName;
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("realmRoles")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("A set of Realm Roles.")
+    private java.util.List<String> realmRoles;
+
+    public java.util.List<String> getRealmRoles() {
+        return realmRoles;
+    }
+
+    public void setRealmRoles(java.util.List<String> realmRoles) {
+        this.realmRoles = realmRoles;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("requiredActions")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("A set of Required Actions.")
+    private java.util.List<String> requiredActions;
+
+    public java.util.List<String> getRequiredActions() {
+        return requiredActions;
+    }
+
+    public void setRequiredActions(java.util.List<String> requiredActions) {
+        this.requiredActions = requiredActions;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("username")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("User Name.")
+    private String username;
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/ValueFromSpec.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/ValueFromSpec.java
@@ -1,0 +1,72 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"configMapKeyRef","fieldRef","resourceFieldRef","secretKeyRef"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class ValueFromSpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("configMapKeyRef")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Selects a key of a ConfigMap.")
+    private ConfigMapKeyRefSpec configMapKeyRef;
+
+    public ConfigMapKeyRefSpec getConfigMapKeyRef() {
+        return configMapKeyRef;
+    }
+
+    public void setConfigMapKeyRef(ConfigMapKeyRefSpec configMapKeyRef) {
+        this.configMapKeyRef = configMapKeyRef;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("fieldRef")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.")
+    private FieldRefSpec fieldRef;
+
+    public FieldRefSpec getFieldRef() {
+        return fieldRef;
+    }
+
+    public void setFieldRef(FieldRefSpec fieldRef) {
+        this.fieldRef = fieldRef;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("resourceFieldRef")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.")
+    private ResourceFieldRefSpec resourceFieldRef;
+
+    public ResourceFieldRefSpec getResourceFieldRef() {
+        return resourceFieldRef;
+    }
+
+    public void setResourceFieldRef(ResourceFieldRefSpec resourceFieldRef) {
+        this.resourceFieldRef = resourceFieldRef;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("secretKeyRef")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Selects a key of a secret in the pod's namespace")
+    private SecretKeyRefSpec secretKeyRef;
+
+    public SecretKeyRefSpec getSecretKeyRef() {
+        return secretKeyRef;
+    }
+
+    public void setSecretKeyRef(SecretKeyRefSpec secretKeyRef) {
+        this.secretKeyRef = secretKeyRef;
+    }
+}

--- a/operator/src/main/java/org/keycloak/v1alpha1/VolumesSpec.java
+++ b/operator/src/main/java/org/keycloak/v1alpha1/VolumesSpec.java
@@ -1,0 +1,47 @@
+package org.keycloak.v1alpha1;
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({"defaultMode","items"})
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@lombok.Setter()
+@lombok.experimental.Accessors(prefix = {
+    "_",
+    ""
+})
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+    @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class VolumesSpec implements io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @com.fasterxml.jackson.annotation.JsonProperty("defaultMode")
+    @com.fasterxml.jackson.annotation.JsonPropertyDescription("Permissions mode.")
+    private Integer defaultMode;
+
+    public Integer getDefaultMode() {
+        return defaultMode;
+    }
+
+    public void setDefaultMode(Integer defaultMode) {
+        this.defaultMode = defaultMode;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("items")
+    private java.util.List<ItemsSpec> items;
+
+    public java.util.List<ItemsSpec> getItems() {
+        return items;
+    }
+
+    public void setItems(java.util.List<ItemsSpec> items) {
+        this.items = items;
+    }
+}

--- a/operator/src/main/kubernetes/kustomization.yml
+++ b/operator/src/main/kubernetes/kustomization.yml
@@ -4,7 +4,8 @@ kind: Kustomization
 namespace: keycloak
 
 resources:
-  - kubernetes/keycloaks.keycloak.org-v1.yml
+  - classes/META-INF/fabric8/keycloaks.keycloak.org-v1.yml
+  - classes/META-INF/fabric8/keycloakrealms.keycloak.org-v1.yml
   - kubernetes/kubernetes.yml
 
 patches:


### PR DESCRIPTION
Resolves #9826 

Currently you need to delete the old operator CRDs before creating the new ones.
This PR makes the upgrades seamless (e.g. the new CRDs are now compatible with the old and they can be upgraded without a complete removal).

Technical details:
 - The code is entirely generated with an advanced version of the upcoming Java generator of fabric8 kubernetes client ( [PR](https://github.com/fabric8io/kubernetes-client/pull/3693) / [exact commit](https://github.com/andreaTP/kubernetes-client/commit/2cbf41e7ffd6b39fcf5ebb0bba6200781bdfef6d) ) starting from the current CRDs
 - The only manual editing required is to mark the old CRDs with `storage=false` (not the default) and `served=false` (disable the k8s API from serving the old versions)