### PR TITLE
Temporarily add more scheduled runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
   # as the ci.yml contains actions that are required for PRs to be merged, it will always need to run on all PRs
   pull_request: {}
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 20,22,0,2,4 * * *'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/operator-ci.yml
+++ b/.github/workflows/operator-ci.yml
@@ -8,7 +8,7 @@ on:
       - '.github/workflows/**'
       - '!.github/workflows/operator-ci.yml'
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 20,22,0,2,4 * * *'
 
 env:
   JDK_VERSION: 11


### PR DESCRIPTION
In order to make the testsuite more stable we should at least temporarily add more scheduled runs so we can get more data
