### PR TITLE
Bump Jackson and Kubernetes-client

### DIFF
--- a/operator/pom.xml
+++ b/operator/pom.xml
@@ -22,8 +22,9 @@
         -->
         <resteasy.version>4.7.5.Final</resteasy.version>
         <wildfly.common.version>1.5.4.Final-format-001</wildfly.common.version>
-        <jackson.version>2.13.1</jackson.version>
-        <kubernetes-client.version>5.12.1</kubernetes-client.version>
+        <jackson.version>2.13.2</jackson.version>
+        <jackson.databind.version>2.13.2.2</jackson.databind.version>
+        <kubernetes-client.version>5.12.2</kubernetes-client.version>
 
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <maven.compiler.parameters>true</maven.compiler.parameters>


### PR DESCRIPTION
Follow up from:
https://github.com/keycloak/keycloak/pull/11174#issuecomment-1092790584

This should be the "safe" subset of dependencies that we can bump without code changes.

Resolves: #11245