### PR TITLE
Hot Rod map storage: User / client session no-downtime store

### DIFF
--- a/model/build-processor/src/main/java/org/keycloak/models/map/processor/GenerateHotRodEntityImplementationsProcessor.java
+++ b/model/build-processor/src/main/java/org/keycloak/models/map/processor/GenerateHotRodEntityImplementationsProcessor.java
@@ -276,12 +276,6 @@ public class GenerateHotRodEntityImplementationsProcessor extends AbstractGenera
                             .filter(variableElement -> variableElement.getSimpleName().toString().equals(hotRodEntityFieldName))
                             .findFirst();
 
-                    if (!hasField(e, hotRodEntityFieldName)) {
-                        // throw an error when no variable found
-                        processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, "Cannot find " + e.getSimpleName().toString() + " field for methods: [" + me.getValue().stream().map(ee -> ee.getSimpleName().toString()).collect(Collectors.joining(", ")) + "]", parentInterfaceElement);
-                        return;
-                    }
-
                     // Implement each method
                     for (ExecutableElement method : methods) {
                         FieldAccessorType fat = FieldAccessorType.determineType(method, me.getKey(), types, fieldType);

--- a/model/map-hot-rod/src/main/java/org/keycloak/models/map/storage/hotRod/HotRodMapStorageProviderFactory.java
+++ b/model/map-hot-rod/src/main/java/org/keycloak/models/map/storage/hotRod/HotRodMapStorageProviderFactory.java
@@ -21,6 +21,7 @@ import org.jboss.logging.Logger;
 import org.keycloak.Config;
 import org.keycloak.common.Profile;
 import org.keycloak.component.AmphibianProviderFactory;
+import org.keycloak.models.AuthenticatedClientSessionModel;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.ClientScopeModel;
 import org.keycloak.models.GroupModel;
@@ -30,6 +31,7 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.RoleModel;
 import org.keycloak.models.UserLoginFailureModel;
 import org.keycloak.models.UserModel;
+import org.keycloak.models.UserSessionModel;
 import org.keycloak.models.map.authSession.MapAuthenticationSessionEntity;
 import org.keycloak.models.map.authSession.MapRootAuthenticationSessionEntity;
 import org.keycloak.models.map.clientscope.MapClientScopeEntity;
@@ -87,10 +89,16 @@ import org.keycloak.models.map.storage.hotRod.user.HotRodUserCredentialEntityDel
 import org.keycloak.models.map.storage.hotRod.user.HotRodUserEntity;
 import org.keycloak.models.map.storage.hotRod.user.HotRodUserEntityDelegate;
 import org.keycloak.models.map.storage.hotRod.user.HotRodUserFederatedIdentityEntityDelegate;
+import org.keycloak.models.map.storage.hotRod.userSession.HotRodAuthenticatedClientSessionEntity;
+import org.keycloak.models.map.storage.hotRod.userSession.HotRodAuthenticatedClientSessionEntityDelegate;
+import org.keycloak.models.map.storage.hotRod.userSession.HotRodUserSessionEntity;
+import org.keycloak.models.map.storage.hotRod.userSession.HotRodUserSessionEntityDelegate;
 import org.keycloak.models.map.user.MapUserConsentEntity;
 import org.keycloak.models.map.user.MapUserCredentialEntity;
 import org.keycloak.models.map.user.MapUserEntity;
 import org.keycloak.models.map.user.MapUserFederatedIdentityEntity;
+import org.keycloak.models.map.userSession.MapAuthenticatedClientSessionEntity;
+import org.keycloak.models.map.userSession.MapUserSessionEntity;
 import org.keycloak.provider.EnvironmentDependentProviderFactory;
 import org.keycloak.sessions.RootAuthenticationSessionModel;
 
@@ -128,7 +136,8 @@ public class HotRodMapStorageProviderFactory implements AmphibianProviderFactory
             .constructor(MapRequiredActionProviderEntity.class,     HotRodRequiredActionProviderEntityDelegate::new)
             .constructor(MapRequiredCredentialEntity.class,         HotRodRequiredCredentialEntityDelegate::new)
             .constructor(MapWebAuthnPolicyEntity.class,             HotRodWebAuthnPolicyEntityDelegate::new)
-
+            .constructor(MapUserSessionEntity.class,                HotRodUserSessionEntityDelegate::new)
+            .constructor(MapAuthenticatedClientSessionEntity.class, HotRodAuthenticatedClientSessionEntityDelegate::new)
             .build();
 
     public static final Map<Class<?>, HotRodEntityDescriptor<?, ?>> ENTITY_DESCRIPTOR_MAP = new HashMap<>();
@@ -179,6 +188,18 @@ public class HotRodMapStorageProviderFactory implements AmphibianProviderFactory
                 new HotRodEntityDescriptor<>(RealmModel.class,
                         HotRodRealmEntity.class,
                         HotRodRealmEntityDelegate::new));
+
+       // User sessions descriptor
+        ENTITY_DESCRIPTOR_MAP.put(UserSessionModel.class,
+                new HotRodEntityDescriptor<>(UserSessionModel.class,
+                        HotRodUserSessionEntity.class,
+                        HotRodUserSessionEntityDelegate::new));
+
+        // Client sessions descriptor
+        ENTITY_DESCRIPTOR_MAP.put(AuthenticatedClientSessionModel.class,
+                new HotRodEntityDescriptor<>(AuthenticatedClientSessionModel.class,
+                        HotRodAuthenticatedClientSessionEntity.class,
+                        HotRodAuthenticatedClientSessionEntityDelegate::new));
     }
 
     @Override

--- a/model/map-hot-rod/src/main/java/org/keycloak/models/map/storage/hotRod/IckleQueryMapModelCriteriaBuilder.java
+++ b/model/map-hot-rod/src/main/java/org/keycloak/models/map/storage/hotRod/IckleQueryMapModelCriteriaBuilder.java
@@ -17,11 +17,13 @@
 
 package org.keycloak.models.map.storage.hotRod;
 
+import org.keycloak.models.AuthenticatedClientSessionModel;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.GroupModel;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.RoleModel;
 import org.keycloak.models.UserModel;
+import org.keycloak.models.UserSessionModel;
 import org.keycloak.models.map.storage.ModelCriteriaBuilder;
 import org.keycloak.models.map.storage.hotRod.common.AbstractHotRodEntity;
 import org.keycloak.storage.SearchableModelField;
@@ -72,6 +74,10 @@ public class IckleQueryMapModelCriteriaBuilder<E extends AbstractHotRodEntity, M
 
         INFINISPAN_NAME_OVERRIDES.put(RealmModel.SearchableFields.CLIENT_INITIAL_ACCESS, "clientInitialAccesses");
         INFINISPAN_NAME_OVERRIDES.put(RealmModel.SearchableFields.COMPONENT_PROVIDER_TYPE, "components.providerType");
+
+        INFINISPAN_NAME_OVERRIDES.put(UserSessionModel.SearchableFields.IS_OFFLINE, "offline");
+        INFINISPAN_NAME_OVERRIDES.put(UserSessionModel.SearchableFields.CLIENT_ID, "authenticatedClientSessions.key");
+        INFINISPAN_NAME_OVERRIDES.put(AuthenticatedClientSessionModel.SearchableFields.IS_OFFLINE, "offline");
     }
 
     static {

--- a/model/map-hot-rod/src/main/java/org/keycloak/models/map/storage/hotRod/client/HotRodProtocolMapperEntity.java
+++ b/model/map-hot-rod/src/main/java/org/keycloak/models/map/storage/hotRod/client/HotRodProtocolMapperEntity.java
@@ -22,7 +22,6 @@ import org.keycloak.models.map.annotations.GenerateHotRodEntityImplementation;
 import org.keycloak.models.map.storage.hotRod.common.AbstractHotRodEntity;
 import org.keycloak.models.map.storage.hotRod.common.HotRodPair;
 
-import java.util.Objects;
 import java.util.Set;
 
 @GenerateHotRodEntityImplementation(implementInterface = "org.keycloak.models.map.client.MapProtocolMapperEntity")

--- a/model/map-hot-rod/src/main/java/org/keycloak/models/map/storage/hotRod/common/HotRodStringPair.java
+++ b/model/map-hot-rod/src/main/java/org/keycloak/models/map/storage/hotRod/common/HotRodStringPair.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.models.map.storage.hotRod.common;
+
+import org.infinispan.protostream.annotations.ProtoDoc;
+import org.infinispan.protostream.annotations.ProtoField;
+
+import java.util.Objects;
+
+/**
+ * Indexed Hot Rod pair entity where both key and value are {@link String} type. The entity should be used when
+ * there is a need to search by key or/and value. Otherwise {@link HotRodPair<String, String>} should be used.
+ */
+@ProtoDoc("@Indexed")
+public class HotRodStringPair {
+
+    @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")
+    @ProtoField(number = 1)
+    public String key;
+
+    @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")
+    @ProtoField(number = 2)
+    public String value;
+
+    public HotRodStringPair() {}
+
+    public HotRodStringPair(String key, String value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        HotRodStringPair that = (HotRodStringPair) o;
+        return Objects.equals(key, that.key) && Objects.equals(value, that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(key, value);
+    }
+}

--- a/model/map-hot-rod/src/main/java/org/keycloak/models/map/storage/hotRod/common/HotRodTypesUtils.java
+++ b/model/map-hot-rod/src/main/java/org/keycloak/models/map/storage/hotRod/common/HotRodTypesUtils.java
@@ -18,12 +18,14 @@
 package org.keycloak.models.map.storage.hotRod.common;
 
 import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.UserSessionModel;
 import org.keycloak.models.map.common.AbstractEntity;
 import org.keycloak.models.map.storage.hotRod.authSession.HotRodAuthenticationSessionEntity;
 import org.keycloak.models.map.storage.hotRod.realm.entity.HotRodLocalizationTexts;
 import org.keycloak.models.map.storage.hotRod.realm.entity.HotRodRequirement;
 import org.keycloak.models.map.storage.hotRod.user.HotRodUserConsentEntity;
 import org.keycloak.models.map.storage.hotRod.user.HotRodUserFederatedIdentityEntity;
+import org.keycloak.models.map.storage.hotRod.userSession.HotRodSessionState;
 
 import java.util.HashMap;
 import java.util.List;
@@ -48,6 +50,10 @@ public class HotRodTypesUtils {
 
     public static <T, V> HotRodPair<T, V> createHotRodPairFromMapEntry(Map.Entry<T, V> entry) {
         return new HotRodPair<>(entry.getKey(), entry.getValue());
+    }
+
+    public static HotRodStringPair createHotRodStringPairFromMapEntry(Map.Entry<String, String> entry) {
+        return new HotRodStringPair(entry.getKey(), entry.getValue());
     }
 
     public static HotRodAttributeEntity createHotRodAttributeEntityFromMapEntry(Map.Entry<String, List<String>> entry) {
@@ -76,6 +82,14 @@ public class HotRodTypesUtils {
     }
 
     public static <K, V> V getValue(HotRodPair<K, V> hotRodPair) {
+        return hotRodPair.getValue();
+    }
+
+    public static String getKey(HotRodStringPair hotRodPair) {
+        return hotRodPair.getKey();
+    }
+
+    public static String getValue(HotRodStringPair hotRodPair) {
         return hotRodPair.getValue();
     }
 
@@ -142,5 +156,13 @@ public class HotRodTypesUtils {
         hotRodLocalizationTexts.setValues(migrateMapToSet(p1, HotRodTypesUtils::createHotRodPairFromMapEntry));
 
         return hotRodLocalizationTexts;
+    }
+
+    public static UserSessionModel.State migrateHotRodSessionStateToState(HotRodSessionState hotRodState) {
+        return UserSessionModel.State.valueOf(hotRodState.name());
+    }
+
+    public static HotRodSessionState migrateStateToHotRodSessionState(UserSessionModel.State state) {
+        return HotRodSessionState.valueOf(state.name());
     }
 }

--- a/model/map-hot-rod/src/main/java/org/keycloak/models/map/storage/hotRod/common/ProtoSchemaInitializer.java
+++ b/model/map-hot-rod/src/main/java/org/keycloak/models/map/storage/hotRod/common/ProtoSchemaInitializer.java
@@ -46,6 +46,9 @@ import org.keycloak.models.map.storage.hotRod.user.HotRodUserConsentEntity;
 import org.keycloak.models.map.storage.hotRod.user.HotRodUserCredentialEntity;
 import org.keycloak.models.map.storage.hotRod.user.HotRodUserEntity;
 import org.keycloak.models.map.storage.hotRod.user.HotRodUserFederatedIdentityEntity;
+import org.keycloak.models.map.storage.hotRod.userSession.HotRodAuthenticatedClientSessionEntity;
+import org.keycloak.models.map.storage.hotRod.userSession.HotRodSessionState;
+import org.keycloak.models.map.storage.hotRod.userSession.HotRodUserSessionEntity;
 
 /**
  * @author <a href="mailto:mkanis@redhat.com">Martin Kanis</a>
@@ -95,8 +98,16 @@ import org.keycloak.models.map.storage.hotRod.user.HotRodUserFederatedIdentityEn
                 HotRodWebAuthnPolicyEntity.class,
                 HotRodRealmEntity.class,
 
+                // User sessions
+                HotRodUserSessionEntity.class,
+                HotRodSessionState.class,
+
+                // Client sessions
+                HotRodAuthenticatedClientSessionEntity.class,
+
                 // Common
                 HotRodPair.class,
+                HotRodStringPair.class,
                 HotRodAttributeEntity.class,
                 HotRodAttributeEntityNonIndexed.class
         },

--- a/model/map-hot-rod/src/main/java/org/keycloak/models/map/storage/hotRod/userSession/HotRodAuthenticatedClientSessionEntity.java
+++ b/model/map-hot-rod/src/main/java/org/keycloak/models/map/storage/hotRod/userSession/HotRodAuthenticatedClientSessionEntity.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.models.map.storage.hotRod.userSession;
+
+import org.infinispan.protostream.annotations.ProtoDoc;
+import org.infinispan.protostream.annotations.ProtoField;
+import org.keycloak.models.map.annotations.GenerateHotRodEntityImplementation;
+import org.keycloak.models.map.storage.hotRod.common.AbstractHotRodEntity;
+import org.keycloak.models.map.storage.hotRod.common.HotRodPair;
+import org.keycloak.models.map.storage.hotRod.common.UpdatableHotRodEntityDelegateImpl;
+import org.keycloak.models.map.userSession.MapAuthenticatedClientSessionEntity;
+
+import java.util.Set;
+
+@GenerateHotRodEntityImplementation(
+        implementInterface = "org.keycloak.models.map.userSession.MapAuthenticatedClientSessionEntity",
+        inherits = "org.keycloak.models.map.storage.hotRod.userSession.HotRodAuthenticatedClientSessionEntity.AbstractHotRodAuthenticatedClientSessionEntityDelegate"
+)
+@ProtoDoc("@Indexed")
+public class HotRodAuthenticatedClientSessionEntity extends AbstractHotRodEntity {
+
+    @ProtoField(number = 1, required = true)
+    public int entityVersion = 1;
+
+    @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")
+    @ProtoField(number = 2, required = true)
+    public String id;
+
+    @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")
+    @ProtoField(number = 3)
+    public String userSessionId;
+
+    @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")
+    @ProtoField(number = 4)
+    public String realmId;
+
+    @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")
+    @ProtoField(number = 5)
+    public String clientId;
+
+    @ProtoField(number = 6)
+    public String authMethod;
+
+    @ProtoField(number = 7)
+    public String redirectUri;
+
+    @ProtoField(number = 8)
+    public Long timestamp;
+
+    @ProtoField(number = 9)
+    public Long expiration;
+
+    @ProtoField(number = 10)
+    public String action;
+
+    @ProtoField(number = 11)
+    public Set<HotRodPair<String, String>> notes;
+
+    @ProtoField(number = 12)
+    public String currentRefreshToken;
+
+    @ProtoField(number = 13)
+    public Integer currentRefreshTokenUseCount;
+
+    @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")
+    @ProtoField(number = 14)
+    public Boolean offline;
+
+    public static abstract class AbstractHotRodAuthenticatedClientSessionEntityDelegate extends UpdatableHotRodEntityDelegateImpl<HotRodAuthenticatedClientSessionEntity> implements MapAuthenticatedClientSessionEntity {
+
+        @Override
+        public String getId() {
+            return getHotRodEntity().id;
+        }
+
+        @Override
+        public void setId(String id) {
+            HotRodAuthenticatedClientSessionEntity entity = getHotRodEntity();
+            if (entity.id != null) throw new IllegalStateException("Id cannot be changed");
+            entity.id = id;
+            entity.updated |= id != null;
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return HotRodAuthenticatedClientSessionEntityDelegate.entityEquals(this, o);
+    }
+
+    @Override
+    public int hashCode() {
+        return HotRodAuthenticatedClientSessionEntityDelegate.entityHashCode(this);
+    }
+}

--- a/model/map-hot-rod/src/main/java/org/keycloak/models/map/storage/hotRod/userSession/HotRodSessionState.java
+++ b/model/map-hot-rod/src/main/java/org/keycloak/models/map/storage/hotRod/userSession/HotRodSessionState.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.models.map.storage.hotRod.userSession;
+
+import org.infinispan.protostream.annotations.ProtoEnumValue;
+
+public enum HotRodSessionState {
+    @ProtoEnumValue(number = 0)
+    LOGGED_IN,
+
+    @ProtoEnumValue(number = 1)
+    LOGGING_OUT,
+
+    @ProtoEnumValue(number = 2)
+    LOGGED_OUT,
+
+    @ProtoEnumValue(number = 3)
+    LOGGED_OUT_UNCONFIRMED
+}

--- a/model/map-hot-rod/src/main/java/org/keycloak/models/map/storage/hotRod/userSession/HotRodUserSessionEntity.java
+++ b/model/map-hot-rod/src/main/java/org/keycloak/models/map/storage/hotRod/userSession/HotRodUserSessionEntity.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.models.map.storage.hotRod.userSession;
+
+import org.infinispan.protostream.annotations.ProtoDoc;
+import org.infinispan.protostream.annotations.ProtoField;
+import org.keycloak.models.UserSessionModel;
+import org.keycloak.models.map.annotations.GenerateHotRodEntityImplementation;
+import org.keycloak.models.map.storage.hotRod.common.AbstractHotRodEntity;
+import org.keycloak.models.map.storage.hotRod.common.HotRodStringPair;
+import org.keycloak.models.map.storage.hotRod.common.UpdatableHotRodEntityDelegateImpl;
+import org.keycloak.models.map.userSession.MapUserSessionEntity;
+
+import java.util.Set;
+
+@GenerateHotRodEntityImplementation(
+        implementInterface = "org.keycloak.models.map.userSession.MapUserSessionEntity",
+        inherits = "org.keycloak.models.map.storage.hotRod.userSession.HotRodUserSessionEntity.AbstractHotRodUserSessionEntityDelegate"
+)
+@ProtoDoc("@Indexed")
+public class HotRodUserSessionEntity extends AbstractHotRodEntity {
+
+    @ProtoField(number = 1, required = true)
+    public int entityVersion = 1;
+
+    @ProtoField(number = 2, required = true)
+    public String id;
+
+    @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")
+    @ProtoField(number = 3)
+    public String realmId;
+
+    @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")
+    @ProtoField(number = 4)
+    public String userId;
+
+    @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")
+    @ProtoField(number = 5)
+    public String brokerSessionId;
+
+    @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")
+    @ProtoField(number = 6)
+    public String brokerUserId;
+
+    @ProtoField(number = 7)
+    public String loginUsername;
+
+    @ProtoField(number = 8)
+    public String ipAddress;
+
+    @ProtoField(number = 9)
+    public String authMethod;
+
+    @ProtoField(number = 10)
+    public Boolean rememberMe;
+
+    @ProtoField(number = 11)
+    public Long started;
+
+    @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")
+    @ProtoField(number = 12)
+    public Long lastSessionRefresh;
+
+    @ProtoField(number = 13)
+    public Long expiration;
+
+    @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")
+    @ProtoField(number = 14)
+    public Set<HotRodStringPair> notes;
+
+    @ProtoField(number = 15)
+    public HotRodSessionState state;
+
+    @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")
+    @ProtoField(number = 16)
+    public Set<HotRodStringPair> authenticatedClientSessions;
+
+    @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")
+    @ProtoField(number = 17)
+    public Boolean offline;
+
+    public static abstract class AbstractHotRodUserSessionEntityDelegate extends UpdatableHotRodEntityDelegateImpl<HotRodUserSessionEntity> implements MapUserSessionEntity {
+
+        @Override
+        public String getId() {
+            return getHotRodEntity().id;
+        }
+
+        @Override
+        public void setId(String id) {
+            HotRodUserSessionEntity entity = getHotRodEntity();
+            if (entity.id != null) throw new IllegalStateException("Id cannot be changed");
+            entity.id = id;
+            entity.updated |= id != null;
+        }
+
+        @Override
+        public UserSessionModel.SessionPersistenceState getPersistenceState() {
+            return UserSessionModel.SessionPersistenceState.PERSISTENT;
+        }
+
+        @Override
+        public void setPersistenceState(UserSessionModel.SessionPersistenceState persistenceState) {
+            if (persistenceState != null && UserSessionModel.SessionPersistenceState.PERSISTENT != persistenceState) {
+                throw new IllegalArgumentException("Transient session should not be stored in the HotRod.");
+            }
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return HotRodUserSessionEntityDelegate.entityEquals(this, o);
+    }
+
+    @Override
+    public int hashCode() {
+        return HotRodUserSessionEntityDelegate.entityHashCode(this);
+    }
+}

--- a/model/map-hot-rod/src/main/resources/config/cacheConfig.xml
+++ b/model/map-hot-rod/src/main/resources/config/cacheConfig.xml
@@ -71,5 +71,22 @@
             </indexing>
             <encoding media-type="application/x-protostream"/>
         </distributed-cache>
+        <distributed-cache name="user-sessions" mode="SYNC">
+            <indexing>
+                <indexed-entities>
+                    <indexed-entity>kc.HotRodUserSessionEntity</indexed-entity>
+                    <indexed-entity>kc.HotRodStringPair</indexed-entity>
+                </indexed-entities>
+            </indexing>
+            <encoding media-type="application/x-protostream"/>
+        </distributed-cache>
+        <distributed-cache name="client-sessions" mode="SYNC">
+            <indexing>
+                <indexed-entities>
+                    <indexed-entity>kc.HotRodAuthenticatedClientSessionEntity</indexed-entity>
+                </indexed-entities>
+            </indexing>
+            <encoding media-type="application/x-protostream"/>
+        </distributed-cache>
     </cache-container>
 </infinispan>

--- a/model/map-hot-rod/src/main/resources/config/infinispan.xml
+++ b/model/map-hot-rod/src/main/resources/config/infinispan.xml
@@ -73,5 +73,22 @@
             </indexing>
             <encoding media-type="application/x-protostream"/>
         </distributed-cache>
+        <distributed-cache name="user-sessions" mode="SYNC">
+            <indexing>
+                <indexed-entities>
+                    <indexed-entity>kc.HotRodUserSessionEntity</indexed-entity>
+                    <indexed-entity>kc.HotRodStringPair</indexed-entity>
+                </indexed-entities>
+            </indexing>
+            <encoding media-type="application/x-protostream"/>
+        </distributed-cache>
+        <distributed-cache name="client-sessions" mode="SYNC">
+            <indexing>
+                <indexed-entities>
+                    <indexed-entity>kc.HotRodAuthenticatedClientSessionEntity</indexed-entity>
+                </indexed-entities>
+            </indexing>
+            <encoding media-type="application/x-protostream"/>
+        </distributed-cache>
     </cache-container>
 </infinispan>

--- a/testsuite/integration-arquillian/tests/base/src/test/resources/META-INF/keycloak-server.json
+++ b/testsuite/integration-arquillian/tests/base/src/test/resources/META-INF/keycloak-server.json
@@ -266,7 +266,7 @@
             "username": "${keycloak.connectionsHotRod.username:myuser}",
             "password": "${keycloak.connectionsHotRod.password:qwer1234!}",
             "enableSecurity": "${keycloak.connectionsHotRod.enableSecurity:true}",
-            "reindexCaches": "${keycloak.connectionsHotRod.reindexCaches:auth-sessions,clients,client-scopes,groups,users,user-login-failures,roles,realms}"
+            "reindexCaches": "${keycloak.connectionsHotRod.reindexCaches:auth-sessions,clients,client-scopes,groups,users,user-login-failures,user-sessions,client-sessions,roles,realms}"
         }
     },
 

--- a/testsuite/integration-arquillian/tests/pom.xml
+++ b/testsuite/integration-arquillian/tests/pom.xml
@@ -1504,6 +1504,7 @@
                                     <keycloak.user.map.storage.provider>hotrod</keycloak.user.map.storage.provider>
                                     <keycloak.loginFailure.map.storage.provider>hotrod</keycloak.loginFailure.map.storage.provider>
                                     <keycloak.realm.map.storage.provider>hotrod</keycloak.realm.map.storage.provider>
+                                    <keycloak.userSession.map.storage.provider>hotrod</keycloak.userSession.map.storage.provider>
                                 </systemPropertyVariables>
                             </configuration>
                         </plugin>

--- a/testsuite/model/src/main/resources/hotrod/infinispan.xml
+++ b/testsuite/model/src/main/resources/hotrod/infinispan.xml
@@ -69,5 +69,22 @@
             </indexing>
             <encoding media-type="application/x-protostream"/>
         </distributed-cache>
+        <distributed-cache name="user-sessions" mode="SYNC">
+            <indexing>
+                <indexed-entities>
+                    <indexed-entity>kc.HotRodUserSessionEntity</indexed-entity>
+                    <indexed-entity>kc.HotRodStringPair</indexed-entity>
+                </indexed-entities>
+            </indexing>
+            <encoding media-type="application/x-protostream"/>
+        </distributed-cache>
+        <distributed-cache name="client-sessions" mode="SYNC">
+            <indexing>
+                <indexed-entities>
+                    <indexed-entity>kc.HotRodAuthenticatedClientSessionEntity</indexed-entity>
+                </indexed-entities>
+            </indexing>
+            <encoding media-type="application/x-protostream"/>
+        </distributed-cache>
     </cache-container>
 </infinispan>

--- a/testsuite/model/src/test/java/org/keycloak/testsuite/model/parameters/HotRodMapStorage.java
+++ b/testsuite/model/src/test/java/org/keycloak/testsuite/model/parameters/HotRodMapStorage.java
@@ -81,8 +81,8 @@ public class HotRodMapStorage extends KeycloakModelParameters {
           .spi(DeploymentStateSpi.NAME).provider(MapDeploymentStateProviderFactory.PROVIDER_ID).config(STORAGE_CONFIG, ConcurrentHashMapStorageProviderFactory.PROVIDER_ID)
           .spi(StoreFactorySpi.NAME).provider(MapAuthorizationStoreFactory.PROVIDER_ID).config(STORAGE_CONFIG, ConcurrentHashMapStorageProviderFactory.PROVIDER_ID)
           .spi("user").provider(MapUserProviderFactory.PROVIDER_ID).config(STORAGE_CONFIG, HotRodMapStorageProviderFactory.PROVIDER_ID)
-          .spi(UserSessionSpi.NAME).provider(MapUserSessionProviderFactory.PROVIDER_ID).config("storage-user-sessions.provider", ConcurrentHashMapStorageProviderFactory.PROVIDER_ID)
-                                                                                       .config("storage-client-sessions.provider", ConcurrentHashMapStorageProviderFactory.PROVIDER_ID)
+          .spi(UserSessionSpi.NAME).provider(MapUserSessionProviderFactory.PROVIDER_ID).config("storage-user-sessions.provider", HotRodMapStorageProviderFactory.PROVIDER_ID)
+                                                                                       .config("storage-client-sessions.provider", HotRodMapStorageProviderFactory.PROVIDER_ID)
           .spi(UserLoginFailureSpi.NAME).provider(MapUserLoginFailureProviderFactory.PROVIDER_ID).config(STORAGE_CONFIG, HotRodMapStorageProviderFactory.PROVIDER_ID)
           .spi("dblock").provider(NoLockingDBLockProviderFactory.PROVIDER_ID).config(STORAGE_CONFIG, ConcurrentHashMapStorageProviderFactory.PROVIDER_ID);
 


### PR DESCRIPTION
I introduced `HotRodStringPair` where `key` and `value` are both type `String` instead of `WrappedMessage`. Reason is that we are not able to use `WrappedMessage` in Ickle Query. See following error:
`ISPN028504 The property authenticatedClientSessions.key is an embedded entity and does not allow comparison predicates`

Question:
Should we use indexes for HotRodStringPair and where we don't use HotRodPair in a query we will use HotRodPair<String, String> instead?

Closes #9675
