### PR TITLE
Instead of returning instances with different semantics, throw an exception.

### DIFF
--- a/server-spi/src/main/java/org/keycloak/models/KeycloakSession.java
+++ b/server-spi/src/main/java/org/keycloak/models/KeycloakSession.java
@@ -206,6 +206,8 @@ public interface KeycloakSession {
     /**
      * The user cache
      *
+     * @deprecated The access to the UserCache interface is no longer possible here, and this method is about to be removed.
+     * Adjust your code according to the Keycloak 19 Upgrading Guide.
      * @return may be null if cache is disabled
      */
     @Deprecated
@@ -271,7 +273,7 @@ public interface KeycloakSession {
     /**
      * Keycloak specific local storage for clients.  No cache in front, this api talks directly to database configured for Keycloak
      *
-     * @return
+     * @deprecated Access to the legacy store is no longer possible via this method. Adjust your code according to the Keycloak 19 Upgrading Guide.
      */
     @Deprecated
     ClientProvider clientLocalStorage();
@@ -279,8 +281,7 @@ public interface KeycloakSession {
     /**
      * Keycloak specific local storage for client scopes.  No cache in front, this api talks directly to database configured for Keycloak
      *
-     * @deprecated Use {@link #clientScopes()} instead
-     * @return
+     * @deprecated Access to the legacy store is no longer possible via this method. Adjust your code according to the Keycloak 19 Upgrading Guide.
      */
     @Deprecated
     ClientScopeProvider clientScopeLocalStorage();
@@ -288,7 +289,7 @@ public interface KeycloakSession {
     /**
      * Keycloak specific local storage for groups.  No cache in front, this api talks directly to storage configured for Keycloak
      *
-     * @return
+     * @deprecated Access to the legacy store is no longer possible via this method. Adjust your code according to the Keycloak 19 Upgrading Guide.
      */
     @Deprecated
     GroupProvider groupLocalStorage();
@@ -296,7 +297,7 @@ public interface KeycloakSession {
     /**
      * Keycloak specific local storage for roles.  No cache in front, this api talks directly to storage configured for Keycloak
      *
-     * @return
+     * @deprecated Access to the legacy store is no longer possible via this method. Adjust your code according to the Keycloak 19 Upgrading Guide.
      */
     @Deprecated
     RoleProvider roleLocalStorage();
@@ -305,7 +306,7 @@ public interface KeycloakSession {
      * Hybrid storage for UserStorageProviders that can't store a specific piece of keycloak data in their external storage.
      * No cache in front.
      *
-     * @return
+     * @deprecated Access to the legacy store is no longer possible via this method. Adjust your code according to the Keycloak 19 Upgrading Guide.
      */
     @Deprecated
     UserFederatedStorageProvider userFederatedStorage();

--- a/services/src/main/java/org/keycloak/services/DefaultKeycloakSession.java
+++ b/services/src/main/java/org/keycloak/services/DefaultKeycloakSession.java
@@ -176,78 +176,67 @@ public class DefaultKeycloakSession implements KeycloakSession {
     @Override
     @Deprecated
     public UserProvider userLocalStorage() {
-        log.warnf("The semantics of this method have changed: Please see the migration guide on how to migrate.%s", StackUtil.getShortStackTrace());
-        return users();
+        throw new IllegalStateException("Access to the legacy store is no longer possible via this method. Adjust your code according to the Keycloak 19 Upgrading Guide.");
     }
 
     @Override
     @Deprecated
     public RealmProvider realmLocalStorage() {
-        return realms();
+        throw new IllegalStateException("Access to the legacy store is no longer possible via this method. Adjust your code according to the Keycloak 19 Upgrading Guide.");
     }
 
     @Override
     @Deprecated
     public ClientProvider clientLocalStorage() {
-        return clients();
+        throw new IllegalStateException("Access to the legacy store is no longer possible via this method. Adjust your code according to the Keycloak 19 Upgrading Guide.");
     }
 
     @Override
     @Deprecated
     public ClientScopeProvider clientScopeLocalStorage() {
-        return clientScopes();
+        throw new IllegalStateException("Access to the legacy store is no longer possible via this method. Adjust your code according to the Keycloak 19 Upgrading Guide.");
     }
 
     @Override
     @Deprecated
     public GroupProvider groupLocalStorage() {
-        return groups();
+        throw new IllegalStateException("Access to the legacy store is no longer possible via this method. Adjust your code according to the Keycloak 19 Upgrading Guide.");
     }
 
     @Override
     @Deprecated
     public ClientProvider clientStorageManager() {
-        return clients();
+        throw new IllegalStateException("Access to the legacy store is no longer possible via this method. Adjust your code according to the Keycloak 19 Upgrading Guide.");
     }
 
     @Override
     @Deprecated
     public ClientScopeProvider clientScopeStorageManager() {
-        return clientScopes();
+        throw new IllegalStateException("Access to the legacy store is no longer possible via this method. Adjust your code according to the Keycloak 19 Upgrading Guide.");
     }
 
     @Override
     @Deprecated
     public RoleProvider roleLocalStorage() {
-        return roles();
+        throw new IllegalStateException("Access to the legacy store is no longer possible via this method. Adjust your code according to the Keycloak 19 Upgrading Guide.");
     }
 
     @Override
     @Deprecated
     public RoleProvider roleStorageManager() {
-        return roles();
+        throw new IllegalStateException("Access to the legacy store is no longer possible via this method. Adjust your code according to the Keycloak 19 Upgrading Guide.");
     }
 
     @Override
     @Deprecated
     public GroupProvider groupStorageManager() {
-        return groups();
+        throw new IllegalStateException("Access to the legacy store is no longer possible via this method. Adjust your code according to the Keycloak 19 Upgrading Guide.");
     }
-
-    private final ThreadLocal<Boolean> recursionPreventionUserStorageManager = new ThreadLocal<>();
 
     @Override
     @Deprecated
     public UserProvider userStorageManager() {
-        if(recursionPreventionUserStorageManager.get() != null) {
-            throw new IllegalStateException("userStorageManager() is being called recursively. Please adjust your code according to the Keycloak 19 migration guide.");
-        }
-        try {
-            recursionPreventionUserStorageManager.set(Boolean.TRUE);
-            return users();
-        } finally {
-            recursionPreventionUserStorageManager.remove();
-        }
+        throw new IllegalStateException("Access to the legacy store is no longer possible via this method. Adjust your code according to the Keycloak 19 Upgrading Guide.");
     }
 
     @Override


### PR DESCRIPTION
This exception points the caller to the migration guide of Keycloak 19.

Closes #12556

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
