### PR TITLE
Fix internal filepath for logging on windows

### DIFF
--- a/quarkus/runtime/src/main/resources/META-INF/keycloak.conf
+++ b/quarkus/runtime/src/main/resources/META-INF/keycloak.conf
@@ -24,10 +24,10 @@ metrics-enabled=false
 
 #logging defaults
 log-console-output=default
-log-file=${kc.home.dir:default}data/log/keycloak.log
+log-file=${kc.home.dir:default}${file.separator}data${file.separator}log${file.separator}keycloak.log
 
 # Storage defaults
-spi-map-storage-concurrenthashmap-dir=${kc.home.dir:default}data/chm
+spi-map-storage-concurrenthashmap-dir=${kc.home.dir:default}${file.separator}data${file.separator}chm
 spi-map-storage-concurrenthashmap-key-type-single-use-objects=string
 spi-map-storage-concurrenthashmap-key-type-realms=string
 spi-map-storage-concurrenthashmap-key-type-authz-resource-servers=string

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/LoggingDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/LoggingDistTest.java
@@ -135,7 +135,7 @@ public class LoggingDistTest {
     void testWinLogLevelSettingsAppliedWhenJsonEnabled(LaunchResult result) {
         CLIResult cliResult = (CLIResult) result;
         assertFalse(cliResult.getOutput().contains("\"loggerName\":\"io.quarkus\",\"level\":\"INFO\")"));
-        assertTrue(cliResult.getOutput().contains("\"loggerName\":\"org.keycloak.quarkus.runtime.storage.database.jpa.QuarkusJpaConnectionProviderFactory\",\"level\":\"DEBUG\""));
+        assertTrue(cliResult.getOutput().contains("\"loggerName\":\"org.keycloak.services.resources.KeycloakApplication\",\"level\":\"DEBUG\""));
         assertTrue(cliResult.getOutput().contains("\"loggerName\":\"org.infinispan.CONTAINER\",\"level\":\"INFO\""));
     }
 


### PR DESCRIPTION
Also fixes filepath for concurrenthashmap and one windows-only test referencing now non-existing (renamed)QuarkusJpaConnectionProviderFactory log output in LoggingDistTest

Closes #12984