### PR TITLE
Fix typo in keycloak.d.ts

### DIFF
--- a/adapters/oidc/js/dist/keycloak.d.ts
+++ b/adapters/oidc/js/dist/keycloak.d.ts
@@ -151,7 +151,7 @@ export interface KeycloakInitOptions {
 	/**
 	 * Specifies an uri to redirect to after silent check-sso.
 	 * Silent check-sso will only happen, when this redirect uri is given and
-	 * the specified uri is available whithin the application.
+	 * the specified uri is available within the application.
 	 */
 	silentCheckSsoRedirectUri?: string;
 


### PR DESCRIPTION
Simple typo fix in the Typescript typings file for keycloak.