### PR TITLE
Removed unused imports with double semicolons

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/InfinispanUserCacheProviderFactory.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/InfinispanUserCacheProviderFactory.java
@@ -30,8 +30,6 @@ import org.keycloak.models.cache.UserCacheProviderFactory;
 import org.keycloak.models.cache.infinispan.entities.Revisioned;
 import org.keycloak.models.cache.infinispan.events.InvalidationEvent;
 import org.keycloak.provider.InvalidationHandler;
-import org.keycloak.provider.InvalidationHandler.InvalidableObjectType;;
-import org.keycloak.provider.InvalidationHandler.ObjectType;;
 
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>


### PR DESCRIPTION
This PR fixes a syntax error while compiling `main` branch with Eclipse JDT compiler in vscode. JDT seems to be bit pickier than JDK about this, but the syntax error was caused by double semicolons `;;`. Since the imports were also unused, this PR just removes them to fix the problem.

Fixes #12837