### PR TITLE
Automatic profile activated by using JDK 9+ …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -220,11 +220,6 @@
 
         <!-- Frontend -->
         <node.version>v16.13.2</node.version>
-
-        <!-- Minimum Java version supported for running Keycloak -->
-        <!-- maven.compiler.target and maven.compiler.source already set to 1.8 in the parent pom -->
-        <!-- other modules will configure a higher Java version (for example Quarkus) -->
-        <maven.compiler.release>8</maven.compiler.release>
     </properties>
 
     <url>http://keycloak.org</url>
@@ -2051,6 +2046,21 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+
+        <profile>
+            <id>built-with-jdk-9-or-later</id>
+            <activation>
+                <!-- only activate this on JDK 9 or later as this option is unknown for JDK 8, and as it is not necessary for JDK 8 -->
+                <!-- support for running with JDK 8 is still necessary for some downstream integration tests -->
+                <jdk>(9,)</jdk>
+            </activation>
+            <properties>
+                <!-- Minimum Java version supported for running Keycloak -->
+                <!-- maven.compiler.target and maven.compiler.source already set to 1.8 in the parent pom -->
+                <!-- other modules will configure a higher Java version (for example, Quarkus) -->
+                <maven.compiler.release>8</maven.compiler.release>
+            </properties>
         </profile>
 
         <profile>


### PR DESCRIPTION
that set the compiler release flag that's not understood by JDK 8

Closes #12631

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
