### PR TITLE
Only show non-hidden options in --help-all for options where supportl…

### DIFF
--- a/quarkus/config-api/src/main/java/org/keycloak/config/StorageOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/StorageOptions.java
@@ -50,7 +50,6 @@ public class StorageOptions {
             .description(String.format("Sets the default storage mechanism for all areas. Possible values are: %s.", storageAreas()))
             .expectedValues(StorageType.values())
             .defaultValue(Optional.empty())
-            .hidden()
             .buildTime(true)
             .build();
 
@@ -170,7 +169,6 @@ public class StorageOptions {
     public static final Option<String> STORAGE_DEPLOYMENT_STATE_RESOURCES_VERSION_SEED = new OptionBuilder<>("storage-deployment-state-version-seed", String.class)
             .category(OptionCategory.STORAGE)
             .description("Secret that serves as a seed to mask the version number of Keycloak in URLs. Need to be identical across all servers in the cluster. Will default to a random number generated when starting the server which is secure but will lead to problems when a loadbalancer without sticky sessions is used or nodes are restarted.")
-            .hidden()
             .buildTime(false)
             .build();
 
@@ -321,25 +319,21 @@ public class StorageOptions {
     public static final Option<String> STORAGE_HOTROD_HOST = new OptionBuilder<>("storage-hotrod-host", String.class)
             .category(OptionCategory.STORAGE)
             .description("Sets the host of the Infinispan server.")
-            .hidden()
             .build();
 
     public static final Option<Integer> STORAGE_HOTROD_PORT = new OptionBuilder<>("storage-hotrod-port", Integer.class)
             .category(OptionCategory.STORAGE)
             .description("Sets the port of the Infinispan server.")
-            .hidden()
             .build();
 
     public static final Option<String> STORAGE_HOTROD_USERNAME = new OptionBuilder<>("storage-hotrod-username", String.class)
             .category(OptionCategory.STORAGE)
             .description("Sets the username of the Infinispan user.")
-            .hidden()
             .build();
 
     public static final Option<String> STORAGE_HOTROD_PASSWORD = new OptionBuilder<>("storage-hotrod-password", String.class)
             .category(OptionCategory.STORAGE)
             .description("Sets the password of the Infinispan user.")
-            .hidden()
             .build();
 
     public static final Option<Boolean> STORAGE_HOTROD_CACHE_CONFIGURE = new OptionBuilder<>("storage-hotrod-cache-configure", Boolean.class)

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/Help.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/Help.java
@@ -169,7 +169,7 @@ public final class Help extends CommandLine.Help {
 
         if (isUnsupportedOption) {
             // unsupported options removed from help if all options are not requested
-            return allOptions;
+            return !option.hidden() && allOptions;
         }
 
         return !option.hidden();

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartDevHelpAll.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartDevHelpAll.unix.approved.txt
@@ -79,12 +79,6 @@ Storage (Experimental):
                        Will default to a random number generated when starting the server which is
                        secure but will lead to problems when a loadbalancer without sticky sessions
                        is used or nodes are restarted.
---storage-hotrod-cache-configure <true|false>
-                     Experimental: When set to true, Keycloak will create and configure Infinispan
-                       caches on startup. Default: true.
---storage-hotrod-cache-reindex <[cache1,cache2,...]|all>
-                     Experimental: List of cache names that should be indexed on Keycloak startup.
-                       Defaulting to `all` which means all caches are reindexed. Default: all.
 --storage-hotrod-host <host>
                      Experimental: Sets the host of the Infinispan server.
 --storage-hotrod-password <password>

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartDevHelpAll.windows.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartDevHelpAll.windows.approved.txt
@@ -79,12 +79,6 @@ Storage (Experimental):
                        Will default to a random number generated when starting the server which is
                        secure but will lead to problems when a loadbalancer without sticky sessions
                        is used or nodes are restarted.
---storage-hotrod-cache-configure <true|false>
-                     Experimental: When set to true, Keycloak will create and configure Infinispan
-                       caches on startup. Default: true.
---storage-hotrod-cache-reindex <[cache1,cache2,...]|all>
-                     Experimental: List of cache names that should be indexed on Keycloak startup.
-                       Defaulting to `all` which means all caches are reindexed. Default: all.
 --storage-hotrod-host <host>
                      Experimental: Sets the host of the Infinispan server.
 --storage-hotrod-password <password>

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartHelpAll.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartHelpAll.unix.approved.txt
@@ -85,12 +85,6 @@ Storage (Experimental):
                        Will default to a random number generated when starting the server which is
                        secure but will lead to problems when a loadbalancer without sticky sessions
                        is used or nodes are restarted.
---storage-hotrod-cache-configure <true|false>
-                     Experimental: When set to true, Keycloak will create and configure Infinispan
-                       caches on startup. Default: true.
---storage-hotrod-cache-reindex <[cache1,cache2,...]|all>
-                     Experimental: List of cache names that should be indexed on Keycloak startup.
-                       Defaulting to `all` which means all caches are reindexed. Default: all.
 --storage-hotrod-host <host>
                      Experimental: Sets the host of the Infinispan server.
 --storage-hotrod-password <password>

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartHelpAll.windows.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartHelpAll.windows.approved.txt
@@ -85,12 +85,6 @@ Storage (Experimental):
                        Will default to a random number generated when starting the server which is
                        secure but will lead to problems when a loadbalancer without sticky sessions
                        is used or nodes are restarted.
---storage-hotrod-cache-configure <true|false>
-                     Experimental: When set to true, Keycloak will create and configure Infinispan
-                       caches on startup. Default: true.
---storage-hotrod-cache-reindex <[cache1,cache2,...]|all>
-                     Experimental: List of cache names that should be indexed on Keycloak startup.
-                       Defaulting to `all` which means all caches are reindexed. Default: all.
 --storage-hotrod-host <host>
                      Experimental: Sets the host of the Infinispan server.
 --storage-hotrod-password <password>

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartOptimizedHelpAll.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartOptimizedHelpAll.unix.approved.txt
@@ -28,12 +28,6 @@ Storage (Experimental):
                        Will default to a random number generated when starting the server which is
                        secure but will lead to problems when a loadbalancer without sticky sessions
                        is used or nodes are restarted.
---storage-hotrod-cache-configure <true|false>
-                     Experimental: When set to true, Keycloak will create and configure Infinispan
-                       caches on startup. Default: true.
---storage-hotrod-cache-reindex <[cache1,cache2,...]|all>
-                     Experimental: List of cache names that should be indexed on Keycloak startup.
-                       Defaulting to `all` which means all caches are reindexed. Default: all.
 --storage-hotrod-host <host>
                      Experimental: Sets the host of the Infinispan server.
 --storage-hotrod-password <password>

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartOptimizedHelpAll.windows.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartOptimizedHelpAll.windows.approved.txt
@@ -28,12 +28,6 @@ Storage (Experimental):
                        Will default to a random number generated when starting the server which is
                        secure but will lead to problems when a loadbalancer without sticky sessions
                        is used or nodes are restarted.
---storage-hotrod-cache-configure <true|false>
-                     Experimental: When set to true, Keycloak will create and configure Infinispan
-                       caches on startup. Default: true.
---storage-hotrod-cache-reindex <[cache1,cache2,...]|all>
-                     Experimental: List of cache names that should be indexed on Keycloak startup.
-                       Defaulting to `all` which means all caches are reindexed. Default: all.
 --storage-hotrod-host <host>
                      Experimental: Sets the host of the Infinispan server.
 --storage-hotrod-password <password>


### PR DESCRIPTION
…evel  is not SUPPORTED

No need to change the approval.txt files for now as the user facing options are the same but the internal logic is now right

Closes #13385
