### PR TITLE
[Issue #14286] Delay LDAPObject creation until mandatory attributes are set

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProvider.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProvider.java
@@ -236,8 +236,8 @@ public class LDAPStorageProvider implements UserStorageProvider,
 
     private void checkDNChanged(RealmModel realm, UserModel local, LDAPObject ldapObject) {
         String dnFromDB = local.getFirstAttribute(LDAPConstants.LDAP_ENTRY_DN);
-        String ldapDn = ldapObject.getDn().toString();
-        if (!ldapDn.equals(dnFromDB)) {
+        String ldapDn = ldapObject.getDn() == null? null : ldapObject.getDn().toString();
+        if (ldapDn != null && !ldapDn.equals(dnFromDB)) {
             logger.debugf("Updated LDAP DN of user '%s' to '%s'", local.getUsername(), ldapDn);
             local.setSingleAttribute(LDAPConstants.LDAP_ENTRY_DN, ldapDn);
 
@@ -284,7 +284,7 @@ public class LDAPStorageProvider implements UserStorageProvider,
         if (!synchronizeRegistrations()) {
             return null;
         }
-        UserModel user = null;
+        final UserModel user;
         if (model.isImportEnabled()) {
             user = UserStoragePrivateUtil.userLocalStorage(session).addUser(realm, username);
             user.setFederationLink(model.getId());
@@ -292,10 +292,11 @@ public class LDAPStorageProvider implements UserStorageProvider,
             user = new InMemoryUserAdapter(session, realm, new StorageId(model.getId(), username).getId());
             user.setUsername(username);
         }
-        LDAPObject ldapUser = LDAPUtils.addUserToLDAP(this, realm, user);
-        LDAPUtils.checkUuid(ldapUser, ldapIdentityStore.getConfig());
-        user.setSingleAttribute(LDAPConstants.LDAP_ID, ldapUser.getUuid());
-        user.setSingleAttribute(LDAPConstants.LDAP_ENTRY_DN, ldapUser.getDn().toString());
+        LDAPObject ldapUser = LDAPUtils.addUserToLDAP(this, realm, user, ldapObject -> {
+            LDAPUtils.checkUuid(ldapObject, ldapIdentityStore.getConfig());
+            user.setSingleAttribute(LDAPConstants.LDAP_ID, ldapObject.getUuid());
+            user.setSingleAttribute(LDAPConstants.LDAP_ENTRY_DN, ldapObject.getDn().toString());
+        });
 
         // Add the user to the default groups and add default required actions
         UserModel proxy = proxy(realm, user, ldapUser, true);

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/model/LDAPObject.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/model/LDAPObject.java
@@ -19,7 +19,6 @@ package org.keycloak.storage.ldap.idm.model;
 
 import org.jboss.logging.Logger;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
@@ -27,6 +26,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Consumer;
 
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
@@ -53,6 +53,41 @@ public class LDAPObject {
 
     // range attributes are always read from 0 to max so just saving the top value
     private final Map<String, Integer> rangedAttributes = new HashMap<>();
+
+    // consumer to be executed when mandatory attributes are set
+    private Consumer<LDAPObject> consumerOnMandatoryAttributesComplete;
+
+    // mandatory attributes defined for the entry
+    private Set<String> mandatoryAttributeNames;
+
+    // mandatory attributes that remain not set
+    private Set<String> mandatoryAttributeNamesRemaining;
+
+    public void executeOnMandatoryAttributesComplete(Set<String> mandatoryAttributeNames, Consumer<LDAPObject> consumer) {
+        this.consumerOnMandatoryAttributesComplete = consumer;
+        this.mandatoryAttributeNames = new LinkedHashSet<>();
+        this.mandatoryAttributeNamesRemaining = new LinkedHashSet<>();
+        // initializes mandatory attributes
+        if (mandatoryAttributeNames != null) {
+            for (String name : mandatoryAttributeNames) {
+                name = name.toLowerCase();
+                this.mandatoryAttributeNames.add(name);
+                Set<String> values = lowerCasedAttributes.get(name);
+                if (values == null || values.isEmpty()) {
+                    this.mandatoryAttributeNamesRemaining.add(name);
+                }
+            }
+        }
+        executeConsumerOnMandatoryAttributesComplete();
+    }
+
+    public boolean isWaitingForExecutionOnMandatoryAttributesComplete() {
+        return consumerOnMandatoryAttributesComplete != null;
+    }
+
+    public Set<String> getMandatoryAttributeNamesRemaining() {
+        return mandatoryAttributeNamesRemaining;
+    }
 
     public String getUuid() {
         return uuid;
@@ -114,13 +149,24 @@ public class LDAPObject {
 
     public void setSingleAttribute(String attributeName, String attributeValue) {
         Set<String> asSet = new LinkedHashSet<>();
-        asSet.add(attributeValue);
+        if (attributeValue != null) {
+            asSet.add(attributeValue);
+        }
         setAttribute(attributeName, asSet);
     }
 
     public void setAttribute(String attributeName, Set<String> attributeValue) {
         attributes.put(attributeName, attributeValue);
-        lowerCasedAttributes.put(attributeName.toLowerCase(), attributeValue);
+        attributeName = attributeName.toLowerCase();
+        lowerCasedAttributes.put(attributeName, attributeValue);
+        if (consumerOnMandatoryAttributesComplete != null) {
+            if (!attributeValue.isEmpty()) {
+                mandatoryAttributeNamesRemaining.remove(attributeName);
+            } else if (mandatoryAttributeNames.contains(attributeName)) {
+                mandatoryAttributeNamesRemaining.add(attributeName);
+            }
+            executeConsumerOnMandatoryAttributesComplete();
+        }
     }
 
     // Case-insensitive
@@ -202,5 +248,15 @@ public class LDAPObject {
     public String toString() {
         return "LDAP Object [ dn: " + dn + " , uuid: " + uuid + ", attributes: " + attributes +
                 ", readOnly attribute names: " + readOnlyAttributeNames + ", ranges: " + rangedAttributes + " ]";
+    }
+
+    private void executeConsumerOnMandatoryAttributesComplete() {
+        if (mandatoryAttributeNamesRemaining.isEmpty()) {
+            final Consumer<LDAPObject> consumer = consumerOnMandatoryAttributesComplete;
+            consumerOnMandatoryAttributesComplete = null;
+            mandatoryAttributeNames = null;
+            mandatoryAttributeNamesRemaining = null;
+            consumer.accept(this);
+        }
     }
 }

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/AbstractLDAPStorageMapper.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/AbstractLDAPStorageMapper.java
@@ -29,6 +29,7 @@ import org.keycloak.storage.user.SynchronizationResult;
 import javax.naming.AuthenticationException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import org.keycloak.models.RoleModel;
 
 /**
@@ -73,6 +74,10 @@ public abstract class AbstractLDAPStorageMapper implements LDAPStorageMapper {
         return false;
     }
 
+    @Override
+    public Set<String> mandatoryAttributeNames() {
+        return null;
+    }
 
     public static boolean parseBooleanParameter(ComponentModel mapperModel, String paramName) {
         String paramm = mapperModel.getConfig().getFirst(paramName);

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/LDAPStorageMapper.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/LDAPStorageMapper.java
@@ -27,6 +27,7 @@ import org.keycloak.storage.user.SynchronizationResult;
 
 import javax.naming.AuthenticationException;
 import java.util.List;
+import java.util.Set;
 import org.keycloak.models.RoleModel;
 import org.keycloak.storage.ldap.LDAPStorageProvider;
 
@@ -85,6 +86,13 @@ public interface LDAPStorageMapper extends Provider {
      */
     void onRegisterUserToLDAP(LDAPObject ldapUser, UserModel localUser, RealmModel realm);
 
+    /**
+     * Method that returns the mandatory attributes that this mapper imposes
+     * on the entry.
+     *
+     * @return The list of mandatory attributes or null
+     */
+    Set<String> mandatoryAttributeNames();
 
     /**
      * Called when invoke proxy on LDAP federation provider

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/LDAPTransaction.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/LDAPTransaction.java
@@ -22,6 +22,7 @@ import java.util.Set;
 
 import org.jboss.logging.Logger;
 import org.keycloak.models.AbstractKeycloakTransaction;
+import org.keycloak.models.ModelException;
 import org.keycloak.storage.ldap.LDAPStorageProvider;
 import org.keycloak.storage.ldap.idm.model.LDAPObject;
 
@@ -47,16 +48,22 @@ public class LDAPTransaction extends AbstractKeycloakTransaction {
     @Override
     protected void commitImpl() {
         if (logger.isTraceEnabled()) {
-            logger.trace("Transaction commit! Updating LDAP attributes for object " + ldapUser.getDn().toString() + ", attributes: " + ldapUser.getAttributes());
+            logger.trace("Transaction commit! Updating LDAP attributes for object " + ldapUser.getDn() + ", attributes: " + ldapUser.getAttributes());
+        }
+        if (ldapUser.isWaitingForExecutionOnMandatoryAttributesComplete()) {
+            throw new ModelException("LDAPObject cannot be commited because some mandatory attributes are not set: "
+                    + ldapUser.getMandatoryAttributeNamesRemaining());
         }
 
-        ldapProvider.getLdapIdentityStore().update(ldapUser);
+        if (!updatedAttributes.isEmpty()) {
+            ldapProvider.getLdapIdentityStore().update(ldapUser);
+        }
     }
 
 
     @Override
     protected void rollbackImpl() {
-        logger.warn("Transaction rollback! Ignoring LDAP updates for object " + ldapUser.getDn().toString());
+        logger.warn("Transaction rollback! Ignoring LDAP updates for object " + ldapUser.getDn());
     }
 
     /**
@@ -65,7 +72,10 @@ public class LDAPTransaction extends AbstractKeycloakTransaction {
      * @param attributeName model attribute name (For example "firstName", "lastName", "street")
      */
     public void addUpdatedAttribute(String attributeName) {
-        updatedAttributes.add(attributeName);
+        if (ldapUser.getDn() != null) {
+            // only add the attribute if the ldapObject is created, it has a DN
+            updatedAttributes.add(attributeName);
+        }
     }
 
     /**

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/TxAwareLDAPUserModelDelegate.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/TxAwareLDAPUserModelDelegate.java
@@ -43,7 +43,7 @@ public abstract class TxAwareLDAPUserModelDelegate extends UserModelDelegate {
         LDAPTransaction transaction = provider.getUserManager().getTransaction(getId());
         if (transaction.getState() == LDAPTransaction.TransactionState.NOT_STARTED) {
             if (logger.isTraceEnabled()) {
-                logger.trace("Starting and enlisting transaction for object " + ldapUser.getDn().toString());
+                logger.trace("Starting and enlisting transaction for object " + ldapUser.getDn());
             }
 
             this.provider.getSession().getTransactionManager().enlistAfterCompletion(transaction);

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/UserAttributeLDAPStorageMapperFactory.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/UserAttributeLDAPStorageMapperFactory.java
@@ -72,13 +72,17 @@ public class UserAttributeLDAPStorageMapperFactory extends AbstractLDAPStorageMa
                     .type(ProviderConfigProperty.BOOLEAN_TYPE).defaultValue("false").add();
         }
         config.property().name(UserAttributeLDAPStorageMapper.IS_MANDATORY_IN_LDAP).label("Is Mandatory In LDAP")
-                .helpText("If true, attribute is mandatory in LDAP. Hence if there is no value in Keycloak DB, the default or empty value will be set to be propagated to LDAP")
+                .helpText("If true, attribute is mandatory in LDAP. When an attribute is mandatory the options attribute default value and force a default value apply to this mapper.")
                 .type(ProviderConfigProperty.BOOLEAN_TYPE)
                 .defaultValue("false").add()
                 .property().name(UserAttributeLDAPStorageMapper.ATTRIBUTE_DEFAULT_VALUE).label("Attribute default value")
                 .helpText("If there is no value in Keycloak DB and attribute is mandatory in LDAP, this value will be propagated to LDAP")
                 .type(ProviderConfigProperty.STRING_TYPE)
                 .defaultValue("").add()
+                .property().name(UserAttributeLDAPStorageMapper.FORCE_DEFAULT_VALUE).label("Force a Default Value")
+                .helpText("If true a empty default value is forced for mandatory attributes even when a default value is not specified. If false the mandatory attribute needs to be manually set during the transaction when the default value option is not configured.")
+                .type(ProviderConfigProperty.BOOLEAN_TYPE)
+                .defaultValue("true").add()
                 .property().name(UserAttributeLDAPStorageMapper.IS_BINARY_ATTRIBUTE).label("Is Binary Attribute")
                 .helpText("Should be true for binary LDAP attributes")
                 .type(ProviderConfigProperty.BOOLEAN_TYPE)

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPProvidersIntegrationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPProvidersIntegrationTest.java
@@ -43,6 +43,7 @@ import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.idm.ComponentRepresentation;
 import org.keycloak.representations.idm.CredentialRepresentation;
+import org.keycloak.representations.idm.ErrorRepresentation;
 import org.keycloak.representations.idm.EventRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
@@ -81,6 +82,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 
 import static org.junit.Assert.assertEquals;
 
@@ -156,6 +159,142 @@ public class LDAPProvidersIntegrationTest extends AbstractLDAPTest {
         });
     }
 
+    @Test
+    public void testSyncRegistrationForceDefault() {
+        // test force default is true by default and works as before
+        UserRepresentation newUser1 = AbstractAuthTest.createUserRepresentation("newuser1", null, null, null, true);
+        String userId;
+        try (Response resp = testRealm().users().create(newUser1)) {
+            userId = ApiUtil.getCreatedId(resp);
+        }
+        newUser1 = testRealm().users().get(userId).toRepresentation();
+        assertFederatedUserLink(newUser1);
+        Assert.assertNotNull(newUser1.getAttributes().get(LDAPConstants.LDAP_ID));
+        MatcherAssert.assertThat(newUser1.firstAttribute(LDAPConstants.LDAP_ENTRY_DN), Matchers.containsString("=newuser1,"));
+
+        String cnValue = testingClient.server().fetch(session -> {
+            LDAPTestContext ctx = LDAPTestContext.init(session);
+            ComponentModel ldapModel = LDAPTestUtils.getLdapProviderModel(ctx.getRealm());
+            ComponentModel cnMapper = LDAPTestUtils.getSubcomponentByName(ctx.getRealm(), ldapModel, "last name");
+            LDAPObject userLdap = ctx.getLdapProvider().loadLDAPUserByUsername(ctx.getRealm(), "newuser1");
+            return userLdap.getAttributeAsString(cnMapper.get(UserAttributeLDAPStorageMapper.LDAP_ATTRIBUTE));
+        }, String.class);
+        Assert.assertEquals("Attribute CN was not set with the forced default value", "", cnValue);
+
+        // remove the created user
+        try (Response resp = testRealm().users().delete(userId)) {
+            Assert.assertEquals(Response.Status.NO_CONTENT.getStatusCode(), resp.getStatus());
+        }
+        Assert.assertTrue(testRealm().users().search("newuser1").isEmpty());
+    }
+
+    @Test
+    public void testSyncRegistrationEmailRDNNoDefault() {
+        testingClient.server().run(session -> {
+            // configure mail as mandatory but not forcing default
+            LDAPTestContext ctx = LDAPTestContext.init(session);
+            ComponentModel ldapModel = LDAPTestUtils.getLdapProviderModel(ctx.getRealm());
+            ComponentModel emailMapper = LDAPTestUtils.getSubcomponentByName(ctx.getRealm(), ldapModel, "email");
+            emailMapper.getConfig().putSingle(UserAttributeLDAPStorageMapper.IS_MANDATORY_IN_LDAP, "true");
+            emailMapper.getConfig().putSingle(UserAttributeLDAPStorageMapper.FORCE_DEFAULT_VALUE, "false");
+            ctx.getRealm().updateComponent(emailMapper);
+        });
+        try {
+            // test the user cannot be created without email
+            UserRepresentation newUser1 = AbstractAuthTest.createUserRepresentation("newuser1", null, "newuser1", "newuser1", true);
+            try (Response resp = testRealm().users().create(newUser1)) {
+                Assert.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), resp.getStatus());
+                ErrorRepresentation error = resp.readEntity(ErrorRepresentation.class);
+                Assert.assertEquals("Could not create user", error.getErrorMessage());
+            }
+            Assert.assertTrue(testRealm().users().search("newuser1").isEmpty());
+
+            // test the user is correctly created with email
+            newUser1 = AbstractAuthTest.createUserRepresentation("newuser1", "newuser1@keycloak.org", "newuser1", "newuser1", true);
+            String userId;
+            try (Response resp = testRealm().users().create(newUser1)) {
+                userId = ApiUtil.getCreatedId(resp);
+            }
+            newUser1 = testRealm().users().get(userId).toRepresentation();
+            assertFederatedUserLink(newUser1);
+            Assert.assertNotNull(newUser1.getAttributes().get(LDAPConstants.LDAP_ID));
+            MatcherAssert.assertThat(newUser1.firstAttribute(LDAPConstants.LDAP_ENTRY_DN), Matchers.containsString("=newuser1,"));
+            Assert.assertEquals("newuser1@keycloak.org", newUser1.getEmail());
+            String emailValueInLdap = testingClient.server().fetch(session -> {
+                LDAPTestContext ctx = LDAPTestContext.init(session);
+                ComponentModel ldapModel = LDAPTestUtils.getLdapProviderModel(ctx.getRealm());
+                ComponentModel emailMapper = LDAPTestUtils.getSubcomponentByName(ctx.getRealm(), ldapModel, "email");
+                LDAPObject userLdap = ctx.getLdapProvider().loadLDAPUserByUsername(ctx.getRealm(), "newuser1");
+                return userLdap.getAttributeAsString(emailMapper.get(UserAttributeLDAPStorageMapper.LDAP_ATTRIBUTE));
+            }, String.class);
+            Assert.assertEquals("newuser1@keycloak.org", emailValueInLdap);
+
+            // remove the created user
+            try (Response resp = testRealm().users().delete(userId)) {
+                Assert.assertEquals(Response.Status.NO_CONTENT.getStatusCode(), resp.getStatus());
+            }
+            Assert.assertTrue(testRealm().users().search("newuser1").isEmpty());
+        } finally {
+            testingClient.server().run(session -> {
+                // revert
+                LDAPTestContext ctx = LDAPTestContext.init(session);
+                ComponentModel ldapModel = LDAPTestUtils.getLdapProviderModel(ctx.getRealm());
+                ComponentModel emailMapper = LDAPTestUtils.getSubcomponentByName(ctx.getRealm(), ldapModel, "email");
+                emailMapper.getConfig().putSingle(UserAttributeLDAPStorageMapper.IS_MANDATORY_IN_LDAP, "false");
+                emailMapper.getConfig().remove(UserAttributeLDAPStorageMapper.FORCE_DEFAULT_VALUE);
+                ctx.getRealm().updateComponent(emailMapper);
+            });
+        }
+    }
+
+    @Test
+    public void testSyncRegistrationEmailRDNDefaultValue() {
+        testingClient.server().run(session -> {
+            // configure mail as mandatory but with a default value
+            LDAPTestContext ctx = LDAPTestContext.init(session);
+            ComponentModel ldapModel = LDAPTestUtils.getLdapProviderModel(ctx.getRealm());
+            ComponentModel emailMapper = LDAPTestUtils.getSubcomponentByName(ctx.getRealm(), ldapModel, "email");
+            emailMapper.getConfig().putSingle(UserAttributeLDAPStorageMapper.IS_MANDATORY_IN_LDAP, "true");
+            emailMapper.getConfig().putSingle(UserAttributeLDAPStorageMapper.ATTRIBUTE_DEFAULT_VALUE, "empty@keycloak.org");
+            ctx.getRealm().updateComponent(emailMapper);
+        });
+        try {
+            // the user should be created with the default value
+            UserRepresentation newUser1 = AbstractAuthTest.createUserRepresentation("newuser1", null, "newuser1", "newuser1", true);
+            String userId;
+            try (Response resp = testRealm().users().create(newUser1)) {
+                userId = ApiUtil.getCreatedId(resp);
+            }
+            newUser1 = testRealm().users().get(userId).toRepresentation();
+            assertFederatedUserLink(newUser1);
+            Assert.assertNotNull(newUser1.getAttributes().get(LDAPConstants.LDAP_ID));
+            MatcherAssert.assertThat(newUser1.firstAttribute(LDAPConstants.LDAP_ENTRY_DN), Matchers.containsString("=newuser1,"));
+            String emailValueInLdap = testingClient.server().fetch(session -> {
+                LDAPTestContext ctx = LDAPTestContext.init(session);
+                ComponentModel ldapModel = LDAPTestUtils.getLdapProviderModel(ctx.getRealm());
+                ComponentModel emailMapper = LDAPTestUtils.getSubcomponentByName(ctx.getRealm(), ldapModel, "email");
+                LDAPObject userLdap = ctx.getLdapProvider().loadLDAPUserByUsername(ctx.getRealm(), "newuser1");
+                return userLdap.getAttributeAsString(emailMapper.get(UserAttributeLDAPStorageMapper.LDAP_ATTRIBUTE));
+            }, String.class);
+            Assert.assertEquals("empty@keycloak.org", emailValueInLdap);
+
+            // remove the created user
+            try (Response resp = testRealm().users().delete(userId)) {
+                Assert.assertEquals(Response.Status.NO_CONTENT.getStatusCode(), resp.getStatus());
+            }
+            Assert.assertTrue(testRealm().users().search("newuser1").isEmpty());
+        } finally {
+            testingClient.server().run(session -> {
+                // revert
+                LDAPTestContext ctx = LDAPTestContext.init(session);
+                ComponentModel ldapModel = LDAPTestUtils.getLdapProviderModel(ctx.getRealm());
+                ComponentModel emailMapper = LDAPTestUtils.getSubcomponentByName(ctx.getRealm(), ldapModel, "email");
+                emailMapper.getConfig().putSingle(UserAttributeLDAPStorageMapper.IS_MANDATORY_IN_LDAP, "false");
+                emailMapper.getConfig().remove(UserAttributeLDAPStorageMapper.ATTRIBUTE_DEFAULT_VALUE);
+                ctx.getRealm().updateComponent(emailMapper);
+            });
+        }
+    }
 
     @Test
     public void testRemoveImportedUsers() {


### PR DESCRIPTION
Closes #14286.

The creation of the LDAP object is delayed to have all the mandatory attributes set in the LDAP object. Main points:

* Interface `LDAPStorageMapper` defines a new method `mandatoryAttributeNames` that returns the mandatory attributes that the mapper imposes over the user ldap object. By default is defined as null (none) in the `AbstractLDAPStorageMapper`.
* Method `addUserToLDAP` receives a new parameter with a consumer to be executed when the mandatory attributes are set and the entry created in ldap. The consumer sets the LDAP_ID and LDAP_ENTRY_DN in the keycloak DB. The LDAPObject returned now can be created or not (and it will be created in the future).
* The transaction can fail because the LDAPObject was not fully set and mandatory attributes are missing.
* `UserAttributeLDAPStorageMapper` is modified to have a new option `attribute.force.default` (default true). This option defines if the mandatory attribute forces a default value or not (even when no default value is defined). Default value true maintains backward compatibility. The default value is also used in `setLDAPAttribute` (I don't know why but previously the option was not used before).
* A few tests added.

@mposolda Please review this when you have some time.
