### PR TITLE
Prevent attempts to delete from federated storage when removing a service account user

### DIFF
--- a/model/legacy-private/src/main/java/org/keycloak/storage/UserStorageManager.java
+++ b/model/legacy-private/src/main/java/org/keycloak/storage/UserStorageManager.java
@@ -282,7 +282,10 @@ public class UserStorageManager extends AbstractStorageManager<UserStorageProvid
 
     @Override
     public boolean removeUser(RealmModel realm, UserModel user) {
-        if (getFederatedStorage() != null) getFederatedStorage().preRemove(realm, user);
+        if (getFederatedStorage() != null && user.getServiceAccountClientLink() == null) {
+            getFederatedStorage().preRemove(realm, user);
+        }
+
         StorageId storageId = new StorageId(user.getId());
 
         if (storageId.getProviderId() == null) {


### PR DESCRIPTION
Do not attempt to delete from federated user tables, when deleting a service account linked user.

These are highly contentious tables in our environments. Deleting a service account user is causing deadlocks in this code path.

I don't think it is possible for these service account users to have links to brokers / federate storage providers. But please let me know if there are any use cases where that might be.

closes #12296 