### PR TITLE
Autofocus 'Sign In With Security Key' button

### DIFF
--- a/themes/src/main/resources/theme/base/login/webauthn-authenticate.ftl
+++ b/themes/src/main/resources/theme/base/login/webauthn-authenticate.ftl
@@ -69,7 +69,7 @@
                 </#if>
 
                 <div id="kc-form-buttons" class="${properties.kcFormButtonsClass!}">
-                    <input id="authenticateWebAuthnButton" type="button" onclick="webAuthnAuthenticate()"
+                    <input id="authenticateWebAuthnButton" type="button" onclick="webAuthnAuthenticate()" autofocus="autofocus"
                            value="${kcSanitize(msg("webauthn-doAuthenticate"))}"
                            class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}"/>
                 </div>


### PR DESCRIPTION
The base webauthn-authenticate.ftl template should be enhanced to achieve autofocus on the 'Sign In With Security Key' button. Without this customization in Keycloak 14 you need to tab twice to this button and then strike enter/space.

Closes #10945

