### PR TITLE
Prevent thread concurrency and not-locked database problems

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/connections/jpa/updater/liquibase/lock/LiquibaseDBLockProviderFactory.java
+++ b/model/jpa/src/main/java/org/keycloak/connections/jpa/updater/liquibase/lock/LiquibaseDBLockProviderFactory.java
@@ -20,17 +20,19 @@ package org.keycloak.connections.jpa.updater.liquibase.lock;
 import java.util.List;
 import org.jboss.logging.Logger;
 import org.keycloak.Config;
+import org.keycloak.common.Profile;
 import org.keycloak.common.util.Time;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.models.dblock.DBLockProviderFactory;
+import org.keycloak.provider.EnvironmentDependentProviderFactory;
 import org.keycloak.provider.ProviderConfigProperty;
 import org.keycloak.provider.ProviderConfigurationBuilder;
 
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
  */
-public class LiquibaseDBLockProviderFactory implements DBLockProviderFactory {
+public class LiquibaseDBLockProviderFactory implements DBLockProviderFactory, EnvironmentDependentProviderFactory {
 
     private static final Logger logger = Logger.getLogger(LiquibaseDBLockProviderFactory.class);
     public static final int PROVIDER_PRIORITY = 1;
@@ -86,5 +88,10 @@ public class LiquibaseDBLockProviderFactory implements DBLockProviderFactory {
                 .type("int")
                 .helpText("The maximum time to wait when waiting to release a database lock.")
                 .add().build();
+    }
+
+    @Override
+    public boolean isSupported() {
+        return !Profile.isFeatureEnabled(Profile.Feature.MAP_STORAGE);
     }
 }

--- a/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/JpaMapStorageProviderFactory.java
+++ b/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/JpaMapStorageProviderFactory.java
@@ -166,6 +166,10 @@ public class JpaMapStorageProviderFactory implements
     private final String sessionProviderKey;
     private final String sessionTxKey;
 
+    // Object instances for each single JpaMapStorageProviderFactory instance per model type.
+    // Used to synchronize on when validating the model type area.
+    private final ConcurrentHashMap<Class<?>, Object> SYNC_MODELS = new ConcurrentHashMap<>();
+
     public final static DeepCloner CLONER = new DeepCloner.Builder()
         //auth-sessions
         .constructor(JpaRootAuthenticationSessionEntity.class,  JpaRootAuthenticationSessionEntity::new)
@@ -374,24 +378,29 @@ public class JpaMapStorageProviderFactory implements
 
         if (this.validatedModelNames.add(modelName)) {
         */
-        if (this.validatedModels.add(modelType)) {
-            Connection connection = getConnection();
-            try {
-                if (logger.isDebugEnabled()) printOperationalInfo(connection);
-
-                MapJpaUpdaterProvider updater = session.getProvider(MapJpaUpdaterProvider.class);
-                MapJpaUpdaterProvider.Status status = updater.validate(modelType, connection, config.get("schema"));
-
-                if (!status.equals(VALID)) {
-                    update(modelType, connection, session);
-                }
-            } finally {
-                if (connection != null) {
+        if (!this.validatedModels.contains(modelType)) {
+            synchronized (SYNC_MODELS.computeIfAbsent(modelType, mc -> new Object())) {
+                if (!this.validatedModels.contains(modelType)) {
+                    Connection connection = getConnection();
                     try {
-                        connection.close();
-                    } catch (SQLException e) {
-                        logger.warn("Can't close connection", e);
+                        if (logger.isDebugEnabled()) printOperationalInfo(connection);
+
+                        MapJpaUpdaterProvider updater = session.getProvider(MapJpaUpdaterProvider.class);
+                        MapJpaUpdaterProvider.Status status = updater.validate(modelType, connection, config.get("schema"));
+
+                        if (!status.equals(VALID)) {
+                            update(modelType, connection, session);
+                        }
+                    } finally {
+                        if (connection != null) {
+                            try {
+                                connection.close();
+                            } catch (SQLException e) {
+                                logger.warn("Can't close connection", e);
+                            }
+                        }
                     }
+                    validatedModels.add(modelType);
                 }
             }
         }

--- a/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/liquibase/connection/DefaultLiquibaseConnectionProvider.java
+++ b/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/liquibase/connection/DefaultLiquibaseConnectionProvider.java
@@ -19,15 +19,20 @@ package org.keycloak.models.map.storage.jpa.liquibase.connection;
 
 import java.sql.Connection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import liquibase.Liquibase;
 import liquibase.Scope;
 import liquibase.database.Database;
 import liquibase.database.DatabaseFactory;
 import liquibase.exception.LiquibaseException;
+import liquibase.exception.ServiceNotFoundException;
 import liquibase.resource.ClassLoaderResourceAccessor;
 import liquibase.resource.ResourceAccessor;
+import liquibase.servicelocator.ServiceLocator;
+import liquibase.sqlgenerator.SqlGeneratorFactory;
 import liquibase.ui.LoggerUIService;
 import org.jboss.logging.Logger;
 import org.keycloak.models.KeycloakSession;
@@ -46,6 +51,7 @@ import org.keycloak.models.KeycloakSession;
 public class DefaultLiquibaseConnectionProvider implements MapLiquibaseConnectionProvider {
 
     private static final Logger logger = Logger.getLogger(DefaultLiquibaseConnectionProvider.class);
+    private static final String KEYCLOAK_JPA_LEGACY_MODULE = "org.keycloak.connections.jpa";
 
     @SuppressWarnings("unused")
     public DefaultLiquibaseConnectionProvider(final KeycloakSession session) {
@@ -90,6 +96,10 @@ public class DefaultLiquibaseConnectionProvider implements MapLiquibaseConnectio
             Scope.exit(scopeId);
         } catch (Exception e) {
             throw new RuntimeException("Failed to exist scope: " + e.getMessage(), e);
+        } finally {
+            // To avoid cached instances from the just closed scope.
+            // Must be called only after exiting the scope.
+            SqlGeneratorFactory.reset();
         }
     }
 
@@ -98,10 +108,34 @@ public class DefaultLiquibaseConnectionProvider implements MapLiquibaseConnectio
         final Map<String, Object> scopeValues = new HashMap<>();
         // Setting the LoggerUIService here prevents Liquibase from logging each change set to the console using java.util.Logging in the Quarkus setup
         scopeValues.put(Scope.Attr.ui.name(), new LoggerUIService());
+
+        // This uses the same serviceloader as the parent (that is replaced in Keycloak Quarkus)
+        // and prevents any class from the legacy JPA store to leak into the service discovery.
+        // This can be removed once the legacy JPA provider is no longer around in both the
+        // Wildfly and Quarkus distributions of Keycloak.
+        ServiceLocator serviceLocator = Scope.getCurrentScope().getServiceLocator();
+        scopeValues.put(Scope.Attr.serviceLocator.name(), new ServiceLocator() {
+            @Override
+            public int getPriority() {
+                return serviceLocator.getPriority();
+            }
+
+            @Override
+            public <T> List<T> findInstances(Class<T> interfaceType) throws ServiceNotFoundException {
+                List<T> instances = serviceLocator.findInstances(interfaceType);
+                // prevent any class from the legacy JPA store to leak into the service discovery
+                instances = instances.stream().filter(t -> !t.getClass().getPackage().getName().startsWith(KEYCLOAK_JPA_LEGACY_MODULE)).collect(Collectors.toList());
+                return instances;
+            }
+        });
         try {
             scopeId = Scope.enter(scopeValues);
         } catch (Exception e) {
             throw new RuntimeException("Failed to initialize Liquibase: " + e.getMessage(), e);
+        } finally {
+            // To avoid cached instances from another scope.
+            // Must be called only after entering the scope.
+            SqlGeneratorFactory.reset();
         }
         return scopeId;
     }

--- a/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/LiquibaseProcessor.java
+++ b/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/LiquibaseProcessor.java
@@ -3,6 +3,7 @@ package org.keycloak.quarkus.deployment;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -11,10 +12,12 @@ import java.util.Set;
 
 import io.quarkus.agroal.spi.JdbcDataSourceBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
+import liquibase.lockservice.StandardLockService;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
+import org.keycloak.config.StorageOptions;
 import org.keycloak.connections.jpa.updater.liquibase.lock.DummyLockService;
 
 import io.quarkus.deployment.annotations.BuildStep;
@@ -27,6 +30,10 @@ import liquibase.parser.core.xml.XMLChangeLogSAXParser;
 import liquibase.servicelocator.LiquibaseService;
 import liquibase.sqlgenerator.SqlGenerator;
 import org.keycloak.quarkus.runtime.KeycloakRecorder;
+
+import static org.keycloak.config.StorageOptions.STORAGE;
+import static org.keycloak.quarkus.runtime.configuration.Configuration.getOptionalValue;
+import static org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider.NS_KEYCLOAK_PREFIX;
 
 class LiquibaseProcessor {
 
@@ -72,8 +79,12 @@ class LiquibaseProcessor {
             }
         }
 
-        services.put(LockService.class.getName(), Arrays.asList(DummyLockService.class.getName()));
-        services.put(ChangeLogParser.class.getName(), Arrays.asList(XMLChangeLogSAXParser.class.getName()));
+        if (StorageOptions.StorageType.jpa.name().equals(getOptionalValue(NS_KEYCLOAK_PREFIX.concat(STORAGE.getKey())).orElse(null))) {
+            services.put(LockService.class.getName(), Collections.singletonList(StandardLockService.class.getName()));
+        } else {
+            services.put(LockService.class.getName(), Collections.singletonList(DummyLockService.class.getName()));
+        }
+        services.put(ChangeLogParser.class.getName(), Collections.singletonList(XMLChangeLogSAXParser.class.getName()));
 
         recorder.configureLiquibase(services);
     }

--- a/testsuite/utils/pom.xml
+++ b/testsuite/utils/pom.xml
@@ -303,6 +303,7 @@
                         <configuration>
                             <systemProperties>
                                 <systemProperty><key>keycloak.profile.feature.map_storage</key><value>enabled</value></systemProperty>
+                                <systemProperty><key>keycloak.dblock.provider</key><value>none</value></systemProperty>
                                 <systemProperty><key>keycloak.realm.provider</key><value>map</value></systemProperty>
                                 <systemProperty><key>keycloak.client.provider</key><value>map</value></systemProperty>
                                 <systemProperty><key>keycloak.clientScope.provider</key><value>map</value></systemProperty>


### PR DESCRIPTION
First commit: Assure that a second thread waits for the first thread to process the database changes. This prevents the "relation "kc_group" does not exist" exception we've been seeing when clicking on "groups" in the UI for the first time with a new database.

Second commit: Fall back to standard Liquibase locking, as DBLockProvider is "none" for the Map storage providers; at least until the map storage will provide its own lock provider.

Liquibase's classic lock provider has issues that need to be tackled in a follow-up issue, see https://github.com/liquibase/liquibase/issues/1311

This also removes the thread-local elements from the `MapJpaLiquibaseUpdaterProvider` that are not used in the new map storage. 

Closes #13130

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
