### PR TITLE
Fixing ClientPoliciesTest failure

### DIFF
--- a/testsuite/integration-arquillian/tests/other/console/src/test/java/org/keycloak/testsuite/console/realm/ClientPoliciesTest.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/test/java/org/keycloak/testsuite/console/realm/ClientPoliciesTest.java
@@ -25,6 +25,7 @@ import org.keycloak.authentication.authenticators.client.ClientIdAndSecretAuthen
 import org.keycloak.authentication.authenticators.client.JWTClientAuthenticator;
 import org.keycloak.representations.idm.ClientPoliciesRepresentation;
 import org.keycloak.representations.idm.ClientProfilesRepresentation;
+import org.keycloak.representations.idm.ClientPolicyConditionConfigurationRepresentation;
 import org.keycloak.services.clientpolicy.condition.ClientAccessTypeConditionFactory;
 import org.keycloak.services.clientpolicy.executor.HolderOfKeyEnforcerExecutorFactory;
 import org.keycloak.services.clientpolicy.executor.SecureClientAuthenticatorExecutorFactory;
@@ -316,15 +317,17 @@ public class ClientPoliciesTest extends AbstractRealmTest {
         assertAlertSuccess();
 
         // assert JSON
+        ClientPolicyConditionConfigurationRepresentation conditionConfig =
+                createClientAccessTypeConditionConfig(Arrays.asList(ClientAccessTypeConditionFactory.TYPE_CONFIDENTIAL, ClientAccessTypeConditionFactory.TYPE_BEARERONLY, ClientAccessTypeConditionFactory.TYPE_PUBLIC));
+        conditionConfig.setNegativeLogic(Boolean.FALSE);
+
         ClientPoliciesRepresentation expected = new ClientPoliciesBuilder()
             .addPolicy(new ClientPolicyBuilder()
                 .createPolicy(policyName, policyDesc, true)
-                .addCondition(ClientAccessTypeConditionFactory.PROVIDER_ID,
-                        createClientAccessTypeConditionConfig(Arrays.asList(ClientAccessTypeConditionFactory.TYPE_CONFIDENTIAL, ClientAccessTypeConditionFactory.TYPE_BEARERONLY, ClientAccessTypeConditionFactory.TYPE_PUBLIC)))
+                .addCondition(ClientAccessTypeConditionFactory.PROVIDER_ID, conditionConfig)
                 .addProfile(profileName)
                 .toRepresentation())
             .toRepresentation();
-
         assertClientPolicy(expected);
 
         // remove condition


### PR DESCRIPTION
closes #10633

There was commit adding condition `is-negative-logic` into Admin console FormView https://github.com/keycloak/keycloak/commit/ef134390c2f6258d8857abb7244b19b70966c9a9. Since then it should also be expected in the `ClientPoliciesTest.testPoliciesFormView() `