### PR TITLE
[DRAFT]: Add 'imagePullSecret' field to the Keycloak CR

### DIFF
--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDeployment.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDeployment.java
@@ -30,6 +30,7 @@ import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.kubernetes.api.model.apps.StatefulSetBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.quarkus.logging.Log;
+import org.keycloak.common.util.CollectionUtil;
 import org.keycloak.operator.Config;
 import org.keycloak.operator.Constants;
 import org.keycloak.operator.crds.v2alpha1.deployment.Keycloak;
@@ -521,6 +522,9 @@ public class KeycloakDeployment extends OperatorManagedResource implements Statu
 
         if (customImage.isPresent()) {
             container.getArgs().add("--optimized");
+            if (CollectionUtil.isNotEmpty(keycloakCR.getSpec().getImagePullSecrets())) {
+                baseDeployment.getSpec().getTemplate().getSpec().setImagePullSecrets(keycloakCR.getSpec().getImagePullSecrets());
+            }
         }
 
         container.setImagePullPolicy(config.keycloak().imagePullPolicy());

--- a/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/KeycloakSpec.java
+++ b/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/KeycloakSpec.java
@@ -17,11 +17,14 @@
 package org.keycloak.operator.crds.v2alpha1.deployment;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import org.keycloak.operator.Constants;
 
 import javax.validation.constraints.NotNull;
+import java.util.ArrayList;
 import java.util.List;
 
 public class KeycloakSpec {
@@ -30,6 +33,9 @@ public class KeycloakSpec {
     private int instances = 1;
     @JsonPropertyDescription("Custom Keycloak image to be used.")
     private String image;
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @JsonPropertyDescription("Secret(s) that might be used when pulling an image from a private container image registry or repository.")
+    private List<LocalObjectReference> imagePullSecrets = new ArrayList();
     @JsonPropertyDescription("Configuration of the Keycloak server.\n" +
             "expressed as a keys (reference: https://www.keycloak.org/server/all-config) and values that can be either direct values or references to secrets.")
     private List<ValueOrSecret> serverConfiguration; // can't use Set due to a bug in Sundrio https://github.com/sundrio/sundrio/issues/316
@@ -108,6 +114,14 @@ public class KeycloakSpec {
 
     public void setImage(String image) {
         this.image = image;
+    }
+
+    public List<LocalObjectReference> getImagePullSecrets() {
+        return this.imagePullSecrets;
+    }
+
+    public void setImagePullSecrets(List<LocalObjectReference> imagePullSecrets) {
+        this.imagePullSecrets = imagePullSecrets;
     }
 
     public List<ValueOrSecret> getServerConfiguration() {

--- a/operator/src/test/resources/test-docker-registry-secret.yaml
+++ b/operator/src/test/resources/test-docker-registry-secret.yaml
@@ -1,0 +1,21 @@
+##
+# This file was created to test the 'ImagePullSecret" field added to 'KeycloakSpec' class. (Issue https://github.com/keycloak/keycloak/issues/12094)
+# The following account on DockerHub Registry was created in order to test the image pull from a private Repository. Such Repository holds the Keycloak custom docker images for integration tests purposes.
+# The credentials are:
+# - URL: https://hub.docker.com/
+# - Username: keycloak4test
+# - Password: vKlQ%$9c2469E@L
+#
+# This yaml file was generated from the following commands:
+# > kubectl create secret docker-registry docker-regcred-custom-kc-imagepullsecret-01 --docker-server=https://index.docker.io/v1/ --docker-username=keycloak4test --docker-password=vKlQ%$9c2469E@L --docker-email=anascime@redhat.com
+# > kubectl get secret docker-regcred-custom-kc-imagepullsecret-01 --output=yaml
+#
+##
+apiVersion: v1
+kind: Secret
+data:
+  .dockerconfigjson: eyJhdXRocyI6eyJodHRwczovL2luZGV4LmRvY2tlci5pby92MS8iOnsidXNlcm5hbWUiOiJrZXljbG9hazR0ZXN0IiwicGFzc3dvcmQiOiJ2S2xRJWMyNDY5RUBMIiwiZW1haWwiOiJhbmFzY2ltZUByZWRoYXQuY29tIiwiYXV0aCI6ImEyVjVZMnh2WVdzMGRHVnpkRHAyUzJ4UkpXTXlORFk1UlVCTSJ9fX0=
+metadata:
+  name: docker-regcred-custom-kc-imagepullsecret-01
+  namespace: default
+type: kubernetes.io/dockerconfigjson


### PR DESCRIPTION
Closes #12094 

[Only in Draft]

- Adding the "imagePullSecrets" field as a first-class field in the Keycloak CR, in order to use and custom Keycloak docker image from a registry that needs authentication;

- There's no more need to configure that "imagePullSecrets" through the unsupported properties section in the Keycloak CRD.

Missing:

- Review, discuss and define the best approach to implement the Integration Test methods for this new field/feature. When opening this Draft PR, one temporary approach was used that might be improved after discussion.
