### PR TITLE
Fix syntax error in services.js (old admin-console) introduced by GHSA-w9mf-83w3-fv49

### DIFF
--- a/themes/src/main/resources/theme/base/admin/resources/js/services.js
+++ b/themes/src/main/resources/theme/base/admin/resources/js/services.js
@@ -958,12 +958,14 @@ function clientSelectControl($scope, realm, Client) {
         allowClear: true,
         query: function (query) {
             Client.query({realm: realm, search: true, clientId: query.term.trim(), max: 20}, function(response) {
-                query.callback({ results: response.map(function (client) {
-                    return { id: client.id, text: client.clientId }
+                query.callback({ results: response.map(
+                    function (client) {
+                        return { id: client.id, text: client.clientId }
+                    })
                 });
             });
         }
-    };
+    }
 }
 
 function roleControl($scope, $route, realm, role, roles, Client,


### PR DESCRIPTION
@abstractj somehow merging https://github.com/keycloak/keycloak/commit/84576ffc0e550ea3683098086a6bc79611741e7b messed up the closing curly braces / parenthesis and semicolons.

Signed-off-by: Thomas Darimont <thomas.darimont@googlemail.com>

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
