### PR TITLE
Move methods from UserStorageUtil to LegacyRealmModel

### DIFF
--- a/model/legacy-private/src/main/java/org/keycloak/migration/migrators/MigrateTo1_3_0.java
+++ b/model/legacy-private/src/main/java/org/keycloak/migration/migrators/MigrateTo1_3_0.java
@@ -22,12 +22,12 @@ import org.keycloak.component.ComponentFactory;
 import org.keycloak.migration.ModelVersion;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.LDAPConstants;
+import org.keycloak.models.LegacyRealmModel;
 import org.keycloak.models.RealmModel;
 import org.keycloak.provider.ProviderFactory;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.storage.UserStorageProvider;
 import org.keycloak.storage.UserStorageProviderModel;
-import org.keycloak.storage.UserStorageUtil;
 
 import javax.naming.directory.SearchControls;
 import java.util.List;
@@ -53,7 +53,7 @@ public class MigrateTo1_3_0 implements Migration {
     }
 
     private void migrateLDAPProviders(KeycloakSession session, RealmModel realm) {
-        UserStorageUtil.getUserStorageProvidersStream(realm).forEachOrdered(fedProvider -> {
+        ((LegacyRealmModel) realm).getUserStorageProvidersStream().forEachOrdered(fedProvider -> {
             if (fedProvider.getProviderId().equals(LDAPConstants.LDAP_PROVIDER)) {
                 fedProvider = new UserStorageProviderModel(fedProvider);  // copy don't want to muck with cache
                 MultivaluedHashMap<String, String> config = fedProvider.getConfig();

--- a/model/legacy-private/src/main/java/org/keycloak/migration/migrators/MigrateTo1_4_0.java
+++ b/model/legacy-private/src/main/java/org/keycloak/migration/migrators/MigrateTo1_4_0.java
@@ -22,8 +22,8 @@ import org.keycloak.migration.ModelVersion;
 import org.keycloak.models.ImpersonationConstants;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.LDAPConstants;
+import org.keycloak.models.LegacyRealmModel;
 import org.keycloak.models.RealmModel;
-import org.keycloak.models.UserModel;
 import org.keycloak.models.cache.UserCache;
 import org.keycloak.models.utils.DefaultAuthenticationFlows;
 import org.keycloak.models.utils.DefaultRequiredActions;
@@ -69,7 +69,7 @@ public class MigrateTo1_4_0 implements Migration {
 
     private void migrateLDAPMappers(KeycloakSession session, RealmModel realm) {
         List<String> mandatoryInLdap = Arrays.asList("username", "username-cn", "first name", "last name");
-        UserStorageUtil.getUserStorageProvidersStream(realm)
+        ((LegacyRealmModel) realm).getUserStorageProvidersStream()
                 .filter(providerModel -> Objects.equals(providerModel.getProviderId(), LDAPConstants.LDAP_PROVIDER))
                 .forEachOrdered(providerModel -> realm.getComponentsStream(providerModel.getId())
                         .filter(mapper -> mandatoryInLdap.contains(mapper.getName()))

--- a/model/legacy-private/src/main/java/org/keycloak/migration/migrators/MigrateTo1_8_0.java
+++ b/model/legacy-private/src/main/java/org/keycloak/migration/migrators/MigrateTo1_8_0.java
@@ -21,11 +21,11 @@ import org.keycloak.component.ComponentModel;
 import org.keycloak.migration.ModelVersion;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.LDAPConstants;
+import org.keycloak.models.LegacyRealmModel;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.storage.UserStorageProviderModel;
-import org.keycloak.storage.UserStorageUtil;
 
 import java.util.Objects;
 
@@ -51,7 +51,7 @@ public class MigrateTo1_8_0 implements Migration {
     }
 
     protected void migrateRealm(RealmModel realm) {
-        UserStorageUtil.getUserStorageProvidersStream(realm)
+        ((LegacyRealmModel) realm).getUserStorageProvidersStream()
                 .filter(fedProvider -> Objects.equals(fedProvider.getProviderId(), LDAPConstants.LDAP_PROVIDER))
                 .filter(this::isActiveDirectory)
                 .filter(fedProvider -> Objects.isNull(getMapperByName(realm, fedProvider, "MSAD account controls")))

--- a/model/legacy-private/src/main/java/org/keycloak/storage/managers/UserStorageSyncManager.java
+++ b/model/legacy-private/src/main/java/org/keycloak/storage/managers/UserStorageSyncManager.java
@@ -26,12 +26,12 @@ import org.keycloak.component.ComponentModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.models.KeycloakSessionTask;
+import org.keycloak.models.LegacyRealmModel;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.storage.UserStorageProvider;
 import org.keycloak.storage.UserStorageProviderFactory;
 import org.keycloak.storage.UserStorageProviderModel;
-import org.keycloak.storage.UserStorageUtil;
 import org.keycloak.storage.user.ImportSynchronization;
 import org.keycloak.storage.user.SynchronizationResult;
 import org.keycloak.timer.TimerProvider;
@@ -62,7 +62,7 @@ public class UserStorageSyncManager {
             public void run(KeycloakSession session) {
                 Stream<RealmModel> realms = session.realms().getRealmsWithProviderTypeStream(UserStorageProvider.class);
                 realms.forEach(realm -> {
-                    Stream<UserStorageProviderModel> providers = UserStorageUtil.getUserStorageProvidersStream(realm);
+                    Stream<UserStorageProviderModel> providers = ((LegacyRealmModel) realm).getUserStorageProvidersStream();
                     providers.forEachOrdered(provider -> {
                         UserStorageProviderFactory factory = (UserStorageProviderFactory) session.getKeycloakSessionFactory().getProviderFactory(UserStorageProvider.class, provider.getProviderId());
                         if (factory instanceof ImportSynchronization && provider.isImportEnabled()) {
@@ -166,7 +166,7 @@ public class UserStorageSyncManager {
 
 
     public static void notifyToRefreshPeriodicSyncAll(KeycloakSession session, RealmModel realm, boolean removed) {
-        UserStorageUtil.getUserStorageProvidersStream(realm).forEachOrdered(fedProvider ->
+        ((LegacyRealmModel) realm).getUserStorageProvidersStream().forEachOrdered(fedProvider ->
            notifyToRefreshPeriodicSync(session, realm, fedProvider, removed));
     }
     
@@ -268,7 +268,7 @@ public class UserStorageSyncManager {
             @Override
             public void run(KeycloakSession session) {
                 RealmModel persistentRealm = session.realms().getRealm(realmId);
-                UserStorageUtil.getUserStorageProvidersStream(persistentRealm)
+                ((LegacyRealmModel) persistentRealm).getUserStorageProvidersStream()
                         .filter(persistentFedProvider -> Objects.equals(provider.getId(), persistentFedProvider.getId()))
                         .forEachOrdered(persistentFedProvider -> {
                             // Update persistent provider in DB

--- a/model/legacy/src/main/java/org/keycloak/models/LegacyRealmModel.java
+++ b/model/legacy/src/main/java/org/keycloak/models/LegacyRealmModel.java
@@ -18,6 +18,8 @@
 package org.keycloak.models;
 
 import org.keycloak.models.RealmModel;
+import org.keycloak.storage.UserStorageProvider;
+import org.keycloak.storage.UserStorageProviderModel;
 import org.keycloak.storage.client.ClientStorageProvider;
 import org.keycloak.storage.client.ClientStorageProviderModel;
 import org.keycloak.storage.role.RoleStorageProvider;
@@ -67,6 +69,25 @@ public interface LegacyRealmModel extends RealmModel {
         return getComponentsStream(getId(), RoleStorageProvider.class.getName())
                 .map(RoleStorageProviderModel::new)
                 .sorted(RoleStorageProviderModel.comparator);
+    }
+
+    /**
+     * @deprecated Use {@link #getUserStorageProvidersStream() getUserStorageProvidersStream} instead.
+     */
+    @Deprecated
+    default List<UserStorageProviderModel> getUserStorageProviders() {
+        return getUserStorageProvidersStream().collect(Collectors.toList());
+    }
+
+    /**
+     * Returns sorted {@link UserStorageProviderModel UserStorageProviderModel} as a stream.
+     * It should be used with forEachOrdered if the ordering is required.
+     * @return Sorted stream of {@link UserStorageProviderModel}. Never returns {@code null}.
+     */
+    default Stream<UserStorageProviderModel> getUserStorageProvidersStream() {
+        return getComponentsStream(getId(), UserStorageProvider.class.getName())
+                .map(UserStorageProviderModel::new)
+                .sorted(UserStorageProviderModel.comparator);
     }
 
 }

--- a/model/legacy/src/main/java/org/keycloak/storage/UserStorageUtil.java
+++ b/model/legacy/src/main/java/org/keycloak/storage/UserStorageUtil.java
@@ -18,26 +18,13 @@
 package org.keycloak.storage;
 
 import org.keycloak.models.KeycloakSession;
-import org.keycloak.models.RealmModel;
 import org.keycloak.models.cache.UserCache;
 import org.keycloak.storage.federated.UserFederatedStorageProvider;
-
-import java.util.stream.Stream;
 
 /**
  * @author Alexander Schwartz
  */
 public class UserStorageUtil {
-    /**
-     * Returns sorted {@link UserStorageProviderModel UserStorageProviderModel} as a stream.
-     * It should be used with forEachOrdered if the ordering is required.
-     * @return Sorted stream of {@link UserStorageProviderModel}. Never returns {@code null}.
-     */
-    public static Stream<UserStorageProviderModel> getUserStorageProvidersStream(RealmModel realm) {
-        return realm.getComponentsStream(realm.getId(), UserStorageProvider.class.getName())
-                .map(UserStorageProviderModel::new)
-                .sorted(UserStorageProviderModel.comparator);
-    }
 
     public static UserFederatedStorageProvider userFederatedStorage(KeycloakSession session) {
         return session.getProvider(UserFederatedStorageProvider.class);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPSyncTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPSyncTest.java
@@ -33,6 +33,7 @@ import org.keycloak.component.ComponentModel;
 import org.keycloak.models.GroupModel;
 import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.models.LDAPConstants;
+import org.keycloak.models.LegacyRealmModel;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.UserProvider;
@@ -148,7 +149,7 @@ public class LDAPSyncTest extends AbstractLDAPTest {
 
             // Assert lastSync time updated
             Assert.assertTrue(ctx.getLdapModel().getLastSync() > 0);
-            UserStorageUtil.getUserStorageProvidersStream(testRealm).forEachOrdered(persistentFedModel -> {
+            ((LegacyRealmModel) testRealm).getUserStorageProvidersStream().forEachOrdered(persistentFedModel -> {
                 if (LDAPStorageProviderFactory.PROVIDER_NAME.equals(persistentFedModel.getProviderId())) {
                     Assert.assertTrue(persistentFedModel.getLastSync() > 0);
                 } else {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/storage/UserStorageProvidersTestUtils.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/storage/UserStorageProvidersTestUtils.java
@@ -4,12 +4,12 @@ import org.jboss.logging.Logger;
 import org.keycloak.common.util.reflections.Types;
 import org.keycloak.component.ComponentModel;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.LegacyRealmModel;
 import org.keycloak.models.ModelException;
 import org.keycloak.models.RealmModel;
 import org.keycloak.storage.UserStorageProvider;
 import org.keycloak.storage.UserStorageProviderFactory;
 import org.keycloak.storage.UserStorageProviderModel;
-import org.keycloak.storage.UserStorageUtil;
 
 import java.util.stream.Stream;
 
@@ -47,7 +47,7 @@ public class UserStorageProvidersTestUtils {
     }
 
     public static <T> Stream<UserStorageProviderModel> getStorageProviders(RealmModel realm, KeycloakSession session, Class<T> type) {
-        return UserStorageUtil.getUserStorageProvidersStream(realm)
+        return ((LegacyRealmModel) realm).getUserStorageProvidersStream()
                 .filter(model -> {
                     UserStorageProviderFactory factory = getUserStorageProviderFactory(model, session);
                     if (factory == null) {

--- a/testsuite/utils/src/main/java/org/keycloak/testsuite/util/cli/SyncDummyFederationProviderCommand.java
+++ b/testsuite/utils/src/main/java/org/keycloak/testsuite/util/cli/SyncDummyFederationProviderCommand.java
@@ -19,10 +19,10 @@ package org.keycloak.testsuite.util.cli;
 
 import org.keycloak.common.util.MultivaluedHashMap;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.LegacyRealmModel;
 import org.keycloak.models.RealmModel;
 import org.keycloak.storage.managers.UserStorageSyncManager;
 import org.keycloak.storage.UserStorageProviderModel;
-import org.keycloak.storage.UserStorageUtil;
 
 import java.util.Objects;
 
@@ -71,7 +71,7 @@ public class SyncDummyFederationProviderCommand extends AbstractCommand {
             return null;
         }
 
-        return UserStorageUtil.getUserStorageProvidersStream(realm)
+        return ((LegacyRealmModel) realm).getUserStorageProvidersStream()
                 .filter(fedProvider -> Objects.equals(fedProvider.getName(), displayName))
                 .findFirst()
                 .orElse(null);


### PR DESCRIPTION
It is better suited to take methods removed from RealmModel earlier.

Closes #12805

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
