### PR TITLE
Ensure single claims are not mapped as an array

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/AbstractUserRoleMappingMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/AbstractUserRoleMappingMapper.java
@@ -72,7 +72,12 @@ abstract class AbstractUserRoleMappingMapper extends AbstractOIDCProtocolMapper 
 
         boolean multiValued = "true".equals(mappingModel.getConfig().get(ProtocolMapperUtils.MULTIVALUED));
         if (!multiValued) {
-            claimValue = realmRoleNames.toString();
+            //when the value is not multivalued, the user expects a single string which is not wrapped as an array
+            if(realmRoleNames.size() > 0 ) {
+                claimValue = realmRoleNames.toArray()[0];
+            } else {
+                claimValue = "";
+            }
         }
 
         //OIDCAttributeMapperHelper.mapClaim(token, mappingModel, claimValue);


### PR DESCRIPTION
When the claim value is expected to be a single value, i.e. the user interface toggle for multi-value is set to off, the user expects a singular value to set in the token.
Currently, the code converts an array to string, which results in [ the_claim_value ], i.e. value is wrapped as an array.

The purpose of this pull request is to ensure that there is a non-zero length array, in which case the first value is returned, as described by the popup tooltip in the UI, else an empty string is returned, which can only occur if the user has no mapped roles.

This change can be tested by...

Create a user and assign multiple realm roles, having the desired target role being the first assigned.
Create a mapper which sets a non-multivalued claim based on the user's role.
Then authenticate as the user and check the mapper has created a claim which is a plain string, e.g. name_of_my_first_role
The test must fail if the value looks like [ name_of_my_first_role ]
Repeat the test for assigning user client role.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
