### PR TITLE
Remove warning from StoragePropertyMappers about the deployment state version seed

### DIFF
--- a/model/map/src/main/java/org/keycloak/models/map/deploymentState/MapDeploymentStateProviderFactory.java
+++ b/model/map/src/main/java/org/keycloak/models/map/deploymentState/MapDeploymentStateProviderFactory.java
@@ -49,8 +49,9 @@ public class MapDeploymentStateProviderFactory implements DeploymentStateProvide
     public void init(Config.Scope config) {
         String seed = config.get(RESOURCES_VERSION_SEED);
         if (seed == null) {
+            // hardcoded until https://github.com/keycloak/keycloak/issues/13828 has been implemented
             Logger.getLogger(DeploymentStateProviderFactory.class)
-                    .warnf("Version seed for deployment state set with a random number. Caution: This can lead to unstable operations when serving resources from the cluster without a sticky loadbalancer or when restarting nodes. Set the '%s' property in the %s provider config of %s SPI for stable operations", RESOURCES_VERSION_SEED, PROVIDER_ID, DeploymentStateSpi.NAME);
+                    .warnf("Version seed for deployment state set with a random number. Caution: This can lead to unstable operations when serving resources from the cluster without a sticky loadbalancer or when restarting nodes. Set the 'storage-deployment-state-version-seed' option with a secret seed to ensure stable operations.", RESOURCES_VERSION_SEED, PROVIDER_ID, DeploymentStateSpi.NAME);
             //generate random string for this installation
             seed = SecretGenerator.getInstance().randomString(10);
         }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/StoragePropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/StoragePropertyMappers.java
@@ -141,7 +141,6 @@ final class StoragePropertyMappers {
                         .build(),
                 fromOption(StorageOptions.STORAGE_DEPLOYMENT_STATE_RESOURCES_VERSION_SEED)
                         .to("kc.spi-deployment-state-map-resources-version-seed")
-                        .transformer(StoragePropertyMappers::getResourcesVersionSeed)
                         .paramLabel("type")
                         .build(),
                 fromOption(StorageOptions.STORAGE_AUTH_SESSION_PROVIDER)
@@ -317,15 +316,6 @@ final class StoragePropertyMappers {
 
     private static Optional<String> getAreaStorage(Optional<String> storage, ConfigSourceInterceptorContext context) {
         return of(storage.isEmpty() ? "jpa" : "map");
-    }
-
-    private static Optional<String> getResourcesVersionSeed(Optional<String> parameterValue, ConfigSourceInterceptorContext context) {
-        if (!parameterValue.isEmpty()) {
-            return parameterValue;
-        }
-        Logger.getLogger(StoragePropertyMappers.class)
-                .warnf("Version seed for deployment state set with a random number. Caution: This can lead to unstable operations when serving resources from the cluster without a sticky loadbalancer or when restarting nodes. Set the '--%s' option with a secret seed to ensure stable operations.", StorageOptions.STORAGE_DEPLOYMENT_STATE_RESOURCES_VERSION_SEED.getKey());
-        return Optional.of(SecretGenerator.getInstance().randomString(10));
     }
 
     private static Optional<String> getCacheStorage(Optional<String> storage, ConfigSourceInterceptorContext context) {


### PR DESCRIPTION
It duplicates the logic in the provider and is incomplete. A follow-up issue will investigate how a provider can defer a configuration option.

This is the back-port to the KC 19 branch.

Closes #13807

Backport of #13827

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
