### PR TITLE
Update jackson-databind dependency to fix CVE-2020-36518

### DIFF
--- a/quarkus/pom.xml
+++ b/quarkus/pom.xml
@@ -38,8 +38,8 @@
             for reference
         -->
         <resteasy.version>4.7.5.Final</resteasy.version>
-        <jackson.version>2.13.1</jackson.version>
-        <jackson.databind.version>${jackson.version}</jackson.databind.version>
+        <jackson.version>2.13.2</jackson.version>
+        <jackson.databind.version>2.13.2.2</jackson.databind.version>
         <hibernate.core.version>5.6.5.Final</hibernate.core.version>
         <mysql.driver.version>8.0.28</mysql.driver.version>
         <postgresql.version>42.3.3</postgresql.version>


### PR DESCRIPTION
Resolves #11071

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->

@pedroigor a few considerations:

-  Other Jackson dependencies are not impacted by this, only `jackson-databind`. I did an update only to make sure that we use the latest release.
-  I had to change `jackson.version`. While `jackson-databind` has its latest release on 2.13.2.2, other dependencies are on `2.13.2` 
