### PR TITLE
Update kc/kcadm/kcreg.sh to support JAVA and JAVA_HOME

### DIFF
--- a/integration/client-cli/admin-cli/src/main/bin/kcadm.sh
+++ b/integration/client-cli/admin-cli/src/main/bin/kcadm.sh
@@ -21,6 +21,12 @@ fi
 
 DIRNAME=`dirname "$RESOLVED_NAME"`
 
+if [ "x$JAVA" = "x" ]; then
+    if [ "x$JAVA_HOME" != "x" ]; then
+        JAVA="$JAVA_HOME/bin/java"
+    else
+        JAVA="java"
+    fi
+fi
 
-java $KC_OPTS -cp $DIRNAME/client/keycloak-admin-cli-${project.version}.jar org.keycloak.client.admin.cli.KcAdmMain "$@"
-
+"$JAVA" $KC_OPTS -cp $DIRNAME/client/keycloak-admin-cli-${project.version}.jar org.keycloak.client.admin.cli.KcAdmMain "$@"

--- a/integration/client-cli/client-registration-cli/src/main/bin/kcreg.sh
+++ b/integration/client-cli/client-registration-cli/src/main/bin/kcreg.sh
@@ -19,5 +19,13 @@ if [ "x$RESOLVED_NAME" = "x" ]; then
     RESOLVED_NAME="$0"
 fi
 
+if [ "x$JAVA" = "x" ]; then
+    if [ "x$JAVA_HOME" != "x" ]; then
+        JAVA="$JAVA_HOME/bin/java"
+    else
+        JAVA="java"
+    fi
+fi
+
 DIRNAME=`dirname "$RESOLVED_NAME"`
-java $KC_OPTS -cp $DIRNAME/client/keycloak-client-registration-cli-${project.version}.jar org.keycloak.client.registration.cli.KcRegMain "$@"
+"$JAVA" $KC_OPTS -cp $DIRNAME/client/keycloak-client-registration-cli-${project.version}.jar org.keycloak.client.registration.cli.KcRegMain "$@"

--- a/quarkus/dist/src/main/content/bin/kc.sh
+++ b/quarkus/dist/src/main/content/bin/kc.sh
@@ -60,6 +60,14 @@ do
     shift
 done
 
+if [ "x$JAVA" = "x" ]; then
+    if [ "x$JAVA_HOME" != "x" ]; then
+        JAVA="$JAVA_HOME/bin/java"
+    else
+        JAVA="java"
+    fi
+fi
+
 #
 # Specify options to pass to the Java VM.
 #
@@ -89,11 +97,11 @@ CLASSPATH_OPTS="$DIRNAME/../lib/quarkus-run.jar"
 JAVA_RUN_OPTS="$JAVA_OPTS $SERVER_OPTS -cp $CLASSPATH_OPTS io.quarkus.bootstrap.runner.QuarkusEntryPoint ${CONFIG_ARGS#?}"
 
 if [[ $CONFIG_ARGS = *"--auto-build"* ]]; then
-    eval java -Dkc.config.rebuild-and-exit=true $JAVA_RUN_OPTS
+    eval "$JAVA" -Dkc.config.rebuild-and-exit=true $JAVA_RUN_OPTS
     EXIT_CODE=$?
     if [ $EXIT_CODE != 0 ]; then
       exit $EXIT_CODE
     fi
 fi
 
-eval exec java ${JAVA_RUN_OPTS}
+eval exec "${JAVA}" ${JAVA_RUN_OPTS}


### PR DESCRIPTION
When executing Keycloak Quarkus `bin/kc.sh`, `bin/kcadm.sh`, `bin/kcreg.sh`,
the first java command found in `$PATH` is executed. The environment
variables `JAVA` and `JAVA_HOME` are not available to specify the java
command / JVM to execute.

This commit updates `bin/kc.sh`, `bin/kcadm.sh`, and `bin/kcreg.sh` to support
environment variables `JAVA` and `JAVA_HOME`.

Resolves #11336

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
