### PR TITLE
Cookies processing refactoring

### DIFF
--- a/common/src/main/java/org/keycloak/common/util/ServerCookie.java
+++ b/common/src/main/java/org/keycloak/common/util/ServerCookie.java
@@ -28,6 +28,7 @@ import java.util.TimeZone;
 /**
  * Server-side cookie representation.  borrowed from Tomcat.
  */
+@Deprecated
 public class ServerCookie implements Serializable {
     private static final String tspecials = ",; ";
     private static final String tspecials2 = "()<>@,;:\\\"/[]?={} \t";

--- a/examples/providers/authenticator/src/main/java/org/keycloak/examples/authenticator/SecretQuestionAuthenticator.java
+++ b/examples/providers/authenticator/src/main/java/org/keycloak/examples/authenticator/SecretQuestionAuthenticator.java
@@ -17,24 +17,24 @@
 
 package org.keycloak.examples.authenticator;
 
-import org.jboss.resteasy.spi.HttpResponse;
 import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.authentication.AuthenticationFlowError;
 import org.keycloak.authentication.Authenticator;
 import org.keycloak.authentication.CredentialValidator;
 import org.keycloak.authentication.RequiredActionFactory;
 import org.keycloak.authentication.RequiredActionProvider;
-import org.keycloak.common.util.ServerCookie;
 import org.keycloak.credential.CredentialProvider;
 import org.keycloak.models.AuthenticatorConfigModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserCredentialModel;
 import org.keycloak.models.UserModel;
+import org.keycloak.services.util.CookieBuilder;
+import org.keycloak.services.util.CookieHelper;
 
 import javax.ws.rs.core.Cookie;
-import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.NewCookie;
 import javax.ws.rs.core.Response;
 import java.net.URI;
 import java.util.Collections;
@@ -88,19 +88,14 @@ public class SecretQuestionAuthenticator implements Authenticator, CredentialVal
 
         }
         URI uri = context.getUriInfo().getBaseUriBuilder().path("realms").path(context.getRealm().getName()).build();
-        addCookie(context, "SECRET_QUESTION_ANSWERED", "true",
-                uri.getRawPath(),
-                null, null,
-                maxCookieAge,
-                false, true);
-    }
 
-    public void addCookie(AuthenticationFlowContext context, String name, String value, String path, String domain, String comment, int maxAge, boolean secure, boolean httpOnly) {
-        HttpResponse response = context.getSession().getContext().getContextObject(HttpResponse.class);
-        StringBuffer cookieBuf = new StringBuffer();
-        ServerCookie.appendCookieValue(cookieBuf, 1, name, value, path, domain, comment, maxAge, secure, httpOnly, null);
-        String cookie = cookieBuf.toString();
-        response.getOutputHeaders().add(HttpHeaders.SET_COOKIE, cookie);
+        final NewCookie cookie = new CookieBuilder("SECRET_QUESTION_ANSWERED", "true")
+                .path(uri.getRawPath())
+                .maxAge(maxCookieAge)
+                .secure(false)
+                .httpOnly(true)
+                .build();
+        CookieHelper.addCookie(cookie);
     }
 
 

--- a/services/src/main/java/org/keycloak/protocol/RestartLoginCookie.java
+++ b/services/src/main/java/org/keycloak/protocol/RestartLoginCookie.java
@@ -27,11 +27,13 @@ import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.services.managers.AuthenticationManager;
 import org.keycloak.services.managers.AuthenticationSessionManager;
+import org.keycloak.services.util.CookieBuilder;
 import org.keycloak.services.util.CookieHelper;
 import org.keycloak.sessions.AuthenticationSessionModel;
 import org.keycloak.sessions.RootAuthenticationSessionModel;
 
 import javax.ws.rs.core.Cookie;
+import javax.ws.rs.core.NewCookie;
 import javax.ws.rs.core.UriInfo;
 import java.util.HashMap;
 import java.util.Map;
@@ -124,13 +126,19 @@ public class RestartLoginCookie implements Token {
         String encoded = session.tokens().encode(restart);
         String path = AuthenticationManager.getRealmCookiePath(realm, uriInfo);
         boolean secureOnly = realm.getSslRequired().isRequired(connection);
-        CookieHelper.addCookie(KC_RESTART, encoded, path, null, null, -1, secureOnly, true);
+
+        final NewCookie cookie = new CookieBuilder(KC_RESTART, encoded)
+                .path(path)
+                .secure(secureOnly)
+                .httpOnly(true)
+                .build();
+        CookieHelper.addCookie(cookie);
     }
 
     public static void expireRestartCookie(RealmModel realm, ClientConnection connection, UriInfo uriInfo) {
         String path = AuthenticationManager.getRealmCookiePath(realm, uriInfo);
         boolean secureOnly = realm.getSslRequired().isRequired(connection);
-        CookieHelper.addCookie(KC_RESTART, "", path, null, null, 0, secureOnly, true);
+        CookieHelper.expireCookie(KC_RESTART, path, secureOnly, true);
     }
 
     public static Cookie getRestartCookie(KeycloakSession session){

--- a/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
@@ -46,7 +46,7 @@ import org.keycloak.events.Errors;
 import org.keycloak.events.EventBuilder;
 import org.keycloak.events.EventType;
 import org.keycloak.forms.login.LoginFormsProvider;
-import org.keycloak.models.SingleUseObjectKeyModel;
+import org.keycloak.locale.LocaleSelectorProvider;
 import org.keycloak.models.AuthenticatedClientSessionModel;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.ClientScopeModel;
@@ -56,6 +56,7 @@ import org.keycloak.models.DefaultActionTokenKey;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.RequiredActionProviderModel;
+import org.keycloak.models.SingleUseObjectKeyModel;
 import org.keycloak.models.SingleUseObjectProvider;
 import org.keycloak.models.UserConsentModel;
 import org.keycloak.models.UserModel;
@@ -82,6 +83,7 @@ import org.keycloak.services.resources.IdentityBrokerService;
 import org.keycloak.services.resources.LoginActionsService;
 import org.keycloak.services.resources.RealmsResource;
 import org.keycloak.services.util.AuthorizationContextUtil;
+import org.keycloak.services.util.CookieBuilder;
 import org.keycloak.services.util.CookieHelper;
 import org.keycloak.services.util.P3PHelper;
 import org.keycloak.sessions.AuthenticationSessionModel;
@@ -99,6 +101,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
@@ -109,7 +112,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.keycloak.common.util.ServerCookie.SameSiteAttributeValue;
 import static org.keycloak.models.UserSessionModel.CORRESPONDING_SESSION_ID;
 import static org.keycloak.protocol.oidc.grants.device.DeviceGrantType.isOAuth2DeviceVerificationFlow;
 import static org.keycloak.services.util.CookieHelper.getCookie;
@@ -210,15 +212,16 @@ public class AuthenticationManager {
     public static boolean expireUserSessionCookie(KeycloakSession session, UserSessionModel userSession, RealmModel realm, UriInfo uriInfo, HttpHeaders headers, ClientConnection connection) {
         try {
             // check to see if any identity cookie is set with the same session and expire it if necessary
-            Cookie cookie = CookieHelper.getCookie(headers.getCookies(), KEYCLOAK_IDENTITY_COOKIE);
-            if (cookie == null) return true;
-            String tokenString = cookie.getValue();
+            Optional<Cookie> cookie = CookieHelper.getCookie(headers.getCookies(), KEYCLOAK_IDENTITY_COOKIE);
+            if (!cookie.isPresent()) return true;
+
+            String tokenString = cookie.get().getValue();
 
             TokenVerifier<AccessToken> verifier = TokenVerifier.create(tokenString, AccessToken.class)
-              .realmUrl(Urls.realmIssuer(uriInfo.getBaseUri(), realm.getName()))
-              .checkActive(false)
-              .checkTokenType(false)
-              .withChecks(VALIDATE_IDENTITY_COOKIE);
+                    .realmUrl(Urls.realmIssuer(uriInfo.getBaseUri(), realm.getName()))
+                    .checkActive(false)
+                    .checkTokenType(false)
+                    .withChecks(VALIDATE_IDENTITY_COOKIE);
 
             String kid = verifier.getHeader().getKeyId();
             String algorithm = verifier.getHeader().getAlgorithm().name();
@@ -782,8 +785,15 @@ public class AuthenticationManager {
             maxAge = realm.getSsoSessionMaxLifespanRememberMe() > 0 ? realm.getSsoSessionMaxLifespanRememberMe() : realm.getSsoSessionMaxLifespan();
         }
         logger.debugv("Create login cookie - name: {0}, path: {1}, max-age: {2}", KEYCLOAK_IDENTITY_COOKIE, cookiePath, maxAge);
-        CookieHelper.addCookie(KEYCLOAK_IDENTITY_COOKIE, encoded, cookiePath, null, null, maxAge, secureOnly, true, SameSiteAttributeValue.NONE);
-        //builder.cookie(new NewCookie(cookieName, encoded, cookiePath, null, null, maxAge, secureOnly));// todo httponly , true);
+
+        final NewCookie loginCookie = new CookieBuilder(KEYCLOAK_IDENTITY_COOKIE, encoded)
+                .path(cookiePath)
+                .maxAge(maxAge)
+                .secure(secureOnly)
+                .httpOnly(true)
+                .build();
+
+        CookieHelper.addCookie(loginCookie);
 
         // With user-storage providers, user ID can contain special characters, which need to be encoded
         String sessionCookieValue = realm.getName() + "/" + Encode.urlEncode(user.getId());
@@ -793,20 +803,37 @@ public class AuthenticationManager {
         // THIS SHOULD NOT BE A HTTPONLY COOKIE!  It is used for OpenID Connect Iframe Session support!
         // Max age should be set to the max lifespan of the session as it's used to invalidate old-sessions on re-login
         int sessionCookieMaxAge = session.isRememberMe() && realm.getSsoSessionMaxLifespanRememberMe() > 0 ? realm.getSsoSessionMaxLifespanRememberMe() : realm.getSsoSessionMaxLifespan();
-        CookieHelper.addCookie(KEYCLOAK_SESSION_COOKIE, sessionCookieValue, cookiePath, null, null, sessionCookieMaxAge, secureOnly, false, SameSiteAttributeValue.NONE);
+
+        final NewCookie sessionCookie = new CookieBuilder(KEYCLOAK_SESSION_COOKIE, sessionCookieValue)
+                .path(cookiePath)
+                .maxAge(sessionCookieMaxAge)
+                .secure(secureOnly)
+                .httpOnly(false)
+                .build();
+
+        CookieHelper.addCookie(sessionCookie);
         P3PHelper.addP3PHeader();
     }
 
     public static void createRememberMeCookie(RealmModel realm, String username, UriInfo uriInfo, ClientConnection connection) {
         String path = getIdentityCookiePath(realm, uriInfo);
         boolean secureOnly = realm.getSslRequired().isRequired(connection);
-        // remember me cookie should be persistent (hardcoded to 365 days for now)
-        //NewCookie cookie = new NewCookie(KEYCLOAK_REMEMBER_ME, "true", path, null, null, realm.getCentralLoginLifespan(), secureOnly);// todo httponly , true);
+
+        String value;
         try {
-            CookieHelper.addCookie(KEYCLOAK_REMEMBER_ME, "username:" + URLEncoder.encode(username, "UTF-8"), path, null, null, 31536000, secureOnly, true);
+            value = "username:" + URLEncoder.encode(username, "UTF-8");
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException("Failed to urlencode", e);
         }
+
+        // remember me cookie should be persistent (hardcoded to 365 days for now)
+        final NewCookie rememberMeCookie = new CookieBuilder(KEYCLOAK_REMEMBER_ME, value)
+                .path(path)
+                .maxAge(31536000)
+                .secure(secureOnly)
+                .httpOnly(true)
+                .build();
+        CookieHelper.addCookie(rememberMeCookie);
     }
 
     public static String getRememberMeUsername(RealmModel realm, HttpHeaders headers) {
@@ -830,19 +857,19 @@ public class AuthenticationManager {
     public static void expireIdentityCookie(RealmModel realm, UriInfo uriInfo, ClientConnection connection) {
         logger.debug("Expiring identity cookie");
         String path = getIdentityCookiePath(realm, uriInfo);
-        expireCookie(realm, KEYCLOAK_IDENTITY_COOKIE, path, true, connection, SameSiteAttributeValue.NONE);
-        expireCookie(realm, KEYCLOAK_SESSION_COOKIE, path, false, connection, SameSiteAttributeValue.NONE);
+        expireCookie(realm, KEYCLOAK_IDENTITY_COOKIE, path, true, connection);
+        expireCookie(realm, KEYCLOAK_SESSION_COOKIE, path, false, connection);
 
         String oldPath = getOldCookiePath(realm, uriInfo);
-        expireCookie(realm, KEYCLOAK_IDENTITY_COOKIE, oldPath, true, connection, SameSiteAttributeValue.NONE);
-        expireCookie(realm, KEYCLOAK_SESSION_COOKIE, oldPath, false, connection, SameSiteAttributeValue.NONE);
+        expireCookie(realm, KEYCLOAK_IDENTITY_COOKIE, oldPath, true, connection);
+        expireCookie(realm, KEYCLOAK_SESSION_COOKIE, oldPath, false, connection);
     }
     public static void expireOldIdentityCookie(RealmModel realm, UriInfo uriInfo, ClientConnection connection) {
         logger.debug("Expiring old identity cookie with wrong path");
 
         String oldPath = getOldCookiePath(realm, uriInfo);
-        expireCookie(realm, KEYCLOAK_IDENTITY_COOKIE, oldPath, true, connection, SameSiteAttributeValue.NONE);
-        expireCookie(realm, KEYCLOAK_SESSION_COOKIE, oldPath, false, connection, SameSiteAttributeValue.NONE);
+        expireCookie(realm, KEYCLOAK_IDENTITY_COOKIE, oldPath, true, connection);
+        expireCookie(realm, KEYCLOAK_SESSION_COOKIE, oldPath, false, connection);
     }
 
 
@@ -850,14 +877,14 @@ public class AuthenticationManager {
         logger.debug("Expiring remember me cookie");
         String path = getIdentityCookiePath(realm, uriInfo);
         String cookieName = KEYCLOAK_REMEMBER_ME;
-        expireCookie(realm, cookieName, path, true, connection, null);
+        expireCookie(realm, cookieName, path, true, connection);
     }
 
     public static void expireOldAuthSessionCookie(RealmModel realm, UriInfo uriInfo, ClientConnection connection) {
         logger.debugv("Expire {1} cookie .", AuthenticationSessionManager.AUTH_SESSION_ID);
 
         String oldPath = getOldCookiePath(realm, uriInfo);
-        expireCookie(realm, AuthenticationSessionManager.AUTH_SESSION_ID, oldPath, true, connection, SameSiteAttributeValue.NONE);
+        expireCookie(realm, AuthenticationSessionManager.AUTH_SESSION_ID, oldPath, true, connection);
     }
 
     protected static String getIdentityCookiePath(RealmModel realm, UriInfo uriInfo) {
@@ -880,10 +907,11 @@ public class AuthenticationManager {
         return uri.getRawPath();
     }
 
-    public static void expireCookie(RealmModel realm, String cookieName, String path, boolean httpOnly, ClientConnection connection, SameSiteAttributeValue sameSite) {
+    public static void expireCookie(RealmModel realm, String cookieName, String path, boolean httpOnly, ClientConnection connection) {
         logger.debugf("Expiring cookie: %s path: %s", cookieName, path);
-        boolean secureOnly = realm.getSslRequired().isRequired(connection);;
-        CookieHelper.addCookie(cookieName, "", path, null, "Expiring cookie", 0, secureOnly, httpOnly, sameSite);
+        boolean secureOnly = realm.getSslRequired().isRequired(connection);
+
+        CookieHelper.expireCookie(cookieName, path, secureOnly, httpOnly);
     }
 
     public AuthResult authenticateIdentityCookie(KeycloakSession session, RealmModel realm) {
@@ -891,13 +919,13 @@ public class AuthenticationManager {
     }
 
     public static AuthResult authenticateIdentityCookie(KeycloakSession session, RealmModel realm, boolean checkActive) {
-        Cookie cookie = CookieHelper.getCookie(session.getContext().getRequestHeaders().getCookies(), KEYCLOAK_IDENTITY_COOKIE);
-        if (cookie == null || "".equals(cookie.getValue())) {
+        Optional<Cookie> cookie = CookieHelper.getCookie(session.getContext().getRequestHeaders().getCookies(), KEYCLOAK_IDENTITY_COOKIE);
+        if (!cookie.isPresent() || "".equals(cookie.get().getValue())) {
             logger.debugv("Could not find cookie: {0}", KEYCLOAK_IDENTITY_COOKIE);
             return null;
         }
 
-        String tokenString = cookie.getValue();
+        String tokenString = cookie.get().getValue();
         AuthResult authResult = verifyIdentityToken(session, realm, session.getContext().getUri(), session.getContext().getConnection(), checkActive, false, null, true, tokenString, session.getContext().getRequestHeaders(), VALIDATE_IDENTITY_COOKIE);
         if (authResult == null) {
             expireIdentityCookie(realm, session.getContext().getUri(), session.getContext().getConnection());
@@ -926,10 +954,10 @@ public class AuthenticationManager {
                                                        ClientSessionContext clientSessionCtx,
                                                        HttpRequest request, UriInfo uriInfo, ClientConnection clientConnection,
                                                        EventBuilder event, AuthenticationSessionModel authSession, LoginProtocol protocol) {
-        Cookie sessionCookie = getCookie(request.getHttpHeaders().getCookies(), AuthenticationManager.KEYCLOAK_SESSION_COOKIE);
-        if (sessionCookie != null) {
+        Optional<Cookie> sessionCookie = getCookie(request.getHttpHeaders().getCookies(), AuthenticationManager.KEYCLOAK_SESSION_COOKIE);
+        if (sessionCookie.isPresent()) {
 
-            String[] split = sessionCookie.getValue().split("/");
+            String[] split = sessionCookie.get().getValue().split("/");
             if (split.length >= 3) {
                 String oldSessionId = split[2];
                 if (!oldSessionId.equals(userSession.getId())) {
@@ -975,13 +1003,13 @@ public class AuthenticationManager {
     }
 
     public static String getSessionIdFromSessionCookie(KeycloakSession session) {
-        Cookie cookie = getCookie(session.getContext().getRequestHeaders().getCookies(), KEYCLOAK_SESSION_COOKIE);
-        if (cookie == null || "".equals(cookie.getValue())) {
+        Optional<Cookie> cookie = getCookie(session.getContext().getRequestHeaders().getCookies(), KEYCLOAK_SESSION_COOKIE);
+        if (!cookie.isPresent() || "".equals(cookie.get().getValue())) {
             logger.debugv("Could not find cookie: {0}", KEYCLOAK_SESSION_COOKIE);
             return null;
         }
 
-        String[] parts = cookie.getValue().split("/", 3);
+        String[] parts = cookie.get().getValue().split("/", 3);
         if (parts.length != 3) {
             logger.debugv("Cannot parse session value from: {0}", KEYCLOAK_SESSION_COOKIE);
             return null;

--- a/services/src/main/java/org/keycloak/services/managers/AuthenticationSessionManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/AuthenticationSessionManager.java
@@ -19,17 +19,18 @@ package org.keycloak.services.managers;
 
 import org.jboss.logging.Logger;
 import org.keycloak.common.ClientConnection;
-import org.keycloak.common.util.ServerCookie.SameSiteAttributeValue;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserSessionModel;
 import org.keycloak.protocol.RestartLoginCookie;
+import org.keycloak.services.util.CookieBuilder;
 import org.keycloak.services.util.CookieHelper;
 import org.keycloak.sessions.AuthenticationSessionModel;
 import org.keycloak.sessions.RootAuthenticationSessionModel;
 import org.keycloak.sessions.StickySessionEncoderProvider;
 
+import javax.ws.rs.core.NewCookie;
 import javax.ws.rs.core.UriInfo;
 import java.util.List;
 import java.util.Objects;
@@ -149,7 +150,12 @@ public class AuthenticationSessionManager {
         StickySessionEncoderProvider encoder = session.getProvider(StickySessionEncoderProvider.class);
         String encodedAuthSessionId = encoder.encodeSessionId(authSessionId);
 
-        CookieHelper.addCookie(AUTH_SESSION_ID, encodedAuthSessionId, cookiePath, null, null, -1, sslRequired, true, SameSiteAttributeValue.NONE);
+        final NewCookie cookie = new CookieBuilder(AUTH_SESSION_ID, encodedAuthSessionId)
+                .path(cookiePath)
+                .secure(sslRequired)
+                .httpOnly(true)
+                .build();
+        CookieHelper.addCookie(cookie);
 
         log.debugf("Set AUTH_SESSION_ID cookie with value %s", encodedAuthSessionId);
     }

--- a/services/src/main/java/org/keycloak/services/resources/WelcomeResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/WelcomeResource.java
@@ -23,11 +23,14 @@ import org.keycloak.common.Version;
 import org.keycloak.common.util.Base64Url;
 import org.keycloak.common.util.MimeTypeUtil;
 import org.keycloak.common.util.SecretGenerator;
+import org.keycloak.locale.LocaleSelectorProvider;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.services.ForbiddenException;
 import org.keycloak.services.ServicesLogger;
 import org.keycloak.services.managers.ApplianceBootstrap;
+import org.keycloak.services.managers.AuthenticationManager;
 import org.keycloak.services.util.CacheControlUtil;
+import org.keycloak.services.util.CookieBuilder;
 import org.keycloak.services.util.CookieHelper;
 import org.keycloak.theme.Theme;
 import org.keycloak.theme.freemarker.FreeMarkerProvider;
@@ -45,6 +48,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Cookie;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.NewCookie;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.Response.Status;
@@ -265,14 +269,22 @@ public class WelcomeResource {
         String stateChecker = Base64Url.encode(SecretGenerator.getInstance().randomBytes());
         String cookiePath = session.getContext().getUri().getPath();
         boolean secureOnly = session.getContext().getUri().getRequestUri().getScheme().equalsIgnoreCase("https");
-        CookieHelper.addCookie(KEYCLOAK_STATE_CHECKER, stateChecker, cookiePath, null, null, 300, secureOnly, true);
+
+        final NewCookie cookie = new CookieBuilder(KEYCLOAK_STATE_CHECKER, stateChecker)
+                .path(cookiePath)
+                .maxAge(300)
+                .secure(secureOnly)
+                .httpOnly(true)
+                .build();
+        CookieHelper.addCookie(cookie);
+
         return stateChecker;
     }
 
     private void expireCsrfCookie() {
         String cookiePath = session.getContext().getUri().getPath();
         boolean secureOnly = session.getContext().getUri().getRequestUri().getScheme().equalsIgnoreCase("https");
-        CookieHelper.addCookie(KEYCLOAK_STATE_CHECKER, "", cookiePath, null, null, 0, secureOnly, true);
+        CookieHelper.expireCookie(KEYCLOAK_STATE_CHECKER, cookiePath, secureOnly, true);
     }
 
     private void csrfCheck(final MultivaluedMap<String, String> formData) {

--- a/services/src/main/java/org/keycloak/services/util/CookieBuilder.java
+++ b/services/src/main/java/org/keycloak/services/util/CookieBuilder.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.services.util;
+
+import javax.ws.rs.core.NewCookie;
+import java.util.Date;
+
+/**
+ * @author <a href="mailto:mabartos@redhat.com">Martin Bartos</a>
+ */
+public class CookieBuilder {
+    private final String name;
+    private final String value;
+
+    private String path;
+    private String domain;
+    private String comment;
+    private int version;
+    private int maxAge;
+    private boolean secure;
+    private boolean httpOnly;
+    private Date expiry;
+
+    public CookieBuilder(String name, String value) {
+        this.name = name;
+        this.value = value;
+    }
+
+    public CookieBuilder path(String path) {
+        this.path = path;
+        return this;
+    }
+
+    public CookieBuilder domain(String domain) {
+        this.domain = domain;
+        return this;
+    }
+
+    public CookieBuilder comment(String comment) {
+        this.comment = comment;
+        return this;
+    }
+
+    public CookieBuilder version(int version) {
+        this.version = version;
+        return this;
+    }
+
+    public CookieBuilder maxAge(int maxAge) {
+        this.maxAge = maxAge;
+        return this;
+    }
+
+    public CookieBuilder secure(boolean secure) {
+        this.secure = secure;
+        return this;
+    }
+
+    public CookieBuilder httpOnly(boolean httpOnly) {
+        this.httpOnly = httpOnly;
+        return this;
+    }
+
+    public CookieBuilder expiry(Date expireDate) {
+        this.expiry = expireDate;
+        return this;
+    }
+
+    public NewCookie build() {
+        return new NewCookie(name, value, path, domain, version, comment, maxAge, expiry, secure, httpOnly);
+    }
+}

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/rest/TestingResourceProvider.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/rest/TestingResourceProvider.java
@@ -111,6 +111,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -587,9 +588,9 @@ public class TestingResourceProvider implements RealmResourceProvider {
     @Produces(MediaType.APPLICATION_JSON)
     public String getSSOCookieValue() {
         Map<String, Cookie> cookies = request.getHttpHeaders().getCookies();
-        Cookie cookie = CookieHelper.getCookie(cookies, AuthenticationManager.KEYCLOAK_IDENTITY_COOKIE);
-        if (cookie == null) return null;
-        return cookie.getValue();
+        Optional<Cookie> cookie = CookieHelper.getCookie(cookies, AuthenticationManager.KEYCLOAK_IDENTITY_COOKIE);
+        if (!cookie.isPresent()) return null;
+        return cookie.get().getValue();
     }
 
 

--- a/testsuite/integration-arquillian/servers/auth-server/undertow/src/main/java/org/keycloak/testsuite/arquillian/undertow/lb/SimpleUndertowLoadBalancer.java
+++ b/testsuite/integration-arquillian/servers/auth-server/undertow/src/main/java/org/keycloak/testsuite/arquillian/undertow/lb/SimpleUndertowLoadBalancer.java
@@ -52,7 +52,6 @@ import java.util.LinkedHashMap;
 import java.util.StringTokenizer;
 
 import static org.keycloak.services.managers.AuthenticationSessionManager.AUTH_SESSION_ID;
-import static org.keycloak.services.util.CookieHelper.LEGACY_COOKIE;
 
 /**
  * Loadbalancer on embedded undertow. Supports sticky session over "AUTH_SESSION_ID" cookie and failover to different node when sticky node not available.
@@ -177,7 +176,6 @@ public class SimpleUndertowLoadBalancer {
     private HttpHandler createHandler() throws Exception {
 
         // TODO: configurable options if needed
-        String[] sessionIds = {AUTH_SESSION_ID, AUTH_SESSION_ID + LEGACY_COOKIE};
         int connectionsPerThread = 20;
         int problemServerRetry = 5; // In case of unavailable node, we will try to ping him every 5 seconds to check if it's back
         int maxTime = 3600000; // 1 hour for proxy request timeout, so we can debug the backend keycloak servers
@@ -191,10 +189,8 @@ public class SimpleUndertowLoadBalancer {
                 .setMaxQueueSize(requestQueueSize)
                 .setSoftMaxConnectionsPerThread(cachedConnectionsPerThread)
                 .setTtl(connectionIdleTimeout)
-                .setProblemServerRetry(problemServerRetry);
-        for (String id : sessionIds) {
-            lb.addSessionCookieName(id);
-        }
+                .setProblemServerRetry(problemServerRetry)
+                .addSessionCookieName(AUTH_SESSION_ID);
 
         return new ProxyHandler(lb, maxTime, ResponseCodeHandler.HANDLE_404);
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerLogoutTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerLogoutTest.java
@@ -107,10 +107,8 @@ public class KcOidcBrokerLogoutTest extends AbstractBaseBrokerTest {
         String idToken = response.getIdToken();
 
         // simulate browser restart by deleting an identity cookie
-        log.debugf("Deleting %s and %s cookies", AuthenticationManager.KEYCLOAK_IDENTITY_COOKIE,
-                AuthenticationManager.KEYCLOAK_IDENTITY_COOKIE + CookieHelper.LEGACY_COOKIE);
+        log.debugf("Deleting %s cookie", AuthenticationManager.KEYCLOAK_IDENTITY_COOKIE);
         driver.manage().deleteCookieNamed(AuthenticationManager.KEYCLOAK_IDENTITY_COOKIE);
-        driver.manage().deleteCookieNamed(AuthenticationManager.KEYCLOAK_IDENTITY_COOKIE + CookieHelper.LEGACY_COOKIE);
 
         logoutFromRealm(getConsumerRoot(), bc.consumerRealmName(), null, idToken);
         driver.navigate().to(getAccountUrl(getProviderRoot(), REALM_PROV_NAME));

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/cluster/AuthenticationSessionFailoverClusterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/cluster/AuthenticationSessionFailoverClusterTest.java
@@ -114,9 +114,6 @@ public class AuthenticationSessionFailoverClusterTest extends AbstractFailoverCl
 
     public static String getAuthSessionCookieValue(WebDriver driver) {
         Cookie authSessionCookie = driver.manage().getCookieNamed(AuthenticationSessionManager.AUTH_SESSION_ID);
-        if (authSessionCookie == null) {
-            authSessionCookie = driver.manage().getCookieNamed(AuthenticationSessionManager.AUTH_SESSION_ID + CookieHelper.LEGACY_COOKIE);
-        }
         Assert.assertNotNull(authSessionCookie);
         return authSessionCookie.getValue();
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/storage/UserStorageTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/storage/UserStorageTest.java
@@ -84,7 +84,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.keycloak.models.UserModel.RequiredAction.UPDATE_PROFILE;
 import static org.keycloak.services.managers.AuthenticationManager.KEYCLOAK_SESSION_COOKIE;
-import static org.keycloak.services.util.CookieHelper.LEGACY_COOKIE;
 import static org.keycloak.storage.UserStorageProviderModel.CACHE_POLICY;
 import static org.keycloak.storage.UserStorageProviderModel.EVICTION_DAY;
 import static org.keycloak.storage.UserStorageProviderModel.EVICTION_HOUR;
@@ -254,15 +253,10 @@ public class UserStorageTest extends AbstractAuthTest {
         assertCurrentUrlStartsWith(testRealmAccountPage);
 
         Cookie sameSiteSessionCookie = driver.manage().getCookieNamed(KEYCLOAK_SESSION_COOKIE);
-        Cookie legacySessionCookie = driver.manage().getCookieNamed(KEYCLOAK_SESSION_COOKIE + LEGACY_COOKIE);
 
         String cookieValue = sameSiteSessionCookie.getValue();
         Assert.assertThat(cookieValue.contains("spécial"), is(false));
         Assert.assertThat(cookieValue.contains("sp%C3%A9cial"), is(true));
-
-        String legacyCookieValue = legacySessionCookie.getValue();
-        Assert.assertThat(legacyCookieValue.contains("spécial"), is(false));
-        Assert.assertThat(legacyCookieValue.contains("sp%C3%A9cial"), is(true));
 
         testRealmAccountPage.logOut();
     }


### PR DESCRIPTION
ONLY DRAFT

Slightly refactored processing of cookies. Just attempt to improve it a little bit, I'm not sure what the pitfalls are here. I've also removed the legacy cookies, but it might be good to ensure backward compatibility. We could leave the logic up to the HttpResponse#addNewCookie(), how exactly to tell the client how to set the cookies. We don't even use `Same-site` for our cookies now, so it's not necessary to keep the particular logic there. Moreover, once we need set `Same-site`, we should probably do it slightly differently than using the current `ServerCookie`, which is a complete mess. 

ATM, the cookies use the `HttpResponse` object fetched from the contextual data of JAX-RS, but for RestEasy Reactive, the HttpResponse is not always there at that time. Maybe, it'd be good to include adding new cookies action to some Response Handler Chain, where the cookies will be added to the response at the end of the lifecycle of a particular response managing. Something like, register adding cookie 'asdf' action to some handler and then actually managing the cookie.