### PR TITLE
Provide a separate guide for configuring the server truststore

### DIFF
--- a/docs/guides/src/main/server/enabletls.adoc
+++ b/docs/guides/src/main/server/enabletls.adoc
@@ -23,13 +23,13 @@ When you use a pair of matching certificate and private key files in PEM format,
 Keycloak creates a keystore out of these files in memory and uses this keystore afterwards.
 
 === Providing a Java Keystore
-When no keystore file is explicitly configured, but `http.enabled` is set to false, Keycloak looks for a `conf/server.keystore` file.
+When no keystore file is explicitly configured, but `http-enabled` is set to false, Keycloak looks for a `conf/server.keystore` file.
 
 As an alternative, you can use an existing keystore by running the following command:
 <@kc.start parameters="--https-key-store-file=/path/to/existing-keystore-file"/>
 
 ==== Setting the Keystore password
-You can set a secure password for your keystore using the `https.key-store.password` option:
+You can set a secure password for your keystore using the `https-key-store-password` option:
 <@kc.start parameters="--https-key-store-password=<value>"/>
 
 If no password is set, the default password `password` is used.
@@ -48,15 +48,23 @@ Keycloak listens for HTTPS traffic on port `8443`. To change this port, use the 
 <@kc.start parameters="--https-port=<port>"/>
 
 == Using a truststore
-Keycloak uses a truststore to store certificates to verify clients that are communicating with Keycloak.
-Examples of client requests are for using mutualTLS, certificate-bound tokens or X.509 authentication.
-This truststore is used for outgoing https requests as well as mTLS requests.
+
+In order to properly validate client certificates and enable certain authentication methods like two-way TLS or mTLS, you can set
+a trust store with all the certificates (and certificate chain) the server should be trusting. There are number of capabilities that rely
+on this trust store to properly authenticate clients using certificates such as:
+
+* Mutual-TLS Client Authentication
+* End-User X.509 Browser Authentication
 
 You can configure the location of this truststore by running the following command:
+
 <@kc.start parameters="--https-trust-store-file=/path/to/file"/>
 
+Note that this trust store is targeted for authenticating clients where Keycloak is acting as a server. For configuring a trust store
+where Keycloak is acting as a client to external services through TLS, please consider looking at the <@links.server id="keycloak-truststore"/> guide.
+
 === Setting the truststore password
-You can set a secure password for your truststore using the `https.trust-store.password` option:
+You can set a secure password for your truststore using the `https-trust-store-password` option:
 <@kc.start parameters="--https-trust-store-password=<value>"/>
 If no password is set, the default password `password` is used.
 

--- a/docs/guides/src/main/server/keycloak-truststore.adoc
+++ b/docs/guides/src/main/server/keycloak-truststore.adoc
@@ -1,0 +1,47 @@
+<#import "/templates/guide.adoc" as tmpl>
+<#import "/templates/kc.adoc" as kc>
+
+<@tmpl.guide
+title="Configuring a Truststore"
+summary="How to configure the Keycloak Truststore to communicate with external services through TLS."
+includedOptions="">
+
+When Keycloak communicates with external services through TLS, it has to validate the remote server’s certificate in order to ensure it is connecting to a trusted server. This is necessary in order to prevent man-in-the-middle attacks. The certificates of these remote server’s or the CA that signed these certificates must be put in a truststore. This truststore is managed by the Keycloak server.
+
+The truststore is used when connecting securely to identity brokers, LDAP identity providers, when sending emails, and for backchannel communication with client applications. It is also useful
+when you want to change the policy on how host names are verified and trusted by the server.
+
+By default, a truststore provider is not configured, and any TLS/HTTPS connections fall back to standard Java Truststore configuration. If there is no trust established, then these outgoing requests will fail.
+
+== Configuring the Keycloak Truststore
+
+You can add your truststore configuration by entering this command:
+
+<@kc.start parameters="--spi-truststore-file-file=myTrustStore.jks --spi-truststore-file-password=password --spi-truststore-file-hostname-verification-policy=ANY"/>
+
+The following are possible configuration options for this setting:
+
+file::
+The path to a Java keystore file.
+HTTPS requests need a way to verify the host of the server to which they are talking.
+This is what the truststore does.
+The keystore contains one or more trusted host certificates or certificate authorities.
+This truststore file should only contain public certificates of your secured hosts.
+This is _REQUIRED_ if any of these properties are defined.
+
+password::
+Password of the keystore.
+This option is _REQUIRED_ if any of these properties are defined.
+
+hostname-verification-policy::
+For HTTPS requests, this option verifies the hostname of the server's certificate. Default: `WILDCARD`
+* `ANY` means that the hostname is not verified.
+* `WILDCARD` allows wildcards in subdomain names, such as *.foo.com.
+* When using `STRICT`, the Common Name (CN) must match the hostname exactly.
+
+=== Example of a truststore configuration
+The following is an example configuration for a truststore that allows you to create trustful connections to all `mycompany.org` domains and its subdomains:
+
+<@kc.start parameters="--spi-truststore-file-file=path/to/truststore.jks --spi-truststore-file-password=change_me --spi-truststore-file-hostname-verification-policy=WILDCARD"/>
+
+</@tmpl.guide>

--- a/docs/guides/src/main/server/outgoinghttp.adoc
+++ b/docs/guides/src/main/server/outgoinghttp.adoc
@@ -1,5 +1,6 @@
 <#import "/templates/guide.adoc" as tmpl>
 <#import "/templates/kc.adoc" as kc>
+<#import "/templates/links.adoc" as links>
 
 <@tmpl.guide
 title="Configuring outgoing HTTP requests"
@@ -118,37 +119,8 @@ In this example, the following occurs:
 * A catch-all pattern ends the proxy-mappings, providing a default proxy for all outgoing requests.
 
 == Outgoing HTTPS request truststore
-When Keycloak calls remote HTTPS endpoints, it has to validate the remote server's certificate to ensure it is connecting to a trusted server. This validation is necessary to prevent man-in-the-middle attacks. The certificates of these remote servers or the CA that signed these certificates must be put in a truststore.
 
-This truststore is used to securely connect to identity brokers, LDAP identity providers, when sending emails, and for backchannel communication with client applications. When no truststore is configured, outgoing HTTPS connections use the standard java truststore configuration by default. When no trust can be established, outgoing HTTPS requests fail.
-
-You can add your truststore configuration by entering this command:
-
-<@kc.start parameters="--spi-truststore-file-file=myTrustStore.jks --spi-truststore-file-password=password --spi-truststore-file-hostname-verification-policy=ANY"/>
-
-The following are possible configuration options for this setting:
-
-file::
-The path to a Java keystore file.
-HTTPS requests need a way to verify the host of the server to which they are talking.
-This is what the truststore does.
-The keystore contains one or more trusted host certificates or certificate authorities.
-This truststore file should only contain public certificates of your secured hosts.
-This is _REQUIRED_ if any of these properties are defined.
-
-password::
-Password of the keystore.
-This option is _REQUIRED_ if any of these properties are defined.
-
-hostname-verification-policy::
-For HTTPS requests, this option verifies the hostname of the server's certificate. Default: `WILDCARD`
-* `ANY` means that the hostname is not verified.
-* `WILDCARD` allows wildcards in subdomain names, such as *.foo.com.
-* When using `STRICT`, the Common Name (CN) must match the hostname exactly.
-
-=== Example of a truststore configuration
-The following is an example configuration for a truststore that allows you to create trustful connections to all `mycompany.org` domains and its subdomains:
-
-<@kc.start parameters="--spi-truststore-file-file=path/to/truststore.jks --spi-truststore-file-password=change_me --spi-truststore-file-hostname-verification-policy=WILDCARD"/>
+Please take a look at the <@links.server id="keycloak-truststore"/> guide about how
+to configure a Keycloak Truststore so that Keycloak is able to perform outgoing requests using TLS.
 
 </@tmpl.guide>

--- a/docs/guides/src/main/server/reverseproxy.adoc
+++ b/docs/guides/src/main/server/reverseproxy.adoc
@@ -1,6 +1,7 @@
 <#import "/templates/guide.adoc" as tmpl>
 <#import "/templates/kc.adoc" as kc>
 <#import "/templates/options.adoc" as opts>
+<#import "/templates/links.adoc" as links>
 
 <@tmpl.guide
 title="Using a reverse proxy"
@@ -150,5 +151,12 @@ to load additional certificates from headers `CERT_CHAIN_0` to `CERT_CHAIN_9` if
 |certificate-chain-length
 | The maximum length of the certificate chain.
 |===
+
+==== Configuring the NGINX provider
+
+The NGINX SSL/TLS module does not expose the client certificate chain. Keycloak’s NGINX certificate lookup provider rebuilds it by using the Keycloak truststore.
+
+If you are using this provider, please take a look at the <@links.server id="keycloak-truststore"/> guide about how
+to configure a Keycloak Truststore.
 
 </@tmpl.guide>


### PR DESCRIPTION
Closes #12260

* Refactor to outgoing requests guide to extract the documentation for the Keycloak Truststore
* Introduce a separate and specific guide for configuring the Keycloak Truststore
* Changes the reverse proxy guide to also include the additional steps to configure the `x509-lookup-provider=nginx` provider.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
