### PR TITLE
don't wrap single value role values as arrays

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/AbstractUserRoleMappingMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/AbstractUserRoleMappingMapper.java
@@ -68,14 +68,21 @@ abstract class AbstractUserRoleMappingMapper extends AbstractOIDCProtocolMapper 
             realmRoleNames = rolesToAdd;
         }
 
-        Object claimValue = realmRoleNames;
+        // Convert the set of role names to an array
+        String[] roles = new String[realmRoleNames.size()];
+        realmRoleNames.toArray(roles);
 
         boolean multiValued = "true".equals(mappingModel.getConfig().get(ProtocolMapperUtils.MULTIVALUED));
+        Object claimValue = roles;
+
         if (!multiValued) {
-            claimValue = realmRoleNames.toString();
+            if(roles.length > 0 ) {
+                claimValue = roles[0]; // Get the first value of the array, which will be just a string value
+            } else {
+                claimValue = ""; // There were no roles available so the claim is blank
+            }
         }
 
-        //OIDCAttributeMapperHelper.mapClaim(token, mappingModel, claimValue);
         mapClaim(token, mappingModel, claimValue, clientId);
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OIDCProtocolMappersTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OIDCProtocolMappersTest.java
@@ -594,6 +594,51 @@ public class OIDCProtocolMappersTest extends AbstractKeycloakTest {
         }
     }
 
+    /**
+     * Chris Nurse 20-Feb-2022
+     * 
+     * PR-4205 serialised single values as an array. This is not desired when the Multivalued options is set to false.
+     * 
+     * This test ensures singular values are not wrapped as an array.
+     * 
+     * The subsequent test for PR-4205 will continue to test functionality where multivalued = true
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testUserRoleToAttributeMappersWithMultiValuedRolesEqualsFalse() throws Exception {
+        // Add mapper for realm roles
+        ProtocolMapperRepresentation realmMapper = ProtocolMapperUtil.createUserRealmRoleMappingMapper("pref.", "Realm roles mapper", "roles-custom.realm-role", true, true, false);
+        ProtocolMapperRepresentation clientMapper = ProtocolMapperUtil.createUserClientRoleMappingMapper("test-app", null, "Client roles mapper", "roles-custom.client-role", true, true, false);
+
+        ProtocolMappersResource protocolMappers = ApiUtil.findClientResourceByClientId(adminClient.realm("test"), "test-app").getProtocolMappers();
+        protocolMappers.createMapper(Arrays.asList(realmMapper, clientMapper));
+
+        // Login user
+        OAuthClient.AccessTokenResponse response = browserLogin("password", "test-user@localhost", "password");
+        IDToken idToken = oauth.verifyIDToken(response.getIdToken());
+
+        // Verify attribute is filled
+        Map<String, Object> roleMappings = (Map<String, Object>)idToken.getOtherClaims().get("roles-custom");
+
+        // Did the mappers insert values into the token?
+        Assert.assertThat(roleMappings.keySet(), containsInAnyOrder("realm-role", "client-role"));
+
+        // Are the values string types?
+        Assert.assertThat(roleMappings.get("realm-role"), CoreMatchers.instanceOf(String.class));
+        Assert.assertThat(roleMappings.get("client-role"), CoreMatchers.instanceOf(String.class));
+
+        // Get the values
+        String realm_role = roleMappings.get("realm-role");
+        String client_role = roleMappings.get("client-role");
+
+        // Are the values wrapped as arrays
+        Assert.assertNotEquals(realm_role.substring(0,1), "[");
+        Assert.assertNotEquals(client_role.substring(0,1), "[");
+
+        // Revert
+        deleteMappers(protocolMappers);
+    }
 
     /**
      * KEYCLOAK-4205


### PR DESCRIPTION
When the claim value is expected to be a single value, i.e. the user interface toggle for multi-value is set to off, the user expects a singular value to be set in the token. Since PR-4205, the code serializes single values as an array rather than a string, which results in [ the_claim_value ], i.e. value is wrapped as an array.

The purpose of this pull request is to ensure that there is a non-zero length array of role names, and that the first value is fetched and serialized as a plain string. 

This change is tested by a new test:
OIDCProtocolMappersTest.testUserRoleToAttributeMappersWithMultiValuedRolesEqualsFalse :

1. When role mapper is not multivalued, ensure claims are returned as a string with a single value
2. Ensure that when serialized, the value is not wrapped in [ ] as an array
