### PR TITLE
Update pt_BR messages for the RP-initiated logout

### DIFF
--- a/themes/src/main/resources-community/theme/base/account/messages/messages_pt_BR.properties
+++ b/themes/src/main/resources-community/theme/base/account/messages/messages_pt_BR.properties
@@ -347,10 +347,3 @@ openshift.scope.user_info=Informa\u00e7\u00f5es do usu\u00e1rio
 openshift.scope.user_check-access=Informa\u00e7\u00f5es de acesso do usu\u00e1rio
 openshift.scope.user_full=Acesso Completo
 openshift.scope.list-projects=Listar projetos
-
-# new RP-initiated logout
-frontchannel-logout.title=Saindo
-frontchannel-logout.message=Voc\u00EA est\u00E1 saindo dos seguintes aplicativos
-logoutConfirmTitle=Saindo
-logoutConfirmHeader=Voc\u00EA realmente deseja sair?
-doLogout=Sair

--- a/themes/src/main/resources-community/theme/base/login/messages/messages_pt_BR.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_pt_BR.properties
@@ -379,3 +379,11 @@ accountUnusable=Qualquer uso subsequente da aplica\u00e7\u00e3o n\u00e3o ser\u00
 userDeletedSuccessfully=Usu\u00e1rio exclu\u00eddo com sucesso
 
 readOnlyUsernameMessage=Voc\u00ea^n\u00e3o pode atualizar o seu nome de usu\u00e1rio, uma vez que \u00e9 apenas de leitura.
+
+# new RP-initiated logout
+frontchannel-logout.title=Saindo
+frontchannel-logout.message=Voc\u00EA est\u00E1 saindo dos seguintes aplicativos
+logoutConfirmTitle=Saindo
+logoutConfirmHeader=Voc\u00EA realmente deseja sair?
+doLogout=Sair
+


### PR DESCRIPTION
This closes (again) [#13083](https://github.com/keycloak/keycloak/issues/13083)

I'm submiting a new PR for this, as the other one (merged - https://github.com/keycloak/keycloak/pull/12882) had a mistake. The messages were added to the wrong file.

I've tested better this time and can confirm the messages are appearing as intended.

I'm sorry for the mess.

<img width="622" alt="image" src="https://user-images.githubusercontent.com/1644644/181614399-206ae174-2b51-4693-ac2a-b4df82c4939d.png">
