### PR TITLE
Allow using an additional persistence unit and datasource

### DIFF
--- a/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
+++ b/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
@@ -48,6 +48,7 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 
@@ -65,6 +66,7 @@ import io.quarkus.deployment.builditem.StaticInitConfigSourceProviderBuildItem;
 import io.quarkus.hibernate.orm.deployment.AdditionalJpaModelBuildItem;
 import io.quarkus.hibernate.orm.deployment.HibernateOrmConfig;
 import io.quarkus.hibernate.orm.deployment.PersistenceXmlDescriptorBuildItem;
+import io.quarkus.hibernate.orm.deployment.integration.HibernateOrmIntegrationRuntimeConfiguredBuildItem;
 import io.quarkus.resteasy.server.common.deployment.ResteasyDeploymentCustomizerBuildItem;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.configuration.ProfileManager;
@@ -84,6 +86,8 @@ import org.jboss.logging.Logger;
 import org.jboss.resteasy.plugins.server.servlet.ResteasyContextParameters;
 import org.jboss.resteasy.spi.ResteasyDeployment;
 import org.keycloak.Config;
+import org.keycloak.connections.jpa.JpaConnectionProvider;
+import org.keycloak.connections.jpa.JpaConnectionSpi;
 import org.keycloak.quarkus.runtime.QuarkusProfile;
 import org.keycloak.quarkus.runtime.configuration.PersistedConfigSource;
 import org.keycloak.quarkus.runtime.configuration.QuarkusPropertiesConfigSource;
@@ -121,6 +125,7 @@ import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.vertx.http.deployment.FilterBuildItem;
 
+import org.keycloak.quarkus.runtime.storage.database.jpa.NamedJpaConnectionProviderFactory;
 import org.keycloak.representations.provider.ScriptProviderDescriptor;
 import org.keycloak.representations.provider.ScriptProviderMetadata;
 import org.keycloak.quarkus.runtime.integration.web.NotFoundHandler;
@@ -191,14 +196,27 @@ class KeycloakProcessor {
      * @param descriptors
      */
     @BuildStep
-    void configureHibernate(HibernateOrmConfig config,
+    @Record(ExecutionTime.RUNTIME_INIT)
+    void configurePersistenceUnits(HibernateOrmConfig config,
             List<PersistenceXmlDescriptorBuildItem> descriptors,
             List<JdbcDataSourceBuildItem> jdbcDataSources,
             BuildProducer<AdditionalJpaModelBuildItem> additionalJpaModel,
-            CombinedIndexBuildItem indexBuildItem) {
-        ParsedPersistenceXmlDescriptor descriptor = descriptors.get(0).getDescriptor();
-        configureJpaProperties(descriptor, config, jdbcDataSources);
-        configureJpaModel(descriptor, indexBuildItem);
+            CombinedIndexBuildItem indexBuildItem,
+            BuildProducer<HibernateOrmIntegrationRuntimeConfiguredBuildItem> runtimeConfigured,
+            KeycloakRecorder recorder) {
+        for (PersistenceXmlDescriptorBuildItem item : descriptors) {
+            ParsedPersistenceXmlDescriptor descriptor = item.getDescriptor();
+
+            if ("keycloak-default".equals(descriptor.getName())) {
+                configureJpaProperties(descriptor, config, jdbcDataSources);
+                configureJpaModel(descriptor, indexBuildItem);
+            } else {
+                Properties properties = descriptor.getProperties();
+                // register a listener for customizing the unit configuration at runtime
+                runtimeConfigured.produce(new HibernateOrmIntegrationRuntimeConfiguredBuildItem("keycloak", descriptor.getName())
+                        .setInitListener(recorder.createUnitListener(properties.getProperty(AvailableSettings.DATASOURCE))));
+            }
+        }
     }
 
     private void configureJpaProperties(ParsedPersistenceXmlDescriptor descriptor, HibernateOrmConfig config,
@@ -245,7 +263,7 @@ class KeycloakProcessor {
     @Consume(RuntimeConfigSetupCompleteBuildItem.class)
     @Record(ExecutionTime.RUNTIME_INIT)
     @BuildStep
-    KeycloakSessionFactoryPreInitBuildItem configureProviders(KeycloakRecorder recorder) {
+    KeycloakSessionFactoryPreInitBuildItem configureProviders(KeycloakRecorder recorder, List<PersistenceXmlDescriptorBuildItem> descriptors) {
         Profile.setInstance(new QuarkusProfile());
         Map<Spi, Map<Class<? extends Provider>, Map<String, Class<? extends ProviderFactory>>>> factories = new HashMap<>();
         Map<Class<? extends Provider>, String> defaultProviders = new HashMap<>();
@@ -253,20 +271,45 @@ class KeycloakProcessor {
 
         for (Entry<Spi, Map<Class<? extends Provider>, Map<String, ProviderFactory>>> entry : loadFactories(preConfiguredProviders)
                 .entrySet()) {
-            checkProviders(entry.getKey(), entry.getValue(), defaultProviders);
+            Spi spi = entry.getKey();
+
+            checkProviders(spi, entry.getValue(), defaultProviders);
 
             for (Entry<Class<? extends Provider>, Map<String, ProviderFactory>> value : entry.getValue().entrySet()) {
                 for (ProviderFactory factory : value.getValue().values()) {
-                    factories.computeIfAbsent(entry.getKey(),
+                    factories.computeIfAbsent(spi,
                             key -> new HashMap<>())
-                            .computeIfAbsent(entry.getKey().getProviderClass(), aClass -> new HashMap<>()).put(factory.getId(),factory.getClass());
+                            .computeIfAbsent(spi.getProviderClass(), aClass -> new HashMap<>()).put(factory.getId(),factory.getClass());
                 }
+            }
+
+            if (spi instanceof JpaConnectionSpi) {
+                configureUserDefinedPersistenceUnits(descriptors, factories, preConfiguredProviders, spi);
             }
         }
 
         recorder.configSessionFactory(factories, defaultProviders, preConfiguredProviders, Environment.isRebuild());
 
         return new KeycloakSessionFactoryPreInitBuildItem();
+    }
+
+    private void configureUserDefinedPersistenceUnits(List<PersistenceXmlDescriptorBuildItem> descriptors,
+            Map<Spi, Map<Class<? extends Provider>, Map<String, Class<? extends ProviderFactory>>>> factories,
+            Map<String, ProviderFactory> preConfiguredProviders, Spi spi) {
+        descriptors.stream()
+                .map(PersistenceXmlDescriptorBuildItem::getDescriptor)
+                .map(ParsedPersistenceXmlDescriptor::getName)
+                .filter(Predicate.not("keycloak-default"::equals)).forEach(new Consumer<String>() {
+                    @Override
+                    public void accept(String unitName) {
+                        NamedJpaConnectionProviderFactory factory = new NamedJpaConnectionProviderFactory();
+
+                        factory.setUnitName(unitName);
+
+                        factories.get(spi).get(JpaConnectionProvider.class).put(unitName, NamedJpaConnectionProviderFactory.class);
+                        preConfiguredProviders.put(unitName, factory);
+                    }
+                });
     }
 
     /**

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/integration/jaxrs/QuarkusKeycloakApplication.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/integration/jaxrs/QuarkusKeycloakApplication.java
@@ -20,9 +20,6 @@ package org.keycloak.quarkus.runtime.integration.jaxrs;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import javax.enterprise.inject.Instance;
-import javax.inject.Inject;
-import javax.persistence.EntityManagerFactory;
 import javax.ws.rs.ApplicationPath;
 
 import org.keycloak.Config;
@@ -47,12 +44,8 @@ public class QuarkusKeycloakApplication extends KeycloakApplication {
         return !WelcomeResource.class.isInstance(o);
     }
 
-    @Inject
-    Instance<EntityManagerFactory> entityManagerFactory;
-
     @Override
     protected void startup() {
-        forceEntityManagerInitialization();
         initializeKeycloakSessionFactory();
         setupScheduledTasks(sessionFactory);
         createAdminUser();
@@ -74,12 +67,6 @@ public class QuarkusKeycloakApplication extends KeycloakApplication {
         sessionFactory = instance;
         instance.init();
         sessionFactory.publish(new PostMigrationEvent());
-    }
-
-    private void forceEntityManagerInitialization() {
-        // also forces an initialization of the entity manager so that providers don't need to wait for any initialization logic
-        // when first creating an entity manager
-        entityManagerFactory.get().createEntityManager().close();
     }
 
     private void createAdminUser() {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/database/jpa/AbstractJpaConnectionProviderFactory.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/database/jpa/AbstractJpaConnectionProviderFactory.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.quarkus.runtime.storage.database.jpa;
+
+import java.lang.annotation.Annotation;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Optional;
+import javax.enterprise.inject.Instance;
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.EntityTransaction;
+import javax.persistence.SynchronizationType;
+import org.hibernate.internal.SessionFactoryImpl;
+import org.keycloak.Config;
+import org.keycloak.connections.jpa.JpaConnectionProviderFactory;
+import org.keycloak.connections.jpa.JpaKeycloakTransaction;
+import org.keycloak.connections.jpa.PersistenceExceptionConverter;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.quarkus.runtime.configuration.Configuration;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.hibernate.orm.PersistenceUnit;
+
+public abstract class AbstractJpaConnectionProviderFactory implements JpaConnectionProviderFactory {
+
+    protected Config.Scope config;
+    protected Boolean xaEnabled;
+    protected EntityManagerFactory entityManagerFactory;
+
+    @Override
+    public Connection getConnection() {
+        SessionFactoryImpl entityManagerFactory = this.entityManagerFactory.unwrap(SessionFactoryImpl.class);
+
+        try {
+            return entityManagerFactory.getJdbcServices().getBootstrapJdbcConnectionAccess().obtainConnection();
+        } catch (SQLException cause) {
+            throw new RuntimeException("Failed to obtain JDBC connection", cause);
+        }
+    }
+
+    @Override
+    public String getSchema() {
+        return Configuration.getRawValue("kc.db-schema");
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+        this.config = config;
+        xaEnabled = "xa".equals(Configuration.getRawValue("kc.transaction-xa-enabled"));
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+        entityManagerFactory = getEntityManagerFactory();
+    }
+
+    @Override
+    public void close() {
+        if (entityManagerFactory != null) {
+            entityManagerFactory.close();
+        }
+    }
+
+    protected abstract EntityManagerFactory getEntityManagerFactory();
+
+    protected Optional<EntityManagerFactory> getEntityManagerFactory(String unitName) {
+        Instance<EntityManagerFactory> instance = Arc.container().select(EntityManagerFactory.class, new PersistenceUnit() {
+
+            @Override
+            public Class<? extends Annotation> annotationType() {
+                return PersistenceUnit.class;
+            }
+
+            @Override
+            public String value() {
+                return unitName;
+            }
+        });
+
+        if (instance.isResolvable()) {
+            return Optional.of(instance.get());
+        }
+
+        return Optional.empty();
+    }
+
+    protected EntityManager createEntityManager(EntityManagerFactory emf, KeycloakSession session) {
+        EntityManager entityManager;
+
+        if (xaEnabled) {
+            entityManager = PersistenceExceptionConverter.create(session, emf.createEntityManager(SynchronizationType.SYNCHRONIZED));
+        } else {
+            entityManager = PersistenceExceptionConverter.create(session, emf.createEntityManager());
+        }
+
+        return entityManager;
+    }
+}

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/database/jpa/NamedJpaConnectionProviderFactory.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/database/jpa/NamedJpaConnectionProviderFactory.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.quarkus.runtime.storage.database.jpa;
+
+import java.util.function.Supplier;
+import javax.persistence.EntityManagerFactory;
+import org.keycloak.connections.jpa.DefaultJpaConnectionProvider;
+import org.keycloak.connections.jpa.JpaConnectionProvider;
+import org.keycloak.models.KeycloakSession;
+
+public final class NamedJpaConnectionProviderFactory extends AbstractJpaConnectionProviderFactory {
+
+    private String unitName;
+
+    @Override
+    public JpaConnectionProvider create(KeycloakSession session) {
+        return new DefaultJpaConnectionProvider(createEntityManager(entityManagerFactory, session));
+    }
+
+    @Override
+    protected EntityManagerFactory getEntityManagerFactory() {
+        return getEntityManagerFactory(unitName).orElseThrow(new Supplier<IllegalStateException>() {
+            @Override
+            public IllegalStateException get() {
+                return new IllegalStateException("Could not resolve named EntityManagerFactory [" + unitName + "]");
+            }
+        });
+    }
+
+    public String getUnitName() {
+        return unitName;
+    }
+
+    public void setUnitName(String unitName) {
+        this.unitName = unitName;
+    }
+
+    @Override
+    public String getId() {
+        return unitName;
+    }
+}


### PR DESCRIPTION
Closes #10579

* Support for multiple persistence units (other than Keycloak default)
* For each user-defined PU, an additional `NamedJpaConnectionFactory` is installed to resolve `JpaConnectionProvider` instances from the `KeycloakSession` based on the name of the PU
* Updated [quickstart](https://github.com/keycloak/keycloak-quickstarts/pull/302) to run using the new distribution.
