### PR TITLE
Fix invalid method reference when compiling with JDK17

### DIFF
--- a/testsuite/model/src/test/java/org/keycloak/testsuite/model/session/OfflineSessionPersistenceTest.java
+++ b/testsuite/model/src/test/java/org/keycloak/testsuite/model/session/OfflineSessionPersistenceTest.java
@@ -176,12 +176,10 @@ public class OfflineSessionPersistenceTest extends KeycloakModelTest {
     @RequireProvider(value = UserSessionProvider.class, only = InfinispanUserSessionProviderFactory.PROVIDER_ID)
     public void testPersistenceMultipleNodesClientSessionAtSameNode() throws InterruptedException {
         int numClients = 2;
-        List<String> clientIds = withRealm(realmId, (session, realm) -> {
-            return IntStream.range(0, numClients)
+        List<String> clientIds = withRealm(realmId, (session, realm) -> IntStream.range(0, numClients)
               .mapToObj(cid -> session.clients().addClient(realm, "client-" + cid))
               .map(ClientModel::getId)
-              .collect(Collectors.toList());
-        });
+              .collect(Collectors.toList()));
 
         // Shutdown factory -> enforce session persistence
         closeKeycloakSessionFactory();
@@ -234,12 +232,10 @@ public class OfflineSessionPersistenceTest extends KeycloakModelTest {
     @RequireProvider(UserSessionPersisterProvider.class)
     @RequireProvider(value = UserSessionProvider.class, only = InfinispanUserSessionProviderFactory.PROVIDER_ID)
     public void testPersistenceMultipleNodesClientSessionsAtRandomNode() throws InterruptedException {
-        List<String> clientIds = withRealm(realmId, (session, realm) -> {
-            return IntStream.range(0, 5)
+        List<String> clientIds = withRealm(realmId, (session, realm) -> IntStream.range(0, 5)
               .mapToObj(cid -> session.clients().addClient(realm, "client-" + cid))
               .map(ClientModel::getId)
-              .collect(Collectors.toList());
-        });
+              .collect(Collectors.toList()));
         List<String> offlineSessionIds = createOfflineSessions(realmId, userIds);
 
         // Shutdown factory -> enforce session persistence


### PR DESCRIPTION
This PR fixes compilation error during build of `testsuite/model/src/test/java/org/keycloak/testsuite/model/session/` on JDK17 (17.0.4 temurin):

```console
$ mvn clean install -DskipTests  
...
[INFO] Tests for logical storage layer .................... FAILURE [  2.019 s]
...
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.1-jboss-1:testCompile (default-testCompile) on project keycloak-model-test: Compilation failure: Compilation failure: 
[ERROR] /home/tsaarni/work/keycloak-worktree/ldap-starttls-sasl-external-new/testsuite/model/src/test/java/org/keycloak/testsuite/model/session/OfflineSessionPersistenceTest.java:[182,20] incompatible types: invalid method reference
[ERROR]     method getId in interface org.keycloak.models.ClientModel cannot be applied to given types
[ERROR]       required: no arguments
[ERROR]       found:    java.lang.Object
[ERROR]       reason: actual and formal argument lists differ in length
[ERROR] /home/tsaarni/work/keycloak-worktree/ldap-starttls-sasl-external-new/testsuite/model/src/test/java/org/keycloak/testsuite/model/session/OfflineSessionPersistenceTest.java:[240,20] incompatible types: invalid method reference
[ERROR]     method getId in interface org.keycloak.models.ClientModel cannot be applied to given types
[ERROR]       required: no arguments
[ERROR]       found:    java.lang.Object
[ERROR]       reason: actual and formal argument lists differ in length
```

Updates #8889