### PR TITLE
Add javadoc artefacts to spring bundles

### DIFF
--- a/adapters/oidc/spring-boot-container-bundle/pom.xml
+++ b/adapters/oidc/spring-boot-container-bundle/pom.xml
@@ -12,6 +12,11 @@
     <dependencies>
         <dependency>
             <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-adapter-core</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
             <artifactId>keycloak-tomcat-adapter</artifactId>
             <scope>compile</scope>
         </dependency>
@@ -56,6 +61,14 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <includeDependencySources>true</includeDependencySources>
+                    <dependencySourceIncludes>org.keycloak:keycloak-adapter-core</dependencySourceIncludes>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/adapters/oidc/spring-boot-legacy-container-bundle/pom.xml
+++ b/adapters/oidc/spring-boot-legacy-container-bundle/pom.xml
@@ -12,6 +12,11 @@
     <dependencies>
         <dependency>
             <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-adapter-core</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
             <artifactId>keycloak-tomcat-adapter</artifactId>
             <scope>compile</scope>
         </dependency>
@@ -56,6 +61,14 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <includeDependencySources>true</includeDependencySources>
+                    <dependencySourceIncludes>org.keycloak:keycloak-adapter-core</dependencySourceIncludes>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
This is only a partial solution as it only contains javadoc for adapter-core, and not for everything. However, including javadocs for all shaded dependencies is not working as it's causing a lot of missing classes, etc.

We do require at least something in the javadoc to be able to deploy the release to Sonatype OSSRH, and this is sufficient to unblock releases.

Closes #10260
