### PR TITLE
Build JavaDoc that matches the source version specified in the project.

### DIFF
--- a/distribution/api-docs-dist/pom.xml
+++ b/distribution/api-docs-dist/pom.xml
@@ -44,6 +44,8 @@
                     <maxmemory>2400m</maxmemory>
                     <encoding>UTF-8</encoding>
                     <includeDependencySources>true</includeDependencySources>
+                    <source>${maven.compiler.source}</source>
+                    <failOnError>true</failOnError>
                 </configuration>
                 <executions>
                     <execution>
@@ -97,6 +99,37 @@
                 <dependency>
                     <groupId>org.keycloak</groupId>
                     <artifactId>keycloak-authz-client</artifactId>
+                </dependency>
+                <!-- Include all classes that are marked "provided" and therefore not included in the dependencies above.
+                This avoids warnings when generating the JavaDoc -->
+                <dependency>
+                    <groupId>org.keycloak</groupId>
+                    <artifactId>keycloak-model-build-processor</artifactId>
+                    <version>${project.version}</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.logging</groupId>
+                    <artifactId>jboss-logging-annotations</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>net.java.dev.jna</groupId>
+                    <artifactId>jna</artifactId>
+                </dependency>
+                <dependency>
+                    <!-- Included here as it provides Nonnull from com.google.code.findbugs:jsr305.
+                    That is used in annotations in FilesPlainTextVaultProvider -->
+                    <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>
+                    <artifactId>owasp-java-html-sanitizer</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.infinispan.protostream</groupId>
+                    <artifactId>protostream-processor</artifactId>
+                    <version>${infinispan.protostream.processor.version}</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.infinispan</groupId>
+                    <artifactId>infinispan-component-annotations</artifactId>
+                    <version>${infinispan.version}</version>
                 </dependency>
             </dependencies>
             <build>


### PR DESCRIPTION
Also fail on errors, so we'll notice the missing JavaDocs next time.

Closes #9841

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->

To test this manually, run the following: 

```
mvn -Pdistribution,distribution-downloads clean install -DskipTests -am -pl distribution/api-docs-dist
``` 

The profile is not part of the standard `ci.yml` run. AFAIK this will only be run during `release.sh` at the moment. 
It is also part of the nightly build, so it will not only run on a release.

After this PR has been approved, the API docs for the old releases should be generated.
