### PR TITLE
Not possible to register webauthn key on Firefox

### DIFF
--- a/services/src/main/java/org/keycloak/credential/WebAuthnCredentialModelInput.java
+++ b/services/src/main/java/org/keycloak/credential/WebAuthnCredentialModelInput.java
@@ -26,6 +26,7 @@ import com.webauthn4j.data.attestation.authenticator.AttestedCredentialData;
 import com.webauthn4j.data.attestation.authenticator.COSEKey;
 import com.webauthn4j.data.attestation.statement.AttestationStatement;
 
+import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -122,7 +123,7 @@ public class WebAuthnCredentialModelInput implements CredentialInput {
     }
 
     public Set<AuthenticatorTransport> getTransports() {
-        return transports;
+        return transports != null ? transports : Collections.emptySet();
     }
 
     public void setTransports(Set<AuthenticatorTransport> transports) {
@@ -170,8 +171,8 @@ public class WebAuthnCredentialModelInput implements CredentialInput {
               .append(Base64.encodeBytes(authenticationRequest.getCredentialId()))
               .append(",");
         }
-        if (CollectionUtils.isNotEmpty(transports)) {
-            final String transportsString = transports.stream()
+        if (CollectionUtils.isNotEmpty(getTransports())) {
+            final String transportsString = getTransports().stream()
                     .map(AuthenticatorTransport::getValue)
                     .collect(Collectors.joining(","));
 

--- a/themes/src/main/resources/theme/base/login/webauthn-register.ftl
+++ b/themes/src/main/resources/theme/base/login/webauthn-register.ftl
@@ -104,10 +104,13 @@
                         $("#attestationObject").val(base64url.encode(new Uint8Array(attestationObject), {pad: false}));
                         $("#publicKeyCredentialId").val(base64url.encode(new Uint8Array(publicKeyCredentialId), {pad: false}));
 
-
-                        let transports = result.response.getTransports();
-                        if (transports) {
-                            $("#transports").val(getTransportsAsString(transports));
+                        if (typeof result.response.getTransports === "function") {
+                            let transports = result.response.getTransports();
+                            if (transports) {
+                                $("#transports").val(getTransportsAsString(transports));
+                            }
+                        } else {
+                            console.log("Your browser is not able to recognize supported transport media for the authenticator.");
                         }
 
                         let initLabel = "WebAuthn Authenticator (Default Label)";


### PR DESCRIPTION
Closes #10020

The method `getTransports()` is not available for Firefox and Safari at this moment, therefore we need to verify it's working without the method as well. At this moment, it's not possible to create any test case for that due to the fact we test WebAuthn only with Chrome so far. Local tests for Chrome passed.

@mposolda Could you please check it out and manually verify the solution with your YubiKey?
@jonkoops Could you please verify the JS changes?

Thanks!