### PR TITLE
DB migration tests execution for Quarkus

### DIFF
--- a/testsuite/integration-arquillian/HOW-TO-RUN.md
+++ b/testsuite/integration-arquillian/HOW-TO-RUN.md
@@ -278,7 +278,7 @@ Run the test (Update according to your DB connection, versions etc):
 
     mvn -B -f testsuite/integration-arquillian/pom.xml \
       clean install \
-      -Pjpa,auth-server-wildfly,db-mariadb,auth-server-migration \
+      -Pjpa,auth-server-wildfly,db-mariadb,auth-server-migration-legacy \
       -Dauth.server.jboss.startup.timeout=900 \
       -Dtest=MigrationTest \
       -Dmigration.mode=auto \

--- a/testsuite/integration-arquillian/servers/migration/assembly.xml
+++ b/testsuite/integration-arquillian/servers/migration/assembly.xml
@@ -17,7 +17,7 @@
 
 <assembly>
     
-    <id>auth-server-migration-${migrated.auth.server.version}</id>
+    <id>${auth.server.output.directory}-${migrated.auth.server.version}</id>
 
     <formats>
         <format>zip</format>
@@ -28,14 +28,14 @@
     <fileSets>
         <fileSet>
             <directory>${auth.server.home}</directory>
-            <outputDirectory>auth-server-migration</outputDirectory>
+            <outputDirectory>${auth.server.output.directory}</outputDirectory>
             <excludes>
                 <exclude>**/*.sh</exclude>
             </excludes>
         </fileSet>
         <fileSet>
             <directory>${auth.server.home}</directory>
-            <outputDirectory>auth-server-migration</outputDirectory>
+            <outputDirectory>${auth.server.output.directory}</outputDirectory>
             <includes>
                 <include>**/*.sh</include>
             </includes>

--- a/testsuite/integration-arquillian/servers/migration/legacy/pom.xml
+++ b/testsuite/integration-arquillian/servers/migration/legacy/pom.xml
@@ -1,0 +1,154 @@
+<?xml version="1.0"?>
+<!--
+~ Copyright 2022 Red Hat, Inc. and/or its affiliates
+~ and other contributors as indicated by the @author tags.
+~
+~ Licensed under the Apache License, Version 2.0 (the "License");
+~ you may not use this file except in compliance with the License.
+~ You may obtain a copy of the License at
+~
+~ http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing, software
+~ distributed under the License is distributed on an "AS IS" BASIS,
+~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~ See the License for the specific language governing permissions and
+~ limitations under the License.
+-->
+
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <parent>
+        <groupId>org.keycloak.testsuite</groupId>
+        <artifactId>integration-arquillian-migration-server-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>integration-arquillian-migration-server-legacy</artifactId>
+    <packaging>pom</packaging>
+    <name>Migration Server Legacy</name>
+
+    <properties>
+        <common.resources>${basedir}/../../auth-server/jboss/common</common.resources>
+        <ant.scenario>scenario-standalone</ant.scenario>
+        <auth.server.dist.artifactId>keycloak-server-dist</auth.server.dist.artifactId>
+        <auth.server.output.directory>auth-server-migration-legacy</auth.server.output.directory>
+
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-keystore</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${auth.server.home}/standalone/configuration</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${common.resources}/keystore</directory>
+                                    <includes>
+                                        <include>keycloak.jks</include>
+                                        <include>keycloak.truststore</include>
+                                    </includes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>configure-server-jpa</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <ant antfile="${common.resources}/ant/configure.xml" target="configure-server-jpa-legacy">
+                                    <!-- These properties become equivalent to properties defined on the command line. -->
+                                    <!-- Without specifying those the default values would be used regardless what is -->
+                                    <!-- defined via -Dproperty=value when executing maven command -->
+                                    <property name="jdbc.driver.tmp.dir">${jdbc.driver.tmp.dir}</property>
+                                    <property name="jdbc.mvn.artifactId">${jdbc.mvn.artifactId}</property>
+                                    <property name="jdbc.mvn.version">${jdbc.mvn.version}</property>
+                                    <property name="keycloak.connectionsJpa.url">${keycloak.connectionsJpa.url}</property>
+                                    <property name="keycloak.connectionsJpa.user">${keycloak.connectionsJpa.user}</property>
+                                    <property name="keycloak.connectionsJpa.password">${keycloak.connectionsJpa.password}</property>
+                                    <property name="keycloak.connectionsJpa.schema">${keycloak.connectionsJpa.schema}</property>
+                                </ant>
+                            </target>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>inject-truststore</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <ant antfile="${common.resources}/ant/configure.xml" target="inject-truststore" />
+                            </target>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>ant-apply-prepared-clis</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <ant antfile="${common.resources}/ant/configure.xml" target="apply-cli-scripts" />
+                            </target>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <!-- to workaround the fact that in older wildlfy/eap versions was missing the option -->
+                        <!-- 'module-root-dir' when adding module we need to move it manually afterwards -->
+                        <id>move-driver-module</id>
+                        <phase>process-test-resources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <move file="${auth.server.home}/modules/test" todir="${auth.server.home}/modules/system/layers/base/" verbose="true" />
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>create-zip</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>../assembly.xml</descriptor>
+                            </descriptors>
+                            <appendAssemblyId>false</appendAssemblyId>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/testsuite/integration-arquillian/servers/migration/pom.xml
+++ b/testsuite/integration-arquillian/servers/migration/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-~ Copyright 2016 Red Hat, Inc. and/or its affiliates
+~ Copyright 2022 Red Hat, Inc. and/or its affiliates
 ~ and other contributors as indicated by the @author tags.
 ~
 ~ Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,14 +25,14 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>integration-arquillian-migration-server</artifactId>
+    <artifactId>integration-arquillian-migration-server-parent</artifactId>
+    <name>Migration Server Parent</name>
     <packaging>pom</packaging>
-    <name>Migration Server</name>
 
     <properties>
-        <common.resources>${basedir}/../auth-server/jboss/common</common.resources>
-        <ant.scenario>scenario-standalone</ant.scenario>
-        <auth.server.home>${project.build.directory}/unpacked/keycloak-${migrated.auth.server.version}</auth.server.home>
+        <auth.server.home>${project.build.directory}/unpacked/keycloak-${migrated.auth.server.version}
+        </auth.server.home>
+        <auth.server.dist.artifactId>keycloak-quarkus-dist</auth.server.dist.artifactId>
         <jdbc.driver.tmp.dir>${project.build.directory}/jdbc-driver</jdbc.driver.tmp.dir>
     </properties>
 
@@ -101,7 +101,7 @@
                             <artifactItems>
                                 <artifactItem>
                                     <groupId>org.keycloak</groupId>
-                                    <artifactId>keycloak-server-dist</artifactId>
+                                    <artifactId>${auth.server.dist.artifactId}</artifactId>
                                     <version>${migrated.auth.server.version}</version>
                                     <type>zip</type>
                                     <outputDirectory>${project.build.directory}/unpacked</outputDirectory>
@@ -130,120 +130,30 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <artifactId>maven-resources-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>copy-keystore</id>
-                        <phase>process-resources</phase>
-                        <goals>
-                            <goal>copy-resources</goal>
-                        </goals>
-                        <configuration>
-                            <outputDirectory>${auth.server.home}/standalone/configuration</outputDirectory>
-                            <resources>
-                                <resource>
-                                    <directory>${common.resources}/keystore</directory>
-                                    <includes>
-                                        <include>keycloak.jks</include>
-                                        <include>keycloak.truststore</include>
-                                    </includes>
-                                </resource>
-                            </resources>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-antrun-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>configure-server-jpa</id>
-                        <phase>generate-resources</phase>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                        <configuration>
-                            <target>
-                                <ant antfile="${common.resources}/ant/configure.xml" target="configure-server-jpa-legacy">
-                                    <!-- These properties become equivalent to properties defined on the command line. -->
-                                    <!-- Without specifying those the default values would be used regardless what is -->
-                                    <!-- defined via -Dproperty=value when executing maven command -->
-                                    <property name="jdbc.driver.tmp.dir">${jdbc.driver.tmp.dir}</property>
-                                    <property name="jdbc.mvn.artifactId">${jdbc.mvn.artifactId}</property>
-                                    <property name="jdbc.mvn.version">${jdbc.mvn.version}</property>
-                                    <property name="keycloak.connectionsJpa.url">${keycloak.connectionsJpa.url}</property>
-                                    <property name="keycloak.connectionsJpa.user">${keycloak.connectionsJpa.user}</property>
-                                    <property name="keycloak.connectionsJpa.password">${keycloak.connectionsJpa.password}</property>
-                                    <property name="keycloak.connectionsJpa.schema">${keycloak.connectionsJpa.schema}</property>
-                                </ant>
-                            </target>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>inject-truststore</id>
-                        <phase>generate-resources</phase>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                        <configuration>
-                            <target>
-                                <ant antfile="${common.resources}/ant/configure.xml" target="inject-truststore" />
-                            </target>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>ant-apply-prepared-clis</id>
-                        <phase>process-resources</phase>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                        <configuration>
-                            <target>
-                                <ant antfile="${common.resources}/ant/configure.xml" target="apply-cli-scripts" />
-                            </target>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <!-- to workaround the fact that in older wildlfy/eap versions was missing the option -->
-                        <!-- 'module-root-dir' when adding module we need to move it manually afterwards -->
-                        <id>move-driver-module</id>
-                        <phase>process-test-resources</phase>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                        <configuration>
-                            <target>
-                                <move file="${auth.server.home}/modules/test" todir="${auth.server.home}/modules/system/layers/base/" verbose="true" />
-                            </target>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>create-zip</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>single</goal>
-                        </goals>
-                        <configuration>
-                            <descriptors>
-                                <descriptor>assembly.xml</descriptor>
-                            </descriptors>
-                            <appendAssemblyId>false</appendAssemblyId>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
     
     <profiles>
+        <profile>
+            <id>auth-server-migration-legacy</id>
+            <modules>
+                <module>legacy</module>
+            </modules>
+            <properties>
+                <auth.server.dist.artifactId>keycloak-server-dist</auth.server.dist.artifactId>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>auth-server-migration</id>
+            <modules>
+                <module>quarkus</module>
+            </modules>
+            <properties>
+                <auth.server.dist.artifactId>keycloak-quarkus-dist</auth.server.dist.artifactId>
+            </properties>
+        </profile>
+
         <profile>
             <id>community</id>
             <activation>
@@ -263,6 +173,7 @@
                 </plugins>
             </build>
         </profile>
+
         <profile>
             <id>productized-server</id>
             <activation>

--- a/testsuite/integration-arquillian/servers/migration/quarkus/pom.xml
+++ b/testsuite/integration-arquillian/servers/migration/quarkus/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0"?>
+<!--
+~ Copyright 2022 Red Hat, Inc. and/or its affiliates
+~ and other contributors as indicated by the @author tags.
+~
+~ Licensed under the Apache License, Version 2.0 (the "License");
+~ you may not use this file except in compliance with the License.
+~ You may obtain a copy of the License at
+~
+~ http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing, software
+~ distributed under the License is distributed on an "AS IS" BASIS,
+~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~ See the License for the specific language governing permissions and
+~ limitations under the License.
+-->
+
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <parent>
+        <groupId>org.keycloak.testsuite</groupId>
+        <artifactId>integration-arquillian-migration-server-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>integration-arquillian-migration-server-quarkus</artifactId>
+    <packaging>pom</packaging>
+
+    <name>Migration Server Quarkus</name>
+
+    <properties>
+        <auth.server.dist.artifactId>keycloak-quarkus-dist</auth.server.dist.artifactId>
+        <auth.server.output.directory>auth-server-migration</auth.server.output.directory>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>create-zip</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>../assembly.xml</descriptor>
+                            </descriptors>
+                            <appendAssemblyId>false</appendAssemblyId>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/testsuite/integration-arquillian/servers/pom.xml
+++ b/testsuite/integration-arquillian/servers/pom.xml
@@ -67,6 +67,13 @@
         </profile>
 
         <profile>
+            <id>auth-server-migration-legacy</id>
+            <modules>
+                <module>migration</module>
+            </modules>
+        </profile>
+
+        <profile>
             <id>win</id>
             <activation>
                 <os>

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/AuthServerTestEnricher.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/AuthServerTestEnricher.java
@@ -338,15 +338,15 @@ public class AuthServerTestEnricher {
             // init migratedAuthServerInfo
             for (ContainerInfo container : suiteContext.getContainers()) {
                 // migrated auth server
-                if (container.getQualifier().equals("auth-server-jboss-migration")) {
+                if (container.getQualifier().equals("auth-server-jboss-migration") || container.getQualifier().equals("auth-server-migration")) {
                     updateWithAuthServerInfo(container);
                     suiteContext.setMigratedAuthServerInfo(container);
                 }
             }
             // validate setup
             if (suiteContext.getMigratedAuthServerInfo() == null) {
-                throw new RuntimeException(String.format("Migration test was enabled but no auth server from which to migrate was activated. "
-                        + "A container matching auth-server-jboss-migration needs to be enabled in arquillian.xml."));
+                throw new RuntimeException("Migration test was enabled but no auth server from which to migrate was activated. "
+                        + "A container matching 'auth-server-jboss-migration' or 'auth-server-migration' needs to be enabled in arquillian.xml.");
             }
         }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/resources/arquillian.xml
+++ b/testsuite/integration-arquillian/tests/base/src/test/resources/arquillian.xml
@@ -729,7 +729,7 @@
 
     <container qualifier="auth-server-jboss-migration" mode="manual" >
         <configuration>
-            <property name="enabled">${auth.server.jboss.migration}</property>
+            <property name="enabled">${auth.server.migration.legacy}</property>
             <property name="adapterImplClass">org.jboss.as.arquillian.container.managed.ManagedDeployableContainer</property>
             <property name="jbossHome">${keycloak.migration.home}</property>
             <property name="javaVmArguments">
@@ -745,5 +745,20 @@
             <property name="startupTimeoutInSeconds">${auth.server.jboss.startup.timeout}</property>
         </configuration>
     </container>
-            
+
+    <container qualifier="auth-server-migration" mode="manual">
+        <configuration>
+            <property name="enabled">${auth.server.migration}</property>
+            <property name="adapterImplClass">org.keycloak.testsuite.arquillian.containers.KeycloakQuarkusServerDeployableContainer</property>
+            <property name="bindHttpPortOffset">${auth.server.port.offset}</property>
+            <property name="javaOpts">-Xms512m -Xmx512m -XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=512m -Djava.net.preferIPv4Stack=true</property>
+            <property name="javaVmArguments">
+                ${migration.import.props.previous}
+                ${auth.server.memory.settings}
+                -Dauth.server.db.host=${auth.server.db.host}
+            </property>
+            <property name="managementPort">${auth.server.management.port}</property>
+        </configuration>
+    </container>
+
 </arquillian>

--- a/testsuite/integration-arquillian/tests/pom.xml
+++ b/testsuite/integration-arquillian/tests/pom.xml
@@ -1785,6 +1785,89 @@
         <!-- Profiles for migration tests-->
 
         <profile>
+            <id>auth-server-migration-legacy</id>
+            <properties>
+                <migration.import.file>target/test-classes/migration-test/migration-realm-${migrated.auth.server.version}.json</migration.import.file>
+                <migration.import.props.previous>
+                    -Dkeycloak.migration.action=import
+                    -Dkeycloak.migration.provider=singleFile
+                    -Dkeycloak.migration.file=${migration.import.file}
+                    -Dkeycloak.migration.strategy=OVERWRITE_EXISTING
+                </migration.import.props.previous>
+                <skip.add.user.json>true</skip.add.user.json>
+            </properties>
+            <dependencies>
+            <dependency>
+                <groupId>org.wildfly.arquillian</groupId>
+                <artifactId>wildfly-arquillian-container-managed</artifactId>
+            </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-enforcer-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>enforce</goal>
+                                </goals>
+                                <configuration>
+                                    <rules>
+                                        <requireProperty>
+                                            <property>migrated.auth.server.version</property>
+                                        </requireProperty>
+                                        <requireProperty>
+                                            <property>migration.mode</property>
+                                        </requireProperty>
+                                    </rules>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <artifactId>maven-dependency-plugin</artifactId>
+                            <executions>
+                                <execution>
+                                    <id>unpack-migrated-auth-server-jboss</id>
+                                    <phase>generate-resources</phase>
+                                    <goals>
+                                        <goal>unpack</goal>
+                                    </goals>
+                                    <configuration>
+                                        <artifactItems>
+                                            <artifactItem>
+                                                <groupId>org.keycloak.testsuite</groupId>
+                                                <artifactId>integration-arquillian-migration-server-legacy</artifactId>
+                                                <version>${project.version}</version>
+                                                <type>zip</type>
+                                            </artifactItem>
+                                        </artifactItems>
+                                        <outputDirectory>${containers.home}</outputDirectory>
+                                        <overWriteIfNewer>true</overWriteIfNewer>
+                                    </configuration>
+                                </execution>
+                            </executions>
+                        </plugin>
+                        <plugin>
+                            <artifactId>maven-surefire-plugin</artifactId>
+                            <configuration>
+                                <systemPropertyVariables>
+                                    <migrated.auth.server.version>${migrated.auth.server.version}</migrated.auth.server.version>
+                                    <auth.server.migration.legacy>true</auth.server.migration.legacy>
+                                    <keycloak.migration.home>${containers.home}/auth-server-migration-legacy</keycloak.migration.home>
+                                    <migration.import.props.previous>${migration.import.props.previous}</migration.import.props.previous>
+                                </systemPropertyVariables>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
+
+        <profile>
             <id>auth-server-migration</id>
             <properties>
                 <migration.import.file>target/test-classes/migration-test/migration-realm-${migrated.auth.server.version}.json</migration.import.file>
@@ -1825,7 +1908,7 @@
                             <artifactId>maven-dependency-plugin</artifactId>
                             <executions>
                                 <execution>
-                                    <id>unpack-migrated-auth-server-jboss</id>
+                                    <id>unpack-migrated-auth-server</id>
                                     <phase>generate-resources</phase>
                                     <goals>
                                         <goal>unpack</goal>
@@ -1850,7 +1933,7 @@
                             <configuration>
                                 <systemPropertyVariables>
                                     <migrated.auth.server.version>${migrated.auth.server.version}</migrated.auth.server.version>
-                                    <auth.server.jboss.migration>true</auth.server.jboss.migration>
+                                    <auth.server.migration>true</auth.server.migration>
                                     <keycloak.migration.home>${containers.home}/auth-server-migration</keycloak.migration.home>
                                     <migration.import.props.previous>${migration.import.props.previous}</migration.import.props.previous>
                                 </systemPropertyVariables>


### PR DESCRIPTION
Closes #12524

The quarkus migration server is created, but it's not possible to execute migration tests for Quarkus due to missing realm configuration, which will be added in the follow-up task. 

Pipeline MR: https://keycloak-gitlab.com/keycloak/keycloak-pipeline/-/merge_requests/150

@miquelsi Could you please take a look at it?
