### PR TITLE
Token endpoint: HTTP 500 unknown error when using client credentials grant type with encrypted id_token but without a encryption key.

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
@@ -734,8 +734,17 @@ public class TokenEndpoint {
         }
 
         // TODO : do the same as codeToToken()
-        AccessTokenResponse res = responseBuilder.build();
-
+        AccessTokenResponse res = null;
+        try {
+            res = responseBuilder.build();
+        } catch (RuntimeException re) {
+            if ("can not get encryption KEK".equals(re.getMessage())) {
+                throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_REQUEST,
+                        "can not get encryption KEK", Response.Status.BAD_REQUEST);
+            } else {
+                throw re;
+            }
+        }
         event.success();
 
         return cors.builder(Response.ok(res, MediaType.APPLICATION_JSON_TYPE)).build();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/IdTokenEncryptionTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/IdTokenEncryptionTest.java
@@ -90,7 +90,7 @@ public class IdTokenEncryptionTest extends AbstractTestRealmKeycloakTest {
 
     @Before
     public void clientConfiguration() {
-        ClientManager.realm(adminClient.realm("test")).clientId("test-app").directAccessGrant(true);
+        ClientManager.realm(adminClient.realm("test")).clientId("test-app").directAccessGrant(true).setServiceAccountsEnabled(true);
         /*
          * Configure the default client ID. Seems like OAuthClient is keeping the state of clientID
          * For example: If some test case configure oauth.clientId("sample-public-client"), other tests
@@ -297,7 +297,7 @@ public class IdTokenEncryptionTest extends AbstractTestRealmKeycloakTest {
 
     @Test
     @UncaughtServerErrorExpected
-    public void testIdTokenEncryptionWithoutEncryptionKEK() {
+    public void testIdTokenEncryptionWithoutEncryptionKEK() throws Exception{
         ClientResource clientResource = null;
         ClientRepresentation clientRep = null;
         try {
@@ -316,13 +316,18 @@ public class IdTokenEncryptionTest extends AbstractTestRealmKeycloakTest {
             String jwksUrl = TestApplicationResourceUrls.clientJwksUri();
             OIDCAdvancedConfigWrapper.fromClientRepresentation(clientRep).setJwksUrl(jwksUrl);
             clientResource.update(clientRep);
- 
+
             // get id token but failed
             OAuthClient.AuthorizationEndpointResponse response = oauth.doLogin("test-user@localhost", "password");
             AccessTokenResponse atr = oauth.doAccessTokenRequest(response.getCode(), "password");
             Assert.assertEquals(OAuthErrorException.INVALID_REQUEST, atr.getError());
             Assert.assertEquals("can not get encryption KEK", atr.getErrorDescription());
 
+            // get id token but failed with client_credentials grant type
+            oauth.scope("openid");
+            OAuthClient.AccessTokenResponse responseClientCredentials = oauth.doClientCredentialsGrantAccessTokenRequest(clientRep.getSecret());
+            Assert.assertEquals(OAuthErrorException.INVALID_REQUEST, responseClientCredentials.getError());
+            Assert.assertEquals("can not get encryption KEK", responseClientCredentials.getErrorDescription());
         } finally {
             // Revert
             clientResource = ApiUtil.findClientByClientId(adminClient.realm("test"), "test-app");


### PR DESCRIPTION
Closes #12348

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
