### PR TITLE
[Fix keycloak#12385] Update option to run kc.bat on windows instead of kc.sh

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/containers/KeycloakQuarkusServerDeployableContainer.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/containers/KeycloakQuarkusServerDeployableContainer.java
@@ -27,6 +27,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.jboss.arquillian.container.spi.client.container.DeployableContainer;
 import org.jboss.arquillian.container.spi.client.container.DeploymentException;
 import org.jboss.arquillian.container.spi.client.container.LifecycleException;
@@ -149,8 +150,7 @@ public class KeycloakQuarkusServerDeployableContainer implements DeployableConta
 
     private String[] getProcessCommands() {
         List<String> commands = new ArrayList<>();
-
-        commands.add("./kc.sh");
+        commands.add(getCommand());
         commands.add("-v");
         commands.add("start");
         commands.add("--http-enabled=true");
@@ -295,6 +295,13 @@ public class KeycloakQuarkusServerDeployableContainer implements DeployableConta
     public void restartServer() throws Exception {
         stop();
         start();
+    }
+
+    private static String getCommand() {
+        if (SystemUtils.IS_OS_WINDOWS) {
+            return "kc.bat";
+        }
+        return "kc.sh";
     }
 
     public List<String> getAdditionalBuildArgs() {

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/containers/KeycloakQuarkusServerDeployableContainer.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/containers/KeycloakQuarkusServerDeployableContainer.java
@@ -301,7 +301,7 @@ public class KeycloakQuarkusServerDeployableContainer implements DeployableConta
         if (SystemUtils.IS_OS_WINDOWS) {
             return "kc.bat";
         }
-        return "kc.sh";
+        return "./kc.sh";
     }
 
     public List<String> getAdditionalBuildArgs() {


### PR DESCRIPTION
Closes #12385

The Current Quarkus container runs kc.sh in the windows machine as seen in the QE test pipeline.

Adding support for kc.bat files to be run when the environment is windows. 


