### PR TITLE
OAuth2DeviceConfig: fix polling interval defaults

### DIFF
--- a/server-spi/src/main/java/org/keycloak/models/OAuth2DeviceConfig.java
+++ b/server-spi/src/main/java/org/keycloak/models/OAuth2DeviceConfig.java
@@ -47,7 +47,7 @@ public final class OAuth2DeviceConfig implements Serializable {
     private transient Supplier<RealmModel> realmForWrite;
 
     private int lifespan = DEFAULT_OAUTH2_DEVICE_CODE_LIFESPAN;
-    private int poolingInterval = DEFAULT_OAUTH2_DEVICE_CODE_LIFESPAN;
+    private int poolingInterval = DEFAULT_OAUTH2_DEVICE_POLLING_INTERVAL;
 
     public OAuth2DeviceConfig(RealmModel realm) {
         this.realm = () -> realm;


### PR DESCRIPTION
Instead of DEFAULT_OAUTH2_DEVICE_POLLING_INTERVAL, constant for the
lifespan was used to initialize the default polling interval.

This leads to inability to continuously poll the result as the result
stuck in the actionTokens cache for far longer than expected (600
seconds instead of 5 seconds). As a result, only the first request for
the token succeeds if a resource owner already did grant the access. If
that has not happened, any additional polling within 600 seconds would
get rejected with a 'slow_down' response.

This makes hard to write OAuth 2.0 clients using device code
authorization grant flow against multiple IdPs. Microsoft's
implementation of OAuth 2.0 device code grant flow requires 'nudging'
the Authorization Server's token endpoint before it even starts
recognizing the device code. Keycloak mismatch of the polling interval
default makes this flow impossible.

Signed-off-by: Alexander Bokovoy <abokovoy@redhat.com>

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
