### PR TITLE
Direct kc.home.dir to Maven's target folder

### DIFF
--- a/quarkus/server/pom.xml
+++ b/quarkus/server/pom.xml
@@ -21,6 +21,12 @@
         </dependency>
     </dependencies>
 
+    <properties>
+        <!-- define this as a property, so it can still be overwritten on the CLI -->
+        <!-- direct the auto-created files to the target folder, so they are cleaned by "mvn clean" -->
+        <kc.home.dir>${project.build.directory}/kc</kc.home.dir>
+    </properties>
+
     <build>
         <finalName>keycloak</finalName>
         <plugins>
@@ -39,6 +45,9 @@
                 <version>${quarkus.version}</version>
                 <configuration>
                     <finalName>keycloak</finalName>
+                    <systemProperties>
+                        <kc.home.dir>${kc.home.dir}</kc.home.dir>
+                    </systemProperties>
                 </configuration>
                 <executions>
                     <execution>

--- a/quarkus/server/src/main/java/org/keycloak/quarkus/_private/IDELauncher.java
+++ b/quarkus/server/src/main/java/org/keycloak/quarkus/_private/IDELauncher.java
@@ -1,5 +1,8 @@
 package org.keycloak.quarkus._private;
 
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -26,6 +29,13 @@ public class IDELauncher {
 
     public static void main(String[] args) {
         List<String> devArgs = new ArrayList<>();
+
+        if (System.getProperty("kc.home.dir") == null) {
+            // direct the auto-created files to the target folder, so they are cleaned by "mvn clean"
+            // users can still provide a different folder by setting the property when starting it from their IDE.
+            Path path = Paths.get(System.getProperty("user.dir"), "target", "kc");
+            System.setProperty("kc.home.dir", path.toAbsolutePath().toString());
+        }
 
         devArgs.addAll(Arrays.asList(args));
 


### PR DESCRIPTION
This prevents files created, for example, the store to end up in the user's home directory.

Closes #12850

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
