### PR TITLE
Create missing data folder in docker image

### DIFF
--- a/quarkus/container/Dockerfile
+++ b/quarkus/container/Dockerfile
@@ -13,7 +13,7 @@ RUN (cd /tmp/keycloak && \
     tar -xvf /tmp/keycloak/keycloak-*.tar.gz && \
     rm /tmp/keycloak/keycloak-*.tar.gz) || true
 
-RUN mv /tmp/keycloak/keycloak-* /opt/keycloak
+RUN mv /tmp/keycloak/keycloak-* /opt/keycloak && mkdir -p /opt/keycloak/data
 
 RUN chmod -R g+rwX /opt/keycloak
 


### PR DESCRIPTION
Resolves: #10806 

This is an additional fix on top of: https://github.com/keycloak/keycloak-quickstarts/issues/300

__Context:__
Updating the guide we discovered that Keycloak was not correctly starting on crc using an embedded database(h2) e.g.:
```bash
KC_DB=dev-file
KC_DB=dev-mem
```

the root cause is the security context automatically applied by OpenShift.
Mounting an empty volume as done [here](https://github.com/keycloak/keycloak-quickstarts/pull/306/files#diff-7f57ae9dd6c06b2b8acf38207598a135753b28d6ea8c33c546e66c483dcf0fb5R89-R95) workaround the issue but the problem seems to be the presence of the root folder `/opt/keycloak/data` that we are proposing to introduce in this PR.

__How to test:__
 - build and publish the Keycloak docker image using this branch
 - comment out `volumes` and `volumeMounts` section from the quickstart template ( or use [this file](https://github.com/andreaTP/keycloak-quickstarts/blob/b8d4bc6939edd7d0884d65789975411868488f69/openshift-examples/keycloak.yaml) changing the coordinates of your image )
 - use either of `KC_DB` values `dev-file` or `dev-mem`
 - follow [this tutorial](https://github.com/keycloak/keycloak-web/pull/288)
 - and `keycloak` correctly starts