### PR TITLE
Do not run snyk github workflow on forks of the repo

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -11,6 +11,7 @@ jobs:
   quarkus:
     name: Quarkus
     runs-on: ubuntu-latest
+    if: ${{ github.repository == 'keycloak/keycloak' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -20,7 +21,7 @@ jobs:
           java-version: ${{ env.DEFAULT_JDK_VERSION }}
           distribution: temurin
           cache: maven
-      
+
       - name: Build Quarkus
         run: mvn -Psnyk-quarkus -pl quarkus/dist -am -DskipTests clean install
 
@@ -39,6 +40,7 @@ jobs:
   operator:
     name: Operator
     runs-on: ubuntu-latest
+    if: ${{ github.repository == 'keycloak/keycloak' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -48,11 +50,11 @@ jobs:
           java-version: ${{ env.DEFAULT_JDK_VERSION }}
           distribution: temurin
           cache: maven
-      
+
       - name: Build Keycloak
         run: mvn -Poperator -pl operator -am -DskipTests clean install
 
-      - uses: snyk/actions/setup@master    
+      - uses: snyk/actions/setup@master
       - name: Check for vulnerabilities for the Operator
         run: snyk test --policy-path=${GITHUB_WORKSPACE}/.github/snyk/.snyk --all-projects --prune-repeated-subdependencies --exclude=tests --sarif-file-output=operator-report.sarif operator
         continue-on-error: true


### PR DESCRIPTION
This change adds a guard, preventing Snyk workflow from running on forks of Keycloak repo.  Snyk API token is required for successful vulnerability scan. Forks likely do not have that configured.

Closes #13267 