### PR TITLE
Update Github Actionbot to latest version

### DIFF
--- a/.github/workflows/github-action-bot.yml
+++ b/.github/workflows/github-action-bot.yml
@@ -20,6 +20,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # to avoid a tag being changed afterwards, use the commit hash of the action
-      - uses: keycloak/keycloak-gh-actionbot@c76e6c1ce249dac0278652c2f94f743fe5bb9bcd # v0.1.0
+      - uses: keycloak/keycloak-gh-actionbot@1f2a036608f4e498bb726f1acc8bd884fd36bb0e # v0.2.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
See the v0.2.0 [release](https://github.com/keycloak/keycloak-gh-actionbot/releases/tag/v0.2.0).