### PR TITLE
Address deprecation warning by replacing succes/error with then/catch

### DIFF
--- a/themes/src/main/resources/theme/keycloak.v2/account/src/app/keycloak-service/keycloak.service.ts
+++ b/themes/src/main/resources/theme/keycloak.v2/account/src/app/keycloak-service/keycloak.service.ts
@@ -64,10 +64,10 @@ export class KeycloakService {
             if (this.keycloakAuth.token) {
                 this.keycloakAuth
                     .updateToken(5)
-                    .success(() => {
+                    .then(() => {
                         resolve(this.keycloakAuth.token as string);
                     })
-                    .error(() => {
+                    .catch(() => {
                         reject('Failed to refresh token');
                     });
             } else {


### PR DESCRIPTION
.success and .error are been deprecated in favor of .then and .catch for dealing with Promises in javascript/typescript

This pull request removes the following warning from the web console:

```
Usage of legacy style promise methods such as `.error()` and `.success()` has been deprecated and support will be removed in future versions. Use standard style promise methods such as `.then() and `.catch()` instead.
```