### PR TITLE
Avoid NullPointerExecption in SessionCodeChecks

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/SessionCodeChecks.java
+++ b/services/src/main/java/org/keycloak/services/resources/SessionCodeChecks.java
@@ -215,7 +215,9 @@ public class SessionCodeChecks {
         if (client == null) {
             event.error(Errors.CLIENT_NOT_FOUND);
             response = ErrorPage.error(session, authSession, Response.Status.BAD_REQUEST, Messages.UNKNOWN_LOGIN_REQUESTER);
-            clientCode.removeExpiredClientSession();
+            if (clientCode != null) {
+                clientCode.removeExpiredClientSession();
+            }
             return false;
         }
 
@@ -225,7 +227,9 @@ public class SessionCodeChecks {
         if (!client.isEnabled()) {
             event.error(Errors.CLIENT_DISABLED);
             response = ErrorPage.error(session,authSession, Response.Status.BAD_REQUEST, Messages.LOGIN_REQUESTER_NOT_ENABLED);
-            clientCode.removeExpiredClientSession();
+            if (clientCode != null) { 
+                clientCode.removeExpiredClientSession();
+            }
             return false;
         }
 


### PR DESCRIPTION
This commit updates [SessionCodeChecks.initialVerify()](https://github.com/keycloak/keycloak/blob/main/services/src/main/java/org/keycloak/services/resources/SessionCodeChecks.java#L198) to avoid NullPointerExecptions.

Private attribute [SessionCodeChecks.clientCode](https://github.com/keycloak/keycloak/blob/main/services/src/main/java/org/keycloak/services/resources/SessionCodeChecks.java#L58) is potentially initialized in initialVerify() lines [252](https://github.com/keycloak/keycloak/blob/main/services/src/main/java/org/keycloak/services/resources/SessionCodeChecks.java#L252) or [268](https://github.com/keycloak/keycloak/blob/main/services/src/main/java/org/keycloak/services/resources/SessionCodeChecks.java#L268). If clientCode is not initialized in lines [218](https://github.com/keycloak/keycloak/blob/main/services/src/main/java/org/keycloak/services/resources/SessionCodeChecks.java#L218) or [228](https://github.com/keycloak/keycloak/blob/main/services/src/main/java/org/keycloak/services/resources/SessionCodeChecks.java#L228), we get a NullPointerException.
