### PR TITLE
Enable dependabot on NPM dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,30 @@ updates:
     labels:
       - area/dependencies
       - area/ci
+  - package-ecosystem: npm
+    directory: /themes/src/main/resources/theme/keycloak/common/resources
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 999
+    rebase-strategy: disabled
+    labels:
+      - area/dependencies
+      - area/admin/ui
+  - package-ecosystem: npm
+    directory: /themes/src/main/resources/theme/keycloak.v2/account/src
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 999
+    rebase-strategy: disabled
+    labels:
+      - area/dependencies
+      - area/account/ui 
+  - package-ecosystem: npm
+    directory: /adapters/oidc/js
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 999
+    rebase-strategy: disabled
+    labels:
+      - area/dependencies
+      - area/adapter/javascript


### PR DESCRIPTION
Enable dependabot for NPM dependencies. 

Note current PR allows all packages but as per dependabot, `ignore` filters can be used to ignore specific dependencies (due to breaking changes etc).