### PR TITLE
Add a missing `=` in `conf/keycloak.conf` example

### DIFF
--- a/docs/guides/src/main/server/configuration.adoc
+++ b/docs/guides/src/main/server/configuration.adoc
@@ -105,7 +105,7 @@ Most optimizations to startup and memory footprint can be achieved by using the 
 db-url-host=keycloak-postgres
 db-username=keycloak
 db-password=change_me
-hostname mykeycloak.acme.com
+hostname=mykeycloak.acme.com
 ```
 
 .Start the server


### PR DESCRIPTION
Add a missing `=` in `conf/keycloak.conf` example

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
