### PR TITLE
Display email address in login-verify-email.ftl [#8873]

### DIFF
--- a/services/src/main/java/org/keycloak/forms/login/freemarker/FreeMarkerLoginFormsProvider.java
+++ b/services/src/main/java/org/keycloak/forms/login/freemarker/FreeMarkerLoginFormsProvider.java
@@ -168,6 +168,7 @@ public class FreeMarkerLoginFormsProvider implements LoginFormsProvider {
                 page = LoginFormsPages.LOGIN_UPDATE_PASSWORD;
                 break;
             case VERIFY_EMAIL:
+                this.attributes.put("verifiedEmail",user.getEmail());
                 actionMessage = Messages.VERIFY_EMAIL;
                 page = LoginFormsPages.LOGIN_VERIFY_EMAIL;
                 break;

--- a/themes/src/main/resources/theme/base/login/login-verify-email.ftl
+++ b/themes/src/main/resources/theme/base/login/login-verify-email.ftl
@@ -3,7 +3,7 @@
     <#if section = "header">
         ${msg("emailVerifyTitle")}
     <#elseif section = "form">
-        <p class="instruction">${msg("emailVerifyInstruction1")}</p>
+        <p class="instruction">${msg("emailVerifyInstruction1",verifiedEmail)}</p> 
     <#elseif section = "info">
         <p class="instruction">
             ${msg("emailVerifyInstruction2")}

--- a/themes/src/main/resources/theme/base/login/messages/messages_en.properties
+++ b/themes/src/main/resources/theme/base/login/messages/messages_en.properties
@@ -146,7 +146,7 @@ oauth2DeviceVerificationFailedMessage=You may close this browser window and go b
 oauth2DeviceConsentDeniedMessage=Consent denied for connecting the device.
 oauth2DeviceAuthorizationGrantDisabledMessage=Client is not allowed to initiate OAuth 2.0 Device Authorization Grant. The flow is disabled for the client.
 
-emailVerifyInstruction1=An email with instructions to verify your email address has been sent to you.
+emailVerifyInstruction1=An email with instructions to verify your email address has been sent to your address {0}.
 emailVerifyInstruction2=Haven''t received a verification code in your email?
 emailVerifyInstruction3=to re-send the email.
 


### PR DESCRIPTION
This feature displays the email address in login-verify-email.ftl , it is  especially useful when user forgot the email address he used for Email verification .
Added the attribute in FreeMarkerLoginFormsProvider.java and displayed it in login-verify-email.ftl  .