### PR TITLE
Script Mapper Performance Issues

### DIFF
--- a/services/src/main/java/org/keycloak/services/ServicesLogger.java
+++ b/services/src/main/java/org/keycloak/services/ServicesLogger.java
@@ -462,4 +462,9 @@ public interface ServicesLogger extends BasicLogger {
     @LogMessage(level = ERROR)
     @Message(id=105, value="Response_mode 'query.jwt' is allowed only when the authorization response token is encrypted")
     void responseModeQueryJwtNotAllowed();
+
+    @LogMessage(level = INFO)
+    @Message(id=106, value="Created script engine '%s', version '%s' for the mime type '%s'")
+    @Once
+    void scriptEngineCreated(String engineName, String engineVersion, String mimeType);
 }


### PR DESCRIPTION
Closes #11005

@stianst @pedroigor Anyone of you is available to review this?

### Details

This is for the fix of performance issue when the script protocol mapper is used. The issue is due the fact that each invocation of the OIDC Script (or OIDC Authenticator or other places which uses JS Script Engine) creates it's own instance of `ScriptEngine` .

This is unnecessary overhead as ScriptEngine can be shared across multiple threads and operated concurrently on case of the Nashorn Script Engine. The thing is, that each thread needs to use it's own `Bindings` to inject java objects operated in the script environment, but that is already used by the Keycloak code.

Some details about Nashorn concurrency for example here (First reply from the Nashorn maintainer Attila Szegedi): https://stackoverflow.com/questions/30140103/should-i-use-a-separate-scriptengine-and-compiledscript-instances-per-each-threa

### Performance results

Tried simple performance test with 100K executions  of OIDC script mapper

**Before fix (openjdk 11):**
Total time of the test: 260 seconds
Time spent in GC: 5.887 seconds
Total classes loaded: 400K (classes continued to load during the test due the repeated compilations of ScriptEngine)

**Before fix (openjdk 8):**
Total time of the test: 118 seconds
Time spent in GC: 2.983 seconds
Total classes loaded: 100K (classes continued to load during the test due the repeated compilations of ScriptEngine)

**After fix (openjdk 11):**
Total time of the test: 15 seconds
Time spent in GC: 0.42 seconds
Total classes loaded: 18K (No classes loaded during the test, most from 18K classes were loaded before performance test executed)

Similar performance for openjdk8 as for openjdk11 achieved after fix

