### PR TITLE
Fixing ClientTokenExchangeTest to also run when TLS is disabled

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ClientTokenExchangeTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ClientTokenExchangeTest.java
@@ -178,7 +178,7 @@ public class ClientTokenExchangeTest extends AbstractKeycloakTest {
         directPublic.setEnabled(true);
         directPublic.setProtocol(OIDCLoginProtocol.LOGIN_PROTOCOL);
         directPublic.setFullScopeAllowed(false);
-        directPublic.addRedirectUri("https://localhost:8543/auth/realms/master/app/auth");
+        directPublic.addRedirectUri("*");
         directPublic.addProtocolMapper(AudienceProtocolMapper.createClaimMapper("client-exchanger-audience", clientExchanger.getClientId(), null, true, false));
 
         ClientModel directUntrustedPublic = realm.addClient("direct-public-untrusted");
@@ -188,7 +188,7 @@ public class ClientTokenExchangeTest extends AbstractKeycloakTest {
         directUntrustedPublic.setEnabled(true);
         directUntrustedPublic.setProtocol(OIDCLoginProtocol.LOGIN_PROTOCOL);
         directUntrustedPublic.setFullScopeAllowed(false);
-        directUntrustedPublic.addRedirectUri("https://localhost:8543/auth/realms/master/app/auth");
+        directUntrustedPublic.addRedirectUri("*");
         directUntrustedPublic.addProtocolMapper(AudienceProtocolMapper.createClaimMapper("client-exchanger-audience", clientExchanger.getClientId(), null, true, false));
 
         ClientModel directNoSecret = realm.addClient("direct-no-secret");


### PR DESCRIPTION
Closes #11818

We don't need to test redirect uris when testing token exchanges.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
