### PR TITLE
Added hint to caching conf file parameter

### DIFF
--- a/docs/guides/src/main/server/caching.adoc
+++ b/docs/guides/src/main/server/caching.adoc
@@ -99,6 +99,8 @@ To specify your own cache configuration file, enter this command:
 
 <@kc.build parameters="--cache-config-file=my-cache-file.xml"/>
 
+The configuration file is relative to the `conf/` directory.
+
 == Transport stacks
 Transport stacks ensure that distributed cache nodes in a cluster communicate in a reliable fashion.
 Keycloak supports a wide range of transport stacks:

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/ClusteringPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/ClusteringPropertyMappers.java
@@ -34,7 +34,8 @@ final class ClusteringPropertyMappers {
                 builder().from("cache-config-file")
                         .mapFrom("cache")
                         .to("kc.spi-connections-infinispan-quarkus-config-file")
-                        .description("Defines the file from which cache configuration should be loaded from.")
+                        .description("Defines the file from which cache configuration should be loaded from. "
+                                + "The configuration file is relative to the 'conf/' directory.")
                         .transformer(new BiFunction<String, ConfigSourceInterceptorContext, String>() {
                             @Override
                             public String apply(String value, ConfigSourceInterceptorContext context) {

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testBuildHelp.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testBuildHelp.unix.approved.txt
@@ -29,7 +29,8 @@ Cluster:
                        disables clustering and is intended for development and testing purposes.
                        Default: ispn.
 --cache-config-file <file>
-                     Defines the file from which cache configuration should be loaded from.
+                     Defines the file from which cache configuration should be loaded from. The
+                       configuration file is relative to the 'conf/' directory.
 --cache-stack <stack>
                      Define the default stack to use for cluster communication and node discovery.
                        This option only takes effect if 'cache' is set to 'ispn'. Default: udp.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testBuildHelp.windows.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testBuildHelp.windows.approved.txt
@@ -29,7 +29,8 @@ Cluster:
                        disables clustering and is intended for development and testing purposes.
                        Default: ispn.
 --cache-config-file <file>
-                     Defines the file from which cache configuration should be loaded from.
+                     Defines the file from which cache configuration should be loaded from. The
+                       configuration file is relative to the 'conf/' directory.
 --cache-stack <stack>
                      Define the default stack to use for cluster communication and node discovery.
                        This option only takes effect if 'cache' is set to 'ispn'. Default: udp.
@@ -104,4 +105,4 @@ running this command every time you change a configuration:
 
     $ kc.bat start --auto-build <OPTIONS>
 
-By doing that you have an additional overhead when the server is starting.
+By doing that you have an additional overhead when the server is starting.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartDevHelpAll.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartDevHelpAll.unix.approved.txt
@@ -21,7 +21,8 @@ Cluster:
                        disables clustering and is intended for development and testing purposes.
                        Default: ispn.
 --cache-config-file <file>
-                     Defines the file from which cache configuration should be loaded from.
+                     Defines the file from which cache configuration should be loaded from. The
+                       configuration file is relative to the 'conf/' directory.
 --cache-stack <stack>
                      Define the default stack to use for cluster communication and node discovery.
                        This option only takes effect if 'cache' is set to 'ispn'. Default: udp.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartDevHelpAll.windows.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartDevHelpAll.windows.approved.txt
@@ -21,7 +21,8 @@ Cluster:
                        disables clustering and is intended for development and testing purposes.
                        Default: ispn.
 --cache-config-file <file>
-                     Defines the file from which cache configuration should be loaded from.
+                     Defines the file from which cache configuration should be loaded from. The
+                       configuration file is relative to the 'conf/' directory.
 --cache-stack <stack>
                      Define the default stack to use for cluster communication and node discovery.
                        This option only takes effect if 'cache' is set to 'ispn'. Default: udp.
@@ -173,4 +174,4 @@ Logging:
 Do NOT start the server using this command when deploying to production.
 
 Use 'kc.bat start-dev --help-all' to list all available options, including
-build options.
+build options.


### PR DESCRIPTION
Added a hint to the --cache-config-file config option that you not need to specify the configuration folder


Closes #11302
<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
