### PR TITLE
Cannot use WebAuthn with WildFly distribution

### DIFF
--- a/distribution/galleon-feature-packs/server-galleon-pack/src/license/keycloak-server-galleon-pack-licenses.xml
+++ b/distribution/galleon-feature-packs/server-galleon-pack/src/license/keycloak-server-galleon-pack-licenses.xml
@@ -225,6 +225,28 @@
                 </license>
             </licenses>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.13.2</version>
+            <licenses>
+                <license>
+                    <name>Apache Software License 2.0</name>
+                    <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url> <!-- Source repo contains no license file -->
+                </license>
+            </licenses>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.13.2</version>
+            <licenses>
+                <license>
+                    <name>Apache Software License 2.0</name>
+                    <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url> <!-- Source repo contains no license file -->
+                </license>
+            </licenses>
+        </dependency>
     </dependencies>
     <others>
         <other>

--- a/distribution/galleon-feature-packs/server-galleon-pack/src/main/resources/modules/system/layers/keycloak/com/fasterxml/jackson/core/jackson-core/main/module.xml
+++ b/distribution/galleon-feature-packs/server-galleon-pack/src/main/resources/modules/system/layers/keycloak/com/fasterxml/jackson/core/jackson-core/main/module.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" standalone="no"?>
+<!--
+  ~ Copyright 2022 Red Hat, Inc. and/or its affiliates
+  ~ and other contributors as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<module xmlns="urn:jboss:module:1.9" name="com.fasterxml.jackson.core.jackson-core">
+     <resources>
+        <artifact name="${com.fasterxml.jackson.core:jackson-core}"></artifact>
+    </resources>
+
+    <dependencies>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
+    </dependencies>
+</module>

--- a/distribution/galleon-feature-packs/server-galleon-pack/src/main/resources/modules/system/layers/keycloak/com/fasterxml/jackson/core/jackson-databind/main/module.xml
+++ b/distribution/galleon-feature-packs/server-galleon-pack/src/main/resources/modules/system/layers/keycloak/com/fasterxml/jackson/core/jackson-databind/main/module.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" standalone="no"?>
+<!--
+  ~ Copyright 2022 Red Hat, Inc. and/or its affiliates
+  ~ and other contributors as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<module xmlns="urn:jboss:module:1.9" name="com.fasterxml.jackson.core.jackson-databind">
+     <resources>
+        <artifact name="${com.fasterxml.jackson.core:jackson-databind}"></artifact>
+    </resources>
+
+    <dependencies>
+        <module name="java.desktop"></module>
+        <module name="java.logging"></module>
+        <module name="java.sql"></module>
+        <module name="java.xml"></module>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
+        <module name="com.fasterxml.jackson.core.jackson-annotations"></module>
+        <module name="com.fasterxml.jackson.core.jackson-core"></module>
+    </dependencies>
+</module>

--- a/testsuite/integration-arquillian/tests/other/webauthn/src/test/java/org/keycloak/testsuite/webauthn/account/AbstractWebAuthnAccountTest.java
+++ b/testsuite/integration-arquillian/tests/other/webauthn/src/test/java/org/keycloak/testsuite/webauthn/account/AbstractWebAuthnAccountTest.java
@@ -47,6 +47,9 @@ import org.keycloak.testsuite.webauthn.pages.WebAuthnLoginPage;
 import org.keycloak.testsuite.webauthn.pages.WebAuthnRegisterPage;
 import org.openqa.selenium.virtualauthenticator.VirtualAuthenticatorOptions;
 
+import javax.ws.rs.ClientErrorException;
+
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.models.AuthenticationExecutionModel.Requirement.REQUIRED;
@@ -133,10 +136,15 @@ public abstract class AbstractWebAuthnAccountTest extends AbstractAuthTest imple
         RequiredActionProviderSimpleRepresentation requiredAction = new RequiredActionProviderSimpleRepresentation();
         requiredAction.setProviderId(WebAuthnRegisterFactory.PROVIDER_ID);
         requiredAction.setName("blahblah");
-        testRealmResource().flows().registerRequiredAction(requiredAction);
 
-        requiredAction.setProviderId(WebAuthnPasswordlessRegisterFactory.PROVIDER_ID);
-        testRealmResource().flows().registerRequiredAction(requiredAction);
+        try {
+            testRealmResource().flows().registerRequiredAction(requiredAction);
+            requiredAction.setProviderId(WebAuthnPasswordlessRegisterFactory.PROVIDER_ID);
+            testRealmResource().flows().registerRequiredAction(requiredAction);
+        } catch (ClientErrorException e) {
+            assertThat(e.getResponse(), notNullValue());
+            assertThat(e.getResponse().getStatus(), is(409));
+        }
     }
 
     protected VirtualAuthenticatorManager getWebAuthnManager() {


### PR DESCRIPTION
Fixes #12762

The current version of Wildfly used for Keycloak contains old FasterXML Jackson transitive dependency and it's not possible to use the WebAuthn feature on the legacy distribution (WildFly). As we still support the legacy version of Keycloak, it's necessary to have it fixed.

@pskopek @drichtarik  Could you please take a look at it? Thanks.