### PR TITLE
Upgrade to Quarkus 2.12.0.Final

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,8 @@ quarkus/data/*.db
 
 # Jakarta transformed sources #
 ###############################
-
 /integration/admin-client-jakarta/src/
 /.metadata/
+
+# Git ephemeral files
+*.versionsBackup

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <jboss.snapshots.repo.id>jboss-snapshots-repository</jboss.snapshots.repo.id>
         <jboss.snapshots.repo.url>https://s01.oss.sonatype.org/content/repositories/snapshots/</jboss.snapshots.repo.url>
 
-        <quarkus.version>2.7.6.Final</quarkus.version>
+        <quarkus.version>2.12.0.Final</quarkus.version>
 
         <!--
         Performing a Wildfly upgrade? Run the:

--- a/quarkus/CONTRIBUTING.md
+++ b/quarkus/CONTRIBUTING.md
@@ -204,6 +204,66 @@ Please, make sure:
 * Make sure you have a test within the [tests/integration](tests/integration) module to cover the changes
 * You probably want to run a full build of the `quarkus` module, including running tests, to make sure you won't be surprised by failures in CI.
 
+## Upgrading Quarkus Version
+
+Upgrading Quarkus requires a few steps:
+
+* Change the Quarkus version
+* Change the dependencies we are using from Quarkus 
+* Run a build to make sure the server extension is not broken
+
+The steps still require a lot of manual work, and we should be improving this.
+
+### Changing the Quarkus version
+
+To change the Quarkus version, you can run the following script:
+
+```bash
+./set-quarkus-version.sh <version>
+```
+
+The `set-quarkus-version.sh` script is enough to change the version for all dependencies we are
+using from Quarkus. 
+
+The `<version>` should point to a branch or a tag from Quarkus repository.
+
+It is also possible to change to a snapshot version by running:
+
+```bash
+./set-quarkus-version.sh
+```
+
+### Run a local build
+
+After changing the dependency versions, you can run a local build to make sure the server extension is not broken by API changes and if
+all tests are passing:
+
+```
+mvn clean install
+```
+
+### Changing versions of JDBC Extensions
+
+It might happen that when upgrading a version for any of the JDBC extensions (e.g.: `quarkus-jdbc-postgresql`) you also need to make sure the server extension is using the same JDBC Drivers.
+
+For that, you should look at the `deployment` module of the corresponding JDBC extension from Quarkus (e.g.: https://github.com/quarkusio/quarkus/blob/main/extensions/jdbc/jdbc-postgresql/deployment/src/main/java/io/quarkus/jdbc/postgresql/deployment/JDBCPostgreSQLProcessor.java) to check if they match with the drivers used by the server extension by looking at the `org.keycloak.config.database.Database` class.
+
+### Changing versions of Quarkiverse dependencies
+
+Make sure the Quarkiverse dependencies are also updated and in sync with the Quarkus version you are upgrading.
+
+For now, we only have this Quarkiverse dependency:
+
+  * https://github.com/quarkiverse/quarkus-vault
+
+### What can go wrong when upgrading?
+
+The perfect scenario is that after performing all the steps above the server extension will compile, the distribution can be built,
+and all tests will pass.
+
+However, it is expected breaking changes between Quarkus upgrades that break the integration code we have in both [deployment](deployment) and [runtime](runtime) modules. When this happens,
+you should understand what is breaking and upgrade the integration code accordingly.
+
 ## References
 
 * [Configuration Guide](https://www.keycloak.org/server/configuration)

--- a/quarkus/config-api/src/main/java/org/keycloak/config/LoggingOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/LoggingOptions.java
@@ -95,6 +95,13 @@ public class LoggingOptions {
             .defaultValue("%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n")
             .build();
 
+    public static final Option<Output> LOG_FILE_OUTPUT = new OptionBuilder<>("log-file-output", Output.class)
+            .category(OptionCategory.LOGGING)
+            .defaultValue(DEFAULT_CONSOLE_OUTPUT)
+            .description("Set the log output to JSON or default (plain) unstructured logging.")
+            .build();
+
+
     public static final Option<Boolean> LOG_GELF_ENABLED = new OptionBuilder<>("log-gelf-enabled", Boolean.class)
             .category(OptionCategory.LOGGING)
             .hidden()

--- a/quarkus/config-api/src/main/java/org/keycloak/config/database/Database.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/database/Database.java
@@ -125,7 +125,7 @@ public final class Database {
                 asList("org.keycloak.connections.jpa.updater.liquibase.UpdatedMySqlDatabase")
         ),
         MARIADB("mariadb",
-                "org.mariadb.jdbc.MySQLDataSource",
+                "org.mariadb.jdbc.MariaDbDataSource",
                 "org.mariadb.jdbc.Driver",
                 "org.hibernate.dialect.MariaDBDialect",
                 "jdbc:mariadb://${kc.db-url-host:localhost}:${kc.db-url-port:3306}/${kc.db-url-database:keycloak}${kc.db-url-properties:}",

--- a/quarkus/pom.xml
+++ b/quarkus/pom.xml
@@ -32,20 +32,28 @@
 
     <properties>
         <!--
-            Override versions based on Quarkus dependencies.
-            Make sure to update these dependencies when Quarkus version changes.
-            See https://github.com/quarkusio/quarkus/blob/<versionTag>/bom/application/pom.xml
-            for reference
+            Do not change the properties bellow.
+            Their names should match the name used by Quarkus BOM and the versions are automatically set when running the 'set-quarkus-version.sh' script.
         -->
-        <resteasy.version>4.7.5.Final</resteasy.version>
-        <jackson.version>2.13.3</jackson.version>
-        <jackson.databind.version>2.13.3</jackson.databind.version>
-        <hibernate.core.version>5.6.5.Final</hibernate.core.version>
-        <mysql.driver.version>8.0.28</mysql.driver.version>
-        <postgresql.version>42.3.3</postgresql.version>
+        <resteasy.version>4.7.7.Final</resteasy.version>
+        <jackson-bom.version>2.13.3</jackson-bom.version>
+        <hibernate-orm.version>5.6.10.Final</hibernate-orm.version>
+        <mysql-jdbc.version>8.0.30</mysql-jdbc.version>
+        <postgresql-jdbc.version>42.4.2</postgresql-jdbc.version>
+        <wildfly-common.version>1.5.4.Final-format-001</wildfly-common.version>
+        <wildfly-elytron.version>1.20.0.Final</wildfly-elytron.version>
         <microprofile-metrics-api.version>3.0.1</microprofile-metrics-api.version>
-        <wildfly.common.version>1.5.4.Final-format-001</wildfly.common.version>
-        <wildfly-elytron.version>1.18.3.Final</wildfly-elytron.version>
+
+        <!--
+            We need to override certain dependencies from the parent POM.
+            TODO: remove these properties after changing the parent POM to use the same property names used by Quarkus BOM.
+        -->
+        <jackson.version>${jackson-bom.version}</jackson.version>
+        <jackson.databind.version>${jackson-bom.version}</jackson.databind.version>
+        <hibernate.core.version>${hibernate-orm.version}</hibernate.core.version>
+        <mysql.driver.version>${mysql-jdbc.version}</mysql.driver.version>
+        <postgresql.version>${postgresql-jdbc.version}</postgresql.version>
+        <wildfly.common.version>${wildfly-common.version}</wildfly.common.version>
 
         <!--
             Java EE dependencies. Not available from JDK 11+.
@@ -58,7 +66,7 @@
         <!--
             Quarkiverse dependency versions
          -->
-        <io.quarkiverse.vault.version>1.1.0</io.quarkiverse.vault.version>
+        <io.quarkiverse.vault.version>2.0.0</io.quarkiverse.vault.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/LoggingPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/LoggingPropertyMappers.java
@@ -30,8 +30,8 @@ public final class LoggingPropertyMappers {
                         .build(),
                 fromOption(LoggingOptions.LOG_CONSOLE_OUTPUT)
                         .to("quarkus.log.console.json")
-                        .paramLabel("default|json")
-                        .transformer(LoggingPropertyMappers::resolveLogConsoleOutput)
+                        .paramLabel("output")
+                        .transformer(LoggingPropertyMappers::resolveLogOutput)
                         .build(),
                 fromOption(LoggingOptions.LOG_CONSOLE_FORMAT)
                         .to("quarkus.log.console.format")
@@ -39,7 +39,6 @@ public final class LoggingPropertyMappers {
                         .build(),
                 fromOption(LoggingOptions.LOG_CONSOLE_COLOR)
                         .to("quarkus.log.console.color")
-                        .paramLabel(Boolean.TRUE + "|" + Boolean.FALSE)
                         .build(),
                 fromOption(LoggingOptions.LOG_CONSOLE_ENABLED)
                         .mapFrom("log")
@@ -53,12 +52,17 @@ public final class LoggingPropertyMappers {
                         .build(),
                 fromOption(LoggingOptions.LOG_FILE)
                         .to("quarkus.log.file.path")
-                        .paramLabel("<path>/<file-name>.log")
+                        .paramLabel("file")
                         .transformer(LoggingPropertyMappers::resolveFileLogLocation)
                         .build(),
                 fromOption(LoggingOptions.LOG_FILE_FORMAT)
                         .to("quarkus.log.file.format")
                         .paramLabel("<format>")
+                        .build(),
+                fromOption(LoggingOptions.LOG_FILE_OUTPUT)
+                        .to("quarkus.log.file.json")
+                        .paramLabel("output")
+                        .transformer(LoggingPropertyMappers::resolveLogOutput)
                         .build(),
                 fromOption(LoggingOptions.LOG_LEVEL)
                         .to("quarkus.log.level")
@@ -68,7 +72,6 @@ public final class LoggingPropertyMappers {
                 fromOption(LoggingOptions.LOG_GELF_ENABLED)
                         .mapFrom("log")
                         .to("quarkus.log.handler.gelf.enabled")
-                        .paramLabel(Boolean.TRUE + "|" + Boolean.FALSE)
                         .transformer(LoggingPropertyMappers.resolveLogHandler("gelf"))
                         .build(),
                 fromOption(LoggingOptions.LOG_GELF_LEVEL)
@@ -89,7 +92,6 @@ public final class LoggingPropertyMappers {
                         .build(),
                 fromOption(LoggingOptions.LOG_GELF_INCLUDE_STACK_TRACE)
                         .to("quarkus.log.handler.gelf.extract-stack-trace")
-                        .paramLabel(Boolean.TRUE + "|" + Boolean.FALSE)
                         .build(),
                 fromOption(LoggingOptions.LOG_GELF_TIMESTAMP_FORMAT)
                         .to("quarkus.log.handler.gelf.timestamp-pattern")
@@ -105,11 +107,9 @@ public final class LoggingPropertyMappers {
                         .build(),
                 fromOption(LoggingOptions.LOG_GELF_INCLUDE_LOG_MSG_PARAMS)
                         .to("quarkus.log.handler.gelf.include-log-message-parameters")
-                        .paramLabel(Boolean.TRUE + "|" + Boolean.FALSE)
                         .build(),
                 fromOption(LoggingOptions.LOG_GELF_INCLUDE_LOCATION)
                         .to("quarkus.log.handler.gelf.include-location")
-                        .paramLabel(Boolean.TRUE + "|" + Boolean.FALSE)
                         .build()
         };
     }
@@ -198,7 +198,7 @@ public final class LoggingPropertyMappers {
         return rootLevel;
     }
 
-    private static Optional<String> resolveLogConsoleOutput(Optional<String> value, ConfigSourceInterceptorContext context) {
+    private static Optional<String> resolveLogOutput(Optional<String> value, ConfigSourceInterceptorContext context) {
         if (value.get().equals(LoggingOptions.DEFAULT_CONSOLE_OUTPUT.name().toLowerCase(Locale.ROOT))) {
             return of(Boolean.FALSE.toString());
         }

--- a/quarkus/runtime/src/main/resources/application.properties
+++ b/quarkus/runtime/src/main/resources/application.properties
@@ -31,3 +31,6 @@ quarkus.devservices.enabled=false
 
 # We want to expose non-application paths (e.g. health) at the root path
 quarkus.http.non-application-root-path=${quarkus.http.root-path}
+
+# Disable specific categories from logs
+quarkus.log.category."io.quarkus.config".level=off

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/ConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/ConfigurationTest.java
@@ -47,8 +47,9 @@ import io.quarkus.runtime.configuration.ConfigUtils;
 import io.smallrye.config.SmallRyeConfigProviderResolver;
 import org.keycloak.quarkus.runtime.Environment;
 import org.keycloak.quarkus.runtime.vault.FilesPlainTextVaultProviderFactory;
-import org.mariadb.jdbc.MySQLDataSource;
+import org.mariadb.jdbc.MariaDbDataSource;
 import org.postgresql.xa.PGXADataSource;
+import com.mysql.cj.jdbc.MysqlDataSource;
 
 public class ConfigurationTest {
 
@@ -332,7 +333,7 @@ public class ConfigurationTest {
         config = createConfig();
         assertEquals("jdbc:mariadb://localhost:3306/keycloak?test=test&test1=test1", config.getConfigValue("quarkus.datasource.jdbc.url").getValue());
         assertEquals(MariaDBDialect.class.getName(), config.getConfigValue("quarkus.hibernate-orm.dialect").getValue());
-        assertEquals(MySQLDataSource.class.getName(), config.getConfigValue("quarkus.datasource.jdbc.driver").getValue());
+        assertEquals(MariaDbDataSource.class.getName(), config.getConfigValue("quarkus.datasource.jdbc.driver").getValue());
 
         System.setProperty(CLI_ARGS, "--db=postgres");
         config = createConfig();

--- a/quarkus/set-quarkus-version.sh
+++ b/quarkus/set-quarkus-version.sh
@@ -1,0 +1,61 @@
+#
+# Copyright 2022 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+if [ "$1" == "-h" ]; then
+  echo "Change the Quarkus version to a specific version."
+  echo "Usage: set-quarkus-version <version>"
+  exit
+fi
+
+DEFAULT_QUARKUS_VERSION="999-SNAPSHOT"
+QUARKUS_VERSION=${1:-"$DEFAULT_QUARKUS_VERSION"}
+QUARKUS_BRANCH="$QUARKUS_VERSION"
+
+if [ "$QUARKUS_BRANCH" == "$DEFAULT_QUARKUS_VERSION" ]; then
+    QUARKUS_BRANCH="main"
+fi
+
+QUARKUS_BOM_URL="https://raw.githubusercontent.com/quarkusio/quarkus/$QUARKUS_BRANCH/bom/application/pom.xml"
+
+if ! $(curl --output /dev/null --silent --head --fail "$QUARKUS_BOM_URL"); then
+    echo "Failed to resolve version from Quarkus BOM at '$QUARKUS_BOM_URL'"
+    exit 1
+fi
+
+QUARKUS_BOM=$(curl -s "$QUARKUS_BOM_URL")
+
+echo "Setting Quarkus version: $QUARKUS_VERSION"
+$(mvn -f ../pom.xml versions:revert 1> /dev/null)
+$(mvn versions:set-property -f ../pom.xml -Dproperty=quarkus.version -DnewVersion="$QUARKUS_VERSION" 1> /dev/null)
+
+DEPENDENCIES_LIST="resteasy jackson-bom hibernate-orm mysql-jdbc postgresql-jdbc microprofile-metrics-api wildfly-common wildfly-elytron"
+
+echo "Changing dependencies: $DEPENDENCIES_LIST"
+$(mvn -f ./pom.xml versions:revert 1> /dev/null)
+
+for dependency in $DEPENDENCIES_LIST; do
+    VERSION=$(grep -oP "(?<=<$dependency.version>).*(?=</$dependency.version)" <<< "$QUARKUS_BOM")
+    if [ "$VERSION" == "" ]; then
+        echo "Failed to resolve version for dependency '$dependency'"
+        exit 1
+    fi
+    echo "Setting $VERSION to $dependency"
+    $(mvn versions:set-property -pl . -Dproperty="$dependency".version -DnewVersion="$VERSION" 1> /dev/null)
+done
+
+echo ""
+echo "Done!"

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartDevHelp.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartDevHelp.unix.approved.txt
@@ -177,14 +177,16 @@ Logging:
                      The format of unstructured console log entries. If the format has spaces in
                        it, escape the value using "<format>". Default: %d{yyyy-MM-dd HH:mm:ss,SSS} %
                        -5p [%c] (%t) %s%e%n.
---log-console-output <default|json>
+--log-console-output <output>
                      Set the log output to JSON or default (plain) unstructured logging. Possible
                        values are: default, json. Default: default.
---log-file <path>/<file-name>.log
-                     Set the log file path and filename. Default: data/log/keycloak.log.
+--log-file <file>    Set the log file path and filename. Default: data/log/keycloak.log.
 --log-file-format <format>
                      Set a format specific to file log entries. Default: %d{yyyy-MM-dd HH:mm:ss,
                        SSS} %-5p [%c] (%t) %s%e%n.
+--log-file-output <output>
+                     Set the log output to JSON or default (plain) unstructured logging. Possible
+                       values are: default, json. Default: default.
 --log-gelf-facility <name>
                      The facility (name of the process) that sends the message. Default: keycloak.
 --log-gelf-host <hostname>

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartDevHelp.windows.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartDevHelp.windows.approved.txt
@@ -177,14 +177,16 @@ Logging:
                      The format of unstructured console log entries. If the format has spaces in
                        it, escape the value using "<format>". Default: %d{yyyy-MM-dd HH:mm:ss,SSS} %
                        -5p [%c] (%t) %s%e%n.
---log-console-output <default|json>
+--log-console-output <output>
                      Set the log output to JSON or default (plain) unstructured logging. Possible
                        values are: default, json. Default: default.
---log-file <path>/<file-name>.log
-                     Set the log file path and filename. Default: data/log/keycloak.log.
+--log-file <file>    Set the log file path and filename. Default: data/log/keycloak.log.
 --log-file-format <format>
                      Set a format specific to file log entries. Default: %d{yyyy-MM-dd HH:mm:ss,
                        SSS} %-5p [%c] (%t) %s%e%n.
+--log-file-output <output>
+                     Set the log output to JSON or default (plain) unstructured logging. Possible
+                       values are: default, json. Default: default.
 --log-gelf-facility <name>
                      The facility (name of the process) that sends the message. Default: keycloak.
 --log-gelf-host <hostname>

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartDevHelpAll.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartDevHelpAll.unix.approved.txt
@@ -238,14 +238,16 @@ Logging:
                      The format of unstructured console log entries. If the format has spaces in
                        it, escape the value using "<format>". Default: %d{yyyy-MM-dd HH:mm:ss,SSS} %
                        -5p [%c] (%t) %s%e%n.
---log-console-output <default|json>
+--log-console-output <output>
                      Set the log output to JSON or default (plain) unstructured logging. Possible
                        values are: default, json. Default: default.
---log-file <path>/<file-name>.log
-                     Set the log file path and filename. Default: data/log/keycloak.log.
+--log-file <file>    Set the log file path and filename. Default: data/log/keycloak.log.
 --log-file-format <format>
                      Set a format specific to file log entries. Default: %d{yyyy-MM-dd HH:mm:ss,
                        SSS} %-5p [%c] (%t) %s%e%n.
+--log-file-output <output>
+                     Set the log output to JSON or default (plain) unstructured logging. Possible
+                       values are: default, json. Default: default.
 --log-gelf-facility <name>
                      The facility (name of the process) that sends the message. Default: keycloak.
 --log-gelf-host <hostname>

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartDevHelpAll.windows.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartDevHelpAll.windows.approved.txt
@@ -238,14 +238,16 @@ Logging:
                      The format of unstructured console log entries. If the format has spaces in
                        it, escape the value using "<format>". Default: %d{yyyy-MM-dd HH:mm:ss,SSS} %
                        -5p [%c] (%t) %s%e%n.
---log-console-output <default|json>
+--log-console-output <output>
                      Set the log output to JSON or default (plain) unstructured logging. Possible
                        values are: default, json. Default: default.
---log-file <path>/<file-name>.log
-                     Set the log file path and filename. Default: data/log/keycloak.log.
+--log-file <file>    Set the log file path and filename. Default: data/log/keycloak.log.
 --log-file-format <format>
                      Set a format specific to file log entries. Default: %d{yyyy-MM-dd HH:mm:ss,
                        SSS} %-5p [%c] (%t) %s%e%n.
+--log-file-output <output>
+                     Set the log output to JSON or default (plain) unstructured logging. Possible
+                       values are: default, json. Default: default.
 --log-gelf-facility <name>
                      The facility (name of the process) that sends the message. Default: keycloak.
 --log-gelf-host <hostname>

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartHelp.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartHelp.unix.approved.txt
@@ -183,14 +183,16 @@ Logging:
                      The format of unstructured console log entries. If the format has spaces in
                        it, escape the value using "<format>". Default: %d{yyyy-MM-dd HH:mm:ss,SSS} %
                        -5p [%c] (%t) %s%e%n.
---log-console-output <default|json>
+--log-console-output <output>
                      Set the log output to JSON or default (plain) unstructured logging. Possible
                        values are: default, json. Default: default.
---log-file <path>/<file-name>.log
-                     Set the log file path and filename. Default: data/log/keycloak.log.
+--log-file <file>    Set the log file path and filename. Default: data/log/keycloak.log.
 --log-file-format <format>
                      Set a format specific to file log entries. Default: %d{yyyy-MM-dd HH:mm:ss,
                        SSS} %-5p [%c] (%t) %s%e%n.
+--log-file-output <output>
+                     Set the log output to JSON or default (plain) unstructured logging. Possible
+                       values are: default, json. Default: default.
 --log-gelf-facility <name>
                      The facility (name of the process) that sends the message. Default: keycloak.
 --log-gelf-host <hostname>

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartHelp.windows.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartHelp.windows.approved.txt
@@ -183,14 +183,16 @@ Logging:
                      The format of unstructured console log entries. If the format has spaces in
                        it, escape the value using "<format>". Default: %d{yyyy-MM-dd HH:mm:ss,SSS} %
                        -5p [%c] (%t) %s%e%n.
---log-console-output <default|json>
+--log-console-output <output>
                      Set the log output to JSON or default (plain) unstructured logging. Possible
                        values are: default, json. Default: default.
---log-file <path>/<file-name>.log
-                     Set the log file path and filename. Default: data/log/keycloak.log.
+--log-file <file>    Set the log file path and filename. Default: data/log/keycloak.log.
 --log-file-format <format>
                      Set a format specific to file log entries. Default: %d{yyyy-MM-dd HH:mm:ss,
                        SSS} %-5p [%c] (%t) %s%e%n.
+--log-file-output <output>
+                     Set the log output to JSON or default (plain) unstructured logging. Possible
+                       values are: default, json. Default: default.
 --log-gelf-facility <name>
                      The facility (name of the process) that sends the message. Default: keycloak.
 --log-gelf-host <hostname>

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartHelpAll.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartHelpAll.unix.approved.txt
@@ -244,14 +244,16 @@ Logging:
                      The format of unstructured console log entries. If the format has spaces in
                        it, escape the value using "<format>". Default: %d{yyyy-MM-dd HH:mm:ss,SSS} %
                        -5p [%c] (%t) %s%e%n.
---log-console-output <default|json>
+--log-console-output <output>
                      Set the log output to JSON or default (plain) unstructured logging. Possible
                        values are: default, json. Default: default.
---log-file <path>/<file-name>.log
-                     Set the log file path and filename. Default: data/log/keycloak.log.
+--log-file <file>    Set the log file path and filename. Default: data/log/keycloak.log.
 --log-file-format <format>
                      Set a format specific to file log entries. Default: %d{yyyy-MM-dd HH:mm:ss,
                        SSS} %-5p [%c] (%t) %s%e%n.
+--log-file-output <output>
+                     Set the log output to JSON or default (plain) unstructured logging. Possible
+                       values are: default, json. Default: default.
 --log-gelf-facility <name>
                      The facility (name of the process) that sends the message. Default: keycloak.
 --log-gelf-host <hostname>

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartHelpAll.windows.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartHelpAll.windows.approved.txt
@@ -244,14 +244,16 @@ Logging:
                      The format of unstructured console log entries. If the format has spaces in
                        it, escape the value using "<format>". Default: %d{yyyy-MM-dd HH:mm:ss,SSS} %
                        -5p [%c] (%t) %s%e%n.
---log-console-output <default|json>
+--log-console-output <output>
                      Set the log output to JSON or default (plain) unstructured logging. Possible
                        values are: default, json. Default: default.
---log-file <path>/<file-name>.log
-                     Set the log file path and filename. Default: data/log/keycloak.log.
+--log-file <file>    Set the log file path and filename. Default: data/log/keycloak.log.
 --log-file-format <format>
                      Set a format specific to file log entries. Default: %d{yyyy-MM-dd HH:mm:ss,
                        SSS} %-5p [%c] (%t) %s%e%n.
+--log-file-output <output>
+                     Set the log output to JSON or default (plain) unstructured logging. Possible
+                       values are: default, json. Default: default.
 --log-gelf-facility <name>
                      The facility (name of the process) that sends the message. Default: keycloak.
 --log-gelf-host <hostname>

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartOptimizedHelp.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartOptimizedHelp.unix.approved.txt
@@ -129,14 +129,16 @@ Logging:
                      The format of unstructured console log entries. If the format has spaces in
                        it, escape the value using "<format>". Default: %d{yyyy-MM-dd HH:mm:ss,SSS} %
                        -5p [%c] (%t) %s%e%n.
---log-console-output <default|json>
+--log-console-output <output>
                      Set the log output to JSON or default (plain) unstructured logging. Possible
                        values are: default, json. Default: default.
---log-file <path>/<file-name>.log
-                     Set the log file path and filename. Default: data/log/keycloak.log.
+--log-file <file>    Set the log file path and filename. Default: data/log/keycloak.log.
 --log-file-format <format>
                      Set a format specific to file log entries. Default: %d{yyyy-MM-dd HH:mm:ss,
                        SSS} %-5p [%c] (%t) %s%e%n.
+--log-file-output <output>
+                     Set the log output to JSON or default (plain) unstructured logging. Possible
+                       values are: default, json. Default: default.
 --log-gelf-facility <name>
                      The facility (name of the process) that sends the message. Default: keycloak.
 --log-gelf-host <hostname>

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartOptimizedHelp.windows.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartOptimizedHelp.windows.approved.txt
@@ -128,14 +128,16 @@ Logging:
                      The format of unstructured console log entries. If the format has spaces in
                        it, escape the value using "<format>". Default: %d{yyyy-MM-dd HH:mm:ss,SSS} %
                        -5p [%c] (%t) %s%e%n.
---log-console-output <default|json>
+--log-console-output <output>
                      Set the log output to JSON or default (plain) unstructured logging. Possible
                        values are: default, json. Default: default.
---log-file <path>/<file-name>.log
-                     Set the log file path and filename. Default: data/log/keycloak.log.
+--log-file <file>    Set the log file path and filename. Default: data/log/keycloak.log.
 --log-file-format <format>
                      Set a format specific to file log entries. Default: %d{yyyy-MM-dd HH:mm:ss,
                        SSS} %-5p [%c] (%t) %s%e%n.
+--log-file-output <output>
+                     Set the log output to JSON or default (plain) unstructured logging. Possible
+                       values are: default, json. Default: default.
 --log-gelf-facility <name>
                      The facility (name of the process) that sends the message. Default: keycloak.
 --log-gelf-host <hostname>

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartOptimizedHelpAll.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartOptimizedHelpAll.unix.approved.txt
@@ -146,14 +146,16 @@ Logging:
                      The format of unstructured console log entries. If the format has spaces in
                        it, escape the value using "<format>". Default: %d{yyyy-MM-dd HH:mm:ss,SSS} %
                        -5p [%c] (%t) %s%e%n.
---log-console-output <default|json>
+--log-console-output <output>
                      Set the log output to JSON or default (plain) unstructured logging. Possible
                        values are: default, json. Default: default.
---log-file <path>/<file-name>.log
-                     Set the log file path and filename. Default: data/log/keycloak.log.
+--log-file <file>    Set the log file path and filename. Default: data/log/keycloak.log.
 --log-file-format <format>
                      Set a format specific to file log entries. Default: %d{yyyy-MM-dd HH:mm:ss,
                        SSS} %-5p [%c] (%t) %s%e%n.
+--log-file-output <output>
+                     Set the log output to JSON or default (plain) unstructured logging. Possible
+                       values are: default, json. Default: default.
 --log-gelf-facility <name>
                      The facility (name of the process) that sends the message. Default: keycloak.
 --log-gelf-host <hostname>

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartOptimizedHelpAll.windows.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartOptimizedHelpAll.windows.approved.txt
@@ -146,14 +146,16 @@ Logging:
                      The format of unstructured console log entries. If the format has spaces in
                        it, escape the value using "<format>". Default: %d{yyyy-MM-dd HH:mm:ss,SSS} %
                        -5p [%c] (%t) %s%e%n.
---log-console-output <default|json>
+--log-console-output <output>
                      Set the log output to JSON or default (plain) unstructured logging. Possible
                        values are: default, json. Default: default.
---log-file <path>/<file-name>.log
-                     Set the log file path and filename. Default: data/log/keycloak.log.
+--log-file <file>    Set the log file path and filename. Default: data/log/keycloak.log.
 --log-file-format <format>
                      Set a format specific to file log entries. Default: %d{yyyy-MM-dd HH:mm:ss,
                        SSS} %-5p [%c] (%t) %s%e%n.
+--log-file-output <output>
+                     Set the log output to JSON or default (plain) unstructured logging. Possible
+                       values are: default, json. Default: default.
 --log-gelf-facility <name>
                      The facility (name of the process) that sends the message. Default: keycloak.
 --log-gelf-host <hostname>


### PR DESCRIPTION
Closes #14003

* Introduces a new `log-file-output` option (similar to `log-console-output`) to switch between `json` and `raw` outputs. This is needed because the behavior changed in Quarkus so that `json` output is automatically enabled if not set otherwise, therefore breaking the current behavior.
* Added a `set-quarkus-versionsh` script to automatize how set the Quarkus version and the version of the dependencies we are overriding from our parent POM. It is going to be useful to enable Keycloak in Quarkus Ecosystem CI.

Feel free to review/approve. But before merging, I would like to run/update(if needed) a few more tests.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
