### PR TITLE
Fix admin user creation message when calling quarkus welcomepage from…

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/services/resources/QuarkusWelcomeResource.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/services/resources/QuarkusWelcomeResource.java
@@ -24,10 +24,10 @@ import org.keycloak.common.util.Base64Url;
 import org.keycloak.common.util.MimeTypeUtil;
 import org.keycloak.common.util.SecretGenerator;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.quarkus.runtime.configuration.Configuration;
 import org.keycloak.services.ForbiddenException;
 import org.keycloak.services.ServicesLogger;
 import org.keycloak.services.managers.ApplianceBootstrap;
-import org.keycloak.services.resources.WelcomeResource;
 import org.keycloak.services.util.CacheControlUtil;
 import org.keycloak.services.util.CookieHelper;
 import org.keycloak.theme.FreeMarkerUtil;
@@ -188,6 +188,11 @@ public class QuarkusWelcomeResource {
                 boolean isLocal = isLocal();
                 map.put("localUser", isLocal);
 
+                String localAdminUrl = getLocalAdminUrl();
+
+                map.put("localAdminUrl", localAdminUrl);
+                map.put("adminUserCreationMessage", "or set the environment variables KEYCLOAK_ADMIN and KEYCLOAK_ADMIN_PASSWORD before starting the server");
+
                 if (isLocal) {
                     String stateChecker = setCsrfCookie();
                     map.put("stateChecker", stateChecker);
@@ -209,6 +214,21 @@ public class QuarkusWelcomeResource {
         } catch (Exception e) {
             throw new WebApplicationException(Response.Status.INTERNAL_SERVER_ERROR);
         }
+    }
+
+    private String getLocalAdminUrl() {
+        boolean isHttpEnabled = Boolean.parseBoolean(Configuration.getConfigValue("kc.http-enabled").getValue());
+        String configPath = Configuration.getConfigValue("kc.http-relative-path").getValue();
+
+        if (!configPath.startsWith("/")) {
+            configPath = "/" + configPath;
+        }
+
+        String configPort = isHttpEnabled ? Configuration.getConfigValue("kc.http-port").getValue() : Configuration.getConfigValue("kc.https-port").getValue() ;
+
+        String scheme = isHttpEnabled ? "http://" : "https://";
+
+        return scheme + "localhost:" + configPort + configPath;
     }
 
     private Theme getTheme() {

--- a/services/src/main/java/org/keycloak/services/resources/WelcomeResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/WelcomeResource.java
@@ -181,7 +181,6 @@ public class WelcomeResource {
 
             map.put("properties", theme.getProperties());
             map.put("adminUrl", session.getContext().getUri(UrlType.ADMIN).getBaseUriBuilder().path("/admin/").build());
-
             map.put("resourcesPath", "resources/" + Version.RESOURCES_VERSION + "/" + theme.getType().toString().toLowerCase() +"/" + theme.getName());
             map.put("resourcesCommonPath", "resources/" + Version.RESOURCES_VERSION + "/common/keycloak");
 
@@ -190,6 +189,8 @@ public class WelcomeResource {
             if (bootstrap) {
                 boolean isLocal = isLocal();
                 map.put("localUser", isLocal);
+                map.put("localAdminUrl", "http://localhost:8080/auth");
+                map.put("adminUserCreationMessage","or use the add-user-keycloak script");
 
                 if (isLocal) {
                     String stateChecker = setCsrfCookie();

--- a/themes/src/main/resources/theme/keycloak/welcome/index.ftl
+++ b/themes/src/main/resources/theme/keycloak/welcome/index.ftl
@@ -60,15 +60,15 @@
                 <p class="alert error">${errorMessage}</p>
                 <h3><img src="welcome-content/user.png">Administration Console</h3>
             <#elseif bootstrap>
-                <#if localUser>
-                    <h3><img src="welcome-content/user.png">Administration Console</h3>
-                    <p>Please create an initial admin user to get started.</p>
-                <#else>
-                    <p class="welcome-message">
-                        <img src="welcome-content/alert.png">You need local access to create the initial admin user. <br><br>Open <a href="http://localhost:8080/auth">http://localhost:8080/auth</a>
-                        <br>or use the add-user-keycloak script.
-                    </p>
-                </#if>
+            <#if localUser>
+                <h3><img src="welcome-content/user.png">Administration Console</h3>
+                <p>Please create an initial admin user to get started.</p>
+            <#else>
+                <p class="welcome-message">
+                    <img src="welcome-content/alert.png">You need local access to create the initial admin user. <br><br>Open <a href="${localAdminUrl}">${localAdminUrl}</a>
+                    <br>${adminUserCreationMessage}.
+                </p>
+            </#if>
             </#if>
 
             <#if bootstrap && localUser>


### PR DESCRIPTION
… remote

For wildfly, everything is as before. For Quarkus, we check if http is enabled and provide the right port and scheme if so, and also we are relative-path aware.

Closes #10335
