### PR TITLE
Make quarkus arquillian container runnable on windows runner.

### DIFF
--- a/testsuite/integration-arquillian/pom.xml
+++ b/testsuite/integration-arquillian/pom.xml
@@ -46,7 +46,7 @@
         <shrinkwrap-resolver.version>3.1.4</shrinkwrap-resolver.version>
         <selenium.version>3.14.0</selenium.version>
         <arquillian-drone.version>2.5.5</arquillian-drone.version>
-        <arquillian-graphene.version>2.5.4</arquillian-graphene.version>
+        <arquillian-graphene.version>3.0.0-alpha.3</arquillian-graphene.version>
         <arquillian-wildfly-container.version>3.0.1.Final</arquillian-wildfly-container.version>
         <arquillian-wls-container.version>1.0.1.Final</arquillian-wls-container.version>
         <arquillian-jetty9-container.version>1.0.0.CR3</arquillian-jetty9-container.version>

--- a/testsuite/integration-arquillian/servers/auth-server/quarkus/assembly.xml
+++ b/testsuite/integration-arquillian/servers/auth-server/quarkus/assembly.xml
@@ -45,7 +45,8 @@
     <files>
         <file>
             <source>src/main/content/conf/cluster-ha.xml</source>
-            <outputDirectory>/auth-server-quarkus/conf</outputDirectory>
+            <!-- use file.seperator to avoid error in build on windows -->
+            <outputDirectory>${file.separator}auth-server-quarkus${file.separator}conf</outputDirectory>
             <destName>cluster-ha.xml</destName>
             <filtered>true</filtered>
         </file>

--- a/testsuite/integration-arquillian/servers/auth-server/quarkus/src/main/content/conf/keycloak.conf
+++ b/testsuite/integration-arquillian/servers/auth-server/quarkus/src/main/content/conf/keycloak.conf
@@ -46,4 +46,4 @@ spi-login-protocol-saml-known-protocols=http=8180,https=8543
 
 # File-Based Vault
 vault=file
-vault-dir=${kc.home.dir}secrets
+vault-dir=${kc.home.dir:}${file.separator}secrets

--- a/testsuite/integration-arquillian/tests/base/pom.xml
+++ b/testsuite/integration-arquillian/tests/base/pom.xml
@@ -44,6 +44,10 @@
         <mvel.version>2.4.0.Final</mvel.version>
         <systemrules.version>1.19.0</systemrules.version>
         <common.resources>${basedir}/../../servers/auth-server/jboss/common</common.resources>
+        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
+        <maven.compiler.release>11</maven.compiler.release>
+        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
     </properties>
     
     <dependencies>
@@ -366,7 +370,10 @@
                     </execution>
                 </executions>
             </plugin>
-
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven-compiler-plugin.version}</version>
+            </plugin>
         </plugins>
 
     </build>

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/FileUtil.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/FileUtil.java
@@ -1,0 +1,95 @@
+package org.keycloak.testsuite.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * This is a copy of
+ * <a href="https://github.com/quarkusio/quarkus/blob/f3f55df9cab105d92525e7165cd43670d03b1ad9/core/deployment/src/main/java/io/quarkus/deployment/util/FileUtil.java">The quarkus FileUtil implementation</a>
+ * so we don't need to import the whole module.
+ */
+public class FileUtil {
+
+    public static void deleteIfExists(final Path path) throws IOException {
+        BasicFileAttributes attributes;
+        try {
+            attributes = Files.readAttributes(path, BasicFileAttributes.class);
+        } catch (IOException ignored) {
+            // Files.isDirectory is also simply returning when any IOException occurs, same behaviour is fine
+            return;
+        }
+        if (attributes.isDirectory()) {
+            deleteDirectoryIfExists(path);
+        } else if (attributes.isRegularFile()) {
+            Files.deleteIfExists(path);
+        }
+    }
+
+    public static void deleteDirectory(final Path directory) throws IOException {
+        if (!Files.isDirectory(directory)) {
+            return;
+        }
+        deleteDirectoryIfExists(directory);
+    }
+
+    private static void deleteDirectoryIfExists(final Path directory) throws IOException {
+        Files.walkFileTree(directory, new SimpleFileVisitor<Path>() {
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                try {
+                    Files.delete(file);
+                } catch (IOException e) {
+                    // ignored
+                }
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                try {
+                    Files.delete(dir);
+                } catch (IOException e) {
+                    // ignored
+                }
+                return FileVisitResult.CONTINUE;
+            }
+
+        });
+    }
+
+    public static byte[] readFileContents(InputStream inputStream) throws IOException {
+        return inputStream.readAllBytes();
+    }
+
+    /**
+     * Translates a file path from the Windows Style to a syntax accepted by Docker and Podman,
+     * so that volumes be safely mounted in both Docker Desktop for Windows and Podman Windows.
+     * <p>
+     * <code>docker run -v /c/foo/bar:/somewhere (...)</code>
+     * <p>
+     * You should only use this method on Windows-style paths, and not Unix-style
+     * paths.
+     *
+     * @param windowsStylePath A path formatted in Windows-style, e.g. "C:\foo\bar".
+     * @return A translated path accepted by Docker, e.g. "/c/foo/bar".
+     */
+    public static String translateToVolumePath(String windowsStylePath) {
+        String translated = windowsStylePath.replace('\\', '/');
+        Pattern p = Pattern.compile("^(\\w)(?:$|:(/)?(.*))");
+        Matcher m = p.matcher(translated);
+        if (m.matches()) {
+            String slash = Optional.ofNullable(m.group(2)).orElse("/");
+            String path = Optional.ofNullable(m.group(3)).orElse("");
+            return "/" + m.group(1).toLowerCase() + slash + path;
+        }
+        return translated;
+    }
+}


### PR DESCRIPTION
- Adds the logic we use for windows quarkus tests also for the arq container of quarkus to spin it up and down correctly on windows
- uses absolute path to bat file location so (misleading) error msg from #12648 is gone. 
- Avoids ANT as part of the first startup bc. finding out the absolute jar path for ant is quite cumbersome, see https://ant.apache.org/manual/Tasks/exec.html , introduces `firstStart` flag in start method of container instead (for now only for windows).
- sets language level for the testsuite classes compilation to 11 to have access to `ProcessHandle` class that is needed for correctly spinning down the application on windows
- Adds maven compiler plugin `3.8.1` to base pom, bc. if not further specified,`maven-compiler-plugin:3.8.1-jboss-1` is used for `testCompile`. The `-jboss-1` seems not on par with the features of the maven-compiler-plugin. The "normal" plugin supports modules (so to say, everything above jdk8) since v3.8.0 - so without it there were multiple "classnotfound" errors.
- Changes arq graphene to 3.x alpha - see https://github.com/arquillian/arquillian-graphene/pull/224#issuecomment-1177412388 for context (jdk11 compatibility)
- fixes broken path to secrets directory on windows in test keycloak.conf

Result: On my windows10 machine I was able to run multiple tests, using e.g. ` mvn -f testsuite/integration-arquillian/pom.xml clean install -Pauth-server-quarkus -Dtest=LoginTest,DefaultHostnameTest,...` so "in general" it works. There may be some other bumps, as I have not executed the whole testsuite, but this should provide a good baseline.

Closes #12648

