### PR TITLE
Add proper variable declaration for AuthZ JS

### DIFF
--- a/adapters/oidc/js/src/keycloak-authz.js
+++ b/adapters/oidc/js/src/keycloak-authz.js
@@ -180,7 +180,7 @@ var KeycloakAuthorization = function (keycloak, options) {
 
                 if (resource.scopes && resource.scopes.length > 0) {
                     permission += "#";
-                    for (j = 0; j < resource.scopes.length; j++) {
+                    for (var j = 0; j < resource.scopes.length; j++) {
                         var scope = resource.scopes[j];
                         if (permission.indexOf('#') != permission.length - 1) {
                             permission += ",";


### PR DESCRIPTION
Adds a missing variable deceleration for the AuthZ JS adapter. This worked before, but since [Strict Mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode) was enabled due to addition of a build step this now throws at runtime.

Closes #14445.