### PR TITLE
Update sha256 import to be default import

### DIFF
--- a/adapters/oidc/js/src/keycloak.js
+++ b/adapters/oidc/js/src/keycloak.js
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 import base64 from 'base64-js';
-import { sha256 } from 'js-sha256';
+import sha256 from 'js-sha256';
 
 if (typeof Promise === 'undefined') {
     throw Error('Keycloak requires an environment that supports Promises. Make sure that you include the appropriate polyfill.');


### PR DESCRIPTION
This should fix the "Failed to compile. ./node_modules/keycloak-js/dist/keycloak.mjs
Can't import the named export 'sha256' from non EcmaScript module (only default export is available)" error.

Closes #10314
