### PR TITLE
Token refresh should consider initially requested scopes (#12326)

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
@@ -198,8 +198,10 @@ public class TokenManager {
             throw new OAuthErrorException(OAuthErrorException.INVALID_GRANT, "Stale token");
         }
 
-        // Setup clientScopes from refresh token to the context
-        String oldTokenScope = oldToken.getScope();
+        // Setup clientScopes from clientSession referenced by refreshToken to the context.
+        // Note: we need to use the scopes from the client session note here,
+        // to ensure that mappers for scopes with "includeInTokenScope" set to "false" are also applied.
+        String oldTokenScope = clientSession.getNote(OAuth2Constants.SCOPE);
 
         // Case when offline token is migrated from previous version
         if (oldTokenScope == null && userSession.isOffline()) {


### PR DESCRIPTION
Mappers of client scopes with `Include In Token Scope` set to `false`
were not applied to AccessTokens generated for token refresh requests.

We now honor the scope information stored in the client session to ensure,
that mappers for all initial requested scope are applied on token refresh.

Fixes #12326

Signed-off-by: Thomas Darimont <thomas.darimont@googlemail.com>

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
