### PR TITLE
Add 'prepublishOnly' script for Keycloak JS

### DIFF
--- a/adapters/oidc/js/package.json
+++ b/adapters/oidc/js/package.json
@@ -9,7 +9,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "rollup --config --configPlugin typescript"
+    "build": "rollup --config --configPlugin typescript",
+    "prepublishOnly": "npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Adds a '[prepublishOnly](https://docs.npmjs.com/cli/v8/using-npm/scripts#pre--post-scripts)' script to the package of Keycloak JS. This allows the release process to build the package in a uniform manner, like other packages such as the Admin Client.