### PR TITLE
Exclude `operator` module by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1950,7 +1950,6 @@
         <profile>
             <id>operator</id>
             <activation>
-                <jdk>[11,)</jdk>
                 <property>
                     <name>operator</name>
                 </property>


### PR DESCRIPTION
Closes #15110 