### PR TITLE
Update base URL for admin rest docs

### DIFF
--- a/services/src/docs/asciidoc/overview.adoc
+++ b/services/src/docs/asciidoc/overview.adoc
@@ -1,12 +1,15 @@
 = ${product.name.full} Admin REST API
 
 == Overview
-This is a REST API reference for the ${product.name.full} Admin
+This is a REST API reference for the ${product.name.full} Admin REST API.
 
 === Version information
 Version: 1
 
 === URI scheme
-Host: localhost:8080
-BasePath: /auth/admin/realms
-Schemes: HTTP
+
+```
+{base url}/admin/realms
+```
+
+For example `http://localhost:8080/admin/realms`


### PR DESCRIPTION
API docs looks like this now:

![image](https://user-images.githubusercontent.com/2271511/180756440-ba7b018b-e532-48d6-8acf-cbeedb696622.png)

It uses to look like:

![image](https://user-images.githubusercontent.com/2271511/180756498-107f706a-13d3-4885-b57d-747e6eff781a.png)


Closes #10464
