### PR TITLE
Adds REGISTER event when new user login through first broker flow

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/IdentityBrokerService.java
+++ b/services/src/main/java/org/keycloak/services/resources/IdentityBrokerService.java
@@ -701,7 +701,8 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
                     federatedUser.setEmailVerified(true);
                 }
 
-                event.event(EventType.REGISTER)
+                event.clone()
+                        .event(EventType.REGISTER)
                         .detail(Details.REGISTER_METHOD, "broker")
                         .detail(Details.EMAIL, federatedUser.getEmail())
                         .success();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractFirstBrokerLoginTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractFirstBrokerLoginTest.java
@@ -1007,9 +1007,14 @@ public abstract class AbstractFirstBrokerLoginTest extends AbstractInitializedBa
         Assert.assertEquals("no-first-name", accountUpdateProfilePage.getUsername());
 
         RealmRepresentation consumerRealmRep = adminClient.realm(bc.consumerRealmName()).toRepresentation();
+        events.expectAccount(EventType.REGISTER).realm(consumerRealmRep).user(Matchers.any(String.class)).session((String) null)
+                .detail(Details.IDENTITY_PROVIDER_USERNAME, "no-first-name")
+                .detail(Details.REGISTER_METHOD, "broker")
+                .assertEvent(getFirstConsumerEvent());
+
         events.expectAccount(EventType.LOGIN).realm(consumerRealmRep).user(Matchers.any(String.class)).session(Matchers.any(String.class))
             .detail(Details.IDENTITY_PROVIDER_USERNAME, "no-first-name")
-            .detail(Details.REGISTER_METHOD, "broker")
+            .detail(Details.IDENTITY_PROVIDER, bc.getIDPAlias())
             .assertEvent(getFirstConsumerEvent());
     }
 
@@ -1045,9 +1050,15 @@ public abstract class AbstractFirstBrokerLoginTest extends AbstractInitializedBa
             .detail(Details.PREVIOUS_EMAIL, "no-first-name@localhost.com")
             .detail(Details.UPDATED_EMAIL, "new-email@localhost.com")
             .assertEvent(getFirstConsumerEvent());
-        events.expectAccount(EventType.LOGIN).realm(consumerRealmRep).user(Matchers.any(String.class)).session(Matchers.any(String.class))
+
+        events.expectAccount(EventType.REGISTER).realm(consumerRealmRep).user(Matchers.any(String.class)).session((String) null)
             .detail(Details.IDENTITY_PROVIDER_USERNAME, "no-first-name")
             .detail(Details.REGISTER_METHOD, "broker")
+            .assertEvent(events.poll());
+
+        events.expectAccount(EventType.LOGIN).realm(consumerRealmRep).user(Matchers.any(String.class)).session(Matchers.any(String.class))
+            .detail(Details.IDENTITY_PROVIDER_USERNAME, "no-first-name")
+            .detail(Details.IDENTITY_PROVIDER, bc.getIDPAlias())
             .assertEvent(events.poll());
     }
 


### PR DESCRIPTION
Updates KcOidcBrokerEventTest, AbstractFirstBrokerLoginTest to factor in REGISTER event in first broker flow

Closes #11646



<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
