### PR TITLE
Initial logging support

### DIFF
--- a/quarkus/dist/src/main/content/bin/kc.bat
+++ b/quarkus/dist/src/main/content/bin/kc.bat
@@ -19,7 +19,7 @@ if "%OS%" == "Windows_NT" (
   set DIRNAME=.\
 )
 
-set "SERVER_OPTS=-Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+set "SERVER_OPTS=-Djava.util.logging.manager=org.jboss.logmanager.LogManager -Dquarkus-log-max-startup-records=10000"
 
 set DEBUG_MODE=false
 set DEBUG_PORT_VAR=8787

--- a/quarkus/dist/src/main/content/bin/kc.sh
+++ b/quarkus/dist/src/main/content/bin/kc.sh
@@ -23,7 +23,7 @@ fi
 GREP="grep"
 DIRNAME=`dirname "$RESOLVED_NAME"`
 
-SERVER_OPTS="-Dkc.home.dir=$DIRNAME/../ -Djboss.server.config.dir=$DIRNAME/../conf -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+SERVER_OPTS="-Dkc.home.dir=$DIRNAME/../ -Djboss.server.config.dir=$DIRNAME/../conf -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Dquarkus-log-max-startup-records=10000"
 
 DEBUG_MODE="${DEBUG:-false}"
 DEBUG_PORT="${DEBUG_PORT:-8787}"

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/Messages.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/Messages.java
@@ -17,6 +17,11 @@
 
 package org.keycloak.quarkus.runtime;
 
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.jboss.logging.Logger;
+
 import picocli.CommandLine;
 
 public final class Messages {
@@ -48,5 +53,14 @@ public final class Messages {
 
     public static String devProfileNotAllowedError(String cmd) {
         return String.format("You can not '%s' the server using the '%s' configuration profile. Please re-build the server first, using 'kc.sh build' for the default production profile, or using 'kc.sh build --profile=<profile>' with a profile more suitable for production.%n", cmd, Environment.DEV_PROFILE_VALUE);
+    }
+
+    public static Throwable invalidLogLevel(String logLevel) {
+        Set<String> values = Arrays.stream(Logger.Level.values()).map(Logger.Level::name).map(String::toLowerCase).collect(Collectors.toSet());
+        return new IllegalStateException("Invalid log level: " + logLevel + ". Possible values are: " + String.join(", ", values) + ".");
+    }
+
+    public static Throwable invalidLogCategoryFormat(String category) {
+        return new IllegalStateException("Invalid log category format: " + category + ". The format is 'category:level' such as 'org.keycloak:debug'.");
     }
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/MicroProfileConfigProvider.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/MicroProfileConfigProvider.java
@@ -35,6 +35,7 @@ public class MicroProfileConfigProvider implements Config.ConfigProvider {
     public static final String NS_KEYCLOAK = "kc";
     public static final String NS_KEYCLOAK_PREFIX = NS_KEYCLOAK + ".";
     public static final String NS_QUARKUS = "quarkus";
+    public static final String NS_QUARKUS_PREFIX = "quarkus" + ".";
 
     private final org.eclipse.microprofile.config.Config config;
 

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/ConfigCategory.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/ConfigCategory.java
@@ -10,6 +10,7 @@ public enum ConfigCategory {
     METRICS("Metrics", 60),
     PROXY("Proxy", 70),
     VAULT("Vault", 80),
+    LOGGING("Logging", 90),
     GENERAL("General", 999);
 
     private final String heading;

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/LoggingPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/LoggingPropertyMappers.java
@@ -1,0 +1,87 @@
+package org.keycloak.quarkus.runtime.configuration.mappers;
+
+import static org.keycloak.quarkus.runtime.integration.QuarkusPlatform.addInitializationException;
+
+import java.util.Locale;
+import java.util.function.BiFunction;
+import java.util.logging.Level;
+
+import org.jboss.logmanager.LogContext;
+import org.keycloak.quarkus.runtime.Messages;
+
+import io.smallrye.config.ConfigSourceInterceptorContext;
+
+final class LoggingPropertyMappers {
+
+    private static final String DEFAULT_LOG_LEVEL = "info";
+
+    private LoggingPropertyMappers(){}
+
+    public static PropertyMapper[] getMappers() {
+        return new PropertyMapper[] {
+                builder().from("log-level")
+                        .to("quarkus.log.level")
+                        .transformer(new BiFunction<String, ConfigSourceInterceptorContext, String>() {
+                            @Override
+                            public String apply(String value, ConfigSourceInterceptorContext configSourceInterceptorContext) {
+                                String rootLevel = DEFAULT_LOG_LEVEL;
+
+                                for (String level : value.split(",")) {
+                                    String[] parts = level.split(":");
+                                    String category = null;
+                                    String categoryLevel;
+
+                                    if (parts.length == 1) {
+                                        categoryLevel = parts[0];
+                                    } else if (parts.length == 2) {
+                                        category = parts[0];
+                                        categoryLevel = parts[1];
+                                    } else {
+                                        addInitializationException(Messages.invalidLogCategoryFormat(level));
+                                        return rootLevel;
+                                    }
+
+                                    Level levelType;
+
+                                    try {
+                                        levelType = toLevel(categoryLevel);
+                                    } catch (IllegalArgumentException iae) {
+                                        addInitializationException(Messages.invalidLogLevel(categoryLevel));
+                                        return rootLevel;
+                                    }
+
+                                    if (category == null) {
+                                        rootLevel = levelType.getName();
+                                    } else {
+                                        setCategoryLevel(category, levelType.getName());
+                                    }
+                                }
+
+                                return rootLevel;
+                            }
+                        })
+                        .defaultValue(DEFAULT_LOG_LEVEL)
+                        .description("The log level of the root category or a comma-separated list of individual categories and their levels. For the root category, you don't need to specify a category.")
+                        .paramLabel("category:level")
+                        .build(),
+                builder().from("log-format")
+                        .to("quarkus.log.console.format")
+                        .defaultValue("%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n")
+                        .description("The format of log entries. If the format has spaces in it, you need to escape the value such as \"<format>\".")
+                        .paramLabel("format")
+                        .build()
+        };
+    }
+
+    private static Level toLevel(String categoryLevel) throws IllegalArgumentException {
+        return LogContext.getLogContext().getLevelForName(categoryLevel.toUpperCase(Locale.ROOT));
+    }
+
+    private static void setCategoryLevel(String category, String level) {
+        LogContext.getLogContext().getLogger(category).setLevel(toLevel(level));
+    }
+
+    private static PropertyMapper.Builder builder() {
+        return PropertyMapper.builder(ConfigCategory.LOGGING);
+    }
+}

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMappers.java
@@ -30,6 +30,7 @@ public final class PropertyMappers {
         MAPPERS.addAll(ProxyPropertyMappers.getProxyPropertyMappers());
         MAPPERS.addAll(VaultPropertyMappers.getVaultPropertyMappers());
         MAPPERS.addAll(FeaturePropertyMappers.getMappers());
+        MAPPERS.addAll(LoggingPropertyMappers.getMappers());
     }
 
     public static ConfigValue getValue(ConfigSourceInterceptorContext context, String name) {
@@ -50,7 +51,7 @@ public final class PropertyMappers {
     }
 
     public static boolean isBuildTimeProperty(String name) {
-        if (isFeaturesBuildTimeProperty(name) || isSpiBuildTimeProperty(name) || name.startsWith(MicroProfileConfigProvider.NS_QUARKUS)) {
+        if (isFeaturesBuildTimeProperty(name) || isSpiBuildTimeProperty(name) || name.startsWith(MicroProfileConfigProvider.NS_QUARKUS_PREFIX)) {
             return true;
         }
 

--- a/quarkus/runtime/src/main/resources/META-INF/services/quarkus.properties
+++ b/quarkus/runtime/src/main/resources/META-INF/services/quarkus.properties
@@ -18,7 +18,6 @@
 # Default options that rely on Quarkus specific options and lacking proper support in Keycloak
 
 # Logging configuration. INFO is the default level for most of the categories
-quarkus.log.level = INFO
 quarkus.log.category."org.jboss.resteasy.resteasy_jaxrs.i18n".level=WARN
 quarkus.log.category."org.infinispan.transaction.lookup.JBossStandaloneJTAManagerLookup".level=WARN
 

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/LoggingDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/LoggingDistTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.it.cli.dist;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.keycloak.it.junit5.extension.CLIResult;
+import org.keycloak.it.junit5.extension.DistributionTest;
+import org.keycloak.it.junit5.extension.RawDistOnly;
+
+import io.quarkus.test.junit.main.Launch;
+import io.quarkus.test.junit.main.LaunchResult;
+
+@DistributionTest(reInstall = DistributionTest.ReInstall.NEVER)
+@RawDistOnly(reason = "Too verbose for docker and enough to check raw dist")
+@TestMethodOrder(OrderAnnotation.class)
+public class LoggingDistTest {
+
+    @Test
+    @Launch({ "start-dev", "--log-level=debug" })
+    void testSetRootLevel(LaunchResult result) {
+        CLIResult cliResult = (CLIResult) result;
+        assertTrue(cliResult.getOutput().contains("DEBUG [org.hibernate"));
+        cliResult.assertStartedDevMode();
+    }
+
+    @Test
+    @Launch({ "start-dev", "--log-level=org.keycloak:debug" })
+    void testSetCategoryLevel(LaunchResult result) {
+        CLIResult cliResult = (CLIResult) result;
+        assertFalse(cliResult.getOutput().contains("DEBUG [org.hibernate"));
+        assertTrue(cliResult.getOutput().contains("DEBUG [org.keycloak"));
+        cliResult.assertStartedDevMode();
+    }
+
+    @Test
+    @Launch({ "start-dev", "--log-level=off,org.keycloak:debug,org.infinispan:info" })
+    void testRootAndCategoryLevels(LaunchResult result) {
+        CLIResult cliResult = (CLIResult) result;
+        assertFalse(cliResult.getOutput().contains("INFO  [io.quarkus"));
+        assertTrue(cliResult.getOutput().contains("DEBUG [org.keycloak"));
+        assertTrue(cliResult.getOutput().contains("INFO  [org.infinispan.CONTAINER]"));
+    }
+
+    @Test
+    @Launch({ "start-dev", "--log-level=off,org.keycloak:warn,debug" })
+    void testSetLastRootLevelIfMultipleSet(LaunchResult result) {
+        CLIResult cliResult = (CLIResult) result;
+        assertTrue(cliResult.getOutput().contains("DEBUG [org.hibernate"));
+        assertFalse(cliResult.getOutput().contains("INFO  [org.keycloak"));
+        cliResult.assertStartedDevMode();
+    }
+
+    @Test
+    @Launch({ "start-dev", "--log-format=\"%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c{1.}] %s%e%n\"" })
+    void testSetLogFormat(LaunchResult result) {
+        CLIResult cliResult = (CLIResult) result;
+        assertFalse(cliResult.getOutput().contains("(keycloak-cache-init)"));
+        cliResult.assertStartedDevMode();
+    }
+}

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartDevHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartDevHelp.approved.txt
@@ -100,6 +100,17 @@ Vault:
 --vault-dir <dir>    If set, secrets can be obtained by reading the content of files within the
                        given directory.
 
+Logging:
+
+--log-format <format>
+                     The format of log entries. If the format has spaces in it, you need to escape
+                       the value such as "<format>". Default: %d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c]
+                       (%t) %s%e%n.
+--log-level <category:level>
+                     The log level of the root category or a comma-separated list of individual
+                       categories and their levels. For the root category, you don't need to
+                       specify a category. Default: info.
+
 Do NOT start the server using this command when deploying to production.
 
 Use 'kc.sh start-dev --help-all' to list all available options, including build

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartDevHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartDevHelpAll.approved.txt
@@ -130,6 +130,17 @@ Vault:
 --vault-dir <dir>    If set, secrets can be obtained by reading the content of files within the
                        given directory.
 
+Logging:
+
+--log-format <format>
+                     The format of log entries. If the format has spaces in it, you need to escape
+                       the value such as "<format>". Default: %d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c]
+                       (%t) %s%e%n.
+--log-level <category:level>
+                     The log level of the root category or a comma-separated list of individual
+                       categories and their levels. For the root category, you don't need to
+                       specify a category. Default: info.
+
 Do NOT start the server using this command when deploying to production.
 
 Use 'kc.sh start-dev --help-all' to list all available options, including build

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartHelp.approved.txt
@@ -103,6 +103,17 @@ Vault:
 --vault-dir <dir>    If set, secrets can be obtained by reading the content of files within the
                        given directory.
 
+Logging:
+
+--log-format <format>
+                     The format of log entries. If the format has spaces in it, you need to escape
+                       the value such as "<format>". Default: %d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c]
+                       (%t) %s%e%n.
+--log-level <category:level>
+                     The log level of the root category or a comma-separated list of individual
+                       categories and their levels. For the root category, you don't need to
+                       specify a category. Default: info.
+
 You may use the "--auto-build" option when starting the server to avoid running
 the "build" command everytime you need to change a static property:
 


### PR DESCRIPTION
Closes #9901

* For now, a single `log-level` configuration option that accepts the root category level or a comma-separated list of categories and their respective levels. For instance: `debug,org.keycloak:debug`.
* Due to how logging is inited at runtime, I had to manually set the category levels.
* We can document the expected levels in the guide. But we can also include them in help.