### PR TITLE
[fixes #9835] - Fix the DynamicScopesRARParseTest by passing the userId variable to the lambda function directly

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/rar/AbstractRARParserTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/rar/AbstractRARParserTest.java
@@ -88,7 +88,7 @@ public abstract class AbstractRARParserTest extends AbstractTestRealmKeycloakTes
      * @return the {@link AuthorizationRequestContextHolder} local testsuite representation of the Authorization Request Context
      * with all the parsed authorization_detail objects.
      */
-    protected AuthorizationRequestContextHolder fetchAuthorizationRequestContextHolder() {
+    protected AuthorizationRequestContextHolder fetchAuthorizationRequestContextHolder(String userId) {
         AuthorizationRequestContextHolder authorizationRequestContextHolder = testingClient.server("test").fetch(session -> {
             final RealmModel realm = session.realms().getRealmByName("test");
             final UserModel user = session.users().getUserById(realm, userId);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/rar/DynamicScopesRARParseTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/rar/DynamicScopesRARParseTest.java
@@ -46,7 +46,6 @@ import static org.junit.Assert.assertEquals;
 public class DynamicScopesRARParseTest extends AbstractRARParserTest {
 
     @Test
-    @Ignore("ignored until we figure out why it fails on Quarkus and Wildfly")
     public void generatedAuthorizationRequestsShouldMatchDefaultScopes() {
         ClientResource testApp = ApiUtil.findClientByClientId(testRealm(), "test-app");
         List<ClientScopeRepresentation> defScopes = testApp.getDefaultClientScopes();
@@ -56,7 +55,7 @@ public class DynamicScopesRARParseTest extends AbstractRARParserTest {
         events.expectLogin()
                 .user(userId)
                 .assertEvent();
-        AuthorizationRequestContextHolder contextHolder = fetchAuthorizationRequestContextHolder();
+        AuthorizationRequestContextHolder contextHolder = fetchAuthorizationRequestContextHolder(userId);
         List<AuthorizationRequestContextHolder.AuthorizationRequestHolder> authorizationRequestHolders = contextHolder.getAuthorizationRequestHolders().stream()
                 .filter(authorizationRequestHolder -> authorizationRequestHolder.getSource().equals(AuthorizationRequestSource.SCOPE))
                 .collect(Collectors.toList());
@@ -73,7 +72,6 @@ public class DynamicScopesRARParseTest extends AbstractRARParserTest {
     }
 
     @Test
-    @Ignore("ignored until we figure out why it fails on Quarkus and Wildfly")
     public void generatedAuthorizationRequestsShouldMatchRequestedAndDefaultScopes() {
         Response response = createScope("static-scope", false);
         String scopeId = ApiUtil.getCreatedId(response);
@@ -93,7 +91,7 @@ public class DynamicScopesRARParseTest extends AbstractRARParserTest {
                 .user(userId)
                 .assertEvent();
 
-        AuthorizationRequestContextHolder contextHolder = fetchAuthorizationRequestContextHolder();
+        AuthorizationRequestContextHolder contextHolder = fetchAuthorizationRequestContextHolder(userId);
         List<AuthorizationRequestContextHolder.AuthorizationRequestHolder> authorizationRequestHolders = contextHolder.getAuthorizationRequestHolders().stream()
                 .filter(authorizationRequestHolder -> authorizationRequestHolder.getSource().equals(AuthorizationRequestSource.SCOPE))
                 .collect(Collectors.toList());
@@ -112,7 +110,6 @@ public class DynamicScopesRARParseTest extends AbstractRARParserTest {
     }
 
     @Test
-    @Ignore("ignored until we figure out why it fails on Quarkus and Wildfly")
     public void generatedAuthorizationRequestsShouldMatchRequestedDynamicAndDefaultScopes() {
         Response response = createScope("dynamic-scope", true);
         String scopeId = ApiUtil.getCreatedId(response);
@@ -132,7 +129,7 @@ public class DynamicScopesRARParseTest extends AbstractRARParserTest {
                 .user(userId)
                 .assertEvent();
 
-        AuthorizationRequestContextHolder contextHolder = fetchAuthorizationRequestContextHolder();
+        AuthorizationRequestContextHolder contextHolder = fetchAuthorizationRequestContextHolder(userId);
         List<AuthorizationRequestContextHolder.AuthorizationRequestHolder> authorizationRequestHolders = contextHolder.getAuthorizationRequestHolders().stream()
                 .filter(authorizationRequestHolder -> authorizationRequestHolder.getSource().equals(AuthorizationRequestSource.SCOPE))
                 .collect(Collectors.toList());


### PR DESCRIPTION
The value of the userId variable that  was defined globally was null when running the Quarkus and Wildfly server tests.

By passing it to the defining funciton, it should compile the lambda in a way that includes the value and avoids the NPE. 

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
