### PR TITLE
Replace log4j1.2 from test scope with reload4j

### DIFF
--- a/model/jpa/pom.xml
+++ b/model/jpa/pom.xml
@@ -40,7 +40,7 @@
         <jdbc.mvn.version>${h2.version}</jdbc.mvn.version>
         <log4j.configuration>file:${project.build.directory}/dependency/log4j.properties</log4j.configuration>
     </properties>
-    
+
     <dependencies>
         <dependency>
             <groupId>org.bouncycastle</groupId>
@@ -114,8 +114,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
+            <groupId>ch.qos.reload4j</groupId>
+            <artifactId>reload4j</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -104,12 +104,12 @@
         <jboss-transaction-api_1.3_spec>2.0.0.Final</jboss-transaction-api_1.3_spec>
         <jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec.version>2.0.1.Final</jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec.version>
         <jboss.spec.javax.servlet.jsp.jboss-jsp-api_2.3_spec.version>2.0.0.Final</jboss.spec.javax.servlet.jsp.jboss-jsp-api_2.3_spec.version>
-        <log4j.version>1.2.17</log4j.version>
+        <reload4j.version>1.2.21</reload4j.version>
         <resteasy.version>3.15.1.Final</resteasy.version>
         <resteasy.undertow.version>${resteasy.version}</resteasy.undertow.version>
         <owasp.html.sanitizer.version>20211018.2</owasp.html.sanitizer.version>
-        <slf4j-api.version>1.7.30</slf4j-api.version>
-        <slf4j.version>1.7.30</slf4j.version>
+        <slf4j-api.version>1.7.36</slf4j-api.version>
+        <slf4j.version>1.7.36</slf4j.version>
         <sun.istack.version>3.0.10</sun.istack.version>
         <sun.xml.bind.version>2.3.3-b02</sun.xml.bind.version>
         <javax.xml.bind.jaxb.version>2.4.0-b180830.0359</javax.xml.bind.jaxb.version>
@@ -404,8 +404,8 @@
                 <version>${resteasy.version}</version>
                 <exclusions>
                     <exclusion>
-                        <groupId>log4j</groupId>
-                        <artifactId>log4j</artifactId>
+                        <groupId>ch.qos.reload4j</groupId>
+                        <artifactId>reload4j</artifactId>
                     </exclusion>
                     <exclusion>
                         <groupId>org.slf4j</groupId>
@@ -544,9 +544,9 @@
                 <version>${jboss.logging.tools.version}</version>
             </dependency>
             <dependency>
-                <groupId>log4j</groupId>
-                <artifactId>log4j</artifactId>
-                <version>${log4j.version}</version>
+                <groupId>ch.qos.reload4j</groupId>
+                <artifactId>reload4j</artifactId>
+                <version>${reload4j.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/quarkus/runtime/pom.xml
+++ b/quarkus/runtime/pom.xml
@@ -484,8 +484,8 @@
             <artifactId>resteasy-core</artifactId>
             <exclusions>
                 <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
+                    <groupId>ch.qos.reload4j</groupId>
+                    <artifactId>reload4j</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
@@ -559,8 +559,8 @@
             <version>${version.com.openshift.openshift-restclient-java}</version>
             <exclusions>
                 <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
+                    <groupId>loch.qos.reload4jg4j</groupId>
+                    <artifactId>reload4j</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>org.slf4j</groupId>

--- a/testsuite/integration-arquillian/tests/pom.xml
+++ b/testsuite/integration-arquillian/tests/pom.xml
@@ -2067,8 +2067,8 @@
                 </dependency>-->
 
                 <dependency>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
+                    <groupId>ch.qos.reload4j</groupId>
+                    <artifactId>reload4j</artifactId>
                 </dependency>
                 <dependency>
                     <groupId>org.slf4j</groupId>
@@ -2429,14 +2429,14 @@
                 <tomcat.javax.net.ssl.properties>-Djavax.net.ssl.trustStore=${app.server.home}/lib/keycloak.truststore -Djavax.net.ssl.trustStorePassword=secret</tomcat.javax.net.ssl.properties>
             </properties>
         </profile>
-        
+
         <profile>
             <id>cache-auth</id>
             <properties>
                 <cache.server.auth>true</cache.server.auth>
             </properties>
         </profile>
-        
+
     </profiles>
 
 </project>

--- a/testsuite/model/pom.xml
+++ b/testsuite/model/pom.xml
@@ -13,7 +13,7 @@
     <name>Tests for logical storage layer</name>
     <description>Tests for storage layer functionality targetting logical layer, i.e. models</description>
     <packaging>jar</packaging>
-    
+
     <properties>
         <keycloak.connectionsJpa.driver>org.h2.Driver</keycloak.connectionsJpa.driver>
         <keycloak.connectionsJpa.database>keycloak</keycloak.connectionsJpa.database>
@@ -28,7 +28,7 @@
         <keycloak.profile.feature.map_storage>disabled</keycloak.profile.feature.map_storage>
         <keycloak.userSessions.infinispan.preloadOfflineSessionsFromDatabase>false</keycloak.userSessions.infinispan.preloadOfflineSessionsFromDatabase>
     </properties>
-    
+
     <dependencies>
         <dependency>
             <groupId>junit</groupId>
@@ -41,8 +41,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
+            <groupId>ch.qos.reload4j</groupId>
+            <artifactId>reload4j</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -149,7 +149,7 @@
                 <configuration>
                     <argLine>@{argLine}</argLine>
                     <systemPropertyVariables>
-                        <!-- keycloak.model.parameters lists parameter classes from 
+                        <!-- keycloak.model.parameters lists parameter classes from
                              org.keycloak.model.parameters package and determine enabled providers -->
                         <keycloak.model.parameters>${keycloak.model.parameters}</keycloak.model.parameters>
                         <keycloak.connectionsJpa.default.driver>${keycloak.connectionsJpa.driver}</keycloak.connectionsJpa.default.driver>
@@ -187,10 +187,10 @@
                         </configuration>
                     </execution>
                 </executions>
-            </plugin>                        
+            </plugin>
         </plugins>
     </build>
-    
+
     <profiles>
         <profile>
             <id>legacy-jpa</id>
@@ -337,5 +337,5 @@
         </profile>
 
     </profiles>
-    
+
 </project>

--- a/testsuite/utils/pom.xml
+++ b/testsuite/utils/pom.xml
@@ -57,8 +57,8 @@
             <artifactId>keycloak-wildfly-adduser</artifactId>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
+            <groupId>ch.qos.reload4j</groupId>
+            <artifactId>reload4j</artifactId>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -88,8 +88,8 @@
             <artifactId>resteasy-jaxrs</artifactId>
             <exclusions>
                 <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
+                    <groupId>ch.qos.reload4j</groupId>
+                    <artifactId>reload4j</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>org.slf4j</groupId>

--- a/util/embedded-ldap/pom.xml
+++ b/util/embedded-ldap/pom.xml
@@ -52,8 +52,8 @@
             <artifactId>jboss-logging</artifactId>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
+            <groupId>ch.qos.reload4j</groupId>
+            <artifactId>reload4j</artifactId>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
This pull request attempts to replace log4j 1.2.17 version (end-of-life) with reload4j in the test suite dependencies.

* https://reload4j.qos.ch/
* https://github.com/qos-ch/reload4j

From reload4j project description: _"The reload4j project is a fork of Apache log4j version 1.2.17 in order to fix most pressing security issues. It is intended as a drop-in replacement for log4j version 1.2.17"_. 

Alternative approach could be go to though the remaining direct `org.apache.log4j` imports and replace them with SLF4J - and bring in some other runtime bindings such as [Log4j 2 SLF4J](https://logging.apache.org/log4j/2.x/log4j-slf4j-impl/index.html).

Fixes #12832.

