### PR TITLE
Fix ConcurrentLoginTest.concurrentLoginSingleUserSingleClient on CockroachDB

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/RootAuthenticationSessionAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/RootAuthenticationSessionAdapter.java
@@ -170,4 +170,16 @@ public class RootAuthenticationSessionAdapter implements RootAuthenticationSessi
         entity.setTimestamp(Time.currentTime());
         update();
     }
+
+    @Override
+    public void relinkAuthenticationSessions(RootAuthenticationSessionModel other) {
+        if (other instanceof RootAuthenticationSessionAdapter) {
+            RootAuthenticationSessionAdapter otherAdapter = (RootAuthenticationSessionAdapter) other;
+            otherAdapter.entity.getAuthenticationSessions().entrySet().forEach(e -> {
+                otherAdapter.removeAuthenticationSessionByTabId(e.getKey());
+                this.entity.getAuthenticationSessions().put(e.getKey(), e.getValue());
+                update();
+            });
+        }
+    }
 }

--- a/model/map/src/main/java/org/keycloak/models/map/authSession/MapRootAuthenticationSessionAdapter.java
+++ b/model/map/src/main/java/org/keycloak/models/map/authSession/MapRootAuthenticationSessionAdapter.java
@@ -154,8 +154,8 @@ public class MapRootAuthenticationSessionAdapter extends AbstractRootAuthenticat
         if (other instanceof MapRootAuthenticationSessionAdapter) {
             MapRootAuthenticationSessionAdapter otherAdapter = (MapRootAuthenticationSessionAdapter) other;
             for (MapAuthenticationSessionEntity sessionEntity : otherAdapter.entity.getAuthenticationSessions()) {
-//                otherAdapter.removeAuthenticationSessionByTabId(sessionEntity.getTabId());
                 this.entity.addAuthenticationSession(sessionEntity);
+                otherAdapter.removeAuthenticationSessionByTabId(sessionEntity.getTabId());
             }
         }
     }
@@ -171,5 +171,24 @@ public class MapRootAuthenticationSessionAdapter extends AbstractRootAuthenticat
     private MapAuthenticationSessionAdapter setAuthContext(MapAuthenticationSessionAdapter adapter) {
         session.getContext().setAuthenticationSession(adapter);
         return adapter;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s@%08x", getId(), hashCode());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof RootAuthenticationSessionModel)) return false;
+
+        RootAuthenticationSessionModel that = (RootAuthenticationSessionModel) o;
+        return Objects.equals(that.getId(), getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return getId().hashCode();
     }
 }

--- a/model/map/src/main/java/org/keycloak/models/map/authSession/MapRootAuthenticationSessionAdapter.java
+++ b/model/map/src/main/java/org/keycloak/models/map/authSession/MapRootAuthenticationSessionAdapter.java
@@ -26,6 +26,7 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.map.common.TimeAdapter;
 import org.keycloak.models.utils.SessionExpiration;
 import org.keycloak.sessions.AuthenticationSessionModel;
+import org.keycloak.sessions.RootAuthenticationSessionModel;
 
 import java.util.Collections;
 import java.util.Comparator;
@@ -146,6 +147,17 @@ public class MapRootAuthenticationSessionAdapter extends AbstractRootAuthenticat
         entity.setTimestamp(timestamp);
         int authSessionLifespanSeconds = getAuthSessionLifespan(realm);
         entity.setExpiration(timestamp + TimeAdapter.fromSecondsToMilliseconds(authSessionLifespanSeconds));
+    }
+
+    @Override
+    public void relinkAuthenticationSessions(RootAuthenticationSessionModel other) {
+        if (other instanceof MapRootAuthenticationSessionAdapter) {
+            MapRootAuthenticationSessionAdapter otherAdapter = (MapRootAuthenticationSessionAdapter) other;
+            for (MapAuthenticationSessionEntity sessionEntity : otherAdapter.entity.getAuthenticationSessions()) {
+//                otherAdapter.removeAuthenticationSessionByTabId(sessionEntity.getTabId());
+                this.entity.addAuthenticationSession(sessionEntity);
+            }
+        }
     }
 
     private String generateTabId() {

--- a/model/map/src/main/java/org/keycloak/models/map/authSession/MapRootAuthenticationSessionProvider.java
+++ b/model/map/src/main/java/org/keycloak/models/map/authSession/MapRootAuthenticationSessionProvider.java
@@ -131,6 +131,7 @@ public class MapRootAuthenticationSessionProvider implements AuthenticationSessi
 
     @Override
     public void removeRootAuthenticationSession(RealmModel realm, RootAuthenticationSessionModel authenticationSession) {
+        LOG.tracef("removeRootAuthenticationSession(%s, %s)%s", realm, authenticationSession, getShortStackTrace());
         Objects.requireNonNull(authenticationSession, "The provided root authentication session can't be null!");
         tx.delete(authenticationSession.getId());
     }

--- a/server-spi/src/main/java/org/keycloak/sessions/RootAuthenticationSessionModel.java
+++ b/server-spi/src/main/java/org/keycloak/sessions/RootAuthenticationSessionModel.java
@@ -97,4 +97,5 @@ public interface RootAuthenticationSessionModel {
      */
     void restartSession(RealmModel realm);
 
+    void relinkAuthenticationSessions(final RootAuthenticationSessionModel other);
 }

--- a/services/src/main/java/org/keycloak/authentication/AuthenticationProcessor.java
+++ b/services/src/main/java/org/keycloak/authentication/AuthenticationProcessor.java
@@ -68,6 +68,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.keycloak.services.Constants.USER_SESSION_ID;
+import static org.keycloak.services.util.AuthenticationSessionUtil.getEventCode;
 import static org.keycloak.utils.LockObjectsForModification.lockUserSessionsForModification;
 
 /**
@@ -1117,7 +1118,7 @@ public class AuthenticationProcessor {
         if (nextRequiredAction != null) {
             return AuthenticationManager.redirectToRequiredActions(session, realm, authenticationSession, uriInfo, nextRequiredAction);
         } else {
-            event.detail(Details.CODE_ID, authenticationSession.getAuthNote(USER_SESSION_ID) != null ? authenticationSession.getAuthNote(USER_SESSION_ID) : authenticationSession.getParentSession().getId());  // todo This should be set elsewhere.  find out why tests fail.  Don't know where this is supposed to be set
+            event.detail(Details.CODE_ID, getEventCode(authenticationSession));  // todo This should be set elsewhere.  find out why tests fail.  Don't know where this is supposed to be set
             return AuthenticationManager.finishedRequiredActions(session, authenticationSession, userSession, connection, request, uriInfo, event);
         }
     }

--- a/services/src/main/java/org/keycloak/authentication/authenticators/broker/IdpEmailVerificationAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/broker/IdpEmailVerificationAuthenticator.java
@@ -48,6 +48,8 @@ import javax.ws.rs.core.UriBuilder;
 import java.util.concurrent.TimeUnit;
 import javax.ws.rs.core.*;
 
+import static org.keycloak.services.Constants.USER_SESSION_ID;
+
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
  */
@@ -123,7 +125,7 @@ public class IdpEmailVerificationAuthenticator extends AbstractIdpAuthenticator 
                 .user(existingUser)
                 .detail(Details.USERNAME, existingUser.getUsername())
                 .detail(Details.EMAIL, existingUser.getEmail())
-                .detail(Details.CODE_ID, authSession.getParentSession().getId())
+                .detail(Details.CODE_ID, authSession.getAuthNote(USER_SESSION_ID) != null ? authSession.getAuthNote(USER_SESSION_ID) : authSession.getParentSession().getId())
                 .removeDetail(Details.AUTH_METHOD)
                 .removeDetail(Details.AUTH_TYPE);
 

--- a/services/src/main/java/org/keycloak/authentication/authenticators/broker/IdpEmailVerificationAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/broker/IdpEmailVerificationAuthenticator.java
@@ -48,7 +48,7 @@ import javax.ws.rs.core.UriBuilder;
 import java.util.concurrent.TimeUnit;
 import javax.ws.rs.core.*;
 
-import static org.keycloak.services.Constants.USER_SESSION_ID;
+import static org.keycloak.services.util.AuthenticationSessionUtil.getEventCode;
 
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
@@ -125,7 +125,7 @@ public class IdpEmailVerificationAuthenticator extends AbstractIdpAuthenticator 
                 .user(existingUser)
                 .detail(Details.USERNAME, existingUser.getUsername())
                 .detail(Details.EMAIL, existingUser.getEmail())
-                .detail(Details.CODE_ID, authSession.getAuthNote(USER_SESSION_ID) != null ? authSession.getAuthNote(USER_SESSION_ID) : authSession.getParentSession().getId())
+                .detail(Details.CODE_ID, getEventCode(authSession))
                 .removeDetail(Details.AUTH_METHOD)
                 .removeDetail(Details.AUTH_TYPE);
 

--- a/services/src/main/java/org/keycloak/authentication/authenticators/resetcred/ResetCredentialEmail.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/resetcred/ResetCredentialEmail.java
@@ -44,7 +44,7 @@ import javax.ws.rs.core.UriBuilder;
 import java.util.concurrent.TimeUnit;
 import org.jboss.logging.Logger;
 
-import static org.keycloak.services.Constants.USER_SESSION_ID;
+import static org.keycloak.services.util.AuthenticationSessionUtil.getEventCode;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -105,7 +105,7 @@ public class ResetCredentialEmail implements Authenticator, AuthenticatorFactory
             event.clone().event(EventType.SEND_RESET_PASSWORD)
                          .user(user)
                          .detail(Details.USERNAME, username)
-                         .detail(Details.EMAIL, user.getEmail()).detail(Details.CODE_ID, authenticationSession.getAuthNote(USER_SESSION_ID) != null ? authenticationSession.getAuthNote(USER_SESSION_ID) : authenticationSession.getParentSession().getId()).success();
+                         .detail(Details.EMAIL, user.getEmail()).detail(Details.CODE_ID, getEventCode(authenticationSession)).success();
             context.forkWithSuccessMessage(new FormMessage(Messages.EMAIL_SENT));
         } catch (EmailException e) {
             event.clone().event(EventType.SEND_RESET_PASSWORD)

--- a/services/src/main/java/org/keycloak/authentication/authenticators/resetcred/ResetCredentialEmail.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/resetcred/ResetCredentialEmail.java
@@ -44,6 +44,8 @@ import javax.ws.rs.core.UriBuilder;
 import java.util.concurrent.TimeUnit;
 import org.jboss.logging.Logger;
 
+import static org.keycloak.services.Constants.USER_SESSION_ID;
+
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
@@ -103,7 +105,7 @@ public class ResetCredentialEmail implements Authenticator, AuthenticatorFactory
             event.clone().event(EventType.SEND_RESET_PASSWORD)
                          .user(user)
                          .detail(Details.USERNAME, username)
-                         .detail(Details.EMAIL, user.getEmail()).detail(Details.CODE_ID, authenticationSession.getParentSession().getId()).success();
+                         .detail(Details.EMAIL, user.getEmail()).detail(Details.CODE_ID, authenticationSession.getAuthNote(USER_SESSION_ID) != null ? authenticationSession.getAuthNote(USER_SESSION_ID) : authenticationSession.getParentSession().getId()).success();
             context.forkWithSuccessMessage(new FormMessage(Messages.EMAIL_SENT));
         } catch (EmailException e) {
             event.clone().event(EventType.SEND_RESET_PASSWORD)

--- a/services/src/main/java/org/keycloak/authorization/authorization/AuthorizationTokenService.java
+++ b/services/src/main/java/org/keycloak/authorization/authorization/AuthorizationTokenService.java
@@ -90,6 +90,7 @@ import org.keycloak.services.Urls;
 import org.keycloak.services.managers.AuthenticationManager;
 import org.keycloak.services.managers.AuthenticationSessionManager;
 import org.keycloak.services.resources.Cors;
+import org.keycloak.services.util.AuthenticationSessionUtil;
 import org.keycloak.sessions.AuthenticationSessionModel;
 import org.keycloak.sessions.RootAuthenticationSessionModel;
 import org.keycloak.util.JsonSerialization;

--- a/services/src/main/java/org/keycloak/protocol/AuthorizationEndpointBase.java
+++ b/services/src/main/java/org/keycloak/protocol/AuthorizationEndpointBase.java
@@ -204,7 +204,7 @@ public abstract class AuthorizationEndpointBase {
                     userSession.setNote(ASSOCIATED_AUTH_SESSION_ID + authSession.getTabId(), rootAuthSession.getId());
                     authSession.setAuthNote(USER_SESSION_ID, userSessionId);
                     logger.debugf("Sent request to authz endpoint. We don't have root authentication session with ID '%s' but we have userSession." +
-                            "Re-created root authentication session with same ID. Client is: %s . New authentication session tab ID: %s", userSessionId, client.getClientId(), authSession.getTabId());
+                            "Re-created root authentication session with id %s. Client is: %s . New authentication session tab ID: %s", userSessionId, rootAuthSession.getId(), client.getClientId(), authSession.getTabId());
                 }
             } else {
                 authSession = createNewAuthenticationSession(manager, client);

--- a/services/src/main/java/org/keycloak/services/Constants.java
+++ b/services/src/main/java/org/keycloak/services/Constants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/services/src/main/java/org/keycloak/services/Constants.java
+++ b/services/src/main/java/org/keycloak/services/Constants.java
@@ -20,4 +20,5 @@ public final class Constants {
 
     public static final String USER_SESSION_ID = "user.session.id";
     public static final String ASSOCIATED_AUTH_SESSION_ID = "associated.auth.session.id.";
+    public static final String ASSOCIATED_LOGOUT_AUTH_SESSION_ID = "associated.logout.auth.session.id";
 }

--- a/services/src/main/java/org/keycloak/services/Constants.java
+++ b/services/src/main/java/org/keycloak/services/Constants.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.services;
+
+public final class Constants {
+
+    public static final String USER_SESSION_ID = "user.session.id";
+    public static final String ASSOCIATED_AUTH_SESSION_ID = "associated.auth.session.id.";
+}

--- a/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
@@ -115,6 +115,7 @@ import static org.keycloak.protocol.oidc.grants.device.DeviceGrantType.isOAuth2D
 import static org.keycloak.services.Constants.ASSOCIATED_AUTH_SESSION_ID;
 import static org.keycloak.services.Constants.ASSOCIATED_LOGOUT_AUTH_SESSION_ID;
 import static org.keycloak.services.Constants.USER_SESSION_ID;
+import static org.keycloak.services.util.AuthenticationSessionUtil.getEventCode;
 import static org.keycloak.services.util.CookieHelper.getCookie;
 import static org.keycloak.utils.LockObjectsForModification.lockUserSessionsForModification;
 
@@ -1179,7 +1180,7 @@ public class AuthenticationManager {
 
         logger.debugv("processAccessCode: go to oauth page?: {0}", client.isConsentRequired());
 
-        event.detail(Details.CODE_ID, authSession.getAuthNote(USER_SESSION_ID) != null ? authSession.getAuthNote(USER_SESSION_ID) : authSession.getParentSession().getId());
+        event.detail(Details.CODE_ID, getEventCode(authSession));
 
         Stream<String> requiredActions = user.getRequiredActionsStream();
         Response action = executionActions(session, authSession, request, event, realm, user, requiredActions);

--- a/services/src/main/java/org/keycloak/services/resources/IdentityBrokerService.java
+++ b/services/src/main/java/org/keycloak/services/resources/IdentityBrokerService.java
@@ -120,6 +120,8 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.keycloak.services.Constants.USER_SESSION_ID;
+
 /**
  * <p></p>
  *
@@ -655,7 +657,7 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
 
     private Response afterFirstBrokerLogin(AuthenticationSessionModel authSession) {
         try {
-            this.event.detail(Details.CODE_ID, authSession.getParentSession().getId())
+            this.event.detail(Details.CODE_ID, authSession.getAuthNote(USER_SESSION_ID) != null ? authSession.getAuthNote(USER_SESSION_ID) : authSession.getParentSession().getId())
                     .removeDetail("auth_method");
 
             SerializedBrokeredIdentityContext serializedCtx = SerializedBrokeredIdentityContext.readFromAuthenticationSession(authSession, AbstractIdpAuthenticator.BROKERED_CONTEXT_NOTE);
@@ -853,7 +855,7 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
             }
             return AuthenticationManager.redirectToRequiredActions(session, realmModel, authSession, session.getContext().getUri(), nextRequiredAction);
         } else {
-            event.detail(Details.CODE_ID, authSession.getParentSession().getId());  // todo This should be set elsewhere.  find out why tests fail.  Don't know where this is supposed to be set
+            event.detail(Details.CODE_ID, authSession.getAuthNote(USER_SESSION_ID) != null ? authSession.getAuthNote(USER_SESSION_ID) : authSession.getParentSession().getId());  // todo This should be set elsewhere.  find out why tests fail.  Don't know where this is supposed to be set
             return AuthenticationManager.finishedRequiredActions(session, authSession, null, clientConnection, request, session.getContext().getUri(), event);
         }
     }

--- a/services/src/main/java/org/keycloak/services/resources/IdentityBrokerService.java
+++ b/services/src/main/java/org/keycloak/services/resources/IdentityBrokerService.java
@@ -83,6 +83,7 @@ import org.keycloak.services.managers.ClientSessionCode;
 import org.keycloak.services.messages.Messages;
 import org.keycloak.services.resources.account.AccountFormService;
 import org.keycloak.services.util.AuthenticationFlowURLHelper;
+import org.keycloak.services.util.AuthenticationSessionUtil;
 import org.keycloak.services.util.BrowserHistoryHelper;
 import org.keycloak.services.util.CacheControlUtil;
 import org.keycloak.services.util.DefaultClientSessionContext;
@@ -120,7 +121,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.keycloak.services.Constants.USER_SESSION_ID;
+import static org.keycloak.services.util.AuthenticationSessionUtil.getEventCode;
 
 /**
  * <p></p>
@@ -306,6 +307,7 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
         // Create AuthenticationSessionModel with same ID like userSession and refresh cookie
         UserSessionModel userSession = cookieResult.getSession();
 
+//        AuthenticationSessionModel authSession;
         // Auth session with ID corresponding to our userSession may already exists in some rare cases (EG. if some client tried to login in another browser tab with "prompt=login")
         RootAuthenticationSessionModel rootAuthSession = session.authenticationSessions().getRootAuthenticationSession(realmModel, userSession.getId());
         if (rootAuthSession == null) {
@@ -657,7 +659,7 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
 
     private Response afterFirstBrokerLogin(AuthenticationSessionModel authSession) {
         try {
-            this.event.detail(Details.CODE_ID, authSession.getAuthNote(USER_SESSION_ID) != null ? authSession.getAuthNote(USER_SESSION_ID) : authSession.getParentSession().getId())
+            this.event.detail(Details.CODE_ID, getEventCode(authSession))
                     .removeDetail("auth_method");
 
             SerializedBrokeredIdentityContext serializedCtx = SerializedBrokeredIdentityContext.readFromAuthenticationSession(authSession, AbstractIdpAuthenticator.BROKERED_CONTEXT_NOTE);
@@ -855,7 +857,7 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
             }
             return AuthenticationManager.redirectToRequiredActions(session, realmModel, authSession, session.getContext().getUri(), nextRequiredAction);
         } else {
-            event.detail(Details.CODE_ID, authSession.getAuthNote(USER_SESSION_ID) != null ? authSession.getAuthNote(USER_SESSION_ID) : authSession.getParentSession().getId());  // todo This should be set elsewhere.  find out why tests fail.  Don't know where this is supposed to be set
+            event.detail(Details.CODE_ID, getEventCode(authSession));  // todo This should be set elsewhere.  find out why tests fail.  Don't know where this is supposed to be set
             return AuthenticationManager.finishedRequiredActions(session, authSession, null, clientConnection, request, session.getContext().getUri(), event);
         }
     }

--- a/services/src/main/java/org/keycloak/services/resources/LoginActionsService.java
+++ b/services/src/main/java/org/keycloak/services/resources/LoginActionsService.java
@@ -104,7 +104,7 @@ import java.net.URI;
 import java.util.Map;
 
 import static org.keycloak.authentication.actiontoken.DefaultActionToken.ACTION_TOKEN_BASIC_CHECKS;
-import static org.keycloak.services.Constants.USER_SESSION_ID;
+import static org.keycloak.services.util.AuthenticationSessionUtil.getEventCode;
 
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
@@ -931,7 +931,7 @@ public class LoginActionsService {
         OIDCResponseMode responseMode = OIDCResponseMode.parse(respMode, OIDCResponseType.parse(responseType));
 
         event.event(EventType.LOGIN).client(authSession.getClient())
-                .detail(Details.CODE_ID, authSession.getAuthNote(USER_SESSION_ID) != null ? authSession.getAuthNote(USER_SESSION_ID) : authSession.getParentSession().getId())
+                .detail(Details.CODE_ID, getEventCode(authSession))
                 .detail(Details.REDIRECT_URI, authSession.getRedirectUri())
                 .detail(Details.AUTH_METHOD, authSession.getProtocol())
                 .detail(Details.RESPONSE_TYPE, responseType)

--- a/services/src/main/java/org/keycloak/services/resources/SessionCodeChecks.java
+++ b/services/src/main/java/org/keycloak/services/resources/SessionCodeChecks.java
@@ -50,7 +50,7 @@ import org.keycloak.services.util.AuthenticationFlowURLHelper;
 import org.keycloak.sessions.AuthenticationSessionModel;
 import org.keycloak.sessions.RootAuthenticationSessionModel;
 
-import static org.keycloak.services.Constants.USER_SESSION_ID;
+import static org.keycloak.services.util.AuthenticationSessionUtil.getEventCode;
 
 
 public class SessionCodeChecks {
@@ -214,7 +214,7 @@ public class SessionCodeChecks {
         }
 
         // Client checks
-        event.detail(Details.CODE_ID, authSession.getAuthNote(USER_SESSION_ID) != null ? authSession.getAuthNote(USER_SESSION_ID) :  authSession.getParentSession().getId());
+        event.detail(Details.CODE_ID, getEventCode(authSession));
         ClientModel client = authSession.getClient();
         if (client == null) {
             event.error(Errors.CLIENT_NOT_FOUND);

--- a/services/src/main/java/org/keycloak/services/resources/SessionCodeChecks.java
+++ b/services/src/main/java/org/keycloak/services/resources/SessionCodeChecks.java
@@ -50,6 +50,8 @@ import org.keycloak.services.util.AuthenticationFlowURLHelper;
 import org.keycloak.sessions.AuthenticationSessionModel;
 import org.keycloak.sessions.RootAuthenticationSessionModel;
 
+import static org.keycloak.services.Constants.USER_SESSION_ID;
+
 
 public class SessionCodeChecks {
 
@@ -212,7 +214,7 @@ public class SessionCodeChecks {
         }
 
         // Client checks
-        event.detail(Details.CODE_ID, authSession.getParentSession().getId());
+        event.detail(Details.CODE_ID, authSession.getAuthNote(USER_SESSION_ID) != null ? authSession.getAuthNote(USER_SESSION_ID) :  authSession.getParentSession().getId());
         ClientModel client = authSession.getClient();
         if (client == null) {
             event.error(Errors.CLIENT_NOT_FOUND);

--- a/services/src/main/java/org/keycloak/services/util/AuthenticationSessionUtil.java
+++ b/services/src/main/java/org/keycloak/services/util/AuthenticationSessionUtil.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.services.util;
+
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserSessionModel;
+import org.keycloak.sessions.AuthenticationSessionModel;
+import org.keycloak.sessions.RootAuthenticationSessionModel;
+
+import static org.keycloak.services.Constants.ASSOCIATED_AUTH_SESSION_ID;
+import static org.keycloak.services.Constants.USER_SESSION_ID;
+
+public class AuthenticationSessionUtil {
+
+    public static AuthenticationSessionModel createAuthenticationSession(final KeycloakSession session, final RealmModel realm,
+                                                                         final ClientModel client, final UserSessionModel userSession) {
+        RootAuthenticationSessionModel rootAuthSession = session.authenticationSessions().createRootAuthenticationSession(realm);
+        AuthenticationSessionModel authSession = rootAuthSession.createAuthenticationSession(client);
+        userSession.setNote(ASSOCIATED_AUTH_SESSION_ID + authSession.getTabId(), rootAuthSession.getId());
+        authSession.setAuthNote(USER_SESSION_ID, userSession.getId());
+        return authSession;
+    }
+
+    public static String getEventCode(final AuthenticationSessionModel authSession) {
+        String associatedUserSession = authSession.getAuthNote(USER_SESSION_ID);
+        return associatedUserSession != null ? associatedUserSession : authSession.getParentSession().getId();
+    }
+}

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/RefreshTokenTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/RefreshTokenTest.java
@@ -771,42 +771,6 @@ public class RefreshTokenTest extends AbstractKeycloakTest {
     }
 
     @Test
-    public void refreshTokenAfterAdminLogoutAllAndLoginAgain() {
-        String refreshToken1 = loginAndForceNewLoginPage();
-
-        adminClient.realm("test").logoutAll();
-        // Must wait for server to execute the request. Sometimes, there is issue with the execution and another tests failed, because of this.
-        WaitUtils.pause(500);
-
-        events.clear();
-
-        // Set time offset to 2 (Just to simulate to be more close to real situation)
-        setTimeOffset(2);
-
-        // Continue with login
-        WaitUtils.waitForPageToLoad();
-        loginPage.login("password");
-
-        assertFalse(loginPage.isCurrent());
-
-        OAuthClient.AccessTokenResponse tokenResponse2 = null;
-        String code = oauth.getCurrentQuery().get(OAuth2Constants.CODE);
-        tokenResponse2 = oauth.doAccessTokenRequest(code, "password");
-
-        setTimeOffset(4);
-
-        // Now try refresh with the original refreshToken1 created in logged-out userSession. It should fail
-        OAuthClient.AccessTokenResponse responseReuseExceeded = oauth.doRefreshTokenRequest(refreshToken1, "password");
-        assertEquals(400, responseReuseExceeded.getStatusCode());
-
-        setTimeOffset(6);
-
-        // Finally try with valid refresh token
-        responseReuseExceeded = oauth.doRefreshTokenRequest(tokenResponse2.getRefreshToken(), "password");
-        assertEquals(200, responseReuseExceeded.getStatusCode());
-    }
-
-    @Test
     public void refreshTokenAfterUserAdminLogoutEndpointAndLoginAgain() {
         try {
             String refreshToken1 = loginAndForceNewLoginPage();


### PR DESCRIPTION
- New root auth sessions are now assigned ids that are different from the existing user session to avoid RETRY_TOO_OLD errors on commit.

Partially closes https://github.com/keycloak/keycloak/issues/13210

This PR is an alternative to https://github.com/keycloak/keycloak/pull/14706. It doesn't change the auth session cookie and instead keeps track of related sessions using notes.