### PR TITLE
#10022 Keycloak API Inconsistent behavior between client and realm scope mappings

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/ScopeMappedResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ScopeMappedResource.java
@@ -205,7 +205,7 @@ public class ScopeMappedResource {
         }
 
         for (RoleRepresentation role : roles) {
-            RoleModel roleModel = realm.getRoleById(role.getId());
+            RoleModel roleModel = role.getId() != null ? realm.getRoleById(role.getId()) : realm.getRole(role.getName());
             if (roleModel == null) {
                 throw new NotFoundException("Role not found");
             }
@@ -237,7 +237,7 @@ public class ScopeMappedResource {
                     .collect(Collectors.toList());
        } else {
             for (RoleRepresentation role : roles) {
-                RoleModel roleModel = realm.getRoleById(role.getId());
+                RoleModel roleModel = role.getId() != null ? realm.getRoleById(role.getId()) : realm.getRole(role.getName());
                 if (roleModel == null) {
                     throw new NotFoundException("Role not found");
                 }


### PR DESCRIPTION
closes #10022.

The keycloak operator cannot apply scope mappings per role name as of this issue (https://github.com/keycloak/keycloak-operator/issues/436). With the provided solution we keep compatibility with existing clients and add an extra level of reliability and convenience using the api.
