### PR TITLE
Docker entrypoint, read environment variables from files.

### DIFF
--- a/quarkus/container/Dockerfile
+++ b/quarkus/container/Dockerfile
@@ -15,6 +15,8 @@ RUN (cd /tmp/keycloak && \
 
 RUN mv /tmp/keycloak/keycloak-* /opt/keycloak && mkdir -p /opt/keycloak/data
 
+COPY docker-entrypoint.sh /opt/keycloak/bin/docker-entrypoint.sh
+
 RUN chmod -R g+rwX /opt/keycloak
 
 FROM registry.access.redhat.com/ubi8-minimal
@@ -32,4 +34,6 @@ USER 1000
 EXPOSE 8080
 EXPOSE 8443
 
-ENTRYPOINT [ "/opt/keycloak/bin/kc.sh" ]
+
+
+ENTRYPOINT [ "/opt/keycloak/bin/docker-entrypoint.sh" ]

--- a/quarkus/container/docker-entrypoint.sh
+++ b/quarkus/container/docker-entrypoint.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+# Entrypoint for the main image.
+
+# -e exits the script on command failure
+# -u exits on unset variables
+# -o pipefail sets pipeline exit code to rightmost non-zero
+set -euo pipefail
+
+# Enable test mode by setting KC_DOCKER_ENTRYPOINT_TEST=1
+# This 
+ENTRYPOINT_TEST=${KC_DOCKER_ENTRYPOINT_TEST:-0}
+unset KC_DOCKER_ENTRYPOINT_TEST
+
+# Script name printed to make it obvious this is the actual entrypoint script
+SCRIPT_NAME=$0
+function write_output (){
+    echo "$SCRIPT_NAME $1"
+}
+
+# Basic support for passing the db password or any other KC_ variable as a mounted file.
+# Looks up environment variables like KC_*_FILE, reads the specified file and exports
+# the content to KC_*
+# e.g. KC_DB_PASSWORD_FILE -> KC_DB_PASSWORD
+# 
+# If a file is variable is defined but the file not found, a misconfiguration is very likely and the script exits.
+# If both the _FILE and the base variable are set, the script exits.
+
+# Find suitable variables
+# Ignore non-zero exit from grep if nothing matches
+vars=($(set | grep -o KC_.*_FILE || true))
+
+# Enumerate variable names
+for varName in ${vars[@]}; do
+    # Output variable, trim the _FILE suffix
+    # e.g. KC_DB_PASSWORD_FILE -> KC_DB_PASSWORD
+    outVarName="${varName%_FILE}"
+    
+    filePath=${!varName:-}
+    outVarValue=${!outVarName:-}
+
+    if [[ $ENTRYPOINT_TEST == 1 ]]; then
+        write_output "TRC: Processing $varName -> $outVarName"
+    fi
+
+    if [[ $filePath && $outVarValue ]]; then
+        write_output "ERR: Both $varName and $outVarName are set (but are exclusive)"
+        exit 1
+    fi
+
+    # File specified but not found. Very likely a misconfiguration.
+    if [[ ! -f $filePath ]]; then
+        write_output "ERR: $varName -> file '$filePath' not found"
+        exit 1
+    fi
+    if [[ ! -r $filePath ]]; then
+        write_output "ERR: $varName -> file '$filePath' unreadable"
+        exit 1
+    fi
+
+    # Read contents
+    content=$(< $filePath)
+    # Export contents if non-empty
+    if [[ -n content ]]; then
+        export $outVarName=$content
+        write_output "INF: exported $outVarName from $varName"
+    # Empty contents, warn but don't fail
+    else
+        write_output "WRN: $varName -> '$filePath' is empty"
+    fi
+
+
+    # Unset the _FILE variable, no longer needed
+    unset "$varName"
+done
+
+if [[ $ENTRYPOINT_TEST == 1 ]]; then
+    # Print any KC_ variables we have. Ignore non-zero exit from grep if none.
+    env | grep KC_.*= || true
+    write_output "Would execute" /opt/keycloak/bin/kc.sh start "$@"
+    write_output "Entrypoint test complete, exiting successfully"
+    exit 0
+fi
+
+# Pass all command parameters to actual startup script
+exec /opt/keycloak/bin/kc.sh start "$@"

--- a/quarkus/container/docker-entrypoint.sh
+++ b/quarkus/container/docker-entrypoint.sh
@@ -83,4 +83,4 @@ if [[ $ENTRYPOINT_TEST == 1 ]]; then
 fi
 
 # Pass all command parameters to actual startup script
-exec /opt/keycloak/bin/kc.sh start "$@"
+exec /opt/keycloak/bin/kc.sh "$@"

--- a/quarkus/container/entrypoint-tests.sh
+++ b/quarkus/container/entrypoint-tests.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+# Tester for docker-entrypoint.sh.
+# Runs a number of test cases and returns an error if any fails.
+#
+# Each case is run in a separate sub-environment so they are not destroyed by
+# any variables in the parent shell. (env -i)
+#
+# How to run: ./entrypoint-tests.sh
+# No extra requirements.
+
+# Prepare test files
+VALID_FILE=$(pwd)/kcdbpw-valid
+echo "pw" > $VALID_FILE
+EMPTY_FILE=$(pwd)/kcdbpw-empty
+rm -f $EMPTY_FILE && touch $EMPTY_FILE
+MISSING_FILE=$(pwd)/kcdbpw-missing
+UNREADABLE_FILE=$(pwd)/kcdbpw-unreadable
+rm -f $UNREADABLE_FILE && touch $UNREADABLE_FILE && chmod -r $UNREADABLE_FILE
+
+FAILING_CASES=(
+    # File specified but missing
+    "KC_DB_PASSWORD_FILE=$MISSING_FILE"
+
+    # Variable present but empty
+    "KC_DB_PASSWORD_FILE= " 
+    
+    # Both a valid file and the plain value passed
+    "KC_DB_PASSWORD_FILE=$VALID_FILE KC_DB_PASSWORD=123"
+
+    # Pass an existing directory as a file
+    "KC_DB_PASSWORD_FILE=$(pwd)"
+
+    # Pass missing directory as a file
+    "KC_DB_PASSWORD_FILE=$(pwd)/nonexistingforsure"
+
+    # Pass unreadable file
+    "KC_DB_PASSWORD_FILE=$UNREADABLE_FILE"
+)
+OK_CASES=(
+    # No parameters, should pass ok
+    ""
+
+    # Empty file, should warn but pass
+    "KC_DB_PASSWORD_FILE=$EMPTY_FILE"
+
+    # File specified and exists, should pass
+    "KC_DB_PASSWORD_FILE=$VALID_FILE"
+)
+
+PASSED=0
+FAILED=0
+
+# Output coloring
+RED=$'\e[0;31m'
+NC=$'\e[0m'
+
+for case in "${FAILING_CASES[@]}"; do
+    output=$(env -i $case KC_DOCKER_ENTRYPOINT_TEST=1 ./docker-entrypoint.sh)
+    code=$?
+    if [[ $code == 0 ]]; then
+        echo "${RED}TEST FAILED${NC}: Expected return > 0 (got $code) for case: '$case'"
+        echo "Entrypoint output:
+$output
+"
+        ((FAILED++))
+    else
+        ((PASSED++))
+    fi
+done
+
+for case in "${OK_CASES[@]}"; do
+    output=$(env -i $case KC_DOCKER_ENTRYPOINT_TEST=1 ./docker-entrypoint.sh)
+    code=$?
+
+    if [[ $code > 0 ]]; then
+        echo "${RED}TEST FAILED${NC}: Unexpected return > 0 ($code) for case: '$case'"
+        echo "Entrypoint output:
+$output"
+        ((FAILED++))
+    else
+        ((PASSED++))
+    fi
+done
+
+# Clean up
+rm -f $VALID_FILE $EMPTY_FILE $UNREADABLE_FILE
+
+
+if [[ $FAILED > 0 ]]; then
+    echo "${RED}Tests executed, passed: $PASSED, failed: $FAILED${NC}"
+    exit 1
+else
+    echo "Tests executed, passed: $PASSED, failed: $FAILED"
+    exit 0
+fi
+


### PR DESCRIPTION
Adds a special entrypoint script for the Docker image.

The script supports using (mounted) files for configuring sensitive variables (like passwords). It is an alternative to passing the sensitive value directly as an environment variable (KC_DB_PASSWORD=MyPassword).

Basic process:

The information is mounted as a file to the container (e.g. /tmp/kc-db-password)
File path is passed as an environment variable (KC_DB_PASSWORD_FILE=/tmp/kc-db-password)
The entrypoint detects KC_DB_PASSWORD_FILE, reads the file content and exports it as KC_DB_PASSWORD
Closes https://github.com/keycloak/keycloak/issues/10816.

Supersedes the previous PR https://github.com/keycloak/keycloak/pull/10918, which I created off main in my fork and had to close.