### PR TITLE
initial impl of running export/import without serving

### DIFF
--- a/quarkus/config-api/src/main/java/org/keycloak/config/HttpOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/HttpOptions.java
@@ -100,4 +100,11 @@ public class HttpOptions {
             .description("The type of the trust store file. " +
                     "If not given, the type is automatically detected based on the file name.")
             .build();
+
+    public static final Option<Boolean> HTTP_SERVER_ENABLED = new OptionBuilder<>("http-server-enabled", Boolean.class)
+            .category(OptionCategory.HTTP)
+            .hidden()
+            .description("Enables or disables the HTTP/s and Socket serving.")
+            .defaultValue(Boolean.TRUE)
+            .build();
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/HttpPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/HttpPropertyMappers.java
@@ -27,6 +27,10 @@ final class HttpPropertyMappers {
                         .transformer(HttpPropertyMappers::getHttpEnabledTransformer)
                         .paramLabel(Boolean.TRUE + "|" + Boolean.FALSE)
                         .build(),
+                fromOption(HttpOptions.HTTP_SERVER_ENABLED)
+                        .to("quarkus.http.host-enabled")
+                        .paramLabel(Boolean.TRUE + "|" + Boolean.FALSE)
+                        .build(),
                 fromOption(HttpOptions.HTTP_HOST)
                         .to("quarkus.http.host")
                         .paramLabel("host")

--- a/quarkus/runtime/src/main/resources/META-INF/keycloak.conf
+++ b/quarkus/runtime/src/main/resources/META-INF/keycloak.conf
@@ -19,6 +19,7 @@ metrics-enabled=false
 
 # The default configuration when running in import or export mode
 %import_export.http-enabled=true
+%import_export.http-server-enabled=false
 %import_export.hostname-strict=false
 %import_export.hostname-strict-https=false
 

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ExportDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ExportDistTest.java
@@ -35,6 +35,7 @@ public class ExportDistTest {
         cliResult.assertMessage("Export of realm 'master' requested.");
         cliResult.assertMessage("Export finished successfully");
         cliResult.assertNoMessage("Changes detected in configuration");
+        cliResult.assertNoMessage("Listening on:");
 
         cliResult = dist.run("export", "--realm=master");
         cliResult.assertError("Must specify either --dir or --file options.");

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ImportDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ImportDistTest.java
@@ -42,5 +42,6 @@ public class ImportDistTest {
         cliResult.assertMessage("Realm 'master' imported");
         cliResult.assertMessage("Import finished successfully");
         cliResult.assertNoMessage("Changes detected in configuration");
+        cliResult.assertNoMessage("Listening on:");
     }
 }


### PR DESCRIPTION
draft pr for solving discussion #10815 - tested the following scenarios manually for now:

**use-case 1:**
1) start keycloak in prod mode w/ postgres on port 8080 and http enabled (no strict/strict-https), config set via keycloak.conf (to be able to export from external database). add some test data to realm
2) stop keycloak
3) run `python3 -m http.server 8080` to bind the port
4) open localhost:8080 to see that current dir is served instead of keycloak (just to make sure)
5) run `./kc.sh export --dir=../export`
6) check results -> output does not show http related error, yay! the generated files are also where they should be, double-yay.

**use-case 2:**
1) delete export directory
2) start keycloak as before in prod mode
3) in another shell window, run the export command again while keycloak is working
4) see the files are generated correctly, no error is thrown.

**use-case 3:** 
Generally: importing when port is bound via `python3 -m http.server 8080` and keycloak is *not* running 
=> works as expected

**use-case 4:** 
importing when keycloak is running (manually added a client to the export json) => works also (which might create some problems?)

@pedroigor PTAL if this moves in the right direction and/or if you miss sth. I don't have much time to look further this week, but I don't think it's that important atm. Happy if anyone wants to take this over from here btw, cc @yeroc @psachmann @vmuzikar 