### PR TITLE
Increase timeout for FIPS job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,7 +294,7 @@ jobs:
     name: Base testsuite (fips)
     needs: build
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     strategy:
       matrix:
         server: ['bcfips-nonapproved-pkcs12']


### PR DESCRIPTION
Timed out in https://github.com/keycloak/keycloak/actions/runs/3465895045/jobs/5789314099
