### PR TITLE
Keep a list of model instances in the JPA map session.

### DIFF
--- a/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/authSession/JpaRootAuthenticationSessionMapKeycloakTransaction.java
+++ b/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/authSession/JpaRootAuthenticationSessionMapKeycloakTransaction.java
@@ -34,7 +34,7 @@ public class JpaRootAuthenticationSessionMapKeycloakTransaction extends JpaMapKe
 
     @SuppressWarnings("unchecked")
     public JpaRootAuthenticationSessionMapKeycloakTransaction(EntityManager em) {
-        super(JpaRootAuthenticationSessionEntity.class, em);
+        super(JpaRootAuthenticationSessionEntity.class, RootAuthenticationSessionModel.class, em);
     }
 
     @Override

--- a/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/authorization/permission/JpaPermissionMapKeycloakTransaction.java
+++ b/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/authorization/permission/JpaPermissionMapKeycloakTransaction.java
@@ -34,7 +34,7 @@ public class JpaPermissionMapKeycloakTransaction extends JpaMapKeycloakTransacti
 
     @SuppressWarnings("unchecked")
     public JpaPermissionMapKeycloakTransaction(EntityManager em) {
-        super(JpaPermissionEntity.class, em);
+        super(JpaPermissionEntity.class, PermissionTicket.class, em);
     }
 
     @Override

--- a/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/authorization/policy/JpaPolicyMapKeycloakTransaction.java
+++ b/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/authorization/policy/JpaPolicyMapKeycloakTransaction.java
@@ -34,7 +34,7 @@ public class JpaPolicyMapKeycloakTransaction extends JpaMapKeycloakTransaction<J
 
     @SuppressWarnings("unchecked")
     public JpaPolicyMapKeycloakTransaction(EntityManager em) {
-        super(JpaPolicyEntity.class, em);
+        super(JpaPolicyEntity.class, Policy.class, em);
     }
 
     @Override

--- a/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/authorization/resource/JpaResourceMapKeycloakTransaction.java
+++ b/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/authorization/resource/JpaResourceMapKeycloakTransaction.java
@@ -34,7 +34,7 @@ public class JpaResourceMapKeycloakTransaction extends JpaMapKeycloakTransaction
 
     @SuppressWarnings("unchecked")
     public JpaResourceMapKeycloakTransaction(EntityManager em) {
-        super(JpaResourceEntity.class, em);
+        super(JpaResourceEntity.class, Resource.class, em);
     }
 
     @Override

--- a/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/authorization/resourceServer/JpaResourceServerMapKeycloakTransaction.java
+++ b/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/authorization/resourceServer/JpaResourceServerMapKeycloakTransaction.java
@@ -34,7 +34,7 @@ public class JpaResourceServerMapKeycloakTransaction extends JpaMapKeycloakTrans
 
     @SuppressWarnings("unchecked")
     public JpaResourceServerMapKeycloakTransaction(EntityManager em) {
-        super(JpaResourceServerEntity.class, em);
+        super(JpaResourceServerEntity.class, ResourceServer.class, em);
     }
 
     @Override

--- a/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/authorization/scope/JpaScopeMapKeycloakTransaction.java
+++ b/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/authorization/scope/JpaScopeMapKeycloakTransaction.java
@@ -34,7 +34,7 @@ public class JpaScopeMapKeycloakTransaction extends JpaMapKeycloakTransaction<Jp
 
     @SuppressWarnings("unchecked")
     public JpaScopeMapKeycloakTransaction(EntityManager em) {
-        super(JpaScopeEntity.class, em);
+        super(JpaScopeEntity.class, Scope.class, em);
     }
 
     @Override

--- a/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/client/JpaClientMapKeycloakTransaction.java
+++ b/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/client/JpaClientMapKeycloakTransaction.java
@@ -34,7 +34,7 @@ public class JpaClientMapKeycloakTransaction extends JpaMapKeycloakTransaction<J
 
     @SuppressWarnings("unchecked")
     public JpaClientMapKeycloakTransaction(EntityManager em) {
-        super(JpaClientEntity.class, em);
+        super(JpaClientEntity.class, ClientModel.class, em);
     }
 
     @Override

--- a/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/clientscope/JpaClientScopeMapKeycloakTransaction.java
+++ b/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/clientscope/JpaClientScopeMapKeycloakTransaction.java
@@ -34,7 +34,7 @@ public class JpaClientScopeMapKeycloakTransaction extends JpaMapKeycloakTransact
 
     @SuppressWarnings("unchecked")
     public JpaClientScopeMapKeycloakTransaction(EntityManager em) {
-        super(JpaClientScopeEntity.class, em);
+        super(JpaClientScopeEntity.class, ClientScopeModel.class, em);
     }
 
     @Override

--- a/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/group/JpaGroupMapKeycloakTransaction.java
+++ b/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/group/JpaGroupMapKeycloakTransaction.java
@@ -34,7 +34,7 @@ public class JpaGroupMapKeycloakTransaction extends JpaMapKeycloakTransaction<Jp
 
     @SuppressWarnings("unchecked")
     public JpaGroupMapKeycloakTransaction(EntityManager em) {
-        super(JpaGroupEntity.class, em);
+        super(JpaGroupEntity.class, GroupModel.class, em);
     }
 
     @Override

--- a/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/loginFailure/JpaUserLoginFailureMapKeycloakTransaction.java
+++ b/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/loginFailure/JpaUserLoginFailureMapKeycloakTransaction.java
@@ -41,7 +41,7 @@ public class JpaUserLoginFailureMapKeycloakTransaction extends JpaMapKeycloakTra
 
     @SuppressWarnings("unchecked")
     public JpaUserLoginFailureMapKeycloakTransaction(EntityManager em) {
-        super(JpaUserLoginFailureEntity.class, em);
+        super(JpaUserLoginFailureEntity.class, UserLoginFailureModel.class, em);
     }
 
     @Override

--- a/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/realm/JpaRealmMapKeycloakTransaction.java
+++ b/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/realm/JpaRealmMapKeycloakTransaction.java
@@ -40,7 +40,7 @@ import static org.keycloak.models.map.storage.jpa.Constants.CURRENT_SCHEMA_VERSI
 public class JpaRealmMapKeycloakTransaction extends JpaMapKeycloakTransaction<JpaRealmEntity, MapRealmEntity, RealmModel> {
 
     public JpaRealmMapKeycloakTransaction(final EntityManager em) {
-        super(JpaRealmEntity.class, em);
+        super(JpaRealmEntity.class, RealmModel.class, em);
     }
 
     @Override

--- a/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/role/JpaRoleMapKeycloakTransaction.java
+++ b/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/role/JpaRoleMapKeycloakTransaction.java
@@ -34,7 +34,7 @@ public class JpaRoleMapKeycloakTransaction extends JpaMapKeycloakTransaction<Jpa
 
     @SuppressWarnings("unchecked")
     public JpaRoleMapKeycloakTransaction(EntityManager em) {
-        super(JpaRoleEntity.class, em);
+        super(JpaRoleEntity.class, RoleModel.class, em);
     }
 
     @Override

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/model/ConcurrentTransactionsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/model/ConcurrentTransactionsTest.java
@@ -109,10 +109,14 @@ public class ConcurrentTransactionsTest extends AbstractTestRealmKeycloakTest {
                                 throw new IllegalStateException("Timeout when waiting for updateLatch");
                             }
 
-                            logger.info("transaction1: Going to read client again");
+                            // the behavior upon reading client information would depend on the store:
+                            // * it might return the new values if this really touches the store and it using read committed and not repeatable read
+                            // * it might return the old values if the information is cached within the current session (either explicitly, or implicitly using the JPA persistence context), or using repeatable read
+                            // * it might throw an exception if a concurrent modification exception occurred when reading additional data from the store and read committed is used
 
-                            client1 = currentSession.clients().getClientByClientId(realm1, "client");
-                            logger.info("transaction1: secret: " + client1.getSecret());
+                            // logger.info("transaction1: Going to read client again");
+                            // client1 = currentSession.clients().getClientByClientId(realm1, "client");
+                            // logger.info("transaction1: secret: " + client1.getSecret());
 
                         } catch (Exception e) {
                             exceptionHolder.set(e);


### PR DESCRIPTION
This allows removing them from the persistence context on bulk delete.

Closes #12384

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
