### PR TITLE
Improve readability and manageability of deployment configuration for operator

### DIFF
--- a/common/src/main/java/org/keycloak/common/util/CollectionUtil.java
+++ b/common/src/main/java/org/keycloak/common/util/CollectionUtil.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.common.util;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -74,5 +75,17 @@ public class CollectionUtil {
 
     public static boolean isNotEmpty(Collection<?> collection) {
         return !isEmpty(collection);
+    }
+
+    /**
+     * Check if any element is present in the collection
+     *
+     * @param collection collection
+     * @param elements   elements that will be searched in the collection
+     * @return true if any of these elements is present in the collection, false otherwise
+     */
+    public static <T> boolean elementsArePresent(Collection<T> collection, T... elements) {
+        if (isEmpty(collection)) return false;
+        return Arrays.stream(elements).anyMatch(collection::contains);
     }
 }

--- a/operator/src/main/java/org/keycloak/operator/controllers/config/DeploymentConfig.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/config/DeploymentConfig.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.operator.controllers.config;
+
+import io.fabric8.kubernetes.api.model.apps.StatefulSet;
+import org.keycloak.operator.controllers.KeycloakDeployment;
+import org.keycloak.operator.crds.v2alpha1.deployment.KeycloakStatusBuilder;
+
+/**
+ * An interface to represent a configuration of the particular deployment
+ *
+ * @author <a href="mailto:mabartos@redhat.com">Martin Bartos</a>
+ */
+public interface DeploymentConfig {
+
+    /**
+     * Update status of the Keycloak Deployment
+     * Mainly used for the validation of the deployment
+     *
+     * @param keycloakDeployment Keycloak deployment
+     * @param status             Status of the deployment
+     */
+    void validateConfiguration(KeycloakDeployment keycloakDeployment, KeycloakStatusBuilder status);
+
+    /**
+     * Configure the particular deployment
+     *
+     * @param keycloakDeployment Keycloak deployment
+     * @param deployment         Real deployment model for K8s
+     */
+    void configure(KeycloakDeployment keycloakDeployment, StatefulSet deployment);
+}

--- a/operator/src/main/java/org/keycloak/operator/controllers/config/HostnameConfig.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/config/HostnameConfig.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.operator.controllers.config;
+
+import io.fabric8.kubernetes.api.model.EnvVarBuilder;
+import io.fabric8.kubernetes.api.model.apps.StatefulSet;
+import org.keycloak.operator.controllers.KeycloakDeployment;
+import org.keycloak.operator.crds.v2alpha1.deployment.KeycloakStatusBuilder;
+
+import java.util.List;
+
+/**
+ * Deployment configuration for Hostname properties
+ */
+public class HostnameConfig implements DeploymentConfig {
+
+    @Override
+    public void validateConfiguration(KeycloakDeployment keycloakDeployment, KeycloakStatusBuilder status) {
+    }
+
+    @Override
+    public void configure(KeycloakDeployment keycloakDeployment, StatefulSet deployment) {
+        var kcContainer = deployment.getSpec().getTemplate().getSpec().getContainers().get(0);
+        var keycloakCR = keycloakDeployment.getKeycloakCR();
+        var hostname = keycloakCR.getSpec().getHostname();
+        var envVars = kcContainer.getEnv();
+
+        if (keycloakCR.getSpec().isHostnameDisabled()) {
+            var disableStrictHostname = List.of(
+                    new EnvVarBuilder()
+                            .withName("KC_HOSTNAME_STRICT")
+                            .withValue("false")
+                            .build(),
+                    new EnvVarBuilder()
+                            .withName("KC_HOSTNAME_STRICT_BACKCHANNEL")
+                            .withValue("false")
+                            .build());
+
+            envVars.addAll(disableStrictHostname);
+        } else {
+            var enabledStrictHostname = List.of(
+                    new EnvVarBuilder()
+                            .withName("KC_HOSTNAME")
+                            .withValue(hostname)
+                            .build());
+
+            envVars.addAll(enabledStrictHostname);
+        }
+    }
+}

--- a/operator/src/main/java/org/keycloak/operator/controllers/config/TlsConfig.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/config/TlsConfig.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.operator.controllers.config;
+
+import io.fabric8.kubernetes.api.model.EnvVarBuilder;
+import io.fabric8.kubernetes.api.model.ExecActionBuilder;
+import io.fabric8.kubernetes.api.model.VolumeBuilder;
+import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
+import io.fabric8.kubernetes.api.model.apps.StatefulSet;
+import org.keycloak.operator.Constants;
+import org.keycloak.operator.controllers.KeycloakDeployment;
+import org.keycloak.operator.crds.v2alpha1.deployment.KeycloakStatusBuilder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Deployment configuration for TLS properties
+ */
+public class TlsConfig implements DeploymentConfig {
+
+    @Override
+    public void validateConfiguration(KeycloakDeployment keycloakDeployment, KeycloakStatusBuilder status) {
+
+    }
+
+    @Override
+    public void configure(KeycloakDeployment keycloakDeployment, StatefulSet deployment) {
+        var kcContainer = deployment.getSpec().getTemplate().getSpec().getContainers().get(0);
+        var keycloakCR = keycloakDeployment.getKeycloakCR();
+        var tlsSecret = keycloakCR.getSpec().getTlsSecret();
+        var envVars = kcContainer.getEnv();
+
+        if (keycloakCR.getSpec().isHttp()) {
+            var disableTls = List.of(
+                    new EnvVarBuilder()
+                            .withName("KC_HTTP_ENABLED")
+                            .withValue("true")
+                            .build(),
+                    new EnvVarBuilder()
+                            .withName("KC_HOSTNAME_STRICT_HTTPS")
+                            .withValue("false")
+                            .build(),
+                    new EnvVarBuilder()
+                            .withName("KC_PROXY")
+                            .withValue("edge")
+                            .build());
+
+            envVars.addAll(disableTls);
+        } else {
+            var enabledTls = List.of(
+                    new EnvVarBuilder()
+                            .withName("KC_HTTPS_CERTIFICATE_FILE")
+                            .withValue(Constants.CERTIFICATES_FOLDER + "/tls.crt")
+                            .build(),
+                    new EnvVarBuilder()
+                            .withName("KC_HTTPS_CERTIFICATE_KEY_FILE")
+                            .withValue(Constants.CERTIFICATES_FOLDER + "/tls.key")
+                            .build(),
+                    new EnvVarBuilder()
+                            .withName("KC_PROXY")
+                            .withValue("passthrough")
+                            .build());
+
+            envVars.addAll(enabledTls);
+
+            var volume = new VolumeBuilder()
+                    .withName("keycloak-tls-certificates")
+                    .withNewSecret()
+                    .withSecretName(tlsSecret)
+                    .withOptional(false)
+                    .endSecret()
+                    .build();
+
+            var volumeMount = new VolumeMountBuilder()
+                    .withName(volume.getName())
+                    .withMountPath(Constants.CERTIFICATES_FOLDER)
+                    .build();
+
+            deployment.getSpec().getTemplate().getSpec().getVolumes().add(volume);
+            kcContainer.getVolumeMounts().add(volumeMount);
+        }
+
+        var kcRelativePath = keycloakDeployment.readConfigurationValue(Constants.KEYCLOAK_HTTP_RELATIVE_PATH_KEY).orElse("");
+        var protocol = (keycloakCR.getSpec().isHttp()) ? "http" : "https";
+        var kcPort = (keycloakCR.getSpec().isHttp()) ? Constants.KEYCLOAK_HTTP_PORT : Constants.KEYCLOAK_HTTPS_PORT;
+
+        var baseProbe = new ArrayList<>(List.of("curl", "--head", "--fail", "--silent"));
+
+        if (!keycloakCR.getSpec().isHttp()) {
+            baseProbe.add("--insecure");
+        }
+
+        var readyProbe = new ArrayList<>(baseProbe);
+        readyProbe.add(protocol + "://127.0.0.1:" + kcPort + kcRelativePath + "/health/ready");
+        var liveProbe = new ArrayList<>(baseProbe);
+        liveProbe.add(protocol + "://127.0.0.1:" + kcPort + kcRelativePath + "/health/live");
+
+        kcContainer
+                .getReadinessProbe()
+                .setExec(new ExecActionBuilder().withCommand(readyProbe).build());
+        kcContainer
+                .getLivenessProbe()
+                .setExec(new ExecActionBuilder().withCommand(liveProbe).build());
+    }
+}

--- a/operator/src/main/java/org/keycloak/utils/DeploymentStatusUtils.java
+++ b/operator/src/main/java/org/keycloak/utils/DeploymentStatusUtils.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.utils;
+
+import org.keycloak.common.util.CollectionUtil;
+import org.keycloak.operator.controllers.KeycloakDeployment;
+import org.keycloak.operator.crds.v2alpha1.deployment.KeycloakStatusBuilder;
+
+import java.util.List;
+
+/**
+ * Util class for managing status of the deployment
+ *
+ * @author <a href="mailto:mabartos@redhat.com">Martin Bartos</a>
+ */
+public class DeploymentStatusUtils {
+
+    /**
+     * Assume the specified first-class citizens are not included in the general server configuration
+     *
+     * @param keycloakDeployment Keycloak deployment
+     * @param status             Status of the deployment
+     * @param firstClassCitizens First-class citizens in the CR
+     */
+    public static void assumeFirstClassCitizens(KeycloakDeployment keycloakDeployment, KeycloakStatusBuilder status, String... firstClassCitizens) {
+        var configNames = keycloakDeployment.getServerConfigNames();
+
+        if (CollectionUtil.elementsArePresent(configNames, firstClassCitizens)) {
+            status.addNotReadyMessage("You need to specify these fields as the first-class citizen of the CR: "
+                    + CollectionUtil.join(List.of(firstClassCitizens), ","));
+        }
+    }
+
+}

--- a/operator/src/main/java/org/keycloak/utils/OperatorConditions.java
+++ b/operator/src/main/java/org/keycloak/utils/OperatorConditions.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.utils;
+
+import java.util.NoSuchElementException;
+import java.util.function.Supplier;
+
+/**
+ * Null-safe condition checks
+ *
+ * @author <a href="mailto:mabartos@redhat.com">Martin Bartos</a>
+ */
+public class OperatorConditions {
+
+    /**
+     * Check whether the supplied object is NULL
+     *
+     * @param object supplied object
+     */
+    public static boolean isNull(Supplier<Object> object) {
+        try {
+            return object.get() == null;
+        } catch (NullPointerException | NoSuchElementException ignore) {
+            return true;
+        }
+    }
+
+    /**
+     * Check whether the supplied object is NOT NULL
+     *
+     * @param object supplied object
+     */
+    public static boolean notNull(Supplier<Object> object) {
+        return !isNull(object);
+    }
+
+    /**
+     * Null-safe check whether the supplied condition is met
+     *
+     * @param condition supplied condition
+     */
+    public static boolean checkCondition(Supplier<Boolean> condition) {
+        return !isNull(condition::get) && condition.get();
+    }
+}

--- a/operator/src/test/java/org/keycloak/operator/testsuite/unit/OperatorConditionsTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/unit/OperatorConditionsTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.operator.testsuite.unit;
+
+import io.fabric8.kubernetes.api.model.PodTemplateSpec;
+import org.junit.jupiter.api.Test;
+import org.keycloak.operator.crds.v2alpha1.deployment.KeycloakSpec;
+import org.keycloak.operator.crds.v2alpha1.deployment.KeycloakSpecUnsupported;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.keycloak.utils.OperatorConditions.checkCondition;
+import static org.keycloak.utils.OperatorConditions.isNull;
+import static org.keycloak.utils.OperatorConditions.notNull;
+
+public class OperatorConditionsTest {
+
+    @Test
+    public void nullObjects() {
+        final var nullSpec = (KeycloakSpec) null;
+        checkNullObjects(() -> nullSpec);
+
+        final Optional<KeycloakSpec> optionalNullSpec = Optional.ofNullable(null);
+        checkNullObjects(() -> optionalNullSpec.get());
+    }
+
+    @Test
+    public void notNullObjects() {
+        final var spec = new KeycloakSpec();
+        final var unsupported = new KeycloakSpecUnsupported();
+        final var podTemplateSet = new PodTemplateSpec();
+
+        spec.setHostname("hostname");
+        podTemplateSet.setAdditionalProperty("asdf", "asdf");
+        unsupported.setPodTeplate(podTemplateSet);
+        spec.setUnsupported(unsupported);
+
+        assertThat(isNull(() -> spec.getHostname().isEmpty())).isFalse();
+        assertThat(notNull(() -> spec.getHostname().isEmpty())).isTrue();
+        assertThat(checkCondition(() -> spec.getHostname().equals("hostname"))).isTrue();
+        assertThat(checkCondition(() -> spec.getHostname().equals(null))).isFalse();
+
+        assertThat(isNull(() -> spec.getUnsupported().getPodTemplate().getAdditionalProperties())).isFalse();
+        assertThat(notNull(() -> spec.getUnsupported().getPodTemplate().getAdditionalProperties())).isTrue();
+        assertThat(checkCondition(() -> spec.getUnsupported().getPodTemplate().getAdditionalProperties().size() == 1)).isTrue();
+    }
+
+    private void checkNullObjects(Supplier<KeycloakSpec> spec) {
+        assertThat(isNull(() -> spec.get().getServerConfiguration().isEmpty())).isTrue();
+        assertThat(isNull(() -> spec.get().getUnsupported().getPodTemplate().getMetadata().getName())).isTrue();
+
+        assertThat(notNull(() -> spec.get().getServerConfiguration().isEmpty())).isFalse();
+        assertThat(notNull(() -> spec.get().getUnsupported().getPodTemplate().getMetadata().getName())).isFalse();
+
+        assertThat(checkCondition(() -> spec.get().getServerConfiguration() != null)).isFalse();
+        assertThat(checkCondition(() -> spec.get().getServerConfiguration().isEmpty() == true)).isFalse();
+    }
+}


### PR DESCRIPTION
Closes #14739

I tried to add an approach to easily customize first-class citizen properties of the CR. I think the configuration should be separated from the main `KeycloakDeployment` class as we assume a lot of changes in this stuff, and the class would rapidly grow; not very well manageable.

I've also slightly refactored that class in order to improve readability and keep a certain "convention" in the method ordering(util/helper methods should be positioned below the main/overriden methods).
I've also refactored the conditions in that class for better readability; I'm aware it's quite comprehensive process to check whether some object in the CR is null or not.

@vmuzikar @Pepo48 @andre-nascimento-rh @pedroigor Could you please check it if you spot anything crucial?
