### PR TITLE
Add option to skip new admin console while doing a build

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -31,8 +31,22 @@
     <description/>
 
     <modules>
-        <module>admin-ui</module>
         <module>server-min</module>
         <module>server-all</module>
     </modules>
+
+    <profiles>
+        <profile>
+            <id>skip-admin2</id>
+            <activation>
+                <property>
+                    <name>!skipAdmin2</name>
+                </property>
+            </activation>
+            <modules>
+                <module>admin-ui</module>
+            </modules>
+        </profile>
+    </profiles>
+
 </project>

--- a/quarkus/runtime/pom.xml
+++ b/quarkus/runtime/pom.xml
@@ -173,22 +173,6 @@
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>
-            <artifactId>keycloak-dependencies-admin-ui-wrapper</artifactId>
-            <type>pom</type>
-            <scope>import</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.keycloak</groupId>
-            <artifactId>keycloak-admin-ui</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.keycloak</groupId>
             <artifactId>keycloak-saml-core-public</artifactId>
             <exclusions>
                 <exclusion>
@@ -561,6 +545,35 @@
             </exclusions>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>skip-admin2</id>
+            <activation>
+                <property>
+                    <name>!skipAdmin2</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.keycloak</groupId>
+                    <artifactId>keycloak-dependencies-admin-ui-wrapper</artifactId>
+                    <type>pom</type>
+                    <scope>import</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.keycloak</groupId>
+                    <artifactId>keycloak-admin-ui</artifactId>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 
     <build>
         <plugins>


### PR DESCRIPTION
Internal build pipelines are not building the new admin console yet, and is failing to build at the moment due to the new admin console dependency missing. This introduces an option that allows excluding the new admin console from the build similarly to the option we have to skip the new account console.