### PR TITLE
Store composite roles within its own table for JPA Map storage.

### DIFF
--- a/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/JpaSubqueryProvider.java
+++ b/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/JpaSubqueryProvider.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.models.map.storage.jpa;
+
+import javax.persistence.criteria.Subquery;
+
+/**
+ * This is handed down to a {@link JpaModelCriteriaBuilder} to be able to create subqueries.
+ * Depending on the caller this will delegate of an instance of a {@link javax.persistence.criteria.CriteriaDelete}
+ * or a {@link javax.persistence.criteria.CriteriaQuery} as necessary.
+ *
+ * @author Alexander Schwartz
+ */
+@FunctionalInterface
+public interface JpaSubqueryProvider {
+    <U> Subquery<U> subquery(Class<U> type);
+}

--- a/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/authSession/JpaRootAuthenticationSessionModelCriteriaBuilder.java
+++ b/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/authSession/JpaRootAuthenticationSessionModelCriteriaBuilder.java
@@ -16,13 +16,10 @@
  */
 package org.keycloak.models.map.storage.jpa.authSession;
 
-import java.util.function.BiFunction;
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.Predicate;
-import javax.persistence.criteria.Root;
 import org.keycloak.models.map.storage.CriterionNotSupportedException;
 import org.keycloak.models.map.storage.jpa.JpaModelCriteriaBuilder;
 import org.keycloak.models.map.storage.jpa.authSession.entity.JpaRootAuthenticationSessionEntity;
+import org.keycloak.models.map.storage.jpa.role.JpaPredicateFunction;
 import org.keycloak.sessions.RootAuthenticationSessionModel;
 import org.keycloak.sessions.RootAuthenticationSessionModel.SearchableFields;
 import org.keycloak.storage.SearchableModelField;
@@ -33,7 +30,7 @@ public class JpaRootAuthenticationSessionModelCriteriaBuilder extends JpaModelCr
         super(JpaRootAuthenticationSessionModelCriteriaBuilder::new);
     }
 
-    private JpaRootAuthenticationSessionModelCriteriaBuilder(BiFunction<CriteriaBuilder, Root<JpaRootAuthenticationSessionEntity>, Predicate> predicateFunc) {
+    private JpaRootAuthenticationSessionModelCriteriaBuilder(JpaPredicateFunction<JpaRootAuthenticationSessionEntity> predicateFunc) {
         super(JpaRootAuthenticationSessionModelCriteriaBuilder::new, predicateFunc);
     }
 
@@ -45,7 +42,7 @@ public class JpaRootAuthenticationSessionModelCriteriaBuilder extends JpaModelCr
 
                     validateValue(value, modelField, op, String.class);
 
-                    return new JpaRootAuthenticationSessionModelCriteriaBuilder((cb, root) -> 
+                    return new JpaRootAuthenticationSessionModelCriteriaBuilder((cb, query, root) ->
                         cb.equal(root.get(modelField.getName()), value[0])
                     );
                 } else {

--- a/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/authorization/resourceServer/JpaResourceServerModelCriteriaBuilder.java
+++ b/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/authorization/resourceServer/JpaResourceServerModelCriteriaBuilder.java
@@ -16,15 +16,12 @@
  */
 package org.keycloak.models.map.storage.jpa.authorization.resourceServer;
 
-import java.util.function.BiFunction;
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.Predicate;
-import javax.persistence.criteria.Root;
 import org.keycloak.authorization.model.ResourceServer;
 import org.keycloak.authorization.model.ResourceServer.SearchableFields;
 import org.keycloak.models.map.storage.CriterionNotSupportedException;
 import org.keycloak.models.map.storage.jpa.JpaModelCriteriaBuilder;
 import org.keycloak.models.map.storage.jpa.authorization.resourceServer.entity.JpaResourceServerEntity;
+import org.keycloak.models.map.storage.jpa.role.JpaPredicateFunction;
 import org.keycloak.storage.SearchableModelField;
 
 public class JpaResourceServerModelCriteriaBuilder extends JpaModelCriteriaBuilder<JpaResourceServerEntity, ResourceServer, JpaResourceServerModelCriteriaBuilder> {
@@ -33,7 +30,7 @@ public class JpaResourceServerModelCriteriaBuilder extends JpaModelCriteriaBuild
         super(JpaResourceServerModelCriteriaBuilder::new);
     }
 
-    private JpaResourceServerModelCriteriaBuilder(BiFunction<CriteriaBuilder, Root<JpaResourceServerEntity>, Predicate> predicateFunc) {
+    private JpaResourceServerModelCriteriaBuilder(JpaPredicateFunction<JpaResourceServerEntity> predicateFunc) {
         super(JpaResourceServerModelCriteriaBuilder::new, predicateFunc);
     }
 
@@ -46,7 +43,7 @@ public class JpaResourceServerModelCriteriaBuilder extends JpaModelCriteriaBuild
 
                     validateValue(value, modelField, op, String.class);
 
-                    return new JpaResourceServerModelCriteriaBuilder((cb, root) -> 
+                    return new JpaResourceServerModelCriteriaBuilder((cb, query, root) ->
                         cb.equal(root.get(modelField.getName()), value[0])
                     );
                 } else {

--- a/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/authorization/scope/JpaScopeModelCriteriaBuilder.java
+++ b/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/authorization/scope/JpaScopeModelCriteriaBuilder.java
@@ -19,11 +19,8 @@ package org.keycloak.models.map.storage.jpa.authorization.scope;
 import java.util.Collection;
 import java.util.Objects;
 import java.util.UUID;
-import java.util.function.BiFunction;
-import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaBuilder.In;
-import javax.persistence.criteria.Predicate;
-import javax.persistence.criteria.Root;
+
 import org.keycloak.authorization.model.Scope;
 import org.keycloak.authorization.model.Scope.SearchableFields;
 import org.keycloak.models.map.common.StringKeyConverter.UUIDKey;
@@ -31,6 +28,7 @@ import org.keycloak.models.map.storage.CriterionNotSupportedException;
 import org.keycloak.models.map.storage.ModelCriteriaBuilder;
 import org.keycloak.models.map.storage.jpa.JpaModelCriteriaBuilder;
 import org.keycloak.models.map.storage.jpa.authorization.scope.entity.JpaScopeEntity;
+import org.keycloak.models.map.storage.jpa.role.JpaPredicateFunction;
 import org.keycloak.storage.SearchableModelField;
 
 public class JpaScopeModelCriteriaBuilder extends JpaModelCriteriaBuilder<JpaScopeEntity, Scope, JpaScopeModelCriteriaBuilder> {
@@ -39,7 +37,7 @@ public class JpaScopeModelCriteriaBuilder extends JpaModelCriteriaBuilder<JpaSco
         super(JpaScopeModelCriteriaBuilder::new);
     }
 
-    private JpaScopeModelCriteriaBuilder(BiFunction<CriteriaBuilder, Root<JpaScopeEntity>, Predicate> predicateFunc) {
+    private JpaScopeModelCriteriaBuilder(JpaPredicateFunction<JpaScopeEntity> predicateFunc) {
         super(JpaScopeModelCriteriaBuilder::new, predicateFunc);
     }
 
@@ -52,7 +50,7 @@ public class JpaScopeModelCriteriaBuilder extends JpaModelCriteriaBuilder<JpaSco
 
                     validateValue(value, modelField, op, String.class);
 
-                    return new JpaScopeModelCriteriaBuilder((cb, root) -> {
+                    return new JpaScopeModelCriteriaBuilder((cb, query, root) -> {
                         UUID uuid = UUIDKey.INSTANCE.fromStringSafe(Objects.toString(value[0], null));
                         if (uuid == null) return cb.or();
                         return cb.equal(root.get(modelField.getName()), uuid);
@@ -62,7 +60,7 @@ public class JpaScopeModelCriteriaBuilder extends JpaModelCriteriaBuilder<JpaSco
 
                     validateValue(value, modelField, op, String.class);
 
-                    return new JpaScopeModelCriteriaBuilder((cb, root) -> 
+                    return new JpaScopeModelCriteriaBuilder((cb, query, root) ->
                         cb.equal(root.get(modelField.getName()), value[0])
                     );
                 } else {
@@ -74,7 +72,7 @@ public class JpaScopeModelCriteriaBuilder extends JpaModelCriteriaBuilder<JpaSco
 
                     validateValue(value, modelField, op, String.class);
 
-                    return new JpaScopeModelCriteriaBuilder((cb, root) -> 
+                    return new JpaScopeModelCriteriaBuilder((cb, query, root) ->
                         cb.like(cb.lower(root.get(modelField.getName())), value[0].toString().toLowerCase())
                     );
                 } else {
@@ -87,10 +85,10 @@ public class JpaScopeModelCriteriaBuilder extends JpaModelCriteriaBuilder<JpaSco
                     final Collection<?> collectionValues = getValuesForInOperator(value, modelField);
 
                     if (collectionValues.isEmpty()) {
-                        return new JpaScopeModelCriteriaBuilder((cb, root) -> cb.or());
+                        return new JpaScopeModelCriteriaBuilder((cb, query, root) -> cb.or());
                     }
 
-                    return new JpaScopeModelCriteriaBuilder((cb, root) ->  {
+                    return new JpaScopeModelCriteriaBuilder((cb, query, root) ->  {
                         In<UUID> in = cb.in(root.get("id"));
                         for (Object id : collectionValues) {
                             try {

--- a/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/clientscope/JpaClientScopeModelCriteriaBuilder.java
+++ b/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/clientscope/JpaClientScopeModelCriteriaBuilder.java
@@ -16,15 +16,12 @@
  */
 package org.keycloak.models.map.storage.jpa.clientscope;
 
-import java.util.function.BiFunction;
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.Predicate;
-import javax.persistence.criteria.Root;
 import org.keycloak.models.ClientScopeModel;
 import org.keycloak.models.ClientScopeModel.SearchableFields;
 import org.keycloak.models.map.storage.CriterionNotSupportedException;
 import org.keycloak.models.map.storage.jpa.JpaModelCriteriaBuilder;
 import org.keycloak.models.map.storage.jpa.clientscope.entity.JpaClientScopeEntity;
+import org.keycloak.models.map.storage.jpa.role.JpaPredicateFunction;
 import org.keycloak.storage.SearchableModelField;
 
 public class JpaClientScopeModelCriteriaBuilder extends JpaModelCriteriaBuilder<JpaClientScopeEntity, ClientScopeModel, JpaClientScopeModelCriteriaBuilder> {
@@ -33,7 +30,7 @@ public class JpaClientScopeModelCriteriaBuilder extends JpaModelCriteriaBuilder<
         super(JpaClientScopeModelCriteriaBuilder::new);
     }
 
-    private JpaClientScopeModelCriteriaBuilder(BiFunction<CriteriaBuilder, Root<JpaClientScopeEntity>, Predicate> predicateFunc) {
+    private JpaClientScopeModelCriteriaBuilder(JpaPredicateFunction<JpaClientScopeEntity> predicateFunc) {
         super(JpaClientScopeModelCriteriaBuilder::new, predicateFunc);
     }
 
@@ -46,7 +43,7 @@ public class JpaClientScopeModelCriteriaBuilder extends JpaModelCriteriaBuilder<
 
                     validateValue(value, modelField, op, String.class);
 
-                    return new JpaClientScopeModelCriteriaBuilder((cb, root) -> 
+                    return new JpaClientScopeModelCriteriaBuilder((cb, query, root) ->
                         cb.equal(root.get(modelField.getName()), value[0])
                     );
                 } else {

--- a/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/event/admin/JpaAdminEventModelCriteriaBuilder.java
+++ b/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/event/admin/JpaAdminEventModelCriteriaBuilder.java
@@ -19,17 +19,15 @@ package org.keycloak.models.map.storage.jpa.event.admin;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
 import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.Predicate;
-import javax.persistence.criteria.Root;
 
 import org.keycloak.events.admin.AdminEvent;
 import org.keycloak.models.map.storage.CriterionNotSupportedException;
 import org.keycloak.models.map.storage.jpa.JpaModelCriteriaBuilder;
 import org.keycloak.models.map.storage.jpa.event.admin.entity.JpaAdminEventEntity;
+import org.keycloak.models.map.storage.jpa.role.JpaPredicateFunction;
 import org.keycloak.storage.SearchableModelField;
 import org.keycloak.util.EnumWithStableIndex;
 
@@ -55,7 +53,7 @@ public class JpaAdminEventModelCriteriaBuilder extends JpaModelCriteriaBuilder<J
         super(JpaAdminEventModelCriteriaBuilder::new);
     }
 
-    private JpaAdminEventModelCriteriaBuilder(BiFunction<CriteriaBuilder, Root<JpaAdminEventEntity>, Predicate> predicateFunc) {
+    private JpaAdminEventModelCriteriaBuilder(JpaPredicateFunction<JpaAdminEventEntity> predicateFunc) {
         super(JpaAdminEventModelCriteriaBuilder::new, predicateFunc);
     }
 
@@ -66,7 +64,7 @@ public class JpaAdminEventModelCriteriaBuilder extends JpaModelCriteriaBuilder<J
                 if (modelField == AdminEvent.SearchableFields.REALM_ID) {
 
                     validateValue(value, modelField, op, String.class);
-                    return new JpaAdminEventModelCriteriaBuilder((cb, root) ->
+                    return new JpaAdminEventModelCriteriaBuilder((cb, query, root) ->
                             cb.equal(root.get(modelField.getName()), value[0])
                     );
                 } else if (modelField == AdminEvent.SearchableFields.AUTH_CLIENT_ID ||
@@ -75,7 +73,7 @@ public class JpaAdminEventModelCriteriaBuilder extends JpaModelCriteriaBuilder<J
                         modelField == AdminEvent.SearchableFields.AUTH_IP_ADDRESS) {
 
                     validateValue(value, modelField, op, String.class);
-                    return new JpaAdminEventModelCriteriaBuilder((cb, root) ->
+                    return new JpaAdminEventModelCriteriaBuilder((cb, query, root) ->
                             cb.equal(
                                     cb.function("->>", String.class, root.get("metadata"),
                                             cb.literal(FIELD_TO_JSON_PROP.get(modelField.getName()))), value[0])
@@ -88,7 +86,7 @@ public class JpaAdminEventModelCriteriaBuilder extends JpaModelCriteriaBuilder<J
 
                     validateValue(value, modelField, op, Number.class);
 
-                    return new JpaAdminEventModelCriteriaBuilder((cb, root) ->
+                    return new JpaAdminEventModelCriteriaBuilder((cb, query, root) ->
                             cb.le(root.get(modelField.getName()), (Number) value[0])
                     );
                 } else {
@@ -98,7 +96,7 @@ public class JpaAdminEventModelCriteriaBuilder extends JpaModelCriteriaBuilder<J
                 if (modelField == AdminEvent.SearchableFields.TIMESTAMP) {
                     validateValue(value, modelField, op, Number.class);
 
-                    return new JpaAdminEventModelCriteriaBuilder((cb, root) ->
+                    return new JpaAdminEventModelCriteriaBuilder((cb, query, root) ->
                             cb.lt(root.get(modelField.getName()), (Number) value[0])
                     );
                 } else {
@@ -108,7 +106,7 @@ public class JpaAdminEventModelCriteriaBuilder extends JpaModelCriteriaBuilder<J
                 if (modelField == AdminEvent.SearchableFields.RESOURCE_PATH) {
                     validateValue(value, modelField, op, String.class);
 
-                    return new JpaAdminEventModelCriteriaBuilder((cb, root) ->
+                    return new JpaAdminEventModelCriteriaBuilder((cb, query, root) ->
                             cb.like(
                                     cb.function("->>", String.class, root.get("metadata"), cb.literal(FIELD_TO_JSON_PROP.get(modelField.getName()))),
                                     value[0].toString())
@@ -120,7 +118,7 @@ public class JpaAdminEventModelCriteriaBuilder extends JpaModelCriteriaBuilder<J
                 if (modelField == AdminEvent.SearchableFields.TIMESTAMP) {
                     validateValue(value, modelField, op, Number.class);
 
-                    return new JpaAdminEventModelCriteriaBuilder((cb, root) ->
+                    return new JpaAdminEventModelCriteriaBuilder((cb, query, root) ->
                             cb.ge(root.get(modelField.getName()), (Number) value[0])
                     );
                 } else {
@@ -131,9 +129,9 @@ public class JpaAdminEventModelCriteriaBuilder extends JpaModelCriteriaBuilder<J
                     Set<Integer> values = super.getValuesForInOperator(value, modelField).stream()
                             .map(o -> ((EnumWithStableIndex) o).getStableIndex()).collect(Collectors.toSet());
 
-                    if (values.isEmpty()) return new JpaAdminEventModelCriteriaBuilder((cb, root) -> cb.or());
+                    if (values.isEmpty()) return new JpaAdminEventModelCriteriaBuilder((cb, query, root) -> cb.or());
 
-                    return new JpaAdminEventModelCriteriaBuilder((cb, root) -> {
+                    return new JpaAdminEventModelCriteriaBuilder((cb, query, root) -> {
                         CriteriaBuilder.In<Integer> in = cb.in(cb.function("->>", String.class, root.get("metadata"),
                                 cb.literal(FIELD_TO_JSON_PROP.get(modelField.getName()))).as(Integer.class));
                         values.forEach(in::value);
@@ -144,9 +142,9 @@ public class JpaAdminEventModelCriteriaBuilder extends JpaModelCriteriaBuilder<J
                     Set<String> values = super.getValuesForInOperator(value, modelField).stream()
                             .map(Object::toString).collect(Collectors.toSet());
 
-                    if (values.isEmpty()) return new JpaAdminEventModelCriteriaBuilder((cb, root) -> cb.or());
+                    if (values.isEmpty()) return new JpaAdminEventModelCriteriaBuilder((cb, query, root) -> cb.or());
 
-                    return new JpaAdminEventModelCriteriaBuilder((cb, root) -> {
+                    return new JpaAdminEventModelCriteriaBuilder((cb, query, root) -> {
                         CriteriaBuilder.In<String> in = cb.in(cb.function("->>", String.class, root.get("metadata"),
                                                               cb.literal(FIELD_TO_JSON_PROP.get(modelField.getName()))));
                         values.forEach(in::value);

--- a/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/event/auth/JpaAuthEventModelCriteriaBuilder.java
+++ b/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/event/auth/JpaAuthEventModelCriteriaBuilder.java
@@ -19,17 +19,15 @@ package org.keycloak.models.map.storage.jpa.event.auth;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
 import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.Predicate;
-import javax.persistence.criteria.Root;
 
 import org.keycloak.events.Event;
 import org.keycloak.models.map.storage.CriterionNotSupportedException;
 import org.keycloak.models.map.storage.jpa.JpaModelCriteriaBuilder;
 import org.keycloak.models.map.storage.jpa.event.auth.entity.JpaAuthEventEntity;
+import org.keycloak.models.map.storage.jpa.role.JpaPredicateFunction;
 import org.keycloak.storage.SearchableModelField;
 import org.keycloak.util.EnumWithStableIndex;
 
@@ -47,7 +45,7 @@ public class JpaAuthEventModelCriteriaBuilder extends JpaModelCriteriaBuilder<Jp
         super(JpaAuthEventModelCriteriaBuilder::new);
     }
 
-    private JpaAuthEventModelCriteriaBuilder(BiFunction<CriteriaBuilder, Root<JpaAuthEventEntity>, Predicate> predicateFunc) {
+    private JpaAuthEventModelCriteriaBuilder(JpaPredicateFunction<JpaAuthEventEntity> predicateFunc) {
         super(JpaAuthEventModelCriteriaBuilder::new, predicateFunc);
     }
 
@@ -58,7 +56,7 @@ public class JpaAuthEventModelCriteriaBuilder extends JpaModelCriteriaBuilder<Jp
                 if (modelField == Event.SearchableFields.REALM_ID) {
 
                     validateValue(value, modelField, op, String.class);
-                    return new JpaAuthEventModelCriteriaBuilder((cb, root) ->
+                    return new JpaAuthEventModelCriteriaBuilder((cb, query, root) ->
                             cb.equal(root.get(modelField.getName()), value[0])
                     );
                 } else if (modelField == Event.SearchableFields.CLIENT_ID ||
@@ -66,7 +64,7 @@ public class JpaAuthEventModelCriteriaBuilder extends JpaModelCriteriaBuilder<Jp
                         modelField == Event.SearchableFields.IP_ADDRESS) {
 
                     validateValue(value, modelField, op, String.class);
-                    return new JpaAuthEventModelCriteriaBuilder((cb, root) ->
+                    return new JpaAuthEventModelCriteriaBuilder((cb, query, root) ->
                             cb.equal(
                                     cb.function("->>", String.class, root.get("metadata"),
                                             cb.literal(FIELD_TO_JSON_PROP.get(modelField.getName()))), value[0])
@@ -79,7 +77,7 @@ public class JpaAuthEventModelCriteriaBuilder extends JpaModelCriteriaBuilder<Jp
 
                     validateValue(value, modelField, op, Number.class);
 
-                    return new JpaAuthEventModelCriteriaBuilder((cb, root) ->
+                    return new JpaAuthEventModelCriteriaBuilder((cb, query, root) ->
                             cb.le(root.get(modelField.getName()), (Number) value[0])
                     );
                 } else {
@@ -89,7 +87,7 @@ public class JpaAuthEventModelCriteriaBuilder extends JpaModelCriteriaBuilder<Jp
                 if (modelField == Event.SearchableFields.TIMESTAMP) {
                     validateValue(value, modelField, op, Number.class);
 
-                    return new JpaAuthEventModelCriteriaBuilder((cb, root) ->
+                    return new JpaAuthEventModelCriteriaBuilder((cb, query, root) ->
                             cb.lt(root.get(modelField.getName()), (Number) value[0])
                     );
                 } else {
@@ -99,7 +97,7 @@ public class JpaAuthEventModelCriteriaBuilder extends JpaModelCriteriaBuilder<Jp
                 if (modelField == Event.SearchableFields.TIMESTAMP) {
                     validateValue(value, modelField, op, Number.class);
 
-                    return new JpaAuthEventModelCriteriaBuilder((cb, root) ->
+                    return new JpaAuthEventModelCriteriaBuilder((cb, query, root) ->
                             cb.ge(root.get(modelField.getName()), (Number) value[0])
                     );
                 } else {
@@ -110,9 +108,9 @@ public class JpaAuthEventModelCriteriaBuilder extends JpaModelCriteriaBuilder<Jp
                     Set<Integer> values = super.getValuesForInOperator(value, modelField).stream()
                             .map(o -> ((EnumWithStableIndex) o).getStableIndex()).collect(Collectors.toSet());
 
-                    if (values.isEmpty()) return new JpaAuthEventModelCriteriaBuilder((cb, root) -> cb.or());
+                    if (values.isEmpty()) return new JpaAuthEventModelCriteriaBuilder((cb, query, root) -> cb.or());
 
-                    return new JpaAuthEventModelCriteriaBuilder((cb, root) -> {
+                    return new JpaAuthEventModelCriteriaBuilder((cb, query, root) -> {
                         CriteriaBuilder.In<Integer> in = cb.in(cb.function("->>", String.class, root.get("metadata"),
                                 cb.literal(FIELD_TO_JSON_PROP.get(modelField.getName()))).as(Integer.class));
                         values.forEach(in::value);

--- a/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/group/JpaGroupModelCriteriaBuilder.java
+++ b/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/group/JpaGroupModelCriteriaBuilder.java
@@ -19,15 +19,14 @@ package org.keycloak.models.map.storage.jpa.group;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
-import java.util.function.BiFunction;
 import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.Predicate;
-import javax.persistence.criteria.Root;
+
 import org.keycloak.models.GroupModel;
 import org.keycloak.models.map.storage.CriterionNotSupportedException;
 import org.keycloak.models.map.storage.jpa.group.entity.JpaGroupEntity;
 import org.keycloak.models.map.storage.jpa.JpaModelCriteriaBuilder;
 import org.keycloak.models.map.storage.jpa.hibernate.jsonb.JsonbType;
+import org.keycloak.models.map.storage.jpa.role.JpaPredicateFunction;
 import org.keycloak.storage.SearchableModelField;
 
 public class JpaGroupModelCriteriaBuilder extends JpaModelCriteriaBuilder<JpaGroupEntity, GroupModel, JpaGroupModelCriteriaBuilder> {
@@ -36,12 +35,11 @@ public class JpaGroupModelCriteriaBuilder extends JpaModelCriteriaBuilder<JpaGro
         super(JpaGroupModelCriteriaBuilder::new);
     }
 
-    private JpaGroupModelCriteriaBuilder(BiFunction<CriteriaBuilder, Root<JpaGroupEntity>, Predicate> predicateFunc) {
+    private JpaGroupModelCriteriaBuilder(JpaPredicateFunction<JpaGroupEntity> predicateFunc) {
         super(JpaGroupModelCriteriaBuilder::new, predicateFunc);
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public JpaGroupModelCriteriaBuilder compare(SearchableModelField<? super GroupModel> modelField, Operator op, Object... value) {
         switch (op) {
             case EQ:
@@ -49,25 +47,25 @@ public class JpaGroupModelCriteriaBuilder extends JpaModelCriteriaBuilder<JpaGro
                     modelField == GroupModel.SearchableFields.NAME) {
                     validateValue(value, modelField, op, String.class);
 
-                    return new JpaGroupModelCriteriaBuilder((cb, root) -> 
+                    return new JpaGroupModelCriteriaBuilder((cb, query, root) ->
                         cb.equal(root.get(modelField.getName()), value[0])
                     );
                 } else if (modelField == GroupModel.SearchableFields.PARENT_ID) {
                     if (value.length == 1 && Objects.isNull(value[0])) {
-                        return new JpaGroupModelCriteriaBuilder((cb, root) -> 
+                        return new JpaGroupModelCriteriaBuilder((cb, query, root) ->
                             cb.isNull(root.get("parentId"))
                         );
                     }
 
                     validateValue(value, modelField, op, String.class);
 
-                    return new JpaGroupModelCriteriaBuilder((cb, root) -> 
+                    return new JpaGroupModelCriteriaBuilder((cb, query, root) ->
                         cb.equal(root.get("parentId"), value[0])
                     );
                 } else if (modelField == GroupModel.SearchableFields.ASSIGNED_ROLE) {
                     validateValue(value, modelField, op, String.class);
 
-                    return new JpaGroupModelCriteriaBuilder((cb, root) -> 
+                    return new JpaGroupModelCriteriaBuilder((cb, query, root) ->
                         cb.isTrue(cb.function("@>",
                             Boolean.TYPE,
                             cb.function("->", JsonbType.class, root.get("metadata"), cb.literal("fGrantedRoles")),
@@ -81,9 +79,9 @@ public class JpaGroupModelCriteriaBuilder extends JpaModelCriteriaBuilder<JpaGro
 
                     Set<UUID> uuids = getUuidsForInOperator(value, modelField);
 
-                    if (uuids.isEmpty()) return new JpaGroupModelCriteriaBuilder((cb, root) -> cb.or());
+                    if (uuids.isEmpty()) return new JpaGroupModelCriteriaBuilder((cb, query, root) -> cb.or());
 
-                    return new JpaGroupModelCriteriaBuilder((cb, root) ->  {
+                    return new JpaGroupModelCriteriaBuilder((cb, query, root) ->  {
                         CriteriaBuilder.In<UUID> in = cb.in(root.get("id"));
                         uuids.forEach(uuid -> in.value(uuid));
                         return in;
@@ -96,7 +94,7 @@ public class JpaGroupModelCriteriaBuilder extends JpaModelCriteriaBuilder<JpaGro
 
                     validateValue(value, modelField, op, String.class);
 
-                    return new JpaGroupModelCriteriaBuilder((cb, root) -> 
+                    return new JpaGroupModelCriteriaBuilder((cb, query, root) ->
                         cb.like(cb.lower(root.get(modelField.getName())), value[0].toString().toLowerCase())
                     );
                 } else {
@@ -105,7 +103,7 @@ public class JpaGroupModelCriteriaBuilder extends JpaModelCriteriaBuilder<JpaGro
             case NOT_EXISTS:
                 if (modelField == GroupModel.SearchableFields.PARENT_ID) {
 
-                    return new JpaGroupModelCriteriaBuilder((cb, root) -> 
+                    return new JpaGroupModelCriteriaBuilder((cb, query, root) ->
                         cb.isNull(root.get("parentId"))
                     );
                 } else {

--- a/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/loginFailure/JpaUserLoginFailureModelCriteriaBuilder.java
+++ b/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/loginFailure/JpaUserLoginFailureModelCriteriaBuilder.java
@@ -16,16 +16,11 @@
  */
 package org.keycloak.models.map.storage.jpa.loginFailure;
 
-import java.util.function.BiFunction;
-
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.Predicate;
-import javax.persistence.criteria.Root;
-
 import org.keycloak.models.UserLoginFailureModel;
 import org.keycloak.models.map.storage.CriterionNotSupportedException;
 import org.keycloak.models.map.storage.jpa.JpaModelCriteriaBuilder;
 import org.keycloak.models.map.storage.jpa.loginFailure.entity.JpaUserLoginFailureEntity;
+import org.keycloak.models.map.storage.jpa.role.JpaPredicateFunction;
 import org.keycloak.storage.SearchableModelField;
 
 /**
@@ -39,7 +34,7 @@ public class JpaUserLoginFailureModelCriteriaBuilder extends JpaModelCriteriaBui
         super(JpaUserLoginFailureModelCriteriaBuilder::new);
     }
 
-    private JpaUserLoginFailureModelCriteriaBuilder(BiFunction<CriteriaBuilder, Root<JpaUserLoginFailureEntity>, Predicate> predicateFunc) {
+    private JpaUserLoginFailureModelCriteriaBuilder(JpaPredicateFunction<JpaUserLoginFailureEntity> predicateFunc) {
         super(JpaUserLoginFailureModelCriteriaBuilder::new, predicateFunc);
     }
 
@@ -52,7 +47,7 @@ public class JpaUserLoginFailureModelCriteriaBuilder extends JpaModelCriteriaBui
 
                     validateValue(value, modelField, op, String.class);
 
-                    return new JpaUserLoginFailureModelCriteriaBuilder((cb, root) ->
+                    return new JpaUserLoginFailureModelCriteriaBuilder((cb, subQueryProvider, root) ->
                             cb.equal(root.get(modelField.getName()), value[0])
                     );
                 } else {

--- a/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/role/JpaPredicateFunction.java
+++ b/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/role/JpaPredicateFunction.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.models.map.storage.jpa.role;
+
+import org.keycloak.models.map.storage.jpa.JpaSubqueryProvider;
+
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * @author Alexander Schwartz
+ */
+@FunctionalInterface
+public interface JpaPredicateFunction<RE> {
+    Predicate apply(CriteriaBuilder t, JpaSubqueryProvider u, Root<RE> v);
+
+    default JpaPredicateFunction<RE> andThen(Function<? super Predicate, Predicate> after) {
+        Objects.requireNonNull(after);
+        return (CriteriaBuilder t, JpaSubqueryProvider u, Root<RE> v) -> after.apply(apply(t, u, v));
+    }
+}

--- a/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/role/JpaRoleMapKeycloakTransaction.java
+++ b/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/role/JpaRoleMapKeycloakTransaction.java
@@ -22,17 +22,15 @@ import javax.persistence.criteria.Root;
 import javax.persistence.criteria.Selection;
 import org.keycloak.models.RoleModel;
 import org.keycloak.models.map.role.MapRoleEntity;
-import org.keycloak.models.map.role.MapRoleEntityDelegate;
 import static org.keycloak.models.map.storage.jpa.Constants.CURRENT_SCHEMA_VERSION_ROLE;
 import org.keycloak.models.map.storage.jpa.JpaMapKeycloakTransaction;
 import org.keycloak.models.map.storage.jpa.JpaModelCriteriaBuilder;
 import org.keycloak.models.map.storage.jpa.JpaRootEntity;
-import org.keycloak.models.map.storage.jpa.role.delegate.JpaRoleDelegateProvider;
+import org.keycloak.models.map.storage.jpa.role.delegate.JpaMapRoleEntityDelegate;
 import org.keycloak.models.map.storage.jpa.role.entity.JpaRoleEntity;
 
 public class JpaRoleMapKeycloakTransaction extends JpaMapKeycloakTransaction<JpaRoleEntity, MapRoleEntity, RoleModel> {
 
-    @SuppressWarnings("unchecked")
     public JpaRoleMapKeycloakTransaction(EntityManager em) {
         super(JpaRoleEntity.class, RoleModel.class, em);
     }
@@ -62,6 +60,6 @@ public class JpaRoleMapKeycloakTransaction extends JpaMapKeycloakTransaction<Jpa
 
     @Override
     protected MapRoleEntity mapToEntityDelegate(JpaRoleEntity original) {
-        return new MapRoleEntityDelegate(new JpaRoleDelegateProvider(original, em));
+        return new JpaMapRoleEntityDelegate(original, em);
     }
 }

--- a/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/role/delegate/JpaMapRoleEntityDelegate.java
+++ b/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/role/delegate/JpaMapRoleEntityDelegate.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.models.map.storage.jpa.role.delegate;
+
+import org.keycloak.models.map.common.StringKeyConverter;
+import org.keycloak.models.map.role.MapRoleEntityDelegate;
+import org.keycloak.models.map.storage.jpa.role.entity.JpaRoleCompositeEntity;
+import org.keycloak.models.map.storage.jpa.role.entity.JpaRoleCompositeEntityKey;
+import org.keycloak.models.map.storage.jpa.role.entity.JpaRoleEntity;
+
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
+import javax.persistence.TypedQuery;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Delegate for the JPA implementation for MapRoleEntityDelegate.
+ * It will delegate all access to the composite roles to a separate table.
+ *
+ * For performance reasons, it caches the composite roles within the session if they have already been retrieved.
+ * This relies on the behavior of {@link org.keycloak.models.map.storage.jpa.JpaMapKeycloakTransaction} that
+ * each entity is created only once within each session.
+ *
+ * @author Alexander Schwartz
+ */
+public class JpaMapRoleEntityDelegate extends MapRoleEntityDelegate {
+    private final EntityManager em;
+
+    private Set<String> compositeRoles;
+
+    public JpaMapRoleEntityDelegate(JpaRoleEntity original, EntityManager em) {
+        super(new JpaRoleDelegateProvider(original, em));
+        this.em = em;
+    }
+
+    @Override
+    public Set<String> getCompositeRoles() {
+        if (compositeRoles == null) {
+            TypedQuery<JpaRoleCompositeEntityKey> query = em.createNamedQuery("selectChildRolesFromCompositeRole", JpaRoleCompositeEntityKey.class);
+            query.setParameter("roleId", StringKeyConverter.UUIDKey.INSTANCE.fromString(getId()));
+            compositeRoles = query.getResultList().stream().map(JpaRoleCompositeEntityKey::getChildRoleId).collect(Collectors.toSet());
+        }
+        return compositeRoles;
+    }
+
+    @Override
+    public void setCompositeRoles(Set<String> compositeRoles) {
+        Query query = em.createNamedQuery("deleteAllChildRolesFromCompositeRole");
+        query.setParameter("roleId", StringKeyConverter.UUIDKey.INSTANCE.fromString(getId()));
+        query.executeUpdate();
+        compositeRoles.forEach(this::addCompositeRole);
+        this.compositeRoles = compositeRoles;
+    }
+
+    @Override
+    public void addCompositeRole(String roleId) {
+        JpaRoleCompositeEntityKey key = new JpaRoleCompositeEntityKey(getId(), roleId);
+        if (compositeRoles != null) {
+            if (compositeRoles.contains(roleId)) {
+                return;
+            }
+        } else {
+            if (em.find(JpaRoleCompositeEntity.class, key) != null) {
+                return;
+            }
+        }
+        JpaRoleCompositeEntity entity = new JpaRoleCompositeEntity(key);
+        em.persist(entity);
+        if (compositeRoles != null) {
+            compositeRoles.add(roleId);
+        }
+    }
+
+    @Override
+    public void removeCompositeRole(String roleId) {
+        Query query = em.createNamedQuery("deleteChildRoleFromCompositeRole");
+        query.setParameter("roleId", StringKeyConverter.UUIDKey.INSTANCE.fromString(getId()));
+        query.setParameter("childRoleId", roleId);
+        query.executeUpdate();
+        if (compositeRoles != null) {
+            compositeRoles.remove(roleId);
+        }
+    }
+
+}

--- a/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/role/entity/JpaRoleCompositeEntity.java
+++ b/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/role/entity/JpaRoleCompositeEntity.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.models.map.storage.jpa.role.entity;
+
+import org.hibernate.annotations.Immutable;
+
+import javax.persistence.EmbeddedId;
+import javax.persistence.Entity;
+import javax.persistence.NamedQueries;
+import javax.persistence.NamedQuery;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
+
+/**
+ * This is a child table of {@link JpaRoleEntity} that is managed via named queries to avoid loading all its contents
+ * via a {@link javax.persistence.OneToMany} relation.
+ */
+@Entity
+@Table(name = "kc_role_composite", uniqueConstraints = {@UniqueConstraint(columnNames = {"role_id", "child_role_id"})})
+@Immutable
+@NamedQueries({
+        @NamedQuery(name = "selectChildRolesFromCompositeRole",
+                query = "select rolecomposite.key from JpaRoleCompositeEntity rolecomposite where rolecomposite.key.roleId = :roleId"),
+        @NamedQuery(name = "deleteChildRoleFromCompositeRole",
+                query = "delete from JpaRoleCompositeEntity rolecomposite where rolecomposite.key.roleId = :roleId and rolecomposite.key.childRoleId = :childRoleId"),
+        @NamedQuery(name = "deleteAllChildRolesFromCompositeRole",
+                query = "delete from JpaRoleCompositeEntity rolecomposite where rolecomposite.key.roleId = :roleId"),
+})
+public class JpaRoleCompositeEntity {
+
+    @EmbeddedId
+    private JpaRoleCompositeEntityKey key = new JpaRoleCompositeEntityKey();
+
+    public JpaRoleCompositeEntity() {
+    }
+
+    public JpaRoleCompositeEntity(JpaRoleCompositeEntityKey key) {
+        this.key = key;
+    }
+
+    @Override
+    public int hashCode() {
+        return getClass().hashCode();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null) return false;
+        if (!(o instanceof JpaRoleCompositeEntity)) return false;
+
+        JpaRoleCompositeEntity that = (JpaRoleCompositeEntity) o;
+
+        if (!key.equals(that.key)) return false;
+
+        return true;
+    }
+
+}

--- a/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/role/entity/JpaRoleCompositeEntityKey.java
+++ b/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/role/entity/JpaRoleCompositeEntityKey.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.models.map.storage.jpa.role.entity;
+
+import org.keycloak.models.map.common.StringKeyConverter;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import java.io.Serializable;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * The composite primary key representation for {@link JpaRoleCompositeEntity}.
+ * Required for performing a lookup by primary key through the JPA entity manager.
+ */
+@Embeddable
+public class JpaRoleCompositeEntityKey implements Serializable {
+
+    @Column(name = "role_id")
+    private UUID roleId;
+
+    public UUID getRoleId() {
+        return roleId;
+    }
+
+    public String getChildRoleId() {
+        return childRoleId;
+    }
+
+    @Column(name = "child_role_id")
+    private String childRoleId;
+
+    public JpaRoleCompositeEntityKey() {
+    }
+
+    public JpaRoleCompositeEntityKey(String roleId, String childRoleId) {
+        this.roleId = StringKeyConverter.UUIDKey.INSTANCE.fromString(roleId);
+        this.childRoleId = childRoleId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null) return false;
+        if (!(o instanceof JpaRoleCompositeEntityKey)) return false;
+
+        JpaRoleCompositeEntityKey that = (JpaRoleCompositeEntityKey) o;
+
+        if (!roleId.equals(that.roleId)) return false;
+        if (!childRoleId.equals(that.childRoleId)) return false;
+
+        return true;
+    }
+    
+    @Override
+    public int hashCode() {
+        return Objects.hash(roleId, childRoleId);
+    }
+
+}

--- a/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/role/entity/JpaRoleEntity.java
+++ b/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/role/entity/JpaRoleEntity.java
@@ -204,22 +204,28 @@ public class JpaRoleEntity extends AbstractRoleEntity implements JpaRootVersione
 
     @Override
     public Set<String> getCompositeRoles() {
-        return metadata.getCompositeRoles();
+        throw new UnsupportedOperationException("this is implemented in JpaMapRoleEntityDelegate, should never be called");
     }
 
     @Override
     public void setCompositeRoles(Set<String> compositeRoles) {
-        metadata.setCompositeRoles(compositeRoles);
+        if (compositeRoles == null) {
+            // this is called when cloning an entity during creation, can't be avoided with the current implementation
+            return;
+        }
+        throw new UnsupportedOperationException("this is implemented in JpaMapRoleEntityDelegate, should never be called");
+
     }
 
     @Override
     public void addCompositeRole(String roleId) {
-        metadata.addCompositeRole(roleId);
+        throw new UnsupportedOperationException("this is implemented in JpaMapRoleEntityDelegate, should never be called");
+
     }
 
     @Override
     public void removeCompositeRole(String roleId) {
-        metadata.removeCompositeRole(roleId);
+        throw new UnsupportedOperationException("this is implemented in JpaMapRoleEntityDelegate, should never be called");
     }
 
     @Override

--- a/model/map-jpa/src/main/resources/META-INF/persistence.xml
+++ b/model/map-jpa/src/main/resources/META-INF/persistence.xml
@@ -31,6 +31,7 @@
     <class>org.keycloak.models.map.storage.jpa.realm.entity.JpaRealmAttributeEntity</class>
     <!--roles-->
     <class>org.keycloak.models.map.storage.jpa.role.entity.JpaRoleEntity</class>
+    <class>org.keycloak.models.map.storage.jpa.role.entity.JpaRoleCompositeEntity</class>
     <class>org.keycloak.models.map.storage.jpa.role.entity.JpaRoleAttributeEntity</class>
     <!--user-login-failures-->
     <class>org.keycloak.models.map.storage.jpa.loginFailure.entity.JpaUserLoginFailureEntity</class>

--- a/model/map-jpa/src/main/resources/META-INF/roles/jpa-roles-changelog-1.xml
+++ b/model/map-jpa/src/main/resources/META-INF/roles/jpa-roles-changelog-1.xml
@@ -73,6 +73,20 @@ limitations under the License.
             <column name="name"/>
             <column name="VALUE(255)" valueComputed="VALUE(255)"/>
         </createIndex>
+        <createTable tableName="kc_role_composite">
+            <column name="role_id" type="UUID">
+                <constraints foreignKeyName="role_composite_fk_root_fkey" references="kc_role(id)" deleteCascade="true" nullable="false"/>
+            </column>
+            <column name="child_role_id" type="KC_KEY">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+        <!-- this primary key will also be used to search by role_id -->
+        <addPrimaryKey columnNames="role_id, child_role_id"
+                       tableName="kc_role_composite" />
+        <createIndex tableName="kc_role_composite" indexName="role_composite_child_role_id">
+            <column name="child_role_id"/>
+        </createIndex>
         <modifySql dbms="postgresql,cockroachdb">
             <replace replace="VALUE(255)" with="(value::varchar(250))"/>
         </modifySql>


### PR DESCRIPTION
This keeps the JSON column small, enables searching by child, and allows modification of the role's children without loading all children.

Closes #11844

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
