### PR TITLE
Configure CodeQL to perform the analysis of the main branch

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -7,10 +7,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [master]
+    branches: [main]
     paths-ignore:
       - 'testsuite/**'
       - 'examples/**'


### PR DESCRIPTION
The CodeQL configuration file still has some references to the old
branch `master`, that means that most of the information provided by the
tool must be outdated.  Change it is necessary to perform the correct
analysis of the codebase.

Closes #10103

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
