### PR TITLE
Add support for filtering by enabled attribute on users count endpoint

### DIFF
--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/UsersResource.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/UsersResource.java
@@ -243,6 +243,30 @@ public interface UsersResource {
                   @QueryParam("username") String username);
 
     /**
+     * Returns the number of users that can be viewed and match the given filters.
+     * If none of the filters is specified this is equivalent to {{@link #count()}}.
+     *
+     * @param search        arbitrary search string for all the fields below
+     * @param last          last name field of a user
+     * @param first         first name field of a user
+     * @param email         email field of a user
+     * @param emailVerified emailVerified field of a user
+     * @param username      username field of a user
+     * @param enabled       Boolean representing if user is enabled or not
+     * @return number of users matching the given filters
+     */
+    @Path("count")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    Integer count(@QueryParam("search") String search,
+                  @QueryParam("lastName") String last,
+                  @QueryParam("firstName") String first,
+                  @QueryParam("email") String email,
+                  @QueryParam("emailVerified") Boolean emailVerified,
+                  @QueryParam("username") String username,
+                  @QueryParam("enabled") Boolean enabled);
+
+    /**
      * Returns the number of users with the given status for emailVerified.
      * If none of the filters is specified this is equivalent to {{@link #count()}}.
      *

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserProvider.java
@@ -680,6 +680,9 @@ public class JpaUserProvider implements UserProvider.Streams, UserCredentialStor
                 case UserModel.EMAIL:
                     restrictions.add(qb.like(from.get("email"), "%" + value + "%"));
                     break;
+                case UserModel.ENABLED:
+                    restrictions.add(qb.equal(from.get("enabled"), Boolean.parseBoolean(value.toLowerCase())));
+                    break;
                 case UserModel.EMAIL_VERIFIED:
                     restrictions.add(qb.equal(from.get("emailVerified"), Boolean.parseBoolean(value.toLowerCase())));
                     break;
@@ -729,6 +732,9 @@ public class JpaUserProvider implements UserProvider.Streams, UserCredentialStor
                 case UserModel.EMAIL:
                     restrictions.add(qb.like(from.get("user").get("email"), "%" + value + "%"));
                     break;
+                case UserModel.ENABLED:
+                     restrictions.add(qb.equal(from.get("enabled"), Boolean.parseBoolean(value.toLowerCase())));
+                     break;
                 case UserModel.EMAIL_VERIFIED:
                     restrictions.add(qb.equal(from.get("emailVerified"), Boolean.parseBoolean(value.toLowerCase())));
                     break;

--- a/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
@@ -361,6 +361,7 @@ public class UsersResource {
      * @param first    first name filter
      * @param email    email filter
      * @param username username filter
+     * @param enabled Boolean representing if user is enabled or not
      * @return the number of users that match the given criteria
      */
     @Path("count")
@@ -372,7 +373,8 @@ public class UsersResource {
                                  @QueryParam("firstName") String first,
                                  @QueryParam("email") String email,
                                  @QueryParam("emailVerified") Boolean emailVerified,
-                                 @QueryParam("username") String username) {
+                                 @QueryParam("username") String username,
+                                 @QueryParam("enabled") Boolean enabled) {
         UserPermissionEvaluator userPermissionEvaluator = auth.users();
         userPermissionEvaluator.requireQuery();
 
@@ -385,7 +387,7 @@ public class UsersResource {
             } else {
                 return session.users().getUsersCount(realm, search.trim(), auth.groups().getGroupsWithViewPermission());
             }
-        } else if (last != null || first != null || email != null || username != null || emailVerified != null) {
+        } else if (last != null || first != null || email != null || username != null || emailVerified != null || enabled != null) {
             Map<String, String> parameters = new HashMap<>();
             if (last != null) {
                 parameters.put(UserModel.LAST_NAME, last);
@@ -401,6 +403,9 @@ public class UsersResource {
             }
             if (emailVerified != null) {
                 parameters.put(UserModel.EMAIL_VERIFIED, emailVerified.toString());
+            }
+            if (enabled != null) {
+                parameters.put(UserModel.ENABLED, enabled.toString());
             }
             if (userPermissionEvaluator.canView()) {
                 return session.users().getUsersCount(realm, parameters);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/UserTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/UserTest.java
@@ -627,6 +627,44 @@ public class UserTest extends AbstractAdminTest {
         return ids;
     }
 
+  @Test
+  public void countUsersByEnabledFilter() {
+
+    // create 2 enabled and 1 disabled user
+    UserRepresentation enabledUser1 = new UserRepresentation();
+    enabledUser1.setUsername("enabled1");
+    enabledUser1.setEmail("enabled1@enabledfilter.com");
+    enabledUser1.setEnabled(true);
+    createUser(enabledUser1);
+
+    UserRepresentation enabledUser2 = new UserRepresentation();
+    enabledUser2.setUsername("enabled2");
+    enabledUser2.setEmail("enabled2@enabledfilter.com");
+    enabledUser2.setEnabled(true);
+    createUser(enabledUser2);
+
+    UserRepresentation disabledUser1 = new UserRepresentation();
+    disabledUser1.setUsername("disabled1");
+    disabledUser1.setEmail("disabled1@enabledfilter.com");
+    disabledUser1.setEnabled(false);
+    createUser(disabledUser1);
+
+    Boolean enabled = true;
+    Boolean disabled = false;
+
+    // count all users with @enabledfilter.com
+    assertThat(realm.users().count(null, null, null, "@enabledfilter.com", null, null, null), is(3));
+
+    // count users that are enabled and have username enabled1
+    assertThat(realm.users().count(null, null, null, "@enabledfilter.com", null, "enabled1", enabled),is(1));
+
+    // count users that are disabled
+    assertThat(realm.users().count(null, null, null, "@enabledfilter.com", null, null, disabled), is(1));
+
+    // count users that are enabled
+    assertThat(realm.users().count(null, null, null, "@enabledfilter.com", null, null, enabled), is(2));
+  }
+
     @Test
     public void searchByEmail() {
         createUsers();


### PR DESCRIPTION
We now allow filtering users by their enabled status on the users/count endpoint.

Let me know if you have any feedback or suggestions to get this merged.
Thanks for this awesome project!

Resolves #10896 