### PR TITLE
Update OpenShift REST client to fix a critical vulnerability on the transitive dependency com.squareup.okhttp3:okhttp

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
         <google.guava.version>30.1-jre</google.guava.version>
 
         <!-- Openshift -->
-        <version.com.openshift.openshift-restclient-java>8.0.0.Final</version.com.openshift.openshift-restclient-java>
+        <version.com.openshift.openshift-restclient-java>9.0.5.Final</version.com.openshift.openshift-restclient-java>
 
         <!-- Others -->
         <commons-lang.version>2.6</commons-lang.version>


### PR DESCRIPTION
transitive dependency com.squareup.okhttp3:okhttp

Resolves #14641

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
