### PR TITLE
Removing unnecessary injection points from JAX-RS (sub)resources

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/protocol/LoginProtocolFactory.java
+++ b/server-spi-private/src/main/java/org/keycloak/protocol/LoginProtocolFactory.java
@@ -19,6 +19,7 @@ package org.keycloak.protocol;
 
 import org.keycloak.events.EventBuilder;
 import org.keycloak.models.ClientModel;
+import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.ProtocolMapperModel;
 import org.keycloak.models.RealmModel;
 import org.keycloak.provider.ProviderFactory;
@@ -38,7 +39,7 @@ public interface LoginProtocolFactory extends ProviderFactory<LoginProtocol> {
     Map<String, ProtocolMapperModel> getBuiltinMappers();
 
 
-    Object createProtocolEndpoint(RealmModel realm, EventBuilder event);
+    Object createProtocolEndpoint(KeycloakSession session, EventBuilder event);
 
 
     /**

--- a/services/src/main/java/org/keycloak/authorization/AuthorizationService.java
+++ b/services/src/main/java/org/keycloak/authorization/AuthorizationService.java
@@ -20,7 +20,6 @@ package org.keycloak.authorization;
 
 import javax.ws.rs.Path;
 
-import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.keycloak.authorization.protection.ProtectionService;
 
 /**
@@ -36,10 +35,6 @@ public class AuthorizationService {
 
     @Path("/protection")
     public Object getProtectionService() {
-        ProtectionService service = new ProtectionService(authorization);
-
-        ResteasyProviderFactory.getInstance().injectProperties(service);
-
-        return service;
+        return new ProtectionService(authorization);
     }
 }

--- a/services/src/main/java/org/keycloak/authorization/admin/AuthorizationService.java
+++ b/services/src/main/java/org/keycloak/authorization/admin/AuthorizationService.java
@@ -21,7 +21,6 @@ package org.keycloak.authorization.admin;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.Path;
 
-import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.keycloak.authorization.AuthorizationProvider;
 import org.keycloak.authorization.model.ResourceServer;
 import org.keycloak.models.ClientModel;
@@ -58,11 +57,7 @@ public class AuthorizationService {
     }
 
     public ResourceServerService getResourceServerService() {
-        ResourceServerService resource = new ResourceServerService(this.authorization, this.resourceServer, this.client, this.auth, adminEvent);
-
-        ResteasyProviderFactory.getInstance().injectProperties(resource);
-
-        return resource;
+        return new ResourceServerService(this.authorization, this.resourceServer, this.client, this.auth, adminEvent);
     }
 
     public void enable(boolean newClient) {

--- a/services/src/main/java/org/keycloak/authorization/admin/PolicyService.java
+++ b/services/src/main/java/org/keycloak/authorization/admin/PolicyService.java
@@ -37,7 +37,6 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
 import org.jboss.resteasy.annotations.cache.NoCache;
-import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.keycloak.authorization.AuthorizationProvider;
 import org.keycloak.authorization.model.Policy;
 import org.keycloak.authorization.model.Resource;
@@ -300,11 +299,7 @@ public class PolicyService {
             this.auth.realm().requireViewAuthorization();
         }
 
-        PolicyEvaluationService resource = new PolicyEvaluationService(this.resourceServer, this.authorization, this.auth);
-
-        ResteasyProviderFactory.getInstance().injectProperties(resource);
-
-        return resource;
+        return new PolicyEvaluationService(this.resourceServer, this.authorization, this.auth);
     }
 
     protected PolicyProviderAdminService getPolicyProviderAdminResource(String policyType) {

--- a/services/src/main/java/org/keycloak/authorization/admin/ResourceServerService.java
+++ b/services/src/main/java/org/keycloak/authorization/admin/ResourceServerService.java
@@ -31,7 +31,6 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
-import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.keycloak.authorization.AuthorizationProvider;
 import org.keycloak.authorization.model.ResourceServer;
 import org.keycloak.events.admin.OperationType;
@@ -143,39 +142,23 @@ public class ResourceServerService {
 
     @Path("/resource")
     public ResourceSetService getResourceSetResource() {
-        ResourceSetService resource = new ResourceSetService(this.session, this.resourceServer, this.authorization, this.auth, adminEvent);
-
-        ResteasyProviderFactory.getInstance().injectProperties(resource);
-
-        return resource;
+        return new ResourceSetService(this.session, this.resourceServer, this.authorization, this.auth, adminEvent);
     }
 
     @Path("/scope")
     public ScopeService getScopeResource() {
-        ScopeService resource = new ScopeService(this.session, this.resourceServer, this.authorization, this.auth, adminEvent);
-
-        ResteasyProviderFactory.getInstance().injectProperties(resource);
-
-        return resource;
+        return new ScopeService(this.session, this.resourceServer, this.authorization, this.auth, adminEvent);
     }
 
     @Path("/policy")
     public PolicyService getPolicyResource() {
-        PolicyService resource = new PolicyService(this.resourceServer, this.authorization, this.auth, adminEvent);
-
-        ResteasyProviderFactory.getInstance().injectProperties(resource);
-
-        return resource;
+        return new PolicyService(this.resourceServer, this.authorization, this.auth, adminEvent);
     }
 
     @Path("/permission")
     public Object getPermissionTypeResource() {
         this.auth.realm().requireViewAuthorization();
-        PermissionService resource = new PermissionService(this.resourceServer, this.authorization, this.auth, adminEvent);
-
-        ResteasyProviderFactory.getInstance().injectProperties(resource);
-
-        return resource;
+        return new PermissionService(this.resourceServer, this.authorization, this.auth, adminEvent);
     }
 
     private void createDefaultPermission(ResourceRepresentation resource, PolicyRepresentation policy) {

--- a/services/src/main/java/org/keycloak/authorization/protection/policy/UserManagedPermissionService.java
+++ b/services/src/main/java/org/keycloak/authorization/protection/policy/UserManagedPermissionService.java
@@ -33,7 +33,6 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
 import org.jboss.resteasy.annotations.cache.NoCache;
-import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.keycloak.OAuthErrorException;
 import org.keycloak.authorization.AuthorizationProvider;
 import org.keycloak.authorization.admin.PermissionService;
@@ -44,7 +43,6 @@ import org.keycloak.authorization.model.Policy;
 import org.keycloak.authorization.model.Resource;
 import org.keycloak.authorization.model.ResourceServer;
 import org.keycloak.authorization.store.ResourceStore;
-import org.keycloak.common.Profile;
 import org.keycloak.representations.idm.authorization.UmaPermissionRepresentation;
 import org.keycloak.services.ErrorResponseException;
 import org.keycloak.services.resources.admin.AdminEventBuilder;
@@ -65,7 +63,6 @@ public class UserManagedPermissionService {
         this.resourceServer = resourceServer;
         this.authorization = authorization;
         delegate = new PermissionService(resourceServer, authorization, null, eventBuilder);
-        ResteasyProviderFactory.getInstance().injectProperties(delegate);
     }
 
     @POST

--- a/services/src/main/java/org/keycloak/broker/oidc/AbstractOAuth2IdentityProvider.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/AbstractOAuth2IdentityProvider.java
@@ -451,16 +451,14 @@ public abstract class AbstractOAuth2IdentityProvider<C extends OAuth2IdentityPro
     }
 
     protected static class Endpoint {
-        protected AuthenticationCallback callback;
-        protected RealmModel realm;
-        protected EventBuilder event;
-        private AbstractOAuth2IdentityProvider provider;
+        protected final AuthenticationCallback callback;
+        protected final RealmModel realm;
+        protected final EventBuilder event;
+        private final AbstractOAuth2IdentityProvider provider;
 
-        @Context
-        protected KeycloakSession session;
+        protected final KeycloakSession session;
 
-        @Context
-        protected ClientConnection clientConnection;
+        protected final ClientConnection clientConnection;
 
         @Context
         protected HttpHeaders headers;
@@ -473,6 +471,8 @@ public abstract class AbstractOAuth2IdentityProvider<C extends OAuth2IdentityPro
             this.realm = realm;
             this.event = event;
             this.provider = provider;
+            this.session = provider.session;
+            this.clientConnection = session.getContext().getConnection();
         }
 
         @GET

--- a/services/src/main/java/org/keycloak/broker/saml/SAMLEndpoint.java
+++ b/services/src/main/java/org/keycloak/broker/saml/SAMLEndpoint.java
@@ -137,29 +137,29 @@ public class SAMLEndpoint {
     public static final String SAML_LOGIN_RESPONSE = "SAML_LOGIN_RESPONSE";
     public static final String SAML_ASSERTION = "SAML_ASSERTION";
     public static final String SAML_AUTHN_STATEMENT = "SAML_AUTHN_STATEMENT";
-    protected RealmModel realm;
+    protected final RealmModel realm;
     protected EventBuilder event;
-    protected SAMLIdentityProviderConfig config;
-    protected IdentityProvider.AuthenticationCallback callback;
-    protected SAMLIdentityProvider provider;
+    protected final SAMLIdentityProviderConfig config;
+    protected final IdentityProvider.AuthenticationCallback callback;
+    protected final SAMLIdentityProvider provider;
     private final DestinationValidator destinationValidator;
 
-    @Context
-    private KeycloakSession session;
+    private final KeycloakSession session;
 
-    @Context
-    private ClientConnection clientConnection;
+    private final ClientConnection clientConnection;
 
     @Context
     private HttpHeaders headers;
 
 
-    public SAMLEndpoint(RealmModel realm, SAMLIdentityProvider provider, SAMLIdentityProviderConfig config, IdentityProvider.AuthenticationCallback callback, DestinationValidator destinationValidator) {
-        this.realm = realm;
+    public SAMLEndpoint(KeycloakSession session, SAMLIdentityProvider provider, SAMLIdentityProviderConfig config, IdentityProvider.AuthenticationCallback callback, DestinationValidator destinationValidator) {
+        this.realm = session.getContext().getRealm();
         this.config = config;
         this.callback = callback;
         this.provider = provider;
         this.destinationValidator = destinationValidator;
+        this.session = session;
+        this.clientConnection = session.getContext().getConnection();
     }
 
     @GET
@@ -598,7 +598,7 @@ public class SAMLEndpoint {
             }
 
             LoginProtocolFactory factory = (LoginProtocolFactory) session.getKeycloakSessionFactory().getProviderFactory(LoginProtocol.class, SamlProtocol.LOGIN_PROTOCOL);
-            SamlService samlService = (SamlService) factory.createProtocolEndpoint(SAMLEndpoint.this.realm, event);
+            SamlService samlService = (SamlService) factory.createProtocolEndpoint(SAMLEndpoint.this.session, event);
             ResteasyProviderFactory.getInstance().injectProperties(samlService);
             AuthenticationSessionModel authSession = samlService.getOrCreateLoginSessionForIdpInitiatedSso(session, SAMLEndpoint.this.realm, oClient.get(), null);
             if (authSession == null) {

--- a/services/src/main/java/org/keycloak/broker/saml/SAMLIdentityProvider.java
+++ b/services/src/main/java/org/keycloak/broker/saml/SAMLIdentityProvider.java
@@ -24,7 +24,6 @@ import org.keycloak.broker.provider.IdentityBrokerException;
 import org.keycloak.broker.provider.IdentityProviderDataMarshaller;
 import org.keycloak.broker.provider.IdentityProviderMapper;
 import org.keycloak.broker.provider.util.SimpleHttp;
-import org.keycloak.broker.saml.mappers.UserAttributeMapper;
 import org.keycloak.common.util.PemUtils;
 import org.keycloak.crypto.Algorithm;
 import org.keycloak.crypto.KeyStatus;
@@ -36,7 +35,6 @@ import org.keycloak.dom.saml.v2.assertion.SubjectType;
 import org.keycloak.dom.saml.v2.metadata.AttributeConsumingServiceType;
 import org.keycloak.dom.saml.v2.metadata.EntityDescriptorType;
 import org.keycloak.dom.saml.v2.metadata.LocalizedNameType;
-import org.keycloak.dom.saml.v2.metadata.RequestedAttributeType;
 import org.keycloak.dom.saml.v2.protocol.AuthnRequestType;
 import org.keycloak.dom.saml.v2.protocol.LogoutRequestType;
 import org.keycloak.dom.saml.v2.protocol.ResponseType;
@@ -84,7 +82,6 @@ import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 import javax.xml.crypto.dsig.CanonicalizationMethod;
 import javax.xml.parsers.ParserConfigurationException;
-import java.util.stream.Collectors;
 import javax.xml.stream.XMLStreamWriter;
 
 import java.io.StringWriter;
@@ -95,7 +92,6 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 
@@ -113,7 +109,7 @@ public class SAMLIdentityProvider extends AbstractIdentityProvider<SAMLIdentityP
 
     @Override
     public Object callback(RealmModel realm, AuthenticationCallback callback, EventBuilder event) {
-        return new SAMLEndpoint(realm, this, getConfig(), callback, destinationValidator);
+        return new SAMLEndpoint(session, this, getConfig(), callback, destinationValidator);
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/protocol/AuthorizationEndpointBase.java
+++ b/services/src/main/java/org/keycloak/protocol/AuthorizationEndpointBase.java
@@ -57,21 +57,23 @@ public abstract class AuthorizationEndpointBase {
 
     public static final String APP_INITIATED_FLOW = "APP_INITIATED_FLOW";
 
-    protected RealmModel realm;
-    protected EventBuilder event;
+    protected final RealmModel realm;
+    protected final EventBuilder event;
     protected AuthenticationManager authManager;
 
     @Context
     protected HttpHeaders headers;
     @Context
     protected HttpRequest httpRequest;
-    @Context
-    protected KeycloakSession session;
-    @Context
-    protected ClientConnection clientConnection;
 
-    public AuthorizationEndpointBase(RealmModel realm, EventBuilder event) {
-        this.realm = realm;
+    protected final KeycloakSession session;
+
+    protected final ClientConnection clientConnection;
+
+    public AuthorizationEndpointBase(KeycloakSession session, EventBuilder event) {
+        this.session = session;
+        this.clientConnection = session.getContext().getConnection();
+        this.realm = session.getContext().getRealm();
         this.event = event;
     }
 

--- a/services/src/main/java/org/keycloak/protocol/docker/DockerAuthV2ProtocolFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/docker/DockerAuthV2ProtocolFactory.java
@@ -49,8 +49,8 @@ public class DockerAuthV2ProtocolFactory extends AbstractLoginProtocolFactory im
     }
 
     @Override
-    public Object createProtocolEndpoint(final RealmModel realm, final EventBuilder event) {
-        return new DockerV2LoginProtocolService(realm, event);
+    public Object createProtocolEndpoint(final KeycloakSession session, final EventBuilder event) {
+        return new DockerV2LoginProtocolService(session, event);
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/protocol/docker/DockerEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/docker/DockerEndpoint.java
@@ -6,7 +6,7 @@ import org.keycloak.events.EventBuilder;
 import org.keycloak.events.EventType;
 import org.keycloak.models.AuthenticationFlowModel;
 import org.keycloak.models.ClientModel;
-import org.keycloak.models.RealmModel;
+import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.UserSessionModel;
 import org.keycloak.protocol.AuthorizationEndpointBase;
 import org.keycloak.protocol.oidc.endpoints.request.AuthorizationEndpointRequest;
@@ -36,8 +36,8 @@ public class DockerEndpoint extends AuthorizationEndpointBase {
     private ClientModel client;
     private AuthenticationSessionModel authenticationSession;
 
-    public DockerEndpoint(final RealmModel realm, final EventBuilder event, final EventType login) {
-        super(realm, event);
+    public DockerEndpoint(KeycloakSession session, final EventBuilder event, final EventType login) {
+        super(session, event);
         this.login = login;
     }
 

--- a/services/src/main/java/org/keycloak/protocol/docker/DockerV2LoginProtocolService.java
+++ b/services/src/main/java/org/keycloak/protocol/docker/DockerV2LoginProtocolService.java
@@ -22,14 +22,14 @@ public class DockerV2LoginProtocolService {
     private final TokenManager tokenManager;
     private final EventBuilder event;
 
-    @Context
-    private KeycloakSession session;
+    private final KeycloakSession session;
 
     @Context
     private HttpHeaders headers;
 
-    public DockerV2LoginProtocolService(final RealmModel realm, final EventBuilder event) {
-        this.realm = realm;
+    public DockerV2LoginProtocolService(final KeycloakSession session, final EventBuilder event) {
+        this.session = session;
+        this.realm = session.getContext().getRealm();
         this.tokenManager = new TokenManager();
         this.event = event;
     }
@@ -60,7 +60,7 @@ public class DockerV2LoginProtocolService {
     public Object auth() {
         ProfileHelper.requireFeature(Profile.Feature.DOCKER);
 
-        final DockerEndpoint endpoint = new DockerEndpoint(realm, event, EventType.LOGIN);
+        final DockerEndpoint endpoint = new DockerEndpoint(session, event, EventType.LOGIN);
         ResteasyProviderFactory.getInstance().injectProperties(endpoint);
         return endpoint;
     }

--- a/services/src/main/java/org/keycloak/protocol/oidc/DefaultTokenExchangeProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/DefaultTokenExchangeProvider.java
@@ -422,7 +422,7 @@ public class DefaultTokenExchangeProvider implements TokenExchangeProvider {
         // Create authSession with target SAML 2.0 client and authenticated user
         LoginProtocolFactory factory = (LoginProtocolFactory) session.getKeycloakSessionFactory()
                 .getProviderFactory(LoginProtocol.class, SamlProtocol.LOGIN_PROTOCOL);
-        SamlService samlService = (SamlService) factory.createProtocolEndpoint(realm, event);
+        SamlService samlService = (SamlService) factory.createProtocolEndpoint(session, event);
         ResteasyProviderFactory.getInstance().injectProperties(samlService);
         AuthenticationSessionModel authSession = samlService.getOrCreateLoginSessionForIdpInitiatedSso(session, realm,
                 targetClient, null);

--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocolFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocolFactory.java
@@ -395,8 +395,8 @@ public class OIDCLoginProtocolFactory extends AbstractLoginProtocolFactory {
     }
 
     @Override
-    public Object createProtocolEndpoint(RealmModel realm, EventBuilder event) {
-        return new OIDCLoginProtocolService(realm, event, providerConfig);
+    public Object createProtocolEndpoint(KeycloakSession session, EventBuilder event) {
+        return new OIDCLoginProtocolService(session, event, providerConfig);
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpoint.java
@@ -30,7 +30,7 @@ import org.keycloak.locale.LocaleSelectorProvider;
 import org.keycloak.models.AuthenticationFlowModel;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.Constants;
-import org.keycloak.models.RealmModel;
+import org.keycloak.models.KeycloakSession;
 import org.keycloak.protocol.AuthorizationEndpointBase;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.protocol.oidc.endpoints.request.AuthorizationEndpointRequest;
@@ -58,8 +58,6 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.List;
 import java.util.Map;
 
@@ -94,8 +92,8 @@ public class AuthorizationEndpoint extends AuthorizationEndpointBase {
     private AuthorizationEndpointRequest request;
     private String redirectUri;
 
-    public AuthorizationEndpoint(RealmModel realm, EventBuilder event) {
-        super(realm, event);
+    public AuthorizationEndpoint(KeycloakSession session, EventBuilder event) {
+        super(session, event);
         event.event(EventType.LOGIN);
     }
 
@@ -117,7 +115,7 @@ public class AuthorizationEndpoint extends AuthorizationEndpointBase {
      */
     @Path("device")
     public Object authorizeDevice() {
-        DeviceEndpoint endpoint = new DeviceEndpoint(realm, event);
+        DeviceEndpoint endpoint = new DeviceEndpoint(session, event);
         ResteasyProviderFactory.getInstance().injectProperties(endpoint);
         return endpoint;
     }

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/LoginStatusIframeEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/LoginStatusIframeEndpoint.java
@@ -28,7 +28,6 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 import java.util.Set;
@@ -40,8 +39,11 @@ import static org.keycloak.protocol.oidc.endpoints.IframeUtil.returnIframeFromRe
  */
 public class LoginStatusIframeEndpoint {
 
-    @Context
-    private KeycloakSession session;
+    private final KeycloakSession session;
+
+    public LoginStatusIframeEndpoint(KeycloakSession session) {
+        this.session = session;
+    }
 
     @GET
     @Produces(MediaType.TEXT_HTML_UTF_8)

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/LogoutEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/LogoutEndpoint.java
@@ -95,13 +95,6 @@ import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import static org.keycloak.models.UserSessionModel.State.LOGGED_OUT;
-import static org.keycloak.models.UserSessionModel.State.LOGGING_OUT;
-import static org.keycloak.services.resources.LoginActionsService.SESSION_CODE;
 
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
@@ -109,11 +102,9 @@ import static org.keycloak.services.resources.LoginActionsService.SESSION_CODE;
 public class LogoutEndpoint {
     private static final Logger logger = Logger.getLogger(LogoutEndpoint.class);
 
-    @Context
-    private KeycloakSession session;
+    private final KeycloakSession session;
 
-    @Context
-    private ClientConnection clientConnection;
+    private final ClientConnection clientConnection;
 
     @Context
     private HttpRequest request;
@@ -131,9 +122,11 @@ public class LogoutEndpoint {
 
     private Cors cors;
 
-    public LogoutEndpoint(TokenManager tokenManager, RealmModel realm, EventBuilder event, OIDCProviderConfig providerConfig) {
+    public LogoutEndpoint(KeycloakSession session, TokenManager tokenManager, EventBuilder event, OIDCProviderConfig providerConfig) {
+        this.session = session;
+        this.clientConnection = session.getContext().getConnection();
         this.tokenManager = tokenManager;
-        this.realm = realm;
+        this.realm = session.getContext().getRealm();
         this.event = event;
         this.providerConfig = providerConfig;
         this.offlineSessionsLazyLoadingEnabled = !Config.scope("userSessions").scope("infinispan").getBoolean("preloadOfflineSessionsFromDatabase", false);

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/ThirdPartyCookiesIframeEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/ThirdPartyCookiesIframeEndpoint.java
@@ -24,7 +24,6 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 
 import static org.keycloak.protocol.oidc.endpoints.IframeUtil.returnIframeFromResources;
@@ -33,8 +32,12 @@ import static org.keycloak.protocol.oidc.endpoints.IframeUtil.returnIframeFromRe
  * @author Vaclav Muzikar <vmuzikar@redhat.com>
  */
 public class ThirdPartyCookiesIframeEndpoint {
-    @Context
-    private KeycloakSession session;
+
+    private final KeycloakSession session;
+
+    public ThirdPartyCookiesIframeEndpoint(KeycloakSession session) {
+        this.session = session;
+    }
 
     @GET
     @Path("step1.html")

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenIntrospectionEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenIntrospectionEndpoint.java
@@ -49,22 +49,22 @@ public class TokenIntrospectionEndpoint {
     private static final String PARAM_TOKEN_TYPE_HINT = "token_type_hint";
     private static final String PARAM_TOKEN = "token";
 
-    @Context
-    private KeycloakSession session;
+    private final KeycloakSession session;
     @Context
     private HttpRequest request;
 
     @Context
     private HttpHeaders headers;
 
-    @Context
-    private ClientConnection clientConnection;
+    private final ClientConnection clientConnection;
 
     private final RealmModel realm;
     private final EventBuilder event;
 
-    public TokenIntrospectionEndpoint(RealmModel realm, EventBuilder event) {
-        this.realm = realm;
+    public TokenIntrospectionEndpoint(KeycloakSession session, EventBuilder event) {
+        this.session = session;
+        this.clientConnection = session.getContext().getConnection();
+        this.realm = session.getContext().getRealm();
         this.event = event;
     }
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenRevocationEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenRevocationEndpoint.java
@@ -62,8 +62,7 @@ import org.keycloak.util.TokenUtil;
 public class TokenRevocationEndpoint {
     private static final String PARAM_TOKEN = "token";
 
-    @Context
-    private KeycloakSession session;
+    private final KeycloakSession session;
 
     @Context
     private HttpRequest request;
@@ -71,19 +70,20 @@ public class TokenRevocationEndpoint {
     @Context
     private HttpHeaders headers;
 
-    @Context
-    private ClientConnection clientConnection;
+    private final ClientConnection clientConnection;
 
     private MultivaluedMap<String, String> formParams;
     private ClientModel client;
-    private RealmModel realm;
-    private EventBuilder event;
+    private final RealmModel realm;
+    private final EventBuilder event;
     private Cors cors;
     private AccessToken token;
     private UserModel user;
 
-    public TokenRevocationEndpoint(RealmModel realm, EventBuilder event) {
-        this.realm = realm;
+    public TokenRevocationEndpoint(KeycloakSession session, EventBuilder event) {
+        this.session = session;
+        this.clientConnection = session.getContext().getConnection();
+        this.realm = session.getContext().getRealm();
         this.event = event;
     }
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/UserInfoEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/UserInfoEndpoint.java
@@ -95,11 +95,9 @@ public class UserInfoEndpoint {
     @Context
     private HttpResponse response;
 
-    @Context
-    private KeycloakSession session;
+    private final KeycloakSession session;
 
-    @Context
-    private ClientConnection clientConnection;
+    private final ClientConnection clientConnection;
 
     private final org.keycloak.protocol.oidc.TokenManager tokenManager;
     private final AppAuthManager appAuthManager;
@@ -108,8 +106,10 @@ public class UserInfoEndpoint {
     private Cors cors;
     private String authorization;
 
-    public UserInfoEndpoint(org.keycloak.protocol.oidc.TokenManager tokenManager, RealmModel realm) {
-        this.realm = realm;
+    public UserInfoEndpoint(KeycloakSession session, org.keycloak.protocol.oidc.TokenManager tokenManager) {
+        this.session = session;
+        this.clientConnection = session.getContext().getConnection();
+        this.realm = session.getContext().getRealm();
         this.tokenManager = tokenManager;
         this.appAuthManager = new AppAuthManager();
         this.error = new OAuth2Error().json(false).realm(realm);

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/ciba/endpoints/CibaRootEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/ciba/endpoints/CibaRootEndpoint.java
@@ -53,11 +53,7 @@ public class CibaRootEndpoint implements OIDCExtProvider, OIDCExtProviderFactory
      */
     @Path("/auth")
     public BackchannelAuthenticationEndpoint authorize() {
-        BackchannelAuthenticationEndpoint endpoint = new BackchannelAuthenticationEndpoint(session, event);
-
-        ResteasyProviderFactory.getInstance().injectProperties(endpoint);
-
-        return endpoint;
+        return new BackchannelAuthenticationEndpoint(session, event);
     }
 
     /**

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/device/endpoints/DeviceEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/device/endpoints/DeviceEndpoint.java
@@ -46,7 +46,6 @@ import org.keycloak.protocol.oidc.grants.device.clientpolicy.context.DeviceAutho
 import org.keycloak.protocol.oidc.utils.AuthorizeClientUtil;
 import org.keycloak.representations.OAuth2DeviceAuthorizationResponse;
 import org.keycloak.saml.common.util.StringUtil;
-import org.keycloak.services.ErrorPageException;
 import org.keycloak.services.ErrorResponseException;
 import org.keycloak.services.ServicesLogger;
 import org.keycloak.services.Urls;
@@ -87,8 +86,8 @@ public class DeviceEndpoint extends AuthorizationEndpointBase implements RealmRe
 
     private Cors cors;
 
-    public DeviceEndpoint(RealmModel realm, EventBuilder event) {
-        super(realm, event);
+    public DeviceEndpoint(KeycloakSession session, EventBuilder event) {
+        super(session, event);
     }
 
     /**

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/device/endpoints/DeviceEndpointFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/device/endpoints/DeviceEndpointFactory.java
@@ -39,7 +39,7 @@ public class DeviceEndpointFactory implements RealmResourceProviderFactory {
         KeycloakContext context = session.getContext();
         RealmModel realm = context.getRealm();
         EventBuilder event = new EventBuilder(realm, session, context.getConnection());
-        DeviceEndpoint provider = new DeviceEndpoint(realm, event);
+        DeviceEndpoint provider = new DeviceEndpoint(session, event);
         ResteasyProviderFactory.getInstance().injectProperties(provider);
         return provider;
     }

--- a/services/src/main/java/org/keycloak/protocol/saml/SamlProtocolFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/SamlProtocolFactory.java
@@ -55,8 +55,8 @@ public class SamlProtocolFactory extends AbstractLoginProtocolFactory {
     private DestinationValidator destinationValidator;
 
     @Override
-    public Object createProtocolEndpoint(RealmModel realm, EventBuilder event) {
-        return new SamlService(realm, event, destinationValidator);
+    public Object createProtocolEndpoint(KeycloakSession session, EventBuilder event) {
+        return new SamlService(session, event, destinationValidator);
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/protocol/saml/SamlService.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/SamlService.java
@@ -161,8 +161,8 @@ public class SamlService extends AuthorizationEndpointBase {
 
     private final DestinationValidator destinationValidator;
 
-    public SamlService(RealmModel realm, EventBuilder event, DestinationValidator destinationValidator) {
-        super(realm, event);
+    public SamlService(KeycloakSession session, EventBuilder event, DestinationValidator destinationValidator) {
+        super(session, event);
         this.destinationValidator = destinationValidator;
     }
 
@@ -1073,7 +1073,7 @@ public class SamlService extends AuthorizationEndpointBase {
     @NoCache
     @Consumes({"application/soap+xml",MediaType.TEXT_XML})
     public Response soapBinding(InputStream inputStream) {
-        SamlEcpProfileService bindingService = new SamlEcpProfileService(realm, event, destinationValidator);
+        SamlEcpProfileService bindingService = new SamlEcpProfileService(session, event, destinationValidator);
 
         ResteasyProviderFactory.getInstance().injectProperties(bindingService);
 
@@ -1403,7 +1403,7 @@ public class SamlService extends AuthorizationEndpointBase {
                         throw new NotFoundException("Protocol not found");
                     }
 
-                    SamlService endpoint = (SamlService) factory.createProtocolEndpoint(realm, event);
+                    SamlService endpoint = (SamlService) factory.createProtocolEndpoint(session, event);
                     ResteasyProviderFactory.getInstance().injectProperties(endpoint);
                     BindingProtocol protocol;
                     if (SamlProtocol.SAML_POST_BINDING.equals(bindingType)) {

--- a/services/src/main/java/org/keycloak/protocol/saml/profile/ecp/SamlEcpProfileService.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/profile/ecp/SamlEcpProfileService.java
@@ -22,7 +22,7 @@ import org.keycloak.events.EventBuilder;
 import org.keycloak.models.AuthenticationFlowModel;
 import org.keycloak.models.AuthenticatedClientSessionModel;
 import org.keycloak.models.ClientModel;
-import org.keycloak.models.RealmModel;
+import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.UserSessionModel;
 import org.keycloak.models.utils.DefaultAuthenticationFlows;
 import org.keycloak.protocol.saml.JaxrsSAML2BindingBuilder;
@@ -57,8 +57,8 @@ public class SamlEcpProfileService extends SamlService {
     private static final String NS_PREFIX_SAML_PROTOCOL = "samlp";
     private static final String NS_PREFIX_SAML_ASSERTION = "saml";
 
-    public SamlEcpProfileService(RealmModel realm, EventBuilder event, DestinationValidator destinationValidator) {
-        super(realm, event, destinationValidator);
+    public SamlEcpProfileService(KeycloakSession session, EventBuilder event, DestinationValidator destinationValidator) {
+        super(session, event, destinationValidator);
     }
 
     public Response authenticate(InputStream inputStream) {

--- a/services/src/main/java/org/keycloak/services/clientregistration/ClientRegistrationService.java
+++ b/services/src/main/java/org/keycloak/services/clientregistration/ClientRegistrationService.java
@@ -24,7 +24,6 @@ import org.keycloak.services.ErrorResponseException;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 
 /**
@@ -32,12 +31,12 @@ import javax.ws.rs.core.Response;
  */
 public class ClientRegistrationService {
 
-    private EventBuilder event;
+    private final EventBuilder event;
 
-    @Context
-    private KeycloakSession session;
+    private final KeycloakSession session;
 
-    public ClientRegistrationService(EventBuilder event) {
+    public ClientRegistrationService(KeycloakSession session, EventBuilder event) {
+        this.session = session;
         this.event = event;
     }
 

--- a/services/src/main/java/org/keycloak/services/resources/AbstractSecuredLocalService.java
+++ b/services/src/main/java/org/keycloak/services/resources/AbstractSecuredLocalService.java
@@ -56,21 +56,24 @@ public abstract class AbstractSecuredLocalService {
     private static final Logger logger = Logger.getLogger(AbstractSecuredLocalService.class);
 
     protected final ClientModel client;
-    protected RealmModel realm;
+    protected final RealmModel realm;
 
     @Context
     protected HttpHeaders headers;
-    @Context
-    protected ClientConnection clientConnection;
+
+    protected final ClientConnection clientConnection;
     protected String stateChecker;
-    @Context
-    protected KeycloakSession session;
+
+    protected final KeycloakSession session;
+
     @Context
     protected HttpRequest request;
     protected Auth auth;
 
-    public AbstractSecuredLocalService(RealmModel realm, ClientModel client) {
-        this.realm = realm;
+    public AbstractSecuredLocalService(KeycloakSession session, ClientModel client) {
+        this.session = session;
+        this.realm = session.getContext().getRealm();
+        this.clientConnection = session.getContext().getConnection();
         this.client = client;
     }
 

--- a/services/src/main/java/org/keycloak/services/resources/ClientsManagementService.java
+++ b/services/src/main/java/org/keycloak/services/resources/ClientsManagementService.java
@@ -45,7 +45,6 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
-import javax.ws.rs.ext.Providers;
 
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
@@ -54,9 +53,9 @@ public class ClientsManagementService {
 
     private static final Logger logger = Logger.getLogger(ClientsManagementService.class);
 
-    private RealmModel realm;
+    private final RealmModel realm;
 
-    private EventBuilder event;
+    private final EventBuilder event;
 
     @Context
     private HttpRequest request;
@@ -64,17 +63,14 @@ public class ClientsManagementService {
     @Context
     protected HttpHeaders headers;
 
-    @Context
-    private ClientConnection clientConnection;
+    private final ClientConnection clientConnection;
 
-    @Context
-    protected Providers providers;
+    protected final KeycloakSession session;
 
-    @Context
-    protected KeycloakSession session;
-
-    public ClientsManagementService(RealmModel realm, EventBuilder event) {
-        this.realm = realm;
+    public ClientsManagementService(KeycloakSession session, EventBuilder event) {
+        this.session = session;
+        this.clientConnection = session.getContext().getConnection();
+        this.realm = session.getContext().getRealm();
         this.event = event;
     }
 

--- a/services/src/main/java/org/keycloak/services/resources/IdentityBrokerService.java
+++ b/services/src/main/java/org/keycloak/services/resources/IdentityBrokerService.java
@@ -134,11 +134,9 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
 
     private final RealmModel realmModel;
 
-    @Context
-    private KeycloakSession session;
+    private final KeycloakSession session;
 
-    @Context
-    private ClientConnection clientConnection;
+    private final ClientConnection clientConnection;
 
     @Context
     private HttpRequest request;
@@ -149,11 +147,13 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
     private EventBuilder event;
 
 
-    public IdentityBrokerService(RealmModel realmModel) {
+    public IdentityBrokerService(KeycloakSession session) {
+        this.session = session;
+        this.clientConnection= session.getContext().getConnection();
+        realmModel = session.getContext().getRealm();
         if (realmModel == null) {
             throw new IllegalArgumentException("Realm can not be null.");
         }
-        this.realmModel = realmModel;
     }
 
     public void init() {

--- a/services/src/main/java/org/keycloak/services/resources/LoginActionsService.java
+++ b/services/src/main/java/org/keycloak/services/resources/LoginActionsService.java
@@ -99,7 +99,6 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriBuilderException;
 import javax.ws.rs.core.UriInfo;
-import javax.ws.rs.ext.Providers;
 import java.net.URI;
 import java.util.Map;
 
@@ -128,7 +127,7 @@ public class LoginActionsService {
     
     public static final String CANCEL_AIA = "cancel-aia";
 
-    private RealmModel realm;
+    private final RealmModel realm;
 
     @Context
     private HttpRequest request;
@@ -136,14 +135,9 @@ public class LoginActionsService {
     @Context
     protected HttpHeaders headers;
 
-    @Context
-    private ClientConnection clientConnection;
+    private final ClientConnection clientConnection;
 
-    @Context
-    protected Providers providers;
-
-    @Context
-    protected KeycloakSession session;
+    protected final KeycloakSession session;
 
     private EventBuilder event;
 
@@ -180,8 +174,10 @@ public class LoginActionsService {
         return baseUriBuilder.path(RealmsResource.class).path(RealmsResource.class, "getLoginActionsService");
     }
 
-    public LoginActionsService(RealmModel realm, EventBuilder event) {
-        this.realm = realm;
+    public LoginActionsService(KeycloakSession session, EventBuilder event) {
+        this.session = session;
+        this.clientConnection = session.getContext().getConnection();
+        this.realm = session.getContext().getRealm();
         this.event = event;
         CacheControlUtil.noBackButtonCacheControlHeader();
     }

--- a/services/src/main/java/org/keycloak/services/resources/PublicRealmResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/PublicRealmResource.java
@@ -51,13 +51,13 @@ public class PublicRealmResource {
     @Context
     protected HttpResponse response;
 
-    @Context
-    protected KeycloakSession session;
+    protected final KeycloakSession session;
 
-    protected RealmModel realm;
+    protected final RealmModel realm;
 
-    public PublicRealmResource(RealmModel realm) {
-        this.realm = realm;
+    public PublicRealmResource(KeycloakSession session) {
+        this.session = session;
+        this.realm = session.getContext().getRealm();
     }
 
     /**

--- a/services/src/main/java/org/keycloak/services/resources/account/AccountConsole.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountConsole.java
@@ -14,11 +14,9 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
-import org.jboss.logging.Logger;
 import org.jboss.resteasy.annotations.cache.NoCache;
 import org.keycloak.authentication.requiredactions.DeleteAccount;
 import org.keycloak.common.Profile;
@@ -53,12 +51,10 @@ import org.keycloak.utils.StringUtil;
  * Created by st on 29/03/17.
  */
 public class AccountConsole {
-    private static final Logger logger = Logger.getLogger(AccountConsole.class);
-    
+
     private final Pattern bundleParamPattern = Pattern.compile("(\\{\\s*(\\d+)\\s*\\})");
 
-    @Context
-    protected KeycloakSession session;
+    protected final KeycloakSession session;
 
     private final AppAuthManager authManager;
     private final RealmModel realm;
@@ -67,8 +63,9 @@ public class AccountConsole {
 
     private Auth auth;
 
-    public AccountConsole(RealmModel realm, ClientModel client, Theme theme) {
-        this.realm = realm;
+    public AccountConsole(KeycloakSession session, ClientModel client, Theme theme) {
+        this.session = session;
+        this.realm = session.getContext().getRealm();
         this.client = client;
         this.theme = theme;
         this.authManager = new AppAuthManager();

--- a/services/src/main/java/org/keycloak/services/resources/account/AccountCredentialResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountCredentialResource.java
@@ -1,7 +1,6 @@
 package org.keycloak.services.resources.account;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import org.jboss.logging.Logger;
 import org.jboss.resteasy.annotations.cache.NoCache;
 import org.keycloak.authentication.Authenticator;
 import org.keycloak.authentication.AuthenticatorFactory;
@@ -54,10 +53,7 @@ import static org.keycloak.utils.CredentialHelper.createUserStorageCredentialRep
 
 public class AccountCredentialResource {
 
-    private static final Logger logger = Logger.getLogger(AccountCredentialResource.class);
-
     public static final String TYPE = "type";
-    public static final String ENABLED_ONLY = "enabled-only";
     public static final String USER_CREDENTIALS = "user-credentials";
 
 

--- a/services/src/main/java/org/keycloak/services/resources/account/AccountFormService.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountFormService.java
@@ -139,12 +139,12 @@ public class AccountFormService extends AbstractSecuredLocalService {
     public static final String ACCOUNT_MGMT_FORWARDED_ERROR_NOTE = "ACCOUNT_MGMT_FORWARDED_ERROR";
 
     private final AppAuthManager authManager;
-    private EventBuilder event;
+    private final EventBuilder event;
     private AccountProvider account;
     private EventStoreProvider eventStore;
 
-    public AccountFormService(RealmModel realm, ClientModel client, EventBuilder event) {
-        super(realm, client);
+    public AccountFormService(KeycloakSession session, ClientModel client, EventBuilder event) {
+        super(session, client);
         this.event = event;
         this.authManager = new AppAuthManager();
     }

--- a/services/src/main/java/org/keycloak/services/resources/account/AccountLoader.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountLoader.java
@@ -51,8 +51,8 @@ import java.util.List;
  */
 public class AccountLoader {
 
-    private KeycloakSession session;
-    private EventBuilder event;
+    private final KeycloakSession session;
+    private final EventBuilder event;
 
     @Context
     private HttpRequest request;
@@ -86,13 +86,12 @@ public class AccountLoader {
             return getAccountRestService(client, null);
         } else {
             if (deprecatedAccount) {
-                AccountFormService accountFormService = new AccountFormService(realm, client, event);
+                AccountFormService accountFormService = new AccountFormService(session, client, event);
                 ResteasyProviderFactory.getInstance().injectProperties(accountFormService);
                 accountFormService.init();
                 return accountFormService;
             } else {
-                AccountConsole console = new AccountConsole(realm, client, theme);
-                ResteasyProviderFactory.getInstance().injectProperties(console);
+                AccountConsole console = new AccountConsole(session, client, theme);
                 console.init();
                 return console;
             }
@@ -151,9 +150,8 @@ public class AccountLoader {
             }
         }
 
-        AccountRestService accountRestService = new AccountRestService(session, auth, client, event, version);
+        AccountRestService accountRestService = new AccountRestService(session, auth, event, version);
         ResteasyProviderFactory.getInstance().injectProperties(accountRestService);
-        accountRestService.init();
         return accountRestService;
     }
 

--- a/services/src/main/java/org/keycloak/services/resources/account/AccountRestService.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountRestService.java
@@ -57,7 +57,6 @@ import org.keycloak.common.enums.AccountRestApiVersion;
 import org.keycloak.common.util.StringPropertyReplacer;
 import org.keycloak.events.Details;
 import org.keycloak.events.EventBuilder;
-import org.keycloak.events.EventStoreProvider;
 import org.keycloak.events.EventType;
 import org.keycloak.models.AccountRoles;
 import org.keycloak.models.AuthenticatedClientSessionModel;
@@ -105,36 +104,30 @@ public class AccountRestService {
     private HttpRequest request;
     @Context
     protected HttpHeaders headers;
-    @Context
-    protected ClientConnection clientConnection;
+
+    protected final ClientConnection clientConnection;
 
     private final KeycloakSession session;
-    private final ClientModel client;
     private final EventBuilder event;
-    private EventStoreProvider eventStore;
-    private Auth auth;
+    private final Auth auth;
     
     private final RealmModel realm;
     private final UserModel user;
     private final Locale locale;
     private final AccountRestApiVersion version;
 
-    public AccountRestService(KeycloakSession session, Auth auth, ClientModel client, EventBuilder event, AccountRestApiVersion version) {
+    public AccountRestService(KeycloakSession session, Auth auth, EventBuilder event, AccountRestApiVersion version) {
         this.session = session;
+        this.clientConnection = session.getContext().getConnection();
         this.auth = auth;
         this.realm = auth.getRealm();
         this.user = auth.getUser();
-        this.client = client;
         this.event = event;
         this.locale = session.getContext().resolveLocale(user);
         this.version = version;
         event.client(auth.getClient()).user(auth.getUser());
     }
     
-    public void init() {
-        eventStore = session.getProvider(EventStoreProvider.class);
-    }
-
     /**
      * Get account information.
      *
@@ -275,7 +268,7 @@ public class AccountRestService {
     public SessionResource sessions() {
         checkAccountApiEnabled();
         auth.requireOneOf(AccountRoles.MANAGE_ACCOUNT, AccountRoles.VIEW_PROFILE);
-        return new SessionResource(session, auth, request);
+        return new SessionResource(session, auth);
     }
 
     @Path("/credentials")
@@ -484,7 +477,7 @@ public class AccountRestService {
     
     @Path("/linked-accounts")
     public LinkedAccountsResource linkedAccounts() {
-        return new LinkedAccountsResource(session, request, client, auth, event, user);
+        return new LinkedAccountsResource(session, request, auth, event, user);
     }
 
     @Path("/groups")

--- a/services/src/main/java/org/keycloak/services/resources/account/CorsPreflightService.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/CorsPreflightService.java
@@ -12,7 +12,7 @@ import javax.ws.rs.core.Response;
  */
 public class CorsPreflightService {
 
-    private HttpRequest request;
+    private final HttpRequest request;
 
     public CorsPreflightService(HttpRequest request) {
         this.request = request;

--- a/services/src/main/java/org/keycloak/services/resources/account/LinkedAccountsResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/LinkedAccountsResource.java
@@ -44,7 +44,6 @@ import org.keycloak.events.Details;
 import org.keycloak.events.EventBuilder;
 import org.keycloak.events.EventType;
 import org.keycloak.models.AccountRoles;
-import org.keycloak.models.ClientModel;
 import org.keycloak.models.FederatedIdentityModel;
 import org.keycloak.models.IdentityProviderModel;
 import org.keycloak.models.KeycloakSession;
@@ -74,7 +73,6 @@ public class LinkedAccountsResource {
     
     private final KeycloakSession session;
     private final HttpRequest request;
-    private final ClientModel client;
     private final EventBuilder event;
     private final UserModel user;
     private final RealmModel realm;
@@ -82,13 +80,11 @@ public class LinkedAccountsResource {
 
     public LinkedAccountsResource(KeycloakSession session, 
                                   HttpRequest request, 
-                                  ClientModel client,
-                                  Auth auth, 
+                                  Auth auth,
                                   EventBuilder event, 
                                   UserModel user) {
         this.session = session;
         this.request = request;
-        this.client = client;
         this.auth = auth;
         this.event = event;
         this.user = user;

--- a/services/src/main/java/org/keycloak/services/resources/account/SessionResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/SessionResource.java
@@ -32,7 +32,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.jboss.resteasy.annotations.cache.NoCache;
-import org.jboss.resteasy.spi.HttpRequest;
 import org.keycloak.device.DeviceActivityManager;
 import org.keycloak.models.AccountRoles;
 import org.keycloak.models.ClientModel;
@@ -57,14 +56,12 @@ public class SessionResource {
     private final Auth auth;
     private final RealmModel realm;
     private final UserModel user;
-    private HttpRequest request;
 
-    public SessionResource(KeycloakSession session, Auth auth, HttpRequest request) {
+    public SessionResource(KeycloakSession session, Auth auth) {
         this.session = session;
         this.auth = auth;
         this.realm = auth.getRealm();
         this.user = auth.getUser();
-        this.request = request;
     }
 
     /**

--- a/services/src/main/java/org/keycloak/services/resources/admin/AdminConsole.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/AdminConsole.java
@@ -55,7 +55,6 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.Providers;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -74,8 +73,7 @@ import java.util.stream.Collectors;
 public class AdminConsole {
     protected static final Logger logger = Logger.getLogger(AdminConsole.class);
 
-    @Context
-    protected ClientConnection clientConnection;
+    protected final ClientConnection clientConnection;
 
     @Context
     protected HttpRequest request;
@@ -83,16 +81,14 @@ public class AdminConsole {
     @Context
     protected HttpResponse response;
 
-    @Context
-    protected KeycloakSession session;
+    protected final KeycloakSession session;
 
-    @Context
-    protected Providers providers;
+    protected final RealmModel realm;
 
-    protected RealmModel realm;
-
-    public AdminConsole(RealmModel realm) {
-        this.realm = realm;
+    public AdminConsole(KeycloakSession session) {
+        this.session = session;
+        this.realm = session.getContext().getRealm();
+        this.clientConnection = session.getContext().getConnection();
     }
 
     public static class WhoAmI {

--- a/services/src/main/java/org/keycloak/services/resources/admin/AttackDetectionResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/AttackDetectionResource.java
@@ -49,22 +49,22 @@ import java.util.Map;
  */
 public class AttackDetectionResource {
     protected static final Logger logger = Logger.getLogger(AttackDetectionResource.class);
-    protected AdminPermissionEvaluator auth;
-    protected RealmModel realm;
-    private AdminEventBuilder adminEvent;
+    protected final AdminPermissionEvaluator auth;
+    protected final RealmModel realm;
+    private final AdminEventBuilder adminEvent;
 
-    @Context
-    protected KeycloakSession session;
+    protected final KeycloakSession session;
 
-    @Context
-    protected ClientConnection connection;
+    protected final ClientConnection connection;
 
     @Context
     protected HttpHeaders headers;
 
-    public AttackDetectionResource(AdminPermissionEvaluator auth, RealmModel realm, AdminEventBuilder adminEvent) {
+    public AttackDetectionResource(KeycloakSession session, AdminPermissionEvaluator auth, AdminEventBuilder adminEvent) {
+        this.session = session;
         this.auth = auth;
-        this.realm = realm;
+        this.realm = session.getContext().getRealm();
+        this.connection = session.getContext().getConnection();
         this.adminEvent = adminEvent.realm(realm).resource(ResourceType.USER_LOGIN_FAILURE);
     }
 

--- a/services/src/main/java/org/keycloak/services/resources/admin/AuthenticationManagementResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/AuthenticationManagementResource.java
@@ -89,14 +89,14 @@ public class AuthenticationManagementResource {
 
     private final RealmModel realm;
     private final KeycloakSession session;
-    private AdminPermissionEvaluator auth;
-    private AdminEventBuilder adminEvent;
+    private final AdminPermissionEvaluator auth;
+    private final AdminEventBuilder adminEvent;
 
     protected static final Logger logger = Logger.getLogger(AuthenticationManagementResource.class);
 
-    public AuthenticationManagementResource(RealmModel realm, KeycloakSession session, AdminPermissionEvaluator auth, AdminEventBuilder adminEvent) {
-        this.realm = realm;
+    public AuthenticationManagementResource(KeycloakSession session, AdminPermissionEvaluator auth, AdminEventBuilder adminEvent) {
         this.session = session;
+        this.realm = session.getContext().getRealm();
         this.auth = auth;
         this.adminEvent = adminEvent.resource(ResourceType.AUTH_FLOW);
     }

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientAttributeCertificateResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientAttributeCertificateResource.java
@@ -77,15 +77,15 @@ public class ClientAttributeCertificateResource {
     public static final String PUBLIC_KEY_PEM = "Public Key PEM";
     public static final String JSON_WEB_KEY_SET = "JSON Web Key Set";
 
-    protected RealmModel realm;
-    private AdminPermissionEvaluator auth;
-    protected ClientModel client;
-    protected KeycloakSession session;
-    protected AdminEventBuilder adminEvent;
-    protected String attributePrefix;
+    protected final RealmModel realm;
+    private final AdminPermissionEvaluator auth;
+    protected final ClientModel client;
+    protected final KeycloakSession session;
+    protected final AdminEventBuilder adminEvent;
+    protected final String attributePrefix;
 
-    public ClientAttributeCertificateResource(RealmModel realm, AdminPermissionEvaluator auth, ClientModel client, KeycloakSession session, String attributePrefix, AdminEventBuilder adminEvent) {
-        this.realm = realm;
+    public ClientAttributeCertificateResource(AdminPermissionEvaluator auth, ClientModel client, KeycloakSession session, String attributePrefix, AdminEventBuilder adminEvent) {
+        this.realm = session.getContext().getRealm();
         this.auth = auth;
         this.client = client;
         this.session = session;

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientInitialAccessResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientInitialAccessResource.java
@@ -51,12 +51,12 @@ public class ClientInitialAccessResource {
     private final RealmModel realm;
     private final AdminEventBuilder adminEvent;
 
-    @Context
     protected KeycloakSession session;
 
-    public ClientInitialAccessResource(RealmModel realm, AdminPermissionEvaluator auth, AdminEventBuilder adminEvent) {
+    public ClientInitialAccessResource(KeycloakSession session, AdminPermissionEvaluator auth, AdminEventBuilder adminEvent) {
+        this.session = session;
         this.auth = auth;
-        this.realm = realm;
+        this.realm = session.getContext().getRealm();
         this.adminEvent = adminEvent.resource(ResourceType.CLIENT_INITIAL_ACCESS_MODEL);
 
     }

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientPoliciesResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientPoliciesResource.java
@@ -46,14 +46,14 @@ public class ClientPoliciesResource {
     @Context
     protected HttpResponse response;
 
-    @Context
-    protected KeycloakSession session;
+    protected final KeycloakSession session;
 
-    protected RealmModel realm;
-    private AdminPermissionEvaluator auth;
+    protected final RealmModel realm;
+    private final AdminPermissionEvaluator auth;
 
-    public ClientPoliciesResource(RealmModel realm, AdminPermissionEvaluator auth) {
-        this.realm = realm;
+    public ClientPoliciesResource(KeycloakSession session, AdminPermissionEvaluator auth) {
+        this.session = session;
+        this.realm = session.getContext().getRealm();
         this.auth = auth;
     }
 

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientProfilesResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientProfilesResource.java
@@ -47,14 +47,14 @@ public class ClientProfilesResource {
     @Context
     protected HttpResponse response;
 
-    @Context
-    protected KeycloakSession session;
+    protected final KeycloakSession session;
 
-    protected RealmModel realm;
-    private AdminPermissionEvaluator auth;
+    protected final RealmModel realm;
+    private final AdminPermissionEvaluator auth;
 
-    public ClientProfilesResource(RealmModel realm, AdminPermissionEvaluator auth) {
-        this.realm = realm;
+    public ClientProfilesResource(KeycloakSession session, AdminPermissionEvaluator auth) {
+        this.session = session;
+        this.realm = session.getContext().getRealm();
         this.auth = auth;
     }
 

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientRegistrationPolicyResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientRegistrationPolicyResource.java
@@ -32,7 +32,6 @@ import org.keycloak.services.resources.admin.permissions.AdminPermissionEvaluato
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import java.util.List;
 import java.util.stream.Stream;
@@ -47,12 +46,12 @@ public class ClientRegistrationPolicyResource {
     private final RealmModel realm;
     private final AdminEventBuilder adminEvent;
 
-    @Context
-    protected KeycloakSession session;
+    protected final KeycloakSession session;
 
-    public ClientRegistrationPolicyResource(RealmModel realm, AdminPermissionEvaluator auth, AdminEventBuilder adminEvent) {
+    public ClientRegistrationPolicyResource(KeycloakSession session, AdminPermissionEvaluator auth, AdminEventBuilder adminEvent) {
+        this.session = session;
         this.auth = auth;
-        this.realm = realm;
+        this.realm = session.getContext().getRealm();
         this.adminEvent = adminEvent.resource(ResourceType.CLIENT_INITIAL_ACCESS_MODEL);
 
     }

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientResource.java
@@ -20,7 +20,6 @@ import javax.ws.rs.core.Response.Status;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.annotations.cache.NoCache;
 import org.jboss.resteasy.spi.BadRequestException;
-import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.keycloak.OAuthErrorException;
 import org.keycloak.authorization.admin.AuthorizationService;
 import org.keycloak.common.ClientConnection;
@@ -69,10 +68,8 @@ import org.keycloak.services.managers.ResourceAdminManager;
 import org.keycloak.services.resources.admin.permissions.AdminPermissionEvaluator;
 import org.keycloak.services.resources.admin.permissions.AdminPermissionManagement;
 import org.keycloak.services.resources.admin.permissions.AdminPermissions;
-import org.keycloak.utils.CredentialHelper;
 import org.keycloak.utils.ProfileHelper;
 import org.keycloak.utils.ReservedCharValidator;
-import org.keycloak.utils.StringUtil;
 import org.keycloak.validation.ValidationUtil;
 
 import javax.ws.rs.Consumes;
@@ -85,7 +82,6 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.HashMap;
@@ -109,10 +105,9 @@ public class ClientResource {
     private AdminPermissionEvaluator auth;
     private AdminEventBuilder adminEvent;
     protected ClientModel client;
-    protected KeycloakSession session;
+    protected final KeycloakSession session;
 
-    @Context
-    protected ClientConnection clientConnection;
+    protected final ClientConnection clientConnection;
 
     public ClientResource(RealmModel realm, AdminPermissionEvaluator auth, ClientModel clientModel, KeycloakSession session, AdminEventBuilder adminEvent) {
         this.realm = realm;
@@ -120,15 +115,14 @@ public class ClientResource {
         this.client = clientModel;
         this.session = session;
         this.adminEvent = adminEvent.resource(ResourceType.CLIENT);
+        this.clientConnection = session.getContext().getConnection();
     }
 
     @Path("protocol-mappers")
     public ProtocolMappersResource getProtocolMappers() {
         AdminPermissionEvaluator.RequirePermissionCheck manageCheck = () -> auth.clients().requireManage(client);
         AdminPermissionEvaluator.RequirePermissionCheck viewCheck = () -> auth.clients().requireView(client);
-        ProtocolMappersResource mappers = new ProtocolMappersResource(realm, client, auth, adminEvent, manageCheck, viewCheck);
-        ResteasyProviderFactory.getInstance().injectProperties(mappers);
-        return mappers;
+        return new ProtocolMappersResource(session, client, auth, adminEvent, manageCheck, viewCheck);
     }
 
     /**
@@ -204,7 +198,7 @@ public class ClientResource {
      */
     @Path("certificates/{attr}")
     public ClientAttributeCertificateResource getCertficateResource(@PathParam("attr") String attributePrefix) {
-        return new ClientAttributeCertificateResource(realm, auth, client, session, attributePrefix, adminEvent);
+        return new ClientAttributeCertificateResource(auth, client, session, attributePrefix, adminEvent);
     }
 
     @GET
@@ -641,11 +635,7 @@ public class ClientResource {
     public AuthorizationService authorization() {
         ProfileHelper.requireFeature(Profile.Feature.AUTHORIZATION);
 
-        AuthorizationService resource = new AuthorizationService(this.session, this.client, this.auth, adminEvent);
-
-        ResteasyProviderFactory.getInstance().injectProperties(resource);
-
-        return resource;
+        return new AuthorizationService(this.session, this.client, this.auth, adminEvent);
     }
 
     /**

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientScopeEvaluateResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientScopeEvaluateResource.java
@@ -102,7 +102,7 @@ public class ClientScopeEvaluateResource {
             throw new NotFoundException("Role Container not found");
         }
 
-        return new ClientScopeEvaluateScopeMappingsResource(roleContainer, auth, client, scopeParam, session);
+        return new ClientScopeEvaluateScopeMappingsResource(roleContainer, auth, client, scopeParam);
     }
 
 

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientScopeEvaluateScopeMappingsResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientScopeEvaluateScopeMappingsResource.java
@@ -30,7 +30,6 @@ import javax.ws.rs.core.MediaType;
 import org.jboss.resteasy.annotations.cache.NoCache;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.ClientScopeModel;
-import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RoleContainerModel;
 import org.keycloak.models.RoleModel;
 import org.keycloak.models.utils.ModelToRepresentation;
@@ -47,16 +46,13 @@ public class ClientScopeEvaluateScopeMappingsResource {
     private final AdminPermissionEvaluator auth;
     private final ClientModel client;
     private final String scopeParam;
-    private final KeycloakSession session;
-
 
     public ClientScopeEvaluateScopeMappingsResource(RoleContainerModel roleContainer, AdminPermissionEvaluator auth, ClientModel client,
-                                                    String scopeParam, KeycloakSession session) {
+                                                    String scopeParam) {
         this.roleContainer = roleContainer;
         this.auth = auth;
         this.client = client;
         this.scopeParam = scopeParam;
-        this.session = session;
     }
 
 

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientScopeResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientScopeResource.java
@@ -18,7 +18,6 @@ package org.keycloak.services.resources.admin;
 
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.annotations.cache.NoCache;
-import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.keycloak.common.Profile;
 import org.keycloak.events.admin.OperationType;
 import org.keycloak.events.admin.ResourceType;
@@ -78,9 +77,7 @@ public class ClientScopeResource {
     public ProtocolMappersResource getProtocolMappers() {
         AdminPermissionEvaluator.RequirePermissionCheck manageCheck = () -> auth.clients().requireManage(clientScope);
         AdminPermissionEvaluator.RequirePermissionCheck viewCheck = () -> auth.clients().requireView(clientScope);
-        ProtocolMappersResource mappers = new ProtocolMappersResource(realm, clientScope, auth, adminEvent, manageCheck, viewCheck);
-        ResteasyProviderFactory.getInstance().injectProperties(mappers);
-        return mappers;
+        return new ProtocolMappersResource(session, clientScope, auth, adminEvent, manageCheck, viewCheck);
     }
 
     /**

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientScopesResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientScopesResource.java
@@ -18,7 +18,6 @@ package org.keycloak.services.resources.admin;
 
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.annotations.cache.NoCache;
-import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.keycloak.events.admin.OperationType;
 import org.keycloak.events.admin.ResourceType;
 import org.keycloak.models.ClientScopeModel;
@@ -38,7 +37,6 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.stream.Stream;
@@ -52,15 +50,15 @@ import java.util.stream.Stream;
  */
 public class ClientScopesResource {
     protected static final Logger logger = Logger.getLogger(ClientScopesResource.class);
-    protected RealmModel realm;
-    private AdminPermissionEvaluator auth;
-    private AdminEventBuilder adminEvent;
+    protected final RealmModel realm;
+    private final AdminPermissionEvaluator auth;
+    private final AdminEventBuilder adminEvent;
 
-    @Context
-    protected KeycloakSession session;
+    protected final KeycloakSession session;
 
-    public ClientScopesResource(RealmModel realm, AdminPermissionEvaluator auth, AdminEventBuilder adminEvent) {
-        this.realm = realm;
+    public ClientScopesResource(KeycloakSession session, AdminPermissionEvaluator auth, AdminEventBuilder adminEvent) {
+        this.session = session;
+        this.realm = session.getContext().getRealm();
         this.auth = auth;
         this.adminEvent = adminEvent.resource(ResourceType.CLIENT_SCOPE);
     }
@@ -121,9 +119,7 @@ public class ClientScopesResource {
         if (clientModel == null) {
             throw new NotFoundException("Could not find client scope");
         }
-        ClientScopeResource clientResource = new ClientScopeResource(realm, auth, clientModel, session, adminEvent);
-        ResteasyProviderFactory.getInstance().injectProperties(clientResource);
-        return clientResource;
+        return new ClientScopeResource(realm, auth, clientModel, session, adminEvent);
     }
 
 }

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientsResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientsResource.java
@@ -18,7 +18,6 @@ package org.keycloak.services.resources.admin;
 
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.annotations.cache.NoCache;
-import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.keycloak.authorization.admin.AuthorizationService;
 import org.keycloak.common.Profile;
 import org.keycloak.events.Errors;
@@ -53,7 +52,6 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.Map;
@@ -71,15 +69,15 @@ import static org.keycloak.utils.StreamsUtil.paginatedStream;
  */
 public class ClientsResource {
     protected static final Logger logger = Logger.getLogger(ClientsResource.class);
-    protected RealmModel realm;
-    private AdminPermissionEvaluator auth;
-    private AdminEventBuilder adminEvent;
+    protected final RealmModel realm;
+    private final AdminPermissionEvaluator auth;
+    private final AdminEventBuilder adminEvent;
 
-    @Context
-    protected KeycloakSession session;
+    protected final KeycloakSession session;
 
-    public ClientsResource(RealmModel realm, AdminPermissionEvaluator auth, AdminEventBuilder adminEvent) {
-        this.realm = realm;
+    public ClientsResource(KeycloakSession session, AdminPermissionEvaluator auth, AdminEventBuilder adminEvent) {
+        this.session = session;
+        this.realm = session.getContext().getRealm();
         this.auth = auth;
         this.adminEvent = adminEvent.resource(ResourceType.CLIENT);
 
@@ -236,9 +234,7 @@ public class ClientsResource {
 
         session.getContext().setClient(clientModel);
 
-        ClientResource clientResource = new ClientResource(realm, auth, clientModel, session, adminEvent);
-        ResteasyProviderFactory.getInstance().injectProperties(clientResource);
-        return clientResource;
+        return new ClientResource(realm, auth, clientModel, session, adminEvent);
     }
 
 }

--- a/services/src/main/java/org/keycloak/services/resources/admin/ComponentResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ComponentResource.java
@@ -72,25 +72,25 @@ import java.util.stream.Stream;
 public class ComponentResource {
     protected static final Logger logger = Logger.getLogger(ComponentResource.class);
 
-    protected RealmModel realm;
+    protected final RealmModel realm;
 
-    private AdminPermissionEvaluator auth;
+    private final AdminPermissionEvaluator auth;
 
-    private AdminEventBuilder adminEvent;
+    private final AdminEventBuilder adminEvent;
 
-    @Context
-    protected ClientConnection clientConnection;
+    protected final ClientConnection clientConnection;
 
-    @Context
-    protected KeycloakSession session;
+    protected final KeycloakSession session;
 
     @Context
     protected HttpHeaders headers;
 
-    public ComponentResource(RealmModel realm, AdminPermissionEvaluator auth, AdminEventBuilder adminEvent) {
+    public ComponentResource(KeycloakSession session, AdminPermissionEvaluator auth, AdminEventBuilder adminEvent) {
+        this.session = session;
         this.auth = auth;
-        this.realm = realm;
+        this.realm = session.getContext().getRealm();
         this.adminEvent = adminEvent.resource(ResourceType.COMPONENT);
+        this.clientConnection = session.getContext().getConnection();
     }
 
     @GET

--- a/services/src/main/java/org/keycloak/services/resources/admin/GroupResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/GroupResource.java
@@ -237,7 +237,7 @@ public class GroupResource {
     public RoleMapperResource getRoleMappings() {
         AdminPermissionEvaluator.RequirePermissionCheck manageCheck = () -> auth.groups().requireManage(group);
         AdminPermissionEvaluator.RequirePermissionCheck viewCheck = () -> auth.groups().requireView(group);
-        RoleMapperResource resource =  new RoleMapperResource(realm, auth, group, adminEvent, manageCheck, viewCheck);
+        RoleMapperResource resource =  new RoleMapperResource(session, auth, group, adminEvent, manageCheck, viewCheck);
         ResteasyProviderFactory.getInstance().injectProperties(resource);
         return resource;
 

--- a/services/src/main/java/org/keycloak/services/resources/admin/GroupsResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/GroupsResource.java
@@ -18,7 +18,6 @@ package org.keycloak.services.resources.admin;
 
 import org.jboss.resteasy.annotations.cache.NoCache;
 import javax.ws.rs.NotFoundException;
-import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.keycloak.common.util.ObjectUtil;
 import org.keycloak.events.admin.OperationType;
 import org.keycloak.events.admin.ResourceType;
@@ -107,9 +106,7 @@ public class GroupsResource {
         if (group == null) {
             throw new NotFoundException("Could not find group by id");
         }
-        GroupResource resource =  new GroupResource(realm, group, session, this.auth, adminEvent);
-        ResteasyProviderFactory.getInstance().injectProperties(resource);
-        return resource;
+        return new GroupResource(realm, group, session, this.auth, adminEvent);
     }
 
     /**

--- a/services/src/main/java/org/keycloak/services/resources/admin/IdentityProvidersResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/IdentityProvidersResource.java
@@ -21,7 +21,6 @@ import com.google.common.collect.Streams;
 import org.jboss.resteasy.annotations.cache.NoCache;
 import org.jboss.resteasy.plugins.providers.multipart.InputPart;
 import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataInput;
-import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.keycloak.broker.provider.IdentityProvider;
 import org.keycloak.broker.provider.IdentityProviderFactory;
 import org.keycloak.broker.social.SocialIdentityProvider;
@@ -215,10 +214,7 @@ public class IdentityProvidersResource {
                 .filter(p -> Objects.equals(p.getAlias(), alias) || Objects.equals(p.getInternalId(), alias))
                 .findFirst().orElse(null);
 
-        IdentityProviderResource identityProviderResource = new IdentityProviderResource(this.auth, realm, session, identityProviderModel, adminEvent);
-        ResteasyProviderFactory.getInstance().injectProperties(identityProviderResource);
-        
-        return identityProviderResource;
+        return new IdentityProviderResource(this.auth, realm, session, identityProviderModel, adminEvent);
     }
 
     private IdentityProviderFactory getProviderFactoryById(String providerId) {

--- a/services/src/main/java/org/keycloak/services/resources/admin/ProtocolMappersResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ProtocolMappersResource.java
@@ -45,7 +45,6 @@ import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.text.MessageFormat;
@@ -64,24 +63,24 @@ import java.util.stream.Stream;
 public class ProtocolMappersResource {
     protected static final Logger logger = Logger.getLogger(ProtocolMappersResource.class);
 
-    protected RealmModel realm;
+    protected final RealmModel realm;
 
-    protected ProtocolMapperContainerModel client;
+    protected final ProtocolMapperContainerModel client;
 
-    protected AdminPermissionEvaluator auth;
-    protected AdminPermissionEvaluator.RequirePermissionCheck managePermission;
-    protected AdminPermissionEvaluator.RequirePermissionCheck viewPermission;
+    protected final AdminPermissionEvaluator auth;
+    protected final AdminPermissionEvaluator.RequirePermissionCheck managePermission;
+    protected final AdminPermissionEvaluator.RequirePermissionCheck viewPermission;
 
-    protected AdminEventBuilder adminEvent;
+    protected final AdminEventBuilder adminEvent;
 
-    @Context
-    protected KeycloakSession session;
+    protected final KeycloakSession session;
 
-    public ProtocolMappersResource(RealmModel realm, ProtocolMapperContainerModel client, AdminPermissionEvaluator auth,
+    public ProtocolMappersResource(KeycloakSession session, ProtocolMapperContainerModel client, AdminPermissionEvaluator auth,
                                    AdminEventBuilder adminEvent,
                                    AdminPermissionEvaluator.RequirePermissionCheck managePermission,
                                    AdminPermissionEvaluator.RequirePermissionCheck viewPermission) {
-        this.realm = realm;
+        this.session = session;
+        this.realm = session.getContext().getRealm();
         this.auth = auth;
         this.client = client;
         this.adminEvent = adminEvent.resource(ResourceType.PROTOCOL_MAPPER);

--- a/services/src/main/java/org/keycloak/services/resources/admin/RealmLocalizationResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RealmLocalizationResource.java
@@ -44,7 +44,6 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import org.keycloak.util.JsonSerialization;
 import org.keycloak.utils.StringUtil;
@@ -53,11 +52,11 @@ public class RealmLocalizationResource {
     private final RealmModel realm;
     private final AdminPermissionEvaluator auth;
 
-    @Context
-    protected KeycloakSession session;
+    protected final KeycloakSession session;
 
-    public RealmLocalizationResource(RealmModel realm, AdminPermissionEvaluator auth) {
-        this.realm = realm;
+    public RealmLocalizationResource(KeycloakSession session, AdminPermissionEvaluator auth) {
+        this.session = session;
+        this.realm = session.getContext().getRealm();
         this.auth = auth;
     }
 

--- a/services/src/main/java/org/keycloak/services/resources/admin/RealmsAdminResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RealmsAdminResource.java
@@ -68,16 +68,16 @@ import static org.keycloak.utils.StreamsUtil.throwIfEmpty;
  */
 public class RealmsAdminResource {
     protected static final Logger logger = Logger.getLogger(RealmsAdminResource.class);
-    protected AdminAuth auth;
-    protected TokenManager tokenManager;
+    protected final AdminAuth auth;
+    protected final TokenManager tokenManager;
 
-    @Context
-    protected KeycloakSession session;
+    protected final KeycloakSession session;
 
-    @Context
-    protected ClientConnection clientConnection;
+    protected final ClientConnection clientConnection;
 
-    public RealmsAdminResource(AdminAuth auth, TokenManager tokenManager) {
+    public RealmsAdminResource(KeycloakSession session, AdminAuth auth, TokenManager tokenManager) {
+        this.session = session;
+        this.clientConnection = session.getContext().getConnection();
         this.auth = auth;
         this.tokenManager = tokenManager;
     }
@@ -183,7 +183,7 @@ public class RealmsAdminResource {
         AdminEventBuilder adminEvent = new AdminEventBuilder(realm, auth, session, clientConnection);
         session.getContext().setRealm(realm);
 
-        RealmAdminResource adminResource = new RealmAdminResource(realmAuth, realm, tokenManager, adminEvent);
+        RealmAdminResource adminResource = new RealmAdminResource(session, realmAuth, adminEvent);
         ResteasyProviderFactory.getInstance().injectProperties(adminResource);
         //resourceContext.initResource(adminResource);
         return adminResource;

--- a/services/src/main/java/org/keycloak/services/resources/admin/RoleByIdResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RoleByIdResource.java
@@ -43,7 +43,6 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.List;
@@ -59,16 +58,15 @@ import java.util.stream.Stream;
 public class RoleByIdResource extends RoleResource {
     protected static final Logger logger = Logger.getLogger(RoleByIdResource.class);
     private final RealmModel realm;
-    private AdminPermissionEvaluator auth;
-    private AdminEventBuilder adminEvent;
+    private final AdminPermissionEvaluator auth;
+    private final AdminEventBuilder adminEvent;
 
-    @Context
-    private KeycloakSession session;
+    private final KeycloakSession session;
 
-    public RoleByIdResource(RealmModel realm, AdminPermissionEvaluator auth, AdminEventBuilder adminEvent) {
-        super(realm);
-
-        this.realm = realm;
+    public RoleByIdResource(KeycloakSession session, AdminPermissionEvaluator auth, AdminEventBuilder adminEvent) {
+        super(session.getContext().getRealm());
+        this.session = session;
+        this.realm = session.getContext().getRealm();
         this.auth = auth;
         this.adminEvent = adminEvent;
     }

--- a/services/src/main/java/org/keycloak/services/resources/admin/RoleMapperResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RoleMapperResource.java
@@ -73,33 +73,33 @@ public class RoleMapperResource {
 
     protected static final Logger logger = Logger.getLogger(RoleMapperResource.class);
 
-    protected RealmModel realm;
+    protected final RealmModel realm;
 
-    private RoleMapperModel roleMapper;
+    private final RoleMapperModel roleMapper;
 
-    private AdminEventBuilder adminEvent;
+    private final AdminEventBuilder adminEvent;
 
-    protected AdminPermissionEvaluator.RequirePermissionCheck managePermission;
-    protected AdminPermissionEvaluator.RequirePermissionCheck viewPermission;
-    private AdminPermissionEvaluator auth;
+    protected final AdminPermissionEvaluator.RequirePermissionCheck managePermission;
+    protected final AdminPermissionEvaluator.RequirePermissionCheck viewPermission;
+    private final AdminPermissionEvaluator auth;
 
-    @Context
-    protected ClientConnection clientConnection;
+    protected final ClientConnection clientConnection;
 
-    @Context
-    protected KeycloakSession session;
+    protected final KeycloakSession session;
 
     @Context
     protected HttpHeaders headers;
 
-    public RoleMapperResource(RealmModel realm,
+    public RoleMapperResource(KeycloakSession session,
                               AdminPermissionEvaluator auth,
                               RoleMapperModel roleMapper,
                               AdminEventBuilder adminEvent,
                               AdminPermissionEvaluator.RequirePermissionCheck manageCheck,
                               AdminPermissionEvaluator.RequirePermissionCheck viewCheck) {
+        this.session = session;
         this.auth = auth;
-        this.realm = realm;
+        this.realm = session.getContext().getRealm();
+        this.clientConnection = session.getContext().getConnection();
         this.adminEvent = adminEvent.resource(ResourceType.REALM_ROLE_MAPPING);
         this.roleMapper = roleMapper;
         this.managePermission = manageCheck;

--- a/services/src/main/java/org/keycloak/services/resources/admin/UserProfileResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UserProfileResource.java
@@ -20,7 +20,6 @@ import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Produces;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
@@ -36,14 +35,14 @@ import org.keycloak.userprofile.UserProfileProvider;
  */
 public class UserProfileResource {
 
-    @Context
-    protected KeycloakSession session;
+    protected final KeycloakSession session;
 
-    protected RealmModel realm;
-    private AdminPermissionEvaluator auth;
+    protected final RealmModel realm;
+    private final AdminPermissionEvaluator auth;
 
-    public UserProfileResource(RealmModel realm, AdminPermissionEvaluator auth) {
-        this.realm = realm;
+    public UserProfileResource(KeycloakSession session, AdminPermissionEvaluator auth) {
+        this.session = session;
+        this.realm = session.getContext().getRealm();
         this.auth = auth;
     }
 

--- a/services/src/main/java/org/keycloak/services/resources/admin/UserResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UserResource.java
@@ -129,25 +129,25 @@ import static org.keycloak.utils.LockObjectsForModification.lockUserSessionsForM
 public class UserResource {
     private static final Logger logger = Logger.getLogger(UserResource.class);
 
-    protected RealmModel realm;
+    protected final RealmModel realm;
 
-    private AdminPermissionEvaluator auth;
+    private final AdminPermissionEvaluator auth;
 
-    private AdminEventBuilder adminEvent;
-    private UserModel user;
+    private final AdminEventBuilder adminEvent;
+    private final UserModel user;
 
-    @Context
-    protected ClientConnection clientConnection;
+    protected final ClientConnection clientConnection;
 
-    @Context
-    protected KeycloakSession session;
+    protected final KeycloakSession session;
 
     @Context
     protected HttpHeaders headers;
     
-    public UserResource(RealmModel realm, UserModel user, AdminPermissionEvaluator auth, AdminEventBuilder adminEvent) {
+    public UserResource(KeycloakSession session, UserModel user, AdminPermissionEvaluator auth, AdminEventBuilder adminEvent) {
+        this.session = session;
         this.auth = auth;
-        this.realm = realm;
+        this.realm = session.getContext().getRealm();
+        this.clientConnection = session.getContext().getConnection();
         this.user = user;
         this.adminEvent = adminEvent.resource(ResourceType.USER);
     }
@@ -581,7 +581,7 @@ public class UserResource {
     public RoleMapperResource getRoleMappings() {
         AdminPermissionEvaluator.RequirePermissionCheck manageCheck = () -> auth.users().requireMapRoles(user);
         AdminPermissionEvaluator.RequirePermissionCheck viewCheck = () -> auth.users().requireView(user);
-        RoleMapperResource resource =  new RoleMapperResource(realm, auth, user, adminEvent, manageCheck, viewCheck);
+        RoleMapperResource resource =  new RoleMapperResource(session, auth, user, adminEvent, manageCheck, viewCheck);
         ResteasyProviderFactory.getInstance().injectProperties(resource);
         return resource;
 

--- a/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
@@ -81,24 +81,24 @@ public class UsersResource {
     private static final Logger logger = Logger.getLogger(UsersResource.class);
     private static final String SEARCH_ID_PARAMETER = "id:";
 
-    protected RealmModel realm;
+    protected final RealmModel realm;
 
-    private AdminPermissionEvaluator auth;
+    private final AdminPermissionEvaluator auth;
 
-    private AdminEventBuilder adminEvent;
+    private final AdminEventBuilder adminEvent;
 
-    @Context
-    protected ClientConnection clientConnection;
+    protected final ClientConnection clientConnection;
 
-    @Context
-    protected KeycloakSession session;
+    protected final KeycloakSession session;
 
     @Context
     protected HttpHeaders headers;
 
-    public UsersResource(RealmModel realm, AdminPermissionEvaluator auth, AdminEventBuilder adminEvent) {
+    public UsersResource(KeycloakSession session, AdminPermissionEvaluator auth, AdminEventBuilder adminEvent) {
+        this.session = session;
+        this.clientConnection = session.getContext().getConnection();
         this.auth = auth;
-        this.realm = realm;
+        this.realm = session.getContext().getRealm();
         this.adminEvent = adminEvent.resource(ResourceType.USER);
     }
 
@@ -226,7 +226,7 @@ public class UsersResource {
             if (auth.users().canQuery()) throw new NotFoundException("User not found");
             else throw new ForbiddenException();
         }
-        UserResource resource = new UserResource(realm, user, auth, adminEvent);
+        UserResource resource = new UserResource(session, user, auth, adminEvent);
         ResteasyProviderFactory.getInstance().injectProperties(resource);
         //resourceContext.initResource(users);
         return resource;
@@ -427,9 +427,7 @@ public class UsersResource {
      */
     @Path("profile")
     public UserProfileResource userProfile() {
-        UserProfileResource resource = new UserProfileResource(realm, auth);
-        ResteasyProviderFactory.getInstance().injectProperties(resource);
-        return resource;
+        return new UserProfileResource(session, auth);
     }
 
     private Stream<UserRepresentation> searchForUser(Map<String, String> attributes, RealmModel realm, UserPermissionEvaluator usersEvaluator, Boolean briefRepresentation, Integer firstResult, Integer maxResults, Boolean includeServiceAccounts) {

--- a/services/src/main/java/org/keycloak/services/resources/admin/info/ServerInfoAdminResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/info/ServerInfoAdminResource.java
@@ -57,7 +57,6 @@ import org.keycloak.theme.Theme;
 import javax.ws.rs.GET;
 import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import java.io.IOException;
 import java.util.Arrays;
@@ -78,8 +77,11 @@ public class ServerInfoAdminResource {
 
     private static final Map<String, List<String>> ENUMS = createEnumsMap(EventType.class, OperationType.class, ResourceType.class);
 
-    @Context
-    private KeycloakSession session;
+    private final KeycloakSession session;
+
+    public ServerInfoAdminResource(KeycloakSession session) {
+        this.session = session;
+    }
 
     /**
      * Get themes, social providers, auth providers, and event listeners available on this server

--- a/services/src/main/java/org/keycloak/social/twitter/TwitterIdentityProvider.java
+++ b/services/src/main/java/org/keycloak/social/twitter/TwitterIdentityProvider.java
@@ -80,7 +80,7 @@ public class TwitterIdentityProvider extends AbstractIdentityProvider<OAuth2Iden
 
     @Override
     public Object callback(RealmModel realm, AuthenticationCallback callback, EventBuilder event) {
-        return new Endpoint(realm, callback, event, this);
+        return new Endpoint(session, callback, event, this);
     }
 
     @Override
@@ -162,22 +162,22 @@ public class TwitterIdentityProvider extends AbstractIdentityProvider<OAuth2Iden
 
 
     protected static class Endpoint {
-        protected RealmModel realm;
-        protected AuthenticationCallback callback;
-        protected EventBuilder event;
-        private TwitterIdentityProvider provider;
+        protected final RealmModel realm;
+        protected final AuthenticationCallback callback;
+        protected final EventBuilder event;
+        private final TwitterIdentityProvider provider;
 
-        @Context
-        protected KeycloakSession session;
+        protected final KeycloakSession session;
 
-        @Context
-        protected ClientConnection clientConnection;
+        protected final ClientConnection clientConnection;
 
         @Context
         protected HttpHeaders headers;
 
-        public Endpoint(RealmModel realm, AuthenticationCallback callback, EventBuilder event, TwitterIdentityProvider provider) {
-            this.realm = realm;
+        public Endpoint(KeycloakSession session, AuthenticationCallback callback, EventBuilder event, TwitterIdentityProvider provider) {
+            this.session = session;
+            this.realm = session.getContext().getRealm();
+            this.clientConnection = session.getContext().getConnection();
             this.callback = callback;
             this.event = event;
             this.provider = provider;


### PR DESCRIPTION
Closes #15450

* Removing injection points for `KeycloakSession` and `ClientConnection`. This is basically the main change here, reflected in all affected files.
* Removing calls to `ResteasyProviderFactory#injectProperties` when possible in case the JAX-RS resource does not have any injection point

More details about the reasons are in the linked issue.

WIP, more changes coming.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
