### PR TITLE
update to quarkus 2.7.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <quarkus.version>2.7.1.Final</quarkus.version>
+        <quarkus.version>2.7.2.Final</quarkus.version>
 
         <!--
         Performing a Wildfly upgrade? Run the:

--- a/quarkus/pom.xml
+++ b/quarkus/pom.xml
@@ -42,7 +42,7 @@
         <jackson.databind.version>${jackson.version}</jackson.databind.version>
         <hibernate.core.version>5.6.5.Final</hibernate.core.version>
         <mysql.driver.version>8.0.28</mysql.driver.version>
-        <postgresql.version>42.3.2</postgresql.version>
+        <postgresql.version>42.3.3</postgresql.version>
         <microprofile-metrics-api.version>3.0.1</microprofile-metrics-api.version>
         <wildfly.common.version>1.5.4.Final-format-001</wildfly.common.version>
         <infinispan.version>13.0.5.Final</infinispan.version>


### PR DESCRIPTION
postgres update to 42.3.3. 

Did a "hands-on" startup performance test between 2.7.1 and 2.7.2, no change observed (between 3.2xx and 3.4xx seconds for start-dev with initialized db, mostly in the 3.3xx or lower 3.4xx timeframe). Also did a few smoketests

Closes #10437

Closes #10282