### PR TITLE
Support 0/1 values for XML boolean attributes

### DIFF
--- a/saml-core/src/main/java/org/keycloak/saml/common/util/StaxParserUtil.java
+++ b/saml-core/src/main/java/org/keycloak/saml/common/util/StaxParserUtil.java
@@ -370,7 +370,7 @@ public class StaxParserUtil {
     public static Boolean getBooleanAttributeValue(StartElement startElement, HasQName attrName) {
         Attribute attr = startElement.getAttributeByName(attrName.getQName());
         String value = getAttributeValue(attr);
-        return value == null ? null : Boolean.valueOf(value);
+        return toBoolean(value);
     }
 
     /**
@@ -384,7 +384,11 @@ public class StaxParserUtil {
     public static Boolean getBooleanAttributeValueRP(StartElement startElement, HasQName attrName) {
         Attribute attr = startElement.getAttributeByName(attrName.getQName());
         String value = getAttributeValueRP(attr);
-        return value == null ? null : Boolean.valueOf(value);
+        return toBoolean(value);
+    }
+
+    private static Boolean toBoolean(String value) {
+    	return value==null ? null : Boolean.valueOf(value) || "1".equals(value);
     }
 
     /**
@@ -523,7 +527,7 @@ public class StaxParserUtil {
      *
      * @param xmlEventReader
      *
-     * @return A <b>trimmed</b> string value with all property references replaced if any. 
+     * @return A <b>trimmed</b> string value with all property references replaced if any.
      * If there are no valid references the input string will be returned
      *
      * @throws ParsingException

--- a/saml-core/src/test/java/org/keycloak/saml/common/util/StaxParserUtilTest.java
+++ b/saml-core/src/test/java/org/keycloak/saml/common/util/StaxParserUtilTest.java
@@ -17,8 +17,13 @@
 package org.keycloak.saml.common.util;
 
 import org.keycloak.saml.common.exceptions.ParsingException;
+import org.keycloak.saml.processing.core.parsers.saml.protocol.SAMLProtocolQNames;
+import org.keycloak.saml.processing.core.parsers.util.HasQName;
+
 import java.nio.charset.Charset;
 import java.util.NoSuchElementException;
+import java.util.function.BiFunction;
+
 import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.events.Characters;
@@ -35,7 +40,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.w3c.dom.Element;
 import org.w3c.dom.Text;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.CoreMatchers.*;
 
 /**
@@ -244,4 +249,42 @@ public class StaxParserUtilTest {
         }
     }
 
+    @Test
+    public void testGetBooleanAttributeValue() throws XMLStreamException, ParsingException {
+        testGetBooleanAttributeValue(new BiFunction<StartElement, HasQName, Boolean>() {
+            @Override
+            public Boolean apply(StartElement t, HasQName u) {
+                return StaxParserUtil.getBooleanAttributeValue(t, u);
+            }
+        });
+    }
+
+    @Test
+    public void testGetBooleanAttributeValueRP() throws XMLStreamException, ParsingException {
+        testGetBooleanAttributeValue(new BiFunction<StartElement, HasQName, Boolean>() {
+            @Override
+            public Boolean apply(StartElement t, HasQName u) {
+                return StaxParserUtil.getBooleanAttributeValueRP(t, u);
+            }
+        });
+    }
+
+    private void testGetBooleanAttributeValue(BiFunction<StartElement, HasQName, Boolean> predicate) throws XMLStreamException, ParsingException {
+        testGetBooleanAttributeValue("<a AllowCreate=\"false\">text</a>", predicate, false);
+        testGetBooleanAttributeValue("<a AllowCreate=\"true\">text</a>", predicate, true);
+        testGetBooleanAttributeValue("<a AllowCreate=\"0\">text</a>", predicate, false);
+        testGetBooleanAttributeValue("<a AllowCreate=\"1\">text</a>", predicate, true);
+        testGetBooleanAttributeValue("<a AllowCreate=\"invalid\">text</a>", predicate, false);
+        testGetBooleanAttributeValue("<a>text</a>", predicate, null);
+    }
+
+    private void testGetBooleanAttributeValue(String xml, BiFunction<StartElement, HasQName, Boolean> predicate, Boolean expectedResult) throws XMLStreamException, ParsingException {
+        XMLEventReader reader = StaxParserUtil.getXMLEventReader(IOUtils.toInputStream(xml, Charset.defaultCharset()));
+
+        assertThat(reader.nextEvent(), instanceOf(StartDocument.class));
+
+        StartElement domElement = StaxParserUtil.getNextStartElement(reader);
+        Boolean bool = predicate.apply(domElement, SAMLProtocolQNames.ATTR_ALLOW_CREATE);
+        assertThat(bool, is(expectedResult));
+    }
 }


### PR DESCRIPTION
Closes #10802

As described in issue, parsing of XML boolean attributes should comply to W3C XML schema definition : https://www.w3.org/TR/xmlschema11-2/#boolean
This PR is a simple fix to let Keycloak be compliant with this schema for SAML