### PR TITLE
Cannot build base testsuite due to missing dependency related to WF

### DIFF
--- a/testsuite/integration-arquillian/tests/pom.xml
+++ b/testsuite/integration-arquillian/tests/pom.xml
@@ -2092,10 +2092,6 @@
                     <groupId>org.keycloak</groupId>
                     <artifactId>keycloak-authz-client</artifactId>
                 </dependency>
-                <dependency>
-                    <groupId>org.keycloak</groupId>
-                    <artifactId>keycloak-wildfly-adduser</artifactId>
-                </dependency>
 
                 <!--UNDERTOW-->
 


### PR DESCRIPTION
Fixes #14072

Spotted in this build with disabled flag `-DincludeWildFly`: https://keycloak-jenkins.com/job/keycloak-build-pipeline/952/console

@nehachopra27 @stianst Could you please check it? Thanks.

EDIT: Works as expected with the MR to the pipeline.
