### PR TITLE
Revert "Allow dependencies from keycloak-admin-ui"

### DIFF
--- a/testsuite/integration-arquillian/pom.xml
+++ b/testsuite/integration-arquillian/pom.xml
@@ -216,6 +216,12 @@
                 <groupId>org.keycloak</groupId>
                 <artifactId>keycloak-admin-ui</artifactId>
                 <version>${keycloak.admin-ui.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/testsuite/utils/pom.xml
+++ b/testsuite/utils/pom.xml
@@ -57,6 +57,12 @@
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-admin-ui</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>


### PR DESCRIPTION
Reverts keycloak/keycloak#13924

PR https://github.com/keycloak/keycloak-ui/pull/3183 removes kotlin and it's dependencies we can have this back