### PR TITLE
Removal of invalid(depricated) SpringBootTest

### DIFF
--- a/testsuite/integration-arquillian/tests/other/springboot-tests/src/test/java/org/keycloak/testsuite/springboot/AccountLinkSpringBootTest.java
+++ b/testsuite/integration-arquillian/tests/other/springboot-tests/src/test/java/org/keycloak/testsuite/springboot/AccountLinkSpringBootTest.java
@@ -493,56 +493,6 @@ public class AccountLinkSpringBootTest extends AbstractSpringBootTest {
     }
 
     @Test
-    public void testAccountNotLinkedAutomatically() throws Exception {
-        RealmResource realm = adminClient.realms().realm(REALM_NAME);
-        List<FederatedIdentityRepresentation> links = realm.users().get(childUserId).getFederatedIdentity();
-        assertThat(links, is(empty()));
-
-        // Login to account mgmt first
-        profilePage.open(REALM_NAME);
-        WaitUtils.waitForPageToLoad();
-
-        assertCurrentUrlStartsWith(testRealmLoginPage);
-        testRealmLoginPage.form().login(CHILD_USERNAME_1, CHILD_PASSWORD_1);
-        profilePage.assertCurrent();
-
-        // Now in another tab, open login screen with "prompt=login" . Login screen will be displayed even if I have SSO cookie
-        UriBuilder linkBuilder = UriBuilder.fromUri(LINKING_URL);
-        String linkUrl = linkBuilder.clone()
-                .queryParam(OIDCLoginProtocol.PROMPT_PARAM, OIDCLoginProtocol.PROMPT_VALUE_LOGIN)
-                .build().toString();
-
-        navigateTo(linkUrl);
-        assertCurrentUrlStartsWith(testRealmLoginPage);
-
-        loginPage.clickSocial(PARENT_REALM);
-
-        testRealmLoginPage.setAuthRealm(PARENT_REALM);
-        assertCurrentUrlStartsWith(testRealmLoginPage);
-        testRealmLoginPage.form().login(PARENT_USERNAME, PARENT_PASSWORD);
-        testRealmLoginPage.setAuthRealm(REALM_NAME);
-
-        // Test I was not automatically linked.
-        links = realm.users().get(childUserId).getFederatedIdentity();
-        assertThat(links, is(empty()));
-
-        loginUpdateProfilePage.assertCurrent();
-        loginUpdateProfilePage.update("Joe", "Doe", "joe@parent.com");
-
-        errorPage.assertCurrent();
-
-        assertThat(errorPage.getError(), is(equalTo("You are already authenticated as different user '"
-                + CHILD_USERNAME_1
-                + "' in this session. Please sign out first.")));
-
-        logoutAll();
-
-        // Remove newly created user
-        String newUserId = ApiUtil.findUserByUsername(realm, PARENT_USERNAME).getId();
-        getCleanup(REALM_NAME).addUserId(newUserId);
-    }
-
-    @Test
     public void testAccountLinkingExpired() throws Exception {
         RealmResource realm = adminClient.realms().realm(REALM_NAME);
         List<FederatedIdentityRepresentation> links = realm.users().get(childUserId).getFederatedIdentity();


### PR DESCRIPTION
The test is no longer valid since #9580 was merged. 
The test is a SpringBootTest duplicate of `testsuite/adapter/servlet/ClientInitiatedAccountLinkTest.testAccountNotLinkedAutomatically()` and should be removed as well.

Closes #10218