### PR TITLE
CodeQL Actions continue to run when a new commit is pushed to a branch

### DIFF
--- a/.github/workflows/codeql-java-analysis.yml
+++ b/.github/workflows/codeql-java-analysis.yml
@@ -6,17 +6,13 @@
 name: "CodeQL Java"
 
 on:
-  push:
-    branches-ignore:
-      - 'main'
-      - 'dependabot/**'
   pull_request:
     branches: [main]
     paths: 
       - '**.java'
       - '.github/workflows/codeql-java-analysis.yml'
   schedule:
-    - cron: '0 9 * * 2'
+    - cron: '0 0 * * *'
     
 jobs:
   analyze:

--- a/.github/workflows/codeql-js-adapter-analysis.yml
+++ b/.github/workflows/codeql-js-adapter-analysis.yml
@@ -6,17 +6,13 @@
 name: "CodeQL JS Adapter"
 
 on:
-  push:
-    branches-ignore:
-      - 'main'
-      - 'dependabot/**'
   pull_request:
     branches: [main]
     paths: 
       - 'adapters/oidc/js/**'
       - '.github/workflows/codeql-js-adapter-analysis.yml'
   schedule:
-    - cron: '0 9 * * 2'
+    - cron: '0 0 * * *'
     
 jobs:
   analyze:

--- a/.github/workflows/codeql-theme-analysis.yml
+++ b/.github/workflows/codeql-theme-analysis.yml
@@ -6,17 +6,13 @@
 name: "CodeQL Themes"
 
 on:
-  push:
-    branches-ignore:
-      - 'main'
-      - 'dependabot/**'
   pull_request:
     branches: [main]
     paths: 
       - 'themes/src/**'
       - '.github/workflows/codeql-theme-analysis.yml'
   schedule:
-    - cron: '0 9 * * 2'
+    - cron: '0 0 * * *'
     
 jobs:
   analyze:


### PR DESCRIPTION
Resolves #13231

Considerations about the changes proposed:

- Prevents CodeQL from running on push on any branch. It is not necessary to run CodeQL every time we push changes
- Run CodeQL only on pull requests and on the daily basis. That should be enough for us to collect valuable information.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
