### PR TITLE
Add support and docs for centralized logging using gelf.

### DIFF
--- a/docs/guides/src/main/server/configuration.adoc
+++ b/docs/guides/src/main/server/configuration.adoc
@@ -188,7 +188,7 @@ However, you might need to use properties directly from Quarkus to enable a spec
 As much as possible, avoid using properties directly from Quarkus. If your need is essential, consider opening an https://github.com/keycloak/keycloak/issues/new?assignees=&labels=kind%2Fenhancement%2Cstatus%2Ftriage&template=enhancement.yml[issue] first and help us
 to improve the server configuration.
 
-If that's not possible for you, you can configure the server using Quarkus properties, perform the following steps:
+If that's not possible, you can configure the server using Quarkus properties. Perform the following steps:
 
 . Create a `conf/quarkus.properties` file and define any property you need.
 
@@ -196,6 +196,6 @@ For a complete list of Quarkus properties, see the https://quarkus.io/guides/all
 
 When a raw quarkus property is a runtime property, it is also handled as runtime property for keycloak. When a quarkus property is a build time property, you have to invoke a new keycloak build first for the property to apply.
 
-Note that some quarkus properties are mapped to internally by the Keycloak configuration, for example `quarkus.http.port` and similar properties that are needed to configure Keycloak. If the property is used by Keycloak, and you define the same property key in the quarkus.properties file, the keycloak configuration value takes precedence over the raw quarkus configuration value, so the value you set in `quarkus.properties` will be ignored when there is a value in the actual Keycloak configuration.
+Note that some quarkus properties are mapped by the Keycloak configuration, for example `quarkus.http.port` and similar properties that are needed to configure Keycloak. If the property is used by Keycloak, and you define the same property key in the quarkus.properties file, the keycloak configuration value takes precedence over the raw quarkus configuration value, so the value you set in `quarkus.properties` will be ignored when there is a matching value in the actual Keycloak configuration.
 
 </@tmpl.guide>

--- a/docs/guides/src/main/server/logging.adoc
+++ b/docs/guides/src/main/server/logging.adoc
@@ -12,6 +12,7 @@ Keycloak uses the jboss logmanager logging framework. The high-level overview fo
 * root
 ** console (_default_)
 ** file
+** gelf
 
 == Logging: Root configuration
 Logging is done on a per-category basis in Keycloak. You can configure logging for the root log level, or for more specific categories like `org.hibernate` or `org.keycloak`. In this guide, you will learn how to configure logging.
@@ -57,7 +58,7 @@ The example above sets the root log level for all loggers to INFO, and the hiber
 To enable one or more log handlers, run the following command:
 <@kc.start parameters="--log=<handler1>,<handler2>"/>
 
-The available handlers are `console` and `file`. The more specific handler configuration mentioned below will only take effect when the handler is added to this comma-separated list.
+The available handlers are `console`, `file` and `gelf`. The more specific handler configuration mentioned below will only take effect when the handler is added to this comma-separated list.
 
 == Console Log Handler
 The console log handler is enabled by default, providing unstructured log messages for the console.
@@ -155,11 +156,282 @@ You can configure a different logging format for the file log handler by running
 
 Please see the <<Configuring the console log format>> section in this guide for more information and a table of the available pattern configuration.
 
-== Configuring raw quarkus logging properties
-At the time of writing, the logging features of the quarkus based Keycloak are basic, yet powerful. Nevertheless, expect more to come and feel free to join the https://github.com/keycloak/keycloak/discussions/8870[discussion] at GitHub.
+== Centralized logging using Gelf
+Keycloak is able to send logs to a centralized log management system like Graylog, Logstash (inside the Elastic Stack or ELK - Elasticsearch, Logstash, Kibana) or Fluentd (inside EFK - Elasticsearch, Fluentd, Kibana). Keycloak leverages the features of the https://quarkus.io/guides/centralized-log-management[Quarkus Logging Gelf] extension to provide support for these environments.
 
-When you need a temporary solution, e.g. for logging to a file or using syslog instead of console, you can check out the https://github.com/keycloak/keycloak/discussions/8870[Quarkus logging guide]. It is possible to use all properties mentioned there, as long as no other than the base logging dependency is involved. For example it is possible to set the log handler to file, but not to use json output, yet, as you would need to provide another dependency for json output to work.
+=== Enable the Gelf handler
+To enable logging using Gelf, you have to add it to the list of activated log handlers.
 
-To use raw quarkus properties, please refer to the <@links.server id="configuration"/> guide at section _Using unsupported server options_.
+.Example:
+<@kc.start parameters="--log=console,gelf"/>
+
+=== Configure the Gelf handler
+
+To configure the Host and Port of your centralized logging system, run the following command and substitute the values with your specific values:
+.Host and port of the Gelf server:
+<@kc.start parameters="--log=console,gelf --log-gelf-host=myhost --log-gelf-port=12345"/>
+
+By default, when the Gelf handler is enabled, the host is using `localhost` as host value and UDP for communication. If you want to use TCP instead of UDP, prefix the host value with `tcp:`. The Default port is `12201`.
+
+.Include or exclude Stacktraces
+By default, Keycloak includes the complete Stacktrace inside the field `StackTrace`. If you do not want to include this field, run the following command:
+
+<@kc.start parameters="--log=console,gelf --log-gelf-include-stack-trace=false"/>
+
+.Configure the timestamp format
+To change the format of the `timestamp` field, for example to only include the date and time down to seconds, run the following command:
+
+<@kc.start parameters="--log=console,gelf --log-gelf-timestamp-format=\"\'yyyy-MM-dd HH:mm:ss\'\""/>
+You may consider to use the config file instead to avoid escaping:
+
+[source, conf]
+----
+log-gelf-timestamp-format=yyyy-MM-dd HH:mm:ss
+----
+
+The default timestamp format is `yyyy-MM-dd HH:mm:ss,SSS`. You can use the https://docs.oracle.com/javase/10/docs/api/java/text/SimpleDateFormat.html[available SimpleDateFormat patterns] to define your needed timestamp.
+
+.Configure the facility
+To set the field `facility` - an indicator of the process or program that is the source of the log messages - to your preferred identifier (Default: keycloak), run the following command:
+
+<@kc.start parameters="--log=console,gelf --log-gelf-facility=MyKeycloak"/>
+
+When you need to configure Keycloak using the CLI and want the facility to contain whitespaces, run the command like below instead:
+
+<@kc.start parameters="--log=console,gelf --log-gelf-facility=\"\'my keycloak\'\""/>
+
+You may consider to use the config file instead to avoid escaping:
+[source, conf]
+----
+log-gelf-facility=my keycloak
+----
+
+.Configure the default message size
+To change the default message size of 8kb (8192 bytes) of Keycloaks gelf log messages, run the following command:
+
+<@kc.start parameters="--log=console,gelf --log-gelf-max-message-size=16384"/>
+
+The maximum size of one gelf log message has to be set in Bytes. The example above increases the size to 16kb. When messages exceed the maximum size, gelf will submit the message in multiple chunks.
+
+.Configure sending of message parameters
+By default, Keycloak includes message parameters of the occured log event. These fields are shown in the output as `MessageParam0`, `MessageParam1`, and so on, depending on the parameter length.
+To switch off this behaviour, run the following command:
+
+<@kc.start parameters="--log=console,gelf --log-gelf-include-message-parameters=false"/>
+
+.Configure sending of source code location
+By default, Keycloak includes the fields `SourceClassName`, `SourceMethodName` and `SourceSimpleClassName` in the gelf log messages to make it for example easier to see the location of an occured exception. To stop sending these fields, run the following command:
+
+<@kc.start parameters="--log=console,gelf --log-gelf-include-location=false"/>
+
+=== Example: Send logs to Graylog
+The following example shows how to send Keycloak logs to the Graylog centralized logging stack. It assumes you have a container tool like https://www.docker.com/[docker] installed to spin up the `compose.yml`.
+
+==== Spin up the Graylog stack
+The composed stack consists of:
+
+* Graylog
+* ElasticSearch
+* MongoDB
+
+[source, yaml]
+----
+version: '3.8'
+
+services:
+  elasticsearch:
+    image: docker.io/elastic/elasticsearch:7.17.4
+    ports:
+      - "9200:9200"
+    environment:
+      ES_JAVA_OPTS: "-Xms512m -Xmx512m"
+      discovery.type: "single-node"
+    networks:
+      - graylog
+
+  mongo:
+    image: mongo:4.0
+    networks:
+      - graylog
+
+  graylog:
+    image: graylog/graylog:4.3.2
+    ports:
+      - "9000:9000"
+      - "12201:12201/udp"
+      - "1514:1514"
+    environment:
+      GRAYLOG_HTTP_EXTERNAL_URI: "http://127.0.0.1:9000/"
+      # CHANGE ME (must be at least 16 characters)!
+      GRAYLOG_PASSWORD_SECRET: "forpasswordencryption"
+      # Password: admin
+      GRAYLOG_ROOT_PASSWORD_SHA2: "8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918"
+    networks:
+      - graylog
+    depends_on:
+      - elasticsearch
+      - mongo
+
+networks:
+  graylog:
+    driver: bridge
+----
+
+Copy and save the example locally into a `compose.yml` file and run:
+
+[source,bash]
+----
+docker compose up -d
+----
+After a few seconds the Stack should be ready to serve requests.
+
+==== Create a Graylog UDP Input
+After the stack is up and running, you need to create a UDP Input Graylog listens to. You can do it from the Graylog web UI (System → Input → Select GELF UDP) available at http://localhost:9000 or using the API:
+
+This `curl` example creates a new GELF UDP Input using the API and the default Graylog login credentials (admin/admin).
+
+[source, bash]
+----
+curl -H "Content-Type: application/json" -H "Authorization: Basic YWRtaW46YWRtaW4=" -H "X-Requested-By: curl" -X POST -v -d \
+'{"title":"udp input","configuration":{"recv_buffer_size":262144,"bind_address":"0.0.0.0","port":12201,"decompress_size_limit":8388608},"type":"org.graylog2.inputs.gelf.udp.GELFUDPInput","global":true}' \
+http://localhost:9000/api/system/inputs
+----
+
+If the stack is still in the bootstrap phase, you receive a response containing `* Empty reply from server`. A successfull response includes `HTTP/1.1 201 Created` to indicate that the UDP input is created.
+
+==== Configure Keycloak to send logs using Gelf
+Keycloak needs to be configured to send logs using Gelf. The appropriate configuration can be seen in the keycloak.conf example below.
+
+Note that for this example to work, it is not really necessary to add the `log-gelf-host` and `log-gelf-port` values to your configuration, as these are the defaults and only shown for illustrational purposes.
+. Keycloak Gelf Configuration
+
+[source, conf]
+----
+log=console,gelf
+log-gelf-host=localhost
+log-gelf-port=12201
+----
+
+==== Graylog: See the results
+Open your web browser, navigate to `http://localhost:9000`, login to the Graylog web UI using the admin credentials (admin/admin) and navigate to Streams → All Messages. Start updating the stream by pressing the play button in the up right corner. Then start Keycloak using `start` or `start-dev` and your gelf config. After a few seconds, Keycloaks messages will appear in the Graylog dashboard.
+
+=== Example Setup using the ELK Stack
+The following example shows how to send Keycloak logs to the ELK centralized logging stack. It assumes you have a container tool like https://www.docker.com/[docker] installed to spin up the `compose.yml`.
+
+==== Enable the logstash gelf plugin and create a pipeline
+Logstash uses an input plugin that can understand and parse the GELF format. To activate it when spinning up the ELK stack later on, create a directory `pipelines` and a file `gelf.conf` located in this directory. Then create an empty `compose.yml` in the parent directory.
+
+.File Structure:
+[source]
+----
+/ELK
+  - compose.yml
+  - pipelines/
+    - gelf.conf
+----
+
+
+Add the following contents to `pipelines/gelf.conf` and save it:
+
+[source, conf]
+----
+input {
+  gelf {
+    port => 12201
+  }
+}
+output {
+  stdout {}
+  elasticsearch {
+    hosts => ["http://elasticsearch:9200"]
+  }
+}
+----
+
+This file activates and configures the logstash gelf plugin and points it to the right elasticsearch instance.
+
+==== Spin up the ELK stack
+The composed stack consists of:
+
+* ElasticSearch
+* Logstash
+* Kibana
+
+Copy the following content to your `compose.yml` file:
+
+[source, yaml]
+----
+# Launch Elasticsearch
+version: '3.8'
+
+services:
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.8.2
+    ports:
+      - "9200:9200"
+      - "9300:9300"
+    environment:
+      ES_JAVA_OPTS: "-Xms512m -Xmx512m"
+    networks:
+      - elk
+
+  logstash:
+    image: docker.elastic.co/logstash/logstash-oss:6.8.2
+    volumes:
+      - source: ./pipelines #the source dir gelf.conf resides
+        target: /usr/share/logstash/pipeline
+        type: bind
+    ports:
+      - "12201:12201/udp"
+      - "5000:5000"
+      - "9600:9600"
+    networks:
+      - elk
+    depends_on:
+      - elasticsearch
+
+  kibana:
+    image: docker.elastic.co/kibana/kibana-oss:6.8.2
+    ports:
+      - "5601:5601"
+    networks:
+      - elk
+    depends_on:
+      - elasticsearch
+
+networks:
+  elk:
+    driver: bridge
+----
+Spin up the stack running the following command:
+
+[source, bash]
+----
+docker compose up -d
+----
+After a few seconds the Stack should be ready to serve requests.
+
+==== Configure Keycloak to send logs using Gelf
+Keycloak needs to be configured to send logs using Gelf. The appropriate configuration can be seen in the keycloak.conf example below.
+
+Note that for this example to work, it is not really necessary to add the `log-gelf-host` and `log-gelf-port` values to your configuration, as these are the defaults and only shown for illustrational purposes.
+. Keycloak Gelf Configuration
+
+[source, conf]
+----
+log=console,gelf
+log-gelf-host=localhost
+log-gelf-port=12201
+----
+
+With this configuration applied, start keycloak using `start-dev` or `start`.
+
+==== Kibana: See the results
+Open http://localhost:5601 to reach the Kibana dashboard. The exact configuration of a good monitoring dashboard is out of scope for this guide. The easiest way to find out if logs sent by Keycloak are delivered to Kibana is to open the http://localhost:5601/app/kibana#/dev_tools/console?_g=()[Dev Tools] and execute the default `match_all` query. The logs should appear in the result field.
+
+=== Configure additional key values
+Currently, the Keycloak configuration does not support partly dynamic configuration keys, as they are used in quarkus properties, e.g. when defining `quarkus.log.handler.gelf.additional-field.<my-name>.value`.
+
+In order to add additional user-defined fields, you can provide them directly through a quarkus.properties file. Please refer to the <@links.server id="configuration"/> guide at section _Using unsupported server options_.
 
 </@tmpl.guide>

--- a/quarkus/config-api/src/main/java/org/keycloak/config/LoggingOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/LoggingOptions.java
@@ -3,7 +3,6 @@ package org.keycloak.config;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.stream.Collectors;
@@ -18,12 +17,13 @@ public class LoggingOptions {
 
     public enum Handler {
         console,
-        file;
+        file,
+        gelf
     }
 
-    public static final Option log = new OptionBuilder("log", List.class, Handler.class)
+    public static final Option LOG = new OptionBuilder("log", List.class, Handler.class)
             .category(OptionCategory.LOGGING)
-            .description("Enable one or more log handlers in a comma-separated list. Available log handlers are: " + Arrays.stream(Handler.values()).limit(2).map(h -> h.toString()).collect(Collectors.joining(",")))
+            .description("Enable one or more log handlers in a comma-separated list. Available log handlers are: " + Arrays.stream(Handler.values()).map(Enum::toString).collect(Collectors.joining(",")))
             .defaultValue(DEFAULT_LOG_HANDLER)
             .expectedValues(Handler.values())
             .build();
@@ -66,13 +66,13 @@ public class LoggingOptions {
             .expectedValues(Output.values())
             .build();
 
-    public static final Option LOG_CONSOLE_FORMAT = new OptionBuilder<>("log-console-format", String.class)
+    public static final Option<String> LOG_CONSOLE_FORMAT = new OptionBuilder<>("log-console-format", String.class)
             .category(OptionCategory.LOGGING)
             .description("The format of unstructured console log entries. If the format has spaces in it, escape the value using \"<format>\".")
             .defaultValue("%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n")
             .build();
 
-    public static final Option LOG_CONSOLE_COLOR = new OptionBuilder<>("log-console-color", Boolean.class)
+    public static final Option<Boolean> LOG_CONSOLE_COLOR = new OptionBuilder<>("log-console-color", Boolean.class)
             .category(OptionCategory.LOGGING)
             .description("Enable or disable colors when logging to console.")
             .defaultValue(Boolean.FALSE) // :-(
@@ -83,7 +83,7 @@ public class LoggingOptions {
             .hidden()
             .build();
 
-    public static final Option LOG_FILE_ENABLED = new OptionBuilder<>("log-file-enabled", Boolean.class)
+    public static final Option<Boolean> LOG_FILE_ENABLED = new OptionBuilder<>("log-file-enabled", Boolean.class)
             .category(OptionCategory.LOGGING)
             .hidden()
             .build();
@@ -94,16 +94,78 @@ public class LoggingOptions {
             .defaultValue(new File(DEFAULT_LOG_PATH))
             .build();
 
-    public static final Option LOG_FILE_FORMAT = new OptionBuilder<>("log-file-format", String.class)
+    public static final Option<String> LOG_FILE_FORMAT = new OptionBuilder<>("log-file-format", String.class)
             .category(OptionCategory.LOGGING)
             .description("Set a format specific to file log entries.")
             .defaultValue("%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n")
             .build();
 
+    public static final Option<Boolean> LOG_GELF_ENABLED = new OptionBuilder<>("log-gelf-enabled", Boolean.class)
+            .category(OptionCategory.LOGGING)
+            .hidden()
+            .build();
+
+    public static final Option<String> LOG_GELF_HOST = new OptionBuilder<>("log-gelf-host", String.class)
+            .category(OptionCategory.LOGGING)
+            .description("Hostname of the Logstash or Graylog Host. By default UDP is used, prefix the host with 'tcp:' to switch to TCP. Example: 'tcp:localhost'")
+            .defaultValue("localhost")
+            .build();
+
+    public static final Option<Integer> LOG_GELF_PORT = new OptionBuilder<>("log-gelf-port", Integer.class)
+            .category(OptionCategory.LOGGING)
+            .description("The port the Logstash or Graylog Host is called on.")
+            .defaultValue(12201)
+            .build();
+
+    public static final Option<String> LOG_GELF_VERSION = new OptionBuilder<>("log-gelf-version", String.class)
+            .category(OptionCategory.LOGGING)
+            .description("The gelf version to be used.")
+            .defaultValue("1.1")
+            .hidden()
+            .expectedValues("1.0", "1.1")
+            .build();
+
+    public static final Option<Boolean> LOG_GELF_INCLUDE_STACK_TRACE = new OptionBuilder<>("log-gelf-include-stack-trace", Boolean.class)
+            .category(OptionCategory.LOGGING)
+            .description("If set to true, occuring stack traces are included in the 'StackTrace' field in the gelf output.")
+            .defaultValue(Boolean.TRUE)
+            .expectedValues(Boolean.TRUE, Boolean.FALSE)
+            .build();
+
+    public static final Option<String> LOG_GELF_TIMESTAMP_FORMAT = new OptionBuilder<>("log-gelf-timestamp-format", String.class)
+            .category(OptionCategory.LOGGING)
+            .description("Set the format for the gelf timestamp field. Uses Java SimpleDateFormat pattern.")
+            .defaultValue("yyyy-MM-dd HH:mm:ss,SSS")
+            .build();
+
+    public static final Option<String> LOG_GELF_FACILITY = new OptionBuilder<>("log-gelf-facility", String.class)
+            .category(OptionCategory.LOGGING)
+            .description("The facility (name of the process) that sends the message.")
+            .defaultValue("keycloak")
+            .build();
+
+    public static final Option<Integer> LOG_GELF_MAX_MSG_SIZE = new OptionBuilder<>("log-gelf-max-message-size", Integer.class)
+            .category(OptionCategory.LOGGING)
+            .description("Maximum message size (in bytes). If the message size is exceeded, gelf will submit the message in multiple chunks.")
+            .defaultValue(8192)
+            .build();
+
+    public static final Option<Boolean> LOG_GELF_INCLUDE_LOG_MSG_PARAMS = new OptionBuilder<>("log-gelf-include-message-parameters", Boolean.class)
+            .category(OptionCategory.LOGGING)
+            .description("Include message parameters from the log event.")
+            .defaultValue(Boolean.TRUE)
+            .build();
+
+    public static final Option<Boolean> LOG_GELF_INCLUDE_LOCATION = new OptionBuilder<>("log-gelf-include-location", Boolean.class)
+            .category(OptionCategory.LOGGING)
+            .description("Include source code location.")
+            .defaultValue(Boolean.TRUE)
+            .build();
+
     public static final List<Option<?>> ALL_OPTIONS = new ArrayList<>();
 
     static {
-        ALL_OPTIONS.add(log);
+        ALL_OPTIONS.add(LOG);
         ALL_OPTIONS.add(LOG_LEVEL);
         ALL_OPTIONS.add(LOG_CONSOLE_OUTPUT);
         ALL_OPTIONS.add(LOG_CONSOLE_FORMAT);
@@ -112,5 +174,15 @@ public class LoggingOptions {
         ALL_OPTIONS.add(LOG_FILE_ENABLED);
         ALL_OPTIONS.add(LOG_FILE);
         ALL_OPTIONS.add(LOG_FILE_FORMAT);
+        ALL_OPTIONS.add(LOG_GELF_ENABLED);
+        ALL_OPTIONS.add(LOG_GELF_HOST);
+        ALL_OPTIONS.add(LOG_GELF_PORT);
+        ALL_OPTIONS.add(LOG_GELF_VERSION);
+        ALL_OPTIONS.add(LOG_GELF_INCLUDE_STACK_TRACE);
+        ALL_OPTIONS.add(LOG_GELF_TIMESTAMP_FORMAT);
+        ALL_OPTIONS.add(LOG_GELF_FACILITY);
+        ALL_OPTIONS.add(LOG_GELF_MAX_MSG_SIZE);
+        ALL_OPTIONS.add(LOG_GELF_INCLUDE_LOG_MSG_PARAMS);
+        ALL_OPTIONS.add(LOG_GELF_INCLUDE_LOCATION);
     }
 }

--- a/quarkus/deployment/pom.xml
+++ b/quarkus/deployment/pom.xml
@@ -84,6 +84,11 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-logging-gelf-deployment</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
             <scope>test</scope>
         </dependency>

--- a/quarkus/runtime/pom.xml
+++ b/quarkus/runtime/pom.xml
@@ -84,6 +84,11 @@
             <artifactId>quarkus-logging-json</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-logging-gelf</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.wildfly.security</groupId>
             <artifactId>wildfly-elytron</artifactId>
             <version>${wildfly-elytron.version}</version>

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/LoggingPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/LoggingPropertyMappers.java
@@ -25,7 +25,7 @@ public final class LoggingPropertyMappers {
 
     public static PropertyMapper[] getMappers() {
         return new PropertyMapper[] {
-                fromOption(LoggingOptions.log)
+                fromOption(LoggingOptions.LOG)
                         .paramLabel("<handler>")
                         .build(),
                 fromOption(LoggingOptions.LOG_CONSOLE_OUTPUT)
@@ -64,6 +64,48 @@ public final class LoggingPropertyMappers {
                         .to("quarkus.log.level")
                         .transformer(LoggingPropertyMappers::resolveLogLevel)
                         .paramLabel("category:level")
+                        .build(),
+                fromOption(LoggingOptions.LOG_GELF_ENABLED)
+                        .mapFrom("log")
+                        .to("quarkus.log.handler.gelf.enabled")
+                        .paramLabel(Boolean.TRUE + "|" + Boolean.FALSE)
+                        .transformer(LoggingPropertyMappers.resolveLogHandler("gelf"))
+                        .build(),
+                fromOption(LoggingOptions.LOG_GELF_HOST)
+                        .to("quarkus.log.handler.gelf.host")
+                        .paramLabel("hostname")
+                        .build(),
+                fromOption(LoggingOptions.LOG_GELF_PORT)
+                        .to("quarkus.log.handler.gelf.port")
+                        .paramLabel("port")
+                        .build(),
+                fromOption(LoggingOptions.LOG_GELF_VERSION)
+                        .to("quarkus.log.handler.gelf.version")
+                        .paramLabel("version")
+                        .build(),
+                fromOption(LoggingOptions.LOG_GELF_INCLUDE_STACK_TRACE)
+                        .to("quarkus.log.handler.gelf.extract-stack-trace")
+                        .paramLabel(Boolean.TRUE + "|" + Boolean.FALSE)
+                        .build(),
+                fromOption(LoggingOptions.LOG_GELF_TIMESTAMP_FORMAT)
+                        .to("quarkus.log.handler.gelf.timestamp-pattern")
+                        .paramLabel("pattern")
+                        .build(),
+                fromOption(LoggingOptions.LOG_GELF_FACILITY)
+                        .to("quarkus.log.handler.gelf.facility")
+                        .paramLabel("name")
+                        .build(),
+                fromOption(LoggingOptions.LOG_GELF_MAX_MSG_SIZE)
+                        .to("quarkus.log.handler.gelf.maximum-message-size")
+                        .paramLabel("size")
+                        .build(),
+                fromOption(LoggingOptions.LOG_GELF_INCLUDE_LOG_MSG_PARAMS)
+                        .to("quarkus.log.handler.gelf.include-log-message-parameters")
+                        .paramLabel(Boolean.TRUE + "|" + Boolean.FALSE)
+                        .build(),
+                fromOption(LoggingOptions.LOG_GELF_INCLUDE_LOCATION)
+                        .to("quarkus.log.handler.gelf.include-location")
+                        .paramLabel(Boolean.TRUE + "|" + Boolean.FALSE)
                         .build()
         };
     }
@@ -80,7 +122,7 @@ public final class LoggingPropertyMappers {
             }
 
             String[] logHandlerValues = handlers.split(",");
-            List<String> availableLogHandlers = Arrays.stream(LoggingOptions.Handler.values()).map(h -> h.name()).collect(Collectors.toList());
+            List<String> availableLogHandlers = Arrays.stream(LoggingOptions.Handler.values()).map(Enum::name).collect(Collectors.toList());
 
             if (!availableLogHandlers.containsAll(List.of(logHandlerValues))) {
                 addInitializationException(Messages.notRecognizedValueInList("log", handlers, String.join(",", availableLogHandlers)));

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/ConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/ConfigurationTest.java
@@ -454,16 +454,25 @@ public class ConfigurationTest {
         SmallRyeConfig config = createConfig();
         assertEquals("true", config.getConfigValue("quarkus.log.console.enable").getValue());
         assertEquals("true", config.getConfigValue("quarkus.log.file.enable").getValue());
+        assertEquals("false", config.getConfigValue("quarkus.log.handler.gelf.enabled").getValue());
 
         System.setProperty(CLI_ARGS, "--log=file");
         SmallRyeConfig config2 = createConfig();
         assertEquals("false", config2.getConfigValue("quarkus.log.console.enable").getValue());
         assertEquals("true", config2.getConfigValue("quarkus.log.file.enable").getValue());
+        assertEquals("false", config2.getConfigValue("quarkus.log.handler.gelf.enabled").getValue());
 
         System.setProperty(CLI_ARGS, "--log=console");
         SmallRyeConfig config3 = createConfig();
         assertEquals("true", config3.getConfigValue("quarkus.log.console.enable").getValue());
         assertEquals("false", config3.getConfigValue("quarkus.log.file.enable").getValue());
+        assertEquals("false", config3.getConfigValue("quarkus.log.handler.gelf.enabled").getValue());
+
+        System.setProperty(CLI_ARGS, "--log=console,gelf");
+        SmallRyeConfig config4 = createConfig();
+        assertEquals("true", config4.getConfigValue("quarkus.log.console.enable").getValue());
+        assertEquals("false", config4.getConfigValue("quarkus.log.file.enable").getValue());
+        assertEquals("true", config4.getConfigValue("quarkus.log.handler.gelf.enabled").getValue());
     }
 
     @Test

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/LoggingTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/LoggingTest.java
@@ -15,7 +15,7 @@ public class LoggingTest {
     @Launch({ CONFIG_FILE_LONG_NAME+"=src/test/resources/LoggingTest/keycloak.conf", "start-dev" })
     void failUnknownHandlersInConfFile(LaunchResult result) {
         CLIResult cliResult = (CLIResult) result;
-        cliResult.assertMessage("Invalid values in list for key: log Values: foo,console. Possible values are a combination of: console,file");
+        cliResult.assertMessage("Invalid values in list for key: log Values: foo,console. Possible values are a combination of: console,file,gelf");
     }
 
     @Test

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartDevHelp.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartDevHelp.unix.approved.txt
@@ -112,7 +112,7 @@ Vault:
 Logging:
 
 --log <handler>      Enable one or more log handlers in a comma-separated list. Available log
-                       handlers are: console,file Default: console.
+                       handlers are: console,file,gelf Default: console.
 --log-console-color <true|false>
                      Enable or disable colors when logging to console. Default: false.
 --log-console-format <format>
@@ -127,6 +127,27 @@ Logging:
 --log-file-format <format>
                      Set a format specific to file log entries. Default: %d{yyyy-MM-dd HH:mm:ss,
                        SSS} %-5p [%c] (%t) %s%e%n.
+--log-gelf-facility <name>
+                     The facility (name of the process) that sends the message. Default: keycloak.
+--log-gelf-host <hostname>
+                     Hostname of the Logstash or Graylog Host. By default UDP is used, prefix the
+                       host with 'tcp:' to switch to TCP. Example: 'tcp:localhost' Default:
+                       localhost.
+--log-gelf-include-location <true|false>
+                     Include source code location. Default: true.
+--log-gelf-include-message-parameters <true|false>
+                     Include message parameters from the log event. Default: true.
+--log-gelf-include-stack-trace <true|false>
+                     If set to true, occuring stack traces are included in the 'StackTrace' field
+                       in the gelf output. Default: true.
+--log-gelf-max-message-size <size>
+                     Maximum message size (in bytes). If the message size is exceeded, gelf will
+                       submit the message in multiple chunks. Default: 8192.
+--log-gelf-port <port>
+                     The port the Logstash or Graylog Host is called on. Default: 12201.
+--log-gelf-timestamp-format <pattern>
+                     Set the format for the gelf timestamp field. Uses Java SimpleDateFormat
+                       pattern. Default: yyyy-MM-dd HH:mm:ss,SSS.
 --log-level <category:level>
                      The log level of the root category or a comma-separated list of individual
                        categories and their levels. For the root category, you don't need to

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartDevHelp.windows.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartDevHelp.windows.approved.txt
@@ -112,7 +112,7 @@ Vault:
 Logging:
 
 --log <handler>      Enable one or more log handlers in a comma-separated list. Available log
-                       handlers are: console,file Default: console.
+                       handlers are: console,file,gelf Default: console.
 --log-console-color <true|false>
                      Enable or disable colors when logging to console. Default: false.
 --log-console-format <format>
@@ -127,6 +127,27 @@ Logging:
 --log-file-format <format>
                      Set a format specific to file log entries. Default: %d{yyyy-MM-dd HH:mm:ss,
                        SSS} %-5p [%c] (%t) %s%e%n.
+--log-gelf-facility <name>
+                     The facility (name of the process) that sends the message. Default: keycloak.
+--log-gelf-host <hostname>
+                     Hostname of the Logstash or Graylog Host. By default UDP is used, prefix the
+                       host with 'tcp:' to switch to TCP. Example: 'tcp:localhost' Default:
+                       localhost.
+--log-gelf-include-location <true|false>
+                     Include source code location. Default: true.
+--log-gelf-include-message-parameters <true|false>
+                     Include message parameters from the log event. Default: true.
+--log-gelf-include-stack-trace <true|false>
+                     If set to true, occuring stack traces are included in the 'StackTrace' field
+                       in the gelf output. Default: true.
+--log-gelf-max-message-size <size>
+                     Maximum message size (in bytes). If the message size is exceeded, gelf will
+                       submit the message in multiple chunks. Default: 8192.
+--log-gelf-port <port>
+                     The port the Logstash or Graylog Host is called on. Default: 12201.
+--log-gelf-timestamp-format <pattern>
+                     Set the format for the gelf timestamp field. Uses Java SimpleDateFormat
+                       pattern. Default: yyyy-MM-dd HH:mm:ss,SSS.
 --log-level <category:level>
                      The log level of the root category or a comma-separated list of individual
                        categories and their levels. For the root category, you don't need to

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartDevHelpAll.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartDevHelpAll.unix.approved.txt
@@ -159,7 +159,7 @@ Vault:
 Logging:
 
 --log <handler>      Enable one or more log handlers in a comma-separated list. Available log
-                       handlers are: console,file Default: console.
+                       handlers are: console,file,gelf Default: console.
 --log-console-color <true|false>
                      Enable or disable colors when logging to console. Default: false.
 --log-console-format <format>
@@ -174,6 +174,27 @@ Logging:
 --log-file-format <format>
                      Set a format specific to file log entries. Default: %d{yyyy-MM-dd HH:mm:ss,
                        SSS} %-5p [%c] (%t) %s%e%n.
+--log-gelf-facility <name>
+                     The facility (name of the process) that sends the message. Default: keycloak.
+--log-gelf-host <hostname>
+                     Hostname of the Logstash or Graylog Host. By default UDP is used, prefix the
+                       host with 'tcp:' to switch to TCP. Example: 'tcp:localhost' Default:
+                       localhost.
+--log-gelf-include-location <true|false>
+                     Include source code location. Default: true.
+--log-gelf-include-message-parameters <true|false>
+                     Include message parameters from the log event. Default: true.
+--log-gelf-include-stack-trace <true|false>
+                     If set to true, occuring stack traces are included in the 'StackTrace' field
+                       in the gelf output. Default: true.
+--log-gelf-max-message-size <size>
+                     Maximum message size (in bytes). If the message size is exceeded, gelf will
+                       submit the message in multiple chunks. Default: 8192.
+--log-gelf-port <port>
+                     The port the Logstash or Graylog Host is called on. Default: 12201.
+--log-gelf-timestamp-format <pattern>
+                     Set the format for the gelf timestamp field. Uses Java SimpleDateFormat
+                       pattern. Default: yyyy-MM-dd HH:mm:ss,SSS.
 --log-level <category:level>
                      The log level of the root category or a comma-separated list of individual
                        categories and their levels. For the root category, you don't need to

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartDevHelpAll.windows.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartDevHelpAll.windows.approved.txt
@@ -159,7 +159,7 @@ Vault:
 Logging:
 
 --log <handler>      Enable one or more log handlers in a comma-separated list. Available log
-                       handlers are: console,file Default: console.
+                       handlers are: console,file,gelf Default: console.
 --log-console-color <true|false>
                      Enable or disable colors when logging to console. Default: false.
 --log-console-format <format>
@@ -174,6 +174,27 @@ Logging:
 --log-file-format <format>
                      Set a format specific to file log entries. Default: %d{yyyy-MM-dd HH:mm:ss,
                        SSS} %-5p [%c] (%t) %s%e%n.
+--log-gelf-facility <name>
+                     The facility (name of the process) that sends the message. Default: keycloak.
+--log-gelf-host <hostname>
+                     Hostname of the Logstash or Graylog Host. By default UDP is used, prefix the
+                       host with 'tcp:' to switch to TCP. Example: 'tcp:localhost' Default:
+                       localhost.
+--log-gelf-include-location <true|false>
+                     Include source code location. Default: true.
+--log-gelf-include-message-parameters <true|false>
+                     Include message parameters from the log event. Default: true.
+--log-gelf-include-stack-trace <true|false>
+                     If set to true, occuring stack traces are included in the 'StackTrace' field
+                       in the gelf output. Default: true.
+--log-gelf-max-message-size <size>
+                     Maximum message size (in bytes). If the message size is exceeded, gelf will
+                       submit the message in multiple chunks. Default: 8192.
+--log-gelf-port <PortNr>
+                     The port the Logstash or Graylog Host is called on. Default: 12201.
+--log-gelf-timestamp-format <pattern>
+                     Set the format for the gelf timestamp field. Uses Java SimpleDateFormat
+                       pattern. Default: yyyy-MM-dd HH:mm:ss,SSS.
 --log-level <category:level>
                      The log level of the root category or a comma-separated list of individual
                        categories and their levels. For the root category, you don't need to

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartHelp.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartHelp.unix.approved.txt
@@ -115,7 +115,7 @@ Vault:
 Logging:
 
 --log <handler>      Enable one or more log handlers in a comma-separated list. Available log
-                       handlers are: console,file Default: console.
+                       handlers are: console,file,gelf Default: console.
 --log-console-color <true|false>
                      Enable or disable colors when logging to console. Default: false.
 --log-console-format <format>
@@ -130,6 +130,27 @@ Logging:
 --log-file-format <format>
                      Set a format specific to file log entries. Default: %d{yyyy-MM-dd HH:mm:ss,
                        SSS} %-5p [%c] (%t) %s%e%n.
+--log-gelf-facility <name>
+                     The facility (name of the process) that sends the message. Default: keycloak.
+--log-gelf-host <hostname>
+                     Hostname of the Logstash or Graylog Host. By default UDP is used, prefix the
+                       host with 'tcp:' to switch to TCP. Example: 'tcp:localhost' Default:
+                       localhost.
+--log-gelf-include-location <true|false>
+                     Include source code location. Default: true.
+--log-gelf-include-message-parameters <true|false>
+                     Include message parameters from the log event. Default: true.
+--log-gelf-include-stack-trace <true|false>
+                     If set to true, occuring stack traces are included in the 'StackTrace' field
+                       in the gelf output. Default: true.
+--log-gelf-max-message-size <size>
+                     Maximum message size (in bytes). If the message size is exceeded, gelf will
+                       submit the message in multiple chunks. Default: 8192.
+--log-gelf-port <port>
+                     The port the Logstash or Graylog Host is called on. Default: 12201.
+--log-gelf-timestamp-format <pattern>
+                     Set the format for the gelf timestamp field. Uses Java SimpleDateFormat
+                       pattern. Default: yyyy-MM-dd HH:mm:ss,SSS.
 --log-level <category:level>
                      The log level of the root category or a comma-separated list of individual
                        categories and their levels. For the root category, you don't need to

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartHelp.windows.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartHelp.windows.approved.txt
@@ -115,7 +115,7 @@ Vault:
 Logging:
 
 --log <handler>      Enable one or more log handlers in a comma-separated list. Available log
-                       handlers are: console,file Default: console.
+                       handlers are: console,file,gelf Default: console.
 --log-console-color <true|false>
                      Enable or disable colors when logging to console. Default: false.
 --log-console-format <format>
@@ -130,6 +130,27 @@ Logging:
 --log-file-format <format>
                      Set a format specific to file log entries. Default: %d{yyyy-MM-dd HH:mm:ss,
                        SSS} %-5p [%c] (%t) %s%e%n.
+--log-gelf-facility <name>
+                     The facility (name of the process) that sends the message. Default: keycloak.
+--log-gelf-host <hostname>
+                     Hostname of the Logstash or Graylog Host. By default UDP is used, prefix the
+                       host with 'tcp:' to switch to TCP. Example: 'tcp:localhost' Default:
+                       localhost.
+--log-gelf-include-location <true|false>
+                     Include source code location. Default: true.
+--log-gelf-include-message-parameters <true|false>
+                     Include message parameters from the log event. Default: true.
+--log-gelf-include-stack-trace <true|false>
+                     If set to true, occuring stack traces are included in the 'StackTrace' field
+                       in the gelf output. Default: true.
+--log-gelf-max-message-size <size>
+                     Maximum message size (in bytes). If the message size is exceeded, gelf will
+                       submit the message in multiple chunks. Default: 8192.
+--log-gelf-port <port>
+                     The port the Logstash or Graylog Host is called on. Default: 12201.
+--log-gelf-timestamp-format <pattern>
+                     Set the format for the gelf timestamp field. Uses Java SimpleDateFormat
+                       pattern. Default: yyyy-MM-dd HH:mm:ss,SSS.
 --log-level <category:level>
                      The log level of the root category or a comma-separated list of individual
                        categories and their levels. For the root category, you don't need to


### PR DESCRIPTION
* 99% 1:1 wrapper of the underlying quarkus gelf extension.
* excluded `filter-stack-trace` and `stack-trace-throwable-reference` options for now, as they are either undocumented on the quarkus side or not important imo.
* added docs and examples for Graylog and ELK stack (EFK also possible, but didn't want to blow it up more)
* NOT added an automated test, as this is really a 1:1 wrapper around the extension, Test setup would be cumbersome, test would take too much time and tests are done in quarkus itself.

Closes #12125