### PR TITLE
Add basic auth compliant to RFC 6749

### DIFF
--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/authentication/ClientIdAndSecretCredentialsProvider.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/authentication/ClientIdAndSecretCredentialsProvider.java
@@ -54,7 +54,7 @@ public class ClientIdAndSecretCredentialsProvider implements ClientCredentialsPr
 
         if (!deployment.isPublicClient()) {
             if (clientSecret != null) {
-                String authorization = BasicAuthHelper.UrlEncoded.createHeader(clientId, clientSecret);
+                String authorization = BasicAuthHelper.RFC6749.createHeader(clientId, clientSecret);
                 requestHeaders.put("Authorization", authorization);
             } else {
                 logger.warnf("Client '%s' doesn't have secret available", clientId);

--- a/core/src/test/java/org/keycloak/util/BasicAuthHelperTest.java
+++ b/core/src/test/java/org/keycloak/util/BasicAuthHelperTest.java
@@ -1,0 +1,52 @@
+package org.keycloak.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class BasicAuthHelperTest {
+
+    @Test
+    public void createHeader() {
+        String username = "Aladdin";
+        String password = "open sesame";
+
+        String actual = BasicAuthHelper.createHeader(username, password);
+        String expect = "Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==";
+
+        assertEquals(expect, actual);
+    }
+
+    @Test
+    public void parseHeader() {
+        String username = "Aladdin";
+        String password = "open sesame";
+
+        String header = BasicAuthHelper.createHeader(username, password);
+        String[] actual = BasicAuthHelper.parseHeader(header);
+
+        assertArrayEquals(new String[] {username, password}, actual);
+    }
+
+    @Test
+    public void rfc6749_createHeader() {
+        String username = "user";
+        String password = "secret/with=special?character";
+
+        String actual = BasicAuthHelper.RFC6749.createHeader(username, password);
+        String expect = "Basic dXNlcjpzZWNyZXQlMkZ3aXRoJTNEc3BlY2lhbCUzRmNoYXJhY3Rlcg==";
+
+        assertEquals(expect, actual);
+    }
+
+    @Test
+    public void rfc6749_parseHeader() {
+        String username = "user";
+        String password = "secret/with=special?character";
+
+        String header = BasicAuthHelper.createHeader(username, password);
+        String[] actual = BasicAuthHelper.parseHeader(header);
+
+        assertArrayEquals(new String[] {username, password}, actual);
+    }
+}

--- a/services/src/main/java/org/keycloak/authentication/authenticators/challenge/BasicAuthAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/challenge/BasicAuthAuthenticator.java
@@ -100,7 +100,7 @@ public class BasicAuthAuthenticator extends AbstractUsernameFormAuthenticator im
     }
 
     protected String[] getChallenge(String authorizationHeader) {
-        String[] challenge = BasicAuthHelper.UrlEncoded.parseHeader(authorizationHeader);
+        String[] challenge = BasicAuthHelper.RFC6749.parseHeader(authorizationHeader);
 
         if (challenge == null || challenge.length < 2) {
             return null;

--- a/services/src/main/java/org/keycloak/authentication/authenticators/client/ClientIdAndSecretAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/client/ClientIdAndSecretAuthenticator.java
@@ -64,7 +64,7 @@ public class ClientIdAndSecretAuthenticator extends AbstractClientAuthenticator 
         MultivaluedMap<String, String> formData = hasFormData ? context.getHttpRequest().getDecodedFormParameters() : null;
 
         if (authorizationHeader != null) {
-            String[] usernameSecret = BasicAuthHelper.UrlEncoded.parseHeader(authorizationHeader);
+            String[] usernameSecret = BasicAuthHelper.RFC6749.parseHeader(authorizationHeader);
             if (usernameSecret != null) {
                 client_id = usernameSecret[0];
                 clientSecret = usernameSecret[1];

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/OAuthClient.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/OAuthClient.java
@@ -745,7 +745,7 @@ public class OAuthClient {
         try (CloseableHttpClient client = httpClient.get()) {
             HttpPost post = new HttpPost(getServiceAccountUrl());
 
-            String authorization = BasicAuthHelper.UrlEncoded.createHeader(clientId, clientSecret);
+            String authorization = BasicAuthHelper.RFC6749.createHeader(clientId, clientSecret);
             post.setHeader("Authorization", authorization);
 
             List<NameValuePair> parameters = new LinkedList<>();


### PR DESCRIPTION
<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->

Supplement for #11908.

## Background
OAuth2 authentication with HTTP Basic authentication scheme is not RFC6749 compliant.

## Changes
1. make default implementation to compliant with [RFC 2617](https://datatracker.ietf.org/doc/html/rfc2617)
2. add another implementation to compliant with [RFC 6749](https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.1)
