### PR TITLE
remove profile references

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/Environment.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/Environment.java
@@ -189,6 +189,36 @@ public final class Environment {
         System.setProperty(LAUNCH_MODE, "test");
     }
 
+    /**
+     * We want to hide the "profiles" from Quarkus to not make things unnecessarily complicated for users,
+     * so this method returns the equivalent launch mode instead. For use in e.g. CLI Output.
+     *
+     * @param profile the internal profile string used
+     * @return the mapped launch mode, none when nothing is given or the profile as is when its
+     * neither null/empty nor matching the quarkus default profiles we use.
+     */
+    public static String getKeycloakModeFromProfile(String profile) {
+
+        if(profile == null || profile.isEmpty()) {
+            return "none";
+        }
+
+        if(profile.equals(LaunchMode.DEVELOPMENT.getDefaultProfile())) {
+            return "development";
+        }
+
+        if(profile.equals(LaunchMode.TEST.getDefaultProfile())) {
+            return "test";
+        }
+
+        if(profile.equals(LaunchMode.NORMAL.getDefaultProfile())) {
+            return "production";
+        }
+
+        //when no profile is matched and not empty, just return the profile name.
+        return profile;
+    }
+
     public static boolean isDistribution() {
         return getHomeDir() != null;
     }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakMain.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakMain.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.quarkus.runtime;
 
+import static org.keycloak.quarkus.runtime.Environment.getKeycloakModeFromProfile;
 import static org.keycloak.quarkus.runtime.Environment.isDevProfile;
 import static org.keycloak.quarkus.runtime.Environment.getProfileOrDefault;
 import static org.keycloak.quarkus.runtime.Environment.isTestLaunchMode;
@@ -83,7 +84,7 @@ public class KeycloakMain implements QuarkusApplication {
             Quarkus.run(KeycloakMain.class, (exitCode, cause) -> {
                 if (cause != null) {
                     errorHandler.error(errStream,
-                            String.format("Failed to start server using profile (%s)", getProfileOrDefault("prod")),
+                            String.format("Failed to start server in (%s) mode", getKeycloakModeFromProfile(getProfileOrDefault("prod"))),
                             cause.getCause());
                 }
 
@@ -95,7 +96,7 @@ public class KeycloakMain implements QuarkusApplication {
             });
         } catch (Throwable cause) {
             errorHandler.error(errStream,
-                    String.format("Unexpected error when starting the server using profile (%s)", getProfileOrDefault("prod")),
+                    String.format("Unexpected error when starting the server in (%s) mode", getKeycloakModeFromProfile(getProfileOrDefault("prod"))),
                     cause.getCause());
         }
     }
@@ -106,7 +107,7 @@ public class KeycloakMain implements QuarkusApplication {
     @Override
     public int run(String... args) throws Exception {
         if (isDevProfile()) {
-            LOGGER.warnf("Running the server in dev mode. DO NOT use this configuration in production.");
+            LOGGER.warnf("Running the server in development mode. DO NOT use this configuration in production.");
         }
 
         int exitCode = ApplicationLifecycleManager.getExitCode();

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/Messages.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/Messages.java
@@ -52,7 +52,7 @@ public final class Messages {
     }
 
     public static String devProfileNotAllowedError(String cmd) {
-        return String.format("You can not '%s' the server using the '%s' configuration profile. Please re-build the server first, using 'kc.sh build' for the default production profile, or using 'kc.sh build --profile=<profile>' with a profile more suitable for production.%n", cmd, Environment.DEV_PROFILE_VALUE);
+        return String.format("You can not '%s' the server in %s mode. Please re-build the server first, using 'kc.sh build' for the default production mode.%n", cmd, Environment.getKeycloakModeFromProfile(Environment.DEV_PROFILE_VALUE));
     }
 
     public static Throwable invalidLogLevel(String logLevel) {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Build.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Build.java
@@ -30,7 +30,6 @@ import io.quarkus.bootstrap.runner.RunnerClassLoader;
 
 import io.quarkus.runtime.configuration.ProfileManager;
 import picocli.CommandLine.Command;
-import picocli.CommandLine.Mixin;
 
 @Command(name = Build.NAME,
         header = "Creates a new and optimized server image.",
@@ -46,9 +45,7 @@ import picocli.CommandLine.Mixin;
             "Consider running this command before running the server in production for an optimal runtime."
         },
         footerHeading = "Examples:",
-        footer = "  Optimize the server based on a profile configuration:%n%n"
-                + "      $ ${PARENT-COMMAND-FULL-NAME:-$PARENTCOMMAND} --profile=prod ${COMMAND-NAME} %n%n"
-                + "  Change the database vendor:%n%n"
+        footer = "  Change the database vendor:%n%n"
                 + "      $ ${PARENT-COMMAND-FULL-NAME:-$PARENTCOMMAND} ${COMMAND-NAME} --db=postgres%n%n"
                 + "  Enable a feature:%n%n"
                 + "      $ ${PARENT-COMMAND-FULL-NAME:-$PARENTCOMMAND} ${COMMAND-NAME} --features=<feature_name>%n%n"

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Main.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Main.java
@@ -95,6 +95,7 @@ public final class Main {
     }
 
     @Option(names = { PROFILE_SHORT_NAME, PROFILE_LONG_NAME },
+            hidden = true,
             description = "Set the profile. Use 'dev' profile to enable development mode.")
     public void setProfile(String profile) {
         Environment.setProfile(profile);

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/ShowConfig.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/ShowConfig.java
@@ -30,6 +30,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
+import org.keycloak.quarkus.runtime.Environment;
 import org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider;
 import org.keycloak.quarkus.runtime.configuration.PersistedConfigSource;
 
@@ -76,7 +77,7 @@ public final class ShowConfig extends AbstractCommand implements Runnable {
     private void printRunTimeConfig(Map<String, Set<String>> properties, String profile) {
         Set<String> uniqueNames = new HashSet<>();
 
-        spec.commandLine().getOut().printf("Current Profile: %s%n", profile == null ? "none" : profile);
+        spec.commandLine().getOut().printf("Current Mode: %s%n", Environment.getKeycloakModeFromProfile(profile));
 
         spec.commandLine().getOut().println("Runtime Configuration:");
 

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/integration/QuarkusPlatform.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/integration/QuarkusPlatform.java
@@ -150,7 +150,7 @@ public class QuarkusPlatform implements PlatformProvider {
                 this.tmpDir = tmpDir;
                 log.debugf("Using server tmp directory: %s", tmpDir.getAbsolutePath());
             } else {
-                throw new RuntimeException("Temporary directory " + tmpDir.getAbsolutePath() + " does not exists and it was not possible to create it.");
+                throw new RuntimeException("Temporary directory " + tmpDir.getAbsolutePath() + " does not exist and it was not possible to create it.");
             }
         }
         return tmpDir;

--- a/quarkus/tests/integration/src/main/java/org/keycloak/it/junit5/extension/CLIResult.java
+++ b/quarkus/tests/integration/src/main/java/org/keycloak/it/junit5/extension/CLIResult.java
@@ -52,12 +52,12 @@ public interface CLIResult extends LaunchResult {
     }
 
     default void assertNotDevMode() {
-        assertFalse(getOutput().contains("Running the server in dev mode."),
+        assertFalse(getOutput().contains("Running the server in development mode."),
                 () -> "The standard output:\n" + getOutput() + "\ndoes include the Start Dev output");
     }
 
     default void assertStartedDevMode() {
-        assertTrue(getOutput().contains("Running the server in dev mode."),
+        assertTrue(getOutput().contains("Running the server in development mode."),
                 () -> "The standard output:\n" + getOutput() + "\ndoesn't include the Start Dev output");
     }
 

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/StartCommandTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/StartCommandTest.java
@@ -39,7 +39,7 @@ public class StartCommandTest {
     @Test
     @Launch({ "--profile=dev", "start" })
     void failUsingDevProfile(LaunchResult result) {
-        assertTrue(result.getErrorOutput().contains("ERROR: You can not 'start' the server using the 'dev' configuration profile. Please re-build the server first, using 'kc.sh build' for the default production profile, or using 'kc.sh build --profile=<profile>' with a profile more suitable for production."),
+        assertTrue(result.getErrorOutput().contains("ERROR: You can not 'start' the server in development mode. Please re-build the server first, using 'kc.sh build' for the default production mode."),
                 () -> "The Output:\n" + result.getErrorOutput() + "doesn't contains the expected string.");
     }
 

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/BuildCommandDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/BuildCommandDistTest.java
@@ -48,7 +48,7 @@ class BuildCommandDistTest {
     void failIfDevProfile(LaunchResult result) {
         assertTrue(result.getErrorOutput().contains("ERROR: Failed to run 'build' command."),
                 () -> "The Error Output:\n" + result.getErrorOutput() + "doesn't contains the expected string.");
-        assertTrue(result.getErrorOutput().contains("ERROR: You can not 'build' the server using the 'dev' configuration profile. Please re-build the server first, using 'kc.sh build' for the default production profile, or using 'kc.sh build --profile=<profile>' with a profile more suitable for production."),
+        assertTrue(result.getErrorOutput().contains("You can not 'build' the server in development mode. Please re-build the server first, using 'kc.sh build' for the default production mode."),
                 () -> "The Error Output:\n" + result.getErrorOutput() + "doesn't contains the expected string.");
         assertTrue(result.getErrorOutput().contains("For more details run the same command passing the '--verbose' option. Also you can use '--help' to see the details about the usage of the particular command."),
                 () -> "The Error Output:\n" + result.getErrorOutput() + "doesn't contains the expected string.");

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartCommandDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartCommandDistTest.java
@@ -35,7 +35,7 @@ public class StartCommandDistTest extends StartCommandTest {
     @Test
     @Launch({ "-pf=dev", "start", "--auto-build", "--http-enabled=true", "--hostname-strict=false" })
     void failIfAutoBuildUsingDevProfile(LaunchResult result) {
-        assertTrue(result.getErrorOutput().contains("ERROR: You can not 'start' the server using the 'dev' configuration profile. Please re-build the server first, using 'kc.sh build' for the default production profile, or using 'kc.sh build --profile=<profile>' with a profile more suitable for production."),
+        assertTrue(result.getErrorOutput().contains("You can not 'start' the server in development mode. Please re-build the server first, using 'kc.sh build' for the default production mode."),
                 () -> "The Output:\n" + result.getErrorOutput() + "doesn't contains the expected string.");
         assertEquals(4, result.getErrorStream().size());
     }

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testBuildHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testBuildHelp.approved.txt
@@ -63,10 +63,6 @@ Vault:
 
 Examples:
 
-  Optimize the server based on a profile configuration:
-
-      $ kc.sh --profile=prod build
-
   Change the database vendor:
 
       $ kc.sh build --db=postgres

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testDefaultToHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testDefaultToHelp.approved.txt
@@ -16,8 +16,6 @@ Options:
                      Set the path to a configuration file. By default, configuration properties are
                        read from the "keycloak.conf" file in the "conf" directory.
 -h, --help           This help message.
--pf, --profile <profile>
-                     Set the profile. Use 'dev' profile to enable development mode.
 -v, --verbose        Print out error details when running this command.
 -V, --version        Show version information
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testHelp.approved.txt
@@ -16,8 +16,6 @@ Options:
                      Set the path to a configuration file. By default, configuration properties are
                        read from the "keycloak.conf" file in the "conf" directory.
 -h, --help           This help message.
--pf, --profile <profile>
-                     Set the profile. Use 'dev' profile to enable development mode.
 -v, --verbose        Print out error details when running this command.
 -V, --version        Show version information
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testHelpShort.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testHelpShort.approved.txt
@@ -16,8 +16,6 @@ Options:
                      Set the path to a configuration file. By default, configuration properties are
                        read from the "keycloak.conf" file in the "conf" directory.
 -h, --help           This help message.
--pf, --profile <profile>
-                     Set the profile. Use 'dev' profile to enable development mode.
 -v, --verbose        Print out error details when running this command.
 -V, --version        Show version information
 


### PR DESCRIPTION
- profile option in cli hidden for now
- removed the word "profile" from all error- / messages in CLI
- removed example for setting the profile from cli hints
- added a wrapper to show mode instead, to not touch internals

Closes #9683
