### PR TITLE
Ensure JDK 1.7 API compatibility for clients when compiling with JDK 1.8+

### DIFF
--- a/adapters/oidc/installed/pom.xml
+++ b/adapters/oidc/installed/pom.xml
@@ -30,6 +30,10 @@
     <name>Keycloak Installed Application</name>
     <description/>
 
+    <properties>
+        <animal-sniffer-signature-version>java18</animal-sniffer-signature-version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.keycloak</groupId>

--- a/adapters/oidc/wildfly-elytron/pom.xml
+++ b/adapters/oidc/wildfly-elytron/pom.xml
@@ -31,6 +31,10 @@
     <name>Keycloak Wildfly Elytron OIDC Adapter</name>
     <description/>
 
+    <properties>
+        <animal-sniffer-signature-version>java18</animal-sniffer-signature-version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.wildfly.common</groupId>

--- a/adapters/saml/wildfly-elytron/pom.xml
+++ b/adapters/saml/wildfly-elytron/pom.xml
@@ -30,6 +30,10 @@
     <name>Keycloak WildFly Elytron SAML Adapter</name>
     <description/>
 
+    <properties>
+        <animal-sniffer-signature-version>java18</animal-sniffer-signature-version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.keycloak</groupId>

--- a/authz/policy/pom.xml
+++ b/authz/policy/pom.xml
@@ -17,6 +17,10 @@
     <name>KeyCloak AuthZ: Provider Parent</name>
     <description>KeyCloak AuthZ: Provider Parent</description>
 
+    <properties>
+        <animal-sniffer-signature-version>java18</animal-sniffer-signature-version>
+    </properties>
+
     <modules>
         <module>common</module>
     </modules>

--- a/common/src/main/java/org/keycloak/common/util/Encode.java
+++ b/common/src/main/java/org/keycloak/common/util/Encode.java
@@ -20,6 +20,7 @@ package org.keycloak.common.util;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
@@ -240,7 +241,10 @@ public class Encode
          int b = Integer.parseInt(matcher.group(1), 16);
          bytes.put((byte) b);
       }
-      bytes.flip();
+      // Cast as a Buffer to ensure that it compiles to JDK 1.7 compatible bytecode,
+      // as otherwise the method in ByteBuffer (available from Java 9 onwards) is put into the bytecode.
+      // Remove once everything uses JDK 11.
+      ((Buffer) bytes).flip();
       try
       {
          return decoder.decode(bytes).toString();

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -29,6 +29,10 @@
     <artifactId>keycloak-docs-parent</artifactId>
     <packaging>pom</packaging>
 
+    <properties>
+        <animal-sniffer-signature-version>java18</animal-sniffer-signature-version>
+    </properties>
+
     <profiles>
         <profile>
             <id>quarkus</id>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -30,6 +30,10 @@
     <artifactId>keycloak-examples-parent</artifactId>
     <packaging>pom</packaging>
 
+    <properties>
+        <animal-sniffer-signature-version>java18</animal-sniffer-signature-version>
+    </properties>
+
     <build>
         <pluginManagement>
             <plugins>

--- a/federation/kerberos/pom.xml
+++ b/federation/kerberos/pom.xml
@@ -29,6 +29,10 @@
     <name>Keycloak Kerberos Federation</name>
     <description />
 
+    <properties>
+        <animal-sniffer-signature-version>java18</animal-sniffer-signature-version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.keycloak</groupId>

--- a/federation/ldap/pom.xml
+++ b/federation/ldap/pom.xml
@@ -29,6 +29,10 @@
     <name>Keycloak LDAP UserStoreProvider</name>
     <description />
 
+    <properties>
+        <animal-sniffer-signature-version>java18</animal-sniffer-signature-version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.keycloak</groupId>

--- a/federation/pom.xml
+++ b/federation/pom.xml
@@ -32,6 +32,10 @@
     <name>Keycloak Federation</name>
     <description />
 
+    <properties>
+        <animal-sniffer-signature-version>java18</animal-sniffer-signature-version>
+    </properties>
+
     <modules>
         <module>kerberos</module>
         <module>ldap</module>

--- a/federation/sssd/pom.xml
+++ b/federation/sssd/pom.xml
@@ -13,6 +13,10 @@
     <name>Keycloak SSSD Federation</name>
     <description/>
 
+    <properties>
+        <animal-sniffer-signature-version>java18</animal-sniffer-signature-version>
+    </properties>
+
     <build>
         <plugins>
             <plugin>

--- a/integration/client-cli/admin-cli/pom.xml
+++ b/integration/client-cli/admin-cli/pom.xml
@@ -29,6 +29,10 @@
     <name>Keycloak Admin CLI</name>
     <description/>
 
+    <properties>
+        <animal-sniffer-signature-version>java18</animal-sniffer-signature-version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.jboss.aesh</groupId>

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -30,6 +30,10 @@
     <artifactId>keycloak-model-pom</artifactId>
     <packaging>pom</packaging>
 
+    <properties>
+        <animal-sniffer-signature-version>java18</animal-sniffer-signature-version>
+    </properties>
+
     <modules>
         <module>jpa</module>
         <module>map-jpa</module>

--- a/operator/pom.xml
+++ b/operator/pom.xml
@@ -172,6 +172,16 @@
                 </executions>
             </plugin>
             <plugin>
+                <!-- to be removed completely once JDK 11+ is used to build the project,
+                as the -release parameter to javac supersedes Animal Sniffer -->
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+                <configuration>
+                    <!-- disabled here, as this tree already uses JDK 11 -->
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,8 @@
         <apacheds.codec.version>2.0.0</apacheds.codec.version>
         <google.zxing.version>3.4.0</google.zxing.version>
         <freemarker.version>2.3.31</freemarker.version>
+        <!-- as long as maven.compiler.target is set to 1.7 -->
+        <animal-sniffer-signature-version>java17</animal-sniffer-signature-version>
 
         <jetty9.version>${jetty92.version}</jetty9.version>
         <liquibase.version>4.8.0</liquibase.version>
@@ -1903,6 +1905,30 @@
                 </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <plugin>
+                <!-- to be removed completely once JDK 11+ is used to build the project,
+                as the -release parameter to javac supersedes Animal Sniffer -->
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+                <version>1.20</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <phase>process-test-classes</phase>
+                        <configuration>
+                            <signature>
+                                <groupId>org.codehaus.mojo.signature</groupId>
+                                <artifactId>${animal-sniffer-signature-version}</artifactId>
+                                <version>1.0</version>
+                            </signature>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
 
     <profiles>

--- a/quarkus/pom.xml
+++ b/quarkus/pom.xml
@@ -152,6 +152,16 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>${maven.compiler.plugin.version}</version>
                 </plugin>
+                <plugin>
+                    <!-- to be removed completely once JDK 11+ is used to build the project,
+                    as the -release parameter to javac supersedes Animal Sniffer -->
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>animal-sniffer-maven-plugin</artifactId>
+                    <configuration>
+                        <!-- disabled here, as this tree already uses JDK 11 -->
+                        <skip>true</skip>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>

--- a/server-spi-private/pom.xml
+++ b/server-spi-private/pom.xml
@@ -92,6 +92,10 @@
         </dependency>
     </dependencies>
 
+    <properties>
+        <animal-sniffer-signature-version>java18</animal-sniffer-signature-version>
+    </properties>
+
     <build>
         <plugins>
             <plugin>

--- a/server-spi/pom.xml
+++ b/server-spi/pom.xml
@@ -30,6 +30,10 @@
     <name>Keycloak Server SPI</name>
     <description/>
 
+    <properties>
+        <animal-sniffer-signature-version>java18</animal-sniffer-signature-version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.jboss.spec.javax.transaction</groupId>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -32,6 +32,7 @@
 
     <properties>
         <version.swagger.doclet>1.1.2</version.swagger.doclet>
+        <animal-sniffer-signature-version>java18</animal-sniffer-signature-version>
     </properties>
 
     <dependencies>

--- a/services/src/main/java/org/keycloak/vault/DefaultVaultCharSecret.java
+++ b/services/src/main/java/org/keycloak/vault/DefaultVaultCharSecret.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.vault;
 
+import java.nio.Buffer;
 import java.nio.CharBuffer;
 import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
@@ -90,6 +91,9 @@ public class DefaultVaultCharSecret implements VaultCharSecret {
                 this.secretArray[i] = (char) ThreadLocalRandom.current().nextInt();
             }
         }
-        this.buffer.clear();
+        // Cast as a Buffer to ensure that it compiles to JDK 1.7 compatible bytecode,
+        // as otherwise the method in ByteBuffer (available from Java 9 onwards) is put into the bytecode.
+        // Remove once everything uses JDK 11.
+        ((Buffer) this.buffer).clear();
     }
 }

--- a/services/src/main/java/org/keycloak/vault/DefaultVaultRawSecret.java
+++ b/services/src/main/java/org/keycloak/vault/DefaultVaultRawSecret.java
@@ -16,6 +16,7 @@
  */
 package org.keycloak.vault;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
@@ -87,7 +88,10 @@ public class DefaultVaultRawSecret implements VaultRawSecret {
             ThreadLocalRandom.current().nextBytes(this.secretArray);
             this.secretArray = null;    // dispose of secretArray
         }
-        rawSecret.clear();
+        // Cast as a Buffer to ensure that it compiles to JDK 1.7 compatible bytecode,
+        // as otherwise the method in ByteBuffer (available from Java 9 onwards) is put into the bytecode.
+        // Remove once everything uses JDK 11.
+        ((Buffer) rawSecret).clear();
         rawSecret = EMPTY_BUFFER;
     }
 }

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -31,6 +31,10 @@
     <name>Keycloak TestSuite</name>
     <description />
 
+    <properties>
+        <animal-sniffer-signature-version>java18</animal-sniffer-signature-version>
+    </properties>
+
     <build>
         <plugins>
             <plugin>

--- a/wildfly/pom.xml
+++ b/wildfly/pom.xml
@@ -30,6 +30,10 @@
     <artifactId>keycloak-wildfly-parent</artifactId>
     <packaging>pom</packaging>
 
+    <properties>
+        <animal-sniffer-signature-version>java18</animal-sniffer-signature-version>
+    </properties>
+
     <modules>
         <module>adduser</module>
         <module>extensions</module>


### PR DESCRIPTION
For server components, ensure JDK 1.8 API compatibility as outlined in https://access.redhat.com/articles/2342861

Closes #10842

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
