### PR TITLE
UserInfo endpoint not fully standards compliant

### DIFF
--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/ClusteringTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/ClusteringTest.java
@@ -100,7 +100,7 @@ public class ClusteringTest extends BaseOperatorTest {
     }
 
     // local debug commands:
-    //    export TOKEN=$(curl --data "grant_type=password&client_id=token-test-client&username=test&password=test" http://localhost:8080/realms/token-test/protocol/openid-connect/token | jq -r '.access_token')
+    //    export TOKEN=$(curl --data "grant_type=password&client_id=token-test-client&username=test&password=test&scope=openid" http://localhost:8080/realms/token-test/protocol/openid-connect/token | jq -r '.access_token')
     //
     //    curl http://localhost:8080/realms/token-test/protocol/openid-connect/userinfo -H "Authorization: bearer $TOKEN"
     //
@@ -170,6 +170,7 @@ public class ClusteringTest extends BaseOperatorTest {
                             .param("client_id", "token-test-client")
                             .param("username", "test")
                             .param("password", "test")
+                            .param("scope", "openid")
                             .post("https://localhost:" + portForward.getLocalPort() + "/realms/token-test/protocol/openid-connect/token")
                             .body()
                             .jsonPath()
@@ -208,7 +209,7 @@ public class ClusteringTest extends BaseOperatorTest {
                     var tokenUrl = "https://" + service.getName() + "." + namespace + ":" + Constants.KEYCLOAK_HTTPS_PORT + "/realms/token-test/protocol/openid-connect/token";
                     Log.info("Checking url: " + tokenUrl);
 
-                    var tokenOutput = K8sUtils.inClusterCurl(k8sclient, namespace, "--insecure", "-s", "--data", "grant_type=password&client_id=token-test-client&username=test&password=test", tokenUrl);
+                    var tokenOutput = K8sUtils.inClusterCurl(k8sclient, namespace, "--insecure", "-s", "--data", "grant_type=password&client_id=token-test-client&username=test&password=test&scope=openid", tokenUrl);
                     Log.info("Curl Output with token: " + tokenOutput);
                     JsonNode tokenAnswer = Serialization.jsonMapper().readTree(tokenOutput);
                     assertThat(tokenAnswer.hasNonNull("access_token")).isTrue();

--- a/services/src/main/java/org/keycloak/utils/OAuth2Error.java
+++ b/services/src/main/java/org/keycloak/utils/OAuth2Error.java
@@ -1,0 +1,305 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.utils;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.ForbiddenException;
+import javax.ws.rs.InternalServerErrorException;
+import javax.ws.rs.NotAuthorizedException;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+
+import org.keycloak.OAuthErrorException;
+import org.keycloak.models.RealmModel;
+import org.keycloak.representations.idm.OAuth2ErrorRepresentation;
+import org.keycloak.services.resources.Cors;
+
+import static javax.ws.rs.core.HttpHeaders.WWW_AUTHENTICATE;
+
+/**
+ * @author <a href="mailto:dmitryt@backbase.com">Dmitry Telegin</a>
+ */
+public class OAuth2Error {
+
+    private static final Map<Response.Status, Class<? extends WebApplicationException>> STATUS_MAP = new HashMap<>();
+
+    private RealmModel realm;
+    private String error;
+    private String errorDescription;
+    private Optional<Cors> cors = Optional.empty();
+
+    private Class<? extends WebApplicationException> clazz;
+    private Response.Status status;
+    private boolean json = true;
+
+    static {
+        STATUS_MAP.put(Response.Status.BAD_REQUEST, BadRequestException.class);
+        STATUS_MAP.put(Response.Status.UNAUTHORIZED, NotAuthorizedException.class);
+        STATUS_MAP.put(Response.Status.FORBIDDEN, ForbiddenException.class);
+        STATUS_MAP.put(Response.Status.INTERNAL_SERVER_ERROR, InternalServerErrorException.class);
+    }
+
+    public OAuth2Error realm(RealmModel realm) {
+        this.realm = realm;
+        return this;
+    }
+
+    public OAuth2Error error(String error) {
+
+        this.error = error;
+
+        switch (error) {
+            case OAuthErrorException.INVALID_GRANT:
+            case OAuthErrorException.INVALID_REQUEST:
+            case OAuthErrorException.UNAUTHORIZED_CLIENT:
+            case OAuthErrorException.UNSUPPORTED_GRANT_TYPE:
+            case OAuthErrorException.INVALID_SCOPE:
+                status = Response.Status.BAD_REQUEST;
+                break;
+            case OAuthErrorException.INVALID_CLIENT:
+            case OAuthErrorException.INVALID_TOKEN:
+                status = Response.Status.UNAUTHORIZED;
+                break;
+            case OAuthErrorException.INSUFFICIENT_SCOPE:
+                status = Response.Status.FORBIDDEN;
+                break;
+            case OAuthErrorException.SERVER_ERROR:
+                status = Response.Status.INTERNAL_SERVER_ERROR;
+                break;
+            default:
+                throw new IllegalArgumentException("Unrecognized OAuth 2.0 error: " + error);
+        }
+
+        return this;
+    }
+
+    public OAuth2Error errorDescription(String errorDescription) {
+        this.errorDescription = errorDescription;
+        return this;
+    }
+
+    public OAuth2Error cors(Cors cors) {
+        this.cors = Optional.ofNullable(cors);
+        return this;
+    }
+
+    public OAuth2Error status(Response.Status status) {
+        this.status = status;
+        return this;
+    }
+
+    public OAuth2Error json(boolean json) {
+        this.json = json;
+        return this;
+    }
+
+    public WebApplicationException build() {
+        clazz = STATUS_MAP.getOrDefault(status, WebApplicationException.class);
+        Response.ResponseBuilder builder = Response.status(status);
+
+        try {
+            Constructor<? extends WebApplicationException> constructor = clazz.getConstructor(new Class[] { Response.class });
+            cors.ifPresent(_cors -> { _cors.build(builder::header); });
+
+            if (json) {
+                OAuth2ErrorRepresentation errorRep = new OAuth2ErrorRepresentation(error, errorDescription);
+                builder.entity(errorRep).type(MediaType.APPLICATION_JSON_TYPE);
+            } else {
+                WWWAuthenticate.BearerChallenge bearer = new WWWAuthenticate.BearerChallenge();
+                bearer.setRealm(realm.getName());
+                bearer.setError(error);
+                bearer.setErrorDescription(errorDescription);
+                WWWAuthenticate wwwAuthenticate = new WWWAuthenticate(bearer);
+                wwwAuthenticate.build(builder::header);
+                builder.entity("");
+            }
+
+            return constructor.newInstance(builder.build());
+        } catch (NoSuchMethodException | SecurityException | InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException ex) {
+            throw new InternalServerErrorException(ex);
+        }
+    }
+
+    public WebApplicationException insufficientScope(String errorDescription) {
+        return this.error(OAuthErrorException.INSUFFICIENT_SCOPE).errorDescription(errorDescription).build();
+    }
+
+    public WebApplicationException invalidToken(String errorDescription) {
+        return this.error(OAuthErrorException.INVALID_TOKEN).errorDescription(errorDescription).build();
+    }
+
+    public WebApplicationException invalidRequest(String errorDescription) {
+        return this.error(OAuthErrorException.INVALID_REQUEST).errorDescription(errorDescription).build();
+    }
+
+    public WebApplicationException unauthorized() {
+        return this.status(Response.Status.UNAUTHORIZED).build();
+    }
+
+    private static class WWWAuthenticate {
+
+        private final List<Challenge> challenges;
+        private Challenge master;
+        private boolean singleHeader = true;
+
+        public WWWAuthenticate(Challenge challenge, Challenge... moreChallenges) {
+            challenges = new ArrayList<>(1 + ((moreChallenges == null) ? 0 : moreChallenges.length));
+            challenges.add(challenge);
+            if (moreChallenges != null) {
+                challenges.addAll(Arrays.asList(moreChallenges));
+            }
+            master = challenge;
+        }
+
+        public void addChallenge(Challenge challenge) {
+            challenges.add(challenge);
+        }
+
+        public void setMasterChallenge(Challenge challenge) {
+            if (challenges.contains(challenge)) {
+                master = challenge;
+            } else {
+                throw new IllegalArgumentException("Unknown challenge: " + challenge);
+            }
+        }
+
+        public void setMasterChallenge(String scheme) {
+            master = challenges.stream()
+                .filter(c -> c.getScheme().equals(scheme))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Unknown challenge: " + scheme));
+        }
+
+        public Challenge getMasterChallenge() {
+            return master;
+        }
+
+        public boolean isSingleHeader() {
+            return singleHeader;
+        }
+
+        public void setSingleHeader(boolean singleHeader) {
+            this.singleHeader = singleHeader;
+        }
+
+        public void setAttribute(String attribute, String value) {
+            challenges.forEach(c -> c.setAttribute(attribute, value));
+        }
+
+        public void build(BiConsumer<String, Object> addHeader) {
+            if (singleHeader) {
+                String header = challenges.stream()
+                    .map(Challenge::toString)
+                    .collect(Collectors.joining(", "));
+                addHeader.accept(WWW_AUTHENTICATE, header);
+            } else {
+                challenges.forEach(c -> addHeader.accept(WWW_AUTHENTICATE, c));
+            }
+        }
+
+        public static abstract class Challenge {
+
+            private final Map<String, String> attributes = new LinkedHashMap<>();
+
+            public void setAttribute(String attribute, String value) {
+                if (value != null) {
+                    attributes.put(attribute, value);
+                }
+            }
+
+            public abstract String getScheme();
+
+            @Override
+            public String toString() {
+                StringBuilder sb = new StringBuilder(getScheme());
+
+                if (!attributes.isEmpty()) {
+                    sb.append(" ").append(
+                        attributes.entrySet().stream()
+                            .map(e -> String.format("%s=\"%s\"", e.getKey(), e.getValue()))
+                            .collect(Collectors.joining(", "))
+                    );
+                }
+
+                return sb.toString();
+            }
+
+        }
+
+        public static class BasicChallenge extends Challenge {
+
+            private static final String BASIC_SCHEME = "Basic";
+            private static final String REALM_ATTRIBUTE = "realm";
+
+            public void setRealm(String realm) {
+                setAttribute(REALM_ATTRIBUTE, realm);
+            }
+
+            @Override
+            public String getScheme() {
+                return BASIC_SCHEME;
+            }
+
+        }
+
+        public static class BearerChallenge extends BasicChallenge {
+
+            private static final String BEARER_SCHEME = "Bearer";
+
+            private static final String ERROR_ATTRIBUTE = "error";
+            private static final String ERROR_DESCRIPTION_ATTRIBUTE = "error_description";
+            private static final String ERROR_URI_ATTRIBUTE = "error_uri";
+            private static final String SCOPE_ATTRIBUTE = "scope";
+
+            public void setError(String error) {
+                setAttribute(ERROR_ATTRIBUTE, error);
+            }
+
+            public void setErrorDescription(String errorDescription) {
+                setAttribute(ERROR_DESCRIPTION_ATTRIBUTE, errorDescription);
+            }
+
+            public void setErrorUri(String errorUri) {
+                setAttribute(ERROR_URI_ATTRIBUTE, errorUri);
+            }
+
+            public void setScope(String scope) {
+                setAttribute(SCOPE_ATTRIBUTE, scope);
+            }
+
+            @Override
+            public String getScheme() {
+                return BEARER_SCHEME;
+            }
+
+        }
+
+    }
+
+}

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/OAuthClient.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/OAuthClient.java
@@ -621,8 +621,10 @@ public class OAuthClient {
             if (clientSessionHost != null) {
                 parameters.add(new BasicNameValuePair(AdapterConstants.CLIENT_SESSION_HOST, clientSessionHost));
             }
-            if (scope != null) {
-                parameters.add(new BasicNameValuePair(OAuth2Constants.SCOPE, scope));
+
+            String scopeParam = openid ? TokenUtil.attachOIDCScope(scope) : scope;
+            if (scopeParam != null && !scopeParam.isEmpty()) {
+                parameters.add(new BasicNameValuePair(OAuth2Constants.SCOPE, scopeParam));
             }
 
             if (userAgent != null) {
@@ -751,8 +753,9 @@ public class OAuthClient {
             List<NameValuePair> parameters = new LinkedList<>();
             parameters.add(new BasicNameValuePair(OAuth2Constants.GRANT_TYPE, OAuth2Constants.CLIENT_CREDENTIALS));
 
-            if (scope != null) {
-                parameters.add(new BasicNameValuePair(OAuth2Constants.SCOPE, scope));
+            String scopeParam = openid ? TokenUtil.attachOIDCScope(scope) : scope;
+            if (scopeParam != null && !scopeParam.isEmpty()) {
+                parameters.add(new BasicNameValuePair(OAuth2Constants.SCOPE, scopeParam));
             }
 
             UrlEncodedFormEntity formEntity;
@@ -1032,8 +1035,9 @@ public class OAuthClient {
                 post.addHeader("Origin", origin);
             }
 
-            if (scope != null) {
-                parameters.add(new BasicNameValuePair(OAuth2Constants.SCOPE, scope));
+            String scopeParam = openid ? TokenUtil.attachOIDCScope(scope) : scope;
+            if (scopeParam != null && !scopeParam.isEmpty()) {
+                parameters.add(new BasicNameValuePair(OAuth2Constants.SCOPE, scopeParam));
             }
             if (nonce != null) {
                 parameters.add(new BasicNameValuePair(OIDCLoginProtocol.NONCE_PARAM, scope));

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OAuth2OnlyTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OAuth2OnlyTest.java
@@ -109,6 +109,7 @@ public class OAuth2OnlyTest extends AbstractTestRealmKeycloakTest {
          * @see AccessTokenTest#testAuthorizationNegotiateHeaderIgnored()
          */
         oauth.init(driver);
+        oauth.openid(false);
     }
 
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/RefreshTokenTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/RefreshTokenTest.java
@@ -17,6 +17,7 @@
 package org.keycloak.testsuite.oauth;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import org.hamcrest.CoreMatchers;
 import org.jboss.arquillian.graphene.page.Page;
 import org.junit.Assert;
 import org.junit.Before;
@@ -42,7 +43,6 @@ import org.keycloak.protocol.oidc.OIDCLoginProtocolService;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.IDToken;
 import org.keycloak.representations.RefreshToken;
-import org.keycloak.representations.UserInfo;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.EventRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
@@ -59,6 +59,7 @@ import org.keycloak.testsuite.util.OAuthClient;
 import org.keycloak.testsuite.util.RealmBuilder;
 import org.keycloak.testsuite.util.RealmManager;
 import org.keycloak.testsuite.util.TokenSignatureUtil;
+import org.keycloak.testsuite.util.UserInfoClientUtil;
 import org.keycloak.testsuite.util.UserManager;
 import org.keycloak.testsuite.util.WaitUtils;
 import org.keycloak.util.BasicAuthHelper;
@@ -79,6 +80,7 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -637,9 +639,15 @@ public class RefreshTokenTest extends AbstractKeycloakTest {
             Assert.assertFalse(jsonNode.get("active").asBoolean());
 
             // Try userInfo with the same old access token. Should fail as well
-            UserInfo userInfo = oauth.doUserInfoRequest(response1.getAccessToken());
-            Assert.assertNull(userInfo.getSubject());
-            Assert.assertEquals(userInfo.getOtherClaims().get(OAuth2Constants.ERROR), OAuthErrorException.INVALID_TOKEN);
+//            UserInfo userInfo = oauth.doUserInfoRequest(response1.getAccessToken());
+            Client client = AdminClientUtil.createResteasyClient();
+            Response userInfoResponse = UserInfoClientUtil.executeUserInfoRequest_getMethod(client, response1.getAccessToken());
+            assertEquals(Response.Status.UNAUTHORIZED.getStatusCode(), userInfoResponse.getStatus());
+            String wwwAuthHeader = userInfoResponse.getHeaderString(HttpHeaders.WWW_AUTHENTICATE);
+            assertNotNull(wwwAuthHeader);
+            assertThat(wwwAuthHeader, CoreMatchers.containsString("Bearer"));
+            assertThat(wwwAuthHeader, CoreMatchers.containsString("error=\"" + OAuthErrorException.INVALID_TOKEN + "\""));
+
             events.clear();
 
             // Try to refresh with one of the old refresh tokens before SSO re-authentication - should fail

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ResourceOwnerPasswordCredentialsGrantTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ResourceOwnerPasswordCredentialsGrantTest.java
@@ -97,6 +97,7 @@ public class ResourceOwnerPasswordCredentialsGrantTest extends AbstractKeycloakT
     @Override
     public void beforeAbstractKeycloakTest() throws Exception {
         super.beforeAbstractKeycloakTest();
+        oauth.openid(false);
     }
 
     @Override
@@ -234,7 +235,7 @@ public class ResourceOwnerPasswordCredentialsGrantTest extends AbstractKeycloakT
 
     @Test
     @EnableFeature(value = Profile.Feature.DYNAMIC_SCOPES, skipRestart = true)
-    public void grantAccessTokenWithUnassignedDynamicScope() throws Exception {;
+    public void grantAccessTokenWithUnassignedDynamicScope() throws Exception {
         oauth.scope("unknown-scope:123");
         oauth.clientId("resource-owner-public");
         OAuthClient.AccessTokenResponse response = oauth.doGrantAccessTokenRequest("secret", "direct-login", "password");


### PR DESCRIPTION
Closes #14184

This is an attempt to make OIDC UserInfo error responses compliant with RFC 6750 (see [discussion](https://github.com/keycloak/keycloak/discussions/8801) for details).

### Changes to error responses

Most error responses now deliver error code and description via the `WWW-Authenticate` challenge attributes, not JSON body as it used to be up to this moment. The responses will be the following, depending on the error condition:

- In case no access token is provided:
  ```
  401 Unauthorized
  WWW-Authenticate: Bearer realm="myrealm"
  ```
- In case several methods are used simultaneously to provide access token (e.g. Authorization header + POST access_token parameter), or POST parameters are duplicated:
  ```
  400 Bad Request
  WWW-Authenticate: Bearer realm="myrealm", error="invalid_request", error_description="..."
  ```
- In case access token is missing `openid` scope:
  ```
  403 Forbidden
  WWW-Authenticate: Bearer realm="myrealm", error="insufficient_scope", error_description="Missing openid scope"
  ```
- In case of inability to resolve cryptographic keys for UserInfo response signing/encryption:
  ```
  500 Internal Server Error
  ```
  Note: RFC 6750 doesn't specify how to provide error details in case of a 500 Internal Server Error. OTOH, this particular case means server misconfiguration, so probably no details should be delivered to the client at all, hence the empty body.
- In case of token validation error, a `401 Unauthorized` is returned in combination with the `invalid_token` error code. This includes user and client related checks and actually captures all the remaining error cases:
  ```
  401 Unauthorized
  WWW-Authenticate: Bearer realm="myrealm", error="invalid_token", error_description="..."
  ```

### Other changes

- access tokens are now required to have `openid` scope, as UserInfo is a feature specific to OpenID Connect and not OAuth 2.0;
- UserInfo now checks the user status, and returns an error response if the user is disabled.

### OAuth2Error

The `OAuth2Error` utility class is suggested as an alternative to `CorsErrorResponseException`, providing more features, flexibility and conciseness. The benefits are the following:

- produces typed exceptions of concrete classes from the `javax.ws.rs` package (`BadRequestException`, `NotAuthorizedException` etc.), which is better for logging and debugging;
- supports optional CORS;
- is able to deliver error code and description both via JSON payload (e.g. TokenEndpoint) and `WWW-Authenticate` challenge (UserInfoEndpoint, client credentials grant);
- supports multiple challenges serialized into a single `WWW-Authenticate header` (will be needed for DPoP; the single header requirement is dictated by poor browser support of multiple `WWW-Authenticate` headers);
- is able to infer HTTP status code from OAuth 2.0 error code. With `CorsErrorResponseException`, we must provide both error code and HTTP status code, which allows for incompatible combinations and leads to non-compliance with standards (examples: [1](https://github.com/keycloak/keycloak/blob/main/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java#L237) [2](https://github.com/keycloak/keycloak/blob/main/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java#L243) [3](https://github.com/keycloak/keycloak/blob/main/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java#L682)); the ability to override HTTP code directly is present as well.
- uses builder pattern to expose the complete functionality:
  ```java
  throw new OAuth2Error().realm(realm)
    .cors(cors).json(false)
    .error(error).errorDescription(errorDescription)
    .build();
  ```
- provides helper methods for more concise code, once the error object is set up:
```java
  error = new OAuth2Error().realm(realm).json(false).cors(cors);
  // ...
  throw error.invalidToken("Token validation failed");
```