### PR TITLE
Rename free-form field from 'serverConfiguration' to 'additionalOptions' in Keycloak CR.

### DIFF
--- a/docs/guides/src/main/operator/advanced-configuration.adoc
+++ b/docs/guides/src/main/operator/advanced-configuration.adoc
@@ -12,7 +12,7 @@ In this guide, you'll learn how to configure your Keycloak deployment using adva
 
 === Server Configuration details
 
-The `serverConfiguration` field of the Keycloak CR allows to pass to Keycloak any available configuration in the form of key-value pairs.
+The `additionalOptions` field of the Keycloak CR allows to pass to Keycloak any available configuration in the form of key-value pairs.
 For all the available configuration options, refer to <@links.server id="all-config"/>.
 
 The values can be expressed as plain text strings or Kubernetes Secret references.
@@ -26,7 +26,7 @@ metadata:
   name: example-kc
 spec:
   ...
-  serverConfiguration:
+  additionalOptions:
     - name: db
       value: postgres # plain text value
     - name: db-url-host
@@ -43,7 +43,7 @@ spec:
 
 === Secret References
 
-A Secret Reference can be either a value in `serverConfiguration` or the `tlsSecret`.
+A Secret Reference can be either a value in `additionalOptions` or the `tlsSecret`.
 
 When specifying a Secret Reference, you have to make sure that a Secret containing the referenced keys is present in the same namespace as the CR referencing it.
 Along with the Keycloak Server Deployment, the operator adds special labels to the referenced Secrets in order to watch for changes.

--- a/docs/guides/src/main/operator/basic-deployment.adoc
+++ b/docs/guides/src/main/operator/basic-deployment.adoc
@@ -120,7 +120,7 @@ metadata:
   name: example-kc
 spec:
   instances: 1
-  serverConfiguration:
+  additionalOptions:
     - name: db
       value: postgres
     - name: db-url-host

--- a/docs/guides/src/main/operator/customizing-keycloak.adoc
+++ b/docs/guides/src/main/operator/customizing-keycloak.adoc
@@ -44,6 +44,6 @@ spec:
 
 .Note:
 [NOTE]
-Using custom images, every build time configuration passed through the `serverConfiguration` key will be ignored.
+Using custom images, every build time configuration passed through the `additionalOptions` key will be ignored.
 
 </@tmpl.guide>

--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDeployment.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDeployment.java
@@ -436,9 +436,9 @@ public class KeycloakDeployment extends OperatorManagedResource implements Statu
                 .collect(Collectors.toList());
 
         // merge with the CR; the values in CR take precedence
-        if (keycloakCR.getSpec().getServerConfiguration() != null) {
-            serverConfig.removeAll(keycloakCR.getSpec().getServerConfiguration());
-            serverConfig.addAll(keycloakCR.getSpec().getServerConfiguration());
+        if (keycloakCR.getSpec().getAdditionalOptions() != null) {
+            serverConfig.removeAll(keycloakCR.getSpec().getAdditionalOptions());
+            serverConfig.addAll(keycloakCR.getSpec().getAdditionalOptions());
         }
 
         // set env vars
@@ -564,12 +564,12 @@ public class KeycloakDeployment extends OperatorManagedResource implements Statu
     protected String readConfigurationValue(String key) {
         if (keycloakCR != null &&
                 keycloakCR.getSpec() != null &&
-                keycloakCR.getSpec().getServerConfiguration() != null
+                keycloakCR.getSpec().getAdditionalOptions() != null
         ) {
 
             var serverConfigValue = keycloakCR
                     .getSpec()
-                    .getServerConfiguration()
+                    .getAdditionalOptions()
                     .stream()
                     .filter(sc -> sc.getName().equals(key))
                     .findFirst();

--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDistConfigurator.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDistConfigurator.java
@@ -178,7 +178,7 @@ public class KeycloakDistConfigurator {
     protected void assumeFirstClassCitizens(KeycloakStatusBuilder status) {
         final var serverConfigNames = keycloakCR
                 .getSpec()
-                .getServerConfiguration()
+                .getAdditionalOptions()
                 .stream()
                 .map(ValueOrSecret::getName)
                 .collect(Collectors.toSet());

--- a/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/KeycloakSpec.java
+++ b/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/KeycloakSpec.java
@@ -44,7 +44,7 @@ public class KeycloakSpec {
 
     @JsonPropertyDescription("Configuration of the Keycloak server.\n" +
             "expressed as a keys (reference: https://www.keycloak.org/server/all-config) and values that can be either direct values or references to secrets.")
-    private List<ValueOrSecret> serverConfiguration; // can't use Set due to a bug in Sundrio https://github.com/sundrio/sundrio/issues/316
+    private List<ValueOrSecret> additionalOptions; // can't use Set due to a bug in Sundrio https://github.com/sundrio/sundrio/issues/316
 
     @JsonProperty("http")
     @JsonPropertyDescription("In this section you can configure Keycloak features related to HTTP and HTTPS")
@@ -156,14 +156,14 @@ public class KeycloakSpec {
         this.imagePullSecrets = imagePullSecrets;
     }
 
-    public List<ValueOrSecret> getServerConfiguration() {
-        if (serverConfiguration == null) {
-            serverConfiguration = new ArrayList<>();
+    public List<ValueOrSecret> getAdditionalOptions() {
+        if (this.additionalOptions == null) {
+            this.additionalOptions = new ArrayList<>();
         }
-        return serverConfiguration;
+        return additionalOptions;
     }
 
-    public void setServerConfiguration(List<ValueOrSecret> serverConfiguration) {
-        this.serverConfiguration = serverConfiguration;
+    public void setAdditionalOptions(List<ValueOrSecret> additionalOptions) {
+        this.additionalOptions = additionalOptions;
     }
 }

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakDeploymentTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakDeploymentTest.java
@@ -100,8 +100,8 @@ public class KeycloakDeploymentTest extends BaseOperatorTest {
             final var dbConf = new ValueOrSecret("db-password", "Ay Caramba!");
 
             kc.getSpec().setImage("quay.io/keycloak/non-existing-keycloak");
-            kc.getSpec().getServerConfiguration().remove(dbConf);
-            kc.getSpec().getServerConfiguration().add(dbConf);
+            kc.getSpec().getAdditionalOptions().remove(dbConf);
+            kc.getSpec().getAdditionalOptions().add(dbConf);
             deployKeycloak(k8sclient, kc, false);
 
             Awaitility.await()
@@ -131,7 +131,7 @@ public class KeycloakDeploymentTest extends BaseOperatorTest {
                     .withName(KeycloakDistConfigurator.getKeycloakOptionEnvVarName(health.getName()))
                     .withValue(health.getValue())
                     .build();
-            kc.getSpec().getServerConfiguration().add(health);
+            kc.getSpec().getAdditionalOptions().add(health);
             deployKeycloak(k8sclient, kc, false);
 
             assertThat(Constants.DEFAULT_DIST_CONFIG.get(health.getName())).isEqualTo("true"); // just a sanity check default values did not change
@@ -483,7 +483,7 @@ public class KeycloakDeploymentTest extends BaseOperatorTest {
     public void testHttpRelativePathWithPlainValue() {
         try {
             var kc = getDefaultKeycloakDeployment();
-            kc.getSpec().getServerConfiguration().add(new ValueOrSecret(Constants.KEYCLOAK_HTTP_RELATIVE_PATH_KEY, "/foobar"));
+            kc.getSpec().getAdditionalOptions().add(new ValueOrSecret(Constants.KEYCLOAK_HTTP_RELATIVE_PATH_KEY, "/foobar"));
             deployKeycloak(k8sclient, kc, true);
 
             var pods = k8sclient
@@ -515,7 +515,7 @@ public class KeycloakDeploymentTest extends BaseOperatorTest {
                     .build();
             k8sclient.secrets().inNamespace(namespace).createOrReplace(httpRelativePathSecret);
 
-            kc.getSpec().getServerConfiguration().add(new ValueOrSecret(Constants.KEYCLOAK_HTTP_RELATIVE_PATH_KEY,
+            kc.getSpec().getAdditionalOptions().add(new ValueOrSecret(Constants.KEYCLOAK_HTTP_RELATIVE_PATH_KEY,
                     new SecretKeySelectorBuilder()
                         .withName(secretName)
                         .withKey(keyName)

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/RealmImportTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/RealmImportTest.java
@@ -146,7 +146,7 @@ public class RealmImportTest extends BaseOperatorTest {
         keycloak.getSpec().setImage(customImage);
         // Removing the Database so that a subsequent build will by default act on h2
         // TODO: uncomment the following line after resolution of: https://github.com/keycloak/keycloak/issues/11767
-        // keycloak.getSpec().getServerConfiguration().removeIf(sc -> sc.getName().equals("db"));
+        // keycloak.getSpec().getAdditionalOptions().removeIf(sc -> sc.getName().equals("db"));
         deployKeycloak(k8sclient, keycloak, false);
 
         // Act

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/WatchedSecretsTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/WatchedSecretsTest.java
@@ -278,10 +278,10 @@ public class WatchedSecretsTest extends BaseOperatorTest {
         var username = new ValueOrSecret("db-username", "postgres");
         var password = new ValueOrSecret("db-password", "testpassword");
 
-        kc.getSpec().getServerConfiguration().remove(username);
-        kc.getSpec().getServerConfiguration().add(username);
-        kc.getSpec().getServerConfiguration().remove(password);
-        kc.getSpec().getServerConfiguration().add(password);
+        kc.getSpec().getAdditionalOptions().remove(username);
+        kc.getSpec().getAdditionalOptions().add(username);
+        kc.getSpec().getAdditionalOptions().remove(password);
+        kc.getSpec().getAdditionalOptions().add(password);
     }
 
     @AfterEach

--- a/operator/src/test/java/org/keycloak/operator/testsuite/unit/CRSerializationTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/unit/CRSerializationTest.java
@@ -55,7 +55,7 @@ public class CRSerializationTest {
         assertThat(transactionsSpec.isXaEnabled(), notNullValue());
         assertThat(transactionsSpec.isXaEnabled(), CoreMatchers.is(false));
 
-        List<ValueOrSecret> serverConfiguration = keycloak.getSpec().getServerConfiguration();
+        List<ValueOrSecret> serverConfiguration = keycloak.getSpec().getAdditionalOptions();
 
         assertNotNull(serverConfiguration);
         assertFalse(serverConfiguration.isEmpty());

--- a/operator/src/test/java/org/keycloak/operator/testsuite/unit/KeycloakDistConfiguratorTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/unit/KeycloakDistConfiguratorTest.java
@@ -158,7 +158,7 @@ public class KeycloakDistConfiguratorTest {
                 .map(f -> new ValueOrSecret(f, "foo"))
                 .collect(Collectors.toUnmodifiableList());
 
-        keycloak.getSpec().setServerConfiguration(serverConfig);
+        keycloak.getSpec().setAdditionalOptions(serverConfig);
 
         final var expectedFields = expectedValues.keySet();
 

--- a/operator/src/test/resources/correct-podtemplate-keycloak.yml
+++ b/operator/src/test/resources/correct-podtemplate-keycloak.yml
@@ -4,7 +4,7 @@ metadata:
   name: example-podtemplate-kc
 spec:
   instances: 1
-  serverConfiguration:
+  additionalOptions:
     - name: db
       value: postgres
     - name: db-url-host

--- a/operator/src/test/resources/empty-podtemplate-keycloak.yml
+++ b/operator/src/test/resources/empty-podtemplate-keycloak.yml
@@ -4,7 +4,7 @@ metadata:
   name: example-podtemplate
 spec:
   instances: 1
-  serverConfiguration:
+  additionalOptions:
     - name: db
       value: postgres
     - name: db-url-host

--- a/operator/src/test/resources/test-serialization-keycloak-cr.yml
+++ b/operator/src/test/resources/test-serialization-keycloak-cr.yml
@@ -5,7 +5,7 @@ metadata:
 spec:
   instances: 3
   image: my-image
-  serverConfiguration:
+  additionalOptions:
     - name: key1
       value: value1
     - name: features


### PR DESCRIPTION
- The "serverConfiguration" field at "KeycloakSpec.java" class was renamed to "additionalOptions";

- All the references and mentions were refactored;

- Some .adoc files and Test files were changed also.

Known Issues:

- The Operator's Test Suites ran successfully via Maven command line. However, some weird errors happened when running such tests in IDE (IntelliJ Idea).


Closes #14410