### PR TITLE
Add Apache Kerby to Quarkus runtime dependencies

### DIFF
--- a/quarkus/runtime/pom.xml
+++ b/quarkus/runtime/pom.xml
@@ -292,6 +292,16 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.apache.kerby</groupId>
+            <artifactId>kerby-asn1</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>org.freemarker</groupId>
             <artifactId>freemarker</artifactId>
             <exclusions>


### PR DESCRIPTION
Apache Kerby is used by WebAuthn attestation verification
Without this library the assertion verification fails in Quarkus distribution

Closes #10779

@mabartos, do we need to write webauthn test against quarkus distribution?
I confirmed it works by manual testing, but not sure how to write test against quarkus distribution.