### PR TITLE
Keycloak server fails to start when using different named schema

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -489,7 +489,7 @@ jobs:
 
       - name: Run Quarkus Storage Tests
         run: |
-          ./mvnw clean install -nsu -B -f quarkus/tests/pom.xml -Ptest-database -Dtest=PostgreSQLDistTest | misc/log/trimmer.sh
+          ./mvnw clean install -nsu -B -f quarkus/tests/pom.xml -Ptest-database -Dtest=PostgreSQLDistTest,DatabaseOptionsDistTest | misc/log/trimmer.sh
           TEST_RESULT=${PIPESTATUS[0]}
           find . -path '*/target/surefire-reports/*.xml' | zip -q reports-quarkus-tests.zip -@
           exit $TEST_RESULT

--- a/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
+++ b/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
@@ -111,7 +111,6 @@ import org.keycloak.policy.BlacklistPasswordPolicyProviderFactory;
 import org.keycloak.protocol.ProtocolMapperSpi;
 import org.keycloak.protocol.oidc.mappers.DeployedScriptOIDCProtocolMapper;
 import org.keycloak.provider.EnvironmentDependentProviderFactory;
-import org.keycloak.provider.KeycloakDeploymentInfo;
 import org.keycloak.provider.Provider;
 import org.keycloak.provider.ProviderFactory;
 import org.keycloak.provider.ProviderManager;
@@ -217,11 +216,13 @@ class KeycloakProcessor {
             if ("keycloak-default".equals(descriptor.getName())) {
                 configureJpaProperties(descriptor, config, jdbcDataSources);
                 configureJpaModel(descriptor, indexBuildItem);
+                runtimeConfigured.produce(new HibernateOrmIntegrationRuntimeConfiguredBuildItem("keycloak", descriptor.getName())
+                        .setInitListener(recorder.createDefaultUnitListener()));
             } else {
                 Properties properties = descriptor.getProperties();
                 // register a listener for customizing the unit configuration at runtime
                 runtimeConfigured.produce(new HibernateOrmIntegrationRuntimeConfiguredBuildItem("keycloak", descriptor.getName())
-                        .setInitListener(recorder.createUnitListener(properties.getProperty(AvailableSettings.DATASOURCE))));
+                        .setInitListener(recorder.createUserDefinedUnitListener(properties.getProperty(AvailableSettings.DATASOURCE))));
             }
         }
     }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakRecorder.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakRecorder.java
@@ -35,6 +35,7 @@ import io.quarkus.smallrye.metrics.runtime.SmallRyeMetricsHandler;
 import io.vertx.core.Handler;
 import io.vertx.ext.web.RoutingContext;
 import org.keycloak.common.Profile;
+import org.keycloak.quarkus.runtime.configuration.Configuration;
 import org.keycloak.quarkus.runtime.integration.QuarkusKeycloakSessionFactory;
 import org.keycloak.quarkus.runtime.storage.database.liquibase.FastServiceLocator;
 import org.keycloak.provider.Provider;
@@ -101,7 +102,7 @@ public class KeycloakRecorder {
         return metricsHandler;
     }
 
-    public HibernateOrmIntegrationRuntimeInitListener createUnitListener(String name) {
+    public HibernateOrmIntegrationRuntimeInitListener createUserDefinedUnitListener(String name) {
         return new HibernateOrmIntegrationRuntimeInitListener() {
             @Override
             public void contributeRuntimeProperties(BiConsumer<String, Object> propertyCollector) {
@@ -116,6 +117,15 @@ public class KeycloakRecorder {
                             }
                         });
                 propertyCollector.accept(AvailableSettings.DATASOURCE, instance.get());
+            }
+        };
+    }
+
+    public HibernateOrmIntegrationRuntimeInitListener createDefaultUnitListener() {
+        return new HibernateOrmIntegrationRuntimeInitListener() {
+            @Override
+            public void contributeRuntimeProperties(BiConsumer<String, Object> propertyCollector) {
+                propertyCollector.accept(AvailableSettings.DEFAULT_SCHEMA, Configuration.getRawValue("kc.db-schema"));
             }
         };
     }

--- a/quarkus/tests/integration/src/main/java/org/keycloak/it/junit5/extension/DatabaseContainer.java
+++ b/quarkus/tests/integration/src/main/java/org/keycloak/it/junit5/extension/DatabaseContainer.java
@@ -18,6 +18,7 @@
 package org.keycloak.it.junit5.extension;
 
 import java.time.Duration;
+import org.jetbrains.annotations.NotNull;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.containers.MariaDBContainer;
 import org.testcontainers.containers.PostgreSQLContainer;
@@ -37,7 +38,8 @@ public class DatabaseContainer {
         container = createContainer()
                 .withDatabaseName("keycloak")
                 .withUsername(getUsername())
-                .withPassword(getPassword());
+                .withPassword(getPassword())
+                .withInitScript(resolveInitScript());
 
         container.withStartupTimeout(Duration.ofMinutes(5)).start();
     }
@@ -72,5 +74,9 @@ public class DatabaseContainer {
             default:
                 throw new RuntimeException("Unsupported database: " + alias);
         }
+    }
+
+    private String resolveInitScript() {
+        return String.format("database/scripts/init-%s.sql", alias);
     }
 }

--- a/quarkus/tests/integration/src/main/resources/database/scripts/init-postgres.sql
+++ b/quarkus/tests/integration/src/main/resources/database/scripts/init-postgres.sql
@@ -15,14 +15,4 @@
  * limitations under the License.
  */
 
-package org.keycloak.it.storage.database.dist;
-
-import org.keycloak.it.junit5.extension.CLITest;
-import org.keycloak.it.junit5.extension.WithDatabase;
-import org.keycloak.it.storage.database.MariaDBTest;
-
-@CLITest
-@WithDatabase(alias = "mariadb")
-public class MariaDBDistTest extends MariaDBTest {
-
-}
+CREATE SCHEMA foo;

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/storage/database/dist/DatabaseOptionsDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/storage/database/dist/DatabaseOptionsDistTest.java
@@ -17,12 +17,22 @@
 
 package org.keycloak.it.storage.database.dist;
 
-import org.keycloak.it.junit5.extension.CLITest;
+import org.junit.jupiter.api.Test;
+import org.keycloak.it.junit5.extension.CLIResult;
+import org.keycloak.it.junit5.extension.DistributionTest;
 import org.keycloak.it.junit5.extension.WithDatabase;
-import org.keycloak.it.storage.database.MariaDBTest;
 
-@CLITest
-@WithDatabase(alias = "mariadb")
-public class MariaDBDistTest extends MariaDBTest {
+import io.quarkus.test.junit.main.Launch;
+import io.quarkus.test.junit.main.LaunchResult;
 
+@DistributionTest
+@WithDatabase(alias = "postgres")
+public class DatabaseOptionsDistTest {
+
+    @Test
+    @Launch({ "start-dev", "--db-schema=foo" })
+    void testSetSchema(LaunchResult result) {
+        CLIResult cliResult = (CLIResult) result;
+        cliResult.assertStartedDevMode();
+    }
 }


### PR DESCRIPTION
Closes #12219
Closes #10235

* The `quarkus.hibernate-orm.database.default-schema` is not forcing a default schema to Hibernate. Something changes that makes the extension to mark the default PU as not coming from an XML file causing the property to not be set https://github.com/quarkusio/quarkus/blob/a71f7f0b4360494157bcf18f0eb3df6f5b2e13a5/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/FastBootHibernatePersistenceProvider.java#L186.
* To force a schema a new PU listener is created to set the default schema to Hibernate directly, pretty much what HHH extension should be doing.

Right now, only `db-schema` is impacted because it is among the runtime properties we are exposing from Quarkus that rely on the PU coming from an XML file.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
