### PR TITLE
Fixes wrong values shown for configkeys (e.g. http-enabled) in show-c…

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/Environment.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/Environment.java
@@ -34,6 +34,7 @@ import java.util.stream.Collectors;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.configuration.ProfileManager;
 import org.apache.commons.lang3.SystemUtils;
+import org.keycloak.quarkus.runtime.configuration.PersistedConfigSource;
 
 public final class Environment {
 
@@ -43,8 +44,8 @@ public final class Environment {
     public static final String DATA_PATH = "/data";
     public static final String DEFAULT_THEMES_PATH = "/themes";
     public static final String DEV_PROFILE_VALUE = "dev";
+    public static final String PROD_PROFILE_VALUE = "prod";
     public static final String LAUNCH_MODE = "kc.launch.mode";
-
     private Environment() {}
 
     public static Boolean isRebuild() {
@@ -116,7 +117,7 @@ public final class Environment {
     public static String getCurrentOrPersistedProfile() {
         String profile = getProfile();
         if(profile == null) {
-            profile = getConfig().getRawValue(PROFILE);
+            profile = PersistedConfigSource.getInstance().getValue(PROFILE);
         }
         return profile;
     }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/PropertyMappingInterceptor.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/PropertyMappingInterceptor.java
@@ -39,8 +39,6 @@ import org.keycloak.quarkus.runtime.configuration.mappers.PropertyMappers;
  */
 public class PropertyMappingInterceptor implements ConfigSourceInterceptor {
 
-    private final boolean isQuarkusPropertiesEnabled = QuarkusPropertiesConfigSource.isQuarkusPropertiesEnabled();
-
     @Override
     public ConfigValue getValue(ConfigSourceInterceptorContext context, String name) {
         ConfigValue value = PropertyMappers.getValue(context, name);

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/QuarkusPropertiesConfigSource.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/QuarkusPropertiesConfigSource.java
@@ -60,10 +60,6 @@ public final class QuarkusPropertiesConfigSource extends AbstractLocationConfigS
         return NAME.equals(value.getConfigSourceName());
     }
 
-    public static boolean isQuarkusPropertiesEnabled() {
-        return parseBoolean(getRawPersistedProperty(QUARKUS_PROPERTY_ENABLED).orElse(Boolean.FALSE.toString()));
-    }
-
     public static Path getConfigurationFile() {
         String homeDir = Environment.getHomeDir();
 

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/ShowConfigCommandTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/ShowConfigCommandTest.java
@@ -35,14 +35,14 @@ public class ShowConfigCommandTest {
     @Launch({ ShowConfig.NAME })
     void testShowConfigCommandShowsRuntimeConfig(LaunchResult result) {
         Assertions.assertTrue(result.getOutput()
-                .contains("Runtime Configuration"));
+                .contains("Current Configuration"));
     }
 
     @Test
     @Launch({ ShowConfig.NAME, "all" })
     void testShowConfigCommandWithAllShowsAllProfiles(LaunchResult result) {
         Assertions.assertTrue(result.getOutput()
-                .contains("Runtime Configuration"));
+                .contains("Current Configuration"));
         Assertions.assertTrue(result.getOutput()
                 .contains("Quarkus Configuration"));
     }

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ShowConfigCommandDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ShowConfigCommandDistTest.java
@@ -1,0 +1,31 @@
+package org.keycloak.it.cli.dist;
+
+import org.junit.jupiter.api.Test;
+import org.keycloak.it.junit5.extension.CLIResult;
+import org.keycloak.it.junit5.extension.DistributionTest;
+import org.keycloak.it.junit5.extension.RawDistOnly;
+import org.keycloak.it.utils.KeycloakDistribution;
+
+@DistributionTest
+public class ShowConfigCommandDistTest {
+
+    @Test
+    @RawDistOnly(reason = "Containers are immutable")
+    void testShowConfigPicksUpRightConfigDependingOnCurrentMode(KeycloakDistribution distribution) {
+        CLIResult initialResult = distribution.run("show-config");
+        initialResult.assertMessage("Current Mode: production");
+        initialResult.assertMessage("kc.http-enabled =  false");
+
+        distribution.run("start-dev");
+
+        CLIResult devModeResult = distribution.run("show-config");
+        devModeResult.assertMessage("Current Mode: development");
+        devModeResult.assertMessage("kc.http-enabled =  true");
+
+        distribution.run("build");
+
+        CLIResult resetResult = distribution.run("show-config");
+        resetResult.assertMessage("Current Mode: production");
+        resetResult.assertMessage("kc.http-enabled =  false");
+    }
+}


### PR DESCRIPTION
…ig when in dev-mode.

also removes unnecessary internal and self-referencing values from output (and the unused isQuarkusPropertiesEnabled code)

Closes #9525

