### PR TITLE
Backport: Changes Doctype in base theme to <!DOCTYPE HTML> (#10271)

### DIFF
--- a/themes/src/main/resources/theme/base/login/template.ftl
+++ b/themes/src/main/resources/theme/base/login/template.ftl
@@ -1,6 +1,6 @@
 <#macro registrationLayout bodyClass="" displayInfo=false displayMessage=true displayRequiredFields=false showAnotherWayIfPresent=true>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"  "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" class="${properties.kcHtmlClass!}">
+<!DOCTYPE html>
+<html class="${properties.kcHtmlClass!}">
 
 <head>
     <meta charset="utf-8">

--- a/themes/src/main/resources/theme/keycloak/welcome/index.ftl
+++ b/themes/src/main/resources/theme/keycloak/welcome/index.ftl
@@ -19,8 +19,8 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
- 
+<!DOCTYPE html>
+
 <html>
 <head>
     <title>Welcome to ${productNameFull}</title>


### PR DESCRIPTION
Closes: #10157
Backport.

Co-authored-by: Michael Rosenberger <michael.rosenberger@aeb.com>
