### PR TITLE
Fix SecureRandom algorithm issue in ElytronHmac test on Windows OSes

### DIFF
--- a/crypto/elytron/src/test/java/org/keycloak/crypto/elytron/test/ElytronHmacTest.java
+++ b/crypto/elytron/src/test/java/org/keycloak/crypto/elytron/test/ElytronHmacTest.java
@@ -39,7 +39,7 @@ public class ElytronHmacTest extends HmacTest {
     public void testHmacSignaturesUsingKeyGen() throws Exception {
         
         KeyGenerator keygen = KeyGenerator.getInstance("HmacSHA256");
-        SecureRandom random = SecureRandom.getInstance("NativePRNG");
+        SecureRandom random = isWindows() ? SecureRandom.getInstance("Windows-PRNG") : SecureRandom.getInstance("NativePRNG");
         random.setSeed(UUID.randomUUID().toString().getBytes());
         keygen.init(random);
         SecretKey secret = keygen.generateKey();
@@ -49,5 +49,8 @@ public class ElytronHmacTest extends HmacTest {
         System.out.println("length: " + encoded.length());
         JWSInput input = new JWSInput(encoded);
         Assert.assertTrue(HMACProvider.verify(input, secret));
+    }
+    private boolean isWindows(){
+        return System.getProperty("os.name").startsWith("Windows");
     }
 }


### PR DESCRIPTION
ElytronHmacTest#testHmacSignaturesUsingKeyGen test is failing on default setup due to the use of unavailable for Windows algorithm: NativePRNG

This PR fixes: https://github.com/keycloak/keycloak/issues/14610

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
