### PR TITLE
[fixes #9225] - Get scopeIds from the AuthorizationRequestContext object when DYNAMIC_SCOPES are enabled to account for them in ProtocolMappers

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
@@ -424,7 +424,7 @@ public class TokenEndpoint {
             throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_SCOPE, "Client no longer has requested consent from user", Response.Status.BAD_REQUEST);
         }
 
-        ClientSessionContext clientSessionCtx = DefaultClientSessionContext.fromClientSessionAndClientScopes(clientSession, clientScopesSupplier.get(), session);
+        ClientSessionContext clientSessionCtx = DefaultClientSessionContext.fromClientSessionAndScopeParameter(clientSession, scopeParam, session);
 
         // Set nonce as an attribute in the ClientSessionContext. Will be used for the token generation
         clientSessionCtx.setAttribute(OIDCLoginProtocol.NONCE_PARAM, codeData.getNonce());

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/ciba/CibaGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/ciba/CibaGrantType.java
@@ -212,7 +212,7 @@ public class CibaGrantType {
         }
 
         ClientSessionContext clientSessionCtx = DefaultClientSessionContext
-                .fromClientSessionAndClientScopes(userSession.getAuthenticatedClientSessionByClient(client.getId()), TokenManager.getRequestedClientScopes(scopeParam, client), session);
+                .fromClientSessionAndScopeParameter(userSession.getAuthenticatedClientSessionByClient(client.getId()), scopeParam, session);
 
         int authTime = Time.currentTime();
         userSession.setNote(AuthenticationManager.AUTH_TIME, String.valueOf(authTime));

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/device/DeviceGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/device/DeviceGrantType.java
@@ -292,8 +292,8 @@ public class DeviceGrantType {
                 "Client no longer has requested consent from user", Response.Status.BAD_REQUEST);
         }
 
-        ClientSessionContext clientSessionCtx = DefaultClientSessionContext.fromClientSessionAndClientScopes(clientSession,
-            TokenManager.getRequestedClientScopes(scopeParam, client), session);
+        ClientSessionContext clientSessionCtx = DefaultClientSessionContext.fromClientSessionAndScopeParameter(clientSession,
+                scopeParam, session);
 
         // Set nonce as an attribute in the ClientSessionContext. Will be used for the token generation
         clientSessionCtx.setAttribute(OIDCLoginProtocol.NONCE_PARAM, deviceCodeModel.getNonce());

--- a/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
@@ -1192,9 +1192,7 @@ public class AuthenticationManager {
         //if Dynamic Scopes are enabled, get the scopes from the AuthorizationRequestContext, passing the session and scopes as parameters
         // then concat a Stream with the ClientModel, as it's discarded in the getAuthorizationRequestContext method
         if (Profile.isFeatureEnabled(Profile.Feature.DYNAMIC_SCOPES)) {
-            return Stream.concat(AuthorizationContextUtil.getAuthorizationRequestContextFromScopes(session, authSession.getClientNote(OAuth2Constants.SCOPE))
-                    .getAuthorizationDetailEntries().stream(),
-                    Collections.singletonList(new AuthorizationDetails(session.getContext().getClient())).stream());
+            return AuthorizationContextUtil.getAuthorizationRequestsStreamFromScopesWithClient(session, authSession.getClientNote(OAuth2Constants.SCOPE));
         }
         // if dynamic scopes are not enabled, we retain the old behaviour, but the ClientScopes will be wrapped in
         // AuthorizationRequest objects to standardize the code handling these.

--- a/services/src/main/java/org/keycloak/services/util/AuthorizationContextUtil.java
+++ b/services/src/main/java/org/keycloak/services/util/AuthorizationContextUtil.java
@@ -1,13 +1,47 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.keycloak.services.util;
 
 import org.keycloak.common.Profile;
+import org.keycloak.models.ClientScopeModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.protocol.oidc.rar.AuthorizationRequestParserProvider;
 import org.keycloak.protocol.oidc.rar.parsers.ClientScopeAuthorizationRequestParserProviderFactory;
+import org.keycloak.rar.AuthorizationDetails;
 import org.keycloak.rar.AuthorizationRequestContext;
+import org.keycloak.rar.AuthorizationRequestSource;
 
+import java.util.stream.Stream;
+
+
+/**
+ * @author <a href="mailto:dgozalob@redhat.com">Daniel Gozalo</a>
+ * Util class to unify a way to obtain the {@link AuthorizationRequestContext}.
+ * <p>
+ * As it can be obtained statically from just the OAuth2 scopes parameter, it can be easily referenced from almost anywhere.
+ */
 public class AuthorizationContextUtil {
 
+    /**
+     * Base function to obtain a bare AuthorizationRequestContext with just OAuth2 Scopes
+     * @param session
+     * @param scope
+     * @return an {@link AuthorizationRequestContext} with scope entries
+     */
     public static AuthorizationRequestContext getAuthorizationRequestContextFromScopes(KeycloakSession session, String scope) {
         if (!Profile.isFeatureEnabled(Profile.Feature.DYNAMIC_SCOPES)) {
             throw new RuntimeException("The Dynamic Scopes feature is not enabled and the AuthorizationRequestContext hasn't been generated");
@@ -23,4 +57,38 @@ public class AuthorizationContextUtil {
         return clientScopeParser.parseScopes(scope);
     }
 
+    /**
+     * An extension of {@link AuthorizationContextUtil#getAuthorizationRequestContextFromScopes} that appends the current context's client
+     * @param session
+     * @param scope
+     * @return an {@link AuthorizationRequestContext} with scope entries and a ClientModel
+     */
+    public static AuthorizationRequestContext getAuthorizationRequestContextFromScopesWithClient(KeycloakSession session, String scope) {
+        AuthorizationRequestContext authorizationRequestContext = getAuthorizationRequestContextFromScopes(session, scope);
+        authorizationRequestContext.getAuthorizationDetailEntries().add(new AuthorizationDetails(session.getContext().getClient()));
+        return authorizationRequestContext;
+    }
+
+    /**
+     * An extension of {@link AuthorizationContextUtil#getAuthorizationRequestContextFromScopesWithClient)} that returns the list as a Stream
+     * @param session
+     * @param scope
+     * @return a Stream of {@link AuthorizationDetails} containing a ClientModel
+     */
+    public static Stream<AuthorizationDetails> getAuthorizationRequestsStreamFromScopesWithClient(KeycloakSession session, String scope) {
+        AuthorizationRequestContext authorizationRequestContext = getAuthorizationRequestContextFromScopesWithClient(session, scope);
+        return authorizationRequestContext.getAuthorizationDetailEntries().stream();
+    }
+
+    /**
+     * Helper method to return a Stream of all the {@link ClientScopeModel} in the current {@link AuthorizationRequestContext}
+     * @param session
+     * @param scope
+     * @return see description
+     */
+    public static Stream<ClientScopeModel> getClientScopesStreamFromAuthorizationRequestContextWithClient(KeycloakSession session, String scope) {
+        return getAuthorizationRequestContextFromScopesWithClient(session, scope).getAuthorizationDetailEntries().stream()
+                .filter(authorizationDetails -> authorizationDetails.getSource() == AuthorizationRequestSource.SCOPE)
+                .map(AuthorizationDetails::getClientScope);
+    }
 }

--- a/services/src/main/java/org/keycloak/services/util/DefaultClientSessionContext.java
+++ b/services/src/main/java/org/keycloak/services/util/DefaultClientSessionContext.java
@@ -71,8 +71,8 @@ public class DefaultClientSessionContext implements ClientSessionContext {
     private Map<String, Object> attributes = new HashMap<>();
 
     private DefaultClientSessionContext(AuthenticatedClientSessionModel clientSession, Set<String> clientScopeIds, KeycloakSession session) {
-        this.clientSession = clientSession;
         this.clientScopeIds = clientScopeIds;
+        this.clientSession = clientSession;
         this.session = session;
     }
 
@@ -86,7 +86,12 @@ public class DefaultClientSessionContext implements ClientSessionContext {
 
 
     public static DefaultClientSessionContext fromClientSessionAndScopeParameter(AuthenticatedClientSessionModel clientSession, String scopeParam, KeycloakSession session) {
-        Stream<ClientScopeModel> requestedClientScopes = TokenManager.getRequestedClientScopes(scopeParam, clientSession.getClient());
+        Stream<ClientScopeModel> requestedClientScopes;
+        if (Profile.isFeatureEnabled(Profile.Feature.DYNAMIC_SCOPES)) {
+            requestedClientScopes = AuthorizationContextUtil.getClientScopesStreamFromAuthorizationRequestContextWithClient(session, scopeParam);
+        } else {
+            requestedClientScopes = TokenManager.getRequestedClientScopes(scopeParam, clientSession.getClient());
+        }
         return fromClientSessionAndClientScopes(clientSession, requestedClientScopes, session);
     }
 
@@ -96,7 +101,10 @@ public class DefaultClientSessionContext implements ClientSessionContext {
     }
 
 
-    public static DefaultClientSessionContext fromClientSessionAndClientScopes(AuthenticatedClientSessionModel clientSession,
+    // in order to standardize the way we create this object and with that data, it's better to compute the client scopes internally instead of relying on external sources
+    // i.e: the TokenManager.getRequestedClientScopes was being called in many places to obtain the ClientScopeModel stream.
+    // by changing this method to private, we'll only call it in this class, while also having a single place to put the DYNAMIC_SCOPES feature flag condition
+    private static DefaultClientSessionContext fromClientSessionAndClientScopes(AuthenticatedClientSessionModel clientSession,
                                                                                Stream<ClientScopeModel> clientScopes,
                                                                                KeycloakSession session) {
         Set<String> clientScopeIds = clientScopes.map(ClientScopeModel::getId).collect(Collectors.toSet());
@@ -157,7 +165,7 @@ public class DefaultClientSessionContext implements ClientSessionContext {
 
     @Override
     public String getScopeString() {
-        if(Profile.isFeatureEnabled(Profile.Feature.DYNAMIC_SCOPES)) {
+        if (Profile.isFeatureEnabled(Profile.Feature.DYNAMIC_SCOPES)) {
             String scopeParam = buildScopesStringFromAuthorizationRequest();
             logger.tracef("Generated scope param with Dynamic Scopes enabled: %1s", scopeParam);
             String scopeSent = clientSession.getNote(OAuth2Constants.SCOPE);


### PR DESCRIPTION
Right now, the [DefaultClientSessionContext.java](https://github.com/keycloak/keycloak/compare/main...dgozalo:9941-execute-token-mappers-with-dynamic-scopes?expand=1#diff-175461f451f23b54b6086c20c3084bcc26be4f93757b89efdee944e279012877) object is obtaining the Scope Ids from the user session.

With Dynamic Scopes and the RAR representation, we are not storing these in there, and instead they are computed from the scopes parameter every time there's a need for them.

With this change, we make sure that we are always accounting for these dynamic scopes in the right place.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
