### PR TITLE
Fix ComponentsTest failures with CockroachDB

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/utils/LockObjectsForModification.java
+++ b/server-spi-private/src/main/java/org/keycloak/utils/LockObjectsForModification.java
@@ -18,6 +18,7 @@
 package org.keycloak.utils;
 
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserSessionModel;
 
 import java.util.HashSet;
@@ -63,6 +64,10 @@ public class LockObjectsForModification {
 
     public static <V> V lockUserSessionsForModification(KeycloakSession session, CallableWithoutThrowingAnException<V> callable) {
         return lockObjectsForModification(session, UserSessionModel.class, callable);
+    }
+
+    public static <V> V lockRealmsForModification(KeycloakSession session, CallableWithoutThrowingAnException<V> callable) {
+        return lockObjectsForModification(session, RealmModel.class, callable);
     }
 
     private static <V> V lockObjectsForModification(KeycloakSession session, Class<?> model, CallableWithoutThrowingAnException<V> callable) {

--- a/server-spi/src/main/java/org/keycloak/models/KeycloakSessionTaskWithResult.java
+++ b/server-spi/src/main/java/org/keycloak/models/KeycloakSessionTaskWithResult.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.models;
+
+/**
+ * Interface for tasks that compute a result and need access to the {@link KeycloakSession}.
+ *
+ * @param <V> the type of the computed result.
+ * @author <a href="mailto:sguilhen@redhat.com">Stefan Guilhen</a>
+ */
+@FunctionalInterface
+public interface KeycloakSessionTaskWithResult<V> {
+
+    /**
+     * Computes a result.
+     *
+     * @param session a reference to the {@link KeycloakSession}.
+     * @return the computed result.
+     */
+    V run(final KeycloakSession session);
+}

--- a/services/src/main/java/org/keycloak/keys/JavaKeystoreKeyProviderFactory.java
+++ b/services/src/main/java/org/keycloak/keys/JavaKeystoreKeyProviderFactory.java
@@ -75,8 +75,7 @@ public class JavaKeystoreKeyProviderFactory extends AbstractRsaKeyProviderFactor
                 .checkSingle(KEY_PASSWORD_PROPERTY, true);
 
         try {
-            new JavaKeystoreKeyProvider(session.getContext().getRealm(), model)
-                    .loadKey(session.getContext().getRealm(), model);
+            new JavaKeystoreKeyProvider(realm, model).loadKey(realm, model);
         } catch (Throwable t) {
             logger.error("Failed to load keys.", t);
             throw new ComponentValidationException("Failed to load keys. " + t.getMessage(), t);

--- a/services/src/main/java/org/keycloak/services/resources/admin/ComponentResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ComponentResource.java
@@ -28,6 +28,7 @@ import org.keycloak.events.admin.OperationType;
 import org.keycloak.events.admin.ResourceType;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
+import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.models.utils.ModelToRepresentation;
 import org.keycloak.models.utils.RepresentationToModel;
 import org.keycloak.models.utils.StripSecretsUtils;
@@ -39,6 +40,7 @@ import org.keycloak.representations.idm.ComponentTypeRepresentation;
 import org.keycloak.representations.idm.ConfigPropertyRepresentation;
 import org.keycloak.services.ErrorResponse;
 import org.keycloak.services.resources.admin.permissions.AdminPermissionEvaluator;
+import org.keycloak.utils.LockObjectsForModification;
 
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.Consumes;
@@ -126,19 +128,22 @@ public class ComponentResource {
     @Consumes(MediaType.APPLICATION_JSON)
     public Response create(ComponentRepresentation rep) {
         auth.realm().requireManageRealm();
-        try {
-            ComponentModel model = RepresentationToModel.toModel(session, rep);
-            if (model.getParentId() == null) model.setParentId(realm.getId());
+        return KeycloakModelUtils.runJobInRetriableTransaction(session.getKeycloakSessionFactory(), kcSession -> {
+            RealmModel realmModel = LockObjectsForModification.lockRealmsForModification(kcSession, () -> kcSession.realms().getRealm(realm.getId()));
+            try {
+                ComponentModel model = RepresentationToModel.toModel(kcSession, rep);
+                if (model.getParentId() == null) model.setParentId(realmModel.getId());
 
-            model = realm.addComponentModel(model);
+                model = realmModel.addComponentModel(model);
 
-            adminEvent.operation(OperationType.CREATE).resourcePath(session.getContext().getUri(), model.getId()).representation(StripSecretsUtils.strip(session, rep)).success();
-            return Response.created(session.getContext().getUri().getAbsolutePathBuilder().path(model.getId()).build()).build();
-        } catch (ComponentValidationException e) {
-            return localizedErrorResponse(e);
-        } catch (IllegalArgumentException e) {
-            throw new BadRequestException(e);
-        }
+                adminEvent.operation(OperationType.CREATE).resourcePath(kcSession.getContext().getUri(), model.getId()).representation(StripSecretsUtils.strip(kcSession, rep)).success();
+                return Response.created(kcSession.getContext().getUri().getAbsolutePathBuilder().path(model.getId()).build()).build();
+            } catch (ComponentValidationException e) {
+                return localizedErrorResponse(e);
+            } catch (IllegalArgumentException e) {
+                throw new BadRequestException(e);
+            }
+        }, 10, 100);
     }
 
     @GET
@@ -160,32 +165,39 @@ public class ComponentResource {
     @Consumes(MediaType.APPLICATION_JSON)
     public Response updateComponent(@PathParam("id") String id, ComponentRepresentation rep) {
         auth.realm().requireManageRealm();
-        try {
-            ComponentModel model = realm.getComponent(id);
-            if (model == null) {
-                throw new NotFoundException("Could not find component");
+        return KeycloakModelUtils.runJobInRetriableTransaction(session.getKeycloakSessionFactory(), kcSession -> {
+            RealmModel realmModel = LockObjectsForModification.lockRealmsForModification(kcSession, () -> kcSession.realms().getRealm(realm.getId()));
+            try {
+                ComponentModel model = realmModel.getComponent(id);
+                if (model == null) {
+                    throw new NotFoundException("Could not find component");
+                }
+                RepresentationToModel.updateComponent(kcSession, rep, model, false);
+                adminEvent.operation(OperationType.UPDATE).resourcePath(kcSession.getContext().getUri()).representation(StripSecretsUtils.strip(kcSession, rep)).success();
+                realmModel.updateComponent(model);
+                return Response.noContent().build();
+            } catch (ComponentValidationException e) {
+                return localizedErrorResponse(e);
+            } catch (IllegalArgumentException e) {
+                throw new BadRequestException();
             }
-            RepresentationToModel.updateComponent(session, rep, model, false);
-            adminEvent.operation(OperationType.UPDATE).resourcePath(session.getContext().getUri()).representation(StripSecretsUtils.strip(session, rep)).success();
-            realm.updateComponent(model);
-            return Response.noContent().build();
-        } catch (ComponentValidationException e) {
-            return localizedErrorResponse(e);
-        } catch (IllegalArgumentException e) {
-            throw new BadRequestException();
-        }
+        }, 10, 100);
     }
     @DELETE
     @Path("{id}")
     public void removeComponent(@PathParam("id") String id) {
         auth.realm().requireManageRealm();
-        ComponentModel model = realm.getComponent(id);
-        if (model == null) {
-            throw new NotFoundException("Could not find component");
-        }
-        adminEvent.operation(OperationType.DELETE).resourcePath(session.getContext().getUri()).success();
-        realm.removeComponent(model);
+        KeycloakModelUtils.runJobInRetriableTransaction(session.getKeycloakSessionFactory(), kcSession -> {
+            RealmModel realmModel = LockObjectsForModification.lockRealmsForModification(kcSession, () -> kcSession.realms().getRealm(realm.getId()));
 
+            ComponentModel model = realmModel.getComponent(id);
+            if (model == null) {
+                throw new NotFoundException("Could not find component");
+            }
+            adminEvent.operation(OperationType.DELETE).resourcePath(kcSession.getContext().getUri()).success();
+            realmModel.removeComponent(model);
+            return null;
+        }, 10 , 100);
     }
 
     private Response localizedErrorResponse(ComponentValidationException cve) {


### PR DESCRIPTION
- Lock realm for modification while manipulating components
- Component creation/edition/removal is now executed in a retriable transaction.

Closes #13209

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
