### PR TITLE
Bump Quarkus Operator SDK version

### DIFF
--- a/operator/pom.xml
+++ b/operator/pom.xml
@@ -22,8 +22,9 @@
         -->
         <resteasy.version>4.7.5.Final</resteasy.version>
         <wildfly.common.version>1.5.4.Final-format-001</wildfly.common.version>
-        <jackson.version>2.13.1</jackson.version>
-        <kubernetes-client.version>5.12.1</kubernetes-client.version>
+        <jackson.version>2.13.2</jackson.version>
+        <jackson.databind.version>2.13.2.2</jackson.databind.version>
+        <kubernetes-client.version>5.12.2</kubernetes-client.version>
 
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <maven.compiler.parameters>true</maven.compiler.parameters>
@@ -32,7 +33,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus.operator.sdk.version>3.0.6</quarkus.operator.sdk.version>
+        <quarkus.operator.sdk.version>3.0.7</quarkus.operator.sdk.version>
         <quarkus.version>2.7.5.Final</quarkus.version>
         <quarkus.container-image.group>keycloak</quarkus.container-image.group>
         <quarkus.jib.base-jvm-image>registry.access.redhat.com/ubi8/openjdk-11-runtime</quarkus.jib.base-jvm-image>

--- a/operator/src/test/java/org/keycloak/operator/PodTemplateTest.java
+++ b/operator/src/test/java/org/keycloak/operator/PodTemplateTest.java
@@ -51,6 +51,12 @@ public class PodTemplateTest {
         // Arrange
         PodTemplateSpec additionalPodTemplate = null;
 
+        try {
+            Thread.sleep(5000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
         // Act
         var podTemplate = getDeployment(additionalPodTemplate).getSpec().getTemplate();
 


### PR DESCRIPTION
Fixes https://github.com/quarkiverse/quarkus-operator-sdk/issues/301
And https://github.com/java-operator-sdk/java-operator-sdk/issues/1136

I'm tentatively sneaking in the update of Jackson dependencies to get rid of CVEs as well:
https://github.com/keycloak/keycloak/pull/11073
I can separate in 2 PRs if requested 🙂 