### PR TITLE
Change the flush mode to auto and fixing check for entities loaded into the session

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserProvider.java
@@ -1083,7 +1083,6 @@ public class JpaUserProvider implements UserProvider.Streams, UserCredentialStor
 
     private UserEntity userInEntityManagerContext(String id) {
         UserEntity user = em.getReference(UserEntity.class, id);
-        boolean isLoaded = em.getEntityManagerFactory().getPersistenceUnitUtil().isLoaded(user);
-        return isLoaded ? user : null;
+        return em.contains(user) ? user : null;
     }
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/database/jpa/AbstractJpaConnectionProviderFactory.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/database/jpa/AbstractJpaConnectionProviderFactory.java
@@ -25,6 +25,7 @@ import javax.enterprise.inject.Instance;
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.EntityTransaction;
+import javax.persistence.FlushModeType;
 import javax.persistence.SynchronizationType;
 import org.hibernate.internal.SessionFactoryImpl;
 import org.keycloak.Config;
@@ -109,6 +110,8 @@ public abstract class AbstractJpaConnectionProviderFactory implements JpaConnect
         } else {
             entityManager = PersistenceExceptionConverter.create(session, emf.createEntityManager());
         }
+
+        entityManager.setFlushMode(FlushModeType.AUTO);
 
         return entityManager;
     }


### PR DESCRIPTION
Closes #10411

* Basically, forces the `FlushMode.AUTO` similarly to Wildfly dist. By default, it is set to `ALWAYS`.
* Fixes the `JpaUserProvider` to not use `PersistenceUnitUtil.isLoaded` but `EntityManager.contains` to check whether entities are loaded into the session

The second one is what behaves differently between Wildfly and Quarkus distribution, Hibernate v5.3 and v5.6, respectively. Accordingly to Hibernate team the usage of `PersistenceUnitUtil` is not reliable. See https://github.com/hibernate/hibernate-orm/blob/main/hibernate-core/src/main/java/org/hibernate/jpa/internal/PersistenceUnitUtilImpl.java#L40.