### PR TITLE
Increase Hang Detection Timeout in Operator Tests

### DIFF
--- a/operator/src/test/resources/application.properties
+++ b/operator/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+quarkus.test.hang-detection-timeout=30m


### PR DESCRIPTION
The hang detection timeout is by default set to 10 minutes, but, in our test-suite there are tests that are, sometimes taking more time to be successfully passing.

Resolves: #10762

Reference documentation: https://quarkus.io/guides/getting-started-testing#hang-detection 
Reference failure: https://github.com/andreaTP/keycloak/runs/5536439177?check_suite_focus=true#step:10:822