### PR TITLE
Avoid including user managed entities into the default PU

### DIFF
--- a/quarkus/tests/integration/pom.xml
+++ b/quarkus/tests/integration/pom.xml
@@ -35,6 +35,7 @@
     <properties>
         <kc.quarkus.tests.dist>raw</kc.quarkus.tests.dist>
         <approvaltests.version>14.0.0</approvaltests.version>
+        <build-helper-maven-plugin.version>3.3.0</build-helper-maven-plugin.version>
     </properties>
 
     <dependencies>
@@ -56,6 +57,10 @@
                     <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>
@@ -103,6 +108,39 @@
                         <kc.quarkus.tests.dist>${kc.quarkus.tests.dist}</kc.quarkus.tests.dist>
                     </systemPropertyVariables>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>${build-helper-maven-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>add-test-provider-sources</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>add-test-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>src/test-providers/java</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>add-test-provider-resources</id>
+                        <phase>generate-test-resources</phase>
+                        <goals>
+                            <goal>add-test-resource</goal>
+                        </goals>
+                        <configuration>
+                            <resources>
+                                <resource>
+                                    <directory>src/test-providers/resources</directory>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/quarkus/tests/integration/src/main/java/org/keycloak/it/TestProvider.java
+++ b/quarkus/tests/integration/src/main/java/org/keycloak/it/TestProvider.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.it;
+
+import java.util.Map;
+
+/**
+ * A base interface for defining a provider so that its corresponding JAR file can be installed before executing tests.
+ */
+public interface TestProvider {
+
+    /**
+     * The provider name.
+     *
+     * @return the name
+     */
+    default String getName() {
+        return "provider";
+    }
+
+    /**
+     * The classes that should be added to the provider JAR file.
+     *
+     * @return the classes
+     */
+    Class[] getClasses();
+
+    /**
+     * A {@link Map} where the key is the name of a file at the package where this provider is located and the value is the
+     * name of the manifest resource that should be created in the provider JAR file.
+     * @return
+     */
+    Map<String, String> getManifestResources();
+}

--- a/quarkus/tests/integration/src/main/java/org/keycloak/it/junit5/extension/CLIResult.java
+++ b/quarkus/tests/integration/src/main/java/org/keycloak/it/junit5/extension/CLIResult.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.it.junit5.extension;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -24,6 +25,7 @@ import static org.testcontainers.shaded.org.hamcrest.MatcherAssert.assertThat;
 import static org.testcontainers.shaded.org.hamcrest.Matchers.*;
 
 import java.util.List;
+import java.util.regex.Pattern;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -150,4 +152,8 @@ public interface CLIResult extends LaunchResult {
         }
     }
 
+    default void assertStringCount(String msg, int count) {
+        Pattern pattern = Pattern.compile(msg);
+        assertEquals(count, pattern.matcher(getOutput()).results().count());
+    }
 }

--- a/quarkus/tests/integration/src/main/java/org/keycloak/it/junit5/extension/CLITestExtension.java
+++ b/quarkus/tests/integration/src/main/java/org/keycloak/it/junit5/extension/CLITestExtension.java
@@ -94,6 +94,8 @@ public class CLITestExtension extends QuarkusMainTestExtension {
                 dist = createDistribution(distConfig);
             }
 
+            copyTestProvider(context.getRequiredTestClass().getAnnotation(TestProvider.class));
+            copyTestProvider(context.getRequiredTestMethod().getAnnotation(TestProvider.class));
             onBeforeStartDistribution(context.getRequiredTestClass().getAnnotation(BeforeStartDistribution.class));
             onBeforeStartDistribution(context.getRequiredTestMethod().getAnnotation(BeforeStartDistribution.class));
 
@@ -103,6 +105,20 @@ public class CLITestExtension extends QuarkusMainTestExtension {
         } else {
             configureProfile(context);
             super.beforeEach(context);
+        }
+    }
+
+    private void copyTestProvider(TestProvider provider) {
+        if (provider == null) {
+            return;
+        }
+
+        if (dist instanceof RawKeycloakDistribution) {
+            try {
+                ((RawKeycloakDistribution) dist).copyProvider(provider.value().getDeclaredConstructor().newInstance());
+            } catch (Exception cause) {
+                throw new RuntimeException("Failed to instantiate test provider: " + provider.getClass(), cause);
+            }
         }
     }
 

--- a/quarkus/tests/integration/src/main/java/org/keycloak/it/junit5/extension/TestProvider.java
+++ b/quarkus/tests/integration/src/main/java/org/keycloak/it/junit5/extension/TestProvider.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.it.junit5.extension;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * {@link TestProvider} is used to install a custom provider into the distribution.
+ */
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TestProvider {
+
+    /**
+     * The {@link TestProvider} to install into the distribution.
+     *
+     * @return
+     */
+    Class<? extends org.keycloak.it.TestProvider> value();
+
+}

--- a/quarkus/tests/integration/src/main/java/org/keycloak/it/utils/KeycloakDistribution.java
+++ b/quarkus/tests/integration/src/main/java/org/keycloak/it/utils/KeycloakDistribution.java
@@ -58,4 +58,8 @@ public interface KeycloakDistribution {
     default void setEnvVar(String kc_db_username, String bad) {
         throw new RuntimeException("Not implemented");
     }
+
+    default void copyOrReplaceFile(Path file, Path targetFile) {
+        throw new RuntimeException("Not implemented");
+    }
 }

--- a/quarkus/tests/integration/src/main/java/org/keycloak/it/utils/RawKeycloakDistribution.java
+++ b/quarkus/tests/integration/src/main/java/org/keycloak/it/utils/RawKeycloakDistribution.java
@@ -53,7 +53,12 @@ import javax.net.ssl.X509TrustManager;
 import io.quarkus.deployment.util.FileUtil;
 import io.quarkus.fs.util.ZipUtils;
 
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.keycloak.common.Version;
+import org.keycloak.it.TestProvider;
 import org.keycloak.it.junit5.extension.CLIResult;
 import org.keycloak.quarkus.runtime.cli.command.Build;
 import org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper;
@@ -467,6 +472,23 @@ public final class RawKeycloakDistribution implements KeycloakDistribution {
         }
     }
 
+    @Override
+    public void copyOrReplaceFile(Path file, Path targetFile) {
+        if (!file.toFile().exists()) {
+            return;
+        }
+
+        File targetDir = distPath.resolve(targetFile).toFile();
+
+        targetDir.mkdirs();
+
+        try {
+            Files.copy(file, targetDir.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        } catch (IOException cause) {
+            throw new RuntimeException("Failed to copy file", cause);
+        }
+    }
+
     public void copyProvider(String groupId, String artifactId) {
         try {
             Files.copy(Maven.resolveArtifact(groupId, artifactId), getDistPath().resolve("providers").resolve(artifactId + ".jar"));
@@ -505,5 +527,25 @@ public final class RawKeycloakDistribution implements KeycloakDistribution {
 
     public Path getDistPath() {
         return distPath;
+    }
+
+    public void copyProvider(TestProvider provider) {
+        Path providerPackagePath = Paths.get(provider.getClass().getResource(".").getPath());
+        JavaArchive providerJar = ShrinkWrap.create(JavaArchive.class, provider.getName() + ".jar")
+                .addClasses(provider.getClasses())
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+        Map<String, String> manifestResources = provider.getManifestResources();
+
+        for (Map.Entry<String, String> resource : manifestResources.entrySet()) {
+            try {
+                providerJar.addAsManifestResource(providerPackagePath.resolve(resource.getKey()).toFile(), resource.getValue());
+            } catch (Exception cause) {
+                throw new RuntimeException("Failed to add manifest resource: " + resource.getKey(), cause);
+            }
+        }
+
+        copyOrReplaceFile(providerPackagePath.resolve("quarkus.properties"), Path.of("conf", "quarkus.properties"));
+
+        providerJar.as(ZipExporter.class).exportTo(getDistPath().resolve("providers").resolve(providerJar.getName()).toFile());
     }
 }

--- a/quarkus/tests/integration/src/test-providers/java/com/acme/provider/user/CustomUserProvider.java
+++ b/quarkus/tests/integration/src/test-providers/java/com/acme/provider/user/CustomUserProvider.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.acme.provider.user;
+
+import java.util.Collections;
+import java.util.Map;
+import org.keycloak.it.TestProvider;
+
+public class CustomUserProvider implements TestProvider {
+
+    @Override
+    public Class[] getClasses() {
+        return new Class[] { Realm.class };
+    }
+
+    @Override
+    public Map<String, String> getManifestResources() {
+        return Collections.singletonMap("persistence.xml", "persistence.xml");
+    }
+}

--- a/quarkus/tests/integration/src/test-providers/java/com/acme/provider/user/Realm.java
+++ b/quarkus/tests/integration/src/test-providers/java/com/acme/provider/user/Realm.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.acme.provider.user;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+@Entity
+public class Realm {
+    @Id
+    private String id;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+}

--- a/quarkus/tests/integration/src/test-providers/resources/com/acme/provider/user/persistence.xml
+++ b/quarkus/tests/integration/src/test-providers/resources/com/acme/provider/user/persistence.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2022 Red Hat, Inc. and/or its affiliates
+  ~ and other contributors as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<persistence version="2.0"
+             xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="
+        http://java.sun.com/xml/ns/persistence
+        http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd">
+    <persistence-unit name="user-store" transaction-type="JTA">
+        <class>com.acme.provider.user.Realm</class>
+        <properties>
+            <property name="hibernate.dialect" value="io.quarkus.hibernate.orm.runtime.dialect.QuarkusH2Dialect" />
+            <!-- Sets the name of the datasource to be the same as the datasource name in quarkus.properties-->
+            <property name="hibernate.connection.datasource" value="user-store" />
+            <property name="javax.persistence.transactionType" value="JTA" />
+            <property name="hibernate.hbm2ddl.auto" value="update" />
+            <property name="hibernate.show_sql" value="false" />
+        </properties>
+    </persistence-unit>
+</persistence>

--- a/quarkus/tests/integration/src/test-providers/resources/com/acme/provider/user/quarkus.properties
+++ b/quarkus/tests/integration/src/test-providers/resources/com/acme/provider/user/quarkus.properties
@@ -1,0 +1,20 @@
+#
+# Copyright 2022 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+quarkus.datasource.user-store.db-kind=h2
+quarkus.datasource.user-store.username=sa
+quarkus.datasource.user-store.jdbc.url=jdbc:h2:mem:user-store;DB_CLOSE_DELAY=-1

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/CustomJpaUserProviderDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/CustomJpaUserProviderDistTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.it.cli.dist;
+
+import org.junit.jupiter.api.Test;
+import org.keycloak.it.junit5.extension.CLIResult;
+import org.keycloak.it.junit5.extension.DistributionTest;
+import org.keycloak.it.junit5.extension.RawDistOnly;
+import org.keycloak.it.junit5.extension.TestProvider;
+import com.acme.provider.user.CustomUserProvider;
+
+import io.quarkus.test.junit.main.Launch;
+import io.quarkus.test.junit.main.LaunchResult;
+
+@DistributionTest(reInstall = DistributionTest.ReInstall.BEFORE_TEST)
+@RawDistOnly(reason = "Containers are immutable")
+public class CustomJpaUserProviderDistTest {
+
+    @Test
+    @TestProvider(CustomUserProvider.class)
+    @Launch({ "start-dev", "--log-level=org.hibernate.jpa.internal.util.LogHelper:debug" })
+    void testUserManagedEntityNotAddedToDefaultPU(LaunchResult result) {
+        CLIResult cliResult = (CLIResult) result;
+        cliResult.assertStringCount("name: user-store", 1);
+        cliResult.assertStringCount("com.acme.provider.user.Realm", 1);
+        cliResult.assertStartedDevMode();
+    }
+}


### PR DESCRIPTION
Closes #12442

In addition to fixing the referenced issue:

* Initial code to make it easier to write tests using custom providers. I did not want to include a separate module for providers' code but keep it simple for now and have them within the tests module.
* The assertions are still based on log messages which work but we should be looking at a better way.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
