### PR TITLE
Remove Dependabot configuration for Keycloak JS

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,13 +23,3 @@ updates:
     ignore:
       - dependency-name: bootstrap
         update-types: ["version-update:semver-major"]
-  - package-ecosystem: npm
-    directory: /adapters/oidc/js
-    schedule:
-      interval: weekly
-      day: saturday
-    open-pull-requests-limit: 999
-    rebase-strategy: disabled
-    labels:
-      - area/dependencies
-      - area/adapter/javascript


### PR DESCRIPTION
The Keycloak JS adapter is being moved to the Keycloak UI repo (https://github.com/keycloak/keycloak-ui/pull/3189). So it's no longer required to keep it's dependencies up-to-date here.