### PR TITLE
Update Quarkus to 2.9.2 (#12210)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <jboss.snapshots.repo.id>jboss-snapshots-repository</jboss.snapshots.repo.id>
         <jboss.snapshots.repo.url>https://s01.oss.sonatype.org/content/repositories/snapshots/</jboss.snapshots.repo.url>
 
-        <quarkus.version>2.7.5.Final</quarkus.version>
+        <quarkus.version>2.9.2.Final</quarkus.version>
 
         <!--
         Performing a Wildfly upgrade? Run the:

--- a/quarkus/pom.xml
+++ b/quarkus/pom.xml
@@ -38,15 +38,16 @@
             for reference
         -->
         <resteasy.version>4.7.5.Final</resteasy.version>
-        <jackson.version>2.13.2</jackson.version>
-        <jackson.databind.version>2.13.2.2</jackson.databind.version>
-        <hibernate.core.version>5.6.5.Final</hibernate.core.version>
-        <mysql.driver.version>8.0.28</mysql.driver.version>
+        <jackson.version>2.13.3</jackson.version>
+        <jackson.databind.version>2.13.3</jackson.databind.version>
+        <hibernate.core.version>5.6.9.Final</hibernate.core.version>
+        <mysql.driver.version>8.0.29</mysql.driver.version>
         <postgresql.version>42.3.3</postgresql.version>
+        <mariadb-jdbc.version>3.0.4</mariadb-jdbc.version>
         <microprofile-metrics-api.version>3.0.1</microprofile-metrics-api.version>
         <wildfly.common.version>1.5.4.Final-format-001</wildfly.common.version>
-        <infinispan.version>13.0.9.Final</infinispan.version>
-        <wildfly-elytron.version>1.18.3.Final</wildfly-elytron.version>
+        <infinispan.version>13.0.10.Final</infinispan.version>
+        <wildfly-elytron.version>1.19.0.Final</wildfly-elytron.version>
 
         <!--
             Java EE dependencies. Not available from JDK 11+.
@@ -59,15 +60,15 @@
         <!--
             Quarkiverse dependency versions
          -->
-        <io.quarkiverse.vault.version>1.0.2</io.quarkiverse.vault.version>
+        <io.quarkiverse.vault.version>1.1.0</io.quarkiverse.vault.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
+        <maven.compiler.plugin.version>3.10.1</maven.compiler.plugin.version>
         <maven.compiler.release>11</maven.compiler.release>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
 
-        <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+        <surefire-plugin.version>3.0.0-M6</surefire-plugin.version>
     </properties>
 
     <dependencyManagement>
@@ -79,7 +80,7 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            
+
             <!-- Override the dependencies below to use the versions used by Keycloak -->
             <dependency>
                 <groupId>org.infinispan</groupId>
@@ -152,6 +153,12 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>${maven.compiler.plugin.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.surefire</groupId>
+                    <artifactId>surefire</artifactId>
+                    <version>${surefire-plugin.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/database/Database.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/database/Database.java
@@ -123,7 +123,7 @@ public final class Database {
                 asList("org.keycloak.connections.jpa.updater.liquibase.UpdatedMySqlDatabase")
         ),
         MARIADB("mariadb",
-                "org.mariadb.jdbc.MySQLDataSource",
+                "org.mariadb.jdbc.MariaDbDataSource",
                 "org.mariadb.jdbc.Driver",
                 "org.hibernate.dialect.MariaDBDialect",
                 "jdbc:mariadb://${kc.db-url-host:localhost}:${kc.db-url-port:3306}/${kc.db-url-database:keycloak}${kc.db-url-properties:}",

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/ConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/ConfigurationTest.java
@@ -45,7 +45,7 @@ import io.quarkus.runtime.configuration.ConfigUtils;
 import io.smallrye.config.SmallRyeConfigProviderResolver;
 import org.keycloak.quarkus.runtime.Environment;
 import org.keycloak.quarkus.runtime.vault.FilesPlainTextVaultProviderFactory;
-import org.mariadb.jdbc.MySQLDataSource;
+import org.mariadb.jdbc.MariaDbDataSource;
 import org.postgresql.xa.PGXADataSource;
 
 public class ConfigurationTest {
@@ -325,7 +325,7 @@ public class ConfigurationTest {
         config = createConfig();
         assertEquals("jdbc:mariadb://localhost:3306/keycloak?test=test&test1=test1", config.getConfigValue("quarkus.datasource.jdbc.url").getValue());
         assertEquals(MariaDBDialect.class.getName(), config.getConfigValue("quarkus.hibernate-orm.dialect").getValue());
-        assertEquals(MySQLDataSource.class.getName(), config.getConfigValue("quarkus.datasource.jdbc.driver").getValue());
+        assertEquals(MariaDbDataSource.class.getName(), config.getConfigValue("quarkus.datasource.jdbc.driver").getValue());
 
         System.setProperty(CLI_ARGS, "--db=postgres");
         config = createConfig();


### PR DESCRIPTION
- Adapt versions according to https://github.com/quarkusio/quarkus/blob/2.9.2.Final/bom/application/pom.xml
- Adapt database config to use `MariaDbDataSource`,  since `MySQLDatasource` is no longer provided by mariadb-java-client
- Update maven-compiler-plugin to 3.10.1
- Update maven-surefire-plugin to 3.0.0-M6

Closes #12210

Signed-off-by: Thomas Darimont <thomas.darimont@googlemail.com>

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
