### PR TITLE
Add common informational variables to all email body templates

### DIFF
--- a/services/src/main/java/org/keycloak/email/freemarker/FreeMarkerEmailTemplateProvider.java
+++ b/services/src/main/java/org/keycloak/email/freemarker/FreeMarkerEmailTemplateProvider.java
@@ -18,7 +18,6 @@
 package org.keycloak.email.freemarker;
 
 import java.io.IOException;
-import java.net.URI;
 import java.text.MessageFormat;
 import java.util.Arrays;
 import java.util.Collections;
@@ -105,8 +104,7 @@ public class FreeMarkerEmailTemplateProvider implements EmailTemplateProvider {
 
     @Override
     public void sendEvent(Event event) throws EmailException {
-        Map<String, Object> attributes = new HashMap<>();
-        attributes.put("user", new ProfileBean(user));
+        Map<String, Object> attributes = new HashMap<>(this.attributes);
         attributes.put("event", new EventBean(event));
 
         send(toCamelCase(event.getType()) + "Subject", "event-" + event.getType().toString().toLowerCase() + ".ftl", attributes);
@@ -115,10 +113,7 @@ public class FreeMarkerEmailTemplateProvider implements EmailTemplateProvider {
     @Override
     public void sendPasswordReset(String link, long expirationInMinutes) throws EmailException {
         Map<String, Object> attributes = new HashMap<>(this.attributes);
-        attributes.put("user", new ProfileBean(user));
         addLinkInfoIntoAttributes(link, expirationInMinutes, attributes);
-
-        attributes.put("realmName", getRealmName());
 
         send("passwordResetSubject", "password-reset.ftl", attributes);
     }
@@ -129,8 +124,6 @@ public class FreeMarkerEmailTemplateProvider implements EmailTemplateProvider {
         setUser(user);
 
         Map<String, Object> attributes = new HashMap<>(this.attributes);
-        attributes.put("user", new ProfileBean(user));
-        attributes.put("realmName", realm.getName());
 
         EmailTemplate email = processTemplate("emailTestSubject", Collections.emptyList(), "email-test.ftl", attributes);
         send(config, email.getSubject(), email.getTextBody(), email.getHtmlBody());
@@ -139,10 +132,7 @@ public class FreeMarkerEmailTemplateProvider implements EmailTemplateProvider {
     @Override
     public void sendConfirmIdentityBrokerLink(String link, long expirationInMinutes) throws EmailException {
         Map<String, Object> attributes = new HashMap<>(this.attributes);
-        attributes.put("user", new ProfileBean(user));
         addLinkInfoIntoAttributes(link, expirationInMinutes, attributes);
-
-        attributes.put("realmName", getRealmName());
 
         BrokeredIdentityContext brokerContext = (BrokeredIdentityContext) this.attributes.get(IDENTITY_PROVIDER_BROKER_CONTEXT);
         String idpAlias = brokerContext.getIdpConfig().getAlias();
@@ -163,10 +153,7 @@ public class FreeMarkerEmailTemplateProvider implements EmailTemplateProvider {
     @Override
     public void sendExecuteActions(String link, long expirationInMinutes) throws EmailException {
         Map<String, Object> attributes = new HashMap<>(this.attributes);
-        attributes.put("user", new ProfileBean(user));
         addLinkInfoIntoAttributes(link, expirationInMinutes, attributes);
-
-        attributes.put("realmName", getRealmName());
 
         send("executeActionsSubject", "executeActions.ftl", attributes);
     }
@@ -174,10 +161,7 @@ public class FreeMarkerEmailTemplateProvider implements EmailTemplateProvider {
     @Override
     public void sendVerifyEmail(String link, long expirationInMinutes) throws EmailException {
         Map<String, Object> attributes = new HashMap<>(this.attributes);
-        attributes.put("user", new ProfileBean(user));
         addLinkInfoIntoAttributes(link, expirationInMinutes, attributes);
-
-        attributes.put("realmName", getRealmName());
 
         send("emailVerificationSubject", "email-verification.ftl", attributes);
     }
@@ -189,18 +173,15 @@ public class FreeMarkerEmailTemplateProvider implements EmailTemplateProvider {
         }
 
         Map<String, Object> attributes = new HashMap<>(this.attributes);
-        attributes.put("user", new ProfileBean(user));
-        attributes.put("newEmail", newEmail);
         addLinkInfoIntoAttributes(link, expirationInMinutes, attributes);
-
-        attributes.put("realmName", getRealmName());
+        attributes.put("newEmail", newEmail);
 
         send("emailUpdateConfirmationSubject", Collections.emptyList(), "email-update-confirmation.ftl", attributes, newEmail);
     }
 
     /**
      * Add link info into template attributes.
-     * 
+     *
      * @param link to add
      * @param expirationInMinutes to add
      * @param attributes to add link info into
@@ -208,12 +189,9 @@ public class FreeMarkerEmailTemplateProvider implements EmailTemplateProvider {
     protected void addLinkInfoIntoAttributes(String link, long expirationInMinutes, Map<String, Object> attributes) throws EmailException {
         attributes.put("link", link);
         attributes.put("linkExpiration", expirationInMinutes);
-        KeycloakUriInfo uriInfo = session.getContext().getUri();
-        URI baseUri = uriInfo.getBaseUri();
         try {
             Locale locale = session.getContext().resolveLocale(user);
             attributes.put("linkExpirationFormatter", new LinkExpirationFormatterMethod(getTheme().getMessages(locale), locale));
-            attributes.put("url", new UrlBean(realm, getTheme(), baseUri, null));
         } catch (IOException e) {
             throw new EmailException("Failed to template email", e);
         }
@@ -229,6 +207,7 @@ public class FreeMarkerEmailTemplateProvider implements EmailTemplateProvider {
             Theme theme = getTheme();
             Locale locale = session.getContext().resolveLocale(user);
             attributes.put("locale", locale);
+            KeycloakUriInfo uriInfo = session.getContext().getUri();
             Properties rb = new Properties();
             if(!StringUtil.isNotBlank(realm.getDefaultLocale()))
             {
@@ -238,6 +217,9 @@ public class FreeMarkerEmailTemplateProvider implements EmailTemplateProvider {
             rb.putAll(realm.getRealmLocalizationTextsByLocale(locale.toLanguageTag()));
             attributes.put("msg", new MessageFormatterMethod(locale, rb));
             attributes.put("properties", theme.getProperties());
+            attributes.put("realmName", getRealmName());
+            attributes.put("user", new ProfileBean(user));
+            attributes.put("url", new UrlBean(realm, theme, uriInfo.getBaseUri(), null));
             String subject = new MessageFormat(rb.getProperty(subjectKey, subjectKey), locale).format(subjectAttributes.toArray());
             String textTemplate = String.format("text/%s", template);
             String textBody;


### PR DESCRIPTION
This change extends changes made in #6512 PR by adding `realmName`, `user` and `url` variables to all email templates. These variables are necessary when styling the email. For example usage of `url.resourcePath` is needed for getting path to image within the theme.

Documentation for the email template variables doesn't exist. Should it be added?