### PR TITLE
Add ability to control debug suspend mode to kc scripts

### DIFF
--- a/quarkus/dist/src/main/content/bin/kc.bat
+++ b/quarkus/dist/src/main/content/bin/kc.bat
@@ -23,6 +23,7 @@ set "SERVER_OPTS=-Djava.util.logging.manager=org.jboss.logmanager.LogManager -Dq
 
 set DEBUG_MODE=false
 set DEBUG_PORT_VAR=8787
+set DEBUG_SUSPEND_VAR=n
 
 rem Read command-line args, the ~ removes the quotes from the parameter
 :READ-ARGS
@@ -35,6 +36,9 @@ if "%KEY%" == "--debug" (
   set "DEBUG_PORT_VAR=%~2"
   if "%DEBUG_PORT_VAR%" == "" (
      set DEBUG_PORT_VAR=8787
+  )
+  if "%DEBUG_SUSPEND_VAR%" == "" (
+     set DEBUG_SUSPEND_VAR=n
   )
   shift
   shift
@@ -84,11 +88,16 @@ if NOT "x%DEBUG%" == "x" (
 if NOT "x%DEBUG_PORT%" == "x" (
   set DEBUG_PORT_VAR=%DEBUG_PORT%
 )
+
+if NOT "x%DEBUG_SUSPEND%" == "x" (
+  set DEBUG_SUSPEND_VAR=%DEBUG_SUSPEND%
+)
+
 rem Set debug settings if not already set
 if "%DEBUG_MODE%" == "true" (
    echo "%JAVA_OPTS%" | findstr /I "\-agentlib:jdwp" > nul
   if errorlevel == 1 (
-     set "JAVA_OPTS=%JAVA_OPTS% -agentlib:jdwp=transport=dt_socket,address=%DEBUG_PORT_VAR%,server=y,suspend=n"
+     set "JAVA_OPTS=%JAVA_OPTS% -agentlib:jdwp=transport=dt_socket,address=%DEBUG_PORT_VAR%,server=y,suspend=%DEBUG_SUSPEND_VAR%"
   ) else (
      echo Debug already enabled in JAVA_OPTS, ignoring --debug argument
   )

--- a/quarkus/dist/src/main/content/bin/kc.sh
+++ b/quarkus/dist/src/main/content/bin/kc.sh
@@ -27,6 +27,7 @@ SERVER_OPTS="-Dkc.home.dir=$DIRNAME/../ -Djboss.server.config.dir=$DIRNAME/../co
 
 DEBUG_MODE="${DEBUG:-false}"
 DEBUG_PORT="${DEBUG_PORT:-8787}"
+DEBUG_SUSPEND="${DEBUG_SUSPEND:-n}"
 
 CONFIG_ARGS=${CONFIG_ARGS:-""}
 
@@ -77,7 +78,7 @@ fi
 if [ "$DEBUG_MODE" = "true" ]; then
     DEBUG_OPT=`echo $JAVA_OPTS | $GREP "\-agentlib:jdwp"`
     if [ "x$DEBUG_OPT" = "x" ]; then
-        JAVA_OPTS="$JAVA_OPTS -agentlib:jdwp=transport=dt_socket,address=$DEBUG_PORT,server=y,suspend=n"
+        JAVA_OPTS="$JAVA_OPTS -agentlib:jdwp=transport=dt_socket,address=$DEBUG_PORT,server=y,suspend=$DEBUG_SUSPEND"
     else
         echo "Debug already enabled in JAVA_OPTS, ignoring --debug argument"
     fi


### PR DESCRIPTION
We now consider the new env variable DEBUG_SUSPEND to control the
suspend mode of the remote debug configuration. DEBUG_SUSPEND defaults to 'n' which was the hard-coded default setting before.

Fixes #10178

Signed-off-by: Thomas Darimont <thomas.darimont@googlemail.com>

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
