### PR TITLE
Allow Edge tests in Admin Console

### DIFF
--- a/testsuite/integration-arquillian/tests/other/console/pom.xml
+++ b/testsuite/integration-arquillian/tests/other/console/pom.xml
@@ -33,7 +33,7 @@
 
     <properties>
         <keycloak.theme.dir>${auth.server.home}/themes</keycloak.theme.dir>
-        <supportedBrowsers>firefox|chrome|internetExplorer|safari|chromeHeadless</supportedBrowsers>
+        <supportedBrowsers>firefox|chrome|internetExplorer|safari|chromeHeadless|edge</supportedBrowsers>
     </properties>
 
     <build>


### PR DESCRIPTION
Allow Admin Console tests to run with Edge browser 
Closes #10539