### PR TITLE
Authorization services refactoring

### DIFF
--- a/authz/policy/common/src/main/java/org/keycloak/authorization/policy/provider/client/ClientPolicyProviderFactory.java
+++ b/authz/policy/common/src/main/java/org/keycloak/authorization/policy/provider/client/ClientPolicyProviderFactory.java
@@ -112,7 +112,7 @@ public class ClientPolicyProviderFactory implements PolicyProviderFactory<Client
                 ResourceServer resourceServer = resourceServerStore.findByClient(removedClient);
 
                 if (resourceServer != null) {
-                    policyStore.findByType(resourceServer.getId(), getId()).forEach(policy -> {
+                    policyStore.findByType(resourceServer, getId()).forEach(policy -> {
                         List<String> clients = new ArrayList<>();
 
                         for (String clientId : getClients(policy)) {

--- a/authz/policy/common/src/main/java/org/keycloak/authorization/policy/provider/client/ClientPolicyProviderFactory.java
+++ b/authz/policy/common/src/main/java/org/keycloak/authorization/policy/provider/client/ClientPolicyProviderFactory.java
@@ -112,7 +112,7 @@ public class ClientPolicyProviderFactory implements PolicyProviderFactory<Client
                 ResourceServer resourceServer = resourceServerStore.findByClient(removedClient);
 
                 if (resourceServer != null) {
-                    policyStore.findByType(getId(), resourceServer.getId()).forEach(policy -> {
+                    policyStore.findByType(resourceServer.getId(), getId()).forEach(policy -> {
                         List<String> clients = new ArrayList<>();
 
                         for (String clientId : getClients(policy)) {

--- a/authz/policy/common/src/main/java/org/keycloak/authorization/policy/provider/clientscope/ClientScopePolicyProviderFactory.java
+++ b/authz/policy/common/src/main/java/org/keycloak/authorization/policy/provider/clientscope/ClientScopePolicyProviderFactory.java
@@ -74,7 +74,7 @@ public class ClientScopePolicyProviderFactory implements PolicyProviderFactory<C
 
                 filters.put(Policy.FilterOption.TYPE, new String[] { getId() });
 
-                policyStore.findByResourceServer(filters, null, -1, -1).forEach(new Consumer<Policy>() {
+                policyStore.findByResourceServer(null, filters, -1, -1).forEach(new Consumer<Policy>() {
 
                     @Override
                     public void accept(Policy policy) {

--- a/authz/policy/common/src/main/java/org/keycloak/authorization/policy/provider/clientscope/ClientScopePolicyProviderFactory.java
+++ b/authz/policy/common/src/main/java/org/keycloak/authorization/policy/provider/clientscope/ClientScopePolicyProviderFactory.java
@@ -74,7 +74,7 @@ public class ClientScopePolicyProviderFactory implements PolicyProviderFactory<C
 
                 filters.put(Policy.FilterOption.TYPE, new String[] { getId() });
 
-                policyStore.findByResourceServer(null, filters, -1, -1).forEach(new Consumer<Policy>() {
+                policyStore.findByResourceServer(null, filters, null, null).forEach(new Consumer<Policy>() {
 
                     @Override
                     public void accept(Policy policy) {

--- a/authz/policy/common/src/main/java/org/keycloak/authorization/policy/provider/permission/UMAPolicyProviderFactory.java
+++ b/authz/policy/common/src/main/java/org/keycloak/authorization/policy/provider/permission/UMAPolicyProviderFactory.java
@@ -28,7 +28,6 @@ import org.keycloak.authorization.policy.provider.PolicyProvider;
 import org.keycloak.authorization.policy.provider.PolicyProviderFactory;
 import org.keycloak.authorization.store.PolicyStore;
 import org.keycloak.models.ClientModel;
-import org.keycloak.models.GroupModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.models.RealmModel;
@@ -397,7 +396,7 @@ public class UMAPolicyProviderFactory implements PolicyProviderFactory<UmaPermis
         rep.setName(KeycloakModelUtils.generateId());
         rep.setCode(condition);
 
-        Policy associatedPolicy = policyStore.create(rep, policy.getResourceServer());
+        Policy associatedPolicy = policyStore.create(policy.getResourceServer(), rep);
 
         associatedPolicy.setOwner(owner);
 
@@ -410,7 +409,7 @@ public class UMAPolicyProviderFactory implements PolicyProviderFactory<UmaPermis
         rep.setName(KeycloakModelUtils.generateId());
         rep.addClient(client);
 
-        Policy associatedPolicy = policyStore.create(rep, policy.getResourceServer());
+        Policy associatedPolicy = policyStore.create(policy.getResourceServer(), rep);
 
         associatedPolicy.setOwner(owner);
 
@@ -423,7 +422,7 @@ public class UMAPolicyProviderFactory implements PolicyProviderFactory<UmaPermis
         rep.setName(KeycloakModelUtils.generateId());
         rep.addGroupPath(group);
 
-        Policy associatedPolicy = policyStore.create(rep, policy.getResourceServer());
+        Policy associatedPolicy = policyStore.create(policy.getResourceServer(), rep);
 
         associatedPolicy.setOwner(owner);
 
@@ -436,7 +435,7 @@ public class UMAPolicyProviderFactory implements PolicyProviderFactory<UmaPermis
         rep.setName(KeycloakModelUtils.generateId());
         rep.addRole(role, false);
 
-        Policy associatedPolicy = policyStore.create(rep, policy.getResourceServer());
+        Policy associatedPolicy = policyStore.create(policy.getResourceServer(), rep);
 
         associatedPolicy.setOwner(owner);
 
@@ -449,7 +448,7 @@ public class UMAPolicyProviderFactory implements PolicyProviderFactory<UmaPermis
         rep.setName(KeycloakModelUtils.generateId());
         rep.addUser(user);
 
-        Policy associatedPolicy = policyStore.create(rep, policy.getResourceServer());
+        Policy associatedPolicy = policyStore.create(policy.getResourceServer(), rep);
 
         associatedPolicy.setOwner(owner);
 

--- a/authz/policy/common/src/main/java/org/keycloak/authorization/policy/provider/role/RolePolicyProviderFactory.java
+++ b/authz/policy/common/src/main/java/org/keycloak/authorization/policy/provider/role/RolePolicyProviderFactory.java
@@ -223,7 +223,7 @@ public class RolePolicyProviderFactory implements PolicyProviderFactory<RolePoli
         ResourceServer resourceServer = resourceServerStore.findByClient(clientModel);
 
         if (resourceServer != null) {
-            policyStore.findByType(resourceServer.getId(), getId()).forEach(policy -> {
+            policyStore.findByType(resourceServer, getId()).forEach(policy -> {
                 List<Map> roles = new ArrayList<>();
 
                 for (Map<String,Object> role : getRoles(policy)) {

--- a/authz/policy/common/src/main/java/org/keycloak/authorization/policy/provider/role/RolePolicyProviderFactory.java
+++ b/authz/policy/common/src/main/java/org/keycloak/authorization/policy/provider/role/RolePolicyProviderFactory.java
@@ -223,7 +223,7 @@ public class RolePolicyProviderFactory implements PolicyProviderFactory<RolePoli
         ResourceServer resourceServer = resourceServerStore.findByClient(clientModel);
 
         if (resourceServer != null) {
-            policyStore.findByType(getId(), resourceServer.getId()).forEach(policy -> {
+            policyStore.findByType(resourceServer.getId(), getId()).forEach(policy -> {
                 List<Map> roles = new ArrayList<>();
 
                 for (Map<String,Object> role : getRoles(policy)) {

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/authorization/PermissionTicketAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/authorization/PermissionTicketAdapter.java
@@ -42,7 +42,7 @@ public class PermissionTicketAdapter implements PermissionTicket, CachedModel<Pe
     @Override
     public PermissionTicket getDelegateForUpdate() {
         if (updated == null) {
-            updated = cacheSession.getPermissionTicketStoreDelegate().findById(cached.getId(), cached.getResourceServerId());
+            updated = cacheSession.getPermissionTicketStoreDelegate().findById(cached.getResourceServerId(), cached.getId());
             if (updated == null) throw new IllegalStateException("Not found in database");
             cacheSession.registerPermissionTicketInvalidation(cached.getId(), cached.getOwner(), cached.getRequester(), cached.getResourceId(), updated.getResource().getName(), cached.getScopeId(), cached.getResourceServerId());
         }
@@ -69,7 +69,7 @@ public class PermissionTicketAdapter implements PermissionTicket, CachedModel<Pe
     protected boolean isUpdated() {
         if (updated != null) return true;
         if (!invalidated) return false;
-        updated = cacheSession.getPermissionTicketStoreDelegate().findById(cached.getId(), cached.getResourceServerId());
+        updated = cacheSession.getPermissionTicketStoreDelegate().findById(cached.getResourceServerId(), cached.getId());
         if (updated == null) throw new IllegalStateException("Not found in database");
         return true;
     }
@@ -126,7 +126,7 @@ public class PermissionTicketAdapter implements PermissionTicket, CachedModel<Pe
     @Override
     public Policy getPolicy() {
         if (isUpdated()) return updated.getPolicy();
-        return cacheSession.getPolicyStore().findById(cached.getPolicy(), cached.getResourceServerId());
+        return cacheSession.getPolicyStore().findById(cached.getResourceServerId(), cached.getPolicy());
     }
 
     @Override
@@ -138,12 +138,12 @@ public class PermissionTicketAdapter implements PermissionTicket, CachedModel<Pe
 
     @Override
     public Resource getResource() {
-        return cacheSession.getResourceStore().findById(cached.getResourceId(), getResourceServer().getId());
+        return cacheSession.getResourceStore().findById(getResourceServer().getId(), cached.getResourceId());
     }
 
     @Override
     public Scope getScope() {
-        return cacheSession.getScopeStore().findById(cached.getScopeId(), getResourceServer().getId());
+        return cacheSession.getScopeStore().findById(getResourceServer().getId(), cached.getScopeId());
     }
 
     @Override

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/authorization/PermissionTicketAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/authorization/PermissionTicketAdapter.java
@@ -145,7 +145,7 @@ public class PermissionTicketAdapter implements PermissionTicket, CachedModel<Pe
 
     @Override
     public Scope getScope() {
-        return cacheSession.getScopeStore().findById(getResourceServer().getId(), cached.getScopeId());
+        return cacheSession.getScopeStore().findById(getResourceServer(), cached.getScopeId());
     }
 
     @Override

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/authorization/PermissionTicketAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/authorization/PermissionTicketAdapter.java
@@ -128,7 +128,7 @@ public class PermissionTicketAdapter implements PermissionTicket, CachedModel<Pe
     @Override
     public Policy getPolicy() {
         if (isUpdated()) return updated.getPolicy();
-        return cacheSession.getPolicyStore().findById(cached.getResourceServerId(), cached.getPolicy());
+        return cacheSession.getPolicyStore().findById(cacheSession.getResourceServerStore().findById(cached.getResourceServerId()), cached.getPolicy());
     }
 
     @Override

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/authorization/PermissionTicketAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/authorization/PermissionTicketAdapter.java
@@ -42,7 +42,8 @@ public class PermissionTicketAdapter implements PermissionTicket, CachedModel<Pe
     @Override
     public PermissionTicket getDelegateForUpdate() {
         if (updated == null) {
-            updated = cacheSession.getPermissionTicketStoreDelegate().findById(cached.getResourceServerId(), cached.getId());
+            ResourceServer resourceServer = cacheSession.getResourceServerStoreDelegate().findById(cached.getResourceServerId());
+            updated = cacheSession.getPermissionTicketStoreDelegate().findById(resourceServer, cached.getId());
             if (updated == null) throw new IllegalStateException("Not found in database");
             cacheSession.registerPermissionTicketInvalidation(cached.getId(), cached.getOwner(), cached.getRequester(), cached.getResourceId(), updated.getResource().getName(), cached.getScopeId(), cached.getResourceServerId());
         }
@@ -69,7 +70,8 @@ public class PermissionTicketAdapter implements PermissionTicket, CachedModel<Pe
     protected boolean isUpdated() {
         if (updated != null) return true;
         if (!invalidated) return false;
-        updated = cacheSession.getPermissionTicketStoreDelegate().findById(cached.getResourceServerId(), cached.getId());
+        ResourceServer resourceServer = cacheSession.getResourceServerStoreDelegate().findById(cached.getResourceServerId());
+        updated = cacheSession.getPermissionTicketStoreDelegate().findById(resourceServer, cached.getId());
         if (updated == null) throw new IllegalStateException("Not found in database");
         return true;
     }

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/authorization/PermissionTicketAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/authorization/PermissionTicketAdapter.java
@@ -140,7 +140,7 @@ public class PermissionTicketAdapter implements PermissionTicket, CachedModel<Pe
 
     @Override
     public Resource getResource() {
-        return cacheSession.getResourceStore().findById(getResourceServer().getId(), cached.getResourceId());
+        return cacheSession.getResourceStore().findById(getResourceServer(), cached.getResourceId());
     }
 
     @Override

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/authorization/PolicyAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/authorization/PolicyAdapter.java
@@ -85,7 +85,7 @@ public class PolicyAdapter implements Policy, CachedModel<Policy> {
     protected boolean isUpdated() {
         if (updated != null) return true;
         if (!invalidated) return false;
-        updated = cacheSession.getPolicyStoreDelegate().findById(cached.getResourceServerId(), cached.getId());
+        updated = cacheSession.getPolicyStoreDelegate().findById(cacheSession.getResourceServerStore().findById(cached.getResourceServerId()), cached.getId());
         if (updated == null) throw new IllegalStateException("Not found in database");
         return true;
     }
@@ -208,7 +208,7 @@ public class PolicyAdapter implements Policy, CachedModel<Policy> {
         PolicyStore policyStore = cacheSession.getPolicyStore();
         String resourceServerId = cached.getResourceServerId();
         for (String id : cached.getAssociatedPoliciesIds(modelSupplier)) {
-            Policy policy = policyStore.findById(resourceServerId, id);
+            Policy policy = policyStore.findById(cacheSession.getResourceServerStore().findById(resourceServerId), id);
             cacheSession.cachePolicy(policy);
             associatedPolicies.add(policy);
         }
@@ -325,6 +325,6 @@ public class PolicyAdapter implements Policy, CachedModel<Policy> {
     }
 
     private Policy getPolicyModel() {
-        return cacheSession.getPolicyStoreDelegate().findById(cached.getResourceServerId(), cached.getId());
+        return cacheSession.getPolicyStoreDelegate().findById(cacheSession.getResourceServerStore().findById(cached.getResourceServerId()), cached.getId());
     }
 }

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/authorization/PolicyAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/authorization/PolicyAdapter.java
@@ -223,9 +223,9 @@ public class PolicyAdapter implements Policy, CachedModel<Policy> {
         if (resources != null) return resources;
         resources = new HashSet<>();
         ResourceStore resourceStore = cacheSession.getResourceStore();
+        ResourceServer resourceServer = getResourceServer();
         for (String resourceId : cached.getResourcesIds(modelSupplier)) {
-            String resourceServerId = cached.getResourceServerId();
-            Resource resource = resourceStore.findById(resourceServerId, resourceId);
+            Resource resource = resourceStore.findById(resourceServer, resourceId);
             cacheSession.cacheResource(resource);
             resources.add(resource);
         }

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/authorization/PolicyAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/authorization/PolicyAdapter.java
@@ -85,7 +85,7 @@ public class PolicyAdapter implements Policy, CachedModel<Policy> {
     protected boolean isUpdated() {
         if (updated != null) return true;
         if (!invalidated) return false;
-        updated = cacheSession.getPolicyStoreDelegate().findById(cached.getId(), cached.getResourceServerId());
+        updated = cacheSession.getPolicyStoreDelegate().findById(cached.getResourceServerId(), cached.getId());
         if (updated == null) throw new IllegalStateException("Not found in database");
         return true;
     }
@@ -208,7 +208,7 @@ public class PolicyAdapter implements Policy, CachedModel<Policy> {
         PolicyStore policyStore = cacheSession.getPolicyStore();
         String resourceServerId = cached.getResourceServerId();
         for (String id : cached.getAssociatedPoliciesIds(modelSupplier)) {
-            Policy policy = policyStore.findById(id, resourceServerId);
+            Policy policy = policyStore.findById(resourceServerId, id);
             cacheSession.cachePolicy(policy);
             associatedPolicies.add(policy);
         }
@@ -225,7 +225,7 @@ public class PolicyAdapter implements Policy, CachedModel<Policy> {
         ResourceStore resourceStore = cacheSession.getResourceStore();
         for (String resourceId : cached.getResourcesIds(modelSupplier)) {
             String resourceServerId = cached.getResourceServerId();
-            Resource resource = resourceStore.findById(resourceId, resourceServerId);
+            Resource resource = resourceStore.findById(resourceServerId, resourceId);
             cacheSession.cacheResource(resource);
             resources.add(resource);
         }
@@ -290,7 +290,7 @@ public class PolicyAdapter implements Policy, CachedModel<Policy> {
         ScopeStore scopeStore = cacheSession.getScopeStore();
         String resourceServerId = cached.getResourceServerId();
         for (String scopeId : cached.getScopesIds(modelSupplier)) {
-            Scope scope = scopeStore.findById(scopeId, resourceServerId);
+            Scope scope = scopeStore.findById(resourceServerId, scopeId);
             cacheSession.cacheScope(scope);
             scopes.add(scope);
         }
@@ -325,6 +325,6 @@ public class PolicyAdapter implements Policy, CachedModel<Policy> {
     }
 
     private Policy getPolicyModel() {
-        return cacheSession.getPolicyStoreDelegate().findById(cached.getId(), cached.getResourceServerId());
+        return cacheSession.getPolicyStoreDelegate().findById(cached.getResourceServerId(), cached.getId());
     }
 }

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/authorization/PolicyAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/authorization/PolicyAdapter.java
@@ -287,10 +287,10 @@ public class PolicyAdapter implements Policy, CachedModel<Policy> {
         if (isUpdated()) return updated.getScopes();
         if (scopes != null) return scopes;
         scopes = new HashSet<>();
+        ResourceServer resourceServer = getResourceServer();
         ScopeStore scopeStore = cacheSession.getScopeStore();
-        String resourceServerId = cached.getResourceServerId();
         for (String scopeId : cached.getScopesIds(modelSupplier)) {
-            Scope scope = scopeStore.findById(resourceServerId, scopeId);
+            Scope scope = scopeStore.findById(resourceServer, scopeId);
             cacheSession.cacheScope(scope);
             scopes.add(scope);
         }

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/authorization/ResourceAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/authorization/ResourceAdapter.java
@@ -81,7 +81,7 @@ public class ResourceAdapter implements Resource, CachedModel<Resource> {
     protected boolean isUpdated() {
         if (updated != null) return true;
         if (!invalidated) return false;
-        updated = cacheSession.getResourceStoreDelegate().findById(cached.getResourceServerId(), cached.getId());
+        updated = cacheSession.getResourceStoreDelegate().findById(getResourceServer(), cached.getId());
         if (updated == null) throw new IllegalStateException("Not found in database");
         return true;
     }
@@ -283,6 +283,6 @@ public class ResourceAdapter implements Resource, CachedModel<Resource> {
     }
 
     private Resource getResourceModel() {
-        return cacheSession.getResourceStoreDelegate().findById(cached.getResourceServerId(), cached.getId());
+        return cacheSession.getResourceStoreDelegate().findById(getResourceServer(), cached.getId());
     }
 }

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/authorization/ResourceAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/authorization/ResourceAdapter.java
@@ -216,7 +216,7 @@ public class ResourceAdapter implements Resource, CachedModel<Resource> {
 
         for (Scope scope : updated.getScopes()) {
             if (!scopes.contains(scope)) {
-                policyStore.findByResource(getResourceServer().getId(), getId(), policy -> policy.removeScope(scope));
+                policyStore.findByResource(getResourceServer(), this, policy -> policy.removeScope(scope));
             }
         }
 

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/authorization/ResourceAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/authorization/ResourceAdapter.java
@@ -204,7 +204,7 @@ public class ResourceAdapter implements Resource, CachedModel<Resource> {
         for (Scope scope : updated.getScopes()) {
             if (!scopes.contains(scope)) {
                 PermissionTicketStore permissionStore = cacheSession.getPermissionTicketStore();
-                List<PermissionTicket> permissions = permissionStore.findByScope(getResourceServer().getId(), scope.getId());
+                List<PermissionTicket> permissions = permissionStore.findByScope(getResourceServer(), scope);
 
                 for (PermissionTicket permission : permissions) {
                     permissionStore.delete(permission.getId());

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/authorization/ResourceAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/authorization/ResourceAdapter.java
@@ -173,7 +173,7 @@ public class ResourceAdapter implements Resource, CachedModel<Resource> {
         if (scopes != null) return scopes;
         scopes = new LinkedList<>();
         for (String scopeId : cached.getScopesIds(modelSupplier)) {
-            scopes.add(cacheSession.getScopeStore().findById(cached.getResourceServerId(), scopeId));
+            scopes.add(cacheSession.getScopeStore().findById(getResourceServer(), scopeId));
         }
         return scopes = Collections.unmodifiableList(scopes);
     }

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/authorization/ResourceAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/authorization/ResourceAdapter.java
@@ -19,7 +19,6 @@ package org.keycloak.models.cache.infinispan.authorization;
 import org.keycloak.authorization.model.CachedModel;
 import org.keycloak.authorization.model.PermissionTicket;
 import org.keycloak.authorization.model.Resource;
-import org.keycloak.authorization.model.ResourceServer;
 import org.keycloak.authorization.model.Scope;
 import org.keycloak.authorization.store.PermissionTicketStore;
 import org.keycloak.authorization.store.PolicyStore;
@@ -81,7 +80,7 @@ public class ResourceAdapter implements Resource, CachedModel<Resource> {
     protected boolean isUpdated() {
         if (updated != null) return true;
         if (!invalidated) return false;
-        updated = cacheSession.getResourceStoreDelegate().findById(cached.getId(), cached.getResourceServerId());
+        updated = cacheSession.getResourceStoreDelegate().findById(cached.getResourceServerId(), cached.getId());
         if (updated == null) throw new IllegalStateException("Not found in database");
         return true;
     }
@@ -173,7 +172,7 @@ public class ResourceAdapter implements Resource, CachedModel<Resource> {
         if (scopes != null) return scopes;
         scopes = new LinkedList<>();
         for (String scopeId : cached.getScopesIds(modelSupplier)) {
-            scopes.add(cacheSession.getScopeStore().findById(scopeId, cached.getResourceServerId()));
+            scopes.add(cacheSession.getScopeStore().findById(cached.getResourceServerId(), scopeId));
         }
         return scopes = Collections.unmodifiableList(scopes);
     }
@@ -204,7 +203,7 @@ public class ResourceAdapter implements Resource, CachedModel<Resource> {
         for (Scope scope : updated.getScopes()) {
             if (!scopes.contains(scope)) {
                 PermissionTicketStore permissionStore = cacheSession.getPermissionTicketStore();
-                List<PermissionTicket> permissions = permissionStore.findByScope(scope.getId(), getResourceServer());
+                List<PermissionTicket> permissions = permissionStore.findByScope(getResourceServer(), scope.getId());
 
                 for (PermissionTicket permission : permissions) {
                     permissionStore.delete(permission.getId());
@@ -216,7 +215,7 @@ public class ResourceAdapter implements Resource, CachedModel<Resource> {
 
         for (Scope scope : updated.getScopes()) {
             if (!scopes.contains(scope)) {
-                policyStore.findByResource(getId(), getResourceServer(), policy -> policy.removeScope(scope));
+                policyStore.findByResource(getResourceServer(), getId(), policy -> policy.removeScope(scope));
             }
         }
 
@@ -283,6 +282,6 @@ public class ResourceAdapter implements Resource, CachedModel<Resource> {
     }
 
     private Resource getResourceModel() {
-        return cacheSession.getResourceStoreDelegate().findById(cached.getId(), cached.getResourceServerId());
+        return cacheSession.getResourceStoreDelegate().findById(cached.getResourceServerId(), cached.getId());
     }
 }

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/authorization/ResourceAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/authorization/ResourceAdapter.java
@@ -19,6 +19,7 @@ package org.keycloak.models.cache.infinispan.authorization;
 import org.keycloak.authorization.model.CachedModel;
 import org.keycloak.authorization.model.PermissionTicket;
 import org.keycloak.authorization.model.Resource;
+import org.keycloak.authorization.model.ResourceServer;
 import org.keycloak.authorization.model.Scope;
 import org.keycloak.authorization.store.PermissionTicketStore;
 import org.keycloak.authorization.store.PolicyStore;
@@ -132,9 +133,9 @@ public class ResourceAdapter implements Resource, CachedModel<Resource> {
     }
 
     @Override
-    public String getResourceServer() {
+    public ResourceServer getResourceServer() {
         if (isUpdated()) return updated.getResourceServer();
-        return cached.getResourceServerId();
+        return cacheSession.getResourceServerStoreDelegate().findById(cached.getResourceServerId());
     }
 
     @Override
@@ -203,7 +204,7 @@ public class ResourceAdapter implements Resource, CachedModel<Resource> {
         for (Scope scope : updated.getScopes()) {
             if (!scopes.contains(scope)) {
                 PermissionTicketStore permissionStore = cacheSession.getPermissionTicketStore();
-                List<PermissionTicket> permissions = permissionStore.findByScope(getResourceServer(), scope.getId());
+                List<PermissionTicket> permissions = permissionStore.findByScope(getResourceServer().getId(), scope.getId());
 
                 for (PermissionTicket permission : permissions) {
                     permissionStore.delete(permission.getId());
@@ -215,7 +216,7 @@ public class ResourceAdapter implements Resource, CachedModel<Resource> {
 
         for (Scope scope : updated.getScopes()) {
             if (!scopes.contains(scope)) {
-                policyStore.findByResource(getResourceServer(), getId(), policy -> policy.removeScope(scope));
+                policyStore.findByResource(getResourceServer().getId(), getId(), policy -> policy.removeScope(scope));
             }
         }
 

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/authorization/ResourceAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/authorization/ResourceAdapter.java
@@ -134,7 +134,6 @@ public class ResourceAdapter implements Resource, CachedModel<Resource> {
 
     @Override
     public ResourceServer getResourceServer() {
-        if (isUpdated()) return updated.getResourceServer();
         return cacheSession.getResourceServerStoreDelegate().findById(cached.getResourceServerId());
     }
 

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/authorization/ResourceServerAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/authorization/ResourceServerAdapter.java
@@ -80,6 +80,11 @@ public class ResourceServerAdapter implements ResourceServer, CachedModel<Resour
     }
 
     @Override
+    public String getClientId() {
+        return getId();
+    }
+
+    @Override
     public boolean isAllowRemoteResourceManagement() {
         if (isUpdated()) return updated.isAllowRemoteResourceManagement();
         return cached.isAllowRemoteResourceManagement();

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/authorization/ResourceServerAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/authorization/ResourceServerAdapter.java
@@ -80,11 +80,6 @@ public class ResourceServerAdapter implements ResourceServer, CachedModel<Resour
     }
 
     @Override
-    public String getClientId() {
-        return getId();
-    }
-
-    @Override
     public boolean isAllowRemoteResourceManagement() {
         if (isUpdated()) return updated.isAllowRemoteResourceManagement();
         return cached.isAllowRemoteResourceManagement();

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/authorization/ScopeAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/authorization/ScopeAdapter.java
@@ -39,7 +39,7 @@ public class ScopeAdapter implements Scope, CachedModel<Scope> {
     public Scope getDelegateForUpdate() {
         if (updated == null) {
             cacheSession.registerScopeInvalidation(cached.getId(), cached.getName(), cached.getResourceServerId());
-            updated = cacheSession.getScopeStoreDelegate().findById(cached.getId(), cached.getResourceServerId());
+            updated = cacheSession.getScopeStoreDelegate().findById(cached.getResourceServerId(), cached.getId());
             if (updated == null) throw new IllegalStateException("Not found in database");
         }
         return updated;
@@ -66,7 +66,7 @@ public class ScopeAdapter implements Scope, CachedModel<Scope> {
     protected boolean isUpdated() {
         if (updated != null) return true;
         if (!invalidated) return false;
-        updated = cacheSession.getScopeStoreDelegate().findById(cached.getId(), cached.getResourceServerId());
+        updated = cacheSession.getScopeStoreDelegate().findById(cached.getResourceServerId(), cached.getId());
         if (updated == null) throw new IllegalStateException("Not found in database");
         return true;
     }

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/authorization/ScopeAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/authorization/ScopeAdapter.java
@@ -39,7 +39,7 @@ public class ScopeAdapter implements Scope, CachedModel<Scope> {
     public Scope getDelegateForUpdate() {
         if (updated == null) {
             cacheSession.registerScopeInvalidation(cached.getId(), cached.getName(), cached.getResourceServerId());
-            updated = cacheSession.getScopeStoreDelegate().findById(cached.getResourceServerId(), cached.getId());
+            updated = cacheSession.getScopeStoreDelegate().findById(getResourceServer(), cached.getId());
             if (updated == null) throw new IllegalStateException("Not found in database");
         }
         return updated;
@@ -66,7 +66,7 @@ public class ScopeAdapter implements Scope, CachedModel<Scope> {
     protected boolean isUpdated() {
         if (updated != null) return true;
         if (!invalidated) return false;
-        updated = cacheSession.getScopeStoreDelegate().findById(cached.getResourceServerId(), cached.getId());
+        updated = cacheSession.getScopeStoreDelegate().findById(getResourceServer(), cached.getId());
         if (updated == null) throw new IllegalStateException("Not found in database");
         return true;
     }

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/authorization/StoreFactoryCacheSession.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/authorization/StoreFactoryCacheSession.java
@@ -520,7 +520,7 @@ public class StoreFactoryCacheSession implements CachedStoreFactoryProvider {
         }
 
         @Override
-        public Scope findById(String resourceServerId, String id) {
+        public Scope findById(ResourceServer resourceServer, String id) {
             if (id == null) return null;
             CachedScope cached = cache.get(id, CachedScope.class);
             if (cached != null) {
@@ -529,7 +529,7 @@ public class StoreFactoryCacheSession implements CachedStoreFactoryProvider {
             if (cached == null) {
                 Long loaded = cache.getCurrentRevision(id);
                 if (! modelMightExist(id)) return null;
-                Scope model = getScopeStoreDelegate().findById(resourceServerId, id);
+                Scope model = getScopeStoreDelegate().findById(resourceServer, id);
                 if (model == null) {
                     setModelDoesNotExists(id, loaded);
                     return null;
@@ -538,7 +538,7 @@ public class StoreFactoryCacheSession implements CachedStoreFactoryProvider {
                 cached = new CachedScope(loaded, model);
                 cache.addRevisioned(cached, startupRevision);
             } else if (invalidations.contains(id)) {
-                return getScopeStoreDelegate().findById(resourceServerId, id);
+                return getScopeStoreDelegate().findById(resourceServer, id);
             } else if (managedScopes.containsKey(id)) {
                 return managedScopes.get(id);
             }
@@ -548,8 +548,9 @@ public class StoreFactoryCacheSession implements CachedStoreFactoryProvider {
         }
 
         @Override
-        public Scope findByName(String resourceServerId, String name) {
+        public Scope findByName(ResourceServer resourceServer, String name) {
             if (name == null) return null;
+            String resourceServerId = resourceServer == null ? null : resourceServer.getId();
             String cacheKey = getScopeByNameCacheKey(name, resourceServerId);
             ScopeListQuery query = cache.get(cacheKey, ScopeListQuery.class);
             if (query != null) {
@@ -557,31 +558,31 @@ public class StoreFactoryCacheSession implements CachedStoreFactoryProvider {
             }
             if (query == null) {
                 Long loaded = cache.getCurrentRevision(cacheKey);
-                Scope model = getScopeStoreDelegate().findByName(resourceServerId, name);
+                Scope model = getScopeStoreDelegate().findByName(resourceServer, name);
                 if (model == null) return null;
                 if (invalidations.contains(model.getId())) return model;
                 query = new ScopeListQuery(loaded, cacheKey, model.getId(), resourceServerId);
                 cache.addRevisioned(query, startupRevision);
                 return model;
             } else if (invalidations.contains(cacheKey)) {
-                return getScopeStoreDelegate().findByName(resourceServerId, name);
+                return getScopeStoreDelegate().findByName(resourceServer, name);
             } else {
                 String id = query.getScopes().iterator().next();
                 if (invalidations.contains(id)) {
-                    return getScopeStoreDelegate().findByName(resourceServerId, name);
+                    return getScopeStoreDelegate().findByName(resourceServer, name);
                 }
-                return findById(query.getResourceServerId(), id);
+                return findById(resourceServer, id);
             }
         }
 
         @Override
-        public List<Scope> findByResourceServer(String id) {
-            return getScopeStoreDelegate().findByResourceServer(id);
+        public List<Scope> findByResourceServer(ResourceServer resourceServer) {
+            return getScopeStoreDelegate().findByResourceServer(resourceServer);
         }
 
         @Override
-        public List<Scope> findByResourceServer(String resourceServerId, Map<Scope.FilterOption, String[]> attributes, int firstResult, int maxResult) {
-            return getScopeStoreDelegate().findByResourceServer(resourceServerId, attributes, firstResult, maxResult);
+        public List<Scope> findByResourceServer(ResourceServer resourceServer, Map<Scope.FilterOption, String[]> attributes, int firstResult, int maxResult) {
+            return getScopeStoreDelegate().findByResourceServer(resourceServer, attributes, firstResult, maxResult);
         }
     }
 

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/authorization/StoreFactoryCacheSession.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/authorization/StoreFactoryCacheSession.java
@@ -605,8 +605,8 @@ public class StoreFactoryCacheSession implements CachedStoreFactoryProvider {
             if (resource == null) return;
 
             cache.invalidateObject(id);
-            invalidationEvents.add(ResourceRemovedEvent.create(id, resource.getName(), resource.getType(), resource.getUris(), resource.getOwner(), resource.getScopes().stream().map(scope -> scope.getId()).collect(Collectors.toSet()), resource.getResourceServer()));
-            cache.resourceRemoval(id, resource.getName(), resource.getType(), resource.getUris(), resource.getOwner(), resource.getScopes().stream().map(scope -> scope.getId()).collect(Collectors.toSet()), resource.getResourceServer(), invalidations);
+            invalidationEvents.add(ResourceRemovedEvent.create(id, resource.getName(), resource.getType(), resource.getUris(), resource.getOwner(), resource.getScopes().stream().map(scope -> scope.getId()).collect(Collectors.toSet()), resource.getResourceServer().getId()));
+            cache.resourceRemoval(id, resource.getName(), resource.getType(), resource.getUris(), resource.getOwner(), resource.getScopes().stream().map(scope -> scope.getId()).collect(Collectors.toSet()), resource.getResourceServer().getId(), invalidations);
             getResourceStoreDelegate().delete(id);
 
         }

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/authorization/StoreFactoryCacheSession.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/authorization/StoreFactoryCacheSession.java
@@ -582,8 +582,8 @@ public class StoreFactoryCacheSession implements CachedStoreFactoryProvider {
         }
 
         @Override
-        public List<Scope> findByResourceServer(ResourceServer resourceServer, Map<Scope.FilterOption, String[]> attributes, int firstResult, int maxResult) {
-            return getScopeStoreDelegate().findByResourceServer(resourceServer, attributes, firstResult, maxResult);
+        public List<Scope> findByResourceServer(ResourceServer resourceServer, Map<Scope.FilterOption, String[]> attributes, Integer firstResult, Integer maxResults) {
+            return getScopeStoreDelegate().findByResourceServer(resourceServer, attributes, firstResult, maxResults);
         }
     }
 
@@ -692,8 +692,8 @@ public class StoreFactoryCacheSession implements CachedStoreFactoryProvider {
         }
 
         @Override
-        public List<Resource> findByOwner(ResourceServer resourceServer, String ownerId, int first, int max) {
-            return getResourceStoreDelegate().findByOwner(resourceServer, ownerId, first, max);
+        public List<Resource> findByOwner(ResourceServer resourceServer, String ownerId, Integer firstResult, Integer maxResults) {
+            return getResourceStoreDelegate().findByOwner(resourceServer, ownerId, firstResult, maxResults);
         }
 
         @Override
@@ -711,8 +711,8 @@ public class StoreFactoryCacheSession implements CachedStoreFactoryProvider {
         }
 
         @Override
-        public List<Resource> findByResourceServer(ResourceServer resourceServer, Map<Resource.FilterOption, String[]> attributes, int firstResult, int maxResult) {
-            return getResourceStoreDelegate().findByResourceServer(resourceServer, attributes, firstResult, maxResult);
+        public List<Resource> findByResourceServer(ResourceServer resourceServer, Map<Resource.FilterOption, String[]> attributes, Integer firstResult, Integer maxResults) {
+            return getResourceStoreDelegate().findByResourceServer(resourceServer, attributes, firstResult, maxResults);
         }
 
         @Override
@@ -976,8 +976,8 @@ public class StoreFactoryCacheSession implements CachedStoreFactoryProvider {
         }
 
         @Override
-        public List<Policy> findByResourceServer(ResourceServer resourceServer, Map<Policy.FilterOption, String[]> attributes, int firstResult, int maxResult) {
-            return getPolicyStoreDelegate().findByResourceServer(resourceServer, attributes, firstResult, maxResult);
+        public List<Policy> findByResourceServer(ResourceServer resourceServer, Map<Policy.FilterOption, String[]> attributes, Integer firstResult, Integer maxResults) {
+            return getPolicyStoreDelegate().findByResourceServer(resourceServer, attributes, firstResult, maxResults);
         }
 
         @Override
@@ -1217,7 +1217,7 @@ public class StoreFactoryCacheSession implements CachedStoreFactoryProvider {
         }
 
         @Override
-        public List<PermissionTicket> find(ResourceServer resourceServer, Map<PermissionTicket.FilterOption, String> attributes, int firstResult, int maxResult) {
+        public List<PermissionTicket> find(ResourceServer resourceServer, Map<PermissionTicket.FilterOption, String> attributes, Integer firstResult, Integer maxResult) {
             return getPermissionTicketStoreDelegate().find(resourceServer, attributes, firstResult, maxResult);
         }
 
@@ -1238,13 +1238,13 @@ public class StoreFactoryCacheSession implements CachedStoreFactoryProvider {
         }
 
         @Override
-        public List<Resource> findGrantedResources(String requester, String name, int first, int max) {
+        public List<Resource> findGrantedResources(String requester, String name, Integer first, Integer max) {
             return getPermissionTicketStoreDelegate().findGrantedResources(requester, name, first, max);
         }
 
         @Override
-        public List<Resource> findGrantedOwnerResources(String owner, int first, int max) {
-            return getPermissionTicketStoreDelegate().findGrantedOwnerResources(owner, first, max);
+        public List<Resource> findGrantedOwnerResources(String owner, Integer firstResult, Integer maxResults) {
+            return getPermissionTicketStoreDelegate().findGrantedOwnerResources(owner, firstResult, maxResults);
         }
 
         @Override

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/authorization/entities/CachedResource.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/authorization/entities/CachedResource.java
@@ -56,7 +56,7 @@ public class CachedResource extends AbstractRevisioned implements InResourceServ
         this.type = resource.getType();
         this.owner = resource.getOwner();
         this.iconUri = resource.getIconUri();
-        this.resourceServerId = resource.getResourceServer();
+        this.resourceServerId = resource.getResourceServer().getId();
         ownerManagedAccess = resource.isOwnerManagedAccess();
 
         this.uris = new DefaultLazyLoader<>(source -> new HashSet<>(source.getUris()), Collections::emptySet);

--- a/model/jpa/src/main/java/org/keycloak/authorization/jpa/store/JPAPermissionTicketStore.java
+++ b/model/jpa/src/main/java/org/keycloak/authorization/jpa/store/JPAPermissionTicketStore.java
@@ -37,8 +37,10 @@ import org.keycloak.authorization.jpa.entities.PermissionTicketEntity;
 import org.keycloak.authorization.model.PermissionTicket;
 import org.keycloak.authorization.model.Resource;
 import org.keycloak.authorization.model.ResourceServer;
+import org.keycloak.authorization.model.Scope;
 import org.keycloak.authorization.store.PermissionTicketStore;
 import org.keycloak.authorization.store.ResourceStore;
+import org.keycloak.common.util.Time;
 import org.keycloak.models.utils.KeycloakModelUtils;
 import javax.persistence.LockModeType;
 
@@ -59,14 +61,14 @@ public class JPAPermissionTicketStore implements PermissionTicketStore {
     }
 
     @Override
-    public long count(String resourceServerId, Map<PermissionTicket.FilterOption, String> attributes) {
+    public long count(ResourceServer resourceServer, Map<PermissionTicket.FilterOption, String> attributes) {
         CriteriaBuilder builder = entityManager.getCriteriaBuilder();
         CriteriaQuery<Long> querybuilder = builder.createQuery(Long.class);
         Root<PermissionTicketEntity> root = querybuilder.from(PermissionTicketEntity.class);
 
         querybuilder.select(root.get("id"));
 
-        List<Predicate> predicates = getPredicates(builder, root, resourceServerId, attributes);
+        List<Predicate> predicates = getPredicates(builder, root, resourceServer, attributes);
 
         querybuilder.where(predicates.toArray(new Predicate[predicates.size()])).orderBy(builder.asc(root.get("id")));
 
@@ -77,12 +79,12 @@ public class JPAPermissionTicketStore implements PermissionTicketStore {
 
     private List<Predicate> getPredicates(CriteriaBuilder builder,
                                           Root<PermissionTicketEntity> root,
-                                          String resourceServerId,
+                                          ResourceServer resourceServer,
                                           Map<PermissionTicket.FilterOption, String> attributes) {
         List<Predicate> predicates = new ArrayList<>();
 
-        if (resourceServerId != null) {
-            predicates.add(builder.equal(root.get("resourceServer").get("id"), resourceServerId));
+        if (resourceServer != null) {
+            predicates.add(builder.equal(root.get("resourceServer").get("id"), resourceServer.getId()));
         }
 
         attributes.forEach((filterOption, value) -> {
@@ -127,16 +129,16 @@ public class JPAPermissionTicketStore implements PermissionTicketStore {
     }
 
     @Override
-    public PermissionTicket create(ResourceServer resourceServer, String resourceId, String scopeId, String requester) {
+    public PermissionTicket create(ResourceServer resourceServer, Resource resource, Scope scope, String requester) {
         PermissionTicketEntity entity = new PermissionTicketEntity();
 
         entity.setId(KeycloakModelUtils.generateId());
-        entity.setResource(ResourceAdapter.toEntity(entityManager, provider.getStoreFactory().getResourceStore().findById(resourceServer.getId(), resourceId)));
+        entity.setResource(ResourceAdapter.toEntity(entityManager, resource));
         entity.setRequester(requester);
-        entity.setCreatedTimestamp(System.currentTimeMillis());
+        entity.setCreatedTimestamp(Time.currentTimeMillis());
 
-        if (scopeId != null) {
-            entity.setScope(ScopeAdapter.toEntity(entityManager, provider.getStoreFactory().getScopeStore().findById(resourceServer.getId(), scopeId)));
+        if (scope != null) {
+            entity.setScope(ScopeAdapter.toEntity(entityManager, scope));
         }
 
         entity.setOwner(entity.getResource().getOwner());
@@ -158,7 +160,7 @@ public class JPAPermissionTicketStore implements PermissionTicketStore {
 
 
     @Override
-    public PermissionTicket findById(String resourceServerId, String id) {
+    public PermissionTicket findById(ResourceServer resourceServer, String id) {
         if (id == null) {
             return null;
         }
@@ -170,17 +172,17 @@ public class JPAPermissionTicketStore implements PermissionTicketStore {
     }
 
     @Override
-    public List<PermissionTicket> findByResourceServer(final String resourceServerId) {
+    public List<PermissionTicket> findByResourceServer(final ResourceServer resourceServer) {
         TypedQuery<String> query = entityManager.createNamedQuery("findPolicyIdByServerId", String.class);
 
-        query.setParameter("serverId", resourceServerId);
+        query.setParameter("serverId", resourceServer == null ? null : resourceServer.getId());
 
         List<String> result = query.getResultList();
         List<PermissionTicket> list = new LinkedList<>();
         PermissionTicketStore ticketStore = provider.getStoreFactory().getPermissionTicketStore();
 
         for (String id : result) {
-            PermissionTicket ticket = ticketStore.findById(resourceServerId, id);
+            PermissionTicket ticket = ticketStore.findById(resourceServer, id);
             if (Objects.nonNull(ticket)) {
                 list.add(ticket);
             }
@@ -190,19 +192,19 @@ public class JPAPermissionTicketStore implements PermissionTicketStore {
     }
 
     @Override
-    public List<PermissionTicket> findByResource(String resourceServerId, final String resourceId) {
+    public List<PermissionTicket> findByResource(ResourceServer resourceServer, final Resource resource) {
         TypedQuery<String> query = entityManager.createNamedQuery("findPermissionIdByResource", String.class);
 
         query.setFlushMode(FlushModeType.COMMIT);
-        query.setParameter("resourceId", resourceId);
-        query.setParameter("serverId", resourceServerId);
+        query.setParameter("resourceId", resource.getId());
+        query.setParameter("serverId", resourceServer == null ? null : resourceServer.getId());
 
         List<String> result = query.getResultList();
         List<PermissionTicket> list = new LinkedList<>();
         PermissionTicketStore ticketStore = provider.getStoreFactory().getPermissionTicketStore();
 
         for (String id : result) {
-            PermissionTicket ticket = ticketStore.findById(resourceServerId, id);
+            PermissionTicket ticket = ticketStore.findById(resourceServer, id);
             if (Objects.nonNull(ticket)) {
                 list.add(ticket);
             }
@@ -212,8 +214,8 @@ public class JPAPermissionTicketStore implements PermissionTicketStore {
     }
 
     @Override
-    public List<PermissionTicket> findByScope(String resourceServerId, String scopeId) {
-        if (scopeId==null) {
+    public List<PermissionTicket> findByScope(ResourceServer resourceServer, Scope scope) {
+        if (scope == null) {
             return Collections.emptyList();
         }
 
@@ -221,15 +223,15 @@ public class JPAPermissionTicketStore implements PermissionTicketStore {
         TypedQuery<String> query = entityManager.createNamedQuery("findPermissionIdByScope", String.class);
 
         query.setFlushMode(FlushModeType.COMMIT);
-        query.setParameter("scopeId", scopeId);
-        query.setParameter("serverId", resourceServerId);
+        query.setParameter("scopeId", scope.getId());
+        query.setParameter("serverId", resourceServer == null ? null : resourceServer.getId());
 
         List<String> result = query.getResultList();
         List<PermissionTicket> list = new LinkedList<>();
         PermissionTicketStore ticketStore = provider.getStoreFactory().getPermissionTicketStore();
 
         for (String id : result) {
-            PermissionTicket ticket = ticketStore.findById(resourceServerId, id);
+            PermissionTicket ticket = ticketStore.findById(resourceServer, id);
             if (Objects.nonNull(ticket)) {
                 list.add(ticket);
             }
@@ -239,14 +241,14 @@ public class JPAPermissionTicketStore implements PermissionTicketStore {
     }
 
     @Override
-    public List<PermissionTicket> find(String resourceServerId, Map<PermissionTicket.FilterOption, String> attributes, int firstResult, int maxResult) {
+    public List<PermissionTicket> find(ResourceServer resourceServer, Map<PermissionTicket.FilterOption, String> attributes, int firstResult, int maxResult) {
         CriteriaBuilder builder = entityManager.getCriteriaBuilder();
         CriteriaQuery<PermissionTicketEntity> querybuilder = builder.createQuery(PermissionTicketEntity.class);
         Root<PermissionTicketEntity> root = querybuilder.from(PermissionTicketEntity.class);
 
         querybuilder.select(root.get("id"));
 
-        List<Predicate> predicates = getPredicates(builder, root, resourceServerId, attributes);
+        List<Predicate> predicates = getPredicates(builder, root, resourceServer, attributes);
 
         querybuilder.where(predicates.toArray(new Predicate[predicates.size()])).orderBy(builder.asc(root.get("id")));
 
@@ -257,7 +259,7 @@ public class JPAPermissionTicketStore implements PermissionTicketStore {
         PermissionTicketStore ticketStore = provider.getStoreFactory().getPermissionTicketStore();
 
         for (String id : result) {
-            PermissionTicket ticket = ticketStore.findById(resourceServerId, id);
+            PermissionTicket ticket = ticketStore.findById(resourceServer, id);
             if (Objects.nonNull(ticket)) {
                 list.add(ticket);
             }
@@ -267,24 +269,24 @@ public class JPAPermissionTicketStore implements PermissionTicketStore {
     }
 
     @Override
-    public List<PermissionTicket> findGranted(String resourceServerId, String userId) {
+    public List<PermissionTicket> findGranted(ResourceServer resourceServer, String userId) {
         Map<PermissionTicket.FilterOption, String> filters = new EnumMap<>(PermissionTicket.FilterOption.class);
 
         filters.put(PermissionTicket.FilterOption.GRANTED, Boolean.TRUE.toString());
         filters.put(PermissionTicket.FilterOption.REQUESTER, userId);
 
-        return find(resourceServerId, filters, -1, -1);
+        return find(resourceServer, filters, -1, -1);
     }
 
     @Override
-    public List<PermissionTicket> findGranted(String resourceServerId, String resourceName, String userId) {
+    public List<PermissionTicket> findGranted(ResourceServer resourceServer, String resourceName, String userId) {
         Map<PermissionTicket.FilterOption, String> filters = new EnumMap<>(PermissionTicket.FilterOption.class);
 
         filters.put(PermissionTicket.FilterOption.RESOURCE_NAME, resourceName);
         filters.put(PermissionTicket.FilterOption.GRANTED, Boolean.TRUE.toString());
         filters.put(PermissionTicket.FilterOption.REQUESTER, userId);
 
-        return find(resourceServerId, filters, -1, -1);
+        return find(resourceServer, filters, -1, -1);
     }
 
     @Override
@@ -338,11 +340,11 @@ public class JPAPermissionTicketStore implements PermissionTicketStore {
     }
 
     @Override
-    public List<PermissionTicket> findByOwner(String resourceServerId, String owner) {
+    public List<PermissionTicket> findByOwner(ResourceServer resourceServer, String owner) {
         TypedQuery<String> query = entityManager.createNamedQuery("findPolicyIdByType", String.class);
 
         query.setFlushMode(FlushModeType.COMMIT);
-        query.setParameter("serverId", resourceServerId);
+        query.setParameter("serverId", resourceServer == null ? null : resourceServer.getId());
         query.setParameter("owner", owner);
 
         List<String> result = query.getResultList();
@@ -350,7 +352,7 @@ public class JPAPermissionTicketStore implements PermissionTicketStore {
         PermissionTicketStore ticketStore = provider.getStoreFactory().getPermissionTicketStore();
 
         for (String id : result) {
-            PermissionTicket ticket = ticketStore.findById(resourceServerId, id);
+            PermissionTicket ticket = ticketStore.findById(resourceServer, id);
             if (Objects.nonNull(ticket)) {
                 list.add(ticket);
             }

--- a/model/jpa/src/main/java/org/keycloak/authorization/jpa/store/JPAPermissionTicketStore.java
+++ b/model/jpa/src/main/java/org/keycloak/authorization/jpa/store/JPAPermissionTicketStore.java
@@ -241,7 +241,7 @@ public class JPAPermissionTicketStore implements PermissionTicketStore {
     }
 
     @Override
-    public List<PermissionTicket> find(ResourceServer resourceServer, Map<PermissionTicket.FilterOption, String> attributes, int firstResult, int maxResult) {
+    public List<PermissionTicket> find(ResourceServer resourceServer, Map<PermissionTicket.FilterOption, String> attributes, Integer firstResult, Integer maxResult) {
         CriteriaBuilder builder = entityManager.getCriteriaBuilder();
         CriteriaQuery<PermissionTicketEntity> querybuilder = builder.createQuery(PermissionTicketEntity.class);
         Root<PermissionTicketEntity> root = querybuilder.from(PermissionTicketEntity.class);
@@ -275,7 +275,7 @@ public class JPAPermissionTicketStore implements PermissionTicketStore {
         filters.put(PermissionTicket.FilterOption.GRANTED, Boolean.TRUE.toString());
         filters.put(PermissionTicket.FilterOption.REQUESTER, userId);
 
-        return find(resourceServer, filters, -1, -1);
+        return find(resourceServer, filters, null, null);
     }
 
     @Override
@@ -286,11 +286,11 @@ public class JPAPermissionTicketStore implements PermissionTicketStore {
         filters.put(PermissionTicket.FilterOption.GRANTED, Boolean.TRUE.toString());
         filters.put(PermissionTicket.FilterOption.REQUESTER, userId);
 
-        return find(resourceServer, filters, -1, -1);
+        return find(resourceServer, filters, null, null);
     }
 
     @Override
-    public List<Resource> findGrantedResources(String requester, String name, int first, int max) {
+    public List<Resource> findGrantedResources(String requester, String name, Integer first, Integer max) {
         TypedQuery<String> query = name == null ? 
                 entityManager.createNamedQuery("findGrantedResources", String.class) :
                 entityManager.createNamedQuery("findGrantedResourcesByName", String.class);
@@ -318,13 +318,13 @@ public class JPAPermissionTicketStore implements PermissionTicketStore {
     }
 
     @Override
-    public List<Resource> findGrantedOwnerResources(String owner, int first, int max) {
+    public List<Resource> findGrantedOwnerResources(String owner, Integer firstResult, Integer maxResults) {
         TypedQuery<String> query = entityManager.createNamedQuery("findGrantedOwnerResources", String.class);
 
         query.setFlushMode(FlushModeType.COMMIT);
         query.setParameter("owner", owner);
 
-        List<String> result = paginateQuery(query, first, max).getResultList();
+        List<String> result = paginateQuery(query, firstResult, maxResults).getResultList();
         List<Resource> list = new LinkedList<>();
         ResourceStore resourceStore = provider.getStoreFactory().getResourceStore();
 

--- a/model/jpa/src/main/java/org/keycloak/authorization/jpa/store/JPAPolicyStore.java
+++ b/model/jpa/src/main/java/org/keycloak/authorization/jpa/store/JPAPolicyStore.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import javax.persistence.EntityManager;
 import javax.persistence.FlushModeType;
@@ -37,7 +38,9 @@ import javax.persistence.criteria.Root;
 import org.keycloak.authorization.AuthorizationProvider;
 import org.keycloak.authorization.jpa.entities.PolicyEntity;
 import org.keycloak.authorization.model.Policy;
+import org.keycloak.authorization.model.Resource;
 import org.keycloak.authorization.model.ResourceServer;
+import org.keycloak.authorization.model.Scope;
 import org.keycloak.authorization.store.PolicyStore;
 import org.keycloak.authorization.store.StoreFactory;
 import org.keycloak.models.utils.KeycloakModelUtils;
@@ -89,7 +92,7 @@ public class JPAPolicyStore implements PolicyStore {
 
 
     @Override
-    public Policy findById(String resourceServerId, String id) {
+    public Policy findById(ResourceServer resourceServer, String id) {
         if (id == null) {
             return null;
         }
@@ -104,11 +107,11 @@ public class JPAPolicyStore implements PolicyStore {
     }
 
     @Override
-    public Policy findByName(String resourceServerId, String name) {
+    public Policy findByName(ResourceServer resourceServer, String name) {
         TypedQuery<PolicyEntity> query = entityManager.createNamedQuery("findPolicyIdByName", PolicyEntity.class);
 
         query.setFlushMode(FlushModeType.COMMIT);
-        query.setParameter("serverId", resourceServerId);
+        query.setParameter("serverId", resourceServer.getId());
         query.setParameter("name", name);
 
         try {
@@ -119,15 +122,15 @@ public class JPAPolicyStore implements PolicyStore {
     }
 
     @Override
-    public List<Policy> findByResourceServer(final String resourceServerId) {
+    public List<Policy> findByResourceServer(final ResourceServer resourceServer) {
         TypedQuery<String> query = entityManager.createNamedQuery("findPolicyIdByServerId", String.class);
 
-        query.setParameter("serverId", resourceServerId);
+        query.setParameter("serverId", resourceServer.getId());
 
         List<String> result = query.getResultList();
         List<Policy> list = new LinkedList<>();
         for (String id : result) {
-            Policy policy = provider.getStoreFactory().getPolicyStore().findById(resourceServerId, id);
+            Policy policy = provider.getStoreFactory().getPolicyStore().findById(resourceServer, id);
             if (Objects.nonNull(policy)) {
                 list.add(policy);
             }
@@ -136,15 +139,15 @@ public class JPAPolicyStore implements PolicyStore {
     }
 
     @Override
-    public List<Policy> findByResourceServer(String resourceServerId, Map<Policy.FilterOption, String[]> attributes, int firstResult, int maxResult) {
+    public List<Policy> findByResourceServer(ResourceServer resourceServer, Map<Policy.FilterOption, String[]> attributes, int firstResult, int maxResult) {
         CriteriaBuilder builder = entityManager.getCriteriaBuilder();
         CriteriaQuery<PolicyEntity> querybuilder = builder.createQuery(PolicyEntity.class);
         Root<PolicyEntity> root = querybuilder.from(PolicyEntity.class);
         List<Predicate> predicates = new ArrayList();
         querybuilder.select(root.get("id"));
 
-        if (resourceServerId != null) {
-            predicates.add(builder.equal(root.get("resourceServer").get("id"), resourceServerId));
+        if (resourceServer != null) {
+            predicates.add(builder.equal(root.get("resourceServer").get("id"), resourceServer.getId()));
         }
 
         attributes.forEach((filterOption, value) -> {
@@ -196,7 +199,7 @@ public class JPAPolicyStore implements PolicyStore {
         List<String> result = paginateQuery(query, firstResult, maxResult).getResultList();
         List<Policy> list = new LinkedList<>();
         for (String id : result) {
-            Policy policy = provider.getStoreFactory().getPolicyStore().findById(resourceServerId, id);
+            Policy policy = provider.getStoreFactory().getPolicyStore().findById(resourceServer, id);
             if (Objects.nonNull(policy)) {
                 list.add(policy);
             }
@@ -205,28 +208,28 @@ public class JPAPolicyStore implements PolicyStore {
     }
 
     @Override
-    public void findByResource(String resourceServerId, String resourceId, Consumer<Policy> consumer) {
+    public void findByResource(ResourceServer resourceServer, Resource resource, Consumer<Policy> consumer) {
         TypedQuery<PolicyEntity> query = entityManager.createNamedQuery("findPolicyIdByResource", PolicyEntity.class);
 
         query.setFlushMode(FlushModeType.COMMIT);
-        query.setParameter("resourceId", resourceId);
-        query.setParameter("serverId", resourceServerId);
+        query.setParameter("resourceId", resource.getId());
+        query.setParameter("serverId", resourceServer.getId());
 
         PolicyStore storeFactory = provider.getStoreFactory().getPolicyStore();
 
         closing(query.getResultStream()
-                .map(entity -> storeFactory.findById(resourceServerId, entity.getId()))
+                .map(entity -> storeFactory.findById(resourceServer, entity.getId()))
                 .filter(Objects::nonNull))
                 .forEach(consumer::accept);
     }
 
     @Override
-    public void findByResourceType(String resourceServerId, String resourceType, Consumer<Policy> consumer) {
+    public void findByResourceType(ResourceServer resourceServer, String resourceType, Consumer<Policy> consumer) {
         TypedQuery<PolicyEntity> query = entityManager.createNamedQuery("findPolicyIdByResourceType", PolicyEntity.class);
 
         query.setFlushMode(FlushModeType.COMMIT);
         query.setParameter("type", resourceType);
-        query.setParameter("serverId", resourceServerId);
+        query.setParameter("serverId", resourceServer.getId());
 
         closing(query.getResultStream()
                 .map(id -> new PolicyAdapter(id, entityManager, provider.getStoreFactory()))
@@ -235,8 +238,8 @@ public class JPAPolicyStore implements PolicyStore {
     }
 
     @Override
-    public List<Policy> findByScopeIds(String resourceServerId, List<String> scopeIds) {
-        if (scopeIds==null || scopeIds.isEmpty()) {
+    public List<Policy> findByScopes(ResourceServer resourceServer, List<Scope> scopes) {
+        if (scopes==null || scopes.isEmpty()) {
             return Collections.emptyList();
         }
 
@@ -244,34 +247,34 @@ public class JPAPolicyStore implements PolicyStore {
         TypedQuery<PolicyEntity> query = entityManager.createNamedQuery("findPolicyIdByScope", PolicyEntity.class);
 
         query.setFlushMode(FlushModeType.COMMIT);
-        query.setParameter("scopeIds", scopeIds);
-        query.setParameter("serverId", resourceServerId);
+        query.setParameter("scopeIds", scopes.stream().map(Scope::getId).collect(Collectors.toSet()));
+        query.setParameter("serverId", resourceServer.getId());
 
         List<Policy> list = new LinkedList<>();
         PolicyStore storeFactory = provider.getStoreFactory().getPolicyStore();
 
         for (PolicyEntity entity : query.getResultList()) {
-            list.add(storeFactory.findById(resourceServerId, entity.getId()));
+            list.add(storeFactory.findById(resourceServer, entity.getId()));
         }
 
         return list;
     }
 
     @Override
-    public void findByScopeIds(String resourceServerId, String resourceId, List<String> scopeIds, Consumer<Policy> consumer) {
+    public void findByScopes(ResourceServer resourceServer, Resource resource, List<Scope> scopes, Consumer<Policy> consumer) {
         // Use separate subquery to handle DB2 and MSSSQL
         TypedQuery<PolicyEntity> query;
 
-        if (resourceId == null) {
+        if (resource == null) {
             query = entityManager.createNamedQuery("findPolicyIdByNullResourceScope", PolicyEntity.class);
         } else {
             query = entityManager.createNamedQuery("findPolicyIdByResourceScope", PolicyEntity.class);
-            query.setParameter("resourceId", resourceId);
+            query.setParameter("resourceId", resource.getId());
         }
 
         query.setFlushMode(FlushModeType.COMMIT);
-        query.setParameter("scopeIds", scopeIds);
-        query.setParameter("serverId", resourceServerId);
+        query.setParameter("scopeIds", scopes.stream().map(Scope::getId).collect(Collectors.toSet()));
+        query.setParameter("serverId", resourceServer.getId());
 
         StoreFactory storeFactory = provider.getStoreFactory();
 
@@ -282,17 +285,17 @@ public class JPAPolicyStore implements PolicyStore {
     }
 
     @Override
-    public List<Policy> findByType(String resourceServerId, String type) {
+    public List<Policy> findByType(ResourceServer resourceServer, String type) {
         TypedQuery<String> query = entityManager.createNamedQuery("findPolicyIdByType", String.class);
 
         query.setFlushMode(FlushModeType.COMMIT);
-        query.setParameter("serverId", resourceServerId);
+        query.setParameter("serverId", resourceServer.getId());
         query.setParameter("type", type);
 
         List<String> result = query.getResultList();
         List<Policy> list = new LinkedList<>();
         for (String id : result) {
-            Policy policy = provider.getStoreFactory().getPolicyStore().findById(resourceServerId, id);
+            Policy policy = provider.getStoreFactory().getPolicyStore().findById(resourceServer, id);
             if (Objects.nonNull(policy)) {
                 list.add(policy);
             }
@@ -301,18 +304,18 @@ public class JPAPolicyStore implements PolicyStore {
     }
 
     @Override
-    public List<Policy> findDependentPolicies(String resourceServerId, String policyId) {
+    public List<Policy> findDependentPolicies(ResourceServer resourceServer, String policyId) {
 
         TypedQuery<String> query = entityManager.createNamedQuery("findPolicyIdByDependentPolices", String.class);
 
         query.setFlushMode(FlushModeType.COMMIT);
-        query.setParameter("serverId", resourceServerId);
+        query.setParameter("serverId", resourceServer.getId());
         query.setParameter("policyId", policyId);
 
         List<String> result = query.getResultList();
         List<Policy> list = new LinkedList<>();
         for (String id : result) {
-            Policy policy = provider.getStoreFactory().getPolicyStore().findById(resourceServerId, id);
+            Policy policy = provider.getStoreFactory().getPolicyStore().findById(resourceServer, id);
             if (Objects.nonNull(policy)) {
                 list.add(policy);
             }

--- a/model/jpa/src/main/java/org/keycloak/authorization/jpa/store/JPAPolicyStore.java
+++ b/model/jpa/src/main/java/org/keycloak/authorization/jpa/store/JPAPolicyStore.java
@@ -60,7 +60,7 @@ public class JPAPolicyStore implements PolicyStore {
     }
 
     @Override
-    public Policy create(AbstractPolicyRepresentation representation, ResourceServer resourceServer) {
+    public Policy create(ResourceServer resourceServer, AbstractPolicyRepresentation representation) {
         PolicyEntity entity = new PolicyEntity();
 
         if (representation.getId() == null) {
@@ -89,7 +89,7 @@ public class JPAPolicyStore implements PolicyStore {
 
 
     @Override
-    public Policy findById(String id, String resourceServerId) {
+    public Policy findById(String resourceServerId, String id) {
         if (id == null) {
             return null;
         }
@@ -104,7 +104,7 @@ public class JPAPolicyStore implements PolicyStore {
     }
 
     @Override
-    public Policy findByName(String name, String resourceServerId) {
+    public Policy findByName(String resourceServerId, String name) {
         TypedQuery<PolicyEntity> query = entityManager.createNamedQuery("findPolicyIdByName", PolicyEntity.class);
 
         query.setFlushMode(FlushModeType.COMMIT);
@@ -127,7 +127,7 @@ public class JPAPolicyStore implements PolicyStore {
         List<String> result = query.getResultList();
         List<Policy> list = new LinkedList<>();
         for (String id : result) {
-            Policy policy = provider.getStoreFactory().getPolicyStore().findById(id, resourceServerId);
+            Policy policy = provider.getStoreFactory().getPolicyStore().findById(resourceServerId, id);
             if (Objects.nonNull(policy)) {
                 list.add(policy);
             }
@@ -136,7 +136,7 @@ public class JPAPolicyStore implements PolicyStore {
     }
 
     @Override
-    public List<Policy> findByResourceServer(Map<Policy.FilterOption, String[]> attributes, String resourceServerId, int firstResult, int maxResult) {
+    public List<Policy> findByResourceServer(String resourceServerId, Map<Policy.FilterOption, String[]> attributes, int firstResult, int maxResult) {
         CriteriaBuilder builder = entityManager.getCriteriaBuilder();
         CriteriaQuery<PolicyEntity> querybuilder = builder.createQuery(PolicyEntity.class);
         Root<PolicyEntity> root = querybuilder.from(PolicyEntity.class);
@@ -196,7 +196,7 @@ public class JPAPolicyStore implements PolicyStore {
         List<String> result = paginateQuery(query, firstResult, maxResult).getResultList();
         List<Policy> list = new LinkedList<>();
         for (String id : result) {
-            Policy policy = provider.getStoreFactory().getPolicyStore().findById(id, resourceServerId);
+            Policy policy = provider.getStoreFactory().getPolicyStore().findById(resourceServerId, id);
             if (Objects.nonNull(policy)) {
                 list.add(policy);
             }
@@ -205,7 +205,7 @@ public class JPAPolicyStore implements PolicyStore {
     }
 
     @Override
-    public void findByResource(String resourceId, String resourceServerId, Consumer<Policy> consumer) {
+    public void findByResource(String resourceServerId, String resourceId, Consumer<Policy> consumer) {
         TypedQuery<PolicyEntity> query = entityManager.createNamedQuery("findPolicyIdByResource", PolicyEntity.class);
 
         query.setFlushMode(FlushModeType.COMMIT);
@@ -215,13 +215,13 @@ public class JPAPolicyStore implements PolicyStore {
         PolicyStore storeFactory = provider.getStoreFactory().getPolicyStore();
 
         closing(query.getResultStream()
-                .map(entity -> storeFactory.findById(entity.getId(), resourceServerId))
+                .map(entity -> storeFactory.findById(resourceServerId, entity.getId()))
                 .filter(Objects::nonNull))
                 .forEach(consumer::accept);
     }
 
     @Override
-    public void findByResourceType(String resourceType, String resourceServerId, Consumer<Policy> consumer) {
+    public void findByResourceType(String resourceServerId, String resourceType, Consumer<Policy> consumer) {
         TypedQuery<PolicyEntity> query = entityManager.createNamedQuery("findPolicyIdByResourceType", PolicyEntity.class);
 
         query.setFlushMode(FlushModeType.COMMIT);
@@ -235,7 +235,7 @@ public class JPAPolicyStore implements PolicyStore {
     }
 
     @Override
-    public List<Policy> findByScopeIds(List<String> scopeIds, String resourceServerId) {
+    public List<Policy> findByScopeIds(String resourceServerId, List<String> scopeIds) {
         if (scopeIds==null || scopeIds.isEmpty()) {
             return Collections.emptyList();
         }
@@ -251,14 +251,14 @@ public class JPAPolicyStore implements PolicyStore {
         PolicyStore storeFactory = provider.getStoreFactory().getPolicyStore();
 
         for (PolicyEntity entity : query.getResultList()) {
-            list.add(storeFactory.findById(entity.getId(), resourceServerId));
+            list.add(storeFactory.findById(resourceServerId, entity.getId()));
         }
 
         return list;
     }
 
     @Override
-    public void findByScopeIds(List<String> scopeIds, String resourceId, String resourceServerId, Consumer<Policy> consumer) {
+    public void findByScopeIds(String resourceServerId, String resourceId, List<String> scopeIds, Consumer<Policy> consumer) {
         // Use separate subquery to handle DB2 and MSSSQL
         TypedQuery<PolicyEntity> query;
 
@@ -282,7 +282,7 @@ public class JPAPolicyStore implements PolicyStore {
     }
 
     @Override
-    public List<Policy> findByType(String type, String resourceServerId) {
+    public List<Policy> findByType(String resourceServerId, String type) {
         TypedQuery<String> query = entityManager.createNamedQuery("findPolicyIdByType", String.class);
 
         query.setFlushMode(FlushModeType.COMMIT);
@@ -292,7 +292,7 @@ public class JPAPolicyStore implements PolicyStore {
         List<String> result = query.getResultList();
         List<Policy> list = new LinkedList<>();
         for (String id : result) {
-            Policy policy = provider.getStoreFactory().getPolicyStore().findById(id, resourceServerId);
+            Policy policy = provider.getStoreFactory().getPolicyStore().findById(resourceServerId, id);
             if (Objects.nonNull(policy)) {
                 list.add(policy);
             }
@@ -301,7 +301,7 @@ public class JPAPolicyStore implements PolicyStore {
     }
 
     @Override
-    public List<Policy> findDependentPolicies(String policyId, String resourceServerId) {
+    public List<Policy> findDependentPolicies(String resourceServerId, String policyId) {
 
         TypedQuery<String> query = entityManager.createNamedQuery("findPolicyIdByDependentPolices", String.class);
 
@@ -312,7 +312,7 @@ public class JPAPolicyStore implements PolicyStore {
         List<String> result = query.getResultList();
         List<Policy> list = new LinkedList<>();
         for (String id : result) {
-            Policy policy = provider.getStoreFactory().getPolicyStore().findById(id, resourceServerId);
+            Policy policy = provider.getStoreFactory().getPolicyStore().findById(resourceServerId, id);
             if (Objects.nonNull(policy)) {
                 list.add(policy);
             }

--- a/model/jpa/src/main/java/org/keycloak/authorization/jpa/store/JPAPolicyStore.java
+++ b/model/jpa/src/main/java/org/keycloak/authorization/jpa/store/JPAPolicyStore.java
@@ -139,7 +139,7 @@ public class JPAPolicyStore implements PolicyStore {
     }
 
     @Override
-    public List<Policy> findByResourceServer(ResourceServer resourceServer, Map<Policy.FilterOption, String[]> attributes, int firstResult, int maxResult) {
+    public List<Policy> findByResourceServer(ResourceServer resourceServer, Map<Policy.FilterOption, String[]> attributes, Integer firstResult, Integer maxResults) {
         CriteriaBuilder builder = entityManager.getCriteriaBuilder();
         CriteriaQuery<PolicyEntity> querybuilder = builder.createQuery(PolicyEntity.class);
         Root<PolicyEntity> root = querybuilder.from(PolicyEntity.class);
@@ -196,7 +196,7 @@ public class JPAPolicyStore implements PolicyStore {
 
         TypedQuery query = entityManager.createQuery(querybuilder);
 
-        List<String> result = paginateQuery(query, firstResult, maxResult).getResultList();
+        List<String> result = paginateQuery(query, firstResult, maxResults).getResultList();
         List<Policy> list = new LinkedList<>();
         for (String id : result) {
             Policy policy = provider.getStoreFactory().getPolicyStore().findById(resourceServer, id);

--- a/model/jpa/src/main/java/org/keycloak/authorization/jpa/store/JPAResourceStore.java
+++ b/model/jpa/src/main/java/org/keycloak/authorization/jpa/store/JPAResourceStore.java
@@ -57,7 +57,7 @@ public class JPAResourceStore implements ResourceStore {
     }
 
     @Override
-    public Resource create(String id, String name, ResourceServer resourceServer, String owner) {
+    public Resource create(ResourceServer resourceServer, String id, String name, String owner) {
         ResourceEntity entity = new ResourceEntity();
 
         if (id == null) {
@@ -86,7 +86,7 @@ public class JPAResourceStore implements ResourceStore {
     }
 
     @Override
-    public Resource findById(String id, String resourceServerId) {
+    public Resource findById(String resourceServerId, String id) {
         if (id == null) {
             return null;
         }
@@ -97,12 +97,12 @@ public class JPAResourceStore implements ResourceStore {
     }
 
     @Override
-    public void findByOwner(String ownerId, String resourceServerId, Consumer<Resource> consumer) {
+    public void findByOwner(String resourceServerId, String ownerId, Consumer<Resource> consumer) {
         findByOwnerFilter(ownerId, resourceServerId, consumer, -1, -1);
     }
 
     @Override
-    public List<Resource> findByOwner(String ownerId, String resourceServerId, int first, int max) {
+    public List<Resource> findByOwner(String resourceServerId, String ownerId, int first, int max) {
         List<Resource> list = new LinkedList<>();
 
         findByOwnerFilter(ownerId, resourceServerId, list::add, first, max);
@@ -133,11 +133,11 @@ public class JPAResourceStore implements ResourceStore {
         }
 
         ResourceStore resourceStore = provider.getStoreFactory().getResourceStore();
-        closing(query.getResultStream().map(id -> resourceStore.findById(id.getId(), resourceServerId))).forEach(consumer);
+        closing(query.getResultStream().map(id -> resourceStore.findById(resourceServerId, id.getId()))).forEach(consumer);
     }
 
     @Override
-    public List<Resource> findByUri(String uri, String resourceServerId) {
+    public List<Resource> findByUri(String resourceServerId, String uri) {
         TypedQuery<String> query = entityManager.createNamedQuery("findResourceIdByUri", String.class);
 
         query.setFlushMode(FlushModeType.COMMIT);
@@ -149,7 +149,7 @@ public class JPAResourceStore implements ResourceStore {
         ResourceStore resourceStore = provider.getStoreFactory().getResourceStore();
 
         for (String id : result) {
-            Resource resource = resourceStore.findById(id, resourceServerId);
+            Resource resource = resourceStore.findById(resourceServerId, id);
 
             if (resource != null) {
                 list.add(resource);
@@ -170,7 +170,7 @@ public class JPAResourceStore implements ResourceStore {
         ResourceStore resourceStore = provider.getStoreFactory().getResourceStore();
 
         for (String id : result) {
-            Resource resource = resourceStore.findById(id, resourceServerId);
+            Resource resource = resourceStore.findById(resourceServerId, id);
 
             if (resource != null) {
                 list.add(resource);
@@ -181,7 +181,7 @@ public class JPAResourceStore implements ResourceStore {
     }
 
     @Override
-    public List<Resource> findByResourceServer(Map<Resource.FilterOption, String[]> attributes, String resourceServerId, int firstResult, int maxResult) {
+    public List<Resource> findByResourceServer(String resourceServerId, Map<Resource.FilterOption, String[]> attributes, int firstResult, int maxResult) {
         CriteriaBuilder builder = entityManager.getCriteriaBuilder();
         CriteriaQuery<ResourceEntity> querybuilder = builder.createQuery(ResourceEntity.class);
         Root<ResourceEntity> root = querybuilder.from(ResourceEntity.class);
@@ -234,7 +234,7 @@ public class JPAResourceStore implements ResourceStore {
         ResourceStore resourceStore = provider.getStoreFactory().getResourceStore();
 
         for (String id : result) {
-            Resource resource = resourceStore.findById(id, resourceServerId);
+            Resource resource = resourceStore.findById(resourceServerId, id);
 
             if (resource != null) {
                 list.add(resource);
@@ -245,7 +245,7 @@ public class JPAResourceStore implements ResourceStore {
     }
 
     @Override
-    public void findByScope(List<String> scopes, String resourceServerId, Consumer<Resource> consumer) {
+    public void findByScope(String resourceServerId, List<String> scopes, Consumer<Resource> consumer) {
         TypedQuery<ResourceEntity> query = entityManager.createNamedQuery("findResourceIdByScope", ResourceEntity.class);
 
         query.setFlushMode(FlushModeType.COMMIT);
@@ -265,7 +265,7 @@ public class JPAResourceStore implements ResourceStore {
     }
 
     @Override
-    public Resource findByName(String name, String ownerId, String resourceServerId) {
+    public Resource findByName(String resourceServerId, String name, String ownerId) {
         TypedQuery<ResourceEntity> query = entityManager.createNamedQuery("findResourceIdByName", ResourceEntity.class);
 
         query.setParameter("serverId", resourceServerId);
@@ -280,12 +280,12 @@ public class JPAResourceStore implements ResourceStore {
     }
 
     @Override
-    public void findByType(String type, String resourceServerId, Consumer<Resource> consumer) {
-        findByType(type, resourceServerId, resourceServerId, consumer);
+    public void findByType(String resourceServerId, String type, Consumer<Resource> consumer) {
+        findByType(resourceServerId, type, resourceServerId, consumer);
     }
 
     @Override
-    public void findByType(String type, String owner, String resourceServerId, Consumer<Resource> consumer) {
+    public void findByType(String resourceServerId, String type, String owner, Consumer<Resource> consumer) {
         TypedQuery<ResourceEntity> query;
 
         if (owner != null) {
@@ -311,7 +311,7 @@ public class JPAResourceStore implements ResourceStore {
     }
 
     @Override
-    public void findByTypeInstance(String type, String resourceServerId, Consumer<Resource> consumer) {
+    public void findByTypeInstance(String resourceServerId, String type, Consumer<Resource> consumer) {
         TypedQuery<ResourceEntity> query = entityManager.createNamedQuery("findResourceIdByTypeInstance", ResourceEntity.class);
 
         query.setFlushMode(FlushModeType.COMMIT);

--- a/model/jpa/src/main/java/org/keycloak/authorization/jpa/store/JPAResourceStore.java
+++ b/model/jpa/src/main/java/org/keycloak/authorization/jpa/store/JPAResourceStore.java
@@ -41,6 +41,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import static org.keycloak.models.jpa.PaginationUtils.paginateQuery;
 import static org.keycloak.utils.StreamsUtil.closing;
@@ -251,7 +252,7 @@ public class JPAResourceStore implements ResourceStore {
         TypedQuery<ResourceEntity> query = entityManager.createNamedQuery("findResourceIdByScope", ResourceEntity.class);
 
         query.setFlushMode(FlushModeType.COMMIT);
-        query.setParameter("scopeIds", scopes);
+        query.setParameter("scopeIds", scopes.stream().map(Scope::getId).collect(Collectors.toSet()));
         query.setParameter("serverId", resourceServer == null ? null : resourceServer.getId());
 
         StoreFactory storeFactory = provider.getStoreFactory();
@@ -308,12 +309,12 @@ public class JPAResourceStore implements ResourceStore {
     }
 
     @Override
-    public void findByTypeInstance(ResourceServer resourceServerId, String type, Consumer<Resource> consumer) {
+    public void findByTypeInstance(ResourceServer resourceServer, String type, Consumer<Resource> consumer) {
         TypedQuery<ResourceEntity> query = entityManager.createNamedQuery("findResourceIdByTypeInstance", ResourceEntity.class);
 
         query.setFlushMode(FlushModeType.COMMIT);
         query.setParameter("type", type);
-        query.setParameter("serverId", resourceServerId);
+        query.setParameter("serverId", resourceServer == null ? null : resourceServer.getId());
 
         StoreFactory storeFactory = provider.getStoreFactory();
 

--- a/model/jpa/src/main/java/org/keycloak/authorization/jpa/store/JPAResourceStore.java
+++ b/model/jpa/src/main/java/org/keycloak/authorization/jpa/store/JPAResourceStore.java
@@ -105,10 +105,10 @@ public class JPAResourceStore implements ResourceStore {
     }
 
     @Override
-    public List<Resource> findByOwner(ResourceServer resourceServer, String ownerId, int first, int max) {
+    public List<Resource> findByOwner(ResourceServer resourceServer, String ownerId, Integer firstResult, Integer maxResults) {
         List<Resource> list = new LinkedList<>();
 
-        findByOwnerFilter(ownerId, resourceServer, list::add, first, max);
+        findByOwnerFilter(ownerId, resourceServer, list::add, firstResult, maxResults);
 
         return list;
     }
@@ -184,7 +184,7 @@ public class JPAResourceStore implements ResourceStore {
     }
 
     @Override
-    public List<Resource> findByResourceServer(ResourceServer resourceServer, Map<Resource.FilterOption, String[]> attributes, int firstResult, int maxResult) {
+    public List<Resource> findByResourceServer(ResourceServer resourceServer, Map<Resource.FilterOption, String[]> attributes, Integer firstResult, Integer maxResults) {
         CriteriaBuilder builder = entityManager.getCriteriaBuilder();
         CriteriaQuery<ResourceEntity> querybuilder = builder.createQuery(ResourceEntity.class);
         Root<ResourceEntity> root = querybuilder.from(ResourceEntity.class);
@@ -232,7 +232,7 @@ public class JPAResourceStore implements ResourceStore {
 
         TypedQuery query = entityManager.createQuery(querybuilder);
 
-        List<String> result = paginateQuery(query, firstResult, maxResult).getResultList();
+        List<String> result = paginateQuery(query, firstResult, maxResults).getResultList();
         List<Resource> list = new LinkedList<>();
         ResourceStore resourceStore = provider.getStoreFactory().getResourceStore();
 

--- a/model/jpa/src/main/java/org/keycloak/authorization/jpa/store/JPAScopeStore.java
+++ b/model/jpa/src/main/java/org/keycloak/authorization/jpa/store/JPAScopeStore.java
@@ -88,7 +88,7 @@ public class JPAScopeStore implements ScopeStore {
     }
 
     @Override
-    public Scope findById(String resourceServerId, String id) {
+    public Scope findById(ResourceServer resourceServer, String id) {
         if (id == null) {
             return null;
         }
@@ -100,45 +100,45 @@ public class JPAScopeStore implements ScopeStore {
     }
 
     @Override
-    public Scope findByName(String resourceServerId, String name) {
+    public Scope findByName(ResourceServer resourceServer, String name) {
         try {
             TypedQuery<String> query = entityManager.createNamedQuery("findScopeIdByName", String.class);
 
             query.setFlushMode(FlushModeType.COMMIT);
-            query.setParameter("serverId", resourceServerId);
+            query.setParameter("serverId", resourceServer.getId());
             query.setParameter("name", name);
 
             String id = query.getSingleResult();
-            return provider.getStoreFactory().getScopeStore().findById(resourceServerId, id);
+            return provider.getStoreFactory().getScopeStore().findById(resourceServer, id);
         } catch (NoResultException nre) {
             return null;
         }
     }
 
     @Override
-    public List<Scope> findByResourceServer(final String serverId) {
+    public List<Scope> findByResourceServer(final ResourceServer resourceServer) {
         TypedQuery<String> query = entityManager.createNamedQuery("findScopeIdByResourceServer", String.class);
 
         query.setFlushMode(FlushModeType.COMMIT);
-        query.setParameter("serverId", serverId);
+        query.setParameter("serverId", resourceServer.getId());
 
         List<String> result = query.getResultList();
         List<Scope> list = new LinkedList<>();
         for (String id : result) {
-            list.add(provider.getStoreFactory().getScopeStore().findById(serverId, id));
+            list.add(provider.getStoreFactory().getScopeStore().findById(resourceServer, id));
         }
         return list;
     }
 
     @Override
-    public List<Scope> findByResourceServer(String resourceServerId, Map<Scope.FilterOption, String[]> attributes, int firstResult, int maxResult) {
+    public List<Scope> findByResourceServer(ResourceServer resourceServer, Map<Scope.FilterOption, String[]> attributes, int firstResult, int maxResult) {
         CriteriaBuilder builder = entityManager.getCriteriaBuilder();
         CriteriaQuery<ScopeEntity> querybuilder = builder.createQuery(ScopeEntity.class);
         Root<ScopeEntity> root = querybuilder.from(ScopeEntity.class);
         querybuilder.select(root.get("id"));
         List<Predicate> predicates = new ArrayList();
 
-        predicates.add(builder.equal(root.get("resourceServer").get("id"), resourceServerId));
+        predicates.add(builder.equal(root.get("resourceServer").get("id"), resourceServer.getId()));
 
         attributes.forEach((filterOption, value) -> {
             switch (filterOption) {
@@ -160,7 +160,7 @@ public class JPAScopeStore implements ScopeStore {
         List result = paginateQuery(query, firstResult, maxResult).getResultList();
         List<Scope> list = new LinkedList<>();
         for (Object id : result) {
-            list.add(provider.getStoreFactory().getScopeStore().findById(resourceServerId, (String)id));
+            list.add(provider.getStoreFactory().getScopeStore().findById(resourceServer, (String)id));
         }
         return list;
 

--- a/model/jpa/src/main/java/org/keycloak/authorization/jpa/store/JPAScopeStore.java
+++ b/model/jpa/src/main/java/org/keycloak/authorization/jpa/store/JPAScopeStore.java
@@ -55,12 +55,12 @@ public class JPAScopeStore implements ScopeStore {
     }
 
     @Override
-    public Scope create(final String name, final ResourceServer resourceServer) {
-        return create(null, name, resourceServer);
+    public Scope create(final ResourceServer resourceServer, final String name) {
+        return create(resourceServer, null, name);
     }
 
     @Override
-    public Scope create(String id, final String name, final ResourceServer resourceServer) {
+    public Scope create(final ResourceServer resourceServer, String id, final String name) {
         ScopeEntity entity = new ScopeEntity();
 
         if (id == null) {
@@ -88,7 +88,7 @@ public class JPAScopeStore implements ScopeStore {
     }
 
     @Override
-    public Scope findById(String id, String resourceServerId) {
+    public Scope findById(String resourceServerId, String id) {
         if (id == null) {
             return null;
         }
@@ -100,7 +100,7 @@ public class JPAScopeStore implements ScopeStore {
     }
 
     @Override
-    public Scope findByName(String name, String resourceServerId) {
+    public Scope findByName(String resourceServerId, String name) {
         try {
             TypedQuery<String> query = entityManager.createNamedQuery("findScopeIdByName", String.class);
 
@@ -109,7 +109,7 @@ public class JPAScopeStore implements ScopeStore {
             query.setParameter("name", name);
 
             String id = query.getSingleResult();
-            return provider.getStoreFactory().getScopeStore().findById(id, resourceServerId);
+            return provider.getStoreFactory().getScopeStore().findById(resourceServerId, id);
         } catch (NoResultException nre) {
             return null;
         }
@@ -125,13 +125,13 @@ public class JPAScopeStore implements ScopeStore {
         List<String> result = query.getResultList();
         List<Scope> list = new LinkedList<>();
         for (String id : result) {
-            list.add(provider.getStoreFactory().getScopeStore().findById(id, serverId));
+            list.add(provider.getStoreFactory().getScopeStore().findById(serverId, id));
         }
         return list;
     }
 
     @Override
-    public List<Scope> findByResourceServer(Map<Scope.FilterOption, String[]> attributes, String resourceServerId, int firstResult, int maxResult) {
+    public List<Scope> findByResourceServer(String resourceServerId, Map<Scope.FilterOption, String[]> attributes, int firstResult, int maxResult) {
         CriteriaBuilder builder = entityManager.getCriteriaBuilder();
         CriteriaQuery<ScopeEntity> querybuilder = builder.createQuery(ScopeEntity.class);
         Root<ScopeEntity> root = querybuilder.from(ScopeEntity.class);
@@ -160,7 +160,7 @@ public class JPAScopeStore implements ScopeStore {
         List result = paginateQuery(query, firstResult, maxResult).getResultList();
         List<Scope> list = new LinkedList<>();
         for (Object id : result) {
-            list.add(provider.getStoreFactory().getScopeStore().findById((String)id, resourceServerId));
+            list.add(provider.getStoreFactory().getScopeStore().findById(resourceServerId, (String)id));
         }
         return list;
 

--- a/model/jpa/src/main/java/org/keycloak/authorization/jpa/store/JPAScopeStore.java
+++ b/model/jpa/src/main/java/org/keycloak/authorization/jpa/store/JPAScopeStore.java
@@ -131,7 +131,7 @@ public class JPAScopeStore implements ScopeStore {
     }
 
     @Override
-    public List<Scope> findByResourceServer(ResourceServer resourceServer, Map<Scope.FilterOption, String[]> attributes, int firstResult, int maxResult) {
+    public List<Scope> findByResourceServer(ResourceServer resourceServer, Map<Scope.FilterOption, String[]> attributes, Integer firstResult, Integer maxResults) {
         CriteriaBuilder builder = entityManager.getCriteriaBuilder();
         CriteriaQuery<ScopeEntity> querybuilder = builder.createQuery(ScopeEntity.class);
         Root<ScopeEntity> root = querybuilder.from(ScopeEntity.class);
@@ -157,7 +157,7 @@ public class JPAScopeStore implements ScopeStore {
 
         TypedQuery query = entityManager.createQuery(querybuilder);
 
-        List result = paginateQuery(query, firstResult, maxResult).getResultList();
+        List result = paginateQuery(query, firstResult, maxResults).getResultList();
         List<Scope> list = new LinkedList<>();
         for (Object id : result) {
             list.add(provider.getStoreFactory().getScopeStore().findById(resourceServer, (String)id));

--- a/model/jpa/src/main/java/org/keycloak/authorization/jpa/store/PermissionTicketAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/authorization/jpa/store/PermissionTicketAdapter.java
@@ -20,6 +20,7 @@ import static org.keycloak.authorization.UserManagedPermissionUtil.updatePolicy;
 
 import javax.persistence.EntityManager;
 
+import org.keycloak.authorization.AuthorizationProvider;
 import org.keycloak.authorization.jpa.entities.PermissionTicketEntity;
 import org.keycloak.authorization.jpa.entities.PolicyEntity;
 import org.keycloak.authorization.jpa.entities.ScopeEntity;
@@ -101,7 +102,8 @@ public class PermissionTicketAdapter implements PermissionTicket, JpaModel<Permi
             return null;
         }
 
-        return storeFactory.getPolicyStore().findById(entity.getResourceServer().getId(), policy.getId());
+        ResourceServer resourceServer = storeFactory.getResourceServerStore().findById(entity.getResourceServer().getId());
+        return storeFactory.getPolicyStore().findById(resourceServer, policy.getId());
     }
 
     @Override

--- a/model/jpa/src/main/java/org/keycloak/authorization/jpa/store/PermissionTicketAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/authorization/jpa/store/PermissionTicketAdapter.java
@@ -115,7 +115,7 @@ public class PermissionTicketAdapter implements PermissionTicket, JpaModel<Permi
 
     @Override
     public Resource getResource() {
-        return storeFactory.getResourceStore().findById(getResourceServer().getId(), entity.getResource().getId());
+        return storeFactory.getResourceStore().findById(getResourceServer(), entity.getResource().getId());
     }
 
     @Override

--- a/model/jpa/src/main/java/org/keycloak/authorization/jpa/store/PermissionTicketAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/authorization/jpa/store/PermissionTicketAdapter.java
@@ -126,7 +126,7 @@ public class PermissionTicketAdapter implements PermissionTicket, JpaModel<Permi
             return null;
         }
 
-        return storeFactory.getScopeStore().findById(getResourceServer().getId(), scope.getId());
+        return storeFactory.getScopeStore().findById(getResourceServer(), scope.getId());
     }
 
     @Override

--- a/model/jpa/src/main/java/org/keycloak/authorization/jpa/store/PermissionTicketAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/authorization/jpa/store/PermissionTicketAdapter.java
@@ -101,7 +101,7 @@ public class PermissionTicketAdapter implements PermissionTicket, JpaModel<Permi
             return null;
         }
 
-        return storeFactory.getPolicyStore().findById(policy.getId(), entity.getResourceServer().getId());
+        return storeFactory.getPolicyStore().findById(entity.getResourceServer().getId(), policy.getId());
     }
 
     @Override
@@ -113,7 +113,7 @@ public class PermissionTicketAdapter implements PermissionTicket, JpaModel<Permi
 
     @Override
     public Resource getResource() {
-        return storeFactory.getResourceStore().findById(entity.getResource().getId(), getResourceServer().getId());
+        return storeFactory.getResourceStore().findById(getResourceServer().getId(), entity.getResource().getId());
     }
 
     @Override
@@ -124,7 +124,7 @@ public class PermissionTicketAdapter implements PermissionTicket, JpaModel<Permi
             return null;
         }
 
-        return storeFactory.getScopeStore().findById(scope.getId(), getResourceServer().getId());
+        return storeFactory.getScopeStore().findById(getResourceServer().getId(), scope.getId());
     }
 
     @Override

--- a/model/jpa/src/main/java/org/keycloak/authorization/jpa/store/PolicyAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/authorization/jpa/store/PolicyAdapter.java
@@ -169,7 +169,7 @@ public class PolicyAdapter extends AbstractAuthorizationModel implements Policy,
     public Set<Resource> getResources() {
         Set<Resource> set = new HashSet<>();
         for (ResourceEntity res : entity.getResources()) {
-            set.add(storeFactory.getResourceStore().findById(res.getId(), entity.getResourceServer().getId()));
+            set.add(storeFactory.getResourceStore().findById(entity.getResourceServer().getId(), res.getId()));
         }
         return Collections.unmodifiableSet(set);
     }
@@ -178,7 +178,7 @@ public class PolicyAdapter extends AbstractAuthorizationModel implements Policy,
     public Set<Scope> getScopes() {
         Set<Scope> set = new HashSet<>();
         for (ScopeEntity res : entity.getScopes()) {
-            set.add(storeFactory.getScopeStore().findById(res.getId(), entity.getResourceServer().getId()));
+            set.add(storeFactory.getScopeStore().findById(entity.getResourceServer().getId(), res.getId()));
         }
         return Collections.unmodifiableSet(set);
     }

--- a/model/jpa/src/main/java/org/keycloak/authorization/jpa/store/PolicyAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/authorization/jpa/store/PolicyAdapter.java
@@ -177,8 +177,9 @@ public class PolicyAdapter extends AbstractAuthorizationModel implements Policy,
     @Override
     public Set<Scope> getScopes() {
         Set<Scope> set = new HashSet<>();
+        ResourceServer resourceServer = getResourceServer();
         for (ScopeEntity res : entity.getScopes()) {
-            set.add(storeFactory.getScopeStore().findById(entity.getResourceServer().getId(), res.getId()));
+            set.add(storeFactory.getScopeStore().findById(resourceServer, res.getId()));
         }
         return Collections.unmodifiableSet(set);
     }

--- a/model/jpa/src/main/java/org/keycloak/authorization/jpa/store/PolicyAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/authorization/jpa/store/PolicyAdapter.java
@@ -168,8 +168,9 @@ public class PolicyAdapter extends AbstractAuthorizationModel implements Policy,
     @Override
     public Set<Resource> getResources() {
         Set<Resource> set = new HashSet<>();
+        ResourceServer resourceServer = getResourceServer();
         for (ResourceEntity res : entity.getResources()) {
-            set.add(storeFactory.getResourceStore().findById(entity.getResourceServer().getId(), res.getId()));
+            set.add(storeFactory.getResourceStore().findById(resourceServer, res.getId()));
         }
         return Collections.unmodifiableSet(set);
     }

--- a/model/jpa/src/main/java/org/keycloak/authorization/jpa/store/ResourceAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/authorization/jpa/store/ResourceAdapter.java
@@ -116,8 +116,9 @@ public class ResourceAdapter extends AbstractAuthorizationModel implements Resou
     @Override
     public List<Scope> getScopes() {
         List<Scope> scopes = new LinkedList<>();
+        ResourceServer resourceServer = getResourceServer();
         for (ScopeEntity scope : entity.getScopes()) {
-            scopes.add(storeFactory.getScopeStore().findById(entity.getResourceServer(), scope.getId()));
+            scopes.add(storeFactory.getScopeStore().findById(resourceServer, scope.getId()));
         }
 
         return Collections.unmodifiableList(scopes);

--- a/model/jpa/src/main/java/org/keycloak/authorization/jpa/store/ResourceAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/authorization/jpa/store/ResourceAdapter.java
@@ -21,6 +21,7 @@ import org.keycloak.authorization.jpa.entities.ResourceEntity;
 import org.keycloak.authorization.jpa.entities.ScopeEntity;
 import org.keycloak.authorization.model.AbstractAuthorizationModel;
 import org.keycloak.authorization.model.Resource;
+import org.keycloak.authorization.model.ResourceServer;
 import org.keycloak.authorization.model.Scope;
 import org.keycloak.authorization.store.StoreFactory;
 import org.keycloak.common.util.MultivaluedHashMap;
@@ -135,8 +136,8 @@ public class ResourceAdapter extends AbstractAuthorizationModel implements Resou
     }
 
     @Override
-    public String getResourceServer() {
-        return entity.getResourceServer();
+    public ResourceServer getResourceServer() {
+        return storeFactory.getResourceServerStore().findById(entity.getResourceServer());
     }
 
     @Override

--- a/model/jpa/src/main/java/org/keycloak/authorization/jpa/store/ResourceAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/authorization/jpa/store/ResourceAdapter.java
@@ -21,7 +21,6 @@ import org.keycloak.authorization.jpa.entities.ResourceEntity;
 import org.keycloak.authorization.jpa.entities.ScopeEntity;
 import org.keycloak.authorization.model.AbstractAuthorizationModel;
 import org.keycloak.authorization.model.Resource;
-import org.keycloak.authorization.model.ResourceServer;
 import org.keycloak.authorization.model.Scope;
 import org.keycloak.authorization.store.StoreFactory;
 import org.keycloak.common.util.MultivaluedHashMap;
@@ -117,7 +116,7 @@ public class ResourceAdapter extends AbstractAuthorizationModel implements Resou
     public List<Scope> getScopes() {
         List<Scope> scopes = new LinkedList<>();
         for (ScopeEntity scope : entity.getScopes()) {
-            scopes.add(storeFactory.getScopeStore().findById(scope.getId(), entity.getResourceServer()));
+            scopes.add(storeFactory.getScopeStore().findById(entity.getResourceServer(), scope.getId()));
         }
 
         return Collections.unmodifiableList(scopes);

--- a/model/jpa/src/main/java/org/keycloak/authorization/jpa/store/ResourceServerAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/authorization/jpa/store/ResourceServerAdapter.java
@@ -88,6 +88,11 @@ public class ResourceServerAdapter extends AbstractAuthorizationModel implements
     }
 
     @Override
+    public String getClientId() {
+        return getId();
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || !(o instanceof ResourceServer)) return false;

--- a/model/jpa/src/main/java/org/keycloak/authorization/jpa/store/ResourceServerAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/authorization/jpa/store/ResourceServerAdapter.java
@@ -88,11 +88,6 @@ public class ResourceServerAdapter extends AbstractAuthorizationModel implements
     }
 
     @Override
-    public String getClientId() {
-        return getId();
-    }
-
-    @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || !(o instanceof ResourceServer)) return false;

--- a/model/map/src/main/java/org/keycloak/models/map/authorization/MapPermissionTicketStore.java
+++ b/model/map/src/main/java/org/keycloak/models/map/authorization/MapPermissionTicketStore.java
@@ -192,7 +192,7 @@ public class MapPermissionTicketStore implements PermissionTicketStore {
     }
 
     @Override
-    public List<PermissionTicket> find(ResourceServer resourceServer, Map<PermissionTicket.FilterOption, String> attributes, int firstResult, int maxResult) {
+    public List<PermissionTicket> find(ResourceServer resourceServer, Map<PermissionTicket.FilterOption, String> attributes, Integer firstResult, Integer maxResult) {
         DefaultModelCriteria<PermissionTicket> mcb = forResourceServer(resourceServer);
 
         if (attributes.containsKey(PermissionTicket.FilterOption.RESOURCE_NAME)) {
@@ -202,7 +202,7 @@ public class MapPermissionTicketStore implements PermissionTicketStore {
 
             filterOptionStringMap.put(Resource.FilterOption.EXACT_NAME, new String[]{expectedResourceName});
             
-            List<Resource> r = authorizationProvider.getStoreFactory().getResourceStore().findByResourceServer(resourceServer, filterOptionStringMap, -1, -1);
+            List<Resource> r = authorizationProvider.getStoreFactory().getResourceStore().findByResourceServer(resourceServer, filterOptionStringMap, null, null);
             if (r == null || r.isEmpty()) {
                 return Collections.emptyList();
             }
@@ -257,7 +257,7 @@ public class MapPermissionTicketStore implements PermissionTicketStore {
         filters.put(PermissionTicket.FilterOption.GRANTED, Boolean.TRUE.toString());
         filters.put(PermissionTicket.FilterOption.REQUESTER, userId);
 
-        return find(resourceServer, filters, -1, -1);
+        return find(resourceServer, filters, null, null);
     }
 
     @Override
@@ -268,11 +268,11 @@ public class MapPermissionTicketStore implements PermissionTicketStore {
         filters.put(PermissionTicket.FilterOption.GRANTED, Boolean.TRUE.toString());
         filters.put(PermissionTicket.FilterOption.REQUESTER, userId);
 
-        return find(resourceServer, filters, -1, -1);
+        return find(resourceServer, filters, null, null);
     }
 
     @Override
-    public List<Resource> findGrantedResources(String requester, String name, int first, int max) {
+    public List<Resource> findGrantedResources(String requester, String name, Integer first, Integer max) {
         DefaultModelCriteria<PermissionTicket> mcb = criteria();
         mcb = mcb.compare(SearchableFields.REQUESTER, Operator.EQ, requester)
                 .compare(SearchableFields.GRANTED_TIMESTAMP, Operator.EXISTS);
@@ -305,7 +305,7 @@ public class MapPermissionTicketStore implements PermissionTicketStore {
     }
 
     @Override
-    public List<Resource> findGrantedOwnerResources(String owner, int first, int max) {
+    public List<Resource> findGrantedOwnerResources(String owner, Integer firstResult, Integer maxResults) {
         DefaultModelCriteria<PermissionTicket> mcb = criteria();
         mcb = mcb.compare(SearchableFields.OWNER, Operator.EQ, owner);
 
@@ -313,7 +313,7 @@ public class MapPermissionTicketStore implements PermissionTicketStore {
         ResourceServerStore resourceServerStore = authorizationProvider.getStoreFactory().getResourceServerStore();
 
         return paginatedStream(tx.read(withCriteria(mcb).orderBy(SearchableFields.RESOURCE_ID, ASCENDING))
-            .filter(distinctByKey(MapPermissionTicketEntity::getResourceId)), first, max)
+            .filter(distinctByKey(MapPermissionTicketEntity::getResourceId)), firstResult, maxResults)
             .map(ticket -> resourceStore.findById(resourceServerStore.findById(ticket.getResourceServerId()), ticket.getResourceId()))
             .collect(Collectors.toList());
     }

--- a/model/map/src/main/java/org/keycloak/models/map/authorization/MapPolicyStore.java
+++ b/model/map/src/main/java/org/keycloak/models/map/authorization/MapPolicyStore.java
@@ -73,7 +73,7 @@ public class MapPolicyStore implements PolicyStore {
     }
 
     @Override
-    public Policy create(AbstractPolicyRepresentation representation, ResourceServer resourceServer) {
+    public Policy create(ResourceServer resourceServer, AbstractPolicyRepresentation representation) {
         LOG.tracef("create(%s, %s, %s)%s", representation.getId(), resourceServer.getId(), resourceServer, getShortStackTrace());
 
         // @UniqueConstraint(columnNames = {"NAME", "RESOURCE_SERVER_ID"})
@@ -103,7 +103,7 @@ public class MapPolicyStore implements PolicyStore {
     }
 
     @Override
-    public Policy findById(String id, String resourceServerId) {
+    public Policy findById(String resourceServerId, String id) {
         LOG.tracef("findById(%s, %s)%s", id, resourceServerId, getShortStackTrace());
 
         return tx.read(withCriteria(forResourceServer(resourceServerId)
@@ -114,7 +114,7 @@ public class MapPolicyStore implements PolicyStore {
     }
 
     @Override
-    public Policy findByName(String name, String resourceServerId) {
+    public Policy findByName(String resourceServerId, String name) {
         LOG.tracef("findByName(%s, %s)%s", name, resourceServerId, getShortStackTrace());
 
         return tx.read(withCriteria(forResourceServer(resourceServerId)
@@ -134,7 +134,7 @@ public class MapPolicyStore implements PolicyStore {
     }
 
     @Override
-    public List<Policy> findByResourceServer(Map<Policy.FilterOption, String[]> attributes, String resourceServerId, int firstResult, int maxResult) {
+    public List<Policy> findByResourceServer(String resourceServerId, Map<Policy.FilterOption, String[]> attributes, int firstResult, int maxResult) {
         LOG.tracef("findByResourceServer(%s, %s, %d, %d)%s", attributes, resourceServerId, firstResult, maxResult, getShortStackTrace());
 
         DefaultModelCriteria<Policy> mcb = forResourceServer(resourceServerId).and(
@@ -151,7 +151,7 @@ public class MapPolicyStore implements PolicyStore {
         return tx.read(withCriteria(mcb).pagination(firstResult, maxResult, SearchableFields.NAME))
             .map(MapPolicyEntity::getId)
             // We need to go through cache
-            .map(id -> authorizationProvider.getStoreFactory().getPolicyStore().findById(id, resourceServerId))
+            .map(id -> authorizationProvider.getStoreFactory().getPolicyStore().findById(resourceServerId, id))
             .collect(Collectors.toList());
     }
 
@@ -194,7 +194,7 @@ public class MapPolicyStore implements PolicyStore {
     }
 
     @Override
-    public void findByResource(String resourceId, String resourceServerId, Consumer<Policy> consumer) {
+    public void findByResource(String resourceServerId, String resourceId, Consumer<Policy> consumer) {
         LOG.tracef("findByResource(%s, %s, %s)%s", resourceId, resourceServerId, consumer, getShortStackTrace());
 
         tx.read(withCriteria(forResourceServer(resourceServerId)
@@ -204,7 +204,7 @@ public class MapPolicyStore implements PolicyStore {
     }
 
     @Override
-    public void findByResourceType(String type, String resourceServerId, Consumer<Policy> policyConsumer) {
+    public void findByResourceType(String resourceServerId, String type, Consumer<Policy> policyConsumer) {
         tx.read(withCriteria(forResourceServer(resourceServerId)
                 .compare(SearchableFields.CONFIG, Operator.LIKE, (Object[]) new String[]{"defaultResourceType", type})))
                 .map(this::entityToAdapter)
@@ -212,7 +212,7 @@ public class MapPolicyStore implements PolicyStore {
     }
 
     @Override
-    public List<Policy> findByScopeIds(List<String> scopeIds, String resourceServerId) {
+    public List<Policy> findByScopeIds(String resourceServerId, List<String> scopeIds) {
         return tx.read(withCriteria(forResourceServer(resourceServerId)
                 .compare(SearchableFields.SCOPE_ID, Operator.IN, scopeIds)))
                 .map(this::entityToAdapter)
@@ -220,7 +220,7 @@ public class MapPolicyStore implements PolicyStore {
     }
 
     @Override
-    public void findByScopeIds(List<String> scopeIds, String resourceId, String resourceServerId, Consumer<Policy> consumer) {
+    public void findByScopeIds(String resourceServerId, String resourceId, List<String> scopeIds, Consumer<Policy> consumer) {
         DefaultModelCriteria<Policy> mcb = forResourceServer(resourceServerId)
                 .compare(SearchableFields.TYPE, Operator.EQ, "scope")
                 .compare(SearchableFields.SCOPE_ID, Operator.IN, scopeIds);
@@ -237,7 +237,7 @@ public class MapPolicyStore implements PolicyStore {
     }
 
     @Override
-    public List<Policy> findByType(String type, String resourceServerId) {
+    public List<Policy> findByType(String resourceServerId, String type) {
         return tx.read(withCriteria(forResourceServer(resourceServerId)
                 .compare(SearchableFields.TYPE, Operator.EQ, type)))
                 .map(this::entityToAdapter)
@@ -245,7 +245,7 @@ public class MapPolicyStore implements PolicyStore {
     }
 
     @Override
-    public List<Policy> findDependentPolicies(String id, String resourceServerId) {
+    public List<Policy> findDependentPolicies(String resourceServerId, String id) {
         return tx.read(withCriteria(forResourceServer(resourceServerId)
                 .compare(SearchableFields.ASSOCIATED_POLICY_ID, Operator.EQ, id)))
                     .map(this::entityToAdapter)

--- a/model/map/src/main/java/org/keycloak/models/map/authorization/MapPolicyStore.java
+++ b/model/map/src/main/java/org/keycloak/models/map/authorization/MapPolicyStore.java
@@ -136,8 +136,8 @@ public class MapPolicyStore implements PolicyStore {
     }
 
     @Override
-    public List<Policy> findByResourceServer(ResourceServer resourceServer, Map<Policy.FilterOption, String[]> attributes, int firstResult, int maxResult) {
-        LOG.tracef("findByResourceServer(%s, %s, %d, %d)%s", attributes, resourceServer, firstResult, maxResult, getShortStackTrace());
+    public List<Policy> findByResourceServer(ResourceServer resourceServer, Map<Policy.FilterOption, String[]> attributes, Integer firstResult, Integer maxResults) {
+        LOG.tracef("findByResourceServer(%s, %s, %d, %d)%s", attributes, resourceServer, firstResult, maxResults, getShortStackTrace());
 
         DefaultModelCriteria<Policy> mcb = forResourceServer(resourceServer).and(
                 attributes.entrySet().stream()
@@ -150,7 +150,7 @@ public class MapPolicyStore implements PolicyStore {
             mcb = mcb.compare(SearchableFields.OWNER, Operator.NOT_EXISTS);
         }
 
-        return tx.read(withCriteria(mcb).pagination(firstResult, maxResult, SearchableFields.NAME))
+        return tx.read(withCriteria(mcb).pagination(firstResult, maxResults, SearchableFields.NAME))
             .map(MapPolicyEntity::getId)
             // We need to go through cache
             .map(id -> authorizationProvider.getStoreFactory().getPolicyStore().findById(resourceServer, id))

--- a/model/map/src/main/java/org/keycloak/models/map/authorization/MapResourceServerStore.java
+++ b/model/map/src/main/java/org/keycloak/models/map/authorization/MapResourceServerStore.java
@@ -98,7 +98,7 @@ public class MapResourceServerStore implements ResourceServerStore {
             .forEach(policyStore::delete);
 
         PermissionTicketStore permissionTicketStore = authorizationProvider.getStoreFactory().getPermissionTicketStore();
-        permissionTicketStore.findByResourceServer(id).stream()
+        permissionTicketStore.findByResourceServer(resourceServer).stream()
                 .map(PermissionTicket::getId)
                 .forEach(permissionTicketStore::delete);
 

--- a/model/map/src/main/java/org/keycloak/models/map/authorization/MapResourceServerStore.java
+++ b/model/map/src/main/java/org/keycloak/models/map/authorization/MapResourceServerStore.java
@@ -108,7 +108,7 @@ public class MapResourceServerStore implements ResourceServerStore {
                 .forEach(resourceStore::delete);
 
         ScopeStore scopeStore = authorizationProvider.getStoreFactory().getScopeStore();
-        scopeStore.findByResourceServer(id).stream()
+        scopeStore.findByResourceServer(resourceServer).stream()
                 .map(Scope::getId)
                 .forEach(scopeStore::delete);
 

--- a/model/map/src/main/java/org/keycloak/models/map/authorization/MapResourceServerStore.java
+++ b/model/map/src/main/java/org/keycloak/models/map/authorization/MapResourceServerStore.java
@@ -93,7 +93,7 @@ public class MapResourceServerStore implements ResourceServerStore {
 
         // TODO: Simplify the following, ideally by leveraging triggers, stored procedures or ref integrity
         PolicyStore policyStore = authorizationProvider.getStoreFactory().getPolicyStore();
-        policyStore.findByResourceServer(id).stream()
+        policyStore.findByResourceServer(resourceServer).stream()
             .map(Policy::getId)
             .forEach(policyStore::delete);
 

--- a/model/map/src/main/java/org/keycloak/models/map/authorization/MapResourceServerStore.java
+++ b/model/map/src/main/java/org/keycloak/models/map/authorization/MapResourceServerStore.java
@@ -103,7 +103,7 @@ public class MapResourceServerStore implements ResourceServerStore {
                 .forEach(permissionTicketStore::delete);
 
         ResourceStore resourceStore = authorizationProvider.getStoreFactory().getResourceStore();
-        resourceStore.findByResourceServer(id).stream()
+        resourceStore.findByResourceServer(resourceServer).stream()
                 .map(Resource::getId)
                 .forEach(resourceStore::delete);
 

--- a/model/map/src/main/java/org/keycloak/models/map/authorization/MapResourceServerStore.java
+++ b/model/map/src/main/java/org/keycloak/models/map/authorization/MapResourceServerStore.java
@@ -41,7 +41,6 @@ import org.keycloak.models.map.storage.MapStorage;
 import org.keycloak.storage.StorageId;
 
 import static org.keycloak.common.util.StackUtil.getShortStackTrace;
-import org.keycloak.models.ClientModel;
 
 public class MapResourceServerStore implements ResourceServerStore {
 

--- a/model/map/src/main/java/org/keycloak/models/map/authorization/MapResourceStore.java
+++ b/model/map/src/main/java/org/keycloak/models/map/authorization/MapResourceStore.java
@@ -72,7 +72,7 @@ public class MapResourceStore implements ResourceStore {
     }
 
     @Override
-    public Resource create(String id, String name, ResourceServer resourceServer, String owner) {
+    public Resource create(ResourceServer resourceServer, String id, String name, String owner) {
         LOG.tracef("create(%s, %s, %s, %s)%s", id, name, resourceServer, owner, getShortStackTrace());
         // @UniqueConstraint(columnNames = {"NAME", "RESOURCE_SERVER_ID", "OWNER"})
         DefaultModelCriteria<Resource> mcb = forResourceServer(resourceServer.getId())
@@ -102,7 +102,7 @@ public class MapResourceStore implements ResourceStore {
     }
 
     @Override
-    public Resource findById(String id, String resourceServerId) {
+    public Resource findById(String resourceServerId, String id) {
         LOG.tracef("findById(%s, %s)%s", id, resourceServerId, getShortStackTrace());
 
         return tx.read(withCriteria(forResourceServer(resourceServerId)
@@ -113,7 +113,7 @@ public class MapResourceStore implements ResourceStore {
     }
 
     @Override
-    public void findByOwner(String ownerId, String resourceServerId, Consumer<Resource> consumer) {
+    public void findByOwner(String resourceServerId, String ownerId, Consumer<Resource> consumer) {
         findByOwnerFilter(ownerId, resourceServerId, consumer, -1, -1);
     }
 
@@ -127,7 +127,7 @@ public class MapResourceStore implements ResourceStore {
     }
 
     @Override
-    public List<Resource> findByOwner(String ownerId, String resourceServerId, int first, int max) {
+    public List<Resource> findByOwner(String resourceServerId, String ownerId, int first, int max) {
         List<Resource> resourceList = new LinkedList<>();
 
         findByOwnerFilter(ownerId, resourceServerId, resourceList::add, first, max);
@@ -136,7 +136,7 @@ public class MapResourceStore implements ResourceStore {
     }
 
     @Override
-    public List<Resource> findByUri(String uri, String resourceServerId) {
+    public List<Resource> findByUri(String resourceServerId, String uri) {
         LOG.tracef("findByUri(%s, %s)%s", uri, resourceServerId, getShortStackTrace());
 
         return tx.read(withCriteria(forResourceServer(resourceServerId)
@@ -155,7 +155,7 @@ public class MapResourceStore implements ResourceStore {
     }
 
     @Override
-    public List<Resource> findByResourceServer(Map<Resource.FilterOption, String[]> attributes, String resourceServerId, int firstResult, int maxResult) {
+    public List<Resource> findByResourceServer(String resourceServerId, Map<Resource.FilterOption, String[]> attributes, int firstResult, int maxResult) {
         LOG.tracef("findByResourceServer(%s, %s, %d, %d)%s", attributes, resourceServerId, firstResult, maxResult, getShortStackTrace());
         DefaultModelCriteria<Resource> mcb = forResourceServer(resourceServerId).and(
                 attributes.entrySet().stream()
@@ -194,7 +194,7 @@ public class MapResourceStore implements ResourceStore {
     }
 
     @Override
-    public void findByScope(List<String> scopes, String resourceServerId, Consumer<Resource> consumer) {
+    public void findByScope(String resourceServerId, List<String> scopes, Consumer<Resource> consumer) {
         LOG.tracef("findByScope(%s, %s, %s)%s", scopes, resourceServerId, consumer, getShortStackTrace());
 
         tx.read(withCriteria(forResourceServer(resourceServerId)
@@ -209,7 +209,7 @@ public class MapResourceStore implements ResourceStore {
     }
 
     @Override
-    public Resource findByName(String name, String ownerId, String resourceServerId) {
+    public Resource findByName(String resourceServerId, String name, String ownerId) {
         LOG.tracef("findByName(%s, %s, %s)%s", name, ownerId, resourceServerId, getShortStackTrace());
         return tx.read(withCriteria(forResourceServer(resourceServerId)
                 .compare(SearchableFields.OWNER, Operator.EQ, ownerId)
@@ -220,7 +220,7 @@ public class MapResourceStore implements ResourceStore {
     }
 
     @Override
-    public void findByType(String type, String resourceServerId, Consumer<Resource> consumer) {
+    public void findByType(String resourceServerId, String type, Consumer<Resource> consumer) {
         LOG.tracef("findByType(%s, %s, %s)%s", type, resourceServerId, consumer, getShortStackTrace());
         tx.read(withCriteria(forResourceServer(resourceServerId)
                 .compare(SearchableFields.TYPE, Operator.EQ, type)))
@@ -229,7 +229,7 @@ public class MapResourceStore implements ResourceStore {
     }
 
     @Override
-    public void findByType(String type, String owner, String resourceServerId, Consumer<Resource> consumer) {
+    public void findByType(String resourceServerId, String type, String owner, Consumer<Resource> consumer) {
         LOG.tracef("findByType(%s, %s, %s, %s)%s", type, owner, resourceServerId, consumer, getShortStackTrace());
 
         DefaultModelCriteria<Resource> mcb = forResourceServer(resourceServerId)
@@ -245,7 +245,7 @@ public class MapResourceStore implements ResourceStore {
     }
 
     @Override
-    public void findByTypeInstance(String type, String resourceServerId, Consumer<Resource> consumer) {
+    public void findByTypeInstance(String resourceServerId, String type, Consumer<Resource> consumer) {
         LOG.tracef("findByTypeInstance(%s, %s, %s)%s", type, resourceServerId, consumer, getShortStackTrace());
         tx.read(withCriteria(forResourceServer(resourceServerId)
                 .compare(SearchableFields.OWNER, Operator.NE, resourceServerId)

--- a/model/map/src/main/java/org/keycloak/models/map/authorization/MapResourceStore.java
+++ b/model/map/src/main/java/org/keycloak/models/map/authorization/MapResourceStore.java
@@ -22,6 +22,7 @@ import org.keycloak.authorization.AuthorizationProvider;
 import org.keycloak.authorization.model.Resource;
 import org.keycloak.authorization.model.Resource.SearchableFields;
 import org.keycloak.authorization.model.ResourceServer;
+import org.keycloak.authorization.model.Scope;
 import org.keycloak.authorization.store.ResourceStore;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.ModelDuplicateException;
@@ -37,6 +38,7 @@ import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -62,20 +64,20 @@ public class MapResourceStore implements ResourceStore {
         return new MapResourceAdapter(origEntity, authorizationProvider.getStoreFactory());
     }
     
-    private DefaultModelCriteria<Resource> forResourceServer(String resourceServerId) {
+    private DefaultModelCriteria<Resource> forResourceServer(ResourceServer resourceServer) {
         DefaultModelCriteria<Resource> mcb = criteria();
 
-        return resourceServerId == null
+        return resourceServer == null
                 ? mcb
                 : mcb.compare(SearchableFields.RESOURCE_SERVER_ID, Operator.EQ,
-                              resourceServerId);
+                resourceServer.getId());
     }
 
     @Override
     public Resource create(ResourceServer resourceServer, String id, String name, String owner) {
         LOG.tracef("create(%s, %s, %s, %s)%s", id, name, resourceServer, owner, getShortStackTrace());
         // @UniqueConstraint(columnNames = {"NAME", "RESOURCE_SERVER_ID", "OWNER"})
-        DefaultModelCriteria<Resource> mcb = forResourceServer(resourceServer.getId())
+        DefaultModelCriteria<Resource> mcb = forResourceServer(resourceServer)
                 .compare(SearchableFields.NAME, Operator.EQ, name)
                 .compare(SearchableFields.OWNER, Operator.EQ, owner);
 
@@ -102,10 +104,10 @@ public class MapResourceStore implements ResourceStore {
     }
 
     @Override
-    public Resource findById(String resourceServerId, String id) {
-        LOG.tracef("findById(%s, %s)%s", id, resourceServerId, getShortStackTrace());
+    public Resource findById(ResourceServer resourceServer, String id) {
+        LOG.tracef("findById(%s, %s)%s", id, resourceServer, getShortStackTrace());
 
-        return tx.read(withCriteria(forResourceServer(resourceServerId)
+        return tx.read(withCriteria(forResourceServer(resourceServer)
                 .compare(SearchableFields.ID, Operator.EQ, id)))
                 .findFirst()
                 .map(this::entityToAdapter)
@@ -113,51 +115,51 @@ public class MapResourceStore implements ResourceStore {
     }
 
     @Override
-    public void findByOwner(String resourceServerId, String ownerId, Consumer<Resource> consumer) {
-        findByOwnerFilter(ownerId, resourceServerId, consumer, -1, -1);
+    public void findByOwner(ResourceServer resourceServer, String ownerId, Consumer<Resource> consumer) {
+        findByOwnerFilter(ownerId, resourceServer, consumer, -1, -1);
     }
 
-    private void findByOwnerFilter(String ownerId, String resourceServerId, Consumer<Resource> consumer, int firstResult, int maxResult) {
-        LOG.tracef("findByOwnerFilter(%s, %s, %s, %d, %d)%s", ownerId, resourceServerId, consumer, firstResult, maxResult, getShortStackTrace());
+    private void findByOwnerFilter(String ownerId, ResourceServer resourceServer, Consumer<Resource> consumer, int firstResult, int maxResult) {
+        LOG.tracef("findByOwnerFilter(%s, %s, %s, %d, %d)%s", ownerId, resourceServer, consumer, firstResult, maxResult, getShortStackTrace());
 
-        tx.read(withCriteria(forResourceServer(resourceServerId).compare(SearchableFields.OWNER, Operator.EQ, ownerId))
+        tx.read(withCriteria(forResourceServer(resourceServer).compare(SearchableFields.OWNER, Operator.EQ, ownerId))
                 .pagination(firstResult, maxResult, SearchableFields.ID)
             ).map(this::entityToAdapter)
             .forEach(consumer);
     }
 
     @Override
-    public List<Resource> findByOwner(String resourceServerId, String ownerId, int first, int max) {
+    public List<Resource> findByOwner(ResourceServer resourceServer, String ownerId, int first, int max) {
         List<Resource> resourceList = new LinkedList<>();
 
-        findByOwnerFilter(ownerId, resourceServerId, resourceList::add, first, max);
+        findByOwnerFilter(ownerId, resourceServer, resourceList::add, first, max);
 
         return resourceList;
     }
 
     @Override
-    public List<Resource> findByUri(String resourceServerId, String uri) {
-        LOG.tracef("findByUri(%s, %s)%s", uri, resourceServerId, getShortStackTrace());
+    public List<Resource> findByUri(ResourceServer resourceServer, String uri) {
+        LOG.tracef("findByUri(%s, %s)%s", uri, resourceServer, getShortStackTrace());
 
-        return tx.read(withCriteria(forResourceServer(resourceServerId)
+        return tx.read(withCriteria(forResourceServer(resourceServer)
                 .compare(SearchableFields.URI, Operator.EQ, uri)))
                 .map(this::entityToAdapter)
                 .collect(Collectors.toList());
     }
 
     @Override
-    public List<Resource> findByResourceServer(String resourceServerId) {
-        LOG.tracef("findByResourceServer(%s)%s", resourceServerId, getShortStackTrace());
+    public List<Resource> findByResourceServer(ResourceServer resourceServer) {
+        LOG.tracef("findByResourceServer(%s)%s", resourceServer, getShortStackTrace());
 
-        return tx.read(withCriteria(forResourceServer(resourceServerId)))
+        return tx.read(withCriteria(forResourceServer(resourceServer)))
                 .map(this::entityToAdapter)
                 .collect(Collectors.toList());
     }
 
     @Override
-    public List<Resource> findByResourceServer(String resourceServerId, Map<Resource.FilterOption, String[]> attributes, int firstResult, int maxResult) {
-        LOG.tracef("findByResourceServer(%s, %s, %d, %d)%s", attributes, resourceServerId, firstResult, maxResult, getShortStackTrace());
-        DefaultModelCriteria<Resource> mcb = forResourceServer(resourceServerId).and(
+    public List<Resource> findByResourceServer(ResourceServer resourceServer, Map<Resource.FilterOption, String[]> attributes, int firstResult, int maxResult) {
+        LOG.tracef("findByResourceServer(%s, %s, %d, %d)%s", attributes, resourceServer, firstResult, maxResult, getShortStackTrace());
+        DefaultModelCriteria<Resource> mcb = forResourceServer(resourceServer).and(
                 attributes.entrySet().stream()
                         .map(this::filterEntryToDefaultModelCriteria)
                         .toArray(DefaultModelCriteria[]::new)
@@ -194,24 +196,19 @@ public class MapResourceStore implements ResourceStore {
     }
 
     @Override
-    public void findByScope(String resourceServerId, List<String> scopes, Consumer<Resource> consumer) {
-        LOG.tracef("findByScope(%s, %s, %s)%s", scopes, resourceServerId, consumer, getShortStackTrace());
+    public void findByScopes(ResourceServer resourceServer, Set<Scope> scopes, Consumer<Resource> consumer) {
+        LOG.tracef("findByScope(%s, %s, %s)%s", scopes, resourceServer, consumer, getShortStackTrace());
 
-        tx.read(withCriteria(forResourceServer(resourceServerId)
-                .compare(SearchableFields.SCOPE_ID, Operator.IN, scopes)))
+        tx.read(withCriteria(forResourceServer(resourceServer)
+                .compare(SearchableFields.SCOPE_ID, Operator.IN, scopes.stream().map(Scope::getId))))
                 .map(this::entityToAdapter)
                 .forEach(consumer);
     }
 
     @Override
-    public Resource findByName(String name, String resourceServerId) {
-        return findByName(name, resourceServerId, resourceServerId);
-    }
-
-    @Override
-    public Resource findByName(String resourceServerId, String name, String ownerId) {
-        LOG.tracef("findByName(%s, %s, %s)%s", name, ownerId, resourceServerId, getShortStackTrace());
-        return tx.read(withCriteria(forResourceServer(resourceServerId)
+    public Resource findByName(ResourceServer resourceServer, String name, String ownerId) {
+        LOG.tracef("findByName(%s, %s, %s)%s", name, ownerId, resourceServer, getShortStackTrace());
+        return tx.read(withCriteria(forResourceServer(resourceServer)
                 .compare(SearchableFields.OWNER, Operator.EQ, ownerId)
                 .compare(SearchableFields.NAME, Operator.EQ, name)))
                 .findFirst()
@@ -220,19 +217,19 @@ public class MapResourceStore implements ResourceStore {
     }
 
     @Override
-    public void findByType(String resourceServerId, String type, Consumer<Resource> consumer) {
-        LOG.tracef("findByType(%s, %s, %s)%s", type, resourceServerId, consumer, getShortStackTrace());
-        tx.read(withCriteria(forResourceServer(resourceServerId)
+    public void findByType(ResourceServer resourceServer, String type, Consumer<Resource> consumer) {
+        LOG.tracef("findByType(%s, %s, %s)%s", type, resourceServer, consumer, getShortStackTrace());
+        tx.read(withCriteria(forResourceServer(resourceServer)
                 .compare(SearchableFields.TYPE, Operator.EQ, type)))
             .map(this::entityToAdapter)
             .forEach(consumer);
     }
 
     @Override
-    public void findByType(String resourceServerId, String type, String owner, Consumer<Resource> consumer) {
-        LOG.tracef("findByType(%s, %s, %s, %s)%s", type, owner, resourceServerId, consumer, getShortStackTrace());
+    public void findByType(ResourceServer resourceServer, String type, String owner, Consumer<Resource> consumer) {
+        LOG.tracef("findByType(%s, %s, %s, %s)%s", type, owner, resourceServer, consumer, getShortStackTrace());
 
-        DefaultModelCriteria<Resource> mcb = forResourceServer(resourceServerId)
+        DefaultModelCriteria<Resource> mcb = forResourceServer(resourceServer)
                 .compare(SearchableFields.TYPE, Operator.EQ, type);
 
         if (owner != null) {
@@ -245,10 +242,10 @@ public class MapResourceStore implements ResourceStore {
     }
 
     @Override
-    public void findByTypeInstance(String resourceServerId, String type, Consumer<Resource> consumer) {
-        LOG.tracef("findByTypeInstance(%s, %s, %s)%s", type, resourceServerId, consumer, getShortStackTrace());
-        tx.read(withCriteria(forResourceServer(resourceServerId)
-                .compare(SearchableFields.OWNER, Operator.NE, resourceServerId)
+    public void findByTypeInstance(ResourceServer resourceServer, String type, Consumer<Resource> consumer) {
+        LOG.tracef("findByTypeInstance(%s, %s, %s)%s", type, resourceServer, consumer, getShortStackTrace());
+        tx.read(withCriteria(forResourceServer(resourceServer)
+                .compare(SearchableFields.OWNER, Operator.NE, resourceServer.getClientId())
                 .compare(SearchableFields.TYPE, Operator.EQ, type)))
                 .map(this::entityToAdapter)
                 .forEach(consumer);

--- a/model/map/src/main/java/org/keycloak/models/map/authorization/MapResourceStore.java
+++ b/model/map/src/main/java/org/keycloak/models/map/authorization/MapResourceStore.java
@@ -129,10 +129,10 @@ public class MapResourceStore implements ResourceStore {
     }
 
     @Override
-    public List<Resource> findByOwner(ResourceServer resourceServer, String ownerId, int first, int max) {
+    public List<Resource> findByOwner(ResourceServer resourceServer, String ownerId, Integer firstResult, Integer maxResults) {
         List<Resource> resourceList = new LinkedList<>();
 
-        findByOwnerFilter(ownerId, resourceServer, resourceList::add, first, max);
+        findByOwnerFilter(ownerId, resourceServer, resourceList::add, firstResult, maxResults);
 
         return resourceList;
     }
@@ -157,15 +157,15 @@ public class MapResourceStore implements ResourceStore {
     }
 
     @Override
-    public List<Resource> findByResourceServer(ResourceServer resourceServer, Map<Resource.FilterOption, String[]> attributes, int firstResult, int maxResult) {
-        LOG.tracef("findByResourceServer(%s, %s, %d, %d)%s", attributes, resourceServer, firstResult, maxResult, getShortStackTrace());
+    public List<Resource> findByResourceServer(ResourceServer resourceServer, Map<Resource.FilterOption, String[]> attributes, Integer firstResult, Integer maxResults) {
+        LOG.tracef("findByResourceServer(%s, %s, %d, %d)%s", attributes, resourceServer, firstResult, maxResults, getShortStackTrace());
         DefaultModelCriteria<Resource> mcb = forResourceServer(resourceServer).and(
                 attributes.entrySet().stream()
                         .map(this::filterEntryToDefaultModelCriteria)
                         .toArray(DefaultModelCriteria[]::new)
         );
 
-        return tx.read(withCriteria(mcb).pagination(firstResult, maxResult, SearchableFields.NAME))
+        return tx.read(withCriteria(mcb).pagination(firstResult, maxResults, SearchableFields.NAME))
                 .map(this::entityToAdapter)
                 .collect(Collectors.toList());
     }

--- a/model/map/src/main/java/org/keycloak/models/map/authorization/MapScopeStore.java
+++ b/model/map/src/main/java/org/keycloak/models/map/authorization/MapScopeStore.java
@@ -60,13 +60,13 @@ public class MapScopeStore implements ScopeStore {
         return new MapScopeAdapter(origEntity, authorizationProvider.getStoreFactory());
     }
 
-    private DefaultModelCriteria<Scope> forResourceServer(String resourceServerId) {
+    private DefaultModelCriteria<Scope> forResourceServer(ResourceServer resourceServer) {
         DefaultModelCriteria<Scope> mcb = criteria();
 
-        return resourceServerId == null
+        return resourceServer == null
                 ? mcb
                 : mcb.compare(SearchableFields.RESOURCE_SERVER_ID, Operator.EQ,
-                resourceServerId);
+                resourceServer.getId());
     }
 
     @Override
@@ -75,7 +75,7 @@ public class MapScopeStore implements ScopeStore {
 
 
         // @UniqueConstraint(columnNames = {"NAME", "RESOURCE_SERVER_ID"})
-        DefaultModelCriteria<Scope> mcb = forResourceServer(resourceServer.getId())
+        DefaultModelCriteria<Scope> mcb = forResourceServer(resourceServer)
                 .compare(SearchableFields.NAME, Operator.EQ, name);
 
         if (tx.getCount(withCriteria(mcb)) > 0) {
@@ -99,10 +99,10 @@ public class MapScopeStore implements ScopeStore {
     }
 
     @Override
-    public Scope findById(String resourceServerId, String id) {
-        LOG.tracef("findById(%s, %s)%s", id, resourceServerId, getShortStackTrace());
+    public Scope findById(ResourceServer resourceServer, String id) {
+        LOG.tracef("findById(%s, %s)%s", id, resourceServer, getShortStackTrace());
 
-        return tx.read(withCriteria(forResourceServer(resourceServerId)
+        return tx.read(withCriteria(forResourceServer(resourceServer)
                 .compare(SearchableFields.ID, Operator.EQ, id)))
                 .findFirst()
                 .map(this::entityToAdapter)
@@ -110,10 +110,10 @@ public class MapScopeStore implements ScopeStore {
     }
 
     @Override
-    public Scope findByName(String resourceServerId, String name) {
-        LOG.tracef("findByName(%s, %s)%s", name, resourceServerId, getShortStackTrace());
+    public Scope findByName(ResourceServer resourceServer, String name) {
+        LOG.tracef("findByName(%s, %s)%s", name, resourceServer, getShortStackTrace());
 
-        return tx.read(withCriteria(forResourceServer(resourceServerId).compare(SearchableFields.NAME,
+        return tx.read(withCriteria(forResourceServer(resourceServer).compare(SearchableFields.NAME,
                 Operator.EQ, name)))
                 .findFirst()
                 .map(this::entityToAdapter)
@@ -121,17 +121,17 @@ public class MapScopeStore implements ScopeStore {
     }
 
     @Override
-    public List<Scope> findByResourceServer(String id) {
-        LOG.tracef("findByResourceServer(%s)%s", id, getShortStackTrace());
+    public List<Scope> findByResourceServer(ResourceServer resourceServer) {
+        LOG.tracef("findByResourceServer(%s)%s", resourceServer, getShortStackTrace());
 
-        return tx.read(withCriteria(forResourceServer(id)))
+        return tx.read(withCriteria(forResourceServer(resourceServer)))
                 .map(this::entityToAdapter)
                 .collect(Collectors.toList());
     }
 
     @Override
-    public List<Scope> findByResourceServer(String resourceServerId, Map<Scope.FilterOption, String[]> attributes, int firstResult, int maxResult) {
-        DefaultModelCriteria<Scope> mcb = forResourceServer(resourceServerId);
+    public List<Scope> findByResourceServer(ResourceServer resourceServer, Map<Scope.FilterOption, String[]> attributes, int firstResult, int maxResult) {
+        DefaultModelCriteria<Scope> mcb = forResourceServer(resourceServer);
 
         for (Scope.FilterOption filterOption : attributes.keySet()) {
             String[] value = attributes.get(filterOption);

--- a/model/map/src/main/java/org/keycloak/models/map/authorization/MapScopeStore.java
+++ b/model/map/src/main/java/org/keycloak/models/map/authorization/MapScopeStore.java
@@ -70,7 +70,7 @@ public class MapScopeStore implements ScopeStore {
     }
 
     @Override
-    public Scope create(String id, String name, ResourceServer resourceServer) {
+    public Scope create(ResourceServer resourceServer, String id, String name) {
         LOG.tracef("create(%s, %s, %s)%s", id, name, resourceServer, getShortStackTrace());
 
 
@@ -99,7 +99,7 @@ public class MapScopeStore implements ScopeStore {
     }
 
     @Override
-    public Scope findById(String id, String resourceServerId) {
+    public Scope findById(String resourceServerId, String id) {
         LOG.tracef("findById(%s, %s)%s", id, resourceServerId, getShortStackTrace());
 
         return tx.read(withCriteria(forResourceServer(resourceServerId)
@@ -110,7 +110,7 @@ public class MapScopeStore implements ScopeStore {
     }
 
     @Override
-    public Scope findByName(String name, String resourceServerId) {
+    public Scope findByName(String resourceServerId, String name) {
         LOG.tracef("findByName(%s, %s)%s", name, resourceServerId, getShortStackTrace());
 
         return tx.read(withCriteria(forResourceServer(resourceServerId).compare(SearchableFields.NAME,
@@ -130,7 +130,7 @@ public class MapScopeStore implements ScopeStore {
     }
 
     @Override
-    public List<Scope> findByResourceServer(Map<Scope.FilterOption, String[]> attributes, String resourceServerId, int firstResult, int maxResult) {
+    public List<Scope> findByResourceServer(String resourceServerId, Map<Scope.FilterOption, String[]> attributes, int firstResult, int maxResult) {
         DefaultModelCriteria<Scope> mcb = forResourceServer(resourceServerId);
 
         for (Scope.FilterOption filterOption : attributes.keySet()) {

--- a/model/map/src/main/java/org/keycloak/models/map/authorization/MapScopeStore.java
+++ b/model/map/src/main/java/org/keycloak/models/map/authorization/MapScopeStore.java
@@ -130,7 +130,7 @@ public class MapScopeStore implements ScopeStore {
     }
 
     @Override
-    public List<Scope> findByResourceServer(ResourceServer resourceServer, Map<Scope.FilterOption, String[]> attributes, int firstResult, int maxResult) {
+    public List<Scope> findByResourceServer(ResourceServer resourceServer, Map<Scope.FilterOption, String[]> attributes, Integer firstResult, Integer maxResults) {
         DefaultModelCriteria<Scope> mcb = forResourceServer(resourceServer);
 
         for (Scope.FilterOption filterOption : attributes.keySet()) {
@@ -148,7 +148,7 @@ public class MapScopeStore implements ScopeStore {
             }
         }
 
-        return tx.read(withCriteria(mcb).pagination(firstResult, maxResult, SearchableFields.NAME))
+        return tx.read(withCriteria(mcb).pagination(firstResult, maxResults, SearchableFields.NAME))
             .map(this::entityToAdapter)
             .collect(Collectors.toList());
     }

--- a/model/map/src/main/java/org/keycloak/models/map/authorization/adapter/MapPermissionTicketAdapter.java
+++ b/model/map/src/main/java/org/keycloak/models/map/authorization/adapter/MapPermissionTicketAdapter.java
@@ -57,7 +57,7 @@ public class MapPermissionTicketAdapter extends AbstractPermissionTicketModel<Ma
     @Override
     public Scope getScope() {
         if (entity.getScopeId() == null) return null;
-        return storeFactory.getScopeStore().findById(entity.getResourceServerId(), entity.getScopeId());
+        return storeFactory.getScopeStore().findById(getResourceServer(), entity.getScopeId());
     }
 
     @Override

--- a/model/map/src/main/java/org/keycloak/models/map/authorization/adapter/MapPermissionTicketAdapter.java
+++ b/model/map/src/main/java/org/keycloak/models/map/authorization/adapter/MapPermissionTicketAdapter.java
@@ -89,7 +89,8 @@ public class MapPermissionTicketAdapter extends AbstractPermissionTicketModel<Ma
     @Override
     public Policy getPolicy() {
         if (entity.getPolicyId() == null) return null;
-        return storeFactory.getPolicyStore().findById(entity.getResourceServerId(), entity.getPolicyId());
+        ResourceServer resourceServer = storeFactory.getResourceServerStore().findById(entity.getResourceServerId());
+        return storeFactory.getPolicyStore().findById(resourceServer, entity.getPolicyId());
     }
 
     @Override

--- a/model/map/src/main/java/org/keycloak/models/map/authorization/adapter/MapPermissionTicketAdapter.java
+++ b/model/map/src/main/java/org/keycloak/models/map/authorization/adapter/MapPermissionTicketAdapter.java
@@ -51,13 +51,13 @@ public class MapPermissionTicketAdapter extends AbstractPermissionTicketModel<Ma
 
     @Override
     public Resource getResource() {
-        return storeFactory.getResourceStore().findById(entity.getResourceId(), entity.getResourceServerId());
+        return storeFactory.getResourceStore().findById(entity.getResourceServerId(), entity.getResourceId());
     }
 
     @Override
     public Scope getScope() {
         if (entity.getScopeId() == null) return null;
-        return storeFactory.getScopeStore().findById(entity.getScopeId(), entity.getResourceServerId());
+        return storeFactory.getScopeStore().findById(entity.getResourceServerId(), entity.getScopeId());
     }
 
     @Override
@@ -89,7 +89,7 @@ public class MapPermissionTicketAdapter extends AbstractPermissionTicketModel<Ma
     @Override
     public Policy getPolicy() {
         if (entity.getPolicyId() == null) return null;
-        return storeFactory.getPolicyStore().findById(entity.getPolicyId(), entity.getResourceServerId());
+        return storeFactory.getPolicyStore().findById(entity.getResourceServerId(), entity.getPolicyId());
     }
 
     @Override

--- a/model/map/src/main/java/org/keycloak/models/map/authorization/adapter/MapPermissionTicketAdapter.java
+++ b/model/map/src/main/java/org/keycloak/models/map/authorization/adapter/MapPermissionTicketAdapter.java
@@ -51,7 +51,7 @@ public class MapPermissionTicketAdapter extends AbstractPermissionTicketModel<Ma
 
     @Override
     public Resource getResource() {
-        return storeFactory.getResourceStore().findById(entity.getResourceServerId(), entity.getResourceId());
+        return storeFactory.getResourceStore().findById(getResourceServer(), entity.getResourceId());
     }
 
     @Override

--- a/model/map/src/main/java/org/keycloak/models/map/authorization/adapter/MapPolicyAdapter.java
+++ b/model/map/src/main/java/org/keycloak/models/map/authorization/adapter/MapPolicyAdapter.java
@@ -127,7 +127,7 @@ public class MapPolicyAdapter extends AbstractPolicyModel<MapPolicyEntity> {
         String resourceServerId = entity.getResourceServerId();
         Set<String> ids = entity.getAssociatedPolicyIds();
         return ids == null ? Collections.emptySet() : ids.stream()
-                .map(policyId -> storeFactory.getPolicyStore().findById(resourceServerId, policyId))
+                .map(policyId -> storeFactory.getPolicyStore().findById(storeFactory.getResourceServerStore().findById(resourceServerId), policyId))
                 .collect(Collectors.toSet());
     }
 

--- a/model/map/src/main/java/org/keycloak/models/map/authorization/adapter/MapPolicyAdapter.java
+++ b/model/map/src/main/java/org/keycloak/models/map/authorization/adapter/MapPolicyAdapter.java
@@ -133,10 +133,10 @@ public class MapPolicyAdapter extends AbstractPolicyModel<MapPolicyEntity> {
 
     @Override
     public Set<Resource> getResources() {
-        String resourceServerId = entity.getResourceServerId();
+        ResourceServer resourceServer = getResourceServer();
         Set<String> ids = entity.getResourceIds();
         return ids == null ? Collections.emptySet() : ids.stream()
-                .map(resourceId -> storeFactory.getResourceStore().findById(resourceServerId, resourceId))
+                .map(resourceId -> storeFactory.getResourceStore().findById(resourceServer, resourceId))
                 .collect(Collectors.toSet());
     }
 

--- a/model/map/src/main/java/org/keycloak/models/map/authorization/adapter/MapPolicyAdapter.java
+++ b/model/map/src/main/java/org/keycloak/models/map/authorization/adapter/MapPolicyAdapter.java
@@ -142,10 +142,10 @@ public class MapPolicyAdapter extends AbstractPolicyModel<MapPolicyEntity> {
 
     @Override
     public Set<Scope> getScopes() {
-        String resourceServerId = entity.getResourceServerId();
+        ResourceServer resourceServer = getResourceServer();
         Set<String> ids = entity.getScopeIds();
         return ids == null ? Collections.emptySet() : ids.stream()
-                .map(scopeId -> storeFactory.getScopeStore().findById(resourceServerId, scopeId))
+                .map(scopeId -> storeFactory.getScopeStore().findById(resourceServer, scopeId))
                 .collect(Collectors.toSet());
     }
 

--- a/model/map/src/main/java/org/keycloak/models/map/authorization/adapter/MapPolicyAdapter.java
+++ b/model/map/src/main/java/org/keycloak/models/map/authorization/adapter/MapPolicyAdapter.java
@@ -127,7 +127,7 @@ public class MapPolicyAdapter extends AbstractPolicyModel<MapPolicyEntity> {
         String resourceServerId = entity.getResourceServerId();
         Set<String> ids = entity.getAssociatedPolicyIds();
         return ids == null ? Collections.emptySet() : ids.stream()
-                .map(policyId -> storeFactory.getPolicyStore().findById(policyId, resourceServerId))
+                .map(policyId -> storeFactory.getPolicyStore().findById(resourceServerId, policyId))
                 .collect(Collectors.toSet());
     }
 
@@ -136,7 +136,7 @@ public class MapPolicyAdapter extends AbstractPolicyModel<MapPolicyEntity> {
         String resourceServerId = entity.getResourceServerId();
         Set<String> ids = entity.getResourceIds();
         return ids == null ? Collections.emptySet() : ids.stream()
-                .map(resourceId -> storeFactory.getResourceStore().findById(resourceId, resourceServerId))
+                .map(resourceId -> storeFactory.getResourceStore().findById(resourceServerId, resourceId))
                 .collect(Collectors.toSet());
     }
 
@@ -145,7 +145,7 @@ public class MapPolicyAdapter extends AbstractPolicyModel<MapPolicyEntity> {
         String resourceServerId = entity.getResourceServerId();
         Set<String> ids = entity.getScopeIds();
         return ids == null ? Collections.emptySet() : ids.stream()
-                .map(scopeId -> storeFactory.getScopeStore().findById(scopeId, resourceServerId))
+                .map(scopeId -> storeFactory.getScopeStore().findById(resourceServerId, scopeId))
                 .collect(Collectors.toSet());
     }
 

--- a/model/map/src/main/java/org/keycloak/models/map/authorization/adapter/MapResourceAdapter.java
+++ b/model/map/src/main/java/org/keycloak/models/map/authorization/adapter/MapResourceAdapter.java
@@ -92,7 +92,7 @@ public class MapResourceAdapter extends AbstractResourceModel<MapResourceEntity>
         Set<String> ids = entity.getScopeIds();
         return ids == null ? Collections.emptyList() : ids.stream()
                 .map(id -> storeFactory
-                        .getScopeStore().findById(id, entity.getResourceServerId()))
+                        .getScopeStore().findById(entity.getResourceServerId(), id))
                 .collect(Collectors.toList());
     }
 
@@ -141,13 +141,13 @@ public class MapResourceAdapter extends AbstractResourceModel<MapResourceEntity>
                 // The scope^ was removed from the Resource
 
                 // Remove permission tickets based on the scope
-                List<PermissionTicket> permissions = permissionStore.findByScope(scope.getId(), getResourceServer());
+                List<PermissionTicket> permissions = permissionStore.findByScope(getResourceServer(), scope.getId());
                 for (PermissionTicket permission : permissions) {
                     permissionStore.delete(permission.getId());
                 }
 
                 // Remove the scope from each Policy for this Resource
-                policyStore.findByResource(getId(), getResourceServer(), policy -> policy.removeScope(scope));
+                policyStore.findByResource(getResourceServer(), getId(), policy -> policy.removeScope(scope));
             }
         }
 

--- a/model/map/src/main/java/org/keycloak/models/map/authorization/adapter/MapResourceAdapter.java
+++ b/model/map/src/main/java/org/keycloak/models/map/authorization/adapter/MapResourceAdapter.java
@@ -91,9 +91,10 @@ public class MapResourceAdapter extends AbstractResourceModel<MapResourceEntity>
     @Override
     public List<Scope> getScopes() {
         Set<String> ids = entity.getScopeIds();
+        ResourceServer resourceServer = getResourceServer();
         return ids == null ? Collections.emptyList() : ids.stream()
                 .map(id -> storeFactory
-                        .getScopeStore().findById(entity.getResourceServerId(), id))
+                        .getScopeStore().findById(resourceServer, id))
                 .collect(Collectors.toList());
     }
 

--- a/model/map/src/main/java/org/keycloak/models/map/authorization/adapter/MapResourceAdapter.java
+++ b/model/map/src/main/java/org/keycloak/models/map/authorization/adapter/MapResourceAdapter.java
@@ -142,7 +142,7 @@ public class MapResourceAdapter extends AbstractResourceModel<MapResourceEntity>
                 // The scope^ was removed from the Resource
 
                 // Remove permission tickets based on the scope
-                List<PermissionTicket> permissions = permissionStore.findByScope(getResourceServer().getId(), scope.getId());
+                List<PermissionTicket> permissions = permissionStore.findByScope(getResourceServer(), scope);
                 for (PermissionTicket permission : permissions) {
                     permissionStore.delete(permission.getId());
                 }

--- a/model/map/src/main/java/org/keycloak/models/map/authorization/adapter/MapResourceAdapter.java
+++ b/model/map/src/main/java/org/keycloak/models/map/authorization/adapter/MapResourceAdapter.java
@@ -148,7 +148,7 @@ public class MapResourceAdapter extends AbstractResourceModel<MapResourceEntity>
                 }
 
                 // Remove the scope from each Policy for this Resource
-                policyStore.findByResource(getResourceServer().getId(), getId(), policy -> policy.removeScope(scope));
+                policyStore.findByResource(getResourceServer(), this, policy -> policy.removeScope(scope));
             }
         }
 

--- a/model/map/src/main/java/org/keycloak/models/map/authorization/adapter/MapResourceAdapter.java
+++ b/model/map/src/main/java/org/keycloak/models/map/authorization/adapter/MapResourceAdapter.java
@@ -18,6 +18,7 @@
 package org.keycloak.models.map.authorization.adapter;
 
 import org.keycloak.authorization.model.PermissionTicket;
+import org.keycloak.authorization.model.ResourceServer;
 import org.keycloak.authorization.model.Scope;
 import org.keycloak.authorization.store.PermissionTicketStore;
 import org.keycloak.authorization.store.PolicyStore;
@@ -108,8 +109,8 @@ public class MapResourceAdapter extends AbstractResourceModel<MapResourceEntity>
     }
 
     @Override
-    public String getResourceServer() {
-        return entity.getResourceServerId();
+    public ResourceServer getResourceServer() {
+        return storeFactory.getResourceServerStore().findById(entity.getResourceServerId());
     }
 
     @Override
@@ -141,13 +142,13 @@ public class MapResourceAdapter extends AbstractResourceModel<MapResourceEntity>
                 // The scope^ was removed from the Resource
 
                 // Remove permission tickets based on the scope
-                List<PermissionTicket> permissions = permissionStore.findByScope(getResourceServer(), scope.getId());
+                List<PermissionTicket> permissions = permissionStore.findByScope(getResourceServer().getId(), scope.getId());
                 for (PermissionTicket permission : permissions) {
                     permissionStore.delete(permission.getId());
                 }
 
                 // Remove the scope from each Policy for this Resource
-                policyStore.findByResource(getResourceServer(), getId(), policy -> policy.removeScope(scope));
+                policyStore.findByResource(getResourceServer().getId(), getId(), policy -> policy.removeScope(scope));
             }
         }
 

--- a/model/map/src/main/java/org/keycloak/models/map/authorization/adapter/MapResourceServerAdapter.java
+++ b/model/map/src/main/java/org/keycloak/models/map/authorization/adapter/MapResourceServerAdapter.java
@@ -35,11 +35,6 @@ public class MapResourceServerAdapter extends AbstractResourceServerModel<MapRes
     }
 
     @Override
-    public String getClientId() {
-        return getId();
-    }
-
-    @Override
     public boolean isAllowRemoteResourceManagement() {
         Boolean isARRM = entity.isAllowRemoteResourceManagement();
         return isARRM == null ? false : isARRM;

--- a/model/map/src/main/java/org/keycloak/models/map/authorization/adapter/MapResourceServerAdapter.java
+++ b/model/map/src/main/java/org/keycloak/models/map/authorization/adapter/MapResourceServerAdapter.java
@@ -35,6 +35,11 @@ public class MapResourceServerAdapter extends AbstractResourceServerModel<MapRes
     }
 
     @Override
+    public String getClientId() {
+        return getId();
+    }
+
+    @Override
     public boolean isAllowRemoteResourceManagement() {
         Boolean isARRM = entity.isAllowRemoteResourceManagement();
         return isARRM == null ? false : isARRM;

--- a/model/map/src/main/java/org/keycloak/models/map/user/MapUserProvider.java
+++ b/model/map/src/main/java/org/keycloak/models/map/user/MapUserProvider.java
@@ -47,7 +47,6 @@ import org.keycloak.models.map.storage.ModelCriteriaBuilder.Operator;
 import org.keycloak.models.map.storage.criteria.DefaultModelCriteria;
 import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.storage.StorageId;
-import org.keycloak.storage.UserStorageManager;
 import org.keycloak.storage.UserStorageProvider;
 import org.keycloak.storage.client.ClientStorageProvider;
 
@@ -684,7 +683,7 @@ public class MapUserProvider implements UserProvider.Streams, UserCredentialStor
             authorizedGroups.removeIf(id -> {
                 Map<Resource.FilterOption, String[]> values = new EnumMap<>(Resource.FilterOption.class);
                 values.put(Resource.FilterOption.EXACT_NAME, new String[] {"group.resource." + id});
-                return resourceStore.findByResourceServer(values, null, 0, 1).isEmpty();
+                return resourceStore.findByResourceServer(null, values, 0, 1).isEmpty();
             });
 
             criteria = criteria.compare(SearchableFields.ASSIGNED_GROUP, Operator.IN, authorizedGroups);

--- a/server-spi-private/src/main/java/org/keycloak/authorization/AuthorizationProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/AuthorizationProvider.java
@@ -334,10 +334,10 @@ public final class AuthorizationProvider implements Provider {
 
                 if (policies != null) {
                     representation.setPolicies(policies.stream().map(id -> {
-                        Policy policy = storeFactory.getPolicyStore().findById(resourceServer.getId(), id);
+                        Policy policy = storeFactory.getPolicyStore().findById(resourceServer, id);
 
                         if (policy == null) {
-                            policy = storeFactory.getPolicyStore().findByName(resourceServer.getId(), id);
+                            policy = storeFactory.getPolicyStore().findByName(resourceServer, id);
                         }
 
                         if (policy == null) {
@@ -369,7 +369,7 @@ public final class AuthorizationProvider implements Provider {
                         }
                     }
 
-                    findDependentPolicies(resourceServer.getId(), policy.getId()).forEach(dependentPolicy -> {
+                    findDependentPolicies(resourceServer, policy.getId()).forEach(dependentPolicy -> {
                         dependentPolicy.removeAssociatedPolicy(policy);
                         if (dependentPolicy.getAssociatedPolicies().isEmpty()) {
                             delete(dependentPolicy.getId());
@@ -381,68 +381,68 @@ public final class AuthorizationProvider implements Provider {
             }
 
             @Override
-            public Policy findById(String resourceServerId, String id) {
-                return policyStore.findById(resourceServerId, id);
+            public Policy findById(ResourceServer resourceServer, String id) {
+                return policyStore.findById(resourceServer, id);
             }
 
             @Override
-            public Policy findByName(String resourceServerId, String name) {
-                return policyStore.findByName(resourceServerId, name);
+            public Policy findByName(ResourceServer resourceServer, String name) {
+                return policyStore.findByName(resourceServer, name);
             }
 
             @Override
-            public List<Policy> findByResourceServer(String resourceServerId) {
-                return policyStore.findByResourceServer(resourceServerId);
+            public List<Policy> findByResourceServer(ResourceServer resourceServer) {
+                return policyStore.findByResourceServer(resourceServer);
             }
 
             @Override
-            public List<Policy> findByResourceServer(String resourceServerId, Map<Policy.FilterOption, String[]> attributes, int firstResult, int maxResult) {
-                return policyStore.findByResourceServer(resourceServerId, attributes, firstResult, maxResult);
+            public List<Policy> findByResourceServer(ResourceServer resourceServer, Map<Policy.FilterOption, String[]> attributes, int firstResult, int maxResult) {
+                return policyStore.findByResourceServer(resourceServer, attributes, firstResult, maxResult);
             }
 
             @Override
-            public List<Policy> findByResource(String resourceServerId, String resourceId) {
-                return policyStore.findByResource(resourceServerId, resourceId);
+            public List<Policy> findByResource(ResourceServer resourceServer, Resource resource) {
+                return policyStore.findByResource(resourceServer, resource);
             }
 
             @Override
-            public void findByResource(String resourceServerId, String resourceId, Consumer<Policy> consumer) {
-                policyStore.findByResource(resourceServerId, resourceId, consumer);
+            public void findByResource(ResourceServer resourceServer, Resource resource, Consumer<Policy> consumer) {
+                policyStore.findByResource(resourceServer, resource, consumer);
             }
 
             @Override
-            public List<Policy> findByResourceType(String resourceServerId, String resourceType) {
-                return policyStore.findByResourceType(resourceServerId, resourceType);
+            public List<Policy> findByResourceType(ResourceServer resourceServer, String resourceType) {
+                return policyStore.findByResourceType(resourceServer, resourceType);
             }
 
             @Override
-            public List<Policy> findByScopeIds(String resourceServerId, List<String> scopeIds) {
-                return policyStore.findByScopeIds(resourceServerId, scopeIds);
+            public List<Policy> findByScopes(ResourceServer resourceServer, List<Scope> scopes) {
+                return policyStore.findByScopes(resourceServer, scopes);
             }
 
             @Override
-            public List<Policy> findByScopeIds(String resourceServerId, String resourceId, List<String> scopeIds) {
-                return policyStore.findByScopeIds(resourceServerId, resourceId, scopeIds);
+            public List<Policy> findByScopes(ResourceServer resourceServer, Resource resource, List<Scope> scopes) {
+                return policyStore.findByScopes(resourceServer, resource, scopes);
             }
 
             @Override
-            public void findByScopeIds(String resourceServerId, String resourceId, List<String> scopeIds, Consumer<Policy> consumer) {
-                policyStore.findByScopeIds(resourceServerId, resourceId, scopeIds, consumer);
+            public void findByScopes(ResourceServer resourceServer, Resource resource, List<Scope> scopes, Consumer<Policy> consumer) {
+                policyStore.findByScopes(resourceServer, resource, scopes, consumer);
             }
 
             @Override
-            public List<Policy> findByType(String resourceServerId, String type) {
-                return policyStore.findByType(resourceServerId, type);
+            public List<Policy> findByType(ResourceServer resourceServer, String type) {
+                return policyStore.findByType(resourceServer, type);
             }
 
             @Override
-            public List<Policy> findDependentPolicies(String resourceServerId, String id) {
-                return policyStore.findDependentPolicies(resourceServerId, id);
+            public List<Policy> findDependentPolicies(ResourceServer resourceServer, String id) {
+                return policyStore.findDependentPolicies(resourceServer, id);
             }
 
             @Override
-            public void findByResourceType(String id, String type, Consumer<Policy> policyConsumer) {
-                policyStore.findByResourceType(id, type, policyConsumer);
+            public void findByResourceType(ResourceServer resourceServer, String type, Consumer<Policy> policyConsumer) {
+                policyStore.findByResourceType(resourceServer, type, policyConsumer);
             }
         };
     }
@@ -473,7 +473,7 @@ public final class AuthorizationProvider implements Provider {
                 }
 
                 PolicyStore policyStore = storeFactory.getPolicyStore();
-                List<Policy> policies = policyStore.findByResource(resource.getResourceServer().getId(), id);
+                List<Policy> policies = policyStore.findByResource(resource.getResourceServer(), resource);
 
                 for (Policy policyModel : policies) {
                     if (policyModel.getResources().size() == 1) {

--- a/server-spi-private/src/main/java/org/keycloak/authorization/AuthorizationProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/AuthorizationProvider.java
@@ -265,23 +265,23 @@ public final class AuthorizationProvider implements Provider {
             }
 
             @Override
-            public Scope findById(String resourceServerId, String id) {
-                return delegate.findById(resourceServerId, id);
+            public Scope findById(ResourceServer resourceServer, String id) {
+                return delegate.findById(resourceServer, id);
             }
 
             @Override
-            public Scope findByName(String resourceServerId, String name) {
-                return delegate.findByName(resourceServerId, name);
+            public Scope findByName(ResourceServer resourceServer, String name) {
+                return delegate.findByName(resourceServer, name);
             }
 
             @Override
-            public List<Scope> findByResourceServer(String id) {
-                return delegate.findByResourceServer(id);
+            public List<Scope> findByResourceServer(ResourceServer resourceServer) {
+                return delegate.findByResourceServer(resourceServer);
             }
 
             @Override
-            public List<Scope> findByResourceServer(String resourceServerId, Map<Scope.FilterOption, String[]> attributes, int firstResult, int maxResult) {
-                return delegate.findByResourceServer(resourceServerId, attributes, firstResult, maxResult);
+            public List<Scope> findByResourceServer(ResourceServer resourceServer, Map<Scope.FilterOption, String[]> attributes, int firstResult, int maxResult) {
+                return delegate.findByResourceServer(resourceServer, attributes, firstResult, maxResult);
             }
         };
     }
@@ -315,10 +315,10 @@ public final class AuthorizationProvider implements Provider {
 
                 if (scopes != null) {
                     representation.setScopes(scopes.stream().map(id -> {
-                        Scope scope = storeFactory.getScopeStore().findById(resourceServer.getId(), id);
+                        Scope scope = storeFactory.getScopeStore().findById(resourceServer, id);
 
                         if (scope == null) {
-                            scope = storeFactory.getScopeStore().findByName(resourceServer.getId(), id);
+                            scope = storeFactory.getScopeStore().findByName(resourceServer, id);
                         }
 
                         if (scope == null) {

--- a/server-spi-private/src/main/java/org/keycloak/authorization/AuthorizationProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/AuthorizationProvider.java
@@ -255,7 +255,7 @@ public final class AuthorizationProvider implements Provider {
             public void delete(String id) {
                 Scope scope = findById(null, id);
                 PermissionTicketStore ticketStore = AuthorizationProvider.this.getStoreFactory().getPermissionTicketStore();
-                List<PermissionTicket> permissions = ticketStore.findByScope(scope.getResourceServer().getId(), id);
+                List<PermissionTicket> permissions = ticketStore.findByScope(scope.getResourceServer(), scope);
 
                 for (PermissionTicket permission : permissions) {
                     ticketStore.delete(permission.getId());
@@ -466,7 +466,7 @@ public final class AuthorizationProvider implements Provider {
                 Resource resource = findById(null, id);
                 StoreFactory storeFactory = AuthorizationProvider.this.getStoreFactory();
                 PermissionTicketStore ticketStore = storeFactory.getPermissionTicketStore();
-                List<PermissionTicket> permissions = ticketStore.findByResource(resource.getResourceServer().getId(), id);
+                List<PermissionTicket> permissions = ticketStore.findByResource(resource.getResourceServer(), resource);
 
                 for (PermissionTicket permission : permissions) {
                     ticketStore.delete(permission.getId());

--- a/server-spi-private/src/main/java/org/keycloak/authorization/AuthorizationProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/AuthorizationProvider.java
@@ -297,10 +297,10 @@ public final class AuthorizationProvider implements Provider {
 
                 if (resources != null) {
                     representation.setResources(resources.stream().map(id -> {
-                        Resource resource = storeFactory.getResourceStore().findById(resourceServer.getId(), id);
+                        Resource resource = storeFactory.getResourceStore().findById(resourceServer, id);
 
                         if (resource == null) {
-                            resource = storeFactory.getResourceStore().findByName(resourceServer.getId(), id);
+                            resource = storeFactory.getResourceStore().findByName(resourceServer, id);
                         }
 
                         if (resource == null) {
@@ -487,88 +487,83 @@ public final class AuthorizationProvider implements Provider {
             }
 
             @Override
-            public Resource findById(String resourceServerId, String id) {
-                return delegate.findById(resourceServerId, id);
+            public Resource findById(ResourceServer resourceServer, String id) {
+                return delegate.findById(resourceServer, id);
             }
 
             @Override
-            public List<Resource> findByOwner(String resourceServerId, String ownerId) {
-                return delegate.findByOwner(resourceServerId, ownerId);
+            public List<Resource> findByOwner(ResourceServer resourceServer, String ownerId) {
+                return delegate.findByOwner(resourceServer, ownerId);
             }
 
             @Override
-            public void findByOwner(String resourceServerId, String ownerId, Consumer<Resource> consumer) {
-                delegate.findByOwner(resourceServerId, ownerId, consumer);
+            public void findByOwner(ResourceServer resourceServer, String ownerId, Consumer<Resource> consumer) {
+                delegate.findByOwner(resourceServer, ownerId, consumer);
             }
 
             @Override
-            public List<Resource> findByOwner(String resourceServerId, String ownerId, int first, int max) {
-                return delegate.findByOwner(resourceServerId, ownerId, first, max);
+            public List<Resource> findByOwner(ResourceServer resourceServer, String ownerId, int first, int max) {
+                return delegate.findByOwner(resourceServer, ownerId, first, max);
             }
 
             @Override
-            public List<Resource> findByUri(String resourceServerId, String uri) {
-                return delegate.findByUri(resourceServerId, uri);
+            public List<Resource> findByUri(ResourceServer resourceServer, String uri) {
+                return delegate.findByUri(resourceServer, uri);
             }
 
             @Override
-            public List<Resource> findByResourceServer(String resourceServerId) {
-                return delegate.findByResourceServer(resourceServerId);
+            public List<Resource> findByResourceServer(ResourceServer resourceServer) {
+                return delegate.findByResourceServer(resourceServer);
             }
 
             @Override
-            public List<Resource> findByResourceServer(String resourceServerId, Map<Resource.FilterOption, String[]> attributes, int firstResult, int maxResult) {
-                return delegate.findByResourceServer(resourceServerId, attributes, firstResult, maxResult);
+            public List<Resource> findByResourceServer(ResourceServer resourceServer, Map<Resource.FilterOption, String[]> attributes, int firstResult, int maxResult) {
+                return delegate.findByResourceServer(resourceServer, attributes, firstResult, maxResult);
             }
 
             @Override
-            public List<Resource> findByScope(String resourceServerId, List<String> id) {
-                return delegate.findByScope(resourceServerId, id);
+            public List<Resource> findByScopes(ResourceServer resourceServer, Set<Scope> scopes) {
+                return delegate.findByScopes(resourceServer, scopes);
             }
 
             @Override
-            public void findByScope(String resourceServerId, List<String> scopes, Consumer<Resource> consumer) {
-                delegate.findByScope(resourceServerId, scopes, consumer);
+            public void findByScopes(ResourceServer resourceServer, Set<Scope> scopes, Consumer<Resource> consumer) {
+                delegate.findByScopes(resourceServer, scopes, consumer);
             }
 
             @Override
-            public Resource findByName(String name, String resourceServerId) {
-                return delegate.findByName(name, resourceServerId);
+            public Resource findByName(ResourceServer resourceServer, String name, String ownerId) {
+                return delegate.findByName(resourceServer, name, ownerId);
             }
 
             @Override
-            public Resource findByName(String resourceServerId, String name, String ownerId) {
-                return delegate.findByName(resourceServerId, name, ownerId);
+            public List<Resource> findByType(ResourceServer resourceServer, String type) {
+                return delegate.findByType(resourceServer, type);
             }
 
             @Override
-            public List<Resource> findByType(String resourceServerId, String type) {
-                return delegate.findByType(resourceServerId, type);
+            public void findByType(ResourceServer resourceServer, String type, Consumer<Resource> consumer) {
+                delegate.findByType(resourceServer, type, consumer);
             }
 
             @Override
-            public void findByType(String resourceServerId, String type, Consumer<Resource> consumer) {
-                delegate.findByType(resourceServerId, type, consumer);
+            public void findByType(ResourceServer resourceServer, String type, String owner, Consumer<Resource> consumer) {
+                delegate.findByType(resourceServer, type, owner, consumer);
             }
 
             @Override
-            public void findByType(String resourceServerId, String type, String owner, Consumer<Resource> consumer) {
-                delegate.findByType(resourceServerId, type, owner, consumer);
+            public List<Resource> findByType(ResourceServer resourceServer, String type, String owner) {
+                return delegate.findByType(resourceServer, type);
             }
 
             @Override
-            public List<Resource> findByType(String resourceServerId, String type, String owner) {
-                return delegate.findByType(resourceServerId, type);
+            public List<Resource> findByTypeInstance(ResourceServer resourceServer, String type) {
+                return delegate.findByTypeInstance(resourceServer, type);
             }
 
             @Override
-            public List<Resource> findByTypeInstance(String type, String resourceServerId) {
-                return delegate.findByTypeInstance(type, resourceServerId);
-            }
-
-            @Override
-            public void findByTypeInstance(String type, String resourceServerId, Consumer<Resource> consumer) {
-                delegate.findByTypeInstance(resourceServerId, type, consumer);
+            public void findByTypeInstance(ResourceServer resourceServer, String type, Consumer<Resource> consumer) {
+                delegate.findByTypeInstance(resourceServer, type, consumer);
             }
         };
     }

--- a/server-spi-private/src/main/java/org/keycloak/authorization/AuthorizationProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/AuthorizationProvider.java
@@ -466,14 +466,14 @@ public final class AuthorizationProvider implements Provider {
                 Resource resource = findById(null, id);
                 StoreFactory storeFactory = AuthorizationProvider.this.getStoreFactory();
                 PermissionTicketStore ticketStore = storeFactory.getPermissionTicketStore();
-                List<PermissionTicket> permissions = ticketStore.findByResource(resource.getResourceServer(), id);
+                List<PermissionTicket> permissions = ticketStore.findByResource(resource.getResourceServer().getId(), id);
 
                 for (PermissionTicket permission : permissions) {
                     ticketStore.delete(permission.getId());
                 }
 
                 PolicyStore policyStore = storeFactory.getPolicyStore();
-                List<Policy> policies = policyStore.findByResource(resource.getResourceServer(), id);
+                List<Policy> policies = policyStore.findByResource(resource.getResourceServer().getId(), id);
 
                 for (Policy policyModel : policies) {
                     if (policyModel.getResources().size() == 1) {

--- a/server-spi-private/src/main/java/org/keycloak/authorization/AuthorizationProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/AuthorizationProvider.java
@@ -280,8 +280,8 @@ public final class AuthorizationProvider implements Provider {
             }
 
             @Override
-            public List<Scope> findByResourceServer(ResourceServer resourceServer, Map<Scope.FilterOption, String[]> attributes, int firstResult, int maxResult) {
-                return delegate.findByResourceServer(resourceServer, attributes, firstResult, maxResult);
+            public List<Scope> findByResourceServer(ResourceServer resourceServer, Map<Scope.FilterOption, String[]> attributes, Integer firstResult, Integer maxResults) {
+                return delegate.findByResourceServer(resourceServer, attributes, firstResult, maxResults);
             }
         };
     }
@@ -396,8 +396,8 @@ public final class AuthorizationProvider implements Provider {
             }
 
             @Override
-            public List<Policy> findByResourceServer(ResourceServer resourceServer, Map<Policy.FilterOption, String[]> attributes, int firstResult, int maxResult) {
-                return policyStore.findByResourceServer(resourceServer, attributes, firstResult, maxResult);
+            public List<Policy> findByResourceServer(ResourceServer resourceServer, Map<Policy.FilterOption, String[]> attributes, Integer firstResult, Integer maxResults) {
+                return policyStore.findByResourceServer(resourceServer, attributes, firstResult, maxResults);
             }
 
             @Override
@@ -502,8 +502,8 @@ public final class AuthorizationProvider implements Provider {
             }
 
             @Override
-            public List<Resource> findByOwner(ResourceServer resourceServer, String ownerId, int first, int max) {
-                return delegate.findByOwner(resourceServer, ownerId, first, max);
+            public List<Resource> findByOwner(ResourceServer resourceServer, String ownerId, Integer firstResult, Integer maxResults) {
+                return delegate.findByOwner(resourceServer, ownerId, firstResult, maxResults);
             }
 
             @Override
@@ -517,8 +517,8 @@ public final class AuthorizationProvider implements Provider {
             }
 
             @Override
-            public List<Resource> findByResourceServer(ResourceServer resourceServer, Map<Resource.FilterOption, String[]> attributes, int firstResult, int maxResult) {
-                return delegate.findByResourceServer(resourceServer, attributes, firstResult, maxResult);
+            public List<Resource> findByResourceServer(ResourceServer resourceServer, Map<Resource.FilterOption, String[]> attributes, Integer firstResult, Integer maxResults) {
+                return delegate.findByResourceServer(resourceServer, attributes, firstResult, maxResults);
             }
 
             @Override

--- a/server-spi-private/src/main/java/org/keycloak/authorization/UserManagedPermissionUtil.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/UserManagedPermissionUtil.java
@@ -46,7 +46,7 @@ public class UserManagedPermissionUtil {
             filter.put(PermissionTicket.FilterOption.RESOURCE_ID, ticket.getResource().getId());
             filter.put(PermissionTicket.FilterOption.POLICY_IS_NOT_NULL, Boolean.TRUE.toString());
 
-            List<PermissionTicket> tickets = storeFactory.getPermissionTicketStore().find(filter, ticket.getResourceServer().getId(), -1, 1);
+            List<PermissionTicket> tickets = storeFactory.getPermissionTicketStore().find(ticket.getResourceServer().getId(), filter, -1, 1);
 
             if (!tickets.isEmpty()) {
                 policy = tickets.iterator().next().getPolicy();
@@ -80,7 +80,7 @@ public class UserManagedPermissionUtil {
             filter.put(PermissionTicket.FilterOption.RESOURCE_ID, ticket.getResource().getId());
             filter.put(PermissionTicket.FilterOption.GRANTED, Boolean.TRUE.toString());
 
-            List<PermissionTicket> tickets = storeFactory.getPermissionTicketStore().find(filter, ticket.getResourceServer().getId(), -1, -1);
+            List<PermissionTicket> tickets = storeFactory.getPermissionTicketStore().find(ticket.getResourceServer().getId(), filter, -1, -1);
 
             if (tickets.isEmpty()) {
                 PolicyStore policyStore = storeFactory.getPolicyStore();
@@ -103,7 +103,7 @@ public class UserManagedPermissionUtil {
         userPolicyRep.setName(KeycloakModelUtils.generateId());
         userPolicyRep.addUser(ticket.getRequester());
 
-        Policy userPolicy = policyStore.create(userPolicyRep, ticket.getResourceServer());
+        Policy userPolicy = policyStore.create(ticket.getResourceServer(), userPolicyRep);
 
         userPolicy.setOwner(ticket.getOwner());
 
@@ -113,7 +113,7 @@ public class UserManagedPermissionUtil {
         policyRep.setType("uma");
         policyRep.addPolicy(userPolicy.getId());
 
-        Policy policy = policyStore.create(policyRep, ticket.getResourceServer());
+        Policy policy = policyStore.create(ticket.getResourceServer(), policyRep);
 
         policy.setOwner(ticket.getOwner());
         policy.addResource(ticket.getResource());

--- a/server-spi-private/src/main/java/org/keycloak/authorization/UserManagedPermissionUtil.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/UserManagedPermissionUtil.java
@@ -46,7 +46,7 @@ public class UserManagedPermissionUtil {
             filter.put(PermissionTicket.FilterOption.RESOURCE_ID, ticket.getResource().getId());
             filter.put(PermissionTicket.FilterOption.POLICY_IS_NOT_NULL, Boolean.TRUE.toString());
 
-            List<PermissionTicket> tickets = storeFactory.getPermissionTicketStore().find(ticket.getResourceServer().getId(), filter, -1, 1);
+            List<PermissionTicket> tickets = storeFactory.getPermissionTicketStore().find(ticket.getResourceServer(), filter, -1, 1);
 
             if (!tickets.isEmpty()) {
                 policy = tickets.iterator().next().getPolicy();
@@ -80,7 +80,7 @@ public class UserManagedPermissionUtil {
             filter.put(PermissionTicket.FilterOption.RESOURCE_ID, ticket.getResource().getId());
             filter.put(PermissionTicket.FilterOption.GRANTED, Boolean.TRUE.toString());
 
-            List<PermissionTicket> tickets = storeFactory.getPermissionTicketStore().find(ticket.getResourceServer().getId(), filter, -1, -1);
+            List<PermissionTicket> tickets = storeFactory.getPermissionTicketStore().find(ticket.getResourceServer(), filter, -1, -1);
 
             if (tickets.isEmpty()) {
                 PolicyStore policyStore = storeFactory.getPolicyStore();

--- a/server-spi-private/src/main/java/org/keycloak/authorization/UserManagedPermissionUtil.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/UserManagedPermissionUtil.java
@@ -46,7 +46,7 @@ public class UserManagedPermissionUtil {
             filter.put(PermissionTicket.FilterOption.RESOURCE_ID, ticket.getResource().getId());
             filter.put(PermissionTicket.FilterOption.POLICY_IS_NOT_NULL, Boolean.TRUE.toString());
 
-            List<PermissionTicket> tickets = storeFactory.getPermissionTicketStore().find(ticket.getResourceServer(), filter, -1, 1);
+            List<PermissionTicket> tickets = storeFactory.getPermissionTicketStore().find(ticket.getResourceServer(), filter, null,  null);
 
             if (!tickets.isEmpty()) {
                 policy = tickets.iterator().next().getPolicy();
@@ -80,7 +80,7 @@ public class UserManagedPermissionUtil {
             filter.put(PermissionTicket.FilterOption.RESOURCE_ID, ticket.getResource().getId());
             filter.put(PermissionTicket.FilterOption.GRANTED, Boolean.TRUE.toString());
 
-            List<PermissionTicket> tickets = storeFactory.getPermissionTicketStore().find(ticket.getResourceServer(), filter, -1, -1);
+            List<PermissionTicket> tickets = storeFactory.getPermissionTicketStore().find(ticket.getResourceServer(), filter, null, null);
 
             if (tickets.isEmpty()) {
                 PolicyStore policyStore = storeFactory.getPolicyStore();

--- a/server-spi-private/src/main/java/org/keycloak/authorization/model/Resource.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/model/Resource.java
@@ -163,7 +163,7 @@ public interface Resource {
      *
      * @return the resource server associated with this resource
      */
-     String getResourceServer();
+     ResourceServer getResourceServer();
 
     /**
      * Returns the resource's owner, which is usually an identifier that uniquely identifies the resource's owner.

--- a/server-spi-private/src/main/java/org/keycloak/authorization/model/ResourceServer.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/model/ResourceServer.java
@@ -83,4 +83,9 @@ public interface ResourceServer {
      * @return the decision strategy
      */
     DecisionStrategy getDecisionStrategy();
+
+    /**
+     * Returns id of a client that this {@link ResourceServer} is associated with
+     */
+    String getClientId();
 }

--- a/server-spi-private/src/main/java/org/keycloak/authorization/model/ResourceServer.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/model/ResourceServer.java
@@ -18,9 +18,18 @@
 
 package org.keycloak.authorization.model;
 
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.ClientScopeModel;
+import org.keycloak.models.ProtocolMapperModel;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.RoleModel;
 import org.keycloak.representations.idm.authorization.DecisionStrategy;
 import org.keycloak.representations.idm.authorization.PolicyEnforcementMode;
 import org.keycloak.storage.SearchableModelField;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
 
 /**
  * Represents a resource server, whose resources are managed and protected. A resource server is basically an existing
@@ -87,5 +96,7 @@ public interface ResourceServer {
     /**
      * Returns id of a client that this {@link ResourceServer} is associated with
      */
-    String getClientId();
+    default String getClientId() {
+        return getId();
+    }
 }

--- a/server-spi-private/src/main/java/org/keycloak/authorization/permission/Permissions.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/permission/Permissions.java
@@ -74,7 +74,7 @@ public final class Permissions {
         }
 
         // obtain all resources where owner is the resource server
-        resourceStore.findByOwner(resourceServer.getId(), resourceServer.getClientId(), resource -> {
+        resourceStore.findByOwner(resourceServer, resourceServer.getClientId(), resource -> {
             if (limit.decrementAndGet() >= 0) {
                 evaluator.accept(createResourcePermissions(resource, resourceServer, resource.getScopes(), authorization, request));
             }
@@ -83,7 +83,7 @@ public final class Permissions {
         // resource server isn't current user
         if (!Objects.equals(resourceServer.getClientId(), identity.getId())) {
             // obtain all resources where owner is the current user
-            resourceStore.findByOwner(resourceServer.getId(), identity.getId(), resource -> {
+            resourceStore.findByOwner(resourceServer, identity.getId(), resource -> {
                 if (limit.decrementAndGet() >= 0) {
                     evaluator.accept(createResourcePermissions(resource, resourceServer, resource.getScopes(), authorization, request));
                 }
@@ -152,7 +152,7 @@ public final class Permissions {
         // is owned by the resource server itself
         StoreFactory storeFactory = authorization.getStoreFactory();
         ResourceStore resourceStore = storeFactory.getResourceStore();
-        resourceStore.findByType(resourceServer.getId(), type, resource1 -> {
+        resourceStore.findByType(resourceServer, type, resource1 -> {
             for (Scope typeScope : resource1.getScopes()) {
                 if (!scopes.contains(typeScope)) {
                     scopes.add(typeScope);

--- a/server-spi-private/src/main/java/org/keycloak/authorization/permission/Permissions.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/permission/Permissions.java
@@ -91,7 +91,7 @@ public final class Permissions {
         }
 
         // obtain all resources granted to the user via permission tickets (uma)
-        List<PermissionTicket> tickets = storeFactory.getPermissionTicketStore().findGranted(resourceServer.getId(), identity.getId());
+        List<PermissionTicket> tickets = storeFactory.getPermissionTicketStore().findGranted(resourceServer, identity.getId());
 
         if (!tickets.isEmpty()) {
             Map<String, ResourcePermission> userManagedPermissions = new HashMap<>();

--- a/server-spi-private/src/main/java/org/keycloak/authorization/permission/Permissions.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/permission/Permissions.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
@@ -73,14 +74,14 @@ public final class Permissions {
         }
 
         // obtain all resources where owner is the resource server
-        resourceStore.findByOwner(resourceServer.getId(), resourceServer.getId(), resource -> {
+        resourceStore.findByOwner(resourceServer.getClientId(), resourceServer.getId(), resource -> {
             if (limit.decrementAndGet() >= 0) {
                 evaluator.accept(createResourcePermissions(resource, resourceServer, resource.getScopes(), authorization, request));
             }
         });
 
         // resource server isn't current user
-        if (resourceServer.getId() != identity.getId()) {
+        if (!Objects.equals(resourceServer.getClientId(), identity.getId())) {
             // obtain all resources where owner is the current user
             resourceStore.findByOwner(identity.getId(), resourceServer.getId(), resource -> {
                 if (limit.decrementAndGet() >= 0) {

--- a/server-spi-private/src/main/java/org/keycloak/authorization/permission/Permissions.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/permission/Permissions.java
@@ -74,7 +74,7 @@ public final class Permissions {
         }
 
         // obtain all resources where owner is the resource server
-        resourceStore.findByOwner(resourceServer.getClientId(), resourceServer.getId(), resource -> {
+        resourceStore.findByOwner(resourceServer.getId(), resourceServer.getClientId(), resource -> {
             if (limit.decrementAndGet() >= 0) {
                 evaluator.accept(createResourcePermissions(resource, resourceServer, resource.getScopes(), authorization, request));
             }
@@ -83,7 +83,7 @@ public final class Permissions {
         // resource server isn't current user
         if (!Objects.equals(resourceServer.getClientId(), identity.getId())) {
             // obtain all resources where owner is the current user
-            resourceStore.findByOwner(identity.getId(), resourceServer.getId(), resource -> {
+            resourceStore.findByOwner(resourceServer.getId(), identity.getId(), resource -> {
                 if (limit.decrementAndGet() >= 0) {
                     evaluator.accept(createResourcePermissions(resource, resourceServer, resource.getScopes(), authorization, request));
                 }
@@ -91,7 +91,7 @@ public final class Permissions {
         }
 
         // obtain all resources granted to the user via permission tickets (uma)
-        List<PermissionTicket> tickets = storeFactory.getPermissionTicketStore().findGranted(identity.getId(), resourceServer.getId());
+        List<PermissionTicket> tickets = storeFactory.getPermissionTicketStore().findGranted(resourceServer.getId(), identity.getId());
 
         if (!tickets.isEmpty()) {
             Map<String, ResourcePermission> userManagedPermissions = new HashMap<>();
@@ -152,7 +152,7 @@ public final class Permissions {
         // is owned by the resource server itself
         StoreFactory storeFactory = authorization.getStoreFactory();
         ResourceStore resourceStore = storeFactory.getResourceStore();
-        resourceStore.findByType(type, resourceServer.getId(), resource1 -> {
+        resourceStore.findByType(resourceServer.getId(), type, resource1 -> {
             for (Scope typeScope : resource1.getScopes()) {
                 if (!scopes.contains(typeScope)) {
                     scopes.add(typeScope);

--- a/server-spi-private/src/main/java/org/keycloak/authorization/policy/evaluation/DecisionPermissionCollector.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/policy/evaluation/DecisionPermissionCollector.java
@@ -191,7 +191,7 @@ public class DecisionPermissionCollector extends AbstractDecisionCollector {
         } else if (!grantedScopes.isEmpty()) {
             ResourceStore resourceStore = authorizationProvider.getStoreFactory().getResourceStore();
 
-            resourceStore.findByScope(resourceServer.getId(), grantedScopes.stream().map(Scope::getId).collect(Collectors.toList()), resource1 -> permissions.add(createPermission(resource, scopeNames, permission.getClaims(), request)));
+            resourceStore.findByScopes(resourceServer, new HashSet<>(grantedScopes), resource1 -> permissions.add(createPermission(resource, scopeNames, permission.getClaims(), request)));
 
             permissions.add(createPermission(null, scopeNames, permission.getClaims(), request));
         }

--- a/server-spi-private/src/main/java/org/keycloak/authorization/policy/evaluation/DecisionPermissionCollector.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/policy/evaluation/DecisionPermissionCollector.java
@@ -170,7 +170,7 @@ public class DecisionPermissionCollector extends AbstractDecisionCollector {
             return true;
         }
         
-        return resource != null && !resource.getOwner().equals(resourceServer.getId());
+        return resource != null && !resource.getOwner().equals(resourceServer.getClientId());
     }
 
     public Collection<Permission> results() {

--- a/server-spi-private/src/main/java/org/keycloak/authorization/policy/evaluation/DecisionPermissionCollector.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/policy/evaluation/DecisionPermissionCollector.java
@@ -191,7 +191,7 @@ public class DecisionPermissionCollector extends AbstractDecisionCollector {
         } else if (!grantedScopes.isEmpty()) {
             ResourceStore resourceStore = authorizationProvider.getStoreFactory().getResourceStore();
 
-            resourceStore.findByScope(grantedScopes.stream().map(Scope::getId).collect(Collectors.toList()), resourceServer.getId(), resource1 -> permissions.add(createPermission(resource, scopeNames, permission.getClaims(), request)));
+            resourceStore.findByScope(resourceServer.getId(), grantedScopes.stream().map(Scope::getId).collect(Collectors.toList()), resource1 -> permissions.add(createPermission(resource, scopeNames, permission.getClaims(), request)));
 
             permissions.add(createPermission(null, scopeNames, permission.getClaims(), request));
         }

--- a/server-spi-private/src/main/java/org/keycloak/authorization/policy/evaluation/DefaultPolicyEvaluator.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/policy/evaluation/DefaultPolicyEvaluator.java
@@ -67,14 +67,14 @@ public class DefaultPolicyEvaluator implements PolicyEvaluator {
         Resource resource = permission.getResource();
 
         if (resource != null) {
-            policyStore.findByResource(resource.getId(), resourceServer.getId(), policyConsumer);
+            policyStore.findByResource(resourceServer.getId(), resource.getId(), policyConsumer);
 
             if (resource.getType() != null) {
-                policyStore.findByResourceType(resource.getType(), resourceServer.getId(), policyConsumer);
+                policyStore.findByResourceType(resourceServer.getId(), resource.getType(), policyConsumer);
 
                 if (!resource.getOwner().equals(resourceServer.getClientId())) {
-                    for (Resource typedResource : resourceStore.findByType(resource.getType(), resourceServer.getId())) {
-                        policyStore.findByResource(typedResource.getId(), resourceServer.getId(), policyConsumer);
+                    for (Resource typedResource : resourceStore.findByType(resourceServer.getId(), resource.getType())) {
+                        policyStore.findByResource(resourceServer.getId(), typedResource.getId(), policyConsumer);
                     }
                 }
             }
@@ -83,7 +83,7 @@ public class DefaultPolicyEvaluator implements PolicyEvaluator {
         Collection<Scope> scopes = permission.getScopes();
 
         if (!scopes.isEmpty()) {
-            policyStore.findByScopeIds(scopes.stream().map(Scope::getId).collect(Collectors.toList()), null, resourceServer.getId(), policyConsumer);
+            policyStore.findByScopeIds(resourceServer.getId(), null, scopes.stream().map(Scope::getId).collect(Collectors.toList()), policyConsumer);
         }
 
         if (verified.get()) {

--- a/server-spi-private/src/main/java/org/keycloak/authorization/policy/evaluation/DefaultPolicyEvaluator.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/policy/evaluation/DefaultPolicyEvaluator.java
@@ -72,7 +72,7 @@ public class DefaultPolicyEvaluator implements PolicyEvaluator {
             if (resource.getType() != null) {
                 policyStore.findByResourceType(resource.getType(), resourceServer.getId(), policyConsumer);
 
-                if (!resource.getOwner().equals(resourceServer.getId())) {
+                if (!resource.getOwner().equals(resourceServer.getClientId())) {
                     for (Resource typedResource : resourceStore.findByType(resource.getType(), resourceServer.getId())) {
                         policyStore.findByResource(typedResource.getId(), resourceServer.getId(), policyConsumer);
                     }

--- a/server-spi-private/src/main/java/org/keycloak/authorization/policy/evaluation/DefaultPolicyEvaluator.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/policy/evaluation/DefaultPolicyEvaluator.java
@@ -19,6 +19,7 @@
 package org.keycloak.authorization.policy.evaluation;
 
 import java.util.Collection;
+import java.util.LinkedList;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
@@ -67,14 +68,14 @@ public class DefaultPolicyEvaluator implements PolicyEvaluator {
         Resource resource = permission.getResource();
 
         if (resource != null) {
-            policyStore.findByResource(resourceServer.getId(), resource.getId(), policyConsumer);
+            policyStore.findByResource(resourceServer, resource, policyConsumer);
 
             if (resource.getType() != null) {
-                policyStore.findByResourceType(resourceServer.getId(), resource.getType(), policyConsumer);
+                policyStore.findByResourceType(resourceServer, resource.getType(), policyConsumer);
 
                 if (!resource.getOwner().equals(resourceServer.getClientId())) {
                     for (Resource typedResource : resourceStore.findByType(resourceServer.getId(), resource.getType())) {
-                        policyStore.findByResource(resourceServer.getId(), typedResource.getId(), policyConsumer);
+                        policyStore.findByResource(resourceServer, typedResource, policyConsumer);
                     }
                 }
             }
@@ -83,7 +84,7 @@ public class DefaultPolicyEvaluator implements PolicyEvaluator {
         Collection<Scope> scopes = permission.getScopes();
 
         if (!scopes.isEmpty()) {
-            policyStore.findByScopeIds(resourceServer.getId(), null, scopes.stream().map(Scope::getId).collect(Collectors.toList()), policyConsumer);
+            policyStore.findByScopes(resourceServer, null, new LinkedList<>(scopes), policyConsumer);
         }
 
         if (verified.get()) {

--- a/server-spi-private/src/main/java/org/keycloak/authorization/policy/evaluation/DefaultPolicyEvaluator.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/policy/evaluation/DefaultPolicyEvaluator.java
@@ -74,7 +74,7 @@ public class DefaultPolicyEvaluator implements PolicyEvaluator {
                 policyStore.findByResourceType(resourceServer, resource.getType(), policyConsumer);
 
                 if (!resource.getOwner().equals(resourceServer.getClientId())) {
-                    for (Resource typedResource : resourceStore.findByType(resourceServer.getId(), resource.getType())) {
+                    for (Resource typedResource : resourceStore.findByType(resourceServer, resource.getType())) {
                         policyStore.findByResource(resourceServer, typedResource, policyConsumer);
                     }
                 }

--- a/server-spi-private/src/main/java/org/keycloak/authorization/policy/evaluation/PermissionTicketAwareDecisionResultCollector.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/policy/evaluation/PermissionTicketAwareDecisionResultCollector.java
@@ -125,10 +125,10 @@ public class PermissionTicketAwareDecisionResultCollector extends DecisionPermis
                         ScopeStore scopeStore = authorization.getStoreFactory().getScopeStore();
 
                         for (String scopeId : scopes) {
-                            Scope scope = scopeStore.findByName(resourceServer.getId(), scopeId);
+                            Scope scope = scopeStore.findByName(resourceServer, scopeId);
 
                             if (scope == null) {
-                                scope = scopeStore.findById(resourceServer.getId(), scopeId);
+                                scope = scopeStore.findById(resourceServer, scopeId);
                             }
 
                             Map<PermissionTicket.FilterOption, String> filters = new EnumMap<>(PermissionTicket.FilterOption.class);

--- a/server-spi-private/src/main/java/org/keycloak/authorization/policy/evaluation/PermissionTicketAwareDecisionResultCollector.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/policy/evaluation/PermissionTicketAwareDecisionResultCollector.java
@@ -99,7 +99,7 @@ public class PermissionTicketAwareDecisionResultCollector extends DecisionPermis
                         resource = resourceStore.findByName(permission.getResourceId(), identity.getId(), resourceServer.getId());
                     }
 
-                    if (resource == null || !resource.isOwnerManagedAccess() || resource.getOwner().equals(identity.getId()) || resource.getOwner().equals(resourceServer.getId())) {
+                    if (resource == null || !resource.isOwnerManagedAccess() || resource.getOwner().equals(identity.getId()) || resource.getOwner().equals(resourceServer.getClientId())) {
                         continue;
                     }
 

--- a/server-spi-private/src/main/java/org/keycloak/authorization/policy/evaluation/PermissionTicketAwareDecisionResultCollector.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/policy/evaluation/PermissionTicketAwareDecisionResultCollector.java
@@ -116,10 +116,10 @@ public class PermissionTicketAwareDecisionResultCollector extends DecisionPermis
                         filters.put(PermissionTicket.FilterOption.REQUESTER, identity.getId());
                         filters.put(PermissionTicket.FilterOption.SCOPE_IS_NULL, Boolean.TRUE.toString());
 
-                        List<PermissionTicket> tickets = authorization.getStoreFactory().getPermissionTicketStore().find(resource.getResourceServer().getId(), filters, -1, -1);
+                        List<PermissionTicket> tickets = authorization.getStoreFactory().getPermissionTicketStore().find(resource.getResourceServer(), filters, -1, -1);
 
                         if (tickets.isEmpty()) {
-                            authorization.getStoreFactory().getPermissionTicketStore().create(resourceServer, resource.getId(), null, identity.getId());
+                            authorization.getStoreFactory().getPermissionTicketStore().create(resourceServer, resource, null, identity.getId());
                         }
                     } else {
                         ScopeStore scopeStore = authorization.getStoreFactory().getScopeStore();
@@ -137,10 +137,10 @@ public class PermissionTicketAwareDecisionResultCollector extends DecisionPermis
                             filters.put(PermissionTicket.FilterOption.REQUESTER, identity.getId());
                             filters.put(PermissionTicket.FilterOption.SCOPE_ID, scope.getId());
 
-                            List<PermissionTicket> tickets = authorization.getStoreFactory().getPermissionTicketStore().find(resource.getResourceServer().getId(), filters, -1, -1);
+                            List<PermissionTicket> tickets = authorization.getStoreFactory().getPermissionTicketStore().find(resource.getResourceServer(), filters, -1, -1);
 
                             if (tickets.isEmpty()) {
-                                authorization.getStoreFactory().getPermissionTicketStore().create(resourceServer, resource.getId(), scope.getId(), identity.getId());
+                                authorization.getStoreFactory().getPermissionTicketStore().create(resourceServer, resource, scope, identity.getId());
                             }
                         }
                     }

--- a/server-spi-private/src/main/java/org/keycloak/authorization/policy/evaluation/PermissionTicketAwareDecisionResultCollector.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/policy/evaluation/PermissionTicketAwareDecisionResultCollector.java
@@ -93,10 +93,10 @@ public class PermissionTicketAwareDecisionResultCollector extends DecisionPermis
 
             if (permissions != null) {
                 for (Permission permission : permissions) {
-                    Resource resource = resourceStore.findById(permission.getResourceId(), resourceServer.getId());
+                    Resource resource = resourceStore.findById(resourceServer.getId(), permission.getResourceId());
 
                     if (resource == null) {
-                        resource = resourceStore.findByName(permission.getResourceId(), identity.getId(), resourceServer.getId());
+                        resource = resourceStore.findByName(resourceServer.getId(), permission.getResourceId(), identity.getId());
                     }
 
                     if (resource == null || !resource.isOwnerManagedAccess() || resource.getOwner().equals(identity.getId()) || resource.getOwner().equals(resourceServer.getClientId())) {
@@ -116,19 +116,19 @@ public class PermissionTicketAwareDecisionResultCollector extends DecisionPermis
                         filters.put(PermissionTicket.FilterOption.REQUESTER, identity.getId());
                         filters.put(PermissionTicket.FilterOption.SCOPE_IS_NULL, Boolean.TRUE.toString());
 
-                        List<PermissionTicket> tickets = authorization.getStoreFactory().getPermissionTicketStore().find(filters, resource.getResourceServer(), -1, -1);
+                        List<PermissionTicket> tickets = authorization.getStoreFactory().getPermissionTicketStore().find(resource.getResourceServer(), filters, -1, -1);
 
                         if (tickets.isEmpty()) {
-                            authorization.getStoreFactory().getPermissionTicketStore().create(resource.getId(), null, identity.getId(), resourceServer);
+                            authorization.getStoreFactory().getPermissionTicketStore().create(resourceServer, resource.getId(), null, identity.getId());
                         }
                     } else {
                         ScopeStore scopeStore = authorization.getStoreFactory().getScopeStore();
 
                         for (String scopeId : scopes) {
-                            Scope scope = scopeStore.findByName(scopeId, resourceServer.getId());
+                            Scope scope = scopeStore.findByName(resourceServer.getId(), scopeId);
 
                             if (scope == null) {
-                                scope = scopeStore.findById(scopeId, resourceServer.getId());
+                                scope = scopeStore.findById(resourceServer.getId(), scopeId);
                             }
 
                             Map<PermissionTicket.FilterOption, String> filters = new EnumMap<>(PermissionTicket.FilterOption.class);
@@ -137,10 +137,10 @@ public class PermissionTicketAwareDecisionResultCollector extends DecisionPermis
                             filters.put(PermissionTicket.FilterOption.REQUESTER, identity.getId());
                             filters.put(PermissionTicket.FilterOption.SCOPE_ID, scope.getId());
 
-                            List<PermissionTicket> tickets = authorization.getStoreFactory().getPermissionTicketStore().find(filters, resource.getResourceServer(), -1, -1);
+                            List<PermissionTicket> tickets = authorization.getStoreFactory().getPermissionTicketStore().find(resource.getResourceServer(), filters, -1, -1);
 
                             if (tickets.isEmpty()) {
-                                authorization.getStoreFactory().getPermissionTicketStore().create(resource.getId(), scope.getId(), identity.getId(), resourceServer);
+                                authorization.getStoreFactory().getPermissionTicketStore().create(resourceServer, resource.getId(), scope.getId(), identity.getId());
                             }
                         }
                     }

--- a/server-spi-private/src/main/java/org/keycloak/authorization/policy/evaluation/PermissionTicketAwareDecisionResultCollector.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/policy/evaluation/PermissionTicketAwareDecisionResultCollector.java
@@ -93,10 +93,10 @@ public class PermissionTicketAwareDecisionResultCollector extends DecisionPermis
 
             if (permissions != null) {
                 for (Permission permission : permissions) {
-                    Resource resource = resourceStore.findById(resourceServer.getId(), permission.getResourceId());
+                    Resource resource = resourceStore.findById(resourceServer, permission.getResourceId());
 
                     if (resource == null) {
-                        resource = resourceStore.findByName(resourceServer.getId(), permission.getResourceId(), identity.getId());
+                        resource = resourceStore.findByName(resourceServer, permission.getResourceId(), identity.getId());
                     }
 
                     if (resource == null || !resource.isOwnerManagedAccess() || resource.getOwner().equals(identity.getId()) || resource.getOwner().equals(resourceServer.getClientId())) {

--- a/server-spi-private/src/main/java/org/keycloak/authorization/policy/evaluation/PermissionTicketAwareDecisionResultCollector.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/policy/evaluation/PermissionTicketAwareDecisionResultCollector.java
@@ -116,7 +116,7 @@ public class PermissionTicketAwareDecisionResultCollector extends DecisionPermis
                         filters.put(PermissionTicket.FilterOption.REQUESTER, identity.getId());
                         filters.put(PermissionTicket.FilterOption.SCOPE_IS_NULL, Boolean.TRUE.toString());
 
-                        List<PermissionTicket> tickets = authorization.getStoreFactory().getPermissionTicketStore().find(resource.getResourceServer(), filters, -1, -1);
+                        List<PermissionTicket> tickets = authorization.getStoreFactory().getPermissionTicketStore().find(resource.getResourceServer().getId(), filters, -1, -1);
 
                         if (tickets.isEmpty()) {
                             authorization.getStoreFactory().getPermissionTicketStore().create(resourceServer, resource.getId(), null, identity.getId());
@@ -137,7 +137,7 @@ public class PermissionTicketAwareDecisionResultCollector extends DecisionPermis
                             filters.put(PermissionTicket.FilterOption.REQUESTER, identity.getId());
                             filters.put(PermissionTicket.FilterOption.SCOPE_ID, scope.getId());
 
-                            List<PermissionTicket> tickets = authorization.getStoreFactory().getPermissionTicketStore().find(resource.getResourceServer(), filters, -1, -1);
+                            List<PermissionTicket> tickets = authorization.getStoreFactory().getPermissionTicketStore().find(resource.getResourceServer().getId(), filters, -1, -1);
 
                             if (tickets.isEmpty()) {
                                 authorization.getStoreFactory().getPermissionTicketStore().create(resourceServer, resource.getId(), scope.getId(), identity.getId());

--- a/server-spi-private/src/main/java/org/keycloak/authorization/policy/evaluation/PermissionTicketAwareDecisionResultCollector.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/policy/evaluation/PermissionTicketAwareDecisionResultCollector.java
@@ -116,7 +116,7 @@ public class PermissionTicketAwareDecisionResultCollector extends DecisionPermis
                         filters.put(PermissionTicket.FilterOption.REQUESTER, identity.getId());
                         filters.put(PermissionTicket.FilterOption.SCOPE_IS_NULL, Boolean.TRUE.toString());
 
-                        List<PermissionTicket> tickets = authorization.getStoreFactory().getPermissionTicketStore().find(resource.getResourceServer(), filters, -1, -1);
+                        List<PermissionTicket> tickets = authorization.getStoreFactory().getPermissionTicketStore().find(resource.getResourceServer(), filters, null, null);
 
                         if (tickets.isEmpty()) {
                             authorization.getStoreFactory().getPermissionTicketStore().create(resourceServer, resource, null, identity.getId());
@@ -137,7 +137,7 @@ public class PermissionTicketAwareDecisionResultCollector extends DecisionPermis
                             filters.put(PermissionTicket.FilterOption.REQUESTER, identity.getId());
                             filters.put(PermissionTicket.FilterOption.SCOPE_ID, scope.getId());
 
-                            List<PermissionTicket> tickets = authorization.getStoreFactory().getPermissionTicketStore().find(resource.getResourceServer(), filters, -1, -1);
+                            List<PermissionTicket> tickets = authorization.getStoreFactory().getPermissionTicketStore().find(resource.getResourceServer(), filters, null, null);
 
                             if (tickets.isEmpty()) {
                                 authorization.getStoreFactory().getPermissionTicketStore().create(resourceServer, resource, scope, identity.getId());

--- a/server-spi-private/src/main/java/org/keycloak/authorization/store/PermissionTicketStore.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/store/PermissionTicketStore.java
@@ -17,12 +17,14 @@
 package org.keycloak.authorization.store;
 
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
 import org.keycloak.authorization.model.PermissionTicket;
 import org.keycloak.authorization.model.Resource;
 import org.keycloak.authorization.model.ResourceServer;
+import org.keycloak.authorization.model.Scope;
 
 /**
  * A {@link PermissionTicketStore} is responsible to manage the persistence of {@link org.keycloak.authorization.model.PermissionTicket} instances.
@@ -34,21 +36,23 @@ public interface PermissionTicketStore {
     /**
      * Returns count of {@link PermissionTicket}, filtered by the given attributes.
      *
-     * @param resourceServerId the resource server id
+     * @param resourceServer the resource server
      * @param attributes permission tickets that do not match the attributes are not included with the count; possible filter options are given by {@link PermissionTicket.FilterOption}
      * @return an integer indicating the amount of permission tickets
      * @throws IllegalArgumentException when there is an unknown attribute in the {@code attributes} map
      */
-    long count(String resourceServerId, Map<PermissionTicket.FilterOption, String> attributes);
+    long count(ResourceServer resourceServer, Map<PermissionTicket.FilterOption, String> attributes);
 
     /**
      * Creates a new {@link PermissionTicket} instance.
      *
-     * @param permission the policy representation
      * @param resourceServer the resource server to which this policy belongs
+     * @param resource resource id
+     * @param scope scope id
+     * @param requester the policy representation
      * @return a new instance of {@link PermissionTicket}
      */
-    PermissionTicket create(ResourceServer resourceServer, String resourceId, String scopeId, String requester);
+    PermissionTicket create(ResourceServer resourceServer, Resource resource, Scope scope, String requester);
 
     /**
      * Deletes a permission from the underlying persistence mechanism.
@@ -60,50 +64,54 @@ public interface PermissionTicketStore {
     /**
      * Returns a {@link PermissionTicket} with the given <code>id</code>
      *
-     * @param resourceServerId the resource server id
+     * @param resourceServer the resource server
      * @param id the identifier of the permission
      * @return a permission with the given identifier.
      */
-    PermissionTicket findById(String resourceServerId, String id);
+    PermissionTicket findById(ResourceServer resourceServer, String id);
 
     /**
-     * Returns a list of {@link PermissionTicket} associated with a {@link ResourceServer} with the given <code>resourceServerId</code>.
+     * Returns a list of {@link PermissionTicket} associated with a {@link ResourceServer}.
      *
-     * @param resourceServerId the identifier of a resource server
+     * @param resourceServer the resource server
      * @return a list of permissions belonging to the given resource server
      */
-    List<PermissionTicket> findByResourceServer(String resourceServerId);
+    List<PermissionTicket> findByResourceServer(ResourceServer resourceServer);
 
     /**
      * Returns a list of {@link PermissionTicket} associated with the given <code>owner</code>.
      *
+     * @param resourceServer the resource server
      * @param owner the identifier of a resource server
      * @return a list of permissions belonging to the given owner
      */
-    List<PermissionTicket> findByOwner(String resourceServerId, String owner);
+    List<PermissionTicket> findByOwner(ResourceServer resourceServer, String owner);
 
     /**
-     * Returns a list of {@link PermissionTicket} associated with a {@link org.keycloak.authorization.core.model.Resource} with the given <code>resourceId</code>.
+     * Returns a list of {@link PermissionTicket} associated with the {@link org.keycloak.authorization.model.Resource resource}.
      *
-     * @param resourceServerId the resource server id
-     * @param resourceId the identifier of a resource
+     * @param resourceServer the resource server
+     * @param resource the resource
      * @return a list of permissions associated with the given resource
+     * TODO: maybe we can get rid of reosourceServer param here as resource has method getResourceServer()
      */
-    List<PermissionTicket> findByResource(String resourceServerId, String resourceId);
+    List<PermissionTicket> findByResource(ResourceServer resourceServer, Resource resource);
 
     /**
-     * Returns a list of {@link PermissionTicket} associated with a {@link org.keycloak.authorization.core.model.Scope} with the given <code>scopeId</code>.
+     * Returns a list of {@link PermissionTicket} associated with the {@link org.keycloak.authorization.model.Scope scope}.
      *
-     * @param resourceServerId the resource server id
-     * @param scopeId the id of the scopes
+     * @param resourceServer the resource server
+     * @param scope the scope
      * @return a list of permissions associated with the given scopes
+     *
+     * TODO: maybe we can get rid of reosourceServer param here as resource has method getResourceServer()
      */
-    List<PermissionTicket> findByScope(String resourceServerId, String scopeId);
+    List<PermissionTicket> findByScope(ResourceServer resourceServer, Scope scope);
 
     /**
      * Returns a list of {@link PermissionTicket}, filtered by the given attributes.
      *
-     * @param resourceServerId an id of resource server that resulting tickets should belong to. Ignored if {@code null}
+     * @param resourceServer a resource server that resulting tickets should belong to. Ignored if {@code null}
      * @param attributes a map of keys and values to filter on; possible filter options are given by {@link PermissionTicket.FilterOption}
      * @param firstResult first result to return; Ignored if negative or zero
      * @param maxResult maximum number of results to return; Ignored if negative
@@ -112,26 +120,28 @@ public interface PermissionTicketStore {
      * @throws IllegalArgumentException when there is an unknown attribute in the {@code attributes} map
      *
      */
-    List<PermissionTicket> find(String resourceServerId, Map<PermissionTicket.FilterOption, String> attributes, int firstResult, int maxResult);
+    List<PermissionTicket> find(ResourceServer resourceServer, Map<PermissionTicket.FilterOption, String> attributes, int firstResult, int maxResult);
 
     /**
      * Returns a list of {@link PermissionTicket} granted to the given {@code userId}.
      *
-     * @param resourceServerId the resource server id
+     * @param resourceServer the resource server
      * @param userId the user id
      * @return a list of permissions granted for a particular user
      */
-    List<PermissionTicket> findGranted(String resourceServerId, String userId);
+    List<PermissionTicket> findGranted(ResourceServer resourceServer, String userId);
 
     /**
      * Returns a list of {@link PermissionTicket} with name equal to {@code resourceName} granted to the given {@code userId}.
      *
-     * @param resourceServerId the resource server id
+     * @param resourceServer the resource server
      * @param resourceName the name of a resource
      * @param userId the user id
      * @return a list of permissions granted for a particular user
+     *
+     * TODO: investigate a way how to replace resourceName with Resource class
      */
-    List<PermissionTicket> findGranted(String resourceServerId, String resourceName, String userId);
+    List<PermissionTicket> findGranted(ResourceServer resourceServer, String resourceName, String userId);
 
     /**
      * Returns a list of {@link Resource} granted to the given {@code requester}

--- a/server-spi-private/src/main/java/org/keycloak/authorization/store/PermissionTicketStore.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/store/PermissionTicketStore.java
@@ -34,12 +34,12 @@ public interface PermissionTicketStore {
     /**
      * Returns count of {@link PermissionTicket}, filtered by the given attributes.
      *
-     * @param attributes permission tickets that do not match the attributes are not included with the count; possible filter options are given by {@link PermissionTicket.FilterOption}
      * @param resourceServerId the resource server id
+     * @param attributes permission tickets that do not match the attributes are not included with the count; possible filter options are given by {@link PermissionTicket.FilterOption}
      * @return an integer indicating the amount of permission tickets
      * @throws IllegalArgumentException when there is an unknown attribute in the {@code attributes} map
      */
-    long count(Map<PermissionTicket.FilterOption, String> attributes, String resourceServerId);
+    long count(String resourceServerId, Map<PermissionTicket.FilterOption, String> attributes);
 
     /**
      * Creates a new {@link PermissionTicket} instance.
@@ -48,7 +48,7 @@ public interface PermissionTicketStore {
      * @param resourceServer the resource server to which this policy belongs
      * @return a new instance of {@link PermissionTicket}
      */
-    PermissionTicket create(String resourceId, String scopeId, String requester, ResourceServer resourceServer);
+    PermissionTicket create(ResourceServer resourceServer, String resourceId, String scopeId, String requester);
 
     /**
      * Deletes a permission from the underlying persistence mechanism.
@@ -60,11 +60,11 @@ public interface PermissionTicketStore {
     /**
      * Returns a {@link PermissionTicket} with the given <code>id</code>
      *
-     * @param id the identifier of the permission
      * @param resourceServerId the resource server id
+     * @param id the identifier of the permission
      * @return a permission with the given identifier.
      */
-    PermissionTicket findById(String id, String resourceServerId);
+    PermissionTicket findById(String resourceServerId, String id);
 
     /**
      * Returns a list of {@link PermissionTicket} associated with a {@link ResourceServer} with the given <code>resourceServerId</code>.
@@ -80,31 +80,31 @@ public interface PermissionTicketStore {
      * @param owner the identifier of a resource server
      * @return a list of permissions belonging to the given owner
      */
-    List<PermissionTicket> findByOwner(String owner, String resourceServerId);
+    List<PermissionTicket> findByOwner(String resourceServerId, String owner);
 
     /**
      * Returns a list of {@link PermissionTicket} associated with a {@link org.keycloak.authorization.core.model.Resource} with the given <code>resourceId</code>.
      *
-     * @param resourceId the identifier of a resource
      * @param resourceServerId the resource server id
+     * @param resourceId the identifier of a resource
      * @return a list of permissions associated with the given resource
      */
-    List<PermissionTicket> findByResource(String resourceId, String resourceServerId);
+    List<PermissionTicket> findByResource(String resourceServerId, String resourceId);
 
     /**
      * Returns a list of {@link PermissionTicket} associated with a {@link org.keycloak.authorization.core.model.Scope} with the given <code>scopeId</code>.
      *
-     * @param scopeId the id of the scopes
      * @param resourceServerId the resource server id
+     * @param scopeId the id of the scopes
      * @return a list of permissions associated with the given scopes
      */
-    List<PermissionTicket> findByScope(String scopeId, String resourceServerId);
+    List<PermissionTicket> findByScope(String resourceServerId, String scopeId);
 
     /**
      * Returns a list of {@link PermissionTicket}, filtered by the given attributes.
      *
-     * @param attributes a map of keys and values to filter on; possible filter options are given by {@link PermissionTicket.FilterOption}
      * @param resourceServerId an id of resource server that resulting tickets should belong to. Ignored if {@code null}
+     * @param attributes a map of keys and values to filter on; possible filter options are given by {@link PermissionTicket.FilterOption}
      * @param firstResult first result to return; Ignored if negative or zero
      * @param maxResult maximum number of results to return; Ignored if negative
      * @return a list of filtered and paginated permissions
@@ -112,26 +112,26 @@ public interface PermissionTicketStore {
      * @throws IllegalArgumentException when there is an unknown attribute in the {@code attributes} map
      *
      */
-    List<PermissionTicket> find(Map<PermissionTicket.FilterOption, String> attributes, String resourceServerId, int firstResult, int maxResult);
+    List<PermissionTicket> find(String resourceServerId, Map<PermissionTicket.FilterOption, String> attributes, int firstResult, int maxResult);
 
     /**
      * Returns a list of {@link PermissionTicket} granted to the given {@code userId}.
      *
-     * @param userId the user id
      * @param resourceServerId the resource server id
+     * @param userId the user id
      * @return a list of permissions granted for a particular user
      */
-    List<PermissionTicket> findGranted(String userId, String resourceServerId);
+    List<PermissionTicket> findGranted(String resourceServerId, String userId);
 
     /**
      * Returns a list of {@link PermissionTicket} with name equal to {@code resourceName} granted to the given {@code userId}.
      *
+     * @param resourceServerId the resource server id
      * @param resourceName the name of a resource
      * @param userId the user id
-     * @param resourceServerId the resource server id
      * @return a list of permissions granted for a particular user
      */
-    List<PermissionTicket> findGranted(String resourceName, String userId, String resourceServerId);
+    List<PermissionTicket> findGranted(String resourceServerId, String resourceName, String userId);
 
     /**
      * Returns a list of {@link Resource} granted to the given {@code requester}

--- a/server-spi-private/src/main/java/org/keycloak/authorization/store/PermissionTicketStore.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/store/PermissionTicketStore.java
@@ -17,7 +17,6 @@
 package org.keycloak.authorization.store;
 
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -113,14 +112,14 @@ public interface PermissionTicketStore {
      *
      * @param resourceServer a resource server that resulting tickets should belong to. Ignored if {@code null}
      * @param attributes a map of keys and values to filter on; possible filter options are given by {@link PermissionTicket.FilterOption}
-     * @param firstResult first result to return; Ignored if negative or zero
-     * @param maxResult maximum number of results to return; Ignored if negative
+     * @param firstResult first result to return. Ignored if negative or {@code null}.
+     * @param maxResults maximum number of results to return. Ignored if negative or {@code null}.
      * @return a list of filtered and paginated permissions
      *
      * @throws IllegalArgumentException when there is an unknown attribute in the {@code attributes} map
      *
      */
-    List<PermissionTicket> find(ResourceServer resourceServer, Map<PermissionTicket.FilterOption, String> attributes, int firstResult, int maxResult);
+    List<PermissionTicket> find(ResourceServer resourceServer, Map<PermissionTicket.FilterOption, String> attributes, Integer firstResult, Integer maxResults);
 
     /**
      * Returns a list of {@link PermissionTicket} granted to the given {@code userId}.
@@ -148,19 +147,19 @@ public interface PermissionTicketStore {
      *
      * @param requester the requester
      * @param name the keyword to query resources by name or null if any resource
-     * @param first first  result
-     * @param max max result
+     * @param firstResult first result to return. Ignored if negative or {@code null}.
+     * @param maxResults maximum number of results to return. Ignored if negative or {@code null}.
      * @return a list of {@link Resource} granted to the given {@code requester}
      */
-    List<Resource> findGrantedResources(String requester, String name, int first, int max);
+    List<Resource> findGrantedResources(String requester, String name, Integer firstResult, Integer maxResults);
 
     /**
      * Returns a list of {@link Resource} granted by the owner to other users
      *
      * @param owner the owner
-     * @param first first  result
-     * @param max max result
+     * @param firstResult first result to return. Ignored if negative or {@code null}.
+     * @param maxResults maximum number of results to return. Ignored if negative or {@code null}.
      * @return a list of {@link Resource} granted by the owner
      */
-    List<Resource> findGrantedOwnerResources(String owner, int first, int max);
+    List<Resource> findGrantedOwnerResources(String owner, Integer firstResult, Integer maxResults);
 }

--- a/server-spi-private/src/main/java/org/keycloak/authorization/store/PolicyStore.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/store/PolicyStore.java
@@ -38,11 +38,11 @@ public interface PolicyStore {
      * Creates a new {@link Policy} instance. The new instance is not necessarily persisted though, which may require
      * a call to the {#save} method to actually make it persistent.
      *
-     * @param representation the policy representation
      * @param resourceServer the resource server to which this policy belongs
+     * @param representation the policy representation
      * @return a new instance of {@link Policy}
      */
-    Policy create(AbstractPolicyRepresentation representation, ResourceServer resourceServer);
+    Policy create(ResourceServer resourceServer, AbstractPolicyRepresentation representation);
 
     /**
      * Deletes a policy from the underlying persistence mechanism.
@@ -54,20 +54,20 @@ public interface PolicyStore {
     /**
      * Returns a {@link Policy} with the given <code>id</code>
      *
-     * @param id the identifier of the policy
      * @param resourceServerId the resource server id
+     * @param id the identifier of the policy
      * @return a policy with the given identifier.
      */
-    Policy findById(String id, String resourceServerId);
+    Policy findById(String resourceServerId, String id);
 
     /**
      * Returns a {@link Policy} with the given <code>name</code>
      *
-     * @param name             the name of the policy
      * @param resourceServerId the resource server id
+     * @param name             the name of the policy
      * @return a policy with the given name.
      */
-    Policy findByName(String name, String resourceServerId);
+    Policy findByName(String resourceServerId, String name);
 
     /**
      * Returns a list of {@link Policy} associated with a {@link ResourceServer} with the given <code>resourceServerId</code>.
@@ -80,42 +80,42 @@ public interface PolicyStore {
     /**
      * Returns a list of {@link Policy} associated with a {@link ResourceServer} with the given <code>resourceServerId</code>.
      *
-     * @param attributes a map holding the attributes that will be used as a filter; possible filter options are given by {@link Policy.FilterOption}
      * @param resourceServerId the identifier of a resource server
+     * @param attributes a map holding the attributes that will be used as a filter; possible filter options are given by {@link Policy.FilterOption}
      * @return a list of policies that belong to the given resource server
      *
      * @throws IllegalArgumentException when there is an unknown attribute in the {@code attributes} map
      */
-    List<Policy> findByResourceServer(Map<Policy.FilterOption, String[]> attributes, String resourceServerId, int firstResult, int maxResult);
+    List<Policy> findByResourceServer(String resourceServerId, Map<Policy.FilterOption, String[]> attributes, int firstResult, int maxResult);
 
     /**
      * Returns a list of {@link Policy} associated with a {@link org.keycloak.authorization.core.model.Resource} with the given <code>resourceId</code>.
      *
-     * @param resourceId the identifier of a resource
      * @param resourceServerId the resource server id
+     * @param resourceId the identifier of a resource
      * @return a list of policies associated with the given resource
      */
-    default List<Policy> findByResource(String resourceId, String resourceServerId) {
+    default List<Policy> findByResource(String resourceServerId, String resourceId) {
         List<Policy> result = new LinkedList<>();
 
-        findByResource(resourceId, resourceServerId, result::add);
+        findByResource(resourceServerId, resourceId, result::add);
 
         return result;
     }
 
-    void findByResource(String resourceId, String resourceServerId, Consumer<Policy> consumer);
+    void findByResource(String resourceServerId, String resourceId, Consumer<Policy> consumer);
 
     /**
      * Returns a list of {@link Policy} associated with a {@link org.keycloak.authorization.core.model.Resource} with the given <code>type</code>.
      *
-     * @param resourceType     the type of a resource
      * @param resourceServerId the resource server id
+     * @param resourceType     the type of a resource
      * @return a list of policies associated with the given resource type
      */
-    default List<Policy> findByResourceType(String resourceType, String resourceServerId) {
+    default List<Policy> findByResourceType(String resourceServerId, String resourceType) {
         List<Policy> result = new LinkedList<>();
 
-        findByResourceType(resourceType, resourceServerId, result::add);
+        findByResourceType(resourceServerId, resourceType, result::add);
 
         return result;
     }
@@ -123,52 +123,52 @@ public interface PolicyStore {
     /**
      * Returns a list of {@link Policy} associated with a {@link org.keycloak.authorization.core.model.Scope} with the given <code>scopeIds</code>.
      *
-     * @param scopeIds the id of the scopes
      * @param resourceServerId the resource server id
+     * @param scopeIds the id of the scopes
      * @return a list of policies associated with the given scopes
      */
-    List<Policy> findByScopeIds(List<String> scopeIds, String resourceServerId);
+    List<Policy> findByScopeIds(String resourceServerId, List<String> scopeIds);
 
     /**
      * Returns a list of {@link Policy} associated with a {@link org.keycloak.authorization.core.model.Scope} with the given <code>resourceId</code> and <code>scopeIds</code>.
      *
-     * @param scopeIds the id of the scopes
-     * @param resourceId the id of the resource. Ignored if {@code null}.
      * @param resourceServerId the resource server id
+     * @param resourceId the id of the resource. Ignored if {@code null}.
+     * @param scopeIds the id of the scopes
      * @return a list of policies associated with the given scopes
      */
-    default List<Policy> findByScopeIds(List<String> scopeIds, String resourceId, String resourceServerId) {
+    default List<Policy> findByScopeIds(String resourceServerId, String resourceId, List<String> scopeIds) {
         List<Policy> result = new LinkedList<>();
 
-        findByScopeIds(scopeIds, resourceId, resourceServerId, result::add);
+        findByScopeIds(resourceServerId, resourceId, scopeIds, result::add);
 
         return result;
     }
 
     /**
-     * Effectively the same method as {@link #findByScopeIds(List, String, String)}, however in the end
+     * Effectively the same method as {@link #findByScopeIds(String, String, List)}, however in the end
      * the {@code consumer} is fed with the result.
      *
      */
-    void findByScopeIds(List<String> scopeIds, String resourceId, String resourceServerId, Consumer<Policy> consumer);
+    void findByScopeIds(String resourceServerId, String resourceId, List<String> scopeIds, Consumer<Policy> consumer);
 
     /**
      * Returns a list of {@link Policy} with the given <code>type</code>.
      *
-     * @param type the type of the policy
      * @param resourceServerId the resource server id
+     * @param type the type of the policy
      * @return a list of policies with the given type
      */
-    List<Policy> findByType(String type, String resourceServerId);
+    List<Policy> findByType(String resourceServerId, String type);
 
     /**
      * Returns a list of {@link Policy} that depends on another policy with the given <code>id</code>.
      *
-     * @param id the id of the policy to query its dependents
      * @param resourceServerId the resource server id
+     * @param id the id of the policy to query its dependents
      * @return a list of policies that depends on the a policy with the given identifier
      */
-    List<Policy> findDependentPolicies(String id, String resourceServerId);
+    List<Policy> findDependentPolicies(String resourceServerId, String id);
 
-    void findByResourceType(String type, String resourceServerId, Consumer<Policy> policyConsumer);
+    void findByResourceType(String resourceServerId, String type, Consumer<Policy> policyConsumer);
 }

--- a/server-spi-private/src/main/java/org/keycloak/authorization/store/PolicyStore.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/store/PolicyStore.java
@@ -24,7 +24,9 @@ import java.util.Map;
 import java.util.function.Consumer;
 
 import org.keycloak.authorization.model.Policy;
+import org.keycloak.authorization.model.Resource;
 import org.keycloak.authorization.model.ResourceServer;
+import org.keycloak.authorization.model.Scope;
 import org.keycloak.representations.idm.authorization.AbstractPolicyRepresentation;
 
 /**
@@ -54,121 +56,135 @@ public interface PolicyStore {
     /**
      * Returns a {@link Policy} with the given <code>id</code>
      *
-     * @param resourceServerId the resource server id
+     * @param resourceServer the resource server
      * @param id the identifier of the policy
      * @return a policy with the given identifier.
      */
-    Policy findById(String resourceServerId, String id);
+    Policy findById(ResourceServer resourceServer, String id);
 
     /**
      * Returns a {@link Policy} with the given <code>name</code>
      *
-     * @param resourceServerId the resource server id
+     * @param resourceServer the resource server
      * @param name             the name of the policy
      * @return a policy with the given name.
      */
-    Policy findByName(String resourceServerId, String name);
+    Policy findByName(ResourceServer resourceServer, String name);
 
     /**
      * Returns a list of {@link Policy} associated with a {@link ResourceServer} with the given <code>resourceServerId</code>.
      *
-     * @param resourceServerId the identifier of a resource server
+     * @param resourceServer the identifier of a resource server
      * @return a list of policies that belong to the given resource server
      */
-    List<Policy> findByResourceServer(String resourceServerId);
+    List<Policy> findByResourceServer(ResourceServer resourceServer);
 
     /**
      * Returns a list of {@link Policy} associated with a {@link ResourceServer} with the given <code>resourceServerId</code>.
      *
-     * @param resourceServerId the identifier of a resource server
+     * @param resourceServer the identifier of a resource server
      * @param attributes a map holding the attributes that will be used as a filter; possible filter options are given by {@link Policy.FilterOption}
      * @return a list of policies that belong to the given resource server
      *
      * @throws IllegalArgumentException when there is an unknown attribute in the {@code attributes} map
      */
-    List<Policy> findByResourceServer(String resourceServerId, Map<Policy.FilterOption, String[]> attributes, int firstResult, int maxResult);
+    List<Policy> findByResourceServer(ResourceServer resourceServer, Map<Policy.FilterOption, String[]> attributes, int firstResult, int maxResult);
 
     /**
-     * Returns a list of {@link Policy} associated with a {@link org.keycloak.authorization.core.model.Resource} with the given <code>resourceId</code>.
+     * Returns a list of {@link Policy} associated with a {@link org.keycloak.authorization.model.Resource} with the given <code>resourceId</code>.
      *
-     * @param resourceServerId the resource server id
-     * @param resourceId the identifier of a resource
+     * @param resourceServer the resource server
+     * @param resource the resource
      * @return a list of policies associated with the given resource
      */
-    default List<Policy> findByResource(String resourceServerId, String resourceId) {
+    default List<Policy> findByResource(ResourceServer resourceServer, Resource resource) {
         List<Policy> result = new LinkedList<>();
 
-        findByResource(resourceServerId, resourceId, result::add);
+        findByResource(resourceServer, resource, result::add);
 
         return result;
     }
 
-    void findByResource(String resourceServerId, String resourceId, Consumer<Policy> consumer);
+    /**
+     * Searches for all policies associated with the {@link org.keycloak.authorization.model.Resource} and passes the result to the {@code consumer}
+     *
+     * @param resourceServer the resourceServer
+     * @param resource the resource
+     * @param consumer consumer of policies resulted from the search
+     */
+    void findByResource(ResourceServer resourceServer, Resource resource, Consumer<Policy> consumer);
 
     /**
-     * Returns a list of {@link Policy} associated with a {@link org.keycloak.authorization.core.model.Resource} with the given <code>type</code>.
+     * Returns a list of {@link Policy} associated with a {@link org.keycloak.authorization.model.ResourceServer} with the given <code>type</code>.
      *
-     * @param resourceServerId the resource server id
-     * @param resourceType     the type of a resource
+     * @param resourceServer the resource server id
+     * @param resourceType the type of a resource
      * @return a list of policies associated with the given resource type
      */
-    default List<Policy> findByResourceType(String resourceServerId, String resourceType) {
+    default List<Policy> findByResourceType(ResourceServer resourceServer, String resourceType) {
         List<Policy> result = new LinkedList<>();
 
-        findByResourceType(resourceServerId, resourceType, result::add);
+        findByResourceType((ResourceServer) null, resourceType, result::add);
 
         return result;
     }
 
     /**
-     * Returns a list of {@link Policy} associated with a {@link org.keycloak.authorization.core.model.Scope} with the given <code>scopeIds</code>.
+     * Searches for policies associated with a {@link org.keycloak.authorization.model.ResourceServer} and passes the result to the consumer
      *
-     * @param resourceServerId the resource server id
-     * @param scopeIds the id of the scopes
-     * @return a list of policies associated with the given scopes
+     * @param resourceServer the resourceServer
+     * @param type the type of a resource
+     * @param policyConsumer consumer of policies resulted from the search
      */
-    List<Policy> findByScopeIds(String resourceServerId, List<String> scopeIds);
+    void findByResourceType(ResourceServer resourceServer, String type, Consumer<Policy> policyConsumer);
 
     /**
-     * Returns a list of {@link Policy} associated with a {@link org.keycloak.authorization.core.model.Scope} with the given <code>resourceId</code> and <code>scopeIds</code>.
+     * Returns a list of {@link Policy} associated with a {@link org.keycloak.authorization.model.Scope} within the given <code>scope</code>.
      *
-     * @param resourceServerId the resource server id
-     * @param resourceId the id of the resource. Ignored if {@code null}.
-     * @param scopeIds the id of the scopes
+     * @param resourceServer the resource server
+     * @param scopes the scopes
      * @return a list of policies associated with the given scopes
      */
-    default List<Policy> findByScopeIds(String resourceServerId, String resourceId, List<String> scopeIds) {
+    List<Policy> findByScopes(ResourceServer resourceServer, List<Scope> scopes);
+
+    /**
+     * Returns a list of {@link Policy} associated with a {@link org.keycloak.authorization.model.Scope} with the given <code>resource</code> and <code>scopes</code>.
+     *
+     * @param resourceServer the resource server
+     * @param resource the resource. Ignored if {@code null}.
+     * @param scopes the scopes
+     * @return a list of policies associated with the given scopes
+     */
+    default List<Policy> findByScopes(ResourceServer resourceServer, Resource resource, List<Scope> scopes) {
         List<Policy> result = new LinkedList<>();
 
-        findByScopeIds(resourceServerId, resourceId, scopeIds, result::add);
+        findByScopes(resourceServer, resource, scopes, result::add);
 
         return result;
     }
 
     /**
-     * Effectively the same method as {@link #findByScopeIds(String, String, List)}, however in the end
+     * Effectively the same method as {@link #findByScopes(ResourceServer, Resource, List)}, however in the end
      * the {@code consumer} is fed with the result.
      *
      */
-    void findByScopeIds(String resourceServerId, String resourceId, List<String> scopeIds, Consumer<Policy> consumer);
+    void findByScopes(ResourceServer resourceServer, Resource resource, List<Scope> scopes, Consumer<Policy> consumer);
 
     /**
      * Returns a list of {@link Policy} with the given <code>type</code>.
      *
-     * @param resourceServerId the resource server id
+     * @param resourceServer the resource server id
      * @param type the type of the policy
      * @return a list of policies with the given type
      */
-    List<Policy> findByType(String resourceServerId, String type);
+    List<Policy> findByType(ResourceServer resourceServer, String type);
 
     /**
      * Returns a list of {@link Policy} that depends on another policy with the given <code>id</code>.
      *
-     * @param resourceServerId the resource server id
+     * @param resourceServer the resource server
      * @param id the id of the policy to query its dependents
      * @return a list of policies that depends on the a policy with the given identifier
      */
-    List<Policy> findDependentPolicies(String resourceServerId, String id);
-
-    void findByResourceType(String resourceServerId, String type, Consumer<Policy> policyConsumer);
+    List<Policy> findDependentPolicies(ResourceServer resourceServer, String id);
 }

--- a/server-spi-private/src/main/java/org/keycloak/authorization/store/PolicyStore.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/store/PolicyStore.java
@@ -84,11 +84,13 @@ public interface PolicyStore {
      *
      * @param resourceServer the identifier of a resource server
      * @param attributes a map holding the attributes that will be used as a filter; possible filter options are given by {@link Policy.FilterOption}
+     * @param firstResult first result to return. Ignored if negative or {@code null}.
+     * @param maxResults maximum number of results to return. Ignored if negative or {@code null}.
      * @return a list of policies that belong to the given resource server
      *
      * @throws IllegalArgumentException when there is an unknown attribute in the {@code attributes} map
      */
-    List<Policy> findByResourceServer(ResourceServer resourceServer, Map<Policy.FilterOption, String[]> attributes, int firstResult, int maxResult);
+    List<Policy> findByResourceServer(ResourceServer resourceServer, Map<Policy.FilterOption, String[]> attributes, Integer firstResult, Integer maxResults);
 
     /**
      * Returns a list of {@link Policy} associated with a {@link org.keycloak.authorization.model.Resource} with the given <code>resourceId</code>.

--- a/server-spi-private/src/main/java/org/keycloak/authorization/store/ResourceServerStore.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/store/ResourceServerStore.java
@@ -50,9 +50,7 @@ public interface ResourceServerStore {
      * @param id the identifier of an existing resource server instance
      *
      * @return the resource server instance with the given identifier or null if no instance was found
-     * @deprecated use {@code findByClient} instead.
      */
-    @Deprecated
     ResourceServer findById(String id);
 
     /**

--- a/server-spi-private/src/main/java/org/keycloak/authorization/store/ResourceStore.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/store/ResourceStore.java
@@ -19,11 +19,13 @@ package org.keycloak.authorization.store;
 
 import org.keycloak.authorization.model.Resource;
 import org.keycloak.authorization.model.ResourceServer;
+import org.keycloak.authorization.model.Scope;
 
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Consumer;
 
 /**
@@ -66,101 +68,112 @@ public interface ResourceStore {
     /**
      * Returns a {@link Resource} instance based on its identifier.
      *
+     * @param resourceServer the resource server
      * @param id the identifier of an existing resource instance
      * @return the resource instance with the given identifier or null if no instance was found
      */
-    Resource findById(String resourceServerId, String id);
+    Resource findById(ResourceServer resourceServer, String id);
 
     /**
      * Finds all {@link Resource} instances with the given {@code ownerId}.
      *
+     *
+     * @param resourceServer
      * @param ownerId the identifier of the owner
      * @return a list with all resource instances owned by the given owner
      */
-    default List<Resource> findByOwner(String resourceServerId, String ownerId) {
+    default List<Resource> findByOwner(ResourceServer resourceServer, String ownerId) {
         List<Resource> list = new LinkedList<>();
 
-        findByOwner(resourceServerId, ownerId, list::add);
+        findByOwner(resourceServer, ownerId, list::add);
 
         return list;
     }
 
-    void findByOwner(String resourceServerId, String ownerId, Consumer<Resource> consumer);
+    void findByOwner(ResourceServer resourceServer, String ownerId, Consumer<Resource> consumer);
 
-    List<Resource> findByOwner(String resourceServerId, String ownerId, int first, int max);
+    List<Resource> findByOwner(ResourceServer resourceServer, String ownerId, int first, int max);
 
     /**
      * Finds all {@link Resource} instances with the given uri.
      *
+     *
+     * @param resourceServer
      * @param uri the identifier of the uri
      * @return a list with all resource instances owned by the given owner
      */
-    List<Resource> findByUri(String resourceServerId, String uri);
+    List<Resource> findByUri(ResourceServer resourceServer, String uri);
 
     /**
      * Finds all {@link Resource} instances associated with a given resource server.
      *
-     * @param resourceServerId the identifier of the resource server
+     * @param resourceServer the identifier of the resource server
      * @return a list with all resources associated with the given resource server
      */
-    List<Resource> findByResourceServer(String resourceServerId);
+    List<Resource> findByResourceServer(ResourceServer resourceServer);
 
     /**
      * Finds all {@link Resource} instances associated with a given resource server.
      *
-     * @param resourceServerId the identifier of the resource server
+     * @param resourceServer the identifier of the resource server
      * @param attributes a map holding the attributes that will be used as a filter; possible filter options are given by {@link Resource.FilterOption}
      * @return a list with all resources associated with the given resource server
      *
      * @throws IllegalArgumentException when there is an unknown attribute in the {@code attributes} map
      */
-    List<Resource> findByResourceServer(String resourceServerId, Map<Resource.FilterOption, String[]> attributes, int firstResult, int maxResult);
+    List<Resource> findByResourceServer(ResourceServer resourceServer, Map<Resource.FilterOption, String[]> attributes, int firstResult, int maxResult);
 
     /**
      * Finds all {@link Resource} associated with a given scope.
      *
-     * @param id one or more scope identifiers
+     *
+     * @param resourceServer
+     * @param scopes one or more scope identifiers
      * @return a list of resources associated with the given scope(s)
      */
-    default List<Resource> findByScope(String resourceServerId, List<String> id) {
+    default List<Resource> findByScopes(ResourceServer resourceServer, Set<Scope> scopes) {
         List<Resource> result = new ArrayList<>();
 
-        findByScope(resourceServerId, id, result::add);
+        findByScopes(resourceServer, scopes, result::add);
 
         return result;
     }
 
-    void findByScope(String resourceServerId, List<String> scopes, Consumer<Resource> consumer);
+    void findByScopes(ResourceServer resourceServer, Set<Scope> scopes, Consumer<Resource> consumer);
 
     /**
      * Find a {@link Resource} by its name where the owner is the resource server itself.
      *
-     * @param resourceServerId the identifier of the resource server
+     * @param resourceServer the resource server
      * @param name the name of the resource
      * @return a resource with the given name
      */
-    Resource findByName(String resourceServerId, String name);
+    default Resource findByName(ResourceServer resourceServer, String name) {
+        return findByName(resourceServer, name, resourceServer.getClientId());
+    }
 
     /**
      * Find a {@link Resource} by its name where the owner is the given <code>ownerId</code>.
      *
-     * @param resourceServerId the identifier of the resource server
+     * @param resourceServer the identifier of the resource server
      * @param name the name of the resource
      * @param ownerId the owner id
      * @return a resource with the given name
      */
-    Resource findByName(String resourceServerId, String name, String ownerId);
+    Resource findByName(ResourceServer resourceServer, String name, String ownerId);
 
     /**
      * Finds all {@link Resource} with the given type.
      *
+     *
+     * @param resourceServer
      * @param type the type of the resource
      * @return a list of resources with the given type
      */
-    default List<Resource> findByType(String resourceServerId, String type) {
+    default List<Resource> findByType(ResourceServer resourceServer, String type) {
         List<Resource> list = new LinkedList<>();
 
-        findByType(resourceServerId, type, list::add);
+        findByType(resourceServer, type, list::add);
 
         return list;
     }
@@ -168,14 +181,16 @@ public interface ResourceStore {
     /**
      * Finds all {@link Resource} with the given type.
      *
+     *
+     * @param resourceServer
      * @param type the type of the resource
      * @param owner the resource owner or null for any resource with a given type
      * @return a list of resources with the given type
      */
-    default List<Resource> findByType(String resourceServerId, String type, String owner) {
+    default List<Resource> findByType(ResourceServer resourceServer, String type, String owner) {
         List<Resource> list = new LinkedList<>();
 
-        findByType(resourceServerId, type, owner, list::add);
+        findByType(resourceServer, type, owner, list::add);
 
         return list;
     }
@@ -183,31 +198,31 @@ public interface ResourceStore {
     /**
      * Finds all {@link Resource} with the given type.
      *
-     * @param resourceServerId the resource server id
+     * @param resourceServer the resource server id
      * @param type the type of the resource
      * @param consumer the result consumer
      * @return a list of resources with the given type
      */
-    void findByType(String resourceServerId, String type, Consumer<Resource> consumer);
+    void findByType(ResourceServer resourceServer, String type, Consumer<Resource> consumer);
 
     /**
      * Finds all {@link Resource} with the given type.
      *
-     * @param resourceServerId the resource server id
+     * @param resourceServer the resource server id
      * @param type the type of the resource
      * @param owner the resource owner or null for any resource with a given type
      * @param consumer the result consumer
      * @return a list of resources with the given type
      */
-    void findByType(String resourceServerId, String type, String owner, Consumer<Resource> consumer);
+    void findByType(ResourceServer resourceServer, String type, String owner, Consumer<Resource> consumer);
 
-    default List<Resource> findByTypeInstance(String resourceServerId, String type) {
+    default List<Resource> findByTypeInstance(ResourceServer resourceServer, String type) {
         List<Resource> list = new LinkedList<>();
 
-        findByTypeInstance(resourceServerId, type, list::add);
+        findByTypeInstance(resourceServer, type, list::add);
 
         return list;
     }
 
-    void findByTypeInstance(String resourceServerId, String type, Consumer<Resource> consumer);
+    void findByTypeInstance(ResourceServer resourceServerId, String type, Consumer<Resource> consumer);
 }

--- a/server-spi-private/src/main/java/org/keycloak/authorization/store/ResourceStore.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/store/ResourceStore.java
@@ -36,25 +36,25 @@ public interface ResourceStore {
     /**
      * <p>Creates a {@link Resource} instance backed by this persistent storage implementation.
      *
-     * @param name the name of this resource. It must be unique.
      * @param resourceServer the resource server to where the given resource belongs to
+     * @param name the name of this resource. It must be unique.
      * @param owner the owner of this resource or null if the resource server is the owner
      * @return an instance backed by the underlying storage implementation
      */
-    default Resource create(String name, ResourceServer resourceServer, String owner) {
-        return create(null, name, resourceServer, owner);
+    default Resource create(ResourceServer resourceServer, String name, String owner) {
+        return create(resourceServer, null, name, owner);
     }
 
     /**
      * <p>Creates a {@link Resource} instance backed by this persistent storage implementation.
      *
+     * @param resourceServer the resource server to where the given resource belongs to
      * @param id the id of this resource. It must be unique. Will be randomly generated if null.
      * @param name the name of this resource. It must be unique.
-     * @param resourceServer the resource server to where the given resource belongs to
      * @param owner the owner of this resource or null if the resource server is the owner
      * @return an instance backed by the underlying storage implementation
      */
-    Resource create(String id, String name, ResourceServer resourceServer, String owner);
+    Resource create(ResourceServer resourceServer, String id, String name, String owner);
 
     /**
      * Removes a {@link Resource} instance, with the given {@code id} from the persistent storage.
@@ -69,7 +69,7 @@ public interface ResourceStore {
      * @param id the identifier of an existing resource instance
      * @return the resource instance with the given identifier or null if no instance was found
      */
-    Resource findById(String id, String resourceServerId);
+    Resource findById(String resourceServerId, String id);
 
     /**
      * Finds all {@link Resource} instances with the given {@code ownerId}.
@@ -77,17 +77,17 @@ public interface ResourceStore {
      * @param ownerId the identifier of the owner
      * @return a list with all resource instances owned by the given owner
      */
-    default List<Resource> findByOwner(String ownerId, String resourceServerId) {
+    default List<Resource> findByOwner(String resourceServerId, String ownerId) {
         List<Resource> list = new LinkedList<>();
 
-        findByOwner(ownerId, resourceServerId, list::add);
+        findByOwner(resourceServerId, ownerId, list::add);
 
         return list;
     }
 
-    void findByOwner(String ownerId, String resourceServerId, Consumer<Resource> consumer);
+    void findByOwner(String resourceServerId, String ownerId, Consumer<Resource> consumer);
 
-    List<Resource> findByOwner(String ownerId, String resourceServerId, int first, int max);
+    List<Resource> findByOwner(String resourceServerId, String ownerId, int first, int max);
 
     /**
      * Finds all {@link Resource} instances with the given uri.
@@ -95,7 +95,7 @@ public interface ResourceStore {
      * @param uri the identifier of the uri
      * @return a list with all resource instances owned by the given owner
      */
-    List<Resource> findByUri(String uri, String resourceServerId);
+    List<Resource> findByUri(String resourceServerId, String uri);
 
     /**
      * Finds all {@link Resource} instances associated with a given resource server.
@@ -108,13 +108,13 @@ public interface ResourceStore {
     /**
      * Finds all {@link Resource} instances associated with a given resource server.
      *
-     * @param attributes a map holding the attributes that will be used as a filter; possible filter options are given by {@link Resource.FilterOption}
      * @param resourceServerId the identifier of the resource server
+     * @param attributes a map holding the attributes that will be used as a filter; possible filter options are given by {@link Resource.FilterOption}
      * @return a list with all resources associated with the given resource server
      *
      * @throws IllegalArgumentException when there is an unknown attribute in the {@code attributes} map
      */
-    List<Resource> findByResourceServer(Map<Resource.FilterOption, String[]> attributes, String resourceServerId, int firstResult, int maxResult);
+    List<Resource> findByResourceServer(String resourceServerId, Map<Resource.FilterOption, String[]> attributes, int firstResult, int maxResult);
 
     /**
      * Finds all {@link Resource} associated with a given scope.
@@ -122,34 +122,34 @@ public interface ResourceStore {
      * @param id one or more scope identifiers
      * @return a list of resources associated with the given scope(s)
      */
-    default List<Resource> findByScope(List<String> id, String resourceServerId) {
+    default List<Resource> findByScope(String resourceServerId, List<String> id) {
         List<Resource> result = new ArrayList<>();
 
-        findByScope(id, resourceServerId, result::add);
+        findByScope(resourceServerId, id, result::add);
 
         return result;
     }
 
-    void findByScope(List<String> scopes, String resourceServerId, Consumer<Resource> consumer);
+    void findByScope(String resourceServerId, List<String> scopes, Consumer<Resource> consumer);
 
     /**
      * Find a {@link Resource} by its name where the owner is the resource server itself.
      *
-     * @param name the name of the resource
      * @param resourceServerId the identifier of the resource server
+     * @param name the name of the resource
      * @return a resource with the given name
      */
-    Resource findByName(String name, String resourceServerId);
+    Resource findByName(String resourceServerId, String name);
 
     /**
      * Find a {@link Resource} by its name where the owner is the given <code>ownerId</code>.
      *
+     * @param resourceServerId the identifier of the resource server
      * @param name the name of the resource
      * @param ownerId the owner id
-     * @param resourceServerId the identifier of the resource server
      * @return a resource with the given name
      */
-    Resource findByName(String name, String ownerId, String resourceServerId);
+    Resource findByName(String resourceServerId, String name, String ownerId);
 
     /**
      * Finds all {@link Resource} with the given type.
@@ -157,10 +157,10 @@ public interface ResourceStore {
      * @param type the type of the resource
      * @return a list of resources with the given type
      */
-    default List<Resource> findByType(String type, String resourceServerId) {
+    default List<Resource> findByType(String resourceServerId, String type) {
         List<Resource> list = new LinkedList<>();
 
-        findByType(type, resourceServerId, list::add);
+        findByType(resourceServerId, type, list::add);
 
         return list;
     }
@@ -172,10 +172,10 @@ public interface ResourceStore {
      * @param owner the resource owner or null for any resource with a given type
      * @return a list of resources with the given type
      */
-    default List<Resource> findByType(String type, String owner, String resourceServerId) {
+    default List<Resource> findByType(String resourceServerId, String type, String owner) {
         List<Resource> list = new LinkedList<>();
 
-        findByType(type, owner, resourceServerId, list::add);
+        findByType(resourceServerId, type, owner, list::add);
 
         return list;
     }
@@ -183,31 +183,31 @@ public interface ResourceStore {
     /**
      * Finds all {@link Resource} with the given type.
      *
-     * @param type the type of the resource
      * @param resourceServerId the resource server id
+     * @param type the type of the resource
      * @param consumer the result consumer
      * @return a list of resources with the given type
      */
-    void findByType(String type, String resourceServerId, Consumer<Resource> consumer);
+    void findByType(String resourceServerId, String type, Consumer<Resource> consumer);
 
     /**
      * Finds all {@link Resource} with the given type.
      *
+     * @param resourceServerId the resource server id
      * @param type the type of the resource
      * @param owner the resource owner or null for any resource with a given type
-     * @param resourceServerId the resource server id
      * @param consumer the result consumer
      * @return a list of resources with the given type
      */
-    void findByType(String type, String owner, String resourceServerId, Consumer<Resource> consumer);
+    void findByType(String resourceServerId, String type, String owner, Consumer<Resource> consumer);
 
-    default List<Resource> findByTypeInstance(String type, String resourceServerId) {
+    default List<Resource> findByTypeInstance(String resourceServerId, String type) {
         List<Resource> list = new LinkedList<>();
 
-        findByTypeInstance(type, resourceServerId, list::add);
+        findByTypeInstance(resourceServerId, type, list::add);
 
         return list;
     }
 
-    void findByTypeInstance(String type, String resourceServerId, Consumer<Resource> consumer);
+    void findByTypeInstance(String resourceServerId, String type, Consumer<Resource> consumer);
 }

--- a/server-spi-private/src/main/java/org/keycloak/authorization/store/ResourceStore.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/store/ResourceStore.java
@@ -92,7 +92,7 @@ public interface ResourceStore {
 
     void findByOwner(ResourceServer resourceServer, String ownerId, Consumer<Resource> consumer);
 
-    List<Resource> findByOwner(ResourceServer resourceServer, String ownerId, int first, int max);
+    List<Resource> findByOwner(ResourceServer resourceServer, String ownerId, Integer firstResult, Integer maxResults);
 
     /**
      * Finds all {@link Resource} instances with the given uri.
@@ -117,11 +117,13 @@ public interface ResourceStore {
      *
      * @param resourceServer the identifier of the resource server
      * @param attributes a map holding the attributes that will be used as a filter; possible filter options are given by {@link Resource.FilterOption}
+     * @param firstResult first result to return. Ignored if negative or {@code null}.
+     * @param maxResults maximum number of results to return. Ignored if negative or {@code null}.
      * @return a list with all resources associated with the given resource server
      *
      * @throws IllegalArgumentException when there is an unknown attribute in the {@code attributes} map
      */
-    List<Resource> findByResourceServer(ResourceServer resourceServer, Map<Resource.FilterOption, String[]> attributes, int firstResult, int maxResult);
+    List<Resource> findByResourceServer(ResourceServer resourceServer, Map<Resource.FilterOption, String[]> attributes, Integer firstResult, Integer maxResults);
 
     /**
      * Finds all {@link Resource} associated with a given scope.

--- a/server-spi-private/src/main/java/org/keycloak/authorization/store/ScopeStore.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/store/ScopeStore.java
@@ -35,26 +35,26 @@ public interface ScopeStore {
      * Creates a new {@link Scope} instance. The new instance is not necessarily persisted though, which may require
      * a call to the {#save} method to actually make it persistent.
      *
-     * @param name the name of the scope
      * @param resourceServer the resource server to which this scope belongs
      *
+     * @param name the name of the scope
      * @return a new instance of {@link Scope}
      */
-    default Scope create(String name, ResourceServer resourceServer) {
-        return create(null, name, resourceServer);
+    default Scope create(ResourceServer resourceServer, String name) {
+        return create(resourceServer, null, name);
     }
 
     /**
      * Creates a new {@link Scope} instance. The new instance is not necessarily persisted though, which may require
      * a call to the {#save} method to actually make it persistent.
      *
-     * @param id the id of the scope. Is generated randomly when null
-     * @param name the name of the scope
      * @param resourceServer the resource server to which this scope belongs
      *
+     * @param id the id of the scope. Is generated randomly when null
+     * @param name the name of the scope
      * @return a new instance of {@link Scope}
      */
-    Scope create(String id, String name, ResourceServer resourceServer);
+    Scope create(ResourceServer resourceServer, String id, String name);
 
     /**
      * Deletes a scope from the underlying persistence mechanism.
@@ -66,21 +66,21 @@ public interface ScopeStore {
     /**
      * Returns a {@link Scope} with the given <code>id</code>
      *
-     * @param id the identifier of the scope
      * @param resourceServerId the resource server id
+     * @param id the identifier of the scope
      * @return a scope with the given identifier.
      */
-    Scope findById(String id, String resourceServerId);
+    Scope findById(String resourceServerId, String id);
 
     /**
      * Returns a {@link Scope} with the given <code>name</code>
      *
+     * @param resourceServerId the resource server id
      * @param name the name of the scope
      *
-     * @param resourceServerId the resource server id
      * @return a scope with the given name.
      */
-    Scope findByName(String name, String resourceServerId);
+    Scope findByName(String resourceServerId, String name);
 
     /**
      * Returns a list of {@link Scope} associated with a {@link ResourceServer} with the given <code>resourceServerId</code>.
@@ -94,12 +94,12 @@ public interface ScopeStore {
     /**
      * Returns a list of {@link Scope} associated with a {@link ResourceServer} with the given <code>resourceServerId</code>.
      *
-     * @param attributes a map holding the attributes that will be used as a filter; possible filter options are given by {@link Scope.FilterOption}
      * @param resourceServerId the identifier of a resource server
+     * @param attributes a map holding the attributes that will be used as a filter; possible filter options are given by {@link Scope.FilterOption}
      * @return a list of scopes that belong to the given resource server
      * 
      * @throws IllegalArgumentException when there is an unknown attribute in the {@code attributes} map
      * 
      */
-    List<Scope> findByResourceServer(Map<Scope.FilterOption, String[]> attributes, String resourceServerId, int firstResult, int maxResult);
+    List<Scope> findByResourceServer(String resourceServerId, Map<Scope.FilterOption, String[]> attributes, int firstResult, int maxResult);
 }

--- a/server-spi-private/src/main/java/org/keycloak/authorization/store/ScopeStore.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/store/ScopeStore.java
@@ -66,40 +66,40 @@ public interface ScopeStore {
     /**
      * Returns a {@link Scope} with the given <code>id</code>
      *
-     * @param resourceServerId the resource server id
+     * @param resourceServer the resource server id
      * @param id the identifier of the scope
      * @return a scope with the given identifier.
      */
-    Scope findById(String resourceServerId, String id);
+    Scope findById(ResourceServer resourceServer, String id);
 
     /**
      * Returns a {@link Scope} with the given <code>name</code>
      *
-     * @param resourceServerId the resource server id
+     * @param resourceServer the resource server
      * @param name the name of the scope
      *
      * @return a scope with the given name.
      */
-    Scope findByName(String resourceServerId, String name);
+    Scope findByName(ResourceServer resourceServer, String name);
 
     /**
-     * Returns a list of {@link Scope} associated with a {@link ResourceServer} with the given <code>resourceServerId</code>.
+     * Returns a list of {@link Scope} associated with a {@link ResourceServer} with the given <code>resourceServer</code>.
      *
-     * @param resourceServerId the identifier of a resource server
+     * @param resourceServer the identifier of a resource server
      *
      * @return a list of scopes that belong to the given resource server
      */
-    List<Scope> findByResourceServer(String id);
+    List<Scope> findByResourceServer(ResourceServer resourceServer);
 
     /**
      * Returns a list of {@link Scope} associated with a {@link ResourceServer} with the given <code>resourceServerId</code>.
      *
-     * @param resourceServerId the identifier of a resource server
+     * @param resourceServer the resource server
      * @param attributes a map holding the attributes that will be used as a filter; possible filter options are given by {@link Scope.FilterOption}
      * @return a list of scopes that belong to the given resource server
      * 
      * @throws IllegalArgumentException when there is an unknown attribute in the {@code attributes} map
      * 
      */
-    List<Scope> findByResourceServer(String resourceServerId, Map<Scope.FilterOption, String[]> attributes, int firstResult, int maxResult);
+    List<Scope> findByResourceServer(ResourceServer resourceServer, Map<Scope.FilterOption, String[]> attributes, int firstResult, int maxResult);
 }

--- a/server-spi-private/src/main/java/org/keycloak/authorization/store/ScopeStore.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/store/ScopeStore.java
@@ -96,10 +96,12 @@ public interface ScopeStore {
      *
      * @param resourceServer the resource server
      * @param attributes a map holding the attributes that will be used as a filter; possible filter options are given by {@link Scope.FilterOption}
+     * @param firstResult first result to return. Ignored if negative or {@code null}.
+     * @param maxResults maximum number of results to return. Ignored if negative or {@code null}.
      * @return a list of scopes that belong to the given resource server
      * 
      * @throws IllegalArgumentException when there is an unknown attribute in the {@code attributes} map
      * 
      */
-    List<Scope> findByResourceServer(ResourceServer resourceServer, Map<Scope.FilterOption, String[]> attributes, int firstResult, int maxResult);
+    List<Scope> findByResourceServer(ResourceServer resourceServer, Map<Scope.FilterOption, String[]> attributes, Integer firstResult, Integer maxResults);
 }

--- a/server-spi-private/src/main/java/org/keycloak/authorization/store/syncronization/ClientApplicationSynchronizer.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/store/syncronization/ClientApplicationSynchronizer.java
@@ -62,7 +62,7 @@ public class ClientApplicationSynchronizer implements Synchronizer<ClientRemoved
         attributes.put(Policy.FilterOption.CONFIG, new String[] {"clients", event.getClient().getId()});
         attributes.put(Policy.FilterOption.ANY_OWNER, Policy.FilterOption.EMPTY_FILTER);
 
-        List<Policy> search = storeFactory.getPolicyStore().findByResourceServer(attributes, null, -1, -1);
+        List<Policy> search = storeFactory.getPolicyStore().findByResourceServer(null, attributes, -1, -1);
 
         for (Policy policy : search) {
             PolicyProviderFactory policyFactory = authorizationProvider.getProviderFactory(policy.getType());

--- a/server-spi-private/src/main/java/org/keycloak/authorization/store/syncronization/ClientApplicationSynchronizer.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/store/syncronization/ClientApplicationSynchronizer.java
@@ -62,7 +62,7 @@ public class ClientApplicationSynchronizer implements Synchronizer<ClientRemoved
         attributes.put(Policy.FilterOption.CONFIG, new String[] {"clients", event.getClient().getId()});
         attributes.put(Policy.FilterOption.ANY_OWNER, Policy.FilterOption.EMPTY_FILTER);
 
-        List<Policy> search = storeFactory.getPolicyStore().findByResourceServer(null, attributes, -1, -1);
+        List<Policy> search = storeFactory.getPolicyStore().findByResourceServer(null, attributes, null, null);
 
         for (Policy policy : search) {
             PolicyProviderFactory policyFactory = authorizationProvider.getProviderFactory(policy.getType());

--- a/server-spi-private/src/main/java/org/keycloak/authorization/store/syncronization/GroupSynchronizer.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/store/syncronization/GroupSynchronizer.java
@@ -51,7 +51,7 @@ public class GroupSynchronizer implements Synchronizer<GroupModel.GroupRemovedEv
         attributes.put(Policy.FilterOption.CONFIG, new String[] {"groups", group.getId()});
         attributes.put(Policy.FilterOption.ANY_OWNER, Policy.FilterOption.EMPTY_FILTER);
 
-        List<Policy> search = policyStore.findByResourceServer(attributes, null, -1, -1);
+        List<Policy> search = policyStore.findByResourceServer(null, attributes, -1, -1);
 
         for (Policy policy : search) {
             PolicyProviderFactory policyFactory = authorizationProvider.getProviderFactory(policy.getType());

--- a/server-spi-private/src/main/java/org/keycloak/authorization/store/syncronization/GroupSynchronizer.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/store/syncronization/GroupSynchronizer.java
@@ -51,7 +51,7 @@ public class GroupSynchronizer implements Synchronizer<GroupModel.GroupRemovedEv
         attributes.put(Policy.FilterOption.CONFIG, new String[] {"groups", group.getId()});
         attributes.put(Policy.FilterOption.ANY_OWNER, Policy.FilterOption.EMPTY_FILTER);
 
-        List<Policy> search = policyStore.findByResourceServer(null, attributes, -1, -1);
+        List<Policy> search = policyStore.findByResourceServer(null, attributes, null, null);
 
         for (Policy policy : search) {
             PolicyProviderFactory policyFactory = authorizationProvider.getProviderFactory(policy.getType());

--- a/server-spi-private/src/main/java/org/keycloak/authorization/store/syncronization/UserSynchronizer.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/store/syncronization/UserSynchronizer.java
@@ -86,7 +86,7 @@ public class UserSynchronizer implements Synchronizer<UserRemovedEvent> {
 
         resourceStore.findByOwner(null, userModel.getId(), resource -> {
             String resourceId = resource.getId();
-            policyStore.findByResource(resource.getResourceServer().getId(), resourceId).forEach(policy -> {
+            policyStore.findByResource(resource.getResourceServer(), resource).forEach(policy -> {
                 if (policy.getResources().size() == 1) {
                     policyStore.delete(policy.getId());
                 } else {

--- a/server-spi-private/src/main/java/org/keycloak/authorization/store/syncronization/UserSynchronizer.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/store/syncronization/UserSynchronizer.java
@@ -60,7 +60,7 @@ public class UserSynchronizer implements Synchronizer<UserRemovedEvent> {
         attributes.put(Policy.FilterOption.TYPE, new String[] {"user"});
         attributes.put(Policy.FilterOption.CONFIG, new String[] {"users", userModel.getId()});
 
-        List<Policy> search = policyStore.findByResourceServer(attributes, null, -1, -1);
+        List<Policy> search = policyStore.findByResourceServer(null, attributes, -1, -1);
 
         for (Policy policy : search) {
             PolicyProviderFactory policyFactory = authorizationProvider.getProviderFactory(policy.getType());
@@ -84,9 +84,9 @@ public class UserSynchronizer implements Synchronizer<UserRemovedEvent> {
         ResourceStore resourceStore = storeFactory.getResourceStore();
         UserModel userModel = event.getUser();
 
-        resourceStore.findByOwner(userModel.getId(), null, resource -> {
+        resourceStore.findByOwner(null, userModel.getId(), resource -> {
             String resourceId = resource.getId();
-            policyStore.findByResource(resourceId, resource.getResourceServer()).forEach(policy -> {
+            policyStore.findByResource(resource.getResourceServer(), resourceId).forEach(policy -> {
                 if (policy.getResources().size() == 1) {
                     policyStore.delete(policy.getId());
                 } else {
@@ -105,7 +105,7 @@ public class UserSynchronizer implements Synchronizer<UserRemovedEvent> {
 
         attributes.put(PermissionTicket.FilterOption.OWNER, userModel.getId());
 
-        for (PermissionTicket ticket : ticketStore.find(attributes, null, -1, -1)) {
+        for (PermissionTicket ticket : ticketStore.find(null, attributes, -1, -1)) {
             ticketStore.delete(ticket.getId());
         }
 
@@ -113,7 +113,7 @@ public class UserSynchronizer implements Synchronizer<UserRemovedEvent> {
         
         attributes.put(PermissionTicket.FilterOption.REQUESTER, userModel.getId());
 
-        for (PermissionTicket ticket : ticketStore.find(attributes, null, -1, -1)) {
+        for (PermissionTicket ticket : ticketStore.find(null, attributes, -1, -1)) {
             ticketStore.delete(ticket.getId());
         }
     }

--- a/server-spi-private/src/main/java/org/keycloak/authorization/store/syncronization/UserSynchronizer.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/store/syncronization/UserSynchronizer.java
@@ -86,7 +86,7 @@ public class UserSynchronizer implements Synchronizer<UserRemovedEvent> {
 
         resourceStore.findByOwner(null, userModel.getId(), resource -> {
             String resourceId = resource.getId();
-            policyStore.findByResource(resource.getResourceServer(), resourceId).forEach(policy -> {
+            policyStore.findByResource(resource.getResourceServer().getId(), resourceId).forEach(policy -> {
                 if (policy.getResources().size() == 1) {
                     policyStore.delete(policy.getId());
                 } else {

--- a/server-spi-private/src/main/java/org/keycloak/authorization/store/syncronization/UserSynchronizer.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/store/syncronization/UserSynchronizer.java
@@ -60,7 +60,7 @@ public class UserSynchronizer implements Synchronizer<UserRemovedEvent> {
         attributes.put(Policy.FilterOption.TYPE, new String[] {"user"});
         attributes.put(Policy.FilterOption.CONFIG, new String[] {"users", userModel.getId()});
 
-        List<Policy> search = policyStore.findByResourceServer(null, attributes, -1, -1);
+        List<Policy> search = policyStore.findByResourceServer(null, attributes, null, null);
 
         for (Policy policy : search) {
             PolicyProviderFactory policyFactory = authorizationProvider.getProviderFactory(policy.getType());
@@ -105,7 +105,7 @@ public class UserSynchronizer implements Synchronizer<UserRemovedEvent> {
 
         attributes.put(PermissionTicket.FilterOption.OWNER, userModel.getId());
 
-        for (PermissionTicket ticket : ticketStore.find(null, attributes, -1, -1)) {
+        for (PermissionTicket ticket : ticketStore.find(null, attributes, null, null)) {
             ticketStore.delete(ticket.getId());
         }
 
@@ -113,7 +113,7 @@ public class UserSynchronizer implements Synchronizer<UserRemovedEvent> {
         
         attributes.put(PermissionTicket.FilterOption.REQUESTER, userModel.getId());
 
-        for (PermissionTicket ticket : ticketStore.find(null, attributes, -1, -1)) {
+        for (PermissionTicket ticket : ticketStore.find(null, attributes, null, null)) {
             ticketStore.delete(ticket.getId());
         }
     }

--- a/server-spi-private/src/main/java/org/keycloak/migration/migrators/MigrateTo2_1_0.java
+++ b/server-spi-private/src/main/java/org/keycloak/migration/migrators/MigrateTo2_1_0.java
@@ -78,7 +78,7 @@ public class MigrateTo2_1_0 implements Migration {
             ResourceServer resourceServer = storeFactory.getResourceServerStore().findByClient(clientModel);
 
             if (resourceServer != null) {
-                policyStore.findByType(resourceServer.getId(), "role").forEach(policy -> {
+                policyStore.findByType(resourceServer, "role").forEach(policy -> {
                     Map<String, String> config = new HashMap(policy.getConfig());
                     String roles = config.get("roles");
                     List roleConfig;

--- a/server-spi-private/src/main/java/org/keycloak/migration/migrators/MigrateTo2_1_0.java
+++ b/server-spi-private/src/main/java/org/keycloak/migration/migrators/MigrateTo2_1_0.java
@@ -78,7 +78,7 @@ public class MigrateTo2_1_0 implements Migration {
             ResourceServer resourceServer = storeFactory.getResourceServerStore().findByClient(clientModel);
 
             if (resourceServer != null) {
-                policyStore.findByType("role", resourceServer.getId()).forEach(policy -> {
+                policyStore.findByType(resourceServer.getId(), "role").forEach(policy -> {
                     Map<String, String> config = new HashMap(policy.getConfig());
                     String roles = config.get("roles");
                     List roleConfig;

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
@@ -910,7 +910,7 @@ public class ModelToRepresentation {
         ResourceServerRepresentation server = new ResourceServerRepresentation();
 
         server.setId(model.getId());
-        server.setClientId(model.getId());
+        server.setClientId(model.getClientId());
         server.setName(client.getClientId());
         server.setAllowRemoteResourceManagement(model.isAllowRemoteResourceManagement());
         server.setPolicyEnforcementMode(model.getPolicyEnforcementMode());
@@ -953,8 +953,9 @@ public class ModelToRepresentation {
         representation.setLogic(policy.getLogic());
         
         if (allFields) {
-            representation.setResourcesData(policy.getResources().stream().map(
-                    resource -> toRepresentation(resource, resource.getResourceServer(), authorization, true)).collect(Collectors.toSet()));
+            representation.setResourcesData(policy.getResources().stream()
+                    .map(resource -> toRepresentation(resource, policy.getResourceServer(), authorization, true))
+                    .collect(Collectors.toSet()));
             representation.setScopesData(policy.getScopes().stream().map(
                     resource -> toRepresentation(resource)).collect(Collectors.toSet()));
         }
@@ -962,11 +963,11 @@ public class ModelToRepresentation {
         return representation;
     }
 
-    public static ResourceRepresentation toRepresentation(Resource model, String resourceServer, AuthorizationProvider authorization) {
+    public static ResourceRepresentation toRepresentation(Resource model, ResourceServer resourceServer, AuthorizationProvider authorization) {
         return toRepresentation(model, resourceServer, authorization, true);
     }
 
-    public static ResourceRepresentation toRepresentation(Resource model, String resourceServer, AuthorizationProvider authorization, Boolean deep) {
+    public static ResourceRepresentation toRepresentation(Resource model, ResourceServer resourceServer, AuthorizationProvider authorization, Boolean deep) {
         ResourceRepresentation resource = new ResourceRepresentation();
 
         resource.setId(model.getId());
@@ -984,8 +985,8 @@ public class ModelToRepresentation {
         KeycloakSession keycloakSession = authorization.getKeycloakSession();
         RealmModel realm = authorization.getRealm();
 
-        if (owner.getId().equals(resourceServer)) {
-            ClientModel clientModel = realm.getClientById(resourceServer);
+        if (owner.getId().equals(resourceServer.getClientId())) {
+            ClientModel clientModel = realm.getClientById(resourceServer.getClientId());
             owner.setName(clientModel.getClientId());
         } else {
             UserModel userModel = keycloakSession.users().getUserById(realm, owner.getId());

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
@@ -2494,10 +2494,10 @@ public class RepresentationToModel {
                 }
                 if (!hasScope) {
                     ResourceServer resourceServer = policy.getResourceServer();
-                    Scope scope = storeFactory.getScopeStore().findById(resourceServer.getId(), scopeId);
+                    Scope scope = storeFactory.getScopeStore().findById(resourceServer, scopeId);
 
                     if (scope == null) {
-                        scope = storeFactory.getScopeStore().findByName(resourceServer.getId(), scopeId);
+                        scope = storeFactory.getScopeStore().findByName(resourceServer, scopeId);
                         if (scope == null) {
                             throw new RuntimeException("Scope with id or name [" + scopeId + "] does not exist");
                         }
@@ -2732,9 +2732,9 @@ public class RepresentationToModel {
         Scope existing;
 
         if (scope.getId() != null) {
-            existing = scopeStore.findById(resourceServer.getId(), scope.getId());
+            existing = scopeStore.findById(resourceServer, scope.getId());
         } else {
-            existing = scopeStore.findByName(resourceServer.getId(), scope.getName());
+            existing = scopeStore.findByName(resourceServer, scope.getName());
         }
 
         if (existing != null) {

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
@@ -2756,9 +2756,9 @@ public class RepresentationToModel {
         return model;
     }
 
-    public static PermissionTicket toModel(PermissionTicketRepresentation representation, String resourceServerId, AuthorizationProvider authorization) {
+    public static PermissionTicket toModel(PermissionTicketRepresentation representation, ResourceServer resourceServer, AuthorizationProvider authorization) {
         PermissionTicketStore ticketStore = authorization.getStoreFactory().getPermissionTicketStore();
-        PermissionTicket ticket = ticketStore.findById(resourceServerId, representation.getId());
+        PermissionTicket ticket = ticketStore.findById(resourceServer, representation.getId());
         boolean granted = representation.isGranted();
 
         if (granted && !ticket.isGranted()) {

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
@@ -2359,10 +2359,10 @@ public class RepresentationToModel {
                     Set<String> policyIds = new HashSet<>();
 
                     for (String policyName : policies) {
-                        Policy policy = policyStore.findByName(resourceServer.getId(), policyName);
+                        Policy policy = policyStore.findByName(resourceServer, policyName);
 
                         if (policy == null) {
-                            policy = policyStore.findById(resourceServer.getId(), policyName);
+                            policy = policyStore.findById(resourceServer, policyName);
                         }
 
                         if (policy == null) {
@@ -2382,10 +2382,10 @@ public class RepresentationToModel {
             }
 
             PolicyStore policyStore = storeFactory.getPolicyStore();
-            Policy policy = policyStore.findById(resourceServer.getId(), policyRepresentation.getId());
+            Policy policy = policyStore.findById(resourceServer, policyRepresentation.getId());
 
             if (policy == null) {
-                policy = policyStore.findByName(resourceServer.getId(), policyRepresentation.getName());
+                policy = policyStore.findByName(resourceServer, policyRepresentation.getName());
             }
 
             if (policy == null) {
@@ -2547,10 +2547,10 @@ public class RepresentationToModel {
                 }
 
                 if (!hasPolicy) {
-                    Policy associatedPolicy = policyStore.findById(resourceServer.getId(), policyId);
+                    Policy associatedPolicy = policyStore.findById(resourceServer, policyId);
 
                     if (associatedPolicy == null) {
-                        associatedPolicy = policyStore.findByName(resourceServer.getId(), policyId);
+                        associatedPolicy = policyStore.findByName(resourceServer, policyId);
                         if (associatedPolicy == null) {
                             throw new RuntimeException("Policy with id or name [" + policyId + "] does not exist");
                         }

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
@@ -2359,10 +2359,10 @@ public class RepresentationToModel {
                     Set<String> policyIds = new HashSet<>();
 
                     for (String policyName : policies) {
-                        Policy policy = policyStore.findByName(policyName, resourceServer.getId());
+                        Policy policy = policyStore.findByName(resourceServer.getId(), policyName);
 
                         if (policy == null) {
-                            policy = policyStore.findById(policyName, resourceServer.getId());
+                            policy = policyStore.findById(resourceServer.getId(), policyName);
                         }
 
                         if (policy == null) {
@@ -2382,14 +2382,14 @@ public class RepresentationToModel {
             }
 
             PolicyStore policyStore = storeFactory.getPolicyStore();
-            Policy policy = policyStore.findById(policyRepresentation.getId(), resourceServer.getId());
+            Policy policy = policyStore.findById(resourceServer.getId(), policyRepresentation.getId());
 
             if (policy == null) {
-                policy = policyStore.findByName(policyRepresentation.getName(), resourceServer.getId());
+                policy = policyStore.findByName(resourceServer.getId(), policyRepresentation.getName());
             }
 
             if (policy == null) {
-                policy = policyStore.create(policyRepresentation, resourceServer);
+                policy = policyStore.create(resourceServer, policyRepresentation);
             } else {
                 policy = toModel(policyRepresentation, authorization, policy);
             }
@@ -2494,10 +2494,10 @@ public class RepresentationToModel {
                 }
                 if (!hasScope) {
                     ResourceServer resourceServer = policy.getResourceServer();
-                    Scope scope = storeFactory.getScopeStore().findById(scopeId, resourceServer.getId());
+                    Scope scope = storeFactory.getScopeStore().findById(resourceServer.getId(), scopeId);
 
                     if (scope == null) {
-                        scope = storeFactory.getScopeStore().findByName(scopeId, resourceServer.getId());
+                        scope = storeFactory.getScopeStore().findByName(resourceServer.getId(), scopeId);
                         if (scope == null) {
                             throw new RuntimeException("Scope with id or name [" + scopeId + "] does not exist");
                         }
@@ -2547,10 +2547,10 @@ public class RepresentationToModel {
                 }
 
                 if (!hasPolicy) {
-                    Policy associatedPolicy = policyStore.findById(policyId, resourceServer.getId());
+                    Policy associatedPolicy = policyStore.findById(resourceServer.getId(), policyId);
 
                     if (associatedPolicy == null) {
-                        associatedPolicy = policyStore.findByName(policyId, resourceServer.getId());
+                        associatedPolicy = policyStore.findByName(resourceServer.getId(), policyId);
                         if (associatedPolicy == null) {
                             throw new RuntimeException("Policy with id or name [" + policyId + "] does not exist");
                         }
@@ -2592,10 +2592,10 @@ public class RepresentationToModel {
                     }
                 }
                 if (!hasResource && !"".equals(resourceId)) {
-                    Resource resource = storeFactory.getResourceStore().findById(resourceId, policy.getResourceServer().getId());
+                    Resource resource = storeFactory.getResourceStore().findById(policy.getResourceServer().getId(), resourceId);
 
                     if (resource == null) {
-                        resource = storeFactory.getResourceStore().findByName(resourceId, policy.getResourceServer().getId());
+                        resource = storeFactory.getResourceStore().findByName(policy.getResourceServer().getId(), resourceId);
                         if (resource == null) {
                             throw new RuntimeException("Resource with id or name [" + resourceId + "] does not exist or is not owned by the resource server");
                         }
@@ -2658,9 +2658,9 @@ public class RepresentationToModel {
         Resource existing;
 
         if (resource.getId() != null) {
-            existing = resourceStore.findById(resource.getId(), resourceServer.getId());
+            existing = resourceStore.findById(resourceServer.getId(), resource.getId());
         } else {
-            existing = resourceStore.findByName(resource.getName(), ownerId, resourceServer.getId());
+            existing = resourceStore.findByName(resourceServer.getId(), resource.getName(), ownerId);
         }
 
         if (existing != null) {
@@ -2695,7 +2695,7 @@ public class RepresentationToModel {
             return existing;
         }
 
-        Resource model = resourceStore.create(resource.getId(), resource.getName(), resourceServer, ownerId);
+        Resource model = resourceStore.create(resourceServer, resource.getId(), resource.getName(), ownerId);
 
         model.setDisplayName(resource.getDisplayName());
         model.setType(resource.getType());
@@ -2732,9 +2732,9 @@ public class RepresentationToModel {
         Scope existing;
 
         if (scope.getId() != null) {
-            existing = scopeStore.findById(scope.getId(), resourceServer.getId());
+            existing = scopeStore.findById(resourceServer.getId(), scope.getId());
         } else {
-            existing = scopeStore.findByName(scope.getName(), resourceServer.getId());
+            existing = scopeStore.findByName(resourceServer.getId(), scope.getName());
         }
 
         if (existing != null) {
@@ -2746,7 +2746,7 @@ public class RepresentationToModel {
             return existing;
         }
 
-        Scope model = scopeStore.create(scope.getId(), scope.getName(), resourceServer);
+        Scope model = scopeStore.create(resourceServer, scope.getId(), scope.getName());
 
         model.setDisplayName(scope.getDisplayName());
         model.setIconUri(scope.getIconUri());
@@ -2758,7 +2758,7 @@ public class RepresentationToModel {
 
     public static PermissionTicket toModel(PermissionTicketRepresentation representation, String resourceServerId, AuthorizationProvider authorization) {
         PermissionTicketStore ticketStore = authorization.getStoreFactory().getPermissionTicketStore();
-        PermissionTicket ticket = ticketStore.findById(representation.getId(), resourceServerId);
+        PermissionTicket ticket = ticketStore.findById(resourceServerId, representation.getId());
         boolean granted = representation.isGranted();
 
         if (granted && !ticket.isGranted()) {

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
@@ -2324,7 +2324,7 @@ public class RepresentationToModel {
 
             if (owner == null) {
                 owner = new ResourceOwnerRepresentation();
-                owner.setId(resourceServer.getId());
+                owner.setId(resourceServer.getClientId());
                 resource.setOwner(owner);
             } else if (owner.getName() != null) {
                 UserModel user = session.users().getUserByUsername(realm, owner.getName());
@@ -2629,16 +2629,16 @@ public class RepresentationToModel {
 
         if (owner == null) {
             owner = new ResourceOwnerRepresentation();
-            owner.setId(resourceServer.getId());
+            owner.setId(resourceServer.getClientId());
         }
 
         String ownerId = owner.getId();
 
         if (ownerId == null) {
-            ownerId = resourceServer.getId();
+            ownerId = resourceServer.getClientId();
         }
 
-        if (!resourceServer.getId().equals(ownerId)) {
+        if (!resourceServer.getClientId().equals(ownerId)) {
             RealmModel realm = authorization.getRealm();
             KeycloakSession keycloakSession = authorization.getKeycloakSession();
             UserProvider users = keycloakSession.users();

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
@@ -2592,10 +2592,10 @@ public class RepresentationToModel {
                     }
                 }
                 if (!hasResource && !"".equals(resourceId)) {
-                    Resource resource = storeFactory.getResourceStore().findById(policy.getResourceServer().getId(), resourceId);
+                    Resource resource = storeFactory.getResourceStore().findById(policy.getResourceServer(), resourceId);
 
                     if (resource == null) {
-                        resource = storeFactory.getResourceStore().findByName(policy.getResourceServer().getId(), resourceId);
+                        resource = storeFactory.getResourceStore().findByName(policy.getResourceServer(), resourceId);
                         if (resource == null) {
                             throw new RuntimeException("Resource with id or name [" + resourceId + "] does not exist or is not owned by the resource server");
                         }
@@ -2658,9 +2658,9 @@ public class RepresentationToModel {
         Resource existing;
 
         if (resource.getId() != null) {
-            existing = resourceStore.findById(resourceServer.getId(), resource.getId());
+            existing = resourceStore.findById(resourceServer, resource.getId());
         } else {
-            existing = resourceStore.findByName(resourceServer.getId(), resource.getName(), ownerId);
+            existing = resourceStore.findByName(resourceServer, resource.getName(), ownerId);
         }
 
         if (existing != null) {

--- a/services/src/main/java/org/keycloak/authorization/admin/PolicyEvaluationService.java
+++ b/services/src/main/java/org/keycloak/authorization/admin/PolicyEvaluationService.java
@@ -175,18 +175,18 @@ public class PolicyEvaluationService {
             Set<Scope> scopes = givenScopes.stream().map(scopeRepresentation -> scopeStore.findByName(resourceServer, scopeRepresentation.getName())).collect(Collectors.toSet());
 
             if (resource.getId() != null) {
-                Resource resourceModel = storeFactory.getResourceStore().findById(resourceServer.getId(), resource.getId());
+                Resource resourceModel = storeFactory.getResourceStore().findById(resourceServer, resource.getId());
                 return new ArrayList<>(Arrays.asList(
                         Permissions.createResourcePermissions(resourceModel, resourceServer, scopes, authorization, request))).stream();
             } else if (resource.getType() != null) {
-                return storeFactory.getResourceStore().findByType(resourceServer.getId(), resource.getType()).stream().map(resource1 -> Permissions.createResourcePermissions(resource1,
+                return storeFactory.getResourceStore().findByType(resourceServer, resource.getType()).stream().map(resource1 -> Permissions.createResourcePermissions(resource1,
                         resourceServer, scopes, authorization, request));
             } else {
                 if (scopes.isEmpty()) {
                     return Stream.empty();
                 }
 
-                List<Resource> resources = storeFactory.getResourceStore().findByScope(resourceServer.getId(), scopes.stream().map(Scope::getId).collect(Collectors.toList()));
+                List<Resource> resources = storeFactory.getResourceStore().findByScopes(resourceServer, scopes);
 
                 if (resources.isEmpty()) {
                     return scopes.stream().map(scope -> new ResourcePermission(null, new ArrayList<>(Arrays.asList(scope)), resourceServer));

--- a/services/src/main/java/org/keycloak/authorization/admin/PolicyEvaluationService.java
+++ b/services/src/main/java/org/keycloak/authorization/admin/PolicyEvaluationService.java
@@ -172,21 +172,21 @@ public class PolicyEvaluationService {
 
             ScopeStore scopeStore = storeFactory.getScopeStore();
 
-            Set<Scope> scopes = givenScopes.stream().map(scopeRepresentation -> scopeStore.findByName(scopeRepresentation.getName(), resourceServer.getId())).collect(Collectors.toSet());
+            Set<Scope> scopes = givenScopes.stream().map(scopeRepresentation -> scopeStore.findByName(resourceServer.getId(), scopeRepresentation.getName())).collect(Collectors.toSet());
 
             if (resource.getId() != null) {
-                Resource resourceModel = storeFactory.getResourceStore().findById(resource.getId(), resourceServer.getId());
+                Resource resourceModel = storeFactory.getResourceStore().findById(resourceServer.getId(), resource.getId());
                 return new ArrayList<>(Arrays.asList(
                         Permissions.createResourcePermissions(resourceModel, resourceServer, scopes, authorization, request))).stream();
             } else if (resource.getType() != null) {
-                return storeFactory.getResourceStore().findByType(resource.getType(), resourceServer.getId()).stream().map(resource1 -> Permissions.createResourcePermissions(resource1,
+                return storeFactory.getResourceStore().findByType(resourceServer.getId(), resource.getType()).stream().map(resource1 -> Permissions.createResourcePermissions(resource1,
                         resourceServer, scopes, authorization, request));
             } else {
                 if (scopes.isEmpty()) {
                     return Stream.empty();
                 }
 
-                List<Resource> resources = storeFactory.getResourceStore().findByScope(scopes.stream().map(Scope::getId).collect(Collectors.toList()), resourceServer.getId());
+                List<Resource> resources = storeFactory.getResourceStore().findByScope(resourceServer.getId(), scopes.stream().map(Scope::getId).collect(Collectors.toList()));
 
                 if (resources.isEmpty()) {
                     return scopes.stream().map(scope -> new ResourcePermission(null, new ArrayList<>(Arrays.asList(scope)), resourceServer));

--- a/services/src/main/java/org/keycloak/authorization/admin/PolicyEvaluationService.java
+++ b/services/src/main/java/org/keycloak/authorization/admin/PolicyEvaluationService.java
@@ -254,7 +254,7 @@ public class PolicyEvaluationService {
                 String clientId = representation.getClientId();
 
                 if (clientId == null) {
-                    clientId = resourceServer.getId();
+                    clientId = resourceServer.getClientId();
                 }
 
                 if (clientId != null) {
@@ -287,7 +287,7 @@ public class PolicyEvaluationService {
             }
 
             if (client == null) {
-                client = realm.getClientById(resourceServer.getId());
+                client = realm.getClientById(resourceServer.getClientId());
             }
 
             accessToken.issuedFor(client.getClientId());

--- a/services/src/main/java/org/keycloak/authorization/admin/PolicyEvaluationService.java
+++ b/services/src/main/java/org/keycloak/authorization/admin/PolicyEvaluationService.java
@@ -172,7 +172,7 @@ public class PolicyEvaluationService {
 
             ScopeStore scopeStore = storeFactory.getScopeStore();
 
-            Set<Scope> scopes = givenScopes.stream().map(scopeRepresentation -> scopeStore.findByName(resourceServer.getId(), scopeRepresentation.getName())).collect(Collectors.toSet());
+            Set<Scope> scopes = givenScopes.stream().map(scopeRepresentation -> scopeStore.findByName(resourceServer, scopeRepresentation.getName())).collect(Collectors.toSet());
 
             if (resource.getId() != null) {
                 Resource resourceModel = storeFactory.getResourceStore().findById(resourceServer.getId(), resource.getId());

--- a/services/src/main/java/org/keycloak/authorization/admin/PolicyResourceService.java
+++ b/services/src/main/java/org/keycloak/authorization/admin/PolicyResourceService.java
@@ -39,7 +39,6 @@ import org.keycloak.authorization.store.PolicyStore;
 import org.keycloak.authorization.store.StoreFactory;
 import org.keycloak.events.admin.OperationType;
 import org.keycloak.events.admin.ResourceType;
-import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.utils.ModelToRepresentation;
 import org.keycloak.models.utils.RepresentationToModel;
 import org.keycloak.representations.idm.authorization.AbstractPolicyRepresentation;
@@ -155,7 +154,7 @@ public class PolicyResourceService {
             return Response.status(Status.NOT_FOUND).build();
         }
 
-        List<Policy> policies = authorization.getStoreFactory().getPolicyStore().findDependentPolicies(policy.getId(), resourceServer.getId());
+        List<Policy> policies = authorization.getStoreFactory().getPolicyStore().findDependentPolicies(resourceServer.getId(), policy.getId());
 
         return Response.ok(policies.stream().map(policy -> {
             PolicyRepresentation representation1 = new PolicyRepresentation();

--- a/services/src/main/java/org/keycloak/authorization/admin/PolicyResourceService.java
+++ b/services/src/main/java/org/keycloak/authorization/admin/PolicyResourceService.java
@@ -154,7 +154,7 @@ public class PolicyResourceService {
             return Response.status(Status.NOT_FOUND).build();
         }
 
-        List<Policy> policies = authorization.getStoreFactory().getPolicyStore().findDependentPolicies(resourceServer.getId(), policy.getId());
+        List<Policy> policies = authorization.getStoreFactory().getPolicyStore().findDependentPolicies(resourceServer, policy.getId());
 
         return Response.ok(policies.stream().map(policy -> {
             PolicyRepresentation representation1 = new PolicyRepresentation();

--- a/services/src/main/java/org/keycloak/authorization/admin/PolicyService.java
+++ b/services/src/main/java/org/keycloak/authorization/admin/PolicyService.java
@@ -206,7 +206,7 @@ public class PolicyService {
 
         if (resource != null && !"".equals(resource.trim())) {
             ResourceStore resourceStore = storeFactory.getResourceStore();
-            Resource resourceModel = resourceStore.findById(resourceServer.getId(), resource);
+            Resource resourceModel = resourceStore.findById(resourceServer, resource);
 
             if (resourceModel == null) {
                 Map<Resource.FilterOption, String[]> resourceFilters = new EnumMap<>(Resource.FilterOption.class);
@@ -217,7 +217,7 @@ public class PolicyService {
                     resourceFilters.put(Resource.FilterOption.OWNER, new String[]{owner});
                 }
 
-                Set<String> resources = resourceStore.findByResourceServer(resourceServer.getId(), resourceFilters, -1, 1).stream().map(Resource::getId).collect(Collectors.toSet());
+                Set<String> resources = resourceStore.findByResourceServer(resourceServer, resourceFilters, -1, 1).stream().map(Resource::getId).collect(Collectors.toSet());
 
                 if (resources.isEmpty()) {
                     return Response.noContent().build();

--- a/services/src/main/java/org/keycloak/authorization/admin/PolicyService.java
+++ b/services/src/main/java/org/keycloak/authorization/admin/PolicyService.java
@@ -88,7 +88,7 @@ public class PolicyService {
             return doCreatePolicyTypeResource(type);
         }
 
-        Policy policy = authorization.getStoreFactory().getPolicyStore().findById(resourceServer.getId(), type);
+        Policy policy = authorization.getStoreFactory().getPolicyStore().findById(resourceServer, type);
 
         return doCreatePolicyResource(policy);
     }
@@ -134,7 +134,7 @@ public class PolicyService {
 
     public Policy create(AbstractPolicyRepresentation representation) {
         PolicyStore policyStore = authorization.getStoreFactory().getPolicyStore();
-        Policy existing = policyStore.findByName(resourceServer.getId(), representation.getName());
+        Policy existing = policyStore.findByName(resourceServer, representation.getName());
 
         if (existing != null) {
             throw new ErrorResponseException("Policy with name [" + representation.getName() + "] already exists", "Conflicting policy", Status.CONFLICT);
@@ -158,7 +158,7 @@ public class PolicyService {
             return Response.status(Status.BAD_REQUEST).build();
         }
 
-        Policy model = storeFactory.getPolicyStore().findByName(this.resourceServer.getId(), name);
+        Policy model = storeFactory.getPolicyStore().findByName(this.resourceServer, name);
 
         if (model == null) {
             return Response.noContent().build();
@@ -265,7 +265,7 @@ public class PolicyService {
 
     protected List<Object> doSearch(Integer firstResult, Integer maxResult, String fields, Map<Policy.FilterOption, String[]> filters) {
         PolicyStore policyStore = authorization.getStoreFactory().getPolicyStore();
-        return policyStore.findByResourceServer(resourceServer.getId(), filters, firstResult != null ? firstResult : -1, maxResult != null ? maxResult : Constants.DEFAULT_MAX_RESULTS).stream()
+        return policyStore.findByResourceServer(resourceServer, filters, firstResult != null ? firstResult : -1, maxResult != null ? maxResult : Constants.DEFAULT_MAX_RESULTS).stream()
                 .map(policy -> toRepresentation(policy, fields, authorization))
                 .collect(Collectors.toList());
     }

--- a/services/src/main/java/org/keycloak/authorization/admin/PolicyService.java
+++ b/services/src/main/java/org/keycloak/authorization/admin/PolicyService.java
@@ -88,7 +88,7 @@ public class PolicyService {
             return doCreatePolicyTypeResource(type);
         }
 
-        Policy policy = authorization.getStoreFactory().getPolicyStore().findById(type, resourceServer.getId());
+        Policy policy = authorization.getStoreFactory().getPolicyStore().findById(resourceServer.getId(), type);
 
         return doCreatePolicyResource(policy);
     }
@@ -134,13 +134,13 @@ public class PolicyService {
 
     public Policy create(AbstractPolicyRepresentation representation) {
         PolicyStore policyStore = authorization.getStoreFactory().getPolicyStore();
-        Policy existing = policyStore.findByName(representation.getName(), resourceServer.getId());
+        Policy existing = policyStore.findByName(resourceServer.getId(), representation.getName());
 
         if (existing != null) {
             throw new ErrorResponseException("Policy with name [" + representation.getName() + "] already exists", "Conflicting policy", Status.CONFLICT);
         }
 
-        return policyStore.create(representation, resourceServer);
+        return policyStore.create(resourceServer, representation);
     }
 
     @Path("/search")
@@ -158,7 +158,7 @@ public class PolicyService {
             return Response.status(Status.BAD_REQUEST).build();
         }
 
-        Policy model = storeFactory.getPolicyStore().findByName(name, this.resourceServer.getId());
+        Policy model = storeFactory.getPolicyStore().findByName(this.resourceServer.getId(), name);
 
         if (model == null) {
             return Response.noContent().build();
@@ -206,7 +206,7 @@ public class PolicyService {
 
         if (resource != null && !"".equals(resource.trim())) {
             ResourceStore resourceStore = storeFactory.getResourceStore();
-            Resource resourceModel = resourceStore.findById(resource, resourceServer.getId());
+            Resource resourceModel = resourceStore.findById(resourceServer.getId(), resource);
 
             if (resourceModel == null) {
                 Map<Resource.FilterOption, String[]> resourceFilters = new EnumMap<>(Resource.FilterOption.class);
@@ -217,7 +217,7 @@ public class PolicyService {
                     resourceFilters.put(Resource.FilterOption.OWNER, new String[]{owner});
                 }
 
-                Set<String> resources = resourceStore.findByResourceServer(resourceFilters, resourceServer.getId(), -1, 1).stream().map(Resource::getId).collect(Collectors.toSet());
+                Set<String> resources = resourceStore.findByResourceServer(resourceServer.getId(), resourceFilters, -1, 1).stream().map(Resource::getId).collect(Collectors.toSet());
 
                 if (resources.isEmpty()) {
                     return Response.noContent().build();
@@ -231,14 +231,14 @@ public class PolicyService {
 
         if (scope != null && !"".equals(scope.trim())) {
             ScopeStore scopeStore = storeFactory.getScopeStore();
-            Scope scopeModel = scopeStore.findById(scope, resourceServer.getId());
+            Scope scopeModel = scopeStore.findById(resourceServer.getId(), scope);
 
             if (scopeModel == null) {
                 Map<Scope.FilterOption, String[]> scopeFilters = new EnumMap<>(Scope.FilterOption.class);
 
                 scopeFilters.put(Scope.FilterOption.NAME, new String[]{scope});
 
-                Set<String> scopes = scopeStore.findByResourceServer(scopeFilters, resourceServer.getId(), -1, 1).stream().map(Scope::getId).collect(Collectors.toSet());
+                Set<String> scopes = scopeStore.findByResourceServer(resourceServer.getId(), scopeFilters, -1, 1).stream().map(Scope::getId).collect(Collectors.toSet());
 
                 if (scopes.isEmpty()) {
                     return Response.noContent().build();
@@ -265,7 +265,7 @@ public class PolicyService {
 
     protected List<Object> doSearch(Integer firstResult, Integer maxResult, String fields, Map<Policy.FilterOption, String[]> filters) {
         PolicyStore policyStore = authorization.getStoreFactory().getPolicyStore();
-        return policyStore.findByResourceServer(filters, resourceServer.getId(), firstResult != null ? firstResult : -1, maxResult != null ? maxResult : Constants.DEFAULT_MAX_RESULTS).stream()
+        return policyStore.findByResourceServer(resourceServer.getId(), filters, firstResult != null ? firstResult : -1, maxResult != null ? maxResult : Constants.DEFAULT_MAX_RESULTS).stream()
                 .map(policy -> toRepresentation(policy, fields, authorization))
                 .collect(Collectors.toList());
     }

--- a/services/src/main/java/org/keycloak/authorization/admin/PolicyService.java
+++ b/services/src/main/java/org/keycloak/authorization/admin/PolicyService.java
@@ -231,14 +231,14 @@ public class PolicyService {
 
         if (scope != null && !"".equals(scope.trim())) {
             ScopeStore scopeStore = storeFactory.getScopeStore();
-            Scope scopeModel = scopeStore.findById(resourceServer.getId(), scope);
+            Scope scopeModel = scopeStore.findById(resourceServer, scope);
 
             if (scopeModel == null) {
                 Map<Scope.FilterOption, String[]> scopeFilters = new EnumMap<>(Scope.FilterOption.class);
 
                 scopeFilters.put(Scope.FilterOption.NAME, new String[]{scope});
 
-                Set<String> scopes = scopeStore.findByResourceServer(resourceServer.getId(), scopeFilters, -1, 1).stream().map(Scope::getId).collect(Collectors.toSet());
+                Set<String> scopes = scopeStore.findByResourceServer(resourceServer, scopeFilters, -1, 1).stream().map(Scope::getId).collect(Collectors.toSet());
 
                 if (scopes.isEmpty()) {
                     return Response.noContent().build();

--- a/services/src/main/java/org/keycloak/authorization/admin/ResourceSetService.java
+++ b/services/src/main/java/org/keycloak/authorization/admin/ResourceSetService.java
@@ -252,10 +252,10 @@ public class ResourceSetService {
         PolicyStore policyStore = authorization.getStoreFactory().getPolicyStore();
         Set<Policy> policies = new HashSet<>();
 
-        policies.addAll(policyStore.findByResource(resourceServer.getId(), model.getId()));
+        policies.addAll(policyStore.findByResource(resourceServer, model));
 
         if (model.getType() != null) {
-            policies.addAll(policyStore.findByResourceType(resourceServer.getId(), model.getType()));
+            policies.addAll(policyStore.findByResourceType(resourceServer, model.getType()));
 
             Map<Resource.FilterOption, String[]> resourceFilter = new EnumMap<>(Resource.FilterOption.class);
 
@@ -263,12 +263,12 @@ public class ResourceSetService {
             resourceFilter.put(Resource.FilterOption.TYPE, new String[]{model.getType()});
 
             for (Resource resourceType : resourceStore.findByResourceServer(resourceServer.getId(), resourceFilter, -1, -1)) {
-                policies.addAll(policyStore.findByResource(resourceServer.getId(), resourceType.getId()));
+                policies.addAll(policyStore.findByResource(resourceServer, resourceType));
             }
         }
 
-        policies.addAll(policyStore.findByScopeIds(resourceServer.getId(), id, model.getScopes().stream().map(scope -> scope.getId()).collect(Collectors.toList())));
-        policies.addAll(policyStore.findByScopeIds(resourceServer.getId(), null, model.getScopes().stream().map(scope -> scope.getId()).collect(Collectors.toList())));
+        policies.addAll(policyStore.findByScopes(resourceServer, model, model.getScopes()));
+        policies.addAll(policyStore.findByScopes(resourceServer, null, model.getScopes()));
 
         List<PolicyRepresentation> representation = new ArrayList<>();
 

--- a/services/src/main/java/org/keycloak/authorization/admin/ResourceSetService.java
+++ b/services/src/main/java/org/keycloak/authorization/admin/ResourceSetService.java
@@ -403,7 +403,7 @@ public class ResourceSetService {
 
             scopeFilter.put(Scope.FilterOption.NAME, new String[] {scope});
 
-            List<Scope> scopes = authorization.getStoreFactory().getScopeStore().findByResourceServer(resourceServer.getId(), scopeFilter, -1, -1);
+            List<Scope> scopes = authorization.getStoreFactory().getScopeStore().findByResourceServer(resourceServer, scopeFilter, -1, -1);
 
             if (scopes.isEmpty()) {
                 return Response.ok(Collections.emptyList()).build();

--- a/services/src/main/java/org/keycloak/authorization/admin/ResourceSetService.java
+++ b/services/src/main/java/org/keycloak/authorization/admin/ResourceSetService.java
@@ -262,7 +262,7 @@ public class ResourceSetService {
             resourceFilter.put(Resource.FilterOption.OWNER, new String[]{resourceServer.getClientId()});
             resourceFilter.put(Resource.FilterOption.TYPE, new String[]{model.getType()});
 
-            for (Resource resourceType : resourceStore.findByResourceServer(resourceServer, resourceFilter, -1, -1)) {
+            for (Resource resourceType : resourceStore.findByResourceServer(resourceServer, resourceFilter, null, null)) {
                 policies.addAll(policyStore.findByResource(resourceServer, resourceType));
             }
         }
@@ -403,7 +403,7 @@ public class ResourceSetService {
 
             scopeFilter.put(Scope.FilterOption.NAME, new String[] {scope});
 
-            List<Scope> scopes = authorization.getStoreFactory().getScopeStore().findByResourceServer(resourceServer, scopeFilter, -1, -1);
+            List<Scope> scopes = authorization.getStoreFactory().getScopeStore().findByResourceServer(resourceServer, scopeFilter, null, null);
 
             if (scopes.isEmpty()) {
                 return Response.ok(Collections.emptyList()).build();

--- a/services/src/main/java/org/keycloak/authorization/admin/ResourceSetService.java
+++ b/services/src/main/java/org/keycloak/authorization/admin/ResourceSetService.java
@@ -123,7 +123,7 @@ public class ResourceSetService {
             throw new ErrorResponseException(OAuthErrorException.INVALID_REQUEST, "You must specify the resource owner.", Status.BAD_REQUEST);
         }
 
-        Resource existingResource = storeFactory.getResourceStore().findByName(this.resourceServer.getId(), resource.getName(), ownerId);
+        Resource existingResource = storeFactory.getResourceStore().findByName(this.resourceServer, resource.getName(), ownerId);
 
         if (existingResource != null) {
             throw new ErrorResponseException(OAuthErrorException.INVALID_REQUEST, "Resource with name [" + resource.getName() + "] already exists.", Status.CONFLICT);
@@ -141,7 +141,7 @@ public class ResourceSetService {
         resource.setId(id);
         StoreFactory storeFactory = this.authorization.getStoreFactory();
         ResourceStore resourceStore = storeFactory.getResourceStore();
-        Resource model = resourceStore.findById(resourceServer.getId(), resource.getId());
+        Resource model = resourceStore.findById(resourceServer, resource.getId());
 
         if (model == null) {
             return Response.status(Status.NOT_FOUND).build();
@@ -159,7 +159,7 @@ public class ResourceSetService {
     public Response delete(@PathParam("id") String id) {
         requireManage();
         StoreFactory storeFactory = authorization.getStoreFactory();
-        Resource resource = storeFactory.getResourceStore().findById(resourceServer.getId(), id);
+        Resource resource = storeFactory.getResourceStore().findById(resourceServer, id);
 
         if (resource == null) {
             return Response.status(Status.NOT_FOUND).build();
@@ -183,7 +183,7 @@ public class ResourceSetService {
     public Response findById(String id, Function<Resource, ? extends ResourceRepresentation> toRepresentation) {
         requireView();
         StoreFactory storeFactory = authorization.getStoreFactory();
-        Resource model = storeFactory.getResourceStore().findById(resourceServer.getId(), id);
+        Resource model = storeFactory.getResourceStore().findById(resourceServer, id);
 
         if (model == null) {
             return Response.status(Status.NOT_FOUND).build();
@@ -199,7 +199,7 @@ public class ResourceSetService {
     public Response getScopes(@PathParam("id") String id) {
         requireView();
         StoreFactory storeFactory = authorization.getStoreFactory();
-        Resource model = storeFactory.getResourceStore().findById(resourceServer.getId(), id);
+        Resource model = storeFactory.getResourceStore().findById(resourceServer, id);
 
         if (model == null) {
             return Response.status(Status.NOT_FOUND).build();
@@ -216,7 +216,7 @@ public class ResourceSetService {
 
         if (model.getType() != null && !model.getOwner().equals(resourceServer.getClientId())) {
             ResourceStore resourceStore = authorization.getStoreFactory().getResourceStore();
-            for (Resource typed : resourceStore.findByType(resourceServer.getId(), model.getType())) {
+            for (Resource typed : resourceStore.findByType(resourceServer, model.getType())) {
                 if (typed.getOwner().equals(resourceServer.getClientId()) && !typed.getId().equals(model.getId())) {
                     scopes.addAll(typed.getScopes().stream().map(model1 -> {
                         ScopeRepresentation scope = new ScopeRepresentation();
@@ -243,7 +243,7 @@ public class ResourceSetService {
         requireView();
         StoreFactory storeFactory = authorization.getStoreFactory();
         ResourceStore resourceStore = storeFactory.getResourceStore();
-        Resource model = resourceStore.findById(resourceServer.getId(), id);
+        Resource model = resourceStore.findById(resourceServer, id);
 
         if (model == null) {
             return Response.status(Status.NOT_FOUND).build();
@@ -262,7 +262,7 @@ public class ResourceSetService {
             resourceFilter.put(Resource.FilterOption.OWNER, new String[]{resourceServer.getClientId()});
             resourceFilter.put(Resource.FilterOption.TYPE, new String[]{model.getType()});
 
-            for (Resource resourceType : resourceStore.findByResourceServer(resourceServer.getId(), resourceFilter, -1, -1)) {
+            for (Resource resourceType : resourceStore.findByResourceServer(resourceServer, resourceFilter, -1, -1)) {
                 policies.addAll(policyStore.findByResource(resourceServer, resourceType));
             }
         }
@@ -296,7 +296,7 @@ public class ResourceSetService {
     public Response getAttributes(@PathParam("id") String id) {
         requireView();
         StoreFactory storeFactory = authorization.getStoreFactory();
-        Resource model = storeFactory.getResourceStore().findById(resourceServer.getId(), id);
+        Resource model = storeFactory.getResourceStore().findById(resourceServer, id);
 
         if (model == null) {
             return Response.status(Status.NOT_FOUND).build();
@@ -317,7 +317,7 @@ public class ResourceSetService {
             return Response.status(Status.BAD_REQUEST).build();
         }
 
-        Resource model = storeFactory.getResourceStore().findByName(this.resourceServer.getId(), name);
+        Resource model = storeFactory.getResourceStore().findByName(this.resourceServer, name);
 
         if (model == null) {
             return Response.status(Status.NO_CONTENT).build();
@@ -412,7 +412,7 @@ public class ResourceSetService {
             search.put(Resource.FilterOption.SCOPE_ID, scopes.stream().map(Scope::getId).toArray(String[]::new));
         }
 
-        List<Resource> resources = storeFactory.getResourceStore().findByResourceServer(this.resourceServer.getId(), search, firstResult != null ? firstResult : -1, maxResult != null ? maxResult : Constants.DEFAULT_MAX_RESULTS);
+        List<Resource> resources = storeFactory.getResourceStore().findByResourceServer(this.resourceServer, search, firstResult != null ? firstResult : -1, maxResult != null ? maxResult : Constants.DEFAULT_MAX_RESULTS);
 
         if (matchingUri != null && matchingUri && resources.isEmpty()) {
             Map<Resource.FilterOption, String[]> attributes = new EnumMap<>(Resource.FilterOption.class);
@@ -420,7 +420,7 @@ public class ResourceSetService {
             attributes.put(Resource.FilterOption.URI_NOT_NULL, new String[] {"true"});
             attributes.put(Resource.FilterOption.OWNER, new String[] {resourceServer.getClientId()});
 
-            List<Resource> serverResources = storeFactory.getResourceStore().findByResourceServer(this.resourceServer.getId(), attributes, firstResult != null ? firstResult : -1, maxResult != null ? maxResult : -1);
+            List<Resource> serverResources = storeFactory.getResourceStore().findByResourceServer(this.resourceServer, attributes, firstResult != null ? firstResult : -1, maxResult != null ? maxResult : -1);
 
             PathMatcher<Map.Entry<String, Resource>> pathMatcher = new PathMatcher<Map.Entry<String, Resource>>() {
                 @Override

--- a/services/src/main/java/org/keycloak/authorization/admin/ResourceSetService.java
+++ b/services/src/main/java/org/keycloak/authorization/admin/ResourceSetService.java
@@ -123,7 +123,7 @@ public class ResourceSetService {
             throw new ErrorResponseException(OAuthErrorException.INVALID_REQUEST, "You must specify the resource owner.", Status.BAD_REQUEST);
         }
 
-        Resource existingResource = storeFactory.getResourceStore().findByName(resource.getName(), ownerId, this.resourceServer.getId());
+        Resource existingResource = storeFactory.getResourceStore().findByName(this.resourceServer.getId(), resource.getName(), ownerId);
 
         if (existingResource != null) {
             throw new ErrorResponseException(OAuthErrorException.INVALID_REQUEST, "Resource with name [" + resource.getName() + "] already exists.", Status.CONFLICT);
@@ -141,7 +141,7 @@ public class ResourceSetService {
         resource.setId(id);
         StoreFactory storeFactory = this.authorization.getStoreFactory();
         ResourceStore resourceStore = storeFactory.getResourceStore();
-        Resource model = resourceStore.findById(resource.getId(), resourceServer.getId());
+        Resource model = resourceStore.findById(resourceServer.getId(), resource.getId());
 
         if (model == null) {
             return Response.status(Status.NOT_FOUND).build();
@@ -159,7 +159,7 @@ public class ResourceSetService {
     public Response delete(@PathParam("id") String id) {
         requireManage();
         StoreFactory storeFactory = authorization.getStoreFactory();
-        Resource resource = storeFactory.getResourceStore().findById(id, resourceServer.getId());
+        Resource resource = storeFactory.getResourceStore().findById(resourceServer.getId(), id);
 
         if (resource == null) {
             return Response.status(Status.NOT_FOUND).build();
@@ -183,7 +183,7 @@ public class ResourceSetService {
     public Response findById(String id, Function<Resource, ? extends ResourceRepresentation> toRepresentation) {
         requireView();
         StoreFactory storeFactory = authorization.getStoreFactory();
-        Resource model = storeFactory.getResourceStore().findById(id, resourceServer.getId());
+        Resource model = storeFactory.getResourceStore().findById(resourceServer.getId(), id);
 
         if (model == null) {
             return Response.status(Status.NOT_FOUND).build();
@@ -199,7 +199,7 @@ public class ResourceSetService {
     public Response getScopes(@PathParam("id") String id) {
         requireView();
         StoreFactory storeFactory = authorization.getStoreFactory();
-        Resource model = storeFactory.getResourceStore().findById(id, resourceServer.getId());
+        Resource model = storeFactory.getResourceStore().findById(resourceServer.getId(), id);
 
         if (model == null) {
             return Response.status(Status.NOT_FOUND).build();
@@ -216,7 +216,7 @@ public class ResourceSetService {
 
         if (model.getType() != null && !model.getOwner().equals(resourceServer.getClientId())) {
             ResourceStore resourceStore = authorization.getStoreFactory().getResourceStore();
-            for (Resource typed : resourceStore.findByType(model.getType(), resourceServer.getId())) {
+            for (Resource typed : resourceStore.findByType(resourceServer.getId(), model.getType())) {
                 if (typed.getOwner().equals(resourceServer.getClientId()) && !typed.getId().equals(model.getId())) {
                     scopes.addAll(typed.getScopes().stream().map(model1 -> {
                         ScopeRepresentation scope = new ScopeRepresentation();
@@ -243,7 +243,7 @@ public class ResourceSetService {
         requireView();
         StoreFactory storeFactory = authorization.getStoreFactory();
         ResourceStore resourceStore = storeFactory.getResourceStore();
-        Resource model = resourceStore.findById(id, resourceServer.getId());
+        Resource model = resourceStore.findById(resourceServer.getId(), id);
 
         if (model == null) {
             return Response.status(Status.NOT_FOUND).build();
@@ -252,23 +252,23 @@ public class ResourceSetService {
         PolicyStore policyStore = authorization.getStoreFactory().getPolicyStore();
         Set<Policy> policies = new HashSet<>();
 
-        policies.addAll(policyStore.findByResource(model.getId(), resourceServer.getId()));
+        policies.addAll(policyStore.findByResource(resourceServer.getId(), model.getId()));
 
         if (model.getType() != null) {
-            policies.addAll(policyStore.findByResourceType(model.getType(), resourceServer.getId()));
+            policies.addAll(policyStore.findByResourceType(resourceServer.getId(), model.getType()));
 
             Map<Resource.FilterOption, String[]> resourceFilter = new EnumMap<>(Resource.FilterOption.class);
 
             resourceFilter.put(Resource.FilterOption.OWNER, new String[]{resourceServer.getClientId()});
             resourceFilter.put(Resource.FilterOption.TYPE, new String[]{model.getType()});
 
-            for (Resource resourceType : resourceStore.findByResourceServer(resourceFilter, resourceServer.getId(), -1, -1)) {
-                policies.addAll(policyStore.findByResource(resourceType.getId(), resourceServer.getId()));
+            for (Resource resourceType : resourceStore.findByResourceServer(resourceServer.getId(), resourceFilter, -1, -1)) {
+                policies.addAll(policyStore.findByResource(resourceServer.getId(), resourceType.getId()));
             }
         }
 
-        policies.addAll(policyStore.findByScopeIds(model.getScopes().stream().map(scope -> scope.getId()).collect(Collectors.toList()), id, resourceServer.getId()));
-        policies.addAll(policyStore.findByScopeIds(model.getScopes().stream().map(scope -> scope.getId()).collect(Collectors.toList()), null, resourceServer.getId()));
+        policies.addAll(policyStore.findByScopeIds(resourceServer.getId(), id, model.getScopes().stream().map(scope -> scope.getId()).collect(Collectors.toList())));
+        policies.addAll(policyStore.findByScopeIds(resourceServer.getId(), null, model.getScopes().stream().map(scope -> scope.getId()).collect(Collectors.toList())));
 
         List<PolicyRepresentation> representation = new ArrayList<>();
 
@@ -296,7 +296,7 @@ public class ResourceSetService {
     public Response getAttributes(@PathParam("id") String id) {
         requireView();
         StoreFactory storeFactory = authorization.getStoreFactory();
-        Resource model = storeFactory.getResourceStore().findById(id, resourceServer.getId());
+        Resource model = storeFactory.getResourceStore().findById(resourceServer.getId(), id);
 
         if (model == null) {
             return Response.status(Status.NOT_FOUND).build();
@@ -317,7 +317,7 @@ public class ResourceSetService {
             return Response.status(Status.BAD_REQUEST).build();
         }
 
-        Resource model = storeFactory.getResourceStore().findByName(name, this.resourceServer.getId());
+        Resource model = storeFactory.getResourceStore().findByName(this.resourceServer.getId(), name);
 
         if (model == null) {
             return Response.status(Status.NO_CONTENT).build();
@@ -403,7 +403,7 @@ public class ResourceSetService {
 
             scopeFilter.put(Scope.FilterOption.NAME, new String[] {scope});
 
-            List<Scope> scopes = authorization.getStoreFactory().getScopeStore().findByResourceServer(scopeFilter, resourceServer.getId(), -1, -1);
+            List<Scope> scopes = authorization.getStoreFactory().getScopeStore().findByResourceServer(resourceServer.getId(), scopeFilter, -1, -1);
 
             if (scopes.isEmpty()) {
                 return Response.ok(Collections.emptyList()).build();
@@ -412,7 +412,7 @@ public class ResourceSetService {
             search.put(Resource.FilterOption.SCOPE_ID, scopes.stream().map(Scope::getId).toArray(String[]::new));
         }
 
-        List<Resource> resources = storeFactory.getResourceStore().findByResourceServer(search, this.resourceServer.getId(), firstResult != null ? firstResult : -1, maxResult != null ? maxResult : Constants.DEFAULT_MAX_RESULTS);
+        List<Resource> resources = storeFactory.getResourceStore().findByResourceServer(this.resourceServer.getId(), search, firstResult != null ? firstResult : -1, maxResult != null ? maxResult : Constants.DEFAULT_MAX_RESULTS);
 
         if (matchingUri != null && matchingUri && resources.isEmpty()) {
             Map<Resource.FilterOption, String[]> attributes = new EnumMap<>(Resource.FilterOption.class);
@@ -420,7 +420,7 @@ public class ResourceSetService {
             attributes.put(Resource.FilterOption.URI_NOT_NULL, new String[] {"true"});
             attributes.put(Resource.FilterOption.OWNER, new String[] {resourceServer.getClientId()});
 
-            List<Resource> serverResources = storeFactory.getResourceStore().findByResourceServer(attributes, this.resourceServer.getId(), firstResult != null ? firstResult : -1, maxResult != null ? maxResult : -1);
+            List<Resource> serverResources = storeFactory.getResourceStore().findByResourceServer(this.resourceServer.getId(), attributes, firstResult != null ? firstResult : -1, maxResult != null ? maxResult : -1);
 
             PathMatcher<Map.Entry<String, Resource>> pathMatcher = new PathMatcher<Map.Entry<String, Resource>>() {
                 @Override

--- a/services/src/main/java/org/keycloak/authorization/admin/ResourceSetService.java
+++ b/services/src/main/java/org/keycloak/authorization/admin/ResourceSetService.java
@@ -113,7 +113,7 @@ public class ResourceSetService {
 
         if (owner == null) {
             owner = new ResourceOwnerRepresentation();
-            owner.setId(resourceServer.getId());
+            owner.setId(resourceServer.getClientId());
             resource.setOwner(owner);
         }
 
@@ -129,7 +129,7 @@ public class ResourceSetService {
             throw new ErrorResponseException(OAuthErrorException.INVALID_REQUEST, "Resource with name [" + resource.getName() + "] already exists.", Status.CONFLICT);
         }
 
-        return toRepresentation(toModel(resource, this.resourceServer, authorization), resourceServer.getId(), authorization);
+        return toRepresentation(toModel(resource, this.resourceServer, authorization), resourceServer, authorization);
     }
 
     @Path("{id}")
@@ -167,7 +167,7 @@ public class ResourceSetService {
 
         storeFactory.getResourceStore().delete(id);
 
-        audit(toRepresentation(resource, resourceServer.getId(), authorization), OperationType.DELETE);
+        audit(toRepresentation(resource, resourceServer, authorization), OperationType.DELETE);
 
         return Response.noContent().build();
     }
@@ -177,7 +177,7 @@ public class ResourceSetService {
     @NoCache
     @Produces("application/json")
     public Response findById(@PathParam("id") String id) {
-        return findById(id, resource -> toRepresentation(resource, resourceServer.getId(), authorization, true));
+        return findById(id, resource -> toRepresentation(resource, resourceServer, authorization, true));
     }
 
     public Response findById(String id, Function<Resource, ? extends ResourceRepresentation> toRepresentation) {
@@ -214,10 +214,10 @@ public class ResourceSetService {
             return representation;
         }).collect(Collectors.toList());
 
-        if (model.getType() != null && !model.getOwner().equals(resourceServer.getId())) {
+        if (model.getType() != null && !model.getOwner().equals(resourceServer.getClientId())) {
             ResourceStore resourceStore = authorization.getStoreFactory().getResourceStore();
             for (Resource typed : resourceStore.findByType(model.getType(), resourceServer.getId())) {
-                if (typed.getOwner().equals(resourceServer.getId()) && !typed.getId().equals(model.getId())) {
+                if (typed.getOwner().equals(resourceServer.getClientId()) && !typed.getId().equals(model.getId())) {
                     scopes.addAll(typed.getScopes().stream().map(model1 -> {
                         ScopeRepresentation scope = new ScopeRepresentation();
                         scope.setId(model1.getId());
@@ -259,7 +259,7 @@ public class ResourceSetService {
 
             Map<Resource.FilterOption, String[]> resourceFilter = new EnumMap<>(Resource.FilterOption.class);
 
-            resourceFilter.put(Resource.FilterOption.OWNER, new String[]{resourceServer.getId()});
+            resourceFilter.put(Resource.FilterOption.OWNER, new String[]{resourceServer.getClientId()});
             resourceFilter.put(Resource.FilterOption.TYPE, new String[]{model.getType()});
 
             for (Resource resourceType : resourceStore.findByResourceServer(resourceFilter, resourceServer.getId(), -1, -1)) {
@@ -323,7 +323,7 @@ public class ResourceSetService {
             return Response.status(Status.NO_CONTENT).build();
         }
 
-        return Response.ok(toRepresentation(model, this.resourceServer.getId(), authorization)).build();
+        return Response.ok(toRepresentation(model, this.resourceServer, authorization)).build();
     }
 
     @GET
@@ -340,7 +340,7 @@ public class ResourceSetService {
                          @QueryParam("deep") Boolean deep,
                          @QueryParam("first") Integer firstResult,
                          @QueryParam("max") Integer maxResult) {
-        return find(id, name, uri, owner, type, scope, matchingUri, exactName, deep, firstResult, maxResult, (BiFunction<Resource, Boolean, ResourceRepresentation>) (resource, deep1) -> toRepresentation(resource, resourceServer.getId(), authorization, deep1));
+        return find(id, name, uri, owner, type, scope, matchingUri, exactName, deep, firstResult, maxResult, (BiFunction<Resource, Boolean, ResourceRepresentation>) (resource, deep1) -> toRepresentation(resource, resourceServer, authorization, deep1));
     }
 
     public Response find(@QueryParam("_id") String id,
@@ -418,7 +418,7 @@ public class ResourceSetService {
             Map<Resource.FilterOption, String[]> attributes = new EnumMap<>(Resource.FilterOption.class);
 
             attributes.put(Resource.FilterOption.URI_NOT_NULL, new String[] {"true"});
-            attributes.put(Resource.FilterOption.OWNER, new String[] {resourceServer.getId()});
+            attributes.put(Resource.FilterOption.OWNER, new String[] {resourceServer.getClientId()});
 
             List<Resource> serverResources = storeFactory.getResourceStore().findByResourceServer(attributes, this.resourceServer.getId(), firstResult != null ? firstResult : -1, maxResult != null ? maxResult : -1);
 

--- a/services/src/main/java/org/keycloak/authorization/admin/ScopeService.java
+++ b/services/src/main/java/org/keycloak/authorization/admin/ScopeService.java
@@ -100,7 +100,7 @@ public class ScopeService {
             this.auth.realm().requireManageAuthorization();
         scope.setId(id);
         StoreFactory storeFactory = authorization.getStoreFactory();
-        Scope model = storeFactory.getScopeStore().findById(scope.getId(), resourceServer.getId());
+        Scope model = storeFactory.getScopeStore().findById(resourceServer.getId(), scope.getId());
 
         if (model == null) {
             return Response.status(Status.NOT_FOUND).build();
@@ -118,20 +118,20 @@ public class ScopeService {
     public Response delete(@PathParam("id") String id) {
         this.auth.realm().requireManageAuthorization();
         StoreFactory storeFactory = authorization.getStoreFactory();
-        List<Resource> resources = storeFactory.getResourceStore().findByScope(Arrays.asList(id), resourceServer.getId());
+        List<Resource> resources = storeFactory.getResourceStore().findByScope(resourceServer.getId(), Arrays.asList(id));
 
         if (!resources.isEmpty()) {
             return ErrorResponse.error("Scopes can not be removed while associated with resources.", Status.BAD_REQUEST);
         }
 
-        Scope scope = storeFactory.getScopeStore().findById(id, resourceServer.getId());
+        Scope scope = storeFactory.getScopeStore().findById(resourceServer.getId(), id);
 
         if (scope == null) {
             return Response.status(Status.NOT_FOUND).build();
         }
 
         PolicyStore policyStore = storeFactory.getPolicyStore();
-        List<Policy> policies = policyStore.findByScopeIds(Arrays.asList(scope.getId()), resourceServer.getId());
+        List<Policy> policies = policyStore.findByScopeIds(resourceServer.getId(), Arrays.asList(scope.getId()));
 
         for (Policy policyModel : policies) {
             if (policyModel.getScopes().size() == 1) {
@@ -154,7 +154,7 @@ public class ScopeService {
     @Produces(MediaType.APPLICATION_JSON)
     public Response findById(@PathParam("id") String id) {
         this.auth.realm().requireViewAuthorization();
-        Scope model = this.authorization.getStoreFactory().getScopeStore().findById(id, resourceServer.getId());
+        Scope model = this.authorization.getStoreFactory().getScopeStore().findById(resourceServer.getId(), id);
 
         if (model == null) {
             return Response.status(Status.NOT_FOUND).build();
@@ -170,13 +170,13 @@ public class ScopeService {
     public Response getResources(@PathParam("id") String id) {
         this.auth.realm().requireViewAuthorization();
         StoreFactory storeFactory = this.authorization.getStoreFactory();
-        Scope model = storeFactory.getScopeStore().findById(id, resourceServer.getId());
+        Scope model = storeFactory.getScopeStore().findById(resourceServer.getId(), id);
 
         if (model == null) {
             return Response.status(Status.NOT_FOUND).build();
         }
 
-        return Response.ok(storeFactory.getResourceStore().findByScope(Arrays.asList(model.getId()), resourceServer.getId()).stream().map(resource -> {
+        return Response.ok(storeFactory.getResourceStore().findByScope(resourceServer.getId(), Arrays.asList(model.getId())).stream().map(resource -> {
             ResourceRepresentation representation = new ResourceRepresentation();
 
             representation.setId(resource.getId());
@@ -193,7 +193,7 @@ public class ScopeService {
     public Response getPermissions(@PathParam("id") String id) {
         this.auth.realm().requireViewAuthorization();
         StoreFactory storeFactory = this.authorization.getStoreFactory();
-        Scope model = storeFactory.getScopeStore().findById(id, resourceServer.getId());
+        Scope model = storeFactory.getScopeStore().findById(resourceServer.getId(), id);
 
         if (model == null) {
             return Response.status(Status.NOT_FOUND).build();
@@ -201,7 +201,7 @@ public class ScopeService {
 
         PolicyStore policyStore = storeFactory.getPolicyStore();
 
-        return Response.ok(policyStore.findByScopeIds(Arrays.asList(model.getId()), resourceServer.getId()).stream().map(policy -> {
+        return Response.ok(policyStore.findByScopeIds(resourceServer.getId(), Arrays.asList(model.getId())).stream().map(policy -> {
             PolicyRepresentation representation = new PolicyRepresentation();
 
             representation.setId(policy.getId());
@@ -224,7 +224,7 @@ public class ScopeService {
             return Response.status(Status.BAD_REQUEST).build();
         }
 
-        Scope model = storeFactory.getScopeStore().findByName(name, this.resourceServer.getId());
+        Scope model = storeFactory.getScopeStore().findByName(this.resourceServer.getId(), name);
 
         if (model == null) {
             return Response.status(Status.NO_CONTENT).build();
@@ -253,7 +253,7 @@ public class ScopeService {
         }
 
         return Response.ok(
-                this.authorization.getStoreFactory().getScopeStore().findByResourceServer(search, this.resourceServer.getId(), firstResult != null ? firstResult : -1, maxResult != null ? maxResult : Constants.DEFAULT_MAX_RESULTS).stream()
+                this.authorization.getStoreFactory().getScopeStore().findByResourceServer(this.resourceServer.getId(), search, firstResult != null ? firstResult : -1, maxResult != null ? maxResult : Constants.DEFAULT_MAX_RESULTS).stream()
                         .map(scope -> toRepresentation(scope))
                         .collect(Collectors.toList()))
                 .build();

--- a/services/src/main/java/org/keycloak/authorization/admin/ScopeService.java
+++ b/services/src/main/java/org/keycloak/authorization/admin/ScopeService.java
@@ -101,7 +101,7 @@ public class ScopeService {
             this.auth.realm().requireManageAuthorization();
         scope.setId(id);
         StoreFactory storeFactory = authorization.getStoreFactory();
-        Scope model = storeFactory.getScopeStore().findById(resourceServer.getId(), scope.getId());
+        Scope model = storeFactory.getScopeStore().findById(resourceServer, scope.getId());
 
         if (model == null) {
             return Response.status(Status.NOT_FOUND).build();
@@ -125,7 +125,7 @@ public class ScopeService {
             return ErrorResponse.error("Scopes can not be removed while associated with resources.", Status.BAD_REQUEST);
         }
 
-        Scope scope = storeFactory.getScopeStore().findById(resourceServer.getId(), id);
+        Scope scope = storeFactory.getScopeStore().findById(resourceServer, id);
 
         if (scope == null) {
             return Response.status(Status.NOT_FOUND).build();
@@ -155,7 +155,7 @@ public class ScopeService {
     @Produces(MediaType.APPLICATION_JSON)
     public Response findById(@PathParam("id") String id) {
         this.auth.realm().requireViewAuthorization();
-        Scope model = this.authorization.getStoreFactory().getScopeStore().findById(resourceServer.getId(), id);
+        Scope model = this.authorization.getStoreFactory().getScopeStore().findById(resourceServer, id);
 
         if (model == null) {
             return Response.status(Status.NOT_FOUND).build();
@@ -171,7 +171,7 @@ public class ScopeService {
     public Response getResources(@PathParam("id") String id) {
         this.auth.realm().requireViewAuthorization();
         StoreFactory storeFactory = this.authorization.getStoreFactory();
-        Scope model = storeFactory.getScopeStore().findById(resourceServer.getId(), id);
+        Scope model = storeFactory.getScopeStore().findById(resourceServer, id);
 
         if (model == null) {
             return Response.status(Status.NOT_FOUND).build();
@@ -194,7 +194,7 @@ public class ScopeService {
     public Response getPermissions(@PathParam("id") String id) {
         this.auth.realm().requireViewAuthorization();
         StoreFactory storeFactory = this.authorization.getStoreFactory();
-        Scope model = storeFactory.getScopeStore().findById(resourceServer.getId(), id);
+        Scope model = storeFactory.getScopeStore().findById(resourceServer, id);
 
         if (model == null) {
             return Response.status(Status.NOT_FOUND).build();
@@ -225,7 +225,7 @@ public class ScopeService {
             return Response.status(Status.BAD_REQUEST).build();
         }
 
-        Scope model = storeFactory.getScopeStore().findByName(this.resourceServer.getId(), name);
+        Scope model = storeFactory.getScopeStore().findByName(this.resourceServer, name);
 
         if (model == null) {
             return Response.status(Status.NO_CONTENT).build();
@@ -254,7 +254,7 @@ public class ScopeService {
         }
 
         return Response.ok(
-                this.authorization.getStoreFactory().getScopeStore().findByResourceServer(this.resourceServer.getId(), search, firstResult != null ? firstResult : -1, maxResult != null ? maxResult : Constants.DEFAULT_MAX_RESULTS).stream()
+                this.authorization.getStoreFactory().getScopeStore().findByResourceServer(this.resourceServer, search, firstResult != null ? firstResult : -1, maxResult != null ? maxResult : Constants.DEFAULT_MAX_RESULTS).stream()
                         .map(scope -> toRepresentation(scope))
                         .collect(Collectors.toList()))
                 .build();

--- a/services/src/main/java/org/keycloak/authorization/admin/ScopeService.java
+++ b/services/src/main/java/org/keycloak/authorization/admin/ScopeService.java
@@ -50,6 +50,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
@@ -131,7 +132,7 @@ public class ScopeService {
         }
 
         PolicyStore policyStore = storeFactory.getPolicyStore();
-        List<Policy> policies = policyStore.findByScopeIds(resourceServer.getId(), Arrays.asList(scope.getId()));
+        List<Policy> policies = policyStore.findByScopes(resourceServer, Collections.singletonList(scope));
 
         for (Policy policyModel : policies) {
             if (policyModel.getScopes().size() == 1) {
@@ -201,7 +202,7 @@ public class ScopeService {
 
         PolicyStore policyStore = storeFactory.getPolicyStore();
 
-        return Response.ok(policyStore.findByScopeIds(resourceServer.getId(), Arrays.asList(model.getId())).stream().map(policy -> {
+        return Response.ok(policyStore.findByScopes(resourceServer, Collections.singletonList(model)).stream().map(policy -> {
             PolicyRepresentation representation = new PolicyRepresentation();
 
             representation.setId(policy.getId());

--- a/services/src/main/java/org/keycloak/authorization/admin/representation/PolicyEvaluationResponseBuilder.java
+++ b/services/src/main/java/org/keycloak/authorization/admin/representation/PolicyEvaluationResponseBuilder.java
@@ -194,7 +194,7 @@ public class PolicyEvaluationResponseBuilder {
 
             filters.put(PermissionTicket.FilterOption.POLICY_ID, policy.getId());
 
-            List<PermissionTicket> tickets = authorization.getStoreFactory().getPermissionTicketStore().find(policy.getResourceServer().getId(), filters, -1, 1);
+            List<PermissionTicket> tickets = authorization.getStoreFactory().getPermissionTicketStore().find(policy.getResourceServer(), filters, -1, 1);
 
             if (!tickets.isEmpty()) {
                 KeycloakSession keycloakSession = authorization.getKeycloakSession();

--- a/services/src/main/java/org/keycloak/authorization/admin/representation/PolicyEvaluationResponseBuilder.java
+++ b/services/src/main/java/org/keycloak/authorization/admin/representation/PolicyEvaluationResponseBuilder.java
@@ -64,7 +64,7 @@ public class PolicyEvaluationResponseBuilder {
         authorizationData.setPermissions(decision.results());
         accessToken.setAuthorization(authorizationData);
 
-        ClientModel clientModel = authorization.getRealm().getClientById(resourceServer.getId());
+        ClientModel clientModel = authorization.getRealm().getClientById(resourceServer.getClientId());
 
         if (!accessToken.hasAudience(clientModel.getClientId())) {
             accessToken.audience(clientModel.getClientId());

--- a/services/src/main/java/org/keycloak/authorization/admin/representation/PolicyEvaluationResponseBuilder.java
+++ b/services/src/main/java/org/keycloak/authorization/admin/representation/PolicyEvaluationResponseBuilder.java
@@ -194,7 +194,7 @@ public class PolicyEvaluationResponseBuilder {
 
             filters.put(PermissionTicket.FilterOption.POLICY_ID, policy.getId());
 
-            List<PermissionTicket> tickets = authorization.getStoreFactory().getPermissionTicketStore().find(filters, policy.getResourceServer().getId(), -1, 1);
+            List<PermissionTicket> tickets = authorization.getStoreFactory().getPermissionTicketStore().find(policy.getResourceServer().getId(), filters, -1, 1);
 
             if (!tickets.isEmpty()) {
                 KeycloakSession keycloakSession = authorization.getKeycloakSession();

--- a/services/src/main/java/org/keycloak/authorization/authorization/AuthorizationTokenService.java
+++ b/services/src/main/java/org/keycloak/authorization/authorization/AuthorizationTokenService.java
@@ -540,7 +540,7 @@ public class AuthorizationTokenService {
                             }
 
                             for (String scopeName : grantedPermission.getScopes()) {
-                                Scope scope = scopeStore.findByName(resourceServer.getId(), scopeName);
+                                Scope scope = scopeStore.findByName(resourceServer, scopeName);
 
                                 if (scope != null) {
                                     if (!permission.getScopes().contains(scope)) {
@@ -685,7 +685,7 @@ public class AuthorizationTokenService {
             requestedScopes.addAll(Arrays.asList(clientAdditionalScopes.split(" ")));
         }
 
-        Set<Scope> requestedScopesModel = requestedScopes.stream().map(s -> scopeStore.findByName(resourceServer.getId(), s)).filter(
+        Set<Scope> requestedScopesModel = requestedScopes.stream().map(s -> scopeStore.findByName(resourceServer, s)).filter(
                 Objects::nonNull).collect(Collectors.toSet());
 
         if (!requestedScopes.isEmpty() && requestedScopesModel.isEmpty()) {

--- a/services/src/main/java/org/keycloak/authorization/authorization/AuthorizationTokenService.java
+++ b/services/src/main/java/org/keycloak/authorization/authorization/AuthorizationTokenService.java
@@ -636,7 +636,7 @@ public class AuthorizationTokenService {
             }
 
             if (!identity.isResourceServer() || !identity.getId().equals(resourceServer.getClientId())) {
-                List<PermissionTicket> tickets = storeFactory.getPermissionTicketStore().findGranted(resourceServer.getId(), resourceId, identity.getId());
+                List<PermissionTicket> tickets = storeFactory.getPermissionTicketStore().findGranted(resourceServer, resourceId, identity.getId());
 
                 if (!tickets.isEmpty()) {
                     List<Scope> scopes = new ArrayList<>();

--- a/services/src/main/java/org/keycloak/authorization/authorization/AuthorizationTokenService.java
+++ b/services/src/main/java/org/keycloak/authorization/authorization/AuthorizationTokenService.java
@@ -516,7 +516,7 @@ public class AuthorizationTokenService {
                             break;
                         }
 
-                        Resource resource = resourceStore.findById(resourceServer.getId(), grantedPermission.getResourceId());
+                        Resource resource = resourceStore.findById(resourceServer, grantedPermission.getResourceId());
 
                         if (resource != null) {
                             ResourcePermission permission = permissionsToEvaluate.get(resource.getId());
@@ -561,7 +561,7 @@ public class AuthorizationTokenService {
             Set<Scope> requestedScopesModel) {
         AtomicBoolean processed = new AtomicBoolean();
 
-        resourceStore.findByScope(resourceServer.getId(), requestedScopesModel.stream().map(Scope::getId).collect(Collectors.toList()), resource -> {
+        resourceStore.findByScopes(resourceServer, requestedScopesModel, resource -> {
             if (limit != null && limit.get() <= 0) {
                 return;
             }
@@ -600,7 +600,7 @@ public class AuthorizationTokenService {
         Resource resource;
 
         if (resourceId.indexOf('-') != -1) {
-            resource = resourceStore.findById(resourceServer.getId(), resourceId);
+            resource = resourceStore.findById(resourceServer, resourceId);
         } else {
             resource = null;
         }
@@ -610,25 +610,25 @@ public class AuthorizationTokenService {
         } else if (resourceId.startsWith("resource-type:")) {
             // only resource types, no resource instances. resource types are owned by the resource server
             String resourceType = resourceId.substring("resource-type:".length());
-            resourceStore.findByType(resourceServer.getId(), resourceType, resourceServer.getClientId(),
+            resourceStore.findByType(resourceServer, resourceType, resourceServer.getClientId(),
                     resource1 -> addPermission(request, resourceServer, authorization, permissionsToEvaluate, limit, requestedScopesModel, resource1));
         } else if (resourceId.startsWith("resource-type-any:")) {
             // any resource with a given type
             String resourceType = resourceId.substring("resource-type-any:".length());
-            resourceStore.findByType(resourceServer.getId(), resourceType, null,
+            resourceStore.findByType(resourceServer, resourceType, null,
                     resource12 -> addPermission(request, resourceServer, authorization, permissionsToEvaluate, limit, requestedScopesModel, resource12));
         } else if (resourceId.startsWith("resource-type-instance:")) {
             // only resource instances with a given type
             String resourceType = resourceId.substring("resource-type-instance:".length());
-            resourceStore.findByTypeInstance(resourceServer.getId(), resourceType,
+            resourceStore.findByTypeInstance(resourceServer, resourceType,
                     resource13 -> addPermission(request, resourceServer, authorization, permissionsToEvaluate, limit, requestedScopesModel, resource13));
         } else if (resourceId.startsWith("resource-type-owner:")) {
             // only resources where the current identity is the owner
             String resourceType = resourceId.substring("resource-type-owner:".length());
-            resourceStore.findByType(resourceServer.getId(), resourceType, identity.getId(),
+            resourceStore.findByType(resourceServer, resourceType, identity.getId(),
                     resource14 -> addPermission(request, resourceServer, authorization, permissionsToEvaluate, limit, requestedScopesModel, resource14));
         } else {
-            Resource ownerResource = resourceStore.findByName(resourceServer.getId(), resourceId, identity.getId());
+            Resource ownerResource = resourceStore.findByName(resourceServer, resourceId, identity.getId());
 
             if (ownerResource != null) {
                 permission.setResourceId(ownerResource.getId());
@@ -656,7 +656,7 @@ public class AuthorizationTokenService {
                     resourcePermission.setGranted(true);
                 }
 
-                Resource serverResource = resourceStore.findByName(resourceServer.getId(), resourceId);
+                Resource serverResource = resourceStore.findByName(resourceServer, resourceId);
 
                 if (serverResource != null) {
                     permission.setResourceId(serverResource.getId());

--- a/services/src/main/java/org/keycloak/authorization/authorization/AuthorizationTokenService.java
+++ b/services/src/main/java/org/keycloak/authorization/authorization/AuthorizationTokenService.java
@@ -224,7 +224,7 @@ public class AuthorizationTokenService {
 
             if (isGranted(ticket, request, permissions)) {
                 AuthorizationProvider authorization = request.getAuthorization();
-                ClientModel targetClient = authorization.getRealm().getClientById(resourceServer.getId());
+                ClientModel targetClient = authorization.getRealm().getClientById(resourceServer.getClientId());
                 Metadata metadata = request.getMetadata();
                 String responseMode = metadata != null ? metadata.getResponseMode() : null;
 
@@ -610,7 +610,7 @@ public class AuthorizationTokenService {
         } else if (resourceId.startsWith("resource-type:")) {
             // only resource types, no resource instances. resource types are owned by the resource server
             String resourceType = resourceId.substring("resource-type:".length());
-            resourceStore.findByType(resourceType, resourceServer.getId(), resourceServer.getId(),
+            resourceStore.findByType(resourceType, resourceServer.getClientId(), resourceServer.getId(),
                     resource1 -> addPermission(request, resourceServer, authorization, permissionsToEvaluate, limit, requestedScopesModel, resource1));
         } else if (resourceId.startsWith("resource-type-any:")) {
             // any resource with a given type
@@ -635,7 +635,7 @@ public class AuthorizationTokenService {
                 addPermission(request, resourceServer, authorization, permissionsToEvaluate, limit, requestedScopesModel, ownerResource);
             }
 
-            if (!identity.isResourceServer() || !identity.getId().equals(resourceServer.getId())) {
+            if (!identity.isResourceServer() || !identity.getId().equals(resourceServer.getClientId())) {
                 List<PermissionTicket> tickets = storeFactory.getPermissionTicketStore().findGranted(resourceId, identity.getId(), resourceServer.getId());
 
                 if (!tickets.isEmpty()) {

--- a/services/src/main/java/org/keycloak/authorization/protection/ProtectionService.java
+++ b/services/src/main/java/org/keycloak/authorization/protection/ProtectionService.java
@@ -73,7 +73,7 @@ public class ProtectionService {
 
     private AdminEventBuilder createAdminEventBuilder(KeycloakIdentity identity, ResourceServer resourceServer) {
         RealmModel realm = authorization.getRealm();
-        ClientModel client = realm.getClientById(resourceServer.getId());
+        ClientModel client = realm.getClientById(resourceServer.getClientId());
         KeycloakSession keycloakSession = authorization.getKeycloakSession();
         UserModel serviceAccount = keycloakSession.users().getServiceAccount(client);
         AdminEventBuilder adminEvent = new AdminEventBuilder(realm, new AdminAuth(realm, identity.getAccessToken(), serviceAccount, client), keycloakSession, clientConnection);
@@ -118,7 +118,7 @@ public class ProtectionService {
         ResourceServer resourceServer = getResourceServer(identity);
         KeycloakSession keycloakSession = authorization.getKeycloakSession();
         RealmModel realm = keycloakSession.getContext().getRealm();
-        ClientModel client = realm.getClientById(resourceServer.getId());
+        ClientModel client = realm.getClientById(resourceServer.getClientId());
 
         if (checkProtectionScope) {
             if (!identity.hasClientRole(client.getClientId(), "uma_protection")) {

--- a/services/src/main/java/org/keycloak/authorization/protection/permission/AbstractPermissionService.java
+++ b/services/src/main/java/org/keycloak/authorization/protection/permission/AbstractPermissionService.java
@@ -133,7 +133,7 @@ public class AbstractPermissionService {
                             .filter(baseScope -> baseScope.getName().equals(scopeName)).findFirst().orElse(null);
                 }
             } else {
-                scope = authorization.getStoreFactory().getScopeStore().findByName(resourceServer.getId(), scopeName);
+                scope = authorization.getStoreFactory().getScopeStore().findByName(resourceServer, scopeName);
             }
 
             if (scope == null) {

--- a/services/src/main/java/org/keycloak/authorization/protection/permission/AbstractPermissionService.java
+++ b/services/src/main/java/org/keycloak/authorization/protection/permission/AbstractPermissionService.java
@@ -74,19 +74,19 @@ public class AbstractPermissionService {
                     throw new ErrorResponseException("invalid_resource_id", "Resource id or name not provided.", Response.Status.BAD_REQUEST);
                 }
             } else {
-                Resource resource = resourceStore.findById(resourceSetId, resourceServer.getId());
+                Resource resource = resourceStore.findById(resourceServer.getId(), resourceSetId);
 
                 if (resource != null) {
                     resources.add(resource);
                 } else {
-                    Resource userResource = resourceStore.findByName(resourceSetId, identity.getId(), this.resourceServer.getId());
+                    Resource userResource = resourceStore.findByName(this.resourceServer.getId(), resourceSetId, identity.getId());
 
                     if (userResource != null) {
                         resources.add(userResource);
                     }
 
                     if (!identity.isResourceServer()) {
-                        Resource serverResource = resourceStore.findByName(resourceSetId, this.resourceServer.getId());
+                        Resource serverResource = resourceStore.findByName(this.resourceServer.getId(), resourceSetId);
 
                         if (serverResource != null) {
                             resources.add(serverResource);
@@ -127,13 +127,13 @@ public class AbstractPermissionService {
                 scope = resource.getScopes().stream().filter(scope1 -> scope1.getName().equals(scopeName)).findFirst().orElse(null);
 
                 if (scope == null && resource.getType() != null) {
-                    scope = resourceStore.findByType(resource.getType(), resourceServer.getId()).stream()
+                    scope = resourceStore.findByType(resourceServer.getId(), resource.getType()).stream()
                             .filter(baseResource -> baseResource.getOwner().equals(resourceServer.getClientId()))
                             .flatMap(resource1 -> resource1.getScopes().stream())
                             .filter(baseScope -> baseScope.getName().equals(scopeName)).findFirst().orElse(null);
                 }
             } else {
-                scope = authorization.getStoreFactory().getScopeStore().findByName(scopeName, resourceServer.getId());
+                scope = authorization.getStoreFactory().getScopeStore().findByName(resourceServer.getId(), scopeName);
             }
 
             if (scope == null) {

--- a/services/src/main/java/org/keycloak/authorization/protection/permission/AbstractPermissionService.java
+++ b/services/src/main/java/org/keycloak/authorization/protection/permission/AbstractPermissionService.java
@@ -128,7 +128,7 @@ public class AbstractPermissionService {
 
                 if (scope == null && resource.getType() != null) {
                     scope = resourceStore.findByType(resource.getType(), resourceServer.getId()).stream()
-                            .filter(baseResource -> baseResource.getOwner().equals(resource.getResourceServer()))
+                            .filter(baseResource -> baseResource.getOwner().equals(resourceServer.getClientId()))
                             .flatMap(resource1 -> resource1.getScopes().stream())
                             .filter(baseScope -> baseScope.getName().equals(scopeName)).findFirst().orElse(null);
                 }

--- a/services/src/main/java/org/keycloak/authorization/protection/permission/AbstractPermissionService.java
+++ b/services/src/main/java/org/keycloak/authorization/protection/permission/AbstractPermissionService.java
@@ -74,19 +74,19 @@ public class AbstractPermissionService {
                     throw new ErrorResponseException("invalid_resource_id", "Resource id or name not provided.", Response.Status.BAD_REQUEST);
                 }
             } else {
-                Resource resource = resourceStore.findById(resourceServer.getId(), resourceSetId);
+                Resource resource = resourceStore.findById(resourceServer, resourceSetId);
 
                 if (resource != null) {
                     resources.add(resource);
                 } else {
-                    Resource userResource = resourceStore.findByName(this.resourceServer.getId(), resourceSetId, identity.getId());
+                    Resource userResource = resourceStore.findByName(this.resourceServer, resourceSetId, identity.getId());
 
                     if (userResource != null) {
                         resources.add(userResource);
                     }
 
                     if (!identity.isResourceServer()) {
-                        Resource serverResource = resourceStore.findByName(this.resourceServer.getId(), resourceSetId);
+                        Resource serverResource = resourceStore.findByName(this.resourceServer, resourceSetId);
 
                         if (serverResource != null) {
                             resources.add(serverResource);
@@ -127,7 +127,7 @@ public class AbstractPermissionService {
                 scope = resource.getScopes().stream().filter(scope1 -> scope1.getName().equals(scopeName)).findFirst().orElse(null);
 
                 if (scope == null && resource.getType() != null) {
-                    scope = resourceStore.findByType(resourceServer.getId(), resource.getType()).stream()
+                    scope = resourceStore.findByType(resourceServer, resource.getType()).stream()
                             .filter(baseResource -> baseResource.getOwner().equals(resourceServer.getClientId()))
                             .flatMap(resource1 -> resource1.getScopes().stream())
                             .filter(baseScope -> baseScope.getName().equals(scopeName)).findFirst().orElse(null);

--- a/services/src/main/java/org/keycloak/authorization/protection/permission/PermissionTicketService.java
+++ b/services/src/main/java/org/keycloak/authorization/protection/permission/PermissionTicketService.java
@@ -102,9 +102,9 @@ public class PermissionTicketService {
         ScopeStore sstore = this.authorization.getStoreFactory().getScopeStore();
 
         if(representation.getScopeName() != null)
-            scope = sstore.findByName(resourceServer.getId(), representation.getScopeName());
+            scope = sstore.findByName(resourceServer, representation.getScopeName());
         else
-            scope = sstore.findById(resourceServer.getId(), representation.getScope());
+            scope = sstore.findById(resourceServer, representation.getScope());
 
         if (scope == null && representation.getScope() !=null )
             throw new ErrorResponseException("invalid_scope", "Scope [" + representation.getScope() + "] is invalid", Response.Status.BAD_REQUEST);
@@ -230,10 +230,10 @@ public class PermissionTicketService {
 
         if (scopeId != null) {
             ScopeStore scopeStore = storeFactory.getScopeStore();
-            Scope scope = scopeStore.findById(resourceServer.getId(), scopeId);
+            Scope scope = scopeStore.findById(resourceServer, scopeId);
 
             if (scope == null) {
-                scope = scopeStore.findByName(resourceServer.getId(), scopeId);
+                scope = scopeStore.findByName(resourceServer, scopeId);
             }
 
             filters.put(PermissionTicket.FilterOption.SCOPE_ID, scope != null ? scope.getId() : scopeId);

--- a/services/src/main/java/org/keycloak/authorization/protection/permission/PermissionTicketService.java
+++ b/services/src/main/java/org/keycloak/authorization/protection/permission/PermissionTicketService.java
@@ -83,7 +83,7 @@ public class PermissionTicketService {
             throw new ErrorResponseException("invalid_permission", "created permissions should have requester or requesterName", Response.Status.BAD_REQUEST);
          
         ResourceStore rstore = this.authorization.getStoreFactory().getResourceStore();
-        Resource resource = rstore.findById(representation.getResource(), resourceServer.getId());
+        Resource resource = rstore.findById(resourceServer.getId(), representation.getResource());
         if (resource == null ) throw new ErrorResponseException("invalid_resource_id", "Resource set with id [" + representation.getResource() + "] does not exists in this server.", Response.Status.BAD_REQUEST);
         
         if (!resource.getOwner().equals(this.identity.getId()))
@@ -102,9 +102,9 @@ public class PermissionTicketService {
         ScopeStore sstore = this.authorization.getStoreFactory().getScopeStore();
 
         if(representation.getScopeName() != null)
-            scope = sstore.findByName(representation.getScopeName(), resourceServer.getId());
+            scope = sstore.findByName(resourceServer.getId(), representation.getScopeName());
         else
-            scope = sstore.findById(representation.getScope(), resourceServer.getId());
+            scope = sstore.findById(resourceServer.getId(), representation.getScope());
 
         if (scope == null && representation.getScope() !=null )
             throw new ErrorResponseException("invalid_scope", "Scope [" + representation.getScope() + "] is invalid", Response.Status.BAD_REQUEST);
@@ -121,10 +121,10 @@ public class PermissionTicketService {
         attributes.put(PermissionTicket.FilterOption.SCOPE_ID, scope.getId());
         attributes.put(PermissionTicket.FilterOption.REQUESTER, user.getId());
         
-        if (!ticketStore.find(attributes, resourceServer.getId(), -1, -1).isEmpty())
+        if (!ticketStore.find(resourceServer.getId(), attributes, -1, -1).isEmpty())
             throw new ErrorResponseException("invalid_permission", "Permission already exists", Response.Status.BAD_REQUEST);
         
-        PermissionTicket ticket = ticketStore.create(resource.getId(), scope.getId(), user.getId(), resourceServer);
+        PermissionTicket ticket = ticketStore.create(resourceServer, resource.getId(), scope.getId(), user.getId());
         if(representation.isGranted())
                 ticket.setGrantedTimestamp(java.lang.System.currentTimeMillis());
         representation = ModelToRepresentation.toRepresentation(ticket, authorization);
@@ -139,7 +139,7 @@ public class PermissionTicketService {
         }
 
         PermissionTicketStore ticketStore = authorization.getStoreFactory().getPermissionTicketStore();
-        PermissionTicket ticket = ticketStore.findById(representation.getId(), resourceServer.getId());
+        PermissionTicket ticket = ticketStore.findById(resourceServer.getId(), representation.getId());
 
         if (ticket == null) {
             throw new ErrorResponseException(OAuthErrorException.INVALID_REQUEST, "invalid_ticket", Response.Status.BAD_REQUEST);
@@ -163,7 +163,7 @@ public class PermissionTicketService {
         }
 
         PermissionTicketStore ticketStore = authorization.getStoreFactory().getPermissionTicketStore();
-        PermissionTicket ticket = ticketStore.findById(id, resourceServer.getId());
+        PermissionTicket ticket = ticketStore.findById(resourceServer.getId(), id);
 
         if (ticket == null) {
             throw new ErrorResponseException(OAuthErrorException.INVALID_REQUEST, "invalid_ticket", Response.Status.BAD_REQUEST);
@@ -192,7 +192,7 @@ public class PermissionTicketService {
 
         Map<PermissionTicket.FilterOption, String> filters = getFilters(storeFactory, resourceId, scopeId, owner, requester, granted);
 
-        return Response.ok().entity(permissionTicketStore.find(filters, resourceServer.getId(), firstResult != null ? firstResult : -1, maxResult != null ? maxResult : Constants.DEFAULT_MAX_RESULTS)
+        return Response.ok().entity(permissionTicketStore.find(resourceServer.getId(), filters, firstResult != null ? firstResult : -1, maxResult != null ? maxResult : Constants.DEFAULT_MAX_RESULTS)
                     .stream()
                         .map(permissionTicket -> ModelToRepresentation.toRepresentation(permissionTicket, authorization, returnNames == null ? false : returnNames))
                         .collect(Collectors.toList()))
@@ -211,7 +211,7 @@ public class PermissionTicketService {
         StoreFactory storeFactory = authorization.getStoreFactory();
         PermissionTicketStore permissionTicketStore = storeFactory.getPermissionTicketStore();
         Map<PermissionTicket.FilterOption, String> filters = getFilters(storeFactory, resourceId, scopeId, owner, requester, granted);
-        long count = permissionTicketStore.count(filters, resourceServer.getId());
+        long count = permissionTicketStore.count(resourceServer.getId(), filters);
 
         return Response.ok().entity(count).build();
     }
@@ -230,10 +230,10 @@ public class PermissionTicketService {
 
         if (scopeId != null) {
             ScopeStore scopeStore = storeFactory.getScopeStore();
-            Scope scope = scopeStore.findById(scopeId, resourceServer.getId());
+            Scope scope = scopeStore.findById(resourceServer.getId(), scopeId);
 
             if (scope == null) {
-                scope = scopeStore.findByName(scopeId, resourceServer.getId());
+                scope = scopeStore.findByName(resourceServer.getId(), scopeId);
             }
 
             filters.put(PermissionTicket.FilterOption.SCOPE_ID, scope != null ? scope.getId() : scopeId);

--- a/services/src/main/java/org/keycloak/authorization/protection/permission/PermissionTicketService.java
+++ b/services/src/main/java/org/keycloak/authorization/protection/permission/PermissionTicketService.java
@@ -121,10 +121,10 @@ public class PermissionTicketService {
         attributes.put(PermissionTicket.FilterOption.SCOPE_ID, scope.getId());
         attributes.put(PermissionTicket.FilterOption.REQUESTER, user.getId());
         
-        if (!ticketStore.find(resourceServer.getId(), attributes, -1, -1).isEmpty())
+        if (!ticketStore.find(resourceServer, attributes, -1, -1).isEmpty())
             throw new ErrorResponseException("invalid_permission", "Permission already exists", Response.Status.BAD_REQUEST);
         
-        PermissionTicket ticket = ticketStore.create(resourceServer, resource.getId(), scope.getId(), user.getId());
+        PermissionTicket ticket = ticketStore.create(resourceServer, resource, scope, user.getId());
         if(representation.isGranted())
                 ticket.setGrantedTimestamp(java.lang.System.currentTimeMillis());
         representation = ModelToRepresentation.toRepresentation(ticket, authorization);
@@ -139,7 +139,7 @@ public class PermissionTicketService {
         }
 
         PermissionTicketStore ticketStore = authorization.getStoreFactory().getPermissionTicketStore();
-        PermissionTicket ticket = ticketStore.findById(resourceServer.getId(), representation.getId());
+        PermissionTicket ticket = ticketStore.findById(resourceServer, representation.getId());
 
         if (ticket == null) {
             throw new ErrorResponseException(OAuthErrorException.INVALID_REQUEST, "invalid_ticket", Response.Status.BAD_REQUEST);
@@ -148,7 +148,7 @@ public class PermissionTicketService {
         if (!ticket.getOwner().equals(this.identity.getId()) && !this.identity.isResourceServer())
             throw new ErrorResponseException("not_authorised", "permissions for [" + representation.getResource() + "] can be updated only by the owner or by the resource server", Response.Status.FORBIDDEN);
 
-        RepresentationToModel.toModel(representation, resourceServer.getId(), authorization);
+        RepresentationToModel.toModel(representation, resourceServer, authorization);
 
         return Response.noContent().build();
     }
@@ -163,7 +163,7 @@ public class PermissionTicketService {
         }
 
         PermissionTicketStore ticketStore = authorization.getStoreFactory().getPermissionTicketStore();
-        PermissionTicket ticket = ticketStore.findById(resourceServer.getId(), id);
+        PermissionTicket ticket = ticketStore.findById(resourceServer, id);
 
         if (ticket == null) {
             throw new ErrorResponseException(OAuthErrorException.INVALID_REQUEST, "invalid_ticket", Response.Status.BAD_REQUEST);
@@ -192,7 +192,7 @@ public class PermissionTicketService {
 
         Map<PermissionTicket.FilterOption, String> filters = getFilters(storeFactory, resourceId, scopeId, owner, requester, granted);
 
-        return Response.ok().entity(permissionTicketStore.find(resourceServer.getId(), filters, firstResult != null ? firstResult : -1, maxResult != null ? maxResult : Constants.DEFAULT_MAX_RESULTS)
+        return Response.ok().entity(permissionTicketStore.find(resourceServer, filters, firstResult != null ? firstResult : -1, maxResult != null ? maxResult : Constants.DEFAULT_MAX_RESULTS)
                     .stream()
                         .map(permissionTicket -> ModelToRepresentation.toRepresentation(permissionTicket, authorization, returnNames == null ? false : returnNames))
                         .collect(Collectors.toList()))
@@ -211,7 +211,7 @@ public class PermissionTicketService {
         StoreFactory storeFactory = authorization.getStoreFactory();
         PermissionTicketStore permissionTicketStore = storeFactory.getPermissionTicketStore();
         Map<PermissionTicket.FilterOption, String> filters = getFilters(storeFactory, resourceId, scopeId, owner, requester, granted);
-        long count = permissionTicketStore.count(resourceServer.getId(), filters);
+        long count = permissionTicketStore.count(resourceServer, filters);
 
         return Response.ok().entity(count).build();
     }

--- a/services/src/main/java/org/keycloak/authorization/protection/permission/PermissionTicketService.java
+++ b/services/src/main/java/org/keycloak/authorization/protection/permission/PermissionTicketService.java
@@ -83,7 +83,7 @@ public class PermissionTicketService {
             throw new ErrorResponseException("invalid_permission", "created permissions should have requester or requesterName", Response.Status.BAD_REQUEST);
          
         ResourceStore rstore = this.authorization.getStoreFactory().getResourceStore();
-        Resource resource = rstore.findById(resourceServer.getId(), representation.getResource());
+        Resource resource = rstore.findById(resourceServer, representation.getResource());
         if (resource == null ) throw new ErrorResponseException("invalid_resource_id", "Resource set with id [" + representation.getResource() + "] does not exists in this server.", Response.Status.BAD_REQUEST);
         
         if (!resource.getOwner().equals(this.identity.getId()))

--- a/services/src/main/java/org/keycloak/authorization/protection/permission/PermissionTicketService.java
+++ b/services/src/main/java/org/keycloak/authorization/protection/permission/PermissionTicketService.java
@@ -121,7 +121,7 @@ public class PermissionTicketService {
         attributes.put(PermissionTicket.FilterOption.SCOPE_ID, scope.getId());
         attributes.put(PermissionTicket.FilterOption.REQUESTER, user.getId());
         
-        if (!ticketStore.find(resourceServer, attributes, -1, -1).isEmpty())
+        if (!ticketStore.find(resourceServer, attributes, null, null).isEmpty())
             throw new ErrorResponseException("invalid_permission", "Permission already exists", Response.Status.BAD_REQUEST);
         
         PermissionTicket ticket = ticketStore.create(resourceServer, resource, scope, user.getId());

--- a/services/src/main/java/org/keycloak/authorization/protection/policy/UserManagedPermissionService.java
+++ b/services/src/main/java/org/keycloak/authorization/protection/policy/UserManagedPermissionService.java
@@ -143,7 +143,7 @@ public class UserManagedPermissionService {
 
     private void checkRequest(String resourceId, UmaPermissionRepresentation representation) {
         ResourceStore resourceStore = this.authorization.getStoreFactory().getResourceStore();
-        Resource resource = resourceStore.findById(resourceServer.getId(), resourceId);
+        Resource resource = resourceStore.findById(resourceServer, resourceId);
 
         if (resource == null) {
             throw new ErrorResponseException(OAuthErrorException.INVALID_REQUEST, "Resource [" + resourceId + "] cannot be found", Response.Status.BAD_REQUEST);

--- a/services/src/main/java/org/keycloak/authorization/protection/policy/UserManagedPermissionService.java
+++ b/services/src/main/java/org/keycloak/authorization/protection/policy/UserManagedPermissionService.java
@@ -132,7 +132,7 @@ public class UserManagedPermissionService {
     }
 
     private Policy getPolicy(@PathParam("policyId") String policyId) {
-        Policy existing = authorization.getStoreFactory().getPolicyStore().findById(policyId, resourceServer.getId());
+        Policy existing = authorization.getStoreFactory().getPolicyStore().findById(resourceServer.getId(), policyId);
 
         if (existing == null) {
             throw new ErrorResponseException(OAuthErrorException.INVALID_REQUEST, "Policy with [" + policyId + "] does not exist", Status.NOT_FOUND);
@@ -143,7 +143,7 @@ public class UserManagedPermissionService {
 
     private void checkRequest(String resourceId, UmaPermissionRepresentation representation) {
         ResourceStore resourceStore = this.authorization.getStoreFactory().getResourceStore();
-        Resource resource = resourceStore.findById(resourceId, resourceServer.getId());
+        Resource resource = resourceStore.findById(resourceServer.getId(), resourceId);
 
         if (resource == null) {
             throw new ErrorResponseException(OAuthErrorException.INVALID_REQUEST, "Resource [" + resourceId + "] cannot be found", Response.Status.BAD_REQUEST);

--- a/services/src/main/java/org/keycloak/authorization/protection/policy/UserManagedPermissionService.java
+++ b/services/src/main/java/org/keycloak/authorization/protection/policy/UserManagedPermissionService.java
@@ -132,7 +132,7 @@ public class UserManagedPermissionService {
     }
 
     private Policy getPolicy(@PathParam("policyId") String policyId) {
-        Policy existing = authorization.getStoreFactory().getPolicyStore().findById(resourceServer.getId(), policyId);
+        Policy existing = authorization.getStoreFactory().getPolicyStore().findById(resourceServer, policyId);
 
         if (existing == null) {
             throw new ErrorResponseException(OAuthErrorException.INVALID_REQUEST, "Policy with [" + policyId + "] does not exist", Status.NOT_FOUND);

--- a/services/src/main/java/org/keycloak/exportimport/util/ExportUtils.java
+++ b/services/src/main/java/org/keycloak/exportimport/util/ExportUtils.java
@@ -340,7 +340,7 @@ public class ExportUtils {
 
         representation.setPolicies(policies);
 
-        List<ScopeRepresentation> scopes = storeFactory.getScopeStore().findByResourceServer(settingsModel.getId()).stream().map(scope -> {
+        List<ScopeRepresentation> scopes = storeFactory.getScopeStore().findByResourceServer(settingsModel).stream().map(scope -> {
             ScopeRepresentation rep = toRepresentation(scope);
 
             rep.setPolicies(null);

--- a/services/src/main/java/org/keycloak/exportimport/util/ExportUtils.java
+++ b/services/src/main/java/org/keycloak/exportimport/util/ExportUtils.java
@@ -331,10 +331,10 @@ public class ExportUtils {
         List<PolicyRepresentation> policies = new ArrayList<>();
         PolicyStore policyStore = storeFactory.getPolicyStore();
 
-        policies.addAll(policyStore.findByResourceServer(settingsModel.getId())
+        policies.addAll(policyStore.findByResourceServer(settingsModel)
                 .stream().filter(policy -> !policy.getType().equals("resource") && !policy.getType().equals("scope") && policy.getOwner() == null)
                 .map(policy -> createPolicyRepresentation(authorization, policy)).collect(Collectors.toList()));
-        policies.addAll(policyStore.findByResourceServer(settingsModel.getId())
+        policies.addAll(policyStore.findByResourceServer(settingsModel)
                 .stream().filter(policy -> (policy.getType().equals("resource") || policy.getType().equals("scope") && policy.getOwner() == null))
                 .map(policy -> createPolicyRepresentation(authorization, policy)).collect(Collectors.toList()));
 

--- a/services/src/main/java/org/keycloak/exportimport/util/ExportUtils.java
+++ b/services/src/main/java/org/keycloak/exportimport/util/ExportUtils.java
@@ -311,9 +311,9 @@ public class ExportUtils {
 
         List<ResourceRepresentation> resources = storeFactory.getResourceStore().findByResourceServer(settingsModel.getId())
                 .stream().map(resource -> {
-                    ResourceRepresentation rep = toRepresentation(resource, settingsModel.getId(), authorization);
+                    ResourceRepresentation rep = toRepresentation(resource, settingsModel, authorization);
 
-                    if (rep.getOwner().getId().equals(settingsModel.getId())) {
+                    if (rep.getOwner().getId().equals(settingsModel.getClientId())) {
                         rep.setOwner((ResourceOwnerRepresentation) null);
                     } else {
                         rep.getOwner().setId(null);

--- a/services/src/main/java/org/keycloak/exportimport/util/ExportUtils.java
+++ b/services/src/main/java/org/keycloak/exportimport/util/ExportUtils.java
@@ -309,7 +309,7 @@ public class ExportUtils {
         representation.setName(null);
         representation.setClientId(null);
 
-        List<ResourceRepresentation> resources = storeFactory.getResourceStore().findByResourceServer(settingsModel.getId())
+        List<ResourceRepresentation> resources = storeFactory.getResourceStore().findByResourceServer(settingsModel)
                 .stream().map(resource -> {
                     ResourceRepresentation rep = toRepresentation(resource, settingsModel, authorization);
 

--- a/services/src/main/java/org/keycloak/forms/account/freemarker/model/AuthorizationBean.java
+++ b/services/src/main/java/org/keycloak/forms/account/freemarker/model/AuthorizationBean.java
@@ -34,6 +34,7 @@ import org.keycloak.authorization.AuthorizationProvider;
 import org.keycloak.authorization.model.PermissionTicket;
 import org.keycloak.authorization.model.Policy;
 import org.keycloak.authorization.model.Resource;
+import org.keycloak.authorization.model.ResourceServer;
 import org.keycloak.authorization.model.Scope;
 import org.keycloak.authorization.store.PermissionTicketStore;
 import org.keycloak.common.util.Time;
@@ -235,7 +236,8 @@ public class AuthorizationBean {
 
         public ResourceBean(Resource resource) {
             RealmModel realm = authorization.getRealm();
-            resourceServer = new ResourceServerBean(realm.getClientById(resource.getResourceServer()));
+            ResourceServer resourceServerModel = authorization.getStoreFactory().getResourceServerStore().findById(resource.getResourceServer());
+            resourceServer = new ResourceServerBean(realm.getClientById(resourceServerModel.getClientId()));
             this.resource = resource;
             userOwner = authorization.getKeycloakSession().users().getUserById(realm, resource.getOwner());
             if (userOwner == null) {

--- a/services/src/main/java/org/keycloak/forms/account/freemarker/model/AuthorizationBean.java
+++ b/services/src/main/java/org/keycloak/forms/account/freemarker/model/AuthorizationBean.java
@@ -69,7 +69,7 @@ public class AuthorizationBean {
         List<String> pathParameters = uriInfo.getPathParameters().get("resource_id");
 
         if (pathParameters != null && !pathParameters.isEmpty()) {
-            Resource resource = authorization.getStoreFactory().getResourceStore().findById(pathParameters.get(0), null);
+            Resource resource = authorization.getStoreFactory().getResourceStore().findById(null, pathParameters.get(0));
 
             if (resource != null && !resource.getOwner().equals(user.getId())) {
                 throw new RuntimeException("User [" + user.getUsername() + "] can not access resource [" + resource.getId() + "]");
@@ -105,7 +105,7 @@ public class AuthorizationBean {
 
     public List<ResourceBean> getResources() {
         if (resources == null) {
-            resources = authorization.getStoreFactory().getResourceStore().findByOwner(user.getId(), null).stream()
+            resources = authorization.getStoreFactory().getResourceStore().findByOwner(null, user.getId()).stream()
                     .filter(Resource::isOwnerManagedAccess)
                     .map(ResourceBean::new)
                     .collect(Collectors.toList());
@@ -122,7 +122,7 @@ public class AuthorizationBean {
 
             PermissionTicketStore ticketStore = authorization.getStoreFactory().getPermissionTicketStore();
 
-            userSharedResources = toResourceRepresentation(ticketStore.find(filters, null, -1, -1));
+            userSharedResources = toResourceRepresentation(ticketStore.find(null, filters, -1, -1));
         }
         return userSharedResources;
     }
@@ -140,7 +140,7 @@ public class AuthorizationBean {
     }
 
     private ResourceBean getResource(String id) {
-        return new ResourceBean(authorization.getStoreFactory().getResourceStore().findById(id, null));
+        return new ResourceBean(authorization.getStoreFactory().getResourceStore().findById(null, id));
     }
 
     public static class RequesterBean {
@@ -306,7 +306,7 @@ public class AuthorizationBean {
                 filters.put(Policy.FilterOption.OWNER, new String[] {getClientOwner().getId()});
             }
 
-            List<Policy> policies = authorization.getStoreFactory().getPolicyStore().findByResourceServer(filters, getResourceServer().getId(), -1, -1);
+            List<Policy> policies = authorization.getStoreFactory().getPolicyStore().findByResourceServer(getResourceServer().getId(), filters, -1, -1);
 
             if (policies.isEmpty()) {
                 return Collections.emptyList();
@@ -318,7 +318,7 @@ public class AuthorizationBean {
 
                         filters1.put(PermissionTicket.FilterOption.POLICY_ID, policy.getId());
 
-                        return authorization.getStoreFactory().getPermissionTicketStore().find(filters1, resourceServer.getId(), -1, 1)
+                        return authorization.getStoreFactory().getPermissionTicketStore().find(resourceServer.getId(), filters1, -1, 1)
                                 .isEmpty();
                     })
                     .map(ManagedPermissionBean::new).collect(Collectors.toList());
@@ -370,7 +370,7 @@ public class AuthorizationBean {
     }
 
     private List<PermissionTicket> findPermissions(Map<PermissionTicket.FilterOption, String> filters) {
-        return authorization.getStoreFactory().getPermissionTicketStore().find(filters, null, -1, -1);
+        return authorization.getStoreFactory().getPermissionTicketStore().find(null, filters, -1, -1);
     }
 
     public class ResourceServerBean {

--- a/services/src/main/java/org/keycloak/forms/account/freemarker/model/AuthorizationBean.java
+++ b/services/src/main/java/org/keycloak/forms/account/freemarker/model/AuthorizationBean.java
@@ -237,7 +237,7 @@ public class AuthorizationBean {
         public ResourceBean(Resource resource) {
             RealmModel realm = authorization.getRealm();
             ResourceServer resourceServerModel = resource.getResourceServer();
-            resourceServer = new ResourceServerBean(realm.getClientById(resourceServerModel.getClientId()));
+            resourceServer = new ResourceServerBean(realm.getClientById(resourceServerModel.getClientId()), resourceServerModel);
             this.resource = resource;
             userOwner = authorization.getKeycloakSession().users().getUserById(realm, resource.getOwner());
             if (userOwner == null) {
@@ -318,7 +318,7 @@ public class AuthorizationBean {
 
                         filters1.put(PermissionTicket.FilterOption.POLICY_ID, policy.getId());
 
-                        return authorization.getStoreFactory().getPermissionTicketStore().find(resourceServer.getId(), filters1, -1, 1)
+                        return authorization.getStoreFactory().getPermissionTicketStore().find(resourceServer.getResourceServerModel(), filters1, -1, 1)
                                 .isEmpty();
                     })
                     .map(ManagedPermissionBean::new).collect(Collectors.toList());
@@ -376,13 +376,15 @@ public class AuthorizationBean {
     public class ResourceServerBean {
 
         private ClientModel clientModel;
+        private ResourceServer resourceServer;
 
-        public ResourceServerBean(ClientModel clientModel) {
+        public ResourceServerBean(ClientModel clientModel, ResourceServer resourceServer) {
             this.clientModel = clientModel;
+            this.resourceServer = resourceServer;
         }
 
         public String getId() {
-            return clientModel.getId();
+            return resourceServer.getId();
         }
 
         public String getName() {
@@ -411,6 +413,10 @@ public class AuthorizationBean {
 
         public String getBaseUri() {
             return ResolveRelative.resolveRelativeUri(session, clientModel.getRootUrl(), clientModel.getBaseUrl());
+        }
+
+        public ResourceServer getResourceServerModel() {
+            return resourceServer;
         }
     }
 

--- a/services/src/main/java/org/keycloak/forms/account/freemarker/model/AuthorizationBean.java
+++ b/services/src/main/java/org/keycloak/forms/account/freemarker/model/AuthorizationBean.java
@@ -306,7 +306,7 @@ public class AuthorizationBean {
                 filters.put(Policy.FilterOption.OWNER, new String[] {getClientOwner().getId()});
             }
 
-            List<Policy> policies = authorization.getStoreFactory().getPolicyStore().findByResourceServer(getResourceServer().getId(), filters, -1, -1);
+            List<Policy> policies = authorization.getStoreFactory().getPolicyStore().findByResourceServer(getResourceServer().getResourceServerModel(), filters, -1, -1);
 
             if (policies.isEmpty()) {
                 return Collections.emptyList();

--- a/services/src/main/java/org/keycloak/forms/account/freemarker/model/AuthorizationBean.java
+++ b/services/src/main/java/org/keycloak/forms/account/freemarker/model/AuthorizationBean.java
@@ -236,7 +236,7 @@ public class AuthorizationBean {
 
         public ResourceBean(Resource resource) {
             RealmModel realm = authorization.getRealm();
-            ResourceServer resourceServerModel = authorization.getStoreFactory().getResourceServerStore().findById(resource.getResourceServer());
+            ResourceServer resourceServerModel = resource.getResourceServer();
             resourceServer = new ResourceServerBean(realm.getClientById(resourceServerModel.getClientId()));
             this.resource = resource;
             userOwner = authorization.getKeycloakSession().users().getUserById(realm, resource.getOwner());

--- a/services/src/main/java/org/keycloak/forms/account/freemarker/model/AuthorizationBean.java
+++ b/services/src/main/java/org/keycloak/forms/account/freemarker/model/AuthorizationBean.java
@@ -122,7 +122,7 @@ public class AuthorizationBean {
 
             PermissionTicketStore ticketStore = authorization.getStoreFactory().getPermissionTicketStore();
 
-            userSharedResources = toResourceRepresentation(ticketStore.find(null, filters, -1, -1));
+            userSharedResources = toResourceRepresentation(ticketStore.find(null, filters, null, null));
         }
         return userSharedResources;
     }
@@ -306,7 +306,7 @@ public class AuthorizationBean {
                 filters.put(Policy.FilterOption.OWNER, new String[] {getClientOwner().getId()});
             }
 
-            List<Policy> policies = authorization.getStoreFactory().getPolicyStore().findByResourceServer(getResourceServer().getResourceServerModel(), filters, -1, -1);
+            List<Policy> policies = authorization.getStoreFactory().getPolicyStore().findByResourceServer(getResourceServer().getResourceServerModel(), filters, null, null);
 
             if (policies.isEmpty()) {
                 return Collections.emptyList();
@@ -370,7 +370,7 @@ public class AuthorizationBean {
     }
 
     private List<PermissionTicket> findPermissions(Map<PermissionTicket.FilterOption, String> filters) {
-        return authorization.getStoreFactory().getPermissionTicketStore().find(null, filters, -1, -1);
+        return authorization.getStoreFactory().getPermissionTicketStore().find(null, filters, null, null);
     }
 
     public class ResourceServerBean {

--- a/services/src/main/java/org/keycloak/services/resources/account/AccountFormService.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountFormService.java
@@ -760,7 +760,7 @@ public class AccountFormService extends AbstractSecuredLocalService {
 
         AuthorizationProvider authorization = session.getProvider(AuthorizationProvider.class);
         PermissionTicketStore ticketStore = authorization.getStoreFactory().getPermissionTicketStore();
-        Resource resource = authorization.getStoreFactory().getResourceStore().findById(resourceId, null);
+        Resource resource = authorization.getStoreFactory().getResourceStore().findById(null, resourceId);
 
         if (resource == null) {
             return ErrorResponse.error("Invalid resource", Response.Status.BAD_REQUEST);
@@ -786,7 +786,7 @@ public class AccountFormService extends AbstractSecuredLocalService {
                 String id = iterator.next();
 
                 if (!id.contains(":")) {
-                    policy = policyStore.findById(id, client.getId());
+                    policy = policyStore.findById(client.getId(), id);
                     iterator.remove();
                     break;
                 }
@@ -800,7 +800,7 @@ public class AccountFormService extends AbstractSecuredLocalService {
                 }
             } else {
                 for (String id : ids) {
-                    scopesToKeep.add(authorization.getStoreFactory().getScopeStore().findById(id.split(":")[1], client.getId()));
+                    scopesToKeep.add(authorization.getStoreFactory().getScopeStore().findById(client.getId(), id.split(":")[1]));
                 }
 
                 for (Scope scope : policy.getScopes()) {
@@ -829,7 +829,7 @@ public class AccountFormService extends AbstractSecuredLocalService {
                 filters.put(PermissionTicket.FilterOption.GRANTED, Boolean.FALSE.toString());
             }
 
-            List<PermissionTicket> tickets = ticketStore.find(filters, resource.getResourceServer(), -1, -1);
+            List<PermissionTicket> tickets = ticketStore.find(resource.getResourceServer(), filters, -1, -1);
             Iterator<PermissionTicket> iterator = tickets.iterator();
 
             while (iterator.hasNext()) {
@@ -884,7 +884,7 @@ public class AccountFormService extends AbstractSecuredLocalService {
 
         AuthorizationProvider authorization = session.getProvider(AuthorizationProvider.class);
         PermissionTicketStore ticketStore = authorization.getStoreFactory().getPermissionTicketStore();
-        Resource resource = authorization.getStoreFactory().getResourceStore().findById(resourceId, null);
+        Resource resource = authorization.getStoreFactory().getResourceStore().findById(null, resourceId);
         ResourceServer resourceServer = authorization.getStoreFactory().getResourceServerStore().findById(resource.getResourceServer());
 
         if (resource == null) {
@@ -918,21 +918,21 @@ public class AccountFormService extends AbstractSecuredLocalService {
             filters.put(PermissionTicket.FilterOption.OWNER, auth.getUser().getId());
             filters.put(PermissionTicket.FilterOption.REQUESTER, user.getId());
 
-            List<PermissionTicket> tickets = ticketStore.find(filters, resource.getResourceServer(), -1, -1);
+            List<PermissionTicket> tickets = ticketStore.find(resource.getResourceServer(), filters, -1, -1);
 
             if (tickets.isEmpty()) {
                 if (scopes != null && scopes.length > 0) {
                     for (String scope : scopes) {
-                        PermissionTicket ticket = ticketStore.create(resourceId, scope, user.getId(), resourceServer);
+                        PermissionTicket ticket = ticketStore.create(resourceServer, resourceId, scope, user.getId());
                         ticket.setGrantedTimestamp(System.currentTimeMillis());
                     }
                 } else {
                     if (resource.getScopes().isEmpty()) {
-                        PermissionTicket ticket = ticketStore.create(resourceId, null, user.getId(), resourceServer);
+                        PermissionTicket ticket = ticketStore.create(resourceServer, resourceId, null, user.getId());
                         ticket.setGrantedTimestamp(System.currentTimeMillis());
                     } else {
                         for (Scope scope : resource.getScopes()) {
-                            PermissionTicket ticket = ticketStore.create(resourceId, scope.getId(), user.getId(), resourceServer);
+                            PermissionTicket ticket = ticketStore.create(resourceServer, resourceId, scope.getId(), user.getId());
                             ticket.setGrantedTimestamp(System.currentTimeMillis());
                         }
                     }
@@ -949,7 +949,7 @@ public class AccountFormService extends AbstractSecuredLocalService {
                 }
 
                 for (String grantScope : grantScopes) {
-                    PermissionTicket ticket = ticketStore.create(resourceId, grantScope, user.getId(), resourceServer);
+                    PermissionTicket ticket = ticketStore.create(resourceServer, resourceId, grantScope, user.getId());
                     ticket.setGrantedTimestamp(System.currentTimeMillis());
                 }
             }
@@ -978,7 +978,7 @@ public class AccountFormService extends AbstractSecuredLocalService {
         }
 
         for (String resourceId : resourceIds) {
-            Resource resource = authorization.getStoreFactory().getResourceStore().findById(resourceId, null);
+            Resource resource = authorization.getStoreFactory().getResourceStore().findById(null, resourceId);
 
             if (resource == null) {
                 return ErrorResponse.error("Invalid resource", Response.Status.BAD_REQUEST);
@@ -995,7 +995,7 @@ public class AccountFormService extends AbstractSecuredLocalService {
                 filters.put(PermissionTicket.FilterOption.GRANTED, Boolean.FALSE.toString());
             }
 
-            for (PermissionTicket ticket : ticketStore.find(filters, resource.getResourceServer(), -1, -1)) {
+            for (PermissionTicket ticket : ticketStore.find(resource.getResourceServer(), filters, -1, -1)) {
                 ticketStore.delete(ticket.getId());
             }
         }

--- a/services/src/main/java/org/keycloak/services/resources/account/AccountFormService.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountFormService.java
@@ -922,7 +922,7 @@ public class AccountFormService extends AbstractSecuredLocalService {
             filters.put(PermissionTicket.FilterOption.OWNER, auth.getUser().getId());
             filters.put(PermissionTicket.FilterOption.REQUESTER, user.getId());
 
-            List<PermissionTicket> tickets = ticketStore.find(resource.getResourceServer(), filters, -1, -1);
+            List<PermissionTicket> tickets = ticketStore.find(resourceServer, filters, -1, -1);
             final String userId = user.getId();
 
             if (tickets.isEmpty()) {

--- a/services/src/main/java/org/keycloak/services/resources/account/AccountFormService.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountFormService.java
@@ -782,13 +782,14 @@ public class AccountFormService extends AbstractSecuredLocalService {
             List<String> ids = new ArrayList<>(Arrays.asList(permissionId));
             Iterator<String> iterator = ids.iterator();
             PolicyStore policyStore = authorization.getStoreFactory().getPolicyStore();
+            ResourceServer resourceServer = authorization.getStoreFactory().getResourceServerStore().findByClient(client);
             Policy policy = null;
 
             while (iterator.hasNext()) {
                 String id = iterator.next();
 
                 if (!id.contains(":")) {
-                    policy = policyStore.findById(client.getId(), id);
+                    policy = policyStore.findById(resourceServer, id);
                     iterator.remove();
                     break;
                 }

--- a/services/src/main/java/org/keycloak/services/resources/account/AccountFormService.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountFormService.java
@@ -803,7 +803,7 @@ public class AccountFormService extends AbstractSecuredLocalService {
                 }
             } else {
                 for (String id : ids) {
-                    scopesToKeep.add(authorization.getStoreFactory().getScopeStore().findById(client.getId(), id.split(":")[1]));
+                    scopesToKeep.add(authorization.getStoreFactory().getScopeStore().findById(resourceServer, id.split(":")[1]));
                 }
 
                 for (Scope scope : policy.getScopes()) {
@@ -929,7 +929,7 @@ public class AccountFormService extends AbstractSecuredLocalService {
 
                 if (scopes != null && scopes.length > 0) {
                     Arrays.stream(scopes)
-                            .map(scopeId -> scopeStore.findById(resourceServer.getId(), scopeId))
+                            .map(scopeId -> scopeStore.findById(resourceServer, scopeId))
                             .filter(Objects::nonNull)
                             .forEach(scope -> ticketStore.create(resourceServer, resource, scope, userId));
                 } else {
@@ -947,7 +947,7 @@ public class AccountFormService extends AbstractSecuredLocalService {
 
                 Arrays.stream(scopes)
                         .filter(((Predicate<String>) alreadyGrantedScopes::contains).negate())
-                        .map(scopeId -> scopeStore.findById(resourceServer.getId(), scopeId))
+                        .map(scopeId -> scopeStore.findById(resourceServer, scopeId))
                         .filter(Objects::nonNull)
                         .forEach(scope -> ticketStore.create(resourceServer, resource, scope, userId));
             }

--- a/services/src/main/java/org/keycloak/services/resources/account/AccountFormService.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountFormService.java
@@ -832,7 +832,7 @@ public class AccountFormService extends AbstractSecuredLocalService {
                 filters.put(PermissionTicket.FilterOption.GRANTED, Boolean.FALSE.toString());
             }
 
-            List<PermissionTicket> tickets = ticketStore.find(resource.getResourceServer(), filters, -1, -1);
+            List<PermissionTicket> tickets = ticketStore.find(resource.getResourceServer(), filters, null, null);
             Iterator<PermissionTicket> iterator = tickets.iterator();
 
             while (iterator.hasNext()) {
@@ -922,7 +922,7 @@ public class AccountFormService extends AbstractSecuredLocalService {
             filters.put(PermissionTicket.FilterOption.OWNER, auth.getUser().getId());
             filters.put(PermissionTicket.FilterOption.REQUESTER, user.getId());
 
-            List<PermissionTicket> tickets = ticketStore.find(resourceServer, filters, -1, -1);
+            List<PermissionTicket> tickets = ticketStore.find(resourceServer, filters, null, null);
             final String userId = user.getId();
 
             if (tickets.isEmpty()) {
@@ -1000,7 +1000,7 @@ public class AccountFormService extends AbstractSecuredLocalService {
                 filters.put(PermissionTicket.FilterOption.GRANTED, Boolean.FALSE.toString());
             }
 
-            for (PermissionTicket ticket : ticketStore.find(resource.getResourceServer(), filters, -1, -1)) {
+            for (PermissionTicket ticket : ticketStore.find(resource.getResourceServer(), filters, null, null)) {
                 ticketStore.delete(ticket.getId());
             }
         }

--- a/services/src/main/java/org/keycloak/services/resources/account/AccountFormService.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountFormService.java
@@ -829,7 +829,7 @@ public class AccountFormService extends AbstractSecuredLocalService {
                 filters.put(PermissionTicket.FilterOption.GRANTED, Boolean.FALSE.toString());
             }
 
-            List<PermissionTicket> tickets = ticketStore.find(resource.getResourceServer(), filters, -1, -1);
+            List<PermissionTicket> tickets = ticketStore.find(resource.getResourceServer().getId(), filters, -1, -1);
             Iterator<PermissionTicket> iterator = tickets.iterator();
 
             while (iterator.hasNext()) {
@@ -885,7 +885,7 @@ public class AccountFormService extends AbstractSecuredLocalService {
         AuthorizationProvider authorization = session.getProvider(AuthorizationProvider.class);
         PermissionTicketStore ticketStore = authorization.getStoreFactory().getPermissionTicketStore();
         Resource resource = authorization.getStoreFactory().getResourceStore().findById(null, resourceId);
-        ResourceServer resourceServer = authorization.getStoreFactory().getResourceServerStore().findById(resource.getResourceServer());
+        ResourceServer resourceServer = resource.getResourceServer();
 
         if (resource == null) {
             return ErrorResponse.error("Invalid resource", Response.Status.BAD_REQUEST);
@@ -918,7 +918,7 @@ public class AccountFormService extends AbstractSecuredLocalService {
             filters.put(PermissionTicket.FilterOption.OWNER, auth.getUser().getId());
             filters.put(PermissionTicket.FilterOption.REQUESTER, user.getId());
 
-            List<PermissionTicket> tickets = ticketStore.find(resource.getResourceServer(), filters, -1, -1);
+            List<PermissionTicket> tickets = ticketStore.find(resource.getResourceServer().getId(), filters, -1, -1);
 
             if (tickets.isEmpty()) {
                 if (scopes != null && scopes.length > 0) {
@@ -995,7 +995,7 @@ public class AccountFormService extends AbstractSecuredLocalService {
                 filters.put(PermissionTicket.FilterOption.GRANTED, Boolean.FALSE.toString());
             }
 
-            for (PermissionTicket ticket : ticketStore.find(resource.getResourceServer(), filters, -1, -1)) {
+            for (PermissionTicket ticket : ticketStore.find(resource.getResourceServer().getId(), filters, -1, -1)) {
                 ticketStore.delete(ticket.getId());
             }
         }

--- a/services/src/main/java/org/keycloak/services/resources/account/resources/AbstractResourceService.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/resources/AbstractResourceService.java
@@ -28,6 +28,7 @@ import java.util.stream.Collectors;
 import org.jboss.resteasy.spi.HttpRequest;
 import org.keycloak.authorization.AuthorizationProvider;
 import org.keycloak.authorization.model.PermissionTicket;
+import org.keycloak.authorization.model.ResourceServer;
 import org.keycloak.authorization.store.PermissionTicketStore;
 import org.keycloak.authorization.store.ResourceStore;
 import org.keycloak.authorization.store.ScopeStore;
@@ -82,7 +83,8 @@ public abstract class AbstractResourceService {
 
             setScopes(resource.getScopes().stream().map(Scope::new).collect(Collectors.toSet()));
 
-            this.client = new Client(provider.getRealm().getClientById(resource.getResourceServer()));
+            ResourceServer resourceServer = provider.getStoreFactory().getResourceServerStore().findById(resource.getResourceServer());
+            this.client = new Client(provider.getRealm().getClientById(resourceServer.getClientId()));
         }
 
         Resource(org.keycloak.authorization.model.Resource resource, AuthorizationProvider provider) {

--- a/services/src/main/java/org/keycloak/services/resources/account/resources/AbstractResourceService.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/resources/AbstractResourceService.java
@@ -83,7 +83,7 @@ public abstract class AbstractResourceService {
 
             setScopes(resource.getScopes().stream().map(Scope::new).collect(Collectors.toSet()));
 
-            ResourceServer resourceServer = provider.getStoreFactory().getResourceServerStore().findById(resource.getResourceServer());
+            ResourceServer resourceServer = resource.getResourceServer();
             this.client = new Client(provider.getRealm().getClientById(resourceServer.getClientId()));
         }
 

--- a/services/src/main/java/org/keycloak/services/resources/account/resources/ResourceService.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/resources/ResourceService.java
@@ -210,10 +210,10 @@ public class ResourceService extends AbstractResourceService {
     }
 
     private org.keycloak.authorization.model.Scope getScope(String scopeId, ResourceServer resourceServer) {
-        org.keycloak.authorization.model.Scope scope = scopeStore.findByName(resourceServer.getId(), scopeId);
+        org.keycloak.authorization.model.Scope scope = scopeStore.findByName(resourceServer, scopeId);
 
         if (scope == null) {
-            scope = scopeStore.findById(resourceServer.getId(), scopeId);
+            scope = scopeStore.findById(resourceServer, scopeId);
         }
         
         return scope;

--- a/services/src/main/java/org/keycloak/services/resources/account/resources/ResourceService.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/resources/ResourceService.java
@@ -135,7 +135,7 @@ public class ResourceService extends AbstractResourceService {
 
             filters.put(PermissionTicket.FilterOption.REQUESTER, user.getId());
 
-            List<PermissionTicket> tickets = ticketStore.find(resource.getResourceServer().getId(), filters, -1, -1);
+            List<PermissionTicket> tickets = ticketStore.find(resource.getResourceServer(), filters, -1, -1);
 
             // grants all requested permissions
             if (tickets.isEmpty()) {
@@ -205,7 +205,7 @@ public class ResourceService extends AbstractResourceService {
 
     private void grantPermission(UserModel user, String scopeId) {
         org.keycloak.authorization.model.Scope scope = getScope(scopeId, resourceServer);
-        PermissionTicket ticket = ticketStore.create(resourceServer, resource.getId(), scope.getId(), user.getId());
+        PermissionTicket ticket = ticketStore.create(resourceServer, resource, scope, user.getId());
         ticket.setGrantedTimestamp(Calendar.getInstance().getTimeInMillis());
     }
 

--- a/services/src/main/java/org/keycloak/services/resources/account/resources/ResourceService.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/resources/ResourceService.java
@@ -87,7 +87,7 @@ public class ResourceService extends AbstractResourceService {
         filters.put(PermissionTicket.FilterOption.GRANTED, Boolean.TRUE.toString());
         filters.put(PermissionTicket.FilterOption.RESOURCE_ID, resource.getId());
 
-        Collection<ResourcePermission> resources = toPermissions(ticketStore.find(filters, null, -1, -1));
+        Collection<ResourcePermission> resources = toPermissions(ticketStore.find(null, filters, -1, -1));
         Collection<Permission> permissions = Collections.EMPTY_LIST;
         
         if (!resources.isEmpty()) {
@@ -135,7 +135,7 @@ public class ResourceService extends AbstractResourceService {
 
             filters.put(PermissionTicket.FilterOption.REQUESTER, user.getId());
 
-            List<PermissionTicket> tickets = ticketStore.find(filters, resource.getResourceServer(), -1, -1);
+            List<PermissionTicket> tickets = ticketStore.find(resource.getResourceServer(), filters, -1, -1);
 
             // grants all requested permissions
             if (tickets.isEmpty()) {
@@ -196,7 +196,7 @@ public class ResourceService extends AbstractResourceService {
         
         Map<String, Permission> requests = new HashMap<>();
 
-        for (PermissionTicket ticket : ticketStore.find(filters, null, -1, -1)) {
+        for (PermissionTicket ticket : ticketStore.find(null, filters, -1, -1)) {
             requests.computeIfAbsent(ticket.getRequester(), requester -> new Permission(ticket, provider)).addScope(ticket.getScope().getName());
         }
         
@@ -205,15 +205,15 @@ public class ResourceService extends AbstractResourceService {
 
     private void grantPermission(UserModel user, String scopeId) {
         org.keycloak.authorization.model.Scope scope = getScope(scopeId, resourceServer);
-        PermissionTicket ticket = ticketStore.create(resource.getId(), scope.getId(), user.getId(), resourceServer);
+        PermissionTicket ticket = ticketStore.create(resourceServer, resource.getId(), scope.getId(), user.getId());
         ticket.setGrantedTimestamp(Calendar.getInstance().getTimeInMillis());
     }
 
     private org.keycloak.authorization.model.Scope getScope(String scopeId, ResourceServer resourceServer) {
-        org.keycloak.authorization.model.Scope scope = scopeStore.findByName(scopeId, resourceServer.getId());
+        org.keycloak.authorization.model.Scope scope = scopeStore.findByName(resourceServer.getId(), scopeId);
 
         if (scope == null) {
-            scope = scopeStore.findById(scopeId, resourceServer.getId());
+            scope = scopeStore.findById(resourceServer.getId(), scopeId);
         }
         
         return scope;

--- a/services/src/main/java/org/keycloak/services/resources/account/resources/ResourceService.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/resources/ResourceService.java
@@ -58,7 +58,7 @@ public class ResourceService extends AbstractResourceService {
             Auth auth, HttpRequest request) {
         super(session, user, auth, request);
         this.resource = resource;
-        this.resourceServer = provider.getStoreFactory().getResourceServerStore().findByClient(provider.getRealm().getClientById(resource.getResourceServer()));
+        this.resourceServer = provider.getStoreFactory().getResourceServerStore().findById(resource.getResourceServer());
     }
 
     /**

--- a/services/src/main/java/org/keycloak/services/resources/account/resources/ResourceService.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/resources/ResourceService.java
@@ -58,7 +58,7 @@ public class ResourceService extends AbstractResourceService {
             Auth auth, HttpRequest request) {
         super(session, user, auth, request);
         this.resource = resource;
-        this.resourceServer = provider.getStoreFactory().getResourceServerStore().findById(resource.getResourceServer());
+        this.resourceServer = resource.getResourceServer();
     }
 
     /**
@@ -135,7 +135,7 @@ public class ResourceService extends AbstractResourceService {
 
             filters.put(PermissionTicket.FilterOption.REQUESTER, user.getId());
 
-            List<PermissionTicket> tickets = ticketStore.find(resource.getResourceServer(), filters, -1, -1);
+            List<PermissionTicket> tickets = ticketStore.find(resource.getResourceServer().getId(), filters, -1, -1);
 
             // grants all requested permissions
             if (tickets.isEmpty()) {

--- a/services/src/main/java/org/keycloak/services/resources/account/resources/ResourceService.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/resources/ResourceService.java
@@ -87,7 +87,7 @@ public class ResourceService extends AbstractResourceService {
         filters.put(PermissionTicket.FilterOption.GRANTED, Boolean.TRUE.toString());
         filters.put(PermissionTicket.FilterOption.RESOURCE_ID, resource.getId());
 
-        Collection<ResourcePermission> resources = toPermissions(ticketStore.find(null, filters, -1, -1));
+        Collection<ResourcePermission> resources = toPermissions(ticketStore.find(null, filters, null, null));
         Collection<Permission> permissions = Collections.EMPTY_LIST;
         
         if (!resources.isEmpty()) {
@@ -135,7 +135,7 @@ public class ResourceService extends AbstractResourceService {
 
             filters.put(PermissionTicket.FilterOption.REQUESTER, user.getId());
 
-            List<PermissionTicket> tickets = ticketStore.find(resource.getResourceServer(), filters, -1, -1);
+            List<PermissionTicket> tickets = ticketStore.find(resource.getResourceServer(), filters, null, null);
 
             // grants all requested permissions
             if (tickets.isEmpty()) {
@@ -196,7 +196,7 @@ public class ResourceService extends AbstractResourceService {
         
         Map<String, Permission> requests = new HashMap<>();
 
-        for (PermissionTicket ticket : ticketStore.find(null, filters, -1, -1)) {
+        for (PermissionTicket ticket : ticketStore.find(null, filters, null, null)) {
             requests.computeIfAbsent(ticket.getRequester(), requester -> new Permission(ticket, provider)).addScope(ticket.getScope().getName());
         }
         

--- a/services/src/main/java/org/keycloak/services/resources/account/resources/ResourcesService.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/resources/ResourcesService.java
@@ -73,7 +73,7 @@ public class ResourcesService extends AbstractResourceService {
             filters.put(org.keycloak.authorization.model.Resource.FilterOption.NAME, new String[] { name });
         }
 
-        return queryResponse((f, m) -> resourceStore.findByResourceServer(filters, null, f, m).stream()
+        return queryResponse((f, m) -> resourceStore.findByResourceServer(null, filters, f, m).stream()
                 .map(resource -> new Resource(resource, user, provider)), first, max);
     }
 
@@ -123,7 +123,7 @@ public class ResourcesService extends AbstractResourceService {
         filters.put(PermissionTicket.FilterOption.REQUESTER, user.getId());
         filters.put(PermissionTicket.FilterOption.GRANTED, Boolean.FALSE.toString());
 
-        final List<PermissionTicket> permissionTickets = ticketStore.find(filters, null, -1, -1);
+        final List<PermissionTicket> permissionTickets = ticketStore.find(null, filters, -1, -1);
 
         final List<ResourcePermission> resourceList = new ArrayList<>(permissionTickets.size());
         for (PermissionTicket ticket : permissionTickets) {
@@ -138,7 +138,7 @@ public class ResourcesService extends AbstractResourceService {
 
     @Path("{id}")
     public Object getResource(@PathParam("id") String id) {
-        org.keycloak.authorization.model.Resource resource = resourceStore.findById(id, null);
+        org.keycloak.authorization.model.Resource resource = resourceStore.findById(null, id);
 
         if (resource == null) {
             throw new NotFoundException("resource_not_found");
@@ -167,9 +167,9 @@ public class ResourcesService extends AbstractResourceService {
                 filters.put(PermissionTicket.FilterOption.GRANTED, Boolean.TRUE.toString());
                 filters.put(PermissionTicket.FilterOption.RESOURCE_ID, resource.getId());
 
-                tickets = ticketStore.find(filters, null, -1, -1);
+                tickets = ticketStore.find(null, filters, -1, -1);
             } else {
-                tickets = ticketStore.findGranted(resource.getName(), user.getId(), null);
+                tickets = ticketStore.findGranted(null, resource.getName(), user.getId());
             }
 
             for (PermissionTicket ticket : tickets) {

--- a/services/src/main/java/org/keycloak/services/resources/account/resources/ResourcesService.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/resources/ResourcesService.java
@@ -167,9 +167,9 @@ public class ResourcesService extends AbstractResourceService {
                 filters.put(PermissionTicket.FilterOption.GRANTED, Boolean.TRUE.toString());
                 filters.put(PermissionTicket.FilterOption.RESOURCE_ID, resource.getId());
 
-                tickets = ticketStore.find(null, filters, -1, -1);
+                tickets = ticketStore.find(resource.getResourceServer(), filters, -1, -1);
             } else {
-                tickets = ticketStore.findGranted(null, resource.getName(), user.getId());
+                tickets = ticketStore.findGranted(resource.getResourceServer(), resource.getName(), user.getId());
             }
 
             for (PermissionTicket ticket : tickets) {

--- a/services/src/main/java/org/keycloak/services/resources/account/resources/ResourcesService.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/resources/ResourcesService.java
@@ -123,7 +123,7 @@ public class ResourcesService extends AbstractResourceService {
         filters.put(PermissionTicket.FilterOption.REQUESTER, user.getId());
         filters.put(PermissionTicket.FilterOption.GRANTED, Boolean.FALSE.toString());
 
-        final List<PermissionTicket> permissionTickets = ticketStore.find(null, filters, -1, -1);
+        final List<PermissionTicket> permissionTickets = ticketStore.find(null, filters, null, null);
 
         final List<ResourcePermission> resourceList = new ArrayList<>(permissionTickets.size());
         for (PermissionTicket ticket : permissionTickets) {
@@ -167,7 +167,7 @@ public class ResourcesService extends AbstractResourceService {
                 filters.put(PermissionTicket.FilterOption.GRANTED, Boolean.TRUE.toString());
                 filters.put(PermissionTicket.FilterOption.RESOURCE_ID, resource.getId());
 
-                tickets = ticketStore.find(resource.getResourceServer(), filters, -1, -1);
+                tickets = ticketStore.find(resource.getResourceServer(), filters, null, null);
             } else {
                 tickets = ticketStore.findGranted(resource.getResourceServer(), resource.getName(), user.getId());
             }

--- a/services/src/main/java/org/keycloak/services/resources/admin/permissions/ClientPermissions.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/permissions/ClientPermissions.java
@@ -204,22 +204,22 @@ class ClientPermissions implements ClientPermissionEvaluator,  ClientPermissionM
 
 
     private Scope manageScope(ResourceServer server) {
-        return authz.getStoreFactory().getScopeStore().findByName(server.getId(), AdminPermissionManagement.MANAGE_SCOPE);
+        return authz.getStoreFactory().getScopeStore().findByName(server, AdminPermissionManagement.MANAGE_SCOPE);
     }
 
     private Scope exchangeToScope(ResourceServer server) {
-        return authz.getStoreFactory().getScopeStore().findByName(server.getId(), TOKEN_EXCHANGE);
+        return authz.getStoreFactory().getScopeStore().findByName(server, TOKEN_EXCHANGE);
     }
 
     private Scope configureScope(ResourceServer server) {
-        return authz.getStoreFactory().getScopeStore().findByName(server.getId(), CONFIGURE_SCOPE);
+        return authz.getStoreFactory().getScopeStore().findByName(server, CONFIGURE_SCOPE);
     }
 
     private Scope viewScope(ResourceServer server) {
-        return authz.getStoreFactory().getScopeStore().findByName(server.getId(), AdminPermissionManagement.VIEW_SCOPE);
+        return authz.getStoreFactory().getScopeStore().findByName(server, AdminPermissionManagement.VIEW_SCOPE);
     }
     private Scope mapRolesScope(ResourceServer server) {
-        return authz.getStoreFactory().getScopeStore().findByName(server.getId(), MAP_ROLES_SCOPE);
+        return authz.getStoreFactory().getScopeStore().findByName(server, MAP_ROLES_SCOPE);
     }
 
     @Override
@@ -610,7 +610,7 @@ class ClientPermissions implements ClientPermissionEvaluator,  ClientPermissionM
             return false;
         }
 
-        Scope scope = authz.getStoreFactory().getScopeStore().findByName(server.getId(), MAP_ROLES_COMPOSITE_SCOPE);
+        Scope scope = authz.getStoreFactory().getScopeStore().findByName(server, MAP_ROLES_COMPOSITE_SCOPE);
         return root.evaluatePermission(resource, server, scope);
     }
     @Override
@@ -632,7 +632,7 @@ class ClientPermissions implements ClientPermissionEvaluator,  ClientPermissionM
             return false;
         }
 
-        Scope scope = authz.getStoreFactory().getScopeStore().findByName(server.getId(), MAP_ROLES_CLIENT_SCOPE);
+        Scope scope = authz.getStoreFactory().getScopeStore().findByName(server, MAP_ROLES_CLIENT_SCOPE);
         return root.evaluatePermission(resource, server, scope);
     }
 

--- a/services/src/main/java/org/keycloak/services/resources/admin/permissions/ClientPermissions.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/permissions/ClientPermissions.java
@@ -126,44 +126,44 @@ class ClientPermissions implements ClientPermissionEvaluator,  ClientPermissionM
             resource.updateScopes(scopeset);
         }
         String managePermissionName = getManagePermissionName(client);
-        Policy managePermission = authz.getStoreFactory().getPolicyStore().findByName(server.getId(), managePermissionName);
+        Policy managePermission = authz.getStoreFactory().getPolicyStore().findByName(server, managePermissionName);
         if (managePermission == null) {
             Helper.addEmptyScopePermission(authz, server, managePermissionName, resource, manageScope);
         }
         String configurePermissionName = getConfigurePermissionName(client);
-        Policy configurePermission = authz.getStoreFactory().getPolicyStore().findByName(server.getId(), configurePermissionName);
+        Policy configurePermission = authz.getStoreFactory().getPolicyStore().findByName(server, configurePermissionName);
         if (configurePermission == null) {
             Helper.addEmptyScopePermission(authz, server, configurePermissionName, resource, configureScope);
         }
         String viewPermissionName = getViewPermissionName(client);
-        Policy viewPermission = authz.getStoreFactory().getPolicyStore().findByName(server.getId(), viewPermissionName);
+        Policy viewPermission = authz.getStoreFactory().getPolicyStore().findByName(server, viewPermissionName);
         if (viewPermission == null) {
             Helper.addEmptyScopePermission(authz, server, viewPermissionName, resource, viewScope);
         }
         String mapRolePermissionName = getMapRolesPermissionName(client);
-        Policy mapRolePermission = authz.getStoreFactory().getPolicyStore().findByName(server.getId(), mapRolePermissionName);
+        Policy mapRolePermission = authz.getStoreFactory().getPolicyStore().findByName(server, mapRolePermissionName);
         if (mapRolePermission == null) {
             Helper.addEmptyScopePermission(authz, server, mapRolePermissionName, resource, mapRoleScope);
         }
         String mapRoleClientScopePermissionName = getMapRolesClientScopePermissionName(client);
-        Policy mapRoleClientScopePermission = authz.getStoreFactory().getPolicyStore().findByName(server.getId(), mapRoleClientScopePermissionName);
+        Policy mapRoleClientScopePermission = authz.getStoreFactory().getPolicyStore().findByName(server, mapRoleClientScopePermissionName);
         if (mapRoleClientScopePermission == null) {
             Helper.addEmptyScopePermission(authz, server, mapRoleClientScopePermissionName, resource, mapRoleClientScope);
         }
         String mapRoleCompositePermissionName = getMapRolesCompositePermissionName(client);
-        Policy mapRoleCompositePermission = authz.getStoreFactory().getPolicyStore().findByName(server.getId(), mapRoleCompositePermissionName);
+        Policy mapRoleCompositePermission = authz.getStoreFactory().getPolicyStore().findByName(server, mapRoleCompositePermissionName);
         if (mapRoleCompositePermission == null) {
             Helper.addEmptyScopePermission(authz, server, mapRoleCompositePermissionName, resource, mapRoleCompositeScope);
         }
         String exchangeToPermissionName = getExchangeToPermissionName(client);
-        Policy exchangeToPermission = authz.getStoreFactory().getPolicyStore().findByName(server.getId(), exchangeToPermissionName);
+        Policy exchangeToPermission = authz.getStoreFactory().getPolicyStore().findByName(server, exchangeToPermissionName);
         if (exchangeToPermission == null) {
             Helper.addEmptyScopePermission(authz, server, exchangeToPermissionName, resource, exchangeToScope);
         }
     }
 
     private void deletePolicy(String name, ResourceServer server) {
-        Policy policy = authz.getStoreFactory().getPolicyStore().findByName(server.getId(), name);
+        Policy policy = authz.getStoreFactory().getPolicyStore().findByName(server, name);
         if (policy != null) {
             authz.getStoreFactory().getPolicyStore().delete(policy.getId());
         }
@@ -319,7 +319,7 @@ class ClientPermissions implements ClientPermissionEvaluator,  ClientPermissionM
                 return false;
             }
 
-            Policy policy = authz.getStoreFactory().getPolicyStore().findByName(server.getId(), getExchangeToPermissionName(to));
+            Policy policy = authz.getStoreFactory().getPolicyStore().findByName(server, getExchangeToPermissionName(to));
             if (policy == null) {
                 logger.debug("No permission object set up for target client");
                 return false;
@@ -369,7 +369,7 @@ class ClientPermissions implements ClientPermissionEvaluator,  ClientPermissionM
         Resource resource =  authz.getStoreFactory().getResourceStore().findByName(server.getId(), getResourceName(client));
         if (resource == null) return false;
 
-        Policy policy = authz.getStoreFactory().getPolicyStore().findByName(server.getId(), getManagePermissionName(client));
+        Policy policy = authz.getStoreFactory().getPolicyStore().findByName(server, getManagePermissionName(client));
         if (policy == null) {
             return false;
         }
@@ -397,7 +397,7 @@ class ClientPermissions implements ClientPermissionEvaluator,  ClientPermissionM
         Resource resource =  authz.getStoreFactory().getResourceStore().findByName(server.getId(), getResourceName(client));
         if (resource == null) return false;
 
-        Policy policy = authz.getStoreFactory().getPolicyStore().findByName(server.getId(), getConfigurePermissionName(client));
+        Policy policy = authz.getStoreFactory().getPolicyStore().findByName(server, getConfigurePermissionName(client));
         if (policy == null) {
             return false;
         }
@@ -443,7 +443,7 @@ class ClientPermissions implements ClientPermissionEvaluator,  ClientPermissionM
         Resource resource =  authz.getStoreFactory().getResourceStore().findByName(server.getId(), getResourceName(client));
         if (resource == null) return false;
 
-        Policy policy = authz.getStoreFactory().getPolicyStore().findByName(server.getId(), getViewPermissionName(client));
+        Policy policy = authz.getStoreFactory().getPolicyStore().findByName(server, getViewPermissionName(client));
         if (policy == null) {
             return false;
         }
@@ -522,7 +522,7 @@ class ClientPermissions implements ClientPermissionEvaluator,  ClientPermissionM
         Resource resource =  authz.getStoreFactory().getResourceStore().findByName(server.getId(), getResourceName(client));
         if (resource == null) return false;
 
-        Policy policy = authz.getStoreFactory().getPolicyStore().findByName(server.getId(), getMapRolesPermissionName(client));
+        Policy policy = authz.getStoreFactory().getPolicyStore().findByName(server, getMapRolesPermissionName(client));
         if (policy == null) {
             return false;
         }
@@ -541,49 +541,49 @@ class ClientPermissions implements ClientPermissionEvaluator,  ClientPermissionM
     public Policy exchangeToPermission(ClientModel client) {
         ResourceServer server = resourceServer(client);
         if (server == null) return null;
-        return authz.getStoreFactory().getPolicyStore().findByName(server.getId(), getExchangeToPermissionName(client));
+        return authz.getStoreFactory().getPolicyStore().findByName(server, getExchangeToPermissionName(client));
     }
 
     @Override
     public Policy mapRolesPermission(ClientModel client) {
         ResourceServer server = resourceServer(client);
         if (server == null) return null;
-        return authz.getStoreFactory().getPolicyStore().findByName(server.getId(), getMapRolesPermissionName(client));
+        return authz.getStoreFactory().getPolicyStore().findByName(server, getMapRolesPermissionName(client));
     }
 
     @Override
     public Policy mapRolesClientScopePermission(ClientModel client) {
         ResourceServer server = resourceServer(client);
         if (server == null) return null;
-        return authz.getStoreFactory().getPolicyStore().findByName(server.getId(), getMapRolesClientScopePermissionName(client));
+        return authz.getStoreFactory().getPolicyStore().findByName(server, getMapRolesClientScopePermissionName(client));
     }
 
     @Override
     public Policy mapRolesCompositePermission(ClientModel client) {
         ResourceServer server = resourceServer(client);
         if (server == null) return null;
-        return authz.getStoreFactory().getPolicyStore().findByName(server.getId(), getMapRolesCompositePermissionName(client));
+        return authz.getStoreFactory().getPolicyStore().findByName(server, getMapRolesCompositePermissionName(client));
     }
 
     @Override
     public Policy managePermission(ClientModel client) {
         ResourceServer server = resourceServer(client);
         if (server == null) return null;
-        return authz.getStoreFactory().getPolicyStore().findByName(server.getId(), getManagePermissionName(client));
+        return authz.getStoreFactory().getPolicyStore().findByName(server, getManagePermissionName(client));
     }
 
     @Override
     public Policy configurePermission(ClientModel client) {
         ResourceServer server = resourceServer(client);
         if (server == null) return null;
-        return authz.getStoreFactory().getPolicyStore().findByName(server.getId(), getConfigurePermissionName(client));
+        return authz.getStoreFactory().getPolicyStore().findByName(server, getConfigurePermissionName(client));
     }
 
     @Override
     public Policy viewPermission(ClientModel client) {
         ResourceServer server = resourceServer(client);
         if (server == null) return null;
-        return authz.getStoreFactory().getPolicyStore().findByName(server.getId(), getViewPermissionName(client));
+        return authz.getStoreFactory().getPolicyStore().findByName(server, getViewPermissionName(client));
     }
 
     @Override
@@ -599,7 +599,7 @@ class ClientPermissions implements ClientPermissionEvaluator,  ClientPermissionM
         Resource resource =  authz.getStoreFactory().getResourceStore().findByName(server.getId(), getResourceName(client));
         if (resource == null) return false;
 
-        Policy policy = authz.getStoreFactory().getPolicyStore().findByName(server.getId(), getMapRolesCompositePermissionName(client));
+        Policy policy = authz.getStoreFactory().getPolicyStore().findByName(server, getMapRolesCompositePermissionName(client));
         if (policy == null) {
             return false;
         }
@@ -621,7 +621,7 @@ class ClientPermissions implements ClientPermissionEvaluator,  ClientPermissionM
         Resource resource =  authz.getStoreFactory().getResourceStore().findByName(server.getId(), getResourceName(client));
         if (resource == null) return false;
 
-        Policy policy = authz.getStoreFactory().getPolicyStore().findByName(server.getId(), getMapRolesClientScopePermissionName(client));
+        Policy policy = authz.getStoreFactory().getPolicyStore().findByName(server, getMapRolesClientScopePermissionName(client));
         if (policy == null) {
             return false;
         }

--- a/services/src/main/java/org/keycloak/services/resources/admin/permissions/ClientPermissions.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/permissions/ClientPermissions.java
@@ -111,7 +111,7 @@ class ClientPermissions implements ClientPermissionEvaluator,  ClientPermissionM
         Scope exchangeToScope = root.initializeScope(TOKEN_EXCHANGE, server);
 
         String resourceName = getResourceName(client);
-        Resource resource = authz.getStoreFactory().getResourceStore().findByName(server.getId(), resourceName);
+        Resource resource = authz.getStoreFactory().getResourceStore().findByName(server, resourceName);
         if (resource == null) {
             resource = authz.getStoreFactory().getResourceStore().create(server, resourceName, server.getClientId());
             resource.setType("Client");
@@ -180,7 +180,7 @@ class ClientPermissions implements ClientPermissionEvaluator,  ClientPermissionM
         deletePolicy(getMapRolesCompositePermissionName(client), server);
         deletePolicy(getConfigurePermissionName(client), server);
         deletePolicy(getExchangeToPermissionName(client), server);
-        Resource resource = authz.getStoreFactory().getResourceStore().findByName(server.getId(), getResourceName(client));;
+        Resource resource = authz.getStoreFactory().getResourceStore().findByName(server, getResourceName(client));;
         if (resource != null) authz.getStoreFactory().getResourceStore().delete(resource.getId());
     }
 
@@ -189,7 +189,7 @@ class ClientPermissions implements ClientPermissionEvaluator,  ClientPermissionM
         ResourceServer server = resourceServer(client);
         if (server == null) return false;
 
-        return authz.getStoreFactory().getResourceStore().findByName(getResourceName(server.getId(), client)) != null;
+        return authz.getStoreFactory().getResourceStore().findByName(server, getResourceName(client)) != null;
     }
 
     @Override
@@ -284,7 +284,7 @@ class ClientPermissions implements ClientPermissionEvaluator,  ClientPermissionM
     public Resource resource(ClientModel client) {
         ResourceServer server = resourceServer(client);
         if (server == null) return null;
-        Resource resource =  authz.getStoreFactory().getResourceStore().findByName(getResourceName(server.getId(), client));
+        Resource resource =  authz.getStoreFactory().getResourceStore().findByName(server, getResourceName(client));
         if (resource == null) return null;
         return resource;
     }
@@ -313,7 +313,7 @@ class ClientPermissions implements ClientPermissionEvaluator,  ClientPermissionM
                 return false;
             }
 
-            Resource resource =  authz.getStoreFactory().getResourceStore().findByName(server.getId(), getResourceName(to));
+            Resource resource =  authz.getStoreFactory().getResourceStore().findByName(server, getResourceName(to));
             if (resource == null) {
                 logger.debug("No resource object set up for target client");
                 return false;
@@ -366,7 +366,7 @@ class ClientPermissions implements ClientPermissionEvaluator,  ClientPermissionM
         ResourceServer server = resourceServer(client);
         if (server == null) return false;
 
-        Resource resource =  authz.getStoreFactory().getResourceStore().findByName(server.getId(), getResourceName(client));
+        Resource resource =  authz.getStoreFactory().getResourceStore().findByName(server, getResourceName(client));
         if (resource == null) return false;
 
         Policy policy = authz.getStoreFactory().getPolicyStore().findByName(server, getManagePermissionName(client));
@@ -394,7 +394,7 @@ class ClientPermissions implements ClientPermissionEvaluator,  ClientPermissionM
         ResourceServer server = resourceServer(client);
         if (server == null) return false;
 
-        Resource resource =  authz.getStoreFactory().getResourceStore().findByName(server.getId(), getResourceName(client));
+        Resource resource =  authz.getStoreFactory().getResourceStore().findByName(server, getResourceName(client));
         if (resource == null) return false;
 
         Policy policy = authz.getStoreFactory().getPolicyStore().findByName(server, getConfigurePermissionName(client));
@@ -440,7 +440,7 @@ class ClientPermissions implements ClientPermissionEvaluator,  ClientPermissionM
         ResourceServer server = resourceServer(client);
         if (server == null) return false;
 
-        Resource resource =  authz.getStoreFactory().getResourceStore().findByName(server.getId(), getResourceName(client));
+        Resource resource =  authz.getStoreFactory().getResourceStore().findByName(server, getResourceName(client));
         if (resource == null) return false;
 
         Policy policy = authz.getStoreFactory().getPolicyStore().findByName(server, getViewPermissionName(client));
@@ -519,7 +519,7 @@ class ClientPermissions implements ClientPermissionEvaluator,  ClientPermissionM
         ResourceServer server = resourceServer(client);
         if (server == null) return false;
 
-        Resource resource =  authz.getStoreFactory().getResourceStore().findByName(server.getId(), getResourceName(client));
+        Resource resource =  authz.getStoreFactory().getResourceStore().findByName(server, getResourceName(client));
         if (resource == null) return false;
 
         Policy policy = authz.getStoreFactory().getPolicyStore().findByName(server, getMapRolesPermissionName(client));
@@ -596,7 +596,7 @@ class ClientPermissions implements ClientPermissionEvaluator,  ClientPermissionM
         ResourceServer server = resourceServer(client);
         if (server == null) return false;
 
-        Resource resource =  authz.getStoreFactory().getResourceStore().findByName(server.getId(), getResourceName(client));
+        Resource resource =  authz.getStoreFactory().getResourceStore().findByName(server, getResourceName(client));
         if (resource == null) return false;
 
         Policy policy = authz.getStoreFactory().getPolicyStore().findByName(server, getMapRolesCompositePermissionName(client));
@@ -618,7 +618,7 @@ class ClientPermissions implements ClientPermissionEvaluator,  ClientPermissionM
         ResourceServer server = resourceServer(client);
         if (server == null) return false;
 
-        Resource resource =  authz.getStoreFactory().getResourceStore().findByName(server.getId(), getResourceName(client));
+        Resource resource =  authz.getStoreFactory().getResourceStore().findByName(server, getResourceName(client));
         if (resource == null) return false;
 
         Policy policy = authz.getStoreFactory().getPolicyStore().findByName(server, getMapRolesClientScopePermissionName(client));

--- a/services/src/main/java/org/keycloak/services/resources/admin/permissions/ClientPermissions.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/permissions/ClientPermissions.java
@@ -113,7 +113,7 @@ class ClientPermissions implements ClientPermissionEvaluator,  ClientPermissionM
         String resourceName = getResourceName(client);
         Resource resource = authz.getStoreFactory().getResourceStore().findByName(resourceName, server.getId());
         if (resource == null) {
-            resource = authz.getStoreFactory().getResourceStore().create(resourceName, server, server.getId());
+            resource = authz.getStoreFactory().getResourceStore().create(resourceName, server, server.getClientId());
             resource.setType("Client");
             Set<Scope> scopeset = new HashSet<>();
             scopeset.add(configureScope);

--- a/services/src/main/java/org/keycloak/services/resources/admin/permissions/ClientPermissions.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/permissions/ClientPermissions.java
@@ -95,15 +95,15 @@ class ClientPermissions implements ClientPermissionEvaluator,  ClientPermissionM
         ResourceServer server = root.findOrCreateResourceServer(client);
         Scope manageScope = manageScope(server);
         if (manageScope == null) {
-            manageScope = authz.getStoreFactory().getScopeStore().create(AdminPermissionManagement.MANAGE_SCOPE, server);
+            manageScope = authz.getStoreFactory().getScopeStore().create(server, AdminPermissionManagement.MANAGE_SCOPE);
         }
         Scope viewScope = viewScope(server);
         if (viewScope == null) {
-            viewScope = authz.getStoreFactory().getScopeStore().create(AdminPermissionManagement.VIEW_SCOPE, server);
+            viewScope = authz.getStoreFactory().getScopeStore().create(server, AdminPermissionManagement.VIEW_SCOPE);
         }
         Scope mapRoleScope = mapRolesScope(server);
         if (mapRoleScope == null) {
-            mapRoleScope = authz.getStoreFactory().getScopeStore().create(MAP_ROLES_SCOPE, server);
+            mapRoleScope = authz.getStoreFactory().getScopeStore().create(server, MAP_ROLES_SCOPE);
         }
         Scope mapRoleClientScope = root.initializeScope(MAP_ROLES_CLIENT_SCOPE, server);
         Scope mapRoleCompositeScope = root.initializeScope(MAP_ROLES_COMPOSITE_SCOPE, server);
@@ -111,9 +111,9 @@ class ClientPermissions implements ClientPermissionEvaluator,  ClientPermissionM
         Scope exchangeToScope = root.initializeScope(TOKEN_EXCHANGE, server);
 
         String resourceName = getResourceName(client);
-        Resource resource = authz.getStoreFactory().getResourceStore().findByName(resourceName, server.getId());
+        Resource resource = authz.getStoreFactory().getResourceStore().findByName(server.getId(), resourceName);
         if (resource == null) {
-            resource = authz.getStoreFactory().getResourceStore().create(resourceName, server, server.getClientId());
+            resource = authz.getStoreFactory().getResourceStore().create(server, resourceName, server.getClientId());
             resource.setType("Client");
             Set<Scope> scopeset = new HashSet<>();
             scopeset.add(configureScope);
@@ -126,44 +126,44 @@ class ClientPermissions implements ClientPermissionEvaluator,  ClientPermissionM
             resource.updateScopes(scopeset);
         }
         String managePermissionName = getManagePermissionName(client);
-        Policy managePermission = authz.getStoreFactory().getPolicyStore().findByName(managePermissionName, server.getId());
+        Policy managePermission = authz.getStoreFactory().getPolicyStore().findByName(server.getId(), managePermissionName);
         if (managePermission == null) {
             Helper.addEmptyScopePermission(authz, server, managePermissionName, resource, manageScope);
         }
         String configurePermissionName = getConfigurePermissionName(client);
-        Policy configurePermission = authz.getStoreFactory().getPolicyStore().findByName(configurePermissionName, server.getId());
+        Policy configurePermission = authz.getStoreFactory().getPolicyStore().findByName(server.getId(), configurePermissionName);
         if (configurePermission == null) {
             Helper.addEmptyScopePermission(authz, server, configurePermissionName, resource, configureScope);
         }
         String viewPermissionName = getViewPermissionName(client);
-        Policy viewPermission = authz.getStoreFactory().getPolicyStore().findByName(viewPermissionName, server.getId());
+        Policy viewPermission = authz.getStoreFactory().getPolicyStore().findByName(server.getId(), viewPermissionName);
         if (viewPermission == null) {
             Helper.addEmptyScopePermission(authz, server, viewPermissionName, resource, viewScope);
         }
         String mapRolePermissionName = getMapRolesPermissionName(client);
-        Policy mapRolePermission = authz.getStoreFactory().getPolicyStore().findByName(mapRolePermissionName, server.getId());
+        Policy mapRolePermission = authz.getStoreFactory().getPolicyStore().findByName(server.getId(), mapRolePermissionName);
         if (mapRolePermission == null) {
             Helper.addEmptyScopePermission(authz, server, mapRolePermissionName, resource, mapRoleScope);
         }
         String mapRoleClientScopePermissionName = getMapRolesClientScopePermissionName(client);
-        Policy mapRoleClientScopePermission = authz.getStoreFactory().getPolicyStore().findByName(mapRoleClientScopePermissionName, server.getId());
+        Policy mapRoleClientScopePermission = authz.getStoreFactory().getPolicyStore().findByName(server.getId(), mapRoleClientScopePermissionName);
         if (mapRoleClientScopePermission == null) {
             Helper.addEmptyScopePermission(authz, server, mapRoleClientScopePermissionName, resource, mapRoleClientScope);
         }
         String mapRoleCompositePermissionName = getMapRolesCompositePermissionName(client);
-        Policy mapRoleCompositePermission = authz.getStoreFactory().getPolicyStore().findByName(mapRoleCompositePermissionName, server.getId());
+        Policy mapRoleCompositePermission = authz.getStoreFactory().getPolicyStore().findByName(server.getId(), mapRoleCompositePermissionName);
         if (mapRoleCompositePermission == null) {
             Helper.addEmptyScopePermission(authz, server, mapRoleCompositePermissionName, resource, mapRoleCompositeScope);
         }
         String exchangeToPermissionName = getExchangeToPermissionName(client);
-        Policy exchangeToPermission = authz.getStoreFactory().getPolicyStore().findByName(exchangeToPermissionName, server.getId());
+        Policy exchangeToPermission = authz.getStoreFactory().getPolicyStore().findByName(server.getId(), exchangeToPermissionName);
         if (exchangeToPermission == null) {
             Helper.addEmptyScopePermission(authz, server, exchangeToPermissionName, resource, exchangeToScope);
         }
     }
 
     private void deletePolicy(String name, ResourceServer server) {
-        Policy policy = authz.getStoreFactory().getPolicyStore().findByName(name, server.getId());
+        Policy policy = authz.getStoreFactory().getPolicyStore().findByName(server.getId(), name);
         if (policy != null) {
             authz.getStoreFactory().getPolicyStore().delete(policy.getId());
         }
@@ -180,7 +180,7 @@ class ClientPermissions implements ClientPermissionEvaluator,  ClientPermissionM
         deletePolicy(getMapRolesCompositePermissionName(client), server);
         deletePolicy(getConfigurePermissionName(client), server);
         deletePolicy(getExchangeToPermissionName(client), server);
-        Resource resource = authz.getStoreFactory().getResourceStore().findByName(getResourceName(client), server.getId());;
+        Resource resource = authz.getStoreFactory().getResourceStore().findByName(server.getId(), getResourceName(client));;
         if (resource != null) authz.getStoreFactory().getResourceStore().delete(resource.getId());
     }
 
@@ -189,7 +189,7 @@ class ClientPermissions implements ClientPermissionEvaluator,  ClientPermissionM
         ResourceServer server = resourceServer(client);
         if (server == null) return false;
 
-        return authz.getStoreFactory().getResourceStore().findByName(getResourceName(client), server.getId()) != null;
+        return authz.getStoreFactory().getResourceStore().findByName(getResourceName(server.getId(), client)) != null;
     }
 
     @Override
@@ -204,22 +204,22 @@ class ClientPermissions implements ClientPermissionEvaluator,  ClientPermissionM
 
 
     private Scope manageScope(ResourceServer server) {
-        return authz.getStoreFactory().getScopeStore().findByName(AdminPermissionManagement.MANAGE_SCOPE, server.getId());
+        return authz.getStoreFactory().getScopeStore().findByName(server.getId(), AdminPermissionManagement.MANAGE_SCOPE);
     }
 
     private Scope exchangeToScope(ResourceServer server) {
-        return authz.getStoreFactory().getScopeStore().findByName(TOKEN_EXCHANGE, server.getId());
+        return authz.getStoreFactory().getScopeStore().findByName(server.getId(), TOKEN_EXCHANGE);
     }
 
     private Scope configureScope(ResourceServer server) {
-        return authz.getStoreFactory().getScopeStore().findByName(CONFIGURE_SCOPE, server.getId());
+        return authz.getStoreFactory().getScopeStore().findByName(server.getId(), CONFIGURE_SCOPE);
     }
 
     private Scope viewScope(ResourceServer server) {
-        return authz.getStoreFactory().getScopeStore().findByName(AdminPermissionManagement.VIEW_SCOPE, server.getId());
+        return authz.getStoreFactory().getScopeStore().findByName(server.getId(), AdminPermissionManagement.VIEW_SCOPE);
     }
     private Scope mapRolesScope(ResourceServer server) {
-        return authz.getStoreFactory().getScopeStore().findByName(MAP_ROLES_SCOPE, server.getId());
+        return authz.getStoreFactory().getScopeStore().findByName(server.getId(), MAP_ROLES_SCOPE);
     }
 
     @Override
@@ -284,7 +284,7 @@ class ClientPermissions implements ClientPermissionEvaluator,  ClientPermissionM
     public Resource resource(ClientModel client) {
         ResourceServer server = resourceServer(client);
         if (server == null) return null;
-        Resource resource =  authz.getStoreFactory().getResourceStore().findByName(getResourceName(client), server.getId());
+        Resource resource =  authz.getStoreFactory().getResourceStore().findByName(getResourceName(server.getId(), client));
         if (resource == null) return null;
         return resource;
     }
@@ -313,13 +313,13 @@ class ClientPermissions implements ClientPermissionEvaluator,  ClientPermissionM
                 return false;
             }
 
-            Resource resource =  authz.getStoreFactory().getResourceStore().findByName(getResourceName(to), server.getId());
+            Resource resource =  authz.getStoreFactory().getResourceStore().findByName(server.getId(), getResourceName(to));
             if (resource == null) {
                 logger.debug("No resource object set up for target client");
                 return false;
             }
 
-            Policy policy = authz.getStoreFactory().getPolicyStore().findByName(getExchangeToPermissionName(to), server.getId());
+            Policy policy = authz.getStoreFactory().getPolicyStore().findByName(server.getId(), getExchangeToPermissionName(to));
             if (policy == null) {
                 logger.debug("No permission object set up for target client");
                 return false;
@@ -366,10 +366,10 @@ class ClientPermissions implements ClientPermissionEvaluator,  ClientPermissionM
         ResourceServer server = resourceServer(client);
         if (server == null) return false;
 
-        Resource resource =  authz.getStoreFactory().getResourceStore().findByName(getResourceName(client), server.getId());
+        Resource resource =  authz.getStoreFactory().getResourceStore().findByName(server.getId(), getResourceName(client));
         if (resource == null) return false;
 
-        Policy policy = authz.getStoreFactory().getPolicyStore().findByName(getManagePermissionName(client), server.getId());
+        Policy policy = authz.getStoreFactory().getPolicyStore().findByName(server.getId(), getManagePermissionName(client));
         if (policy == null) {
             return false;
         }
@@ -394,10 +394,10 @@ class ClientPermissions implements ClientPermissionEvaluator,  ClientPermissionM
         ResourceServer server = resourceServer(client);
         if (server == null) return false;
 
-        Resource resource =  authz.getStoreFactory().getResourceStore().findByName(getResourceName(client), server.getId());
+        Resource resource =  authz.getStoreFactory().getResourceStore().findByName(server.getId(), getResourceName(client));
         if (resource == null) return false;
 
-        Policy policy = authz.getStoreFactory().getPolicyStore().findByName(getConfigurePermissionName(client), server.getId());
+        Policy policy = authz.getStoreFactory().getPolicyStore().findByName(server.getId(), getConfigurePermissionName(client));
         if (policy == null) {
             return false;
         }
@@ -440,10 +440,10 @@ class ClientPermissions implements ClientPermissionEvaluator,  ClientPermissionM
         ResourceServer server = resourceServer(client);
         if (server == null) return false;
 
-        Resource resource =  authz.getStoreFactory().getResourceStore().findByName(getResourceName(client), server.getId());
+        Resource resource =  authz.getStoreFactory().getResourceStore().findByName(server.getId(), getResourceName(client));
         if (resource == null) return false;
 
-        Policy policy = authz.getStoreFactory().getPolicyStore().findByName(getViewPermissionName(client), server.getId());
+        Policy policy = authz.getStoreFactory().getPolicyStore().findByName(server.getId(), getViewPermissionName(client));
         if (policy == null) {
             return false;
         }
@@ -519,10 +519,10 @@ class ClientPermissions implements ClientPermissionEvaluator,  ClientPermissionM
         ResourceServer server = resourceServer(client);
         if (server == null) return false;
 
-        Resource resource =  authz.getStoreFactory().getResourceStore().findByName(getResourceName(client), server.getId());
+        Resource resource =  authz.getStoreFactory().getResourceStore().findByName(server.getId(), getResourceName(client));
         if (resource == null) return false;
 
-        Policy policy = authz.getStoreFactory().getPolicyStore().findByName(getMapRolesPermissionName(client), server.getId());
+        Policy policy = authz.getStoreFactory().getPolicyStore().findByName(server.getId(), getMapRolesPermissionName(client));
         if (policy == null) {
             return false;
         }
@@ -541,49 +541,49 @@ class ClientPermissions implements ClientPermissionEvaluator,  ClientPermissionM
     public Policy exchangeToPermission(ClientModel client) {
         ResourceServer server = resourceServer(client);
         if (server == null) return null;
-        return authz.getStoreFactory().getPolicyStore().findByName(getExchangeToPermissionName(client), server.getId());
+        return authz.getStoreFactory().getPolicyStore().findByName(server.getId(), getExchangeToPermissionName(client));
     }
 
     @Override
     public Policy mapRolesPermission(ClientModel client) {
         ResourceServer server = resourceServer(client);
         if (server == null) return null;
-        return authz.getStoreFactory().getPolicyStore().findByName(getMapRolesPermissionName(client), server.getId());
+        return authz.getStoreFactory().getPolicyStore().findByName(server.getId(), getMapRolesPermissionName(client));
     }
 
     @Override
     public Policy mapRolesClientScopePermission(ClientModel client) {
         ResourceServer server = resourceServer(client);
         if (server == null) return null;
-        return authz.getStoreFactory().getPolicyStore().findByName(getMapRolesClientScopePermissionName(client), server.getId());
+        return authz.getStoreFactory().getPolicyStore().findByName(server.getId(), getMapRolesClientScopePermissionName(client));
     }
 
     @Override
     public Policy mapRolesCompositePermission(ClientModel client) {
         ResourceServer server = resourceServer(client);
         if (server == null) return null;
-        return authz.getStoreFactory().getPolicyStore().findByName(getMapRolesCompositePermissionName(client), server.getId());
+        return authz.getStoreFactory().getPolicyStore().findByName(server.getId(), getMapRolesCompositePermissionName(client));
     }
 
     @Override
     public Policy managePermission(ClientModel client) {
         ResourceServer server = resourceServer(client);
         if (server == null) return null;
-        return authz.getStoreFactory().getPolicyStore().findByName(getManagePermissionName(client), server.getId());
+        return authz.getStoreFactory().getPolicyStore().findByName(server.getId(), getManagePermissionName(client));
     }
 
     @Override
     public Policy configurePermission(ClientModel client) {
         ResourceServer server = resourceServer(client);
         if (server == null) return null;
-        return authz.getStoreFactory().getPolicyStore().findByName(getConfigurePermissionName(client), server.getId());
+        return authz.getStoreFactory().getPolicyStore().findByName(server.getId(), getConfigurePermissionName(client));
     }
 
     @Override
     public Policy viewPermission(ClientModel client) {
         ResourceServer server = resourceServer(client);
         if (server == null) return null;
-        return authz.getStoreFactory().getPolicyStore().findByName(getViewPermissionName(client), server.getId());
+        return authz.getStoreFactory().getPolicyStore().findByName(server.getId(), getViewPermissionName(client));
     }
 
     @Override
@@ -596,10 +596,10 @@ class ClientPermissions implements ClientPermissionEvaluator,  ClientPermissionM
         ResourceServer server = resourceServer(client);
         if (server == null) return false;
 
-        Resource resource =  authz.getStoreFactory().getResourceStore().findByName(getResourceName(client), server.getId());
+        Resource resource =  authz.getStoreFactory().getResourceStore().findByName(server.getId(), getResourceName(client));
         if (resource == null) return false;
 
-        Policy policy = authz.getStoreFactory().getPolicyStore().findByName(getMapRolesCompositePermissionName(client), server.getId());
+        Policy policy = authz.getStoreFactory().getPolicyStore().findByName(server.getId(), getMapRolesCompositePermissionName(client));
         if (policy == null) {
             return false;
         }
@@ -610,7 +610,7 @@ class ClientPermissions implements ClientPermissionEvaluator,  ClientPermissionM
             return false;
         }
 
-        Scope scope = authz.getStoreFactory().getScopeStore().findByName(MAP_ROLES_COMPOSITE_SCOPE, server.getId());
+        Scope scope = authz.getStoreFactory().getScopeStore().findByName(server.getId(), MAP_ROLES_COMPOSITE_SCOPE);
         return root.evaluatePermission(resource, server, scope);
     }
     @Override
@@ -618,10 +618,10 @@ class ClientPermissions implements ClientPermissionEvaluator,  ClientPermissionM
         ResourceServer server = resourceServer(client);
         if (server == null) return false;
 
-        Resource resource =  authz.getStoreFactory().getResourceStore().findByName(getResourceName(client), server.getId());
+        Resource resource =  authz.getStoreFactory().getResourceStore().findByName(server.getId(), getResourceName(client));
         if (resource == null) return false;
 
-        Policy policy = authz.getStoreFactory().getPolicyStore().findByName(getMapRolesClientScopePermissionName(client), server.getId());
+        Policy policy = authz.getStoreFactory().getPolicyStore().findByName(server.getId(), getMapRolesClientScopePermissionName(client));
         if (policy == null) {
             return false;
         }
@@ -632,7 +632,7 @@ class ClientPermissions implements ClientPermissionEvaluator,  ClientPermissionM
             return false;
         }
 
-        Scope scope = authz.getStoreFactory().getScopeStore().findByName(MAP_ROLES_CLIENT_SCOPE, server.getId());
+        Scope scope = authz.getStoreFactory().getScopeStore().findByName(server.getId(), MAP_ROLES_CLIENT_SCOPE);
         return root.evaluatePermission(resource, server, scope);
     }
 

--- a/services/src/main/java/org/keycloak/services/resources/admin/permissions/GroupPermissions.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/permissions/GroupPermissions.java
@@ -118,27 +118,27 @@ class GroupPermissions implements GroupPermissionEvaluator, GroupPermissionManag
             groupResource.setType("Group");
         }
         String managePermissionName = getManagePermissionGroup(group);
-        Policy managePermission = policyStore.findByName(server.getId(), managePermissionName);
+        Policy managePermission = policyStore.findByName(server, managePermissionName);
         if (managePermission == null) {
             Helper.addEmptyScopePermission(authz, server, managePermissionName, groupResource, manageScope);
         }
         String viewPermissionName = getViewPermissionGroup(group);
-        Policy viewPermission = policyStore.findByName(server.getId(), viewPermissionName);
+        Policy viewPermission = policyStore.findByName(server, viewPermissionName);
         if (viewPermission == null) {
             Helper.addEmptyScopePermission(authz, server, viewPermissionName, groupResource, viewScope);
         }
         String manageMembersPermissionName = getManageMembersPermissionGroup(group);
-        Policy manageMembersPermission = policyStore.findByName(server.getId(), manageMembersPermissionName);
+        Policy manageMembersPermission = policyStore.findByName(server, manageMembersPermissionName);
         if (manageMembersPermission == null) {
             Helper.addEmptyScopePermission(authz, server, manageMembersPermissionName, groupResource, manageMembersScope);
         }
         String viewMembersPermissionName = getViewMembersPermissionGroup(group);
-        Policy viewMembersPermission = policyStore.findByName(server.getId(), viewMembersPermissionName);
+        Policy viewMembersPermission = policyStore.findByName(server, viewMembersPermissionName);
         if (viewMembersPermission == null) {
             Helper.addEmptyScopePermission(authz, server, viewMembersPermissionName, groupResource, viewMembersScope);
         }
         String manageMembershipPermissionName = getManageMembershipPermissionGroup(group);
-        Policy manageMembershipPermission = policyStore.findByName(server.getId(), manageMembershipPermissionName);
+        Policy manageMembershipPermission = policyStore.findByName(server, manageMembershipPermissionName);
         if (manageMembershipPermission == null) {
             Helper.addEmptyScopePermission(authz, server, manageMembershipPermissionName, groupResource, manageMembershipScope);
         }
@@ -178,35 +178,35 @@ class GroupPermissions implements GroupPermissionEvaluator, GroupPermissionManag
     public Policy viewMembersPermission(GroupModel group) {
         ResourceServer server = root.realmResourceServer();
         if (server == null) return null;
-        return policyStore.findByName(server.getId(), getViewMembersPermissionGroup(group));
+        return policyStore.findByName(server, getViewMembersPermissionGroup(group));
     }
 
     @Override
     public Policy manageMembersPermission(GroupModel group) {
         ResourceServer server = root.realmResourceServer();
         if (server == null) return null;
-        return policyStore.findByName(server.getId(), getManageMembersPermissionGroup(group));
+        return policyStore.findByName(server, getManageMembersPermissionGroup(group));
     }
 
     @Override
     public Policy manageMembershipPermission(GroupModel group) {
         ResourceServer server = root.realmResourceServer();
         if (server == null) return null;
-        return policyStore.findByName(server.getId(), getManageMembershipPermissionGroup(group));
+        return policyStore.findByName(server, getManageMembershipPermissionGroup(group));
     }
 
     @Override
     public Policy viewPermission(GroupModel group) {
         ResourceServer server = root.realmResourceServer();
         if (server == null) return null;
-        return policyStore.findByName(server.getId(), getViewPermissionGroup(group));
+        return policyStore.findByName(server, getViewPermissionGroup(group));
     }
 
     @Override
     public Policy managePermission(GroupModel group) {
         ResourceServer server = root.realmResourceServer();
         if (server == null) return null;
-        return policyStore.findByName(server.getId(), getManagePermissionGroup(group));
+        return policyStore.findByName(server, getManagePermissionGroup(group));
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/services/resources/admin/permissions/GroupPermissions.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/permissions/GroupPermissions.java
@@ -105,7 +105,7 @@ class GroupPermissions implements GroupPermissionEvaluator, GroupPermissionManag
         Scope manageMembershipScope = root.initializeRealmScope(MANAGE_MEMBERSHIP_SCOPE);
 
         String groupResourceName = getGroupResourceName(group);
-        Resource groupResource = resourceStore.findByName(server.getId(), groupResourceName);
+        Resource groupResource = resourceStore.findByName(server, groupResourceName);
         if (groupResource == null) {
             groupResource = resourceStore.create(server, groupResourceName, server.getClientId());
             Set<Scope> scopeset = new HashSet<>();
@@ -162,7 +162,7 @@ class GroupPermissions implements GroupPermissionEvaluator, GroupPermissionManag
         ResourceServer server = root.realmResourceServer();
         if (server == null) return false;
 
-        return resourceStore.findByName(server.getId(), getGroupResourceName(group)) != null;
+        return resourceStore.findByName(server, getGroupResourceName(group)) != null;
     }
 
     @Override
@@ -213,7 +213,7 @@ class GroupPermissions implements GroupPermissionEvaluator, GroupPermissionManag
     public Resource resource(GroupModel group) {
         ResourceServer server = root.realmResourceServer();
         if (server == null) return null;
-        Resource resource =  resourceStore.findByName(server.getId(), getGroupResourceName(group));
+        Resource resource =  resourceStore.findByName(server, getGroupResourceName(group));
         if (resource == null) return null;
         return resource;
     }
@@ -325,7 +325,7 @@ class GroupPermissions implements GroupPermissionEvaluator, GroupPermissionManag
 
         Set<String> granted = new HashSet<>();
 
-        resourceStore.findByType(server.getId(), "Group", resource -> {
+        resourceStore.findByType(server, "Group", resource -> {
             if (hasPermission(resource, null, VIEW_MEMBERS_SCOPE, MANAGE_MEMBERS_SCOPE)) {
                 granted.add(resource.getName().substring(RESOURCE_NAME_PREFIX.length()));
             }
@@ -400,7 +400,7 @@ class GroupPermissions implements GroupPermissionEvaluator, GroupPermissionManag
             return false;
         }
 
-        Resource resource =  resourceStore.findByName(server.getId(), getGroupResourceName(group));
+        Resource resource =  resourceStore.findByName(server, getGroupResourceName(group));
 
         if (resource == null) {
             return false;
@@ -437,7 +437,7 @@ class GroupPermissions implements GroupPermissionEvaluator, GroupPermissionManag
         ResourceServer server = root.realmResourceServer();
         if (server == null) return null;
         String groupResourceName = getGroupResourceName(group);
-        return resourceStore.findByName(server.getId(), groupResourceName);
+        return resourceStore.findByName(server, groupResourceName);
     }
 
     private void deletePermissions(GroupModel group) {

--- a/services/src/main/java/org/keycloak/services/resources/admin/permissions/GroupPermissions.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/permissions/GroupPermissions.java
@@ -105,9 +105,9 @@ class GroupPermissions implements GroupPermissionEvaluator, GroupPermissionManag
         Scope manageMembershipScope = root.initializeRealmScope(MANAGE_MEMBERSHIP_SCOPE);
 
         String groupResourceName = getGroupResourceName(group);
-        Resource groupResource = resourceStore.findByName(groupResourceName, server.getId());
+        Resource groupResource = resourceStore.findByName(server.getId(), groupResourceName);
         if (groupResource == null) {
-            groupResource = resourceStore.create(groupResourceName, server, server.getClientId());
+            groupResource = resourceStore.create(server, groupResourceName, server.getClientId());
             Set<Scope> scopeset = new HashSet<>();
             scopeset.add(manageScope);
             scopeset.add(viewScope);
@@ -118,27 +118,27 @@ class GroupPermissions implements GroupPermissionEvaluator, GroupPermissionManag
             groupResource.setType("Group");
         }
         String managePermissionName = getManagePermissionGroup(group);
-        Policy managePermission = policyStore.findByName(managePermissionName, server.getId());
+        Policy managePermission = policyStore.findByName(server.getId(), managePermissionName);
         if (managePermission == null) {
             Helper.addEmptyScopePermission(authz, server, managePermissionName, groupResource, manageScope);
         }
         String viewPermissionName = getViewPermissionGroup(group);
-        Policy viewPermission = policyStore.findByName(viewPermissionName, server.getId());
+        Policy viewPermission = policyStore.findByName(server.getId(), viewPermissionName);
         if (viewPermission == null) {
             Helper.addEmptyScopePermission(authz, server, viewPermissionName, groupResource, viewScope);
         }
         String manageMembersPermissionName = getManageMembersPermissionGroup(group);
-        Policy manageMembersPermission = policyStore.findByName(manageMembersPermissionName, server.getId());
+        Policy manageMembersPermission = policyStore.findByName(server.getId(), manageMembersPermissionName);
         if (manageMembersPermission == null) {
             Helper.addEmptyScopePermission(authz, server, manageMembersPermissionName, groupResource, manageMembersScope);
         }
         String viewMembersPermissionName = getViewMembersPermissionGroup(group);
-        Policy viewMembersPermission = policyStore.findByName(viewMembersPermissionName, server.getId());
+        Policy viewMembersPermission = policyStore.findByName(server.getId(), viewMembersPermissionName);
         if (viewMembersPermission == null) {
             Helper.addEmptyScopePermission(authz, server, viewMembersPermissionName, groupResource, viewMembersScope);
         }
         String manageMembershipPermissionName = getManageMembershipPermissionGroup(group);
-        Policy manageMembershipPermission = policyStore.findByName(manageMembershipPermissionName, server.getId());
+        Policy manageMembershipPermission = policyStore.findByName(server.getId(), manageMembershipPermissionName);
         if (manageMembershipPermission == null) {
             Helper.addEmptyScopePermission(authz, server, manageMembershipPermissionName, groupResource, manageMembershipScope);
         }
@@ -162,7 +162,7 @@ class GroupPermissions implements GroupPermissionEvaluator, GroupPermissionManag
         ResourceServer server = root.realmResourceServer();
         if (server == null) return false;
 
-        return resourceStore.findByName(getGroupResourceName(group), server.getId()) != null;
+        return resourceStore.findByName(server.getId(), getGroupResourceName(group)) != null;
     }
 
     @Override
@@ -178,42 +178,42 @@ class GroupPermissions implements GroupPermissionEvaluator, GroupPermissionManag
     public Policy viewMembersPermission(GroupModel group) {
         ResourceServer server = root.realmResourceServer();
         if (server == null) return null;
-        return policyStore.findByName(getViewMembersPermissionGroup(group), server.getId());
+        return policyStore.findByName(server.getId(), getViewMembersPermissionGroup(group));
     }
 
     @Override
     public Policy manageMembersPermission(GroupModel group) {
         ResourceServer server = root.realmResourceServer();
         if (server == null) return null;
-        return policyStore.findByName(getManageMembersPermissionGroup(group), server.getId());
+        return policyStore.findByName(server.getId(), getManageMembersPermissionGroup(group));
     }
 
     @Override
     public Policy manageMembershipPermission(GroupModel group) {
         ResourceServer server = root.realmResourceServer();
         if (server == null) return null;
-        return policyStore.findByName(getManageMembershipPermissionGroup(group), server.getId());
+        return policyStore.findByName(server.getId(), getManageMembershipPermissionGroup(group));
     }
 
     @Override
     public Policy viewPermission(GroupModel group) {
         ResourceServer server = root.realmResourceServer();
         if (server == null) return null;
-        return policyStore.findByName(getViewPermissionGroup(group), server.getId());
+        return policyStore.findByName(server.getId(), getViewPermissionGroup(group));
     }
 
     @Override
     public Policy managePermission(GroupModel group) {
         ResourceServer server = root.realmResourceServer();
         if (server == null) return null;
-        return policyStore.findByName(getManagePermissionGroup(group), server.getId());
+        return policyStore.findByName(server.getId(), getManagePermissionGroup(group));
     }
 
     @Override
     public Resource resource(GroupModel group) {
         ResourceServer server = root.realmResourceServer();
         if (server == null) return null;
-        Resource resource =  resourceStore.findByName(getGroupResourceName(group), server.getId());
+        Resource resource =  resourceStore.findByName(server.getId(), getGroupResourceName(group));
         if (resource == null) return null;
         return resource;
     }
@@ -325,7 +325,7 @@ class GroupPermissions implements GroupPermissionEvaluator, GroupPermissionManag
 
         Set<String> granted = new HashSet<>();
 
-        resourceStore.findByType("Group", server.getId(), resource -> {
+        resourceStore.findByType(server.getId(), "Group", resource -> {
             if (hasPermission(resource, null, VIEW_MEMBERS_SCOPE, MANAGE_MEMBERS_SCOPE)) {
                 granted.add(resource.getName().substring(RESOURCE_NAME_PREFIX.length()));
             }
@@ -400,7 +400,7 @@ class GroupPermissions implements GroupPermissionEvaluator, GroupPermissionManag
             return false;
         }
 
-        Resource resource =  resourceStore.findByName(getGroupResourceName(group), server.getId());
+        Resource resource =  resourceStore.findByName(server.getId(), getGroupResourceName(group));
 
         if (resource == null) {
             return false;
@@ -437,7 +437,7 @@ class GroupPermissions implements GroupPermissionEvaluator, GroupPermissionManag
         ResourceServer server = root.realmResourceServer();
         if (server == null) return null;
         String groupResourceName = getGroupResourceName(group);
-        return resourceStore.findByName(groupResourceName, server.getId());
+        return resourceStore.findByName(server.getId(), groupResourceName);
     }
 
     private void deletePermissions(GroupModel group) {

--- a/services/src/main/java/org/keycloak/services/resources/admin/permissions/GroupPermissions.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/permissions/GroupPermissions.java
@@ -107,7 +107,7 @@ class GroupPermissions implements GroupPermissionEvaluator, GroupPermissionManag
         String groupResourceName = getGroupResourceName(group);
         Resource groupResource = resourceStore.findByName(groupResourceName, server.getId());
         if (groupResource == null) {
-            groupResource = resourceStore.create(groupResourceName, server, server.getId());
+            groupResource = resourceStore.create(groupResourceName, server, server.getClientId());
             Set<Scope> scopeset = new HashSet<>();
             scopeset.add(manageScope);
             scopeset.add(viewScope);

--- a/services/src/main/java/org/keycloak/services/resources/admin/permissions/Helper.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/permissions/Helper.java
@@ -46,7 +46,7 @@ class Helper {
         representation.addScope(scope.getName());
         representation.addPolicy(policy.getName());
 
-        return authz.getStoreFactory().getPolicyStore().create(representation, resourceServer);
+        return authz.getStoreFactory().getPolicyStore().create(resourceServer, representation);
     }
 
     public static Policy addEmptyScopePermission(AuthorizationProvider authz, ResourceServer resourceServer, String name, Resource resource, Scope scope) {
@@ -58,7 +58,7 @@ class Helper {
         representation.addResource(resource.getName());
         representation.addScope(scope.getName());
 
-        return authz.getStoreFactory().getPolicyStore().create(representation, resourceServer);
+        return authz.getStoreFactory().getPolicyStore().create(resourceServer, representation);
     }
 
     public static Policy createRolePolicy(AuthorizationProvider authz, ResourceServer resourceServer, RoleModel role) {
@@ -78,7 +78,7 @@ class Helper {
         config.put("roles", roleValues);
         representation.setConfig(config);
 
-        return authz.getStoreFactory().getPolicyStore().create(representation, resourceServer);
+        return authz.getStoreFactory().getPolicyStore().create(resourceServer, representation);
     }
 
     public static String getRolePolicyName(RoleModel role) {

--- a/services/src/main/java/org/keycloak/services/resources/admin/permissions/IdentityProviderPermissions.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/permissions/IdentityProviderPermissions.java
@@ -82,14 +82,14 @@ class IdentityProviderPermissions implements  IdentityProviderPermissionManageme
             resource.updateScopes(scopeset);
         }
         String exchangeToPermissionName = getExchangeToPermissionName(idp);
-        Policy exchangeToPermission = authz.getStoreFactory().getPolicyStore().findByName(server.getId(), exchangeToPermissionName);
+        Policy exchangeToPermission = authz.getStoreFactory().getPolicyStore().findByName(server, exchangeToPermissionName);
         if (exchangeToPermission == null) {
             Helper.addEmptyScopePermission(authz, server, exchangeToPermissionName, resource, exchangeToScope);
         }
     }
 
     private void deletePolicy(String name, ResourceServer server) {
-        Policy policy = authz.getStoreFactory().getPolicyStore().findByName(server.getId(), name);
+        Policy policy = authz.getStoreFactory().getPolicyStore().findByName(server, name);
         if (policy != null) {
             authz.getStoreFactory().getPolicyStore().delete(policy.getId());
         }
@@ -159,7 +159,7 @@ class IdentityProviderPermissions implements  IdentityProviderPermissionManageme
             return false;
         }
 
-        Policy policy = authz.getStoreFactory().getPolicyStore().findByName(server.getId(), getExchangeToPermissionName(to));
+        Policy policy = authz.getStoreFactory().getPolicyStore().findByName(server, getExchangeToPermissionName(to));
         if (policy == null) {
             logger.debug("No permission object set up for target idp");
             return false;
@@ -194,7 +194,7 @@ class IdentityProviderPermissions implements  IdentityProviderPermissionManageme
     public Policy exchangeToPermission(IdentityProviderModel idp) {
         ResourceServer server = root.initializeRealmResourceServer();
         if (server == null) return null;
-        return authz.getStoreFactory().getPolicyStore().findByName(server.getId(), getExchangeToPermissionName(idp));
+        return authz.getStoreFactory().getPolicyStore().findByName(server, getExchangeToPermissionName(idp));
     }
 
 }

--- a/services/src/main/java/org/keycloak/services/resources/admin/permissions/IdentityProviderPermissions.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/permissions/IdentityProviderPermissions.java
@@ -124,7 +124,7 @@ class IdentityProviderPermissions implements  IdentityProviderPermissionManageme
 
 
     private Scope exchangeToScope(ResourceServer server) {
-        return authz.getStoreFactory().getScopeStore().findByName(server.getId(), TOKEN_EXCHANGE);
+        return authz.getStoreFactory().getScopeStore().findByName(server, TOKEN_EXCHANGE);
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/services/resources/admin/permissions/IdentityProviderPermissions.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/permissions/IdentityProviderPermissions.java
@@ -73,23 +73,23 @@ class IdentityProviderPermissions implements  IdentityProviderPermissionManageme
         Scope exchangeToScope = root.initializeScope(TOKEN_EXCHANGE, server);
 
         String resourceName = getResourceName(idp);
-        Resource resource = authz.getStoreFactory().getResourceStore().findByName(resourceName, server.getId());
+        Resource resource = authz.getStoreFactory().getResourceStore().findByName(server.getId(), resourceName);
         if (resource == null) {
-            resource = authz.getStoreFactory().getResourceStore().create(resourceName, server, server.getClientId());
+            resource = authz.getStoreFactory().getResourceStore().create(server, resourceName, server.getClientId());
             resource.setType("IdentityProvider");
             Set<Scope> scopeset = new HashSet<>();
             scopeset.add(exchangeToScope);
             resource.updateScopes(scopeset);
         }
         String exchangeToPermissionName = getExchangeToPermissionName(idp);
-        Policy exchangeToPermission = authz.getStoreFactory().getPolicyStore().findByName(exchangeToPermissionName, server.getId());
+        Policy exchangeToPermission = authz.getStoreFactory().getPolicyStore().findByName(server.getId(), exchangeToPermissionName);
         if (exchangeToPermission == null) {
             Helper.addEmptyScopePermission(authz, server, exchangeToPermissionName, resource, exchangeToScope);
         }
     }
 
     private void deletePolicy(String name, ResourceServer server) {
-        Policy policy = authz.getStoreFactory().getPolicyStore().findByName(name, server.getId());
+        Policy policy = authz.getStoreFactory().getPolicyStore().findByName(server.getId(), name);
         if (policy != null) {
             authz.getStoreFactory().getPolicyStore().delete(policy.getId());
         }
@@ -100,7 +100,7 @@ class IdentityProviderPermissions implements  IdentityProviderPermissionManageme
         ResourceServer server = root.initializeRealmResourceServer();
         if (server == null) return;
         deletePolicy(getExchangeToPermissionName(idp), server);
-        Resource resource = authz.getStoreFactory().getResourceStore().findByName(getResourceName(idp), server.getId());;
+        Resource resource = authz.getStoreFactory().getResourceStore().findByName(server.getId(), getResourceName(idp));;
         if (resource != null) authz.getStoreFactory().getResourceStore().delete(resource.getId());
     }
 
@@ -109,7 +109,7 @@ class IdentityProviderPermissions implements  IdentityProviderPermissionManageme
         ResourceServer server = root.initializeRealmResourceServer();
         if (server == null) return false;
 
-        return authz.getStoreFactory().getResourceStore().findByName(getResourceName(idp), server.getId()) != null;
+        return authz.getStoreFactory().getResourceStore().findByName(server.getId(), getResourceName(idp)) != null;
     }
 
     @Override
@@ -124,14 +124,14 @@ class IdentityProviderPermissions implements  IdentityProviderPermissionManageme
 
 
     private Scope exchangeToScope(ResourceServer server) {
-        return authz.getStoreFactory().getScopeStore().findByName(TOKEN_EXCHANGE, server.getId());
+        return authz.getStoreFactory().getScopeStore().findByName(server.getId(), TOKEN_EXCHANGE);
     }
 
     @Override
     public Resource resource(IdentityProviderModel idp) {
         ResourceServer server = root.initializeRealmResourceServer();
         if (server == null) return null;
-        Resource resource =  authz.getStoreFactory().getResourceStore().findByName(getResourceName(idp), server.getId());
+        Resource resource =  authz.getStoreFactory().getResourceStore().findByName(server.getId(), getResourceName(idp));
         if (resource == null) return null;
         return resource;
     }
@@ -153,13 +153,13 @@ class IdentityProviderPermissions implements  IdentityProviderPermissionManageme
             return false;
         }
 
-        Resource resource =  authz.getStoreFactory().getResourceStore().findByName(getResourceName(to), server.getId());
+        Resource resource =  authz.getStoreFactory().getResourceStore().findByName(server.getId(), getResourceName(to));
         if (resource == null) {
             logger.debug("No resource object set up for target idp");
             return false;
         }
 
-        Policy policy = authz.getStoreFactory().getPolicyStore().findByName(getExchangeToPermissionName(to), server.getId());
+        Policy policy = authz.getStoreFactory().getPolicyStore().findByName(server.getId(), getExchangeToPermissionName(to));
         if (policy == null) {
             logger.debug("No permission object set up for target idp");
             return false;
@@ -194,7 +194,7 @@ class IdentityProviderPermissions implements  IdentityProviderPermissionManageme
     public Policy exchangeToPermission(IdentityProviderModel idp) {
         ResourceServer server = root.initializeRealmResourceServer();
         if (server == null) return null;
-        return authz.getStoreFactory().getPolicyStore().findByName(getExchangeToPermissionName(idp), server.getId());
+        return authz.getStoreFactory().getPolicyStore().findByName(server.getId(), getExchangeToPermissionName(idp));
     }
 
 }

--- a/services/src/main/java/org/keycloak/services/resources/admin/permissions/IdentityProviderPermissions.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/permissions/IdentityProviderPermissions.java
@@ -75,7 +75,7 @@ class IdentityProviderPermissions implements  IdentityProviderPermissionManageme
         String resourceName = getResourceName(idp);
         Resource resource = authz.getStoreFactory().getResourceStore().findByName(resourceName, server.getId());
         if (resource == null) {
-            resource = authz.getStoreFactory().getResourceStore().create(resourceName, server, server.getId());
+            resource = authz.getStoreFactory().getResourceStore().create(resourceName, server, server.getClientId());
             resource.setType("IdentityProvider");
             Set<Scope> scopeset = new HashSet<>();
             scopeset.add(exchangeToScope);

--- a/services/src/main/java/org/keycloak/services/resources/admin/permissions/IdentityProviderPermissions.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/permissions/IdentityProviderPermissions.java
@@ -73,7 +73,7 @@ class IdentityProviderPermissions implements  IdentityProviderPermissionManageme
         Scope exchangeToScope = root.initializeScope(TOKEN_EXCHANGE, server);
 
         String resourceName = getResourceName(idp);
-        Resource resource = authz.getStoreFactory().getResourceStore().findByName(server.getId(), resourceName);
+        Resource resource = authz.getStoreFactory().getResourceStore().findByName(server, resourceName);
         if (resource == null) {
             resource = authz.getStoreFactory().getResourceStore().create(server, resourceName, server.getClientId());
             resource.setType("IdentityProvider");
@@ -100,7 +100,7 @@ class IdentityProviderPermissions implements  IdentityProviderPermissionManageme
         ResourceServer server = root.initializeRealmResourceServer();
         if (server == null) return;
         deletePolicy(getExchangeToPermissionName(idp), server);
-        Resource resource = authz.getStoreFactory().getResourceStore().findByName(server.getId(), getResourceName(idp));;
+        Resource resource = authz.getStoreFactory().getResourceStore().findByName(server, getResourceName(idp));;
         if (resource != null) authz.getStoreFactory().getResourceStore().delete(resource.getId());
     }
 
@@ -109,7 +109,7 @@ class IdentityProviderPermissions implements  IdentityProviderPermissionManageme
         ResourceServer server = root.initializeRealmResourceServer();
         if (server == null) return false;
 
-        return authz.getStoreFactory().getResourceStore().findByName(server.getId(), getResourceName(idp)) != null;
+        return authz.getStoreFactory().getResourceStore().findByName(server, getResourceName(idp)) != null;
     }
 
     @Override
@@ -131,7 +131,7 @@ class IdentityProviderPermissions implements  IdentityProviderPermissionManageme
     public Resource resource(IdentityProviderModel idp) {
         ResourceServer server = root.initializeRealmResourceServer();
         if (server == null) return null;
-        Resource resource =  authz.getStoreFactory().getResourceStore().findByName(server.getId(), getResourceName(idp));
+        Resource resource =  authz.getStoreFactory().getResourceStore().findByName(server, getResourceName(idp));
         if (resource == null) return null;
         return resource;
     }
@@ -153,7 +153,7 @@ class IdentityProviderPermissions implements  IdentityProviderPermissionManageme
             return false;
         }
 
-        Resource resource =  authz.getStoreFactory().getResourceStore().findByName(server.getId(), getResourceName(to));
+        Resource resource =  authz.getStoreFactory().getResourceStore().findByName(server, getResourceName(to));
         if (resource == null) {
             logger.debug("No resource object set up for target idp");
             return false;

--- a/services/src/main/java/org/keycloak/services/resources/admin/permissions/MgmtPermissions.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/permissions/MgmtPermissions.java
@@ -283,17 +283,17 @@ class MgmtPermissions implements AdminPermissionEvaluator, AdminPermissionManage
 
     public Scope initializeRealmScope(String name) {
         ResourceServer server = initializeRealmResourceServer();
-        Scope scope  = authz.getStoreFactory().getScopeStore().findByName(name, server.getId());
+        Scope scope  = authz.getStoreFactory().getScopeStore().findByName(server.getId(), name);
         if (scope == null) {
-            scope = authz.getStoreFactory().getScopeStore().create(name, server);
+            scope = authz.getStoreFactory().getScopeStore().create(server, name);
         }
         return scope;
     }
 
     public Scope initializeScope(String name, ResourceServer server) {
-        Scope scope  = authz.getStoreFactory().getScopeStore().findByName(name, server.getId());
+        Scope scope  = authz.getStoreFactory().getScopeStore().findByName(server.getId(), name);
         if (scope == null) {
-            scope = authz.getStoreFactory().getScopeStore().create(name, server);
+            scope = authz.getStoreFactory().getScopeStore().create(server, name);
         }
         return scope;
     }
@@ -316,7 +316,7 @@ class MgmtPermissions implements AdminPermissionEvaluator, AdminPermissionManage
     public Scope realmScope(String scope) {
         ResourceServer server = realmResourceServer();
         if (server == null) return null;
-        return authz.getStoreFactory().getScopeStore().findByName(scope, server.getId());
+        return authz.getStoreFactory().getScopeStore().findByName(server.getId(), scope);
     }
 
     public boolean evaluatePermission(Resource resource, ResourceServer resourceServer, Scope... scope) {

--- a/services/src/main/java/org/keycloak/services/resources/admin/permissions/MgmtPermissions.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/permissions/MgmtPermissions.java
@@ -283,7 +283,7 @@ class MgmtPermissions implements AdminPermissionEvaluator, AdminPermissionManage
 
     public Scope initializeRealmScope(String name) {
         ResourceServer server = initializeRealmResourceServer();
-        Scope scope  = authz.getStoreFactory().getScopeStore().findByName(server.getId(), name);
+        Scope scope  = authz.getStoreFactory().getScopeStore().findByName(server, name);
         if (scope == null) {
             scope = authz.getStoreFactory().getScopeStore().create(server, name);
         }
@@ -291,7 +291,7 @@ class MgmtPermissions implements AdminPermissionEvaluator, AdminPermissionManage
     }
 
     public Scope initializeScope(String name, ResourceServer server) {
-        Scope scope  = authz.getStoreFactory().getScopeStore().findByName(server.getId(), name);
+        Scope scope  = authz.getStoreFactory().getScopeStore().findByName(server, name);
         if (scope == null) {
             scope = authz.getStoreFactory().getScopeStore().create(server, name);
         }
@@ -316,7 +316,7 @@ class MgmtPermissions implements AdminPermissionEvaluator, AdminPermissionManage
     public Scope realmScope(String scope) {
         ResourceServer server = realmResourceServer();
         if (server == null) return null;
-        return authz.getStoreFactory().getScopeStore().findByName(server.getId(), scope);
+        return authz.getStoreFactory().getScopeStore().findByName(server, scope);
     }
 
     public boolean evaluatePermission(Resource resource, ResourceServer resourceServer, Scope... scope) {

--- a/services/src/main/java/org/keycloak/services/resources/admin/permissions/RolePermissions.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/permissions/RolePermissions.java
@@ -526,15 +526,15 @@ class RolePermissions implements RolePermissionEvaluator, RolePermissionManageme
     }
 
     private Scope mapRoleScope(ResourceServer server) {
-        return authz.getStoreFactory().getScopeStore().findByName(server.getId(), MAP_ROLE_SCOPE);
+        return authz.getStoreFactory().getScopeStore().findByName(server, MAP_ROLE_SCOPE);
     }
 
     private Scope mapClientScope(ResourceServer server) {
-        return authz.getStoreFactory().getScopeStore().findByName(server.getId(), MAP_ROLE_CLIENT_SCOPE_SCOPE);
+        return authz.getStoreFactory().getScopeStore().findByName(server, MAP_ROLE_CLIENT_SCOPE_SCOPE);
     }
 
     private Scope mapCompositeScope(ResourceServer server) {
-        return authz.getStoreFactory().getScopeStore().findByName(server.getId(), MAP_ROLE_COMPOSITE_SCOPE);
+        return authz.getStoreFactory().getScopeStore().findByName(server, MAP_ROLE_COMPOSITE_SCOPE);
     }
 
 

--- a/services/src/main/java/org/keycloak/services/resources/admin/permissions/RolePermissions.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/permissions/RolePermissions.java
@@ -99,7 +99,7 @@ class RolePermissions implements RolePermissionEvaluator, RolePermissionManageme
     public Policy mapRolePermission(RoleModel role) {
         ResourceServer server = resourceServer(role);
         if (server == null) return null;
-        return  authz.getStoreFactory().getPolicyStore().findByName(server.getId(), getMapRolePermissionName(role));
+        return  authz.getStoreFactory().getPolicyStore().findByName(server, getMapRolePermissionName(role));
     }
 
     @Override
@@ -107,7 +107,7 @@ class RolePermissions implements RolePermissionEvaluator, RolePermissionManageme
         ResourceServer server = resourceServer(role);
         if (server == null) return null;
 
-        return  authz.getStoreFactory().getPolicyStore().findByName(server.getId(), getMapCompositePermissionName(role));
+        return  authz.getStoreFactory().getPolicyStore().findByName(server, getMapCompositePermissionName(role));
     }
 
     @Override
@@ -115,7 +115,7 @@ class RolePermissions implements RolePermissionEvaluator, RolePermissionManageme
         ResourceServer server = resourceServer(role);
         if (server == null) return null;
 
-        return  authz.getStoreFactory().getPolicyStore().findByName(server.getId(), getMapClientScopePermissionName(role));
+        return  authz.getStoreFactory().getPolicyStore().findByName(server, getMapClientScopePermissionName(role));
     }
 
     @Override
@@ -300,7 +300,7 @@ class RolePermissions implements RolePermissionEvaluator, RolePermissionManageme
         ResourceServer resourceServer = resourceServer(role);
         if (resourceServer == null) return false;
 
-        Policy policy = authz.getStoreFactory().getPolicyStore().findByName(resourceServer.getId(), getMapRolePermissionName(role));
+        Policy policy = authz.getStoreFactory().getPolicyStore().findByName(resourceServer, getMapRolePermissionName(role));
         if (policy == null || policy.getAssociatedPolicies().isEmpty()) {
             return false;
         }
@@ -390,7 +390,7 @@ class RolePermissions implements RolePermissionEvaluator, RolePermissionManageme
         ResourceServer resourceServer = resourceServer(role);
         if (resourceServer == null) return false;
 
-        Policy policy = authz.getStoreFactory().getPolicyStore().findByName(resourceServer.getId(), getMapCompositePermissionName(role));
+        Policy policy = authz.getStoreFactory().getPolicyStore().findByName(resourceServer, getMapCompositePermissionName(role));
         if (policy == null || policy.getAssociatedPolicies().isEmpty()) {
             return false;
         }
@@ -429,7 +429,7 @@ class RolePermissions implements RolePermissionEvaluator, RolePermissionManageme
         ResourceServer resourceServer = resourceServer(role);
         if (resourceServer == null) return false;
 
-        Policy policy = authz.getStoreFactory().getPolicyStore().findByName(resourceServer.getId(), getMapClientScopePermissionName(role));
+        Policy policy = authz.getStoreFactory().getPolicyStore().findByName(resourceServer, getMapClientScopePermissionName(role));
         if (policy == null || policy.getAssociatedPolicies().isEmpty()) {
             return false;
         }
@@ -520,7 +520,7 @@ class RolePermissions implements RolePermissionEvaluator, RolePermissionManageme
     @Override
     public Policy rolePolicy(ResourceServer server, RoleModel role) {
         String policyName = Helper.getRolePolicyName(role);
-        Policy policy = authz.getStoreFactory().getPolicyStore().findByName(server.getId(), policyName);
+        Policy policy = authz.getStoreFactory().getPolicyStore().findByName(server, policyName);
         if (policy != null) return policy;
         return Helper.createRolePolicy(authz, server, role, policyName);
     }

--- a/services/src/main/java/org/keycloak/services/resources/admin/permissions/RolePermissions.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/permissions/RolePermissions.java
@@ -81,7 +81,7 @@ class RolePermissions implements RolePermissionEvaluator, RolePermissionManageme
         policy = mapCompositePermission(role);
         if (policy != null) authz.getStoreFactory().getPolicyStore().delete(policy.getId());
 
-        Resource resource = authz.getStoreFactory().getResourceStore().findByName(server.getId(), getRoleResourceName(role));
+        Resource resource = authz.getStoreFactory().getResourceStore().findByName(server, getRoleResourceName(role));
         if (resource != null) authz.getStoreFactory().getResourceStore().delete(resource.getId());
     }
 
@@ -123,7 +123,7 @@ class RolePermissions implements RolePermissionEvaluator, RolePermissionManageme
         ResourceStore resourceStore = authz.getStoreFactory().getResourceStore();
         ResourceServer server = resourceServer(role);
         if (server == null) return null;
-        return  resourceStore.findByName(server.getId(), getRoleResourceName(role));
+        return  resourceStore.findByName(server, getRoleResourceName(role));
     }
 
     @Override
@@ -558,7 +558,7 @@ class RolePermissions implements RolePermissionEvaluator, RolePermissionManageme
         }
 
         String roleResourceName = getRoleResourceName(role);
-        Resource resource = authz.getStoreFactory().getResourceStore().findByName(server.getId(), roleResourceName);
+        Resource resource = authz.getStoreFactory().getResourceStore().findByName(server, roleResourceName);
         if (resource == null) {
             resource = authz.getStoreFactory().getResourceStore().create(server, roleResourceName, server.getClientId());
             Set<Scope> scopeset = new HashSet<>();

--- a/services/src/main/java/org/keycloak/services/resources/admin/permissions/RolePermissions.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/permissions/RolePermissions.java
@@ -81,7 +81,7 @@ class RolePermissions implements RolePermissionEvaluator, RolePermissionManageme
         policy = mapCompositePermission(role);
         if (policy != null) authz.getStoreFactory().getPolicyStore().delete(policy.getId());
 
-        Resource resource = authz.getStoreFactory().getResourceStore().findByName(getRoleResourceName(role), server.getId());
+        Resource resource = authz.getStoreFactory().getResourceStore().findByName(server.getId(), getRoleResourceName(role));
         if (resource != null) authz.getStoreFactory().getResourceStore().delete(resource.getId());
     }
 
@@ -99,7 +99,7 @@ class RolePermissions implements RolePermissionEvaluator, RolePermissionManageme
     public Policy mapRolePermission(RoleModel role) {
         ResourceServer server = resourceServer(role);
         if (server == null) return null;
-        return  authz.getStoreFactory().getPolicyStore().findByName(getMapRolePermissionName(role), server.getId());
+        return  authz.getStoreFactory().getPolicyStore().findByName(server.getId(), getMapRolePermissionName(role));
     }
 
     @Override
@@ -107,7 +107,7 @@ class RolePermissions implements RolePermissionEvaluator, RolePermissionManageme
         ResourceServer server = resourceServer(role);
         if (server == null) return null;
 
-        return  authz.getStoreFactory().getPolicyStore().findByName(getMapCompositePermissionName(role), server.getId());
+        return  authz.getStoreFactory().getPolicyStore().findByName(server.getId(), getMapCompositePermissionName(role));
     }
 
     @Override
@@ -115,7 +115,7 @@ class RolePermissions implements RolePermissionEvaluator, RolePermissionManageme
         ResourceServer server = resourceServer(role);
         if (server == null) return null;
 
-        return  authz.getStoreFactory().getPolicyStore().findByName(getMapClientScopePermissionName(role), server.getId());
+        return  authz.getStoreFactory().getPolicyStore().findByName(server.getId(), getMapClientScopePermissionName(role));
     }
 
     @Override
@@ -123,7 +123,7 @@ class RolePermissions implements RolePermissionEvaluator, RolePermissionManageme
         ResourceStore resourceStore = authz.getStoreFactory().getResourceStore();
         ResourceServer server = resourceServer(role);
         if (server == null) return null;
-        return  resourceStore.findByName(getRoleResourceName(role), server.getId());
+        return  resourceStore.findByName(server.getId(), getRoleResourceName(role));
     }
 
     @Override
@@ -300,7 +300,7 @@ class RolePermissions implements RolePermissionEvaluator, RolePermissionManageme
         ResourceServer resourceServer = resourceServer(role);
         if (resourceServer == null) return false;
 
-        Policy policy = authz.getStoreFactory().getPolicyStore().findByName(getMapRolePermissionName(role), resourceServer.getId());
+        Policy policy = authz.getStoreFactory().getPolicyStore().findByName(resourceServer.getId(), getMapRolePermissionName(role));
         if (policy == null || policy.getAssociatedPolicies().isEmpty()) {
             return false;
         }
@@ -390,7 +390,7 @@ class RolePermissions implements RolePermissionEvaluator, RolePermissionManageme
         ResourceServer resourceServer = resourceServer(role);
         if (resourceServer == null) return false;
 
-        Policy policy = authz.getStoreFactory().getPolicyStore().findByName(getMapCompositePermissionName(role), resourceServer.getId());
+        Policy policy = authz.getStoreFactory().getPolicyStore().findByName(resourceServer.getId(), getMapCompositePermissionName(role));
         if (policy == null || policy.getAssociatedPolicies().isEmpty()) {
             return false;
         }
@@ -429,7 +429,7 @@ class RolePermissions implements RolePermissionEvaluator, RolePermissionManageme
         ResourceServer resourceServer = resourceServer(role);
         if (resourceServer == null) return false;
 
-        Policy policy = authz.getStoreFactory().getPolicyStore().findByName(getMapClientScopePermissionName(role), resourceServer.getId());
+        Policy policy = authz.getStoreFactory().getPolicyStore().findByName(resourceServer.getId(), getMapClientScopePermissionName(role));
         if (policy == null || policy.getAssociatedPolicies().isEmpty()) {
             return false;
         }
@@ -520,21 +520,21 @@ class RolePermissions implements RolePermissionEvaluator, RolePermissionManageme
     @Override
     public Policy rolePolicy(ResourceServer server, RoleModel role) {
         String policyName = Helper.getRolePolicyName(role);
-        Policy policy = authz.getStoreFactory().getPolicyStore().findByName(policyName, server.getId());
+        Policy policy = authz.getStoreFactory().getPolicyStore().findByName(server.getId(), policyName);
         if (policy != null) return policy;
         return Helper.createRolePolicy(authz, server, role, policyName);
     }
 
     private Scope mapRoleScope(ResourceServer server) {
-        return authz.getStoreFactory().getScopeStore().findByName(MAP_ROLE_SCOPE, server.getId());
+        return authz.getStoreFactory().getScopeStore().findByName(server.getId(), MAP_ROLE_SCOPE);
     }
 
     private Scope mapClientScope(ResourceServer server) {
-        return authz.getStoreFactory().getScopeStore().findByName(MAP_ROLE_CLIENT_SCOPE_SCOPE, server.getId());
+        return authz.getStoreFactory().getScopeStore().findByName(server.getId(), MAP_ROLE_CLIENT_SCOPE_SCOPE);
     }
 
     private Scope mapCompositeScope(ResourceServer server) {
-        return authz.getStoreFactory().getScopeStore().findByName(MAP_ROLE_COMPOSITE_SCOPE, server.getId());
+        return authz.getStoreFactory().getScopeStore().findByName(server.getId(), MAP_ROLE_COMPOSITE_SCOPE);
     }
 
 
@@ -546,21 +546,21 @@ class RolePermissions implements RolePermissionEvaluator, RolePermissionManageme
         }
         Scope mapRoleScope = mapRoleScope(server);
         if (mapRoleScope == null) {
-            mapRoleScope = authz.getStoreFactory().getScopeStore().create(MAP_ROLE_SCOPE, server);
+            mapRoleScope = authz.getStoreFactory().getScopeStore().create(server, MAP_ROLE_SCOPE);
         }
         Scope mapClientScope = mapClientScope(server);
         if (mapClientScope == null) {
-            mapClientScope = authz.getStoreFactory().getScopeStore().create(MAP_ROLE_CLIENT_SCOPE_SCOPE, server);
+            mapClientScope = authz.getStoreFactory().getScopeStore().create(server, MAP_ROLE_CLIENT_SCOPE_SCOPE);
         }
         Scope mapCompositeScope = mapCompositeScope(server);
         if (mapCompositeScope == null) {
-            mapCompositeScope = authz.getStoreFactory().getScopeStore().create(MAP_ROLE_COMPOSITE_SCOPE, server);
+            mapCompositeScope = authz.getStoreFactory().getScopeStore().create(server, MAP_ROLE_COMPOSITE_SCOPE);
         }
 
         String roleResourceName = getRoleResourceName(role);
-        Resource resource = authz.getStoreFactory().getResourceStore().findByName(roleResourceName, server.getId());
+        Resource resource = authz.getStoreFactory().getResourceStore().findByName(server.getId(), roleResourceName);
         if (resource == null) {
-            resource = authz.getStoreFactory().getResourceStore().create(roleResourceName, server, server.getClientId());
+            resource = authz.getStoreFactory().getResourceStore().create(server, roleResourceName, server.getClientId());
             Set<Scope> scopeset = new HashSet<>();
             scopeset.add(mapClientScope);
             scopeset.add(mapCompositeScope);

--- a/services/src/main/java/org/keycloak/services/resources/admin/permissions/RolePermissions.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/permissions/RolePermissions.java
@@ -560,7 +560,7 @@ class RolePermissions implements RolePermissionEvaluator, RolePermissionManageme
         String roleResourceName = getRoleResourceName(role);
         Resource resource = authz.getStoreFactory().getResourceStore().findByName(roleResourceName, server.getId());
         if (resource == null) {
-            resource = authz.getStoreFactory().getResourceStore().create(roleResourceName, server, server.getId());
+            resource = authz.getStoreFactory().getResourceStore().create(roleResourceName, server, server.getClientId());
             Set<Scope> scopeset = new HashSet<>();
             scopeset.add(mapClientScope);
             scopeset.add(mapCompositeScope);

--- a/services/src/main/java/org/keycloak/services/resources/admin/permissions/UserPermissions.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/permissions/UserPermissions.java
@@ -114,27 +114,27 @@ class UserPermissions implements UserPermissionEvaluator, UserPermissionManageme
             scopeset.add(userImpersonatedScope);
             usersResource.updateScopes(scopeset);
         }
-        Policy managePermission = policyStore.findByName(server.getId(), MANAGE_PERMISSION_USERS);
+        Policy managePermission = policyStore.findByName(server, MANAGE_PERMISSION_USERS);
         if (managePermission == null) {
             Helper.addEmptyScopePermission(authz, server, MANAGE_PERMISSION_USERS, usersResource, manageScope);
         }
-        Policy viewPermission = policyStore.findByName(server.getId(), VIEW_PERMISSION_USERS);
+        Policy viewPermission = policyStore.findByName(server, VIEW_PERMISSION_USERS);
         if (viewPermission == null) {
             Helper.addEmptyScopePermission(authz, server, VIEW_PERMISSION_USERS, usersResource, viewScope);
         }
-        Policy mapRolesPermission = policyStore.findByName(server.getId(), MAP_ROLES_PERMISSION_USERS);
+        Policy mapRolesPermission = policyStore.findByName(server, MAP_ROLES_PERMISSION_USERS);
         if (mapRolesPermission == null) {
             Helper.addEmptyScopePermission(authz, server, MAP_ROLES_PERMISSION_USERS, usersResource, mapRolesScope);
         }
-        Policy membershipPermission = policyStore.findByName(server.getId(), MANAGE_GROUP_MEMBERSHIP_PERMISSION_USERS);
+        Policy membershipPermission = policyStore.findByName(server, MANAGE_GROUP_MEMBERSHIP_PERMISSION_USERS);
         if (membershipPermission == null) {
             Helper.addEmptyScopePermission(authz, server, MANAGE_GROUP_MEMBERSHIP_PERMISSION_USERS, usersResource, manageGroupMembershipScope);
         }
-        Policy impersonatePermission = policyStore.findByName(server.getId(), ADMIN_IMPERSONATING_PERMISSION);
+        Policy impersonatePermission = policyStore.findByName(server, ADMIN_IMPERSONATING_PERMISSION);
         if (impersonatePermission == null) {
             Helper.addEmptyScopePermission(authz, server, ADMIN_IMPERSONATING_PERMISSION, usersResource, impersonateScope);
         }
-        impersonatePermission = policyStore.findByName(server.getId(), USER_IMPERSONATED_PERMISSION);
+        impersonatePermission = policyStore.findByName(server, USER_IMPERSONATED_PERMISSION);
         if (impersonatePermission == null) {
             Helper.addEmptyScopePermission(authz, server, USER_IMPERSONATED_PERMISSION, usersResource, userImpersonatedScope);
         }
@@ -189,33 +189,33 @@ class UserPermissions implements UserPermissionEvaluator, UserPermissionManageme
 
     @Override
     public Policy managePermission() {
-        return policyStore.findByName(root.realmResourceServer().getId(), MANAGE_PERMISSION_USERS);
+        return policyStore.findByName(root.realmResourceServer(), MANAGE_PERMISSION_USERS);
     }
 
     @Override
     public Policy viewPermission() {
-        return policyStore.findByName(root.realmResourceServer().getId(), VIEW_PERMISSION_USERS);
+        return policyStore.findByName(root.realmResourceServer(), VIEW_PERMISSION_USERS);
     }
 
     @Override
     public Policy manageGroupMembershipPermission() {
-        return policyStore.findByName(root.realmResourceServer().getId(), MANAGE_GROUP_MEMBERSHIP_PERMISSION_USERS);
+        return policyStore.findByName(root.realmResourceServer(), MANAGE_GROUP_MEMBERSHIP_PERMISSION_USERS);
     }
 
     @Override
     public Policy mapRolesPermission() {
-        return policyStore.findByName(root.realmResourceServer().getId(), MAP_ROLES_PERMISSION_USERS);
+        return policyStore.findByName(root.realmResourceServer(), MAP_ROLES_PERMISSION_USERS);
     }
 
 
     @Override
     public Policy adminImpersonatingPermission() {
-        return policyStore.findByName(root.realmResourceServer().getId(), ADMIN_IMPERSONATING_PERMISSION);
+        return policyStore.findByName(root.realmResourceServer(), ADMIN_IMPERSONATING_PERMISSION);
     }
 
     @Override
     public Policy userImpersonatedPermission() {
-        return policyStore.findByName(root.realmResourceServer().getId(), USER_IMPERSONATED_PERMISSION);
+        return policyStore.findByName(root.realmResourceServer(), USER_IMPERSONATED_PERMISSION);
     }
 
     /**
@@ -377,7 +377,7 @@ class UserPermissions implements UserPermissionEvaluator, UserPermissionManageme
             return true;
         }
 
-        Policy policy = authz.getStoreFactory().getPolicyStore().findByName(server.getId(), USER_IMPERSONATED_PERMISSION);
+        Policy policy = authz.getStoreFactory().getPolicyStore().findByName(server, USER_IMPERSONATED_PERMISSION);
 
         if (policy == null) {
             return true;

--- a/services/src/main/java/org/keycloak/services/resources/admin/permissions/UserPermissions.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/permissions/UserPermissions.java
@@ -39,10 +39,8 @@ import org.keycloak.models.UserModel;
 import org.keycloak.representations.idm.authorization.Permission;
 import org.keycloak.services.ForbiddenException;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -104,9 +102,9 @@ class UserPermissions implements UserPermissionEvaluator, UserPermissionManageme
         Scope userImpersonatedScope = root.initializeRealmScope(USER_IMPERSONATED_SCOPE);
         Scope manageGroupMembershipScope = root.initializeRealmScope(MANAGE_GROUP_MEMBERSHIP_SCOPE);
 
-        Resource usersResource = resourceStore.findByName(USERS_RESOURCE, server.getId());
+        Resource usersResource = resourceStore.findByName(server.getId(), USERS_RESOURCE);
         if (usersResource == null) {
-            usersResource = resourceStore.create(USERS_RESOURCE, server, server.getClientId());
+            usersResource = resourceStore.create(server, USERS_RESOURCE, server.getClientId());
             Set<Scope> scopeset = new HashSet<>();
             scopeset.add(manageScope);
             scopeset.add(viewScope);
@@ -116,27 +114,27 @@ class UserPermissions implements UserPermissionEvaluator, UserPermissionManageme
             scopeset.add(userImpersonatedScope);
             usersResource.updateScopes(scopeset);
         }
-        Policy managePermission = policyStore.findByName(MANAGE_PERMISSION_USERS, server.getId());
+        Policy managePermission = policyStore.findByName(server.getId(), MANAGE_PERMISSION_USERS);
         if (managePermission == null) {
             Helper.addEmptyScopePermission(authz, server, MANAGE_PERMISSION_USERS, usersResource, manageScope);
         }
-        Policy viewPermission = policyStore.findByName(VIEW_PERMISSION_USERS, server.getId());
+        Policy viewPermission = policyStore.findByName(server.getId(), VIEW_PERMISSION_USERS);
         if (viewPermission == null) {
             Helper.addEmptyScopePermission(authz, server, VIEW_PERMISSION_USERS, usersResource, viewScope);
         }
-        Policy mapRolesPermission = policyStore.findByName(MAP_ROLES_PERMISSION_USERS, server.getId());
+        Policy mapRolesPermission = policyStore.findByName(server.getId(), MAP_ROLES_PERMISSION_USERS);
         if (mapRolesPermission == null) {
             Helper.addEmptyScopePermission(authz, server, MAP_ROLES_PERMISSION_USERS, usersResource, mapRolesScope);
         }
-        Policy membershipPermission = policyStore.findByName(MANAGE_GROUP_MEMBERSHIP_PERMISSION_USERS, server.getId());
+        Policy membershipPermission = policyStore.findByName(server.getId(), MANAGE_GROUP_MEMBERSHIP_PERMISSION_USERS);
         if (membershipPermission == null) {
             Helper.addEmptyScopePermission(authz, server, MANAGE_GROUP_MEMBERSHIP_PERMISSION_USERS, usersResource, manageGroupMembershipScope);
         }
-        Policy impersonatePermission = policyStore.findByName(ADMIN_IMPERSONATING_PERMISSION, server.getId());
+        Policy impersonatePermission = policyStore.findByName(server.getId(), ADMIN_IMPERSONATING_PERMISSION);
         if (impersonatePermission == null) {
             Helper.addEmptyScopePermission(authz, server, ADMIN_IMPERSONATING_PERMISSION, usersResource, impersonateScope);
         }
-        impersonatePermission = policyStore.findByName(USER_IMPERSONATED_PERMISSION, server.getId());
+        impersonatePermission = policyStore.findByName(server.getId(), USER_IMPERSONATED_PERMISSION);
         if (impersonatePermission == null) {
             Helper.addEmptyScopePermission(authz, server, USER_IMPERSONATED_PERMISSION, usersResource, userImpersonatedScope);
         }
@@ -160,7 +158,7 @@ class UserPermissions implements UserPermissionEvaluator, UserPermissionManageme
         ResourceServer server = root.realmResourceServer();
         if (server == null) return false;
 
-        Resource resource =  resourceStore.findByName(USERS_RESOURCE, server.getId());
+        Resource resource =  resourceStore.findByName(server.getId(), USERS_RESOURCE);
         if (resource == null) return false;
 
         Policy policy = managePermission();
@@ -186,38 +184,38 @@ class UserPermissions implements UserPermissionEvaluator, UserPermissionManageme
         ResourceServer server = root.realmResourceServer();
         if (server == null) return null;
 
-        return  resourceStore.findByName(USERS_RESOURCE, server.getId());
+        return  resourceStore.findByName(server.getId(), USERS_RESOURCE);
     }
 
     @Override
     public Policy managePermission() {
-        return policyStore.findByName(MANAGE_PERMISSION_USERS, root.realmResourceServer().getId());
+        return policyStore.findByName(root.realmResourceServer().getId(), MANAGE_PERMISSION_USERS);
     }
 
     @Override
     public Policy viewPermission() {
-        return policyStore.findByName(VIEW_PERMISSION_USERS, root.realmResourceServer().getId());
+        return policyStore.findByName(root.realmResourceServer().getId(), VIEW_PERMISSION_USERS);
     }
 
     @Override
     public Policy manageGroupMembershipPermission() {
-        return policyStore.findByName(MANAGE_GROUP_MEMBERSHIP_PERMISSION_USERS, root.realmResourceServer().getId());
+        return policyStore.findByName(root.realmResourceServer().getId(), MANAGE_GROUP_MEMBERSHIP_PERMISSION_USERS);
     }
 
     @Override
     public Policy mapRolesPermission() {
-        return policyStore.findByName(MAP_ROLES_PERMISSION_USERS, root.realmResourceServer().getId());
+        return policyStore.findByName(root.realmResourceServer().getId(), MAP_ROLES_PERMISSION_USERS);
     }
 
 
     @Override
     public Policy adminImpersonatingPermission() {
-        return policyStore.findByName(ADMIN_IMPERSONATING_PERMISSION, root.realmResourceServer().getId());
+        return policyStore.findByName(root.realmResourceServer().getId(), ADMIN_IMPERSONATING_PERMISSION);
     }
 
     @Override
     public Policy userImpersonatedPermission() {
-        return policyStore.findByName(USER_IMPERSONATED_PERMISSION, root.realmResourceServer().getId());
+        return policyStore.findByName(root.realmResourceServer().getId(), USER_IMPERSONATED_PERMISSION);
     }
 
     /**
@@ -373,13 +371,13 @@ class UserPermissions implements UserPermissionEvaluator, UserPermissionManageme
             return true;
         }
 
-        Resource resource =  resourceStore.findByName(USERS_RESOURCE, server.getId());
+        Resource resource =  resourceStore.findByName(server.getId(), USERS_RESOURCE);
 
         if (resource == null) {
             return true;
         }
 
-        Policy policy = authz.getStoreFactory().getPolicyStore().findByName(USER_IMPERSONATED_PERMISSION, server.getId());
+        Policy policy = authz.getStoreFactory().getPolicyStore().findByName(server.getId(), USER_IMPERSONATED_PERMISSION);
 
         if (policy == null) {
             return true;
@@ -481,7 +479,7 @@ class UserPermissions implements UserPermissionEvaluator, UserPermissionManageme
             return false;
         }
 
-        Resource resource =  resourceStore.findByName(USERS_RESOURCE, server.getId());
+        Resource resource =  resourceStore.findByName(server.getId(), USERS_RESOURCE);
         List<String> expectedScopes = Arrays.asList(scopes);
 
         if (resource == null) {
@@ -540,7 +538,7 @@ class UserPermissions implements UserPermissionEvaluator, UserPermissionManageme
             policyStore.delete(policy.getId());
 
         }
-        Resource usersResource = resourceStore.findByName(USERS_RESOURCE, server.getId());
+        Resource usersResource = resourceStore.findByName(server.getId(), USERS_RESOURCE);
         if (usersResource != null) {
             resourceStore.delete(usersResource.getId());
         }

--- a/services/src/main/java/org/keycloak/services/resources/admin/permissions/UserPermissions.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/permissions/UserPermissions.java
@@ -102,7 +102,7 @@ class UserPermissions implements UserPermissionEvaluator, UserPermissionManageme
         Scope userImpersonatedScope = root.initializeRealmScope(USER_IMPERSONATED_SCOPE);
         Scope manageGroupMembershipScope = root.initializeRealmScope(MANAGE_GROUP_MEMBERSHIP_SCOPE);
 
-        Resource usersResource = resourceStore.findByName(server.getId(), USERS_RESOURCE);
+        Resource usersResource = resourceStore.findByName(server, USERS_RESOURCE);
         if (usersResource == null) {
             usersResource = resourceStore.create(server, USERS_RESOURCE, server.getClientId());
             Set<Scope> scopeset = new HashSet<>();
@@ -158,7 +158,7 @@ class UserPermissions implements UserPermissionEvaluator, UserPermissionManageme
         ResourceServer server = root.realmResourceServer();
         if (server == null) return false;
 
-        Resource resource =  resourceStore.findByName(server.getId(), USERS_RESOURCE);
+        Resource resource =  resourceStore.findByName(server, USERS_RESOURCE);
         if (resource == null) return false;
 
         Policy policy = managePermission();
@@ -184,7 +184,7 @@ class UserPermissions implements UserPermissionEvaluator, UserPermissionManageme
         ResourceServer server = root.realmResourceServer();
         if (server == null) return null;
 
-        return  resourceStore.findByName(server.getId(), USERS_RESOURCE);
+        return  resourceStore.findByName(server, USERS_RESOURCE);
     }
 
     @Override
@@ -371,7 +371,7 @@ class UserPermissions implements UserPermissionEvaluator, UserPermissionManageme
             return true;
         }
 
-        Resource resource =  resourceStore.findByName(server.getId(), USERS_RESOURCE);
+        Resource resource =  resourceStore.findByName(server, USERS_RESOURCE);
 
         if (resource == null) {
             return true;
@@ -479,7 +479,7 @@ class UserPermissions implements UserPermissionEvaluator, UserPermissionManageme
             return false;
         }
 
-        Resource resource =  resourceStore.findByName(server.getId(), USERS_RESOURCE);
+        Resource resource =  resourceStore.findByName(server, USERS_RESOURCE);
         List<String> expectedScopes = Arrays.asList(scopes);
 
         if (resource == null) {
@@ -538,7 +538,7 @@ class UserPermissions implements UserPermissionEvaluator, UserPermissionManageme
             policyStore.delete(policy.getId());
 
         }
-        Resource usersResource = resourceStore.findByName(server.getId(), USERS_RESOURCE);
+        Resource usersResource = resourceStore.findByName(server, USERS_RESOURCE);
         if (usersResource != null) {
             resourceStore.delete(usersResource.getId());
         }

--- a/services/src/main/java/org/keycloak/services/resources/admin/permissions/UserPermissions.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/permissions/UserPermissions.java
@@ -106,7 +106,7 @@ class UserPermissions implements UserPermissionEvaluator, UserPermissionManageme
 
         Resource usersResource = resourceStore.findByName(USERS_RESOURCE, server.getId());
         if (usersResource == null) {
-            usersResource = resourceStore.create(USERS_RESOURCE, server, server.getId());
+            usersResource = resourceStore.create(USERS_RESOURCE, server, server.getClientId());
             Set<Scope> scopeset = new HashSet<>();
             scopeset.add(manageScope);
             scopeset.add(viewScope);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/BrokerLinkAndTokenExchangeTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/BrokerLinkAndTokenExchangeTest.java
@@ -290,7 +290,7 @@ public class BrokerLinkAndTokenExchangeTest extends AbstractServletsAdapterTest 
         clientRep.addClient(client.getId());
         clientRep.addClient(directExchanger.getId());
         ResourceServer server = management.realmResourceServer();
-        Policy clientPolicy = management.authz().getStoreFactory().getPolicyStore().create(clientRep, server);
+        Policy clientPolicy = management.authz().getStoreFactory().getPolicyStore().create(server, clientRep);
         management.idps().exchangeToPermission(idp).addAssociatedPolicy(clientPolicy);
 
 
@@ -300,7 +300,7 @@ public class BrokerLinkAndTokenExchangeTest extends AbstractServletsAdapterTest 
         clientImpersonateRep.setName("clientImpersonators");
         clientImpersonateRep.addClient(directExchanger.getId());
         server = management.realmResourceServer();
-        Policy clientImpersonatePolicy = management.authz().getStoreFactory().getPolicyStore().create(clientImpersonateRep, server);
+        Policy clientImpersonatePolicy = management.authz().getStoreFactory().getPolicyStore().create(server, clientImpersonateRep);
         management.users().setPermissionsEnabled(true);
         management.users().adminImpersonatingPermission().addAssociatedPolicy(clientImpersonatePolicy);
         management.users().adminImpersonatingPermission().setDecisionStrategy(DecisionStrategy.AFFIRMATIVE);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/AuthzCleanupTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/AuthzCleanupTest.java
@@ -95,7 +95,7 @@ public class AuthzCleanupTest extends AbstractKeycloakTest {
         representation.setLogic(Logic.POSITIVE);
         representation.addRole(roleName, true);
 
-        return authz.getStoreFactory().getPolicyStore().create(representation, resourceServer);
+        return authz.getStoreFactory().getPolicyStore().create(resourceServer, representation);
     }
 
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/FineGrainAdminUnitTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/FineGrainAdminUnitTest.java
@@ -1128,7 +1128,7 @@ public class FineGrainAdminUnitTest extends AbstractKeycloakTest {
             ClientModel realmAdminClient = realm.getClientByClientId(Constants.REALM_MANAGEMENT_CLIENT_ID);
             ResourceServer resourceServer = provider.getStoreFactory().getResourceServerStore().findByClient(realmAdminClient);
 
-            policy.addAssociatedPolicy(provider.getStoreFactory().getPolicyStore().findByName(resourceServer.getId(), "Only regular-admin-user"));
+            policy.addAssociatedPolicy(provider.getStoreFactory().getPolicyStore().findByName(resourceServer, "Only regular-admin-user"));
         });
 
         try (Keycloak client = Keycloak.getInstance(getAuthServerContextRoot() + "/auth",
@@ -1197,7 +1197,7 @@ public class FineGrainAdminUnitTest extends AbstractKeycloakTest {
                 ResourceServer resourceServer = provider.getStoreFactory().getResourceServerStore().findByClient(realmAdminClient);
 
                 policy.addAssociatedPolicy(provider.getStoreFactory().getPolicyStore()
-                        .findByName(resourceServer.getId(), "Only regular-admin-user"));
+                        .findByName(resourceServer, "Only regular-admin-user"));
             }
         });
 
@@ -1280,7 +1280,7 @@ public class FineGrainAdminUnitTest extends AbstractKeycloakTest {
                 }
 
                 policy.addAssociatedPolicy(provider.getStoreFactory().getPolicyStore()
-                        .findByName(management.realmResourceServer().getId(), "Only regular-admin-user"));
+                        .findByName(management.realmResourceServer(), "Only regular-admin-user"));
 
             }
         });

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/FineGrainAdminUnitTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/FineGrainAdminUnitTest.java
@@ -824,7 +824,7 @@ public class FineGrainAdminUnitTest extends AbstractKeycloakTest {
     public static void invokeDelete(KeycloakSession session)  {
         RealmModel realm = session.realms().getRealmByName(TEST);
         AdminPermissionManagement management = AdminPermissions.management(session, realm);
-        List<Resource> byResourceServer = management.authz().getStoreFactory().getResourceStore().findByResourceServer(management.realmResourceServer().getId());
+        List<Resource> byResourceServer = management.authz().getStoreFactory().getResourceStore().findByResourceServer(management.realmResourceServer());
         Assert.assertEquals(5, byResourceServer.size());
         RoleModel removedRole = realm.getRole("removedRole");
         realm.removeRole(removedRole);
@@ -833,15 +833,15 @@ public class FineGrainAdminUnitTest extends AbstractKeycloakTest {
         client.removeRole(removedClientRole);
         GroupModel group = KeycloakModelUtils.findGroupByPath(realm, "removedGroup");
         realm.removeGroup(group);
-        byResourceServer = management.authz().getStoreFactory().getResourceStore().findByResourceServer(management.realmResourceServer().getId());
+        byResourceServer = management.authz().getStoreFactory().getResourceStore().findByResourceServer(management.realmResourceServer());
         Assert.assertEquals(2, byResourceServer.size());
         realm.removeClient(client.getId());
-        byResourceServer = management.authz().getStoreFactory().getResourceStore().findByResourceServer(management.realmResourceServer().getId());
+        byResourceServer = management.authz().getStoreFactory().getResourceStore().findByResourceServer(management.realmResourceServer());
         Assert.assertEquals(1, byResourceServer.size());
         management.users().setPermissionsEnabled(false);
-        Resource userResource = management.authz().getStoreFactory().getResourceStore().findByName(management.realmResourceServer().getId(), "Users");
+        Resource userResource = management.authz().getStoreFactory().getResourceStore().findByName(management.realmResourceServer(), "Users");
         Assert.assertNull(userResource);
-        byResourceServer = management.authz().getStoreFactory().getResourceStore().findByResourceServer(management.realmResourceServer().getId());
+        byResourceServer = management.authz().getStoreFactory().getResourceStore().findByResourceServer(management.realmResourceServer());
         Assert.assertEquals(0, byResourceServer.size());
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/FineGrainAdminUnitTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/FineGrainAdminUnitTest.java
@@ -40,7 +40,6 @@ import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.models.utils.RepresentationToModel;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.ClientScopeRepresentation;
-import org.keycloak.representations.idm.GroupRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
@@ -274,7 +273,7 @@ public class FineGrainAdminUnitTest extends AbstractKeycloakTest {
         groupManagerRep.addUser("groupManager");
         groupManagerRep.addUser("noMapperGroupManager");
         ResourceServer server = permissions.realmResourceServer();
-        Policy groupManagerPolicy = permissions.authz().getStoreFactory().getPolicyStore().create(groupManagerRep, server);
+        Policy groupManagerPolicy = permissions.authz().getStoreFactory().getPolicyStore().create(server, groupManagerRep);
         permissions.groups().manageMembersPermission(group).addAssociatedPolicy(groupManagerPolicy);
         permissions.groups().manageMembershipPermission(group).addAssociatedPolicy(groupManagerPolicy);
         permissions.groups().viewPermission(group).addAssociatedPolicy(groupManagerPolicy);
@@ -288,7 +287,7 @@ public class FineGrainAdminUnitTest extends AbstractKeycloakTest {
         UserPolicyRepresentation userRep = new UserPolicyRepresentation();
         userRep.setName("userClientMapper");
         userRep.addUser("clientMapper");
-        Policy userPolicy = permissions.authz().getStoreFactory().getPolicyStore().create(userRep, permissions.clients().resourceServer(client));
+        Policy userPolicy = permissions.authz().getStoreFactory().getPolicyStore().create(permissions.clients().resourceServer(client), userRep);
         clientMapperPolicy.addAssociatedPolicy(userPolicy);
 
         UserModel clientManager = session.users().addUser(realm, "clientManager");
@@ -300,7 +299,7 @@ public class FineGrainAdminUnitTest extends AbstractKeycloakTest {
         userRep = new UserPolicyRepresentation();
         userRep.setName("clientManager");
         userRep.addUser("clientManager");
-        userPolicy = permissions.authz().getStoreFactory().getPolicyStore().create(userRep, permissions.clients().resourceServer(client));
+        userPolicy = permissions.authz().getStoreFactory().getPolicyStore().create(permissions.clients().resourceServer(client), userRep);
         clientManagerPolicy.addAssociatedPolicy(userPolicy);
 
 
@@ -313,7 +312,7 @@ public class FineGrainAdminUnitTest extends AbstractKeycloakTest {
         userRep = new UserPolicyRepresentation();
         userRep.setName("clientConfigure");
         userRep.addUser("clientConfigurer");
-        userPolicy = permissions.authz().getStoreFactory().getPolicyStore().create(userRep, permissions.clients().resourceServer(client));
+        userPolicy = permissions.authz().getStoreFactory().getPolicyStore().create(permissions.clients().resourceServer(client), userRep);
         clientConfigurePolicy.addAssociatedPolicy(userPolicy);
 
 
@@ -326,7 +325,7 @@ public class FineGrainAdminUnitTest extends AbstractKeycloakTest {
         UserPolicyRepresentation groupViewMembersRep = new UserPolicyRepresentation();
         groupViewMembersRep.setName("groupMemberViewers");
         groupViewMembersRep.addUser("groupViewer");
-        Policy groupViewMembersPolicy = permissions.authz().getStoreFactory().getPolicyStore().create(groupViewMembersRep, server);
+        Policy groupViewMembersPolicy = permissions.authz().getStoreFactory().getPolicyStore().create(server, groupViewMembersRep);
         Policy groupViewMembersPermission = permissions.groups().viewMembersPermission(group);
         groupViewMembersPermission.addAssociatedPolicy(groupViewMembersPolicy);
 
@@ -840,7 +839,7 @@ public class FineGrainAdminUnitTest extends AbstractKeycloakTest {
         byResourceServer = management.authz().getStoreFactory().getResourceStore().findByResourceServer(management.realmResourceServer().getId());
         Assert.assertEquals(1, byResourceServer.size());
         management.users().setPermissionsEnabled(false);
-        Resource userResource = management.authz().getStoreFactory().getResourceStore().findByName("Users", management.realmResourceServer().getId());
+        Resource userResource = management.authz().getStoreFactory().getResourceStore().findByName(management.realmResourceServer().getId(), "Users");
         Assert.assertNull(userResource);
         byResourceServer = management.authz().getStoreFactory().getResourceStore().findByResourceServer(management.realmResourceServer().getId());
         Assert.assertEquals(0, byResourceServer.size());
@@ -1002,7 +1001,7 @@ public class FineGrainAdminUnitTest extends AbstractKeycloakTest {
 
             AuthorizationProvider provider = session.getProvider(AuthorizationProvider.class);
 
-            Policy userPolicy = provider.getStoreFactory().getPolicyStore().create(userPolicyRepresentation, management.realmResourceServer());
+            Policy userPolicy = provider.getStoreFactory().getPolicyStore().create(management.realmResourceServer(), userPolicyRepresentation);
 
             policy.addAssociatedPolicy(RepresentationToModel.toModel(userPolicyRepresentation, provider, userPolicy));
 
@@ -1096,7 +1095,7 @@ public class FineGrainAdminUnitTest extends AbstractKeycloakTest {
             Policy policy = clientPermission.viewPermission(clientModel);
             AuthorizationProvider provider = session.getProvider(AuthorizationProvider.class);
             Policy userPolicy = provider.getStoreFactory().getPolicyStore()
-                    .create(userPolicyRepresentation, management.realmResourceServer());
+                    .create(management.realmResourceServer(), userPolicyRepresentation);
 
             policy.addAssociatedPolicy(RepresentationToModel.toModel(userPolicyRepresentation, provider, userPolicy));
         });
@@ -1129,7 +1128,7 @@ public class FineGrainAdminUnitTest extends AbstractKeycloakTest {
             ClientModel realmAdminClient = realm.getClientByClientId(Constants.REALM_MANAGEMENT_CLIENT_ID);
             ResourceServer resourceServer = provider.getStoreFactory().getResourceServerStore().findByClient(realmAdminClient);
 
-            policy.addAssociatedPolicy(provider.getStoreFactory().getPolicyStore().findByName("Only regular-admin-user", resourceServer.getId()));
+            policy.addAssociatedPolicy(provider.getStoreFactory().getPolicyStore().findByName(resourceServer.getId(), "Only regular-admin-user"));
         });
 
         try (Keycloak client = Keycloak.getInstance(getAuthServerContextRoot() + "/auth",
@@ -1198,7 +1197,7 @@ public class FineGrainAdminUnitTest extends AbstractKeycloakTest {
                 ResourceServer resourceServer = provider.getStoreFactory().getResourceServerStore().findByClient(realmAdminClient);
 
                 policy.addAssociatedPolicy(provider.getStoreFactory().getPolicyStore()
-                        .findByName("Only regular-admin-user", resourceServer.getId()));
+                        .findByName(resourceServer.getId(), "Only regular-admin-user"));
             }
         });
 
@@ -1277,11 +1276,11 @@ public class FineGrainAdminUnitTest extends AbstractKeycloakTest {
 
                 if (i == 15) {
                     provider.getStoreFactory().getPolicyStore()
-                            .create(userPolicyRepresentation, management.realmResourceServer());
+                            .create(management.realmResourceServer(), userPolicyRepresentation);
                 }
 
                 policy.addAssociatedPolicy(provider.getStoreFactory().getPolicyStore()
-                        .findByName("Only regular-admin-user", management.realmResourceServer().getId()));
+                        .findByName(management.realmResourceServer().getId(), "Only regular-admin-user"));
 
             }
         });
@@ -1364,7 +1363,7 @@ public class FineGrainAdminUnitTest extends AbstractKeycloakTest {
         clientRep.setName("to");
         clientRep.addClient(tokenexclient.getId());
         ResourceServer server = management.realmResourceServer();
-        Policy clientPolicy = management.authz().getStoreFactory().getPolicyStore().create(clientRep, server);
+        Policy clientPolicy = management.authz().getStoreFactory().getPolicyStore().create(server, clientRep);
         management.clients().exchangeToPermission(adminCli).addAssociatedPolicy(clientPolicy);
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/FineGrainAdminUnitTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/FineGrainAdminUnitTest.java
@@ -1127,8 +1127,9 @@ public class FineGrainAdminUnitTest extends AbstractKeycloakTest {
 
             AuthorizationProvider provider = session.getProvider(AuthorizationProvider.class);
             ClientModel realmAdminClient = realm.getClientByClientId(Constants.REALM_MANAGEMENT_CLIENT_ID);
+            ResourceServer resourceServer = provider.getStoreFactory().getResourceServerStore().findByClient(realmAdminClient);
 
-            policy.addAssociatedPolicy(provider.getStoreFactory().getPolicyStore().findByName("Only regular-admin-user", realmAdminClient.getId()));
+            policy.addAssociatedPolicy(provider.getStoreFactory().getPolicyStore().findByName("Only regular-admin-user", resourceServer.getId()));
         });
 
         try (Keycloak client = Keycloak.getInstance(getAuthServerContextRoot() + "/auth",
@@ -1194,9 +1195,10 @@ public class FineGrainAdminUnitTest extends AbstractKeycloakTest {
 
                 AuthorizationProvider provider = session.getProvider(AuthorizationProvider.class);
                 ClientModel realmAdminClient = realm.getClientByClientId(Constants.REALM_MANAGEMENT_CLIENT_ID);
+                ResourceServer resourceServer = provider.getStoreFactory().getResourceServerStore().findByClient(realmAdminClient);
 
                 policy.addAssociatedPolicy(provider.getStoreFactory().getPolicyStore()
-                        .findByName("Only regular-admin-user", realmAdminClient.getId()));
+                        .findByName("Only regular-admin-user", resourceServer.getId()));
             }
         });
 
@@ -1279,7 +1281,7 @@ public class FineGrainAdminUnitTest extends AbstractKeycloakTest {
                 }
 
                 policy.addAssociatedPolicy(provider.getStoreFactory().getPolicyStore()
-                        .findByName("Only regular-admin-user", realmAdminClient.getId()));
+                        .findByName("Only regular-admin-user", management.realmResourceServer().getId()));
 
             }
         });

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/PolicyEvaluationCompositeRoleTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/PolicyEvaluationCompositeRoleTest.java
@@ -78,8 +78,8 @@ public class PolicyEvaluationCompositeRoleTest extends AbstractAuthzTest {
         ResourceServer resourceServer = authz.getStoreFactory().getResourceServerStore().create(client);
         Policy policy = createRolePolicy(authz, resourceServer, role1);
 
-        Scope scope = authz.getStoreFactory().getScopeStore().create("myscope", resourceServer);
-        Resource resource = authz.getStoreFactory().getResourceStore().create("myresource", resourceServer, resourceServer.getClientId());
+        Scope scope = authz.getStoreFactory().getScopeStore().create(resourceServer, "myscope");
+        Resource resource = authz.getStoreFactory().getResourceStore().create(resourceServer, "myresource", resourceServer.getClientId());
         addScopePermission(authz, resourceServer, "mypermission", resource, scope, policy);
 
         RoleModel composite = realm.addRole("composite");
@@ -100,7 +100,7 @@ public class PolicyEvaluationCompositeRoleTest extends AbstractAuthzTest {
         representation.setDecisionStrategy(DecisionStrategy.UNANIMOUS);
         representation.setLogic(Logic.POSITIVE);
 
-        return authz.getStoreFactory().getPolicyStore().create(representation, resourceServer);
+        return authz.getStoreFactory().getPolicyStore().create(resourceServer, representation);
     }
 
 
@@ -116,7 +116,7 @@ public class PolicyEvaluationCompositeRoleTest extends AbstractAuthzTest {
         config.put("roles", roleValues);
         representation.setConfig(config);
 
-        return authz.getStoreFactory().getPolicyStore().create(representation, resourceServer);
+        return authz.getStoreFactory().getPolicyStore().create(resourceServer, representation);
     }
 
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/PolicyEvaluationCompositeRoleTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/PolicyEvaluationCompositeRoleTest.java
@@ -79,7 +79,7 @@ public class PolicyEvaluationCompositeRoleTest extends AbstractAuthzTest {
         Policy policy = createRolePolicy(authz, resourceServer, role1);
 
         Scope scope = authz.getStoreFactory().getScopeStore().create("myscope", resourceServer);
-        Resource resource = authz.getStoreFactory().getResourceStore().create("myresource", resourceServer, resourceServer.getId());
+        Resource resource = authz.getStoreFactory().getResourceStore().create("myresource", resourceServer, resourceServer.getClientId());
         addScopePermission(authz, resourceServer, "mypermission", resource, scope, policy);
 
         RoleModel composite = realm.addRole("composite");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/PolicyEvaluationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/PolicyEvaluationTest.java
@@ -619,7 +619,7 @@ public class PolicyEvaluationTest extends AbstractAuthzTest {
 
         Policy policy = storeFactory.getPolicyStore().create(policyRepresentation, resourceServer);
         PolicyProvider provider = authorization.getProvider(policy.getType());
-        Resource resource = storeFactory.getResourceStore().create("testCheckResourceAttributesResource", resourceServer, resourceServer.getId());
+        Resource resource = storeFactory.getResourceStore().create("testCheckResourceAttributesResource", resourceServer, resourceServer.getClientId());
 
         resource.setAttribute("a1", Arrays.asList("1", "2"));
         resource.setAttribute("a2", Arrays.asList("3"));
@@ -653,7 +653,7 @@ public class PolicyEvaluationTest extends AbstractAuthzTest {
 
         Policy policy = storeFactory.getPolicyStore().create(policyRepresentation, resourceServer);
 
-        Resource resource = storeFactory.getResourceStore().create("Resource A", resourceServer, resourceServer.getId());
+        Resource resource = storeFactory.getResourceStore().create("Resource A", resourceServer, resourceServer.getClientId());
         Scope scope = storeFactory.getScopeStore().create("Scope A", resourceServer);
 
         resource.updateScopes(new HashSet<>(Arrays.asList(scope)));
@@ -716,7 +716,7 @@ public class PolicyEvaluationTest extends AbstractAuthzTest {
 
         storeFactory.getPolicyStore().create(writePermission, resourceServer);
 
-        Resource resource = storeFactory.getResourceStore().create(KeycloakModelUtils.generateId(), resourceServer, resourceServer.getId());
+        Resource resource = storeFactory.getResourceStore().create(KeycloakModelUtils.generateId(), resourceServer, resourceServer.getClientId());
 
         PermissionEvaluator evaluator = authorization.evaluators().from(Arrays.asList(new ResourcePermission(resource, Arrays.asList(readScope, writeScope), resourceServer)), createEvaluationContext(session, Collections.emptyMap()));
         Collection<Permission> permissions = evaluator.evaluate(resourceServer, null);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/PolicyEvaluationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/PolicyEvaluationTest.java
@@ -145,7 +145,7 @@ public class PolicyEvaluationTest extends AbstractAuthzTest {
         policyRepresentation.setNotOnOrAfter(new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(notOnOrAfterDate));
 
         // evaluation should succeed with the default context as it uses the current time as the date to be compared.
-        Policy policy = storeFactory.getPolicyStore().create(policyRepresentation, resourceServer);
+        Policy policy = storeFactory.getPolicyStore().create(resourceServer, policyRepresentation);
         PolicyProvider provider = authorization.getProvider(policy.getType());
         DefaultEvaluation evaluation = createEvaluation(session, authorization, resourceServer, policy);
         provider.evaluate(evaluation);
@@ -181,7 +181,7 @@ public class PolicyEvaluationTest extends AbstractAuthzTest {
 
         policyRepresentation.setCode(builder.toString());
 
-        Policy policy = storeFactory.getPolicyStore().create(policyRepresentation, resourceServer);
+        Policy policy = storeFactory.getPolicyStore().create(resourceServer, policyRepresentation);
         PolicyProvider provider = authorization.getProvider(policy.getType());
 
         DefaultEvaluation evaluation = createEvaluation(session, authorization, resourceServer, policy);
@@ -340,7 +340,7 @@ public class PolicyEvaluationTest extends AbstractAuthzTest {
 
         policyRepresentation.setCode(builder.toString());
 
-        Policy policy = storeFactory.getPolicyStore().create(policyRepresentation, resourceServer);
+        Policy policy = storeFactory.getPolicyStore().create(resourceServer, policyRepresentation);
         PolicyProvider provider = authorization.getProvider(policy.getType());
 
         DefaultEvaluation evaluation = createEvaluation(session, authorization, resourceServer, policy);
@@ -387,7 +387,7 @@ public class PolicyEvaluationTest extends AbstractAuthzTest {
 
         policyRepresentation.setCode(builder.toString());
 
-        Policy policy = storeFactory.getPolicyStore().create(policyRepresentation, resourceServer);
+        Policy policy = storeFactory.getPolicyStore().create(resourceServer, policyRepresentation);
         PolicyProvider provider = authorization.getProvider(policy.getType());
 
         DefaultEvaluation evaluation = createEvaluation(session, authorization, resourceServer, policy);
@@ -434,7 +434,7 @@ public class PolicyEvaluationTest extends AbstractAuthzTest {
 
         policyRepresentation.setCode(builder.toString());
 
-        Policy policy = storeFactory.getPolicyStore().create(policyRepresentation, resourceServer);
+        Policy policy = storeFactory.getPolicyStore().create(resourceServer, policyRepresentation);
         PolicyProvider provider = authorization.getProvider(policy.getType());
 
         DefaultEvaluation evaluation = createEvaluation(session, authorization, resourceServer, policy);
@@ -482,7 +482,7 @@ public class PolicyEvaluationTest extends AbstractAuthzTest {
 
         policyRepresentation.setCode(builder.toString());
 
-        Policy policy = storeFactory.getPolicyStore().create(policyRepresentation, resourceServer);
+        Policy policy = storeFactory.getPolicyStore().create(resourceServer, policyRepresentation);
         PolicyProvider provider = authorization.getProvider(policy.getType());
 
         DefaultEvaluation evaluation = createEvaluation(session, authorization, resourceServer, policy);
@@ -514,7 +514,7 @@ public class PolicyEvaluationTest extends AbstractAuthzTest {
 
         policyRepresentation.setCode(builder.toString());
 
-        Policy policy = storeFactory.getPolicyStore().create(policyRepresentation, resourceServer);
+        Policy policy = storeFactory.getPolicyStore().create(resourceServer, policyRepresentation);
         PolicyProvider provider = authorization.getProvider(policy.getType());
 
         DefaultEvaluation evaluation = createEvaluation(session, authorization, resourceServer, policy);
@@ -546,7 +546,7 @@ public class PolicyEvaluationTest extends AbstractAuthzTest {
 
         policyRepresentation.setCode(builder.toString());
 
-        Policy policy = storeFactory.getPolicyStore().create(policyRepresentation, resourceServer);
+        Policy policy = storeFactory.getPolicyStore().create(resourceServer, policyRepresentation);
         PolicyProvider provider = authorization.getProvider(policy.getType());
 
         DefaultEvaluation evaluation = createEvaluation(session, authorization, resourceServer, policy);
@@ -584,7 +584,7 @@ public class PolicyEvaluationTest extends AbstractAuthzTest {
 
         policyRepresentation.setCode(builder.toString());
 
-        Policy policy = storeFactory.getPolicyStore().create(policyRepresentation, resourceServer);
+        Policy policy = storeFactory.getPolicyStore().create(resourceServer, policyRepresentation);
         PolicyProvider provider = authorization.getProvider(policy.getType());
 
         DefaultEvaluation evaluation = createEvaluation(session, authorization, resourceServer, policy);
@@ -617,9 +617,9 @@ public class PolicyEvaluationTest extends AbstractAuthzTest {
 
         policyRepresentation.setCode(builder.toString());
 
-        Policy policy = storeFactory.getPolicyStore().create(policyRepresentation, resourceServer);
+        Policy policy = storeFactory.getPolicyStore().create(resourceServer, policyRepresentation);
         PolicyProvider provider = authorization.getProvider(policy.getType());
-        Resource resource = storeFactory.getResourceStore().create("testCheckResourceAttributesResource", resourceServer, resourceServer.getClientId());
+        Resource resource = storeFactory.getResourceStore().create(resourceServer, "testCheckResourceAttributesResource", resourceServer.getClientId());
 
         resource.setAttribute("a1", Arrays.asList("1", "2"));
         resource.setAttribute("a2", Arrays.asList("3"));
@@ -651,10 +651,10 @@ public class PolicyEvaluationTest extends AbstractAuthzTest {
 
         policyRepresentation.setCode(builder.toString());
 
-        Policy policy = storeFactory.getPolicyStore().create(policyRepresentation, resourceServer);
+        Policy policy = storeFactory.getPolicyStore().create(resourceServer, policyRepresentation);
 
-        Resource resource = storeFactory.getResourceStore().create("Resource A", resourceServer, resourceServer.getClientId());
-        Scope scope = storeFactory.getScopeStore().create("Scope A", resourceServer);
+        Resource resource = storeFactory.getResourceStore().create(resourceServer, "Resource A", resourceServer.getClientId());
+        Scope scope = storeFactory.getScopeStore().create(resourceServer, "Scope A");
 
         resource.updateScopes(new HashSet<>(Arrays.asList(scope)));
 
@@ -664,7 +664,7 @@ public class PolicyEvaluationTest extends AbstractAuthzTest {
         permission.addPolicy(policy.getId());
         permission.addResource(resource.getId());
 
-        storeFactory.getPolicyStore().create(permission, resourceServer);
+        storeFactory.getPolicyStore().create(resourceServer, permission);
 
         session.getTransactionManager().commit();
 
@@ -689,8 +689,8 @@ public class PolicyEvaluationTest extends AbstractAuthzTest {
         StoreFactory storeFactory = authorization.getStoreFactory();
         ResourceServer resourceServer = storeFactory.getResourceServerStore().findByClient(clientModel);
 
-        Scope readScope = storeFactory.getScopeStore().create("read", resourceServer);
-        Scope writeScope = storeFactory.getScopeStore().create("write", resourceServer);
+        Scope readScope = storeFactory.getScopeStore().create(resourceServer, "read");
+        Scope writeScope = storeFactory.getScopeStore().create(resourceServer, "write");
 
         JSPolicyRepresentation policy = new JSPolicyRepresentation();
 
@@ -698,7 +698,7 @@ public class PolicyEvaluationTest extends AbstractAuthzTest {
         policy.setCode("$evaluation.grant()");
         policy.setLogic(Logic.NEGATIVE);
 
-        storeFactory.getPolicyStore().create(policy, resourceServer);
+        storeFactory.getPolicyStore().create(resourceServer, policy);
 
         ScopePermissionRepresentation readPermission = new ScopePermissionRepresentation();
 
@@ -706,7 +706,7 @@ public class PolicyEvaluationTest extends AbstractAuthzTest {
         readPermission.addScope(readScope.getId());
         readPermission.addPolicy(policy.getName());
 
-        storeFactory.getPolicyStore().create(readPermission, resourceServer);
+        storeFactory.getPolicyStore().create(resourceServer, readPermission);
 
         ScopePermissionRepresentation writePermission = new ScopePermissionRepresentation();
 
@@ -714,9 +714,9 @@ public class PolicyEvaluationTest extends AbstractAuthzTest {
         writePermission.addScope(writeScope.getId());
         writePermission.addPolicy(policy.getName());
 
-        storeFactory.getPolicyStore().create(writePermission, resourceServer);
+        storeFactory.getPolicyStore().create(resourceServer, writePermission);
 
-        Resource resource = storeFactory.getResourceStore().create(KeycloakModelUtils.generateId(), resourceServer, resourceServer.getClientId());
+        Resource resource = storeFactory.getResourceStore().create(resourceServer, KeycloakModelUtils.generateId(), resourceServer.getClientId());
 
         PermissionEvaluator evaluator = authorization.evaluators().from(Arrays.asList(new ResourcePermission(resource, Arrays.asList(readScope, writeScope), resourceServer)), createEvaluationContext(session, Collections.emptyMap()));
         Collection<Permission> permissions = evaluator.evaluate(resourceServer, null);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/UmaRepresentationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/UmaRepresentationTest.java
@@ -143,7 +143,7 @@ public class UmaRepresentationTest extends AbstractResourceServerTest {
         ResourceServer resourceServer = authorization.getStoreFactory().getResourceServerStore().findByClient(client);
         ResourceBean resourceBean = authorizationBean.new ResourceBean(
             authorization.getStoreFactory().getResourceStore().findByName(
-                "Resource A", user.getId(), resourceServer.getId()
+                    resourceServer.getId(), "Resource A", user.getId()
             )
         );
 
@@ -169,7 +169,7 @@ public class UmaRepresentationTest extends AbstractResourceServerTest {
         ResourceServer resourceServer = authorization.getStoreFactory().getResourceServerStore().findByClient(client);
         ResourceBean resourceBean = authorizationBean.new ResourceBean(
             authorization.getStoreFactory().getResourceStore().findByName(
-                "Resource A", client.getId(), resourceServer.getId()
+                    resourceServer.getId(), "Resource A", client.getId()
             )
         );
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/UmaRepresentationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/UmaRepresentationTest.java
@@ -143,7 +143,7 @@ public class UmaRepresentationTest extends AbstractResourceServerTest {
         ResourceServer resourceServer = authorization.getStoreFactory().getResourceServerStore().findByClient(client);
         ResourceBean resourceBean = authorizationBean.new ResourceBean(
             authorization.getStoreFactory().getResourceStore().findByName(
-                    resourceServer.getId(), "Resource A", user.getId()
+                    resourceServer, "Resource A", user.getId()
             )
         );
 
@@ -169,7 +169,7 @@ public class UmaRepresentationTest extends AbstractResourceServerTest {
         ResourceServer resourceServer = authorization.getStoreFactory().getResourceServerStore().findByClient(client);
         ResourceBean resourceBean = authorizationBean.new ResourceBean(
             authorization.getStoreFactory().getResourceStore().findByName(
-                    resourceServer.getId(), "Resource A", client.getId()
+                    resourceServer, "Resource A", client.getId()
             )
         );
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/UmaRepresentationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/UmaRepresentationTest.java
@@ -16,6 +16,7 @@ import org.keycloak.testsuite.arquillian.annotation.AuthServerContainerExclude;
 import org.keycloak.testsuite.arquillian.annotation.AuthServerContainerExclude.AuthServer;
 
 import java.util.List;
+import org.keycloak.authorization.model.ResourceServer;
 
 @AuthServerContainerExclude(AuthServer.REMOTE)
 public class UmaRepresentationTest extends AbstractResourceServerTest {
@@ -139,9 +140,10 @@ public class UmaRepresentationTest extends AbstractResourceServerTest {
         AuthorizationBean authorizationBean  = new AuthorizationBean(session, null, session.getContext().getUri());
         ClientModel client = session.getContext().getRealm().getClientByClientId("resource-server-test");
         UserModel user = session.userStorageManager().getUserByUsername(session.getContext().getRealm(), "marta");
+        ResourceServer resourceServer = authorization.getStoreFactory().getResourceServerStore().findByClient(client);
         ResourceBean resourceBean = authorizationBean.new ResourceBean(
             authorization.getStoreFactory().getResourceStore().findByName(
-                "Resource A", user.getId(), client.getId()
+                "Resource A", user.getId(), resourceServer.getId()
             )
         );
 
@@ -164,9 +166,10 @@ public class UmaRepresentationTest extends AbstractResourceServerTest {
 
         AuthorizationBean authorizationBean  = new AuthorizationBean(session, null, session.getContext().getUri());
         ClientModel client = session.getContext().getRealm().getClientByClientId("resource-server-test");
+        ResourceServer resourceServer = authorization.getStoreFactory().getResourceServerStore().findByClient(client);
         ResourceBean resourceBean = authorizationBean.new ResourceBean(
             authorization.getStoreFactory().getResourceStore().findByName(
-                "Resource A", client.getId(), client.getId()
+                "Resource A", client.getId(), resourceServer.getId()
             )
         );
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/UserManagedPermissionServiceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/UserManagedPermissionServiceTest.java
@@ -924,7 +924,7 @@ public class UserManagedPermissionServiceTest extends AbstractResourceServerTest
         filters.put(OWNER, new String[] {user.getId()});
 
         List<Policy> policies = provider.getStoreFactory().getPolicyStore()
-                .findByResourceServer(filters, resourceServer.getId(), -1, -1);
+                .findByResourceServer(resourceServer.getId(), filters, -1, -1);
         assertEquals(1, policies.size());
 
         Policy policy = policies.get(0);
@@ -939,7 +939,7 @@ public class UserManagedPermissionServiceTest extends AbstractResourceServerTest
 
         filters.put(OWNER, new String[] {user.getId()});
         policies = provider.getStoreFactory().getPolicyStore()
-                .findByResourceServer(filters, resourceServer.getId(), -1, -1);
+                .findByResourceServer(resourceServer.getId(), filters, -1, -1);
         assertTrue(policies.isEmpty());
     }
 
@@ -978,7 +978,7 @@ public class UserManagedPermissionServiceTest extends AbstractResourceServerTest
         filters.put(OWNER, new String[] {user.getId()});
 
         List<Policy> policies = provider.getStoreFactory().getPolicyStore()
-                .findByResourceServer(filters, resourceServer.getId(), -1, -1);
+                .findByResourceServer(resourceServer.getId(), filters, -1, -1);
         assertEquals(1, policies.size());
 
         Policy policy = policies.get(0);
@@ -994,7 +994,7 @@ public class UserManagedPermissionServiceTest extends AbstractResourceServerTest
         filters.put(OWNER, new String[] {user.getId()});
 
         policies = provider.getStoreFactory().getPolicyStore()
-                .findByResourceServer(filters, resourceServer.getId(), -1, -1);
+                .findByResourceServer(resourceServer.getId(), filters, -1, -1);
         assertTrue(policies.isEmpty());
     }
 
@@ -1033,7 +1033,7 @@ public class UserManagedPermissionServiceTest extends AbstractResourceServerTest
         filters.put(OWNER, new String[] {user.getId()});
 
         List<Policy> policies = provider.getStoreFactory().getPolicyStore()
-            .findByResourceServer(filters, resourceServer.getId(), -1, -1);
+            .findByResourceServer(resourceServer.getId(), filters, -1, -1);
         assertEquals(1, policies.size());
 
         Policy policy = policies.get(0);
@@ -1049,7 +1049,7 @@ public class UserManagedPermissionServiceTest extends AbstractResourceServerTest
         filters.put(OWNER, new String[] {user.getId()});
 
         policies = provider.getStoreFactory().getPolicyStore()
-            .findByResourceServer(filters, resourceServer.getId(), -1, -1);
+            .findByResourceServer(resourceServer.getId(), filters, -1, -1);
         assertTrue(policies.isEmpty());
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/UserManagedPermissionServiceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/UserManagedPermissionServiceTest.java
@@ -924,7 +924,7 @@ public class UserManagedPermissionServiceTest extends AbstractResourceServerTest
         filters.put(OWNER, new String[] {user.getId()});
 
         List<Policy> policies = provider.getStoreFactory().getPolicyStore()
-                .findByResourceServer(resourceServer.getId(), filters, -1, -1);
+                .findByResourceServer(resourceServer, filters, -1, -1);
         assertEquals(1, policies.size());
 
         Policy policy = policies.get(0);
@@ -939,7 +939,7 @@ public class UserManagedPermissionServiceTest extends AbstractResourceServerTest
 
         filters.put(OWNER, new String[] {user.getId()});
         policies = provider.getStoreFactory().getPolicyStore()
-                .findByResourceServer(resourceServer.getId(), filters, -1, -1);
+                .findByResourceServer(resourceServer, filters, -1, -1);
         assertTrue(policies.isEmpty());
     }
 
@@ -978,7 +978,7 @@ public class UserManagedPermissionServiceTest extends AbstractResourceServerTest
         filters.put(OWNER, new String[] {user.getId()});
 
         List<Policy> policies = provider.getStoreFactory().getPolicyStore()
-                .findByResourceServer(resourceServer.getId(), filters, -1, -1);
+                .findByResourceServer(resourceServer, filters, -1, -1);
         assertEquals(1, policies.size());
 
         Policy policy = policies.get(0);
@@ -994,7 +994,7 @@ public class UserManagedPermissionServiceTest extends AbstractResourceServerTest
         filters.put(OWNER, new String[] {user.getId()});
 
         policies = provider.getStoreFactory().getPolicyStore()
-                .findByResourceServer(resourceServer.getId(), filters, -1, -1);
+                .findByResourceServer(resourceServer, filters, -1, -1);
         assertTrue(policies.isEmpty());
     }
 
@@ -1033,7 +1033,7 @@ public class UserManagedPermissionServiceTest extends AbstractResourceServerTest
         filters.put(OWNER, new String[] {user.getId()});
 
         List<Policy> policies = provider.getStoreFactory().getPolicyStore()
-            .findByResourceServer(resourceServer.getId(), filters, -1, -1);
+            .findByResourceServer(resourceServer, filters, -1, -1);
         assertEquals(1, policies.size());
 
         Policy policy = policies.get(0);
@@ -1049,7 +1049,7 @@ public class UserManagedPermissionServiceTest extends AbstractResourceServerTest
         filters.put(OWNER, new String[] {user.getId()});
 
         policies = provider.getStoreFactory().getPolicyStore()
-            .findByResourceServer(resourceServer.getId(), filters, -1, -1);
+            .findByResourceServer(resourceServer, filters, -1, -1);
         assertTrue(policies.isEmpty());
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/UserManagedPermissionServiceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/UserManagedPermissionServiceTest.java
@@ -41,6 +41,7 @@ import org.keycloak.authorization.client.resource.ProtectionResource;
 import org.keycloak.authorization.client.util.HttpResponseException;
 import org.keycloak.authorization.model.Policy;
 import org.keycloak.authorization.model.Resource;
+import org.keycloak.authorization.model.ResourceServer;
 import org.keycloak.common.Profile;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
@@ -916,13 +917,14 @@ public class UserManagedPermissionServiceTest extends AbstractResourceServerTest
         ClientModel client = realm.getClientByClientId("resource-server-test");
         AuthorizationProvider provider = session.getProvider(AuthorizationProvider.class);
         UserModel user = session.users().getUserByUsername(realm, "marta");
+        ResourceServer resourceServer = provider.getStoreFactory().getResourceServerStore().findByClient(client);
         Map<Policy.FilterOption, String[]> filters = new HashMap<>();
 
         filters.put(Policy.FilterOption.TYPE, new String[] {"uma"});
         filters.put(OWNER, new String[] {user.getId()});
 
         List<Policy> policies = provider.getStoreFactory().getPolicyStore()
-                .findByResourceServer(filters, client.getId(), -1, -1);
+                .findByResourceServer(filters, resourceServer.getId(), -1, -1);
         assertEquals(1, policies.size());
 
         Policy policy = policies.get(0);
@@ -937,7 +939,7 @@ public class UserManagedPermissionServiceTest extends AbstractResourceServerTest
 
         filters.put(OWNER, new String[] {user.getId()});
         policies = provider.getStoreFactory().getPolicyStore()
-                .findByResourceServer(filters, client.getId(), -1, -1);
+                .findByResourceServer(filters, resourceServer.getId(), -1, -1);
         assertTrue(policies.isEmpty());
     }
 
@@ -969,13 +971,14 @@ public class UserManagedPermissionServiceTest extends AbstractResourceServerTest
         ClientModel client = realm.getClientByClientId("resource-server-test");
         AuthorizationProvider provider = session.getProvider(AuthorizationProvider.class);
         UserModel user = session.users().getUserByUsername(realm, "marta");
+        ResourceServer resourceServer = provider.getStoreFactory().getResourceServerStore().findByClient(client);
         Map<Policy.FilterOption, String[]> filters = new HashMap<>();
 
         filters.put(Policy.FilterOption.TYPE, new String[] {"uma"});
         filters.put(OWNER, new String[] {user.getId()});
 
         List<Policy> policies = provider.getStoreFactory().getPolicyStore()
-                .findByResourceServer(filters, client.getId(), -1, -1);
+                .findByResourceServer(filters, resourceServer.getId(), -1, -1);
         assertEquals(1, policies.size());
 
         Policy policy = policies.get(0);
@@ -991,7 +994,7 @@ public class UserManagedPermissionServiceTest extends AbstractResourceServerTest
         filters.put(OWNER, new String[] {user.getId()});
 
         policies = provider.getStoreFactory().getPolicyStore()
-                .findByResourceServer(filters, client.getId(), -1, -1);
+                .findByResourceServer(filters, resourceServer.getId(), -1, -1);
         assertTrue(policies.isEmpty());
     }
 
@@ -1023,13 +1026,14 @@ public class UserManagedPermissionServiceTest extends AbstractResourceServerTest
         ClientModel client = realm.getClientByClientId("resource-server-test");
         AuthorizationProvider provider = session.getProvider(AuthorizationProvider.class);
         UserModel user = session.users().getUserByUsername(realm, "marta");
+        ResourceServer resourceServer = provider.getStoreFactory().getResourceServerStore().findByClient(client);
         Map<Policy.FilterOption, String[]> filters = new HashMap<>();
 
         filters.put(Policy.FilterOption.TYPE, new String[] {"uma"});
         filters.put(OWNER, new String[] {user.getId()});
 
         List<Policy> policies = provider.getStoreFactory().getPolicyStore()
-            .findByResourceServer(filters, client.getId(), -1, -1);
+            .findByResourceServer(filters, resourceServer.getId(), -1, -1);
         assertEquals(1, policies.size());
 
         Policy policy = policies.get(0);
@@ -1045,7 +1049,7 @@ public class UserManagedPermissionServiceTest extends AbstractResourceServerTest
         filters.put(OWNER, new String[] {user.getId()});
 
         policies = provider.getStoreFactory().getPolicyStore()
-            .findByResourceServer(filters, client.getId(), -1, -1);
+            .findByResourceServer(filters, resourceServer.getId(), -1, -1);
         assertTrue(policies.isEmpty());
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/UserManagedPermissionServiceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/UserManagedPermissionServiceTest.java
@@ -924,7 +924,7 @@ public class UserManagedPermissionServiceTest extends AbstractResourceServerTest
         filters.put(OWNER, new String[] {user.getId()});
 
         List<Policy> policies = provider.getStoreFactory().getPolicyStore()
-                .findByResourceServer(resourceServer, filters, -1, -1);
+                .findByResourceServer(resourceServer, filters, null, null);
         assertEquals(1, policies.size());
 
         Policy policy = policies.get(0);
@@ -939,7 +939,7 @@ public class UserManagedPermissionServiceTest extends AbstractResourceServerTest
 
         filters.put(OWNER, new String[] {user.getId()});
         policies = provider.getStoreFactory().getPolicyStore()
-                .findByResourceServer(resourceServer, filters, -1, -1);
+                .findByResourceServer(resourceServer, filters, null, null);
         assertTrue(policies.isEmpty());
     }
 
@@ -978,7 +978,7 @@ public class UserManagedPermissionServiceTest extends AbstractResourceServerTest
         filters.put(OWNER, new String[] {user.getId()});
 
         List<Policy> policies = provider.getStoreFactory().getPolicyStore()
-                .findByResourceServer(resourceServer, filters, -1, -1);
+                .findByResourceServer(resourceServer, filters, null, null);
         assertEquals(1, policies.size());
 
         Policy policy = policies.get(0);
@@ -994,7 +994,7 @@ public class UserManagedPermissionServiceTest extends AbstractResourceServerTest
         filters.put(OWNER, new String[] {user.getId()});
 
         policies = provider.getStoreFactory().getPolicyStore()
-                .findByResourceServer(resourceServer, filters, -1, -1);
+                .findByResourceServer(resourceServer, filters, null, null);
         assertTrue(policies.isEmpty());
     }
 
@@ -1033,7 +1033,7 @@ public class UserManagedPermissionServiceTest extends AbstractResourceServerTest
         filters.put(OWNER, new String[] {user.getId()});
 
         List<Policy> policies = provider.getStoreFactory().getPolicyStore()
-            .findByResourceServer(resourceServer, filters, -1, -1);
+            .findByResourceServer(resourceServer, filters, null, null);
         assertEquals(1, policies.size());
 
         Policy policy = policies.get(0);
@@ -1049,7 +1049,7 @@ public class UserManagedPermissionServiceTest extends AbstractResourceServerTest
         filters.put(OWNER, new String[] {user.getId()});
 
         policies = provider.getStoreFactory().getPolicyStore()
-            .findByResourceServer(resourceServer, filters, -1, -1);
+            .findByResourceServer(resourceServer, filters, null, null);
         assertTrue(policies.isEmpty());
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/SocialLoginTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/SocialLoginTest.java
@@ -232,7 +232,7 @@ public class SocialLoginTest extends AbstractKeycloakTest {
         AdminPermissionManagement management = AdminPermissions.management(session, realm);
         management.users().setPermissionsEnabled(true);
         ResourceServer server = management.realmResourceServer();
-        Policy clientPolicy = management.authz().getStoreFactory().getPolicyStore().create(clientPolicyRep, server);
+        Policy clientPolicy = management.authz().getStoreFactory().getPolicyStore().create(server, clientPolicyRep);
         management.users().adminImpersonatingPermission().addAssociatedPolicy(clientPolicy);
         management.users().adminImpersonatingPermission().setDecisionStrategy(DecisionStrategy.AFFIRMATIVE);
         realm.getIdentityProvidersStream().forEach(idp -> {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ClientTokenExchangeSAML2Test.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ClientTokenExchangeSAML2Test.java
@@ -203,7 +203,7 @@ public class ClientTokenExchangeSAML2Test extends AbstractKeycloakTest {
         assertNotNull(samlUnsignedAndUnencryptedTarget);
 
         ResourceServer server = management.realmResourceServer();
-        Policy clientPolicy = management.authz().getStoreFactory().getPolicyStore().create(clientRep, server);
+        Policy clientPolicy = management.authz().getStoreFactory().getPolicyStore().create(server, clientRep);
         management.clients().exchangeToPermission(samlSignedTarget).addAssociatedPolicy(clientPolicy);
         management.clients().exchangeToPermission(samlEncryptedTarget).addAssociatedPolicy(clientPolicy);
         management.clients().exchangeToPermission(samlSignedAndEncryptedTarget).addAssociatedPolicy(clientPolicy);
@@ -217,7 +217,7 @@ public class ClientTokenExchangeSAML2Test extends AbstractKeycloakTest {
         clientImpersonateRep.addClient(directPublic.getId());
         clientImpersonateRep.addClient(directNoSecret.getId());
         server = management.realmResourceServer();
-        Policy clientImpersonatePolicy = management.authz().getStoreFactory().getPolicyStore().create(clientImpersonateRep, server);
+        Policy clientImpersonatePolicy = management.authz().getStoreFactory().getPolicyStore().create(server, clientImpersonateRep);
         management.users().setPermissionsEnabled(true);
         management.users().adminImpersonatingPermission().addAssociatedPolicy(clientImpersonatePolicy);
         management.users().adminImpersonatingPermission().setDecisionStrategy(DecisionStrategy.AFFIRMATIVE);
@@ -697,7 +697,7 @@ public class ClientTokenExchangeSAML2Test extends AbstractKeycloakTest {
         clientImpersonateRep.addClient(directExchanger.getId());
 
         ResourceServer server = management.realmResourceServer();
-        Policy clientImpersonatePolicy = management.authz().getStoreFactory().getPolicyStore().create(clientImpersonateRep, server);
+        Policy clientImpersonatePolicy = management.authz().getStoreFactory().getPolicyStore().create(server, clientImpersonateRep);
         management.users().setPermissionsEnabled(true);
         management.users().adminImpersonatingPermission().addAssociatedPolicy(clientImpersonatePolicy);
         management.users().adminImpersonatingPermission().setDecisionStrategy(DecisionStrategy.AFFIRMATIVE);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ClientTokenExchangeTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ClientTokenExchangeTest.java
@@ -203,7 +203,7 @@ public class ClientTokenExchangeTest extends AbstractKeycloakTest {
         clientRep.addClient(noRefreshToken.getId());
 
         ResourceServer server = management.realmResourceServer();
-        Policy clientPolicy = management.authz().getStoreFactory().getPolicyStore().create(clientRep, server);
+        Policy clientPolicy = management.authz().getStoreFactory().getPolicyStore().create(server, clientRep);
         management.clients().exchangeToPermission(target).addAssociatedPolicy(clientPolicy);
 
         // permission for user impersonation for a client
@@ -214,7 +214,7 @@ public class ClientTokenExchangeTest extends AbstractKeycloakTest {
         clientImpersonateRep.addClient(directPublic.getId());
         clientImpersonateRep.addClient(directNoSecret.getId());
         server = management.realmResourceServer();
-        Policy clientImpersonatePolicy = management.authz().getStoreFactory().getPolicyStore().create(clientImpersonateRep, server);
+        Policy clientImpersonatePolicy = management.authz().getStoreFactory().getPolicyStore().create(server, clientImpersonateRep);
         management.users().setPermissionsEnabled(true);
         management.users().adminImpersonatingPermission().addAssociatedPolicy(clientImpersonatePolicy);
         management.users().adminImpersonatingPermission().setDecisionStrategy(DecisionStrategy.AFFIRMATIVE);
@@ -559,7 +559,7 @@ public class ClientTokenExchangeTest extends AbstractKeycloakTest {
         clientImpersonateRep.addClient(directExchanger.getId());
 
         ResourceServer server = management.realmResourceServer();
-        Policy clientImpersonatePolicy = management.authz().getStoreFactory().getPolicyStore().create(clientImpersonateRep, server);
+        Policy clientImpersonatePolicy = management.authz().getStoreFactory().getPolicyStore().create(server, clientImpersonateRep);
         management.users().setPermissionsEnabled(true);
         management.users().adminImpersonatingPermission().addAssociatedPolicy(clientImpersonatePolicy);
         management.users().adminImpersonatingPermission().setDecisionStrategy(DecisionStrategy.AFFIRMATIVE);


### PR DESCRIPTION
This PR contains refactoring of Authz services interfaces. 

The main changes:

- Reordering method's parameters to have "owning/parent" entities (mostly `ResourceServer` or `Resource`) as the first parameter of each method (similarly as Realm for other entities) 
- Changing methods to use model objects instead of id reference for identifying searching options (e.g. changing `String resourceServerId` to `ResourceServer resourceServer`)
- Using Integer objects for pagination instead of primitive ints

I tried to split the changes into more commits, but it may happen there are some conflicts between commits, for example, commit 1 may contain some changes removed by commit 3 and so on. Sorry for that.

Also, the first commit fe5417a5fe1739c70b9a8944f139ce42926f2088 contains changes that should be probably part of #10509. I used the changes for that issue as a base for the refactoring and then we realized it would be better to do the refactoring separately, however, removing that commit means a significant amount of time spent on resolving conflicts as changes done in that commit are in the same lines as other refactoring changes. So I decided to leave the changes in the interfaces/services/model in this PR and remove changes in Map storage. This means the code distinguishes between `Client.id` and `ResourceServer.id`, but it is always the same.

@vramik I will send this as a draft PR because I am not sure this is complete, if you find something is missing please let me know and I will add it.