### PR TITLE
Make OLM tests Maven build self-contained

### DIFF
--- a/operator/app/scripts/olm-testing.sh
+++ b/operator/app/scripts/olm-testing.sh
@@ -18,8 +18,8 @@ VERSION="86400000.0.0"
 
 # Build the operator Docker image
 (
-  cd $SCRIPT_DIR/../../
-  mvn clean package -pl :keycloak-operator -am \
+  cd $SCRIPT_DIR/../../../
+  mvn clean package -Poperator -pl :keycloak-operator -am \
     -Dquarkus.container-image.build=true \
     -Dquarkus.container-image.image="ttl.sh/${UUID}keycloak-operator:${VERSION}" \
     -Doperator.keycloak.image="ttl.sh/${UUID}keycloak:${VERSION}" \


### PR DESCRIPTION
This got broken when merging the config improvement.

Resolves #12254 