### PR TITLE
fix wrong xRobotsTag label bound

### DIFF
--- a/themes/src/main/resources/theme/base/admin/resources/partials/defense-headers.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/defense-headers.html
@@ -37,7 +37,7 @@
                 <kc-tooltip>{{:: 'content-type-options-tooltip' | translate}}</kc-tooltip>
             </div>
             <div class="form-group">
-                <label class="col-md-2 control-label" for="xContentTypeOptions"><a href="https://developers.google.com/webmasters/control-crawl-index/docs/robots_meta_tag" target="_blank">{{:: 'robots-tag' | translate}}</a></label>
+                <label class="col-md-2 control-label" for="xRobotsTag"><a href="https://developers.google.com/webmasters/control-crawl-index/docs/robots_meta_tag" target="_blank">{{:: 'robots-tag' | translate}}</a></label>
                 <div class="col-sm-6">
                     <input class="form-control" id="xRobotsTag" type="text" ng-model="realm.browserSecurityHeaders.xRobotsTag">
                 </div>


### PR DESCRIPTION
Set the `for` attribute of the xRobotsTag label to `xRobotsTag`

Closes #12286

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
