### PR TITLE
Introduce profile (enabled with -DincludeWildFly) to not include WildFly distribution in default builds

### DIFF
--- a/distribution/feature-packs/pom.xml
+++ b/distribution/feature-packs/pom.xml
@@ -32,7 +32,20 @@
 
     <modules>
         <module>adapter-feature-pack</module>
-        <module>server-feature-pack-dependencies</module>
-        <module>server-feature-pack</module>
     </modules>
+
+    <profiles>
+        <profile>
+            <id>wildfly-dist</id>
+            <activation>
+                <property>
+                    <name>includeWildFly</name>
+                </property>
+            </activation>
+            <modules>
+                <module>server-feature-pack-dependencies</module>
+                <module>server-feature-pack</module>
+            </modules>
+        </profile>
+    </profiles>
 </project>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -39,10 +39,8 @@
         <module>adapters</module>
         <module>saml-adapters</module>
         <module>feature-packs</module>
-        <module>galleon-feature-packs</module>
         <module>licenses-common</module>
         <module>maven-plugins</module>
-        <module>server-dist</module>
         <!--<module>server-overlay</module>-->
     </modules>
 
@@ -74,6 +72,18 @@
     </repositories>
 
     <profiles>
+        <profile>
+            <id>wildfly-dist</id>
+            <activation>
+                <property>
+                    <name>includeWildFly</name>
+                </property>
+            </activation>
+            <modules>
+                <module>galleon-feature-packs</module>
+                <module>server-dist</module>
+            </modules>
+        </profile>
         <profile>
             <id>legacy-dist</id>
             <activation>

--- a/pom.xml
+++ b/pom.xml
@@ -284,7 +284,6 @@
         <module>themes</module>
         <module>model</module>
         <module>util</module>
-        <module>wildfly</module>
         <module>integration</module>
         <module>adapters</module>
         <module>authz</module>
@@ -1903,6 +1902,18 @@
     </build>
 
     <profiles>
+        <profile>
+            <id>wildfly-dist</id>
+            <activation>
+                <property>
+                    <name>includeWildFly</name>
+                </property>
+            </activation>
+            <modules>
+                <module>wildfly</module>
+            </modules>
+        </profile>
+
         <profile>
             <id>community</id>
             <activation>

--- a/testsuite/utils/pom.xml
+++ b/testsuite/utils/pom.xml
@@ -69,10 +69,6 @@
             <artifactId>keycloak-admin-client</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.keycloak</groupId>
-            <artifactId>keycloak-wildfly-adduser</artifactId>
-        </dependency>
-        <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
             <scope>compile</scope>

--- a/wildfly/pom.xml
+++ b/wildfly/pom.xml
@@ -23,7 +23,7 @@
         <version>999-SNAPSHOT</version>
     </parent>
 
-    <name>Keycloak WildFly Integration</name>
+    <name>Keycloak WildFly Server Integration Parent</name>
     <description/>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
As a first step before deleting the WildFly distribution I propose we wrap it in a profile that has to be explicitly enabled. That allows us to quickly identify anything in CI or other places that still depend on the WF dist, then make a temporary quick fix to enable it while we work on a permanent resolution to replace WF with Quarkus in those use-cases.