### PR TITLE
[Draft]: Changing the 'start' command to run '--auto-build' option by default

### DIFF
--- a/docs/guides/src/main/server/index.adoc
+++ b/docs/guides/src/main/server/index.adoc
@@ -1,10 +1,14 @@
 <#list ctx.guides as guide>
-:links_server_${guide.id}_name: ${guide.title}
-:links_server_${guide.id}_url: #${guide.id}
+
+    :links_server_${guide.id}_name: ${guide.title}
+    :links_server_${guide.id}_url: #${guide.id}
+
 </#list>
 
-= Keycloak server guide
+= Keycloak Server Guide
 
 <#list ctx.guides as guide>
-include::${guide.template}[leveloffset=+1]
+
+    include::${guide.template}[leveloffset = +1]
+
 </#list>

--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDeployment.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDeployment.java
@@ -31,6 +31,7 @@ import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.quarkus.logging.Log;
+import io.sundr.codegen.api.SystemOutput;
 import org.keycloak.operator.Config;
 import org.keycloak.operator.Constants;
 import org.keycloak.operator.crds.v2alpha1.deployment.Keycloak;
@@ -521,8 +522,9 @@ public class KeycloakDeployment extends OperatorManagedResource implements Statu
         Container container = baseDeployment.getSpec().getTemplate().getSpec().getContainers().get(0);
         var customImage = Optional.ofNullable(keycloakCR.getSpec().getImage());
         container.setImage(customImage.orElse(config.keycloak().image()));
-        if (customImage.isEmpty()) {
-            container.getArgs().add("--auto-build");
+
+        if (customImage.isPresent()) {
+            container.getArgs().add("--no-auto-build");
         }
 
         container.setImagePullPolicy(config.keycloak().imagePullPolicy());

--- a/operator/src/main/resources/application.properties
+++ b/operator/src/main/resources/application.properties
@@ -5,7 +5,9 @@ quarkus.container-image.builder=jib
 quarkus.operator-sdk.crd.validate=false
 
 # Operator config
-operator.keycloak.image=quay.io/keycloak/keycloak:nightly
+# operator.keycloak.image=quay.io/keycloak/keycloak:nightly
+# operator.keycloak.image=alns-rh-keycloak:1.0.0-Pure
+operator.keycloak.image=scout23df/alns-keycloak-wip:1.0.0-Pure
 operator.keycloak.image-pull-policy=Always
 
 # https://quarkus.io/guides/deploying-to-kubernetes#environment-variables-from-keyvalue-pairs

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakDeploymentTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakDeploymentTest.java
@@ -367,8 +367,7 @@ public class KeycloakDeploymentTest extends BaseOperatorTest {
                     .list()
                     .getItems();
 
-            assertEquals(1, pods.get(0).getSpec().getContainers().get(0).getArgs().size());
-            assertEquals("start", pods.get(0).getSpec().getContainers().get(0).getArgs().get(0));
+            assertThat(pods.get(0).getSpec().getContainers().get(0).getArgs()).containsExactly("start", "--no-auto-build");
         } catch (Exception e) {
             savePodLogs();
             throw e;

--- a/quarkus/dist/src/main/content/bin/kc.bat
+++ b/quarkus/dist/src/main/content/bin/kc.bat
@@ -140,6 +140,15 @@ if %errorlevel% GTR 0 (
         set "CONFIG_ARGS=%CONFIG_ARGS:--auto-build=% --auto-build"
     )
 )
+
+rem Handling the --no-auto-build for 'start-dev' command
+call:getQtyOccurenceInString "start-dev" "%CONFIG_ARGS%"
+if %errorlevel% GTR 0 (
+    call:getQtyOccurenceInString "--no-auto-build" "%CONFIG_ARGS%"
+    if !errorlevel! GTR 0 (
+        echo "The --no-auto-build' option has no effect for 'start-dev' command, which always run '--auto-build' by default."
+    )
+)
 rem ============================================================================
 
 set "JAVA_RUN_OPTS=%JAVA_OPTS% -Dkc.home.dir="%DIRNAME%.." -Djboss.server.config.dir="%DIRNAME%..\conf" -Dkeycloak.theme.dir="%DIRNAME%..\themes" %SERVER_OPTS% -cp "%CLASSPATH_OPTS%" io.quarkus.bootstrap.runner.QuarkusEntryPoint %CONFIG_ARGS%"

--- a/quarkus/dist/src/main/content/bin/kc.sh
+++ b/quarkus/dist/src/main/content/bin/kc.sh
@@ -1,16 +1,5 @@
 #!/bin/bash
 
-function printArrayElementsInLines() {
-    local sourceArray=${!1}
-    printf "%s\n" ${sourceArray[@]}
-}
-
-function checkIfArrayContains() {
-    local sourceArray=${!1}
-    local stringToSearch="$2"
-    printArrayElementsInLines sourceArray[@] | grep -q "^$stringToSearch$"
-}
-
 function countOccurrencesInArray() {
     local sourceArray=${!1}
     local stringToSearch="$2"
@@ -90,9 +79,9 @@ do
     shift
 done
 
-
 # Handling the default adding of the '--auto-build' when issuing 'start' operation :: Keeping compatibility and Avoiding the duplicated '--auto-build' input
-if checkIfArrayContains CONFIG_ARGS[@] "start" = true; then
+TMP_CHECK_IF_START_CMD=`echo $CONFIG_ARGS | $GREP "start"`
+if [ "x$TMP_CHECK_IF_START_CMD" != "x" ]; then
     autoBuildOptionFlagName="--auto-build"
     countOccurrencesInArray CONFIG_ARGS[@] "${autoBuildOptionFlagName}"
     autoBuildOptionCount=$?
@@ -107,8 +96,6 @@ if checkIfArrayContains CONFIG_ARGS[@] "start" = true; then
         countOccurrencesInArray CONFIG_ARGS[@] "${autoBuildOptionFlagName}"
         autoBuildOptionCount=$?
     done
-
-    # echo ">>> Final Result :: CONFIG_ARGS = $CONFIG_ARGS :: "
 fi
 
 if [ "x$JAVA" = "x" ]; then
@@ -146,6 +133,17 @@ fi
 CLASSPATH_OPTS="'$DIRNAME'/../lib/quarkus-run.jar"
 
 JAVA_RUN_OPTS="$JAVA_OPTS $SERVER_OPTS -cp $CLASSPATH_OPTS io.quarkus.bootstrap.runner.QuarkusEntryPoint ${CONFIG_ARGS#?}"
+
+# Handling the --no-auto-build for 'start-dev' command
+TMP_CHECK_IF_START_CMD=`echo $CONFIG_ARGS | $GREP "start-dev"`
+if [ "x$TMP_CHECK_IF_START_CMD" != "x" ]; then
+    noAutoBuildOptionFlagName="--no-auto-build"
+
+    TMP_CHECK_IF_START_CMD=`echo $CONFIG_ARGS | $GREP "no-auto-build"`
+    if [ "x$TMP_CHECK_IF_START_CMD" != "x" ]; then
+        echo "The --no-auto-build' option has no effect for 'start-dev' command, which always run '--auto-build' by default."
+    fi
+fi
 
 if [[ $CONFIG_ARGS = *"--auto-build"* ]]; then
     eval "$JAVA" -Dkc.config.rebuild-and-exit=true $JAVA_RUN_OPTS

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakMain.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakMain.java
@@ -23,6 +23,7 @@ import static org.keycloak.quarkus.runtime.Environment.getProfileOrDefault;
 import static org.keycloak.quarkus.runtime.Environment.isImportExportMode;
 import static org.keycloak.quarkus.runtime.Environment.isTestLaunchMode;
 import static org.keycloak.quarkus.runtime.cli.Picocli.parseAndRun;
+import static org.keycloak.quarkus.runtime.cli.command.AbstractStartCommand.*;
 import static org.keycloak.quarkus.runtime.cli.command.Start.isDevProfileNotAllowed;
 
 import java.io.PrintWriter;
@@ -40,9 +41,11 @@ import org.keycloak.Config;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.models.KeycloakTransactionManager;
+import org.keycloak.common.util.CollectionUtil;
 import org.keycloak.quarkus.runtime.cli.ExecutionExceptionHandler;
 import org.keycloak.quarkus.runtime.cli.Picocli;
 import org.keycloak.common.Version;
+import org.keycloak.quarkus.runtime.cli.command.AbstractStartCommand;
 import org.keycloak.quarkus.runtime.cli.command.Start;
 import org.keycloak.services.ServicesLogger;
 import org.keycloak.services.managers.ApplianceBootstrap;
@@ -82,6 +85,12 @@ public class KeycloakMain implements QuarkusApplication {
             start(errorHandler, errStream);
 
             return;
+        }
+
+        if (cliArgs.contains(NO_AUTO_BUILD_OPTION_LONG)) {
+            cliArgs.remove(AUTO_BUILD_OPTION_LONG);
+            cliArgs.remove(AUTO_BUILD_OPTION_SHORT);
+            cliArgs.remove(NO_AUTO_BUILD_OPTION_LONG);
         }
 
         // parse arguments and execute any of the configured commands

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakMain.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakMain.java
@@ -87,7 +87,7 @@ public class KeycloakMain implements QuarkusApplication {
             return;
         }
 
-        if (cliArgs.contains(NO_AUTO_BUILD_OPTION_LONG)) {
+        if (cliArgs.contains(Start.NAME) && cliArgs.contains(NO_AUTO_BUILD_OPTION_LONG)) {
             cliArgs.remove(AUTO_BUILD_OPTION_LONG);
             cliArgs.remove(AUTO_BUILD_OPTION_SHORT);
             cliArgs.remove(NO_AUTO_BUILD_OPTION_LONG);

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/AbstractStartCommand.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/AbstractStartCommand.java
@@ -25,6 +25,7 @@ import picocli.CommandLine;
 public abstract class AbstractStartCommand extends AbstractCommand implements Runnable {
 
     public static final String AUTO_BUILD_OPTION_LONG = "--auto-build";
+    public static final String NO_AUTO_BUILD_OPTION_LONG = "--no-auto-build";
     public static final String AUTO_BUILD_OPTION_SHORT = "-b";
 
     @Override

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Start.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Start.java
@@ -52,7 +52,7 @@ public final class Start extends AbstractStartCommand implements Runnable {
     Boolean autoConfig;
 
     @CommandLine.Option(names = {NO_AUTO_BUILD_OPTION_LONG},
-            description = "Avoids the '--auto-build' automatic run, which from version 19.0.0, is triggered by default when issuing the 'start' command.",
+            description = "Avoids the automatic run of the '--auto-build' option, which from version 19.0.0, is triggered by default when issuing the 'start' command.",
             paramLabel = NO_PARAM_LABEL,
             order = 1)
     Boolean noAutoConfig;

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Start.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Start.java
@@ -45,10 +45,17 @@ public final class Start extends AbstractStartCommand implements Runnable {
     @CommandLine.Option(names = {AUTO_BUILD_OPTION_SHORT, AUTO_BUILD_OPTION_LONG},
             description = "Automatically detects whether the server configuration changed and a new server image must be built" +
                     " prior to starting the server. This option provides an alternative to manually running the '" + Build.NAME + "'" +
-                    " prior to starting the server. Use this configuration carefully in production as it might impact the startup time.",
+                    " prior to starting the server. Use this configuration carefully in production as it might impact the startup time." +
+                    " From version 19.0.0, this option is triggered by default when issuing the 'start' command.",
             paramLabel = NO_PARAM_LABEL,
             order = 1)
     Boolean autoConfig;
+
+    @CommandLine.Option(names = {NO_AUTO_BUILD_OPTION_LONG},
+            description = "Avoids the '--auto-build' automatic run, which from version 19.0.0, is triggered by default when issuing the 'start' command.",
+            paramLabel = NO_PARAM_LABEL,
+            order = 1)
+    Boolean noAutoConfig;
 
     @CommandLine.Mixin
     ImportRealmMixin importRealmMixin;

--- a/quarkus/tests/integration/src/main/java/org/keycloak/it/junit5/extension/CLIResult.java
+++ b/quarkus/tests/integration/src/main/java/org/keycloak/it/junit5/extension/CLIResult.java
@@ -17,21 +17,20 @@
 
 package org.keycloak.it.junit5.extension;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
-import static org.testcontainers.shaded.org.hamcrest.MatcherAssert.assertThat;
-import static org.testcontainers.shaded.org.hamcrest.Matchers.containsString;
-
-import java.util.List;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.approvaltests.Approvals;
 import io.quarkus.test.junit.main.LaunchResult;
+import org.approvaltests.Approvals;
 import org.approvaltests.namer.NamedEnvironment;
 import org.keycloak.it.junit5.extension.approvalTests.KcNamerFactory;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.testcontainers.shaded.org.hamcrest.MatcherAssert.assertThat;
+import static org.testcontainers.shaded.org.hamcrest.Matchers.containsString;
+import static org.testcontainers.shaded.org.hamcrest.Matchers.not;
 
 public interface CLIResult extends LaunchResult {
 
@@ -93,7 +92,7 @@ public interface CLIResult extends LaunchResult {
     }
 
     default void assertNoMessage(String message) {
-        assertFalse(getOutput().contains(message));
+        assertThat(getOutput(), not(containsString(message)));
     }
 
     default void assertBuild() {

--- a/quarkus/tests/integration/src/main/java/org/keycloak/it/junit5/extension/CLIResult.java
+++ b/quarkus/tests/integration/src/main/java/org/keycloak/it/junit5/extension/CLIResult.java
@@ -92,6 +92,10 @@ public interface CLIResult extends LaunchResult {
         assertThat(getOutput(), containsString(message));
     }
 
+    default void assertNoMessage(String message) {
+        assertFalse(getOutput().contains(message));
+    }
+
     default void assertBuild() {
         assertMessage("Server configuration updated and persisted");
     }

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/HelpCommandTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/HelpCommandTest.java
@@ -27,6 +27,8 @@ import io.quarkus.test.junit.main.LaunchResult;
 import org.keycloak.quarkus.runtime.cli.command.Start;
 import org.keycloak.quarkus.runtime.cli.command.StartDev;
 
+import static org.keycloak.quarkus.runtime.cli.command.AbstractStartCommand.NO_AUTO_BUILD_OPTION_LONG;
+
 @CLITest
 public class HelpCommandTest {
 
@@ -52,7 +54,7 @@ public class HelpCommandTest {
     }
 
     @Test
-    @Launch({ Start.NAME, "--help" })
+    @Launch({ Start.NAME, "--help", NO_AUTO_BUILD_OPTION_LONG })
     void testStartHelp(LaunchResult result) {
         CLIResult cliResult = (CLIResult) result;
         cliResult.assertHelp();

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/StartCommandTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/StartCommandTest.java
@@ -18,6 +18,7 @@
 package org.keycloak.it.cli;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.keycloak.quarkus.runtime.cli.command.AbstractStartCommand.NO_AUTO_BUILD_OPTION_LONG;
 
 import org.junit.jupiter.api.Test;
 import org.keycloak.it.junit5.extension.CLIResult;
@@ -51,7 +52,7 @@ public class StartCommandTest {
     }
 
     @Test
-    @Launch({ "-v", "start", "--db=dev-mem" })
+    @Launch({ "-v", "start", "--db=dev-mem", NO_AUTO_BUILD_OPTION_LONG })
     void failBuildPropertyNotAvailable(LaunchResult result) {
         CLIResult cliResult = (CLIResult) result;
         cliResult.assertError("Unknown option: '--db'");

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/BuildAndStartDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/BuildAndStartDistTest.java
@@ -31,6 +31,8 @@ import org.keycloak.it.utils.KeycloakDistribution;
 import io.quarkus.test.junit.main.Launch;
 import io.quarkus.test.junit.main.LaunchResult;
 
+import static org.keycloak.quarkus.runtime.cli.command.AbstractStartCommand.NO_AUTO_BUILD_OPTION_LONG;
+
 @DistributionTest(reInstall = DistributionTest.ReInstall.NEVER)
 @RawDistOnly(reason = "Containers are immutable")
 @TestMethodOrder(OrderAnnotation.class)
@@ -45,7 +47,7 @@ public class BuildAndStartDistTest {
     }
 
     @Test
-    @Launch({ "start", "--http-enabled=true", "--hostname-strict=false" })
+    @Launch({ "start", "--http-enabled=true", "--hostname-strict=false", NO_AUTO_BUILD_OPTION_LONG })
     @Order(2)
     void testStartUsingCliArgs(LaunchResult result) {
         CLIResult cliResult = (CLIResult) result;

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/FeaturesDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/FeaturesDistTest.java
@@ -19,6 +19,7 @@ import org.keycloak.quarkus.runtime.cli.command.StartDev;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.keycloak.quarkus.runtime.cli.command.AbstractStartCommand.NO_AUTO_BUILD_OPTION_LONG;
 
 @DistributionTest
 @RawDistOnly(reason = "Containers are immutable")
@@ -35,7 +36,7 @@ public class FeaturesDistTest {
     }
 
     @Test
-    @Launch({ Start.NAME, "--http-enabled=true", "--hostname-strict=false"})
+    @Launch({ Start.NAME, "--http-enabled=true", "--hostname-strict=false", NO_AUTO_BUILD_OPTION_LONG})
     @Order(2)
     public void testFeatureEnabledOnStart(LaunchResult result) {
         assertPreviewFeaturesEnabled((CLIResult) result);

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/QuarkusPropertiesDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/QuarkusPropertiesDistTest.java
@@ -21,6 +21,7 @@ import static io.restassured.RestAssured.when;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.keycloak.quarkus.runtime.cli.command.AbstractStartCommand.NO_AUTO_BUILD_OPTION_LONG;
 
 import java.util.function.Consumer;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
@@ -119,7 +120,7 @@ public class QuarkusPropertiesDistTest {
 
     @Test
     @KeepServerAlive
-    @Launch({ "start", "--http-enabled=true", "--hostname-strict=false" })
+    @Launch({ "start", "--http-enabled=true", "--hostname-strict=false", NO_AUTO_BUILD_OPTION_LONG })
     @Order(9)
     void testUnknownQuarkusBuildTimePropertyApplied(LaunchResult result) {
         CLIResult cliResult = (CLIResult) result;

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartHelp.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartHelp.unix.approved.txt
@@ -16,6 +16,7 @@ Options:
 -h, --help           This help message.
 --import-realm       Import realms during startup by reading any realm configuration file from the
                        'data/import' directory.
+--no-auto-build      [TBD]
 
 Database:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartHelp.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartHelp.unix.approved.txt
@@ -12,11 +12,13 @@ Options:
                        server image must be built prior to starting the server. This option
                        provides an alternative to manually running the 'build' prior to starting
                        the server. Use this configuration carefully in production as it might
-                       impact the startup time.
+                       impact the startup time. From version 19.0.0, this option is triggered by
+                       default when issuing the 'start' command.
 -h, --help           This help message.
 --import-realm       Import realms during startup by reading any realm configuration file from the
                        'data/import' directory.
---no-auto-build      [TBD]
+--no-auto-build      Avoids the automatic run of the '--auto-build' option, which from version
+                       19.0.0, is triggered by default when issuing the 'start' command.
 
 Database:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartHelp.windows.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartHelp.windows.approved.txt
@@ -16,6 +16,7 @@ Options:
 -h, --help           This help message.
 --import-realm       Import realms during startup by reading any realm configuration file from the
                        'data/import' directory.
+--no-auto-build      [TBD]
 
 Database:
 


### PR DESCRIPTION
Resolves #10737

- Most part of the "'--auto-build' option added by default when issuing a 'start' command" handling was implemented in "kc.sh" and "kc.bat" script files;

- Also was added a WARNING message informing about the future deprecation of the need of issuing 'start --auto-build ...' If the user types '--auto-build' with 'start' command;

- Some existent Integration Test methods were adjusted and other ones were implemented to test this new behavior. Tests pass successfully also in Windows Environment;

- [WIP]: The Guides (*.adoc files) will be updated according to this change;

- [WIP]: The Operator will be updated according to this change;