### PR TITLE
Make KeycloakErrorHandler more robust against NPEs #15278

### DIFF
--- a/services/src/main/java/org/keycloak/services/error/KeycloakErrorHandler.java
+++ b/services/src/main/java/org/keycloak/services/error/KeycloakErrorHandler.java
@@ -58,8 +58,10 @@ public class KeycloakErrorHandler implements ExceptionMapper<Throwable> {
 
     public static Response getResponse(HttpHeaders headers, Throwable throwable) {
         KeycloakSession session = Resteasy.getContextData(KeycloakSession.class);
-        KeycloakTransaction tx = session.getTransactionManager();
-        tx.setRollbackOnly();
+        if (session != null) {
+            KeycloakTransaction tx = session.getTransactionManager();
+            tx.setRollbackOnly();
+        }
 
         int statusCode = getStatusCode(throwable);
 


### PR DESCRIPTION
This fix helps to avoid NPEs in some cases, e.g. requests to unmapped Keycloak resources.

Fixes #15278

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
