### PR TITLE
[#11036] Identity Providers: Add support for elliptic curve signatures (ES256/ES384/ES512) using JWKS URL

### DIFF
--- a/common/src/main/java/org/keycloak/common/util/DerUtils.java
+++ b/common/src/main/java/org/keycloak/common/util/DerUtils.java
@@ -57,9 +57,13 @@ public final class DerUtils {
     }
 
     public static PublicKey decodePublicKey(byte[] der) throws NoSuchAlgorithmException, InvalidKeySpecException, NoSuchProviderException {
+        return decodePublicKey(der, "RSA");
+    }
+
+    public static PublicKey decodePublicKey(byte[] der, String type) throws NoSuchAlgorithmException, InvalidKeySpecException, NoSuchProviderException {
         X509EncodedKeySpec spec =
                 new X509EncodedKeySpec(der);
-        KeyFactory kf = KeyFactory.getInstance("RSA", BouncyIntegration.PROVIDER);
+        KeyFactory kf = KeyFactory.getInstance(type, BouncyIntegration.PROVIDER);
         return kf.generatePublic(spec);
     }
 

--- a/common/src/main/java/org/keycloak/common/util/PemUtils.java
+++ b/common/src/main/java/org/keycloak/common/util/PemUtils.java
@@ -73,13 +73,23 @@ public final class PemUtils {
      * @throws Exception
      */
     public static PublicKey decodePublicKey(String pem) {
+        return decodePublicKey(pem, "RSA");
+    }
+
+    /**
+     * Decode a Public Key from a PEM string
+     * @param pem The pem encoded pblic key
+     * @param type The type of the key (RSA, EC,...)
+     * @return The public key or null
+     */
+    public static PublicKey decodePublicKey(String pem, String type) {
         if (pem == null) {
             return null;
         }
 
         try {
             byte[] der = pemToDer(pem);
-            return DerUtils.decodePublicKey(der);
+            return DerUtils.decodePublicKey(der, type);
         } catch (Exception e) {
             throw new PemException(e);
         }

--- a/server-spi-private/src/main/java/org/keycloak/crypto/SignatureProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/crypto/SignatureProvider.java
@@ -21,9 +21,27 @@ import org.keycloak.provider.Provider;
 
 public interface SignatureProvider extends Provider {
 
+    static void checkKeyForSignature(KeyWrapper key, String algorithm, String type) throws SignatureException {
+        if (!type.equals(key.getType()) || !algorithm.equals(key.getAlgorithmOrDefault())) {
+            throw new SignatureException(String.format("Key with algorithm %s and type %s is incorrect for provider algorithm %s",
+                    key.getAlgorithm(), key.getType(), algorithm));
+        }
+    }
+
+    static void checkKeyForVerification(KeyWrapper key, String algorithm, String type) throws VerificationException {
+        if (!type.equals(key.getType()) || !algorithm.equals(key.getAlgorithmOrDefault())) {
+            throw new VerificationException(String.format("Key with algorithm %s and type %s is incorrect for provider algorithm %s",
+                    key.getAlgorithm(), key.getType(), algorithm));
+        }
+    }
+
     SignatureSignerContext signer() throws SignatureException;
 
+    SignatureSignerContext signer(KeyWrapper key) throws SignatureException;
+
     SignatureVerifierContext verifier(String kid) throws VerificationException;
+
+    SignatureVerifierContext verifier(KeyWrapper key) throws VerificationException;
 
     boolean isAsymmetricAlgorithm();
 

--- a/services/src/main/java/org/keycloak/crypto/AsymmetricSignatureProvider.java
+++ b/services/src/main/java/org/keycloak/crypto/AsymmetricSignatureProvider.java
@@ -35,8 +35,20 @@ public class AsymmetricSignatureProvider implements SignatureProvider {
     }
 
     @Override
+    public SignatureSignerContext signer(KeyWrapper key) throws SignatureException {
+        SignatureProvider.checkKeyForSignature(key, algorithm, KeyType.RSA);
+        return new ServerAsymmetricSignatureSignerContext(key);
+    }
+
+    @Override
     public SignatureVerifierContext verifier(String kid) throws VerificationException {
         return new ServerAsymmetricSignatureVerifierContext(session, kid, algorithm);
+    }
+
+    @Override
+    public SignatureVerifierContext verifier(KeyWrapper key) throws VerificationException {
+        SignatureProvider.checkKeyForVerification(key, algorithm, KeyType.RSA);
+        return new ServerAsymmetricSignatureVerifierContext(key);
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/crypto/ECDSASignatureProvider.java
+++ b/services/src/main/java/org/keycloak/crypto/ECDSASignatureProvider.java
@@ -29,8 +29,20 @@ public class ECDSASignatureProvider implements SignatureProvider {
     }
 
     @Override
+    public SignatureSignerContext signer(KeyWrapper key) throws SignatureException {
+        SignatureProvider.checkKeyForSignature(key, algorithm, KeyType.EC);
+        return new ServerECDSASignatureSignerContext(key);
+    }
+
+    @Override
     public SignatureVerifierContext verifier(String kid) throws VerificationException {
         return new ServerECDSASignatureVerifierContext(session, kid, algorithm);
+    }
+
+    @Override
+    public SignatureVerifierContext verifier(KeyWrapper key) throws VerificationException {
+        SignatureProvider.checkKeyForVerification(key, algorithm, KeyType.EC);
+        return new ServerECDSASignatureVerifierContext(key);
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/crypto/MacSecretSignatureProvider.java
+++ b/services/src/main/java/org/keycloak/crypto/MacSecretSignatureProvider.java
@@ -35,8 +35,20 @@ public class MacSecretSignatureProvider implements SignatureProvider {
     }
 
     @Override
+    public SignatureSignerContext signer(KeyWrapper key) throws SignatureException {
+        SignatureProvider.checkKeyForSignature(key, algorithm, KeyType.OCT);
+        return new ServerMacSignatureSignerContext(key);
+    }
+
+    @Override
     public SignatureVerifierContext verifier(String kid) throws VerificationException {
         return new ServerMacSignatureVerifierContext(session, kid, algorithm);
+    }
+
+    @Override
+    public SignatureVerifierContext verifier(KeyWrapper key) throws VerificationException {
+        SignatureProvider.checkKeyForVerification(key, algorithm, KeyType.OCT);
+        return new ServerMacSignatureVerifierContext(key);
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/crypto/ServerAsymmetricSignatureSignerContext.java
+++ b/services/src/main/java/org/keycloak/crypto/ServerAsymmetricSignatureSignerContext.java
@@ -24,6 +24,10 @@ public class ServerAsymmetricSignatureSignerContext extends AsymmetricSignatureS
         super(getKey(session, algorithm));
     }
 
+    public ServerAsymmetricSignatureSignerContext(KeyWrapper key) throws SignatureException {
+        super(key);
+    }
+
     static KeyWrapper getKey(KeycloakSession session, String algorithm) {
         KeyWrapper key = session.keys().getActiveKey(session.getContext().getRealm(), KeyUse.SIG, algorithm);
         if (key == null) {

--- a/services/src/main/java/org/keycloak/crypto/ServerAsymmetricSignatureVerifierContext.java
+++ b/services/src/main/java/org/keycloak/crypto/ServerAsymmetricSignatureVerifierContext.java
@@ -25,6 +25,10 @@ public class ServerAsymmetricSignatureVerifierContext extends AsymmetricSignatur
         super(getKey(session, kid, algorithm));
     }
 
+    public ServerAsymmetricSignatureVerifierContext(KeyWrapper key) throws VerificationException {
+        super(key);
+    }
+
     static KeyWrapper getKey(KeycloakSession session, String kid, String algorithm) throws VerificationException {
         KeyWrapper key = session.keys().getKey(session.getContext().getRealm(), kid, KeyUse.SIG, algorithm);
         if (key == null) {

--- a/services/src/main/java/org/keycloak/crypto/ServerMacSignatureSignerContext.java
+++ b/services/src/main/java/org/keycloak/crypto/ServerMacSignatureSignerContext.java
@@ -24,6 +24,10 @@ public class ServerMacSignatureSignerContext extends MacSignatureSignerContext {
         super(getKey(session, algorithm));
     }
 
+    public ServerMacSignatureSignerContext(KeyWrapper key) throws SignatureException {
+        super(key);
+    }
+
     private static KeyWrapper getKey(KeycloakSession session, String algorithm) {
         KeyWrapper key = session.keys().getActiveKey(session.getContext().getRealm(), KeyUse.SIG, algorithm);
         if (key == null) {

--- a/services/src/main/java/org/keycloak/crypto/ServerMacSignatureVerifierContext.java
+++ b/services/src/main/java/org/keycloak/crypto/ServerMacSignatureVerifierContext.java
@@ -25,6 +25,10 @@ public class ServerMacSignatureVerifierContext extends MacSignatureVerifierConte
         super(getKey(session, kid, algorithm));
     }
 
+    public ServerMacSignatureVerifierContext(KeyWrapper key) throws VerificationException {
+        super(key);
+    }
+
     private static KeyWrapper getKey(KeycloakSession session, String kid, String algorithm) throws VerificationException {
         KeyWrapper key = session.keys().getKey(session.getContext().getRealm(), kid, KeyUse.SIG, algorithm);
         if (key == null) {

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/admin/ApiUtil.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/admin/ApiUtil.java
@@ -23,7 +23,6 @@ import org.keycloak.admin.client.resource.ClientScopeResource;
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.admin.client.resource.RoleResource;
 import org.keycloak.admin.client.resource.UserResource;
-import org.keycloak.crypto.Algorithm;
 import org.keycloak.crypto.KeyStatus;
 import org.keycloak.crypto.KeyUse;
 import org.keycloak.representations.idm.ClientRepresentation;
@@ -280,4 +279,13 @@ public class ApiUtil {
         return null;
     }
 
+    public static KeysMetadataRepresentation.KeyMetadataRepresentation findActiveSigningKey(RealmResource realm, String alg) {
+        KeysMetadataRepresentation keyMetadata = realm.keys().getKeyMetadata();
+        for (KeysMetadataRepresentation.KeyMetadataRepresentation rep : keyMetadata.getKeys()) {
+            if (rep.getPublicKey() != null && KeyStatus.valueOf(rep.getStatus()).isActive() && KeyUse.SIG.equals(rep.getUse()) && alg.equals(rep.getAlgorithm())) {
+                return rep;
+            }
+        }
+        return null;
+    }
 }


### PR DESCRIPTION
Closes #11036 

I'm trying to fix issue #11036. Notes:

* The `OIDCIdentityProvider` will use a `SignatureProvider` to perform the verification instead of the fixed `RSAProvider`.
* The `SignatureProvider` provider interface is extended to obtain the verifier and signer using a specific key (it's inside a private folder so I think it's OK, right now the providers can only be used with domain keys and not in a generic way like it's needed here).
* The `HardcodedPublicKeyLoader` is also modified to allow different algorithms in the direct broker configuration (attribute with the Public Key). Depending the algorithm the attribute is decoded as a RSA or EC public key or even an HMAC secret key.
* `KcOIDCBrokerWithSignatureTest` is modified to add a test using ES256 and PS512 with jwks-url and ES256, PS512 and HS512 using direct broker configuration.

If you see something wrong or improvable please let me know.