### PR TITLE
container doc example, remove port from KC_HOSTNAME env

### DIFF
--- a/docs/guides/src/main/server/containers.adoc
+++ b/docs/guides/src/main/server/containers.adoc
@@ -38,7 +38,7 @@ ENV KEYCLOAK_ADMIN_PASSWORD=change_me
 ENV KC_DB_URL=<DBURL>
 ENV KC_DB_USERNAME=<DBUSERNAME>
 ENV KC_DB_PASSWORD=<DBPASSWORD>
-ENV KC_HOSTNAME=localhost:8443
+ENV KC_HOSTNAME=localhost
 ENTRYPOINT ["/opt/keycloak/bin/kc.sh", "start"]
 ----
 The build process includes multiple stages:


### PR DESCRIPTION
Hi,

I used the container spec from this documentation example and if I do not change the KC_HOSTNAME env to "localhost" I get a weird error because my browser tries to access the Keycloak backend using https://localhost:8443:8443. It works fine if I remove the port. I think there is a separate configuration option for the port called "hostname-port".