### PR TITLE
Limit paths for running the operator CI

### DIFF
--- a/.github/workflows/operator-ci.yml
+++ b/.github/workflows/operator-ci.yml
@@ -1,6 +1,20 @@
 name: Keycloak Operator CI
 
-on: [push, pull_request]
+on:
+  push:
+    paths:
+      - 'core/**'
+      - 'common/**'
+      - 'operator/**'
+      - 'pom.xml'
+      - '.github/workflows/operator-ci.yml'
+  pull_request:
+    paths:
+      - 'core/**'
+      - 'common/**'
+      - 'operator/**'
+      - 'pom.xml'
+      - '.github/workflows/operator-ci.yml'
 
 env:
   JDK_VERSION: 11


### PR DESCRIPTION
This is the implementation of the path whitelist discussed in #9927 for the operator CI.

The operator CI will run only if something gets modified under those specific paths.

cc. @hmlnarik @vmuzikar 