### PR TITLE
Fix link to rest api in import export guide for operator

### DIFF
--- a/docs/guides/src/main/operator/realm-import.adoc
+++ b/docs/guides/src/main/operator/realm-import.adoc
@@ -6,11 +6,11 @@
 <@tmpl.guide
 title="Keycloak Realm Import"
 priority=30
-summary="How to perform an automated Keyacloak Realm Import">
+summary="How to perform an automated Keycloak Realm Import using the operator">
 
 == Keycloak Realm Import
 
-The Keycloak Operator ships with the feature of automatically perform a realm import for the Keycloak Deployment.
+The Keycloak Operator ships with the ability to automatically perform a realm import for the Keycloak Deployment.
 
 .Note:
 [NOTE]
@@ -18,12 +18,12 @@ If a Realm with the same name already exists in Keycloak it will not be overwrit
 
 .Note:
 [NOTE]
-The Realm Import CR only supports creation of new realms and doesn't updates or delete those. +
-Changes to the realm performed directly on Keycloak are not synched back in the CR.
+The Realm Import CR only supports creation of new realms and doesn't update or delete those. +
+Changes to the realm performed directly on Keycloak are not synced back in the CR.
 
 === Writing Realm Import CR
 
-A Realm Import Custom Resource(CR) looks like follows:
+A Realm Import Custom Resource (CR) looks like follows:
 
 [source,yaml]
 ----
@@ -37,10 +37,10 @@ spec:
     ...
 ----
 
-This CR should be created in the same namespace as the Keycloak Deployment CR defined in the field `keycloakCRName`.
-The `realm` field accepts a full https://www.keycloak.org/docs-api/{version}/rest-api/index.html#_realmrepresentation[RealmRepresentation].
+This CR should be created in the same namespace as the Keycloak Deployment CR, defined in the field `keycloakCRName`.
+The `realm` field accepts a full https://www.keycloak.org/docs-api/{majorMinorVersion}/rest-api/index.html#_realmrepresentation[RealmRepresentation].
 
-The suggested way to obtain a `RealmRepresentation` is leveraging the export functionality <@links.server id="importExport"/>
+The recommended way to obtain a `RealmRepresentation` is leveraging the export functionality <@links.server id="importExport"/>
 
 * export the Realm to a single file
 * convert the json to yaml
@@ -68,14 +68,14 @@ EOF
 kubectl apply -f example-realm-import.yaml
 ----
 
-And you can check the progress of the Import by running:
+You can check the status of the running import by using the following command:
 
 [source,bash]
 ----
 kubectl get keycloakrealmimports/my-realm-kc -o go-template='{{range .status.conditions}}CONDITION: {{.type}}{{"\n"}}  STATUS: {{.status}}{{"\n"}}  MESSAGE: {{.message}}{{"\n"}}{{end}}'
 ----
 
-When the import successfully completed the output will look like follow:
+When the import has successfully completed, the output will look like the example below:
 
 [source,bash]
 ----


### PR DESCRIPTION
Has to be merged together with the PR for keycloak/keycloak-web#316 (PR: https://github.com/keycloak/keycloak-web/pull/317 ) to work correctly.

Also fixes a few typos in the guide

Closes #11930
