### PR TITLE
Fix encoding in messages_fr.properties

### DIFF
--- a/themes/src/main/resources-community/theme/base/login/messages/messages_fr.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_fr.properties
@@ -391,7 +391,7 @@ irreversibleAction=Cette action est irr\u00e9versible
 deleteAccountConfirm=Confirmation de suppression de compte
 
 deletingImplies=Supprimer votre compte implique:
-errasingData=Supprimer toutes vos données
+errasingData=Supprimer toutes vos donn\u00e9es
 loggingOutImmediately=Vous d\u00e9connecter imm\u00e9diatement
 accountUnusable=Toute utilisation future de l''application sera impossible avec ce compte
 userDeletedSuccessfully=Utilisateur supprim\u00e9 avec succ\u00e8s


### PR DESCRIPTION
`é` is not in unicode format.

Message was rendered as

> Supprimer toutes vos donnÃ©es