### PR TITLE
Revise AuthenticationSelectionResolver (#12102)

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/MultiFactorAuthenticationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/MultiFactorAuthenticationTest.java
@@ -147,8 +147,11 @@ public class MultiFactorAuthenticationTest extends AbstractTestRealmKeycloakTest
             // like user with user-with-one-configured-otp. However OTP is preferred credential for him, so OTP mechanism will take preference
             loginUsernameOnlyPage.open();
             loginUsernameOnlyPage.login("user-with-two-configured-otp");
-            loginTotpPage.assertCurrent();
-            loginTotpPage.assertTryAnotherWayLinkAvailability(true);
+            passwordPage.assertCurrent();
+            passwordPage.assertTryAnotherWayLinkAvailability(true);
+            passwordPage.clickTryAnotherWayLink();
+            selectAuthenticatorPage.assertCurrent();
+            selectAuthenticatorPage.selectLoginMethod(SelectAuthenticatorPage.AUTHENTICATOR_APPLICATION);
 
             // More OTP credentials should be available for this user
             loginTotpPage.assertOtpCredentialSelectorAvailability(true);
@@ -156,7 +159,7 @@ public class MultiFactorAuthenticationTest extends AbstractTestRealmKeycloakTest
             loginTotpPage.clickTryAnotherWayLink();
 
             selectAuthenticatorPage.assertCurrent();
-            Assert.assertEquals(Arrays.asList(SelectAuthenticatorPage.AUTHENTICATOR_APPLICATION, SelectAuthenticatorPage.PASSWORD), selectAuthenticatorPage.getAvailableLoginMethods());
+            Assert.assertEquals(Arrays.asList(SelectAuthenticatorPage.PASSWORD, SelectAuthenticatorPage.AUTHENTICATOR_APPLICATION), selectAuthenticatorPage.getAvailableLoginMethods());
         } finally {
             BrowserFlowTest.revertFlows(testRealm(), "browser - alternative");
         }


### PR DESCRIPTION
Previously the order of the generated AuthenticationExecutionOptions
was partially based on the order of user credentials, and  not
on the order of the Authentication flow definition.

This change simplifies the logic of the AuthenticationSelectionResolver and
collects the Authentication options in the order they are defined in the
corresponding Authentication flow.

The new behavior is now easier to understand because the order of the
executions in the authentication flow is now followed exactly when
generating the authentication options.

Note: This might change the order in which authentication options
are presented for some users.

Signed-off-by: Thomas Darimont <thomas.darimont@googlemail.com>

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
