### PR TITLE
Continue client browser flow after User login from Identity Provider

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/authentication/AuthenticationFlow.java
+++ b/server-spi-private/src/main/java/org/keycloak/authentication/AuthenticationFlow.java
@@ -21,6 +21,8 @@ import jakarta.ws.rs.core.Response;
 import java.util.Collections;
 import java.util.List;
 
+import org.keycloak.models.AuthenticationExecutionModel;
+
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
@@ -36,4 +38,6 @@ public interface AuthenticationFlow {
     default List<AuthenticationFlowException> getFlowExceptions(){
         return Collections.emptyList();
     }
+
+    default Response continueClientAuthAfterIdPLogin(AuthenticationExecutionModel model){ throw new IllegalStateException("Not supposed to be invoked"); }
 }

--- a/server-spi-private/src/main/java/org/keycloak/authentication/AuthenticationFlowContext.java
+++ b/server-spi-private/src/main/java/org/keycloak/authentication/AuthenticationFlowContext.java
@@ -75,6 +75,11 @@ public interface AuthenticationFlowContext extends AbstractAuthenticationFlowCon
     String getFlowPath();
 
     /**
+     * @return flow id
+     */
+    String getFlowId();
+
+    /**
      * Create a Freemarker form builder that presets the user, action URI, and a generated access code
      *
      * @return

--- a/services/src/main/java/org/keycloak/authentication/AuthenticationProcessor.java
+++ b/services/src/main/java/org/keycloak/authentication/AuthenticationProcessor.java
@@ -89,6 +89,8 @@ public class AuthenticationProcessor {
     public static final String CURRENT_AUTHENTICATION_EXECUTION = "current.authentication.execution";
     public static final String LAST_PROCESSED_EXECUTION = "last.processed.execution";
     public static final String CURRENT_FLOW_PATH = "current.flow.path";
+    public static final String CLIENT_FLOW_ID = "client.flow.id";
+    public static final String CLIENT_AUTHENTICATION_EXECUTION = "client.authentication.execution";
     public static final String FORKED_FROM = "forked.from";
     public static final String AUTHN_CREDENTIALS = "authn.credentials";
 
@@ -286,6 +288,10 @@ public class AuthenticationProcessor {
 
     public String getFlowPath() {
         return flowPath;
+    }
+
+    public String getFlowId() {
+        return flowId;
     }
 
     public void setAutheticatedUser(UserModel user) {
@@ -542,6 +548,11 @@ public class AuthenticationProcessor {
         @Override
         public String getFlowPath() {
             return AuthenticationProcessor.this.getFlowPath();
+        }
+
+        @Override
+        public String getFlowId() {
+            return AuthenticationProcessor.this.getFlowId();
         }
 
         @Override
@@ -935,6 +946,7 @@ public class AuthenticationProcessor {
     }
 
     public AuthenticationFlow createFlowExecution(String flowId, AuthenticationExecutionModel execution) {
+
         AuthenticationFlowModel flow = realm.getAuthenticationFlowById(flowId);
         if (flow == null) {
             logger.error("Unknown flow to execute with");
@@ -996,7 +1008,16 @@ public class AuthenticationProcessor {
         authSession.setAuthenticatedUser(null);
         authSession.clearExecutionStatus();
         authSession.clearUserSessionNotes();
+        String client_execution = authSession.getAuthNote(AuthenticationProcessor.CLIENT_AUTHENTICATION_EXECUTION);
+        String client_flow = authSession.getAuthNote(AuthenticationProcessor.CLIENT_FLOW_ID);
         authSession.clearAuthNotes();
+        //keep CLIENT_AUTHENTICATION_EXECUTION and CLIENT_FLOW_ID if they exist
+        if (client_execution != null) {
+            authSession.setAuthNote(AuthenticationProcessor.CLIENT_AUTHENTICATION_EXECUTION, client_execution);
+        }
+        if (client_flow != null) {
+            authSession.setAuthNote(AuthenticationProcessor.CLIENT_FLOW_ID, client_flow);
+        }
 
         Set<String> requiredActions = authSession.getRequiredActions();
         for (String reqAction : requiredActions) {

--- a/services/src/main/java/org/keycloak/authentication/DefaultAuthenticationFlow.java
+++ b/services/src/main/java/org/keycloak/authentication/DefaultAuthenticationFlow.java
@@ -153,6 +153,20 @@ public class DefaultAuthenticationFlow implements AuthenticationFlow {
         } else return response;
     }
 
+    @Override
+    public Response continueClientAuthAfterIdPLogin(AuthenticationExecutionModel model){
+        AuthenticatorFactory factory = getAuthenticatorFactory(model);
+        Authenticator authenticator = createAuthenticator(factory);
+        AuthenticationProcessor.Result result = processor.createAuthenticatorContext(model, null, null);
+        authenticator.action(result);
+        Response response = processResult(result, true);
+        if (response == null) {
+            return continueAuthenticationAfterSuccessfulAction(model);
+        } else {
+            return response;
+        }
+    }
+
 
     /**
      * Called after "actionExecutionModel" execution is finished (Either successful or attempted). Find the next appropriate authentication

--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/IdentityProviderAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/IdentityProviderAuthenticator.java
@@ -22,6 +22,7 @@ import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.authentication.AuthenticationProcessor;
 import org.keycloak.authentication.Authenticator;
 import org.keycloak.constants.AdapterConstants;
+import org.keycloak.events.Details;
 import org.keycloak.models.IdentityProviderModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
@@ -78,6 +79,8 @@ public class IdentityProviderAuthenticator implements Authenticator {
     protected void redirect(AuthenticationFlowContext context, String providerId, String loginHint) {
         IdentityProviderModel idp = context.getSession().identityProviders().getByAlias(providerId);
         if (idp != null && idp.isEnabled()) {
+            context.getAuthenticationSession().setAuthNote(AuthenticationProcessor.CLIENT_FLOW_ID, context.getFlowId());
+            context.getAuthenticationSession().setAuthNote(AuthenticationProcessor.CLIENT_AUTHENTICATION_EXECUTION, context.getExecution().getId());
             String accessCode = new ClientSessionCode<>(context.getSession(), context.getRealm(), context.getAuthenticationSession()).getOrGenerateCode();
             String clientId = context.getAuthenticationSession().getClient().getClientId();
             String tabId = context.getAuthenticationSession().getTabId();
@@ -101,6 +104,9 @@ public class IdentityProviderAuthenticator implements Authenticator {
 
     @Override
     public void action(AuthenticationFlowContext context) {
+        //If IDENTITY_PROVIDER_USERNAME is not null, then user has logged in via IdP -> return success
+        if (context.getAuthenticationSession().getUserSessionNotes().get(Details.IDENTITY_PROVIDER_USERNAME) != null)
+            context.success();
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/UsernamePasswordForm.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/UsernamePasswordForm.java
@@ -19,8 +19,10 @@ package org.keycloak.authentication.authenticators.browser;
 
 import org.keycloak.WebAuthnConstants;
 import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.authentication.AuthenticationProcessor;
 import org.keycloak.authentication.AuthenticatorUtil;
 import org.keycloak.authentication.Authenticator;
+import org.keycloak.events.Details;
 import org.keycloak.forms.login.LoginFormsProvider;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
@@ -52,18 +54,21 @@ public class UsernamePasswordForm extends AbstractUsernameFormAuthenticator impl
 
     @Override
     public void action(AuthenticationFlowContext context) {
-        MultivaluedMap<String, String> formData = context.getHttpRequest().getDecodedFormParameters();
-        if (formData.containsKey("cancel")) {
-            context.cancelLogin();
-            return;
-        } else if (webauthnAuth != null && webauthnAuth.isPasskeysEnabled()
-                && (formData.containsKey(WebAuthnConstants.AUTHENTICATOR_DATA) || formData.containsKey(WebAuthnConstants.ERROR))) {
-            // webauth form submission, try to action using the webauthn authenticator
-            webauthnAuth.action(context);
-            return;
-        } else if (!validateForm(context, formData)) {
-            // normal username and form authenticator
-            return;
+        // If IDENTITY_PROVIDER_USERNAME is not null, user has logged in via IdP -> return success
+        if (context.getAuthenticationSession().getUserSessionNotes().get(Details.IDENTITY_PROVIDER_USERNAME) == null) {
+            MultivaluedMap<String, String> formData = context.getHttpRequest().getDecodedFormParameters();
+            if (formData.containsKey("cancel")) {
+                context.cancelLogin();
+                return;
+            } else if (webauthnAuth != null && webauthnAuth.isPasskeysEnabled()
+                    && (formData.containsKey(WebAuthnConstants.AUTHENTICATOR_DATA) || formData.containsKey(WebAuthnConstants.ERROR))) {
+                // webauth form submission, try to action using the webauthn authenticator
+                webauthnAuth.action(context);
+                return;
+            } else if (!validateForm(context, formData)) {
+                // normal username and form authenticator
+                return;
+            }
         }
         context.success(PasswordCredentialModel.TYPE);
     }
@@ -86,6 +91,8 @@ public class UsernamePasswordForm extends AbstractUsernameFormAuthenticator impl
     public void authenticate(AuthenticationFlowContext context) {
         MultivaluedMap<String, String> formData = new MultivaluedHashMap<>();
         String loginHint = context.getAuthenticationSession().getClientNote(OIDCLoginProtocol.LOGIN_HINT_PARAM);
+        context.getAuthenticationSession().setAuthNote(AuthenticationProcessor.CLIENT_FLOW_ID, context.getFlowId());
+        context.getAuthenticationSession().setAuthNote(AuthenticationProcessor.CLIENT_AUTHENTICATION_EXECUTION, context.getExecution().getId());
 
         String rememberMeUsername = AuthenticationManager.getRememberMeUsername(context.getSession());
 

--- a/services/src/main/java/org/keycloak/services/resources/IdentityBrokerService.java
+++ b/services/src/main/java/org/keycloak/services/resources/IdentityBrokerService.java
@@ -25,6 +25,8 @@ import org.keycloak.broker.provider.IdpLinkAction;
 import org.keycloak.broker.provider.UserAuthenticationIdentityProvider;
 import org.keycloak.http.HttpRequest;
 import org.keycloak.OAuthErrorException;
+import org.keycloak.authentication.AuthenticationFlow;
+import org.keycloak.authentication.AuthenticationFlowException;
 import org.keycloak.authentication.AuthenticationProcessor;
 import org.keycloak.authentication.authenticators.broker.AbstractIdpAuthenticator;
 import org.keycloak.authentication.authenticators.broker.util.PostBrokerLoginConstants;
@@ -52,6 +54,7 @@ import org.keycloak.events.EventType;
 import org.keycloak.locale.LocaleSelectorProvider;
 import org.keycloak.models.AccountRoles;
 import org.keycloak.models.AuthenticatedClientSessionModel;
+import org.keycloak.models.AuthenticationExecutionModel;
 import org.keycloak.models.AuthenticationFlowModel;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.ClientSessionContext;
@@ -911,6 +914,41 @@ public class IdentityBrokerService implements UserAuthenticationIdentityProvider
 
         if (isDebugEnabled()) {
             logger.debugf("Performing local authentication for user [%s].", federatedUser);
+        }
+
+        //code for returning to client browser flow
+        String execution = authSession.getAuthNote(AuthenticationProcessor.CLIENT_AUTHENTICATION_EXECUTION);
+        String flowId =  authSession.getAuthNote(AuthenticationProcessor.CLIENT_FLOW_ID);
+
+        if (execution != null && flowId !=null) {
+            AuthenticationExecutionModel model = realmModel.getAuthenticationExecutionById(execution);
+            //remove the CLIENT_AUTHENTICATION_EXECUTION and CLIENT_FLOW_ID from session
+            authSession.removeAuthNote(AuthenticationProcessor.CLIENT_AUTHENTICATION_EXECUTION);
+            authSession.removeAuthNote(AuthenticationProcessor.CLIENT_FLOW_ID);
+
+            AuthenticationProcessor processor = new AuthenticationProcessor();
+            processor.setAuthenticationSession(authSession)
+                    .setFlowPath(LoginActionsService.AUTHENTICATE_PATH)
+                    .setBrowserFlow(true)
+                    .setFlowId(flowId)
+                    .setConnection(clientConnection)
+                    .setEventBuilder(event)
+                    .setRealm(realmModel)
+                    .setSession(session)
+                    .setUriInfo(session.getContext().getUri())
+                    .setRequest(request);
+            processor.setAutheticatedUser(federatedUser);
+            AuthenticationFlow authenticationFlow = processor.createFlowExecution(flowId, model);
+            //maybe find next flow
+            Response challenge = authenticationFlow.continueClientAuthAfterIdPLogin(model);
+            if (challenge != null) {
+                return challenge;
+            }
+            if (!authenticationFlow.isSuccessful()) {
+                throw new AuthenticationFlowException(authenticationFlow.getFlowExceptions());
+            }
+        } else {
+            logger.warn("CLIENT_AUTHENTICATION_EXECUTION and CLIENT_FLOW_ID are not included in the authenticationSession");
         }
 
         AuthenticationManager.setClientScopesInSession(session, authSession);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcFirstBrokerLoginNewAuthTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcFirstBrokerLoginNewAuthTest.java
@@ -93,6 +93,9 @@ public class KcOidcFirstBrokerLoginNewAuthTest extends AbstractInitializedBaseBr
         loginTotpPage.assertCurrent();
         loginTotpPage.login(totp.generateTOTP(totpSecret));
 
+        //return to client flow -> otp has been configured -> ask again
+        loginTotpPage.login(totp.generateTOTP(totpSecret));
+
         assertUserAuthenticatedInConsumer(consumerRealmUserId);
     }
 
@@ -131,7 +134,7 @@ public class KcOidcFirstBrokerLoginNewAuthTest extends AbstractInitializedBaseBr
 
         // Create user and link him with TOTP
         String consumerRealmUserId = createUser("consumer");
-        addTOTPToUser("consumer");
+        String totpSecret = addTOTPToUser("consumer");
 
         loginWithBrokerAndConfirmLinkAccount();
 
@@ -149,6 +152,9 @@ public class KcOidcFirstBrokerLoginNewAuthTest extends AbstractInitializedBaseBr
         // Login with password
         Assert.assertTrue(passwordPage.isCurrent("consumer"));
         passwordPage.login("password");
+
+        //return to client flow -> otp has been configured -> ask again
+        loginTotpPage.login(totp.generateTOTP(totpSecret));
 
         assertUserAuthenticatedInConsumer(consumerRealmUserId);
     }
@@ -182,6 +188,9 @@ public class KcOidcFirstBrokerLoginNewAuthTest extends AbstractInitializedBaseBr
         loginTotpPage.assertCurrent();
 
         // Login with OTP now
+        loginTotpPage.login(totp.generateTOTP(totpSecret));
+
+        //return to client flow -> otp has been configured -> ask again
         loginTotpPage.login(totp.generateTOTP(totpSecret));
 
         assertUserAuthenticatedInConsumer(consumerRealmUserId);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcPostBrokerLoginTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcPostBrokerLoginTest.java
@@ -252,6 +252,7 @@ public class KcOidcPostBrokerLoginTest extends AbstractInitializedBaseBrokerTest
         loginPage.open(bc.consumerRealmName());
         logInWithBroker(bc);
 
+        loginTotpPage.login(totp.generateTOTP(totpSecret));
         appPage.assertCurrent();
         AccountHelper.logout(adminClient.realm(bc.consumerRealmName()), bc.getUserLogin());
         AccountHelper.logout(adminClient.realm(bc.providerRealmName()), bc.getUserLogin());


### PR DESCRIPTION
Closes #10250

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->

Our implementation saves in AuthNotes of AuthenticationSessionModel all needed information for Client Browser Flow ( AuthenticationProcessor.CURRENT_AUTHENTICATION_EXECUTION of Client Browser Flow, flowid) before redirecting to Identity Provider login. After Identity Provider login has successfully finished, Keycloak can retrieve all needed information for Client Browser Flow from AuthNotes of AuthenticationSessionModel and proceed with Client Browser Flow. 

Browser flows execution are now continuing after Identity Provider Login. That's why some tests need to be changed. Some changes indicate that Browser flow with Identity Provider login, is working well. I do not know if we need extra tests.
More tests failures are related with SamlClientBuilder and its related code.  I do not know well test implementation of SamlClientBuilder in order to make appropriate changes in it or found possible errors in my code. Finally, KcOidcBrokerTest/KcSamlBrokerTest test method testPostBrokerLoginFlowWithOTP failure is strange.