### PR TITLE
Iss11579 hostname strict https contexts fix

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/Environment.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/Environment.java
@@ -44,6 +44,7 @@ public final class Environment {
     public static final String DATA_PATH = "/data";
     public static final String DEFAULT_THEMES_PATH = "/themes";
     public static final String DEV_PROFILE_VALUE = "dev";
+    public static final String PROD_PROFILE_VALUE = "prod";
     public static final String LAUNCH_MODE = "kc.launch.mode";
 
     private Environment() {}
@@ -130,6 +131,14 @@ public final class Environment {
         }
         
         return profile;
+    }
+
+    public static boolean isProdMode() {
+        if (PROD_PROFILE_VALUE.equalsIgnoreCase(getProfile())) {
+            return true;
+        }
+
+        return PROD_PROFILE_VALUE.equals(getBuildTimeProperty(PROFILE).orElse(null));
     }
 
     public static boolean isDevMode() {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/Environment.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/Environment.java
@@ -46,6 +46,7 @@ public final class Environment {
     public static final String DEV_PROFILE_VALUE = "dev";
     public static final String PROD_PROFILE_VALUE = "prod";
     public static final String LAUNCH_MODE = "kc.launch.mode";
+    public static final String INSECURE_PRODMODE_FLAG = "kc.mode.production.insecure";
 
     private Environment() {}
 
@@ -105,6 +106,15 @@ public final class Environment {
         }
 
         return profile;
+    }
+
+    public static void setInsecureInProdMode(boolean isInsecure) {
+        System.setProperty(INSECURE_PRODMODE_FLAG, String.valueOf(isInsecure));
+    }
+
+    public static boolean isPossiblyInsecureProdModeConfig() {
+
+        return Boolean.getBoolean(INSECURE_PRODMODE_FLAG);
     }
 
     public static void setProfile(String profile) {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakMain.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakMain.java
@@ -20,6 +20,7 @@ package org.keycloak.quarkus.runtime;
 import static org.keycloak.quarkus.runtime.Environment.getKeycloakModeFromProfile;
 import static org.keycloak.quarkus.runtime.Environment.isDevProfile;
 import static org.keycloak.quarkus.runtime.Environment.getProfileOrDefault;
+import static org.keycloak.quarkus.runtime.Environment.isPossiblyInsecureProdModeConfig;
 import static org.keycloak.quarkus.runtime.Environment.isTestLaunchMode;
 import static org.keycloak.quarkus.runtime.cli.Picocli.parseAndRun;
 import static org.keycloak.quarkus.runtime.cli.command.Start.isDevProfileNotAllowed;
@@ -110,8 +111,13 @@ public class KeycloakMain implements QuarkusApplication {
      */
     @Override
     public int run(String... args) throws Exception {
+
+        if (isPossiblyInsecureProdModeConfig()) {
+            Logger.getLogger(KeycloakMain.class).warnf(Messages.noProxyButHttpEnabledAndTlsSetupExistsInProdModeWarning());
+        }
+
         if (isDevProfile()) {
-            Logger.getLogger(KeycloakMain.class).warnf("Running the server in development mode. DO NOT use this configuration in production.");
+            Logger.getLogger(KeycloakMain.class).warnf(Messages.doNotUseDevModeInProductionWarning());
         }
 
         int exitCode = ApplicationLifecycleManager.getExitCode();

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/Messages.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/Messages.java
@@ -20,6 +20,8 @@ package org.keycloak.quarkus.runtime;
 import java.util.Arrays;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import org.apache.commons.lang.StringUtils;
 import org.jboss.logging.Logger;
 
 import picocli.CommandLine;
@@ -38,11 +40,19 @@ public final class Messages {
         return new IllegalArgumentException("Invalid value [" + mode + "] for configuration property [proxy].");
     }
 
-    public static IllegalStateException httpsConfigurationNotSet() {
-        StringBuilder builder = new StringBuilder("Key material not provided to setup HTTPS. Please configure your keys/certificates");
-        if (!Environment.DEV_PROFILE_VALUE.equals(Environment.getProfile())) {
-            builder.append(" or start the server in development mode");
+    public static IllegalStateException httpsConfigurationNotSet(String proxyMode) {
+        StringBuilder builder = new StringBuilder("Key material not provided to setup HTTPS. Please configure your keys/certificates. ");
+
+        if (!StringUtils.isBlank(proxyMode)) {
+            builder.append(" or use proxy mode `edge` to allow HTTP traffic behind your proxy. Current proxy mode: ")
+                    .append(proxyMode)
+                    .append(" does not support HTTP traffic in production mode. ");
         }
+
+        if (!Environment.DEV_PROFILE_VALUE.equals(Environment.getProfile())) {
+            builder.append("Alternatively, start the server in development mode");
+        }
+
         builder.append(".");
         return new IllegalStateException(builder.toString());
     }
@@ -53,6 +63,14 @@ public final class Messages {
 
     public static String devProfileNotAllowedError(String cmd) {
         return String.format("You can not '%s' the server in %s mode. Please re-build the server first, using 'kc.sh build' for the default production mode.%n", cmd, Environment.getKeycloakModeFromProfile(Environment.DEV_PROFILE_VALUE));
+    }
+
+    public static String doNotUseDevModeInProductionWarning() {
+        return "Running the server in development mode. DO NOT use this configuration in production.";
+    }
+
+    public static String noProxyButHttpEnabledAndTlsSetupExistsInProdModeWarning() {
+        return "The applied configuration uses no proxy configuration and HTTP enabled. This is an INSECURE production configuration. Keycloak needs transport encryption to function securely and OIDC-compliant. Suggestion: proxy=edge.";
     }
 
     public static Throwable invalidLogLevel(String logLevel) {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/ExecutionExceptionHandler.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/ExecutionExceptionHandler.java
@@ -101,8 +101,8 @@ public final class ExecutionExceptionHandler implements CommandLine.IExecutionEx
             FileSystemException fse = (FileSystemException) cause;
             ConfigValue httpsCertFile = getConfig().getConfigValue("kc.https-certificate-file");
 
-            if (fse.getFile().equals(Optional.ofNullable(httpsCertFile.getValue()).orElse(null))) {
-                logError(errorWriter, Messages.httpsConfigurationNotSet().getMessage());
+            if (fse.getFile().equals(httpsCertFile.getValue())) {
+                logError(errorWriter, Messages.httpsConfigurationNotSet("").getMessage());
             }
         }
     }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Main.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Main.java
@@ -21,7 +21,6 @@ import static org.keycloak.quarkus.runtime.cli.Picocli.NO_PARAM_LABEL;
 
 import org.keycloak.quarkus.runtime.Environment;
 import org.keycloak.quarkus.runtime.cli.ExecutionExceptionHandler;
-import org.keycloak.quarkus.runtime.configuration.KeycloakConfigSourceProvider;
 import org.keycloak.quarkus.runtime.configuration.KeycloakPropertiesConfigSource;
 
 import picocli.CommandLine;

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/HttpPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/HttpPropertyMappers.java
@@ -131,13 +131,13 @@ final class HttpPropertyMappers {
         }
 
         if (!enabled) {
-            ConfigValue proceed = context.proceed("kc.https-certificate-file");
+            ConfigValue certConfig = context.proceed("kc.https-certificate-file");
 
-            if (proceed == null || proceed.getValue() == null) {
-                proceed = getMapper("quarkus.http.ssl.certificate.key-store-file").getConfigValue(context);
+            if (certConfig == null || certConfig.getValue() == null) {
+                certConfig = getMapper("quarkus.http.ssl.certificate.key-store-file").getConfigValue(context);
             }
 
-            if (proceed == null || proceed.getValue() == null) {
+            if (certConfig == null || certConfig.getValue() == null) {
                 addInitializationException(Messages.httpsConfigurationNotSet());
             }
         }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/ProxyPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/ProxyPropertyMappers.java
@@ -29,7 +29,7 @@ final class ProxyPropertyMappers {
                         .build(),
                 builder().to("quarkus.http.proxy.enable-forwarded-host")
                         .mapFrom("proxy")
-                        .defaultValue("false")
+                        .defaultValue(Boolean.FALSE.toString())
                         .transformer(ProxyPropertyMappers::resolveEnableForwardedHost)
                         .category(ConfigCategory.PROXY)
                         .build()

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/StartCommandTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/StartCommandTest.java
@@ -44,7 +44,7 @@ public class StartCommandTest {
     }
 
     @Test
-    @Launch({ "-v", "start", "--http-enabled=true", "--hostname-strict=false" })
+    @Launch({ "-v", "start", "--http-enabled=true", "--hostname-strict=false", "--proxy=edge" })
     void testHttpEnabled(LaunchResult result) {
         CLIResult cliResult = (CLIResult) result;
         cliResult.assertStarted();

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/BuildAndStartDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/BuildAndStartDistTest.java
@@ -45,7 +45,7 @@ public class BuildAndStartDistTest {
     }
 
     @Test
-    @Launch({ "start", "--http-enabled=true", "--hostname-strict=false" })
+    @Launch({ "start", "--http-enabled=true", "--hostname-strict=false", "--proxy=edge" })
     @Order(2)
     void testStartUsingCliArgs(LaunchResult result) {
         CLIResult cliResult = (CLIResult) result;
@@ -77,6 +77,7 @@ public class BuildAndStartDistTest {
         public void accept(KeycloakDistribution distribution) {
             distribution.setProperty("http-enabled", "true");
             distribution.setProperty("hostname-strict", "false");
+            distribution.setProperty("proxy", "edge");
             distribution.setProperty("cache", "local");
         }
     }

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ClusterConfigDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ClusterConfigDistTest.java
@@ -69,7 +69,7 @@ public class ClusterConfigDistTest {
     }
 
     @Test
-    @Launch({ "start", "--auto-build", "--http-enabled=true", "--hostname-strict false" })
+    @Launch({ "start", "--auto-build", "--http-enabled=true", "--hostname-strict false", "--proxy=edge" })
     void testStartDefaultsToClustering(LaunchResult result) {
         CLIResult cliResult = (CLIResult) result;
         cliResult.assertStarted();

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/HostnameDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/HostnameDistTest.java
@@ -71,12 +71,6 @@ public class HostnameDistTest {
     }
 
     @Test
-    @Launch({ "start-dev", "--hostname=mykeycloak.127.0.0.1.nip.io", "--proxy=edge", "--hostname-strict-https=true" })
-    public void testUseDefaultPortsAndHttpsSchemeWhenProxyIsSetAndStrictHttpsEnabled() {
-        assertFrontEndUrl("http://mykeycloak.127.0.0.1.nip.io:8080", "https://mykeycloak.127.0.0.1.nip.io/");
-    }
-
-    @Test
     @Launch({ "start-dev", "--hostname=mykeycloak.127.0.0.1.nip.io" })
     public void testBackEndUrlFromRequest() {
         assertBackEndUrl("http://localhost:8080", "http://localhost:8080/");

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/QuarkusPropertiesAutoBuildDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/QuarkusPropertiesAutoBuildDistTest.java
@@ -60,7 +60,7 @@ public class QuarkusPropertiesAutoBuildDistTest {
 
     @Test
     @BeforeStartDistribution(UpdateConsoleLogLevelToInfo.class)
-    @Launch({ "start", "--auto-build", "--http-enabled=true", "--hostname-strict=false", "--cache=local" })
+    @Launch({ "start", "--auto-build", "--http-enabled=true", "--hostname-strict=false", "--proxy=edge", "--cache=local" })
     @Order(3)
     void testNoReAugAfterChangingRuntimeProperty(LaunchResult result) {
         CLIResult cliResult = (CLIResult) result;
@@ -106,7 +106,7 @@ public class QuarkusPropertiesAutoBuildDistTest {
 
     @Test
     @BeforeStartDistribution(EnableDatasourceMetrics.class)
-    @Launch({ "start", "--auto-build", "--http-enabled=true", "--hostname-strict=false", "--cache=local" })
+    @Launch({ "start", "--auto-build", "--http-enabled=true", "--hostname-strict=false", "--proxy=edge", "--cache=local" })
     @Order(8)
     void testWrappedBuildPropertyTriggersBuildButGetsIgnoredWhenSetByQuarkus(LaunchResult result) {
         CLIResult cliResult = (CLIResult) result;

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/QuarkusPropertiesDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/QuarkusPropertiesDistTest.java
@@ -119,7 +119,7 @@ public class QuarkusPropertiesDistTest {
 
     @Test
     @KeepServerAlive
-    @Launch({ "start", "--http-enabled=true", "--hostname-strict=false" })
+    @Launch({ "start", "--http-enabled=true", "--hostname-strict=false", "--proxy=edge" })
     @Order(9)
     void testUnknownQuarkusBuildTimePropertyApplied(LaunchResult result) {
         CLIResult cliResult = (CLIResult) result;

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartAutoBuildDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartAutoBuildDistTest.java
@@ -37,7 +37,7 @@ import io.quarkus.test.junit.main.LaunchResult;
 public class StartAutoBuildDistTest {
 
     @Test
-    @Launch({ "start", "--auto-build", "--http-enabled=true", "--hostname-strict=false", "--cache=local" })
+    @Launch({ "start", "--auto-build", "--http-enabled=true", "--hostname-strict=false", "--proxy=edge", "--cache=local" })
     @Order(1)
     void testStartAutoBuild(LaunchResult result) {
         CLIResult cliResult = (CLIResult) result;
@@ -46,13 +46,13 @@ public class StartAutoBuildDistTest {
         cliResult.assertMessage("Server configuration updated and persisted. Run the following command to review the configuration:");
         cliResult.assertMessage("kc.sh show-config");
         cliResult.assertMessage("Next time you run the server, just run:");
-        cliResult.assertMessage("kc.sh start --http-enabled=true --hostname-strict=false");
+        cliResult.assertMessage("kc.sh start --http-enabled=true --hostname-strict=false --proxy=edge");
         assertFalse(cliResult.getOutput().contains("--cache"));
         cliResult.assertStarted();
     }
 
     @Test
-    @Launch({ "start", "--auto-build", "--http-enabled=true", "--hostname-strict=false", "--cache=local" })
+    @Launch({ "start", "--auto-build", "--http-enabled=true", "--hostname-strict=false", "--proxy=edge", "--cache=local" })
     @Order(2)
     void testShouldNotReAugIfConfigIsSame(LaunchResult result) {
         CLIResult cliResult = (CLIResult) result;
@@ -61,7 +61,7 @@ public class StartAutoBuildDistTest {
     }
 
     @Test
-    @Launch({ "start", "--auto-build", "--db=dev-mem", "--http-enabled=true", "--hostname-strict=false", "--cache=local" })
+    @Launch({ "start", "--auto-build", "--db=dev-mem", "--http-enabled=true", "--hostname-strict=false", "--proxy=edge", "--cache=local" })
     @Order(3)
     void testShouldReAugIfConfigChanged(LaunchResult result) {
         CLIResult cliResult = (CLIResult) result;
@@ -70,7 +70,7 @@ public class StartAutoBuildDistTest {
     }
 
     @Test
-    @Launch({ "start", "--auto-build", "--db=dev-mem", "--http-enabled=true", "--hostname-strict=false", "--cache=local" })
+    @Launch({ "start", "--auto-build", "--db=dev-mem", "--http-enabled=true", "--hostname-strict=false", "--proxy=edge", "--cache=local" })
     @Order(4)
     void testShouldNotReAugIfSameDatabase(LaunchResult result) {
         CLIResult cliResult = (CLIResult) result;
@@ -87,7 +87,7 @@ public class StartAutoBuildDistTest {
     }
 
     @Test
-    @Launch({ "start", "--auto-build", "--http-enabled=true", "--hostname-strict=false", "--cache=local" })
+    @Launch({ "start", "--auto-build", "--http-enabled=true", "--hostname-strict=false", "--proxy=edge", "--cache=local" })
     @Order(6)
     void testReAugWhenNoOptionAfterBuild(LaunchResult result) {
         CLIResult cliResult = (CLIResult) result;

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartCommandDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartCommandDistTest.java
@@ -48,7 +48,7 @@ public class StartCommandDistTest extends StartCommandTest {
     }
 
     @Test
-    @Launch({ "start", "--auto-build", "--http-enabled=true", "--hostname-strict=false", "--cache=local" })
+    @Launch({ "start", "--auto-build", "--http-enabled=true", "--hostname-strict=false", "--proxy=edge","--cache=local" })
     void testStartUsingAutoBuild(LaunchResult result) {
         CLIResult cliResult = (CLIResult) result;
         cliResult.assertMessage("Changes detected in configuration. Updating the server image.");
@@ -56,7 +56,7 @@ public class StartCommandDistTest extends StartCommandTest {
         cliResult.assertMessage("Server configuration updated and persisted. Run the following command to review the configuration:");
         cliResult.assertMessage("kc.sh show-config");
         cliResult.assertMessage("Next time you run the server, just run:");
-        cliResult.assertMessage("kc.sh start --http-enabled=true --hostname-strict=false");
+        cliResult.assertMessage("kc.sh start --http-enabled=true --hostname-strict=false --proxy=edge");
         assertFalse(cliResult.getOutput().contains("--cache"));
         cliResult.assertStarted();
     }


### PR DESCRIPTION
**UPDATE**: to get a cross-link (thought that was done automatically): This PR is on hold atm. See the discussion here: https://github.com/keycloak/keycloak/pull/11856

---- 
This Draft PR should finally get rid of all the `HOSTNAME_STRICT_HTTPS` issues.

As said e.g. in #11579, the aforementioned config property was never meant to be visible to users. But as a matter of fact we messed up and it is now needed for many environments to actually work the way it is expected.

**I would also love to get some feedback if this configuration would work for ppl _without_ setting `hostname-strict-https=false` manually.** 

**While I work on a way to automate this feedback, I uploaded an image containing these changes to quay.io, so feel free to try it out and provide feedback.**

- Link: [here](https://quay.io/repository/dguhr/keycloak?tab=tags)
-  use e.g. `docker pull quay.io/dguhr/keycloak:test`.

This PR removes the need to set this property completely, it is "moved under the hood" depending on the rules in the following table:

_Assumption_: Keycloak gets started in production mode with http enabled. So invoked using: `kc.sh start --http-enabled=true` followed by the configuration values you see in the table.

| Proxy  | Existing HTTPS Setup | **HOSTNAME-STRICT-HTTPS** gets set to: | Result | Comment
| ------------- | ------------- | ------------- | ------------- | ------------- | 
|  none | no  | Throw **Error** | Startup Error  | Without a proxy and without TLS setup, this is not a valid production setup  |
| none | yes  | **FALSE** + Add Warning at startup | Start + Warning  | Mostly for development purposes, "start" is often also used for development right now, but at least a HTTPS setup should be there. |
| edge  | no  | **FALSE** | Startup normally  | Valid config, proxy terminates TLS, Keycloak only gets http requests is totally fine. |
| edge  | yes  | **FALSE**  | Startup normally | Valid config, proxy terminates TLS, Keycloak only gets http requests is totally fine.   |
| passthrough  | no  | Throw **Error** | Startup error  | Passthrough indicates an existing HTTPS Setup has to be configured.  |
| passthrough  | yes  | **TRUE** | Startup normally  | Normal startup, Keycloak only reachable using HTTPS.  |
| reencrypt  | no  | Throw **Error** | Startup Error  | reencrypt also indicates an existing HTTPS setup has to be configured. |
| reencrypt  | yes  | **TRUE**  |  Startup normally  | Normal startup, Keycloak only reachable using HTTPS.  |

