### PR TITLE
Fix running operator image tests with prebuilt image

### DIFF
--- a/.github/workflows/operator-ci.yml
+++ b/.github/workflows/operator-ci.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Test operator running locally
         run: |
           mvn clean verify -Poperator -pl :keycloak-operator -am \
-              -Dquarkus.kubernetes.deployment-target=kubernetes \
+              -Dquarkus.kubernetes.image-pull-policy=IfNotPresent \
               -Doperator.keycloak.image=keycloak:${{ steps.vars.outputs.version }} \
               -Dtest.operator.custom.image=custom-keycloak:${{ steps.vars.outputs.version }} \
               -Doperator.keycloak.image-pull-policy=Never \
@@ -128,7 +128,7 @@ jobs:
           eval $(minikube -p minikube docker-env)
           mvn clean verify -Poperator -pl :keycloak-operator -am \
               -Dquarkus.container-image.build=true \
-              -Dquarkus.kubernetes.deployment-target=kubernetes \
+              -Dquarkus.kubernetes.image-pull-policy=IfNotPresent \
               -Doperator.keycloak.image=keycloak:${{ steps.vars.outputs.version }} \
               -Dquarkus.jib.jvm-arguments="-Djava.util.logging.manager=org.jboss.logmanager.LogManager","-Doperator.keycloak.image-pull-policy=Never" \
               -Dtest.operator.custom.image=custom-keycloak:${{ steps.vars.outputs.version }} \

--- a/operator/README.md
+++ b/operator/README.md
@@ -77,7 +77,7 @@ Testing allows 2 methods specified in the property `test.operator.deployment` : 
 mvn clean verify \
   -Dquarkus.container-image.build=true \
   -Dquarkus.container-image.tag=test \
-  -Dquarkus.kubernetes.deployment-target=kubernetes \
+  -Dquarkus.kubernetes.image-pull-policy=IfNotPresent \
   -Dtest.operator.deployment=remote
 ```
 
@@ -101,4 +101,19 @@ And run the tests passing an extra Java property:
 
 ```bash
 -Dtest.operator.custom.image=custom-keycloak:latest
+```
+
+### Testing using a pre-built operator image from a remote registry
+You can run the testsuite using an already built operator image from a remote image registry. 
+
+To do this, you need to set `quarkus.container-image.build=false` and specify the desired image 
+you want to use by setting `quarkus.container-image.image=<your-image>:<your-tag>`
+
+#### Example:
+
+```bash
+ mvn clean verify \
+      -Dquarkus.container-image.build=false \
+      -Dquarkus.container-image.image=quay.io/keycloak/keycloak-operator:nightly \
+      -Dtest.operator.deployment=remote
 ```

--- a/operator/app/src/main/kubernetes/minikube.yml
+++ b/operator/app/src/main/kubernetes/minikube.yml
@@ -1,0 +1,1 @@
+kubernetes.yml


### PR DESCRIPTION
Also removes the unneeded map from ClusterOperatorTest that intercepts the ImagePullPolicy bc. this is kinda unexpected and not needed.
    
Now we're using `IfNotPresent` (as it was in v1 of this PR in the map) but from the expected minikube.yml and as such we have one source of truth (the yml files) and nothing intercepting and manipulating it in the code.

plus a few minor improvements to testsetup to make sonarlint happier.

Tested locally using the example I added to the readme (using operator nightly build).

Closes #9898

**edit 9/6/22: ** rebased with latest changes from main.