### PR TITLE
Use Chrome as the default JavaScript browser

### DIFF
--- a/testsuite/integration-arquillian/tests/pom.xml
+++ b/testsuite/integration-arquillian/tests/pom.xml
@@ -215,7 +215,7 @@
         <github.secretToken/>
         <ieDriverArch>Win32</ieDriverArch>
         <ieDriverVersion/>
-        <js.browser>phantomjs</js.browser>
+        <js.browser>chrome</js.browser>
         <js.chromeArguments>--headless</js.chromeArguments>
         <htmlUnitBrowserVersion>chrome</htmlUnitBrowserVersion>
         <firefox_binary/> <!-- the path is set automatically based on the OS -->


### PR DESCRIPTION
Sets Chrome as the default browser instead of PhantomJS (which is not a real browser and has been [deprecated since 2018](https://github.com/ariya/phantomjs/issues/15344)).