### PR TITLE
Hard coded string with localized message replaced

### DIFF
--- a/themes/src/main/resources-community/theme/keycloak.v2/account/messages/messages_de.properties
+++ b/themes/src/main/resources-community/theme/keycloak.v2/account/messages/messages_de.properties
@@ -99,6 +99,7 @@ invalidRequestMessage=Ung\u00FCltige Anfrage
 
 # Applications page
 applicationsPageTitle=Anwendungen
+applicationsPageSubTitle=Verwalten Sie Ihre Anwendungsberechtigungen
 internalApp=Intern
 thirdPartyApp=Drittanbieter
 offlineAccess=Offline Zugriff

--- a/themes/src/main/resources/theme/keycloak.v2/account/messages/messages_en.properties
+++ b/themes/src/main/resources/theme/keycloak.v2/account/messages/messages_en.properties
@@ -117,6 +117,7 @@ invalidRequestMessage=Invalid request
 
 # Applications page
 applicationsPageTitle=Applications
+applicationsPageSubTitle=Manage your application permissions
 internalApp=Internal
 thirdPartyApp=Third-party
 offlineAccess=Offline access

--- a/themes/src/main/resources/theme/keycloak.v2/account/src/app/content/applications-page/ApplicationsPage.tsx
+++ b/themes/src/main/resources/theme/keycloak.v2/account/src/app/content/applications-page/ApplicationsPage.tsx
@@ -131,7 +131,7 @@ export class ApplicationsPage extends React.Component<ApplicationsPageProps, App
     return (
       <ContentPage
         title={Msg.localize('applicationsPageTitle')}
-        introMessage="Manage your application permissions."
+        introMessage={Msg.localize('applicationsPageSubTitle')}
       >
         <PageSection isFilled variant={PageSectionVariants.light}>
 


### PR DESCRIPTION
Hard coded string with localized message replaced

![grafik](https://user-images.githubusercontent.com/3062585/175571335-babea175-5a98-4542-9bf4-ce6f934a41ec.png)


Closes #12727
