### PR TITLE
Backport: Closes #10243 (#10244)

### DIFF
--- a/quarkus/dist/src/main/content/bin/kc.bat
+++ b/quarkus/dist/src/main/content/bin/kc.bat
@@ -131,7 +131,7 @@ SetLocal EnableDelayedExpansion
 set "AUTO_BUILD_OPTION=auto-build"
 
 if not "!CONFIG_ARGS:%AUTO_BUILD_OPTION%=!"=="!CONFIG_ARGS!" (
-  %JAVA% -Dkc.config.rebuild-and-exit=true %JAVA_RUN_OPTS%
+  "%JAVA%" -Dkc.config.rebuild-and-exit=true %JAVA_RUN_OPTS%
 )
 
 "%JAVA%" %JAVA_RUN_OPTS%


### PR DESCRIPTION
Backport of #10243 (kc.bat error when directory has spaces)
