### PR TITLE
Requests to health endpoint still dispatched to worker threads when http-relative-path is set

### DIFF
--- a/distribution/galleon-feature-packs/server-galleon-pack/src/main/resources/modules/system/layers/keycloak/org/keycloak/keycloak-admin-ui/main/module.xml
+++ b/distribution/galleon-feature-packs/server-galleon-pack/src/main/resources/modules/system/layers/keycloak/org/keycloak/keycloak-admin-ui/main/module.xml
@@ -19,4 +19,15 @@
     <resources>
         <artifact name="${org.keycloak:keycloak-admin-ui}"/>
     </resources>
+    <dependencies>
+        <module name="javax.api"/>
+        <module name="javax.ws.rs.api"/>
+        <module name="org.keycloak.keycloak-core"/>
+        <module name="org.keycloak.keycloak-common"/>
+        <module name="org.keycloak.keycloak-server-spi"/>
+        <module name="org.keycloak.keycloak-server-spi-private"/>
+        <module name="org.keycloak.keycloak-services"/>
+        <module name="com.fasterxml.jackson.core.jackson-core"/>
+        <module name="com.fasterxml.jackson.core.jackson-databind"/>
+    </dependencies>
 </module>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -75,17 +75,6 @@
 
     <profiles>
         <profile>
-            <id>legacy-dist</id>
-            <activation>
-                <property>
-                    <name>legacy-dist</name>
-                </property>
-            </activation>
-            <modules>
-                <module>server-legacy-dist</module>
-            </modules>
-        </profile>
-        <profile>
             <id>distribution-downloads</id>
             <modules>
                 <module>api-docs-dist</module>

--- a/quarkus/config-api/src/main/java/org/keycloak/config/HttpOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/HttpOptions.java
@@ -21,7 +21,7 @@ public class HttpOptions {
 
     public static final Option HTTP_RELATIVE_PATH = new OptionBuilder<>("http-relative-path", String.class)
             .category(OptionCategory.HTTP)
-            .description("Set the path relative to '/' for serving resources.")
+            .description("Set the path relative to '/' for serving resources. The path must start with a '/'.")
             .defaultValue("/")
             .buildTime(true)
             .build();

--- a/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
+++ b/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
@@ -73,6 +73,7 @@ import io.quarkus.hibernate.orm.deployment.integration.HibernateOrmIntegrationRu
 import io.quarkus.resteasy.server.common.deployment.ResteasyDeploymentCustomizerBuildItem;
 import io.quarkus.runtime.configuration.ProfileManager;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
+import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
 import io.smallrye.config.ConfigValue;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.jpa.boot.internal.ParsedPersistenceXmlDescriptor;
@@ -481,8 +482,19 @@ class KeycloakProcessor {
 
     @Record(ExecutionTime.STATIC_INIT)
     @BuildStep
-    void initializeFilter(BuildProducer<FilterBuildItem> filters, KeycloakRecorder recorder) {
-        filters.produce(new FilterBuildItem(recorder.createRequestFilter(isHealthEnabled() || isMetricsEnabled()),FilterBuildItem.AUTHORIZATION - 10));
+    void initializeFilter(BuildProducer<FilterBuildItem> filters, KeycloakRecorder recorder, HttpBuildTimeConfig httpBuildConfig) {
+        String rootPath = httpBuildConfig.rootPath;
+        List<String> ignoredPaths = new ArrayList<>();
+
+        if (isHealthEnabled()) {
+            ignoredPaths.add(rootPath + "health");
+        }
+
+        if (isMetricsEnabled()) {
+            ignoredPaths.add(rootPath + "metrics");
+        }
+
+        filters.produce(new FilterBuildItem(recorder.createRequestFilter(ignoredPaths),FilterBuildItem.AUTHORIZATION - 10));
     }
 
     @BuildStep

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakRecorder.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakRecorder.java
@@ -139,19 +139,26 @@ public class KeycloakRecorder {
         };
     }
 
-    public QuarkusRequestFilter createRequestFilter(boolean healthOrMetricsEnabled) {
-        Predicate<RoutingContext> ignoreContext = null;
+    public QuarkusRequestFilter createRequestFilter(List<String> ignoredPaths) {
+        return new QuarkusRequestFilter(createIgnoredHttpPathsPredicate(ignoredPaths));
+    }
 
-        if (healthOrMetricsEnabled) {
-            // ignore metrics and health endpoints because they execute in their own worker thread
-            ignoreContext = new Predicate<>() {
-                @Override
-                public boolean test(RoutingContext context) {
-                    return context.request().uri().startsWith("/health") || context.request().uri().startsWith("/metrics");
-                }
-            };
+    private Predicate<RoutingContext> createIgnoredHttpPathsPredicate(List<String> ignoredPaths) {
+        if (ignoredPaths == null || ignoredPaths.isEmpty()) {
+            return null;
         }
 
-        return new QuarkusRequestFilter(ignoreContext);
+        return new Predicate<>() {
+            @Override
+            public boolean test(RoutingContext context) {
+                for (String ignoredPath : ignoredPaths) {
+                    if (context.request().uri().startsWith(ignoredPath)) {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+        };
     }
 }

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/HealthDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/HealthDistTest.java
@@ -20,8 +20,18 @@ package org.keycloak.it.cli.dist;
 import io.quarkus.test.junit.main.Launch;
 import org.junit.jupiter.api.Test;
 import org.keycloak.it.junit5.extension.DistributionTest;
+import org.keycloak.it.utils.KeycloakDistribution;
 
 import static io.restassured.RestAssured.when;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
 
 @DistributionTest(keepAlive =true)
 public class HealthDistTest {
@@ -55,5 +65,40 @@ public class HealthDistTest {
         // Metrics should not be enabled
         when().get("/metrics").then()
                 .statusCode(404);
+    }
+
+    @Test
+    void testUsingRelativePath(KeycloakDistribution distribution) {
+        for (String relativePath : List.of("/auth", "/auth/")) {
+            distribution.run("start-dev", "--health-enabled=true", "--http-relative-path=" + relativePath);
+            if (!relativePath.endsWith("/")) {
+                relativePath = relativePath + "/";
+            }
+            when().get(relativePath + "health").then().statusCode(200);
+            distribution.stop();
+        }
+    }
+
+    @Test
+    void testMultipleRequests(KeycloakDistribution distribution) throws Exception {
+        for (String relativePath : List.of("/", "/auth/")) {
+            distribution.run("start-dev", "--health-enabled=true", "--http-relative-path=" + relativePath);
+            CompletableFuture future = CompletableFuture.completedFuture(null);
+
+            for (int i = 0; i < 3; i++) {
+                future = CompletableFuture.allOf(CompletableFuture.runAsync(new Runnable() {
+                    @Override
+                    public void run() {
+                        for (int i = 0; i < 200; i++) {
+                            when().get(relativePath + "health").then().statusCode(200);
+                        }
+                    }
+                }), future);
+            }
+
+            future.get(5, TimeUnit.MINUTES);
+
+            distribution.stop();
+        }
     }
 }

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testBuildHelp.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testBuildHelp.unix.approved.txt
@@ -49,7 +49,8 @@ Feature:
 HTTP/TLS:
 
 --http-relative-path <path>
-                     Set the path relative to '/' for serving resources. Default: /.
+                     Set the path relative to '/' for serving resources. The path must start with a
+                       '/'. Default: /.
 
 Health:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartDevHelp.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartDevHelp.unix.approved.txt
@@ -102,7 +102,8 @@ HTTP/TLS:
 --http-host <host>   The used HTTP Host. Default: 0.0.0.0.
 --http-port <port>   The used HTTP port. Default: 8080.
 --http-relative-path <path>
-                     Set the path relative to '/' for serving resources. Default: /.
+                     Set the path relative to '/' for serving resources. The path must start with a
+                       '/'. Default: /.
 --https-certificate-file <file>
                      The file path to a server certificate or certificate chain in PEM format.
 --https-certificate-key-file <file>

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartDevHelpAll.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartDevHelpAll.unix.approved.txt
@@ -169,7 +169,8 @@ HTTP/TLS:
 --http-host <host>   The used HTTP Host. Default: 0.0.0.0.
 --http-port <port>   The used HTTP port. Default: 8080.
 --http-relative-path <path>
-                     Set the path relative to '/' for serving resources. Default: /.
+                     Set the path relative to '/' for serving resources. The path must start with a
+                       '/'. Default: /.
 --https-certificate-file <file>
                      The file path to a server certificate or certificate chain in PEM format.
 --https-certificate-key-file <file>

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartHelp.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartHelp.unix.approved.txt
@@ -108,7 +108,8 @@ HTTP/TLS:
 --http-host <host>   The used HTTP Host. Default: 0.0.0.0.
 --http-port <port>   The used HTTP port. Default: 8080.
 --http-relative-path <path>
-                     Set the path relative to '/' for serving resources. Default: /.
+                     Set the path relative to '/' for serving resources. The path must start with a
+                       '/'. Default: /.
 --https-certificate-file <file>
                      The file path to a server certificate or certificate chain in PEM format.
 --https-certificate-key-file <file>

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartHelpAll.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartHelpAll.unix.approved.txt
@@ -175,7 +175,8 @@ HTTP/TLS:
 --http-host <host>   The used HTTP Host. Default: 0.0.0.0.
 --http-port <port>   The used HTTP port. Default: 8080.
 --http-relative-path <path>
-                     Set the path relative to '/' for serving resources. Default: /.
+                     Set the path relative to '/' for serving resources. The path must start with a
+                       '/'. Default: /.
 --https-certificate-file <file>
                      The file path to a server certificate or certificate chain in PEM format.
 --https-certificate-key-file <file>


### PR DESCRIPTION
Closes #14011

 Conflicts:
	quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testBuildHelp.unix.approved.txt
	quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartDevHelp.unix.approved.txt
	quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartDevHelpAll.unix.approved.txt
	quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartHelp.unix.approved.txt
	quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/approvals/cli/help/HelpCommandTest.testStartHelpAll.unix.approved.txt

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
