### PR TITLE
Fix QuickStart tests in the GH actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Build Keycloak
         run: |
-           ./mvnw clean install -nsu -B -e -DskipTests -Pdistribution
+           ./mvnw clean install -nsu -B -e -DskipTests -Pdistribution -DincludeWildFly    # QuickStarts tests need WildFly distribution to be present
            ./mvnw clean install -nsu -B -e -f testsuite/integration-arquillian/servers/auth-server -Pauth-server-quarkus
            ./mvnw clean install -nsu -B -e -f testsuite/integration-arquillian/servers/auth-server -Pauth-server-undertow
 


### PR DESCRIPTION
Fixes #14080

QuickStart tests require WildFly distribution to be present, and the `keycloak-server-dist` artifact doesn't exist anymore after executing the build phase. It should be enabled until the QuickStarts use Quarkus-based Keycloak.

@ahus1 @stianst Could you please check it out? Thanks