### PR TITLE
Adding user session creation time when calculating client session lifespan

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanUserSessionProvider.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanUserSessionProvider.java
@@ -195,6 +195,7 @@ public class InfinispanUserSessionProvider implements UserSessionProvider {
         entity.setRealmId(realm.getId());
         entity.setTimestamp(Time.currentTime());
         entity.getNotes().put(AuthenticatedClientSessionModel.STARTED_AT_NOTE, String.valueOf(entity.getTimestamp()));
+        entity.getNotes().put(AuthenticatedClientSessionEntity.USER_SESSION_STARTED_AT_NOTE, String.valueOf(userSession.getStarted()));
 
         InfinispanChangelogBasedTransaction<String, UserSessionEntity> userSessionUpdateTx = getTransaction(false);
         InfinispanChangelogBasedTransaction<UUID, AuthenticatedClientSessionEntity> clientSessionUpdateTx = getClientSessionTransaction(false);

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/entities/AuthenticatedClientSessionEntity.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/entities/AuthenticatedClientSessionEntity.java
@@ -27,6 +27,7 @@ import org.infinispan.commons.marshall.Externalizer;
 import org.infinispan.commons.marshall.MarshallUtil;
 import org.infinispan.commons.marshall.SerializeWith;
 import org.jboss.logging.Logger;
+import org.keycloak.common.util.Time;
 import org.keycloak.models.sessions.infinispan.changes.SessionEntityWrapper;
 import org.keycloak.models.sessions.infinispan.util.KeycloakMarshallUtil;
 import java.util.UUID;
@@ -42,6 +43,7 @@ public class AuthenticatedClientSessionEntity extends SessionEntity {
 
     // Metadata attribute, which contains the last timestamp available on remoteCache. Used in decide whether we need to write to remoteCache (DC) or not
     public static final String LAST_TIMESTAMP_REMOTE = "lstr";
+    public static final String USER_SESSION_STARTED_AT_NOTE = "userSessionStartedAt";
 
     private String authMethod;
     private String redirectUri;
@@ -81,6 +83,12 @@ public class AuthenticatedClientSessionEntity extends SessionEntity {
 
     public void setTimestamp(int timestamp) {
         this.timestamp = timestamp;
+    }
+
+    public int getUserSessionStarted() {
+        String started = getNotes().get(USER_SESSION_STARTED_AT_NOTE);
+        // Fallback to current time if "started" note is not available.
+        return started == null ? Time.currentTime() : Integer.parseInt(started);
     }
 
     public String getAction() {

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/util/SessionTimeouts.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/util/SessionTimeouts.java
@@ -103,7 +103,7 @@ public class SessionTimeouts {
      * @return
      */
     public static long getClientSessionLifespanMs(RealmModel realm, AuthenticatedClientSessionEntity clientSessionEntity) {
-        int timeSinceTimestampUpdate = Time.currentTime() - clientSessionEntity.getTimestamp();
+        int timeSinceUserSessionStart = Time.currentTime() - clientSessionEntity.getUserSessionStarted();
 
         int sessionMaxLifespan = Math.max(realm.getSsoSessionMaxLifespan(), realm.getSsoSessionMaxLifespanRememberMe());
 
@@ -114,7 +114,7 @@ public class SessionTimeouts {
 
         sessionMaxLifespan = Math.max(sessionMaxLifespan, MINIMAL_EXPIRATION_SEC);
 
-        long timeToExpire = sessionMaxLifespan - timeSinceTimestampUpdate;
+        long timeToExpire = sessionMaxLifespan - timeSinceUserSessionStart;
 
         // Indication that entry should be expired
         if (timeToExpire <=0) {
@@ -218,7 +218,7 @@ public class SessionTimeouts {
         // By default, this is disabled, so offlineSessions have just "maxIdle"
         if (!realm.isOfflineSessionMaxLifespanEnabled() && realm.getClientOfflineSessionMaxLifespan() <= 0) return -1l;
 
-        int timeSinceTimestamp = Time.currentTime() - authenticatedClientSessionEntity.getTimestamp();
+        int timeSinceUserSessionStart = Time.currentTime() - authenticatedClientSessionEntity.getUserSessionStarted();
 
         int sessionMaxLifespan = Math.max(realm.getOfflineSessionMaxLifespan(), MINIMAL_EXPIRATION_SEC);
 
@@ -227,7 +227,7 @@ public class SessionTimeouts {
             sessionMaxLifespan = realm.getClientOfflineSessionMaxLifespan();
         }
 
-        long timeToExpire = sessionMaxLifespan - timeSinceTimestamp;
+        long timeToExpire = sessionMaxLifespan - timeSinceUserSessionStart;
 
         // Indication that entry should be expired
         if (timeToExpire <=0) {


### PR DESCRIPTION
Adding user session creation time when calculating client session lifespan

New client session note is added storing information about start timestamp of associated user session

Closes #14854

