### PR TITLE
adding admin-ui dependencies to integration-arquillian testsuite

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,8 @@
         <jboss.as.version>7.2.0.Final</jboss.as.version>
         <jboss.as.subsystem.test.version>7.5.22.Final-redhat-1</jboss.as.subsystem.test.version>
 
+        <keycloak.admin-ui.version>${project.version}</keycloak.admin-ui.version>
+
         <!-- Versions used mostly for Undertow server, aligned with WildFly -->
         <jboss.aesh.version>0.66.19</jboss.aesh.version>
         <aesh.version>2.4</aesh.version>
@@ -1418,7 +1420,7 @@
             <dependency>
                 <groupId>org.keycloak</groupId>
                 <artifactId>keycloak-admin-ui</artifactId>
-                <version>${project.version}</version>
+                <version>${keycloak.admin-ui.version}</version>
             </dependency>
 
             <!-- Openshift -->

--- a/testsuite/integration-arquillian/pom.xml
+++ b/testsuite/integration-arquillian/pom.xml
@@ -206,6 +206,24 @@
                 <artifactId>undertow-embedded</artifactId>
                 <version>${undertow-embedded.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.keycloak</groupId>
+                <artifactId>keycloak-dependencies-admin-ui-wrapper</artifactId>
+                <type>pom</type>
+                <version>${project.version}</version>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.keycloak</groupId>
+                <artifactId>keycloak-admin-ui</artifactId>
+                <version>${keycloak.admin-ui.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     
@@ -574,5 +592,20 @@
             </properties>
         </profile>
     </profiles>
+
+    <repositories>
+        <repository>
+            <id>sonatype-snapshots</id>
+            <name>Sonatype Snapshots</name>
+            <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+            </snapshots>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+        </repository>
+    </repositories>
 
 </project>


### PR DESCRIPTION
Fix for issue : #13465

Current Test pipelines are failing due to missing keycloak-admin-ui dependancy in the testsuite.
https://test-pipelines.com/job/universal-test-pipeline-server/1967/