### PR TITLE
Backport Update Quarkus to 2.7.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <jboss.snapshots.repo.id>jboss-snapshots-repository</jboss.snapshots.repo.id>
         <jboss.snapshots.repo.url>https://s01.oss.sonatype.org/content/repositories/snapshots/</jboss.snapshots.repo.url>
 
-        <quarkus.version>2.7.4.Final</quarkus.version>
+        <quarkus.version>2.7.5.Final</quarkus.version>
 
         <!--
         Performing a Wildfly upgrade? Run the:


### PR DESCRIPTION
No dependencies changed for us. No startup degradation (instead it got a bit better afaict)
Backport

Closes #10819