### PR TITLE
docs(keycloak-js): add README

### DIFF
--- a/adapters/oidc/js/README.md
+++ b/adapters/oidc/js/README.md
@@ -1,0 +1,3 @@
+# Keycloak JS
+
+The documentation can be found in the [Keycloak documentation](https://www.keycloak.org/docs/latest/securing_apps/index.html#_javascript_adapter).

--- a/distribution/adapters/js-adapter-npm-zip/assembly.xml
+++ b/distribution/adapters/js-adapter-npm-zip/assembly.xml
@@ -29,6 +29,10 @@
             <outputDirectory>/</outputDirectory>
             <filtered>true</filtered>
         </file>
+        <file>
+            <source>../../../adapters/oidc/js/README.md</source>
+            <outputDirectory>/</outputDirectory>
+        </file>
     </files>
 
     <fileSets>


### PR DESCRIPTION
The current package of the javascript adapter (also known as keycloak-js) lacks a README and thus any documentation. This can be found elsewhere. However, it would be nice if it was at least linked. Since this is only a small effort, I thought I can skip the issue and create a pull request directly. The README would also be shifted to the NPM registry, which is nice.