### PR TITLE
Fix running clusteraware scheduled tasks in Wildfly after legacy migration

### DIFF
--- a/model/legacy-private/src/main/java/org/keycloak/services/scheduled/ClusterAwareScheduledTaskRunner.java
+++ b/model/legacy-private/src/main/java/org/keycloak/services/scheduled/ClusterAwareScheduledTaskRunner.java
@@ -49,11 +49,13 @@ public class ClusterAwareScheduledTaskRunner extends ScheduledTaskRunner {
         ClusterProvider clusterProvider = session.getProvider(ClusterProvider.class);
         String taskKey = task.getClass().getSimpleName();
 
+        // copying over the value as parent class is in another module that wouldn't allow access from the lambda in Wildfly
+        ScheduledTask localTask = this.task;
         ExecutionResult<Void> result = clusterProvider.executeIfNotExecuted(taskKey, intervalSecs, new Callable<Void>() {
 
             @Override
             public Void call() throws Exception {
-                task.run(session);
+                localTask.run(session);
                 return null;
             }
 


### PR DESCRIPTION
This is a backport of #13831

Closes #13396

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
