### PR TITLE
Fix race condition while updating Secrets labels in Operator

### DIFF
--- a/operator/src/main/java/org/keycloak/operator/controllers/WatchedSecretsStore.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/WatchedSecretsStore.java
@@ -111,13 +111,12 @@ public class WatchedSecretsStore extends OperatorManagedResource {
 
                 Log.infof("Adding label to Secret \"%s\"", secret.getMetadata().getName());
 
-                secret = new SecretBuilder(secret)
-                        .editMetadata()
-                        .addToLabels(Constants.KEYCLOAK_COMPONENT_LABEL, WATCHED_SECRETS_LABEL_VALUE)
-                        .endMetadata()
-                        .build();
-
-                client.secrets().inNamespace(secret.getMetadata().getNamespace()).withName(secret.getMetadata().getName()).patch(secret);
+                client.secrets().inNamespace(secret.getMetadata().getNamespace()).withName(secret.getMetadata().getName())
+                        .edit(s -> new SecretBuilder(s)
+                                .editMetadata()
+                                .addToLabels(Constants.KEYCLOAK_COMPONENT_LABEL, WATCHED_SECRETS_LABEL_VALUE)
+                                .endMetadata()
+                                .build());
             }
         }
     }
@@ -194,8 +193,13 @@ public class WatchedSecretsStore extends OperatorManagedResource {
     }
 
     private static void cleanObsoleteLabelFromSecret(KubernetesClient client, Secret secret) {
-        secret.getMetadata().getLabels().remove(Constants.KEYCLOAK_COMPONENT_LABEL);
-        client.secrets().inNamespace(secret.getMetadata().getNamespace()).withName(secret.getMetadata().getName()).patch(secret);
+        client.secrets().inNamespace(secret.getMetadata().getNamespace()).withName(secret.getMetadata().getName())
+                .edit(s -> new SecretBuilder(s)
+                        .editMetadata()
+                        .removeFromLabels(Constants.KEYCLOAK_COMPONENT_LABEL)
+                        .endMetadata()
+                        .build()
+                );
     }
 
     public static EventSource getWatchedSecretsEventSource(KubernetesClient client, String namespace) {

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/BaseOperatorTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/BaseOperatorTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
 import org.keycloak.operator.Constants;
 import org.keycloak.operator.crds.v2alpha1.deployment.Keycloak;
 
@@ -103,8 +104,11 @@ public abstract class BaseOperatorTest {
   }
 
   @BeforeEach
-  public void beforeEach() {
-    Log.info(((operatorDeployment == OperatorDeployment.remote) ? "Remote " : "Local ") + "Run Test :" + namespace);
+  public void beforeEach(TestInfo testInfo) {
+    String testClassName = testInfo.getTestClass().map(c -> c.getSimpleName() + ".").orElse("");
+    Log.info("\n------- STARTING: " + testClassName + testInfo.getDisplayName() + "\n"
+            + "------- Namespace: " + namespace + "\n"
+            + "------- Mode: " + ((operatorDeployment == OperatorDeployment.remote) ? "remote" : "local"));
   }
 
   private static void createK8sClient() {

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/RealmImportTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/RealmImportTest.java
@@ -24,6 +24,7 @@ import io.quarkus.test.junit.QuarkusTest;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.keycloak.operator.testsuite.utils.CRAssert;
 import org.keycloak.operator.controllers.KeycloakService;
@@ -49,8 +50,8 @@ public class RealmImportTest extends BaseOperatorTest {
 
     @Override
     @BeforeEach
-    public void beforeEach() {
-        super.beforeEach();
+    public void beforeEach(TestInfo testInfo) {
+        super.beforeEach(testInfo);
         // Recreating the database and the realm import CR to keep this test isolated
         k8sclient.load(getClass().getResourceAsStream("/example-realm.yaml")).inNamespace(namespace).delete();
         k8sclient.load(getClass().getResourceAsStream("/incorrect-realm.yaml")).inNamespace(namespace).delete();


### PR DESCRIPTION
Closes #12942

There was occasionally a race condition in the Operator on watched Secrets when Operator overwrote a Secret that user (or test) just modified. That was due to incorrect handling of Secrets editing.

I did not add a new test for this as it is a bit hard to reliably reproduce. But the change is pretty simple as it is basically just alignment with [best practices](https://github.com/fabric8io/kubernetes-client/blob/f3e776b1557aa54c02b078f2b75382d932489e10/doc/CHEATSHEET.md#secret) in Fabric8.

I also sneaked in a log improvement for tests.