### PR TITLE
Fix negative expire values for refresh tokens (#11990)

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
@@ -1077,8 +1077,9 @@ public class TokenManager {
                 clientSessionMaxLifespan = realm.getClientSessionMaxLifespan();
             }
 
+            AuthenticatedClientSessionModel clientSession = clientSessionCtx.getClientSession();
             if (clientSessionMaxLifespan > 0) {
-                int clientSessionMaxExpiration = userSession.getStarted() + clientSessionMaxLifespan;
+                int clientSessionMaxExpiration = clientSession.getTimestamp() + clientSessionMaxLifespan;
                 sessionExpires = sessionExpires < clientSessionMaxExpiration ? sessionExpires : clientSessionMaxExpiration;
             }
 

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/OAuthClient.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/OAuthClient.java
@@ -314,6 +314,13 @@ public class OAuthClient {
         return new AuthorizationEndpointResponse(this);
     }
 
+    public AuthorizationEndpointResponse doSilentLogin() {
+        openLoginForm();
+        WaitUtils.waitForPageToLoad();
+
+        return new AuthorizationEndpointResponse(this);
+    }
+
     public AuthorizationEndpointResponse doLoginSocial(String brokerId, String username, String password) {
         openLoginForm();
         WaitUtils.waitForPageToLoad();


### PR DESCRIPTION
When the client session max lifetime is set shorter than the sso session max lifetime, at the point where the client session gets terminated, the refresh token endpoint returns 400. 

When the user then tries to login again the SSO remembers that there is a session but the resulting refresh token of the token request has a negative expire time.

Now the getRefreshExpiration method correctly uses the clientSession to
calculate the expire time for the refresh token.

Fixes #11990

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
