### PR TITLE
Add admin events for realm create/delete

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/RealmAdminResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RealmAdminResource.java
@@ -450,6 +450,12 @@ public class RealmAdminResource {
         if (!new RealmManager(session).removeRealm(realm)) {
             throw new NotFoundException("Realm doesn't exist");
         }
+
+        // The delete event is associated with the realm of the user executing the operation,
+        // instead of the realm being deleted.
+        AdminEventBuilder deleteAdminEvent = new AdminEventBuilder(auth.adminAuth().getRealm(), auth.adminAuth(), session, connection);
+        deleteAdminEvent.operation(OperationType.DELETE).resource(ResourceType.REALM)
+                .realm(auth.adminAuth().getRealm().getId()).resourcePath(realm.getName()).success();
     }
 
     /**


### PR DESCRIPTION
This PR adds realm `CREATE` and `DELETE` events at realm creation and deletion for having audit trail also for those operations and for helping troubleshooting.

Fixes #10733

The event log listeners will of course receive these events normally, but when saving events to database there is additional complication. Stored admin events are modeled as resources under realms. They are fetched by `GET /{realm}/admin-events`. That works for fetching events about operations for "child" resources such as users of a realm but it raises a question: which realm would be used to fetch events of realm creation and deletion?

Note: Proposal 1 is currently implemented by this PR.

**Proposal 1:** 

Associate events with the realm of authenticated administrator instead of the realm that is being created or deleted. Add the realm name as resource path in the event. In this way, `master` realm becomes the "parent" of all realms when it comes to fetching the create/delete realm events. There is asymmetry in this proposal, since the existing `UPDATE` events are of course saved to the realm being updated.

**Proposal 2:**

Associate events with the realm being created/deleted. The resource path of the event becomes empty since the operation addresses realm itself and not a resource under realm. 

In proposal 2, it must be accepted that event storing will not work reliably because:

* `CREATE` can be lost since at realm creation the realm does not exist yet and saving is not likely to be enabled (at least when creating from GUI without import file).
* `DELETE` is lost at the same time the realm delete operation is executed.

Signed-off-by: Tero Saarni <tero.saarni@est.tech>
