### PR TITLE
Use the map storage's updated flag for Hibernate dirty checking

### DIFF
--- a/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/JpaMapStorageProviderFactory.java
+++ b/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/JpaMapStorageProviderFactory.java
@@ -95,6 +95,7 @@ import org.keycloak.models.map.storage.jpa.clientscope.JpaClientScopeMapKeycloak
 import org.keycloak.models.map.storage.jpa.clientscope.entity.JpaClientScopeEntity;
 import org.keycloak.models.map.storage.jpa.group.JpaGroupMapKeycloakTransaction;
 import org.keycloak.models.map.storage.jpa.group.entity.JpaGroupEntity;
+import org.keycloak.models.map.storage.jpa.hibernate.dirtiness.JpaDirtinessStrategy;
 import org.keycloak.models.map.storage.jpa.hibernate.listeners.JpaAutoFlushListener;
 import org.keycloak.models.map.storage.jpa.hibernate.listeners.JpaEntityVersionListener;
 import org.keycloak.models.map.storage.jpa.hibernate.listeners.JpaOptimisticLockingListener;
@@ -258,6 +259,7 @@ public class JpaMapStorageProviderFactory implements
                     properties.put("hibernate.show_sql", config.getBoolean("showSql", false));
                     properties.put("hibernate.format_sql", config.getBoolean("formatSql", true));
                     properties.put("hibernate.dialect", config.get("driverDialect"));
+                    properties.put(AvailableSettings.CUSTOM_ENTITY_DIRTINESS_STRATEGY, "org.keycloak.models.map.storage.jpa.hibernate.dirtiness.JpaDirtinessStrategy");
 
                     properties.put(
                             "hibernate.integrator_provider",

--- a/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/authSession/entity/JpaAuthenticationSessionEntity.java
+++ b/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/authSession/entity/JpaAuthenticationSessionEntity.java
@@ -278,6 +278,17 @@ public class JpaAuthenticationSessionEntity extends UpdatableEntity.Impl impleme
     }
 
     @Override
+    public boolean isUpdated() {
+        return updated || metadata.isUpdated();
+    }
+
+    @Override
+    public void clearUpdatedFlag() {
+        updated = false;
+        metadata.clearUpdatedFlag();
+    }
+
+    @Override
     public int hashCode() {
         return getClass().hashCode();
     }

--- a/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/authSession/entity/JpaRootAuthenticationSessionEntity.java
+++ b/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/authSession/entity/JpaRootAuthenticationSessionEntity.java
@@ -216,6 +216,19 @@ public class JpaRootAuthenticationSessionEntity extends AbstractRootAuthenticati
     }
 
     @Override
+    public boolean isUpdated() {
+        return updated || (metadata != null && metadata.isUpdated());
+    }
+
+    @Override
+    public void clearUpdatedFlag() {
+        updated = false;
+        if (metadata != null) {
+            metadata.clearUpdatedFlag();
+        }
+    }
+
+    @Override
     public int hashCode() {
         return getClass().hashCode();
     }

--- a/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/client/entity/JpaClientEntity.java
+++ b/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/client/entity/JpaClientEntity.java
@@ -580,6 +580,19 @@ public class JpaClientEntity extends AbstractClientEntity implements JpaRootVers
     }
 
     @Override
+    public boolean isUpdated() {
+        return updated || (metadata != null && metadata.isUpdated());
+    }
+
+    @Override
+    public void clearUpdatedFlag() {
+        updated = false;
+        if (metadata != null) {
+            metadata.clearUpdatedFlag();
+        }
+    }
+
+    @Override
     public int hashCode() {
         return getClass().hashCode();
     }

--- a/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/clientscope/entity/JpaClientScopeEntity.java
+++ b/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/clientscope/entity/JpaClientScopeEntity.java
@@ -257,6 +257,19 @@ public class JpaClientScopeEntity extends AbstractClientScopeEntity implements J
     }
 
     @Override
+    public boolean isUpdated() {
+        return updated || (metadata != null && metadata.isUpdated());
+    }
+
+    @Override
+    public void clearUpdatedFlag() {
+        updated = false;
+        if (metadata != null) {
+            metadata.clearUpdatedFlag();
+        }
+    }
+
+    @Override
     public int hashCode() {
         return getClass().hashCode();
     }

--- a/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/group/entity/JpaGroupEntity.java
+++ b/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/group/entity/JpaGroupEntity.java
@@ -246,6 +246,19 @@ public class JpaGroupEntity extends AbstractGroupEntity implements JpaRootVersio
     }
 
     @Override
+    public boolean isUpdated() {
+        return updated || (metadata != null && metadata.isUpdated());
+    }
+
+    @Override
+    public void clearUpdatedFlag() {
+        updated = false;
+        if (metadata != null) {
+            metadata.clearUpdatedFlag();
+        }
+    }
+
+    @Override
     public int hashCode() {
         return getClass().hashCode();
     }

--- a/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/hibernate/dirtiness/JpaDirtinessStrategy.java
+++ b/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/hibernate/dirtiness/JpaDirtinessStrategy.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022. Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.models.map.storage.jpa.hibernate.dirtiness;
+
+import org.hibernate.Session;
+import org.hibernate.boot.internal.DefaultCustomEntityDirtinessStrategy;
+import org.hibernate.persister.entity.EntityPersister;
+import org.keycloak.models.map.common.UpdatableEntity;
+
+/**
+ * A Dirtiness strategy that can check the dirtiness of an entity if it is an
+ * {@link UpdatableEntity} and when it hasn't been updated.
+ * If it has been updated, the standard mechanisms of Hibernate are in effect to find out if it is really dirty,
+ * and which fields have been changed.
+ *
+ * This avoids an expensive check for attributes like metadata that would otherwise traverse a lot of entries.
+ *
+ * @author Alexander Schwartz
+ */
+public class JpaDirtinessStrategy extends DefaultCustomEntityDirtinessStrategy {
+
+    @Override
+    public boolean canDirtyCheck(Object entity, EntityPersister persister, Session session) {
+        return entity instanceof UpdatableEntity && !(((UpdatableEntity) entity).isUpdated());
+    }
+
+    @Override
+    public boolean isDirty(Object entity, EntityPersister persister, Session session) {
+        // as the previous call of canDirtyCheck only returned true for non-updated entity, we can return false here without an additional check
+        return false;
+    }
+
+    @Override
+    public void resetDirty(Object entity, EntityPersister persister, Session session) {
+        if (entity instanceof UpdatableEntity) {
+            ((UpdatableEntity) entity).clearUpdatedFlag();
+        }
+    }
+
+    @Override
+    public void findDirty(Object entity, EntityPersister persister, Session session, DirtyCheckContext dirtyCheckContext) {
+        // Hibernate will have already found the modified attributes
+    }
+}

--- a/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/loginFailure/entity/JpaUserLoginFailureEntity.java
+++ b/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/loginFailure/entity/JpaUserLoginFailureEntity.java
@@ -203,6 +203,19 @@ public class JpaUserLoginFailureEntity extends MapUserLoginFailureEntity.Abstrac
     }
 
     @Override
+    public boolean isUpdated() {
+        return updated || (metadata != null && metadata.isUpdated());
+    }
+
+    @Override
+    public void clearUpdatedFlag() {
+        updated = false;
+        if (metadata != null) {
+            metadata.clearUpdatedFlag();
+        }
+    }
+
+    @Override
     public int hashCode() {
         return getClass().hashCode();
     }

--- a/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/realm/entity/JpaComponentEntity.java
+++ b/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/realm/entity/JpaComponentEntity.java
@@ -197,6 +197,17 @@ public class JpaComponentEntity extends UpdatableEntity.Impl implements MapCompo
     }
 
     @Override
+    public boolean isUpdated() {
+        return updated || metadata.isUpdated();
+    }
+
+    @Override
+    public void clearUpdatedFlag() {
+        updated = false;
+        metadata.clearUpdatedFlag();
+    }
+
+    @Override
     public int hashCode() {
         return getClass().hashCode();
     }

--- a/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/realm/entity/JpaRealmEntity.java
+++ b/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/realm/entity/JpaRealmEntity.java
@@ -16,6 +16,7 @@
  */
 package org.keycloak.models.map.storage.jpa.realm.entity;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -1013,6 +1014,19 @@ public class JpaRealmEntity extends MapRealmEntity.AbstractRealmEntity implement
     @Override
     public int hashCode() {
         return getClass().hashCode();
+    }
+
+    @Override
+    public boolean isUpdated() {
+        return updated || (metadata != null && metadata.isUpdated());
+    }
+
+    @Override
+    public void clearUpdatedFlag() {
+        updated = false;
+        if (metadata != null) {
+            metadata.clearUpdatedFlag();
+        }
     }
 
     @Override

--- a/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/role/entity/JpaRoleEntity.java
+++ b/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/role/entity/JpaRoleEntity.java
@@ -266,6 +266,19 @@ public class JpaRoleEntity extends AbstractRoleEntity implements JpaRootVersione
     }
 
     @Override
+    public boolean isUpdated() {
+        return updated || (metadata != null && metadata.isUpdated());
+    }
+
+    @Override
+    public void clearUpdatedFlag() {
+        updated = false;
+        if (metadata != null) {
+            metadata.clearUpdatedFlag();
+        }
+    }
+
+    @Override
     public int hashCode() {
         return getClass().hashCode();
     }


### PR DESCRIPTION
This is overwriting the isUpdated() method on entities as the modification information is available from the metadata field. It doesn't call super.isUpdated() as that would load the lazy collections.
For nested entities (like the components in realms) are ignored.

Closes #11766

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
