### PR TITLE
ID token encryption without specifying id_token_encrypted_response_enc does not follow OIDC Dynamic Client Registration specification

### DIFF
--- a/services/src/main/java/org/keycloak/jose/jws/DefaultTokenManager.java
+++ b/services/src/main/java/org/keycloak/jose/jws/DefaultTokenManager.java
@@ -297,6 +297,7 @@ public class DefaultTokenManager implements TokenManager {
         if (category == null) return null;
         switch (category) {
             case ID:
+                return getEncryptAlgorithm(OIDCConfigAttributes.ID_TOKEN_ENCRYPTED_RESPONSE_ENC, JWEConstants.A128CBC_HS256);
             case LOGOUT:
                 return getEncryptAlgorithm(OIDCConfigAttributes.ID_TOKEN_ENCRYPTED_RESPONSE_ENC);
             case AUTHORIZATION_RESPONSE:

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/IdTokenEncryptionTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/IdTokenEncryptionTest.java
@@ -190,6 +190,11 @@ public class IdTokenEncryptionTest extends AbstractTestRealmKeycloakTest {
         testIdTokenSignatureAndEncryption(Algorithm.PS512, JWEConstants.RSA_OAEP, JWEConstants.A256GCM);
     }
 
+    @Test
+    public void testIdTokenEncryptionAlgRSA_OAEPEncDefault() {
+        testIdTokenSignatureAndEncryption(Algorithm.PS256, JWEConstants.RSA_OAEP, null);
+    }
+
     private void testIdTokenSignatureAndEncryption(String sigAlgorithm, String algAlgorithm, String encAlgorithm) {
         ClientResource clientResource = null;
         ClientRepresentation clientRep = null;
@@ -230,6 +235,7 @@ public class IdTokenEncryptionTest extends AbstractTestRealmKeycloakTest {
             Assert.assertEquals("JWT", jweHeader.getContentType());
 
             // verify and decrypt JWE
+            if (encAlgorithm == null) encAlgorithm = JWEConstants.A128CBC_HS256;
             JWEAlgorithmProvider algorithmProvider = getJweAlgorithmProvider(algAlgorithm);
             JWEEncryptionProvider encryptionProvider = getJweEncryptionProvider(encAlgorithm);
             byte[] decodedString = TokenUtil.jweKeyEncryptionVerifyAndDecode(decryptionKEK, jweStr, algorithmProvider, encryptionProvider);


### PR DESCRIPTION
Closes #11392
