### PR TITLE
Fixes #9482: A user could be assigned to a parent group if he is already assigned to a subgroup.

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/membership/group/GroupLDAPStorageMapper.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/membership/group/GroupLDAPStorageMapper.java
@@ -751,7 +751,7 @@ public class GroupLDAPStorageMapper extends AbstractLDAPStorageMapper implements
 
         @Override
         public boolean isMemberOf(GroupModel group) {
-            return getGroupsStream().anyMatch(Predicate.isEqual(group));
+            return RoleUtils.isDirectMember(getGroupsStream(),group);
         }
 
         protected Stream<GroupModel> getLDAPGroupMappingsConverted() {

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/UserAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/UserAdapter.java
@@ -392,7 +392,7 @@ public class UserAdapter implements UserModel.Streams, JpaModel<UserEntity> {
 
     @Override
     public void joinGroup(GroupModel group) {
-        if (isMemberOf(group)) return;
+        if (RoleUtils.isDirectMember(getGroupsStream(), group)) return;
         joinGroupImpl(group);
 
     }

--- a/model/map/src/main/java/org/keycloak/models/map/user/MapUserAdapter.java
+++ b/model/map/src/main/java/org/keycloak/models/map/user/MapUserAdapter.java
@@ -255,6 +255,7 @@ public abstract class MapUserAdapter extends AbstractUserModel<MapUserEntity> {
 
     @Override
     public void joinGroup(GroupModel group) {
+        if (RoleUtils.isDirectMember(getGroupsStream(), group)) return;
         entity.addGroupsMembership(group.getId());
     }
 

--- a/server-spi-private/src/main/java/org/keycloak/storage/adapter/UpdateOnlyChangeUserModelDelegate.java
+++ b/server-spi-private/src/main/java/org/keycloak/storage/adapter/UpdateOnlyChangeUserModelDelegate.java
@@ -25,6 +25,7 @@ import java.util.stream.Collectors;
 import org.keycloak.models.GroupModel;
 import org.keycloak.models.RoleModel;
 import org.keycloak.models.UserModel;
+import org.keycloak.models.utils.RoleUtils;
 import org.keycloak.models.utils.UserModelDelegate;
 
 import static org.keycloak.common.util.ObjectUtil.isEqualOrBothNull;
@@ -170,7 +171,7 @@ public class UpdateOnlyChangeUserModelDelegate extends UserModelDelegate {
 
     @Override
     public void joinGroup(GroupModel group) {
-        if (!isMemberOf(group)) {
+        if (!RoleUtils.isDirectMember(getGroupsStream(),group)) {
             delegate.joinGroup(group);
         }
 
@@ -178,7 +179,7 @@ public class UpdateOnlyChangeUserModelDelegate extends UserModelDelegate {
 
     @Override
     public void leaveGroup(GroupModel group) {
-        if (isMemberOf(group)) {
+        if (RoleUtils.isDirectMember(getGroupsStream(),group)) {
             delegate.leaveGroup(group);
         }
     }

--- a/server-spi/src/main/java/org/keycloak/models/utils/RoleUtils.java
+++ b/server-spi/src/main/java/org/keycloak/models/utils/RoleUtils.java
@@ -81,6 +81,16 @@ public class RoleUtils {
     }
 
     /**
+     *
+     * @param groups
+     * @param targetGroup
+     * @return true if targetGroup is in groups directly
+     */
+    public static boolean isDirectMember(Stream<GroupModel> groups, GroupModel targetGroup) {
+        return groups.anyMatch(g -> targetGroup.getId().equals(g.getId()));
+    }
+
+    /**
      * @param roles
      * @param targetRole
      * @return true if targetRole is in roles (directly or indirectly via composite role)

--- a/services/src/main/java/org/keycloak/services/resources/admin/UserResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UserResource.java
@@ -50,6 +50,7 @@ import org.keycloak.models.UserModel;
 import org.keycloak.models.UserSessionModel;
 import org.keycloak.models.utils.ModelToRepresentation;
 import org.keycloak.models.utils.RepresentationToModel;
+import org.keycloak.models.utils.RoleUtils;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.protocol.oidc.utils.RedirectUtils;
 import org.keycloak.provider.ProviderFactory;
@@ -933,7 +934,7 @@ public class UserResource {
             throw new NotFoundException("Group not found");
         }
         auth.groups().requireManageMembership(group);
-        if (!user.isMemberOf(group)){
+        if (!RoleUtils.isDirectMember(user.getGroupsStream(),group)){
             user.joinGroup(group);
             adminEvent.operation(OperationType.CREATE).resource(ResourceType.GROUP_MEMBERSHIP).representation(ModelToRepresentation.toRepresentation(group, true)).resourcePath(session.getContext().getUri()).success();
         }


### PR DESCRIPTION
Closes #9482 
Changed precondition for joining a group from is not a member to has group not directly assigned.