### PR TITLE
Add Wayfair to Adopters

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -54,4 +54,5 @@ List of organization names below is based on information collected using Keycloa
 * TrackingSport
 * TRT9 - Brasil
 * UnitedHealthcare
+* Wayfair LLC
 * ...More individuals


### PR DESCRIPTION
## Changelog

### Added
* Wayfair to list of Adopters

## Summary
Wayfair is the largest e-commerce home goods company in US and has adopted Keycloak for our Supplier login portal and our Internal Employee login.

## Details

https://partners.wayfair.com/v/login/index is Wayfair's supplier portal serving around 80000 logins a day using Keycloak and we have many more internal tools adopting and loving Keycloak.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
