### PR TITLE
Mistyping correction

### DIFF
--- a/server-spi/src/main/java/org/keycloak/urls/HostnameProvider.java
+++ b/server-spi/src/main/java/org/keycloak/urls/HostnameProvider.java
@@ -34,7 +34,7 @@ public interface HostnameProvider extends Provider {
      * Returns the URL scheme. If not implemented will delegate to {@link #getScheme(UriInfo)}.
      *
      * @param originalUriInfo the original URI
-     * @param uype type of the request
+     * @param type type of the request
      * @return the schema
      */
     default String getScheme(UriInfo originalUriInfo, UrlType type) {


### PR DESCRIPTION
[HostnameProvider.getScheme](https://github.com/keycloak/keycloak/blob/a6dd9dc0f1605ce0ac2b424df10e15a6eff6ff70/server-spi/src/main/java/org/keycloak/urls/HostnameProvider.java#L37) mistyping in comment

Closes https://github.com/keycloak/keycloak/issues/11288