### PR TITLE
Move init builtin mappers from static init to factory init

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocolFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocolFactory.java
@@ -117,6 +117,7 @@ public class OIDCLoginProtocolFactory extends AbstractLoginProtocolFactory {
         if (providerConfig.suppressLogoutConfirmationScreen()) {
             logger.warnf("Deprecated switch '%s' is enabled. Please try to disable it and update your clients to use OpenID Connect compliant way for RP-initiated logout.", SUPPRESS_LOGOUT_CONFIRMATION_SCREEN);
         }
+        initBuiltin();
     }
 
     @Override
@@ -131,7 +132,8 @@ public class OIDCLoginProtocolFactory extends AbstractLoginProtocolFactory {
 
     static Map<String, ProtocolMapperModel> builtins = new HashMap<>();
 
-    static {
+    // Visible for testing
+    public void initBuiltin() {
                 ProtocolMapperModel model;
         model = UserPropertyMapper.createClaimMapper(USERNAME,
                 "username",

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/ServerInfoTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/ServerInfoTest.java
@@ -19,11 +19,14 @@ package org.keycloak.testsuite.admin;
 
 import org.junit.Test;
 import org.keycloak.common.Version;
+import org.keycloak.protocol.oidc.OIDCLoginProtocolFactory;
+import org.keycloak.representations.idm.ProtocolMapperRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.info.ProviderRepresentation;
 import org.keycloak.representations.info.ServerInfoRepresentation;
 import org.keycloak.testsuite.AbstractKeycloakTest;
 import org.keycloak.testsuite.Assert;
+import org.keycloak.testsuite.auth.page.login.Login;
 
 import java.util.List;
 import java.util.Map;
@@ -69,11 +72,39 @@ public class ServerInfoTest extends AbstractKeycloakTest {
         assertNotNull(info.getSystemInfo().getServerTime());
         assertNotNull(info.getSystemInfo().getUptime());
 
+        assertNotNull(info.getBuiltinProtocolMappers());
+        assertNotNull(getBuiltinProtocolMapper(info, Login.OIDC, OIDCLoginProtocolFactory.ACR));
+
         if (isJpaRealmProvider()) {
             Map<String, ProviderRepresentation> jpaProviders = info.getProviders().get("connectionsJpa").getProviders();
             ProviderRepresentation jpaProvider = jpaProviders.values().iterator().next();
             log.infof("JPA Connections provider info: %s", jpaProvider.getOperationalInfo());
         }
+    }
+
+    /*@Test
+    @DisableFeature(value = Profile.Feature.STEP_UP_AUTHENTICATION, skipRestart = true)
+    public void testDisableStepupAuthenticationFeature() throws Exception {
+        // refresh builtin based on feature changed
+        testingClient.server().fetchString(it -> {
+            ((OIDCLoginProtocolFactory) it.getKeycloakSessionFactory()
+                .getProviderFactory(LoginProtocol.class, Login.OIDC))
+                .initBuiltin();
+            return null;
+        });
+
+        ServerInfoRepresentation info = adminClient.serverInfo().getInfo();
+        assertNotNull(info.getBuiltinProtocolMappers());
+        assertNull(getBuiltinProtocolMapper(info, Login.OIDC, OIDCLoginProtocolFactory.ACR));
+    }*/
+
+    private static ProtocolMapperRepresentation getBuiltinProtocolMapper(ServerInfoRepresentation info, String protocol, String name) {
+        return info.getBuiltinProtocolMappers()
+            .get(protocol)
+            .stream()
+            .filter(it -> name.equals(it.getName()))
+            .findFirst()
+            .orElse(null);
     }
 
     @Override


### PR DESCRIPTION
Closes #15349

The built-in mappers are initialized from static currently.

I am trying to create a unit test but failed.
I found no way to set up `disabled features` at the test server startup.
Need the team to help me how to fix this test.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
