### PR TITLE
Add additional package for deep reflection within the surefire.system.args for failing tests with JDK17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1904,6 +1904,7 @@
             <properties>
                 <surefire.system.args>
                     --add-opens=java.base/java.lang=ALL-UNNAMED
+                    --add-opens=java.base/java.util=ALL-UNNAMED
                 </surefire.system.args>
             </properties>
         </profile>


### PR DESCRIPTION
Add new packages for deep reflection within the surefire.system.args for test compatibility with JDK17

Similar to the fix we did for LDAP tests which were failing with JDK17 in the PR  #9980 , we need additional packages to be added within those args to allow deep reflection which supports the marshaling of Map behind the system env variables, as part of some tests

Closes #14997
