### PR TITLE
Update webauthn4j to 0.20.0

### DIFF
--- a/distribution/feature-packs/server-feature-pack/src/main/resources/licenses/keycloak/licenses.xml
+++ b/distribution/feature-packs/server-feature-pack/src/main/resources/licenses/keycloak/licenses.xml
@@ -136,22 +136,22 @@
     <dependency>
       <groupId>com.webauthn4j</groupId>
       <artifactId>webauthnj4-core</artifactId>
-      <version>0.19.3.RELEASE</version>
+      <version>0.20.0.RELEASE</version>
       <licenses>
         <license>
           <name>Apache Software License 2.0</name>
-          <url>https://raw.githubusercontent.com/webauthn4j/webauthn4j/0.19.3.RELEASE/LICENSE.txt</url>
+          <url>https://raw.githubusercontent.com/webauthn4j/webauthn4j/0.20.0.RELEASE/LICENSE.txt</url>
         </license>
       </licenses>
     </dependency>
     <dependency>
       <groupId>com.webauthn4j</groupId>
       <artifactId>webauthnj4-util</artifactId>
-      <version>0.19.3.RELEASE</version>
+      <version>0.20.0.RELEASE</version>
       <licenses>
         <license>
           <name>Apache Software License 2.0</name>
-          <url>https://raw.githubusercontent.com/webauthn4j/webauthn4j/0.19.3.RELEASE/LICENSE.txt</url>
+          <url>https://raw.githubusercontent.com/webauthn4j/webauthn4j/0.20.0.RELEASE/LICENSE.txt</url>
         </license>
       </licenses>
     </dependency>

--- a/distribution/galleon-feature-packs/server-galleon-pack/src/license/keycloak-server-galleon-pack-licenses.xml
+++ b/distribution/galleon-feature-packs/server-galleon-pack/src/license/keycloak-server-galleon-pack-licenses.xml
@@ -151,22 +151,22 @@
         <dependency>
             <groupId>com.webauthn4j</groupId>
             <artifactId>webauthnj4-core</artifactId>
-            <version>0.19.3.RELEASE</version>
+            <version>0.20.0.RELEASE</version>
             <licenses>
                 <license>
                     <name>Apache Software License 2.0</name>
-                    <url>https://raw.githubusercontent.com/webauthn4j/webauthn4j/0.19.3.RELEASE/LICENSE.txt</url>
+                    <url>https://raw.githubusercontent.com/webauthn4j/webauthn4j/0.20.0.RELEASE/LICENSE.txt</url>
                 </license>
             </licenses>
         </dependency>
         <dependency>
             <groupId>com.webauthn4j</groupId>
             <artifactId>webauthnj4-util</artifactId>
-            <version>0.19.3.RELEASE</version>
+            <version>0.20.0.RELEASE</version>
             <licenses>
                 <license>
                     <name>Apache Software License 2.0</name>
-                    <url>https://raw.githubusercontent.com/webauthn4j/webauthn4j/0.19.3.RELEASE/LICENSE.txt</url>
+                    <url>https://raw.githubusercontent.com/webauthn4j/webauthn4j/0.20.0.RELEASE/LICENSE.txt</url>
                 </license>
             </licenses>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -201,7 +201,7 @@
         <spring-boot26.version>2.6.1</spring-boot26.version>
 
         <!-- webauthn support -->
-        <webauthn4j.version>0.19.3.RELEASE</webauthn4j.version>
+        <webauthn4j.version>0.20.0.RELEASE</webauthn4j.version>
         <org.apache.kerby.kerby-asn1.version>2.0.0</org.apache.kerby.kerby-asn1.version>
 
         <!-- WildFly Galleon Build related properties -->


### PR DESCRIPTION
Yesterday, webauthn4j released a new version which contains a couple of
bug fixes plus CVE updates for its dependencies:

Breaking changes
    - Add EdDSA support #662
    - Correct AuthenticationAlgorithm(0x0011) value #657

Dependency Upgrades
    - Bump spring-boot-dependencies from 2.6.7 to 2.7.0 #661
    - Bump jacksonVersion from 2.13.2 to 2.13.3 #660
    - Bump kerby-asn1 from 2.0.1 to 2.0.2 #659
Bump checker-qual from 3.21.4 to 3.22.0 #654

Resolves #12311

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
