### PR TITLE
[14210] BouncyCastleProvider: Tests failing due to cast error

### DIFF
--- a/crypto/default/src/main/java/org/keycloak/crypto/def/DefaultCryptoProvider.java
+++ b/crypto/default/src/main/java/org/keycloak/crypto/def/DefaultCryptoProvider.java
@@ -22,13 +22,13 @@ import org.keycloak.common.crypto.UserIdentityExtractorProvider;
  */
 public class DefaultCryptoProvider implements CryptoProvider {
 
-    private final BouncyCastleProvider bcProvider;
+    private final Provider bcProvider;
 
     private Map<String, Object> providers = new ConcurrentHashMap<>();
 
     public DefaultCryptoProvider() {
         // Make sure to instantiate this only once due it is expensive. And skip registration if already available in Java security providers (EG. due explicitly configured in java security file)
-        BouncyCastleProvider existingBc = (BouncyCastleProvider) Security.getProvider(CryptoConstants.BC_PROVIDER_ID);
+        Provider existingBc = Security.getProvider(CryptoConstants.BC_PROVIDER_ID);
         this.bcProvider = existingBc == null ? new BouncyCastleProvider() : existingBc;
 
         providers.put(CryptoConstants.A128KW, new AesKeyWrapAlgorithmProvider());


### PR DESCRIPTION
Closes #14210 

Adapter Tests are failing due to following cast error

`Caused by: java.lang.ClassCastException: class org.bouncycastle.jce.provider.BouncyCastleProvider cannot be cast to class org.bouncycastle.jce.provider.BouncyCastleProvider (org.bouncycastle.jce.provider.BouncyCastleProvider is in unnamed module of loader 'deployment.token-min-ttl.war' @4fc03346; org.bouncycastle.jce.provider.BouncyCastleProvider is in unnamed module of loader 'deployment.customer-portal.war' @52038a4a)
`