### PR TITLE
Revert changes that block themes being loaded from custom providers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,7 +174,9 @@ jobs:
       - name: Update maven settings
         if: ${{ github.event_name != 'pull_request' || matrix.server != 'undertow-map-hot-rod' || env.GIT_HOTROD_RELEVANT_DIFF != 0 }}
         run: mkdir -p ~/.m2 ; cp .github/settings.xml ~/.m2/
-
+      - name: Prepare test providers
+        if: ${{ matrix.server == 'quarkus' || matrix.server == 'quarkus-map' }}
+        run: ./mvnw clean install -nsu -B -e -f testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers -Pauth-server-quarkus
       - name: Run base tests
         if: ${{ github.event_name != 'pull_request' || matrix.server != 'undertow-map-hot-rod' || env.GIT_HOTROD_RELEVANT_DIFF != 0 }}
         run: |

--- a/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
+++ b/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
@@ -576,9 +576,7 @@ class KeycloakProcessor {
                 }
             }
 
-            if (!providers.isEmpty()) {
-                factories.put(spi, providers);
-            }
+            factories.put(spi, providers);
         }
 
         return factories;

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/pom.xml
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/pom.xml
@@ -115,4 +115,26 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>auth-server-quarkus</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <configuration>
+                            <excludes>
+                                <!-- For quarkus we don't want the test provider installed to avoid false positives -->
+                                <!-- Themes from providers are automatically registered -->
+                                <excludes>**/TestThemeResourceProvider**</excludes>
+                                <excludes>**/org.keycloak.theme.ThemeResourceProviderFactory</excludes>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
Closes #13401

* Fix a regression introduced by https://github.com/keycloak/keycloak/pull/12963 that blocks themes from being loaded from custom providers
* Make sure the test suite is covering this scenario for the Quarkus distribution



<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
