### PR TITLE
client-secret-rotation, allowing no expiration for new secret

### DIFF
--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/ClientSecretRotationExecutorFactory.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/ClientSecretRotationExecutorFactory.java
@@ -35,7 +35,7 @@ public class ClientSecretRotationExecutorFactory implements ClientPolicyExecutor
     static {
         ProviderConfigProperty secretExpirationPeriod = new ProviderConfigProperty(
             SECRET_EXPIRATION_PERIOD, "Secret expiration",
-            "When the secret is rotated. The time frequency for generating a new secret. (In seconds)",
+            "When the secret is rotated. The time frequency for generating a new secret. When this is set to 0, the new secret will have no expiration (In seconds)",
             ProviderConfigProperty.STRING_TYPE, DEFAULT_SECRET_EXPIRATION_PERIOD);
         configProperties.add(secretExpirationPeriod);
 


### PR DESCRIPTION
Related to the discussion [#9156 Client secret policies to support secret rotation](https://github.com/keycloak/keycloak/discussions/9156), this change allows configuring no expiration for the new secrets generated after rotating the old ones, by using the value 0 in the realm policy.