### PR TITLE
Set Keycloak JS version number in `set-version.sh`

### DIFF
--- a/set-version.sh
+++ b/set-version.sh
@@ -2,6 +2,13 @@
 
 NEW_VERSION=$1
 
+# Maven
 mvn versions:set -DnewVersion=$NEW_VERSION -DgenerateBackupPoms=false -DgroupId=org.keycloak* -DartifactId=*
 
+# Docker
 sed -i "s/ENV KEYCLOAK_VERSION .*/ENV KEYCLOAK_VERSION $NEW_VERSION/" quarkus/container/Dockerfile
+
+# NPM
+cd adapters/oidc/js
+npm version --no-git-tag-version $NEW_VERSION
+cd $OLDPWD


### PR DESCRIPTION
Sets the version of Keycloak JS when running `set-version.sh`. This is to facilitate moving the release process for NPM packages away from Maven.