### PR TITLE
Automatic scan Keycloak docker image for vulnerabilities

### DIFF
--- a/.github/workflows/trivy-analysis.yml
+++ b/.github/workflows/trivy-analysis.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   # Run the job twice a day  
   schedule:
-    - cron: "0 0,12 * * *"
+    - cron: "0 0 * * *"
 
 jobs:
   quarkus-dist:

--- a/.github/workflows/trivy-analysis.yml
+++ b/.github/workflows/trivy-analysis.yml
@@ -1,0 +1,64 @@
+name: Trivy
+on:
+  workflow_dispatch:
+  # Run the job twice a day  
+  schedule:
+    - cron: "0 0,12 * * *"
+
+jobs:
+  quarkus-dist:
+    name: Vulnerability scanner for Quarkus distribution images
+    runs-on: "ubuntu-18.04"
+    steps:
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@296212627a1e693efa09c00adc3e03b2ba8edf18
+        with:
+          image-ref: 'quay.io/keycloak/keycloak:nightly'
+          format: 'template'
+          template: '@/contrib/sarif.tpl'
+          output: 'trivy-results.sarif'
+          severity: 'MEDIUM,CRITICAL,HIGH'
+          ignore-unfixed: true
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: 'trivy-results.sarif'
+
+  legacy-dist:
+    name: Vulnerability scanner for WildFly distribution images
+    runs-on: "ubuntu-18.04"
+    steps:
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@296212627a1e693efa09c00adc3e03b2ba8edf18
+        with:
+          image-ref: 'quay.io/keycloak/keycloak:legacy'
+          format: 'template'
+          template: '@/contrib/sarif.tpl'
+          output: 'legacy-results.sarif'
+          severity: 'MEDIUM,CRITICAL,HIGH'
+          ignore-unfixed: true
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: 'legacy-results.sarif'
+
+  keycloak-operator:
+    name: Vulnerability scanner for Keycloak Operator distribution images
+    runs-on: "ubuntu-18.04"
+    steps:
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@296212627a1e693efa09c00adc3e03b2ba8edf18
+        with:
+          image-ref: 'quay.io/keycloak/keycloak-operator:nightly'
+          format: 'template'
+          template: '@/contrib/sarif.tpl'
+          output: 'operator-results.sarif'
+          severity: 'MEDIUM,CRITICAL,HIGH'
+          ignore-unfixed: true
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: 'operator-results.sarif'


### PR DESCRIPTION
The changes proposed here will run Trivy scanner twice a day to search
vulnerabilities into our main images.

Resolves #10764

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
