### PR TITLE
Clear import/export properties at the end of the test

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/client/resources/TestingExportImportResource.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/client/resources/TestingExportImportResource.java
@@ -46,59 +46,59 @@ public interface TestingExportImportResource {
     @Path("/get-users-per-file")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    public Integer getUsersPerFile();
+    Integer getUsersPerFile();
 
     @PUT
     @Path("/set-users-per-file")
     @Consumes(MediaType.APPLICATION_JSON)
-    public void setUsersPerFile(@QueryParam("usersPerFile") Integer usersPerFile);
+    void setUsersPerFile(@QueryParam("usersPerFile") Integer usersPerFile);
 
     @GET
     @Path("/get-dir")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    public String getDir();
+    String getDir();
 
     @PUT
     @Path("/set-dir")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    public String setDir(@QueryParam("dir") String dir);
+    String setDir(@QueryParam("dir") String dir);
 
     @PUT
     @Path("/set-import-strategy")
     @Consumes(MediaType.APPLICATION_JSON)
-    public void setStrategy(@QueryParam("importStrategy") Strategy strategy);
+    void setStrategy(@QueryParam("importStrategy") Strategy strategy);
 
     @PUT
     @Path("/export-import-provider")
     @Consumes(MediaType.APPLICATION_JSON)
-    public void setProvider(@QueryParam("exportImportProvider") String exportImportProvider);
+    void setProvider(@QueryParam("exportImportProvider") String exportImportProvider);
 
     @PUT
     @Path("/export-import-file")
     @Consumes(MediaType.APPLICATION_JSON)
-    public void setFile(@QueryParam("file") String file);
+    void setFile(@QueryParam("file") String file);
 
     @PUT
     @Path("/export-import-action")
     @Consumes(MediaType.APPLICATION_JSON)
-    public void setAction(@QueryParam("exportImportAction") String exportImportAction);
+    void setAction(@QueryParam("exportImportAction") String exportImportAction);
 
     @PUT
     @Path("/set-realm-name")
     @Consumes(MediaType.APPLICATION_JSON)
-    public void setRealmName(@QueryParam("realmName") String realmName);
+    void setRealmName(@QueryParam("realmName") String realmName);
 
     @GET
     @Path("/get-test-dir")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    public String getExportImportTestDirectory();
+    String getExportImportTestDirectory();
 
     @GET
     @Path("/clear")
     @Produces(MediaType.APPLICATION_JSON)
-    public Response clear();
+    void clear();
 
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientPoliciesImportExportTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientPoliciesImportExportTest.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.testsuite.client;
 
+import org.junit.After;
 import org.junit.Test;
 import org.keycloak.exportimport.ExportImportConfig;
 import org.keycloak.exportimport.singlefile.SingleFileExportProviderFactory;
@@ -55,6 +56,11 @@ public class ClientPoliciesImportExportTest extends AbstractClientPoliciesTest {
     @Override
     public void beforeAbstractKeycloakTestRealmImport() {
         removeAllRealmsDespiteMaster();
+    }
+
+    @After
+    public void afterImportExport() {
+        testingClient.testing().exportImport().clear();
     }
 
     @Test


### PR DESCRIPTION
This avoids the pollution of system properties that might lead to failures following tests.

Closes #11670

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
