### PR TITLE
Order realms on realm-list.html

### DIFF
--- a/themes/src/main/resources/theme/base/admin/resources/partials/realm-list.html
+++ b/themes/src/main/resources/theme/base/admin/resources/partials/realm-list.html
@@ -9,7 +9,7 @@
             </tr>
         </thead>
         <tbody>
-            <tr data-ng-repeat="r in realms">
+            <tr data-ng-repeat="r in realms | orderBy:'realm'">
                 <td><a href="#/realms/{{r.realm}}">{{r.realm}}</a></td>
             </tr>
         </tbody>


### PR DESCRIPTION
With a large number of realms it is hard to find the one you're interested in since they don't appear in alphabetic order.

This change orders realms by realm name.