### PR TITLE
Remove deprecated methods in data providers and models

### DIFF
--- a/federation/kerberos/src/main/java/org/keycloak/federation/kerberos/KerberosFederationProvider.java
+++ b/federation/kerberos/src/main/java/org/keycloak/federation/kerberos/KerberosFederationProvider.java
@@ -51,9 +51,9 @@ import java.util.stream.Stream;
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
  */
 public class KerberosFederationProvider implements UserStorageProvider,
-        UserLookupProvider.Streams,
+        UserLookupProvider,
         CredentialInputValidator,
-        CredentialInputUpdater.Streams,
+        CredentialInputUpdater,
         CredentialAuthentication,
         ImportedUserValidation {
 

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProvider.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProvider.java
@@ -93,11 +93,11 @@ import static org.keycloak.utils.StreamsUtil.paginatedStream;
  */
 public class LDAPStorageProvider implements UserStorageProvider,
         CredentialInputValidator,
-        CredentialInputUpdater.Streams,
+        CredentialInputUpdater,
         CredentialAuthentication,
-        UserLookupProvider.Streams,
+        UserLookupProvider,
         UserRegistrationProvider,
-        UserQueryProvider.Streams,
+        UserQueryProvider,
         ImportedUserValidation {
     private static final Logger logger = Logger.getLogger(LDAPStorageProvider.class);
     private static final int DEFAULT_MAX_RESULTS = Integer.MAX_VALUE >> 1;

--- a/federation/sssd/src/main/java/org/keycloak/federation/sssd/SSSDFederationProvider.java
+++ b/federation/sssd/src/main/java/org/keycloak/federation/sssd/SSSDFederationProvider.java
@@ -45,8 +45,8 @@ import java.util.stream.Stream;
  * @version $Revision: 1 $
  */
 public class SSSDFederationProvider implements UserStorageProvider,
-        UserLookupProvider.Streams,
-        CredentialInputUpdater.Streams,
+        UserLookupProvider,
+        CredentialInputUpdater,
         CredentialInputValidator,
         ImportedUserValidation {
 

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/GroupAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/GroupAdapter.java
@@ -36,7 +36,7 @@ import java.util.stream.Stream;
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
  */
-public class GroupAdapter implements GroupModel.Streams {
+public class GroupAdapter implements GroupModel {
 
     protected final CachedGroup cached;
     protected final RealmCacheSession cacheSession;

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmAdapter.java
@@ -667,12 +667,6 @@ public class RealmAdapter implements CachedRealmModel {
     }
 
     @Override
-    public List<RequiredCredentialModel> getRequiredCredentials() {
-        if (isUpdated()) return updated.getRequiredCredentials();
-        return cached.getRequiredCredentials();
-    }
-
-    @Override
     public void addRequiredCredential(String cred) {
         getDelegateForUpdate();
         updated.addRequiredCredential(cred);

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/UserAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/UserAdapter.java
@@ -46,7 +46,7 @@ import java.util.stream.Stream;
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
  */
-public class UserAdapter implements CachedUserModel.Streams {
+public class UserAdapter implements CachedUserModel {
 
     private final Supplier<UserModel> modelSupplier;
     protected final CachedUser cached;

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/UserCacheSession.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/UserCacheSession.java
@@ -78,7 +78,7 @@ import java.util.stream.Stream;
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
  */
-public class UserCacheSession implements UserCache.Streams, OnCreateComponent, OnUpdateComponent {
+public class UserCacheSession implements UserCache, OnCreateComponent, OnUpdateComponent {
     protected static final Logger logger = Logger.getLogger(UserCacheSession.class);
     protected UserCacheManager cache;
     protected KeycloakSession session;

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/GroupAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/GroupAdapter.java
@@ -44,7 +44,7 @@ import static org.keycloak.utils.StreamsUtil.closing;
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
  */
-public class GroupAdapter implements GroupModel.Streams , JpaModel<GroupEntity> {
+public class GroupAdapter implements GroupModel , JpaModel<GroupEntity> {
 
     protected GroupEntity group;
     protected EntityManager em;

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
@@ -562,7 +562,7 @@ public class JpaRealmProvider implements RealmProvider, ClientProvider, ClientSc
 
     @Override
     public Long getGroupsCountByNameContaining(RealmModel realm, String search) {
-        return searchForGroupByNameStream(realm, search, null, null).count();
+        return searchForGroupByNameStream(realm, search, false, null, null).count();
     }
 
     @Override
@@ -963,12 +963,6 @@ public class JpaRealmProvider implements RealmProvider, ClientProvider, ClientSc
                 .filter(clientScope -> Objects.equals(clientScope.getProtocol(), clientProtocol))
                 .collect(Collectors.toMap(ClientScopeModel::getName, Function.identity()));
     }
-
-    @Override
-    public Stream<GroupModel> searchForGroupByNameStream(RealmModel realm, String search, Integer first, Integer max) {
-        return searchForGroupByNameStream(realm, search, false, first, max);
-    }
-
     @Override
     public Stream<GroupModel> searchForGroupByNameStream(RealmModel realm, String search, Boolean exact, Integer first, Integer max) {
         TypedQuery<String> query;

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserCredentialStore.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserCredentialStore.java
@@ -43,7 +43,7 @@ import static org.keycloak.utils.StreamsUtil.closing;
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
  */
-public class JpaUserCredentialStore implements UserCredentialStore.Streams {
+public class JpaUserCredentialStore implements UserCredentialStore {
 
     // Typical priority difference between 2 credentials
     public static final int PRIORITY_DIFFERENCE = 10;

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserProvider.java
@@ -81,7 +81,7 @@ import static org.keycloak.utils.StreamsUtil.closing;
  * @version $Revision: 1 $
  */
 @SuppressWarnings("JpaQueryApiInspection")
-public class JpaUserProvider implements UserProvider.Streams, UserCredentialStore.Streams {
+public class JpaUserProvider implements UserProvider, UserCredentialStore {
 
     private static final String EMAIL = "email";
     private static final String EMAIL_VERIFIED = "emailVerified";

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/UserAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/UserAdapter.java
@@ -56,7 +56,7 @@ import static org.keycloak.utils.StreamsUtil.closing;
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
  */
-public class UserAdapter implements UserModel.Streams, JpaModel<UserEntity> {
+public class UserAdapter implements UserModel, JpaModel<UserEntity> {
 
     protected UserEntity user;
     protected EntityManager em;

--- a/model/jpa/src/main/java/org/keycloak/storage/jpa/JpaUserFederatedStorageProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/storage/jpa/JpaUserFederatedStorageProvider.java
@@ -72,7 +72,7 @@ import static org.keycloak.utils.StreamsUtil.closing;
  */
 public class JpaUserFederatedStorageProvider implements
         UserFederatedStorageProvider.Streams,
-        UserCredentialStore.Streams {
+        UserCredentialStore {
 
     protected static final Logger logger = Logger.getLogger(JpaUserFederatedStorageProvider.class);
 

--- a/model/legacy-private/src/main/java/org/keycloak/storage/GroupStorageManager.java
+++ b/model/legacy-private/src/main/java/org/keycloak/storage/GroupStorageManager.java
@@ -55,20 +55,6 @@ public class GroupStorageManager extends AbstractStorageManager<GroupStorageProv
         return provider.getGroupById(realm, id);
     }
 
-    /**
-     * Obtaining groups from an external client storage is time-bounded. In case the external group storage
-     * isn't available at least groups from a local storage are returned. For this purpose
-     * the {@link org.keycloak.services.DefaultKeycloakSessionFactory#getClientStorageProviderTimeout()} property is used.
-     * Default value is 3000 milliseconds and it's configurable.
-     * See {@link org.keycloak.services.DefaultKeycloakSessionFactory} for details.
-     *
-     */
-    @Override
-    @Deprecated
-    public Stream<GroupModel> searchForGroupByNameStream(RealmModel realm, String search, Integer firstResult, Integer maxResults) {
-        return searchForGroupByNameStream(realm, search, false, firstResult, maxResults);
-    }
-
     @Override
     public Stream<GroupModel> searchGroupsByAttributes(RealmModel realm, Map<String, String> attributes, Integer firstResult, Integer maxResults) {
         Stream<GroupModel> local = localStorage().searchGroupsByAttributes(realm, attributes, firstResult, maxResults);

--- a/model/legacy-private/src/main/java/org/keycloak/storage/UserStorageManager.java
+++ b/model/legacy-private/src/main/java/org/keycloak/storage/UserStorageManager.java
@@ -73,7 +73,7 @@ import org.keycloak.storage.user.UserRegistrationProvider;
  * @version $Revision: 1 $
  */
 public class UserStorageManager extends AbstractStorageManager<UserStorageProvider, UserStorageProviderModel>
-        implements UserProvider.Streams, OnUserCache, OnCreateComponent, OnUpdateComponent {
+        implements UserProvider, OnUserCache, OnCreateComponent, OnUpdateComponent {
 
     private static final Logger logger = Logger.getLogger(UserStorageManager.class);
 

--- a/model/legacy-services/src/main/java/org/keycloak/credential/UserCredentialStoreManager.java
+++ b/model/legacy-services/src/main/java/org/keycloak/credential/UserCredentialStoreManager.java
@@ -35,7 +35,7 @@ import java.util.stream.Stream;
  * @version $Revision: 1 $
  */
 @Deprecated
-public class UserCredentialStoreManager implements UserCredentialManager.Streams, OnUserCache {
+public class UserCredentialStoreManager implements UserCredentialManager, OnUserCache {
 
     private final static Logger log = Logger.getLogger(UserCredentialStoreManager.class);
 

--- a/model/legacy/src/main/java/org/keycloak/models/UserModelDefaultMethods.java
+++ b/model/legacy/src/main/java/org/keycloak/models/UserModelDefaultMethods.java
@@ -61,12 +61,12 @@ public abstract class UserModelDefaultMethods implements UserModel {
         return getClass().getName() + "@" + getId();
     }
 
+
     /**
-     * The {@link UserModelDefaultMethods.Streams} class extends the {@link UserModelDefaultMethods} abstract class and
-     * implements the {@link UserModel.Streams} interface, allowing subclasses to focus on the implementation of the
-     * {@link Stream}-based query methods and providing default implementations for the collections-based variants that
-     * delegate to their {@link Stream} counterparts.
+     * @deprecated This interface is no longer necessary, collection-based methods were removed from the parent interface
+     * and therefore the parent interface can be used directly
      */
-    public abstract static class Streams extends UserModelDefaultMethods implements UserModel.Streams {
+    @Deprecated
+    public abstract static class Streams extends UserModelDefaultMethods implements UserModel {
     }
 }

--- a/model/legacy/src/main/java/org/keycloak/models/cache/CachedUserModel.java
+++ b/model/legacy/src/main/java/org/keycloak/models/cache/CachedUserModel.java
@@ -59,10 +59,10 @@ public interface CachedUserModel extends UserModel {
     ConcurrentMap getCachedWith();
 
     /**
-     * The {@link CachedUserModel.Streams} interface differs from {@link CachedUserModel} in that it extends the
-     * {@link UserModel.Streams} interface, allowing implementations of {@link CachedUserModel} to focus on the
-     * {@link java.util.stream.Stream}-based methods in the {@link UserModel} interface.
+     * @deprecated This interface is no longer necessary, collection-based methods were removed from the parent interface
+     * and therefore the parent interface can be used directly
      */
+    @Deprecated
     interface Streams extends CachedUserModel, UserModel.Streams {
     }
 }

--- a/model/legacy/src/main/java/org/keycloak/models/cache/UserCache.java
+++ b/model/legacy/src/main/java/org/keycloak/models/cache/UserCache.java
@@ -49,10 +49,10 @@ public interface UserCache extends UserProvider {
     void clear();
 
     /**
-     * The {@link UserCache.Streams} interface differs from {@link UserCache} in that it extends the {@link UserProvider.Streams}
-     * interface, allowing implementations of {@link UserCache} to focus on the {@link java.util.stream.Stream}-based methods
-     * in the {@link UserProvider} interface.
+     * @deprecated This interface is no longer necessary, collection-based methods were removed from the parent interface
+     * and therefore the parent interface can be used directly
      */
+    @Deprecated
     interface Streams extends UserCache, UserProvider.Streams {
     }
 }

--- a/model/legacy/src/main/java/org/keycloak/storage/adapter/AbstractUserAdapter.java
+++ b/model/legacy/src/main/java/org/keycloak/storage/adapter/AbstractUserAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -61,9 +61,16 @@ public abstract class AbstractUserAdapter extends UserModelDefaultMethods {
         this.storageProviderModel = storageProviderModel;
     }
 
-    @Override
+    /**
+     * @deprecated User {@link #getRequiredActionsStream()}
+     */
     public Set<String> getRequiredActions() {
         return Collections.emptySet();
+    }
+
+    @Override
+    public Stream<String> getRequiredActionsStream() {
+        return getRequiredActions().stream();
     }
 
     @Override
@@ -109,12 +116,19 @@ public abstract class AbstractUserAdapter extends UserModelDefaultMethods {
         return true;
     }
 
-    @Override
+    /**
+     * @deprecated Use {@link #getGroupsStream()} instead
+     */
     public Set<GroupModel> getGroups() {
         Set<GroupModel> set = new HashSet<>();
         if (appendDefaultGroups()) set.addAll(realm.getDefaultGroupsStream().collect(Collectors.toSet()));
         set.addAll(getGroupsInternal());
         return set;
+    }
+
+    @Override
+    public Stream<GroupModel> getGroupsStream() {
+        return getGroups().stream();
     }
 
     @Override
@@ -134,14 +148,30 @@ public abstract class AbstractUserAdapter extends UserModelDefaultMethods {
         return RoleUtils.isMember(getGroups().stream(), group);
     }
 
-    @Override
+    /**
+     *
+     * @deprecated Use {@link #getRealmRoleMappingsStream()} instead
+     */
     public Set<RoleModel> getRealmRoleMappings() {
         return getRoleMappings().stream().filter(RoleUtils::isRealmRole).collect(Collectors.toSet());
     }
 
     @Override
+    public Stream<RoleModel> getRealmRoleMappingsStream() {
+        return getRealmRoleMappings().stream();
+    }
+
+    /**
+     *
+     * @deprecated Use {@link #getClientRoleMappingsStream(ClientModel)} instead
+     */
     public Set<RoleModel> getClientRoleMappings(ClientModel app) {
         return getRoleMappings().stream().filter(r -> RoleUtils.isClientRole(r, app)).collect(Collectors.toSet());
+    }
+
+    @Override
+    public Stream<RoleModel> getClientRoleMappingsStream(ClientModel app) {
+        return getClientRoleMappings(app).stream();
     }
 
     @Override
@@ -171,7 +201,10 @@ public abstract class AbstractUserAdapter extends UserModelDefaultMethods {
         return Collections.emptySet();
     }
 
-    @Override
+    /**
+     *
+     * @deprecated Use {@link #getRoleMappingsStream()} instead
+     */
     public Set<RoleModel> getRoleMappings() {
         Set<RoleModel> set = new HashSet<>();
         if (appendDefaultRolesToRoleMappings()) set.addAll(realm.getDefaultRole().getCompositesStream().collect(Collectors.toSet()));
@@ -179,6 +212,10 @@ public abstract class AbstractUserAdapter extends UserModelDefaultMethods {
         return set;
     }
 
+    @Override
+    public Stream<RoleModel> getRoleMappingsStream() {
+        return getRoleMappings().stream();
+    }
 
     @Override
     public void deleteRoleMapping(RoleModel role) {
@@ -304,12 +341,19 @@ public abstract class AbstractUserAdapter extends UserModelDefaultMethods {
         return attributes;
     }
 
-    @Override
+    /**
+     * @deprecated Use {@link #getAttributeStream(String)} instead
+     */
     public List<String> getAttribute(String name) {
         if (name.equals(UserModel.USERNAME)) {
             return Collections.singletonList(getUsername());
         }
         return Collections.emptyList();
+    }
+
+    @Override
+    public Stream<String> getAttributeStream(String name) {
+        return getAttribute(name).stream();
     }
 
     @Override
@@ -371,12 +415,13 @@ public abstract class AbstractUserAdapter extends UserModelDefaultMethods {
     }
 
     /**
-     * The {@link AbstractUserAdapter.Streams} class extends the {@link AbstractUserAdapter} abstract class and implements
-     * the {@link UserModel.Streams} interface, allowing subclasses to focus on the implementation of the {@link Stream}-based
-     * query methods and providing default implementations for the collections-based variants that delegate to their
-     * {@link Stream} counterparts.
+     * The {@link Streams} interface makes all collection-based methods in {@link AbstractUserAdapter} default by providing
+     * implementations that delegate to the {@link Stream}-based variants instead of the other way around.
+     * <p/>
+     * It allows for implementations to focus on the {@link Stream}-based approach for processing sets of data and benefit
+     * from the potential memory and performance optimizations of that approach.
      */
-    public abstract static class Streams extends AbstractUserAdapter implements UserModel.Streams {
+    public abstract static class Streams extends AbstractUserAdapter implements UserModel {
 
         public Streams(final KeycloakSession session, final RealmModel realm, final ComponentModel storageProviderModel) {
             super(session, realm, storageProviderModel);

--- a/model/legacy/src/main/java/org/keycloak/storage/adapter/AbstractUserAdapterFederatedStorage.java
+++ b/model/legacy/src/main/java/org/keycloak/storage/adapter/AbstractUserAdapterFederatedStorage.java
@@ -73,9 +73,16 @@ public abstract class AbstractUserAdapterFederatedStorage extends UserModelDefau
         return UserStorageUtil.userFederatedStorage(session);
     }
 
-    @Override
+    /**
+     * @deprecated Use {@link #getRequiredActionsStream()} instead
+     */
     public Set<String> getRequiredActions() {
         return getFederatedStorage().getRequiredActions(realm, this.getId());
+    }
+
+    @Override
+    public Stream<String> getRequiredActionsStream() {
+        return getRequiredActions().stream();
     }
 
     @Override
@@ -128,13 +135,18 @@ public abstract class AbstractUserAdapterFederatedStorage extends UserModelDefau
      *
      *
      * @return
+     * @deprecated Use {@link #getGroupsStream()} instead
      */
-    @Override
     public Set<GroupModel> getGroups() {
         Set<GroupModel> set = new HashSet<>(getFederatedStorage().getGroups(realm, this.getId()));
         if (appendDefaultGroups()) set.addAll(realm.getDefaultGroupsStream().collect(Collectors.toSet()));
         set.addAll(getGroupsInternal());
         return set;
+    }
+
+    @Override
+    public Stream<GroupModel> getGroupsStream() {
+        return getGroups().stream();
     }
 
     @Override
@@ -161,10 +173,16 @@ public abstract class AbstractUserAdapterFederatedStorage extends UserModelDefau
      *
      *
      * @return
+     *
+     * @deprecated Use {@link #getRealmRoleMappingsStream()} instead
      */
-    @Override
     public Set<RoleModel> getRealmRoleMappings() {
         return this.getRoleMappings().stream().filter(RoleUtils::isRealmRole).collect(Collectors.toSet());
+    }
+
+    @Override
+    public Stream<RoleModel> getRealmRoleMappingsStream() {
+        return getRealmRoleMappings().stream();
     }
 
     /**
@@ -174,10 +192,15 @@ public abstract class AbstractUserAdapterFederatedStorage extends UserModelDefau
      *
      *
      * @return
+     * @deprecated Use {@link #getClientRoleMappingsStream(ClientModel)} instead
      */
-    @Override
     public Set<RoleModel> getClientRoleMappings(ClientModel app) {
         return getRoleMappings().stream().filter(r -> RoleUtils.isClientRole(r, app)).collect(Collectors.toSet());
+    }
+
+    @Override
+    public Stream<RoleModel> getClientRoleMappingsStream(ClientModel app) {
+        return getClientRoleMappings(app).stream();
     }
 
     @Override
@@ -213,13 +236,19 @@ public abstract class AbstractUserAdapterFederatedStorage extends UserModelDefau
      * to pull role mappings from provider.  Implementors can override that method
      *
      * @return
+     *
+     * @deprecated Use {@link #getRoleMappingsStream()} instead
      */
-    @Override
     public Set<RoleModel> getRoleMappings() {
         Set<RoleModel> set = new HashSet<>(getFederatedRoleMappings());
         if (appendDefaultRolesToRoleMappings()) set.addAll(realm.getDefaultRole().getCompositesStream().collect(Collectors.toSet()));
         set.addAll(getRoleMappingsInternal());
         return set;
+    }
+
+    @Override
+    public Stream<RoleModel> getRoleMappingsStream() {
+        return getRoleMappings().stream();
     }
 
     protected Set<RoleModel> getFederatedRoleMappings() {
@@ -364,13 +393,20 @@ public abstract class AbstractUserAdapterFederatedStorage extends UserModelDefau
         return attributes;
     }
 
-    @Override
+    /**
+     * @deprecated Use {@link #getAttributeStream(String)} instead
+     */
     public List<String> getAttribute(String name) {
         if (UserModel.USERNAME.equals(name)) {
             return Collections.singletonList(getUsername());
         }
         List<String> result = getFederatedStorage().getAttributes(realm, this.getId()).get(mapAttribute(name));
         return (result == null) ? Collections.emptyList() : result;
+    }
+
+    @Override
+    public Stream<String> getAttributeStream(String name) {
+        return getAttribute(name).stream();
     }
 
     protected String mapAttribute(String attributeName) {
@@ -423,12 +459,13 @@ public abstract class AbstractUserAdapterFederatedStorage extends UserModelDefau
     }
 
     /**
-     * The {@link AbstractUserAdapterFederatedStorage.Streams} class extends the {@link AbstractUserAdapterFederatedStorage}
-     * abstract class and implements the {@link UserModel.Streams} interface, allowing subclasses to focus on the implementation
-     * of the {@link Stream}-based query methods and providing default implementations for the collections-based variants
-     * that delegate to their {@link Stream} counterparts.
+     * The {@link Streams} interface makes all collection-based methods in {@link AbstractUserAdapterFederatedStorage} default by providing
+     * implementations that delegate to the {@link Stream}-based variants instead of the other way around.
+     * <p/>
+     * It allows for implementations to focus on the {@link Stream}-based approach for processing sets of data and benefit
+     * from the potential memory and performance optimizations of that approach.
      */
-    public abstract static class Streams extends AbstractUserAdapterFederatedStorage implements UserModel.Streams {
+    public abstract static class Streams extends AbstractUserAdapterFederatedStorage implements UserModel {
 
         public Streams(final KeycloakSession session, final RealmModel realm, final ComponentModel storageProviderModel) {
             super(session, realm, storageProviderModel);

--- a/model/map/src/main/java/org/keycloak/models/map/group/AbstractGroupModel.java
+++ b/model/map/src/main/java/org/keycloak/models/map/group/AbstractGroupModel.java
@@ -24,7 +24,7 @@ import org.keycloak.models.map.common.AbstractEntity;
 
 import java.util.Objects;
 
-public abstract class AbstractGroupModel<E extends AbstractEntity> implements GroupModel.Streams {
+public abstract class AbstractGroupModel<E extends AbstractEntity> implements GroupModel {
 
     protected final KeycloakSession session;
     protected final RealmModel realm;

--- a/model/map/src/main/java/org/keycloak/models/map/group/MapGroupProvider.java
+++ b/model/map/src/main/java/org/keycloak/models/map/group/MapGroupProvider.java
@@ -138,7 +138,7 @@ public class MapGroupProvider implements GroupProvider {
 
     @Override
     public Long getGroupsCountByNameContaining(RealmModel realm, String search) {
-        return searchForGroupByNameStream(realm, search, null, null).count();
+        return searchForGroupByNameStream(realm, search, false, null, null).count();
     }
 
     @Override
@@ -166,12 +166,6 @@ public class MapGroupProvider implements GroupProvider {
                 (DefaultModelCriteria<GroupModel> mcb) -> mcb.compare(SearchableFields.PARENT_ID, Operator.NOT_EXISTS),
                 qp -> qp.offset(firstResult).limit(maxResults)
         );
-    }
-
-    @Override
-    @Deprecated
-    public Stream<GroupModel> searchForGroupByNameStream(RealmModel realm, String search, Integer firstResult, Integer maxResults) {
-        return searchForGroupByNameStream(realm, search, false, firstResult, maxResults);
     }
 
     public Stream<GroupModel> searchForGroupByNameStream(RealmModel realm, String search, Boolean exact, Integer firstResult, Integer maxResults) {

--- a/model/map/src/main/java/org/keycloak/models/map/user/AbstractUserModel.java
+++ b/model/map/src/main/java/org/keycloak/models/map/user/AbstractUserModel.java
@@ -25,7 +25,7 @@ import org.keycloak.models.map.common.AbstractEntity;
 
 import java.util.Objects;
 
-public abstract class AbstractUserModel<E extends AbstractEntity> implements UserModel.Streams {
+public abstract class AbstractUserModel<E extends AbstractEntity> implements UserModel {
 
     protected final KeycloakSession session;
     protected final RealmModel realm;

--- a/model/map/src/main/java/org/keycloak/models/map/user/MapUserProvider.java
+++ b/model/map/src/main/java/org/keycloak/models/map/user/MapUserProvider.java
@@ -82,7 +82,7 @@ import static org.keycloak.models.map.storage.QueryParameters.withCriteria;
 import static org.keycloak.models.map.storage.criteria.DefaultModelCriteria.criteria;
 import static org.keycloak.models.utils.KeycloakModelUtils.isUsernameCaseSensitive;
 
-public class MapUserProvider implements UserProvider.Streams {
+public class MapUserProvider implements UserProvider {
 
     private static final Logger LOG = Logger.getLogger(MapUserProvider.class);
     private final KeycloakSession session;

--- a/server-spi-private/src/main/java/org/keycloak/events/EventQuery.java
+++ b/server-spi-private/src/main/java/org/keycloak/events/EventQuery.java
@@ -105,14 +105,6 @@ public interface EventQuery {
     EventQuery orderByAscTime();
 
     /**
-     * @deprecated Use {@link #getResultStream() getResultStream} instead.
-     */
-    @Deprecated
-    default List<Event> getResultList() {
-        return getResultStream().collect(Collectors.toList());
-    }
-
-    /**
      * Returns requested results that match given criteria as a stream.
      * @return Stream of events. Never returns {@code null}.
      */

--- a/server-spi-private/src/main/java/org/keycloak/events/admin/AdminEventQuery.java
+++ b/server-spi-private/src/main/java/org/keycloak/events/admin/AdminEventQuery.java
@@ -142,15 +142,6 @@ public interface AdminEventQuery {
     AdminEventQuery orderByAscTime();
 
     /**
-     * Executes the query and returns the results
-     * @deprecated Use {@link #getResultStream() getResultStream} instead.
-     */
-    @Deprecated
-    default List<AdminEvent> getResultList() {
-        return getResultStream().collect(Collectors.toList());
-    }
-
-    /**
      * Executes the query and returns the results as a stream.
      * @return Stream of admin events. Never returns {@code null}.
      */

--- a/server-spi-private/src/main/java/org/keycloak/keys/KeyProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/keys/KeyProvider.java
@@ -29,18 +29,6 @@ import java.util.stream.Stream;
  */
 public interface KeyProvider extends Provider {
 
-
-    /**
-     * Returns the {@code KeyWrapper} for a {@code KeyProvider}.
-     *
-     * @return Returns the {@code KeyWrapper} for a {@code KeyProvider}.
-     * @deprecated Use {@link #getKeysStream() getKeysStream} instead.
-     */
-    @Deprecated
-    default List<KeyWrapper> getKeys() {
-        return getKeysStream().collect(Collectors.toList());
-    }
-
     /**
      * Returns the {@code KeyWrapper} for a {@code KeyProvider}.
      *

--- a/server-spi-private/src/main/java/org/keycloak/models/delegate/ClientModelLazyDelegate.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/delegate/ClientModelLazyDelegate.java
@@ -525,18 +525,8 @@ public class ClientModelLazyDelegate implements ClientModel {
     }
 
     @Override
-    public Set<RoleModel> getScopeMappings() {
-        return getDelegate().getScopeMappings();
-    }
-
-    @Override
     public Stream<RoleModel> getScopeMappingsStream() {
         return getDelegate().getScopeMappingsStream();
-    }
-
-    @Override
-    public Set<RoleModel> getRealmScopeMappings() {
-        return getDelegate().getRealmScopeMappings();
     }
 
     @Override
@@ -585,18 +575,8 @@ public class ClientModelLazyDelegate implements ClientModel {
     }
 
     @Override
-    public Set<RoleModel> getRoles() {
-        return getDelegate().getRoles();
-    }
-
-    @Override
     public Stream<RoleModel> getRolesStream() {
         return getDelegate().getRolesStream();
-    }
-
-    @Override
-    public Set<RoleModel> getRoles(Integer firstResult, Integer maxResults) {
-        return getDelegate().getRoles(firstResult, maxResults);
     }
 
     @Override
@@ -605,18 +585,8 @@ public class ClientModelLazyDelegate implements ClientModel {
     }
 
     @Override
-    public Set<RoleModel> searchForRoles(String search, Integer first, Integer max) {
-        return getDelegate().searchForRoles(search, first, max);
-    }
-
-    @Override
     public Stream<RoleModel> searchForRolesStream(String search, Integer first, Integer max) {
         return getDelegate().searchForRolesStream(search, first, max);
-    }
-
-    @Override
-    public List<String> getDefaultRoles() {
-        return getDelegate().getDefaultRoles();
     }
 
     @Override
@@ -637,11 +607,6 @@ public class ClientModelLazyDelegate implements ClientModel {
     @Override
     public void removeDefaultRoles(String... defaultRoles) {
         getDelegate().removeDefaultRoles(defaultRoles);
-    }
-
-    @Override
-    public Set<ProtocolMapperModel> getProtocolMappers() {
-        return getDelegate().getProtocolMappers();
     }
 
     @Override

--- a/server-spi/src/main/java/org/keycloak/credential/CredentialInputUpdater.java
+++ b/server-spi/src/main/java/org/keycloak/credential/CredentialInputUpdater.java
@@ -33,19 +33,6 @@ public interface CredentialInputUpdater {
     void disableCredentialType(RealmModel realm, UserModel user, String credentialType);
 
     /**
-     *
-     * Returns a set of credential types that can be disabled by disableCredentialType() method
-     *
-     * @param realm
-     * @param user
-     * @return
-     * @deprecated Use {@link #getDisableableCredentialTypesStream(RealmModel, UserModel) getDisableableCredentialTypesStream}
-     * instead.
-     */
-    @Deprecated
-    Set<String> getDisableableCredentialTypes(RealmModel realm, UserModel user);
-
-    /**
      * Obtains the set of credential types that can be disabled via {@link #disableCredentialType(RealmModel, UserModel, String)
      * disableCredentialType}.
      *
@@ -53,25 +40,13 @@ public interface CredentialInputUpdater {
      * @param user the user whose credentials are being searched.
      * @return a non-null {@link Stream} of credential types.
      */
-    default Stream<String> getDisableableCredentialTypesStream(RealmModel realm, UserModel user) {
-        Set<String> result = this.getDisableableCredentialTypes(realm, user);
-        return result != null ? result.stream() : Stream.empty();
-    }
+    Stream<String> getDisableableCredentialTypesStream(RealmModel realm, UserModel user);
 
     /**
-     * The {@link CredentialInputUpdater.Streams} interface makes all collection-based methods in {@link CredentialInputUpdater}
-     * default by providing implementations that delegate to the {@link Stream}-based variants instead of the other way around.
-     * <p/>
-     * It allows for implementations to focus on the {@link Stream}-based approach for processing sets of data and benefit
-     * from the potential memory and performance optimizations of that approach.
+     * @deprecated This interface is no longer necessary, collection-based methods were removed from the parent interface
+     * and therefore the parent interface can be used directly
      */
+    @Deprecated
     interface Streams extends CredentialInputUpdater {
-        @Override
-        default Set<String> getDisableableCredentialTypes(RealmModel realm, UserModel user) {
-            return this.getDisableableCredentialTypesStream(realm, user).collect(Collectors.toSet());
-        }
-
-        @Override
-        Stream<String> getDisableableCredentialTypesStream(RealmModel realm, UserModel user);
     }
 }

--- a/server-spi/src/main/java/org/keycloak/credential/UserCredentialStore.java
+++ b/server-spi/src/main/java/org/keycloak/credential/UserCredentialStore.java
@@ -47,29 +47,13 @@ public interface UserCredentialStore extends Provider {
     CredentialModel getStoredCredentialById(RealmModel realm, UserModel user, String id);
 
     /**
-     * @deprecated Use {@link SubjectCredentialManager#getStoredCredentialsStream()} instead.
-     */
-    @Deprecated
-    List<CredentialModel> getStoredCredentials(RealmModel realm, UserModel user);
-
-    /**
      * Obtains the stored credentials associated with the specified user.
      *
      * @param realm a reference to the realm.
      * @param user the user whose credentials are being searched.
      * @return a non-null {@link Stream} of credentials.
      */
-    default Stream<CredentialModel> getStoredCredentialsStream(RealmModel realm, UserModel user) {
-        List<CredentialModel> result = this.getStoredCredentials(realm, user);
-        return result != null ? result.stream() : Stream.empty();
-    }
-
-    /**
-     * @deprecated Use {@link SubjectCredentialManager#getStoredCredentialsByTypeStream(String)}
-     * instead.
-     */
-    @Deprecated
-    List<CredentialModel> getStoredCredentialsByType(RealmModel realm, UserModel user, String type);
+    Stream<CredentialModel> getStoredCredentialsStream(RealmModel realm, UserModel user);
 
     /**
      * Obtains the stored credentials associated with the specified user that match the specified type.
@@ -79,10 +63,7 @@ public interface UserCredentialStore extends Provider {
      * @param type the type of credentials being searched.
      * @return a non-null {@link Stream} of credentials.
      */
-    default Stream<CredentialModel> getStoredCredentialsByTypeStream(RealmModel realm, UserModel user, String type) {
-        List<CredentialModel> result = user.credentialManager().getStoredCredentialsByTypeStream(type).collect(Collectors.toList());
-        return result != null ? result.stream() : Stream.empty();
-    }
+    Stream<CredentialModel> getStoredCredentialsByTypeStream(RealmModel realm, UserModel user, String type);
 
     CredentialModel getStoredCredentialByNameAndType(RealmModel realm, UserModel user, String name, String type);
 
@@ -90,27 +71,10 @@ public interface UserCredentialStore extends Provider {
     boolean moveCredentialTo(RealmModel realm, UserModel user, String id, String newPreviousCredentialId);
 
     /**
-     * The {@link UserCredentialStore.Streams} interface makes all collection-based methods in {@link UserCredentialStore}
-     * default by providing implementations that delegate to the {@link Stream}-based variants instead of the other way around.
-     * <p/>
-     * It allows for implementations to focus on the {@link Stream}-based approach for processing sets of data and benefit
-     * from the potential memory and performance optimizations of that approach.
+     * @deprecated This interface is no longer necessary, collection-based methods were removed from the parent interface
+     * and therefore the parent interface can be used directly
      */
+    @Deprecated
     interface Streams extends UserCredentialStore {
-        @Override
-        default List<CredentialModel> getStoredCredentials(RealmModel realm, UserModel user) {
-            return user.credentialManager().getStoredCredentialsStream().collect(Collectors.toList());
-        }
-
-        @Override
-        Stream<CredentialModel> getStoredCredentialsStream(RealmModel realm, UserModel user);
-
-        @Override
-        default List<CredentialModel> getStoredCredentialsByType(RealmModel realm, UserModel user, String type) {
-            return user.credentialManager().getStoredCredentialsByTypeStream(type).collect(Collectors.toList());
-        }
-
-        @Override
-        Stream<CredentialModel> getStoredCredentialsByTypeStream(RealmModel realm, UserModel user, String type);
     }
 }

--- a/server-spi/src/main/java/org/keycloak/models/ClientProvider.java
+++ b/server-spi/src/main/java/org/keycloak/models/ClientProvider.java
@@ -34,19 +34,6 @@ import java.util.stream.Stream;
 public interface ClientProvider extends ClientLookupProvider, Provider {
 
     /**
-     * Returns the clients of the given realm.
-     * @deprecated use the stream variant instead
-     * @param realm Realm.
-     * @param firstResult First result to return. Ignored if negative or {@code null}.
-     * @param maxResults Maximum number of results to return. Ignored if negative or {@code null}.
-     * @return List of the clients. Never returns {@code null}.
-     */
-    @Deprecated
-    default List<ClientModel> getClients(RealmModel realm, Integer firstResult, Integer maxResults) {
-        return getClientsStream(realm, firstResult, maxResults).collect(Collectors.toList());
-    }
-
-    /**
      * Returns the clients of the given realm as a stream.
      * @param realm Realm.
      * @param firstResult First result to return. Ignored if negative or {@code null}.
@@ -54,18 +41,6 @@ public interface ClientProvider extends ClientLookupProvider, Provider {
      * @return Stream of the clients. Never returns {@code null}.
      */
     Stream<ClientModel> getClientsStream(RealmModel realm, Integer firstResult, Integer maxResults);
-
-    /**
-     * Returns all the clients of the given realm.
-     * @deprecated use the stream variant instead
-     * Effectively the same as the call {@code getClients(realm, null, null)}.
-     * @param realm Realm.
-     * @return List of the clients. Never returns {@code null}.
-     */
-    @Deprecated
-    default List<ClientModel> getClients(RealmModel realm) {
-        return this.getClientsStream(realm, null, null).collect(Collectors.toList());
-    }
 
     /**
      * Returns all the clients of the given realm as a stream.
@@ -109,31 +84,11 @@ public interface ClientProvider extends ClientLookupProvider, Provider {
     long getClientsCount(RealmModel realm);
 
     /**
-     * Returns a list of clients that are expected to always show up in account console.
-     * @deprecated use the stream variant instead
-     * @param realm Realm owning the clients.
-     * @return List of the clients. Never returns {@code null}.
-     */
-    @Deprecated
-    default List<ClientModel> getAlwaysDisplayInConsoleClients(RealmModel realm) {
-        return getAlwaysDisplayInConsoleClientsStream(realm).collect(Collectors.toList());
-    }
-
-    /**
      * Returns a stream of clients that are expected to always show up in account console.
      * @param realm Realm owning the clients.
      * @return Stream of the clients. Never returns {@code null}.
      */
     Stream<ClientModel> getAlwaysDisplayInConsoleClientsStream(RealmModel realm);
-
-    /**
-     * Removes given client from the given realm.
-     * @param id Internal ID of the client
-     * @param realm Realm.
-     * @return {@code true} if the client existed and has been removed, {@code false} otherwise.
-     * @deprecated Use {@link #removeClient(RealmModel, String)} instead.
-     */
-    default boolean removeClient(String id, RealmModel realm) { return this.removeClient(realm, id); }
 
     /**
      * Removes given client from the given realm.

--- a/server-spi/src/main/java/org/keycloak/models/ClientSessionContext.java
+++ b/server-spi/src/main/java/org/keycloak/models/ClientSessionContext.java
@@ -35,43 +35,16 @@ public interface ClientSessionContext {
     Set<String> getClientScopeIds();
 
     /**
-     * @deprecated Use {@link #getClientScopesStream() getClientScopesStream} instead.
-     * @return Set of protocol mappers
-     */
-    @Deprecated
-    default Set<ClientScopeModel> getClientScopes() {
-        return getClientScopesStream().collect(Collectors.toSet());
-    }
-
-    /**
      * Returns client scopes as a stream.
      * @return Stream of client scopes. Never returns {@code null}.
      */
     Stream<ClientScopeModel> getClientScopesStream();
 
     /**
-     * @deprecated Use {@link #getRolesStream() getRolesStream} instead.
-     * @return expanded roles (composite roles already applied)
-     */
-    @Deprecated
-    default Set<RoleModel> getRoles() {
-        return getRolesStream().collect(Collectors.toSet());
-    }
-
-    /**
      * Returns all roles including composite ones as a stream.
      * @return Stream of {@link RoleModel}. Never returns {@code null}.
      */
     Stream<RoleModel> getRolesStream();
-
-    /**
-     * @deprecated Use {@link #getProtocolMappersStream() getProtocolMappersStream} instead.
-     * @return Set of protocol mappers
-     */
-    @Deprecated
-    default Set<ProtocolMapperModel> getProtocolMappers() {
-        return getProtocolMappersStream().collect(Collectors.toSet());
-    }
 
     /**
      * Returns protocol mappers as a stream.

--- a/server-spi/src/main/java/org/keycloak/models/GroupModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/GroupModel.java
@@ -91,23 +91,13 @@ public interface GroupModel extends RoleMapperModel {
      */
     String getFirstAttribute(String name);
 
-    /**
-     * @param name
-     * @return list of all attribute values or empty list if there are not any values. Never return null
-     * @deprecated Use {@link #getAttributeStream(String) getAttributeStream} instead.
-     */
-    @Deprecated
-    List<String> getAttribute(String name);
 
     /**
      * Returns group attributes that match the given name as a stream.
      * @param name {@code String} Name of the attribute to be used as a filter.
      * @return Stream of all attribute values or empty stream if there are not any values. Never return {@code null}.
      */
-    default Stream<String> getAttributeStream(String name) {
-        List<String> value = this.getAttribute(name);
-        return value != null ? value.stream() : Stream.empty();
-    }
+    Stream<String> getAttributeStream(String name);
 
     Map<String, List<String>> getAttributes();
 
@@ -115,19 +105,10 @@ public interface GroupModel extends RoleMapperModel {
     String getParentId();
 
     /**
-     * @deprecated Use {@link #getSubGroupsStream() getSubGroupsStream} instead.
-     */
-    @Deprecated
-    Set<GroupModel> getSubGroups();
-
-    /**
      * Returns all sub groups for the parent group as a stream.
      * @return Stream of {@link GroupModel}. Never returns {@code null}.
      */
-    default Stream<GroupModel> getSubGroupsStream() {
-        Set<GroupModel> value = this.getSubGroups();
-        return value != null ? value.stream() : Stream.empty();
-    }
+    Stream<GroupModel> getSubGroupsStream();
 
     /**
      * You must also call addChild on the parent group, addChild on RealmModel if there is no parent group
@@ -151,27 +132,10 @@ public interface GroupModel extends RoleMapperModel {
     void removeChild(GroupModel subGroup);
 
     /**
-     * The {@link GroupModel.Streams} interface makes all collection-based methods in {@link GroupModel} default by providing
-     * implementations that delegate to the {@link Stream}-based variants instead of the other way around.
-     * <p/>
-     * It allows for implementations to focus on the {@link Stream}-based approach for processing sets of data and benefit
-     * from the potential memory and performance optimizations of that approach.
+     * @deprecated This interface is no longer necessary, collection-based methods were removed from the parent interface
+     * and therefore the parent interface can be used directly
      */
-    interface Streams extends GroupModel, RoleMapperModel.Streams {
-        @Override
-        default List<String> getAttribute(String name) {
-            return this.getAttributeStream(name).collect(Collectors.toList());
-        }
-
-        @Override
-        Stream<String> getAttributeStream(String name);
-
-        @Override
-        default Set<GroupModel> getSubGroups() {
-            return this.getSubGroupsStream().collect(Collectors.toSet());
-        }
-
-        @Override
-        Stream<GroupModel> getSubGroupsStream();
+    @Deprecated
+    interface Streams extends GroupModel, RoleMapperModel {
     }
 }

--- a/server-spi/src/main/java/org/keycloak/models/GroupProvider.java
+++ b/server-spi/src/main/java/org/keycloak/models/GroupProvider.java
@@ -33,30 +33,6 @@ import java.util.stream.Stream;
 public interface GroupProvider extends Provider, GroupLookupProvider {
 
     /**
-     * Returns a group from the given realm with the corresponding id
-     * 
-     * @param id Id.
-     * @param realm Realm.
-     * @return GroupModel with the corresponding id.
-     * @deprecated Use method {@link #getGroupById(RealmModel, String) getGroupById}
-     */
-    default GroupModel getGroupById(String id, RealmModel realm) {
-        return getGroupById(realm, id);
-    }
-
-    /**
-     * Returns groups for the given realm.
-     *
-     * @param realm Realm.
-     * @return List of groups in the Realm.
-     * @deprecated Use {@link #getGroupsStream(RealmModel) getGroupsStream} instead.
-     */
-    @Deprecated
-    default List<GroupModel> getGroups(RealmModel realm) {
-        return getGroupsStream(realm).collect(Collectors.toList());
-    }
-
-    /**
      * Returns groups for the given realm.
      *
      * @param realm Realm.
@@ -139,21 +115,6 @@ public interface GroupProvider extends Provider, GroupLookupProvider {
      * @param role Role.
      * @param firstResult First result to return. Ignored if negative or {@code null}.
      * @param maxResults Maximum number of results to return. Ignored if negative or {@code null}.
-     * @return List of groups with the given role.
-     * @deprecated Use {@link #getGroupsByRoleStream(RealmModel, RoleModel, Integer, Integer) getGroupsByRoleStream} instead.
-     */
-    @Deprecated
-    default List<GroupModel> getGroupsByRole(RealmModel realm, RoleModel role, int firstResult, int maxResults) {
-        return  getGroupsByRoleStream(realm, role, firstResult, maxResults).collect(Collectors.toList());
-    }
-
-    /**
-     * Returns groups with the given role in the given realm.
-     *
-     * @param realm Realm.
-     * @param role Role.
-     * @param firstResult First result to return. Ignored if negative or {@code null}.
-     * @param maxResults Maximum number of results to return. Ignored if negative or {@code null}.
      * @return Stream of groups with the given role. Never returns {@code null}.
      */
      Stream<GroupModel> getGroupsByRoleStream(RealmModel realm, RoleModel role, Integer firstResult, Integer maxResults);
@@ -162,35 +123,9 @@ public interface GroupProvider extends Provider, GroupLookupProvider {
      * Returns all top level groups (i.e. groups without parent group) for the given realm.
      *
      * @param realm Realm.
-     * @return List of all top level groups in the realm.
-     * @deprecated Use {@link #getTopLevelGroupsStream(RealmModel) getTopLevelGroupsStream} instead.
-     */
-    @Deprecated
-    default List<GroupModel> getTopLevelGroups(RealmModel realm) {
-        return getTopLevelGroupsStream(realm).collect(Collectors.toList());
-    }
-
-    /**
-     * Returns all top level groups (i.e. groups without parent group) for the given realm.
-     *
-     * @param realm Realm.
      * @return Stream of all top level groups in the realm. Never returns {@code null}.
      */
     Stream<GroupModel> getTopLevelGroupsStream(RealmModel realm);
-
-    /**
-     * Returns top level groups (i.e. groups without parent group) for the given realm.
-     *
-     * @param realm Realm.
-     * @param firstResult First result to return. Ignored if negative or {@code null}.
-     * @param maxResults Maximum number of results to return. Ignored if negative or {@code null}.
-     * @return List of top level groups in the realm.
-     * @deprecated Use {@link #getTopLevelGroupsStream(RealmModel, Integer, Integer) getTopLevelGroupsStream} instead.
-     */
-    @Deprecated
-    default List<GroupModel> getTopLevelGroups(RealmModel realm, Integer firstResult, Integer maxResults) {
-        return getTopLevelGroupsStream(realm, firstResult, maxResults).collect(Collectors.toList());
-    }
 
     /**
      * Returns top level groups (i.e. groups without parent group) for the given realm.

--- a/server-spi/src/main/java/org/keycloak/models/KeyManager.java
+++ b/server-spi/src/main/java/org/keycloak/models/KeyManager.java
@@ -42,35 +42,10 @@ public interface KeyManager {
 
     /**
      * Returns all {@code KeyWrapper} for the given realm.
-     *
-     * @param realm {@code RealmModel}.
-     * @return List of all {@code KeyWrapper} in the realm.
-     * @deprecated Use {@link #getKeysStream(RealmModel) getKeysStream} instead.
-     */
-    @Deprecated
-    default List<KeyWrapper> getKeys(RealmModel realm) {
-        return getKeysStream(realm).collect(Collectors.toList());
-    }
-
-    /**
-     * Returns all {@code KeyWrapper} for the given realm.
      * @param realm {@code RealmModel}.
      * @return Stream of all {@code KeyWrapper} in the realm. Never returns {@code null}.
      */
     Stream<KeyWrapper> getKeysStream(RealmModel realm);
-
-    /**
-     * Returns all {@code KeyWrapper} for the given realm that match given criteria.
-     * @param realm {@code RealmModel}.
-     * @param use {@code KeyUse}.
-     * @param algorithm {@code String}.
-     * @return List of all {@code KeyWrapper} in the realm.
-     * @deprecated Use {@link #getKeysStream(RealmModel, KeyUse, String) getKeysStream} instead.
-     */
-    @Deprecated
-    default List<KeyWrapper> getKeys(RealmModel realm, KeyUse use, String algorithm) {
-        return getKeysStream(realm, use, algorithm).collect(Collectors.toList());
-    }
 
     /**
      * Returns all {@code KeyWrapper} for the given realm that match given criteria.

--- a/server-spi/src/main/java/org/keycloak/models/KeycloakSessionFactory.java
+++ b/server-spi/src/main/java/org/keycloak/models/KeycloakSessionFactory.java
@@ -49,17 +49,6 @@ public interface KeycloakSessionFactory extends ProviderEventManager, Invalidati
     <T extends Provider> ProviderFactory<T> getProviderFactory(Class<T> clazz, String realmId, String componentId, Function<KeycloakSessionFactory, ComponentModel> modelGetter);
 
     /**
-     * Returns list of provider factories for the given provider.
-     * @param clazz {@code Class<? extends Provider>}
-     * @return {@code List<ProviderFactory>} List of provider factories
-     * @deprecated Use {@link #getProviderFactoriesStream(Class) getProviderFactoriesStream} instead.
-     */
-    @Deprecated
-    default List<ProviderFactory> getProviderFactories(Class<? extends Provider> clazz) {
-        return getProviderFactoriesStream(clazz).collect(Collectors.toList());
-    }
-
-    /**
      * Returns stream of provider factories for the given provider.
      * @param clazz {@code Class<? extends Provider>}
      * @return {@code Stream<ProviderFactory>} Stream of provider factories. Never returns {@code null}.

--- a/server-spi/src/main/java/org/keycloak/models/ProtocolMapperContainerModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/ProtocolMapperContainerModel.java
@@ -27,15 +27,6 @@ import java.util.stream.Stream;
  */
 public interface ProtocolMapperContainerModel {
     /**
-     * @deprecated Use {@link #getProtocolMappersStream() getProtocolMappersStream} instead.
-     * @return Set of protocol mappers
-     */
-    @Deprecated
-    default Set<ProtocolMapperModel> getProtocolMappers() {
-        return getProtocolMappersStream().collect(Collectors.toSet());
-    }
-
-    /**
      * Returns protocol mappers as a stream.
      * @return Stream of protocol mapper. Never returns {@code null}.
      */

--- a/server-spi/src/main/java/org/keycloak/models/RealmModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/RealmModel.java
@@ -268,14 +268,6 @@ public interface RealmModel extends RoleContainerModel {
     void setActionTokenGeneratedByUserLifespan(String actionTokenType, Integer seconds);
 
     /**
-     * @deprecated Use {@link #getRequiredCredentialsStream() getRequiredCredentialsStream} instead.
-     */
-    @Deprecated
-    default List<RequiredCredentialModel> getRequiredCredentials() {
-        return getRequiredCredentialsStream().collect(Collectors.toList());
-    }
-
-    /**
      * Returns required credentials as a stream.
      * @return Stream of {@link RequiredCredentialModel}. Never returns {@code null}.
      */
@@ -317,14 +309,6 @@ public interface RealmModel extends RoleContainerModel {
     RoleModel getRoleById(String id);
 
     /**
-     * @deprecated Use {@link #getDefaultGroupsStream() getDefaultGroupsStream} instead.
-     */
-    @Deprecated
-    default List<GroupModel> getDefaultGroups() {
-        return getDefaultGroupsStream().collect(Collectors.toList());
-    }
-
-    /**
      * Returns default groups as a stream.
      * @return Stream of {@link GroupModel}. Never returns {@code null}.
      */
@@ -335,26 +319,10 @@ public interface RealmModel extends RoleContainerModel {
     void removeDefaultGroup(GroupModel group);
 
     /**
-     * @deprecated Use {@link #getClientsStream() getClientsStream} instead.
-     */
-    @Deprecated
-    default List<ClientModel> getClients() {
-        return getClientsStream(null, null).collect(Collectors.toList());
-    }
-
-    /**
      * Returns clients as a stream.
      * @return Stream of {@link ClientModel}. Never returns {@code null}.
      */
     Stream<ClientModel> getClientsStream();
-
-    /**
-     * @deprecated Use {@link #getClientsStream(Integer, Integer) getClientsStream} instead.
-     */
-    @Deprecated
-    default List<ClientModel> getClients(Integer firstResult, Integer maxResults) {
-        return getClientsStream(firstResult, maxResults).collect(Collectors.toList());
-    }
 
     /**
      * Returns clients as a stream.
@@ -365,14 +333,6 @@ public interface RealmModel extends RoleContainerModel {
     Stream<ClientModel> getClientsStream(Integer firstResult, Integer maxResults);
 
     Long getClientsCount();
-
-    /**
-     * @deprecated Use {@link #getAlwaysDisplayInConsoleClientsStream() getAlwaysDisplayInConsoleClientsStream} instead.
-     */
-    @Deprecated
-    default List<ClientModel> getAlwaysDisplayInConsoleClients() {
-        return getAlwaysDisplayInConsoleClientsStream().collect(Collectors.toList());
-    }
 
     /**
      * Returns clients which are always displayed in the admin console as a stream.
@@ -388,14 +348,6 @@ public interface RealmModel extends RoleContainerModel {
 
     ClientModel getClientById(String id);
     ClientModel getClientByClientId(String clientId);
-
-    /**
-     * @deprecated Use {@link #searchClientByClientIdStream(String, Integer, Integer) searchClientByClientId} instead.
-     */
-    @Deprecated
-    default List<ClientModel> searchClientByClientId(String clientId, Integer firstResult, Integer maxResults) {
-        return searchClientByClientIdStream(clientId, firstResult, maxResults).collect(Collectors.toList());
-    }
 
     /**
      * Search for clients by provided client's id.
@@ -436,14 +388,6 @@ public interface RealmModel extends RoleContainerModel {
     void setDockerAuthenticationFlow(AuthenticationFlowModel flow);
 
     /**
-     * @deprecated Use {@link #getAuthenticationFlowsStream() getAuthenticationFlowsStream} instead.
-     */
-    @Deprecated
-    default List<AuthenticationFlowModel> getAuthenticationFlows() {
-        return getAuthenticationFlowsStream().collect(Collectors.toList());
-    }
-
-    /**
      * Returns authentications flows as a stream.
      * @return Stream of {@link AuthenticationFlowModel}. Never returns {@code null}.
      */
@@ -454,14 +398,6 @@ public interface RealmModel extends RoleContainerModel {
     AuthenticationFlowModel getAuthenticationFlowById(String id);
     void removeAuthenticationFlow(AuthenticationFlowModel model);
     void updateAuthenticationFlow(AuthenticationFlowModel model);
-
-    /**
-     * @deprecated Use {@link #getAuthenticationExecutionsStream(String) getAuthenticationExecutionsStream} instead.
-     */
-    @Deprecated
-    default List<AuthenticationExecutionModel> getAuthenticationExecutions(String flowId) {
-        return getAuthenticationExecutionsStream(flowId).collect(Collectors.toList());
-    }
 
     /**
      * Returns sorted (according to priority) {@link AuthenticationExecutionModel AuthenticationExecutionModel} as a stream.
@@ -478,14 +414,6 @@ public interface RealmModel extends RoleContainerModel {
     void removeAuthenticatorExecution(AuthenticationExecutionModel model);
 
     /**
-     * @deprecated Use {@link #getAuthenticatorConfigsStream() getAuthenticatorConfigsStream} instead.
-     */
-    @Deprecated
-    default List<AuthenticatorConfigModel> getAuthenticatorConfigs() {
-        return getAuthenticatorConfigsStream().collect(Collectors.toList());
-    }
-
-    /**
      * Returns authentication configs as a stream.
      * @return Stream of {@link AuthenticatorConfigModel}. Never returns {@code null}.
      */
@@ -496,14 +424,6 @@ public interface RealmModel extends RoleContainerModel {
     void removeAuthenticatorConfig(AuthenticatorConfigModel model);
     AuthenticatorConfigModel getAuthenticatorConfigById(String id);
     AuthenticatorConfigModel getAuthenticatorConfigByAlias(String alias);
-
-    /**
-     * @deprecated Use {@link #getRequiredActionProvidersStream() getRequiredActionProvidersStream} instead.
-     */
-    @Deprecated
-    default List<RequiredActionProviderModel> getRequiredActionProviders() {
-        return getRequiredActionProvidersStream().collect(Collectors.toList());
-    }
 
     /**
      * Returns sorted {@link RequiredActionProviderModel RequiredActionProviderModel} as a stream.
@@ -519,14 +439,6 @@ public interface RealmModel extends RoleContainerModel {
     RequiredActionProviderModel getRequiredActionProviderByAlias(String alias);
 
     /**
-     * @deprecated Use {@link #getIdentityProvidersStream() getIdentityProvidersStream} instead.
-     */
-    @Deprecated
-    default List<IdentityProviderModel> getIdentityProviders() {
-        return getIdentityProvidersStream().collect(Collectors.toList());
-    }
-
-    /**
      * Returns identity providers as a stream.
      * @return Stream of {@link IdentityProviderModel}. Never returns {@code null}.
      */
@@ -538,26 +450,10 @@ public interface RealmModel extends RoleContainerModel {
     void updateIdentityProvider(IdentityProviderModel identityProvider);
 
     /**
-     * @deprecated Use {@link #getIdentityProviderMappersStream() getIdentityProviderMappersStream} instead.
-     */
-    @Deprecated
-    default Set<IdentityProviderMapperModel> getIdentityProviderMappers() {
-        return getIdentityProviderMappersStream().collect(Collectors.toSet());
-    }
-
-    /**
      * Returns identity provider mappers as a stream.
      * @return Stream of {@link IdentityProviderMapperModel}. Never returns {@code null}.
      */
     Stream<IdentityProviderMapperModel> getIdentityProviderMappersStream();
-
-    /**
-     * @deprecated Use {@link #getIdentityProviderMappersByAliasStream(String) getIdentityProviderMappersByAliasStream} instead.
-     */
-    @Deprecated
-    default Set<IdentityProviderMapperModel> getIdentityProviderMappersByAlias(String brokerAlias) {
-        return getIdentityProviderMappersByAliasStream(brokerAlias).collect(Collectors.toSet());
-    }
 
     /**
      * Returns identity provider mappers by the provided alias as a stream.
@@ -610,14 +506,6 @@ public interface RealmModel extends RoleContainerModel {
     void removeComponents(String parentId);
 
     /**
-     * @deprecated Use {@link #getComponentsStream(String, String) getComponentsStream} instead.
-     */
-    @Deprecated
-    default List<ComponentModel> getComponents(String parentId, String providerType) {
-        return getComponentsStream(parentId, providerType).collect(Collectors.toList());
-    }
-
-    /**
      * Returns stream of ComponentModels for specific parentId and providerType.
      * @param parentId {@code String} id of parent
      * @param providerType {@code String} type of provider
@@ -631,22 +519,6 @@ public interface RealmModel extends RoleContainerModel {
      * @return Stream of {@link ComponentModel}. Never returns {@code null}.
      */
     Stream<ComponentModel> getComponentsStream(String parentId);
-
-    /**
-     * @deprecated Use {@link #getComponentsStream(String) getComponentsStream} instead.
-     */
-    @Deprecated
-    default List<ComponentModel> getComponents(String parentId) {
-        return getComponentsStream(parentId).collect(Collectors.toList());
-    }
-
-    /**
-     * @deprecated Use {@link #getComponentsStream() getComponentsStream} instead.
-     */
-    @Deprecated
-    default List<ComponentModel> getComponents() {
-        return getComponentsStream().collect(Collectors.toList());
-    }
 
     /**
      * Returns stream of component models.
@@ -704,28 +576,12 @@ public interface RealmModel extends RoleContainerModel {
     void setEventsExpiration(long expiration);
 
     /**
-     * @deprecated Use {@link #getEventsListenersStream() getEventsListenersStream} instead.
-     */
-    @Deprecated
-    default Set<String> getEventsListeners() {
-        return getEventsListenersStream().collect(Collectors.toSet());
-    }
-
-    /**
      * Returns events listeners as a stream.
      * @return Stream of {@code String}. Never returns {@code null}.
      */
     Stream<String> getEventsListenersStream();
 
     void setEventsListeners(Set<String> listeners);
-
-    /**
-     * @deprecated Use {@link #getEnabledEventTypesStream() getEnabledEventTypesStream} instead.
-     */
-    @Deprecated
-    default Set<String> getEnabledEventTypes() {
-        return getEnabledEventTypesStream().collect(Collectors.toSet());
-    }
 
     /**
      * Returns enabled event types as a stream.
@@ -765,14 +621,6 @@ public interface RealmModel extends RoleContainerModel {
     void setInternationalizationEnabled(boolean enabled);
 
     /**
-     * @deprecated Use {@link #getSupportedLocalesStream() getSupportedLocalesStream} instead.
-     */
-    @Deprecated
-    default Set<String> getSupportedLocales() {
-        return getSupportedLocalesStream().collect(Collectors.toSet());
-    }
-
-    /**
      * Returns supported locales as a stream.
      * @return Stream of {@code String}. Never returns {@code null}.
      */
@@ -799,14 +647,6 @@ public interface RealmModel extends RoleContainerModel {
     GroupModel getGroupById(String id);
 
     /**
-     * @deprecated Use {@link #getGroupsStream() getGroupsStream} instead.
-     */
-    @Deprecated
-    default List<GroupModel> getGroups() {
-        return getGroupsStream().collect(Collectors.toList());
-    }
-
-    /**
      * Returns groups as a stream.
      * @return Stream of {@link GroupModel}. Never returns {@code null}.
      */
@@ -816,26 +656,10 @@ public interface RealmModel extends RoleContainerModel {
     Long getGroupsCountByNameContaining(String search);
 
     /**
-     * @deprecated Use {@link #getTopLevelGroups() getTopLevelGroups} instead.
-     */
-    @Deprecated
-    default List<GroupModel> getTopLevelGroups() {
-        return getTopLevelGroupsStream().collect(Collectors.toList());
-    }
-
-    /**
      * Returns top level groups as a stream.
      * @return Stream of {@link GroupModel}. Never returns {@code null}.
      */
     Stream<GroupModel> getTopLevelGroupsStream();
-
-    /**
-     * @deprecated Use {@link #getTopLevelGroupsStream(Integer, Integer) getTopLevelGroupsStream} instead.
-     */
-    @Deprecated
-    default List<GroupModel> getTopLevelGroups(Integer first, Integer max) {
-        return getTopLevelGroupsStream(first, max).collect(Collectors.toList());
-    }
 
     /**
      * Returns top level groups as a stream.
@@ -844,14 +668,6 @@ public interface RealmModel extends RoleContainerModel {
      * @return Stream of {@link GroupModel}. Never returns {@code null}.
      */
     Stream<GroupModel> getTopLevelGroupsStream(Integer first, Integer max);
-
-    /**
-     * @deprecated Use {@link GroupProvider#searchForGroupByNameStream(RealmModel, String, Boolean, Integer, Integer)} instead.
-     */
-    @Deprecated
-    default List<GroupModel> searchForGroupByName(String search, Integer first, Integer max) {
-        return searchForGroupByNameStream(search, first, max).collect(Collectors.toList());
-    }
 
     /**
      * Searches for groups by provided name. Results that match the given filter are returned as a stream.
@@ -866,14 +682,6 @@ public interface RealmModel extends RoleContainerModel {
 
     boolean removeGroup(GroupModel group);
     void moveGroup(GroupModel group, GroupModel toParent);
-
-    /**
-     * @deprecated Use {@link #getClientScopesStream() getClientScopesStream} instead.
-     */
-    @Deprecated
-    default List<ClientScopeModel> getClientScopes() {
-        return getClientScopesStream().collect(Collectors.toList());
-    }
 
     /**
      * Returns all client scopes of this realm as a stream.
@@ -937,14 +745,6 @@ public interface RealmModel extends RoleContainerModel {
     boolean removeRealmLocalizationTexts(String locale);
     Map<String, Map<String, String>> getRealmLocalizationTexts();
     Map<String, String> getRealmLocalizationTextsByLocale(String locale);
-
-    /**
-     * @deprecated Use {@link #getDefaultClientScopesStream(boolean) getDefaultClientScopesStream} instead.
-     */
-    @Deprecated
-    default List<ClientScopeModel> getDefaultClientScopes(boolean defaultScope) {
-        return getDefaultClientScopesStream(defaultScope).collect(Collectors.toList());
-    }
 
     /**
      * Returns default client scopes of this realm either default ones or optional ones.

--- a/server-spi/src/main/java/org/keycloak/models/RealmProvider.java
+++ b/server-spi/src/main/java/org/keycloak/models/RealmProvider.java
@@ -127,30 +127,6 @@ public interface RealmProvider extends Provider /* TODO: Remove in future versio
     // including the "default" body to be able to add a note on deprecation
 
     /**
-     * @deprecated Use {@link #getRealmsStream() getRealmsStream} instead.
-     */
-    @Deprecated
-    default List<RealmModel> getRealms() {
-        return getRealmsStream().collect(Collectors.toList());
-    }
-
-    /**
-     * @deprecated Use {@link #getRealmsWithProviderTypeStream(Class) getRealmsWithProviderTypeStream} instead.
-     */
-    @Deprecated
-    default List<RealmModel> getRealmsWithProviderType(Class<?> type) {
-        return getRealmsWithProviderTypeStream(type).collect(Collectors.toList());
-    }
-
-    /**
-     * @deprecated Use {@link #listClientInitialAccessStream(RealmModel) listClientInitialAccessStream} instead.
-     */
-    @Deprecated
-    default List<ClientInitialAccessModel> listClientInitialAccess(RealmModel realm) {
-        return listClientInitialAccessStream(realm).collect(Collectors.toList());
-    }
-
-    /**
      * @deprecated Use the corresponding method from {@link ClientProvider}. */
     @Override
     public ClientModel addClient(RealmModel realm, String id, String clientId);
@@ -160,49 +136,6 @@ public interface RealmProvider extends Provider /* TODO: Remove in future versio
     @Override
     default ClientModel addClient(RealmModel realm, String clientId) {
         return addClient(realm, null, clientId);
-    }
-
-    /**
-     * @deprecated Use the corresponding method from {@link ClientProvider}. */
-    @Override
-    default List<ClientModel> getClients(RealmModel realm) {
-        return this.getClients(realm, null, null);
-    }
-
-    /**
-     * @deprecated Use the corresponding method from {@link ClientProvider}. */
-    @Override
-    default List<ClientModel> getClients(RealmModel realm, Integer firstResult, Integer maxResults) {
-        return getClientsStream(realm, firstResult, maxResults).collect(Collectors.toList());
-    }
-
-    /**
-     * @deprecated Use the corresponding method from {@link ClientProvider}. */
-    @Override
-    default List<ClientModel> searchClientsByClientId(String clientId, Integer firstResult, Integer maxResults, RealmModel realm) {
-        return searchClientsByClientIdStream(realm, clientId, firstResult, maxResults).collect(Collectors.toList());
-    }
-
-    /**
-     * @deprecated Use the corresponding method from {@link ClientProvider}. */
-    @Override
-    default ClientModel getClientByClientId(String clientId, RealmModel realm) { return getClientByClientId(realm, clientId); }
-
-    /**
-     * @deprecated Use the corresponding method from {@link ClientProvider}. */
-    @Override
-    default ClientModel getClientById(String id, RealmModel realm) { return getClientById(realm, id); }
-
-    /**
-     * @deprecated Use the corresponding method from {@link ClientProvider}. */
-    @Override
-    default boolean removeClient(String id, RealmModel realm) { return this.removeClient(realm, id); }
-
-    /**
-     * @deprecated Use the corresponding method from {@link ClientProvider}. */
-    @Override
-    default  List<ClientModel> getAlwaysDisplayInConsoleClients(RealmModel realm) {
-        return getAlwaysDisplayInConsoleClientsStream(realm).collect(Collectors.toList());
     }
 
     /**
@@ -241,13 +174,6 @@ public interface RealmProvider extends Provider /* TODO: Remove in future versio
      * @deprecated Use the corresponding method from {@link RoleProvider}. */
     default RoleModel getRoleById(String id, RealmModel realm) {
         return getRoleById(realm, id);
-    }
-
-    /**
-     * @deprecated Use the corresponding method from {@link RoleProvider}. */
-    @Override
-    default Set<RoleModel> getRealmRoles(RealmModel realm) {
-        return getRealmRoles(realm, null, null);
     }
 
     /**
@@ -319,54 +245,12 @@ public interface RealmProvider extends Provider /* TODO: Remove in future versio
     /**
      * @deprecated Use the corresponding method from {@link GroupProvider}. */
     @Override
-    default GroupModel getGroupById(String id, RealmModel realm) {
-        return getGroupById(realm, id);
-    }
-
-    /**
-     * @deprecated Use the corresponding method from {@link GroupProvider}. */
-    @Override
-    default List<GroupModel> getGroups(RealmModel realm) {
-        return getGroupsStream(realm).collect(Collectors.toList());
-    }
-
-    /**
-     * @deprecated Use the corresponding method from {@link GroupProvider}. */
-    @Override
     Long getGroupsCount(RealmModel realm, Boolean onlyTopGroups);
 
     /**
      * @deprecated Use the corresponding method from {@link GroupProvider}. */
     @Override
     Long getGroupsCountByNameContaining(RealmModel realm, String search);
-
-    /**
-     * @deprecated Use the corresponding method from {@link GroupProvider}. */
-    @Override
-    default List<GroupModel> getGroupsByRole(RealmModel realm, RoleModel role, int firstResult, int maxResults) {
-        return getGroupsByRoleStream(realm, role, firstResult, maxResults).collect(Collectors.toList());
-    }
-
-    /**
-     * @deprecated Use the corresponding method from {@link GroupProvider}. */
-    @Override
-    default List<GroupModel> getTopLevelGroups(RealmModel realm) {
-        return getTopLevelGroupsStream(realm).collect(Collectors.toList());
-    }
-
-    /**
-     * @deprecated Use the corresponding method from {@link GroupProvider}. */
-    @Override
-    default List<GroupModel> getTopLevelGroups(RealmModel realm, Integer first, Integer max) {
-        return getTopLevelGroupsStream(realm, first, max).collect(Collectors.toList());
-    }
-
-    /**
-     * @deprecated Use the corresponding method from {@link GroupProvider}. */
-    @Override
-    default List<GroupModel> searchForGroupByName(RealmModel realm, String search, Integer first, Integer max) {
-        return searchForGroupByNameStream(realm, search, first, max).collect(Collectors.toList());
-    }
 
     /**
      * @deprecated Use the corresponding method from {@link GroupProvider}. */

--- a/server-spi/src/main/java/org/keycloak/models/RoleContainerModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/RoleContainerModel.java
@@ -51,26 +51,10 @@ public interface RoleContainerModel {
     boolean removeRole(RoleModel role);
 
     /**
-     * @deprecated Use {@link #getRolesStream() getRolesStream} instead.
-     */
-    @Deprecated
-    default Set<RoleModel> getRoles() {
-        return getRolesStream().collect(Collectors.toSet());
-    }
-
-    /**
      * Returns available roles as a stream.
      * @return Stream of {@link RoleModel}. Never returns {@code null}.
      */
     Stream<RoleModel> getRolesStream();
-
-    /**
-     * @deprecated Use {@link #getRolesStream(Integer, Integer) getRolesStream} instead.
-     */
-    @Deprecated
-    default Set<RoleModel> getRoles(Integer firstResult, Integer maxResults) {
-        return getRolesStream(firstResult, maxResults).collect(Collectors.toSet());
-    }
 
     /**
      * Returns available roles as a stream.
@@ -79,14 +63,6 @@ public interface RoleContainerModel {
      * @return Stream of {@link RoleModel}. Never returns {@code null}.
      */
     Stream<RoleModel> getRolesStream(Integer firstResult, Integer maxResults);
-
-    /**
-     * @deprecated Use {@link #searchForRolesStream(String, Integer, Integer) searchForRolesStream} instead.
-     */
-    @Deprecated
-    default Set<RoleModel> searchForRoles(String search, Integer first, Integer max) {
-        return searchForRolesStream(search, first, max).collect(Collectors.toSet());
-    }
 
     /**
      * Searches roles by the given name. Returns all roles that match the given filter.

--- a/server-spi/src/main/java/org/keycloak/models/RoleMapperModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/RoleMapperModel.java
@@ -27,41 +27,19 @@ import java.util.stream.Stream;
  * @version $Revision: 1 $
  */
 public interface RoleMapperModel {
-    /**
-     * Returns set of realm roles that are directly set to this object.
-     * @return see description
-     * @deprecated Use {@link #getRealmRoleMappingsStream() getRealmRoleMappingsStream} instead.
-     */
-    @Deprecated
-    Set<RoleModel> getRealmRoleMappings();
 
     /**
      * Returns stream of realm roles that are directly set to this object.
      * @return Stream of {@link RoleModel}. Never returns {@code null}.
      */
-    default Stream<RoleModel> getRealmRoleMappingsStream() {
-        Set<RoleModel> value = this.getRealmRoleMappings();
-        return value != null ? value.stream() : Stream.empty();
-    }
-
-    /**
-     * Returns set of client roles that are directly set to this object for the given client.
-     * @param app Client to get the roles for
-     * @return see description
-     * @deprecated Use {@link #getClientRoleMappingsStream(ClientModel) getClientRoleMappingsStream} instead.
-     */
-    @Deprecated
-    Set<RoleModel> getClientRoleMappings(ClientModel app);
+    Stream<RoleModel> getRealmRoleMappingsStream();
 
     /**
      * Returns stream of client roles that are directly set to this object for the given client.
      * @param app {@link ClientModel} Client to get the roles for.
      * @return Stream of {@link RoleModel}. Never returns {@code null}.
      */
-    default Stream<RoleModel> getClientRoleMappingsStream(ClientModel app) {
-        Set<RoleModel> value = this.getClientRoleMappings(app);
-        return value != null ? value.stream() : Stream.empty();
-    }
+    Stream<RoleModel> getClientRoleMappingsStream(ClientModel app);
 
     /**
      * Returns {@code true}, if this object is directly assigned the given role.
@@ -97,21 +75,10 @@ public interface RoleMapperModel {
     void grantRole(RoleModel role);
 
     /**
-     * Returns set of all role (both realm all client) that are directly set to this object.
-     * @return
-     * @deprecated Use {@link #getRoleMappingsStream() getRoleMappingsStream} instead.
-     */
-    @Deprecated
-    Set<RoleModel> getRoleMappings();
-
-    /**
      * Returns stream of all role (both realm all client) that are directly set to this object.
      * @return Stream of {@link RoleModel}. Never returns {@code null}.
      */
-    default Stream<RoleModel> getRoleMappingsStream() {
-        Set<RoleModel> value = this.getRoleMappings();
-        return value != null ? value.stream() : Stream.empty();
-    }
+    Stream<RoleModel> getRoleMappingsStream();
 
     /**
      * Removes the given role mapping from this object.
@@ -120,35 +87,10 @@ public interface RoleMapperModel {
     void deleteRoleMapping(RoleModel role);
 
     /**
-     * The {@link Streams} interface makes all collection-based methods in {@link RoleMapperModel} default by providing
-     * implementations that delegate to the {@link Stream}-based variants instead of the other way around.
-     * <p/>
-     * It allows for implementations to focus on the {@link Stream}-based approach for processing sets of data and benefit
-     * from the potential memory and performance optimizations of that approach.
+     * @deprecated This interface is no longer necessary, collection-based methods were removed from the parent interface
+     * and therefore the parent interface can be used directly
      */
+    @Deprecated
     interface Streams extends RoleMapperModel {
-        @Override
-        default Set<RoleModel> getRealmRoleMappings() {
-            return this.getRealmRoleMappingsStream().collect(Collectors.toSet());
-        }
-
-        @Override
-        Stream<RoleModel> getRealmRoleMappingsStream();
-
-        @Override
-        default Set<RoleModel> getClientRoleMappings(ClientModel app) {
-            return this.getClientRoleMappingsStream(app).collect(Collectors.toSet());
-        }
-
-        @Override
-        Stream<RoleModel> getClientRoleMappingsStream(ClientModel app);
-
-        @Override
-        default Set<RoleModel> getRoleMappings() {
-            return this.getRoleMappingsStream().collect(Collectors.toSet());
-        }
-
-        @Override
-        Stream<RoleModel> getRoleMappingsStream();
     }
 }

--- a/server-spi/src/main/java/org/keycloak/models/RoleModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/RoleModel.java
@@ -71,14 +71,6 @@ public interface RoleModel {
     void removeCompositeRole(RoleModel role);
 
     /**
-     * @deprecated Use {@link #getCompositesStream() getCompositesStream} instead.
-     */
-    @Deprecated
-    default Set<RoleModel> getComposites() {
-        return getCompositesStream().collect(Collectors.toSet());
-    }
-
-    /**
      * Returns all composite roles as a stream.
      * @return Stream of {@link RoleModel}. Never returns {@code null}.
      */
@@ -112,14 +104,6 @@ public interface RoleModel {
 
     default String getFirstAttribute(String name) {
         return getAttributeStream(name).findFirst().orElse(null);
-    }
-
-    /**
-     * @deprecated Use {@link #getAttributeStream(String) getAttributeStream} instead.
-     */
-    @Deprecated
-    default List<String> getAttribute(String name) {
-        return getAttributeStream(name).collect(Collectors.toList());
     }
 
     /**

--- a/server-spi/src/main/java/org/keycloak/models/RoleProvider.java
+++ b/server-spi/src/main/java/org/keycloak/models/RoleProvider.java
@@ -51,18 +51,6 @@ public interface RoleProvider extends Provider, RoleLookupProvider {
     RoleModel addRealmRole(RealmModel realm, String id, String name);
 
     /**
-     * Returns all the realm roles of the given realm.
-     * Effectively the same as the call {@code getRealmRoles(realm, null, null)}.
-     * @param realm Realm.
-     * @return List of the roles. Never returns {@code null}.
-     * @deprecated use the stream variant instead
-     */
-    @Deprecated
-    default Set<RoleModel> getRealmRoles(RealmModel realm) {
-        return getRealmRolesStream(realm, null, null).collect(Collectors.toSet());
-    }
-
-    /**
      * Returns all the realm roles of the given realm as a stream.
      * Effectively the same as the call {@code getRealmRolesStream(realm, null, null)}.
      * @param realm Realm.

--- a/server-spi/src/main/java/org/keycloak/models/ScopeContainerModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/ScopeContainerModel.java
@@ -29,29 +29,10 @@ import java.util.stream.Stream;
 public interface ScopeContainerModel {
 
     /**
-     * @deprecated Use {@link #getScopeMappingsStream() getScopeMappingsStream} instead.
-     */
-    @Deprecated
-    default Set<RoleModel> getScopeMappings() {
-        return getScopeMappingsStream().collect(Collectors.toSet());
-    }
-
-    /**
      * Returns scope mappings for this scope container as a stream.
      * @return Stream of {@link RoleModel}. Never returns {@code null}.
      */
     Stream<RoleModel> getScopeMappingsStream();
-
-    /**
-     * From the scope mappings returned by {@link #getScopeMappings()} returns only those
-     * that belong to the realm that owns this scope container.
-     * @return set of {@link RealmModel}
-     * @deprecated Use {@link #getRealmScopeMappingsStream() getRealmScopeMappingsStream} instead.
-     */
-    @Deprecated
-    default Set<RoleModel> getRealmScopeMappings() {
-        return getRealmScopeMappingsStream().collect(Collectors.toSet());
-    }
 
     /**
      * From the scope mappings returned by {@link #getScopeMappingsStream()} returns only those

--- a/server-spi/src/main/java/org/keycloak/models/UserCredentialManager.java
+++ b/server-spi/src/main/java/org/keycloak/models/UserCredentialManager.java
@@ -96,23 +96,14 @@ public interface UserCredentialManager extends UserCredentialStore {
     void disableCredentialType(RealmModel realm, UserModel user, String credentialType);
 
     /**
-     * Returns a set of credential types that can be disabled by disableCredentialType() method
-     *
-     * @param realm
-     * @param user
-     * @return
-     * @deprecated Use {@link UserModel#credentialManager()} and {@link SubjectCredentialManager#getDisableableCredentialTypesStream()} instead.
-     */
-    @Deprecated
-    Set<String> getDisableableCredentialTypes(RealmModel realm, UserModel user);
-
-    /**
      * Obtains the credential types that can be disabled.
      * method.
      *
      * @param realm a reference to the realm.
      * @param user the user whose credentials are being searched.
      * @return a non-null {@link Stream} of credential types.
+     *
+     * @deprecated Use {@link UserModel#credentialManager()} and then call {@link SubjectCredentialManager#getDisableableCredentialTypesStream()}
      */
     default Stream<String> getDisableableCredentialTypesStream(RealmModel realm, UserModel user) {
         return user.credentialManager().getDisableableCredentialTypesStream();
@@ -155,16 +146,6 @@ public interface UserCredentialManager extends UserCredentialStore {
     CredentialValidationOutput authenticate(KeycloakSession session, RealmModel realm, CredentialInput input);
 
     /**
-     * Return credential types, which are provided by the user storage where user is stored. Returned values can contain for example "password", "otp" etc.
-     * This will always return empty list for "local" users, which are not backed by any user storage
-     *
-     * @deprecated Use {@link UserModel#credentialManager()} and then call {@link SubjectCredentialManager#getConfiguredUserStorageCredentialTypesStream()}
-     * instead.
-     */
-    @Deprecated
-    List<String> getConfiguredUserStorageCredentialTypes(RealmModel realm, UserModel user);
-
-    /**
      * Obtains the credential types provided by the user storage where the specified user is stored. Examples of returned
      * values are "password", "otp", etc.
      * <p/>
@@ -173,33 +154,18 @@ public interface UserCredentialManager extends UserCredentialStore {
      * @param realm a reference to the realm.
      * @param user a reference to the user.
      * @return a non-null {@link Stream} of credential types.
+     *
+     * @deprecated Use {@link UserModel#credentialManager()} and then call {@link SubjectCredentialManager#getConfiguredUserStorageCredentialTypesStream()}
      */
     default Stream<String> getConfiguredUserStorageCredentialTypesStream(RealmModel realm, UserModel user) {
         return user.credentialManager().getConfiguredUserStorageCredentialTypesStream();
     }
 
     /**
-     * The {@link UserCredentialManager.Streams} interface makes all collection-based methods in {@link UserCredentialManager}
-     * default by providing implementations that delegate to the {@link Stream}-based variants instead of the other way around.
-     * <p/>
-     * It allows for implementations to focus on the {@link Stream}-based approach for processing sets of data and benefit
-     * from the potential memory and performance optimizations of that approach.
+     * @deprecated This interface is no longer necessary, collection-based methods were removed from the parent interface
+     * and therefore the parent interface can be used directly
      */
-    interface Streams extends UserCredentialManager, UserCredentialStore.Streams {
-        @Override
-        default Set<String> getDisableableCredentialTypes(RealmModel realm, UserModel user) {
-            return user.credentialManager().getDisableableCredentialTypesStream().collect(Collectors.toSet());
-        }
-
-        @Override
-        Stream<String> getDisableableCredentialTypesStream(RealmModel realm, UserModel user);
-
-        @Override
-        default List<String> getConfiguredUserStorageCredentialTypes(RealmModel realm, UserModel user) {
-            return user.credentialManager().getConfiguredUserStorageCredentialTypesStream().collect(Collectors.toList());
-        }
-
-        @Override
-        Stream<String> getConfiguredUserStorageCredentialTypesStream(RealmModel realm, UserModel user);
+    @Deprecated
+    interface Streams extends UserCredentialManager, UserCredentialStore {
     }
 }

--- a/server-spi/src/main/java/org/keycloak/models/UserModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/UserModel.java
@@ -152,41 +152,21 @@ public interface UserModel extends RoleMapperModel {
     String getFirstAttribute(String name);
 
     /**
-     * @param name
-     * @return list of all attribute values or empty list if there are not any values. Never return null
-     * @deprecated Use {@link #getAttributeStream(String) getAttributeStream} instead.
-     */
-    @Deprecated
-    List<String> getAttribute(String name);
-
-    /**
      * Obtains all values associated with the specified attribute name.
      *
      * @param name the name of the attribute.
      * @return a non-null {@link Stream} of attribute values.
      */
-    default Stream<String> getAttributeStream(final String name) {
-        List<String> value = this.getAttribute(name);
-        return value != null ? value.stream() : Stream.empty();
-    }
+    Stream<String> getAttributeStream(final String name);
 
     Map<String, List<String>> getAttributes();
-
-    /**
-     * @deprecated Use {@link #getRequiredActionsStream() getRequiredActionsStream} instead.
-     */
-    @Deprecated
-    Set<String> getRequiredActions();
 
     /**
      * Obtains the names of required actions associated with the user.
      *
      * @return a non-null {@link Stream} of required action names.
      */
-    default Stream<String> getRequiredActionsStream() {
-        Set<String> value = this.getRequiredActions();
-        return value != null ? value.stream() : Stream.empty();
-    }
+    Stream<String> getRequiredActionsStream();
 
     void addRequiredAction(String action);
 
@@ -226,37 +206,11 @@ public interface UserModel extends RoleMapperModel {
     void setEmailVerified(boolean verified);
 
     /**
-     * @deprecated Use {@link #getGroupsStream() getGroupsStream} instead.
-     */
-    @Deprecated
-    Set<GroupModel> getGroups();
-
-    /**
      * Obtains the groups associated with the user.
      *
      * @return a non-null {@link Stream} of groups.
      */
-    default Stream<GroupModel> getGroupsStream() {
-        Set<GroupModel> value = this.getGroups();
-        return value != null ? value.stream() : Stream.empty();
-    }
-
-    /**
-     * @deprecated Use {@link #getGroupsStream(String, Integer, Integer) getGroupsStream} instead.
-     */
-    @Deprecated
-    default Set<GroupModel> getGroups(int first, int max) {
-        return getGroupsStream(null, first, max).collect(Collectors.toSet());
-    }
-
-    /**
-     * @deprecated Use {@link #getGroupsStream(String, Integer, Integer) getGroupsStream} instead.
-     */
-    @Deprecated
-    default Set<GroupModel> getGroups(String search, int first, int max) {
-        return getGroupsStream(search, first, max)
-                .collect(Collectors.toCollection(LinkedHashSet::new));
-    }
+    Stream<GroupModel> getGroupsStream();
 
     /**
      * Returns a paginated stream of groups within this realm with search in the name
@@ -323,35 +277,10 @@ public interface UserModel extends RoleMapperModel {
     }
 
     /**
-     * The {@link UserModel.Streams} interface makes all collection-based methods in {@link UserModel} default by providing
-     * implementations that delegate to the {@link Stream}-based variants instead of the other way around.
-     * <p/>
-     * It allows for implementations to focus on the {@link Stream}-based approach for processing sets of data and benefit
-     * from the potential memory and performance optimizations of that approach.
+     * @deprecated This interface is no longer necessary, collection-based methods were removed from the parent interface
+     * and therefore the parent interface can be used directly
      */
-    interface Streams extends UserModel, RoleMapperModel.Streams {
-        @Override
-        default List<String> getAttribute(String name) {
-            return this.getAttributeStream(name).collect(Collectors.toList());
-        }
-
-        @Override
-        Stream<String> getAttributeStream(final String name);
-
-        @Override
-        default Set<String> getRequiredActions() {
-            return this.getRequiredActionsStream().collect(Collectors.toSet());
-        }
-
-        @Override
-        Stream<String> getRequiredActionsStream();
-
-        @Override
-        default Set<GroupModel> getGroups() {
-            return this.getGroupsStream().collect(Collectors.toSet());
-        }
-
-        @Override
-        Stream<GroupModel> getGroupsStream();
+    @Deprecated
+    interface Streams extends UserModel, RoleMapperModel {
     }
 }

--- a/server-spi/src/main/java/org/keycloak/models/UserProvider.java
+++ b/server-spi/src/main/java/org/keycloak/models/UserProvider.java
@@ -73,15 +73,6 @@ public interface UserProvider extends Provider,
     UserModel getServiceAccount(ClientModel client);
 
     /**
-     * @deprecated Use {@link UserQueryProvider#searchForUserStream(RealmModel, Map)} with
-     * {@link UserModel#INCLUDE_SERVICE_ACCOUNT} within params instead.
-     */
-    @Deprecated
-    default List<UserModel> getUsers(RealmModel realm, boolean includeServiceAccounts) {
-        return this.getUsersStream(realm, includeServiceAccounts).collect(Collectors.toList());
-    }
-
-    /**
      * Obtains the users associated with the specified realm.
      *
      * @param realm a reference to the realm being used for the search.
@@ -96,15 +87,6 @@ public interface UserProvider extends Provider,
         Map<String, String> searchAttributes = new HashMap<>(1);
         searchAttributes.put(UserModel.INCLUDE_SERVICE_ACCOUNT, Boolean.toString(includeServiceAccounts));
         return this.searchForUserStream(realm, searchAttributes);
-    }
-
-    /**
-     * @deprecated Use {@link UserQueryProvider#searchForUserStream(RealmModel, Map, Integer, Integer)} with 
-     * {@link UserModel#INCLUDE_SERVICE_ACCOUNT} within params instead.
-     */
-    @Deprecated
-    default List<UserModel> getUsers(RealmModel realm, int firstResult, int maxResults, boolean includeServiceAccounts) {
-        return this.getUsersStream(realm, firstResult, maxResults, includeServiceAccounts).collect(Collectors.toList());
     }
 
     /**
@@ -185,22 +167,13 @@ public interface UserProvider extends Provider,
     UserConsentModel getConsentByClient(RealmModel realm, String userId, String clientInternalId);
 
     /**
-     * @deprecated Use {@link #getConsentsStream(RealmModel, String) getConsentsStream} instead.
-     */
-    @Deprecated
-    List<UserConsentModel> getConsents(RealmModel realm, String userId);
-
-    /**
      * Obtains the consents associated with the user identified by the specified {@code userId}.
      *
      * @param realm a reference to the realm.
      * @param userId the user identifier.
      * @return a non-null {@link Stream} of consents associated with the user.
      */
-    default Stream<UserConsentModel> getConsentsStream(RealmModel realm, String userId) {
-        List<UserConsentModel> value = this.getConsents(realm, userId);
-        return value != null ? value.stream() : Stream.empty();
-    }
+    Stream<UserConsentModel> getConsentsStream(RealmModel realm, String userId);
 
     /**
      * Update client scopes in the stored user consent
@@ -260,22 +233,13 @@ public interface UserProvider extends Provider,
     void updateFederatedIdentity(RealmModel realm, UserModel federatedUser, FederatedIdentityModel federatedIdentityModel);
 
     /**
-     * @deprecated Use {@link #getFederatedIdentitiesStream(RealmModel, UserModel) getFederatedIdentitiesStream} instead.
-     */
-    @Deprecated
-    Set<FederatedIdentityModel> getFederatedIdentities(UserModel user, RealmModel realm);
-
-    /**
      * Obtains the federated identities of the specified user.
      *
      * @param realm a reference to the realm.
      * @param user the reference to the user.
      * @return a non-null {@link Stream} of federated identities associated with the user.
      */
-    default Stream<FederatedIdentityModel> getFederatedIdentitiesStream(RealmModel realm, UserModel user) {
-        Set<FederatedIdentityModel> value = this.getFederatedIdentities(user, realm);
-        return value != null ? value.stream() : Stream.empty();
-    }
+    Stream<FederatedIdentityModel> getFederatedIdentitiesStream(RealmModel realm, UserModel user);
 
     /**
      * Returns details of the association between the user and the socialProvider.
@@ -285,14 +249,7 @@ public interface UserProvider extends Provider,
      * @param socialProvider the id of the identity provider
      * @return federatedIdentityModel or {@code null} if no association exists
      */
-    default FederatedIdentityModel getFederatedIdentity(RealmModel realm, UserModel user, String socialProvider) {
-        return getFederatedIdentity(user, socialProvider, realm);
-    }
-    /**
-     * @deprecated Use {@link #getFederatedIdentity(RealmModel, UserModel, String) getFederatedIdentity} instead.
-     */
-    @Deprecated
-    FederatedIdentityModel getFederatedIdentity(UserModel user, String socialProvider, RealmModel realm);
+    FederatedIdentityModel getFederatedIdentity(RealmModel realm, UserModel user, String socialProvider);
 
     /**
      * Returns a userModel that corresponds to the given socialLink.
@@ -303,14 +260,7 @@ public interface UserProvider extends Provider,
      *
      * @throws IllegalStateException when there are more users for the given socialLink
      */
-    default UserModel getUserByFederatedIdentity(RealmModel realm, FederatedIdentityModel socialLink) {
-        return getUserByFederatedIdentity(socialLink, realm);
-    }
-    /**
-     * @deprecated Use {@link #getUserByFederatedIdentity(RealmModel, FederatedIdentityModel) getUserByFederatedIdentity} instead.
-     */
-    @Deprecated
-    UserModel getUserByFederatedIdentity(FederatedIdentityModel socialLink, RealmModel realm);
+    UserModel getUserByFederatedIdentity(RealmModel realm, FederatedIdentityModel socialLink);
 
     /* PRE REMOVE methods - for cleaning user related properties when some other entity is removed */
 
@@ -391,44 +341,10 @@ public interface UserProvider extends Provider,
     void close();
 
     /**
-     * The {@link UserProvider.Streams} interface makes all collection-based methods in {@link UserProvider} default by
-     * providing implementations that delegate to the {@link Stream}-based variants instead of the other way around.
-     * <p/>
-     * It allows for implementations to focus on the {@link Stream}-based approach for processing sets of data and benefit
-     * from the potential memory and performance optimizations of that approach.
+     * @deprecated This interface is no longer necessary, collection-based methods were removed from the parent interface
+     * and therefore the parent interface can be used directly
      */
-    interface Streams extends UserProvider, UserQueryProvider.Streams, UserLookupProvider.Streams {
-
-        @Override
-        FederatedIdentityModel getFederatedIdentity(RealmModel realm, UserModel user, String socialProvider);
-
-        @Override
-        default FederatedIdentityModel getFederatedIdentity(UserModel user, String socialProvider, RealmModel realm) {
-            return getFederatedIdentity(realm, user, socialProvider);
-        }
-
-        @Override
-        UserModel getUserByFederatedIdentity(RealmModel realm, FederatedIdentityModel socialLink);
-
-        @Override
-        default UserModel getUserByFederatedIdentity(FederatedIdentityModel socialLink, RealmModel realm) {
-            return getUserByFederatedIdentity(realm, socialLink);
-        }
-        
-        @Override
-        default Set<FederatedIdentityModel> getFederatedIdentities(UserModel user, RealmModel realm) {
-            return this.getFederatedIdentitiesStream(realm, user).collect(Collectors.toSet());
-        }
-
-        @Override
-        Stream<FederatedIdentityModel> getFederatedIdentitiesStream(RealmModel realm, UserModel user);
-
-        @Override
-        default List<UserConsentModel> getConsents(RealmModel realm, String userId) {
-            return this.getConsentsStream(realm, userId).collect(Collectors.toList());
-        }
-
-        @Override
-        Stream<UserConsentModel> getConsentsStream(RealmModel realm, String userId);
+    @Deprecated
+    interface Streams extends UserProvider, UserQueryProvider, UserLookupProvider {
     }
 }

--- a/server-spi/src/main/java/org/keycloak/models/UserSessionProvider.java
+++ b/server-spi/src/main/java/org/keycloak/models/UserSessionProvider.java
@@ -20,11 +20,9 @@ package org.keycloak.models;
 import org.keycloak.provider.Provider;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -57,14 +55,6 @@ public interface UserSessionProvider extends Provider {
     UserSessionModel getUserSession(RealmModel realm, String id);
 
     /**
-     * @deprecated Use {@link #getUserSessionsStream(RealmModel, ClientModel) getUserSessionsStream} instead.
-     */
-    @Deprecated
-    default List<UserSessionModel> getUserSessions(RealmModel realm, UserModel user) {
-        return this.getUserSessionsStream(realm, user).collect(Collectors.toList());
-    }
-
-    /**
      * Obtains the online user sessions associated with the specified user.
      *
      * @param realm a reference to the realm.
@@ -74,14 +64,6 @@ public interface UserSessionProvider extends Provider {
     Stream<UserSessionModel> getUserSessionsStream(RealmModel realm, UserModel user);
 
     /**
-     * @deprecated Use {@link #getUserSessionsStream(RealmModel, ClientModel) getUserSessionsStream} instead.
-     */
-    @Deprecated
-    default List<UserSessionModel> getUserSessions(RealmModel realm, ClientModel client) {
-        return this.getUserSessionsStream(realm, client).collect(Collectors.toList());
-    }
-
-    /**
      * Obtains the online user sessions associated with the specified client.
      *
      * @param realm a reference to the realm.
@@ -89,14 +71,6 @@ public interface UserSessionProvider extends Provider {
      * @return a non-null {@link Stream} of online user sessions.
      */
     Stream<UserSessionModel> getUserSessionsStream(RealmModel realm, ClientModel client);
-
-    /**
-     * @deprecated Use {@link #getUserSessionsStream(RealmModel, ClientModel, Integer, Integer) getUserSessionsStream} instead.
-     */
-    @Deprecated
-    default List<UserSessionModel> getUserSessions(RealmModel realm, ClientModel client, int firstResult, int maxResults) {
-        return this.getUserSessionsStream(realm, client, firstResult, maxResults).collect(Collectors.toList());
-    }
 
     /**
      * Obtains the online user sessions associated with the specified client, starting from the {@code firstResult} and containing
@@ -109,15 +83,6 @@ public interface UserSessionProvider extends Provider {
      * @return a non-null {@link Stream} of online user sessions.
      */
     Stream<UserSessionModel> getUserSessionsStream(RealmModel realm, ClientModel client, Integer firstResult, Integer maxResults);
-
-    /**
-     * @deprecated Use {@link #getUserSessionByBrokerUserIdStream(RealmModel, String) getUserSessionByBrokerUserIdStream}
-     * instead.
-     */
-    @Deprecated
-    default List<UserSessionModel> getUserSessionByBrokerUserId(RealmModel realm, String brokerUserId) {
-        return this.getUserSessionByBrokerUserIdStream(realm, brokerUserId).collect(Collectors.toList());
-    }
 
     /**
      * Obtains the online user sessions associated with the user that matches the specified {@code brokerUserId}.
@@ -213,14 +178,6 @@ public interface UserSessionProvider extends Provider {
     AuthenticatedClientSessionModel createOfflineClientSession(AuthenticatedClientSessionModel clientSession, UserSessionModel offlineUserSession);
 
     /**
-     * @deprecated Use {@link #getOfflineUserSessionsStream(RealmModel, UserModel) getOfflineUserSessionsStream} instead.
-     */
-    @Deprecated
-    default List<UserSessionModel> getOfflineUserSessions(RealmModel realm, UserModel user) {
-        return this.getOfflineUserSessionsStream(realm, user).collect(Collectors.toList());
-    }
-
-    /**
      * Obtains the offline user sessions associated with the specified user.
      *
      * @param realm a reference to the realm.
@@ -232,15 +189,6 @@ public interface UserSessionProvider extends Provider {
     UserSessionModel getOfflineUserSessionByBrokerSessionId(RealmModel realm, String brokerSessionId);
 
     /**
-     * @deprecated Use {@link #getOfflineUserSessionByBrokerUserIdStream(RealmModel, String) getOfflineUserSessionByBrokerUserIdStream}
-     * instead.
-     */
-    @Deprecated
-    default List<UserSessionModel> getOfflineUserSessionByBrokerUserId(RealmModel realm, String brokerUserId) {
-        return this.getOfflineUserSessionByBrokerUserIdStream(realm, brokerUserId).collect(Collectors.toList());
-    }
-
-    /**
      * Obtains the offline user sessions associated with the user that matches the specified {@code brokerUserId}.
      *
      * @param realm a reference to the realm.
@@ -250,15 +198,6 @@ public interface UserSessionProvider extends Provider {
     Stream<UserSessionModel> getOfflineUserSessionByBrokerUserIdStream(RealmModel realm, String brokerUserId);
 
     long getOfflineSessionsCount(RealmModel realm, ClientModel client);
-
-    /**
-     * @deprecated use {@link #getOfflineUserSessionsStream(RealmModel, ClientModel, Integer, Integer) getOfflineUserSessionsStream}
-     * instead.
-     */
-    @Deprecated
-    default List<UserSessionModel> getOfflineUserSessions(RealmModel realm, ClientModel client, int first, int max) {
-        return this.getOfflineUserSessionsStream(realm, client, first, max).collect(Collectors.toList());
-    }
 
     /**
      * Obtains the offline user sessions associated with the specified client, starting from the {@code firstResult} and

--- a/server-spi/src/main/java/org/keycloak/models/utils/RoleUtils.java
+++ b/server-spi/src/main/java/org/keycloak/models/utils/RoleUtils.java
@@ -43,27 +43,6 @@ public class RoleUtils {
      * @param groups
      * @param targetGroup
      * @return true if targetGroup is in groups (directly or indirectly via parent child relationship)
-     * @deprecated Use {@link #isMember(Stream, GroupModel)} isMember(Stream, GroupModel)} instead.
-     */
-    public static boolean isMember(Set<GroupModel> groups, GroupModel targetGroup) {
-        // collecting to set to keep "Breadth First Search" like functionality
-        if (groups.contains(targetGroup)) return true;
-
-        for (GroupModel mapping : groups) {
-            GroupModel child = mapping;
-            while (child.getParent() != null) {
-                if (child.getParent().equals(targetGroup)) return true;
-                child = child.getParent();
-            }
-        }
-        return false;
-    }
-
-    /**
-     *
-     * @param groups
-     * @param targetGroup
-     * @return true if targetGroup is in groups (directly or indirectly via parent child relationship)
      */
     public static boolean isMember(Stream<GroupModel> groups, GroupModel targetGroup) {
         // collecting to set to keep "Breadth First Search" like functionality
@@ -131,24 +110,6 @@ public class RoleUtils {
         }
 
         return false;
-    }
-
-    /**
-     * Checks whether the {@code targetRole} is contained in any of the {@code groups} or their parents
-     * (if requested)
-     * @param groups
-     * @param targetRole
-     * @param checkParentGroup When {@code true}, also parent group is recursively checked for role
-     * @return true if targetRole is in roles (directly or indirectly via composite role)
-     * @deprecated Use {@link #hasRoleFromGroup(Stream, RoleModel, boolean)} hasRoleFromGroup(Stream, RoleModel, boolean)} instead.
-     */
-    public static boolean hasRoleFromGroup(Iterable<GroupModel> groups, RoleModel targetRole, boolean checkParentGroup) {
-        if (groups == null) {
-            return false;
-        }
-
-        return StreamSupport.stream(groups.spliterator(), false)
-                .anyMatch(group -> hasRoleFromGroup(group, targetRole, checkParentGroup));
     }
 
     /**

--- a/server-spi/src/main/java/org/keycloak/models/utils/UserModelDelegate.java
+++ b/server-spi/src/main/java/org/keycloak/models/utils/UserModelDelegate.java
@@ -33,7 +33,7 @@ import java.util.stream.Stream;
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
  */
-public class UserModelDelegate implements UserModel.Streams {
+public class UserModelDelegate implements UserModel {
     protected UserModel delegate;
 
     public UserModelDelegate(UserModel delegate) {

--- a/server-spi/src/main/java/org/keycloak/sessions/AuthenticationSessionProvider.java
+++ b/server-spi/src/main/java/org/keycloak/sessions/AuthenticationSessionProvider.java
@@ -38,18 +38,6 @@ public interface AuthenticationSessionProvider extends Provider {
     RootAuthenticationSessionModel createRootAuthenticationSession(RealmModel realm);
 
     /**
-     * Creates a new root authentication session specified by the provided id and realm.
-     * @param id {@code String} Id of newly created root authentication session. If {@code null} a random id will be generated.
-     * @param realm {@code RealmModel} Can't be {@code null}.
-     * @return Returns created {@code RootAuthenticationSessionModel}. Never returns {@code null}.
-     * @deprecated Use {@link #createRootAuthenticationSession(RealmModel, String)} createRootAuthenticationSession} instead.
-     */
-    @Deprecated
-    default RootAuthenticationSessionModel createRootAuthenticationSession(String id, RealmModel realm) {
-        return createRootAuthenticationSession(realm, id);
-    }
-
-    /**
      * Creates a new root authentication session specified by the provided realm and id.
      * @param realm {@code RealmModel} Can't be {@code null}.
      * @param id {@code String} Id of newly created root authentication session. If {@code null} a random id will be generated.

--- a/server-spi/src/main/java/org/keycloak/storage/client/ClientLookupProvider.java
+++ b/server-spi/src/main/java/org/keycloak/storage/client/ClientLookupProvider.java
@@ -42,15 +42,6 @@ public interface ClientLookupProvider {
     ClientModel getClientById(RealmModel realm, String id);
 
     /**
-     * Exact search for a client by its internal ID.
-     * @param realm Realm to limit the search.
-     * @param id Internal ID
-     * @return Model of the client, or {@code null} if no client is found.
-     * @deprecated Use {@link #getClientById(org.keycloak.models.RealmModel, java.lang.String)} instead.
-     */
-    default ClientModel getClientById(String id, RealmModel realm) { return getClientById(realm, id); }
-
-    /**
      * Exact search for a client by its public client identifier.
      * @param realm Realm to limit the search for clients.
      * @param clientId String that identifies the client to the external parties.
@@ -58,31 +49,6 @@ public interface ClientLookupProvider {
      * @return Model of the client, or {@code null} if no client is found.
      */
     ClientModel getClientByClientId(RealmModel realm, String clientId);
-
-    /**
-     * Exact search for a client by its public client identifier.
-     * @param realm Realm to limit the search.
-     * @param clientId String that identifies the client to the external parties.
-     *   Maps to {@code client_id} in OIDC or {@code entityID} in SAML.
-     * @return Model of the client, or {@code null} if no client is found.
-     * @deprecated Use {@link #getClientByClientId(org.keycloak.models.RealmModel, java.lang.String)} instead.
-     */
-    default ClientModel getClientByClientId(String clientId, RealmModel realm) { return getClientByClientId(realm, clientId); }
-
-    /**
-     * Case-insensitive search for clients that contain the given string in their public client identifier.
-     * @param realm Realm to limit the search for clients.
-     * @param clientId Searched substring of the public client
-     *   identifier ({@code client_id} in OIDC or {@code entityID} in SAML.)
-     * @param firstResult First result to return. Ignored if negative or {@code null}.
-     * @param maxResults Maximum number of results to return. Ignored if negative or {@code null}.
-     * @return List of ClientModel or an empty list if no client is found.
-     * @deprecated Use {@link #searchClientsByClientIdStream(org.keycloak.models.RealmModel, java.lang.String, java.lang.Integer, java.lang.Integer)} instead.
-     */
-    @Deprecated
-    default List<ClientModel> searchClientsByClientId(String clientId, Integer firstResult, Integer maxResults, RealmModel realm) {
-        return searchClientsByClientIdStream(realm, clientId, firstResult, maxResults).collect(Collectors.toList());
-    }
 
     /**
      * Case-insensitive search for clients that contain the given string in their public client identifier.

--- a/server-spi/src/main/java/org/keycloak/storage/group/GroupLookupProvider.java
+++ b/server-spi/src/main/java/org/keycloak/storage/group/GroupLookupProvider.java
@@ -34,21 +34,6 @@ public interface GroupLookupProvider {
      * @return GroupModel with the corresponding id.
      */
     GroupModel getGroupById(RealmModel realm, String id);
-    
-    /**
-     * Returns groups with the given string in name for the given realm.
-     *
-     * @param realm Realm.
-     * @param search Case sensitive searched string.
-     * @param firstResult First result to return. Ignored if {@code null}.
-     * @param maxResults Maximum number of results to return. Ignored if {@code null}.
-     * @return List of groups with the given string in name.
-     * @deprecated Use {@link #searchForGroupByNameStream(RealmModel, String, Integer, Integer) searchForGroupByNameStream} instead.
-     */
-    @Deprecated
-    default List<GroupModel> searchForGroupByName(RealmModel realm, String search, Integer firstResult, Integer maxResults) {
-        return searchForGroupByNameStream(realm, search, firstResult, maxResults).collect(Collectors.toList());
-    }
 
     /**
      * Returns the group hierarchy with the given string in name for the given realm.

--- a/server-spi/src/main/java/org/keycloak/storage/user/UserLookupProvider.java
+++ b/server-spi/src/main/java/org/keycloak/storage/user/UserLookupProvider.java
@@ -42,14 +42,7 @@ public interface UserLookupProvider {
      * @param realm the realm model
      * @return found user model, or {@code null} if no such user exists
      */
-    default UserModel getUserById(RealmModel realm, String id) {
-        return getUserById(id, realm);
-    }
-    /**
-     * @deprecated Use {@link #getUserById(RealmModel, String) getUserById} instead.
-     */
-    @Deprecated
-    UserModel getUserById(String id, RealmModel realm);
+    UserModel getUserById(RealmModel realm, String id);
 
     /**
      * Exact search for a user by its username.
@@ -62,19 +55,11 @@ public interface UserLookupProvider {
      * insensitive mode and there are more users with username which differs only 
      * by case 
      */
-    default UserModel getUserByUsername(RealmModel realm, String username) {
-        return getUserByUsername(username, realm);
-    }
+    UserModel getUserByUsername(RealmModel realm, String username);
 
     default CredentialValidationOutput getUserByCredential(RealmModel realm, CredentialInput input) {
         return null;
     }
-
-    /**
-     * @deprecated Use {@link #getUserByUsername(RealmModel, String) getUserByUsername} instead.
-     */
-    @Deprecated
-    UserModel getUserByUsername(String username, RealmModel realm);
 
     /**
      * Returns a user with the given email belonging to the realm
@@ -85,39 +70,13 @@ public interface UserLookupProvider {
      *
      * @throws org.keycloak.models.ModelDuplicateException when there are more users with same email
      */
-    default UserModel getUserByEmail(RealmModel realm, String email) {
-        return getUserByEmail(email, realm);
-    }
+    UserModel getUserByEmail(RealmModel realm, String email);
+
     /**
-     * @deprecated Use {@link #getUserByEmail(RealmModel, String) getUserByEmail} instead.
+     * @deprecated This interface is no longer necessary, collection-based methods were removed from the parent interface
+     * and therefore the parent interface can be used directly
      */
     @Deprecated
-    UserModel getUserByEmail(String email, RealmModel realm);
-    
     interface Streams extends UserLookupProvider {
-        @Override
-        UserModel getUserById(RealmModel realm, String id);
-        
-        @Override
-        default UserModel getUserById(String id, RealmModel realm) {
-            return getUserById(realm, id);
-        }
-
-        @Override
-        UserModel getUserByUsername(RealmModel realm, String username);
-
-        @Override
-        default UserModel getUserByUsername(String username, RealmModel realm) {
-            return getUserByUsername(realm, username);
-        }
-
-        @Override
-        UserModel getUserByEmail(RealmModel realm, String email);
-
-        @Override
-        default UserModel getUserByEmail(String email, RealmModel realm) {
-            return getUserByEmail(realm, email);
-        }
-
     }
 }

--- a/server-spi/src/main/java/org/keycloak/storage/user/UserQueryProvider.java
+++ b/server-spi/src/main/java/org/keycloak/storage/user/UserQueryProvider.java
@@ -75,14 +75,6 @@ public interface UserQueryProvider {
      * @return number of users that match the search
      */
     default int getUsersCount(RealmModel realm, String search) {
-        return getUsersCount(search, realm);
-    }
-
-    /**
-     * @deprecated Use {@link #getUsersCount(RealmModel, String) getUsersCount}
-     */
-    @Deprecated
-    default int getUsersCount(String search, RealmModel realm) {
         return (int) searchForUserStream(realm, search).count();
     }
 
@@ -96,14 +88,6 @@ public interface UserQueryProvider {
      * @return number of users that match the search and given groups
      */
     default int getUsersCount(RealmModel realm, String search, Set<String> groupIds) {
-        return getUsersCount(search, realm, groupIds);
-    }
-
-    /**
-     * @deprecated Use {@link #getUsersCount(RealmModel, String, Set) getUsersCount} instead.
-     */
-    @Deprecated
-    default int getUsersCount(String search, RealmModel realm, Set<String> groupIds) {
         if (groupIds == null || groupIds.isEmpty()) {
             return 0;
         }
@@ -118,13 +102,6 @@ public interface UserQueryProvider {
      * @return number of users that match the given filters
      */
     default int getUsersCount(RealmModel realm, Map<String, String> params) {
-        return getUsersCount(params, realm);
-    }
-    /**
-     * @deprecated Use {@link #getUsersCount(RealmModel, Set) getUsersCount} instead.
-     */
-    @Deprecated
-    default int getUsersCount(Map<String, String> params, RealmModel realm) {
         return (int) searchForUserStream(realm, params).count();
     }
 
@@ -138,13 +115,6 @@ public interface UserQueryProvider {
      * @return number of users that match the given filters and groups
      */
     default int getUsersCount(RealmModel realm, Map<String, String> params, Set<String> groupIds) {
-        return getUsersCount(params, realm, groupIds);
-    }
-    /**
-     * @deprecated Use {@link #getUsersCount(RealmModel, Map, Set) getUsersCount} instead.
-     */
-    @Deprecated
-    default int getUsersCount(Map<String, String> params, RealmModel realm, Set<String> groupIds) {
         if (groupIds == null || groupIds.isEmpty()) {
             return 0;
         }
@@ -176,13 +146,6 @@ public interface UserQueryProvider {
     }
 
     /**
-     * @deprecated Use {@link #searchForUserStream(RealmModel, Map)} with an empty params map instead.
-     */
-    @Deprecated
-    default List<UserModel> getUsers(RealmModel realm) {
-        return searchForUserStream(realm, Collections.emptyMap()).collect(Collectors.toList());
-    }
-    /**
      * Searches all users in the realm.
      *
      * @param realm a reference to the realm.
@@ -192,14 +155,6 @@ public interface UserQueryProvider {
     @Deprecated
     default Stream<UserModel> getUsersStream(RealmModel realm) {
         return searchForUserStream(realm, Collections.emptyMap());
-    }
-
-    /**
-     * @deprecated Use {@link #searchForUserStream(RealmModel, Map, Integer, Integer)} with an empty params map instead.
-     */
-    @Deprecated
-    default List<UserModel> getUsers(RealmModel realm, int firstResult, int maxResults) {
-        return searchForUserStream(realm, Collections.emptyMap(), firstResult, maxResults).collect(Collectors.toList());
     }
 
     /**
@@ -219,22 +174,6 @@ public interface UserQueryProvider {
     /**
      * Searches for users whose username, email, first name or last name contain any of the strings in {@code search} separated by whitespace.
      * <p/>
-     * If possible, implementations should treat the parameter values as partial match patterns i.e. in RDMBS terms use LIKE.
-     * <p/>
-     * This method is used by the admin console search box
-     *
-     * @param search case insensitive list of string separated by whitespaces.
-     * @param realm realm to search within
-     * @return list of users that satisfies the given search condition
-     *
-     * @deprecated Use {@link #searchForUserStream(RealmModel, String) searchForUserStream} instead.
-     */
-    @Deprecated
-    List<UserModel> searchForUser(String search, RealmModel realm);
-
-    /**
-     * Searches for users whose username, email, first name or last name contain any of the strings in {@code search} separated by whitespace.
-     * <p/>
      * If possible, implementations should treat the parameter values as partial match patterns (i.e. in RDMBS terms use LIKE).
      * <p/>
      * This method is used by the admin console search box
@@ -244,28 +183,8 @@ public interface UserQueryProvider {
      * @return a non-null {@link Stream} of users that match the search string.
      */
     default Stream<UserModel> searchForUserStream(RealmModel realm, String search) {
-        List<UserModel> value = this.searchForUser(search, realm);
-        return value != null ? value.stream() : Stream.empty();
+        return searchForUserStream(realm, search, null, null);
     }
-
-    /**
-     * Searches for users whose username, email, first name or last name contain any of the strings in {@code search} separated by whitespace.
-     * The resulting user list should be paginated with respect to parameters {@code firstResult} and {@code maxResults}
-     * <p/>
-     * If possible, implementations should treat the parameter values as partial match patterns i.e. in RDMBS terms use LIKE.
-     * <p/>
-     * This method is used by the admin console search box
-     *
-     * @param search case insensitive list of string separated by whitespaces.
-     * @param realm a reference to the realm
-     * @param firstResult first result to return. Ignored if negative or zero.
-     * @param maxResults maximum number of results to return. Ignored if negative.
-     * @return paginated list of users from the realm that satisfies given search
-     *
-     * @deprecated Use {@link #searchForUserStream(RealmModel, String, Integer, Integer) searchForUserStream} instead.
-     */
-    @Deprecated
-    List<UserModel> searchForUser(String search, RealmModel realm, int firstResult, int maxResults);
 
     /**
      * Searches for users whose username, email, first name or last name contain any of the strings in {@code search} separated by whitespace.
@@ -280,48 +199,7 @@ public interface UserQueryProvider {
      * @param maxResults maximum number of results to return. Ignored if negative or {@code null}.
      * @return a non-null {@link Stream} of users that match the search criteria.
      */
-    default Stream<UserModel> searchForUserStream(RealmModel realm, String search, Integer firstResult, Integer maxResults) {
-        List<UserModel> value = this.searchForUser(search, realm, firstResult == null ? -1 : firstResult, maxResults == null ? -1 : maxResults);
-        return value != null ? value.stream() : Stream.empty();
-    }
-
-    /**
-     * Search for user by a map of parameters.
-     * <p/>
-     * Valid parameters are:
-     * <ul>
-     *     <li>{@link UserModel#FIRST_NAME} - first name (case insensitive string)</li>
-     *     <li>{@link UserModel#LAST_NAME} - last name (case insensitive string)</li>
-     *     <li>{@link UserModel#EMAIL} - email (case insensitive string)</li>
-     *     <li>{@link UserModel#USERNAME} - username (case insensitive string)</li>
-     *     <li>{@link UserModel#EMAIL_VERIFIED} - search only for users with verified/non-verified email (true/false)</li>
-     *     <li>{@link UserModel#ENABLED} - search only for enabled/disabled users (true/false)</li>
-     *     <li>{@link UserModel#IDP_ALIAS} - search only for users that have a federated identity
-     *     from idp with the given alias configured (case sensitive string)</li>
-     *     <li>{@link UserModel#IDP_USER_ID} - search for users with federated identity with
-     *     the given userId (case sensitive string)</li>
-     *     <li>{@link UserModel#SEARCH} - Searches for users whose username, email, first name or last name contain any
-     *     of the strings in {@code search} separated by whitespace. If possible, implementations should treat the
-     *     parameter values as partial match patterns (i.e. in RDMBS terms use LIKE).</li>
-     *     <li>{@link UserModel#EXACT} - Used alongside with {@link UserModel#FIRST_NAME}, {@link UserModel#LAST_NAME},
-     *     {@link UserModel#EMAIL} and {@link UserModel#USERNAME} parameters; if true searching is done using equals 
-     *     otherwise partial match should be enough to fulfill these parameters</li>
-     *     <li>{@link UserModel#INCLUDE_SERVICE_ACCOUNT} - When false, users that have a service account link are not
-     *     included in result</li>
-     * </ul>
-     *
-     * If possible, implementations should treat the parameter values as partial match patterns i.e. in RDMBS terms use LIKE.
-     * <p/>
-     * This method is used by the REST API when querying users.
-     *
-     * @param params a map containing the search parameters
-     * @param realm a reference to the realm
-     * @return list of users that satisfies given search conditions
-     *
-     * @deprecated Use {@link #searchForUserStream(RealmModel, Map) searchForUserStream} instead.
-     */
-    @Deprecated
-    List<UserModel> searchForUser(Map<String, String> params, RealmModel realm);
+    Stream<UserModel> searchForUserStream(RealmModel realm, String search, Integer firstResult, Integer maxResults);
 
     /**
      * Searches for user by parameter.
@@ -348,41 +226,8 @@ public interface UserQueryProvider {
      * @return a non-null {@link Stream} of users that match the search parameters.
      */
     default Stream<UserModel> searchForUserStream(RealmModel realm, Map<String, String> params) {
-        List<UserModel> value = this.searchForUser(params, realm);
-        return value != null ? value.stream() : Stream.empty();
+        return searchForUserStream(realm, params, null, null);
     }
-
-    /**
-     * Search for user by parameter.
-     * <p/>
-     * Valid parameters are:
-     * <ul>
-     *     <li>{@link UserModel#FIRST_NAME} - first name (case insensitive string)</li>
-     *     <li>{@link UserModel#LAST_NAME} - last name (case insensitive string)</li>
-     *     <li>{@link UserModel#EMAIL} - email (case insensitive string)</li>
-     *     <li>{@link UserModel#USERNAME} - username (case insensitive string)</li>
-     *     <li>{@link UserModel#EMAIL_VERIFIED} - search only for users with verified/non-verified email (true/false)</li>
-     *     <li>{@link UserModel#ENABLED} - search only for enabled/disabled users (true/false)</li>
-     *     <li>{@link UserModel#IDP_ALIAS} - search only for users that have a federated identity
-     *     from idp with the given alias configured (case sensitive string)</li>
-     *     <li>{@link UserModel#IDP_USER_ID} - search for users with federated identity with
-     *     the given userId (case sensitive string)</li>
-     * </ul>
-     *
-     * If possible, implementations should treat the parameter values as patterns i.e. in RDMBS terms use LIKE.
-     * <p/>
-     * This method is used by the REST API when querying users.
-     *
-     * @param params a map containing the search parameters.
-     * @param realm a reference to the realm.
-     * @param firstResult first result to return. Ignored if negative.
-     * @param maxResults maximum number of results to return. Ignored if negative.
-     * @return a non-null {@link Stream} of users that match the search criteria.
-     *
-     * @deprecated Use {@link #searchForUserStream(RealmModel, Map, Integer, Integer) searchForUserStream} instead.
-     */
-    @Deprecated
-    List<UserModel> searchForUser(Map<String, String> params, RealmModel realm, int firstResult, int maxResults);
 
     /**
      * Searches for user by parameter. If possible, implementations should treat the parameter values as partial match patterns
@@ -412,22 +257,7 @@ public interface UserQueryProvider {
      * @param maxResults maximum number of results to return. Ignored if negative or {@code null}.
      * @return a non-null {@link Stream} of users that match the search criteria.
      */
-    default Stream<UserModel> searchForUserStream(RealmModel realm, Map<String, String> params, Integer firstResult, Integer maxResults) {
-        List<UserModel> value = this.searchForUser(params, realm, firstResult == null ? -1 : firstResult, maxResults == null ? -1 : maxResults);
-        return value != null ? value.stream() : Stream.empty();
-    }
-
-    /**
-     * Get users that belong to a specific group.
-     *
-     * @param realm a reference to the realm
-     * @param group a reference to the group
-     * @return a list of all users that are members of the given group
-     *
-     * @deprecated Use {@link #getGroupMembersStream(RealmModel, GroupModel) getGroupMembersStream} instead.
-     */
-    @Deprecated
-    List<UserModel> getGroupMembers(RealmModel realm, GroupModel group);
+    Stream<UserModel> searchForUserStream(RealmModel realm, Map<String, String> params, Integer firstResult, Integer maxResults);
 
     /**
      * Obtains users that belong to a specific group.
@@ -437,23 +267,8 @@ public interface UserQueryProvider {
      * @return a non-null {@link Stream} of users that belong to the group.
      */
     default Stream<UserModel> getGroupMembersStream(RealmModel realm, GroupModel group) {
-        List<UserModel> value = this.getGroupMembers(realm, group);
-        return value != null ? value.stream() : Stream.empty();
+        return getGroupMembersStream(realm, group, null, null);
     }
-
-    /**
-     * Gets paginated list of users that belong to a specific group.
-     *
-     * @param realm a reference to the realm
-     * @param group a reference to the group
-     * @param firstResult first result to return. Ignored if negative or zero.
-     * @param maxResults maximum number of results to return. Ignored if negative.
-     * @return paginated list of members of the given group
-     *
-     * @deprecated Use {@link #getGroupMembersStream(RealmModel, GroupModel, Integer, Integer) getGroupMembersStream} instead.
-     */
-    @Deprecated
-    List<UserModel> getGroupMembers(RealmModel realm, GroupModel group, int firstResult, int maxResults);
 
     /**
      * Obtains users that belong to a specific group.
@@ -464,24 +279,7 @@ public interface UserQueryProvider {
      * @param maxResults maximum number of results to return. Ignored if negative or {@code null}.
      * @return a non-null {@link Stream} of users that belong to the group.
      */
-    default Stream<UserModel> getGroupMembersStream(RealmModel realm, GroupModel group, Integer firstResult, Integer maxResults) {
-        List<UserModel> value = this.getGroupMembers(realm, group, firstResult == null ? -1 : firstResult, maxResults == null ? -1 : maxResults);
-        return value != null ? value.stream() : Stream.empty();
-    }
-
-    /**
-     * Get users that belong to a specific role.
-     *
-     * @param realm a reference to the realm
-     * @param role a reference to the role
-     * @return a list of users that has the given role assigned
-     *
-     * @deprecated Use {@link #getRoleMembersStream(RealmModel, RoleModel) getRoleMembersStream} instead.
-     */
-    @Deprecated
-    default List<UserModel> getRoleMembers(RealmModel realm, RoleModel role) {
-        return this.getRoleMembersStream(realm, role).collect(Collectors.toList());
-    }
+    Stream<UserModel> getGroupMembersStream(RealmModel realm, GroupModel group, Integer firstResult, Integer maxResults);
 
     /**
      * Obtains users that have the specified role.
@@ -495,22 +293,6 @@ public interface UserQueryProvider {
     }
 
     /**
-     * Search for users that have a specific role with a specific roleId.
-     *
-     * @param realm a reference to the realm
-     * @param role a reference to the role
-     * @param firstResult first result to return. Ignored if negative or zero.
-     * @param maxResults maximum number of results to return. Ignored if negative.
-     * @return a paginated list of users that has the given role assigned
-     *
-     * @deprecated Use {@link #getRoleMembersStream(RealmModel, RoleModel, Integer, Integer) getRoleMembersStream} instead.
-     */
-    @Deprecated
-    default List<UserModel> getRoleMembers(RealmModel realm, RoleModel role, int firstResult, int maxResults) {
-        return Collections.emptyList();
-    }
-
-    /**
      * Searches for users that have the specified role.
      *
      * @param realm a reference to the realm.
@@ -520,23 +302,8 @@ public interface UserQueryProvider {
      * @return a non-null {@link Stream} of users that have the specified role.
      */
     default Stream<UserModel> getRoleMembersStream(RealmModel realm, RoleModel role, Integer firstResult, Integer maxResults) {
-        return getRoleMembers(realm, role, firstResult == null ? -1 : firstResult, maxResults== null ? -1 : maxResults)
-                .stream();
+        return Stream.empty();
     }
-
-    /**
-     * Search for users that have a specific attribute with a specific value.
-     *
-     * @param attrName a name of the attribute that will be searched
-     * @param attrValue a value of the attribute that will be searched
-     * @param realm a reference to the realm
-     * @return list of users with the given attribute name and value
-     *
-     * @deprecated Use {@link #searchForUserByUserAttributeStream(RealmModel, String, String) searchForUserByUserAttributeStream}
-     * instead.
-     */
-    @Deprecated
-    List<UserModel> searchForUserByUserAttribute(String attrName, String attrValue, RealmModel realm);
 
     /**
      * Searches for users that have a specific attribute with a specific value.
@@ -546,126 +313,13 @@ public interface UserQueryProvider {
      * @param attrValue the attribute value.
      * @return a non-null {@link Stream} of users that match the search criteria.
      */
-    default Stream<UserModel> searchForUserByUserAttributeStream(RealmModel realm, String attrName, String attrValue) {
-        List<UserModel> value = this.searchForUserByUserAttribute(attrName, attrValue, realm);
-        return value != null ? value.stream() : Stream.empty();
-    }
+    Stream<UserModel> searchForUserByUserAttributeStream(RealmModel realm, String attrName, String attrValue);
 
     /**
-     * The {@link Streams} interface makes all collection-based methods in {@link UserQueryProvider} default by
-     * providing implementations that delegate to the {@link Stream}-based variants instead of the other way around.
-     * <p/>
-     * It allows for implementations to focus on the {@link Stream}-based approach for processing sets of data and benefit
-     * from the potential memory and performance optimizations of that approach.
+     * @deprecated This interface is no longer necessary, collection-based methods were removed from the parent interface
+     * and therefore the parent interface can be used directly
      */
+    @Deprecated
     interface Streams extends UserQueryProvider {
-
-        @Override
-        default int getUsersCount(RealmModel realm, String search) {
-            return (int) searchForUserStream(realm, search).count();
-        }
-
-        @Override
-        default int getUsersCount(String search, RealmModel realm) {
-            return getUsersCount(realm, search);
-        }
-
-        @Override
-        default int getUsersCount(RealmModel realm, String search, Set<String> groupIds) {
-            if (groupIds == null || groupIds.isEmpty()) {
-                return 0;
-            }
-            return countUsersInGroups(searchForUserStream(realm, search), groupIds);
-        }
-
-        @Override
-        default int getUsersCount(String search, RealmModel realm, Set<String> groupIds) {
-            return getUsersCount(realm, search, groupIds);
-        }
-
-        @Override
-        default int getUsersCount(RealmModel realm, Map<String, String> params) {
-            return (int) searchForUserStream(realm, params).count();
-        }
-
-        @Override
-        default int getUsersCount( Map<String, String> params, RealmModel realm) {
-            return getUsersCount(realm, params);
-        }
-
-        @Override
-        default int getUsersCount(RealmModel realm, Map<String, String> params, Set<String> groupIds) {
-            if (groupIds == null || groupIds.isEmpty()) {
-                return 0;
-            }
-            return countUsersInGroups(searchForUserStream(realm, params), groupIds);
-        }
-
-        @Override
-        default int getUsersCount(Map<String, String> params, RealmModel realm, Set<String> groupIds) {
-            return getUsersCount(realm, params, groupIds);
-        }
-
-        @Override
-        default List<UserModel> searchForUser(String search, RealmModel realm) {
-            return this.searchForUserStream(realm, search).collect(Collectors.toList());
-        }
-
-        @Override
-        default Stream<UserModel> searchForUserStream(RealmModel realm, String search) {
-            return searchForUserStream(realm, search, null, null);
-        }
-
-        @Override
-        default List<UserModel> searchForUser(String search, RealmModel realm, int firstResult, int maxResults) {
-            return this.searchForUserStream(realm, search, firstResult, maxResults).collect(Collectors.toList());
-        }
-
-        @Override
-        Stream<UserModel> searchForUserStream(RealmModel realm, String search, Integer firstResult, Integer maxResults);
-
-        @Override
-        default List<UserModel> searchForUser(Map<String, String> params, RealmModel realm) {
-            return this.searchForUserStream(realm, params).collect(Collectors.toList());
-        }
-
-        @Override
-        default Stream<UserModel> searchForUserStream(RealmModel realm, Map<String, String> params) {
-            return searchForUserStream(realm, params, null, null);
-        }
-
-        @Override
-        default List<UserModel> searchForUser(Map<String, String> params, RealmModel realm, int firstResult, int maxResults) {
-            return this.searchForUserStream(realm, params, firstResult, maxResults).collect(Collectors.toList());
-        }
-
-        @Override
-        Stream<UserModel> searchForUserStream(RealmModel realm, Map<String, String> params, Integer firstResult, Integer maxResults);
-
-        @Override
-        default List<UserModel> getGroupMembers(RealmModel realm, GroupModel group) {
-            return this.getGroupMembersStream(realm, group).collect(Collectors.toList());
-        }
-
-        @Override
-        default Stream<UserModel> getGroupMembersStream(RealmModel realm, GroupModel group) {
-            return this.getGroupMembersStream(realm, group, null, null);
-        }
-
-        @Override
-        default List<UserModel> getGroupMembers(RealmModel realm, GroupModel group, int firstResult, int maxResults) {
-            return this.getGroupMembersStream(realm, group, firstResult, maxResults).collect(Collectors.toList());
-        }
-
-        @Override
-        Stream<UserModel> getGroupMembersStream(RealmModel realm, GroupModel group, Integer firstResult, Integer maxResults);
-
-        @Override
-        default List<UserModel> searchForUserByUserAttribute(String attrName, String attrValue, RealmModel realm) {
-            return this.searchForUserByUserAttributeStream(realm, attrName, attrValue).collect(Collectors.toList());
-        }
-
-        @Override
-        Stream<UserModel> searchForUserByUserAttributeStream(RealmModel realm, String attrName, String attrValue);
     }
 }

--- a/services/src/main/java/org/keycloak/credential/PasswordCredentialProvider.java
+++ b/services/src/main/java/org/keycloak/credential/PasswordCredentialProvider.java
@@ -37,7 +37,7 @@ import java.util.stream.Stream;
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
  */
-public class PasswordCredentialProvider implements CredentialProvider<PasswordCredentialModel>, CredentialInputUpdater.Streams,
+public class PasswordCredentialProvider implements CredentialProvider<PasswordCredentialModel>, CredentialInputUpdater,
         CredentialInputValidator {
 
     private static final Logger logger = Logger.getLogger(PasswordCredentialProvider.class);

--- a/services/src/main/java/org/keycloak/userprofile/validator/ReadOnlyAttributeUnchangedValidator.java
+++ b/services/src/main/java/org/keycloak/userprofile/validator/ReadOnlyAttributeUnchangedValidator.java
@@ -74,16 +74,9 @@ public class ReadOnlyAttributeUnchangedValidator implements SimpleValidator {
         }
 
         UserModel user = attributeContext.getUser();
-
-        List<String> existingAttrValues = user == null ? null : user.getAttribute(key);
-        String existingValue = null;
-
-        if (existingAttrValues != null && !existingAttrValues.isEmpty()) {
-            existingValue = existingAttrValues.get(0);
-        }
+        String existingValue = user == null ? null : user.getFirstAttribute(key);
 
         String value = null;
-
         if (!values.isEmpty()) {
             value = values.get(0);
         }

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/federation/BackwardsCompatibilityUserStorage.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/federation/BackwardsCompatibilityUserStorage.java
@@ -18,13 +18,12 @@
 
 package org.keycloak.testsuite.federation;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.jboss.logging.Logger;
 import org.keycloak.common.util.Time;
@@ -80,7 +79,7 @@ public class BackwardsCompatibilityUserStorage implements UserLookupProvider, Us
     }
 
     @Override
-    public UserModel getUserById(String id, RealmModel realm) {
+    public UserModel getUserById(RealmModel realm, String id) {
         StorageId storageId = new StorageId(id);
         final String username = storageId.getExternalId();
         if (!users.containsKey(translateUserName(username))) return null;
@@ -215,7 +214,7 @@ public class BackwardsCompatibilityUserStorage implements UserLookupProvider, Us
     }
 
     @Override
-    public Set<String> getDisableableCredentialTypes(RealmModel realm, UserModel user) {
+    public Stream<String> getDisableableCredentialTypesStream(RealmModel realm, UserModel user) {
         Set<String> types = new HashSet<>();
 
         MyUser myUser = getMyUser(user);
@@ -223,7 +222,7 @@ public class BackwardsCompatibilityUserStorage implements UserLookupProvider, Us
             types.add(CredentialModel.OTP);
         }
 
-        return types;
+        return types.stream();
     }
 
     @Override
@@ -291,14 +290,14 @@ public class BackwardsCompatibilityUserStorage implements UserLookupProvider, Us
     }
 
     @Override
-    public UserModel getUserByUsername(String username, RealmModel realm) {
+    public UserModel getUserByUsername(RealmModel realm, String username) {
         if (!users.containsKey(translateUserName(username))) return null;
 
         return createUser(realm, username);
     }
 
     @Override
-    public UserModel getUserByEmail(String email, RealmModel realm) {
+    public UserModel getUserByEmail(RealmModel realm, String email) {
         return null;
     }
 
@@ -322,12 +321,11 @@ public class BackwardsCompatibilityUserStorage implements UserLookupProvider, Us
     }
 
     @Override
-    public List<UserModel> getUsers(RealmModel realm) {
-        return getUsers(realm, -1, -1);
+    public Stream<UserModel> getUsersStream(RealmModel realm) {
+        return getUsers(realm, -1, -1).stream();
     }
 
-    @Override
-    public List<UserModel> getUsers(RealmModel realm, int firstResult, int maxResults) {
+    private List<UserModel> getUsers(RealmModel realm, int firstResult, int maxResults) {
         return users.values()
                 .stream()
                 .skip(firstResult).limit(maxResults)
@@ -336,44 +334,44 @@ public class BackwardsCompatibilityUserStorage implements UserLookupProvider, Us
     }
 
     @Override
-    public List<UserModel> searchForUser(String search, RealmModel realm) {
-        return searchForUser(search, realm, -1, -1);
+    public Stream<UserModel> searchForUserStream(RealmModel realm, String search) {
+        return searchForUserStream(realm, search, -1, -1);
     }
 
     @Override
-    public List<UserModel> searchForUser(String search, RealmModel realm, int firstResult, int maxResults) {
+    public Stream<UserModel> searchForUserStream(RealmModel realm, String search, Integer firstResult, Integer maxResults) {
         UserModel user = getUserByUsername(realm, search);
-        return user == null ? Collections.emptyList() : Arrays.asList(user);
+        return user == null ? Stream.empty() : Stream.of(user);
     }
 
     @Override
-    public List<UserModel> searchForUser(Map<String, String> params, RealmModel realm) {
+    public Stream<UserModel> searchForUserStream(RealmModel realm, Map<String, String> params) {
         // Assume that this is not supported
-        return Collections.emptyList();
+        return Stream.empty();
     }
 
     @Override
-    public List<UserModel> searchForUser(Map<String, String> params, RealmModel realm, int firstResult, int maxResults) {
+    public Stream<UserModel> searchForUserStream(RealmModel realm, Map<String, String> params, Integer firstResult, Integer maxResults) {
         // Assume that this is not supported
-        return Collections.emptyList();
+        return Stream.empty();
     }
 
     @Override
-    public List<UserModel> getGroupMembers(RealmModel realm, GroupModel group, int firstResult, int maxResults) {
+    public Stream<UserModel> getGroupMembersStream(RealmModel realm, GroupModel group, Integer firstResult, Integer maxResults) {
         // Assume that this is not supported
-        return Collections.emptyList();
+        return Stream.empty();
     }
 
     @Override
-    public List<UserModel> getGroupMembers(RealmModel realm, GroupModel group) {
+    public Stream<UserModel> getGroupMembersStream(RealmModel realm, GroupModel group) {
         // Assume that this is not supported
-        return Collections.emptyList();
+        return Stream.empty();
     }
 
     @Override
-    public List<UserModel> searchForUserByUserAttribute(String attrName, String attrValue, RealmModel realm) {
+    public Stream<UserModel> searchForUserByUserAttributeStream(RealmModel realm, String attrName, String attrValue) {
         // Assume that this is not supported
-        return Collections.emptyList();
+        return Stream.empty();
     }
 
     @Override

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/federation/DummyUserFederationProvider.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/federation/DummyUserFederationProvider.java
@@ -42,7 +42,7 @@ import java.util.Set;
  * @version $Revision: 1 $
  */
 public class DummyUserFederationProvider implements UserStorageProvider,
-        UserLookupProvider.Streams,
+        UserLookupProvider,
         UserRegistrationProvider,
         CredentialInputValidator {
 

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/federation/FailableHardcodedStorageProvider.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/federation/FailableHardcodedStorageProvider.java
@@ -42,8 +42,8 @@ import java.util.stream.Stream;
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
  */
-public class FailableHardcodedStorageProvider implements UserStorageProvider, UserLookupProvider.Streams, UserQueryProvider.Streams,
-        ImportedUserValidation, CredentialInputUpdater.Streams, CredentialInputValidator {
+public class FailableHardcodedStorageProvider implements UserStorageProvider, UserLookupProvider, UserQueryProvider,
+        ImportedUserValidation, CredentialInputUpdater, CredentialInputValidator {
 
     public static String username = "billb";
     public static String password = "password";

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/federation/HardcodedGroupStorageProvider.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/federation/HardcodedGroupStorageProvider.java
@@ -54,12 +54,6 @@ public class HardcodedGroupStorageProvider implements GroupStorageProvider {
     }
 
     @Override
-    @Deprecated
-    public Stream<GroupModel> searchForGroupByNameStream(RealmModel realm, String search, Integer firstResult, Integer maxResults) {
-        return searchForGroupByNameStream(realm, search, false, firstResult, maxResults);
-    }
-
-    @Override
     public Stream<GroupModel> searchForGroupByNameStream(RealmModel realm, String search, Boolean exact, Integer firstResult, Integer maxResults) {
         if (Boolean.parseBoolean(component.getConfig().getFirst(HardcodedGroupStorageProviderFactory.DELAYED_SEARCH))) try {
             Thread.sleep(5000l);
@@ -93,7 +87,7 @@ public class HardcodedGroupStorageProvider implements GroupStorageProvider {
     }
 
 
-    public class HardcodedGroupAdapter implements GroupModel.Streams {
+    public class HardcodedGroupAdapter implements GroupModel {
 
         private final RealmModel realm;
         private StorageId storageId;

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/federation/PassThroughFederatedUserStorageProvider.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/federation/PassThroughFederatedUserStorageProvider.java
@@ -37,6 +37,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Provides one user where everything is stored in user federated storage
@@ -46,7 +47,7 @@ import java.util.stream.Collectors;
  */
 public class PassThroughFederatedUserStorageProvider implements
         UserStorageProvider,
-        UserLookupProvider.Streams,
+        UserLookupProvider,
         CredentialInputValidator,
         CredentialInputUpdater
 {
@@ -121,8 +122,8 @@ public class PassThroughFederatedUserStorageProvider implements
     }
 
     @Override
-    public Set<String> getDisableableCredentialTypes(RealmModel realm, UserModel user) {
-        return CREDENTIAL_TYPES;
+    public Stream<String> getDisableableCredentialTypesStream(RealmModel realm, UserModel user) {
+        return CREDENTIAL_TYPES.stream();
     }
 
     @Override

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/federation/UserMapStorage.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/federation/UserMapStorage.java
@@ -58,8 +58,8 @@ import static org.keycloak.utils.StreamsUtil.paginatedStream;
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
  */
-public class UserMapStorage implements UserLookupProvider.Streams, UserStorageProvider, UserRegistrationProvider, CredentialInputUpdater.Streams,
-        CredentialInputValidator, UserGroupMembershipFederatedStorage.Streams, UserQueryProvider.Streams, ImportedUserValidation {
+public class UserMapStorage implements UserLookupProvider, UserStorageProvider, UserRegistrationProvider, CredentialInputUpdater,
+        CredentialInputValidator, UserGroupMembershipFederatedStorage.Streams, UserQueryProvider, ImportedUserValidation {
 
     private static final Logger log = Logger.getLogger(UserMapStorage.class);
     

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/federation/UserPropertyFileStorage.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/federation/UserPropertyFileStorage.java
@@ -52,7 +52,7 @@ import static org.keycloak.utils.StreamsUtil.paginatedStream;
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
  */
-public class UserPropertyFileStorage implements UserLookupProvider.Streams, UserStorageProvider, UserQueryProvider.Streams, CredentialInputValidator {
+public class UserPropertyFileStorage implements UserLookupProvider, UserStorageProvider, UserQueryProvider, CredentialInputValidator {
 
     public static final String SEARCH_METHOD = "searchForUserStream(RealmMode, String, Integer, Integer)";
     public static final String COUNT_SEARCH_METHOD = "getUsersCount(RealmModel, String)";

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPUserPropertiesMappingTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPUserPropertiesMappingTest.java
@@ -88,11 +88,11 @@ public class LDAPUserPropertiesMappingTest extends AbstractLDAPTest {
             KeycloakContext context = session.getContext();
             RealmModel realm = context.getRealm();
 
-            UserModel test10 = session.users().getUserByUsername(DIETMAR, realm);
+            UserModel test10 = session.users().getUserByUsername(realm, DIETMAR);
             Assert.assertTrue(test10.isEnabled());
             Assert.assertTrue(test10.isEmailVerified());
 
-            UserModel test11 = session.users().getUserByUsername(STEFAN, realm);
+            UserModel test11 = session.users().getUserByUsername(realm, STEFAN);
             Assert.assertFalse(test11.isEnabled());
             Assert.assertFalse(test11.isEmailVerified());
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/storage/GroupStorageTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/storage/GroupStorageTest.java
@@ -101,7 +101,7 @@ public class GroupStorageTest extends AbstractTestRealmKeycloakTest {
                 RealmModel realm = session.realms().getRealmByName(AuthRealm.TEST);
 
                 assertThat(session.groups()
-                            .searchForGroupByName(realm, "group", null, null).stream()
+                            .searchForGroupByNameStream(realm, "group", false, null, null)
                             .map(GroupModel::getName)
                             .collect(Collectors.toList()),
                         allOf(
@@ -119,7 +119,7 @@ public class GroupStorageTest extends AbstractTestRealmKeycloakTest {
                 RealmModel realm = session.realms().getRealmByName(AuthRealm.TEST);
                 // search for groups and check hardcoded-group is not present
                 assertThat(session.groups()
-                            .searchForGroupByName(realm, "group", null, null).stream()
+                            .searchForGroupByNameStream(realm, "group", false, null, null)
                             .map(GroupModel::getName)
                             .collect(Collectors.toList()),
                         allOf(


### PR DESCRIPTION
This PR removes all methods we deprecated while preparing the new Map storage. It includes mainly methods that were deprecated due to one of these two reasons:
- The method was streamified - there is an equivalent method returning stream instead of collection
- The method has the wrong order of parameters - during the cleanup we changed all methods to have the `RealmModel` as the first parameter


I tried to split the work into commits, so it is easy to review. Please let me know if I forgot about something.

Fixes: #14720