### PR TITLE
Add support for arm64 & ppc64le

### DIFF
--- a/.github/workflows/release-container.yml
+++ b/.github/workflows/release-container.yml
@@ -49,7 +49,7 @@
         uses: docker/build-push-action@v3
         with:
           context: quarkus/container
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/ppc64le
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/operator/olm-base/manifests/clusterserviceversion.yaml
+++ b/operator/olm-base/manifests/clusterserviceversion.yaml
@@ -42,6 +42,10 @@ metadata:
           }
         }
       ]
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.arm64: supported
+    operatorframework.io/arch.ppc64le: supported
   name: keycloak-operator.vREPLACE_ME_VERSION
   namespace: placeholder
 spec:


### PR DESCRIPTION
This PR adds multi-arch support for arm64 and ppc64le architecture along with amd64.
This is not a change in terms of function, it just adds build targets to support more platforms.

Signed-off-by: Marvin Giessing <marvin.giessing@gmail.com>

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
