### PR TITLE
Add SAML Javascript Mapper for NameID

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/saml/mappers/NameIdScriptBasedMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/mappers/NameIdScriptBasedMapper.java
@@ -1,0 +1,78 @@
+package org.keycloak.protocol.saml.mappers;
+
+import org.jboss.logging.Logger;
+import org.keycloak.models.*;
+import org.keycloak.protocol.ProtocolMapperConfigException;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.scripting.ScriptCompilationException;
+import org.keycloak.scripting.ScriptExecutionException;
+import org.keycloak.scripting.ScriptingProvider;
+
+import java.util.List;
+import java.util.ArrayList;
+
+public class NameIdScriptBasedMapper extends AbstractSAMLProtocolMapper implements SAMLNameIdMapper {
+    private static final List<ProviderConfigProperty> configProperties = new ArrayList<>();
+    public static final String PROVIDER_ID = "saml-javascript-nameid-mapper";
+    private static final Logger LOGGER = Logger.getLogger(NameIdScriptBasedMapper.class);
+
+    static {
+        ScriptMapperHelper.setConfigProperties(configProperties);
+        NameIdMapperHelper.setConfigProperties(configProperties);
+    }
+
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return configProperties;
+    }
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public String getDisplayType() {
+        return "Javascript Mapper for NameID";
+    }
+
+    @Override
+    public String getDisplayCategory() {
+        return NameIdMapperHelper.NAMEID_MAPPER_CATEGORY;
+    }
+
+    @Override
+    public String getHelpText() {
+        return "Evaluates a JavaScript function to produce a NameID value based on context information.";
+    }
+
+    @Override
+    public String mapperNameId(String nameIdFormat, ProtocolMapperModel mappingModel, KeycloakSession session,
+                               UserSessionModel userSession, AuthenticatedClientSessionModel clientSession) {
+        Object nameId;
+        try {
+            nameId = ScriptMapperHelper.executeScript(mappingModel, session, userSession, clientSession, PROVIDER_ID);
+            return String.valueOf(nameId);
+        } catch (ScriptExecutionException ex) {
+            LOGGER.error("Error during execution of ProtocolMapper script", ex);
+            return "";
+        }
+    }
+
+    @Override
+    public void validateConfig(KeycloakSession session, RealmModel realm, ProtocolMapperContainerModel client, 
+                               ProtocolMapperModel mapperModel) throws ProtocolMapperConfigException {
+        String scriptCode = mapperModel.getConfig().get(ProviderConfigProperty.SCRIPT_TYPE);
+        if (scriptCode == null) {
+            return;
+        }
+
+        ScriptingProvider scripting = session.getProvider(ScriptingProvider.class);
+        ScriptModel scriptModel = scripting.createScript(realm.getId(), ScriptModel.TEXT_JAVASCRIPT, 
+                                                         mapperModel.getName() + "-script", scriptCode, "");
+
+        try {
+            scripting.prepareEvaluatableScript(scriptModel);
+        } catch (ScriptCompilationException ex) {
+            throw new ProtocolMapperConfigException("error", "{0}", ex.getMessage());
+        }
+    }
+}

--- a/services/src/main/java/org/keycloak/protocol/saml/mappers/ScriptBasedMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/mappers/ScriptBasedMapper.java
@@ -6,7 +6,6 @@ import org.keycloak.dom.saml.v2.assertion.AttributeType;
 import org.keycloak.models.*;
 import org.keycloak.protocol.ProtocolMapperConfigException;
 import org.keycloak.provider.ProviderConfigProperty;
-import org.keycloak.scripting.EvaluatableScriptAdapter;
 import org.keycloak.scripting.ScriptCompilationException;
 import org.keycloak.scripting.ScriptingProvider;
 
@@ -32,34 +31,8 @@ public class ScriptBasedMapper extends AbstractSAMLProtocolMapper implements SAM
      * both for the frontend (gui elements in the mapper) and for the backend.
      */
     static {
+        ScriptMapperHelper.setConfigProperties(configProperties);
         ProviderConfigProperty property = new ProviderConfigProperty();
-        property.setType(ProviderConfigProperty.SCRIPT_TYPE);
-        property.setLabel(ProviderConfigProperty.SCRIPT_TYPE);
-        property.setName(ProviderConfigProperty.SCRIPT_TYPE);
-        property.setHelpText(
-                "Script to compute the attribute value. \n" + //
-                        " Available variables: \n" + //
-                        " 'user' - the current user.\n" + //
-                        " 'realm' - the current realm.\n" + //
-                        " 'clientSession' - the current clientSession.\n" + //
-                        " 'userSession' - the current userSession.\n" + //
-                        " 'keycloakSession' - the current keycloakSession.\n\n" +
-                        "To use: the last statement is the value returned to Java.\n" +
-                        "The result will be tested if it can be iterated upon (e.g. an array or a collection).\n" +
-                        " - If it is not, toString() will be called on the object to get the value of the attribute\n" +
-                        " - If it is, toString() will be called on all elements to return multiple attribute values.\n"//
-        );
-        property.setDefaultValue("/**\n" + //
-                " * Available variables: \n" + //
-                " * user - the current user\n" + //
-                " * realm - the current realm\n" + //
-                " * clientSession - the current clientSession\n" + //
-                " * userSession - the current userSession\n" + //
-                " * keycloakSession - the current keycloakSession\n" + //
-                " */\n\n\n//insert your code here..." //
-        );
-        configProperties.add(property);
-        property = new ProviderConfigProperty();
         property.setName(SINGLE_VALUE_ATTRIBUTE);
         property.setLabel("Single Value Attribute");
         property.setType(ProviderConfigProperty.BOOLEAN_TYPE);
@@ -109,26 +82,12 @@ public class ScriptBasedMapper extends AbstractSAMLProtocolMapper implements SAM
     public void transformAttributeStatement(AttributeStatementType attributeStatement, ProtocolMapperModel mappingModel,
                                             KeycloakSession session, UserSessionModel userSession,
                                             AuthenticatedClientSessionModel clientSession) {
-        UserModel user = userSession.getUser();
-        String scriptSource = mappingModel.getConfig().get(ProviderConfigProperty.SCRIPT_TYPE);
-        RealmModel realm = userSession.getRealm();
-
         String single = mappingModel.getConfig().get(SINGLE_VALUE_ATTRIBUTE);
         boolean singleAttribute = Boolean.parseBoolean(single);
 
-        ScriptingProvider scripting = session.getProvider(ScriptingProvider.class);
-        ScriptModel scriptModel = scripting.createScript(realm.getId(), ScriptModel.TEXT_JAVASCRIPT, "attribute-mapper-script_" + mappingModel.getName(), scriptSource, null);
-
-        EvaluatableScriptAdapter script = scripting.prepareEvaluatableScript(scriptModel);
         Object attributeValue;
         try {
-            attributeValue = script.eval((bindings) -> {
-                bindings.put("user", user);
-                bindings.put("realm", realm);
-                bindings.put("clientSession", clientSession);
-                bindings.put("userSession", userSession);
-                bindings.put("keycloakSession", session);
-            });
+            attributeValue = ScriptMapperHelper.executeScript(mappingModel, session, userSession, clientSession, PROVIDER_ID);
             //If the result is a an array or is iterable, get all values
             if (attributeValue.getClass().isArray()){
                 attributeValue = Arrays.asList((Object[])attributeValue);

--- a/services/src/main/java/org/keycloak/protocol/saml/mappers/ScriptMapperHelper.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/mappers/ScriptMapperHelper.java
@@ -1,0 +1,67 @@
+package org.keycloak.protocol.saml.mappers;
+
+import org.keycloak.models.*;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.scripting.EvaluatableScriptAdapter;
+import org.keycloak.scripting.ScriptExecutionException;
+import org.keycloak.scripting.ScriptingProvider;
+
+import java.util.*;
+
+public class ScriptMapperHelper {
+    public static void setConfigProperties(List<ProviderConfigProperty> configProperties) {
+        ProviderConfigProperty property = new ProviderConfigProperty();
+        property.setType(ProviderConfigProperty.SCRIPT_TYPE);
+        property.setLabel(ProviderConfigProperty.SCRIPT_TYPE);
+        property.setName(ProviderConfigProperty.SCRIPT_TYPE);
+        property.setHelpText(
+                "Script to compute the attribute value. \n" + //
+                        " Available variables: \n" + //
+                        " 'user' - the current user.\n" + //
+                        " 'realm' - the current realm.\n" + //
+                        " 'clientSession' - the current clientSession.\n" + //
+                        " 'userSession' - the current userSession.\n" + //
+                        " 'keycloakSession' - the current keycloakSession.\n\n" +
+                        "To use: the last statement is the value returned to Java.\n" +
+                        "The result will be tested if it can be iterated upon (e.g. an array or a collection).\n" +
+                        " - If it is not, toString() will be called on the object to get the value of the attribute\n" +
+                        " - If it is, toString() will be called on all elements to return multiple attribute values.\n"//
+        );
+        property.setDefaultValue("/**\n" + //
+                " * Available variables: \n" + //
+                " * user - the current user\n" + //
+                " * realm - the current realm\n" + //
+                " * clientSession - the current clientSession\n" + //
+                " * userSession - the current userSession\n" + //
+                " * keycloakSession - the current keycloakSession\n" + //
+                " */\n\n\n//insert your code here..." //
+        );
+        configProperties.add(property);
+    }
+
+    public static Object executeScript(ProtocolMapperModel mappingModel, 
+                                       KeycloakSession session, 
+                                       UserSessionModel userSession, 
+                                       AuthenticatedClientSessionModel clientSession,
+                                       String providerId) throws ScriptExecutionException {
+        UserModel user = userSession.getUser();
+        RealmModel realm = userSession.getRealm();
+
+        ScriptingProvider scripting = session.getProvider(ScriptingProvider.class);
+        String scriptSource = mappingModel.getConfig().get(ProviderConfigProperty.SCRIPT_TYPE);
+        ScriptModel scriptModel = scripting.createScript(realm.getId(), 
+                                                         ScriptModel.TEXT_JAVASCRIPT, 
+                                                         providerId + "_script_" + mappingModel.getName(), 
+                                                         scriptSource, 
+                                                         null);
+        EvaluatableScriptAdapter script = scripting.prepareEvaluatableScript(scriptModel);
+
+        return script.eval((bindings) -> {
+            bindings.put("user", user);
+            bindings.put("realm", realm);
+            bindings.put("clientSession", clientSession);
+            bindings.put("userSession", userSession);
+            bindings.put("keycloakSession", session);
+        });
+    }
+}

--- a/services/src/main/resources/META-INF/services/org.keycloak.protocol.ProtocolMapper
+++ b/services/src/main/resources/META-INF/services/org.keycloak.protocol.ProtocolMapper
@@ -45,3 +45,4 @@ org.keycloak.protocol.saml.mappers.SAMLAudienceProtocolMapper
 org.keycloak.protocol.saml.mappers.SAMLAudienceResolveProtocolMapper
 org.keycloak.protocol.oidc.mappers.ClaimsParameterTokenMapper
 org.keycloak.protocol.saml.mappers.UserAttributeNameIdMapper
+org.keycloak.protocol.saml.mappers.NameIdScriptBasedMapper

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/NameIdScriptMapperTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/NameIdScriptMapperTest.java
@@ -1,0 +1,92 @@
+package org.keycloak.testsuite.saml;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.keycloak.dom.saml.v2.assertion.NameIDType;
+import org.keycloak.dom.saml.v2.protocol.ResponseType;
+import org.keycloak.protocol.saml.SamlConfigAttributes;
+import org.keycloak.protocol.saml.mappers.NameIdMapperHelper;
+import org.keycloak.protocol.saml.mappers.NameIdScriptBasedMapper;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.saml.common.constants.JBossSAMLURIConstants;
+import org.keycloak.saml.processing.core.saml.v2.common.SAMLDocumentHolder;
+import org.keycloak.testsuite.updaters.ClientAttributeUpdater;
+import org.keycloak.testsuite.updaters.ProtocolMappersUpdater;
+import org.keycloak.testsuite.util.SamlClientBuilder;
+import org.keycloak.testsuite.util.SamlClient.Binding;
+
+import static org.junit.Assert.assertEquals;
+import static org.keycloak.testsuite.saml.RoleMapperTest.createSamlProtocolMapper;
+import static org.keycloak.testsuite.util.ServerURLs.AUTH_SERVER_PORT;
+import static org.keycloak.testsuite.util.ServerURLs.AUTH_SERVER_SCHEME;
+import static org.keycloak.testsuite.util.ServerURLs.AUTH_SERVER_SSL_REQUIRED;
+
+import java.io.IOException;
+
+public class NameIdScriptMapperTest extends AbstractSamlTest {
+    public static final String SAML_ASSERTION_CONSUMER_URL_EMPLOYEE_2 = AUTH_SERVER_SCHEME + "://localhost:"
+            + (AUTH_SERVER_SSL_REQUIRED ? AUTH_SERVER_PORT : 8080) + "/employee2/";
+
+    private ClientAttributeUpdater cau;
+    private ProtocolMappersUpdater pmu;
+
+    private final String SCRIPT_USERNAME_EMAIL = "var result = user.getUsername() + user.getEmail();\nexports = result;";
+    private final String SCRIPT_ERROR = "exports = nothing;";
+    private final String SCRIPT_REALM_BINDING = "var result = realm.getName();\nexports = result;";
+
+    @Before
+    public void setNameIdConfigAndCleanMappers() {
+        this.cau = ClientAttributeUpdater.forClient(adminClient, REALM_NAME, SAML_CLIENT_ID_EMPLOYEE_2)
+                        .setAttribute(SamlConfigAttributes.SAML_NAME_ID_FORMAT_ATTRIBUTE, "persistent")
+                        .setAttribute(SamlConfigAttributes.SAML_FORCE_NAME_ID_FORMAT_ATTRIBUTE, "true").update();
+        this.pmu = cau.protocolMappers().clear().update();
+    }
+
+    @After
+    public void revertCleanMappersAndScopes() throws IOException {
+            this.pmu.close();
+            this.cau.close();
+    }
+
+    @Test
+    public void testNameIdScriptMapperUserBinding() {
+        pmu.add(createSamlProtocolMapper(NameIdScriptBasedMapper.PROVIDER_ID, 
+                NameIdMapperHelper.MAPPER_NAMEID_FORMAT, JBossSAMLURIConstants.NAMEID_FORMAT_PERSISTENT.get(),
+                ProviderConfigProperty.SCRIPT_TYPE, SCRIPT_USERNAME_EMAIL))
+            .update();
+        testExpectedNameId(bburkeUser.getUsername() + bburkeUser.getEmail());
+    }
+
+    @Test
+    public void testNameIdScriptMapperRealmBinding() {
+        pmu.add(createSamlProtocolMapper(NameIdScriptBasedMapper.PROVIDER_ID, 
+                NameIdMapperHelper.MAPPER_NAMEID_FORMAT, JBossSAMLURIConstants.NAMEID_FORMAT_PERSISTENT.get(),
+                ProviderConfigProperty.SCRIPT_TYPE, SCRIPT_REALM_BINDING))
+            .update();
+        testExpectedNameId(REALM_NAME);
+    }
+
+    @Test
+    public void testScriptException() {
+        pmu.add(createSamlProtocolMapper(NameIdScriptBasedMapper.PROVIDER_ID, 
+                NameIdMapperHelper.MAPPER_NAMEID_FORMAT, JBossSAMLURIConstants.NAMEID_FORMAT_PERSISTENT.get(),
+                ProviderConfigProperty.SCRIPT_TYPE, SCRIPT_ERROR)).update();
+        testExpectedNameId("");
+    }
+
+    private void testExpectedNameId(String expectedNameId) {
+        ResponseType rt = getSamlResponseObject();
+        NameIDType nameId = (NameIDType) rt.getAssertions().get(0).getAssertion().getSubject().getSubType().getBaseID();
+        assertEquals(expectedNameId,nameId.getValue());
+        assertEquals(JBossSAMLURIConstants.STATUS_SUCCESS.get(),rt.getStatus().getStatusCode().getValue().toString());
+    }
+
+    private ResponseType getSamlResponseObject(){
+        SAMLDocumentHolder document = new SamlClientBuilder()
+                .authnRequest(getAuthServerSamlEndpoint(REALM_NAME), SAML_CLIENT_ID_EMPLOYEE_2,
+                        SAML_ASSERTION_CONSUMER_URL_EMPLOYEE_2, Binding.POST)
+                .build().login().user(bburkeUser).build().getSamlResponse(Binding.POST);
+        return (ResponseType) document.getSamlObject();
+    }
+}


### PR DESCRIPTION
The new mapper is a fusion of the `Javascript Mapper` and the `User Attribute Mapper For NameID`. I have also extracted some common code (script execution and adding the script property) to a helper class in order not to introduce duplicate code.

Closes #14136

