### PR TITLE
Liquibase should differentiate between CockroachDB and PostgreSQL despite them same driver

### DIFF
--- a/quarkus/config-api/src/main/java/org/keycloak/config/database/Database.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/database/Database.java
@@ -135,7 +135,7 @@ public final class Database {
                 "org.postgresql.Driver",
                 "io.quarkus.hibernate.orm.runtime.dialect.QuarkusPostgreSQL10Dialect",
                 "jdbc:postgresql://${kc.db-url-host:localhost}:${kc.db-url-port:5432}/${kc.db-url-database:keycloak}${kc.db-url-properties:}",
-                asList("liquibase.database.core.PostgresDatabase",
+                asList("liquibase.database.core.PostgresDatabase", "liquibase.database.core.CockroachDatabase",
                         "org.keycloak.connections.jpa.updater.liquibase.PostgresPlusDatabase"),
                 "postgres"
         ),


### PR DESCRIPTION
Only this way the different SQL script for CockroachDB and PostgreSQL will work as expected on Quarkus.

Closes #13317

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
