### PR TITLE
/clients-registrations API doesn't return secret anymore and is not coherent #11116

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,4 @@ quarkus/data/*.db
 ###############################
 
 /integration/admin-client-jakarta/src/
+/.metadata/

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
@@ -690,6 +690,13 @@ public class ModelToRepresentation {
         rep.setNotBefore(clientModel.getNotBefore());
         rep.setNodeReRegistrationTimeout(clientModel.getNodeReRegistrationTimeout());
         rep.setClientAuthenticatorType(clientModel.getClientAuthenticatorType());
+        
+        // adding the secret if non public or bearer only
+        if (clientModel.isBearerOnly() || clientModel.isPublicClient()) {
+            rep.setSecret(null);
+        } else {
+            rep.setSecret(clientModel.getSecret());
+        }
 
         rep.setDefaultClientScopes(new LinkedList<>(clientModel.getClientScopes(true).keySet()));
         rep.setOptionalClientScopes(new LinkedList<>(clientModel.getClientScopes(false).keySet()));

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -1431,7 +1432,16 @@ public class RepresentationToModel {
             client.setClientAuthenticatorType(KeycloakModelUtils.getDefaultClientAuthenticatorType());
         }
 
-        client.setSecret(resourceRep.getSecret());
+        // adding secret if the client isn't public nor bearer only
+        if (Objects.nonNull(resourceRep.getSecret())) {
+            client.setSecret(resourceRep.getSecret());
+        } else {
+            if (client.isPublicClient() || client.isBearerOnly()) {
+                client.setSecret(null);
+            } else {
+                KeycloakModelUtils.generateSecret(client);
+            }
+        }
 
         if (resourceRep.getAttributes() != null) {
             for (Map.Entry<String, String> entry : resourceRep.getAttributes().entrySet()) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/ClientTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/ClientTest.java
@@ -100,6 +100,7 @@ public class ClientTest extends AbstractAdminTest {
         rep.setClientId("my-app");
         rep.setDescription("my-app description");
         rep.setEnabled(true);
+        rep.setPublicClient(true);
         Response response = realm.clients().create(rep);
         response.close();
         String id = ApiUtil.getCreatedId(response);
@@ -112,6 +113,37 @@ public class ClientTest extends AbstractAdminTest {
         rep.setId(id);
 
         return rep;
+    }
+    
+    private ClientRepresentation createClientNonPublic() {
+        ClientRepresentation rep = new ClientRepresentation();
+        rep.setClientId("my-app");
+        rep.setDescription("my-app description");
+        rep.setEnabled(true);
+        rep.setPublicClient(false);
+        Response response = realm.clients().create(rep);
+        response.close();
+        String id = ApiUtil.getCreatedId(response);
+        getCleanup().addClientUuid(id);
+        ClientRepresentation found = ApiUtil.findClientResourceByClientId(realm, "my-app").toRepresentation();
+
+        assertEquals("my-app", found.getClientId());
+        assertAdminEvents.assertEvent(realmId, OperationType.CREATE, AdminEventPaths.clientResourcePath(id), rep, ResourceType.CLIENT);
+
+        rep.setId(id);
+
+        return rep;
+    }
+    
+    @Test
+    @AuthServerContainerExclude(AuthServer.REMOTE)
+    public void createClientVerifyWithSecret() {
+        String id = createClientNonPublic().getId();
+
+        ClientResource client = realm.clients().get(id);
+        assertNotNull(client);
+        assertNotNull(client.toRepresentation().getSecret());
+        Assert.assertNames(realm.clients().findAll(), "account", "account-console", "realm-management", "security-admin-console", "broker", "my-app", Constants.ADMIN_CLI_CLIENT_ID);
     }
 
     @Test

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/OIDCClientRegistrationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/OIDCClientRegistrationTest.java
@@ -266,7 +266,8 @@ public class OIDCClientRegistrationTest extends AbstractClientRegistrationTest {
         String clientId = response.getClientId();
         ClientRepresentation kcClientRep = getKeycloakClient(clientId);
         Assert.assertFalse(kcClientRep.isPublicClient());
-        Assert.assertNull(kcClientRep.getSecret());
+        Assert.assertFalse(kcClientRep.isBearerOnly());
+        Assert.assertNotNull(kcClientRep.getSecret());
     }
 
     @Test


### PR DESCRIPTION
Also fixing the https://github.com/keycloak/keycloak/issues/11897 and https://github.com/keycloak/keycloak/issues/11248
Closes: #11116 #11897 #11248