### PR TITLE
Ensure that parent's version ID is incremented when an attribute changes

### DIFF
--- a/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/JpaChildEntity.java
+++ b/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/JpaChildEntity.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022. Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.models.map.storage.jpa;
+
+/**
+ * Interface for all child entities for JPA map storage.
+ */
+public interface JpaChildEntity<R> {
+
+    /**
+     * Parent entity that should get its optimistic locking version updated upon changes in the child
+     */
+    R getParent();
+}

--- a/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/JpaChildEntityListener.java
+++ b/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/JpaChildEntityListener.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2022. Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.models.map.storage.jpa;
+
+import org.hibernate.HibernateException;
+import org.hibernate.Session;
+import org.hibernate.event.spi.PreDeleteEvent;
+import org.hibernate.event.spi.PreDeleteEventListener;
+import org.hibernate.event.spi.PreInsertEvent;
+import org.hibernate.event.spi.PreInsertEventListener;
+import org.hibernate.event.spi.PreUpdateEvent;
+import org.hibernate.event.spi.PreUpdateEventListener;
+
+import javax.persistence.LockModeType;
+
+/**
+ * Listen on changes on child entities and forces an optimistic locking increment on the topmost parent.
+ *
+ * This support a multiple level parent-child relationship, where only the upmost parent is locked.
+ */
+public class JpaChildEntityListener implements PreInsertEventListener, PreDeleteEventListener, PreUpdateEventListener {
+
+    public static final JpaChildEntityListener INSTANCE = new JpaChildEntityListener();
+
+    /**
+     * Check if the entity is a child with a parent and force optimistic locking increment on the upmost parent.
+     */
+    public void checkRoot(Session session, Object entity) throws HibernateException {
+        if(entity instanceof JpaChildEntity) {
+            Object root = entity;
+            while (root instanceof JpaChildEntity) {
+                root = ((JpaChildEntity<?>) entity).getParent();
+            }
+            session.lock(root, LockModeType.OPTIMISTIC_FORCE_INCREMENT);
+        }
+    }
+
+    @Override
+    public boolean onPreInsert(PreInsertEvent event) {
+        checkRoot(event.getSession(), event.getEntity());
+        return false;
+    }
+
+    @Override
+    public boolean onPreDelete(PreDeleteEvent event) {
+        checkRoot(event.getSession(), event.getEntity());
+        return false;
+    }
+
+    @Override
+    public boolean onPreUpdate(PreUpdateEvent event) {
+        checkRoot(event.getSession(), event.getEntity());
+        return false;
+    }
+}

--- a/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/client/entity/JpaClientAttributeEntity.java
+++ b/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/client/entity/JpaClientAttributeEntity.java
@@ -28,10 +28,11 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import org.hibernate.annotations.Nationalized;
+import org.keycloak.models.map.storage.jpa.JpaChildEntity;
 
 @Entity
 @Table(name = "client_attribute")
-public class JpaClientAttributeEntity implements Serializable {
+public class JpaClientAttributeEntity implements JpaChildEntity<JpaClientEntity>, Serializable {
 
     @Id
     @Column
@@ -99,5 +100,10 @@ public class JpaClientAttributeEntity implements Serializable {
         return Objects.equals(getClient(), that.getClient()) &&
                Objects.equals(getName(), that.getName()) &&
                Objects.equals(getValue(), that.getValue());
+    }
+
+    @Override
+    public JpaClientEntity getParent() {
+        return getClient();
     }
 }

--- a/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/client/entity/JpaClientEntity.java
+++ b/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/client/entity/JpaClientEntity.java
@@ -587,7 +587,6 @@ public class JpaClientEntity extends AbstractClientEntity implements Serializabl
             JpaClientAttributeEntity attr = iterator.next();
             if (Objects.equals(attr.getName(), name)) {
                 iterator.remove();
-                attr.setClient(null);
             }
         }
     }
@@ -625,9 +624,7 @@ public class JpaClientEntity extends AbstractClientEntity implements Serializabl
     public void setAttributes(Map<String, List<String>> attributes) {
         checkEntityVersionForUpdate();
         for (Iterator<JpaClientAttributeEntity> iterator = this.attributes.iterator(); iterator.hasNext();) {
-            JpaClientAttributeEntity attr = iterator.next();
             iterator.remove();
-            attr.setClient(null);
         }
         if (attributes != null) {
             for (Map.Entry<String, List<String>> attrEntry : attributes.entrySet()) {

--- a/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/role/entity/JpaRoleAttributeEntity.java
+++ b/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/role/entity/JpaRoleAttributeEntity.java
@@ -28,10 +28,12 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import org.hibernate.annotations.Nationalized;
+import org.keycloak.models.map.storage.jpa.JpaChildEntity;
+import org.keycloak.models.map.storage.jpa.client.entity.JpaClientEntity;
 
 @Entity
 @Table(name = "role_attribute")
-public class JpaRoleAttributeEntity implements Serializable {
+public class JpaRoleAttributeEntity implements JpaChildEntity<JpaRoleEntity>, Serializable {
 
     @Id
     @Column
@@ -99,5 +101,10 @@ public class JpaRoleAttributeEntity implements Serializable {
         return Objects.equals(getRole(), that.getRole()) &&
                Objects.equals(getName(), that.getName()) &&
                Objects.equals(getValue(), that.getValue());
+    }
+
+    @Override
+    public JpaRoleEntity getParent() {
+        return role;
     }
 }

--- a/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/role/entity/JpaRoleEntity.java
+++ b/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/role/entity/JpaRoleEntity.java
@@ -257,9 +257,7 @@ public class JpaRoleEntity extends AbstractRoleEntity implements Serializable, J
     public void setAttributes(Map<String, List<String>> attributes) {
         checkEntityVersionForUpdate();
         for (Iterator<JpaRoleAttributeEntity> iterator = this.attributes.iterator(); iterator.hasNext();) {
-            JpaRoleAttributeEntity attr = iterator.next();
             iterator.remove();
-            attr.setRole(null);
         }
         if (attributes != null) {
             for (Map.Entry<String, List<String>> entry : attributes.entrySet()) {
@@ -285,7 +283,6 @@ public class JpaRoleEntity extends AbstractRoleEntity implements Serializable, J
             JpaRoleAttributeEntity attr = iterator.next();
             if (Objects.equals(attr.getName(), name)) {
                 iterator.remove();
-                attr.setRole(null);
             }
         }
     }


### PR DESCRIPTION
This is necessary to allow the optimistic locking functionality to work as expected when changing only attributes on an entity.

Closes #9874

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
