### PR TITLE
[chore] Remove Quarkus tests workaround for log capturing

### DIFF
--- a/quarkus/tests/integration/src/main/java/org/keycloak/it/junit5/extension/CLITestExtension.java
+++ b/quarkus/tests/integration/src/main/java/org/keycloak/it/junit5/extension/CLITestExtension.java
@@ -92,8 +92,6 @@ public class CLITestExtension extends QuarkusMainTestExtension {
         } else {
             configureProfile(context);
             configureDatabase(context);
-            // WORKAROUND: this intercepts the output when actually starting the server.
-            QuarkusConsole.installRedirects();
             super.beforeEach(context);
         }
     }


### PR DESCRIPTION
Since the latest bump of Quarkus, we missed to remove a temporary workaround for a fix that is now upstream.

Followup to #9872

cc. @DGuhr @pedroigor 
