### PR TITLE
Updating RestEasy changes for Jetty App Server

### DIFF
--- a/testsuite/integration-arquillian/servers/app-server/jetty/common/src/main/java/org/keycloak/testsuite/arquillian/jetty/JettyAppServer.java
+++ b/testsuite/integration-arquillian/servers/app-server/jetty/common/src/main/java/org/keycloak/testsuite/arquillian/jetty/JettyAppServer.java
@@ -43,6 +43,7 @@ import org.jboss.arquillian.container.spi.client.protocol.metadata.HTTPContext;
 import org.jboss.arquillian.container.spi.client.protocol.metadata.ProtocolMetaData;
 import org.jboss.arquillian.container.spi.client.protocol.metadata.Servlet;
 import org.jboss.logging.Logger;
+import org.jboss.resteasy.core.ResteasyDeploymentImpl;
 import org.jboss.resteasy.plugins.server.servlet.HttpServlet30Dispatcher;
 import org.jboss.resteasy.spi.ResteasyDeployment;
 import org.jboss.shrinkwrap.api.Archive;
@@ -240,7 +241,7 @@ public class JettyAppServer implements DeployableContainer<JettyAppServerConfigu
             resteasyServlet.setInitParameter("javax.ws.rs.Application", jaxrsApplication);
         } else if (!pathAnnotatedClasses.isEmpty()) {
             log.debug("App has @Path annotated classes: " + pathAnnotatedClasses);
-            ResteasyDeployment deployment = new ResteasyDeployment();
+            ResteasyDeployment deployment = new ResteasyDeploymentImpl();
             deployment.setApplication(new RestSamlApplicationConfig(pathAnnotatedClasses));
             webAppContext.setAttribute(ResteasyDeployment.class.getName(), deployment);
         } else {


### PR DESCRIPTION
Current Adapter test pipelines are failing due to JettyAppServer.java:[243,45] org.jboss.resteasy.spi.ResteasyDeployment is abstract; cannot be instantiated. Followup from https://github.com/keycloak/keycloak/issues/10916
