### PR TITLE
Fix idelauncher resourceloading

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/services/resources/QuarkusWelcomeResource.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/services/resources/QuarkusWelcomeResource.java
@@ -65,8 +65,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 @Path("/")
 public class QuarkusWelcomeResource {
 
-    protected static final Logger logger = Logger.getLogger(WelcomeResource.class);
-
+    private static final Logger logger = Logger.getLogger(QuarkusWelcomeResource.class);
     private static final String KEYCLOAK_STATE_CHECKER = "WELCOME_STATE_CHECKER";
 
     private AtomicBoolean shouldBootstrap;

--- a/services/src/main/java/org/keycloak/theme/ClassLoaderTheme.java
+++ b/services/src/main/java/org/keycloak/theme/ClassLoaderTheme.java
@@ -110,7 +110,13 @@ public class ClassLoaderTheme implements Theme {
         if (rootResourceURL == null) {
             return null;
         }
-        final String rootPath = rootResourceURL.getPath();
+        String rootPath = rootResourceURL.getPath();
+
+        if (rootPath.endsWith("//")) {
+            // needed for asset loading in quarkus IDELauncher - see gh issue #9942
+            rootPath = rootPath.substring(0, rootPath.length() -1);
+        }
+
         final URL resourceURL = classLoader.getResource(resourceRoot + path);
         if(resourceURL == null || !resourceURL.getPath().startsWith(rootPath)) {
             return null;


### PR DESCRIPTION
caused by doubled slashes when getting the path for resources while running IDELauncher. So now we sanitize them. Tested by building and running  wf and quarkus distribution, running from idelauncher and running using quarkus:dev, assets got always loaded.

closes #9942

