### PR TITLE
Abort CodeQL runs on new pushes to a pull-request's branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,8 @@ name: Keycloak CI
 on:
   push:
     branches-ignore: [main]
-  pull_request:
-    paths-ignore:
-      - '.github/workflows/**'
-      - '!.github/workflows/ci.yml'
+  # as the ci.yml contains actions that are required for PRs to be merged, it will always need to run on all PRs
+  pull_request: {}
   schedule:
     - cron: '0 0 * * *'
 
@@ -15,7 +13,7 @@ env:
 
 concurrency:
   # Only run once for latest commit per ref and cancel other (previous) runs.
-  group: ci-keycloak-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/codeql-java-analysis.yml
+++ b/.github/workflows/codeql-java-analysis.yml
@@ -17,7 +17,12 @@ on:
       - '.github/workflows/codeql-java-analysis.yml'
   schedule:
     - cron: '0 9 * * 2'
-    
+
+concurrency:
+  # Only run once for latest commit per ref and cancel other (previous) runs.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: CodeQL analyze

--- a/.github/workflows/codeql-js-adapter-analysis.yml
+++ b/.github/workflows/codeql-js-adapter-analysis.yml
@@ -17,7 +17,12 @@ on:
       - '.github/workflows/codeql-js-adapter-analysis.yml'
   schedule:
     - cron: '0 9 * * 2'
-    
+
+concurrency:
+  # Only run once for latest commit per ref and cancel other (previous) runs.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: CodeQL analyze

--- a/.github/workflows/codeql-theme-analysis.yml
+++ b/.github/workflows/codeql-theme-analysis.yml
@@ -17,7 +17,12 @@ on:
       - '.github/workflows/codeql-theme-analysis.yml'
   schedule:
     - cron: '0 9 * * 2'
-    
+
+concurrency:
+  # Only run once for latest commit per ref and cancel other (previous) runs.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: CodeQL analyze

--- a/.github/workflows/operator-ci.yml
+++ b/.github/workflows/operator-ci.yml
@@ -17,7 +17,7 @@ env:
 
 concurrency:
   # Only run once for latest commit per ref and cancel other (previous) runs.
-  group: ci-operator-keycloak-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
This also prevents that a push to a branch cancels an already running action on the same branch in those cases where the job is not running for a pull request.

Closes #13231

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
