### PR TITLE
Add duplicate parameters check process in Device Authz Endpoint.

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/device/endpoints/DeviceEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/device/endpoints/DeviceEndpoint.java
@@ -111,6 +111,12 @@ public class DeviceEndpoint extends AuthorizationEndpointBase implements RealmRe
         AuthorizationEndpointRequest request = AuthorizationEndpointRequestParserProcessor.parseRequest(event, session, client,
             httpRequest.getDecodedFormParameters());
 
+        if (request.getInvalidRequestMessage() != null) {
+            event.error(Errors.INVALID_REQUEST);
+            throw new ErrorResponseException(OAuthErrorException.INVALID_GRANT,
+                request.getInvalidRequestMessage(), Response.Status.BAD_REQUEST);
+        }
+
         if (!TokenUtil.isOIDCRequest(request.getScope())) {
             ServicesLogger.LOGGER.oidcScopeMissing();
         }


### PR DESCRIPTION
Similar to the past [PR](https://github.com/keycloak/keycloak/pull/7544).
AuthorizationEndpointRequest class already checks duplicated parameters but DeviceEndpoint class has not checked its error. Thus a check process is added in handleDeviceRequest().

Closes #11294

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
