### PR TITLE
Missing translations for german account console v2 added

### DIFF
--- a/themes/src/main/resources-community/theme/base/account/messages/messages_de.properties
+++ b/themes/src/main/resources-community/theme/base/account/messages/messages_de.properties
@@ -8,6 +8,11 @@ doLogIn=Anmelden
 doLink=Verkn\u00FCpfen
 noAccessMessage=Zugriff verweigert
 
+personalInfoSidebarTitle=Pers\u00F6nliche Informationen
+accountSecuritySidebarTitle=Konto Sicherheit
+signingInSidebarTitle=Anmeldung
+deviceActivitySidebarTitle=Ger\u00E4te Aktivit\u00E4t
+linkedAccountsSidebarTitle=Verkn\u00FCpfte Konten
 
 editAccountHtmlTitle=Benutzerkonto bearbeiten
 personalInfoHtmlTitle=Pers\u00F6nliche Informationen


### PR DESCRIPTION
Missing translations for account console v2 added

now it looks again like in previous versions
![grafik](https://user-images.githubusercontent.com/3062585/175119755-18e6b709-a5ee-4208-b0a8-aa1ebbac1ddb.png)


Closes #12658
