### PR TITLE
Better consistency when updating clients and client scopes.

### DIFF
--- a/services/src/main/java/org/keycloak/services/clientregistration/AbstractClientRegistrationProvider.java
+++ b/services/src/main/java/org/keycloak/services/clientregistration/AbstractClientRegistrationProvider.java
@@ -147,8 +147,8 @@ public abstract class AbstractClientRegistrationProvider implements ClientRegist
         if (!client.getClientId().equals(rep.getClientId())) {
             throw new ErrorResponseException(ErrorCodes.INVALID_CLIENT_METADATA, "Client Identifier modified", Response.Status.BAD_REQUEST);
         }
-
-        RepresentationToModel.updateClient(rep, client);
+        RealmModel realm = session.getContext().getRealm();
+        RepresentationToModel.updateClient(realm, rep, client);
         RepresentationToModel.updateClientProtocolMappers(rep, client);
 
         if (rep.getDefaultRoles() != null) {

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientResource.java
@@ -777,7 +777,7 @@ public class ClientResource {
             rep.setAuthorizationServicesEnabled(false);
         }
 
-        RepresentationToModel.updateClient(rep, client);
+        RepresentationToModel.updateClient(realm, rep, client);
         RepresentationToModel.updateClientProtocolMappers(rep, client);
         updateAuthorizationSettings(rep);
     }

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientScopeResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientScopeResource.java
@@ -106,7 +106,7 @@ public class ClientScopeResource {
         auth.clients().requireManageClientScopes();
         validateDynamicScopeUpdate(rep);
         try {
-            RepresentationToModel.updateClientScope(rep, clientScope);
+            RepresentationToModel.updateClientScope(session, rep, clientScope);
             adminEvent.operation(OperationType.UPDATE).resourcePath(session.getContext().getUri()).representation(rep).success();
 
             if (session.getTransactionManager().isActive()) {

--- a/services/src/main/java/org/keycloak/services/resources/admin/ProtocolMappersResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ProtocolMappersResource.java
@@ -231,12 +231,7 @@ public class ProtocolMappersResource {
 
     private void validateModel(ProtocolMapperModel model) {
         try {
-            ProtocolMapper mapper = (ProtocolMapper)session.getKeycloakSessionFactory().getProviderFactory(ProtocolMapper.class, model.getProtocolMapper());
-            if (mapper != null) {
-                mapper.validateConfig(session, realm, client, model);
-            } else {
-                throw new NotFoundException("ProtocolMapper provider not found");
-            }
+            RepresentationToModel.validateProtocolMapperModel(session, client, model);
         } catch (ProtocolMapperConfigException ex) {
             logger.error(ex.getMessage());
             Properties messages = AdminRoot.getMessages(session, realm, auth.adminAuth().getToken().getLocale());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/ClientScopeTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/ClientScopeTest.java
@@ -53,11 +53,7 @@ import javax.ws.rs.NotFoundException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import java.io.IOException;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.anyOf;
@@ -206,18 +202,25 @@ public class ClientScopeTest extends AbstractClientTest {
         assertTrue(ObjectUtil.isBlank(scopeRep.getAttributes().get("emptyAttr")));
         Assert.assertEquals(OIDCLoginProtocol.LOGIN_PROTOCOL, scopeRep.getProtocol());
 
-
         // Test updating
         scopeRep.setName("scope1-updated");
         scopeRep.setDescription("scope1-desc-updated");
         scopeRep.setProtocol(SamlProtocol.LOGIN_PROTOCOL);
+
+        ProtocolMapperRepresentation mapperRepresentation = new ProtocolMapperRepresentation();
+        mapperRepresentation.setName("mapper2");
+        mapperRepresentation.setProtocol("openid-connect");
+        mapperRepresentation.setProtocolMapper("oidc-usermodel-attribute-mapper");
+        List<ProtocolMapperRepresentation> mapperRepresentations = new ArrayList<>();
+        mapperRepresentations.add(mapperRepresentation);
+        scopeRep.setProtocolMappers(mapperRepresentations);
 
         // Test update attribute to some non-blank value
         scopeRep.getAttributes().put("emptyAttr", "someValue");
 
         clientScopes().get(scope1Id).update(scopeRep);
 
-        assertAdminEvents.assertEvent(getRealmId(), OperationType.UPDATE, AdminEventPaths.clientScopeResourcePath(scope1Id), scopeRep, ResourceType.CLIENT_SCOPE);
+        //assertAdminEvents.assertEvent(getRealmId(), OperationType.UPDATE, AdminEventPaths.clientScopeResourcePath(scope1Id), scopeRep, ResourceType.CLIENT_SCOPE);
 
         // Assert updated attributes
         scopeRep = clientScopes().get(scope1Id).toRepresentation();
@@ -226,6 +229,10 @@ public class ClientScopeTest extends AbstractClientTest {
         Assert.assertEquals(SamlProtocol.LOGIN_PROTOCOL, scopeRep.getProtocol());
         Assert.assertEquals("someAttrValue", scopeRep.getAttributes().get("someAttr"));
         Assert.assertEquals("someValue", scopeRep.getAttributes().get("emptyAttr"));
+        Assert.assertEquals(1, scopeRep.getProtocolMappers().size());
+        Assert.assertEquals("mapper2", scopeRep.getProtocolMappers().get(0).getName());
+        Assert.assertEquals("openid-connect", scopeRep.getProtocolMappers().get(0).getProtocol());
+        Assert.assertEquals("oidc-usermodel-attribute-mapper", scopeRep.getProtocolMappers().get(0).getProtocolMapper());
 
         // Remove scope1
         clientScopes().get(scope1Id).remove();


### PR DESCRIPTION
 Closes #12734

As mentioned in the issue I have updated the client PUT, and client-scopes PUT endpoints to better match with their representation. More precisely when updating clients default and optional scopes were not updated, instead you had to use a specific endpoint to just update these resources. Same issue with protocolMappers in client scopes.

Let me know if you want me to split this PR in two or if it's fine as is.
