### PR TITLE
Fixes the  "Page Not Found - We are Sorry" after successful login and logout from a desktop app. Now shows simple message.

### DIFF
--- a/adapters/oidc/installed/src/main/java/org/keycloak/adapters/installed/KeycloakInstalled.java
+++ b/adapters/oidc/installed/src/main/java/org/keycloak/adapters/installed/KeycloakInstalled.java
@@ -69,7 +69,7 @@ import io.undertow.util.StatusCodes;
  */
 public class KeycloakInstalled {
     private static final String KEYCLOAK_JSON = "META-INF/keycloak.json";
-    private static final String LOGGED_OUT = "loggedout";
+    private static final String LOGGED_OUT = "logout";
 
     private KeycloakDeployment deployment;
 


### PR DESCRIPTION
Per @stianst comment on [PR 12796](https://github.com/keycloak/keycloak/pull/12796) "We need to fix KeycloakInstalled instead. The '/delegated' endpoint was a broken concept that should never have been introduced. It also has a CSRF issue as it's an open endpoint anyone can link to that will invalidate a users session. The proper fix here is to remove getRedirectUrl. Instead of redirecting it should show a message that the browser tab can be closed like it did previously". 

This PR attempts to do just that, without any fancy formatting, or customizability of the messages, which could be implemented in the future.

Closes #9401
