### PR TITLE
Update webauth4j dependency version to 0.19.3.RELEASE

### DIFF
--- a/distribution/feature-packs/server-feature-pack/src/main/resources/licenses/keycloak/licenses.xml
+++ b/distribution/feature-packs/server-feature-pack/src/main/resources/licenses/keycloak/licenses.xml
@@ -136,22 +136,22 @@
     <dependency>
       <groupId>com.webauthn4j</groupId>
       <artifactId>webauthnj4-core</artifactId>
-      <version>0.12.0.RELEASE</version>
+      <version>0.19.3.RELEASE</version>
       <licenses>
         <license>
           <name>Apache Software License 2.0</name>
-          <url>https://raw.githubusercontent.com/webauthn4j/webauthn4j/0.12.0.RELEASE/LICENSE.txt</url>
+          <url>https://raw.githubusercontent.com/webauthn4j/webauthn4j/0.19.3.RELEASE/LICENSE.txt</url>
         </license>
       </licenses>
     </dependency>
     <dependency>
       <groupId>com.webauthn4j</groupId>
       <artifactId>webauthnj4-util</artifactId>
-      <version>0.12.0.RELEASE</version>
+      <version>0.19.3.RELEASE</version>
       <licenses>
         <license>
           <name>Apache Software License 2.0</name>
-          <url>https://raw.githubusercontent.com/webauthn4j/webauthn4j/0.12.0.RELEASE/LICENSE.txt</url>
+          <url>https://raw.githubusercontent.com/webauthn4j/webauthn4j/0.19.3.RELEASE/LICENSE.txt</url>
         </license>
       </licenses>
     </dependency>

--- a/distribution/galleon-feature-packs/server-galleon-pack/src/license/keycloak-server-galleon-pack-licenses.xml
+++ b/distribution/galleon-feature-packs/server-galleon-pack/src/license/keycloak-server-galleon-pack-licenses.xml
@@ -151,22 +151,22 @@
         <dependency>
             <groupId>com.webauthn4j</groupId>
             <artifactId>webauthnj4-core</artifactId>
-            <version>0.12.0.RELEASE</version>
+            <version>0.19.3.RELEASE</version>
             <licenses>
                 <license>
                     <name>Apache Software License 2.0</name>
-                    <url>https://raw.githubusercontent.com/webauthn4j/webauthn4j/0.12.0.RELEASE/LICENSE.txt</url>
+                    <url>https://raw.githubusercontent.com/webauthn4j/webauthn4j/0.19.3.RELEASE/LICENSE.txt</url>
                 </license>
             </licenses>
         </dependency>
         <dependency>
             <groupId>com.webauthn4j</groupId>
             <artifactId>webauthnj4-util</artifactId>
-            <version>0.12.0.RELEASE</version>
+            <version>0.19.3.RELEASE</version>
             <licenses>
                 <license>
                     <name>Apache Software License 2.0</name>
-                    <url>https://raw.githubusercontent.com/webauthn4j/webauthn4j/0.12.0.RELEASE/LICENSE.txt</url>
+                    <url>https://raw.githubusercontent.com/webauthn4j/webauthn4j/0.19.3.RELEASE/LICENSE.txt</url>
                 </license>
             </licenses>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -199,7 +199,7 @@
         <spring-boot26.version>2.6.1</spring-boot26.version>
 
         <!-- webauthn support -->
-        <webauthn4j.version>0.12.0.RELEASE</webauthn4j.version>
+        <webauthn4j.version>0.19.3.RELEASE</webauthn4j.version>
         <org.apache.kerby.kerby-asn1.version>2.0.0</org.apache.kerby.kerby-asn1.version>
 
         <!-- WildFly Galleon Build related properties -->

--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/WebAuthnAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/WebAuthnAuthenticator.java
@@ -203,9 +203,8 @@ public class WebAuthnAuthenticator implements Authenticator, CredentialValidator
                 signature
                 );
 
-        AuthenticationParameters authenticationParameters = new AuthenticationParameters(
+        WebAuthnCredentialModelInput.KeycloakWebAuthnAuthenticationParameters authenticationParameters = new WebAuthnCredentialModelInput.KeycloakWebAuthnAuthenticationParameters(
                 server,
-                null, // here authenticator cannot be fetched, set it afterwards in WebAuthnCredentialProvider.isValid()
                 isUVFlagChecked
                 );
 

--- a/services/src/main/java/org/keycloak/credential/WebAuthnCredentialModelInput.java
+++ b/services/src/main/java/org/keycloak/credential/WebAuthnCredentialModelInput.java
@@ -16,6 +16,8 @@
 
 package org.keycloak.credential;
 
+import com.webauthn4j.authenticator.Authenticator;
+import com.webauthn4j.server.ServerProperty;
 import org.keycloak.common.util.Base64;
 
 import com.webauthn4j.data.AuthenticationParameters;
@@ -27,6 +29,7 @@ import com.webauthn4j.data.attestation.statement.AttestationStatement;
 import org.keycloak.common.util.CollectionUtil;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -34,7 +37,7 @@ public class WebAuthnCredentialModelInput implements CredentialInput {
 
     private AttestedCredentialData attestedCredentialData;
     private AttestationStatement attestationStatement;
-    private AuthenticationParameters authenticationParameters; // not persisted because it can only be used on authentication operation.
+    private KeycloakWebAuthnAuthenticationParameters authenticationParameters; // not persisted because it can only be used on authentication operation.
     private AuthenticationRequest authenticationRequest; // not persisted because it can only be used on authentication operation.
     private long count;
     private String credentialDBId;
@@ -74,11 +77,11 @@ public class WebAuthnCredentialModelInput implements CredentialInput {
         return count;
     }
 
-    public AuthenticationParameters getAuthenticationParameters() {
+    public KeycloakWebAuthnAuthenticationParameters getAuthenticationParameters() {
         return authenticationParameters;
     }
 
-    public void setAuthenticationParameters(AuthenticationParameters authenticationParameters) {
+    public void setAuthenticationParameters(KeycloakWebAuthnAuthenticationParameters authenticationParameters) {
         this.authenticationParameters = authenticationParameters;
     }
 
@@ -183,5 +186,24 @@ public class WebAuthnCredentialModelInput implements CredentialInput {
         if (sb.length() > 0)
             sb.deleteCharAt(sb.lastIndexOf(","));
         return sb.toString();
+    }
+
+    public static class KeycloakWebAuthnAuthenticationParameters{
+
+        private final ServerProperty serverProperty;
+        private final boolean userVerificationRequired;
+
+        public KeycloakWebAuthnAuthenticationParameters(ServerProperty serverProperty, boolean userVerificationRequired) {
+            this.serverProperty = serverProperty;
+            this.userVerificationRequired = userVerificationRequired;
+        }
+
+        public ServerProperty getServerProperty() {
+            return serverProperty;
+        }
+
+        public boolean isUserVerificationRequired() {
+            return userVerificationRequired;
+        }
     }
 }


### PR DESCRIPTION
Addresses #9506

Commit 94ed5b7 updates `keycloak/licenses.xml` and `keycloak-server-galleon-pack-licenses.xml`, 
but `rh-sso/licenses.xml` and `rh-sso-server-galleon-pack-licenses.xml` also needs update.
Could someone from Red Hat engineering team create a Red Hat build webauthn4j 0.19.3.RELEASE and update `rh-sso/licenses.xml` and `rh-sso-server-galleon-pack-licenses.xml` ?
