### PR TITLE
Ensure single values are not wrapped as an array

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/AbstractUserRoleMappingMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/AbstractUserRoleMappingMapper.java
@@ -72,7 +72,9 @@ abstract class AbstractUserRoleMappingMapper extends AbstractOIDCProtocolMapper 
 
         boolean multiValued = "true".equals(mappingModel.getConfig().get(ProtocolMapperUtils.MULTIVALUED));
         if (!multiValued) {
-            claimValue = realmRoleNames.toString();
+            // When multivalued is false, the user expects a clean string value, not an array
+            // If no roles are assigned, the claimValue is assigned an empty string
+            claimValue = realmRoleNames.length > 0 ? realmRoleNames[0].toString() : '';
         }
 
         //OIDCAttributeMapperHelper.mapClaim(token, mappingModel, claimValue);

--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/AbstractUserRoleMappingMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/AbstractUserRoleMappingMapper.java
@@ -74,7 +74,7 @@ abstract class AbstractUserRoleMappingMapper extends AbstractOIDCProtocolMapper 
         if (!multiValued) {
             // When multivalued is false, the user expects a clean string value, not an array
             // If no roles are assigned, the claimValue is assigned an empty string
-            claimValue = realmRoleNames.length > 0 ? realmRoleNames[0].toString() : '';
+            claimValue = realmRoleNames.size > 0 ? realmRoleNames[0] : '';
         }
 
         //OIDCAttributeMapperHelper.mapClaim(token, mappingModel, claimValue);

--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/AbstractUserRoleMappingMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/AbstractUserRoleMappingMapper.java
@@ -74,7 +74,7 @@ abstract class AbstractUserRoleMappingMapper extends AbstractOIDCProtocolMapper 
         if (!multiValued) {
             // When multivalued is false, the user expects a clean string value, not an array
             // If no roles are assigned, the claimValue is assigned an empty string
-            claimValue = realmRoleNames.size > 0 ? realmRoleNames[0] : '';
+            claimValue = realmRoleNames.size > 0 ? realmRoleNames[0] : "";
         }
 
         //OIDCAttributeMapperHelper.mapClaim(token, mappingModel, claimValue);


### PR DESCRIPTION
When the claim value is expected to be a single value, i.e. the user interface toggle for multi-value is set to off, the user expects a singular value to set in the token.
Currently, the code converts an array to string, which results in [ the_claim_value ], i.e. value is wrapped as an array. 

The purpose of this pull request is to ensure that there is a non-zero length array, in which case the first value is returned, as described by the popup tooltip in the UI, else an empty string is returned, which can only occur if the user has no mapped roles.

This change can be tested by...

1. Create a user and assign multiple realm roles, having the desired target role being the first assigned.
2. Create a mapper which sets a non-multivalued claim based on the user's role. 
3. Then authenticate as the user and check the mapper has created a claim which is a plain string, e.g.   name_of_my_first_role 
4. The test must fail if the value looks like [ name_of_my_first_role ]  
5. Repeat the test for assigning user client role. I am not certain if this pull request will solve for realm roles AND client roles. Happy to apply the same fix if someone can point me at the code, if indeed it is a different handler to this use case.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
