### PR TITLE
Fixes the regression in 19 for MariaDB, MySQL and other DBs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -492,7 +492,7 @@ jobs:
 
       - name: Run Quarkus Storage Tests
         run: |
-          ./mvnw clean install -nsu -B -f quarkus/tests/pom.xml -Ptest-database -Dtest=PostgreSQLDistTest,DatabaseOptionsDistTest,JPAStoreDistTest,HotRodStoreDistTest,MixedStoreDistTest | misc/log/trimmer.sh
+          ./mvnw clean install -nsu -B -f quarkus/tests/pom.xml -Ptest-database -Dtest=PostgreSQLDistTest,MariaDBDistTest#testSuccessful,MySQLDistTest#testSuccessful,DatabaseOptionsDistTest,JPAStoreDistTest,HotRodStoreDistTest,MixedStoreDistTest | misc/log/trimmer.sh
           TEST_RESULT=${PIPESTATUS[0]}
           find . -path '*/target/surefire-reports/*.xml' | zip -q reports-quarkus-tests.zip -@
           exit $TEST_RESULT

--- a/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/IsJpaStoreEnabled.java
+++ b/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/IsJpaStoreEnabled.java
@@ -25,6 +25,11 @@ import java.util.Optional;
 import java.util.function.BooleanSupplier;
 import org.keycloak.config.StorageOptions;
 
+/***
+ * Checks if JPA is enabled either for the legacy or the new store.
+ *
+ * Returns true if the legacy store is used or the new store is used with storage==jpa
+ */
 public class IsJpaStoreEnabled implements BooleanSupplier {
 
     @Override

--- a/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/IsLegacyStoreEnabled.java
+++ b/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/IsLegacyStoreEnabled.java
@@ -23,6 +23,9 @@ import static org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvi
 
 import java.util.function.BooleanSupplier;
 
+/**
+ * Checks if the legacy store is enabled. returns true if no storage=... is set. Returns false otherwise.
+ */
 public class IsLegacyStoreEnabled implements BooleanSupplier {
 
     @Override

--- a/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
+++ b/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
@@ -127,7 +127,6 @@ import io.quarkus.vertx.http.deployment.FilterBuildItem;
 
 import org.keycloak.quarkus.runtime.services.health.KeycloakReadyHealthCheck;
 import org.keycloak.quarkus.runtime.storage.database.jpa.NamedJpaConnectionProviderFactory;
-import org.keycloak.quarkus.runtime.storage.database.jpa.QuarkusJpaMapStorageProviderFactory;
 import org.keycloak.quarkus.runtime.themes.FlatClasspathThemeResourceProviderFactory;
 import org.keycloak.representations.provider.ScriptProviderDescriptor;
 import org.keycloak.representations.provider.ScriptProviderMetadata;
@@ -471,8 +470,13 @@ class KeycloakProcessor {
     }
 
     @BuildStep(onlyIf = IsJpaStoreEnabled.class, onlyIfNot = IsLegacyStoreEnabled.class)
-    void indexJpaStore(BuildProducer<IndexDependencyBuildItem> indexDependencyBuildItemBuildProducer) {
+    void indexNewJpaStore(BuildProducer<IndexDependencyBuildItem> indexDependencyBuildItemBuildProducer) {
         indexDependencyBuildItemBuildProducer.produce(new IndexDependencyBuildItem("org.keycloak", "keycloak-model-map-jpa"));
+    }
+
+    @BuildStep(onlyIf = IsLegacyStoreEnabled.class)
+    void indexLegacyJpaStore(BuildProducer<IndexDependencyBuildItem> indexDependencyBuildItemBuildProducer) {
+        indexDependencyBuildItemBuildProducer.produce(new IndexDependencyBuildItem("org.keycloak", "keycloak-model-jpa"));
     }
 
     @Record(ExecutionTime.STATIC_INIT)

--- a/quarkus/tests/integration/pom.xml
+++ b/quarkus/tests/integration/pom.xml
@@ -87,6 +87,10 @@
             <groupId>org.testcontainers</groupId>
             <artifactId>mariadb</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mysql</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/quarkus/tests/integration/src/main/java/org/keycloak/it/junit5/extension/DatabaseContainer.java
+++ b/quarkus/tests/integration/src/main/java/org/keycloak/it/junit5/extension/DatabaseContainer.java
@@ -23,6 +23,7 @@ import org.keycloak.it.utils.KeycloakDistribution;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.containers.MariaDBContainer;
+import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.DockerImageName;
@@ -95,15 +96,19 @@ public class DatabaseContainer {
     private GenericContainer<?> createContainer() {
         String POSTGRES_IMAGE = System.getProperty("kc.db.postgresql.container.image", "postgres:alpine");
         String MARIADB_IMAGE = System.getProperty("kc.db.mariadb.container.image", "mariadb:10.5.9");
+        String MYSQL_IMAGE = System.getProperty("kc.db.mysql.container.image", "mysql:latest");
 
         DockerImageName POSTGRES = DockerImageName.parse(POSTGRES_IMAGE).asCompatibleSubstituteFor("postgres");
         DockerImageName MARIADB = DockerImageName.parse(MARIADB_IMAGE).asCompatibleSubstituteFor("mariadb");
+        DockerImageName MYSQL = DockerImageName.parse(MYSQL_IMAGE).asCompatibleSubstituteFor("mysql");
 
         switch (alias) {
             case "postgres":
                 return configureJdbcContainer(new PostgreSQLContainer(POSTGRES));
             case "mariadb":
                 return configureJdbcContainer(new MariaDBContainer(MARIADB));
+            case "mysql":
+                return configureJdbcContainer(new MySQLContainer(MYSQL));
             case "infinispan":
                 return configureInfinispanUser(new GenericContainer("quay.io/infinispan/server:12.1.7.Final"))
                         .withExposedPorts(11222);

--- a/quarkus/tests/integration/src/main/resources/database/scripts/init-mariadb.sql
+++ b/quarkus/tests/integration/src/main/resources/database/scripts/init-mariadb.sql
@@ -14,16 +14,3 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-package org.keycloak.it.storage.database.dist;
-
-import org.keycloak.it.junit5.extension.CLITest;
-import org.keycloak.it.junit5.extension.DistributionTest;
-import org.keycloak.it.junit5.extension.WithDatabase;
-import org.keycloak.it.storage.database.MariaDBTest;
-
-@DistributionTest(removeBuildOptionsAfterBuild = true)
-@WithDatabase(alias = "mariadb")
-public class MariaDBDistTest extends MariaDBTest {
-
-}

--- a/quarkus/tests/integration/src/main/resources/database/scripts/init-mysql.sql
+++ b/quarkus/tests/integration/src/main/resources/database/scripts/init-mysql.sql
@@ -14,16 +14,3 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-package org.keycloak.it.storage.database.dist;
-
-import org.keycloak.it.junit5.extension.CLITest;
-import org.keycloak.it.junit5.extension.DistributionTest;
-import org.keycloak.it.junit5.extension.WithDatabase;
-import org.keycloak.it.storage.database.MariaDBTest;
-
-@DistributionTest(removeBuildOptionsAfterBuild = true)
-@WithDatabase(alias = "mariadb")
-public class MariaDBDistTest extends MariaDBTest {
-
-}

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/storage/database/dist/MySQLDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/storage/database/dist/MySQLDistTest.java
@@ -1,0 +1,10 @@
+package org.keycloak.it.storage.database.dist;
+
+import org.keycloak.it.junit5.extension.DistributionTest;
+import org.keycloak.it.junit5.extension.WithDatabase;
+import org.keycloak.it.storage.database.MySQLTest;
+
+@DistributionTest(removeBuildOptionsAfterBuild = true)
+@WithDatabase(alias = "mysql")
+public class MySQLDistTest extends MySQLTest {
+}


### PR DESCRIPTION
databases that are not using an official liquibase type in Database.java could not be seeded anymore because

the liquibase types we use in model-jpa were not indexed and loaded during the build anymore.

Introduces highly needed tests for other databases than postgres, because postgres has an official liquibase databasetype in its list

in database.java and as such differs from nearly all other vendors.

Closes #13389
