### PR TITLE
Ignore duplicates in protocolMappers when updating

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
@@ -1667,7 +1667,7 @@ public class RepresentationToModel {
         if (rep.getProtocolMappers() != null) {
             Map<String,ProtocolMapperModel> existingProtocolMappers =
                     resource.getProtocolMappersStream().collect(Collectors.toMap(mapper ->
-                            generateProtocolNameKey(mapper.getProtocol(), mapper.getName()), Function.identity()));
+                            generateProtocolNameKey(mapper.getProtocol(), mapper.getName()), Function.identity(), (prev, curr) -> curr));
 
 
             for (ProtocolMapperRepresentation protocolMapperRepresentation : rep.getProtocolMappers()) {


### PR DESCRIPTION
Resolves #12484 

This PR restores the behavior of the previous implementation:
https://github.com/keycloak/keycloak/blame/e6bd12b174a4346af605d2d54d1d3c22ad0a80a0/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java#L1561
allowing duplicates.

I'm unable to reproduce this issue in the tests:
https://github.com/keycloak/keycloak/blob/e1213714015fa26568a688718a70f1b95b1ee00c/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/ClientTest.java#L825

as, attempting to provide duplicates, always fails earlier in the chain.
