### PR TITLE
Refactor Operator test packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -436,7 +436,7 @@ jobs:
           echo '::group::Compiling testsuite'
           ./mvnw clean install -nsu -B -Pauth-server-quarkus -DskipTests -f testsuite/pom.xml
           echo '::endgroup::'
-          ./mvnw clean install -nsu -B -Pauth-server-cluster-quarkus -Dsession.cache.owners=2 -Dtest=**.cluster.** -f testsuite/integration-arquillian/pom.xml  | misc/log/trimmer.sh
+          ./mvnw clean install -nsu -B -Pauth-server-cluster-quarkus -Dsession.cache.owners=2 -Dtest=**.cluster.** -f testsuite/integration-arquillian/tests/base/pom.xml  | misc/log/trimmer.sh
           TEST_RESULT=${PIPESTATUS[0]}
           find . -path '*/target/surefire-reports/*.xml' | zip -q reports-quarkus-cluster-tests.zip -@
           exit $TEST_RESULT

--- a/operator/app/pom.xml
+++ b/operator/app/pom.xml
@@ -38,7 +38,6 @@
         <quarkus.version>2.7.5.Final</quarkus.version>
         <quarkus.container-image.group>keycloak</quarkus.container-image.group>
         <quarkus.jib.base-jvm-image>registry.access.redhat.com/ubi8/openjdk-11-runtime</quarkus.jib.base-jvm-image>
-        <maven-failsafe-plugin.version>2.22.0</maven-failsafe-plugin.version>
     </properties>
     
     <dependencyManagement>
@@ -263,13 +262,17 @@
                 </executions>
             </plugin>
             <plugin>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <version>${maven-failsafe-plugin.version}</version>
+                <artifactId>maven-surefire-plugin</artifactId>
                 <executions>
+                <!--
+                    need to run at "verify" to support testing with images (which are built at "package")
+                    using surefire instead of failsafe to align with rest of the KC project
+                -->
                     <execution>
+                        <id>default-test</id>
+                        <phase>verify</phase>
                         <goals>
-                            <goal>integration-test</goal>
-                            <goal>verify</goal>
+                            <goal>test</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/operator/app/src/test/java/org/keycloak/operator/testsuite/integration/BaseOperatorTest.java
+++ b/operator/app/src/test/java/org/keycloak/operator/testsuite/integration/BaseOperatorTest.java
@@ -1,4 +1,21 @@
-package org.keycloak.operator;
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.operator.testsuite.integration;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.NamespaceBuilder;
@@ -19,6 +36,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.keycloak.operator.Constants;
 import org.keycloak.operator.crds.v2alpha1.deployment.Keycloak;
 
 import javax.enterprise.inject.Instance;
@@ -34,9 +52,9 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.keycloak.operator.utils.K8sUtils.getResourceFromFile;
+import static org.keycloak.operator.testsuite.utils.K8sUtils.getResourceFromFile;
 
-public abstract class ClusterOperatorTest {
+public abstract class BaseOperatorTest {
 
   public static final String QUARKUS_KUBERNETES_DEPLOYMENT_TARGET = "quarkus.kubernetes.deployment-target";
   public static final String OPERATOR_DEPLOYMENT_PROP = "test.operator.deployment";
@@ -151,7 +169,7 @@ public abstract class ClusterOperatorTest {
   protected static void deployDB() {
     // DB
     Log.info("Creating new PostgreSQL deployment");
-    k8sclient.load(ClusterOperatorTest.class.getResourceAsStream("/example-postgres.yaml")).inNamespace(namespace).createOrReplace();
+    k8sclient.load(BaseOperatorTest.class.getResourceAsStream("/example-postgres.yaml")).inNamespace(namespace).createOrReplace();
 
     // Check DB has deployed and ready
     Log.info("Checking Postgres is running");

--- a/operator/app/src/test/java/org/keycloak/operator/testsuite/integration/ClusteringTest.java
+++ b/operator/app/src/test/java/org/keycloak/operator/testsuite/integration/ClusteringTest.java
@@ -1,4 +1,21 @@
-package org.keycloak.operator;
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.operator.testsuite.integration;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import io.fabric8.kubernetes.client.utils.Serialization;
@@ -7,10 +24,11 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
-import org.keycloak.operator.utils.CRAssert;
+import org.keycloak.operator.Constants;
+import org.keycloak.operator.testsuite.utils.CRAssert;
 import org.keycloak.operator.controllers.KeycloakService;
 import org.keycloak.operator.crds.v2alpha1.deployment.Keycloak;
-import org.keycloak.operator.utils.K8sUtils;
+import org.keycloak.operator.testsuite.utils.K8sUtils;
 import org.keycloak.operator.crds.v2alpha1.realmimport.KeycloakRealmImport;
 import org.keycloak.operator.crds.v2alpha1.realmimport.KeycloakRealmImportStatusCondition;
 import org.keycloak.operator.crds.v2alpha1.deployment.KeycloakStatusCondition;
@@ -23,7 +41,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 
 @QuarkusTest
-public class ClusteringE2EIT extends ClusterOperatorTest {
+public class ClusteringTest extends BaseOperatorTest {
 
     @Test
     public void testKeycloakScaleAsExpected() {

--- a/operator/app/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakDeploymentTest.java
+++ b/operator/app/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakDeploymentTest.java
@@ -1,4 +1,21 @@
-package org.keycloak.operator;
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.operator.testsuite.integration;
 
 import io.fabric8.kubernetes.api.model.EnvVarBuilder;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
@@ -9,7 +26,8 @@ import io.quarkus.test.junit.QuarkusTest;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
-import org.keycloak.operator.utils.K8sUtils;
+import org.keycloak.operator.Constants;
+import org.keycloak.operator.testsuite.utils.K8sUtils;
 import org.keycloak.operator.controllers.KeycloakAdminSecret;
 import org.keycloak.operator.controllers.KeycloakDeployment;
 import org.keycloak.operator.controllers.KeycloakService;
@@ -30,12 +48,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.keycloak.operator.utils.K8sUtils.deployKeycloak;
-import static org.keycloak.operator.utils.K8sUtils.getDefaultKeycloakDeployment;
-import static org.keycloak.operator.utils.K8sUtils.waitForKeycloakToBeReady;
+import static org.keycloak.operator.testsuite.utils.K8sUtils.deployKeycloak;
+import static org.keycloak.operator.testsuite.utils.K8sUtils.getDefaultKeycloakDeployment;
+import static org.keycloak.operator.testsuite.utils.K8sUtils.waitForKeycloakToBeReady;
 
 @QuarkusTest
-public class KeycloakDeploymentE2EIT extends ClusterOperatorTest {
+public class KeycloakDeploymentTest extends BaseOperatorTest {
     @Test
     public void testBasicKeycloakDeploymentAndDeletion() {
         try {

--- a/operator/app/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakIngressTest.java
+++ b/operator/app/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakIngressTest.java
@@ -1,4 +1,21 @@
-package org.keycloak.operator;
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.operator.testsuite.integration;
 
 import io.fabric8.kubernetes.api.model.networking.v1.ServiceBackendPortBuilder;
 import io.quarkus.logging.Log;
@@ -6,7 +23,8 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
-import org.keycloak.operator.utils.K8sUtils;
+import org.keycloak.operator.Constants;
+import org.keycloak.operator.testsuite.utils.K8sUtils;
 import org.keycloak.operator.controllers.KeycloakIngress;
 
 import java.util.Map;
@@ -15,7 +33,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @QuarkusTest
-public class KeycloakIngressE2EIT extends ClusterOperatorTest {
+public class KeycloakIngressTest extends BaseOperatorTest {
 
     @Test
     public void testIngressOnHTTP() {

--- a/operator/app/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakServicesTest.java
+++ b/operator/app/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakServicesTest.java
@@ -1,4 +1,21 @@
-package org.keycloak.operator;
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.operator.testsuite.integration;
 
 import io.fabric8.kubernetes.api.model.ServiceSpecBuilder;
 import io.quarkus.logging.Log;
@@ -7,14 +24,14 @@ import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.keycloak.operator.controllers.KeycloakDiscoveryService;
 import org.keycloak.operator.controllers.KeycloakService;
-import org.keycloak.operator.utils.K8sUtils;
+import org.keycloak.operator.testsuite.utils.K8sUtils;
 
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @QuarkusTest
-public class KeycloakServicesE2EIT extends ClusterOperatorTest {
+public class KeycloakServicesTest extends BaseOperatorTest {
     @Test
     public void testMainServiceDurability() {
         var kc = K8sUtils.getDefaultKeycloakDeployment();

--- a/operator/app/src/test/java/org/keycloak/operator/testsuite/integration/PodTemplateTest.java
+++ b/operator/app/src/test/java/org/keycloak/operator/testsuite/integration/PodTemplateTest.java
@@ -1,4 +1,21 @@
-package org.keycloak.operator;
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.operator.testsuite.integration;
 
 import io.fabric8.kubernetes.api.model.PodTemplateSpecBuilder;
 import io.fabric8.kubernetes.client.dsl.Resource;
@@ -7,7 +24,7 @@ import io.quarkus.logging.Log;
 import io.quarkus.test.junit.QuarkusTest;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
-import org.keycloak.operator.utils.CRAssert;
+import org.keycloak.operator.testsuite.utils.CRAssert;
 import org.keycloak.operator.crds.v2alpha1.deployment.Keycloak;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
@@ -15,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.keycloak.operator.crds.v2alpha1.deployment.KeycloakStatusCondition.HAS_ERRORS;
 
 @QuarkusTest
-public class PodTemplateE2EIT extends ClusterOperatorTest {
+public class PodTemplateTest extends BaseOperatorTest {
 
     private Keycloak getEmptyPodTemplateKeycloak() {
         return Serialization.unmarshal(getClass().getResourceAsStream("/empty-podtemplate-keycloak.yml"), Keycloak.class);

--- a/operator/app/src/test/java/org/keycloak/operator/testsuite/integration/RealmImportTest.java
+++ b/operator/app/src/test/java/org/keycloak/operator/testsuite/integration/RealmImportTest.java
@@ -1,4 +1,21 @@
-package org.keycloak.operator;
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.operator.testsuite.integration;
 
 import io.fabric8.kubernetes.api.model.LocalObjectReferenceBuilder;
 import io.fabric8.kubernetes.api.model.PodTemplateSpecBuilder;
@@ -8,7 +25,7 @@ import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
-import org.keycloak.operator.utils.CRAssert;
+import org.keycloak.operator.testsuite.utils.CRAssert;
 import org.keycloak.operator.controllers.KeycloakService;
 import org.keycloak.operator.crds.v2alpha1.realmimport.KeycloakRealmImport;
 import org.keycloak.operator.crds.v2alpha1.deployment.KeycloakSpecUnsupported;
@@ -19,15 +36,15 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.keycloak.operator.Constants.KEYCLOAK_HTTPS_PORT;
-import static org.keycloak.operator.utils.K8sUtils.deployKeycloak;
-import static org.keycloak.operator.utils.K8sUtils.getDefaultKeycloakDeployment;
-import static org.keycloak.operator.utils.K8sUtils.inClusterCurl;
+import static org.keycloak.operator.testsuite.utils.K8sUtils.deployKeycloak;
+import static org.keycloak.operator.testsuite.utils.K8sUtils.getDefaultKeycloakDeployment;
+import static org.keycloak.operator.testsuite.utils.K8sUtils.inClusterCurl;
 import static org.keycloak.operator.crds.v2alpha1.realmimport.KeycloakRealmImportStatusCondition.DONE;
 import static org.keycloak.operator.crds.v2alpha1.realmimport.KeycloakRealmImportStatusCondition.HAS_ERRORS;
 import static org.keycloak.operator.crds.v2alpha1.realmimport.KeycloakRealmImportStatusCondition.STARTED;
 
 @QuarkusTest
-public class RealmImportE2EIT extends ClusterOperatorTest {
+public class RealmImportTest extends BaseOperatorTest {
 
     @Override
     @BeforeEach

--- a/operator/app/src/test/java/org/keycloak/operator/testsuite/integration/WatchedSecretsTest.java
+++ b/operator/app/src/test/java/org/keycloak/operator/testsuite/integration/WatchedSecretsTest.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.keycloak.operator;
+package org.keycloak.operator.testsuite.integration;
 
 import io.fabric8.kubernetes.api.model.Secret;
 import io.quarkus.logging.Log;
@@ -24,6 +24,7 @@ import org.awaitility.Awaitility;
 import org.bouncycastle.util.encoders.Base64;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.keycloak.operator.Constants;
 import org.keycloak.operator.controllers.WatchedSecretsStore;
 import org.keycloak.operator.crds.v2alpha1.deployment.Keycloak;
 import org.keycloak.operator.crds.v2alpha1.deployment.KeycloakStatusCondition;
@@ -37,15 +38,15 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.keycloak.operator.utils.CRAssert.assertKeycloakStatusCondition;
-import static org.keycloak.operator.utils.K8sUtils.deployKeycloak;
-import static org.keycloak.operator.utils.K8sUtils.getDefaultKeycloakDeployment;
+import static org.keycloak.operator.testsuite.utils.CRAssert.assertKeycloakStatusCondition;
+import static org.keycloak.operator.testsuite.utils.K8sUtils.deployKeycloak;
+import static org.keycloak.operator.testsuite.utils.K8sUtils.getDefaultKeycloakDeployment;
 
 /**
  * @author Vaclav Muzikar <vmuzikar@redhat.com>
  */
 @QuarkusTest
-public class WatchedSecretsTestE2EIT extends ClusterOperatorTest {
+public class WatchedSecretsTest extends BaseOperatorTest {
     @Test
     public void testSecretsAreWatched() {
         try {

--- a/operator/app/src/test/java/org/keycloak/operator/testsuite/unit/CRSerializationTest.java
+++ b/operator/app/src/test/java/org/keycloak/operator/testsuite/unit/CRSerializationTest.java
@@ -1,4 +1,21 @@
-package org.keycloak.operator;
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.operator.testsuite.unit;
 
 import io.fabric8.kubernetes.client.utils.Serialization;
 import org.junit.jupiter.api.Test;

--- a/operator/app/src/test/java/org/keycloak/operator/testsuite/unit/IngressLogicTest.java
+++ b/operator/app/src/test/java/org/keycloak/operator/testsuite/unit/IngressLogicTest.java
@@ -1,13 +1,31 @@
-package org.keycloak.operator;
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.operator.testsuite.unit;
 
 import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
 import io.fabric8.kubernetes.api.model.networking.v1.IngressBuilder;
 import org.junit.jupiter.api.Test;
 import org.keycloak.operator.controllers.KeycloakIngress;
 import org.keycloak.operator.crds.v2alpha1.deployment.Keycloak;
-import org.keycloak.operator.utils.K8sUtils;
+import org.keycloak.operator.testsuite.utils.K8sUtils;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class IngressLogicTest {
 

--- a/operator/app/src/test/java/org/keycloak/operator/testsuite/unit/PodTemplateTest.java
+++ b/operator/app/src/test/java/org/keycloak/operator/testsuite/unit/PodTemplateTest.java
@@ -1,4 +1,21 @@
-package org.keycloak.operator;
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.operator.testsuite.unit;
 
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
@@ -7,6 +24,7 @@ import io.fabric8.kubernetes.api.model.ProbeBuilder;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
+import org.keycloak.operator.Config;
 import org.keycloak.operator.controllers.KeycloakDeployment;
 import org.keycloak.operator.crds.v2alpha1.deployment.Keycloak;
 import org.keycloak.operator.crds.v2alpha1.deployment.KeycloakSpec;

--- a/operator/app/src/test/java/org/keycloak/operator/testsuite/utils/CRAssert.java
+++ b/operator/app/src/test/java/org/keycloak/operator/testsuite/utils/CRAssert.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.keycloak.operator.utils;
+package org.keycloak.operator.testsuite.utils;
 
 import io.fabric8.kubernetes.client.utils.Serialization;
 import io.quarkus.logging.Log;

--- a/operator/app/src/test/java/org/keycloak/operator/testsuite/utils/K8sUtils.java
+++ b/operator/app/src/test/java/org/keycloak/operator/testsuite/utils/K8sUtils.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.keycloak.operator.utils;
+package org.keycloak.operator.testsuite.utils;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.Pod;

--- a/pom.xml
+++ b/pom.xml
@@ -1718,9 +1718,8 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.0.0-M5</version>
+                    <version>3.0.0-M6</version>
                     <configuration>
-                        <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
                         <forkMode>once</forkMode>
                         <argLine>-Djava.awt.headless=true ${surefire.memory.settings} ${surefire.system.args} -Duser.language=en -Duser.region=US</argLine>
                         <runOrder>alphabetical</runOrder>

--- a/quarkus/pom.xml
+++ b/quarkus/pom.xml
@@ -67,7 +67,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
 
-        <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+        <surefire-plugin.version>3.0.0-M6</surefire-plugin.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Closes #12353

The change from failsafe to surefire was motivated by the test classes renaming. It was also a good opportunity to align with rest of the KC project and use surefire.