### PR TITLE
Fix #11963 Wrong order of stylesheets in Account-Theme (keycloak.v2) 

### DIFF
--- a/themes/src/main/resources/theme/keycloak.v2/account/index.ftl
+++ b/themes/src/main/resources/theme/keycloak.v2/account/index.ftl
@@ -108,18 +108,17 @@
         <script>
             var content = <#include "resources/content.json"/>
         </script>
+        
+        <link rel="stylesheet" type="text/css" href="${resourceCommonUrl}/web_modules/@patternfly/react-core/dist/styles/base.css"/>
+        <link rel="stylesheet" type="text/css" href="${resourceCommonUrl}/web_modules/@patternfly/react-core/dist/styles/app.css"/>
+        <link rel="stylesheet" type="text/css" href="${resourceCommonUrl}/web_modules/@patternfly/patternfly/patternfly-addons.css"/>
+        <link href="${resourceUrl}/public/layout.css" rel="stylesheet"/>
 
         <#if properties.styles?has_content>
             <#list properties.styles?split(' ') as style>
             <link href="${resourceUrl}/${style}" rel="stylesheet"/>
             </#list>
         </#if>
-
-        
-        <link rel="stylesheet" type="text/css" href="${resourceCommonUrl}/web_modules/@patternfly/react-core/dist/styles/base.css"/>
-        <link rel="stylesheet" type="text/css" href="${resourceCommonUrl}/web_modules/@patternfly/react-core/dist/styles/app.css"/>
-        <link rel="stylesheet" type="text/css" href="${resourceCommonUrl}/web_modules/@patternfly/patternfly/patternfly-addons.css"/>
-        <link href="${resourceUrl}/public/layout.css" rel="stylesheet"/>
     </head>
 
     <body>


### PR DESCRIPTION
This PR changes the order of how styles are imported in the account theme index.ftl. Adding the custom styles last allows for an easier way to overwrite the default theme styles without the need to add !important or more detailed CSS selectors. 

Fixes #11963