### PR TITLE
#10443 start-dev: parsing command lines parameters

### DIFF
--- a/quarkus/dist/src/main/content/bin/kc.bat
+++ b/quarkus/dist/src/main/content/bin/kc.bat
@@ -47,7 +47,6 @@ if "%KEY%" == "--debug" (
 if "%KEY%" == "start-dev" (
   set "CONFIG_ARGS=%CONFIG_ARGS% --profile=dev %KEY% --auto-build"
   shift
-  shift
   goto READ-ARGS
 )
 if not "%KEY:~0,2%"=="--" if "%KEY:~0,2%"=="-D" (


### PR DESCRIPTION
kc.bat called "shift" twice after parsing "start-dev". But "start-dev" is only one parameter so that "shift" should be called only once or else further command line parameters won't be parsed correctly.

Closes #10443

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
