### PR TITLE
Fix 2FA user page icon

### DIFF
--- a/themes/src/main/resources/theme/keycloak.v2/account/src/app/content/signingin-page/SigningInPage.tsx
+++ b/themes/src/main/resources/theme/keycloak.v2/account/src/app/content/signingin-page/SigningInPage.tsx
@@ -419,7 +419,7 @@ class SigningInPage extends React.Component<
                                         >
                                             <span className="pf-c-button__icon">
                                                 <i
-                                                    className="fas fa-plus-circle"
+                                                    className="fa fa-plus-circle"
                                                     aria-hidden="true"
                                                 ></i>
                                             </span>
@@ -447,7 +447,7 @@ class SigningInPage extends React.Component<
                                 >
                                     <span className="pf-c-button__icon">
                                         <i
-                                            className="fas fa-plus-circle"
+                                            className="fa fa-plus-circle"
                                             aria-hidden="true"
                                         ></i>
                                     </span>


### PR DESCRIPTION
Related to user profile pages v2 themes:

A button icon has an incorrect class for font-awesome. This results in a square box instead of the expected plus sign.

This change fixes the class and results in the expected plus sign