### PR TITLE
Minimize workflow runs on Dependabot updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches-ignore: [main]
   pull_request:
+    paths-ignore:
+      - '.github/workflows/**'
+      - '!.github/workflows/ci.yml'
   schedule:
     - cron: '0 0 * * *'
 

--- a/.github/workflows/codeql-java-analysis.yml
+++ b/.github/workflows/codeql-java-analysis.yml
@@ -7,7 +7,9 @@ name: "CodeQL Java"
 
 on:
   push:
-    branches-ignore: [main]
+    branches-ignore:
+      - 'main'
+      - 'dependabot/**'
   pull_request:
     branches: [main]
     paths: 

--- a/.github/workflows/codeql-js-adapter-analysis.yml
+++ b/.github/workflows/codeql-js-adapter-analysis.yml
@@ -7,7 +7,9 @@ name: "CodeQL JS Adapter"
 
 on:
   push:
-    branches-ignore: [main]
+    branches-ignore:
+      - 'main'
+      - 'dependabot/**'
   pull_request:
     branches: [main]
     paths: 

--- a/.github/workflows/codeql-theme-analysis.yml
+++ b/.github/workflows/codeql-theme-analysis.yml
@@ -7,7 +7,9 @@ name: "CodeQL Themes"
 
 on:
   push:
-    branches-ignore: [main]
+    branches-ignore:
+      - 'main'
+      - 'dependabot/**'
   pull_request:
     branches: [main]
     paths: 

--- a/.github/workflows/operator-ci.yml
+++ b/.github/workflows/operator-ci.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches-ignore: [main]
   pull_request:
+    paths-ignore:
+      - '.github/workflows/**'
+      - '!.github/workflows/operator-ci.yml'
   schedule:
     - cron: '0 0 * * *'
 


### PR DESCRIPTION
Workflows will only run when their own workflow file changes, not on other workflow files. Dependabot branches are ignored for "push" builds, will only run on "pull" builds as code scanning on dependabot is not available for "push" builds.

Closes #12911

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
