### PR TITLE
KEYCLOAK-11883 Make realm-name available to executeActions email subject

### DIFF
--- a/services/src/main/java/org/keycloak/email/freemarker/FreeMarkerEmailTemplateProvider.java
+++ b/services/src/main/java/org/keycloak/email/freemarker/FreeMarkerEmailTemplateProvider.java
@@ -167,7 +167,10 @@ public class FreeMarkerEmailTemplateProvider implements EmailTemplateProvider {
 
         attributes.put("realmName", getRealmName());
 
-        send("executeActionsSubject", "executeActions.ftl", attributes);
+        ArrayList<Object> subjectAttrs = new ArrayList<>();
+        // In theme/email/messages/executeActionsSubject real-name can be used using {0}
+        al.add(getRealmName());
+        send("executeActionsSubject", subjectAttrs, "executeActions.ftl", attributes);
     }
 
     @Override


### PR DESCRIPTION
Relevant Issue: https://github.com/keycloak/keycloak/issues/11883

Brief detail about change: Have supplied subject attribute argument with a list containing realm-name, in future more such attributes can be made available.