### PR TITLE
fix(themes/keycloak.v2): mixed tags in index.ftl

### DIFF
--- a/themes/src/main/resources/theme/keycloak.v2/account/index.ftl
+++ b/themes/src/main/resources/theme/keycloak.v2/account/index.ftl
@@ -145,19 +145,18 @@
 
 <div id="spinner_screen" style="display:block; height:100%">
     <div style="width: 320px; height: 328px; text-align: center; position: absolute; top:0;	bottom: 0; left: 0;	right: 0; margin: auto;">
-                <#if properties.logo?has_content>
-                <img src="${resourceUrl}${properties.logo}" alt="Logo" class="brand">
-                <#else>
-                <img src="${resourceUrl}/public/logo.svg" alt="Logo" class="brand">
-                </#if>
-                <p>${msg("loadingMessage")}</p>
-                <div >
-                    <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="margin: auto; background: rgb(255, 255, 255); display: block; shape-rendering: auto;" width="200px" height="200px" viewBox="0 0 100 100" preserveAspectRatio="xMidYMid">
-                    <path d="M10 50A40 40 0 0 0 90 50A40 42 0 0 1 10 50" fill="#5DBCD2" stroke="none" transform="rotate(16.3145 50 51)">
-                        <animateTransform attributeName="transform" type="rotate" dur="1s" repeatCount="indefinite" keyTimes="0;1" values="0 50 51;360 50 51"></animateTransform>
-                    </path>
-                </div>
-            </div>
+        <#if properties.logo?has_content>
+        <img src="${resourceUrl}${properties.logo}" alt="Logo" class="brand">
+        <#else>
+        <img src="${resourceUrl}/public/logo.svg" alt="Logo" class="brand">
+        </#if>
+        <p>${msg("loadingMessage")}</p>
+        <div>
+            <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="margin: auto; background: rgb(255, 255, 255); display: block; shape-rendering: auto;" width="200px" height="200px" viewBox="0 0 100 100" preserveAspectRatio="xMidYMid">
+                <path d="M10 50A40 40 0 0 0 90 50A40 42 0 0 1 10 50" fill="#5DBCD2" stroke="none" transform="rotate(16.3145 50 51)">
+                    <animateTransform attributeName="transform" type="rotate" dur="1s" repeatCount="indefinite" keyTimes="0;1" values="0 50 51;360 50 51"></animateTransform>
+                </path>
+            </svg>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Minor fixes for the index template in the Keycloak.v2 Account template:

- add missing closing tag for the SVG spinner
- remove two orphan closing divs
- fix indentation


