### PR TITLE
improvement to `operator` readme, links to documentation

### DIFF
--- a/operator/README.md
+++ b/operator/README.md
@@ -3,12 +3,7 @@
 The module holds the codebase to build the Keycloak Operator on top of [Quarkus](https://quarkus.io/).
 Using the [Quarkus Operator SDK](https://github.com/quarkiverse/quarkus-operator-sdk).
 
-Also see [documentation](https://www.keycloak.org/guides#operator):
-- [Keycloak Operator Installation](https://www.keycloak.org/operator/installation)
-- [Basic Keycloak Deployment](https://www.keycloak.org/operator/basic-deployment)
-- [Keycloak Realm Import](https://www.keycloak.org/operator/realm-import)
-- [Advanced configuration](https://www.keycloak.org/operator/advanced-configuration)
-- [Using custom Keycloak images](https://www.keycloak.org/operator/customizing-keycloak)
+Also see [Operator guides](https://www.keycloak.org/guides#operator)
 
 ## Activating the Module
 

--- a/operator/README.md
+++ b/operator/README.md
@@ -3,6 +3,13 @@
 The module holds the codebase to build the Keycloak Operator on top of [Quarkus](https://quarkus.io/).
 Using the [Quarkus Operator SDK](https://github.com/quarkiverse/quarkus-operator-sdk).
 
+Also see [documentation](https://www.keycloak.org/guides#operator):
+- [Keycloak Operator Installation](https://www.keycloak.org/operator/installation)
+- [Basic Keycloak Deployment](https://www.keycloak.org/operator/basic-deployment)
+- [Keycloak Realm Import](https://www.keycloak.org/operator/realm-import)
+- [Advanced configuration](https://www.keycloak.org/operator/advanced-configuration)
+- [Using custom Keycloak images](https://www.keycloak.org/operator/customizing-keycloak)
+
 ## Activating the Module
 
 When build from the project root directory, this module is only enabled if the installed JDK is 11 or newer. 


### PR DESCRIPTION
Some links to the documentation in the readme.

> Also see [documentation](https://www.keycloak.org/guides#operator):
>    [Keycloak Operator Installation](https://www.keycloak.org/operator/installation)
>    [Basic Keycloak Deployment](https://www.keycloak.org/operator/basic-deployment)
>    [Keycloak Realm Import](https://www.keycloak.org/operator/realm-import)
>    [Advanced configuration](https://www.keycloak.org/operator/advanced-configuration)
>    [Using custom Keycloak images](https://www.keycloak.org/operator/customizing-keycloak)


https://github.com/keycloak/keycloak/tree/main/operator is the same operator as documented here https://www.keycloak.org/guides#operator , right?