### PR TITLE
fix(#15687): consider IdentityProviderModel from third party packages as well

### DIFF
--- a/server-spi/src/main/java/org/keycloak/models/IdentityProviderModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/IdentityProviderModel.java
@@ -70,6 +70,8 @@ public class IdentityProviderModel implements Serializable {
 
     private String displayName;
 
+    private String displayIconClasses;
+
     private IdentityProviderSyncMode syncMode;
 
     /**
@@ -96,6 +98,7 @@ public class IdentityProviderModel implements Serializable {
             this.addReadTokenRoleOnCreate = model.addReadTokenRoleOnCreate;
             this.firstBrokerLoginFlowId = model.getFirstBrokerLoginFlowId();
             this.postBrokerLoginFlowId = model.getPostBrokerLoginFlowId();
+            this.displayIconClasses = model.getDisplayIconClasses();
         }
     }
 
@@ -206,7 +209,7 @@ public class IdentityProviderModel implements Serializable {
     }
 
     public String getDisplayIconClasses() {
-        return null;
+        return displayIconClasses;
     }
 
     /**


### PR DESCRIPTION
Closes #15687

@stianst: I gave https://github.com/klausbetz/apple-identity-provider-keycloak/issues/10 another try and I'm curios what you think about it 😄 

This is a PR that contains a fix for #14974 (see this description of the bug: https://github.com/klausbetz/apple-identity-provider-keycloak/issues/10#issuecomment-1302659885).

Changes of this PR allow `IdentityProviderModel.getDisplayIconClasses` to take affect when it's overridden in a third party provider package, which enables a custom icon to be shown on the login page.

<img width="1122" alt="Bildschirmfoto 2022-11-13 um 22 56 21" src="https://user-images.githubusercontent.com/78362353/201546581-d1973725-3a21-4812-bdac-1cf0efa10c19.png">
