### PR TITLE
Possibility to switch between FIPS and non-FIPS during keycloak+quarkus seerver build

### DIFF
--- a/core/src/main/java/org/keycloak/crypto/integration/CryptoIntegration.java
+++ b/core/src/main/java/org/keycloak/crypto/integration/CryptoIntegration.java
@@ -1,0 +1,47 @@
+package org.keycloak.crypto.integration;
+
+import org.jboss.logging.Logger;
+import org.keycloak.common.util.BouncyIntegration;
+import org.keycloak.common.util.reflections.Reflections;
+
+/**
+ * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
+ */
+public class CryptoIntegration {
+
+    protected static final Logger logger = Logger.getLogger(CryptoIntegration.class);
+
+    private static volatile CryptoProvider securityProvider;
+
+    public static CryptoProvider getProvider() {
+        if (securityProvider == null) {
+            securityProvider = detectProvider();
+            logger.infof("Detected security provider: %s", securityProvider);
+        }
+        return securityProvider;
+    }
+
+
+    // This can be possibly set by the configuration (SPI) to override the "detected" instance
+    public static void setProvider(CryptoProvider provider) {
+        securityProvider = provider;
+    }
+
+
+    // Try to auto-detect provider. Currently autodetected based on whether we have BC or BCFIPS on the classpath. Should be probably improved and rather
+    // detected based on the system security settings or with ServiceLoader etc. Ideally, the BouncyCastle implementation should be chosen based on the SecurityProvider rather than vice-versa.
+    private static CryptoProvider detectProvider() {
+        if (BouncyIntegration.PROVIDER.equals("BCFIPS")) {
+            try {
+                // TODO This may not work on Wildfly (assuming FIPS module will be different Wildfly module than keycloak-core). May need to be improved (EG. with usage of org.keycloak.platform.Platform)
+                Class<CryptoProvider> clazz = Reflections.classForName("org.keycloak.crypto.fips.FIPS1402Provider", CryptoIntegration.class.getClassLoader());
+                return clazz.newInstance();
+            } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
+                throw new RuntimeException("Exception when trying to create FIPS provider. Thread classloader: " + Thread.currentThread().getContextClassLoader(), e);
+            }
+        } else {
+            return new DefaultCryptoProvider();
+        }
+    }
+
+}

--- a/core/src/main/java/org/keycloak/crypto/integration/CryptoProvider.java
+++ b/core/src/main/java/org/keycloak/crypto/integration/CryptoProvider.java
@@ -1,0 +1,22 @@
+package org.keycloak.crypto.integration;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.SecureRandom;
+
+import org.keycloak.jose.jwe.alg.JWEAlgorithmProvider;
+
+/**
+ * Abstraction to handle differences between the APIs for non-fips and fips mode
+ *
+ * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
+ */
+public interface CryptoProvider {
+
+    /**
+     * @return secureRandom implementation based on the available security algorithms according to environment (FIPS non-fips)
+     */
+    SecureRandom getSecureRandom() throws NoSuchAlgorithmException, NoSuchProviderException;
+
+    JWEAlgorithmProvider getAesKeyWrapAlgorithmProvider();
+}

--- a/core/src/main/java/org/keycloak/crypto/integration/DefaultCryptoProvider.java
+++ b/core/src/main/java/org/keycloak/crypto/integration/DefaultCryptoProvider.java
@@ -1,0 +1,23 @@
+package org.keycloak.crypto.integration;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+
+import org.keycloak.jose.jwe.alg.AesKeyWrapAlgorithmProvider;
+import org.keycloak.jose.jwe.alg.JWEAlgorithmProvider;
+
+/**
+ * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
+ */
+public class DefaultCryptoProvider implements CryptoProvider {
+
+    @Override
+    public SecureRandom getSecureRandom() throws NoSuchAlgorithmException {
+        return SecureRandom.getInstance("SHA1PRNG");
+    }
+
+    @Override
+    public JWEAlgorithmProvider getAesKeyWrapAlgorithmProvider() {
+        return new AesKeyWrapAlgorithmProvider();
+    }
+}

--- a/core/src/main/java/org/keycloak/jose/jwe/JWERegistry.java
+++ b/core/src/main/java/org/keycloak/jose/jwe/JWERegistry.java
@@ -20,7 +20,7 @@ package org.keycloak.jose.jwe;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.keycloak.jose.jwe.alg.AesKeyWrapAlgorithmProvider;
+import org.keycloak.crypto.integration.CryptoIntegration;
 import org.keycloak.jose.jwe.alg.DirectAlgorithmProvider;
 import org.keycloak.jose.jwe.alg.JWEAlgorithmProvider;
 import org.keycloak.jose.jwe.alg.RsaKeyEncryption256JWEAlgorithmProvider;
@@ -47,7 +47,7 @@ class JWERegistry {
     static {
         // Provider 'dir' just directly uses encryption keys for encrypt/decrypt content.
         ALG_PROVIDERS.put(JWEConstants.DIR, new DirectAlgorithmProvider());
-        ALG_PROVIDERS.put(JWEConstants.A128KW, new AesKeyWrapAlgorithmProvider());
+        ALG_PROVIDERS.put(JWEConstants.A128KW, CryptoIntegration.getProvider().getAesKeyWrapAlgorithmProvider());
         ALG_PROVIDERS.put(JWEConstants.RSA_OAEP, new RsaKeyEncryptionJWEAlgorithmProvider("RSA/ECB/OAEPWithSHA-1AndMGF1Padding"));
         ALG_PROVIDERS.put(JWEConstants.RSA_OAEP_256, new RsaKeyEncryption256JWEAlgorithmProvider("RSA/ECB/OAEPWithSHA-256AndMGF1Padding"));
 

--- a/core/src/test/java/org/keycloak/jose/jwk/JWKTest.java
+++ b/core/src/test/java/org/keycloak/jose/jwk/JWKTest.java
@@ -25,6 +25,7 @@ import org.keycloak.common.util.BouncyIntegration;
 import org.keycloak.common.util.KeyUtils;
 import org.keycloak.common.util.PemUtils;
 import org.keycloak.crypto.JavaAlgorithm;
+import org.keycloak.crypto.integration.CryptoIntegration;
 import org.keycloak.util.JsonSerialization;
 
 import java.nio.charset.StandardCharsets;
@@ -33,7 +34,6 @@ import java.security.KeyPairGenerator;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.SecureRandom;
-import java.security.Security;
 import java.security.Signature;
 import java.security.cert.X509Certificate;
 import java.security.interfaces.ECPublicKey;
@@ -130,7 +130,7 @@ public class JWKTest {
     @Test
     public void publicEs256() throws Exception {
         KeyPairGenerator keyGen = KeyPairGenerator.getInstance("EC", BouncyIntegration.PROVIDER);
-        SecureRandom randomGen = SecureRandom.getInstance("SHA1PRNG");
+        SecureRandom randomGen = CryptoIntegration.getProvider().getSecureRandom();
         ECGenParameterSpec ecSpec = new ECGenParameterSpec("secp256r1");
         keyGen.initialize(ecSpec, randomGen);
         KeyPair keyPair = keyGen.generateKeyPair();

--- a/crypto/fips1402/pom.xml
+++ b/crypto/fips1402/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0"?>
+<!--
+  ~ Copyright 2022 Red Hat, Inc. and/or its affiliates
+  ~ and other contributors as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <parent>
+        <artifactId>keycloak-crypto-parent</artifactId>
+        <groupId>org.keycloak</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>keycloak-fips1402</artifactId>
+    <name>Keycloak FIPS 140-2 Integration</name>
+    <description/>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-core</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcprov-jdk15on</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcpkix-jdk15on</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bc-fips</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bctls-fips</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-fips</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/crypto/fips1402/src/main/java/org/keycloak/crypto/fips/FIPS1402Provider.java
+++ b/crypto/fips1402/src/main/java/org/keycloak/crypto/fips/FIPS1402Provider.java
@@ -1,0 +1,27 @@
+package org.keycloak.crypto.fips;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.SecureRandom;
+
+import org.keycloak.crypto.integration.CryptoProvider;
+import org.keycloak.jose.jwe.alg.JWEAlgorithmProvider;
+
+
+/**
+ * Integration based on FIPS 140-2
+ *
+ * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
+ */
+public class FIPS1402Provider implements CryptoProvider {
+
+    @Override
+    public SecureRandom getSecureRandom() throws NoSuchAlgorithmException, NoSuchProviderException {
+        return SecureRandom.getInstance("DEFAULT","BCFIPS");
+    }
+
+    @Override
+    public JWEAlgorithmProvider getAesKeyWrapAlgorithmProvider() {
+        return new FIPSAesKeyWrapAlgorithmProvider();
+    }
+}

--- a/crypto/fips1402/src/main/java/org/keycloak/crypto/fips/FIPSAesKeyWrapAlgorithmProvider.java
+++ b/crypto/fips1402/src/main/java/org/keycloak/crypto/fips/FIPSAesKeyWrapAlgorithmProvider.java
@@ -1,0 +1,37 @@
+package org.keycloak.crypto.fips;
+
+import java.security.Key;
+
+import org.bouncycastle.crypto.KeyUnwrapper;
+import org.bouncycastle.crypto.KeyWrapper;
+import org.bouncycastle.crypto.SymmetricKey;
+import org.bouncycastle.crypto.SymmetricSecretKey;
+import org.bouncycastle.crypto.fips.FipsAES;
+import org.keycloak.jose.jwe.JWEKeyStorage;
+import org.keycloak.jose.jwe.alg.JWEAlgorithmProvider;
+import org.keycloak.jose.jwe.enc.JWEEncryptionProvider;
+
+/**
+ * Variant of {@link org.keycloak.jose.jwe.alg.AesKeyWrapAlgorithmProvider} based on FIPS
+ */
+public class FIPSAesKeyWrapAlgorithmProvider implements JWEAlgorithmProvider {
+
+    @Override
+    public byte[] decodeCek(byte[] encodedCek, Key encryptionKey) throws Exception {
+        byte[] keyBytes = encryptionKey.getEncoded(); // bytes making up AES key doing the wrapping
+        SymmetricKey aesKey = new SymmetricSecretKey(FipsAES.KW, keyBytes);
+        FipsAES.KeyWrapOperatorFactory factory = new FipsAES.KeyWrapOperatorFactory();
+        KeyUnwrapper unwrapper = factory.createKeyUnwrapper(aesKey, FipsAES.KW);
+        return unwrapper.unwrap(encodedCek, 0, encodedCek.length);
+    }
+
+    @Override
+    public byte[] encodeCek(JWEEncryptionProvider encryptionProvider, JWEKeyStorage keyStorage, Key encryptionKey) throws Exception {
+        byte[] inputKeyBytes = keyStorage.getCekBytes(); // bytes making up the key to be wrapped
+        byte[] keyBytes = encryptionKey.getEncoded(); // bytes making up AES key doing the wrapping
+        SymmetricKey aesKey = new SymmetricSecretKey(FipsAES.KW, keyBytes);
+        FipsAES.KeyWrapOperatorFactory factory = new FipsAES.KeyWrapOperatorFactory();
+        KeyWrapper wrapper = factory.createKeyWrapper(aesKey, FipsAES.KW);
+        return wrapper.wrap(inputKeyBytes, 0, inputKeyBytes.length);
+    }
+}

--- a/crypto/fips1402/src/main/resources/META-INF/services/org.keycloak.crypto.integration.CryptoProvider
+++ b/crypto/fips1402/src/main/resources/META-INF/services/org.keycloak.crypto.integration.CryptoProvider
@@ -1,0 +1,18 @@
+#
+# Copyright 2022 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.keycloak.crypto.fips.FIPS1402Provider

--- a/crypto/fips1402/src/test/java/org/keycloak/crypto/fips/test/FIPS1402UnitTest.java
+++ b/crypto/fips1402/src/test/java/org/keycloak/crypto/fips/test/FIPS1402UnitTest.java
@@ -1,0 +1,25 @@
+package org.keycloak.crypto.fips.test;
+
+import java.security.SecureRandom;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.keycloak.crypto.fips.FIPSAesKeyWrapAlgorithmProvider;
+import org.keycloak.crypto.integration.CryptoIntegration;
+import org.keycloak.jose.jwe.alg.JWEAlgorithmProvider;
+
+/**
+ * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
+ */
+public class FIPS1402UnitTest {
+
+
+    @Test
+    public void testFips() throws Exception {
+        JWEAlgorithmProvider jweAlg = CryptoIntegration.getProvider().getAesKeyWrapAlgorithmProvider();
+        Assert.assertEquals(jweAlg.getClass(), FIPSAesKeyWrapAlgorithmProvider.class);
+
+        SecureRandom scr = CryptoIntegration.getProvider().getSecureRandom();
+        Assert.assertEquals("BCFIPS", scr.getProvider().getName());
+    }
+}

--- a/crypto/pom.xml
+++ b/crypto/pom.xml
@@ -1,0 +1,36 @@
+<!--
+  ~ Copyright 2022 Red Hat, Inc. and/or its affiliates
+  ~ and other contributors as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <parent>
+        <artifactId>keycloak-parent</artifactId>
+        <groupId>org.keycloak</groupId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <name>Keycloak Crypto Parent</name>
+    <description/>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>keycloak-crypto-parent</artifactId>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>fips1402</module>
+    </modules>
+</project>

--- a/docs/fips.md
+++ b/docs/fips.md
@@ -1,0 +1,38 @@
+FIPS 140-2 Integration
+======================
+
+Build with FIPS
+---------------
+
+With OpenJDK 11 on the classpath, run this from the project root directory:
+
+```
+mvn clean install -DskipTests=true -Dfips140-2 -Pquarkus
+```
+The property `fips140-2` is used to trigger maven profile to build keycloak+quarkus distribution with `bouncycastle-fips` dependencies instead of plain `bouncycastle`
+and also with `keycloak-fips140-2` module containing some security code dependent on bouncycastle-fips APIs.
+
+Then unzip and check only bouncycastle-fips libraries are inside "lib" directory:
+```
+tar xf $KEYCLOAK_SOURCES/quarkus/dist/target/keycloak-999-SNAPSHOT.tar.gz
+ls keycloak-999-SNAPSHOT/lib/lib/main/org.bouncycastle.bc*
+```
+Output should be something like:
+```
+keycloak-999-SNAPSHOT/lib/lib/main/org.bouncycastle.bc-fips-1.0.2.jar      keycloak-999-SNAPSHOT/lib/lib/main/org.bouncycastle.bctls-fips-1.0.11.jar
+keycloak-999-SNAPSHOT/lib/lib/main/org.bouncycastle.bcpkix-fips-1.0.3.jar
+```
+
+Similarly the JAR keycloak-fips-integration should be available:
+```
+ls keycloak-999-SNAPSHOT/lib/lib/main/org.keycloak.keycloak-fips-integration-999-SNAPSHOT.jar
+```
+
+Now run the server on the FIPS enabled machine with FIPS-enabled OpenJDK (Tested on RHEL 8.6):
+```
+cd keycloak-999-SNAPSHOT/bin
+./kc.sh start-dev
+```
+
+NOTE: Right now, server should start, and I am able to create admin user on `http://localhost:8080`, but I am not able to finish
+login to the admin console. However the Keycloak uses bouncycastle-fips libraries and the `CryptoIntegration` uses `FIPS1402Provider`. More fixes are required to have Keycloak server working...

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,12 @@
         <apache.mime4j.version>0.6</apache.mime4j.version>
         <jboss.dmr.version>1.5.1.Final</jboss.dmr.version>
         <bouncycastle.version>1.68</bouncycastle.version>
+
+        <!-- TODO Are these correct versions? -->
+        <bouncycastle.fips.version>1.0.2</bouncycastle.fips.version>
+        <bouncycastle.pkixfips.version>1.0.3</bouncycastle.pkixfips.version>
+        <bouncycastle.tlsfips.version>1.0.11</bouncycastle.tlsfips.version>
+
         <cxf.version>3.3.10</cxf.version>
         <cxf.jetty.version>3.3.10</cxf.jetty.version>
         <cxf.jaxrs.version>3.3.10</cxf.jaxrs.version>
@@ -264,6 +270,7 @@
         <module>boms</module>
         <module>common</module>
         <module>core</module>
+        <module>crypto</module>
         <module>dependencies</module>
         <module>docs</module>
         <module>server-spi</module>
@@ -355,6 +362,21 @@
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bcpkix-jdk15on</artifactId>
                 <version>${bouncycastle.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bc-fips</artifactId>
+                <version>${bouncycastle.fips.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bctls-fips</artifactId>
+                <version>${bouncycastle.tlsfips.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcpkix-fips</artifactId>
+                <version>${bouncycastle.pkixfips.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.github.ua-parser</groupId>
@@ -1559,6 +1581,11 @@
             <dependency>
                 <groupId>org.keycloak</groupId>
                 <artifactId>keycloak-client-registration-cli</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.keycloak</groupId>
+                <artifactId>keycloak-fips1402</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -77,9 +77,9 @@
         <bouncycastle.version>1.68</bouncycastle.version>
 
         <!-- TODO Are these correct versions? -->
-        <bouncycastle.fips.version>1.0.2</bouncycastle.fips.version>
-        <bouncycastle.pkixfips.version>1.0.3</bouncycastle.pkixfips.version>
-        <bouncycastle.tlsfips.version>1.0.11</bouncycastle.tlsfips.version>
+        <bouncycastle.fips.version>1.0.2.3</bouncycastle.fips.version>
+        <bouncycastle.pkixfips.version>1.0.5</bouncycastle.pkixfips.version>
+        <bouncycastle.tlsfips.version>1.0.12.2</bouncycastle.tlsfips.version>
 
         <cxf.version>3.3.10</cxf.version>
         <cxf.jetty.version>3.3.10</cxf.jetty.version>

--- a/quarkus/runtime/pom.xml
+++ b/quarkus/runtime/pom.xml
@@ -363,26 +363,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-jdk15on</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk15on</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-server-hotrod</artifactId>
             <version>${infinispan.version}</version>
@@ -574,6 +554,88 @@
                 <dependency>
                     <groupId>org.keycloak</groupId>
                     <artifactId>keycloak-admin-ui</artifactId>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <profile>
+            <id>crypto-default</id>
+            <activation>
+                <property>
+                    <name>!fips140-2</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcpkix-jdk15on</artifactId>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcprov-jdk15on</artifactId>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <profile>
+            <id>fips140-2</id>
+            <activation>
+                <property>
+                    <name>fips140-2</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.keycloak</groupId>
+                    <artifactId>keycloak-fips1402</artifactId>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bc-fips</artifactId>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bctls-fips</artifactId>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcpkix-fips</artifactId>
                     <exclusions>
                         <exclusion>
                             <groupId>*</groupId>

--- a/quarkus/runtime/pom.xml
+++ b/quarkus/runtime/pom.xml
@@ -606,42 +606,6 @@
                 <dependency>
                     <groupId>org.keycloak</groupId>
                     <artifactId>keycloak-fips1402</artifactId>
-                    <exclusions>
-                        <exclusion>
-                            <groupId>*</groupId>
-                            <artifactId>*</artifactId>
-                        </exclusion>
-                    </exclusions>
-                </dependency>
-                <dependency>
-                    <groupId>org.bouncycastle</groupId>
-                    <artifactId>bc-fips</artifactId>
-                    <exclusions>
-                        <exclusion>
-                            <groupId>*</groupId>
-                            <artifactId>*</artifactId>
-                        </exclusion>
-                    </exclusions>
-                </dependency>
-                <dependency>
-                    <groupId>org.bouncycastle</groupId>
-                    <artifactId>bctls-fips</artifactId>
-                    <exclusions>
-                        <exclusion>
-                            <groupId>*</groupId>
-                            <artifactId>*</artifactId>
-                        </exclusion>
-                    </exclusions>
-                </dependency>
-                <dependency>
-                    <groupId>org.bouncycastle</groupId>
-                    <artifactId>bcpkix-fips</artifactId>
-                    <exclusions>
-                        <exclusion>
-                            <groupId>*</groupId>
-                            <artifactId>*</artifactId>
-                        </exclusion>
-                    </exclusions>
                 </dependency>
             </dependencies>
         </profile>


### PR DESCRIPTION
This prototype PR handles:

- Build Keycloak quarkus distribution either with the plain `bouncycastle` dependencies (same behaviour as current Keycloak) or with `bouncycastle-fips` dependencies

- PR introduces the `SecurityProvider` interface to handle differences between bouncycastle APIs. As sometimes the code and API calls may need to be different according to if you use `bouncycastle` or `bouncycastle-fips` dependencies. The default implementation is still use the  code dependent on the `bouncycastle` . So this PR should not break anything (hopefully) as the default implementation uses same behaviour as current Keycloak upstream (so non-fips by default).

- PR introduces `keycloak-fips-integration` module with the implementation of `SecurityProvider` using `bouncycastle-fips` . So the idea is, that for all the codes, where the differences are between the calls to `bouncycastle` and `bouncycastle-fips`, the new method will be introduced to the `SecurityProvider` . The module `keycloak-fips-integration` has dependencies on the `bouncycastle-fips` libraries.

- The maven profile is introduced in the `quarkus` module to allow building with FIPS. By default, project is built with non-fips based profile, however there is possibility to build with the `fips` profile, which will add the `bouncycastle-fips` dependencies and the new module `keycloak-fips-integration` to the keycloak + quarkus. The instructions on how to build keycloak+quarkus with bouncycastle-fips is described in the README inside docs/fips.md
