### PR TITLE
Update to UA Parser 1.5.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
         <xmlsec.version>2.2.3</xmlsec.version>
         <glassfish.json.version>1.1.6</glassfish.json.version>
         <wildfly.common.version>1.5.4.Final</wildfly.common.version>
-        <ua-parser.version>1.4.3</ua-parser.version>
+        <ua-parser.version>1.5.2</ua-parser.version>
         <picketbox.version>5.0.3.Final-redhat-00007</picketbox.version>
         <google.guava.version>30.1-jre</google.guava.version>
 

--- a/server-spi-private/src/main/java/org/keycloak/device/DeviceActivityManager.java
+++ b/server-spi-private/src/main/java/org/keycloak/device/DeviceActivityManager.java
@@ -41,11 +41,7 @@ public class DeviceActivityManager {
     private static final Parser UA_PARSER;
 
     static {
-        try {
-            UA_PARSER = new Parser();
-        } catch (IOException cause) {
-            throw new RuntimeException("Failed to create user agent parser", cause);
-        }
+        UA_PARSER = new Parser();
     }
 
     /** Returns the device information associated with the given {@code userSession}.


### PR DESCRIPTION
With this update Chrome, Firefox and Edge are showing correctly:

![image](https://user-images.githubusercontent.com/2271511/152770854-92268e4e-725f-478c-a56e-829895099c10.png)


Resolves: #10029, resolves #10010
