### PR TITLE
Support for multiple keys with same kid, which differ just by algorit…

### DIFF
--- a/core/src/main/java/org/keycloak/crypto/PublicKeysWrapper.java
+++ b/core/src/main/java/org/keycloak/crypto/PublicKeysWrapper.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ *  and other contributors as indicated by the @author tags.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.keycloak.crypto;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
+ */
+public class PublicKeysWrapper {
+
+    private final List<KeyWrapper> keys;
+
+    public static final PublicKeysWrapper EMPTY = new PublicKeysWrapper(Collections.emptyList());
+
+    public PublicKeysWrapper(List<KeyWrapper> keys) {
+        this.keys = keys;
+    }
+
+    public List<KeyWrapper> getKeys() {
+        return keys;
+    }
+
+    public List<String> getKids() {
+        return keys.stream()
+                .map(KeyWrapper::getKid)
+                .collect(Collectors.toList());
+    }
+
+    public KeyWrapper getKeyByKidAndAlg(String kid, String alg) {
+        return keys.stream()
+                .filter(keyWrapper -> kid == null || kid.equals(keyWrapper.getKid()))
+                .filter(keyWrapper -> alg == null || alg.equals(keyWrapper.getAlgorithmOrDefault()) || (keyWrapper.getAlgorithm() == null && kid != null))
+                .findFirst().orElse(null);
+    }
+}

--- a/core/src/main/java/org/keycloak/util/JWKSUtils.java
+++ b/core/src/main/java/org/keycloak/util/JWKSUtils.java
@@ -17,17 +17,19 @@
 
 package org.keycloak.util;
 
+import org.jboss.logging.Logger;
 import org.keycloak.crypto.KeyUse;
 import org.keycloak.crypto.KeyWrapper;
+import org.keycloak.crypto.PublicKeysWrapper;
 import org.keycloak.jose.jwk.JSONWebKeySet;
 import org.keycloak.jose.jwk.JWK;
 import org.keycloak.jose.jwk.JWKParser;
 
 import java.security.PublicKey;
-import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
@@ -36,27 +38,22 @@ public class JWKSUtils {
 
     private static final Logger logger = Logger.getLogger(JWKSUtils.class.getName());
 
+    /**
+     * @deprecated Use {@link #getKeyWrappersForUse(JSONWebKeySet, JWK.Use)}
+     **/
+    @Deprecated
     public static Map<String, PublicKey> getKeysForUse(JSONWebKeySet keySet, JWK.Use requestedUse) {
-        Map<String, PublicKey> result = new HashMap<>();
-
-        for (JWK jwk : keySet.getKeys()) {
-            JWKParser parser = JWKParser.create(jwk);
-            if (jwk.getPublicKeyUse() == null) {
-                logger.log(Level.FINE, "Ignoring JWK key '%s'. Missing required field 'use'.", jwk.getKeyId());
-            } else if (requestedUse.asString().equals(jwk.getPublicKeyUse()) && parser.isKeyTypeSupported(jwk.getKeyType())) {
-                result.put(jwk.getKeyId(), parser.toPublicKey());
-            }
-        }
-
-        return result;
+        return getKeyWrappersForUse(keySet, requestedUse).getKeys()
+                .stream()
+                .collect(Collectors.toMap(KeyWrapper::getKid, keyWrapper -> (PublicKey) keyWrapper.getPublicKey()));
     }
 
-    public static Map<String, KeyWrapper> getKeyWrappersForUse(JSONWebKeySet keySet, JWK.Use requestedUse) {
-        Map<String, KeyWrapper> result = new HashMap<>();
+    public static PublicKeysWrapper getKeyWrappersForUse(JSONWebKeySet keySet, JWK.Use requestedUse) {
+        List<KeyWrapper> result = new ArrayList<>();
         for (JWK jwk : keySet.getKeys()) {
             JWKParser parser = JWKParser.create(jwk);
             if (jwk.getPublicKeyUse() == null) {
-                logger.log(Level.FINE, "Ignoring JWK key '%s'. Missing required field 'use'.", jwk.getKeyId());
+                logger.debugf("Ignoring JWK key '%s'. Missing required field 'use'.", jwk.getKeyId());
             } else if (requestedUse.asString().equals(jwk.getPublicKeyUse()) && parser.isKeyTypeSupported(jwk.getKeyType())) {
                 KeyWrapper keyWrapper = new KeyWrapper();
                 keyWrapper.setKid(jwk.getKeyId());
@@ -66,10 +63,10 @@ public class JWKSUtils {
                 keyWrapper.setType(jwk.getKeyType());
                 keyWrapper.setUse(getKeyUse(jwk.getPublicKeyUse()));
                 keyWrapper.setPublicKey(parser.toPublicKey());
-                result.put(keyWrapper.getKid(), keyWrapper);
+                result.add(keyWrapper);
             }
         }
-        return result;
+        return new PublicKeysWrapper(result);
     }
 
     private static KeyUse getKeyUse(String keyUse) {
@@ -87,7 +84,7 @@ public class JWKSUtils {
         for (JWK jwk : keySet.getKeys()) {
             JWKParser parser = JWKParser.create(jwk);
             if (jwk.getPublicKeyUse() == null) {
-                logger.log(Level.FINE, "Ignoring JWK key '%s'. Missing required field 'use'.", jwk.getKeyId());
+                logger.debugf("Ignoring JWK key '%s'. Missing required field 'use'.", jwk.getKeyId());
             } else if (requestedUse.asString().equals(parser.getJwk().getPublicKeyUse()) && parser.isKeyTypeSupported(jwk.getKeyType())) {
                 return jwk;
             }

--- a/core/src/test/java/org/keycloak/util/JWKSUtilsTest.java
+++ b/core/src/test/java/org/keycloak/util/JWKSUtilsTest.java
@@ -21,12 +21,14 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.keycloak.crypto.KeyUse;
 import org.keycloak.crypto.KeyWrapper;
-import org.keycloak.jose.jwk.*;
+import org.keycloak.crypto.PublicKeysWrapper;
+import org.keycloak.jose.jwk.JSONWebKeySet;
+import org.keycloak.jose.jwk.JWK;
 import org.keycloak.rule.CryptoInitRule;
 
-import java.util.Map;
-
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 
 public abstract class JWKSUtilsTest {
@@ -61,6 +63,14 @@ public abstract class JWKSUtilsTest {
                 "  }," +
                 "  {" +
                 "   \"kty\": \"RSA\"," +
+                "   \"alg\": \"RS512\"," +
+                "   \"use\": \"sig\"," +
+                "   \"kid\": \"" + kidRsa1 + "\"," +
+                "   \"n\": \"soFDjoZ5mQ8XAA7reQAFg90inKAHk0DXMTizo4JuOsgzUbhcplIeZ7ks83hsEjm8mP8lUVaHMPMAHEIp3gu6Xxsg-s73ofx1dtt_Fo7aj8j383MFQGl8-FvixTVobNeGeC0XBBQjN8lEl-lIwOa4ZoERNAShplTej0ntDp7TQm0=\"," +
+                "   \"e\": \"AQAB\"" +
+                "  }," +
+                "  {" +
+                "   \"kty\": \"RSA\"," +
                 "   \"kid\": \"" + kidInvalidKey + "\"," +
                 "   \"n\": \"soFDjoZ5mQ8XAA7reQAFg90inKAHk0DXMTizo4JuOsgzUbhcplIeZ7ks83hsEjm8mP8lUVaHMPMAHEIp3gu6Xxsg-s73ofx1dtt_Fo7aj8j383MFQGl8-FvixTVobNeGeC0XBBQjN8lEl-lIwOa4ZoERNAShplTej0ntDp7TQm0=\"," +
                 "   \"e\": \"AQAB\"" +
@@ -84,35 +94,60 @@ public abstract class JWKSUtilsTest {
                 "  }" +
                 "] }";
         JSONWebKeySet jsonWebKeySet = JsonSerialization.readValue(jwksJson, JSONWebKeySet.class);
-        Map<String, KeyWrapper> keyWrappersForUse = JWKSUtils.getKeyWrappersForUse(jsonWebKeySet, JWK.Use.SIG);
-        assertEquals(4, keyWrappersForUse.size());
+        PublicKeysWrapper keyWrappersForUse = JWKSUtils.getKeyWrappersForUse(jsonWebKeySet, JWK.Use.SIG);
+        assertEquals(5, keyWrappersForUse.getKeys().size());
 
-        KeyWrapper key = keyWrappersForUse.get(kidRsa1);
+        // get by both kid and alg
+        KeyWrapper key = keyWrappersForUse.getKeyByKidAndAlg(kidRsa1, "RS256");
         assertNotNull(key);
         assertEquals("RS256", key.getAlgorithmOrDefault());
         assertEquals(KeyUse.SIG, key.getUse());
         assertEquals(kidRsa1, key.getKid());
         assertEquals("RSA", key.getType());
 
-         key = keyWrappersForUse.get(kidRsa2);
+        // get by both kid and alg with RS512. It is same 'kid' as the previous, but should choose "RS512" key now
+        key = keyWrappersForUse.getKeyByKidAndAlg(kidRsa1, "RS512");
+        assertNotNull(key);
+        assertEquals("RS512", key.getAlgorithmOrDefault());
+        assertEquals(KeyUse.SIG, key.getUse());
+        assertEquals(kidRsa1, key.getKid());
+        assertEquals("RSA", key.getType());
+
+        // Get by kid only. Should choose default algorithm, so RS256
+        key = keyWrappersForUse.getKeyByKidAndAlg(kidRsa1, null);
+        assertNotNull(key);
+        assertEquals("RS256", key.getAlgorithmOrDefault());
+        assertEquals(KeyUse.SIG, key.getUse());
+        assertEquals(kidRsa1, key.getKid());
+        assertEquals("RSA", key.getType());
+
+        key = keyWrappersForUse.getKeyByKidAndAlg(kidRsa2, null);
         assertNotNull(key);
         assertEquals("RS256", key.getAlgorithmOrDefault());
         assertEquals(KeyUse.SIG, key.getUse());
         assertEquals(kidRsa2, key.getKid());
         assertEquals("RSA", key.getType());
 
-        key = keyWrappersForUse.get(kidEC1);
+        key = keyWrappersForUse.getKeyByKidAndAlg(kidEC1, null);
         assertNotNull(key);
         assertEquals("ES384", key.getAlgorithmOrDefault());
         assertEquals(KeyUse.SIG, key.getUse());
         assertEquals(kidEC1, key.getKid());
         assertEquals("EC", key.getType());
 
-        key = keyWrappersForUse.get(kidEC2);
+        key = keyWrappersForUse.getKeyByKidAndAlg(kidEC2, null);
         assertNotNull(key);
         assertNull(key.getAlgorithmOrDefault());
         assertEquals(KeyUse.SIG, key.getUse());
         assertEquals(kidEC2, key.getKid());
+        assertEquals("EC", key.getType());
+
+        // Search by alg only
+        key = keyWrappersForUse.getKeyByKidAndAlg(null, "ES384");
+        assertNotNull(key);
+        assertEquals("ES384", key.getAlgorithmOrDefault());
+        assertEquals(KeyUse.SIG, key.getUse());
+        assertEquals(kidEC1, key.getKid());
         assertEquals("EC", key.getType());
     }
 

--- a/model/infinispan/src/main/java/org/keycloak/keys/infinispan/PublicKeysEntry.java
+++ b/model/infinispan/src/main/java/org/keycloak/keys/infinispan/PublicKeysEntry.java
@@ -18,9 +18,7 @@
 package org.keycloak.keys.infinispan;
 
 import java.io.Serializable;
-import java.util.Map;
-
-import org.keycloak.crypto.KeyWrapper;
+import org.keycloak.crypto.PublicKeysWrapper;
 
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
@@ -29,9 +27,9 @@ public class PublicKeysEntry implements Serializable {
 
     private final int lastRequestTime;
 
-    private final Map<String, KeyWrapper> currentKeys;
+    private final PublicKeysWrapper currentKeys;
 
-    public PublicKeysEntry(int lastRequestTime, Map<String, KeyWrapper> currentKeys) {
+    public PublicKeysEntry(int lastRequestTime, PublicKeysWrapper currentKeys) {
         this.lastRequestTime = lastRequestTime;
         this.currentKeys = currentKeys;
     }
@@ -40,7 +38,7 @@ public class PublicKeysEntry implements Serializable {
         return lastRequestTime;
     }
 
-    public Map<String, KeyWrapper> getCurrentKeys() {
+    public PublicKeysWrapper getCurrentKeys() {
         return currentKeys;
     }
 }

--- a/model/infinispan/src/test/java/org/keycloak/keys/infinispan/InfinispanKeyStorageProviderTest.java
+++ b/model/infinispan/src/test/java/org/keycloak/keys/infinispan/InfinispanKeyStorageProviderTest.java
@@ -17,7 +17,6 @@
 
 package org.keycloak.keys.infinispan;
 
-import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -38,7 +37,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.keycloak.common.util.Time;
 import org.keycloak.connections.infinispan.InfinispanConnectionProvider;
-import org.keycloak.crypto.KeyWrapper;
+import org.keycloak.crypto.PublicKeysWrapper;
 import org.keycloak.keys.PublicKeyLoader;
 
 /**
@@ -129,7 +128,7 @@ public class InfinispanKeyStorageProviderTest {
         @Override
         public void run() {
             InfinispanPublicKeyStorageProvider provider = new InfinispanPublicKeyStorageProvider(null, keys, tasksInProgress, minTimeBetweenRequests);
-            provider.getPublicKey(modelKey, "kid1", new SampleLoader(modelKey));
+            provider.getPublicKey(modelKey, "kid1", null, new SampleLoader(modelKey));
         }
 
     }
@@ -144,12 +143,12 @@ public class InfinispanKeyStorageProviderTest {
         }
 
         @Override
-        public Map<String, KeyWrapper> loadKeys() throws Exception {
+        public PublicKeysWrapper loadKeys() throws Exception {
             counters.putIfAbsent(modelKey, new AtomicInteger(0));
             AtomicInteger currentCounter = counters.get(modelKey);
 
             currentCounter.incrementAndGet();
-            return Collections.emptyMap();
+            return PublicKeysWrapper.EMPTY;
         }
     }
 

--- a/model/map/src/main/java/org/keycloak/models/map/keys/MapPublicKeyStorageProviderFactory.java
+++ b/model/map/src/main/java/org/keycloak/models/map/keys/MapPublicKeyStorageProviderFactory.java
@@ -18,7 +18,7 @@
 package org.keycloak.models.map.keys;
 
 import org.keycloak.common.Profile;
-import org.keycloak.crypto.KeyWrapper;
+import org.keycloak.crypto.PublicKeysWrapper;
 import org.keycloak.keys.PublicKeyStorageProviderFactory;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.map.common.AbstractEntity;
@@ -32,7 +32,7 @@ import java.util.concurrent.FutureTask;
 public class MapPublicKeyStorageProviderFactory extends AbstractMapProviderFactory<MapPublicKeyStorageProvider, AbstractEntity, Object>
         implements PublicKeyStorageProviderFactory<MapPublicKeyStorageProvider>, EnvironmentDependentProviderFactory {
 
-    private final Map<String, FutureTask<Map<String, KeyWrapper>>> tasksInProgress = new ConcurrentHashMap<>();
+    private final Map<String, FutureTask<PublicKeysWrapper>> tasksInProgress = new ConcurrentHashMap<>();
 
     public MapPublicKeyStorageProviderFactory() {
         super(Object.class, MapPublicKeyStorageProvider.class);

--- a/server-spi-private/src/main/java/org/keycloak/keys/PublicKeyLoader.java
+++ b/server-spi-private/src/main/java/org/keycloak/keys/PublicKeyLoader.java
@@ -17,15 +17,13 @@
 
 package org.keycloak.keys;
 
-import java.util.Map;
-
-import org.keycloak.crypto.KeyWrapper;
+import org.keycloak.crypto.PublicKeysWrapper;
 
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
  */
 public interface PublicKeyLoader {
 
-    Map<String, KeyWrapper> loadKeys() throws Exception;
+    PublicKeysWrapper loadKeys() throws Exception;
 
 }

--- a/server-spi-private/src/main/java/org/keycloak/keys/PublicKeyStorageProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/keys/PublicKeyStorageProvider.java
@@ -31,10 +31,11 @@ public interface PublicKeyStorageProvider extends Provider {
      *
      * @param modelKey
      * @param kid
+     * @param algorithm The returned key must match this algorithm (unless the algorithm is not set in the JWK)
      * @param loader
      * @return
      */
-	KeyWrapper getPublicKey(String modelKey, String kid, PublicKeyLoader loader);
+	KeyWrapper getPublicKey(String modelKey, String kid, String algorithm, PublicKeyLoader loader);
 
     /**
      * Get first found public key to verify messages signed by particular client having several public keys. Used for example during JWT client authentication

--- a/services/src/main/java/org/keycloak/keys/AbstractRsaKeyProvider.java
+++ b/services/src/main/java/org/keycloak/keys/AbstractRsaKeyProvider.java
@@ -75,7 +75,7 @@ public abstract class AbstractRsaKeyProvider implements KeyProvider {
         key.setProviderId(model.getId());
         key.setProviderPriority(model.get("priority", 0l));
 
-        key.setKid(KeyUtils.createKeyId(keyPair.getPublic()));
+        key.setKid(model.get(Attributes.KID_KEY) != null ? model.get(Attributes.KID_KEY) : KeyUtils.createKeyId(keyPair.getPublic()));
         key.setUse(keyUse == null ? KeyUse.SIG : keyUse);
         key.setType(KeyType.RSA);
         key.setAlgorithm(algorithm);

--- a/services/src/main/java/org/keycloak/keys/loader/ClientPublicKeyLoader.java
+++ b/services/src/main/java/org/keycloak/keys/loader/ClientPublicKeyLoader.java
@@ -22,6 +22,7 @@ import org.keycloak.authentication.authenticators.client.JWTClientAuthenticator;
 import org.keycloak.common.util.KeyUtils;
 import org.keycloak.crypto.KeyUse;
 import org.keycloak.crypto.KeyWrapper;
+import org.keycloak.crypto.PublicKeysWrapper;
 import org.keycloak.jose.jwk.JSONWebKeySet;
 import org.keycloak.jose.jwk.JWK;
 import org.keycloak.keys.PublicKeyLoader;
@@ -40,7 +41,6 @@ import org.keycloak.util.JsonSerialization;
 import java.security.PublicKey;
 import java.security.cert.X509Certificate;
 import java.util.Collections;
-import java.util.Map;
 
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
@@ -66,7 +66,7 @@ public class ClientPublicKeyLoader implements PublicKeyLoader {
     }
 
     @Override
-    public Map<String, KeyWrapper> loadKeys() throws Exception {
+    public PublicKeysWrapper loadKeys() throws Exception {
         OIDCAdvancedConfigWrapper config = OIDCAdvancedConfigWrapper.fromClientModel(client);
         if (config.isUseJwksUrl()) {
             String jwksUrl = config.getJwksUrl();
@@ -80,14 +80,14 @@ public class ClientPublicKeyLoader implements PublicKeyLoader {
             try {
                 CertificateRepresentation certInfo = CertificateInfoHelper.getCertificateFromClient(client, JWTClientAuthenticator.ATTR_PREFIX);
                 KeyWrapper publicKey = getSignatureValidationKey(certInfo);
-                return Collections.singletonMap(publicKey.getKid(), publicKey);
+                return new PublicKeysWrapper(Collections.singletonList(publicKey));
             } catch (ModelException me) {
                 logger.warnf(me, "Unable to retrieve publicKey for verify signature of client '%s' . Error details: %s", client.getClientId(), me.getMessage());
-                return Collections.emptyMap();
+                return PublicKeysWrapper.EMPTY;
             }
         } else {
             logger.warnf("Unable to retrieve publicKey of client '%s' for the specified purpose other than verifying signature", client.getClientId());
-            return Collections.emptyMap();
+            return PublicKeysWrapper.EMPTY;
         }
     }
 

--- a/services/src/main/java/org/keycloak/keys/loader/HardcodedPublicKeyLoader.java
+++ b/services/src/main/java/org/keycloak/keys/loader/HardcodedPublicKeyLoader.java
@@ -19,15 +19,14 @@ package org.keycloak.keys.loader;
 import org.keycloak.common.util.Base64Url;
 import org.keycloak.common.util.KeyUtils;
 import org.keycloak.common.util.PemUtils;
-import org.keycloak.crypto.Algorithm;
 import org.keycloak.crypto.JavaAlgorithm;
 import org.keycloak.crypto.KeyType;
 import org.keycloak.crypto.KeyUse;
 import org.keycloak.crypto.KeyWrapper;
+import org.keycloak.crypto.PublicKeysWrapper;
 import org.keycloak.keys.PublicKeyLoader;
 
 import java.util.Collections;
-import java.util.Map;
 
 /**
  *
@@ -36,10 +35,6 @@ import java.util.Map;
 public class HardcodedPublicKeyLoader implements PublicKeyLoader {
 
     private final KeyWrapper keyWrapper;
-
-    public HardcodedPublicKeyLoader(String kid, String pem) {
-        this(kid, pem, Algorithm.RS256);
-    }
 
     public HardcodedPublicKeyLoader(String kid, String encodedKey, String algorithm) {
         if (encodedKey != null && !encodedKey.trim().isEmpty()) {
@@ -63,10 +58,10 @@ public class HardcodedPublicKeyLoader implements PublicKeyLoader {
     }
 
     @Override
-    public Map<String, KeyWrapper> loadKeys() throws Exception {
+    public PublicKeysWrapper loadKeys() throws Exception {
         return keyWrapper != null
-                ? Collections.unmodifiableMap(Collections.singletonMap(keyWrapper.getKid(), getSavedPublicKey()))
-                : Collections.emptyMap();
+                ? new PublicKeysWrapper(Collections.singletonList(getSavedPublicKey()))
+                : PublicKeysWrapper.EMPTY;
     }
 
     protected KeyWrapper getSavedPublicKey() {

--- a/services/src/main/java/org/keycloak/keys/loader/OIDCIdentityProviderPublicKeyLoader.java
+++ b/services/src/main/java/org/keycloak/keys/loader/OIDCIdentityProviderPublicKeyLoader.java
@@ -25,6 +25,7 @@ import org.keycloak.crypto.Algorithm;
 import org.keycloak.crypto.KeyType;
 import org.keycloak.crypto.KeyUse;
 import org.keycloak.crypto.KeyWrapper;
+import org.keycloak.crypto.PublicKeysWrapper;
 import org.keycloak.jose.jwk.JSONWebKeySet;
 import org.keycloak.jose.jwk.JWK;
 import org.keycloak.keys.PublicKeyLoader;
@@ -34,7 +35,6 @@ import org.keycloak.util.JWKSUtils;
 
 import java.security.PublicKey;
 import java.util.Collections;
-import java.util.Map;
 
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
@@ -52,7 +52,7 @@ public class OIDCIdentityProviderPublicKeyLoader implements PublicKeyLoader {
     }
 
     @Override
-    public Map<String, KeyWrapper> loadKeys() throws Exception {
+    public PublicKeysWrapper loadKeys() throws Exception {
         if (config.isUseJwksUrl()) {
             String jwksUrl = config.getJwksUrl();
             JSONWebKeySet jwks = JWKSHttpUtils.sendJwksRequest(session, jwksUrl);
@@ -61,12 +61,12 @@ public class OIDCIdentityProviderPublicKeyLoader implements PublicKeyLoader {
             try {
             	KeyWrapper publicKey = getSavedPublicKey();
                 if (publicKey == null) {
-                    return Collections.emptyMap();
+                    return PublicKeysWrapper.EMPTY;
                 }
-                return Collections.singletonMap(publicKey.getKid(), publicKey);
+                return new PublicKeysWrapper(Collections.singletonList(publicKey));
             } catch (Exception e) {
                 logger.warnf(e, "Unable to retrieve publicKey for verify signature of identityProvider '%s' . Error details: %s", config.getAlias(), e.getMessage());
-                return Collections.emptyMap();
+                return PublicKeysWrapper.EMPTY;
             }
         }
     }

--- a/services/src/main/java/org/keycloak/keys/loader/PublicKeyStorageManager.java
+++ b/services/src/main/java/org/keycloak/keys/loader/PublicKeyStorageManager.java
@@ -49,10 +49,11 @@ public class PublicKeyStorageManager {
 
     public static KeyWrapper getClientPublicKeyWrapper(KeycloakSession session, ClientModel client, JWSInput input) {
         String kid = input.getHeader().getKeyId();
+        String alg = input.getHeader().getRawAlgorithm();
         PublicKeyStorageProvider keyStorage = session.getProvider(PublicKeyStorageProvider.class);
         String modelKey = PublicKeyStorageUtils.getClientModelCacheKey(client.getRealm().getId(), client.getId());
         ClientPublicKeyLoader loader = new ClientPublicKeyLoader(session, client);
-        return keyStorage.getPublicKey(modelKey, kid, loader);
+        return keyStorage.getPublicKey(modelKey, kid, alg, loader);
     }
 
     public static KeyWrapper getClientPublicKeyWrapper(KeycloakSession session, ClientModel client, JWK.Use keyUse, String algAlgorithm) {
@@ -89,11 +90,6 @@ public class PublicKeyStorageManager {
                 : kid, pem, alg);
         }
 
-        return keyStorage.getPublicKey(modelKey, kid, loader);
-    }
-
-    public static PublicKey getIdentityProviderPublicKey(KeycloakSession session, RealmModel realm, OIDCIdentityProviderConfig idpConfig, JWSInput input) {
-        KeyWrapper key = getIdentityProviderKeyWrapper(session, realm, idpConfig, input);
-        return key != null? (PublicKey) key.getPublicKey() : null;
+        return keyStorage.getPublicKey(modelKey, kid, alg, loader);
     }
 }

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/rest/TestApplicationResourceProviderFactory.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/rest/TestApplicationResourceProviderFactory.java
@@ -34,6 +34,7 @@ import org.keycloak.services.resource.RealmResourceProviderFactory;
 import org.keycloak.testsuite.rest.representation.TestAuthenticationChannelRequest;
 
 import java.security.KeyPair;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
@@ -86,19 +87,24 @@ public class TestApplicationResourceProviderFactory implements RealmResourceProv
 
     public static class OIDCClientData {
 
-        private KeyPair keyPair;
+        private List<OIDCKeyData> keys = new ArrayList<>();
+
         private String oidcRequest;
         private List<String> sectorIdentifierRedirectUris;
-        private String keyType = KeyType.RSA;
-        private String keyAlgorithm;
-        private KeyUse keyUse = KeyUse.SIG;
 
-        public KeyPair getSigningKeyPair() {
-            return keyPair;
+        public List<OIDCKeyData> getKeys() {
+            return keys;
         }
 
-        public void setSigningKeyPair(KeyPair signingKeyPair) {
-            this.keyPair = signingKeyPair;
+        public OIDCKeyData getFirstKey() {
+            return keys.isEmpty() ? null : keys.get(0);
+        }
+
+        public void addKey(OIDCKeyData key, boolean keepExistingKeys) {
+            if (!keepExistingKeys) {
+                this.keys = new ArrayList<>();
+            }
+            this.keys.add(0, key);
         }
 
         public String getOidcRequest() {
@@ -115,6 +121,27 @@ public class TestApplicationResourceProviderFactory implements RealmResourceProv
 
         public void setSectorIdentifierRedirectUris(List<String> sectorIdentifierRedirectUris) {
             this.sectorIdentifierRedirectUris = sectorIdentifierRedirectUris;
+        }
+
+    }
+
+    public static class OIDCKeyData {
+
+        private KeyPair keyPair;
+
+        private String keyType = KeyType.RSA;
+        private String keyAlgorithm;
+        private KeyUse keyUse = KeyUse.SIG;
+
+        // Kid will be randomly generated (based on the key hash) if not provided here
+        private String kid;
+
+        public KeyPair getSigningKeyPair() {
+            return keyPair;
+        }
+
+        public void setSigningKeyPair(KeyPair signingKeyPair) {
+            this.keyPair = signingKeyPair;
         }
 
         public String getSigningKeyType() {
@@ -163,6 +190,14 @@ public class TestApplicationResourceProviderFactory implements RealmResourceProv
 
         public void setKeyUse(KeyUse keyUse) {
             this.keyUse = keyUse;
+        }
+
+        public String getKid() {
+            return kid;
+        }
+
+        public void setKid(String kid) {
+            this.kid = kid;
         }
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/client/resources/TestOIDCEndpointsApplicationResource.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/client/resources/TestOIDCEndpointsApplicationResource.java
@@ -46,11 +46,23 @@ public interface TestOIDCEndpointsApplicationResource {
     @Path("/generate-keys")
     Map<String, String> generateKeys(@QueryParam("jwaAlgorithm") String jwaAlgorithm);
 
+    /**
+     * Generate single private/public keyPair
+     *
+     * @param jwaAlgorithm
+     * @param advertiseJWKAlgorithm whether algorithm should be adwertised in JWKS or not (Once the keys are returned by JWKS)
+     * @param keepExistingKeys Should be existing keys kept replaced with newly generated keyPair. If it is not kept, then resulting JWK will contain single key. It is false by default.
+     *                         The value 'true' is useful if we want to test with multiple client keys (For example mulitple keys set in the JWKS and test if correct key is picked)
+     * @param kid Explicitly set specified "kid" for newly generated keypair. If not specified, the kid will be generated
+     * @return
+     */
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/generate-keys")
     Map<String, String> generateKeys(@QueryParam("jwaAlgorithm") String jwaAlgorithm,
-            @QueryParam("advertiseJWKAlgorithm") Boolean advertiseJWKAlgorithm);
+                                     @QueryParam("advertiseJWKAlgorithm") Boolean advertiseJWKAlgorithm,
+                                     @QueryParam("keepExistingKeys") Boolean keepExistingKeys,
+                                     @QueryParam("kid") String kid);
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
…hm in the JWKS

Closes #14794

@stianst @pedroigor Anyone of you is able to review this one please? During investigation of #14794, I figured that we didn't have proper support for the JWKS with multiple keys of same `kid` (where those keys with same `kid` differ by algorithm).

So the issue #14794 is a regression, but it worked before likely just by accident (it looks the right key was accidentally chosen in Keycloak 18 for the particular user's scenario, which stopped working due some refactoring done in Keycloak 19 because of some work done on #11036 )