### PR TITLE
WIP:  Comment out full LDAP Component Config update

### DIFF
--- a/services/src/main/java/org/keycloak/services/managers/UserStorageSyncManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/UserStorageSyncManager.java
@@ -264,7 +264,9 @@ public class UserStorageSyncManager {
                             // Update persistent provider in DB
                             int lastSync = Time.currentTime();
                             persistentFedProvider.setLastSync(lastSync);
-                            persistentRealm.updateComponent(persistentFedProvider);
+                            // This causes too much contention in the COMPONENT_CONFIG table.
+                            // Replace me with a single update statement to the `lastSync` value
+                            //persistentRealm.updateComponent(persistentFedProvider);
 
                             // Update "cached" reference
                             provider.setLastSync(lastSync);


### PR DESCRIPTION
I've been tracking down this bug for several months, and it's proving difficult because it's rare to recreate.  The gist is that the LDAP user sync process will delete and re-insert the entire LDAP configuration in the `component_config` table.  Some kind of race condition causes these values to duplicate in the table.  The Keycloak application picks up on the duplicate values, and it spreads through the cluster.  Rinse and repeat enough times and there are 300,000 records in the `component_config` table.  The keycloak application consumes a ton of memory, slows down, and eventually crashes.

My production setup is roughly:

* Keycloak deployed to AWS ECS containers across two regions.  (Oregon and Virginia)
  * Two HA containers in each region, so 4 total in a JDBC Ping ISPN cache
  * Both regions are connected with the same VPC and containers can talk directly to each other
* Postgres Aurora in each region with its own reader/writer
* AWS Database Migration Service used as a bidirectional replication between each region
* LDAP as a federation source, with daily full syncs, and 5 minute partial syncs
* This bug happened in both Keycloak v13.0.0 and v18.0.0

After a while, I see something like this in my logs:

```
0:08:41,638 INFO  [org.keycloak.storage.ldap.LDAPIdentityStoreRegistry] (default task-63) 
Creating new LDAP Store for the LDAP storage provider: 'ldap', LDAP Configuration: 
{fullSyncPeriod=[604800, 604800], pagination=[true, true], startTls=[false, false], 
connectionPooling=[true, true], cachePolicy=[DEFAULT, DEFAULT] 
. . . 
```

And then it snowballs into

```
17:58:22,617 INFO  [org.keycloak.storage.ldap.LDAPIdentityStoreRegistry] (default task-218) 
Creating new LDAP Store for the LDAP storage provider: 'ldap', LDAP Configuration: 
{pagination=[true, true, true, true], fullSyncPeriod=[604800, 604800, 604800, 604800], 
. . . 
```

```
03:08:21,712 INFO  [org.keycloak.storage.ldap.LDAPIdentityStoreRegistry] (default task-289) 
Creating new LDAP Store for the LDAP storage provider: 'ldap', LDAP Configuration: 
{pagination=[true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, 
true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, 
true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, 
true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, 
true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, 
true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, 
true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, 
true, true, true, true, true], fullSyncPeriod=[604800, 604800, 604800, 604800, 604800, 604800, 
604800, 604800, 604800, 604800, 604800, 604800, 604800, 604800, 604800, 604800, 604800, 
604800, 604800, 604800, 604800, 604800, 604800, 604800, 604800, 604800, 604800, 604800, 604800, 
```

My quick workaround in testing is to remove all of this wild contention to delete all the things and re-insert the same values over and over.  

I realize that this isn't a perfect fix, because the point of this section of code is to update the `lastSync` value to a new epoch value.  However, it's been difficult for me to track down all of the abstractions of the `updateComponent()` function to either:

* Change the delete/insert to an update -- this would be lighter on a replication system
* Conditionally check the values in the database, and only delete/insert values that have changed
* Remove the whole realm update, and replace with an individual ComponentConfig update instead

CC @patriot1burke and @mposolda who seem to have the most commits in this section of the code base.

Thank you!

