### PR TITLE
DO NOT MERGE - Draft for quarkus 2.8.0.CR1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <jboss.snapshots.repo.id>jboss-snapshots-repository</jboss.snapshots.repo.id>
         <jboss.snapshots.repo.url>https://s01.oss.sonatype.org/content/repositories/snapshots/</jboss.snapshots.repo.url>
 
-        <quarkus.version>2.7.5.Final</quarkus.version>
+        <quarkus.version>2.8.0.CR1</quarkus.version>
 
         <!--
         Performing a Wildfly upgrade? Run the:

--- a/quarkus/pom.xml
+++ b/quarkus/pom.xml
@@ -40,7 +40,7 @@
         <resteasy.version>4.7.5.Final</resteasy.version>
         <jackson.version>2.13.1</jackson.version>
         <jackson.databind.version>${jackson.version}</jackson.databind.version>
-        <hibernate.core.version>5.6.5.Final</hibernate.core.version>
+        <hibernate.core.version>5.6.7.Final</hibernate.core.version>
         <mysql.driver.version>8.0.28</mysql.driver.version>
         <postgresql.version>42.3.3</postgresql.version>
         <microprofile-metrics-api.version>3.0.1</microprofile-metrics-api.version>


### PR DESCRIPTION
Draft  PR to test new quarkus version as quarkus just released their 2.8.0.CR1

upgrade of hibernate to 5.6.7 included

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
