### PR TITLE
Authz client not updated with the way of encoding the basic header

### DIFF
--- a/authz/client/src/main/java/org/keycloak/authorization/client/Configuration.java
+++ b/authz/client/src/main/java/org/keycloak/authorization/client/Configuration.java
@@ -85,7 +85,7 @@ public class Configuration extends AdapterConfig {
                     throw new RuntimeException("Client secret not provided.");
                 }
 
-                requestHeaders.put("Authorization", BasicAuthHelper.createHeader(getResource(), secret));
+                requestHeaders.put("Authorization", BasicAuthHelper.RFC6749.createHeader(getResource(), secret));
             }
         };
     }


### PR DESCRIPTION
Closes #15086

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
