### PR TITLE
Avoid loading entire composite role collection to add/remove items or check presence (fixes #11796)

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/CompositeRoleEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/CompositeRoleEntity.java
@@ -1,0 +1,90 @@
+package org.keycloak.models.jpa.entities;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.IdClass;
+import javax.persistence.NamedQueries;
+import javax.persistence.NamedQuery;
+import javax.persistence.QueryHint;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
+
+import org.hibernate.jpa.QueryHints;
+
+@Entity
+@IdClass(CompositeRoleEntityKey.class)
+@Table(name="COMPOSITE_ROLE", uniqueConstraints = {
+      @UniqueConstraint(columnNames = { "COMPOSITE", "CHILD_ROLE" })
+})
+@NamedQueries({
+    @NamedQuery(name="getChildrenRoleIds", hints = @QueryHint(name = QueryHints.HINT_READONLY, value = "true"),
+            query="select compositerole.childRoleId from CompositeRoleEntity compositerole where compositerole.compositeId = :roleId"),
+    @NamedQuery(name="getCompositeRolesByCompositeIds", hints = @QueryHint(name = QueryHints.HINT_READONLY, value = "true"),
+            query="select compositerole from CompositeRoleEntity compositerole where compositerole.compositeId in :roleIds"),
+    @NamedQuery(name="getChildRoleIdsForCompositeIds", hints = @QueryHint(name = QueryHints.HINT_READONLY, value = "true"),
+            query="select compositerole.childRoleId from CompositeRoleEntity compositerole where compositerole.compositeId in :roleIds"),
+    @NamedQuery(name="removeCompositeAndChildRoleEntry",
+            query="delete from CompositeRoleEntity compositerole where compositerole.compositeId = :compositeId and compositerole.childRoleId = :childId"),
+})
+public class CompositeRoleEntity implements Serializable {
+
+    private static final long serialVersionUID = 7375648337789837909L;
+    
+    @Id
+    @Column(name="COMPOSITE", length = 36, nullable = false)
+    private String compositeId;
+
+    @Id
+    @Column(name="CHILD_ROLE", length = 36, nullable = false)
+    private String childRoleId;
+    
+    public CompositeRoleEntity() {
+        super();
+    }
+
+    public CompositeRoleEntity(CompositeRoleEntityKey key) {
+        super();
+        setCompositeId(key.getCompositeId());
+        setChildRoleId(key.getChildRoleId());
+    }
+
+    public String getCompositeId() {
+        return compositeId;
+    }
+
+    public void setCompositeId(String compositeId) {
+        this.compositeId = compositeId;
+    }
+
+    public String getChildRoleId() {
+        return childRoleId;
+    }
+
+    public void setChildRoleId(String childRoleId) {
+        this.childRoleId = childRoleId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null) return false;
+        if (!(o instanceof CompositeRoleEntity)) return false;
+
+        CompositeRoleEntity that = (CompositeRoleEntity) o;
+
+        if (!compositeId.equals(that.compositeId)) return false;
+        if (!childRoleId.equals(that.childRoleId)) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(compositeId, childRoleId);
+    }
+    
+}

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/CompositeRoleEntityKey.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/CompositeRoleEntityKey.java
@@ -1,0 +1,64 @@
+package org.keycloak.models.jpa.entities;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * The composite primary key representation for {@link CompositeRoleEntity}.
+ * Required to perform lookup by primary key through JPA entity manager.
+ */
+public class CompositeRoleEntityKey implements Serializable {
+
+    private static final long serialVersionUID = -6078479162595894390L;
+
+    private String compositeId;
+    private String childRoleId;
+    
+    public CompositeRoleEntityKey() {
+        super();
+    }
+
+    public CompositeRoleEntityKey(String compositeId, String childRoleId) {
+        super();
+        this.compositeId = compositeId;
+        this.childRoleId = childRoleId;
+    }
+    
+    public String getCompositeId() {
+        return compositeId;
+    }
+
+    public String getChildRoleId() {
+        return childRoleId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null) return false;
+        if (!(o instanceof CompositeRoleEntityKey)) return false;
+
+        CompositeRoleEntityKey that = (CompositeRoleEntityKey) o;
+
+        if (!compositeId.equals(that.compositeId)) return false;
+        if (!childRoleId.equals(that.childRoleId)) return false;
+
+        return true;
+    }
+    
+    @Override
+    public int hashCode() {
+        return Objects.hash(compositeId, childRoleId);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("CompositeRolePK [")
+                .append("compositeId=").append(compositeId)
+                .append(", childRoleId=").append(childRoleId)
+                .append("]");
+        return builder.toString();
+    }
+
+}

--- a/model/jpa/src/main/resources/META-INF/persistence.xml
+++ b/model/jpa/src/main/resources/META-INF/persistence.xml
@@ -32,6 +32,7 @@
         <class>org.keycloak.models.jpa.entities.UserFederationMapperEntity</class>
         <class>org.keycloak.models.jpa.entities.RoleEntity</class>
         <class>org.keycloak.models.jpa.entities.RoleAttributeEntity</class>
+        <class>org.keycloak.models.jpa.entities.CompositeRoleEntity</class>
         <class>org.keycloak.models.jpa.entities.FederatedIdentityEntity</class>
         <class>org.keycloak.models.jpa.entities.MigrationModelEntity</class>
         <class>org.keycloak.models.jpa.entities.UserEntity</class>


### PR DESCRIPTION
Emerging the JPA entity join COMPOSITE_ROLE table to allow optimized access and lookups.

Used here in the role composite collection management (to avoid trigger a full JPA load via the join table).

Closes #11796