### PR TITLE
Fix compilation errors with Eclipse Java compiler

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/events/AuthenticationSessionAuthNoteUpdateEvent.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/events/AuthenticationSessionAuthNoteUpdateEvent.java
@@ -122,7 +122,7 @@ public class AuthenticationSessionAuthNoteUpdateEvent implements ClusterEvent {
               MarshallUtil.unmarshallString(input),
               MarshallUtil.unmarshallString(input),
               MarshallUtil.unmarshallString(input),
-              MarshallUtil.unmarshallMap(input, HashMap::new)
+              MarshallUtil.<String, String, Map<String, String>>unmarshallMap(input, HashMap::new)
             );
         }
 

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/SessionEntityWrapper.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/SessionEntityWrapper.java
@@ -191,7 +191,7 @@ public class SessionEntityWrapper<S extends SessionEntity> {
                 return res;
             } else {
                 UUID sessionVersion = new UUID(input.readLong(), input.readLong());
-                HashMap<String, String> map = MarshallUtil.unmarshallMap(input, HashMap::new);
+                HashMap<String, String> map = MarshallUtil.<String, String, HashMap<String, String>>unmarshallMap(input, HashMap::new);
                 final SessionEntity entity = (SessionEntity) input.readObject();
                 if (log.isTraceEnabled()) {
                     log.tracef("Found entity locally: entity=%s, version=%s, metadata=%s", entity, sessionVersion, map);

--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCClientSecretConfigWrapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCClientSecretConfigWrapper.java
@@ -211,7 +211,7 @@ public class OIDCClientSecretConfigWrapper extends AbstractClientConfigWrapper {
     public ReadOnlyRotatedSecretClientModel toRotatedClientModel() throws InvalidObjectException {
         if (Objects.isNull(this.clientModel))
             throw new InvalidObjectException(getClass().getCanonicalName() + " does not have an attribute of type " + ClientModel.class.getCanonicalName());
-        return new ReadOnlyRotatedSecretClientModel();
+        return new ReadOnlyRotatedSecretClientModel(clientModel);
     }
 
     /**
@@ -219,8 +219,8 @@ public class OIDCClientSecretConfigWrapper extends AbstractClientConfigWrapper {
      */
     public class ReadOnlyRotatedSecretClientModel extends ClientModelLazyDelegate {
 
-        private ReadOnlyRotatedSecretClientModel() {
-            super(() -> OIDCClientSecretConfigWrapper.this.clientModel);
+        private ReadOnlyRotatedSecretClientModel(ClientModel clientModel) {
+            super(() -> clientModel);
         }
 
         @Override


### PR DESCRIPTION
This change allows compiling Keycloak with Eclipse JDT Java compiler by working around (likely) compiler bugs described in the linked issue.

Fixes #13145