### PR TITLE
Bumped maven-war-plugin for JDK17 compatibility

### DIFF
--- a/testsuite/integration-arquillian/test-apps/photoz/photoz-restful-api/pom.xml
+++ b/testsuite/integration-arquillian/test-apps/photoz/photoz-restful-api/pom.xml
@@ -72,7 +72,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.3.2</version>
                 <configuration>
                     <attachClasses>true</attachClasses>
                 </configuration>


### PR DESCRIPTION
Building `testsuite/integration-arquillian/test-apps/photoz/photoz-restful-api/` fails with JDK17 (17.0.4 temurin) with following error

```console
$ mvn clean install -DskipTests  
...
[INFO] Keycloak Authz Test: Photoz RESTful API ............ FAILURE [  0.337 s]
...
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-war-plugin:3.0.0:war (default-war) on project photoz-restful-api: Execution default-war of goal org.apache.maven.plugins:maven-war-plugin:3.0.0:war failed: Unable to load the mojo 'war' in the plugin 'org.apache.maven.plugins:maven-war-plugin:3.0.0' due to an API incompatibility: org.codehaus.plexus.component.repository.exception.ComponentLookupException: null
[ERROR] -----------------------------------------------------
[ERROR] realm =    plugin>org.apache.maven.plugins:maven-war-plugin:3.0.0
[ERROR] strategy = org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy
[ERROR] urls[0] = file:/home/tsaarni/.m2/repository/org/apache/maven/plugins/maven-war-plugin/3.0.0/maven-war-plugin-3.0.0.jar
[ERROR] urls[1] = file:/home/tsaarni/.m2/repository/org/sonatype/sisu/sisu-inject-bean/1.4.2/sisu-inject-bean-1.4.2.jar
[ERROR] urls[2] = file:/home/tsaarni/.m2/repository/org/sonatype/sisu/sisu-guice/2.1.7/sisu-guice-2.1.7-noaop.jar
[ERROR] urls[3] = file:/home/tsaarni/.m2/repository/org/sonatype/aether/aether-util/1.7/aether-util-1.7.jar
[ERROR] urls[4] = file:/home/tsaarni/.m2/repository/org/codehaus/plexus/plexus-component-annotations/1.6/plexus-component-annotations-1.6.jar
[ERROR] urls[5] = file:/home/tsaarni/.m2/repository/org/sonatype/plexus/plexus-sec-dispatcher/1.3/plexus-sec-dispatcher-1.3.jar
[ERROR] urls[6] = file:/home/tsaarni/.m2/repository/org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.jar
[ERROR] urls[7] = file:/home/tsaarni/.m2/repository/org/apache/maven/maven-archiver/3.1.1/maven-archiver-3.1.1.jar
[ERROR] urls[8] = file:/home/tsaarni/.m2/repository/org/apache/maven/shared/maven-shared-utils/3.0.1/maven-shared-utils-3.0.1.jar
[ERROR] urls[9] = file:/home/tsaarni/.m2/repository/commons-io/commons-io/2.5/commons-io-2.5.jar
[ERROR] urls[10] = file:/home/tsaarni/.m2/repository/org/codehaus/plexus/plexus-archiver/3.4/plexus-archiver-3.4.jar
[ERROR] urls[11] = file:/home/tsaarni/.m2/repository/org/codehaus/plexus/plexus-io/2.7.1/plexus-io-2.7.1.jar
[ERROR] urls[12] = file:/home/tsaarni/.m2/repository/org/apache/commons/commons-compress/1.11/commons-compress-1.11.jar
[ERROR] urls[13] = file:/home/tsaarni/.m2/repository/org/iq80/snappy/snappy/0.4/snappy-0.4.jar
[ERROR] urls[14] = file:/home/tsaarni/.m2/repository/org/tukaani/xz/1.5/xz-1.5.jar
[ERROR] urls[15] = file:/home/tsaarni/.m2/repository/org/codehaus/plexus/plexus-interpolation/1.22/plexus-interpolation-1.22.jar
[ERROR] urls[16] = file:/home/tsaarni/.m2/repository/com/thoughtworks/xstream/xstream/1.4.9/xstream-1.4.9.jar
[ERROR] urls[17] = file:/home/tsaarni/.m2/repository/xmlpull/xmlpull/1.1.3.1/xmlpull-1.1.3.1.jar
[ERROR] urls[18] = file:/home/tsaarni/.m2/repository/xpp3/xpp3_min/1.1.4c/xpp3_min-1.1.4c.jar
[ERROR] urls[19] = file:/home/tsaarni/.m2/repository/org/codehaus/plexus/plexus-utils/3.0.24/plexus-utils-3.0.24.jar
[ERROR] urls[20] = file:/home/tsaarni/.m2/repository/org/apache/maven/shared/maven-filtering/3.1.1/maven-filtering-3.1.1.jar
[ERROR] urls[21] = file:/home/tsaarni/.m2/repository/org/sonatype/plexus/plexus-build-api/0.0.7/plexus-build-api-0.0.7.jar
[ERROR] urls[22] = file:/home/tsaarni/.m2/repository/org/apache/maven/shared/maven-mapping/3.0.0/maven-mapping-3.0.0.jar
[ERROR] Number of foreign imports: 1
[ERROR] import: Entry[import  from realm ClassRealm[maven.api, parent: null]]
[ERROR] 
[ERROR] -----------------------------------------------------
[ERROR] : ExceptionInInitializerError: Unable to make field private final java.util.Comparator java.util.TreeMap.comparator accessible: module java.base does not "opens java.util" to unnamed module @4db73e18
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/PluginContainerException
[ERROR] 
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <args> -rf :photoz-restful-api
```

This PR bumps the version of the `maven-war-plugin`.

Updates #8889 
