### PR TITLE
Fixes wrong encoding in container image

### DIFF
--- a/quarkus/container/Dockerfile
+++ b/quarkus/container/Dockerfile
@@ -18,11 +18,12 @@ RUN mv /tmp/keycloak/keycloak-* /opt/keycloak && mkdir -p /opt/keycloak/data
 RUN chmod -R g+rwX /opt/keycloak
 
 FROM registry.access.redhat.com/ubi8-minimal
+ENV LANG en_US.UTF-8
 
 COPY --from=build-env --chown=1000:0 /opt/keycloak /opt/keycloak
 
 RUN microdnf update -y && \
-    microdnf install -y java-11-openjdk-headless && microdnf clean all && rm -rf /var/cache/yum/* && \
+    microdnf install -y --nodocs java-11-openjdk-headless glibc-langpack-en && microdnf clean all && rm -rf /var/cache/yum/* && \
     echo "keycloak:x:0:root" >> /etc/group && \
     echo "keycloak:x:1000:0:keycloak user:/opt/keycloak:/sbin/nologin" >> /etc/passwd
 


### PR DESCRIPTION
Solution taken from https://access.redhat.com/solutions/5211991 - ~~would also work without the `sed` part on line 22(tried locally), but I guess this makes sure all other stuff in the container also picks the right locale up.~~

Tested building locally, and doing ` docker run --rm -it --entrypoint bash kc_lang_test` -> looked at `locale`output gave me `en_US.UTF-8` everywhere. Serverinfo now also shows right encoding.
 
Closes #11545

