### PR TITLE
Use correct path for 'text-security' CSS

### DIFF
--- a/examples/themes/src/main/resources/theme/logo-example/admin/theme.properties
+++ b/examples/themes/src/main/resources/theme/logo-example/admin/theme.properties
@@ -17,4 +17,4 @@
 
 parent=keycloak
 import=common/keycloak
-styles=lib/patternfly/css/patternfly.css node_modules/select2/select2.css css/styles.css lib/angular/treeview/css/angular.treeview.css node_modules/text-security/dist/text-security.css css/logo.css
+styles=lib/patternfly/css/patternfly.css node_modules/select2/select2.css css/styles.css lib/angular/treeview/css/angular.treeview.css node_modules/text-security/text-security.css css/logo.css


### PR DESCRIPTION
This path was incorrect in one of the examples.

Resolves #13058