### PR TITLE
Add Proxy & LB instructions to container doc

### DIFF
--- a/docs/guides/src/main/server/containers.adoc
+++ b/docs/guides/src/main/server/containers.adoc
@@ -155,6 +155,20 @@ Keycloak only allows to create the initial admin user from a local network conne
 -e KEYCLOAK_ADMIN_PASSWORD=change_me
 ----
 
+== Running a Keycloak container behind a Load Balancer or Proxy
+If you are running a Keycloak cluster behind a load balancer or proxy you will need to provide an aditianl environment variable.
+
+You will need to determine the https://www.keycloak.org/server/reverseproxy[Proxy Mode] you want to run your container in.
+
+[source, bash]
+----
+podman|docker run --name keycloak_test -p 8080:8080 \
+        -e KEYCLOAK_ADMIN=admin -e KEYCLOAK_ADMIN_PASSWORD=change_me \
+        -e KC_PROXY=proxy_mode \
+        quay.io/keycloak/keycloak:latest \
+        start-dev
+----
+
 == Importing A Realm On Startup
 
 The https://quay.io/keycloak/keycloak[published Keycloak containers] have a directory `/opt/keycloak/data/import`. If you put one or more import files in that directory via a volume mount or other means and add the startup argument `--import-realm`, the Keycloak container will import that data on startup! This may only make sense to do in Dev mode.


### PR DESCRIPTION
Updated container documentation to include information about running keycloak behind a load balancer or proxy.

I image this is a very common implementation and this documentation could save people a lot of time.