### PR TITLE
Add scope parameter to KeycloakInitOptions

### DIFF
--- a/adapters/oidc/js/dist/keycloak.d.ts
+++ b/adapters/oidc/js/dist/keycloak.d.ts
@@ -182,6 +182,13 @@ export interface KeycloakInitOptions {
 	enableLogging?: boolean
 
 	/**
+	 * Set the default scope parameter to the login endpoint. Use a space-delimited list of scopes. 
+	 * Note that the scope 'openid' will be always be added to the list of scopes by the adapter.
+	 * Note that the default scope specified here is overwritten if the `login()` options specify scope explicitly.
+	 */
+	scope?: string
+	
+	/**
 	 * Configures how long will Keycloak adapter wait for receiving messages from server in ms. This is used,
 	 * for example, when waiting for response of 3rd party cookies check.
 	 *


### PR DESCRIPTION
keycloak-js init() supports scope parameter as implemented in [keycloak.js:151](https://github.com/keycloak/keycloak/blob/3bcdb44d6a2d365c4a42c6d91dd7cb555897db49/adapters/oidc/js/src/keycloak.js#L151).

However, the corresponding parameter is missing from the interface definition [keycloak.d.ts:55](https://github.com/keycloak/keycloak/blob/main/adapters/oidc/js/dist/keycloak.d.ts#L55).

The parameter should be added to the interface.

Closes #11824 