### PR TITLE
Add option in admin group search by name to reproduce previous behavoir

### DIFF
--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/GroupsResource.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/GroupsResource.java
@@ -79,6 +79,25 @@ public interface GroupsResource {
                                      @QueryParam("first") Integer first,
                                      @QueryParam("max") Integer max,
                                      @QueryParam("briefRepresentation") @DefaultValue("true") boolean briefRepresentation);
+
+    /**
+     * Get groups by pagination params.
+     * @param search max number of occurrences
+     * @param first index of the first element
+     * @param max max number of occurrences
+     * @param briefRepresentation if false, return groups with their attributes
+     * @param filterSubGroup if false, return groups with their subgroups or if true filter subgroups based on the search params
+     * @return A list containing the slice of all groups.
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    List<GroupRepresentation> groups(@QueryParam("search") String search,
+                                     @QueryParam("first") Integer first,
+                                     @QueryParam("max") Integer max,
+                                     @QueryParam("briefRepresentation") @DefaultValue("true") boolean briefRepresentation,
+                                     @QueryParam("filterSubGroup") @DefaultValue("true") boolean filterSubGroup);
+
     /**
      * Counts all groups.
      * @return A map containing key "count" with number of groups as value.

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
@@ -152,8 +152,12 @@ public class ModelToRepresentation {
     }
 
     public static Stream<GroupRepresentation> searchForGroupByName(RealmModel realm, boolean full, String search, Integer first, Integer max) {
+        return searchForGroupByName(realm, full, search, first, max, false);
+    }
+
+    public static Stream<GroupRepresentation> searchForGroupByName(RealmModel realm, boolean full, String search, Integer first, Integer max, boolean filterSubGroup) {
         return realm.searchForGroupByNameStream(search, first, max)
-                .map(g -> toGroupHierarchy(g, full, search));
+                .map(g -> toGroupHierarchy(g, full, filterSubGroup ? search : null));
     }
 
     public static Stream<GroupRepresentation> searchForGroupByName(UserModel user, boolean full, String search, Integer first, Integer max) {

--- a/services/src/main/java/org/keycloak/services/resources/admin/GroupsResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/GroupsResource.java
@@ -77,11 +77,12 @@ public class GroupsResource {
     public Stream<GroupRepresentation> getGroups(@QueryParam("search") String search,
                                                  @QueryParam("first") Integer firstResult,
                                                  @QueryParam("max") Integer maxResults,
-                                                 @QueryParam("briefRepresentation") @DefaultValue("true") boolean briefRepresentation) {
+                                                 @QueryParam("briefRepresentation") @DefaultValue("true") boolean briefRepresentation,
+                                                 @QueryParam("filterSubGroup") @DefaultValue("true") boolean filterSubGroup) {
         auth.groups().requireList();
 
         if (Objects.nonNull(search)) {
-            return ModelToRepresentation.searchForGroupByName(realm, !briefRepresentation, search.trim(), firstResult, maxResults);
+            return ModelToRepresentation.searchForGroupByName(realm, !briefRepresentation, search.trim(), firstResult, maxResults, filterSubGroup);
         } else if(Objects.nonNull(firstResult) && Objects.nonNull(maxResults)) {
             return ModelToRepresentation.toGroupHierarchy(realm, !briefRepresentation, firstResult, maxResults);
         } else {


### PR DESCRIPTION
Based on discussion of this issue https://github.com/keycloak/keycloak/issues/9435 we add a flag to the Admin API, search groups by name query, in order to reproduce the behavior that was prior [this merge](https://github.com/keycloak/keycloak/pull/8134/commits/aef0dc435d0726fba1cf1d30eb480b94721f5634).

This PR add a flag called `filterSubGroup` that has a default value to `true` to keep the current behavior. Passing `false` will populate the subGroup hierarchy as it was until version 15.1.0 

Frontend behavior can be restored if wanted using this flag. 
