### PR TITLE
CryptoIntegration initialization using the same classloader

### DIFF
--- a/common/src/main/java/org/keycloak/common/util/CertificateUtils.java
+++ b/common/src/main/java/org/keycloak/common/util/CertificateUtils.java
@@ -31,7 +31,7 @@ import org.keycloak.common.crypto.CryptoIntegration;
 public class CertificateUtils {
 
     static {
-        CryptoIntegration.init(ClassLoader.getSystemClassLoader());
+        CryptoIntegration.init(CertificateUtils.class.getClassLoader());
     }
 
 

--- a/common/src/main/java/org/keycloak/common/util/PemUtils.java
+++ b/common/src/main/java/org/keycloak/common/util/PemUtils.java
@@ -38,7 +38,7 @@ public class PemUtils {
     public static final String END_CERT = "-----END CERTIFICATE-----";
 
     static {
-        CryptoIntegration.init(ClassLoader.getSystemClassLoader());
+        CryptoIntegration.init(PemUtils.class.getClassLoader());
     }
 
     /**


### PR DESCRIPTION
Initialize CryptoIntegration using the same classloader that was used to load CertificateUtils and PemUtils classes

Closes #13803

