### PR TITLE
Allow resoving theme resources from flat classpath

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/themes/FlatClasspathThemeResourceProviderFactory.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/themes/FlatClasspathThemeResourceProviderFactory.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.quarkus.runtime.themes;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Enumeration;
+import org.keycloak.theme.ClasspathThemeResourceProviderFactory;
+
+public class FlatClasspathThemeResourceProviderFactory extends ClasspathThemeResourceProviderFactory {
+
+    public static final String ID = "flat-classpath";
+
+    @Override
+    public InputStream getResourceAsStream(String path) throws IOException {
+        Enumeration<URL> resources = classLoader.getResources(THEME_RESOURCES_RESOURCES);
+
+        while (resources.hasMoreElements()) {
+            InputStream is = getResourceAsStream(path, resources.nextElement());
+
+            if (is != null) {
+                return is;
+            }
+        }
+
+        return null;
+    }
+
+    @Override
+    public String getId() {
+        return ID;
+    }
+}

--- a/services/src/main/java/org/keycloak/theme/ClasspathThemeResourceProviderFactory.java
+++ b/services/src/main/java/org/keycloak/theme/ClasspathThemeResourceProviderFactory.java
@@ -15,12 +15,13 @@ import org.keycloak.models.KeycloakSessionFactory;
 
 public class ClasspathThemeResourceProviderFactory implements ThemeResourceProviderFactory, ThemeResourceProvider {
 
-    public static final String THEME_RESOURCES_TEMPLATES = "theme-resources/templates/";
-    public static final String THEME_RESOURCES_RESOURCES = "theme-resources/resources/";
-    public static final String THEME_RESOURCES_MESSAGES = "theme-resources/messages/";
+    public static final String THEME_RESOURCES = "theme-resources";
+    public static final String THEME_RESOURCES_TEMPLATES = THEME_RESOURCES + "/templates/";
+    public static final String THEME_RESOURCES_RESOURCES = THEME_RESOURCES + "/resources/";
+    public static final String THEME_RESOURCES_MESSAGES = THEME_RESOURCES + "/messages/";
 
     private final String id;
-    private final ClassLoader classLoader;
+    protected final ClassLoader classLoader;
 
     public ClasspathThemeResourceProviderFactory() {
         this("classpath", Thread.currentThread().getContextClassLoader());
@@ -43,7 +44,10 @@ public class ClasspathThemeResourceProviderFactory implements ThemeResourceProvi
 
     @Override
     public InputStream getResourceAsStream(String path) throws IOException {
-        final URL rootResourceURL = classLoader.getResource(THEME_RESOURCES_RESOURCES);
+        return getResourceAsStream(path, classLoader.getResource(THEME_RESOURCES_RESOURCES));
+    }
+
+    protected InputStream getResourceAsStream(String path, URL rootResourceURL) throws IOException {
         if (rootResourceURL == null) {
             return null;
         }


### PR DESCRIPTION
Closes #10951

* Replaces the `org.keycloak.theme.ClasspathThemeResourceProviderFactory` with a new factory that is capable of resolving multiple resources from Quarkus flat classpath
* Avoid installing a theme resource provider if there are no resources available from the classpath

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
