### PR TITLE
Prevent registration of an e-mail as username if it's already associated with existing user

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
@@ -134,6 +134,12 @@ public class UsersResource {
         if (session.users().getUserByUsername(realm, username) != null) {
             return ErrorResponse.exists("User exists with same username");
         }
+
+        // Check if username is already used as email by other user
+        if (session.users().getUserByEmail(realm, username) != null){
+            return ErrorResponse.exists("User name is already associated with an existing user");
+        }
+
         if (rep.getEmail() != null && !realm.isDuplicateEmailsAllowed()) {
             try {
                 if(session.users().getUserByEmail(realm, rep.getEmail()) != null) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/UserTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/UserTest.java
@@ -262,6 +262,23 @@ public class UserTest extends AbstractAdminTest {
         }
     }
 
+    @Test
+    public void createDuplicatedNameAssociatedWithEmail() {
+        createUser();
+
+        UserRepresentation user = new UserRepresentation();
+        user.setUsername("user1@localhost");
+
+        try (Response response = realm.users().create(user)) {
+            assertEquals(409, response.getStatus());
+            assertAdminEvents.assertEmpty();
+
+            ErrorRepresentation error = response.readEntity(ErrorRepresentation.class);
+            Assert.assertEquals("User name is already associated with an existing user", error.getErrorMessage());
+        }
+
+    }
+
     //KEYCLOAK-14611
     @Test
     public void createDuplicateEmailWithExistingDuplicates() {


### PR DESCRIPTION
This PR tries to solve the issue: https://github.com/keycloak/keycloak/issues/15024

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->

Resolves #15024
