### PR TITLE
Automate images re-spinning in GH actions

### DIFF
--- a/.github/scripts/need-respin.sh
+++ b/.github/scripts/need-respin.sh
@@ -1,0 +1,22 @@
+#! /bin/bash
+set -euxo pipefail
+
+image=$1
+#  Get Latest Keycloak release tag
+tag=$(curl -sL http://github.com/keycloak/keycloak/releases/latest -H "Accept: application/json" | jq -r '.tag_name')
+
+docker pull ${image}:${tag}
+
+base_image_url=$(docker inspect ${image}:${tag} | jq -r '.[0].Config.Labels.url')
+
+base_image_name=$(docker inspect ${image}:${tag} | jq -r '.[0].Config.Labels.url' | sed 's/.*#\///' | sed 's/\/images.*//')
+
+docker pull ${base_image_name}:latest
+
+latest_base_image_url=$(docker inspect ${base_image_name}:latest | jq -r '.[0].Config.Labels.url')
+
+if [ "${base_image_url}" = "${latest_base_image_url}" ]; then
+    exit -1 # no need respin
+else
+    exit 0
+fi

--- a/.github/workflows/release-container.yml
+++ b/.github/workflows/release-container.yml
@@ -4,6 +4,8 @@
     push:
       tags:
         - '[0-9]+.[0-9]+.[0-9]+'
+    schedule:
+      - cron: '0 0 * * *'
   concurrency: keycloak-container-release
 
   jobs:
@@ -13,6 +15,12 @@
       steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Check respin
+        id: respin
+        continue-on-error: true
+        run: |
+          ./.github/scripts/need-respin.sh quay.io/keycloak/keycloak
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
@@ -46,6 +54,7 @@
             type=semver,pattern={{major}}.{{minor}}
 
       - name: Build and push the image
+        if: ${{ ( github.event_name != 'schedule' ) || ( github.event_name == 'schedule' && steps.respin.conclusion == 'success' ) }}
         uses: docker/build-push-action@v3
         with:
           context: quarkus/container

--- a/.github/workflows/release-container.yml
+++ b/.github/workflows/release-container.yml
@@ -5,7 +5,7 @@
       tags:
         - '[0-9]+.[0-9]+.[0-9]+'
     schedule:
-      - cron: '0 0 * * *'
+      - cron: '7 0 * * *'
   concurrency: keycloak-container-release
 
   jobs:

--- a/.github/workflows/release-operator-container.yml
+++ b/.github/workflows/release-operator-container.yml
@@ -6,7 +6,7 @@ on:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '7 0 * * *'
 concurrency: keycloak-operator-container-release
 
 env:

--- a/.github/workflows/release-operator-container.yml
+++ b/.github/workflows/release-operator-container.yml
@@ -5,6 +5,8 @@ on:
   push:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
+  schedule:
+    - cron: '0 0 * * *'
 concurrency: keycloak-operator-container-release
 
 env:
@@ -17,6 +19,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Check respin
+        id: respin
+        continue-on-error: true
+        run: |
+          ./.github/scripts/need-respin.sh quay.io/keycloak/keycloak-operator
         
       - uses: actions/setup-java@v3
         with:
@@ -56,6 +64,7 @@ jobs:
                       
       - name: Build and push the operator image
         working-directory: operator
+        if: ${{ ( github.event_name != 'schedule' ) || ( github.event_name == 'schedule' && steps.respin.conclusion == 'success' ) }}
         run: |
           echo "${{ steps.meta.outputs.tags }}" | xargs -I {} \
           mvn clean package \


### PR DESCRIPTION
Draft PR to automate images respinning in CI. The logic is as follows:

 - fetch latest release from GH releases
 - extract the base image from the Keycloak image labels
 - pull the base image at the tag `latest`
 - compare the `url`s if they change upstream image has been respun/has changes
