### PR TITLE
Ensure that only JDK 8 APIs are used where JDK 8 is still required.

### DIFF
--- a/adapters/oidc/adapter-core/pom.xml
+++ b/adapters/oidc/adapter-core/pom.xml
@@ -31,9 +31,6 @@
     <description/>
 
     <properties>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
-
         <keycloak.osgi.export>
             org.keycloak.adapters.*
         </keycloak.osgi.export>

--- a/adapters/oidc/jetty/jetty-core/pom.xml
+++ b/adapters/oidc/jetty/jetty-core/pom.xml
@@ -29,9 +29,6 @@
     <artifactId>keycloak-jetty-core</artifactId>
     <name>Keycloak Jetty Core Integration</name>
     <properties>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
-
         <keycloak.osgi.export>
             org.keycloak.adapters.jetty.core.*
         </keycloak.osgi.export>

--- a/adapters/oidc/servlet-filter/pom.xml
+++ b/adapters/oidc/servlet-filter/pom.xml
@@ -31,9 +31,6 @@
     <description/>
 
     <properties>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
-
         <keycloak.osgi.export>
             org.keycloak.adapters.servlet.*
         </keycloak.osgi.export>

--- a/adapters/oidc/tomcat/tomcat-core/pom.xml
+++ b/adapters/oidc/tomcat/tomcat-core/pom.xml
@@ -28,10 +28,6 @@
 
     <artifactId>keycloak-tomcat-core-adapter</artifactId>
     <name>Keycloak Tomcat Core Integration</name>
-    <properties>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
-    </properties>
     <description />
 
     <dependencies>

--- a/adapters/oidc/tomcat/tomcat/pom.xml
+++ b/adapters/oidc/tomcat/tomcat/pom.xml
@@ -28,10 +28,6 @@
 
     <artifactId>keycloak-tomcat-adapter</artifactId>
     <name>Keycloak Tomcat Integration</name>
-    <properties>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
-    </properties>
     <description />
 
     <dependencies>

--- a/adapters/oidc/undertow/pom.xml
+++ b/adapters/oidc/undertow/pom.xml
@@ -31,9 +31,6 @@
     <description/>
 
     <properties>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
-
         <keycloak.osgi.export>
             org.keycloak.adapters.undertow.*
         </keycloak.osgi.export>

--- a/adapters/saml/core-public/pom.xml
+++ b/adapters/saml/core-public/pom.xml
@@ -32,9 +32,6 @@
 
 
     <properties>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
-
         <timestamp>${maven.build.timestamp}</timestamp>
         <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
     </properties>

--- a/adapters/saml/core/pom.xml
+++ b/adapters/saml/core/pom.xml
@@ -31,9 +31,6 @@
     <description/>
 
     <properties>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
-
         <timestamp>${maven.build.timestamp}</timestamp>
         <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
     </properties>

--- a/adapters/saml/jetty/jetty-core/pom.xml
+++ b/adapters/saml/jetty/jetty-core/pom.xml
@@ -29,9 +29,6 @@
     <artifactId>keycloak-saml-jetty-adapter-core</artifactId>
     <name>Keycloak Jetty Core SAML Integration</name>
     <properties>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
-
         <jetty9.version>8.1.17.v20150415</jetty9.version>
         <keycloak.osgi.export>
             org.keycloak.adapters.jetty.core.*

--- a/adapters/saml/servlet-filter/pom.xml
+++ b/adapters/saml/servlet-filter/pom.xml
@@ -30,11 +30,6 @@
     <name>Keycloak SAML Servlet Filter</name>
     <description />
 
-    <properties>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.jboss.logging</groupId>

--- a/adapters/saml/tomcat/tomcat-core/pom.xml
+++ b/adapters/saml/tomcat/tomcat-core/pom.xml
@@ -28,10 +28,6 @@
 
     <artifactId>keycloak-saml-tomcat-adapter-core</artifactId>
     <name>Keycloak Tomcat Core SAML Integration</name>
-    <properties>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
-    </properties>
     <description />
 
     <dependencies>

--- a/adapters/saml/tomcat/tomcat/pom.xml
+++ b/adapters/saml/tomcat/tomcat/pom.xml
@@ -28,10 +28,6 @@
 
     <artifactId>keycloak-saml-tomcat-adapter</artifactId>
     <name>Keycloak Tomcat SAML Integration</name>
-    <properties>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
-    </properties>
     <description />
 
     <dependencies>

--- a/adapters/spi/adapter-spi/pom.xml
+++ b/adapters/spi/adapter-spi/pom.xml
@@ -31,9 +31,6 @@
     <description/>
 
     <properties>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
-
         <keycloak.osgi.export>
             org.keycloak.adapters.spi.*
         </keycloak.osgi.export>

--- a/adapters/spi/jboss-adapter-core/pom.xml
+++ b/adapters/spi/jboss-adapter-core/pom.xml
@@ -30,11 +30,6 @@
     <name>Common JBoss/Wildfly Core Classes</name>
     <description/>
 
-    <properties>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.jboss.logging</groupId>

--- a/adapters/spi/jetty-adapter-spi/pom.xml
+++ b/adapters/spi/jetty-adapter-spi/pom.xml
@@ -29,9 +29,6 @@
     <artifactId>keycloak-jetty-adapter-spi</artifactId>
     <name>Keycloak Jetty Adapter SPI</name>
     <properties>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
-
         <jetty9.version>8.1.17.v20150415</jetty9.version>
         <keycloak.osgi.export>
             org.keycloak.adapters.jetty.spi.*

--- a/adapters/spi/servlet-adapter-spi/pom.xml
+++ b/adapters/spi/servlet-adapter-spi/pom.xml
@@ -31,9 +31,6 @@
     <description/>
 
     <properties>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
-
         <keycloak.osgi.export>
             org.keycloak.adapters.servlet.*
         </keycloak.osgi.export>

--- a/adapters/spi/tomcat-adapter-spi/pom.xml
+++ b/adapters/spi/tomcat-adapter-spi/pom.xml
@@ -28,10 +28,6 @@
 
     <artifactId>keycloak-tomcat-adapter-spi</artifactId>
     <name>Keycloak Tomcat Adapter SPI</name>
-    <properties>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
-    </properties>
     <description />
 
     <dependencies>

--- a/adapters/spi/undertow-adapter-spi/pom.xml
+++ b/adapters/spi/undertow-adapter-spi/pom.xml
@@ -31,9 +31,6 @@
     <description/>
 
     <properties>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
-
         <keycloak.osgi.export>
             org.keycloak.adapters.undertow.*
         </keycloak.osgi.export>

--- a/authz/client/pom.xml
+++ b/authz/client/pom.xml
@@ -18,9 +18,6 @@
     <description>KeyCloak AuthZ: Client API</description>
 
     <properties>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
-
         <keycloak.osgi.export>
             org.keycloak.authorization.client.*
         </keycloak.osgi.export>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -32,9 +32,6 @@
     <description>Common library and dependencies shared with server and all adapters</description>
 
     <properties>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
-
         <timestamp>${maven.build.timestamp}</timestamp>
         <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
         <keycloak.osgi.export>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -32,9 +32,6 @@
     <description/>
 
     <properties>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
-
         <timestamp>${maven.build.timestamp}</timestamp>
         <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
         <keycloak.osgi.export>

--- a/docs/building.md
+++ b/docs/building.md
@@ -1,6 +1,6 @@
 ## Building from source
 
-Ensure you have JDK 8 (or newer), Maven 3.5.4 (or newer) and Git installed
+Ensure you have JDK 11 (or newer), Maven 3.5.4 (or newer) and Git installed
 
     java -version
     mvn -version

--- a/pom.xml
+++ b/pom.xml
@@ -218,6 +218,11 @@
 
         <!-- Frontend -->
         <node.version>v16.13.2</node.version>
+
+        <!-- Minimum Java version supported for running Keycloak -->
+        <!-- maven.compiler.target and maven.compiler.source already set to 1.8 in the parent pom -->
+        <!-- other modules will configure a higher Java version (for example Quarkus) -->
+        <maven.compiler.release>8</maven.compiler.release>
     </properties>
 
     <url>http://keycloak.org</url>

--- a/saml-core-api/pom.xml
+++ b/saml-core-api/pom.xml
@@ -31,9 +31,6 @@
     <description/>
 
     <properties>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
-
         <timestamp>${maven.build.timestamp}</timestamp>
         <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
     </properties>

--- a/saml-core/pom.xml
+++ b/saml-core/pom.xml
@@ -31,9 +31,6 @@
     <description/>
 
     <properties>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
-
         <timestamp>${maven.build.timestamp}</timestamp>
         <skip.security-manager.tests>true</skip.security-manager.tests>
         <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>

--- a/testsuite/integration-arquillian/test-apps/pom.xml
+++ b/testsuite/integration-arquillian/test-apps/pom.xml
@@ -25,9 +25,4 @@
         <module>cors</module>
         <module>spring-boot-adapter-app</module>
     </modules>
-
-    <properties>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
-    </properties>
 </project>


### PR DESCRIPTION
Setting the minimum requirement for the compiler to JDK 11, while the result can still run on JDK 8 for the legacy distribution.

Also avoid setting properties to the same value as in the JBoss parent project, thereby making the pom.xml files leaner.

Closes #10842

When running build with JDK 8, it will complain that the release flag is unknown, therefore JDK 11 is needed for the build: 

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.1-jboss-1:compile (default-compile) on project keycloak-server-spi-private: Fatal error compiling: invalid flag: --release -> [Help 1]
```

When using an API that is not allowed (for example `Collectors.toUnmodifiableList();` that is available only from JDK 10) in keycloak-core, the build will complain as follows:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.1-jboss-1:compile (default-compile) on project keycloak-core: Compilation failure
[ERROR] /home/aschwart/redhat/workspace/keycloak-pr-2/core/src/main/java/org/keycloak/crypto/AsymmetricSignatureSignerContext.java:[29,19] cannot find symbol
[ERROR]   symbol:   method toUnmodifiableList()
[ERROR]   location: class java.util.stream.Collectors
```


<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
