### PR TITLE
No model or integration test should run longer than 90 seconds

### DIFF
--- a/saml-core/src/test/java/org/keycloak/saml/processing/core/parsers/saml/SAMLAttributeQueryParserTest.java
+++ b/saml-core/src/test/java/org/keycloak/saml/processing/core/parsers/saml/SAMLAttributeQueryParserTest.java
@@ -43,7 +43,7 @@ public class SAMLAttributeQueryParserTest {
         this.parser = new SAMLParser();
     }
 
-    @Test(timeout = 2000000)
+    @Test(timeout = 2000)
     public void testSaml20AttributeQuery() throws Exception {
         try (InputStream is = SAMLAttributeQueryParserTest.class.getResourceAsStream("saml20-attributequery.xml")) {
             Object parsedObject = parser.parse(is);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/AbstractKeycloakTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/AbstractKeycloakTest.java
@@ -27,6 +27,8 @@ import org.jboss.logging.Logger;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import org.junit.runners.model.TestTimedOutException;
 import org.keycloak.admin.client.Keycloak;
@@ -34,7 +36,6 @@ import org.keycloak.admin.client.resource.AuthenticationManagementResource;
 import org.keycloak.admin.client.resource.RealmsResource;
 import org.keycloak.admin.client.resource.UserResource;
 import org.keycloak.admin.client.resource.UsersResource;
-import org.keycloak.common.Profile;
 import org.keycloak.common.util.KeycloakUriBuilder;
 import org.keycloak.common.util.Time;
 import org.keycloak.models.RealmProvider;
@@ -115,6 +116,9 @@ public abstract class AbstractKeycloakTest {
     protected static final String ENGLISH_LOCALE_NAME = "English";
 
     protected Logger log = Logger.getLogger(this.getClass());
+
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(90);
 
     @ClassRule
     public static CryptoInitRule cryptoInitRule = new CryptoInitRule();

--- a/testsuite/model/src/test/java/org/keycloak/testsuite/model/KeycloakModelTest.java
+++ b/testsuite/model/src/test/java/org/keycloak/testsuite/model/KeycloakModelTest.java
@@ -17,6 +17,7 @@
 package org.keycloak.testsuite.model;
 
 import org.junit.Assert;
+import org.junit.rules.Timeout;
 import org.keycloak.Config.Scope;
 import org.keycloak.authorization.AuthorizationSpi;
 import org.keycloak.authorization.DefaultAuthorizationProviderFactory;
@@ -120,6 +121,9 @@ public abstract class KeycloakModelTest {
     private static final AtomicInteger FACTORY_COUNT = new AtomicInteger();
     protected final Logger log = Logger.getLogger(getClass());
     private static final List<String> MAIN_THREAD_NAMES = Arrays.asList("main", "Time-limited test");
+
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(90);
 
     @ClassRule
     public static final TestRule GUARANTEE_REQUIRED_FACTORY = new TestRule() {

--- a/testsuite/model/src/test/java/org/keycloak/testsuite/model/session/OfflineSessionPersistenceTest.java
+++ b/testsuite/model/src/test/java/org/keycloak/testsuite/model/session/OfflineSessionPersistenceTest.java
@@ -171,7 +171,7 @@ public class OfflineSessionPersistenceTest extends KeycloakModelTest {
         assertOfflineSessionsExist(realmId, offlineSessionIds);
     }
 
-    @Test(timeout = 90 * 1000)
+    @Test
     @RequireProvider(UserSessionPersisterProvider.class)
     @RequireProvider(value = UserSessionProvider.class, only = InfinispanUserSessionProviderFactory.PROVIDER_ID)
     public void testPersistenceMultipleNodesClientSessionAtSameNode() throws InterruptedException {
@@ -228,7 +228,7 @@ public class OfflineSessionPersistenceTest extends KeycloakModelTest {
         inIndependentFactories(NUM_FACTORIES + 1, 30, () -> assertOfflineSessionsExist(realmId, clientSessionIds));
     }
 
-    @Test(timeout = 90 * 1000)
+    @Test
     @RequireProvider(UserSessionPersisterProvider.class)
     @RequireProvider(value = UserSessionProvider.class, only = InfinispanUserSessionProviderFactory.PROVIDER_ID)
     public void testPersistenceMultipleNodesClientSessionsAtRandomNode() throws InterruptedException {
@@ -366,7 +366,7 @@ public class OfflineSessionPersistenceTest extends KeycloakModelTest {
         });
     }
 
-    @Test(timeout = 90 * 1000)
+    @Test
     @RequireProvider(UserSessionPersisterProvider.class)
     @RequireProvider(value = UserSessionProvider.class, only = InfinispanUserSessionProviderFactory.PROVIDER_ID)
     public void testPersistenceClientSessionsMultipleNodes() throws InterruptedException {


### PR DESCRIPTION
This prevents a build timing out on a single test after hours. It also provides the main thread's stack trace which could point to the cause.

Closes #15118

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
