### PR TITLE
Fix jspath for old admin console and frontend url (regression from 18 onwards)

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/AdminConsole.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/AdminConsole.java
@@ -328,7 +328,14 @@ public class AdminConsole {
                 adminBaseUrl = adminBaseUrl.substring(0, adminBaseUrl.length() - 1);
             }
 
+            String kcJsRelativeBasePath = adminBaseUri.getPath();
+
+            if(!kcJsRelativeBasePath.endsWith("/")) {
+                kcJsRelativeBasePath = kcJsRelativeBasePath + "/";
+            }
+
             URI authServerBaseUri = session.getContext().getUri(UrlType.FRONTEND).getBaseUri();
+
             String authServerBaseUrl = authServerBaseUri.toString();
             if (authServerBaseUrl.endsWith("/")) {
                 authServerBaseUrl = authServerBaseUrl.substring(0, authServerBaseUrl.length() - 1);
@@ -339,7 +346,7 @@ public class AdminConsole {
             map.put("consoleBaseUrl", Urls.adminConsoleRoot(adminBaseUri, realm.getName()).getPath());
             map.put("resourceUrl", Urls.themeRoot(adminBaseUri).getPath() + "/admin/" + theme.getName());
             map.put("resourceCommonUrl", Urls.themeRoot(adminBaseUri).getPath() + "/common/keycloak");
-            map.put("keycloakJsUrl", adminBaseUri.getPath() + "js/keycloak.js?version=" + Version.RESOURCES_VERSION);
+            map.put("keycloakJsUrl", kcJsRelativeBasePath + "js/keycloak.js?version=" + Version.RESOURCES_VERSION);
             map.put("masterRealm", Config.getAdminRealm());
             map.put("resourceVersion", Version.RESOURCES_VERSION);
             map.put("loginRealm", realm.getName());


### PR DESCRIPTION
- fix keycloak.js path handling for old admin console.
- introduce test to make sure it doesn't happen again

@pedroigor @stianst This is a regression from #11109 - would be nice if you could check it. As we don't have wildfly CI anymore, I checked locally running 
`mvn -f testsuite/integration-arquillian/pom.xml clean install -Pauth-server-wildfly -Dtest=DefaultHostnameTest,AdminConsoleLandingPageTest`

and did some exploratory testing. Still not 100% sure this is the idiomatic way, so feel free to suggest a better one.

Closes #13786 