### PR TITLE
Possible client enumeration in the authorization endpoint.

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpoint.java
@@ -230,7 +230,7 @@ public class AuthorizationEndpoint extends AuthorizationEndpointBase {
         client = realm.getClientByClientId(clientId);
         if (client == null) {
             event.error(Errors.CLIENT_NOT_FOUND);
-            throw new ErrorPageException(session, authenticationSession, Response.Status.BAD_REQUEST, Messages.CLIENT_NOT_FOUND);
+            throw new ErrorPageException(session, authenticationSession, Response.Status.BAD_REQUEST, Messages.INVALID_PARAMETER, OIDCLoginProtocol.REDIRECT_URI_PARAM);
         }
 
         if (!client.isEnabled()) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/error/UncaughtErrorPageTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/error/UncaughtErrorPageTest.java
@@ -182,7 +182,7 @@ public class UncaughtErrorPageTest extends AbstractKeycloakTest {
         oauth.openLoginForm();
 
         assertTrue(errorPage.isCurrent());
-        assertEquals("Client not found.", errorPage.getError());
+        assertEquals("Invalid parameter: redirect_uri", errorPage.getError());
     }
 
     @Test


### PR DESCRIPTION
Changing the message Client Not Found to Invalid Parameter: redirect_uri when the client not found

Closes #12164