### PR TITLE
Update infinispan to prevent null pointer exception error

### DIFF
--- a/quarkus/pom.xml
+++ b/quarkus/pom.xml
@@ -45,7 +45,7 @@
         <postgresql.version>42.3.3</postgresql.version>
         <microprofile-metrics-api.version>3.0.1</microprofile-metrics-api.version>
         <wildfly.common.version>1.5.4.Final-format-001</wildfly.common.version>
-        <infinispan.version>13.0.8.Final</infinispan.version>
+        <infinispan.version>13.0.9.Final</infinispan.version>
         <wildfly-elytron.version>1.18.3.Final</wildfly-elytron.version>
 
         <!--


### PR DESCRIPTION
locally I did not get the startup error when using a custom jgroups stack after the update (created a custom stack as in #11645 but using values from [here](https://github.com/infinispan/infinispan/tree/main/core/src/main/resources/default-configs.) instead of the ticket as i dont have a jgroups setup right now)).  

Closes #11645

