### PR TITLE
[12826] Configuring Postgres and MariaDb version

### DIFF
--- a/quarkus/README.md
+++ b/quarkus/README.md
@@ -105,3 +105,7 @@ These tests are disabled by default. They using Quarkus development mode predefi
     mvn clean install -Dkc.test.storage.database=true -Dtest=MariaDBStartDatabaseTest
 
 to spin up a MariaDB container and start Keycloak with it.
+
+To use a specific database container image, use the option -Dkc.db.postgresql.container.image to specify the image tag of the postgres image to use or -Dkc.db.mariadb.container.image=<name:tag> for mariadb.
+Example:
+mvn clean install -Dkc.test.storage.database=true -Dtest=PostgreSQLDistTest -Dkc.db.postgresql.container.image=postgres:

--- a/quarkus/tests/integration/pom.xml
+++ b/quarkus/tests/integration/pom.xml
@@ -116,9 +116,12 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <argLine>-Xmx1024m -XX:MaxMetaspaceSize=512m</argLine>
-                            <systemProperties>
+                            <systemPropertyVariables>
                                 <kc.test.storage.database>true</kc.test.storage.database>
-                            </systemProperties>
+                                <!--DB Container -->
+                                <kc.db.postgresql.container.image>postgres:alpine</kc.db.postgresql.container.image>
+                                <kc.db.mariadb.container.image>mariadb:10.5.9</kc.db.mariadb.container.image>
+                            </systemPropertyVariables>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/quarkus/tests/integration/src/main/java/org/keycloak/it/junit5/extension/DatabaseContainer.java
+++ b/quarkus/tests/integration/src/main/java/org/keycloak/it/junit5/extension/DatabaseContainer.java
@@ -22,6 +22,7 @@ import org.jetbrains.annotations.NotNull;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.containers.MariaDBContainer;
 import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
 
 public class DatabaseContainer {
 
@@ -66,11 +67,18 @@ public class DatabaseContainer {
     }
 
     private JdbcDatabaseContainer createContainer() {
+
+        String POSTGRES_IMAGE = System.getProperty("kc.db.postgresql.container.image");
+        String MARIADB_IMAGE = System.getProperty("kc.db.mariadb.container.image");
+
+        DockerImageName POSTGRES = DockerImageName.parse(POSTGRES_IMAGE).asCompatibleSubstituteFor("postgres");
+        DockerImageName MARIADB = DockerImageName.parse(MARIADB_IMAGE).asCompatibleSubstituteFor("mariadb");
+
         switch (alias) {
             case "postgres":
-                return new PostgreSQLContainer("postgres:alpine");
+                return new PostgreSQLContainer(POSTGRES);
             case "mariadb":
-                return new MariaDBContainer("mariadb:10.5.9");
+                return new MariaDBContainer(MARIADB);
             default:
                 throw new RuntimeException("Unsupported database: " + alias);
         }


### PR DESCRIPTION
Closes https://github.com/keycloak/keycloak/issues/12826 Configuring Postgres and MariaDb version

Added a Postgres parameter -Dkc.db.postgresql.container.image and -Dkc.db.mariadb.container.image which could be configured on the runtime.
