### PR TITLE
Add SAML builtin protocol mappers for impersonator information

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/saml/SamlProtocolFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/SamlProtocolFactory.java
@@ -21,6 +21,7 @@ import org.keycloak.Config;
 import org.keycloak.events.EventBuilder;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.ClientScopeModel;
+import org.keycloak.models.ImpersonationSessionNote;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.ProtocolMapperModel;
 import org.keycloak.models.RealmModel;
@@ -30,6 +31,7 @@ import org.keycloak.protocol.LoginProtocol;
 import org.keycloak.protocol.saml.mappers.AttributeStatementHelper;
 import org.keycloak.protocol.saml.mappers.RoleListMapper;
 import org.keycloak.protocol.saml.mappers.UserPropertyAttributeStatementMapper;
+import org.keycloak.protocol.saml.mappers.UserSessionNoteStatementMapper;
 import org.keycloak.representations.idm.CertificateRepresentation;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.saml.SignatureAlgorithm;
@@ -90,6 +92,10 @@ public class SamlProtocolFactory extends AbstractLoginProtocolFactory {
                 X500SAMLProfileConstants.SURNAME.getFriendlyName(),
                 true, "${familyName}");
         builtins.put("X500 surname", model);
+        model = UserSessionNoteStatementMapper.createUserSessionNoteMapper(ImpersonationSessionNote.IMPERSONATOR_ID);
+        builtins.put(ImpersonationSessionNote.IMPERSONATOR_ID.getDisplayName(), model);
+        model = UserSessionNoteStatementMapper.createUserSessionNoteMapper(ImpersonationSessionNote.IMPERSONATOR_USERNAME);
+        builtins.put(ImpersonationSessionNote.IMPERSONATOR_USERNAME.getDisplayName(), model);
         model = RoleListMapper.create("role list", "Role", AttributeStatementHelper.BASIC, null, false);
         builtins.put("role list", model);
         defaultBuiltins.add(model);

--- a/services/src/main/java/org/keycloak/protocol/saml/mappers/UserSessionNoteStatementMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/mappers/UserSessionNoteStatementMapper.java
@@ -22,10 +22,16 @@ import org.keycloak.models.AuthenticatedClientSessionModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.ProtocolMapperModel;
 import org.keycloak.models.UserSessionModel;
+import org.keycloak.models.UserSessionNoteDescriptor;
+import org.keycloak.protocol.ProtocolMapperUtils;
+import org.keycloak.protocol.saml.SamlProtocol;
 import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.saml.common.constants.JBossSAMLURIConstants;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Maps a user session note to a SAML attribute
@@ -81,4 +87,23 @@ public class UserSessionNoteStatementMapper extends AbstractSAMLProtocolMapper i
         AttributeStatementHelper.addAttribute(attributeStatement, mappingModel, value);
 
     }
+
+    /**
+     * For session notes defined using a {@link UserSessionNoteDescriptor} enum
+     *
+     * @param userSessionNoteDescriptor User session note descriptor for which to create a protocol mapper model.
+     */
+    public static ProtocolMapperModel createUserSessionNoteMapper(UserSessionNoteDescriptor userSessionNoteDescriptor) {
+        ProtocolMapperModel mapper = new ProtocolMapperModel();
+        mapper.setName(userSessionNoteDescriptor.getDisplayName());
+        mapper.setProtocolMapper(PROVIDER_ID);
+        mapper.setProtocol(SamlProtocol.LOGIN_PROTOCOL);
+        Map<String, String> config = new HashMap<>();
+        config.put(ProtocolMapperUtils.USER_SESSION_NOTE, userSessionNoteDescriptor.toString());
+        config.put(AttributeStatementHelper.SAML_ATTRIBUTE_NAME, userSessionNoteDescriptor.getTokenClaim());
+        config.put(AttributeStatementHelper.FRIENDLY_NAME, userSessionNoteDescriptor.getDisplayName());
+        mapper.setConfig(config);
+        return mapper;
+    }
+
 }


### PR DESCRIPTION

Note: I did not add tests, because adding built-in mappers is already covered by `ClientProtocolMapperTest`

Closes #11610