### PR TITLE
Fix test failure in X509BrowserCRLTest on IBM JDK. Don't display deta…

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/x509/X509ClientCertificateAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/x509/X509ClientCertificateAuthenticator.java
@@ -96,7 +96,7 @@ public class X509ClientCertificateAuthenticator extends AbstractX509ClientCertif
                 String errorMessage = "Certificate validation's failed.";
                 // TODO is calling form().setErrors enough to show errors on login screen?
                 context.challenge(createErrorResponse(context, certs[0].getSubjectDN().getName(),
-                        errorMessage, e.getMessage()));
+                        errorMessage, "Certificate revoked or incorrect."));
                 context.attempted();
                 return;
             }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/x509/X509BrowserCRLTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/x509/X509BrowserCRLTest.java
@@ -136,7 +136,7 @@ public class X509BrowserCRLTest extends AbstractX509AuthenticationTest {
         Assert.assertNotNull(cfgId);
 
         // Verify there is an error message because of invalid CRL signature
-        assertLoginFailedWithExpectedX509Error("Certificate validation's failed.\nSignature length not correct");
+        assertLoginFailedWithExpectedX509Error("Certificate validation's failed.\nCertificate revoked or incorrect.");
     }
 
 
@@ -194,7 +194,7 @@ public class X509BrowserCRLTest extends AbstractX509AuthenticationTest {
 
 
     private void assertLoginFailedDueRevokedCertificate() {
-        assertLoginFailedWithExpectedX509Error("Certificate validation's failed.\nCertificate has been revoked, certificate's subject:");
+        assertLoginFailedWithExpectedX509Error("Certificate validation's failed.\nCertificate revoked or incorrect.");
     }
 
     private void assertLoginFailedWithExpectedX509Error(String expectedError) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/x509/X509BrowserLoginTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/x509/X509BrowserLoginTest.java
@@ -106,7 +106,7 @@ public class X509BrowserLoginTest extends AbstractX509AuthenticationTest {
         loginConfirmationPage.open();
 
         Assert.assertThat(loginPage.getError(), containsString("Certificate validation's failed.\n" +
-                "Key Usage bit 'dataEncipherment' is not set."));
+                "Certificate revoked or incorrect."));
     }
 
     @Test


### PR DESCRIPTION
…ils of exception message to the end user

Closes #12458

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
