### PR TITLE
Fix UnrecognizedPropertyException on method realmResource.flows().getExecution(String)

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
@@ -878,18 +878,37 @@ public class ModelToRepresentation {
 
     public static AuthenticationExecutionExportRepresentation toRepresentation(RealmModel realm, AuthenticationExecutionModel model) {
         AuthenticationExecutionExportRepresentation rep = new AuthenticationExecutionExportRepresentation();
+        mapCommonExecutionFields(realm, model, rep);
+
+        if (model.getFlowId() != null) {
+            AuthenticationFlowModel flow = realm.getAuthenticationFlowById(model.getFlowId());
+            rep.setFlowAlias(flow.getAlias());
+        }
+
+        return rep;
+    }
+
+    private static void mapCommonExecutionFields(RealmModel realm, AuthenticationExecutionModel model,
+            AbstractAuthenticationExecutionRepresentation rep) {
         if (model.getAuthenticatorConfig() != null) {
             AuthenticatorConfigModel config = realm.getAuthenticatorConfigById(model.getAuthenticatorConfig());
             rep.setAuthenticatorConfig(config.getAlias());
         }
         rep.setAuthenticator(model.getAuthenticator());
         rep.setAuthenticatorFlow(model.isAuthenticatorFlow());
-        if (model.getFlowId() != null) {
-            AuthenticationFlowModel flow = realm.getAuthenticationFlowById(model.getFlowId());
-            rep.setFlowAlias(flow.getAlias());
-        }
         rep.setPriority(model.getPriority());
         rep.setRequirement(model.getRequirement().name());
+    }
+
+    public static AuthenticationExecutionRepresentation toByIdRepresentation(RealmModel realm,
+            AuthenticationExecutionModel model) {
+        AuthenticationExecutionRepresentation rep = new AuthenticationExecutionRepresentation();
+        mapCommonExecutionFields(realm, model, rep);
+
+        rep.setId(model.getId());
+        rep.setFlowId(model.getFlowId());
+        rep.setParentFlow(model.getParentFlow());
+
         return rep;
     }
 

--- a/services/src/main/java/org/keycloak/services/resources/admin/AuthenticationManagementResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/AuthenticationManagementResource.java
@@ -689,7 +689,7 @@ public class AuthenticationManagementResource {
     @GET
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
-    public Response getExecution(final @PathParam("executionId") String executionId) {
+    public AuthenticationExecutionRepresentation getExecution(final @PathParam("executionId") String executionId) {
     	//http://localhost:8080/auth/admin/realms/master/authentication/executions/cf26211b-9e68-4788-b754-1afd02e59d7f
         auth.realm().requireManageRealm();
 
@@ -699,7 +699,7 @@ public class AuthenticationManagementResource {
             throw new NotFoundException("Illegal execution");
         }
 
-        return Response.ok(model.get()).build();
+        return ModelToRepresentation.toByIdRepresentation(realm, model.get());
     }
 
     /**

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/authentication/AbstractAuthenticationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/authentication/AbstractAuthenticationTest.java
@@ -24,8 +24,10 @@ import org.keycloak.admin.client.resource.AuthenticationManagementResource;
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.events.admin.OperationType;
 import org.keycloak.events.admin.ResourceType;
+import org.keycloak.representations.idm.AbstractAuthenticationExecutionRepresentation;
 import org.keycloak.representations.idm.AuthenticationExecutionExportRepresentation;
 import org.keycloak.representations.idm.AuthenticationExecutionInfoRepresentation;
+import org.keycloak.representations.idm.AuthenticationExecutionRepresentation;
 import org.keycloak.representations.idm.AuthenticationFlowRepresentation;
 import org.keycloak.representations.idm.AuthenticatorConfigRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
@@ -105,14 +107,34 @@ public abstract class AbstractAuthenticationTest extends AbstractKeycloakTest {
         Assert.assertEquals("Execution requirement choices - " + actual.getProviderId(), expected.getRequirementChoices(), actual.getRequirementChoices());
     }
 
-    void compareExecution(AuthenticationExecutionExportRepresentation expected, AuthenticationExecutionExportRepresentation actual) {
-        Assert.assertEquals("Execution flowAlias - " + actual.getFlowAlias(), expected.getFlowAlias(), actual.getFlowAlias());
-        Assert.assertEquals("Execution authenticator - " + actual.getAuthenticator(), expected.getAuthenticator(), actual.getAuthenticator());
-        Assert.assertEquals("Execution userSetupAllowed - " + actual.getAuthenticator(), expected.isUserSetupAllowed(), actual.isUserSetupAllowed());
-        Assert.assertEquals("Execution authenticatorFlow - " + actual.getAuthenticator(), expected.isAuthenticatorFlow(), actual.isAuthenticatorFlow());
-        Assert.assertEquals("Execution authenticatorConfig - " + actual.getAuthenticator(), expected.getAuthenticatorConfig(), actual.getAuthenticatorConfig());
-        Assert.assertEquals("Execution priority - " + actual.getAuthenticator(), expected.getPriority(), actual.getPriority());
-        Assert.assertEquals("Execution requirement - " + actual.getAuthenticator(), expected.getRequirement(), actual.getRequirement());
+    void compareExecution(AuthenticationExecutionRepresentation expected,
+                          AuthenticationExecutionRepresentation actual) {
+        compareCommonExecutionSettings(expected, actual);
+        Assert.assertEquals("Execution parentFlow - " + actual.getAuthenticator(), expected.getParentFlow(),
+                actual.getParentFlow());
+    }
+
+    void compareExecution(AuthenticationExecutionExportRepresentation expected,
+            AuthenticationExecutionExportRepresentation actual) {
+        compareCommonExecutionSettings(expected, actual);
+        Assert.assertEquals("Execution flowAlias - " + actual.getFlowAlias(), expected.getFlowAlias(),
+                actual.getFlowAlias());
+        Assert.assertEquals("Execution userSetupAllowed - " + actual.getAuthenticator(), expected.isUserSetupAllowed(),
+                actual.isUserSetupAllowed());
+        Assert.assertEquals("Execution priority - " + actual.getAuthenticator(), expected.getPriority(),
+                actual.getPriority());
+    }
+
+    private static void compareCommonExecutionSettings(AbstractAuthenticationExecutionRepresentation expected,
+            AbstractAuthenticationExecutionRepresentation actual) {
+        Assert.assertEquals("Execution authenticator - " + actual.getAuthenticator(), expected.getAuthenticator(),
+                actual.getAuthenticator());
+        Assert.assertEquals("Execution authenticatorFlow - " + actual.getAuthenticator(),
+                expected.isAuthenticatorFlow(), actual.isAuthenticatorFlow());
+        Assert.assertEquals("Execution authenticatorConfig - " + actual.getAuthenticator(),
+                expected.getAuthenticatorConfig(), actual.getAuthenticatorConfig());
+        Assert.assertEquals("Execution requirement - " + actual.getAuthenticator(), expected.getRequirement(),
+                actual.getRequirement());
     }
 
     void compareExecutions(List<AuthenticationExecutionExportRepresentation> expected, List<AuthenticationExecutionExportRepresentation> actual) {
@@ -150,6 +172,17 @@ public abstract class AbstractAuthenticationTest extends AbstractKeycloakTest {
         flow.setTopLevel(topLevel);
         flow.setBuiltIn(builtIn);
         return flow;
+    }
+
+    AuthenticationExecutionRepresentation newExec(String authenticator, String requirement, boolean authenticatorFlow,
+            String parentFlowId) {
+        AuthenticationExecutionRepresentation execution = new AuthenticationExecutionRepresentation();
+        execution.setAuthenticator(authenticator);
+        execution.setRequirement(requirement);
+        execution.setAuthenticatorFlow(authenticatorFlow);
+        execution.setParentFlow(parentFlowId);
+
+        return execution;
     }
 
     AuthenticationExecutionInfoRepresentation newExecInfo(String displayName, String providerId, Boolean configurable,


### PR DESCRIPTION
- In the backend, map the execution model to the expected type AuthenticationExecutionRepresentation, instead of directly returning the model, containing properties like "enabled"
- improve existing test to check the corresponding endpoint with the Admin API

Closes #14115

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
