### PR TITLE
Logout confirm page is failing to log the user out on auth-server-wildfly

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/AbstractPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/AbstractPage.java
@@ -23,7 +23,7 @@ import org.keycloak.common.util.KeycloakUriBuilder;
 import org.keycloak.testsuite.arquillian.SuiteContext;
 import org.keycloak.testsuite.util.DroneUtils;
 import org.keycloak.testsuite.util.OAuthClient;
-import org.openqa.selenium.By;
+import org.keycloak.testsuite.util.WaitUtils;
 import org.openqa.selenium.WebDriver;
 
 import java.net.URI;
@@ -44,6 +44,7 @@ public abstract class AbstractPage {
     protected OAuthClient oauth;
 
     public void assertCurrent() {
+        WaitUtils.waitForPageToLoad();
         String name = getClass().getSimpleName();
         Assert.assertTrue("Expected " + name + " but was " + DroneUtils.getCurrentDriver().getTitle() + " (" + DroneUtils.getCurrentDriver().getCurrentUrl() + ")",
                 isCurrent());


### PR DESCRIPTION
Some `Cookies` tests started failing after some changes to the logout process in Keycloak (RP-initiated logout). The main cause of this was the Cookies tests use two separate hostnames and it wasn't possible to rely on the particular cookies. Therefore, it was necessary to define either `id_token_hint` (ID token) or at least `client` (clientId) parameters in order to properly log out the user.

Fixes #11753
