### PR TITLE
Fix for "updatedAt" user attribute in "profile" client scope 

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocolFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocolFactory.java
@@ -145,7 +145,7 @@ public class OIDCLoginProtocolFactory extends AbstractLoginProtocolFactory {
         createUserAttributeMapper(GENDER, "gender", IDToken.GENDER, "String");
         createUserAttributeMapper(BIRTHDATE, "birthdate", IDToken.BIRTHDATE, "String");
         createUserAttributeMapper(ZONEINFO, "zoneinfo", IDToken.ZONEINFO, "String");
-        createUserAttributeMapper(UPDATED_AT, "updatedAt", IDToken.UPDATED_AT, "String");
+        createUserAttributeMapper(UPDATED_AT, "updatedAt", IDToken.UPDATED_AT, "long");
         createUserAttributeMapper(LOCALE, "locale", IDToken.LOCALE, "String");
 
         createUserAttributeMapper(PHONE_NUMBER, "phoneNumber", IDToken.PHONE_NUMBER, "String");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/OIDCScopeTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/OIDCScopeTest.java
@@ -91,6 +91,7 @@ public class OIDCScopeTest extends AbstractOIDCScopeTest {
         attrs.add("street", "Elm 5");
         attrs.add("phoneNumber", "111-222-333");
         attrs.add("phoneNumberVerified", "true");
+        attrs.add("updatedAt", "1643282255");
         user.setAttributes(attrs);
 
         testRealm.getUsers().add(user);
@@ -218,6 +219,7 @@ public class OIDCScopeTest extends AbstractOIDCScopeTest {
             Assert.assertEquals("John", idToken.getGivenName());
             Assert.assertEquals("Doe", idToken.getFamilyName());
             Assert.assertEquals("John Doe", idToken.getName());
+            Assert.assertEquals(new Long(1643282255L),idToken.getUpdatedAt());
         } else {
             Assert.assertNull(idToken.getPreferredUsername());
             Assert.assertNull(idToken.getGivenName());


### PR DESCRIPTION
[10081] Changed default String type to Long for updatedAt attribute
