### PR TITLE
Enhanced AcccessTokenIntrospectionProvider events.

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/events/Errors.java
+++ b/server-spi-private/src/main/java/org/keycloak/events/Errors.java
@@ -65,6 +65,8 @@ public interface Errors {
     String INVALID_INPUT = "invalid_input";
     String COOKIE_NOT_FOUND = "cookie_not_found";
 
+    String TOKEN_INTROSPECTION_FAILED = "token_introspection_failed";
+
     String REGISTRATION_DISABLED = "registration_disabled";
     String RESET_CREDENTIAL_DISABLED = "reset_credential_disabled";
 

--- a/server-spi-private/src/main/java/org/keycloak/protocol/oidc/TokenIntrospectionProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/protocol/oidc/TokenIntrospectionProvider.java
@@ -17,6 +17,7 @@
  */
 package org.keycloak.protocol.oidc;
 
+import org.keycloak.events.EventBuilder;
 import org.keycloak.provider.Provider;
 
 import javax.ws.rs.core.Response;
@@ -34,5 +35,5 @@ public interface TokenIntrospectionProvider extends Provider {
      * @param token the token to introspect.
      * @return the response with the information about the token
      */
-    Response introspect(String token);
+    Response introspect(String token, EventBuilder eventBuilder);
 }

--- a/services/src/main/java/org/keycloak/authorization/protection/introspect/RPTIntrospectionProvider.java
+++ b/services/src/main/java/org/keycloak/authorization/protection/introspect/RPTIntrospectionProvider.java
@@ -28,6 +28,10 @@ import javax.ws.rs.core.Response;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.jboss.logging.Logger;
+import org.keycloak.events.Details;
+import org.keycloak.events.Errors;
+import org.keycloak.events.EventBuilder;
+import org.keycloak.events.EventType;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.protocol.oidc.AccessTokenIntrospectionProvider;
 import org.keycloak.representations.AccessToken;
@@ -49,10 +53,10 @@ public class RPTIntrospectionProvider extends AccessTokenIntrospectionProvider {
     }
 
     @Override
-    public Response introspect(String token) {
+    public Response introspect(String token, EventBuilder eventBuilder) {
         LOGGER.debug("Introspecting requesting party token");
         try {
-            AccessToken accessToken = verifyAccessToken(token);
+            AccessToken accessToken = verifyAccessToken(token, eventBuilder);
 
             ObjectNode tokenMetadata;
 
@@ -85,12 +89,16 @@ public class RPTIntrospectionProvider extends AccessTokenIntrospectionProvider {
                 }
             } else {
                 tokenMetadata = JsonSerialization.createObjectNode();
+                eventBuilder.detail(Details.REASON, "Requesting party token verification returned null token");
+                eventBuilder.error(Errors.TOKEN_INTROSPECTION_FAILED);
             }
 
             tokenMetadata.put("active", accessToken != null);
 
             return Response.ok(JsonSerialization.writeValueAsBytes(tokenMetadata)).type(MediaType.APPLICATION_JSON_TYPE).build();
         } catch (Exception e) {
+            eventBuilder.detail(Details.REASON, e.getMessage());
+            eventBuilder.error(Errors.TOKEN_INTROSPECTION_FAILED);
             throw new RuntimeException("Error creating token introspection response.", e);
         }
     }

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenIntrospectionEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenIntrospectionEndpoint.java
@@ -107,7 +107,7 @@ public class TokenIntrospectionEndpoint {
 
         try {
 
-            Response response = provider.introspect(token);
+            Response response = provider.introspect(token, event);
 
             this.event.success();
 

--- a/services/src/main/java/org/keycloak/protocol/openshift/OpenShiftTokenReviewEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/openshift/OpenShiftTokenReviewEndpoint.java
@@ -102,10 +102,13 @@ public class OpenShiftTokenReviewEndpoint implements OIDCExtProvider, Environmen
             verifier.verify();
             token = verifier.getToken();
         } catch (VerificationException e) {
+            event.detail(Details.REASON, "Token verification failure: "+e.getMessage()).error(Errors.INVALID_TOKEN);
+            event.error(Errors.TOKEN_INTROSPECTION_FAILED);
             error(401, Errors.INVALID_TOKEN, "Token verification failure");
         }
 
-        if (!tokenManager.checkTokenValidForIntrospection(session, realm, token, true)) {
+        if (!tokenManager.checkTokenValidForIntrospection(session, realm, token, true, event)) {
+            event.error(Errors.TOKEN_INTROSPECTION_FAILED);
             error(401, Errors.INVALID_TOKEN, "Token verification failure");
         }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ServiceAccountTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ServiceAccountTest.java
@@ -363,10 +363,11 @@ public class ServiceAccountTest extends AbstractKeycloakTest {
         // Check that it is not possible to introspect token anymore
         Assert.assertFalse(getIntrospectionResponse("service-account-cl", "secret1", tokenString));
         // TODO: This would be better to be "INTROSPECT_TOKEN_ERROR"
-        events.expect(EventType.INTROSPECT_TOKEN)
+        events.expect(EventType.INTROSPECT_TOKEN_ERROR)
                 .client("service-account-cl")
                 .user(Matchers.isEmptyOrNullString())
                 .session(Matchers.isEmptyOrNullString())
+                .error(Errors.TOKEN_INTROSPECTION_FAILED)
                 .assertEvent();
     }
 


### PR DESCRIPTION
Enhanced AcccessTokenIntrospectionProvider events.

Added INTROSPECT_TOKEN_ERROR event in erroneous cases, with details.

Closes [#13052](https://github.com/keycloak/keycloak/issues/13052)

