### PR TITLE
ConfigurationTest : Changed hardcoded path separator to File.separator, so that test can be run on any platform.

### DIFF
--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/ConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/ConfigurationTest.java
@@ -237,7 +237,7 @@ public class ConfigurationTest {
         System.setProperty(CLI_ARGS, "--db=dev-file");
         SmallRyeConfig config = createConfig();
         assertEquals(QuarkusH2Dialect.class.getName(), config.getConfigValue("quarkus.hibernate-orm.dialect").getValue());
-        assertEquals("jdbc:h2:file:~/data/h2/keycloakdb;;AUTO_SERVER=TRUE", config.getConfigValue("quarkus.datasource.jdbc.url").getValue());
+        assertEquals("jdbc:h2:file:~"+File.separator+"data"+File.separator+"h2"+File.separator+"keycloakdb;;AUTO_SERVER=TRUE", config.getConfigValue("quarkus.datasource.jdbc.url").getValue());
 
         System.setProperty(CLI_ARGS, "--db=dev-mem");
         config = createConfig();


### PR DESCRIPTION
Currrently path seperator are hardcoded in `ConfigurationTest` "/" for assertion.

While running test on windows  above test fails. 

So changing it to `File.Separator`  will run on any platform .

I wanted to contribute to project, before that I was trying to run test on my windows machine.
