### PR TITLE
Prevent double-submit of the form that could lead to a failing request in the backend.

### DIFF
--- a/themes/src/main/resources/theme/base/admin/resources/js/controllers/clients.js
+++ b/themes/src/main/resources/theme/base/admin/resources/js/controllers/clients.js
@@ -2226,8 +2226,11 @@ module.controller('ClientScopeMappingCtrl', function($scope, $http, realm, $rout
        return $scope.client.fullScopeAllowed;
     }
 
-    $scope.changeFlag = function() {
+    $scope.changeFlag = function(event) {
         console.log('changeFlag');
+        event.stopPropagation();
+        event.preventDefault();
+        $scope.client.fullScopeAllowed = !$scope.client.fullScopeAllowed
         Client.update({
             realm : realm.realm,
             client : client.id

--- a/themes/src/main/resources/theme/base/admin/resources/partials/client-scope-mappings.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/client-scope-mappings.html
@@ -15,7 +15,7 @@
                     <label class="col-md-2 control-label" for="fullScopeAllowed">{{:: 'full-scope-allowed' | translate}}</label>
                     <kc-tooltip>{{:: 'full-scope-allowed.tooltip' | translate}}</kc-tooltip>
                     <div class="col-md-6">
-                        <input kc-read-only="!client.access.manage" ng-model="client.fullScopeAllowed" ng-click="changeFlag()" name="fullScopeAllowed" id="fullScopeAllowed" onoffswitch on-text="{{:: 'onText' | translate}}" off-text="{{:: 'offText' | translate}}" />
+                        <input kc-read-only="!client.access.manage" ng-model="client.fullScopeAllowed" ng-click="changeFlag($event)" name="fullScopeAllowed" id="fullScopeAllowed" onoffswitch on-text="{{:: 'onText' | translate}}" off-text="{{:: 'offText' | translate}}" />
                     </div>
                 </div>
             </fieldset>


### PR DESCRIPTION
This happend when switching the fullScopeAllowed for a client.

As this element is wrapped inside a form, the click would otherwise also submit the form.

Closes #11819

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
