### PR TITLE
Make all fields in HotRod store optional

### DIFF
--- a/model/map-hot-rod/src/main/java/org/keycloak/models/map/storage/hotRod/authSession/HotRodRootAuthenticationSessionEntity.java
+++ b/model/map-hot-rod/src/main/java/org/keycloak/models/map/storage/hotRod/authSession/HotRodRootAuthenticationSessionEntity.java
@@ -39,10 +39,10 @@ import java.util.Set;
 public class HotRodRootAuthenticationSessionEntity extends AbstractHotRodEntity {
 
     @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")
-    @ProtoField(number = 1, required = true)
-    public int entityVersion = 1;
+    @ProtoField(number = 1)
+    public Integer entityVersion = 1;
 
-    @ProtoField(number = 2, required = true)
+    @ProtoField(number = 2)
     public String id;
 
     @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")

--- a/model/map-hot-rod/src/main/java/org/keycloak/models/map/storage/hotRod/client/HotRodClientEntity.java
+++ b/model/map-hot-rod/src/main/java/org/keycloak/models/map/storage/hotRod/client/HotRodClientEntity.java
@@ -42,11 +42,11 @@ import java.util.stream.Stream;
 public class HotRodClientEntity extends AbstractHotRodEntity {
 
     @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")
-    @ProtoField(number = 1, required = true)
-    public int entityVersion = 1;
+    @ProtoField(number = 1)
+    public Integer entityVersion = 1;
 
     @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")
-    @ProtoField(number = 2, required = true)
+    @ProtoField(number = 2)
     public String id;
 
     @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")

--- a/model/map-hot-rod/src/main/java/org/keycloak/models/map/storage/hotRod/clientscope/HotRodClientScopeEntity.java
+++ b/model/map-hot-rod/src/main/java/org/keycloak/models/map/storage/hotRod/clientscope/HotRodClientScopeEntity.java
@@ -41,10 +41,10 @@ import java.util.Set;
 public class HotRodClientScopeEntity extends AbstractHotRodEntity  {
 
     @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")
-    @ProtoField(number = 1, required = true)
-    public int entityVersion = 1;
+    @ProtoField(number = 1)
+    public Integer entityVersion = 1;
 
-    @ProtoField(number = 2, required = true)
+    @ProtoField(number = 2)
     public String id;
 
     @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")

--- a/model/map-hot-rod/src/main/java/org/keycloak/models/map/storage/hotRod/group/HotRodGroupEntity.java
+++ b/model/map-hot-rod/src/main/java/org/keycloak/models/map/storage/hotRod/group/HotRodGroupEntity.java
@@ -61,11 +61,11 @@ public class HotRodGroupEntity extends AbstractHotRodEntity {
     }
 
     @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")
-    @ProtoField(number = 1, required = true)
-    public int entityVersion = 1;
+    @ProtoField(number = 1)
+    public Integer entityVersion = 1;
 
     @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")
-    @ProtoField(number = 2, required = true)
+    @ProtoField(number = 2)
     public String id;
 
     @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")

--- a/model/map-hot-rod/src/main/java/org/keycloak/models/map/storage/hotRod/loginFailure/HotRodUserLoginFailureEntity.java
+++ b/model/map-hot-rod/src/main/java/org/keycloak/models/map/storage/hotRod/loginFailure/HotRodUserLoginFailureEntity.java
@@ -32,10 +32,10 @@ import org.keycloak.models.map.storage.hotRod.common.UpdatableHotRodEntityDelega
 public class HotRodUserLoginFailureEntity extends AbstractHotRodEntity {
 
     @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")
-    @ProtoField(number = 1, required = true)
-    public int entityVersion = 1;
+    @ProtoField(number = 1)
+    public Integer entityVersion = 1;
 
-    @ProtoField(number = 2, required = true)
+    @ProtoField(number = 2)
     public String id;
 
     @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")

--- a/model/map-hot-rod/src/main/java/org/keycloak/models/map/storage/hotRod/realm/HotRodRealmEntity.java
+++ b/model/map-hot-rod/src/main/java/org/keycloak/models/map/storage/hotRod/realm/HotRodRealmEntity.java
@@ -72,8 +72,8 @@ import java.util.stream.Collectors;
 public class HotRodRealmEntity extends AbstractHotRodEntity {
 
     @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")
-    @ProtoField(number = 1, required = true)
-    public int entityVersion = 1;
+    @ProtoField(number = 1)
+    public Integer entityVersion = 1;
 
     @ProtoField(number = 2)
     public String id;

--- a/model/map-hot-rod/src/main/java/org/keycloak/models/map/storage/hotRod/role/HotRodRoleEntity.java
+++ b/model/map-hot-rod/src/main/java/org/keycloak/models/map/storage/hotRod/role/HotRodRoleEntity.java
@@ -59,11 +59,11 @@ public class HotRodRoleEntity extends AbstractHotRodEntity {
     }
 
     @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")
-    @ProtoField(number = 1, required = true)
-    public int entityVersion = 1;
+    @ProtoField(number = 1)
+    public Integer entityVersion = 1;
 
     @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")
-    @ProtoField(number = 2, required = true)
+    @ProtoField(number = 2)
     public String id;
 
     @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")

--- a/model/map-hot-rod/src/main/java/org/keycloak/models/map/storage/hotRod/user/HotRodUserEntity.java
+++ b/model/map-hot-rod/src/main/java/org/keycloak/models/map/storage/hotRod/user/HotRodUserEntity.java
@@ -51,11 +51,11 @@ public class HotRodUserEntity extends AbstractHotRodEntity {
     private static final Logger LOG = Logger.getLogger(HotRodUserEntity.class);
 
     @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")
-    @ProtoField(number = 1, required = true)
-    public int entityVersion = 1;
+    @ProtoField(number = 1)
+    public Integer entityVersion = 1;
 
     @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")
-    @ProtoField(number = 2, required = true)
+    @ProtoField(number = 2)
     public String id;
 
     @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")

--- a/model/map-hot-rod/src/main/java/org/keycloak/models/map/storage/hotRod/userSession/HotRodAuthenticatedClientSessionEntity.java
+++ b/model/map-hot-rod/src/main/java/org/keycloak/models/map/storage/hotRod/userSession/HotRodAuthenticatedClientSessionEntity.java
@@ -35,11 +35,11 @@ import java.util.Set;
 public class HotRodAuthenticatedClientSessionEntity extends AbstractHotRodEntity {
 
     @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")
-    @ProtoField(number = 1, required = true)
-    public int entityVersion = 1;
+    @ProtoField(number = 1)
+    public Integer entityVersion = 1;
 
     @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")
-    @ProtoField(number = 2, required = true)
+    @ProtoField(number = 2)
     public String id;
 
     @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")

--- a/model/map-hot-rod/src/main/java/org/keycloak/models/map/storage/hotRod/userSession/HotRodUserSessionEntity.java
+++ b/model/map-hot-rod/src/main/java/org/keycloak/models/map/storage/hotRod/userSession/HotRodUserSessionEntity.java
@@ -36,10 +36,10 @@ import java.util.Set;
 public class HotRodUserSessionEntity extends AbstractHotRodEntity {
 
     @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")
-    @ProtoField(number = 1, required = true)
-    public int entityVersion = 1;
+    @ProtoField(number = 1)
+    public Integer entityVersion = 1;
 
-    @ProtoField(number = 2, required = true)
+    @ProtoField(number = 2)
     public String id;
 
     @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")


### PR DESCRIPTION
Making a primitive field optional requires to specify `defaultValue` otherwise it complains:
```
org.infinispan.protostream.annotations.ProtoSchemaBuilderException: Primitive field 'entityVersion' of org.keycloak.models.map.storage.hotRod.userSession.HotRodAuthenticatedClientSessionEntity is not nullable so it should be either marked required or should have a default value.
``` 
Another option is to change `int` to `Integer`.

@mhajas WDYT?

Closes #11141 
