### PR TITLE
fixed grammar in health.adoc

### DIFF
--- a/docs/guides/src/main/server/health.adoc
+++ b/docs/guides/src/main/server/health.adoc
@@ -28,7 +28,7 @@ The result is returned in json format and it looks as follows:
 ----
 
 == Enabling the health checks
-Is possible to enable the health checks using the build time option `health-enabled`:
+It is possible to enable the health checks using the build time option `health-enabled`:
 
 <@kc.build parameters="--health-enabled=true"/>
 


### PR DESCRIPTION
Fixed a minor grammar error / typo in https://www.keycloak.org/server/health therefore the creation of a separate issue has been skipped.
