### PR TITLE
`KerberosLdapTest` is failing on Undertow

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1718,7 +1718,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.0.0-M6</version>
+                    <version>3.0.0-M7</version>
                     <configuration>
                         <forkMode>once</forkMode>
                         <argLine>-Djava.awt.headless=true ${surefire.memory.settings} ${surefire.system.args} -Duser.language=en -Duser.region=US</argLine>

--- a/quarkus/pom.xml
+++ b/quarkus/pom.xml
@@ -67,7 +67,8 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
 
-        <surefire-plugin.version>3.0.0-M6</surefire-plugin.version>
+        <!-- Needs to be aligned with Quarkus, see e.g. https://github.com/quarkusio/quarkus-quickstarts/blob/2.7.6.Final/getting-started-async/pom.xml#L14 -->
+        <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Closes #12504

The root cause appears to be [SUREFIRE-2076](https://issues.apache.org/jira/browse/SUREFIRE-2076).