### PR TITLE
Quarkus Tests on Windows

### DIFF
--- a/quarkus/tests/integration/src/main/java/org/keycloak/it/junit5/extension/CLIResult.java
+++ b/quarkus/tests/integration/src/main/java/org/keycloak/it/junit5/extension/CLIResult.java
@@ -20,6 +20,8 @@ package org.keycloak.it.junit5.extension;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.testcontainers.shaded.org.hamcrest.MatcherAssert.assertThat;
+import static org.testcontainers.shaded.org.hamcrest.Matchers.containsString;
 
 import java.util.List;
 
@@ -38,6 +40,11 @@ public interface CLIResult extends LaunchResult {
             @Override
             public List<String> getOutputStream() {
                 return outputStream;
+            }
+
+            @Override
+            public String getErrorOutput() {
+                return String.join("\n", errStream).replace("\r","");
             }
 
             @Override
@@ -82,7 +89,7 @@ public interface CLIResult extends LaunchResult {
     }
 
     default void assertMessage(String message) {
-        assertTrue(getOutput().contains(message));
+        assertThat(getOutput(), containsString(message));
     }
 
     default void assertBuild() {
@@ -112,7 +119,7 @@ public interface CLIResult extends LaunchResult {
     default void assertJsonLogDefaultsApplied() throws JsonProcessingException {
         ObjectMapper objectMapper = new ObjectMapper();
 
-        String[] splittedOutput = getOutput().split(System.lineSeparator());
+        String[] splittedOutput = getOutput().split("\n");
 
         int counter = 0;
 

--- a/quarkus/tests/integration/src/main/java/org/keycloak/it/utils/KeycloakDistribution.java
+++ b/quarkus/tests/integration/src/main/java/org/keycloak/it/utils/KeycloakDistribution.java
@@ -1,12 +1,13 @@
 package org.keycloak.it.utils;
 
+import org.keycloak.quarkus.runtime.Environment;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.List;
 
-import static org.keycloak.quarkus.runtime.Environment.LAUNCH_MODE;
-
 public interface KeycloakDistribution {
+
+    String SCRIPT_CMD = Environment.isWindows() ? "kc.bat" : "kc.sh";
+    String SCRIPT_CMD_INVOKABLE = Environment.isWindows() ? SCRIPT_CMD : "./"+SCRIPT_CMD;
 
     void start(List<String> arguments);
 
@@ -23,21 +24,7 @@ public interface KeycloakDistribution {
     boolean isManualStop();
 
     default String[] getCliArgs(List<String> arguments) {
-        List<String> commands = new ArrayList<>();
-
-        commands.add("./kc.sh");
-
-        if (this.isDebug()) {
-            commands.add("--debug");
-        }
-
-        if (!this.isManualStop()) {
-            commands.add("-D" + LAUNCH_MODE + "=test");
-        }
-
-        commands.addAll(arguments);
-
-        return commands.toArray(new String[0]);
+        throw new RuntimeException("Not implemented");
     }
 
     default void setManualStop(boolean manualStop) {

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/OptionValidationTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/OptionValidationTest.java
@@ -18,13 +18,16 @@
 package org.keycloak.it.cli;
 
 import org.junit.jupiter.api.Test;
+import org.keycloak.it.junit5.extension.CLIResult;
 import org.keycloak.it.junit5.extension.CLITest;
 
 import io.quarkus.test.junit.main.Launch;
 import io.quarkus.test.junit.main.LaunchResult;
+import org.keycloak.it.utils.KeycloakDistribution;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @CLITest
 public class OptionValidationTest {
@@ -32,43 +35,49 @@ public class OptionValidationTest {
     @Test
     @Launch({"build", "--db"})
     public void failMissingOptionValue(LaunchResult result) {
-        assertTrue(result.getErrorOutput().contains("Missing required value for option '--db' (vendor). Expected values are: dev-file, dev-mem, mariadb, mssql, mysql, oracle, postgres"));
+        CLIResult cliResult = (CLIResult) result;
+        assertThat(cliResult.getErrorOutput(), containsString("Missing required value for option '--db' (vendor). Expected values are: dev-file, dev-mem, mariadb, mssql, mysql, oracle, postgres"));
     }
 
     @Test
     @Launch({"build", "--db", "foo", "bar"})
     public void failMultipleOptionValue(LaunchResult result) {
-        assertTrue(result.getErrorOutput().contains("Option '--db' expects a single value (vendor) Expected values are: dev-file, dev-mem, mariadb, mssql, mysql, oracle, postgres"));
+        CLIResult cliResult = (CLIResult) result;
+        assertThat(cliResult.getErrorOutput(), containsString("Option '--db' expects a single value (vendor) Expected values are: dev-file, dev-mem, mariadb, mssql, mysql, oracle, postgres"));
     }
 
     @Test
     @Launch({"build", "--nosuch"})
     public void failUnknownOption(LaunchResult result) {
+        CLIResult cliResult = (CLIResult) result;
         assertEquals("Unknown option: '--nosuch'\n" +
-                "Try 'kc.sh build --help' for more information on the available options.", result.getErrorOutput());
+                "Try '" + KeycloakDistribution.SCRIPT_CMD + " build --help' for more information on the available options.", cliResult.getErrorOutput());
     }
 
     @Test
     @Launch({"start", "--db-pasword mytestpw"})
     public void failUnknownOptionWhitespaceSeparatorNotShowingValue(LaunchResult result) {
+        CLIResult cliResult = (CLIResult) result;
         assertEquals("Unknown option: '--db-pasword'\n" +
                 "Possible solutions: --db-username, --db-url-host, --db-pool-min-size, --db-password, --db-url-properties, --db-url-database, --db-schema, --db-pool-max-size, --db-pool-initial-size, --db-url, --db-url-port\n" +
-                "Try 'kc.sh start --help' for more information on the available options.", result.getErrorOutput());
+                "Try '" + KeycloakDistribution.SCRIPT_CMD + " start --help' for more information on the available options.", cliResult.getErrorOutput());
     }
 
     @Test
     @Launch({"start", "--db-pasword=mytestpw"})
     public void failUnknownOptionEqualsSeparatorNotShowingValue(LaunchResult result) {
+        CLIResult cliResult = (CLIResult) result;
         assertEquals("Unknown option: '--db-pasword'\n" +
                 "Possible solutions: --db-username, --db-url-host, --db-pool-min-size, --db-password, --db-url-properties, --db-url-database, --db-schema, --db-pool-max-size, --db-pool-initial-size, --db-url, --db-url-port\n" +
-                "Try 'kc.sh start --help' for more information on the available options.", result.getErrorOutput());
+                "Try '" + KeycloakDistribution.SCRIPT_CMD + " start --help' for more information on the available options.", cliResult.getErrorOutput());
     }
 
     @Test
     @Launch({"start", "--db-username=foobar","--db-pasword=mytestpw", "--foobar=barfoo"})
     public void failWithFirstOptionOnMultipleUnknownOptions(LaunchResult result) {
+        CLIResult cliResult = (CLIResult) result;
         assertEquals("Unknown option: '--db-pasword'\n" +
                 "Possible solutions: --db-username, --db-url-host, --db-pool-min-size, --db-password, --db-url-properties, --db-url-database, --db-schema, --db-pool-max-size, --db-pool-initial-size, --db-url, --db-url-port\n" +
-                "Try 'kc.sh start --help' for more information on the available options.", result.getErrorOutput());
+                "Try '" + KeycloakDistribution.SCRIPT_CMD + " start --help' for more information on the available options.", cliResult.getErrorOutput());
     }
 }

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/BuildCommandDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/BuildCommandDistTest.java
@@ -26,6 +26,7 @@ import org.keycloak.it.junit5.extension.DistributionTest;
 
 import io.quarkus.test.junit.main.Launch;
 import io.quarkus.test.junit.main.LaunchResult;
+import org.keycloak.it.utils.KeycloakDistribution;
 
 @DistributionTest
 class BuildCommandDistTest {
@@ -39,7 +40,7 @@ class BuildCommandDistTest {
                 () -> "The Output:\n" + result.getOutput() + "doesn't contains the expected string.");
         assertTrue(result.getOutput().contains("Server configuration updated and persisted. Run the following command to review the configuration:"),
                 () -> "The Output:\n" + result.getOutput() + "doesn't contains the expected string.");
-        assertTrue(result.getOutput().contains("kc.sh show-config"),
+        assertTrue(result.getOutput().contains(KeycloakDistribution.SCRIPT_CMD + " show-config"),
                 () -> "The Output:\n" + result.getOutput() + "doesn't contains the expected string.");
     }
 

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ClusterConfigDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ClusterConfigDistTest.java
@@ -22,6 +22,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.nio.file.Path;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.keycloak.it.junit5.extension.BeforeStartDistribution;
 import org.keycloak.it.junit5.extension.CLIResult;
 import org.keycloak.it.junit5.extension.DistributionTest;
@@ -69,12 +71,23 @@ public class ClusterConfigDistTest {
     }
 
     @Test
-    @Launch({ "start", "--auto-build", "--http-enabled=true", "--hostname-strict false" })
+    @EnabledOnOs(value = { OS.LINUX, OS.MAC }, disabledReason = "different shell escaping behaviour on Windows.")
+    @Launch({ "start", "--auto-build", "--log-level=info,org.infinispan.remoting.transport.jgroups.JGroupsTransport:debug","--http-enabled=true", "--hostname-strict=false" })
     void testStartDefaultsToClustering(LaunchResult result) {
         CLIResult cliResult = (CLIResult) result;
         cliResult.assertStarted();
         cliResult.assertClusteredCache();
-        assertTrue(cliResult.getOutput().contains("org.jgroups.protocols.UDP"));
+        assertTrue(cliResult.getOutput().contains("JGroups protocol stack: UDP"));
+    }
+
+    @Test
+    @EnabledOnOs(value = { OS.WINDOWS }, disabledReason = "different shell behaviour on Windows.")
+    @Launch({ "start", "--auto-build", "--log-level=\"info,org.infinispan.remoting.transport.jgroups.JGroupsTransport:debug","--http-enabled=true\"", "--hostname-strict=false" })
+    void testWinStartDefaultsToClustering(LaunchResult result) {
+        CLIResult cliResult = (CLIResult) result;
+        cliResult.assertStarted();
+        cliResult.assertClusteredCache();
+        assertTrue(cliResult.getOutput().contains("JGroups protocol stack: UDP"));
     }
 
     @Test

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/FeaturesDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/FeaturesDistTest.java
@@ -7,6 +7,8 @@ import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.keycloak.it.junit5.extension.CLIResult;
 import org.keycloak.it.junit5.extension.DistributionTest;
 import org.keycloak.it.junit5.extension.RawDistOnly;
@@ -56,8 +58,21 @@ public class FeaturesDistTest {
     }
 
     @Test
+    @EnabledOnOs(value = { OS.LINUX, OS.MAC }, disabledReason = "different shell escaping behaviour on Windows.")
     @Launch({StartDev.NAME, "--features=token-exchange,admin-fine-grained-authz"})
     public void testEnableMultipleFeatures(LaunchResult result) {
+        CLIResult cliResult = (CLIResult) result;
+        cliResult.assertStartedDevMode();
+        assertThat(cliResult.getOutput(), CoreMatchers.allOf(
+                containsString("Preview feature enabled: admin_fine_grained_authz"),
+                containsString("Preview feature enabled: token_exchange")));
+        assertFalse(cliResult.getOutput().contains("declarative-user-profile"));
+    }
+
+    @Test
+    @EnabledOnOs(value = { OS.WINDOWS }, disabledReason = "different shell escaping behaviour on Windows.")
+    @Launch({StartDev.NAME, "--features=\"token-exchange,admin-fine-grained-authz\""})
+    public void testWinEnableMultipleFeatures(LaunchResult result) {
         CLIResult cliResult = (CLIResult) result;
         cliResult.assertStartedDevMode();
         assertThat(cliResult.getOutput(), CoreMatchers.allOf(

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/LoggingDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/LoggingDistTest.java
@@ -22,6 +22,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.keycloak.it.junit5.extension.CLIResult;
 import org.keycloak.it.junit5.extension.DistributionTest;
 import org.keycloak.it.junit5.extension.RawDistOnly;
@@ -60,6 +62,7 @@ public class LoggingDistTest {
     }
 
     @Test
+    @EnabledOnOs(value = { OS.LINUX, OS.MAC }, disabledReason = "different shell escaping behaviour on Windows.")
     @Launch({ "start-dev", "--log-level=off,org.keycloak:debug,org.infinispan:info" })
     void testRootAndCategoryLevels(LaunchResult result) {
         CLIResult cliResult = (CLIResult) result;
@@ -69,6 +72,17 @@ public class LoggingDistTest {
     }
 
     @Test
+    @EnabledOnOs(value = { OS.WINDOWS }, disabledReason = "different shell escaping behaviour on Windows.")
+    @Launch({ "start-dev", "--log-level=\"off,org.keycloak:debug,org.infinispan:info\"" })
+    void testWinRootAndCategoryLevels(LaunchResult result) {
+        CLIResult cliResult = (CLIResult) result;
+        assertFalse(cliResult.getOutput().contains("INFO  [io.quarkus"));
+        assertTrue(cliResult.getOutput().contains("DEBUG [org.keycloak"));
+        assertTrue(cliResult.getOutput().contains("INFO  [org.infinispan.CONTAINER]"));
+    }
+
+    @Test
+    @EnabledOnOs(value = { OS.LINUX, OS.MAC }, disabledReason = "different shell escaping behaviour on Windows.")
     @Launch({ "start-dev", "--log-level=off,org.keycloak:warn,debug" })
     void testSetLastRootLevelIfMultipleSet(LaunchResult result) {
         CLIResult cliResult = (CLIResult) result;
@@ -78,6 +92,17 @@ public class LoggingDistTest {
     }
 
     @Test
+    @EnabledOnOs(value = { OS.WINDOWS }, disabledReason = "different shell escaping behaviour on Windows.")
+    @Launch({ "start-dev", "--log-level=\"off,org.keycloak:warn,debug\"" })
+    void testWinSetLastRootLevelIfMultipleSet(LaunchResult result) {
+        CLIResult cliResult = (CLIResult) result;
+        assertTrue(cliResult.getOutput().contains("DEBUG [org.hibernate"));
+        assertFalse(cliResult.getOutput().contains("INFO  [org.keycloak"));
+        cliResult.assertStartedDevMode();
+    }
+
+    @Test
+    @EnabledOnOs(value = { OS.LINUX, OS.MAC }, disabledReason = "different shell escaping behaviour on Windows.")
     @Launch({ "start-dev", "--log-console-format=\"%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c{1.}] %s%e%n\"" })
     void testSetLogFormat(LaunchResult result) {
         CLIResult cliResult = (CLIResult) result;
@@ -94,6 +119,7 @@ public class LoggingDistTest {
     }
 
     @Test
+    @EnabledOnOs(value = { OS.LINUX, OS.MAC }, disabledReason = "different shell escaping behaviour on Windows.")
     @Launch({ "start-dev", "--log-level=off,org.keycloak:debug,org.infinispan:info", "--log-console-output=json" })
     void testLogLevelSettingsAppliedWhenJsonEnabled(LaunchResult result) {
         CLIResult cliResult = (CLIResult) result;
@@ -103,6 +129,17 @@ public class LoggingDistTest {
     }
 
     @Test
+    @EnabledOnOs(value = { OS.WINDOWS }, disabledReason = "different shell escaping behaviour on Windows.")
+    @Launch({ "start-dev", "--log-level=\"off,org.keycloak:debug,org.infinispan:info\"", "--log-console-output=json" })
+    void testWinLogLevelSettingsAppliedWhenJsonEnabled(LaunchResult result) {
+        CLIResult cliResult = (CLIResult) result;
+        assertFalse(cliResult.getOutput().contains("\"loggerName\":\"io.quarkus\",\"level\":\"INFO\")"));
+        assertTrue(cliResult.getOutput().contains("\"loggerName\":\"org.keycloak.quarkus.runtime.storage.database.jpa.QuarkusJpaConnectionProviderFactory\",\"level\":\"DEBUG\""));
+        assertTrue(cliResult.getOutput().contains("\"loggerName\":\"org.infinispan.CONTAINER\",\"level\":\"INFO\""));
+    }
+
+    @Test
+    @EnabledOnOs(value = { OS.LINUX, OS.MAC }, disabledReason = "different shell escaping behaviour on Windows.")
     @Launch({ "start-dev", "--log=console,file"})
     void testKeycloakLogFileCreated(RawDistRootPath path) {
         Path logFilePath = Paths.get(path.getDistRootPath() + File.separator + LoggingPropertyMappers.DEFAULT_LOG_PATH);
@@ -111,6 +148,16 @@ public class LoggingDistTest {
     }
 
     @Test
+    @EnabledOnOs(value = { OS.WINDOWS }, disabledReason = "different shell escaping behaviour on Windows.")
+    @Launch({ "start-dev", "--log=\"console,file\""})
+    void testWinKeycloakLogFileCreated(RawDistRootPath path) {
+        Path logFilePath = Paths.get(path.getDistRootPath() + File.separator + LoggingPropertyMappers.DEFAULT_LOG_PATH);
+        File logFile = new File(logFilePath.toString());
+        assertTrue(logFile.isFile(), "Log file does not exist!");
+    }
+
+    @Test
+    @EnabledOnOs(value = { OS.LINUX, OS.MAC }, disabledReason = "different shell escaping behaviour on Windows.")
     @Launch({ "start-dev", "--log=console,file", "--log-file-format=\"%d{HH:mm:ss} %-5p [%c{1.}] (%t) %s%e%n\""})
     void testFileLoggingHasDifferentFormat(RawDistRootPath path) throws IOException {
         Path logFilePath = Paths.get(path.getDistRootPath() + File.separator + LoggingPropertyMappers.DEFAULT_LOG_PATH);

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartAutoBuildDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartAutoBuildDistTest.java
@@ -30,6 +30,7 @@ import org.keycloak.it.junit5.extension.RawDistOnly;
 
 import io.quarkus.test.junit.main.Launch;
 import io.quarkus.test.junit.main.LaunchResult;
+import org.keycloak.it.utils.KeycloakDistribution;
 
 @DistributionTest(reInstall = DistributionTest.ReInstall.NEVER)
 @RawDistOnly(reason = "Containers are immutable")
@@ -44,9 +45,9 @@ public class StartAutoBuildDistTest {
         cliResult.assertMessage("Changes detected in configuration. Updating the server image.");
         cliResult.assertMessage("Updating the configuration and installing your custom providers, if any. Please wait.");
         cliResult.assertMessage("Server configuration updated and persisted. Run the following command to review the configuration:");
-        cliResult.assertMessage("kc.sh show-config");
+        cliResult.assertMessage(KeycloakDistribution.SCRIPT_CMD + " show-config");
         cliResult.assertMessage("Next time you run the server, just run:");
-        cliResult.assertMessage("kc.sh start --http-enabled=true --hostname-strict=false");
+        cliResult.assertMessage(KeycloakDistribution.SCRIPT_CMD + " start --http-enabled=true --hostname-strict=false");
         assertFalse(cliResult.getOutput().contains("--cache"));
         cliResult.assertStarted();
     }

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartCommandDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartCommandDistTest.java
@@ -17,6 +17,8 @@
 
 package org.keycloak.it.cli.dist;
 
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -28,16 +30,17 @@ import org.keycloak.it.junit5.extension.DistributionTest;
 
 import io.quarkus.test.junit.main.Launch;
 import io.quarkus.test.junit.main.LaunchResult;
+import org.keycloak.it.utils.KeycloakDistribution;
 
 @DistributionTest
 public class StartCommandDistTest extends StartCommandTest {
 
     @Test
-    @Launch({ "-pf=dev", "start", "--auto-build", "--http-enabled=true", "--hostname-strict=false" })
+    @Launch({ "--profile=dev", "start", "--auto-build", "--http-enabled=true", "--hostname-strict=false" })
     void failIfAutoBuildUsingDevProfile(LaunchResult result) {
-        assertTrue(result.getErrorOutput().contains("You can not 'start' the server in development mode. Please re-build the server first, using 'kc.sh build' for the default production mode."),
-                () -> "The Output:\n" + result.getErrorOutput() + "doesn't contains the expected string.");
-        assertEquals(4, result.getErrorStream().size());
+        CLIResult cliResult = (CLIResult) result;
+        assertThat(cliResult.getErrorOutput(), containsString("You can not 'start' the server in development mode. Please re-build the server first, using 'kc.sh build' for the default production mode."));
+        assertEquals(4, cliResult.getErrorStream().size());
     }
 
     @Test
@@ -54,9 +57,9 @@ public class StartCommandDistTest extends StartCommandTest {
         cliResult.assertMessage("Changes detected in configuration. Updating the server image.");
         cliResult.assertMessage("Updating the configuration and installing your custom providers, if any. Please wait.");
         cliResult.assertMessage("Server configuration updated and persisted. Run the following command to review the configuration:");
-        cliResult.assertMessage("kc.sh show-config");
+        cliResult.assertMessage(KeycloakDistribution.SCRIPT_CMD + " show-config");
         cliResult.assertMessage("Next time you run the server, just run:");
-        cliResult.assertMessage("kc.sh start --http-enabled=true --hostname-strict=false");
+        cliResult.assertMessage(KeycloakDistribution.SCRIPT_CMD + " start --http-enabled=true --hostname-strict=false");
         assertFalse(cliResult.getOutput().contains("--cache"));
         cliResult.assertStarted();
     }


### PR DESCRIPTION
Tested using Windows 10 locally and on windows-latest (server 2k22) in ci.

This PR makes it generally possible to execute the Quarkus Integration Tests on Windows.

A potential Windows runner ( #9834 ) is excluded from the scope here for now as the CI is a bit exhausted and we should get a discussion around how and where this should be done started first.

Also I was blocked to check further on the arquillian testsuite changes bc. the module is stuck to Java8 for now, and we need the Java9 ProcessHandle (afaict) to get restarts etc. working on windows.

Closes #10926


_note_: This is essentially the same PR as https://github.com/keycloak/keycloak/pull/11254 with a few deletions based on the review there. 