### PR TITLE
Quarkus update to 2.7.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <quarkus.version>2.5.4.Final</quarkus.version>
+        <quarkus.version>2.7.0.Final</quarkus.version>
 
         <!--
         Performing a Wildfly upgrade? Run the:

--- a/quarkus/deployment/pom.xml
+++ b/quarkus/deployment/pom.xml
@@ -79,8 +79,9 @@
             <artifactId>quarkus-smallrye-metrics-deployment</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.quarkus</groupId>
+            <groupId>io.quarkiverse.vault</groupId>
             <artifactId>quarkus-vault-deployment</artifactId>
+            <version>1.0.1</version>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/quarkus/pom.xml
+++ b/quarkus/pom.xml
@@ -37,16 +37,15 @@
             See https://github.com/quarkusio/quarkus/blob/<versionTag>/bom/application/pom.xml
             for reference
         -->
-        <resteasy.version>4.7.3.Final</resteasy.version>
-        <jackson.version>2.12.5</jackson.version>
+        <resteasy.version>4.7.5.Final</resteasy.version>
+        <jackson.version>2.13.1</jackson.version>
         <jackson.databind.version>${jackson.version}</jackson.databind.version>
-        <hibernate.core.version>5.6.1.Final</hibernate.core.version>
-        <mysql.driver.version>8.0.27</mysql.driver.version>
+        <hibernate.core.version>5.6.5.Final</hibernate.core.version>
+        <mysql.driver.version>8.0.28</mysql.driver.version>
         <postgresql.version>42.3.1</postgresql.version>
         <microprofile-metrics-api.version>3.0</microprofile-metrics-api.version>
         <wildfly.common.version>1.5.4.Final-format-001</wildfly.common.version>
-        <infinispan.version>13.0.0.Final</infinispan.version>
-
+        <infinispan.version>13.0.5.Final</infinispan.version>
         <!--
             Java EE dependencies. Not available from JDK 11+.
             The dependencies and their versions are the same used by Wildfly distribution.

--- a/quarkus/runtime/pom.xml
+++ b/quarkus/runtime/pom.xml
@@ -80,8 +80,9 @@
             <artifactId>quarkus-smallrye-metrics</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.quarkus</groupId>
+            <groupId>io.quarkiverse.vault</groupId>
             <artifactId>quarkus-vault</artifactId>
+            <version>1.0.1</version>
         </dependency>
 
         <!-- CLI -->

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/vault/QuarkusVaultProvider.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/vault/QuarkusVaultProvider.java
@@ -24,6 +24,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+
 import org.keycloak.vault.AbstractVaultProvider;
 import org.keycloak.vault.VaultKeyResolver;
 import org.keycloak.vault.VaultRawSecret;

--- a/quarkus/runtime/src/main/resources/META-INF/services/quarkus.properties
+++ b/quarkus/runtime/src/main/resources/META-INF/services/quarkus.properties
@@ -21,3 +21,6 @@
 quarkus.log.level = INFO
 quarkus.log.category."org.jboss.resteasy.resteasy_jaxrs.i18n".level=WARN
 quarkus.log.category."org.infinispan.transaction.lookup.JBossStandaloneJTAManagerLookup".level=WARN
+
+#jndi needed for LDAP lookups
+quarkus.naming.enable-jndi=true

--- a/quarkus/tests/integration/src/main/java/org/keycloak/it/utils/RawKeycloakDistribution.java
+++ b/quarkus/tests/integration/src/main/java/org/keycloak/it/utils/RawKeycloakDistribution.java
@@ -45,9 +45,10 @@ import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
+
+import io.quarkus.fs.util.ZipUtils;
 import org.apache.commons.io.FileUtils;
 
-import io.quarkus.bootstrap.util.ZipUtils;
 import org.keycloak.common.Version;
 
 public final class RawKeycloakDistribution implements KeycloakDistribution {

--- a/testsuite/integration-arquillian/servers/auth-server/quarkus/src/main/content/conf/quarkus.properties
+++ b/testsuite/integration-arquillian/servers/auth-server/quarkus/src/main/content/conf/quarkus.properties
@@ -1,0 +1,1 @@
+quarkus.naming.enable-jndi=true


### PR DESCRIPTION
Minor and micro dependency updates, some relocations (e.g. vault, ZipUtils), so some changes were needed to make this work. Also, jndi was disabled by default now in quarkus, but seems we need it for the LDAP lookup, so I added the flag to quarkus.properties from classpath. Without jndi enabled, the `UserFederationLdapConnectionTest` failed.

Closes #9872

