### PR TITLE
Fix duplicate parameter check for UserInfo endpoint.

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/UserInfoTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/UserInfoTest.java
@@ -708,6 +708,26 @@ public class UserInfoTest extends AbstractKeycloakTest {
     }
 
     @Test
+    public void testUnsuccessfulUserInfoRequestwithDuplicatedParams() {
+        Client client = AdminClientUtil.createResteasyClient();
+
+        try {
+            AccessTokenResponse accessTokenResponse = executeGrantAccessTokenRequest(client);
+
+            Form form = new Form();
+            form.param("access_token", accessTokenResponse.getToken());
+            form.param("access_token", accessTokenResponse.getToken());
+
+            WebTarget userInfoTarget = UserInfoClientUtil.getUserInfoWebTarget(client);
+            Response response = userInfoTarget.request().post(Entity.form(form));
+            response.close();
+            assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+        } finally {
+            client.close();
+        }
+    }
+
+    @Test
     public void testUserInfoRequestWithSamlClient() throws Exception {
         // obtain an access token
         String accessToken = oauth.doGrantAccessTokenRequest("test", "test-user@localhost", "password", null, "saml-client", "secret").getAccessToken();


### PR DESCRIPTION
Similar to past PR (https://github.com/keycloak/keycloak/pull/11295).
The error response of UserInfo endpoint follows RFC6750.
Thus, the checking process of duplicated parameters is added to UserInfo endpoint.

Closes https://github.com/keycloak/keycloak/issues/14016
