### PR TITLE
Replace the cryptographic algorithm by SHA-2

### DIFF
--- a/model/map/src/main/java/org/keycloak/models/map/deploymentState/MapDeploymentStateProviderFactory.java
+++ b/model/map/src/main/java/org/keycloak/models/map/deploymentState/MapDeploymentStateProviderFactory.java
@@ -55,7 +55,7 @@ public class MapDeploymentStateProviderFactory implements DeploymentStateProvide
             seed = SecretGenerator.getInstance().randomString(10);
         }
         try {
-            Version.RESOURCES_VERSION = Base64Url.encode(MessageDigest.getInstance("MD5")
+            Version.RESOURCES_VERSION = Base64Url.encode(MessageDigest.getInstance("SHA-256")
                     .digest((seed + new ModelVersion(Version.VERSION_KEYCLOAK).toString()).getBytes()))
                     .substring(0, 5);
         } catch (NoSuchAlgorithmException e) {


### PR DESCRIPTION
The static code scanning analysis detected the usage of MD5 as part of [
MapDeploymentStateProviderFactory](https://github.com/keycloak/keycloak/blob/a6dd9dc0f1605ce0ac2b424df10e15a6eff6ff70/model/map/src/main/java/org/keycloak/models/map/deploymentState/MapDeploymentStateProviderFactory.java#L58-L58).

Even though we could not find any ways of exploiting the code, we should
avoid its usage considering that MD5 is not collision-resistant.

Resolves #11290

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
