### PR TITLE
Avoid unexpected invalid_grant error on offline token refresh when offline session cache limits are configured

### DIFF
--- a/core/src/main/java/org/keycloak/representations/IDToken.java
+++ b/core/src/main/java/org/keycloak/representations/IDToken.java
@@ -54,6 +54,7 @@ public class IDToken extends JsonWebToken {
     public static final String CLAIMS_LOCALES = "claims_locales";
     public static final String ACR = "acr";
     public static final String SESSION_ID = "sid";
+    public static final String OFFLINE_SESSION_ID = "offline_sid";
 
     // Financial API - Part 2: Read and Write API Security Profile
     // http://openid.net/specs/openid-financial-api-part-2.html#authorization-server
@@ -139,6 +140,13 @@ public class IDToken extends JsonWebToken {
 
     @JsonProperty(ACR)
     protected String acr;
+
+    /**
+     * Holds the (user) sessionId of the originating offline session, in case the token was created by means of an
+     * offline token.
+     */
+    @JsonProperty(OFFLINE_SESSION_ID)
+    protected String offlineSessionId;
 
     // Financial API - Part 2: Read and Write API Security Profile
     // http://openid.net/specs/openid-financial-api-part-2.html#authorization-server
@@ -382,6 +390,19 @@ public class IDToken extends JsonWebToken {
 
     public void setStateHash(String stateHash) {
         this.stateHash = stateHash;
+    }
+
+    public String getOfflineSessionId() {
+        /*
+         * Backwards-compatibility: For tokens created after offlineSessionId was introduced, it would be ok to just
+         * return the offlineSessionId.
+         * The sessionId is returned for older tokens.
+         */
+        return offlineSessionId != null ? offlineSessionId : sessionState;
+    }
+
+    public void setOfflineSessionId(String offlineSessionId) {
+        this.offlineSessionId = offlineSessionId;
     }
 
     @Override

--- a/core/src/main/java/org/keycloak/representations/RefreshToken.java
+++ b/core/src/main/java/org/keycloak/representations/RefreshToken.java
@@ -17,17 +17,23 @@
 
 package org.keycloak.representations;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.keycloak.TokenCategory;
 import org.keycloak.util.TokenUtil;
-
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
  */
 public class RefreshToken extends AccessToken {
+
+    public static final String ONLINE_SESSION_ID = "online_sid";
+
+    /**
+     * Holds the (user) sessionId of the originating online session, in case of an offline token.
+     */
+    @JsonProperty(ONLINE_SESSION_ID)
+    protected String onlineSessionId;
 
     private RefreshToken() {
         type(TokenUtil.TOKEN_TYPE_REFRESH);
@@ -52,5 +58,18 @@ public class RefreshToken extends AccessToken {
     @Override
     public TokenCategory getCategory() {
         return TokenCategory.INTERNAL;
+    }
+
+    public String getOnlineSessionId() {
+        /*
+         * Backwards-compatibility: For tokens created after onlineSessionId was introduced, it would be ok to just
+         * return the onlineSessionId.
+         * The sessionId is returned for older tokens.
+         */
+        return onlineSessionId != null ? onlineSessionId : sessionState;
+    }
+
+    public void setOnlineSessionId(String onlineSessionId) {
+        this.onlineSessionId = onlineSessionId;
     }
 }

--- a/model/map/src/main/java/org/keycloak/models/map/userSession/MapUserSessionProvider.java
+++ b/model/map/src/main/java/org/keycloak/models/map/userSession/MapUserSessionProvider.java
@@ -412,7 +412,7 @@ public class MapUserSessionProvider implements UserSessionProvider {
     public UserSessionModel createOfflineUserSession(UserSessionModel userSession) {
         LOG.tracef("createOfflineUserSession(%s)%s", userSession, getShortStackTrace());
 
-        MapUserSessionEntity offlineUserSession = createUserSessionEntityInstance(userSession, true);
+        MapUserSessionEntity offlineUserSession = createUserSessionEntityInstance(userSession);
         offlineUserSession = userSessionTx.create(offlineUserSession);
 
         // set a reference for the offline user session to the original online user session
@@ -618,7 +618,7 @@ public class MapUserSessionProvider implements UserSessionProvider {
         return userSessionEntity;
     }
 
-    private MapUserSessionEntity createUserSessionEntityInstance(UserSessionModel userSession, boolean offline) {
+    private MapUserSessionEntity createUserSessionEntityInstance(UserSessionModel userSession) {
         MapUserSessionEntity entity = new MapUserSessionEntity(null, userSession.getRealm().getId());
 
         entity.setAuthMethod(userSession.getAuthMethod());
@@ -636,7 +636,7 @@ public class MapUserSessionProvider implements UserSessionProvider {
 
         entity.setStarted(userSession.getStarted());
         entity.setLastSessionRefresh(userSession.getLastSessionRefresh());
-        entity.setOffline(offline);
+        entity.setOffline(true);
 
         return entity;
     }

--- a/server-spi-private/src/main/java/org/keycloak/models/session/DisabledUserSessionPersisterProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/session/DisabledUserSessionPersisterProvider.java
@@ -67,13 +67,13 @@ public class DisabledUserSessionPersisterProvider implements UserSessionPersiste
     }
 
     @Override
-    public void createUserSession(UserSessionModel userSession, boolean offline) {
+    public void createUserSession(UserSessionModel userSession, boolean offline, String userSessionId) {
 
     }
 
     @Override
-    public void createClientSession(AuthenticatedClientSessionModel clientSession, boolean offline) {
-
+    public void createClientSession(AuthenticatedClientSessionModel clientSession, boolean offline,
+            String userSessionId) {
     }
 
     @Override
@@ -128,6 +128,11 @@ public class DisabledUserSessionPersisterProvider implements UserSessionPersiste
     @Override
     public Stream<UserSessionModel> loadUserSessionsStream(Integer firstResult, Integer maxResults, boolean offline,
                                                            String lastUserSessionId) {
+        return Stream.empty();
+    }
+
+    @Override
+    public Stream<AuthenticatedClientSessionModel> loadClientSessions(RealmModel realm, String userSessionId, String userId, boolean offline) {
         return Stream.empty();
     }
 

--- a/server-spi-private/src/main/java/org/keycloak/models/session/PersistentAuthenticatedClientSessionAdapter.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/session/PersistentAuthenticatedClientSessionAdapter.java
@@ -45,7 +45,8 @@ public class PersistentAuthenticatedClientSessionAdapter implements Authenticate
 
     private PersistentClientSessionData data;
 
-    public PersistentAuthenticatedClientSessionAdapter(KeycloakSession session, AuthenticatedClientSessionModel clientSession) {
+    public PersistentAuthenticatedClientSessionAdapter(KeycloakSession session,
+            AuthenticatedClientSessionModel clientSession, String userSessionId) {
         data = new PersistentClientSessionData();
         data.setAction(clientSession.getAction());
         data.setAuthMethod(clientSession.getProtocol());
@@ -55,7 +56,7 @@ public class PersistentAuthenticatedClientSessionAdapter implements Authenticate
         model = new PersistentClientSessionModel();
         model.setClientId(clientSession.getClient().getId());
         model.setUserId(clientSession.getUserSession().getUser().getId());
-        model.setUserSessionId(clientSession.getUserSession().getId());
+        model.setUserSessionId(userSessionId);
         model.setTimestamp(clientSession.getTimestamp());
 
         this.session = session;

--- a/server-spi-private/src/main/java/org/keycloak/models/session/UserSessionPersisterProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/session/UserSessionPersisterProvider.java
@@ -36,10 +36,10 @@ import java.util.stream.Stream;
 public interface UserSessionPersisterProvider extends Provider {
 
     // Persist just userSession. Not it's clientSessions
-    void createUserSession(UserSessionModel userSession, boolean offline);
+    void createUserSession(UserSessionModel userSession, boolean offline, String userSessionId);
 
     // Assuming that corresponding userSession is already persisted
-    void createClientSession(AuthenticatedClientSessionModel clientSession, boolean offline);
+    void createClientSession(AuthenticatedClientSessionModel clientSession, boolean offline, String userSessionId);
 
     // Called during logout (for online session) or during periodic expiration. It will remove all corresponding clientSessions too
     void removeUserSession(String userSessionId, boolean offline);
@@ -108,6 +108,14 @@ public interface UserSessionPersisterProvider extends Provider {
      */
     Stream<UserSessionModel> loadUserSessionsStream(Integer firstResult, Integer maxResults, boolean offline,
                                                     String lastUserSessionId);
+
+    /**
+     * Loads the client sessions for the given userSessionId.
+     *
+     * @return the client sessions
+     */
+    Stream<AuthenticatedClientSessionModel> loadClientSessions(RealmModel realm, String userSessionId, String userId,
+            boolean offline);
 
     /**
      * Retrieves the count of user sessions for all realms.

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/LogoutEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/LogoutEndpoint.java
@@ -258,7 +258,7 @@ public class LogoutEndpoint {
 
             if (userSessionModel != null) {
                 checkTokenIssuedAt(token, userSessionModel);
-                logout(userSessionModel, offline);
+                logout(userSessionModel, offline, token.getOnlineSessionId());
             }
         } catch (OAuthErrorException e) {
             // KEYCLOAK-6771 Certificate Bound Token
@@ -436,8 +436,9 @@ public class LogoutEndpoint {
                                 clientResponse.getResponseCode().get() == Response.Status.NO_CONTENT.getStatusCode())));
     }
 
-    private void logout(UserSessionModel userSession, boolean offline) {
-        AuthenticationManager.backchannelLogout(session, realm, userSession, session.getContext().getUri(), clientConnection, headers, true, offline);
+    private void logout(UserSessionModel userSession, boolean offline, String onlineUserSessionId) {
+        AuthenticationManager.backchannelLogout(session, realm, userSession, session.getContext().getUri(),
+                clientConnection, headers, true, offline, onlineUserSessionId);
         event.user(userSession.getUser()).session(userSession).success();
     }
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/UserInfoEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/UserInfoEndpoint.java
@@ -284,18 +284,23 @@ public class UserInfoEndpoint {
             return createTransientSessionForClient(token, client);
         }
 
-        UserSessionModel userSession = new UserSessionCrossDCManager(session).getUserSessionWithClient(realm, token.getSessionState(), false, client.getId());
+        UserSessionModel userSession = new UserSessionCrossDCManager(session).getUserSessionWithClient(realm,
+                token.getSessionState(), false, client.getId());
         UserSessionModel offlineUserSession = null;
         if (AuthenticationManager.isSessionValid(realm, userSession)) {
             checkTokenIssuedAt(token, userSession, event, client);
             event.session(userSession);
             return userSession;
         } else {
-            offlineUserSession = new UserSessionCrossDCManager(session).getUserSessionWithClient(realm, token.getSessionState(), true, client.getId());
-            if (AuthenticationManager.isOfflineSessionValid(realm, offlineUserSession)) {
-                checkTokenIssuedAt(token, offlineUserSession, event, client);
-                event.session(offlineUserSession);
-                return offlineUserSession;
+            String relatedOfflineSessionId = token.getOfflineSessionId();
+            if (relatedOfflineSessionId != null) {
+                offlineUserSession = new UserSessionCrossDCManager(session).getUserSessionWithClient(realm,
+                        relatedOfflineSessionId, true, client.getId());
+                if (AuthenticationManager.isOfflineSessionValid(realm, offlineUserSession)) {
+                    checkTokenIssuedAt(token, offlineUserSession, event, client);
+                    event.session(offlineUserSession);
+                    return offlineUserSession;
+                }
             }
         }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/storage/ClientStorageTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/storage/ClientStorageTest.java
@@ -503,7 +503,7 @@ public class ClientStorageTest extends AbstractTestRealmKeycloakTest {
         Assert.assertTrue(refreshedToken.getRealmAccess().isUserInRole(Constants.OFFLINE_ACCESS_ROLE));
 
 
-        EventRepresentation refreshEvent = events.expectRefresh(offlineToken.getId(), sessionId)
+        EventRepresentation refreshEvent = events.expectRefresh(offlineToken.getId(), offlineUserSessionId)
                 .client("hardcoded-client")
                 .user(userId)
                 .removeDetail(Details.UPDATED_REFRESH_TOKEN_ID)

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OfflineTokenTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OfflineTokenTest.java
@@ -305,7 +305,7 @@ public class OfflineTokenTest extends AbstractKeycloakTest {
         Assert.assertEquals(1, refreshedToken.getResourceAccess("test-app").getRoles().size());
         assertTrue(refreshedToken.getResourceAccess("test-app").isUserInRole("customer-user"));
 
-        EventRepresentation refreshEvent = events.expectRefresh(offlineToken.getId(), sessionId)
+        EventRepresentation refreshEvent = events.expectRefresh(offlineToken.getId(), offlineToken.getSessionId())
                 .client("offline-client")
                 .user(userId)
                 .removeDetail(Details.UPDATED_REFRESH_TOKEN_ID)
@@ -385,7 +385,7 @@ public class OfflineTokenTest extends AbstractKeycloakTest {
         // Assert second refresh with same refresh token will fail
         OAuthClient.AccessTokenResponse response = oauth.doRefreshTokenRequest(offlineTokenString, "secret1");
         Assert.assertEquals(400, response.getStatusCode());
-        events.expectRefresh(offlineToken.getId(), token.getSessionState())
+        events.expectRefresh(offlineToken.getId(), offlineToken.getSessionState())
                 .client("offline-client")
                 .error(Errors.INVALID_TOKEN)
                 .user(userId)
@@ -691,7 +691,7 @@ public class OfflineTokenTest extends AbstractKeycloakTest {
 
         codeId = loginEvent.getDetails().get(Details.CODE_ID);
 
-        events.expectCodeToToken(codeId, offlineToken2.getSessionState())
+        events.expectCodeToToken(codeId, offlineToken2.getOnlineSessionId())
                 .client("offline-client")
                 .detail(Details.REFRESH_TOKEN_TYPE, TokenUtil.TOKEN_TYPE_OFFLINE)
                 .assertEvent();

--- a/testsuite/utils/src/main/java/org/keycloak/testsuite/util/cli/PersistSessionsCommand.java
+++ b/testsuite/utils/src/main/java/org/keycloak/testsuite/util/cli/PersistSessionsCommand.java
@@ -19,6 +19,7 @@ package org.keycloak.testsuite.util.cli;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.keycloak.models.AuthenticatedClientSessionModel;
@@ -115,10 +116,11 @@ public class PersistSessionsCommand extends AbstractCommand {
                 for (String userSessionId : userSessionIds) {
                     counter++;
                     UserSessionModel userSession = session.sessions().getUserSession(realm, userSessionId);
-                    persister.createUserSession(userSession, true);
+                    String offlineUserSessionId = UUID.randomUUID().toString();
+                    persister.createUserSession(userSession, true, offlineUserSessionId);
 
                     AuthenticatedClientSessionModel clientSession = userSession.getAuthenticatedClientSessions().get(testApp.getId());
-                    persister.createClientSession(clientSession, true);
+                    persister.createClientSession(clientSession, true, offlineUserSessionId);
                 }
 
                 log.infof("%d user sessions persisted. Continue", counter);


### PR DESCRIPTION
- make sure that for each userSession there is only one clientSession (this improves utilization of userSession and clientSession caches - at least when both are configured with the same maximum number of entries)
- reload the clientSession from the database, in case it is not found in the cache - update the cache in this case

Closes #9959
