### PR TITLE
Baseline: Ability to set SupportLevel for categories and show marker …

### DIFF
--- a/quarkus/config-api/src/main/java/org/keycloak/config/ConfigSupportLevel.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/ConfigSupportLevel.java
@@ -1,0 +1,8 @@
+package org.keycloak.config;
+
+public enum ConfigSupportLevel {
+    DEPRECATED,
+    EXPERIMENTAL,
+    PREVIEW,
+    SUPPORTED
+}

--- a/quarkus/config-api/src/main/java/org/keycloak/config/Option.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/Option.java
@@ -2,7 +2,6 @@ package org.keycloak.config;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 public class Option<T> {
 
@@ -21,7 +20,7 @@ public class Option<T> {
         this.category = category;
         this.hidden = hidden;
         this.buildTime = buildTime;
-        this.description = description;
+        this.description = getDescriptionByCategorySupportLevel(description);
         this.defaultValue = defaultValue;
         this.expectedValues = expectedValues;
     }
@@ -67,4 +66,22 @@ public class Option<T> {
         );
     }
 
+    private String getDescriptionByCategorySupportLevel(String description) {
+        if(description == null || description.isBlank()) {
+            return description;
+        }
+
+        switch(this.getCategory().getSupportLevel()) {
+            case PREVIEW:
+                description = "Preview: " + description;
+                break;
+            case EXPERIMENTAL:
+                description = "Experimental: " + description;
+                break;
+            default:
+                description = description;
+        }
+
+        return description;
+    }
 }

--- a/quarkus/config-api/src/main/java/org/keycloak/config/OptionCategory.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/OptionCategory.java
@@ -2,27 +2,29 @@ package org.keycloak.config;
 
 public enum OptionCategory {
     // ordered by name asc
-    CLUSTERING("Cluster", 10),
-    STORAGE("Storage", 15),
-    DATABASE("Database", 20),
-    TRANSACTION("Transaction",30),
-    FEATURE("Feature", 40),
-    HOSTNAME("Hostname", 50),
-    HTTP("HTTP/TLS", 60),
-    HEALTH("Health", 70),
-    METRICS("Metrics", 80),
-    PROXY("Proxy", 90),
-    VAULT("Vault", 100),
-    LOGGING("Logging", 110),
-    GENERAL("General", 999);
+    CLUSTERING("Cluster", 10, ConfigSupportLevel.SUPPORTED),
+    STORAGE("Storage", 15, ConfigSupportLevel.EXPERIMENTAL),
+    DATABASE("Database", 20, ConfigSupportLevel.SUPPORTED),
+    TRANSACTION("Transaction",30, ConfigSupportLevel.SUPPORTED),
+    FEATURE("Feature", 40, ConfigSupportLevel.SUPPORTED),
+    HOSTNAME("Hostname", 50, ConfigSupportLevel.SUPPORTED),
+    HTTP("HTTP/TLS", 60, ConfigSupportLevel.SUPPORTED),
+    HEALTH("Health", 70, ConfigSupportLevel.SUPPORTED),
+    METRICS("Metrics", 80, ConfigSupportLevel.SUPPORTED),
+    PROXY("Proxy", 90, ConfigSupportLevel.SUPPORTED),
+    VAULT("Vault", 100, ConfigSupportLevel.SUPPORTED),
+    LOGGING("Logging", 110, ConfigSupportLevel.SUPPORTED),
+    GENERAL("General", 999, ConfigSupportLevel.SUPPORTED);
 
-    private final String heading;
-
+    private String heading;
     //Categories with a lower number are shown before groups with a higher number
     private final int order;
+    private final ConfigSupportLevel supportLevel;
 
-    OptionCategory(String heading, int order) {
-        this.heading = heading; this.order = order;
+    OptionCategory(String heading, int order, ConfigSupportLevel supportLevel) {
+        this.order = order;
+        this.supportLevel = supportLevel;
+        this.heading = getHeadingBySupportLevel(heading);
     }
 
     public String getHeading() {
@@ -33,4 +35,19 @@ public enum OptionCategory {
         return this.order;
     }
 
+    public ConfigSupportLevel getSupportLevel() {
+        return this.supportLevel;
+    }
+
+    private String getHeadingBySupportLevel(String heading) {
+        if (this.supportLevel.equals(ConfigSupportLevel.EXPERIMENTAL)){
+            heading = heading + " (Experimental)";
+        }
+
+        if (this.supportLevel.equals(ConfigSupportLevel.PREVIEW)){
+            heading = heading + " (Preview)";
+        }
+
+        return heading;
+    }
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/Picocli.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/Picocli.java
@@ -47,6 +47,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.eclipse.microprofile.config.spi.ConfigSource;
+import org.keycloak.config.ConfigSupportLevel;
 import org.keycloak.config.MultiOption;
 import org.keycloak.config.OptionCategory;
 import org.keycloak.quarkus.runtime.cli.command.Build;
@@ -399,6 +400,7 @@ public final class Picocli {
 
             for(PropertyMapper mapper: mappersInCategory) {
                 String name = mapper.getCliFormat();
+
                 String description = mapper.getDescription();
 
                 if (description == null || cSpec.optionsMap().containsKey(name) || name.endsWith(OPTION_PART_SEPARATOR)) {

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testBuildHelp.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testBuildHelp.unix.approved.txt
@@ -35,9 +35,10 @@ Cluster:
                      Define the default stack to use for cluster communication and node discovery.
                        This option only takes effect if 'cache' is set to 'ispn'. Default: udp.
 
-Storage:
+Storage (Experimental):
 
---storage <type>     Sets a storage mechanism. Possible values are: legacy, chm. Default: legacy.
+--storage <type>     Experimental: Sets a storage mechanism. Possible values are: legacy, chm.
+                       Default: legacy.
 
 Database:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testBuildHelp.windows.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testBuildHelp.windows.approved.txt
@@ -35,9 +35,10 @@ Cluster:
                      Define the default stack to use for cluster communication and node discovery.
                        This option only takes effect if 'cache' is set to 'ispn'. Default: udp.
 
-Storage:
+Storage (Experimental):
 
---storage <type>     Sets a storage mechanism. Possible values are: legacy, chm. Default: legacy.
+--storage <type>     Experimental: Sets a storage mechanism. Possible values are: legacy, chm. Default:
+                       legacy.
 
 Database:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartDevHelpAll.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartDevHelpAll.unix.approved.txt
@@ -27,9 +27,10 @@ Cluster:
                      Define the default stack to use for cluster communication and node discovery.
                        This option only takes effect if 'cache' is set to 'ispn'. Default: udp.
 
-Storage:
+Storage (Experimental):
 
---storage <type>     Sets a storage mechanism. Possible values are: legacy, chm. Default: legacy.
+--storage <type>     Experimental: Sets a storage mechanism. Possible values are: legacy, chm.
+                       Default: legacy.
 
 Database:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartDevHelpAll.windows.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartDevHelpAll.windows.approved.txt
@@ -27,9 +27,10 @@ Cluster:
                      Define the default stack to use for cluster communication and node discovery.
                        This option only takes effect if 'cache' is set to 'ispn'. Default: udp.
 
-Storage:
+Storage (Experimental):
 
---storage <type>     Sets a storage mechanism. Possible values are: legacy, chm. Default: legacy.
+--storage <type>     Experimental: Sets a storage mechanism. Possible values are: legacy, chm. Default:
+                       legacy.
 
 Database:
 


### PR DESCRIPTION
…in CLI help

Closes #12927

Successor of #12917 - Created another PR bc I changed some implementation details so now the Options' and Categories' description are self contained and always shown the right way no matter what calls them (e.g. cli help, docs, ...).  