### PR TITLE
Modernize TypeScript definitions of JS adapter

### DIFF
--- a/adapters/oidc/js/dist/keycloak-authz.d.ts
+++ b/adapters/oidc/js/dist/keycloak-authz.d.ts
@@ -18,105 +18,99 @@
  * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-import * as Keycloak from './keycloak';
+import Keycloak from './keycloak';
 
-export as namespace KeycloakAuthorization;
+export interface KeycloakAuthorizationPromise {
+	then(onGrant: (rpt: string) => void, onDeny: () => void, onError: () => void): void;
+}
 
-export = KeycloakAuthorization;
+export interface AuthorizationRequest {
+	/**
+	 * An array of objects representing the resource and scopes.
+	 */
+	permissions?:ResourcePermission[],
 
-/**
- * Creates a new Keycloak client instance.
- * @param config Path to a JSON config file or a plain config object.
- */
-declare function KeycloakAuthorization(keycloak: Keycloak.KeycloakInstance): KeycloakAuthorization.KeycloakAuthorizationInstance;
+	/**
+	 * A permission ticket obtained from a resource server when using UMA authorization protocol.
+	 */
+	ticket?:string,
 
-declare namespace KeycloakAuthorization {
-	interface KeycloakAuthorizationPromise {
-		then(onGrant: (rpt: string) => void, onDeny: () => void, onError: () => void): void;
-	}
+	/**
+	 * A boolean value indicating whether the server should create permission requests to the resources
+	 * and scopes referenced by a permission ticket. This parameter will only take effect when used together
+	 * with the ticket parameter as part of a UMA authorization process.
+	 */
+	submitRequest?:boolean,
 
-    interface AuthorizationRequest {
-        /**
-         * An array of objects representing the resource and scopes.
-         */
-        permissions?:ResourcePermission[],
+	/**
+	 * Defines additional information about this authorization request in order to specify how it should be processed
+	 * by the server.
+	 */
+	metadata?:AuthorizationRequestMetadata,
 
-        /**
-         * A permission ticket obtained from a resource server when using UMA authorization protocol.
-         */
-        ticket?:string,
+	/**
+	 * Defines whether or not this authorization request should include the current RPT. If set to true, the RPT will
+	 * be sent and permissions in the current RPT will be included in the new RPT. Otherwise, only the permissions referenced in this
+	 * authorization request will be granted in the new RPT.
+	 */
+	incrementalAuthorization?:boolean
+}
 
-        /**
-         * A boolean value indicating whether the server should create permission requests to the resources
-         * and scopes referenced by a permission ticket. This parameter will only take effect when used together
-         * with the ticket parameter as part of a UMA authorization process.
-         */
-        submitRequest?:boolean,
+export interface AuthorizationRequestMetadata {
+	/**
+	 * A boolean value indicating to the server if resource names should be included in the RPT’s permissions.
+	 * If false, only the resource identifier is included.
+	 */
+	responseIncludeResourceName?:any,
 
-        /**
-         * Defines additional information about this authorization request in order to specify how it should be processed
-         * by the server.
-         */
-        metadata?:AuthorizationRequestMetadata,
+	/**
+	 * An integer N that defines a limit for the amount of permissions an RPT can have. When used together with
+	 * rpt parameter, only the last N requested permissions will be kept in the RPT.
+	 */
+	response_permissions_limit?:number
+}
 
-        /**
-         * Defines whether or not this authorization request should include the current RPT. If set to true, the RPT will
-         * be sent and permissions in the current RPT will be included in the new RPT. Otherwise, only the permissions referenced in this
-         * authorization request will be granted in the new RPT.
-         */
-        incrementalAuthorization?:boolean
-    }
+export interface ResourcePermission {
+	/**
+	 * The id or name of a resource.
+	 */
+	id:string,
 
-    interface AuthorizationRequestMetadata {
-        /**
-         * A boolean value indicating to the server if resource names should be included in the RPT’s permissions.
-         * If false, only the resource identifier is included.
-         */
-        responseIncludeResourceName?:any,
+	/**
+	 * An array of strings where each value is the name of a scope associated with the resource.
+	 */
+	scopes?:string[]
+}
 
-        /**
-         * An integer N that defines a limit for the amount of permissions an RPT can have. When used together with
-         * rpt parameter, only the last N requested permissions will be kept in the RPT.
-         */
-        response_permissions_limit?:number
-    }
+export default class KeycloakAuthorization {
+	/**
+	 * Creates a new Keycloak client instance.
+	 * @param config Path to a JSON config file or a plain config object.
+	 */
+	constructor(keycloak: Keycloak)
 
-    interface ResourcePermission {
-        /**
-         * The id or name of a resource.
-         */
-        id:string,
+	rpt: any;
+	config: { rpt_endpoint: string };
 
-        /**
-         * An array of strings where each value is the name of a scope associated with the resource.
-         */
-        scopes?:string[]
-    }
+	init(): void;
 
-	interface KeycloakAuthorizationInstance {
-		rpt: any;
-		config: { rpt_endpoint: string };
+	/**
+	 * This method enables client applications to better integrate with resource servers protected by a Keycloak
+	 * policy enforcer using UMA protocol.
+	 *
+	 * The authorization request must be provided with a ticket.
+	 *
+	 * @param authorizationRequest An AuthorizationRequest instance with a valid permission ticket set.
+	 * @returns A promise to set functions to be invoked on grant, deny or error.
+	 */
+	authorize(authorizationRequest: AuthorizationRequest): KeycloakAuthorizationPromise;
 
-		init(): void;
-
-		/**
-         * This method enables client applications to better integrate with resource servers protected by a Keycloak
-         * policy enforcer using UMA protocol.
-         *
-         * The authorization request must be provided with a ticket.
-         *
-         * @param authorizationRequest An AuthorizationRequest instance with a valid permission ticket set.
-         * @returns A promise to set functions to be invoked on grant, deny or error.
-         */
-		authorize(authorizationRequest: AuthorizationRequest): KeycloakAuthorizationPromise;
-
-		/**
-		 * Obtains all entitlements from a Keycloak server based on a given resourceServerId.
-         *
-         * @param resourceServerId The id (client id) of the resource server to obtain permissions from.
-         * @param authorizationRequest An AuthorizationRequest instance.
-         * @returns A promise to set functions to be invoked on grant, deny or error.
-		 */
-		entitlement(resourceServerId: string, authorizationRequest?: AuthorizationRequest): KeycloakAuthorizationPromise;
-	}
+	/**
+	 * Obtains all entitlements from a Keycloak server based on a given resourceServerId.
+	 *
+	 * @param resourceServerId The id (client id) of the resource server to obtain permissions from.
+	 * @param authorizationRequest An AuthorizationRequest instance.
+	 * @returns A promise to set functions to be invoked on grant, deny or error.
+	 */
+	entitlement(resourceServerId: string, authorizationRequest?: AuthorizationRequest): KeycloakAuthorizationPromise;
 }

--- a/adapters/oidc/js/dist/keycloak-authz.d.ts
+++ b/adapters/oidc/js/dist/keycloak-authz.d.ts
@@ -82,6 +82,11 @@ export interface ResourcePermission {
 	scopes?:string[]
 }
 
+/**
+ * @deprecated Instead of importing 'KeycloakAuthorizationInstance' you can import 'KeycloakAuthorization' directly as a type.
+ */
+export type KeycloakAuthorizationInstance = KeycloakAuthorization;
+
 export default class KeycloakAuthorization {
 	/**
 	 * Creates a new Keycloak client instance.

--- a/adapters/oidc/js/dist/keycloak-authz.d.ts
+++ b/adapters/oidc/js/dist/keycloak-authz.d.ts
@@ -87,7 +87,12 @@ export interface ResourcePermission {
  */
 export type KeycloakAuthorizationInstance = KeycloakAuthorization;
 
-export default class KeycloakAuthorization {
+/**
+ * @deprecated Construct a KeycloakAuthorization instance using the `new` keyword instead.
+ */
+declare function KeycloakAuthorization(keycloak: Keycloak): KeycloakAuthorization;
+
+declare class KeycloakAuthorization {
 	/**
 	 * Creates a new Keycloak client instance.
 	 * @param config Path to a JSON config file or a plain config object.
@@ -119,6 +124,8 @@ export default class KeycloakAuthorization {
 	 */
 	entitlement(resourceServerId: string, authorizationRequest?: AuthorizationRequest): KeycloakAuthorizationPromise;
 }
+
+export default KeycloakAuthorization;
 
 /**
  * @deprecated The 'KeycloakAuthorization' namespace is deprecated, use named imports instead.

--- a/adapters/oidc/js/dist/keycloak-authz.d.ts
+++ b/adapters/oidc/js/dist/keycloak-authz.d.ts
@@ -119,3 +119,8 @@ export default class KeycloakAuthorization {
 	 */
 	entitlement(resourceServerId: string, authorizationRequest?: AuthorizationRequest): KeycloakAuthorizationPromise;
 }
+
+/**
+ * @deprecated The 'KeycloakAuthorization' namespace is deprecated, use named imports instead.
+ */
+export as namespace KeycloakAuthorization;

--- a/adapters/oidc/js/dist/keycloak.d.ts
+++ b/adapters/oidc/js/dist/keycloak.d.ts
@@ -327,10 +327,15 @@ export interface KeycloakRoles {
 export type KeycloakInstance = Keycloak;
 
 /**
+ * @deprecated Construct a Keycloak instance using the `new` keyword instead.
+ */
+declare function Keycloak(config?: KeycloakConfig | string): Keycloak;
+
+/**
  * A client for the Keycloak authentication server.
  * @see {@link https://keycloak.gitbooks.io/securing-client-applications-guide/content/topics/oidc/javascript-adapter.html|Keycloak JS adapter documentation}
  */
-export default class Keycloak {
+declare class Keycloak {
 	/**
 	 * Creates a new Keycloak client instance.
 	 * @param config A configuration object or path to a JSON config file.
@@ -614,6 +619,8 @@ export default class Keycloak {
 	*/
 	loadUserInfo(): KeycloakPromise<{}, void>;
 }
+
+export default Keycloak;
 
 /**
  * @deprecated The 'Keycloak' namespace is deprecated, use named imports instead.

--- a/adapters/oidc/js/dist/keycloak.d.ts
+++ b/adapters/oidc/js/dist/keycloak.d.ts
@@ -322,6 +322,11 @@ export interface KeycloakRoles {
 }
 
 /**
+ * @deprecated Instead of importing 'KeycloakInstance' you can import 'Keycloak' directly as a type.
+ */
+export type KeycloakInstance = Keycloak;
+
+/**
  * A client for the Keycloak authentication server.
  * @see {@link https://keycloak.gitbooks.io/securing-client-applications-guide/content/topics/oidc/javascript-adapter.html|Keycloak JS adapter documentation}
  */

--- a/adapters/oidc/js/dist/keycloak.d.ts
+++ b/adapters/oidc/js/dist/keycloak.d.ts
@@ -18,600 +18,594 @@
  * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-export as namespace Keycloak;
+export type KeycloakOnLoad = 'login-required'|'check-sso';
+export type KeycloakResponseMode = 'query'|'fragment';
+export type KeycloakResponseType = 'code'|'id_token token'|'code id_token token';
+export type KeycloakFlow = 'standard'|'implicit'|'hybrid';
+export type KeycloakPkceMethod = 'S256';
 
-export = Keycloak;
+export interface KeycloakConfig {
+	/**
+	 * URL to the Keycloak server, for example: http://keycloak-server/auth
+	 */
+	url?: string;
+	/**
+	 * Name of the realm, for example: 'myrealm'
+	 */
+	realm: string;
+	/**
+	 * Client identifier, example: 'myapp'
+	 */
+	clientId: string;
+}
 
-/**
- * Creates a new Keycloak client instance.
- * @param config A configuration object or path to a JSON config file.
- */
-declare function Keycloak(config?: Keycloak.KeycloakConfig | string): Keycloak.KeycloakInstance;
-
-declare namespace Keycloak {
-	type KeycloakOnLoad = 'login-required'|'check-sso';
-	type KeycloakResponseMode = 'query'|'fragment';
-	type KeycloakResponseType = 'code'|'id_token token'|'code id_token token';
-	type KeycloakFlow = 'standard'|'implicit'|'hybrid';
-	type KeycloakPkceMethod = 'S256';
-
-	interface KeycloakConfig {
-		/**
-		 * URL to the Keycloak server, for example: http://keycloak-server/auth
-		 */
-		url?: string;
-		/**
-		 * Name of the realm, for example: 'myrealm'
-		 */
-		realm: string;
-		/**
-		 * Client identifier, example: 'myapp'
-		 */
-		clientId: string;
-	}
-
-	interface KeycloakInitOptions {
-		/**
-		 * Adds a [cryptographic nonce](https://en.wikipedia.org/wiki/Cryptographic_nonce)
-		 * to verify that the authentication response matches the request.
-		 * @default true
-		 */
-		useNonce?: boolean;
-
-		/**
-		 * 
-		 * Allow usage of different types of adapters or a custom adapter to make Keycloak work in different environments.
-		 *
-		 * The following options are supported:
-		 * - `default` - Use default APIs that are available in browsers.
-		 * - `cordova` - Use a WebView in Cordova.
-		 * - `cordova-native` - Use Cordova native APIs, this is recommended over `cordova`.
-		 *
-		 * It's also possible to pass in a custom adapter for the environment you are running Keycloak in. In order to do so extend the `KeycloakAdapter` interface and implement the methods that are defined there.
-		 *
-		 * For example:
-		 *
-		 * ```ts
-		 * import Keycloak, { KeycloakAdapter } from 'keycloak-js';
-		 *
-		 * // Implement the 'KeycloakAdapter' interface so that all required methods are guaranteed to be present.
-		 * const MyCustomAdapter: KeycloakAdapter = {
-		 * 	login(options) {
-		 * 		// Write your own implementation here.
-		 * 	}
-		 *
-		 * 	// The other methods go here...
-		 * };
-		 *
-		 * const keycloak = new Keycloak();
-		 *
-		 * keycloak.init({
-		 * 	adapter: MyCustomAdapter,
-		 * });
-		 * ```
-		 */
-		adapter?: 'default' | 'cordova' | 'cordova-native' | KeycloakAdapter;
-		
-		/**
-		 * Specifies an action to do on load.
-		 */
-		onLoad?: KeycloakOnLoad;
-
-		/**
-		 * Set an initial value for the token.
-		 */
-		token?: string;
-
-		/**
-		 * Set an initial value for the refresh token.
-		 */
-		refreshToken?: string;
-
-		/**
-		 * Set an initial value for the id token (only together with `token` or
-		 * `refreshToken`).
-		 */
-		idToken?: string;
-
-		/**
-		 * Set an initial value for skew between local time and Keycloak server in
-		 * seconds (only together with `token` or `refreshToken`).
-		 */
-		timeSkew?: number;
-
-		/**
-		 * Set to enable/disable monitoring login state.
-		 * @default true
-		 */
-		checkLoginIframe?: boolean;
-
-		/**
-		 * Set the interval to check login state (in seconds).
-		 * @default 5
-		 */
-		checkLoginIframeInterval?: number;
-
-		/**
-		 * Set the OpenID Connect response mode to send to Keycloak upon login.
-		 * @default fragment After successful authentication Keycloak will redirect
-		 *                   to JavaScript application with OpenID Connect parameters
-		 *                   added in URL fragment. This is generally safer and
-		 *                   recommended over query.
-		 */
-		responseMode?: KeycloakResponseMode;
-
-		/**
-		 * Specifies a default uri to redirect to after login or logout.
-		 * This is currently supported for adapter 'cordova-native' and 'default'
-		 */
-		redirectUri?: string;
-
-		/**
-		 * Specifies an uri to redirect to after silent check-sso.
-		 * Silent check-sso will only happen, when this redirect uri is given and
-		 * the specified uri is available whithin the application.
-		 */
-		silentCheckSsoRedirectUri?: string;
-
-		/**
-		 * Specifies whether the silent check-sso should fallback to "non-silent"
-		 * check-sso when 3rd party cookies are blocked by the browser. Defaults
-		 * to true.
-		 */
-		silentCheckSsoFallback?: boolean;
-
-		/**
-		 * Set the OpenID Connect flow.
-		 * @default standard
-		 */
-		flow?: KeycloakFlow;
-
-		/**
-		 * Configures the Proof Key for Code Exchange (PKCE) method to use.
-		 * The currently allowed method is 'S256'.
-		 * If not configured, PKCE will not be used.
-		 */
-		pkceMethod?: KeycloakPkceMethod;
-
-		/**
-		 * Enables logging messages from Keycloak to the console.
-		 * @default false
-		 */
-		enableLogging?: boolean
-
-		/**
-		 * Configures how long will Keycloak adapter wait for receiving messages from server in ms. This is used,
-		 * for example, when waiting for response of 3rd party cookies check.
-		 *
-		 * @default 10000
-		 */
-		messageReceiveTimeout?: number
-	}
-
-	interface KeycloakLoginOptions {
-		/**
-		 * Specifies the scope parameter for the login url
-		 * The scope 'openid' will be added to the scope if it is missing or undefined.
-		 */
-		scope?: string;
-
-		/**
-		 * Specifies the uri to redirect to after login.
-		 */
-		redirectUri?: string;
-
-		/**
-		 * By default the login screen is displayed if the user is not logged into
-		 * Keycloak. To only authenticate to the application if the user is already
-		 * logged in and not display the login page if the user is not logged in, set
-		 * this option to `'none'`. To always require re-authentication and ignore
-		 * SSO, set this option to `'login'`.
-		 */
-		prompt?: 'none'|'login';
-
-		/**
-		 * If value is `'register'` then user is redirected to registration page,
-		 * otherwise to login page.
-		 */
-		action?: string;
-
-		/**
-		 * Used just if user is already authenticated. Specifies maximum time since
-		 * the authentication of user happened. If user is already authenticated for
-		 * longer time than `'maxAge'`, the SSO is ignored and he will need to
-		 * authenticate again.
-		 */
-		maxAge?: number;
-
-		/**
-		 * Used to pre-fill the username/email field on the login form.
-		 */
-		loginHint?: string;
-
-		/**
-		 * Used to tell Keycloak which IDP the user wants to authenticate with.
-		 */
-		idpHint?: string;
-
-	        /**
-		 * Sets the 'ui_locales' query param in compliance with section 3.1.2.1
-                 * of the OIDC 1.0 specification.
-		 */
-		locale?: string;
-
-		/**
-		 * Specifies arguments that are passed to the Cordova in-app-browser (if applicable).
-		 * Options 'hidden' and 'location' are not affected by these arguments.
-		 * All available options are defined at https://cordova.apache.org/docs/en/latest/reference/cordova-plugin-inappbrowser/.
-		 * Example of use: { zoom: "no", hardwareback: "yes" }
-		 */
-		cordovaOptions?: { [optionName: string]: string };
-	}
-
-	interface KeycloakLogoutOptions {
-		/**
-		 * Specifies the uri to redirect to after logout.
-		 */
-		redirectUri?: string;
-	}
-
-	interface KeycloakRegisterOptions extends Omit<KeycloakLoginOptions, 'action'> { }
-	
-	interface KeycloakAccountOptions {
-		/**
-		 * Specifies the uri to redirect to when redirecting back to the application.
-		 */
-		redirectUri?: string;	
-	}
-
-	type KeycloakPromiseCallback<T> = (result: T) => void;
-
-	interface KeycloakPromise<TSuccess, TError> extends Promise<TSuccess> {
-		/**
-		 * Function to call if the promised action succeeds.
-		 * 
-		 * @deprecated Use `.then()` instead.
-		 */
-		success(callback: KeycloakPromiseCallback<TSuccess>): KeycloakPromise<TSuccess, TError>;
-
-		/**
-		 * Function to call if the promised action throws an error.
-		 * 
-		 * @deprecated Use `.catch()` instead.
-		 */
-		error(callback: KeycloakPromiseCallback<TError>): KeycloakPromise<TSuccess, TError>;
-	}
-
-	interface KeycloakError {
-		error: string;
-		error_description: string;
-	}
-
-	interface KeycloakAdapter {
-		login(options?: KeycloakLoginOptions): KeycloakPromise<void, void>;
-		logout(options?: KeycloakLogoutOptions): KeycloakPromise<void, void>;
-		register(options?: KeycloakRegisterOptions): KeycloakPromise<void, void>;
-		accountManagement(): KeycloakPromise<void, void>;
-		redirectUri(options: { redirectUri: string; }, encodeHash: boolean): string;
-	}
-
-	interface KeycloakProfile {
-		id?: string;
-		username?: string;
-		email?: string;
-		firstName?: string;
-		lastName?: string;
-		enabled?: boolean;
-		emailVerified?: boolean;
-		totp?: boolean;
-		createdTimestamp?: number;
-	}
-
-	interface KeycloakTokenParsed {
-		iss?: string;
-		sub?: string;
-		aud?: string;
-		exp?: number;
-		iat?: number;
-		auth_time?: number;
-		nonce?: string;
-		acr?: string;
-		amr?: string;
-		azp?: string;
-		session_state?: string;
-		realm_access?: KeycloakRoles;
-		resource_access?: KeycloakResourceAccess;
-		[key: string]: any; // Add other attributes here.
-	}
-
-	interface KeycloakResourceAccess {
-		[key: string]: KeycloakRoles
-	}
-
-	interface KeycloakRoles {
-		roles: string[];
-	}
+export interface KeycloakInitOptions {
+	/**
+	 * Adds a [cryptographic nonce](https://en.wikipedia.org/wiki/Cryptographic_nonce)
+	 * to verify that the authentication response matches the request.
+	 * @default true
+	 */
+	useNonce?: boolean;
 
 	/**
-	 * A client for the Keycloak authentication server.
-	 * @see {@link https://keycloak.gitbooks.io/securing-client-applications-guide/content/topics/oidc/javascript-adapter.html|Keycloak JS adapter documentation}
+	 * 
+	 * Allow usage of different types of adapters or a custom adapter to make Keycloak work in different environments.
+	 *
+	 * The following options are supported:
+	 * - `default` - Use default APIs that are available in browsers.
+	 * - `cordova` - Use a WebView in Cordova.
+	 * - `cordova-native` - Use Cordova native APIs, this is recommended over `cordova`.
+	 *
+	 * It's also possible to pass in a custom adapter for the environment you are running Keycloak in. In order to do so extend the `KeycloakAdapter` interface and implement the methods that are defined there.
+	 *
+	 * For example:
+	 *
+	 * ```ts
+	 * import Keycloak, { KeycloakAdapter } from 'keycloak-js';
+	 *
+	 * // Implement the 'KeycloakAdapter' interface so that all required methods are guaranteed to be present.
+	 * const MyCustomAdapter: KeycloakAdapter = {
+	 * 	login(options) {
+	 * 		// Write your own implementation here.
+	 * 	}
+	 *
+	 * 	// The other methods go here...
+	 * };
+	 *
+	 * const keycloak = new Keycloak();
+	 *
+	 * keycloak.init({
+	 * 	adapter: MyCustomAdapter,
+	 * });
+	 * ```
 	 */
-	interface KeycloakInstance {
-		/**
-		 * Is true if the user is authenticated, false otherwise.
-		 */
-		authenticated?: boolean;
+	adapter?: 'default' | 'cordova' | 'cordova-native' | KeycloakAdapter;
+	
+	/**
+	 * Specifies an action to do on load.
+	 */
+	onLoad?: KeycloakOnLoad;
 
-		/**
-		 * The user id.
-		 */
-		subject?: string;
+	/**
+	 * Set an initial value for the token.
+	 */
+	token?: string;
 
-		/**
-		 * Response mode passed in init (default value is `'fragment'`).
-		 */
-		responseMode?: KeycloakResponseMode;
+	/**
+	 * Set an initial value for the refresh token.
+	 */
+	refreshToken?: string;
 
-		/**
-		 * Response type sent to Keycloak with login requests. This is determined
-		 * based on the flow value used during initialization, but can be overridden
-		 * by setting this value.
-		 */
-		responseType?: KeycloakResponseType;
+	/**
+	 * Set an initial value for the id token (only together with `token` or
+	 * `refreshToken`).
+	 */
+	idToken?: string;
 
-		/**
-		 * Flow passed in init.
-		 */
-		flow?: KeycloakFlow;
+	/**
+	 * Set an initial value for skew between local time and Keycloak server in
+	 * seconds (only together with `token` or `refreshToken`).
+	 */
+	timeSkew?: number;
 
-		/**
-		 * The realm roles associated with the token.
-		 */
-		realmAccess?: KeycloakRoles;
+	/**
+	 * Set to enable/disable monitoring login state.
+	 * @default true
+	 */
+	checkLoginIframe?: boolean;
 
-		/**
-		 * The resource roles associated with the token.
-		 */
-		resourceAccess?: KeycloakResourceAccess;
+	/**
+	 * Set the interval to check login state (in seconds).
+	 * @default 5
+	 */
+	checkLoginIframeInterval?: number;
 
-		/**
-		 * The base64 encoded token that can be sent in the Authorization header in
-		 * requests to services.
-		 */
-		token?: string;
+	/**
+	 * Set the OpenID Connect response mode to send to Keycloak upon login.
+	 * @default fragment After successful authentication Keycloak will redirect
+	 *                   to JavaScript application with OpenID Connect parameters
+	 *                   added in URL fragment. This is generally safer and
+	 *                   recommended over query.
+	 */
+	responseMode?: KeycloakResponseMode;
 
-		/**
-		 * The parsed token as a JavaScript object.
-		 */
-		tokenParsed?: KeycloakTokenParsed;
+	/**
+	 * Specifies a default uri to redirect to after login or logout.
+	 * This is currently supported for adapter 'cordova-native' and 'default'
+	 */
+	redirectUri?: string;
 
-		/**
-		 * The base64 encoded refresh token that can be used to retrieve a new token.
-		 */
-		refreshToken?: string;
+	/**
+	 * Specifies an uri to redirect to after silent check-sso.
+	 * Silent check-sso will only happen, when this redirect uri is given and
+	 * the specified uri is available whithin the application.
+	 */
+	silentCheckSsoRedirectUri?: string;
 
-		/**
-		 * The parsed refresh token as a JavaScript object.
-		 */
-		refreshTokenParsed?: KeycloakTokenParsed;
+	/**
+	 * Specifies whether the silent check-sso should fallback to "non-silent"
+	 * check-sso when 3rd party cookies are blocked by the browser. Defaults
+	 * to true.
+	 */
+	silentCheckSsoFallback?: boolean;
 
-		/**
-		 * The base64 encoded ID token.
-		 */
-		idToken?: string;
+	/**
+	 * Set the OpenID Connect flow.
+	 * @default standard
+	 */
+	flow?: KeycloakFlow;
 
-		/**
-		 * The parsed id token as a JavaScript object.
-		 */
-		idTokenParsed?: KeycloakTokenParsed;
+	/**
+	 * Configures the Proof Key for Code Exchange (PKCE) method to use.
+	 * The currently allowed method is 'S256'.
+	 * If not configured, PKCE will not be used.
+	 */
+	pkceMethod?: KeycloakPkceMethod;
 
-		/**
-		 * The estimated time difference between the browser time and the Keycloak
-		 * server in seconds. This value is just an estimation, but is accurate
-		 * enough when determining if a token is expired or not.
-		 */
-		timeSkew?: number;
+	/**
+	 * Enables logging messages from Keycloak to the console.
+	 * @default false
+	 */
+	enableLogging?: boolean
 
-		/**
-		 * @private Undocumented.
-		 */
-		loginRequired?: boolean;
+	/**
+	 * Configures how long will Keycloak adapter wait for receiving messages from server in ms. This is used,
+	 * for example, when waiting for response of 3rd party cookies check.
+	 *
+	 * @default 10000
+	 */
+	messageReceiveTimeout?: number
+}
 
-		/**
-		 * @private Undocumented.
-		 */
-		authServerUrl?: string;
+export interface KeycloakLoginOptions {
+	/**
+	 * Specifies the scope parameter for the login url
+	 * The scope 'openid' will be added to the scope if it is missing or undefined.
+	 */
+	scope?: string;
 
-		/**
-		 * @private Undocumented.
-		 */
-		realm?: string;
+	/**
+	 * Specifies the uri to redirect to after login.
+	 */
+	redirectUri?: string;
 
-		/**
-		 * @private Undocumented.
-		 */
-		clientId?: string;
+	/**
+	 * By default the login screen is displayed if the user is not logged into
+	 * Keycloak. To only authenticate to the application if the user is already
+	 * logged in and not display the login page if the user is not logged in, set
+	 * this option to `'none'`. To always require re-authentication and ignore
+	 * SSO, set this option to `'login'`.
+	 */
+	prompt?: 'none'|'login';
 
-		/**
-		 * @private Undocumented.
-		 */
-		clientSecret?: string;
+	/**
+	 * If value is `'register'` then user is redirected to registration page,
+	 * otherwise to login page.
+	 */
+	action?: string;
 
-		/**
-		 * @private Undocumented.
-		 */
-		redirectUri?: string;
+	/**
+	 * Used just if user is already authenticated. Specifies maximum time since
+	 * the authentication of user happened. If user is already authenticated for
+	 * longer time than `'maxAge'`, the SSO is ignored and he will need to
+	 * authenticate again.
+	 */
+	maxAge?: number;
 
-		/**
-		 * @private Undocumented.
-		 */
-		sessionId?: string;
+	/**
+	 * Used to pre-fill the username/email field on the login form.
+	 */
+	loginHint?: string;
 
-		/**
-		 * @private Undocumented.
-		 */
-		profile?: KeycloakProfile;
+	/**
+	 * Used to tell Keycloak which IDP the user wants to authenticate with.
+	 */
+	idpHint?: string;
 
-		/**
-		 * @private Undocumented.
-		 */
-		userInfo?: {}; // KeycloakUserInfo;
+				/**
+	 * Sets the 'ui_locales' query param in compliance with section 3.1.2.1
+							 * of the OIDC 1.0 specification.
+	 */
+	locale?: string;
 
-		/**
-		 * Called when the adapter is initialized.
-		 */
-		onReady?(authenticated?: boolean): void;
+	/**
+	 * Specifies arguments that are passed to the Cordova in-app-browser (if applicable).
+	 * Options 'hidden' and 'location' are not affected by these arguments.
+	 * All available options are defined at https://cordova.apache.org/docs/en/latest/reference/cordova-plugin-inappbrowser/.
+	 * Example of use: { zoom: "no", hardwareback: "yes" }
+	 */
+	cordovaOptions?: { [optionName: string]: string };
+}
 
-		/**
-		 * Called when a user is successfully authenticated.
-		 */
-		onAuthSuccess?(): void;
+export interface KeycloakLogoutOptions {
+	/**
+	 * Specifies the uri to redirect to after logout.
+	 */
+	redirectUri?: string;
+}
 
-		/**
-		 * Called if there was an error during authentication.
-		 */
-		onAuthError?(errorData: KeycloakError): void;
+export interface KeycloakRegisterOptions extends Omit<KeycloakLoginOptions, 'action'> { }
 
-		/**
-		 * Called when the token is refreshed.
-		 */
-		onAuthRefreshSuccess?(): void;
+export interface KeycloakAccountOptions {
+	/**
+	 * Specifies the uri to redirect to when redirecting back to the application.
+	 */
+	redirectUri?: string;	
+}
 
-		/**
-		 * Called if there was an error while trying to refresh the token.
-		 */
-		onAuthRefreshError?(): void;
+export type KeycloakPromiseCallback<T> = (result: T) => void;
 
-		/**
-		 * Called if the user is logged out (will only be called if the session
-		 * status iframe is enabled, or in Cordova mode).
-		 */
-		onAuthLogout?(): void;
+export interface KeycloakPromise<TSuccess, TError> extends Promise<TSuccess> {
+	/**
+	 * Function to call if the promised action succeeds.
+	 * 
+	 * @deprecated Use `.then()` instead.
+	 */
+	success(callback: KeycloakPromiseCallback<TSuccess>): KeycloakPromise<TSuccess, TError>;
 
-		/**
-		 * Called when the access token is expired. If a refresh token is available
-		 * the token can be refreshed with Keycloak#updateToken, or in cases where
-		 * it's not (ie. with implicit flow) you can redirect to login screen to
-		 * obtain a new access token.
-		 */
-		onTokenExpired?(): void;
+	/**
+	 * Function to call if the promised action throws an error.
+	 * 
+	 * @deprecated Use `.catch()` instead.
+	 */
+	error(callback: KeycloakPromiseCallback<TError>): KeycloakPromise<TSuccess, TError>;
+}
 
-		/**
-		 * Called when a AIA has been requested by the application.
-		 */
-		onActionUpdate?(status: 'success'|'cancelled'|'error'): void;
+export interface KeycloakError {
+	error: string;
+	error_description: string;
+}
 
-		/**
-		 * Called to initialize the adapter.
-		 * @param initOptions Initialization options.
-		 * @returns A promise to set functions to be invoked on success or error.
-		 */
-		init(initOptions: KeycloakInitOptions): KeycloakPromise<boolean, KeycloakError>;
+export interface KeycloakAdapter {
+	login(options?: KeycloakLoginOptions): KeycloakPromise<void, void>;
+	logout(options?: KeycloakLogoutOptions): KeycloakPromise<void, void>;
+	register(options?: KeycloakRegisterOptions): KeycloakPromise<void, void>;
+	accountManagement(): KeycloakPromise<void, void>;
+	redirectUri(options: { redirectUri: string; }, encodeHash: boolean): string;
+}
 
-		/**
-		 * Redirects to login form.
-		 * @param options Login options.
-		 */
-		login(options?: KeycloakLoginOptions): KeycloakPromise<void, void>;
+export interface KeycloakProfile {
+	id?: string;
+	username?: string;
+	email?: string;
+	firstName?: string;
+	lastName?: string;
+	enabled?: boolean;
+	emailVerified?: boolean;
+	totp?: boolean;
+	createdTimestamp?: number;
+}
 
-		/**
-		 * Redirects to logout.
-		 * @param options Logout options.
-		 */
-		logout(options?: KeycloakLogoutOptions): KeycloakPromise<void, void>;
+export interface KeycloakTokenParsed {
+	iss?: string;
+	sub?: string;
+	aud?: string;
+	exp?: number;
+	iat?: number;
+	auth_time?: number;
+	nonce?: string;
+	acr?: string;
+	amr?: string;
+	azp?: string;
+	session_state?: string;
+	realm_access?: KeycloakRoles;
+	resource_access?: KeycloakResourceAccess;
+	[key: string]: any; // Add other attributes here.
+}
 
-		/**
-		 * Redirects to registration form.
-		 * @param options The options used for the registration.
-		 */
-		register(options?: KeycloakRegisterOptions): KeycloakPromise<void, void>;
+export interface KeycloakResourceAccess {
+	[key: string]: KeycloakRoles
+}
 
-		/**
-		 * Redirects to the Account Management Console.
-		 */
-		accountManagement(): KeycloakPromise<void, void>;
+export interface KeycloakRoles {
+	roles: string[];
+}
 
-		/**
-		 * Returns the URL to login form.
-		 * @param options Supports same options as Keycloak#login.
-		 */
-		createLoginUrl(options?: KeycloakLoginOptions): string;
+/**
+ * A client for the Keycloak authentication server.
+ * @see {@link https://keycloak.gitbooks.io/securing-client-applications-guide/content/topics/oidc/javascript-adapter.html|Keycloak JS adapter documentation}
+ */
+export default class Keycloak {
+	/**
+	 * Creates a new Keycloak client instance.
+	 * @param config A configuration object or path to a JSON config file.
+	 */
+	constructor(config?: KeycloakConfig | string)
 
-		/**
-		 * Returns the URL to logout the user.
-		 * @param options Logout options.
-		 */
-		createLogoutUrl(options?: KeycloakLogoutOptions): string;
+	/**
+	 * Is true if the user is authenticated, false otherwise.
+	 */
+	authenticated?: boolean;
 
-		/**
-		 * Returns the URL to registration page.
-		 * @param options The options used for creating the registration URL.
-		 */
-		createRegisterUrl(options?: KeycloakRegisterOptions): string;
+	/**
+	* The user id.
+	*/
+	subject?: string;
 
-		/**
-		 * Returns the URL to the Account Management Console.
-		 * @param options The options used for creating the account URL.
-		 */
-		createAccountUrl(options?: KeycloakAccountOptions): string;
+	/**
+	* Response mode passed in init (default value is `'fragment'`).
+	*/
+	responseMode?: KeycloakResponseMode;
 
-		/**
-		 * Returns true if the token has less than `minValidity` seconds left before
-		 * it expires.
-		 * @param minValidity If not specified, `0` is used.
-		 */
-		isTokenExpired(minValidity?: number): boolean;
+	/**
+	* Response type sent to Keycloak with login requests. This is determined
+	* based on the flow value used during initialization, but can be overridden
+	* by setting this value.
+	*/
+	responseType?: KeycloakResponseType;
 
-		/**
-		 * If the token expires within `minValidity` seconds, the token is refreshed.
-		 * If the session status iframe is enabled, the session status is also
-		 * checked.
-		 * @returns A promise to set functions that can be invoked if the token is
-		 *          still valid, or if the token is no longer valid.
-		 * @example
-		 * ```js
-		 * keycloak.updateToken(5).then(function(refreshed) {
-		 *   if (refreshed) {
-		 *     alert('Token was successfully refreshed');
-		 *   } else {
-		 *     alert('Token is still valid');
-		 *   }
-		 * }).catch(function() {
-		 *   alert('Failed to refresh the token, or the session has expired');
-		 * });
-		 */
-		updateToken(minValidity: number): KeycloakPromise<boolean, boolean>;
+	/**
+	* Flow passed in init.
+	*/
+	flow?: KeycloakFlow;
 
-		/**
-		 * Clears authentication state, including tokens. This can be useful if
-		 * the application has detected the session was expired, for example if
-		 * updating token fails. Invoking this results in Keycloak#onAuthLogout
-		 * callback listener being invoked.
-		 */
-		clearToken(): void;
+	/**
+	* The realm roles associated with the token.
+	*/
+	realmAccess?: KeycloakRoles;
 
-		/**
-		 * Returns true if the token has the given realm role.
-		 * @param role A realm role name.
-		 */
-		hasRealmRole(role: string): boolean;
+	/**
+	* The resource roles associated with the token.
+	*/
+	resourceAccess?: KeycloakResourceAccess;
 
-		/**
-		 * Returns true if the token has the given role for the resource.
-		 * @param role A role name.
-		 * @param resource If not specified, `clientId` is used.
-		 */
-		hasResourceRole(role: string, resource?: string): boolean;
+	/**
+	* The base64 encoded token that can be sent in the Authorization header in
+	* requests to services.
+	*/
+	token?: string;
 
-		/**
-		 * Loads the user's profile.
-		 * @returns A promise to set functions to be invoked on success or error.
-		 */
-		loadUserProfile(): KeycloakPromise<KeycloakProfile, void>;
+	/**
+	* The parsed token as a JavaScript object.
+	*/
+	tokenParsed?: KeycloakTokenParsed;
 
-		/**
-		 * @private Undocumented.
-		 */
-		loadUserInfo(): KeycloakPromise<{}, void>;
-	}
+	/**
+	* The base64 encoded refresh token that can be used to retrieve a new token.
+	*/
+	refreshToken?: string;
+
+	/**
+	* The parsed refresh token as a JavaScript object.
+	*/
+	refreshTokenParsed?: KeycloakTokenParsed;
+
+	/**
+	* The base64 encoded ID token.
+	*/
+	idToken?: string;
+
+	/**
+	* The parsed id token as a JavaScript object.
+	*/
+	idTokenParsed?: KeycloakTokenParsed;
+
+	/**
+	* The estimated time difference between the browser time and the Keycloak
+	* server in seconds. This value is just an estimation, but is accurate
+	* enough when determining if a token is expired or not.
+	*/
+	timeSkew?: number;
+
+	/**
+	* @private Undocumented.
+	*/
+	loginRequired?: boolean;
+
+	/**
+	* @private Undocumented.
+	*/
+	authServerUrl?: string;
+
+	/**
+	* @private Undocumented.
+	*/
+	realm?: string;
+
+	/**
+	* @private Undocumented.
+	*/
+	clientId?: string;
+
+	/**
+	* @private Undocumented.
+	*/
+	clientSecret?: string;
+
+	/**
+	* @private Undocumented.
+	*/
+	redirectUri?: string;
+
+	/**
+	* @private Undocumented.
+	*/
+	sessionId?: string;
+
+	/**
+	* @private Undocumented.
+	*/
+	profile?: KeycloakProfile;
+
+	/**
+	* @private Undocumented.
+	*/
+	userInfo?: {}; // KeycloakUserInfo;
+
+	/**
+	* Called when the adapter is initialized.
+	*/
+	onReady?(authenticated?: boolean): void;
+
+	/**
+	* Called when a user is successfully authenticated.
+	*/
+	onAuthSuccess?(): void;
+
+	/**
+	* Called if there was an error during authentication.
+	*/
+	onAuthError?(errorData: KeycloakError): void;
+
+	/**
+	* Called when the token is refreshed.
+	*/
+	onAuthRefreshSuccess?(): void;
+
+	/**
+	* Called if there was an error while trying to refresh the token.
+	*/
+	onAuthRefreshError?(): void;
+
+	/**
+	* Called if the user is logged out (will only be called if the session
+	* status iframe is enabled, or in Cordova mode).
+	*/
+	onAuthLogout?(): void;
+
+	/**
+	* Called when the access token is expired. If a refresh token is available
+	* the token can be refreshed with Keycloak#updateToken, or in cases where
+	* it's not (ie. with implicit flow) you can redirect to login screen to
+	* obtain a new access token.
+	*/
+	onTokenExpired?(): void;
+
+	/**
+	* Called when a AIA has been requested by the application.
+	*/
+	onActionUpdate?(status: 'success'|'cancelled'|'error'): void;
+
+	/**
+	* Called to initialize the adapter.
+	* @param initOptions Initialization options.
+	* @returns A promise to set functions to be invoked on success or error.
+	*/
+	init(initOptions: KeycloakInitOptions): KeycloakPromise<boolean, KeycloakError>;
+
+	/**
+	* Redirects to login form.
+	* @param options Login options.
+	*/
+	login(options?: KeycloakLoginOptions): KeycloakPromise<void, void>;
+
+	/**
+	* Redirects to logout.
+	* @param options Logout options.
+	*/
+	logout(options?: KeycloakLogoutOptions): KeycloakPromise<void, void>;
+
+	/**
+	* Redirects to registration form.
+	* @param options The options used for the registration.
+	*/
+	register(options?: KeycloakRegisterOptions): KeycloakPromise<void, void>;
+
+	/**
+	* Redirects to the Account Management Console.
+	*/
+	accountManagement(): KeycloakPromise<void, void>;
+
+	/**
+	* Returns the URL to login form.
+	* @param options Supports same options as Keycloak#login.
+	*/
+	createLoginUrl(options?: KeycloakLoginOptions): string;
+
+	/**
+	* Returns the URL to logout the user.
+	* @param options Logout options.
+	*/
+	createLogoutUrl(options?: KeycloakLogoutOptions): string;
+
+	/**
+	* Returns the URL to registration page.
+	* @param options The options used for creating the registration URL.
+	*/
+	createRegisterUrl(options?: KeycloakRegisterOptions): string;
+
+	/**
+	* Returns the URL to the Account Management Console.
+	* @param options The options used for creating the account URL.
+	*/
+	createAccountUrl(options?: KeycloakAccountOptions): string;
+
+	/**
+	* Returns true if the token has less than `minValidity` seconds left before
+	* it expires.
+	* @param minValidity If not specified, `0` is used.
+	*/
+	isTokenExpired(minValidity?: number): boolean;
+
+	/**
+	* If the token expires within `minValidity` seconds, the token is refreshed.
+	* If the session status iframe is enabled, the session status is also
+	* checked.
+	* @returns A promise to set functions that can be invoked if the token is
+	*          still valid, or if the token is no longer valid.
+	* @example
+	* ```js
+	* keycloak.updateToken(5).then(function(refreshed) {
+	*   if (refreshed) {
+	*     alert('Token was successfully refreshed');
+	*   } else {
+	*     alert('Token is still valid');
+	*   }
+	* }).catch(function() {
+	*   alert('Failed to refresh the token, or the session has expired');
+	* });
+	*/
+	updateToken(minValidity: number): KeycloakPromise<boolean, boolean>;
+
+	/**
+	* Clears authentication state, including tokens. This can be useful if
+	* the application has detected the session was expired, for example if
+	* updating token fails. Invoking this results in Keycloak#onAuthLogout
+	* callback listener being invoked.
+	*/
+	clearToken(): void;
+
+	/**
+	* Returns true if the token has the given realm role.
+	* @param role A realm role name.
+	*/
+	hasRealmRole(role: string): boolean;
+
+	/**
+	* Returns true if the token has the given role for the resource.
+	* @param role A role name.
+	* @param resource If not specified, `clientId` is used.
+	*/
+	hasResourceRole(role: string, resource?: string): boolean;
+
+	/**
+	* Loads the user's profile.
+	* @returns A promise to set functions to be invoked on success or error.
+	*/
+	loadUserProfile(): KeycloakPromise<KeycloakProfile, void>;
+
+	/**
+	* @private Undocumented.
+	*/
+	loadUserInfo(): KeycloakPromise<{}, void>;
 }

--- a/adapters/oidc/js/dist/keycloak.d.ts
+++ b/adapters/oidc/js/dist/keycloak.d.ts
@@ -614,3 +614,8 @@ export default class Keycloak {
 	*/
 	loadUserInfo(): KeycloakPromise<{}, void>;
 }
+
+/**
+ * @deprecated The 'Keycloak' namespace is deprecated, use named imports instead.
+ */
+export as namespace Keycloak;

--- a/themes/src/main/resources/theme/keycloak.v2/account/src/app/keycloak-service/keycloak.service.ts
+++ b/themes/src/main/resources/theme/keycloak.v2/account/src/app/keycloak-service/keycloak.service.ts
@@ -14,10 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {KeycloakLoginOptions} from "../../../../../../../../../../adapters/oidc/js";
+import Keycloak, { KeycloakLoginOptions } from "../../../../../../../../../../adapters/oidc/js";
 
 declare const baseUrl: string;
-export type KeycloakClient = Keycloak.KeycloakInstance;
+export type KeycloakClient = Keycloak;
 
 export class KeycloakService {
     private keycloakAuth: KeycloakClient;


### PR DESCRIPTION
Updates the type definitions of the JavaScript adapter to use modern [ES module](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) syntax. This removes the [needless namespacing](https://www.typescriptlang.org/docs/handbook/namespaces-and-modules.html#needless-namespacing) and replaces it with named export statements.

Note that the diff in Github looks intimidating, but this is mostly due to indentation changes so I recommend to review the diff locally in your IDE. 

Closes #9045.