### PR TITLE
Enable keycloak.v2 admin theme by default when admin2 feature is enabled

### DIFF
--- a/services/src/main/java/org/keycloak/theme/DefaultThemeSelectorProvider.java
+++ b/services/src/main/java/org/keycloak/theme/DefaultThemeSelectorProvider.java
@@ -10,6 +10,7 @@ public class DefaultThemeSelectorProvider implements ThemeSelectorProvider {
 
     public static final String LOGIN_THEME_KEY = "login_theme";
     private static final boolean isAccount2Enabled = Profile.isFeatureEnabled(Profile.Feature.ACCOUNT2);
+    private static final boolean isAdmin2Enabled = Profile.isFeatureEnabled(Profile.Feature.ADMIN2);
 
     private final KeycloakSession session;
 
@@ -50,6 +51,8 @@ public class DefaultThemeSelectorProvider implements ThemeSelectorProvider {
         if (name == null || name.isEmpty()) {
             name = Config.scope("theme").get("default", Version.NAME.toLowerCase());
             if ((type == Theme.Type.ACCOUNT) && isAccount2Enabled) {
+                name = name.concat(".v2");
+            } else if ((type == Theme.Type.ADMIN) && isAdmin2Enabled) {
                 name = name.concat(".v2");
             }
         }


### PR DESCRIPTION
Closes #9858
