### PR TITLE
Update GitHub actions dependencies

### DIFF
--- a/.github/workflows/codeql-java-analysis.yml
+++ b/.github/workflows/codeql-java-analysis.yml
@@ -32,7 +32,7 @@ jobs:
       run: mkdir -p ~/.m2 ; cp .github/settings.xml ~/.m2/
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2.1.8
+      uses: github/codeql-action/init@v2.1.9
       with:
         languages: java
       
@@ -40,6 +40,6 @@ jobs:
       run: mvn install -Dmaven.test.skip -DskipQuarkus -DskipTestsuite -DskipExamples -DskipTests
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2.1.8
+      uses: github/codeql-action/analyze@v2.1.9
       env: 
         CODEQL_ACTION_EXTRA_OPTIONS: '{"database":{"interpret-results":["--max-paths",0]}}'

--- a/.github/workflows/codeql-js-adapter-analysis.yml
+++ b/.github/workflows/codeql-js-adapter-analysis.yml
@@ -32,7 +32,7 @@ jobs:
       run: mkdir -p ~/.m2 ; cp .github/settings.xml ~/.m2/
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2.1.8
+      uses: github/codeql-action/init@v2.1.9
       env: 
         CODEQL_ACTION_EXTRA_OPTIONS: '{"database":{"finalize":["--no-run-unnecessary-builds"]}}'
       with:
@@ -43,6 +43,6 @@ jobs:
       run: mvn install -Dmaven.test.skip -DskipQuarkus -DskipTestsuite -DskipExamples -DskipTests
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2.1.8
+      uses: github/codeql-action/analyze@v2.1.9
       env: 
         CODEQL_ACTION_EXTRA_OPTIONS: '{"database":{"interpret-results":["--max-paths",0]}}'

--- a/.github/workflows/codeql-theme-analysis.yml
+++ b/.github/workflows/codeql-theme-analysis.yml
@@ -32,7 +32,7 @@ jobs:
       run: mkdir -p ~/.m2 ; cp .github/settings.xml ~/.m2/
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2.1.8
+      uses: github/codeql-action/init@v2.1.9
       env: 
         CODEQL_ACTION_EXTRA_OPTIONS: '{"database":{"finalize":["--no-run-unnecessary-builds"]}}'
       with:
@@ -43,6 +43,6 @@ jobs:
       run: mvn install -Dmaven.test.skip -DskipQuarkus -DskipTestsuite -DskipExamples -DskipTests
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2.1.8
+      uses: github/codeql-action/analyze@v2.1.9
       env: 
         CODEQL_ACTION_EXTRA_OPTIONS: '{"database":{"interpret-results":["--max-paths",0]}}'

--- a/.github/workflows/operator-ci.yml
+++ b/.github/workflows/operator-ci.yml
@@ -59,7 +59,7 @@ jobs:
           java-version: ${{ env.JDK_VERSION }}
           cache: 'maven'
       - name: Setup Minikube-Kubernetes
-        uses: manusa/actions-setup-minikube@v2.4.3
+        uses: manusa/actions-setup-minikube@v2.6.0
         with:
           minikube version: ${{ env.MINIKUBE_VERSION }}
           kubernetes version: ${{ env.KUBERNETES_VERSION }}
@@ -105,7 +105,7 @@ jobs:
           java-version: ${{ env.JDK_VERSION }}
           cache: 'maven'
       - name: Setup Minikube-Kubernetes
-        uses: manusa/actions-setup-minikube@v2.4.3
+        uses: manusa/actions-setup-minikube@v2.6.0
         with:
           minikube version: ${{ env.MINIKUBE_VERSION }}
           kubernetes version: ${{ env.KUBERNETES_VERSION }}
@@ -151,7 +151,7 @@ jobs:
           java-version: ${{ env.JDK_VERSION }}
           cache: 'maven'
       - name: Setup Minikube-Kubernetes
-        uses: manusa/actions-setup-minikube@v2.4.3
+        uses: manusa/actions-setup-minikube@v2.6.0
         with:
           minikube version: ${{ env.MINIKUBE_VERSION }}
           kubernetes version: ${{ env.KUBERNETES_VERSION }}

--- a/.github/workflows/release-container.yml
+++ b/.github/workflows/release-container.yml
@@ -15,14 +15,14 @@
         uses: actions/checkout@v3
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
         
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
         
       - name: Container metadata
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: quay.io/keycloak/keycloak
           tags: |
@@ -31,14 +31,14 @@
             type=semver,pattern={{major}}.{{minor}}
 
       - name: Login to Quay
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: quarkus/container
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/release-operator-container.yml
+++ b/.github/workflows/release-operator-container.yml
@@ -20,7 +20,7 @@ jobs:
         
       - name: Container metadata
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: quay.io/keycloak/keycloak-operator
           tags: |
@@ -29,7 +29,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
 
       - name: Login to Quay
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -32,7 +32,7 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
       - name: Upload scanner results to GitHub
-        uses: github/codeql-action/upload-sarif@v2.1.8
+        uses: github/codeql-action/upload-sarif@v2.1.9
         with:
           sarif_file: quarkus-report.sarif
 
@@ -60,6 +60,6 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
       - name: Upload scanner results for the Operator to GitHub
-        uses: github/codeql-action/upload-sarif@v2.1.8
+        uses: github/codeql-action/upload-sarif@v2.1.9
         with:
           sarif_file: operator-report.sarif

--- a/.github/workflows/trivy-analysis.yml
+++ b/.github/workflows/trivy-analysis.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: "ubuntu-18.04"
     steps:
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@40c4ca9e7421287d0c5576712fdff370978f9c3c
+        uses: aquasecurity/trivy-action@2b30463ddb3d11724a04e760e020c7d9af24d8b3
         with:
           image-ref: 'quay.io/keycloak/keycloak:nightly'
           format: 'template'
@@ -20,7 +20,7 @@ jobs:
           ignore-unfixed: true
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2.1.8
+        uses: github/codeql-action/upload-sarif@v2.1.9
         with:
           sarif_file: 'trivy-results.sarif'
 
@@ -29,7 +29,7 @@ jobs:
     runs-on: "ubuntu-18.04"
     steps:
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@40c4ca9e7421287d0c5576712fdff370978f9c3c
+        uses: aquasecurity/trivy-action@2b30463ddb3d11724a04e760e020c7d9af24d8b3
         with:
           image-ref: 'quay.io/keycloak/keycloak:legacy'
           format: 'template'
@@ -39,7 +39,7 @@ jobs:
           ignore-unfixed: true
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2.1.8
+        uses: github/codeql-action/upload-sarif@v2.1.9
         with:
           sarif_file: 'legacy-results.sarif'
 
@@ -48,7 +48,7 @@ jobs:
     runs-on: "ubuntu-18.04"
     steps:
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@40c4ca9e7421287d0c5576712fdff370978f9c3c
+        uses: aquasecurity/trivy-action@2b30463ddb3d11724a04e760e020c7d9af24d8b3
         with:
           image-ref: 'quay.io/keycloak/keycloak-operator:nightly'
           format: 'template'
@@ -58,6 +58,6 @@ jobs:
           ignore-unfixed: true
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2.1.8
+        uses: github/codeql-action/upload-sarif@v2.1.9
         with:
           sarif_file: 'operator-results.sarif'

--- a/operator/src/test/java/org/keycloak/operator/KeycloakIngressE2EIT.java
+++ b/operator/src/test/java/org/keycloak/operator/KeycloakIngressE2EIT.java
@@ -126,6 +126,9 @@ public class KeycloakIngressE2EIT extends ClusterOperatorTest {
         kc.getSpec().setDisableDefaultIngress(true);
         K8sUtils.deployKeycloak(k8sclient, kc, true);
 
-        assertThat(k8sclient.network().v1().ingresses().inNamespace(namespace).list().getItems().size()).isEqualTo(0);
+        Awaitility.await()
+                .untilAsserted(() -> {
+                    assertThat(k8sclient.network().v1().ingresses().inNamespace(namespace).list().getItems().size()).isEqualTo(0);
+                });
     }
 }


### PR DESCRIPTION
- Bump aquasecurity/trivy-action from 0.2.3 to 0.2.5
- Bump github/codeql-action from 2.1.8 to 2.1.9
- Bump docker/setup-buildx-action from 1 to 2
- Bump docker/build-push-action from 2 to 3
- Bump manusa/actions-setup-minikube from 2.4.3 to 2.6.0
- Bump docker/setup-qemu-action from 1 to 2
- Bump docker/metadata-action from 3 to 4
- Bump docker/login-action from 1 to 2

Resolves #11953

Signed-off-by: dependabot[bot] <support@github.com>

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
