### PR TITLE
Update Quarkus to 2.7.6.Final

### DIFF
--- a/operator/app/pom.xml
+++ b/operator/app/pom.xml
@@ -23,8 +23,8 @@
         -->
         <resteasy.version>4.7.5.Final</resteasy.version>
         <wildfly.common.version>1.5.4.Final-format-001</wildfly.common.version>
-        <jackson.version>2.13.2</jackson.version>
-        <jackson.databind.version>2.13.2.2</jackson.databind.version>
+        <jackson.version>2.13.3</jackson.version>
+        <jackson.databind.version>2.13.3</jackson.databind.version>
         <kubernetes-client.version>5.12.2</kubernetes-client.version>
 
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
@@ -34,8 +34,8 @@
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus.operator.sdk.version>3.0.7</quarkus.operator.sdk.version>
-        <quarkus.version>2.7.5.Final</quarkus.version>
+        <quarkus.operator.sdk.version>3.0.8</quarkus.operator.sdk.version>
+        <quarkus.version>2.7.6.Final</quarkus.version>
         <quarkus.container-image.group>keycloak</quarkus.container-image.group>
         <quarkus.jib.base-jvm-image>registry.access.redhat.com/ubi8/openjdk-11-runtime</quarkus.jib.base-jvm-image>
         <maven-failsafe-plugin.version>2.22.0</maven-failsafe-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <jboss.snapshots.repo.id>jboss-snapshots-repository</jboss.snapshots.repo.id>
         <jboss.snapshots.repo.url>https://s01.oss.sonatype.org/content/repositories/snapshots/</jboss.snapshots.repo.url>
 
-        <quarkus.version>2.7.5.Final</quarkus.version>
+        <quarkus.version>2.7.6.Final</quarkus.version>
 
         <!--
         Performing a Wildfly upgrade? Run the:

--- a/quarkus/pom.xml
+++ b/quarkus/pom.xml
@@ -38,8 +38,8 @@
             for reference
         -->
         <resteasy.version>4.7.5.Final</resteasy.version>
-        <jackson.version>2.13.2</jackson.version>
-        <jackson.databind.version>2.13.2.2</jackson.databind.version>
+        <jackson.version>2.13.3</jackson.version>
+        <jackson.databind.version>2.13.3</jackson.databind.version>
         <hibernate.core.version>5.6.5.Final</hibernate.core.version>
         <mysql.driver.version>8.0.28</mysql.driver.version>
         <postgresql.version>42.3.3</postgresql.version>
@@ -59,7 +59,7 @@
         <!--
             Quarkiverse dependency versions
          -->
-        <io.quarkiverse.vault.version>1.0.2</io.quarkiverse.vault.version>
+        <io.quarkiverse.vault.version>1.1.0</io.quarkiverse.vault.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>

--- a/quarkus/tests/integration/src/main/java/org/keycloak/it/junit5/extension/CLIResult.java
+++ b/quarkus/tests/integration/src/main/java/org/keycloak/it/junit5/extension/CLIResult.java
@@ -101,7 +101,7 @@ public interface CLIResult extends LaunchResult {
     }
 
     default void assertBuildRuntimeMismatchWarning(String quarkusBuildtimePropKey) {
-        assertTrue(getOutput().contains(" - " + quarkusBuildtimePropKey + " is set to 'false' but it is build time fixed to 'true'. Did you change the property " + quarkusBuildtimePropKey + " after building the application?"));
+        assertTrue(getOutput().contains(" - " + quarkusBuildtimePropKey + " is set to 'true' but it is build time fixed to 'false'. Did you change the property " + quarkusBuildtimePropKey + " after building the application?"));
     }
 
     default boolean isClustered() {

--- a/quarkus/tests/integration/src/main/java/org/keycloak/it/utils/DockerKeycloakDistribution.java
+++ b/quarkus/tests/integration/src/main/java/org/keycloak/it/utils/DockerKeycloakDistribution.java
@@ -43,7 +43,7 @@ public final class DockerKeycloakDistribution implements KeycloakDistribution {
 
     private GenericContainer getKeycloakContainer() {
         if (!distributionFile.exists()) {
-            throw new RuntimeException("Distribution archive " + distributionFile.getAbsolutePath() +" doesn't exists");
+            throw new RuntimeException("Distribution archive " + distributionFile.getAbsolutePath() +" doesn't exist");
         }
         return new GenericContainer(
                 new ImageFromDockerfile("keycloak-under-test", false)

--- a/quarkus/tests/integration/src/main/java/org/keycloak/it/utils/RawKeycloakDistribution.java
+++ b/quarkus/tests/integration/src/main/java/org/keycloak/it/utils/RawKeycloakDistribution.java
@@ -328,7 +328,7 @@ public final class RawKeycloakDistribution implements KeycloakDistribution {
 
             File distFile = new File("../../dist/" + File.separator + "target" + File.separator + "keycloak-" + Version.VERSION_KEYCLOAK + ".zip");
             if (!distFile.exists()) {
-                throw new RuntimeException("Distribution archive " + distFile.getAbsolutePath() +" doesn't exists");
+                throw new RuntimeException("Distribution archive " + distFile.getAbsolutePath() +" doesn't exist");
             }
             distRootPath.toFile().mkdirs();
             String distDirName = distFile.getName();

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/QuarkusPropertiesDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/QuarkusPropertiesDistTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Changes apart from parent bom update: Jackson to 2.13.3 and Quarkiverse vault to 1.1.0
Also fixes a test regression by changing the values to the actual expected values. This test was weird... when I understand it correctly, the https://github.com/keycloak/keycloak/blob/d8358bed99fa2164c16f5338dccadc8b221cb8de/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/QuarkusPropertiesDistTest.java Test nr 7 should never have worked in the first place, or to state otherwise, tested the actually wrong thing. cc @pedroigor pls validate I am right here:

Assumption: 
1) Test 7 updates an "unknown for us" quarkus property (hibernate-metrics) without doing a build.
2) correctly, error is shown that tells the user "this is set to true without a rebuild, but is build-time fixed to false bc. `false` is the default value (ref: [Quarkus v2.2](https://quarkus.io/version/2.2/guides/all-config.html#quarkus-hibernate-orm_quarkus.hibernate-orm.metrics.enabled) / [Quarkus v2.7](https://quarkus.io/version/2.7/guides/all-config.html#quarkus-hibernate-orm_quarkus.hibernate-orm.metrics.enabled) )
3) All fine. *shrugs

So for me it seems previous to 2.7.6 the errormsg was just wrong, it applied still `false` but said build time fixed to `true`, which was the value we set at runtime. hence the old error msg was checked to be correct, but should never been correct in the first place.

If that assumption is true, then the fix was easy, just change the errormsg to include the right values (true instead of false). Just want to doublecheck here if that logic makes sense, I think so but not entirely sure ;)


Closes #12370 
