### PR TITLE
Hide 'unknown' transport media type label for WebAuthn authenticators

### DIFF
--- a/services/src/main/java/org/keycloak/forms/login/freemarker/model/WebAuthnAuthenticatorsBean.java
+++ b/services/src/main/java/org/keycloak/forms/login/freemarker/model/WebAuthnAuthenticatorsBean.java
@@ -56,6 +56,7 @@ public class WebAuthnAuthenticatorsBean {
 
     public static class WebAuthnAuthenticatorBean {
         public static final String DEFAULT_ICON = "kcWebAuthnDefaultIcon";
+        public static final String UNKNOWN_AUTH_ICON = "kcWebAuthnUnknownIcon";
 
         private final String credentialId;
         private final String label;
@@ -135,6 +136,7 @@ public class WebAuthnAuthenticatorsBean {
                 } else {
                     final Set<String> displayNameProperties = trans.stream()
                             .map(Transport::getDisplayNameProperty)
+                            .filter(StringUtil::isNotBlank)
                             .collect(Collectors.toSet());
 
                     return new TransportsBean(displayNameProperties, DEFAULT_ICON);
@@ -146,7 +148,7 @@ public class WebAuthnAuthenticatorsBean {
                 NFC("nfc", AuthenticatorTransport.NFC.getValue(), "kcWebAuthnNFC"),
                 BLE("bluetooth", AuthenticatorTransport.BLE.getValue(), "kcWebAuthnBLE"),
                 INTERNAL("internal", AuthenticatorTransport.INTERNAL.getValue(), "kcWebAuthnInternal"),
-                UNKNOWN("unknown", null, DEFAULT_ICON);
+                UNKNOWN("", "", UNKNOWN_AUTH_ICON);
 
                 private final String displayNameProperty;
                 private final String mapperName;
@@ -154,8 +156,8 @@ public class WebAuthnAuthenticatorsBean {
 
                 /**
                  * @param displayNameProperty Message property - defined in messages_xx.properties
-                 * @param mapperName used for mapping transport media name
-                 * @param iconClass icon class for particular transport media - defined in theme.properties
+                 * @param mapperName          used for mapping transport media name
+                 * @param iconClass           icon class for particular transport media - defined in theme.properties
                  */
                 Transport(String displayNameProperty, String mapperName, String iconClass) {
                     this.displayNameProperty = displayNameProperty;
@@ -186,7 +188,7 @@ public class WebAuthnAuthenticatorsBean {
                     if (StringUtil.isBlank(mapperName)) return UNKNOWN;
 
                     return Arrays.stream(Transport.values())
-                            .filter(f -> Objects.nonNull(f.getMapperName()))
+                            .filter(f -> StringUtil.isNotBlank(f.getMapperName()))
                             .filter(f -> f.getMapperName().equals(mapperName))
                             .findFirst()
                             .orElse(UNKNOWN);

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/UIUtils.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/UIUtils.java
@@ -17,7 +17,11 @@ import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.Select;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
+import java.util.Optional;
+import java.util.function.Supplier;
+
 import static org.keycloak.testsuite.util.DroneUtils.getCurrentDriver;
+import static org.keycloak.testsuite.util.WaitUtils.log;
 import static org.keycloak.testsuite.util.WaitUtils.waitForPageToLoad;
 import static org.keycloak.testsuite.util.WaitUtils.waitUntilElement;
 import static org.keycloak.testsuite.util.WaitUtils.waitUntilElementClassContains;
@@ -157,13 +161,39 @@ public final class UIUtils {
             try {
                 // Safari on macOS doesn't comply with WebDriver specs yet again - getText() retrieves hidden text by CSS.
                 text = element.findElement(By.xpath("./span[not(contains(@class,'ng-hide'))]")).getText();
-            }
-            catch (NoSuchElementException e) {
+            } catch (NoSuchElementException e) {
                 // no op
             }
             return text.trim(); // Safari on macOS sometimes for no obvious reason surrounds the text with spaces
         }
         return text;
+    }
+
+    /**
+     * Get text from required WebElement
+     *
+     * @param element required WebElement
+     * @return text from element, or null if element is not found
+     */
+    public static String getTextFromElementOrNull(Supplier<WebElement> element) {
+        return Optional.ofNullable(getElementOrNull(element))
+                .map(UIUtils::getTextFromElement)
+                .orElse(null);
+    }
+
+    /**
+     * Get required WebElement
+     *
+     * @param element required WebElement
+     * @return element, or null if element is not found
+     */
+    public static WebElement getElementOrNull(Supplier<WebElement> element) {
+        try {
+            return element.get();
+        } catch (NoSuchElementException e) {
+            log.debug("Particular element is not found.", e);
+            return null;
+        }
     }
 
     /**

--- a/testsuite/integration-arquillian/tests/other/webauthn/src/main/java/org/keycloak/testsuite/webauthn/pages/WebAuthnAuthenticatorsList.java
+++ b/testsuite/integration-arquillian/tests/other/webauthn/src/main/java/org/keycloak/testsuite/webauthn/pages/WebAuthnAuthenticatorsList.java
@@ -28,7 +28,7 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-import static org.keycloak.testsuite.util.UIUtils.getTextFromElement;
+import static org.keycloak.testsuite.util.UIUtils.getTextFromElementOrNull;
 
 /**
  * Helper class for getting available authenticators on WebAuthnLogin page
@@ -44,10 +44,10 @@ public class WebAuthnAuthenticatorsList {
         try {
             List<WebAuthnAuthenticatorItem> items = new ArrayList<>();
             for (WebElement auth : authenticators) {
-                String name = getTextFromElement(auth.findElement(By.id("kc-webauthn-authenticator-label")));
-                String createdAt = getTextFromElement(auth.findElement(By.id("kc-webauthn-authenticator-created")));
-                String createdAtLabel = getTextFromElement(auth.findElement(By.id("kc-webauthn-authenticator-created-label")));
-                String transport = getTextFromElement(auth.findElement(By.id("kc-webauthn-authenticator-transport")));
+                String name = getTextFromElementOrNull(() -> auth.findElement(By.id("kc-webauthn-authenticator-label")));
+                String createdAt = getTextFromElementOrNull(() -> auth.findElement(By.id("kc-webauthn-authenticator-created")));
+                String createdAtLabel = getTextFromElementOrNull(() -> auth.findElement(By.id("kc-webauthn-authenticator-created-label")));
+                String transport = getTextFromElementOrNull(() -> auth.findElement(By.id("kc-webauthn-authenticator-transport")));
                 items.add(new WebAuthnAuthenticatorItem(name, createdAt, createdAtLabel, transport));
             }
             return items;

--- a/testsuite/integration-arquillian/tests/other/webauthn/src/test/java/org/keycloak/testsuite/webauthn/account/WebAuthnTransportLocaleTest.java
+++ b/testsuite/integration-arquillian/tests/other/webauthn/src/test/java/org/keycloak/testsuite/webauthn/account/WebAuthnTransportLocaleTest.java
@@ -18,21 +18,23 @@
 package org.keycloak.testsuite.webauthn.account;
 
 import org.hamcrest.Matchers;
-import org.jboss.arquillian.graphene.page.Page;
 import org.junit.Test;
+import org.keycloak.testsuite.webauthn.authenticators.DefaultVirtualAuthOptions;
 import org.keycloak.testsuite.webauthn.pages.WebAuthnAuthenticatorsList;
-import org.keycloak.testsuite.webauthn.pages.WebAuthnLoginPage;
 import org.openqa.selenium.virtualauthenticator.VirtualAuthenticatorOptions;
 
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.List;
 import java.util.Locale;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.keycloak.testsuite.webauthn.authenticators.DefaultVirtualAuthOptions.DEFAULT;
 import static org.keycloak.testsuite.webauthn.authenticators.DefaultVirtualAuthOptions.DEFAULT_BLE;
 import static org.keycloak.testsuite.webauthn.authenticators.DefaultVirtualAuthOptions.DEFAULT_INTERNAL;
 import static org.keycloak.testsuite.webauthn.authenticators.DefaultVirtualAuthOptions.DEFAULT_NFC;
@@ -63,6 +65,80 @@ public class WebAuthnTransportLocaleTest extends AbstractWebAuthnAccountTest {
     @Test
     public void localizationTransportInternal() {
         assertLocalizationIndividual(DEFAULT_INTERNAL.getOptions(), "Internal", "Interní");
+    }
+
+    @Test
+    public void multipleTransports() throws IOException {
+        final String AUTHENTICATOR_LABEL = "authenticator#";
+        final Integer EXPECTED_COUNT = 5;
+
+        final BiConsumer<DefaultVirtualAuthOptions, Integer> addAndVerifyAuthenticator = (options, number) -> {
+            getWebAuthnManager().useAuthenticator(options.getOptions());
+            addWebAuthnCredential(AUTHENTICATOR_LABEL + number);
+
+            int webAuthnCount = webAuthnCredentialType.getUserCredentialsCount();
+            assertThat(webAuthnCount, is(number));
+        };
+
+        addAndVerifyAuthenticator.accept(DEFAULT_INTERNAL, 1);
+        addAndVerifyAuthenticator.accept(DEFAULT_BLE, 2);
+        addAndVerifyAuthenticator.accept(DEFAULT_NFC, 3);
+        addAndVerifyAuthenticator.accept(DEFAULT_USB, 4);
+        addAndVerifyAuthenticator.accept(DEFAULT, 5);
+
+        setUpWebAuthnFlow("webAuthnFlow");
+
+        logout();
+        signingInPage.navigateTo();
+        loginToAccount();
+        webAuthnLoginPage.assertCurrent();
+
+        final Supplier<List<WebAuthnAuthenticatorsList.WebAuthnAuthenticatorItem>> getItems = () -> {
+            final WebAuthnAuthenticatorsList authenticators = webAuthnLoginPage.getAuthenticators();
+            assertThat(authenticators, notNullValue());
+            assertThat(authenticators.getCount(), is(EXPECTED_COUNT));
+
+            final List<WebAuthnAuthenticatorsList.WebAuthnAuthenticatorItem> list = authenticators.getItems();
+            assertThat(list, notNullValue());
+            assertThat(list.size(), is(EXPECTED_COUNT));
+            return list;
+        };
+
+        final BiConsumer<String, Integer> assertAuthenticatorTransport = (transport, number) -> {
+            List<WebAuthnAuthenticatorsList.WebAuthnAuthenticatorItem> list = getItems.get();
+            assertThat(list, notNullValue());
+            WebAuthnAuthenticatorsList.WebAuthnAuthenticatorItem item = list.get(number - 1);
+
+            assertThat(item, notNullValue());
+            assertThat(item.getName(), is(AUTHENTICATOR_LABEL + number));
+            assertThat(item.getTransport(), is(transport));
+        };
+
+        assertAuthenticatorTransport.accept("Internal", 1);
+        assertAuthenticatorTransport.accept("Bluetooth", 2);
+        assertAuthenticatorTransport.accept("NFC", 3);
+        assertAuthenticatorTransport.accept("USB", 4);
+        assertAuthenticatorTransport.accept("USB", 5);
+
+        webAuthnLoginPage.assertCurrent();
+        webAuthnLoginPage.clickAuthenticate();
+
+        logout();
+        signingInPage.navigateTo();
+        loginToAccount();
+        webAuthnLoginPage.assertCurrent();
+
+        try (Closeable c = setLocalesUpdater(Locale.ENGLISH.getLanguage(), "cs").update()) {
+
+            driver.navigate().refresh();
+            webAuthnLoginPage.openLanguage("Čeština");
+
+            assertAuthenticatorTransport.accept("Interní", 1);
+            assertAuthenticatorTransport.accept("Bluetooth", 2);
+            assertAuthenticatorTransport.accept("NFC", 3);
+            assertAuthenticatorTransport.accept("USB", 4);
+            assertAuthenticatorTransport.accept("USB", 5);
+        }
     }
 
     private void assertLocalizationIndividual(VirtualAuthenticatorOptions options, String originalName, String localizedText) {

--- a/themes/src/main/resources/theme/base/login/webauthn-authenticate.ftl
+++ b/themes/src/main/resources/theme/base/login/webauthn-authenticate.ftl
@@ -40,7 +40,7 @@
                                             ${kcSanitize(msg('${authenticator.label}'))?no_esc}
                                         </div>
 
-                                        <#if authenticator.transports??>
+                                        <#if authenticator.transports?? && authenticator.transports.displayNameProperties?has_content>
                                             <div id="kc-webauthn-authenticator-transport"
                                                  class="${properties.kcSelectAuthListItemDescriptionClass!}">
                                                 <#list authenticator.transports.displayNameProperties as nameProperty>
@@ -51,6 +51,7 @@
                                                 </#list>
                                             </div>
                                         </#if>
+
                                         <div class="${properties.kcSelectAuthListItemDescriptionClass!}">
                                             <span id="kc-webauthn-authenticator-created-label">
                                                 ${kcSanitize(msg('webauthn-createdAt-label'))?no_esc}

--- a/themes/src/main/resources/theme/keycloak/login/resources/css/login.css
+++ b/themes/src/main/resources/theme/keycloak/login/resources/css/login.css
@@ -283,6 +283,10 @@ div.kc-logo-text span {
     font-size: 1.8em;
 }
 
+#kc-form-webauthn .select-auth-box-icon-properties.unknown-transport-class {
+    margin-top: 3px;
+}
+
 #kc-form-webauthn .pf-l-stack__item {
     margin: -1px 0;
 }

--- a/themes/src/main/resources/theme/keycloak/login/theme.properties
+++ b/themes/src/main/resources/theme/keycloak/login/theme.properties
@@ -53,6 +53,7 @@ kcResetFlowIcon=pficon pficon-arrow fa
 # WebAuthn icons
 kcWebAuthnKeyIcon=pficon pficon-key
 kcWebAuthnDefaultIcon=pficon pficon-key
+kcWebAuthnUnknownIcon=pficon pficon-key unknown-transport-class
 kcWebAuthnUSB=fa fa-usb
 kcWebAuthnNFC=fa fa-wifi
 kcWebAuthnBLE=fa fa-bluetooth-b


### PR DESCRIPTION
Closes #10036

@mposolda Could you please take a look at it? Thanks.

Local tests passed.