### PR TITLE
Allow for the backend to return granted scopes in any order.

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/AssertEvents.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/AssertEvents.java
@@ -36,6 +36,7 @@ import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.representations.idm.UserSessionRepresentation;
 import org.keycloak.util.TokenUtil;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -310,7 +311,23 @@ public class AssertEvents implements TestRule {
         }
 
         public ExpectedEvent detail(String key, String value) {
-            return detail(key, CoreMatchers.equalTo(value));
+            if (key.equals(Details.SCOPE)) {
+                // the scopes can be given in any order,
+                // therefore, use a matcher that takes a string and ignores the order of the scopes
+                return detail(key, new TypeSafeMatcher<String>() {
+                    @Override
+                    protected boolean matchesSafely(String actualValue) {
+                        return Matchers.containsInAnyOrder(value.split(" ")).matches(Arrays.asList(actualValue.split(" ")));
+                    }
+
+                    @Override
+                    public void describeTo(Description description) {
+                        description.appendText("contains scope in any order");
+                    }
+                });
+            } else {
+                return detail(key, CoreMatchers.equalTo(value));
+            }
         }
 
         public ExpectedEvent detail(String key, Matcher<? super String> matcher) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/AccountRestServiceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/AccountRestServiceTest.java
@@ -1029,9 +1029,8 @@ public class AccountRestServiceTest extends AbstractRestServiceTest {
                 .asJson(ConsentRepresentation.class);
         assertTrue(consentRepresentation.getCreatedDate() > 0);
         assertTrue(consentRepresentation.getLastUpdatedDate() > 0);
-        assertEquals(2, consentRepresentation.getGrantedScopes().size());
-        assertEquals(requestedScopes.get(0).getId(), consentRepresentation.getGrantedScopes().get(0).getId());
-        assertEquals(requestedScopes.get(1).getId(), consentRepresentation.getGrantedScopes().get(1).getId());
+        assertThat(consentRepresentation.getGrantedScopes().stream().map(ConsentScopeRepresentation::getId).collect(Collectors.toList()),
+                containsInAnyOrder(requestedScopes.stream().map(ClientScopeRepresentation::getId).toArray()));
 
         events.poll();
         String expectedScopeDetails = requestedScopes.stream().map(cs->cs.getName()).collect(Collectors.joining(" "));


### PR DESCRIPTION
Closes #12395

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
