### PR TITLE
Add http request options in js adapter

### DIFF
--- a/adapters/oidc/js/dist/keycloak.d.ts
+++ b/adapters/oidc/js/dist/keycloak.d.ts
@@ -23,6 +23,7 @@ export type KeycloakResponseMode = 'query'|'fragment';
 export type KeycloakResponseType = 'code'|'id_token token'|'code id_token token';
 export type KeycloakFlow = 'standard'|'implicit'|'hybrid';
 export type KeycloakPkceMethod = 'S256';
+export type KeycloakHttpRequestType = 'refresh_token'|'authorization_code'|'load_config'|'openid_configuration'|'load_user_profile'|'load_user_info';
 
 export interface KeycloakConfig {
 	/**
@@ -175,6 +176,11 @@ export interface KeycloakInitOptions {
 	 * @default 10000
 	 */
 	messageReceiveTimeout?: number
+
+	/**
+	 * Set additional headers for each HTTP requests.
+	 */
+	httpRequestHeaders?: { [headerName: string]: string | string[] }
 }
 
 export interface KeycloakLoginOptions {
@@ -505,6 +511,11 @@ declare class Keycloak {
 	* Called when a AIA has been requested by the application.
 	*/
 	onActionUpdate?(status: 'success'|'cancelled'|'error'): void;
+
+	/**
+	 * Called when HTTP request is sent to allow customization.
+	 */
+	onHttpRequestSend?(req: XMLHttpRequest, type: KeycloakHttpRequestType): void;
 
 	/**
 	* Called to initialize the adapter.

--- a/adapters/oidc/js/src/keycloak.js
+++ b/adapters/oidc/js/src/keycloak.js
@@ -157,6 +157,12 @@ function Keycloak (config) {
             } else {
                 kc.messageReceiveTimeout = 10000;
             }
+
+            if (typeof initOptions.httpRequestHeaders === 'object') {
+                kc.httpRequestHeaders = initOptions.httpRequestHeaders;
+            } else {
+                kc.httpRequestHeaders = {};
+            }
         }
 
         if (!kc.responseMode) {
@@ -531,6 +537,11 @@ function Keycloak (config) {
             }
         }
 
+        applyHttpRequestHeaders(req)
+        if (kc.onHttpRequestSend) {
+            kc.onHttpRequestSend(req, 'load_user_profile')
+        }
+
         req.send();
 
         return promise.promise;
@@ -554,6 +565,11 @@ function Keycloak (config) {
                     promise.setError();
                 }
             }
+        }
+
+        applyHttpRequestHeaders(req)
+        if (kc.onHttpRequestSend) {
+            kc.onHttpRequestSend(req, 'load_user_info')
         }
 
         req.send();
@@ -649,6 +665,11 @@ function Keycloak (config) {
                         }
                     };
 
+                    applyHttpRequestHeaders(req)
+                    if (kc.onHttpRequestSend) {
+                        kc.onHttpRequestSend(req, 'refresh_token')
+                    }
+
                     req.send(params);
                 }
             }
@@ -674,6 +695,19 @@ function Keycloak (config) {
             kc.onAuthLogout && kc.onAuthLogout();
             if (kc.loginRequired) {
                 kc.login();
+            }
+        }
+    }
+
+    function applyHttpRequestHeaders(req) {
+        for (var headerName in kc.httpRequestHeaders) {
+            var headerValue = kc.httpRequestHeaders[headerName];
+            if (Array.isArray(headerValue)) {
+                for (var i = 0; i < headerValue.length; i++) {
+                    req.setRequestHeader(headerName, headerValue[i]);
+                }
+            } else {
+                req.setRequestHeader(headerName, headerValue);
             }
         }
     }
@@ -752,6 +786,11 @@ function Keycloak (config) {
                     }
                 }
             };
+
+            applyHttpRequestHeaders(req)
+            if (kc.onHttpRequestSend) {
+                kc.onHttpRequestSend(req, 'authorization_code')
+            }
 
             req.send(params);
         }
@@ -875,6 +914,11 @@ function Keycloak (config) {
                 }
             };
 
+            applyHttpRequestHeaders(req)
+            if (kc.onHttpRequestSend) {
+                kc.onHttpRequestSend(req, 'load_config')
+            }
+
             req.send();
         } else {
             if (!config.clientId) {
@@ -925,6 +969,11 @@ function Keycloak (config) {
                             }
                         }
                     };
+
+                    applyHttpRequestHeaders(req)
+                    if (kc.onHttpRequestSend) {
+                        kc.onHttpRequestSend(req, 'openid_configuration')
+                    }
 
                     req.send();
                 } else {


### PR DESCRIPTION
This adds httpRequestHeaders and httpRequestWillSend init options so end user can send aditionnal headers or perform custom tweaks on http requests before they are sent.

Closes #10312