### PR TITLE
Updated URLs for the CRDs

### DIFF
--- a/docs/guides/src/main/operator/installation.adoc
+++ b/docs/guides/src/main/operator/installation.adoc
@@ -39,8 +39,8 @@ To install the operator on a vanilla Kubernetes cluster, you first need to insta
 
 [source,bash,subs="attributes+"]
 ----
-kubectl apply -f https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/{version}/kubernetes/keycloaks.k8s.keycloak.org-v1.yml
-kubectl apply -f https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/{version}/kubernetes/keycloakrealmimports.k8s.keycloak.org-v1.yml
+kubectl apply -f https://raw.githubusercontent.com/keycloak/keycloak/{version}/kubernetes/keycloaks.keycloak.org-v1.yml
+kubectl apply -f https://raw.githubusercontent.com/keycloak/keycloak/{version}/kubernetes/keycloakrealmimports.keycloak.org-v1.yml
 ----
 
 After successfull CRD installation, install the Keycloak Operator deployment by running the following command:


### PR DESCRIPTION
Updated the URLs  to the CRD's used to install the operator on vanilla Kubernetes cluster

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
