### PR TITLE
Allow simulated redirects

### DIFF
--- a/saml-core-api/src/main/java/org/keycloak/saml/common/constants/GeneralConstants.java
+++ b/saml-core-api/src/main/java/org/keycloak/saml/common/constants/GeneralConstants.java
@@ -155,4 +155,5 @@ public interface GeneralConstants {
 
     public static final String  SAML_CHARSET_NAME = System.getProperty("keycloak.saml.saml_message_charset", "UTF-8");
     public static final Charset SAML_CHARSET = Charset.forName(SAML_CHARSET_NAME);
+    String SIMULATE_REDIRECT = "simulate_redirect";
 }

--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocol.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocol.java
@@ -49,6 +49,7 @@ import org.keycloak.protocol.oidc.utils.OIDCResponseType;
 import org.keycloak.representations.AccessTokenResponse;
 import org.keycloak.representations.adapters.action.PushNotBeforeAction;
 import org.keycloak.services.CorsErrorResponseException;
+import org.keycloak.saml.common.constants.GeneralConstants;
 import org.keycloak.services.ServicesLogger;
 import org.keycloak.services.clientpolicy.ClientPolicyException;
 import org.keycloak.services.clientpolicy.context.ImplicitHybridTokenResponse;
@@ -213,7 +214,7 @@ public class OIDCLoginProtocol implements LoginProtocol {
         setupResponseTypeAndMode(responseTypeParam, responseModeParam);
 
         String redirect = authSession.getRedirectUri();
-        OIDCRedirectUriBuilder redirectUri = OIDCRedirectUriBuilder.fromUri(redirect, responseMode, session, clientSession);
+        OIDCRedirectUriBuilder redirectUri = OIDCRedirectUriBuilder.fromUri(redirect, responseMode, session, clientSession, "true".equals(this.uriInfo.getQueryParameters().getFirst(GeneralConstants.SIMULATE_REDIRECT)));
         String state = authSession.getClientNote(OIDCLoginProtocol.STATE_PARAM);
         logger.debugv("redirectAccessCode: state: {0}", state);
         if (state != null)
@@ -314,7 +315,8 @@ public class OIDCLoginProtocol implements LoginProtocol {
         String redirect = authSession.getRedirectUri();
         String state = authSession.getClientNote(OIDCLoginProtocol.STATE_PARAM);
 
-        OIDCRedirectUriBuilder redirectUri = OIDCRedirectUriBuilder.fromUri(redirect, responseMode, session, null);
+        OIDCRedirectUriBuilder redirectUri = OIDCRedirectUriBuilder.fromUri(redirect, responseMode, session, null,
+          "true".equals(uriInfo.getQueryParameters().getFirst(GeneralConstants.SIMULATE_REDIRECT)));
 
         if (error != Error.CANCELLED_AIA_SILENT) {
             redirectUri.addParam(OAuth2Constants.ERROR, translateError(error));

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpoint.java
@@ -40,6 +40,7 @@ import org.keycloak.protocol.oidc.grants.device.endpoints.DeviceEndpoint;
 import org.keycloak.protocol.oidc.utils.OIDCRedirectUriBuilder;
 import org.keycloak.protocol.oidc.utils.OIDCResponseMode;
 import org.keycloak.protocol.oidc.utils.OIDCResponseType;
+import org.keycloak.saml.common.constants.GeneralConstants;
 import org.keycloak.services.ErrorPageException;
 import org.keycloak.services.Urls;
 import org.keycloak.services.clientpolicy.ClientPolicyException;
@@ -257,7 +258,8 @@ public class AuthorizationEndpoint extends AuthorizationEndpointBase {
     }
 
     private Response redirectErrorToClient(OIDCResponseMode responseMode, String error, String errorDescription) {
-        OIDCRedirectUriBuilder errorResponseBuilder = OIDCRedirectUriBuilder.fromUri(redirectUri, responseMode, session, null)
+        OIDCRedirectUriBuilder errorResponseBuilder = OIDCRedirectUriBuilder.fromUri(redirectUri, responseMode, session, null,
+            "true".equals(this.httpRequest.getUri().getQueryParameters().getFirst(GeneralConstants.SIMULATE_REDIRECT)))
                 .addParam(OAuth2Constants.ERROR, error);
 
         if (errorDescription != null) {


### PR DESCRIPTION
Requests with `simulate_redirect=true` won't generate a 301. This is very useful for themes that want to submit forms in javascript with XHR.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
