### PR TITLE
Ensure prompt=none is forwarded when a prompt is also specified in the IDP config

### DIFF
--- a/services/src/main/java/org/keycloak/broker/oidc/AbstractOAuth2IdentityProvider.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/AbstractOAuth2IdentityProvider.java
@@ -22,6 +22,7 @@ import org.jboss.logging.Logger;
 import org.jboss.resteasy.spi.HttpRequest;
 import org.keycloak.OAuth2Constants;
 import org.keycloak.OAuthErrorException;
+import org.keycloak.authentication.AuthenticationProcessor;
 import org.keycloak.broker.provider.AbstractIdentityProvider;
 import org.keycloak.broker.provider.AuthenticationRequest;
 import org.keycloak.broker.provider.BrokeredIdentityContext;
@@ -335,7 +336,8 @@ public abstract class AbstractOAuth2IdentityProvider<C extends OAuth2IdentityPro
             uriBuilder.queryParam(OIDCLoginProtocol.UI_LOCALES_PARAM, session.getContext().resolveLocale(null).toLanguageTag());
         }
 
-        String prompt = getConfig().getPrompt();
+        boolean forwardedPassiveLogin = "true".equals(request.getAuthenticationSession().getAuthNote(AuthenticationProcessor.FORWARDED_PASSIVE_LOGIN));
+        String prompt = forwardedPassiveLogin ? "none" : getConfig().getPrompt();
         if (prompt == null || prompt.isEmpty()) {
             prompt = request.getAuthenticationSession().getClientNote(OAuth2Constants.PROMPT);
         }


### PR DESCRIPTION
Resolves #12469

This modifies `AbstractOAuth2IdentityProvider#createAuthorizationUrl()` to check if `FORWARDED_PASSIVE_LOGIN` was set by an authenticator while appending the `prompt` query parameter.

This value should only be true when both the application-supplied param is "none" and the IDP is configured to forward prompt=none.

https://github.com/keycloak/keycloak/blob/442eff01691c5dba44ee334c0ae3652921080187/services/src/main/java/org/keycloak/authentication/authenticators/browser/IdentityProviderAuthenticator.java#L92-L96