### PR TITLE
E-mail accounts validation during the registration process

### DIFF
--- a/core/src/main/java/org/keycloak/representations/idm/RealmRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/idm/RealmRepresentation.java
@@ -81,6 +81,7 @@ public class RealmRepresentation {
     protected Boolean duplicateEmailsAllowed;
     protected Boolean resetPasswordAllowed;
     protected Boolean editUsernameAllowed;
+    protected Boolean emailFormatAsUsernameAllowed;
 
     @Deprecated
     protected Boolean userCacheEnabled;
@@ -643,6 +644,14 @@ public class RealmRepresentation {
 
     public void setEditUsernameAllowed(Boolean editUsernameAllowed) {
         this.editUsernameAllowed = editUsernameAllowed;
+    }
+
+    public Boolean isEmailFormatAsUsernameAllowed() {
+        return emailFormatAsUsernameAllowed;
+    }
+
+    public void setEmailFormatAsUsernameAllowed(Boolean emailFormatAsUsernameAllowed) {
+        this.emailFormatAsUsernameAllowed = emailFormatAsUsernameAllowed;
     }
 
     @Deprecated

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmAdapter.java
@@ -196,6 +196,18 @@ public class RealmAdapter implements CachedRealmModel {
     }
 
     @Override
+    public boolean isEmailFormatAsUsernameAllowed() {
+        if (isUpdated()) return updated.isEmailFormatAsUsernameAllowed();
+        return cached.isEmailFormatAsUsernameAllowed();
+    }
+
+    @Override
+    public void setEmailFormatAsUsernameAllowed(boolean emailFormatAsUsernameAllowed) {
+        getDelegateForUpdate();
+        updated.setEmailFormatAsUsernameAllowed(emailFormatAsUsernameAllowed);
+    }
+
+    @Override
     public boolean isRememberMe() {
         if (isUpdated()) return updated.isRememberMe();
         return cached.isRememberMe();

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/entities/CachedRealm.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/entities/CachedRealm.java
@@ -71,6 +71,7 @@ public class CachedRealm extends AbstractExtendableRevisioned {
     protected boolean resetPasswordAllowed;
     protected boolean identityFederationEnabled;
     protected boolean editUsernameAllowed;
+    protected boolean emailFormatAsUsernameAllowed;
     //--- brute force settings
     protected boolean bruteForceProtected;
     protected boolean permanentLockout;
@@ -191,6 +192,7 @@ public class CachedRealm extends AbstractExtendableRevisioned {
         resetPasswordAllowed = model.isResetPasswordAllowed();
         identityFederationEnabled = model.isIdentityFederationEnabled();
         editUsernameAllowed = model.isEditUsernameAllowed();
+        emailFormatAsUsernameAllowed = model.isEmailFormatAsUsernameAllowed();
         //--- brute force settings
         bruteForceProtected = model.isBruteForceProtected();
         permanentLockout = model.isPermanentLockout();
@@ -416,6 +418,10 @@ public class CachedRealm extends AbstractExtendableRevisioned {
 
     public boolean isEditUsernameAllowed() {
         return editUsernameAllowed;
+    }
+
+    public boolean isEmailFormatAsUsernameAllowed() {
+        return emailFormatAsUsernameAllowed;
     }
 
     public String getDefaultSignatureAlgorithm() {

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/RealmAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/RealmAdapter.java
@@ -160,6 +160,16 @@ public class RealmAdapter implements LegacyRealmModel, JpaModel<RealmEntity> {
     }
 
     @Override
+    public boolean isEmailFormatAsUsernameAllowed() {
+        return getAttribute(RealmAttributes.EMAIL_AS_USERNAME_ALLOWED, false);
+    }
+
+    @Override
+    public void setEmailFormatAsUsernameAllowed(boolean emailFormatAsUsernameAllowed) {
+        setAttribute(RealmAttributes.EMAIL_AS_USERNAME_ALLOWED, emailFormatAsUsernameAllowed);
+    }
+
+    @Override
     public boolean isRememberMe() {
         return realm.isRememberMe();
     }

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/RealmAttributes.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/RealmAttributes.java
@@ -53,4 +53,6 @@ public interface RealmAttributes {
 
     String ADMIN_EVENTS_EXPIRATION = "adminEventsExpiration";
 
+    String EMAIL_AS_USERNAME_ALLOWED = "emailAsUsernameAllowed";
+
 }

--- a/model/legacy-private/src/main/java/org/keycloak/storage/datastore/LegacyExportImportManager.java
+++ b/model/legacy-private/src/main/java/org/keycloak/storage/datastore/LegacyExportImportManager.java
@@ -262,6 +262,7 @@ public class LegacyExportImportManager implements ExportImportManager {
         if (rep.isRegistrationAllowed() != null) newRealm.setRegistrationAllowed(rep.isRegistrationAllowed());
         if (rep.isRegistrationEmailAsUsername() != null)
             newRealm.setRegistrationEmailAsUsername(rep.isRegistrationEmailAsUsername());
+        if (rep.isEmailFormatAsUsernameAllowed() != null) newRealm.setEmailFormatAsUsernameAllowed(rep.isEmailFormatAsUsernameAllowed());
         if (rep.isRememberMe() != null) newRealm.setRememberMe(rep.isRememberMe());
         if (rep.isVerifyEmail() != null) newRealm.setVerifyEmail(rep.isVerifyEmail());
         if (rep.isLoginWithEmailAllowed() != null) newRealm.setLoginWithEmailAllowed(rep.isLoginWithEmailAllowed());
@@ -711,6 +712,7 @@ public class LegacyExportImportManager implements ExportImportManager {
         if (rep.isRegistrationAllowed() != null) realm.setRegistrationAllowed(rep.isRegistrationAllowed());
         if (rep.isRegistrationEmailAsUsername() != null)
             realm.setRegistrationEmailAsUsername(rep.isRegistrationEmailAsUsername());
+        if (rep.isEmailFormatAsUsernameAllowed() != null) realm.setEmailFormatAsUsernameAllowed(rep.isEmailFormatAsUsernameAllowed());
         if (rep.isRememberMe() != null) realm.setRememberMe(rep.isRememberMe());
         if (rep.isVerifyEmail() != null) realm.setVerifyEmail(rep.isVerifyEmail());
         if (rep.isLoginWithEmailAllowed() != null) realm.setLoginWithEmailAllowed(rep.isLoginWithEmailAllowed());

--- a/model/map-hot-rod/src/main/java/org/keycloak/models/map/storage/hotRod/realm/HotRodRealmEntity.java
+++ b/model/map-hot-rod/src/main/java/org/keycloak/models/map/storage/hotRod/realm/HotRodRealmEntity.java
@@ -271,6 +271,9 @@ public class HotRodRealmEntity extends AbstractHotRodEntity {
     @ProtoField(number = 77)
     public Set<String> supportedLocales;
 
+    @ProtoField(number = 78)
+    public Boolean emailFormatAsUsernameAllowed;
+
 
     public static abstract class AbstractHotRodRealmEntityDelegate extends UpdatableHotRodEntityDelegateImpl<HotRodRealmEntity> implements MapRealmEntity {
 

--- a/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/realm/entity/JpaRealmEntity.java
+++ b/model/map-jpa/src/main/java/org/keycloak/models/map/storage/jpa/realm/entity/JpaRealmEntity.java
@@ -245,6 +245,16 @@ public class JpaRealmEntity extends MapRealmEntity.AbstractRealmEntity implement
     }
 
     @Override
+    public Boolean isEmailFormatAsUsernameAllowed() {
+        return this.metadata.isEmailFormatAsUsernameAllowed();
+    }
+
+    @Override
+    public void setEmailFormatAsUsernameAllowed(Boolean emailFormatAsUsernameAllowed) {
+        this.metadata.setEmailFormatAsUsernameAllowed(emailFormatAsUsernameAllowed);
+    }
+
+    @Override
     public Boolean isVerifyEmail() {
         return this.metadata.isVerifyEmail();
     }

--- a/model/map/src/main/java/org/keycloak/models/map/datastore/MapExportImportManager.java
+++ b/model/map/src/main/java/org/keycloak/models/map/datastore/MapExportImportManager.java
@@ -236,6 +236,7 @@ public class MapExportImportManager implements ExportImportManager {
         if (rep.isDuplicateEmailsAllowed() != null) newRealm.setDuplicateEmailsAllowed(rep.isDuplicateEmailsAllowed());
         if (rep.isResetPasswordAllowed() != null) newRealm.setResetPasswordAllowed(rep.isResetPasswordAllowed());
         if (rep.isEditUsernameAllowed() != null) newRealm.setEditUsernameAllowed(rep.isEditUsernameAllowed());
+        if (rep.isEmailFormatAsUsernameAllowed() != null) newRealm.setEmailFormatAsUsernameAllowed(rep.isEmailFormatAsUsernameAllowed());
         if (rep.getLoginTheme() != null) newRealm.setLoginTheme(rep.getLoginTheme());
         if (rep.getAccountTheme() != null) newRealm.setAccountTheme(rep.getAccountTheme());
         if (rep.getAdminTheme() != null) newRealm.setAdminTheme(rep.getAdminTheme());
@@ -701,6 +702,7 @@ public class MapExportImportManager implements ExportImportManager {
         if (rep.isDuplicateEmailsAllowed() != null) realm.setDuplicateEmailsAllowed(rep.isDuplicateEmailsAllowed());
         if (rep.isResetPasswordAllowed() != null) realm.setResetPasswordAllowed(rep.isResetPasswordAllowed());
         if (rep.isEditUsernameAllowed() != null) realm.setEditUsernameAllowed(rep.isEditUsernameAllowed());
+        if (rep.isEmailFormatAsUsernameAllowed() != null) realm.setEmailFormatAsUsernameAllowed(rep.isEmailFormatAsUsernameAllowed());
         if (rep.getSslRequired() != null) realm.setSslRequired(SslRequired.valueOf(rep.getSslRequired().toUpperCase()));
         if (rep.getAccessCodeLifespan() != null) realm.setAccessCodeLifespan(rep.getAccessCodeLifespan());
         if (rep.getAccessCodeLifespanUserAction() != null)

--- a/model/map/src/main/java/org/keycloak/models/map/realm/MapRealmAdapter.java
+++ b/model/map/src/main/java/org/keycloak/models/map/realm/MapRealmAdapter.java
@@ -170,6 +170,17 @@ public class MapRealmAdapter extends AbstractRealmModel<MapRealmEntity> implemen
     }
 
     @Override
+    public boolean isEmailFormatAsUsernameAllowed() {
+        Boolean is = entity.isEmailFormatAsUsernameAllowed();
+        return Optional.ofNullable(is).orElse(false);
+    }
+
+    @Override
+    public void setEmailFormatAsUsernameAllowed(boolean emailFormatAsUsernameAllowed) {
+        entity.setEmailFormatAsUsernameAllowed(emailFormatAsUsernameAllowed);
+    }
+
+    @Override
     public boolean isRememberMe() {
         Boolean is = entity.isRememberMe();
         return is == null ? false : is;

--- a/model/map/src/main/java/org/keycloak/models/map/realm/MapRealmEntity.java
+++ b/model/map/src/main/java/org/keycloak/models/map/realm/MapRealmEntity.java
@@ -260,6 +260,9 @@ public interface MapRealmEntity extends UpdatableEntity, AbstractEntity, EntityW
     Boolean isRegistrationEmailAsUsername();
     void setRegistrationEmailAsUsername(Boolean registrationEmailAsUsername);
 
+    Boolean isEmailFormatAsUsernameAllowed();
+    void setEmailFormatAsUsernameAllowed(Boolean emailFormatAsUsernameAllowed);
+
     Boolean isVerifyEmail();
     void setVerifyEmail(Boolean verifyEmail);
 

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
@@ -417,6 +417,7 @@ public class ModelToRepresentation {
         rep.setDuplicateEmailsAllowed(realm.isDuplicateEmailsAllowed());
         rep.setResetPasswordAllowed(realm.isResetPasswordAllowed());
         rep.setEditUsernameAllowed(realm.isEditUsernameAllowed());
+        rep.setEmailFormatAsUsernameAllowed(realm.isEmailFormatAsUsernameAllowed());
         rep.setDefaultSignatureAlgorithm(realm.getDefaultSignatureAlgorithm());
         rep.setRevokeRefreshToken(realm.isRevokeRefreshToken());
         rep.setRefreshTokenMaxReuse(realm.getRefreshTokenMaxReuse());

--- a/server-spi-private/src/test/java/org/keycloak/broker/provider/util/IdentityBrokerStateTestHelpers.java
+++ b/server-spi-private/src/test/java/org/keycloak/broker/provider/util/IdentityBrokerStateTestHelpers.java
@@ -639,6 +639,16 @@ public class IdentityBrokerStateTestHelpers {
         }
 
         @Override
+        public boolean isEmailFormatAsUsernameAllowed() {
+            return false;
+        }
+
+        @Override
+        public void setEmailFormatAsUsernameAllowed(boolean emailFormatAsUsernameAllowed) {
+
+        }
+
+        @Override
         public boolean isRememberMe() {
             return false;
         }

--- a/server-spi/src/main/java/org/keycloak/models/RealmModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/RealmModel.java
@@ -109,6 +109,10 @@ public interface RealmModel extends RoleContainerModel {
 
     void setRegistrationEmailAsUsername(boolean registrationEmailAsUsername);
 
+    boolean isEmailFormatAsUsernameAllowed();
+
+    void setEmailFormatAsUsernameAllowed(boolean emailFormatAsUsernameAllowed);
+
     boolean isRememberMe();
 
     void setRememberMe(boolean rememberMe);

--- a/services/src/main/java/org/keycloak/services/messages/Messages.java
+++ b/services/src/main/java/org/keycloak/services/messages/Messages.java
@@ -75,6 +75,8 @@ public class Messages {
     public static final String INVALID_TOTP = "invalidTotpMessage";
 
     public static final String USERNAME_EXISTS = "usernameExistsMessage";
+    public static final String EMAIL_FORMAT_AS_USERNAME_NOT_ALLOWED = "emailFormatAsUsernameNotAllowed";
+
     public static final String RECAPTCHA_FAILED = "recaptchaFailed";
     public static final String RECAPTCHA_NOT_CONFIGURED = "recaptchaNotConfigured";
 

--- a/services/src/main/java/org/keycloak/userprofile/AbstractUserProfileProvider.java
+++ b/services/src/main/java/org/keycloak/userprofile/AbstractUserProfileProvider.java
@@ -54,6 +54,7 @@ import org.keycloak.userprofile.validator.ReadOnlyAttributeUnchangedValidator;
 import org.keycloak.userprofile.validator.RegistrationEmailAsUsernameEmailValueValidator;
 import org.keycloak.userprofile.validator.RegistrationEmailAsUsernameUsernameValueValidator;
 import org.keycloak.userprofile.validator.RegistrationUsernameExistsValidator;
+import org.keycloak.userprofile.validator.UsernameEmailFormatValidator;
 import org.keycloak.userprofile.validator.UsernameHasValueValidator;
 import org.keycloak.userprofile.validator.UsernameIDNHomographValidator;
 import org.keycloak.userprofile.validator.UsernameMutationValidator;
@@ -314,6 +315,7 @@ public abstract class AbstractUserProfileProvider<U extends UserProfileProvider>
                 AbstractUserProfileProvider::editUsernameCondition,
                 AbstractUserProfileProvider::readUsernameCondition,
                 new AttributeValidatorMetadata(UsernameHasValueValidator.ID),
+                new AttributeValidatorMetadata(UsernameEmailFormatValidator.ID),
                 new AttributeValidatorMetadata(UsernameIDNHomographValidator.ID),
                 new AttributeValidatorMetadata(DuplicateUsernameValidator.ID),
                 new AttributeValidatorMetadata(UsernameMutationValidator.ID)).setAttributeDisplayName("${username}");

--- a/services/src/main/java/org/keycloak/userprofile/validator/EmailExistsAsUsernameValidator.java
+++ b/services/src/main/java/org/keycloak/userprofile/validator/EmailExistsAsUsernameValidator.java
@@ -64,15 +64,20 @@ public class EmailExistsAsUsernameValidator implements SimpleValidator {
         RealmModel realm = session.getContext().getRealm();
 
         if (!realm.isDuplicateEmailsAllowed() && realm.isRegistrationEmailAsUsername()) {
-            UserModel user = UserProfileAttributeValidationContext.from(context).getAttributeContext().getUser();
-            UserModel userByEmail = session.users().getUserByEmail(realm, value);
-            if (userByEmail != null && user != null && !userByEmail.getId().equals(user.getId())) {
-                context.addError(new ValidationError(ID, inputHint, Messages.USERNAME_EXISTS)
-                    .setStatusCode(Response.Status.CONFLICT));
-            }
+            checkUsernameEmailOwner(session, realm, inputHint, value, context);
         }
 
         return context;
+    }
+
+    public static void checkUsernameEmailOwner(KeycloakSession session, RealmModel realm, String inputHint, String value, ValidationContext context) {
+        final UserModel user = UserProfileAttributeValidationContext.from(context).getAttributeContext().getUser();
+        final UserModel userByEmail = session.users().getUserByEmail(realm, value);
+
+        if (userByEmail != null && user != null && !userByEmail.getId().equals(user.getId())) {
+            context.addError(new ValidationError(ID, inputHint, Messages.USERNAME_EXISTS)
+                    .setStatusCode(Response.Status.CONFLICT));
+        }
     }
 
 }

--- a/services/src/main/java/org/keycloak/userprofile/validator/UsernameEmailFormatValidator.java
+++ b/services/src/main/java/org/keycloak/userprofile/validator/UsernameEmailFormatValidator.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.userprofile.validator;
+
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.services.messages.Messages;
+import org.keycloak.services.validation.Validation;
+import org.keycloak.validate.SimpleValidator;
+import org.keycloak.validate.ValidationContext;
+import org.keycloak.validate.ValidationError;
+import org.keycloak.validate.ValidatorConfig;
+import org.keycloak.validate.Validators;
+
+import javax.ws.rs.core.Response;
+import java.util.List;
+
+public class UsernameEmailFormatValidator implements SimpleValidator {
+
+    public static final String ID = "up-username-has-email-format";
+
+    @Override
+    public String getId() {
+        return ID;
+    }
+
+    @Override
+    public ValidationContext validate(Object input, String inputHint, ValidationContext context, ValidatorConfig config) {
+        List<String> values = (List<String>) input;
+
+        if (values == null || values.isEmpty()) {
+            return context;
+        }
+
+        final String username = values.get(0);
+
+        if (Validation.isBlank(username))
+            return context;
+
+        final KeycloakSession session = context.getSession();
+        final RealmModel realm = session.getContext().getRealm();
+
+        if (realm.isRegistrationEmailAsUsername()) {
+            return context;
+        }
+
+        if (!realm.isEmailFormatAsUsernameAllowed()) {
+            final ValidationContext usernameEmailFormat = Validators.emailValidator().validate(username);
+
+            if (usernameEmailFormat.isValid()) {
+                context.addError(new ValidationError(ID, inputHint, Messages.EMAIL_FORMAT_AS_USERNAME_NOT_ALLOWED).setStatusCode(Response.Status.BAD_REQUEST));
+            }
+        } else {
+            EmailExistsAsUsernameValidator.checkUsernameEmailOwner(session, realm, inputHint, username, context);
+        }
+
+        return context;
+    }
+}

--- a/services/src/main/resources/META-INF/services/org.keycloak.validate.ValidatorFactory
+++ b/services/src/main/resources/META-INF/services/org.keycloak.validate.ValidatorFactory
@@ -3,6 +3,7 @@ org.keycloak.userprofile.validator.AttributeRequiredByMetadataValidator
 org.keycloak.userprofile.validator.ReadOnlyAttributeUnchangedValidator
 org.keycloak.userprofile.validator.DuplicateUsernameValidator
 org.keycloak.userprofile.validator.UsernameHasValueValidator
+org.keycloak.userprofile.validator.UsernameEmailFormatValidator
 org.keycloak.userprofile.validator.UsernameIDNHomographValidator
 org.keycloak.userprofile.validator.UsernameMutationValidator
 org.keycloak.userprofile.validator.DuplicateEmailValidator

--- a/themes/src/main/resources-community/theme/base/login/messages/messages_cs.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_cs.properties
@@ -235,6 +235,8 @@ invalidPasswordConfirmMessage=Potvrzení hesla se neshoduje.
 invalidTotpMessage=Neplatný kód ověřování.
 
 usernameExistsMessage=Uživatelské jméno již existuje.
+emailFormatAsUsernameNotAllowed=E-mail nesmí být použit jako uživatelské jméno.
+
 emailExistsMessage=E-mail již existuje.
 
 federatedIdentityExistsMessage=Uživatel s {0} {1} již existuje. Přihlaste se ke správě účtu a propojte účet.

--- a/themes/src/main/resources/theme/base/login/messages/messages_en.properties
+++ b/themes/src/main/resources/theme/base/login/messages/messages_en.properties
@@ -256,6 +256,7 @@ invalidPasswordConfirmMessage=Password confirmation doesn''t match.
 invalidTotpMessage=Invalid authenticator code.
 
 usernameExistsMessage=Username already exists.
+emailFormatAsUsernameNotAllowed=You cannot use email as a username.
 emailExistsMessage=Email already exists.
 
 federatedIdentityExistsMessage=User with {0} {1} already exists. Please login to account management to link the account.


### PR DESCRIPTION
Fixes #15024

IMHO, the proper solution for the issue is to definitely avoid situations when an email is specified as a username and already associated with an existing user (as described in #15082). However, I'd say it's better to use a User Profile validator for this case. 

Moreover, it'd be good to avoid using an email format for usernames. However, for specific domains, there might be different requirements, and thus, I've also created a flag for the realm.

By default, using an email format for usernames is denied, but it's possible to allow it by realm flag. 