### PR TITLE
fix : nightly release download path in Dockerfile

### DIFF
--- a/quarkus/container/Dockerfile
+++ b/quarkus/container/Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.access.redhat.com/ubi8-minimal AS build-env
 
 ENV KEYCLOAK_VERSION 999-SNAPSHOT
-ARG KEYCLOAK_DIST=https://github.com/keycloak/keycloak/releases/download/$KEYCLOAK_VERSION/keycloak-$KEYCLOAK_VERSION.tar.gz
+ARG KEYCLOAK_DIST=https://github.com/keycloak/keycloak/releases/download/nightly/keycloak-$KEYCLOAK_VERSION.tar.gz
 
 RUN microdnf install -y tar gzip
 


### PR DESCRIPTION
Nightly release download path should be "https://github.com/keycloak/keycloak/releases/download/nightly/keycloak-999-SNAPSHOT.tar.gz" instead of "https://github.com/keycloak/keycloak/releases/download/999-SNAPSHOT/keycloak-999-SNAPSHOT.tar.gz"

Closes #11104 

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>