### PR TITLE
Fix slow deletion on `deleteClientSessionsByRealm` and `deleteClientSessionsByUser` when using mysql and mariadb by converting sub-query to join

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/models/jpa/session/PersistentClientSessionEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/session/PersistentClientSessionEntity.java
@@ -30,11 +30,15 @@ import java.io.Serializable;
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
  */
 @NamedQueries({
-        @NamedQuery(name="deleteClientSessionsByRealm", query="delete from PersistentClientSessionEntity sess where sess.userSessionId IN (select u.userSessionId from PersistentUserSessionEntity u where u.realmId = :realmId)"),
+        // sub-query with deletion performs very slow in MySQL/MariaDB databases
+        // It is removed from here and added manually in JpaUtils to give a native implementation if needed
+        // @NamedQuery(name="deleteClientSessionsByRealm", query="delete from PersistentClientSessionEntity sess where sess.userSessionId IN (select u.userSessionId from PersistentUserSessionEntity u where u.realmId = :realmId)"),
         @NamedQuery(name="deleteClientSessionsByClient", query="delete from PersistentClientSessionEntity sess where sess.clientId = :clientId"),
         @NamedQuery(name="deleteClientSessionsByExternalClient", query="delete from PersistentClientSessionEntity sess where sess.clientStorageProvider = :clientStorageProvider and sess.externalClientId = :externalClientId"),
         @NamedQuery(name="deleteClientSessionsByClientStorageProvider", query="delete from PersistentClientSessionEntity sess where sess.clientStorageProvider = :clientStorageProvider"),
-        @NamedQuery(name="deleteClientSessionsByUser", query="delete from PersistentClientSessionEntity sess where sess.userSessionId IN (select u.userSessionId from PersistentUserSessionEntity u where u.userId = :userId)"),
+        // sub-query with deletion performs very slow in MySQL/MariaDB databases
+        // It is removed from here and added manually in JpaUtils to give a native implementation if needed
+        // @NamedQuery(name="deleteClientSessionsByUser", query="delete from PersistentClientSessionEntity sess where sess.userSessionId IN (select u.userSessionId from PersistentUserSessionEntity u where u.userId = :userId)"),
         @NamedQuery(name="deleteClientSessionsByUserSession", query="delete from PersistentClientSessionEntity sess where sess.userSessionId = :userSessionId and sess.offline = :offline"),
         // KEYCLOAK-18842: The deleteExpiredClientSessions performs very slow in MySQL/MariaDB databases
         //                 It is removed from here and added manually in JpaUtils to give a native implementation if needed

--- a/model/jpa/src/main/resources/META-INF/queries-default.properties
+++ b/model/jpa/src/main/resources/META-INF/queries-default.properties
@@ -8,3 +8,11 @@
 deleteExpiredClientSessions=delete from PersistentClientSessionEntity sess where sess.userSessionId IN (\
  select u.userSessionId from PersistentUserSessionEntity u \
  where u.realmId = :realmId AND u.offline = :offline AND u.lastSessionRefresh < :lastSessionRefresh)
+
+deleteClientSessionsByRealm=delete from PersistentClientSessionEntity sess where sess.userSessionId IN (\
+  select u.userSessionId from PersistentUserSessionEntity u \
+  where u.realmId = :realmId)
+
+deleteClientSessionsByUser=delete from PersistentClientSessionEntity sess where sess.userSessionId IN (\
+  select u.userSessionId from PersistentUserSessionEntity u \
+  where u.userId = :userId)

--- a/model/jpa/src/main/resources/META-INF/queries-mariadb.properties
+++ b/model/jpa/src/main/resources/META-INF/queries-mariadb.properties
@@ -7,3 +7,9 @@
 deleteExpiredClientSessions[native]=delete c from OFFLINE_CLIENT_SESSION c join OFFLINE_USER_SESSION u \
  where c.USER_SESSION_ID = u.USER_SESSION_ID and u.REALM_ID = :realmId and u.OFFLINE_FLAG = :offline \
  and u.LAST_SESSION_REFRESH < :lastSessionRefresh
+
+deleteClientSessionsByRealm[native]=delete c from OFFLINE_CLIENT_SESSION c join OFFLINE_USER_SESSION u \
+ where c.USER_SESSION_ID = u.USER_SESSION_ID and u.REALM_ID = :realmId
+
+deleteClientSessionsByUser[native]=delete c from OFFLINE_CLIENT_SESSION c join OFFLINE_USER_SESSION u \
+ where c.USER_SESSION_ID = u.USER_SESSION_ID and u.USER_ID = :userId

--- a/model/jpa/src/main/resources/META-INF/queries-mysql.properties
+++ b/model/jpa/src/main/resources/META-INF/queries-mysql.properties
@@ -7,3 +7,9 @@
 deleteExpiredClientSessions[native]=delete c from OFFLINE_CLIENT_SESSION c join OFFLINE_USER_SESSION u \
  where c.USER_SESSION_ID = u.USER_SESSION_ID and u.REALM_ID = :realmId and u.OFFLINE_FLAG = :offline \
  and u.LAST_SESSION_REFRESH < :lastSessionRefresh
+
+deleteClientSessionsByRealm[native]=delete c from OFFLINE_CLIENT_SESSION c join OFFLINE_USER_SESSION u \
+ where c.USER_SESSION_ID = u.USER_SESSION_ID and u.REALM_ID = :realmId
+
+deleteClientSessionsByUser[native]=delete c from OFFLINE_CLIENT_SESSION c join OFFLINE_USER_SESSION u \
+ where c.USER_SESSION_ID = u.USER_SESSION_ID and u.USER_ID = :userId


### PR DESCRIPTION
<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
## Background

From this issue https://github.com/keycloak/keycloak/issues/12523 background.
I found that the PR https://github.com/keycloak/keycloak/pull/8415 fixes the slow query on `deleteExpiredClientSessions`.

## Features

This PR fixes another 2 slow queries on `deleteClientSessionsByRealm` and `deleteClientSessionsByUser` when using mysql and mariadb by converting sub-query to join.

I test in my local and the SQL runs normally.
```
2022-06-21 01:42:03,183 DEBUG [org.hibernate.SQL] (vert.x-worker-thread-0) delete c from OFFLINE_CLIENT_SESSION c join OFFLINE_USER_SESSION u where c.USER_SESSION_ID = u.USER_SESSION_ID and u.USER_ID = ?

2022-06-21 01:42:22,943 DEBUG [org.hibernate.SQL] (vert.x-worker-thread-0) delete c from OFFLINE_CLIENT_SESSION c join OFFLINE_USER_SESSION u where c.USER_SESSION_ID = u.USER_SESSION_ID and u.REALM_ID = ?
```