### PR TITLE
Added code to allow a client to override the session idle and max lifetime realm values.

### DIFF
--- a/services/src/main/java/org/keycloak/services/util/TokenClientAttributeHelper.java
+++ b/services/src/main/java/org/keycloak/services/util/TokenClientAttributeHelper.java
@@ -1,0 +1,49 @@
+package org.keycloak.services.util;
+
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.RealmModel;
+
+import java.util.Map;
+
+public class TokenClientAttributeHelper {
+    public static Integer getClientSessionIdleTimeout(RealmModel realm, String clientId) {
+        String clientSessionIdleTemp = TokenClientAttributeHelper.getAttributes(realm, clientId, "client.session.idle.timeout");
+        if (clientSessionIdleTemp != null) {
+            return Integer.valueOf(clientSessionIdleTemp);
+        }
+
+        return null;
+    }
+
+    public static Integer getClientSessionMaxLifespan(RealmModel realm, String clientId) {
+        String clientSessionMaxLifespan = TokenClientAttributeHelper.getAttributes(realm, clientId, "client.session.max.lifespan");
+        if (clientSessionMaxLifespan != null) {
+            return Integer.valueOf(clientSessionMaxLifespan);
+        }
+
+        return null;
+    }
+
+    private static String getAttributes(RealmModel realm, String clientId, String attributeName) {
+        if (realm == null || clientId == null || attributeName == null) {
+            return null;
+        }
+
+        ClientModel model = realm.getClientByClientId(clientId);
+        if (model == null) {
+            return null;
+        }
+
+        Map<String, String> attributes = model.getAttributes();
+        if (attributes == null) {
+            return null;
+        }
+
+        String value = attributes.get(attributeName);
+        if (value == null) {
+            return null;
+        }
+
+        return value;
+    }
+}

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/util/TokenClientAttributeHelperTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/util/TokenClientAttributeHelperTest.java
@@ -1,0 +1,90 @@
+package org.keycloak.testsuite.util;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.keycloak.models.*;
+import org.keycloak.models.UserManager;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.services.util.TokenClientAttributeHelper;
+import org.keycloak.testsuite.AbstractTestRealmKeycloakTest;
+import org.keycloak.testsuite.arquillian.annotation.AuthServerContainerExclude;
+import org.keycloak.testsuite.arquillian.annotation.ModelTest;
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+
+@AuthServerContainerExclude(AuthServerContainerExclude.AuthServer.REMOTE)
+public class TokenClientAttributeHelperTest extends AbstractTestRealmKeycloakTest {
+
+    @Override
+    public void configureTestRealm(RealmRepresentation testRealm) {
+    }
+
+
+    @Before
+    public  void before() {
+        testingClient.server().run( session -> {
+            RealmModel realm = session.realms().getRealmByName("test");
+            session.users().addUser(realm, "user1");
+        });
+    }
+
+
+    @After
+    public void after() {
+        testingClient.server().run( session -> {
+            RealmModel realm = session.realms().getRealmByName("test");
+            session.sessions().removeUserSessions(realm);
+            UserModel user1 = session.users().getUserByUsername(realm, "user1");
+
+            org.keycloak.models.UserManager um = new UserManager(session);
+            if (user1 != null) {
+                um.removeUser(realm, user1);
+            }
+        });
+    }
+
+    @Test
+    @ModelTest
+    public void testGetClientSessionIdleTimeoutValue(KeycloakSession session) {
+        RealmModel realm = session.realms().getRealmByName("test");
+
+        ClientModel clientOverrides = realm.addClient("client-session-idle");
+        clientOverrides.setAttribute("client.session.idle.timeout", "3");
+
+        Integer result = TokenClientAttributeHelper.getClientSessionIdleTimeout(realm, clientOverrides.getClientId());
+        assertThat(result, is(notNullValue()));
+    }
+
+    @Test
+    @ModelTest
+    public void testGetClientSessionIdleTimeoutNull(KeycloakSession session) {
+        RealmModel realm = session.realms().getRealmByName("test");
+        ClientModel clientOverrides = realm.addClient("client-session-idle-null");
+
+        Integer result = TokenClientAttributeHelper.getClientSessionIdleTimeout(realm, clientOverrides.getClientId());
+        assertThat(result, is(nullValue()));
+    }
+
+    @Test
+    @ModelTest
+    public void testGetClientSessionMaxLifespanValue(KeycloakSession session) {
+        RealmModel realm = session.realms().getRealmByName("test");
+
+        ClientModel clientOverrides = realm.addClient("client-max-lifespan");
+        clientOverrides.setAttribute("client.session.max.lifespan", "5");
+
+        Integer result = TokenClientAttributeHelper.getClientSessionMaxLifespan(realm, clientOverrides.getClientId());
+        assertThat(result, is(notNullValue()));
+    }
+
+    @Test
+    @ModelTest
+    public void testGetClientSessionMaxLifespanNull(KeycloakSession session) {
+        RealmModel realm = session.realms().getRealmByName("test");
+        ClientModel clientOverrides = realm.addClient("client-max-lifespan-null");
+
+        Integer result = TokenClientAttributeHelper.getClientSessionMaxLifespan(realm, clientOverrides.getClientId());
+        assertThat(result, is(nullValue()));
+    }
+}


### PR DESCRIPTION
Currently the fields in a client for client session idle and client max lifetime in the admin portal take values to override the realm settings, but the values do not get used. The code in this PR will add the check to the AuthenticationManager. The code works with both cookie and api usage paths, and integration testing has been added for the code updates.

Closes #11959