### PR TITLE
Can not set a jgroups stack other than the defaults from Infinispan

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/ClusteringPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/ClusteringPropertyMappers.java
@@ -26,8 +26,7 @@ final class ClusteringPropertyMappers {
                 builder().from("cache-stack")
                         .to("kc.spi-connections-infinispan-quarkus-stack")
                         .description("Define the default stack to use for cluster communication and node discovery. This option only takes effect "
-                                + "if 'cache' is set to 'ispn'.")
-                        .defaultValue("udp")
+                                + "if 'cache' is set to 'ispn'. Default: udp.")
                         .paramLabel("stack")
                         .isBuildTimeProperty(true)
                         .expectedValues(Arrays.asList("tcp", "udp", "kubernetes", "ec2", "azure", "google"))

--- a/quarkus/tests/integration/src/main/java/org/keycloak/it/utils/KeycloakDistribution.java
+++ b/quarkus/tests/integration/src/main/java/org/keycloak/it/utils/KeycloakDistribution.java
@@ -1,5 +1,6 @@
 package org.keycloak.it.utils;
 
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -48,6 +49,10 @@ public interface KeycloakDistribution {
     }
 
     default void deleteQuarkusProperties() {
+        throw new RuntimeException("Not implemented");
+    }
+
+    default void copyOrReplaceFileFromClasspath(String file, Path distDir) {
         throw new RuntimeException("Not implemented");
     }
 }

--- a/quarkus/tests/integration/src/main/java/org/keycloak/it/utils/RawKeycloakDistribution.java
+++ b/quarkus/tests/integration/src/main/java/org/keycloak/it/utils/RawKeycloakDistribution.java
@@ -26,8 +26,10 @@ import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
@@ -335,6 +337,17 @@ public final class RawKeycloakDistribution implements KeycloakDistribution {
 
         if (file.exists()) {
             file.delete();
+        }
+    }
+
+    @Override
+    public void copyOrReplaceFileFromClasspath(String file, Path targetFile) {
+        File targetDir = distPath.resolve(targetFile).toFile();
+
+        try {
+            Files.copy(getClass().getResourceAsStream(file), targetDir.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        } catch (IOException cause) {
+            throw new RuntimeException("Failed to copy file", cause);
         }
     }
 

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ClusterConfigDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ClusterConfigDistTest.java
@@ -17,19 +17,22 @@
 
 package org.keycloak.it.cli.dist;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.nio.file.Path;
+import java.util.function.Consumer;
 import org.junit.jupiter.api.Test;
-import org.keycloak.it.cli.StartCommandTest;
+import org.keycloak.it.junit5.extension.BeforeStartDistribution;
 import org.keycloak.it.junit5.extension.CLIResult;
 import org.keycloak.it.junit5.extension.DistributionTest;
+import org.keycloak.it.junit5.extension.RawDistOnly;
+import org.keycloak.it.utils.KeycloakDistribution;
 
 import io.quarkus.test.junit.main.Launch;
 import io.quarkus.test.junit.main.LaunchResult;
 
 @DistributionTest
+@RawDistOnly(reason = "Not possible to mount files using docker.")
 public class ClusterConfigDistTest {
 
     @Test
@@ -66,11 +69,12 @@ public class ClusterConfigDistTest {
     }
 
     @Test
-    @Launch({ "start", "--http-enabled=true", "--hostname-strict false" })
+    @Launch({ "start", "--auto-build", "--http-enabled=true", "--hostname-strict false" })
     void testStartDefaultsToClustering(LaunchResult result) {
         CLIResult cliResult = (CLIResult) result;
         cliResult.assertStarted();
         cliResult.assertClusteredCache();
+        assertTrue(cliResult.getOutput().contains("org.jgroups.protocols.UDP"));
     }
 
     @Test
@@ -79,5 +83,21 @@ public class ClusterConfigDistTest {
         CLIResult cliResult = (CLIResult) result;
         cliResult.assertStartedDevMode();
         cliResult.assertLocalCache();
+    }
+
+    @Test
+    @BeforeStartDistribution(ConfigureCacheUsingAsyncEncryption.class)
+    @Launch({ "start-dev", "--cache-config-file=cache-ispn-asym-enc.xml" })
+    void testCustomCacheStackInConfigFile(LaunchResult result) {
+        CLIResult cliResult = (CLIResult) result;
+        assertTrue(cliResult.getOutput().contains("ERROR: server.jks"));
+    }
+
+    public static class ConfigureCacheUsingAsyncEncryption implements Consumer<KeycloakDistribution> {
+
+        @Override
+        public void accept(KeycloakDistribution distribution) {
+            distribution.copyOrReplaceFileFromClasspath("/cache-ispn-asym-enc.xml", Path.of("conf", "cache-ispn-asym-enc.xml"));
+        }
     }
 }

--- a/quarkus/tests/integration/src/test/resources/cache-ispn-asym-enc.xml
+++ b/quarkus/tests/integration/src/test/resources/cache-ispn-asym-enc.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 Red Hat, Inc. and/or its affiliates
+  ~ and other contributors as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<infinispan
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="urn:infinispan:config:13.0 http://www.infinispan.org/schemas/infinispan-config-13.0.xsd"
+        xmlns="urn:infinispan:config:13.0">
+
+<jgroups>
+    <stack name="encrypt-udp" extends="udp">
+      <SSL_KEY_EXCHANGE keystore_name="server.jks"
+                        keystore_password="password"
+                        stack.combine="INSERT_AFTER"
+                        stack.position="VERIFY_SUSPECT"/>
+      <ASYM_ENCRYPT asym_keylength="2048"
+                    asym_algorithm="RSA"
+                    change_key_on_coord_leave = "false"
+                    change_key_on_leave = "false"
+                    use_external_key_exchange = "true"
+                    stack.combine="INSERT_BEFORE"
+                    stack.position="pbcast.NAKACK2"/>
+    </stack>
+  </jgroups>
+
+    <cache-container name="keycloak">
+        <transport lock-timeout="60000" stack="encrypt-udp"/>
+        <local-cache name="realms">
+            <encoding>
+                <key media-type="application/x-java-object"/>
+                <value media-type="application/x-java-object"/>
+            </encoding>
+            <memory max-count="10000"/>
+        </local-cache>
+        <local-cache name="users">
+            <encoding>
+                <key media-type="application/x-java-object"/>
+                <value media-type="application/x-java-object"/>
+            </encoding>
+            <memory max-count="10000"/>
+        </local-cache>
+        <distributed-cache name="sessions" owners="2">
+            <expiration lifespan="-1"/>            
+        </distributed-cache>
+        <distributed-cache name="authenticationSessions" owners="2">
+            <expiration lifespan="-1"/>
+        </distributed-cache>
+        <distributed-cache name="offlineSessions" owners="2">
+            <expiration lifespan="-1"/>
+        </distributed-cache>
+        <distributed-cache name="clientSessions" owners="2">
+            <expiration lifespan="-1"/>
+        </distributed-cache>
+        <distributed-cache name="offlineClientSessions" owners="2">
+            <expiration lifespan="-1"/>
+        </distributed-cache>
+        <distributed-cache name="loginFailures" owners="2">
+            <expiration lifespan="-1"/>
+        </distributed-cache>
+        <local-cache name="authorization">
+            <encoding>
+                <key media-type="application/x-java-object"/>
+                <value media-type="application/x-java-object"/>
+            </encoding>
+            <memory max-count="10000"/>
+        </local-cache>
+        <replicated-cache name="work">
+            <expiration lifespan="-1"/>
+        </replicated-cache>
+        <local-cache name="keys">
+            <encoding>
+                <key media-type="application/x-java-object"/>
+                <value media-type="application/x-java-object"/>
+            </encoding>
+            <expiration max-idle="3600000"/>
+            <memory max-count="1000"/>
+        </local-cache>
+        <distributed-cache name="actionTokens" owners="2">
+            <encoding>
+                <key media-type="application/x-java-object"/>
+                <value media-type="application/x-java-object"/>
+            </encoding>
+            <expiration max-idle="-1" lifespan="-1" interval="300000"/>
+            <memory max-count="-1"/>
+        </distributed-cache>
+    </cache-container>
+</infinispan>


### PR DESCRIPTION
Basically:

* Removing the default value for `cache-stack` so that we can decide whether we should solely rely on the config from a the configuration file. By default, ISPN is going to use UDP anyways, and removing the value keeps the same behavior.
* I would like to improve our configuration layer later so that we are able to distinguish whether it was provided or not. Right now we can not infer that easily. For instance, based on the config source name of a `ConfigValue`.

Closes #10052

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
