### PR TITLE
Showing consent screen text instead of scope name in consent part of …

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/account/AccountRestService.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountRestService.java
@@ -311,7 +311,7 @@ public class AccountRestService {
 
     private ConsentRepresentation modelToRepresentation(UserConsentModel model) {
         List<ConsentScopeRepresentation> grantedScopes = model.getGrantedClientScopes().stream()
-                .map(m -> new ConsentScopeRepresentation(m.getId(), m.getName(), StringPropertyReplacer.replaceProperties(m.getConsentScreenText(), getProperties())))
+                .map(m -> new ConsentScopeRepresentation(m.getId(), m.getConsentScreenText()!= null ? m.getConsentScreenText() : m.getName(), StringPropertyReplacer.replaceProperties(m.getConsentScreenText(), getProperties())))
                 .collect(Collectors.toList());
         return new ConsentRepresentation(grantedScopes, model.getCreatedDate(), model.getLastUpdatedDate());
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/AccountRestServiceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/AccountRestServiceTest.java
@@ -33,6 +33,7 @@ import org.keycloak.credential.CredentialTypeMetadata;
 import org.keycloak.events.Details;
 import org.keycloak.events.EventType;
 import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.ClientScopeModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.credential.OTPCredentialModel;
 import org.keycloak.models.credential.PasswordCredentialModel;
@@ -962,7 +963,7 @@ public class AccountRestServiceTest extends AbstractRestServiceTest {
         assertFalse(app.getConsent().getGrantedScopes().isEmpty());
         ConsentScopeRepresentation grantedScope = app.getConsent().getGrantedScopes().get(0);
         assertEquals(clientScopeRepresentation.getId(), grantedScope.getId());
-        assertEquals(clientScopeRepresentation.getName(), grantedScope.getName());
+        assertEquals(clientScopeRepresentation.getAttributes().get(ClientScopeModel.CONSENT_SCREEN_TEXT) != null ? clientScopeRepresentation.getAttributes().get(ClientScopeModel.CONSENT_SCREEN_TEXT) : clientScopeRepresentation.getName(), grantedScope.getName());
     }
 
     @Test

--- a/themes/src/main/resources/theme/keycloak.v2/account/src/app/content/applications-page/ApplicationsPage.tsx
+++ b/themes/src/main/resources/theme/keycloak.v2/account/src/app/content/applications-page/ApplicationsPage.tsx
@@ -224,7 +224,7 @@ export class ApplicationsPage extends React.Component<ApplicationsPageProps, App
                             {application.consent.grantedScopes.map((scope: GrantedScope, scopeIndex: number) => {
                                 return (
                                   <React.Fragment key={'scope-' + scopeIndex} >
-                                    <DescriptionListDescription><CheckIcon /> {scope.name}</DescriptionListDescription>
+                                      <DescriptionListDescription><CheckIcon />{Msg.localize(scope.name)}</DescriptionListDescription>
                                   </React.Fragment>
                                 )
                               })}


### PR DESCRIPTION
…Application page in Account console

Closes #13109

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
![correctConsent_ApplicationPage](https://user-images.githubusercontent.com/55974447/179467817-2ffeeebf-3574-4a38-8a8f-ab284ec1bb46.PNG)
Correct consent in Application Page of Account Console
