### PR TITLE
Fix issue where admin2 was not enabled by default if account2 was disabled

### DIFF
--- a/server-spi/src/main/java/org/keycloak/theme/ThemeSelectorProvider.java
+++ b/server-spi/src/main/java/org/keycloak/theme/ThemeSelectorProvider.java
@@ -17,6 +17,9 @@
 
 package org.keycloak.theme;
 
+import org.keycloak.Config;
+import org.keycloak.common.Profile;
+import org.keycloak.common.Version;
 import org.keycloak.provider.Provider;
 
 /**
@@ -31,5 +34,15 @@ public interface ThemeSelectorProvider extends Provider {
      * @return
      */
     String getThemeName(Theme.Type type);
+
+    default String getDefaultThemeName(Theme.Type type) {
+        String name = Config.scope("theme").get("default", Version.NAME.toLowerCase());
+        if ((type == Theme.Type.ACCOUNT) && Profile.isFeatureEnabled(Profile.Feature.ACCOUNT2)) {
+            name = name.concat(".v2");
+        } else if ((type == Theme.Type.ADMIN) && Profile.isFeatureEnabled(Profile.Feature.ADMIN2)) {
+            name = name.concat(".v2");
+        }
+        return name;
+    }
 
 }

--- a/services/src/main/java/org/keycloak/theme/DefaultThemeSelectorProvider.java
+++ b/services/src/main/java/org/keycloak/theme/DefaultThemeSelectorProvider.java
@@ -47,12 +47,7 @@ public class DefaultThemeSelectorProvider implements ThemeSelectorProvider {
         }
 
         if (name == null || name.isEmpty()) {
-            name = Config.scope("theme").get("default", Version.NAME.toLowerCase());
-            if ((type == Theme.Type.ACCOUNT) && Profile.isFeatureEnabled(Profile.Feature.ACCOUNT2)) {
-                name = name.concat(".v2");
-            } else if ((type == Theme.Type.ADMIN) && Profile.isFeatureEnabled(Profile.Feature.ADMIN2)) {
-                name = name.concat(".v2");
-            }
+            name = getDefaultThemeName(type);
         }
 
         return name;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/AdminConsoleLandingPageTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/AdminConsoleLandingPageTest.java
@@ -13,11 +13,12 @@ import org.keycloak.testsuite.AbstractKeycloakTest;
 import org.keycloak.testsuite.arquillian.annotation.DisableFeature;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-@DisableFeature(value = Profile.Feature.ACCOUNT2, skipRestart = true) // TODO remove this (KEYCLOAK-16228)
 public class AdminConsoleLandingPageTest extends AbstractKeycloakTest {
 
     private CloseableHttpClient client;
@@ -44,16 +45,14 @@ public class AdminConsoleLandingPageTest extends AbstractKeycloakTest {
     public void landingPage() throws IOException {
         String body = SimpleHttp.doGet(suiteContext.getAuthServerInfo().getContextRoot() + "/auth/admin/master/console", client).asString();
 
-        String authUrl = body.substring(body.indexOf("var authUrl = '") + 15);
-        authUrl = authUrl.substring(0, authUrl.indexOf("'"));
+        Map<String, String> config = getConfig(body);
+        String authUrl = config.get("authUrl");
         Assert.assertEquals(suiteContext.getAuthServerInfo().getContextRoot() + "/auth", authUrl);
 
-        String resourceUrl = body.substring(body.indexOf("var resourceUrl = '") + 19);
-        resourceUrl = resourceUrl.substring(0, resourceUrl.indexOf("'"));
-        Assert.assertTrue(resourceUrl.matches("/auth/resources/[^/]*/admin/([a-z]*|[a-z]*-[a-z]*)"));
+        String resourceUrl = config.get("resourceUrl");
+        Assert.assertTrue(resourceUrl.matches("/auth/resources/[^/]*/admin/keycloak.v2"));
 
-        String consoleBaseUrl = body.substring(body.indexOf("var consoleBaseUrl = '") + 22);
-        consoleBaseUrl = consoleBaseUrl.substring(0, consoleBaseUrl.indexOf("'"));
+        String consoleBaseUrl = config.get("consoleBaseUrl");
         Assert.assertEquals(consoleBaseUrl, "/auth/admin/master/console/");
 
         Pattern p = Pattern.compile("link href=\"([^\"]*)\"");
@@ -75,6 +74,22 @@ public class AdminConsoleLandingPageTest extends AbstractKeycloakTest {
                 Assert.assertTrue(url, url.startsWith("/auth/resources/"));
             }
         }
+    }
+
+    private static Map<String, String> getConfig(String body) {
+        Map<String, String> variables = new HashMap<>();
+        String start = "<script id=\"environment\" type=\"application/json\">";
+        String end = "</script>";
+
+        String config = body.substring(body.indexOf(start) + start.length());
+        config = config.substring(0, config.indexOf(end)).trim();
+
+        Matcher matcher = Pattern.compile(".*\"(.*)\": \"(.*)\"").matcher(config);
+        while (matcher.find()) {
+            variables.put(matcher.group(1), matcher.group(2));
+        }
+
+        return variables;
     }
 
 }


### PR DESCRIPTION
Refactoring ThemeSelector and DefaultThemeManager to re-use the same logic for selecting default theme as there used to be two places where one had a broken implementation

Closes #14889
