### PR TITLE
Removing injection points for Resteasy objects and resolving instances from keycloak context instead

### DIFF
--- a/services/src/main/java/org/keycloak/broker/oidc/AbstractOAuth2IdentityProvider.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/AbstractOAuth2IdentityProvider.java
@@ -69,7 +69,6 @@ import javax.crypto.spec.SecretKeySpec;
 import javax.ws.rs.GET;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
@@ -460,11 +459,9 @@ public abstract class AbstractOAuth2IdentityProvider<C extends OAuth2IdentityPro
 
         protected final ClientConnection clientConnection;
 
-        @Context
-        protected HttpHeaders headers;
+        protected final HttpHeaders headers;
 
-        @Context
-        protected HttpRequest httpRequest;
+        protected final HttpRequest httpRequest;
 
         public Endpoint(AuthenticationCallback callback, RealmModel realm, EventBuilder event, AbstractOAuth2IdentityProvider provider) {
             this.callback = callback;
@@ -473,6 +470,8 @@ public abstract class AbstractOAuth2IdentityProvider<C extends OAuth2IdentityPro
             this.provider = provider;
             this.session = provider.session;
             this.clientConnection = session.getContext().getConnection();
+            this.httpRequest = session.getContext().getContextObject(HttpRequest.class);
+            this.headers = session.getContext().getRequestHeaders();
         }
 
         @GET

--- a/services/src/main/java/org/keycloak/broker/saml/SAMLEndpoint.java
+++ b/services/src/main/java/org/keycloak/broker/saml/SAMLEndpoint.java
@@ -20,7 +20,6 @@ package org.keycloak.broker.saml;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.annotations.cache.NoCache;
 
-import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.keycloak.broker.provider.BrokeredIdentityContext;
 import org.keycloak.broker.provider.IdentityBrokerException;
 import org.keycloak.broker.provider.IdentityProvider;
@@ -81,7 +80,6 @@ import javax.ws.rs.Path;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -148,8 +146,7 @@ public class SAMLEndpoint {
 
     private final ClientConnection clientConnection;
 
-    @Context
-    private HttpHeaders headers;
+    private final HttpHeaders headers;
 
 
     public SAMLEndpoint(KeycloakSession session, SAMLIdentityProvider provider, SAMLIdentityProviderConfig config, IdentityProvider.AuthenticationCallback callback, DestinationValidator destinationValidator) {
@@ -160,6 +157,7 @@ public class SAMLEndpoint {
         this.destinationValidator = destinationValidator;
         this.session = session;
         this.clientConnection = session.getContext().getConnection();
+        this.headers = session.getContext().getRequestHeaders();
     }
 
     @GET
@@ -599,7 +597,6 @@ public class SAMLEndpoint {
 
             LoginProtocolFactory factory = (LoginProtocolFactory) session.getKeycloakSessionFactory().getProviderFactory(LoginProtocol.class, SamlProtocol.LOGIN_PROTOCOL);
             SamlService samlService = (SamlService) factory.createProtocolEndpoint(SAMLEndpoint.this.session, event);
-            ResteasyProviderFactory.getInstance().injectProperties(samlService);
             AuthenticationSessionModel authSession = samlService.getOrCreateLoginSessionForIdpInitiatedSso(session, SAMLEndpoint.this.realm, oClient.get(), null);
             if (authSession == null) {
                 event.error(Errors.INVALID_REDIRECT_URI);

--- a/services/src/main/java/org/keycloak/protocol/AuthorizationEndpointBase.java
+++ b/services/src/main/java/org/keycloak/protocol/AuthorizationEndpointBase.java
@@ -42,7 +42,6 @@ import org.keycloak.services.resources.LoginActionsService;
 import org.keycloak.sessions.AuthenticationSessionModel;
 import org.keycloak.sessions.RootAuthenticationSessionModel;
 
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 
@@ -61,10 +60,9 @@ public abstract class AuthorizationEndpointBase {
     protected final EventBuilder event;
     protected AuthenticationManager authManager;
 
-    @Context
-    protected HttpHeaders headers;
-    @Context
-    protected HttpRequest httpRequest;
+    protected final HttpHeaders headers;
+
+    protected final HttpRequest httpRequest;
 
     protected final KeycloakSession session;
 
@@ -75,6 +73,8 @@ public abstract class AuthorizationEndpointBase {
         this.clientConnection = session.getContext().getConnection();
         this.realm = session.getContext().getRealm();
         this.event = event;
+        this.httpRequest = session.getContext().getContextObject(HttpRequest.class);
+        this.headers = session.getContext().getRequestHeaders();
     }
 
     protected AuthenticationProcessor createProcessor(AuthenticationSessionModel authSession, String flowId, String flowPath) {

--- a/services/src/main/java/org/keycloak/protocol/docker/DockerV2LoginProtocolService.java
+++ b/services/src/main/java/org/keycloak/protocol/docker/DockerV2LoginProtocolService.java
@@ -1,36 +1,24 @@
 package org.keycloak.protocol.docker;
 
-import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.keycloak.common.Profile;
 import org.keycloak.events.EventBuilder;
 import org.keycloak.events.EventType;
 import org.keycloak.models.KeycloakSession;
-import org.keycloak.models.RealmModel;
-import org.keycloak.protocol.oidc.TokenManager;
 import org.keycloak.services.resources.RealmsResource;
 import org.keycloak.utils.ProfileHelper;
 
 import javax.ws.rs.Path;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 
 public class DockerV2LoginProtocolService {
 
-    private final RealmModel realm;
-    private final TokenManager tokenManager;
     private final EventBuilder event;
 
     private final KeycloakSession session;
 
-    @Context
-    private HttpHeaders headers;
-
     public DockerV2LoginProtocolService(final KeycloakSession session, final EventBuilder event) {
         this.session = session;
-        this.realm = session.getContext().getRealm();
-        this.tokenManager = new TokenManager();
         this.event = event;
     }
 
@@ -60,8 +48,6 @@ public class DockerV2LoginProtocolService {
     public Object auth() {
         ProfileHelper.requireFeature(Profile.Feature.DOCKER);
 
-        final DockerEndpoint endpoint = new DockerEndpoint(session, event, EventType.LOGIN);
-        ResteasyProviderFactory.getInstance().injectProperties(endpoint);
-        return endpoint;
+        return new DockerEndpoint(session, event, EventType.LOGIN);
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oidc/DefaultTokenExchangeProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/DefaultTokenExchangeProvider.java
@@ -18,7 +18,6 @@
 package org.keycloak.protocol.oidc;
 
 import org.jboss.logging.Logger;
-import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.keycloak.OAuth2Constants;
 import org.keycloak.OAuthErrorException;
 import org.keycloak.broker.provider.BrokeredIdentityContext;
@@ -423,7 +422,6 @@ public class DefaultTokenExchangeProvider implements TokenExchangeProvider {
         LoginProtocolFactory factory = (LoginProtocolFactory) session.getKeycloakSessionFactory()
                 .getProviderFactory(LoginProtocol.class, SamlProtocol.LOGIN_PROTOCOL);
         SamlService samlService = (SamlService) factory.createProtocolEndpoint(session, event);
-        ResteasyProviderFactory.getInstance().injectProperties(samlService);
         AuthenticationSessionModel authSession = samlService.getOrCreateLoginSessionForIdpInitiatedSso(session, realm,
                 targetClient, null);
         if (authSession == null) {

--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocolService.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocolService.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Optional;
 import org.jboss.resteasy.annotations.cache.NoCache;
 import org.jboss.resteasy.spi.HttpRequest;
-import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.keycloak.OAuthErrorException;
 import org.keycloak.common.ClientConnection;
 import org.keycloak.crypto.KeyType;
@@ -56,7 +55,6 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -78,11 +76,9 @@ public class OIDCLoginProtocolService {
 
     private final KeycloakSession session;
 
-    @Context
-    private HttpHeaders headers;
+    private final HttpHeaders headers;
 
-    @Context
-    private HttpRequest request;
+    private final HttpRequest request;
 
     private final ClientConnection clientConnection;
 
@@ -93,6 +89,8 @@ public class OIDCLoginProtocolService {
         this.tokenManager = new TokenManager();
         this.event = event;
         this.providerConfig = providerConfig;
+        this.request = session.getContext().getContextObject(HttpRequest.class);
+        this.headers = session.getContext().getRequestHeaders();
     }
 
     public static UriBuilder tokenServiceBaseUrl(UriInfo uriInfo) {
@@ -158,9 +156,7 @@ public class OIDCLoginProtocolService {
      */
     @Path("auth")
     public Object auth() {
-        AuthorizationEndpoint endpoint = new AuthorizationEndpoint(session, event);
-        ResteasyProviderFactory.getInstance().injectProperties(endpoint);
-        return endpoint;
+        return new AuthorizationEndpoint(session, event);
     }
 
     /**
@@ -169,7 +165,6 @@ public class OIDCLoginProtocolService {
     @Path("registrations")
     public Object registrations() {
         AuthorizationEndpoint endpoint = new AuthorizationEndpoint(session, event);
-        ResteasyProviderFactory.getInstance().injectProperties(endpoint);
         return endpoint.register();
     }
 
@@ -179,7 +174,6 @@ public class OIDCLoginProtocolService {
     @Path("forgot-credentials")
     public Object forgotCredentialsPage() {
         AuthorizationEndpoint endpoint = new AuthorizationEndpoint(session, event);
-        ResteasyProviderFactory.getInstance().injectProperties(endpoint);
         return endpoint.forgotCredentials();
     }
 
@@ -188,9 +182,7 @@ public class OIDCLoginProtocolService {
      */
     @Path("token")
     public Object token() {
-        TokenEndpoint endpoint = new TokenEndpoint(session, tokenManager, event);
-        ResteasyProviderFactory.getInstance().injectProperties(endpoint);
-        return endpoint;
+        return new TokenEndpoint(session, tokenManager, event);
     }
 
     @Path("login-status-iframe.html")
@@ -243,25 +235,19 @@ public class OIDCLoginProtocolService {
 
     @Path("userinfo")
     public Object issueUserInfo() {
-        UserInfoEndpoint endpoint = new UserInfoEndpoint(session, tokenManager);
-        ResteasyProviderFactory.getInstance().injectProperties(endpoint);
-        return endpoint;
+        return new UserInfoEndpoint(session, tokenManager);
     }
 
     /* old deprecated logout endpoint needs to be removed in the future
     * https://issues.redhat.com/browse/KEYCLOAK-2940 */
     @Path("logout")
     public Object logout() {
-        LogoutEndpoint endpoint = new LogoutEndpoint(session, tokenManager, event, providerConfig);
-        ResteasyProviderFactory.getInstance().injectProperties(endpoint);
-        return endpoint;
+        return new LogoutEndpoint(session, tokenManager, event, providerConfig);
     }
 
     @Path("revoke")
     public Object revoke() {
-        TokenRevocationEndpoint endpoint = new TokenRevocationEndpoint(session, event);
-        ResteasyProviderFactory.getInstance().injectProperties(endpoint);
-        return endpoint;
+        return new TokenRevocationEndpoint(session, event);
     }
 
     @Path("oauth/oob")

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpoint.java
@@ -18,7 +18,6 @@
 package org.keycloak.protocol.oidc.endpoints;
 
 import org.jboss.logging.Logger;
-import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.keycloak.OAuth2Constants;
 import org.keycloak.authentication.AuthenticationProcessor;
 import org.keycloak.constants.AdapterConstants;
@@ -115,9 +114,7 @@ public class AuthorizationEndpoint extends AuthorizationEndpointBase {
      */
     @Path("device")
     public Object authorizeDevice() {
-        DeviceEndpoint endpoint = new DeviceEndpoint(session, event);
-        ResteasyProviderFactory.getInstance().injectProperties(endpoint);
-        return endpoint;
+        return new DeviceEndpoint(session, event);
     }
 
     private Response process(MultivaluedMap<String, String> params) {

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/LogoutEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/LogoutEndpoint.java
@@ -88,7 +88,6 @@ import javax.ws.rs.OPTIONS;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
@@ -106,11 +105,9 @@ public class LogoutEndpoint {
 
     private final ClientConnection clientConnection;
 
-    @Context
-    private HttpRequest request;
+    private final HttpRequest request;
 
-    @Context
-    private HttpHeaders headers;
+    private final HttpHeaders headers;
 
     private final TokenManager tokenManager;
     private final RealmModel realm;
@@ -130,6 +127,8 @@ public class LogoutEndpoint {
         this.event = event;
         this.providerConfig = providerConfig;
         this.offlineSessionsLazyLoadingEnabled = !Config.scope("userSessions").scope("infinispan").getBoolean("preloadOfflineSessionsFromDatabase", false);
+        this.request = session.getContext().getContextObject(HttpRequest.class);
+        this.headers = session.getContext().getRequestHeaders();
     }
 
     @Path("/")

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenIntrospectionEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenIntrospectionEndpoint.java
@@ -33,8 +33,6 @@ import org.keycloak.services.clientpolicy.ClientPolicyException;
 import org.keycloak.services.clientpolicy.context.TokenIntrospectContext;
 
 import javax.ws.rs.POST;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
@@ -50,11 +48,8 @@ public class TokenIntrospectionEndpoint {
     private static final String PARAM_TOKEN = "token";
 
     private final KeycloakSession session;
-    @Context
-    private HttpRequest request;
 
-    @Context
-    private HttpHeaders headers;
+    private final HttpRequest request;
 
     private final ClientConnection clientConnection;
 
@@ -66,6 +61,7 @@ public class TokenIntrospectionEndpoint {
         this.clientConnection = session.getContext().getConnection();
         this.realm = session.getContext().getRealm();
         this.event = event;
+        this.request = session.getContext().getContextObject(HttpRequest.class);
     }
 
     @POST

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenRevocationEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenRevocationEndpoint.java
@@ -24,8 +24,6 @@ import java.util.stream.Collectors;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.OPTIONS;
 import javax.ws.rs.POST;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -64,11 +62,7 @@ public class TokenRevocationEndpoint {
 
     private final KeycloakSession session;
 
-    @Context
-    private HttpRequest request;
-
-    @Context
-    private HttpHeaders headers;
+    private final HttpRequest request;
 
     private final ClientConnection clientConnection;
 
@@ -85,6 +79,7 @@ public class TokenRevocationEndpoint {
         this.clientConnection = session.getContext().getConnection();
         this.realm = session.getContext().getRealm();
         this.event = event;
+        this.request = session.getContext().getContextObject(HttpRequest.class);
     }
 
     @POST

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/UserInfoEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/UserInfoEndpoint.java
@@ -18,7 +18,6 @@ package org.keycloak.protocol.oidc.endpoints;
 
 import org.jboss.resteasy.annotations.cache.NoCache;
 import org.jboss.resteasy.spi.HttpRequest;
-import org.jboss.resteasy.spi.HttpResponse;
 import org.keycloak.OAuth2Constants;
 import org.keycloak.TokenCategory;
 import org.keycloak.TokenVerifier;
@@ -74,7 +73,6 @@ import javax.ws.rs.GET;
 import javax.ws.rs.OPTIONS;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.MultivaluedMap;
@@ -89,11 +87,7 @@ import java.util.Map;
  */
 public class UserInfoEndpoint {
 
-    @Context
-    private HttpRequest request;
-
-    @Context
-    private HttpResponse response;
+    private final HttpRequest request;
 
     private final KeycloakSession session;
 
@@ -113,6 +107,7 @@ public class UserInfoEndpoint {
         this.tokenManager = tokenManager;
         this.appAuthManager = new AppAuthManager();
         this.error = new OAuth2Error().json(false).realm(realm);
+        this.request = session.getContext().getContextObject(HttpRequest.class);
     }
 
     @Path("/")
@@ -124,9 +119,9 @@ public class UserInfoEndpoint {
     @Path("/")
     @GET
     @NoCache
-    public Response issueUserInfoGet(@Context final HttpHeaders headers) {
+    public Response issueUserInfoGet() {
         setupCors();
-        String accessToken = this.appAuthManager.extractAuthorizationHeaderTokenOrReturnNull(headers);
+        String accessToken = this.appAuthManager.extractAuthorizationHeaderTokenOrReturnNull(session.getContext().getRequestHeaders());
         authorization(accessToken);
         return issueUserInfo();
     }

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/ciba/endpoints/BackchannelAuthenticationCallbackEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/ciba/endpoints/BackchannelAuthenticationCallbackEndpoint.java
@@ -42,7 +42,6 @@ import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -56,11 +55,11 @@ public class BackchannelAuthenticationCallbackEndpoint extends AbstractCibaEndpo
 
     private static final Logger logger = Logger.getLogger(BackchannelAuthenticationCallbackEndpoint.class);
 
-    @Context
-    private HttpRequest httpRequest;
+    private final HttpRequest httpRequest;
 
     public BackchannelAuthenticationCallbackEndpoint(KeycloakSession session, EventBuilder event) {
         super(session, event);
+        this.httpRequest = session.getContext().getContextObject(HttpRequest.class);
     }
 
     @Path("/")

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/ciba/endpoints/BackchannelAuthenticationEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/ciba/endpoints/BackchannelAuthenticationEndpoint.java
@@ -48,7 +48,6 @@ import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
 import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -76,7 +75,8 @@ public class BackchannelAuthenticationEndpoint extends AbstractCibaEndpoint {
     @NoCache
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Produces(MediaType.APPLICATION_JSON)
-    public Response processGrantRequest(@Context HttpRequest httpRequest) {
+    public Response processGrantRequest() {
+        HttpRequest httpRequest = session.getContext().getContextObject(HttpRequest.class);
         CIBAAuthenticationRequest request = authorizeClient(httpRequest.getDecodedFormParameters());
 
         try {

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/ciba/endpoints/CibaRootEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/ciba/endpoints/CibaRootEndpoint.java
@@ -19,7 +19,6 @@ package org.keycloak.protocol.oidc.grants.ciba.endpoints;
 
 import javax.ws.rs.Path;
 
-import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.keycloak.common.Profile;
 import org.keycloak.events.EventBuilder;
 import org.keycloak.models.KeycloakSession;
@@ -63,11 +62,7 @@ public class CibaRootEndpoint implements OIDCExtProvider, OIDCExtProviderFactory
      */
     @Path("/auth/callback")
     public BackchannelAuthenticationCallbackEndpoint authenticate() {
-        BackchannelAuthenticationCallbackEndpoint endpoint = new BackchannelAuthenticationCallbackEndpoint(session, event);
-
-        ResteasyProviderFactory.getInstance().injectProperties(endpoint);
-
-        return endpoint;
+        return new BackchannelAuthenticationCallbackEndpoint(session, event);
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/device/endpoints/DeviceEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/device/endpoints/DeviceEndpoint.java
@@ -65,7 +65,6 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -81,13 +80,13 @@ public class DeviceEndpoint extends AuthorizationEndpointBase implements RealmRe
 
     protected static final Logger logger = Logger.getLogger(DeviceEndpoint.class);
 
-    @Context
-    private HttpRequest request;
+    private final HttpRequest request;
 
     private Cors cors;
 
     public DeviceEndpoint(KeycloakSession session, EventBuilder event) {
         super(session, event);
+        this.request = session.getContext().getContextObject(HttpRequest.class);
     }
 
     /**

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/device/endpoints/DeviceEndpointFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/device/endpoints/DeviceEndpointFactory.java
@@ -19,7 +19,6 @@
 
 package org.keycloak.protocol.oidc.grants.device.endpoints;
 
-import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.keycloak.Config;
 import org.keycloak.events.EventBuilder;
 import org.keycloak.models.KeycloakContext;
@@ -39,9 +38,7 @@ public class DeviceEndpointFactory implements RealmResourceProviderFactory {
         KeycloakContext context = session.getContext();
         RealmModel realm = context.getRealm();
         EventBuilder event = new EventBuilder(realm, session, context.getConnection());
-        DeviceEndpoint provider = new DeviceEndpoint(session, event);
-        ResteasyProviderFactory.getInstance().injectProperties(provider);
-        return provider;
+        return new DeviceEndpoint(session, event);
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/protocol/oidc/par/endpoints/ParEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/par/endpoints/ParEndpoint.java
@@ -39,7 +39,6 @@ import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
@@ -59,8 +58,7 @@ public class ParEndpoint extends AbstractParEndpoint {
     private static final String REQUEST_URI_PREFIX = "urn:ietf:params:oauth:request_uri:";
     public static final int REQUEST_URI_PREFIX_LENGTH = REQUEST_URI_PREFIX.length();
 
-    @Context
-    private HttpRequest httpRequest;
+    private final HttpRequest httpRequest;
 
     private AuthorizationEndpointRequest authorizationRequest;
 
@@ -71,6 +69,7 @@ public class ParEndpoint extends AbstractParEndpoint {
 
     public ParEndpoint(KeycloakSession session, EventBuilder event) {
         super(session, event);
+        this.httpRequest = session.getContext().getContextObject(HttpRequest.class);
     }
 
     @Path("/")

--- a/services/src/main/java/org/keycloak/protocol/oidc/par/endpoints/ParRootEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/par/endpoints/ParRootEndpoint.java
@@ -19,7 +19,6 @@ package org.keycloak.protocol.oidc.par.endpoints;
 
 import javax.ws.rs.Path;
 
-import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.keycloak.common.Profile;
 import org.keycloak.events.EventBuilder;
 import org.keycloak.models.KeycloakSession;
@@ -45,11 +44,7 @@ public class ParRootEndpoint implements OIDCExtProvider, OIDCExtProviderFactory,
 
     @Path("/request")
     public ParEndpoint request() {
-        ParEndpoint endpoint = new ParEndpoint(session, event);
-
-        ResteasyProviderFactory.getInstance().injectProperties(endpoint);
-
-        return endpoint;
+        return new ParEndpoint(session, event);
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/protocol/saml/SamlService.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/SamlService.java
@@ -25,7 +25,6 @@ import org.jboss.logging.Logger;
 import org.jboss.resteasy.annotations.cache.NoCache;
 import org.jboss.resteasy.specimpl.ResteasyHttpHeaders;
 import org.jboss.resteasy.spi.HttpRequest;
-import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.keycloak.broker.saml.SAMLDataMarshaller;
 import org.keycloak.common.ClientConnection;
 import org.keycloak.common.VerificationException;
@@ -1075,8 +1074,6 @@ public class SamlService extends AuthorizationEndpointBase {
     public Response soapBinding(InputStream inputStream) {
         SamlEcpProfileService bindingService = new SamlEcpProfileService(session, event, destinationValidator);
 
-        ResteasyProviderFactory.getInstance().injectProperties(bindingService);
-
         return bindingService.authenticate(inputStream);
     }
 
@@ -1335,8 +1332,8 @@ public class SamlService extends AuthorizationEndpointBase {
             this.realmId = realm.getId();
             this.httpHeaders = new ResteasyHttpHeaders(headers.getRequestHeaders());
             this.connection = connection;
-            this.response = Resteasy.getContextData(org.jboss.resteasy.spi.HttpResponse.class);
-            this.request = Resteasy.getContextData(HttpRequest.class);
+            this.response = session.getContext().getContextObject(org.jboss.resteasy.spi.HttpResponse.class);
+            this.request = session.getContext().getContextObject(HttpRequest.class);
             this.bindingType = bindingType;
         }
 
@@ -1404,7 +1401,6 @@ public class SamlService extends AuthorizationEndpointBase {
                     }
 
                     SamlService endpoint = (SamlService) factory.createProtocolEndpoint(session, event);
-                    ResteasyProviderFactory.getInstance().injectProperties(endpoint);
                     BindingProtocol protocol;
                     if (SamlProtocol.SAML_POST_BINDING.equals(bindingType)) {
                         protocol = endpoint.newPostBindingProtocol();

--- a/services/src/main/java/org/keycloak/services/error/KcUnrecognizedPropertyExceptionHandler.java
+++ b/services/src/main/java/org/keycloak/services/error/KcUnrecognizedPropertyExceptionHandler.java
@@ -22,9 +22,9 @@ import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.core.Context;
-import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
+import org.keycloak.models.KeycloakSession;
 
 /**
  * Override explicitly added ExceptionMapper for handling <code>UnrecognizedPropertyException</code> in RestEasy Jackson
@@ -34,13 +34,13 @@ import javax.ws.rs.ext.ExceptionMapper;
 public class KcUnrecognizedPropertyExceptionHandler implements ExceptionMapper<UnrecognizedPropertyException> {
 
     @Context
-    private HttpHeaders headers;
+    KeycloakSession session;
 
     /**
      * Return escaped original message
      */
     @Override
     public Response toResponse(UnrecognizedPropertyException exception) {
-        return KeycloakErrorHandler.getResponse(headers, new BadRequestException(exception.getMessage()));
+        return KeycloakErrorHandler.getResponse(session, new BadRequestException(exception.getMessage()));
     }
 }

--- a/services/src/main/java/org/keycloak/services/resources/AbstractSecuredLocalService.java
+++ b/services/src/main/java/org/keycloak/services/resources/AbstractSecuredLocalService.java
@@ -37,7 +37,6 @@ import org.keycloak.util.TokenUtil;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.NewCookie;
 import javax.ws.rs.core.Response;
@@ -58,16 +57,14 @@ public abstract class AbstractSecuredLocalService {
     protected final ClientModel client;
     protected final RealmModel realm;
 
-    @Context
-    protected HttpHeaders headers;
+    protected final HttpHeaders headers;
 
     protected final ClientConnection clientConnection;
     protected String stateChecker;
 
     protected final KeycloakSession session;
 
-    @Context
-    protected HttpRequest request;
+    protected final HttpRequest request;
     protected Auth auth;
 
     public AbstractSecuredLocalService(KeycloakSession session, ClientModel client) {
@@ -75,6 +72,8 @@ public abstract class AbstractSecuredLocalService {
         this.realm = session.getContext().getRealm();
         this.clientConnection = session.getContext().getConnection();
         this.client = client;
+        this.request = session.getContext().getContextObject(HttpRequest.class);
+        this.headers = session.getContext().getRequestHeaders();
     }
 
     @Path("login-redirect")
@@ -83,8 +82,7 @@ public abstract class AbstractSecuredLocalService {
                                   @QueryParam("state") String state,
                                   @QueryParam("error") String error,
                                   @QueryParam("path") String path,
-                                  @QueryParam("referrer") String referrer,
-                                  @Context HttpHeaders headers) {
+                                  @QueryParam("referrer") String referrer) {
         try {
             if (error != null) {
                 if (OAuthErrorException.ACCESS_DENIED.equals(error)) {

--- a/services/src/main/java/org/keycloak/services/resources/ClientsManagementService.java
+++ b/services/src/main/java/org/keycloak/services/resources/ClientsManagementService.java
@@ -39,7 +39,6 @@ import javax.ws.rs.HeaderParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
@@ -57,11 +56,9 @@ public class ClientsManagementService {
 
     private final EventBuilder event;
 
-    @Context
-    private HttpRequest request;
+    private final HttpRequest request;
 
-    @Context
-    protected HttpHeaders headers;
+    protected final HttpHeaders headers;
 
     private final ClientConnection clientConnection;
 
@@ -72,6 +69,8 @@ public class ClientsManagementService {
         this.clientConnection = session.getContext().getConnection();
         this.realm = session.getContext().getRealm();
         this.event = event;
+        this.request = session.getContext().getContextObject(HttpRequest.class);
+        this.headers = session.getContext().getRequestHeaders();
     }
 
     public static UriBuilder clientsManagementBaseUrl(UriBuilder baseUriBuilder) {

--- a/services/src/main/java/org/keycloak/services/resources/IdentityBrokerService.java
+++ b/services/src/main/java/org/keycloak/services/resources/IdentityBrokerService.java
@@ -99,7 +99,6 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
@@ -138,11 +137,9 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
 
     private final ClientConnection clientConnection;
 
-    @Context
-    private HttpRequest request;
+    private final HttpRequest request;
 
-    @Context
-    private HttpHeaders headers;
+    private final HttpHeaders headers;
 
     private EventBuilder event;
 
@@ -154,6 +151,8 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
         if (realmModel == null) {
             throw new IllegalArgumentException("Realm can not be null.");
         }
+        this.request = session.getContext().getContextObject(HttpRequest.class);
+        this.headers = session.getContext().getRequestHeaders();
     }
 
     public void init() {

--- a/services/src/main/java/org/keycloak/services/resources/JsResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/JsResource.java
@@ -46,9 +46,6 @@ public class JsResource {
     @Context
     private KeycloakSession session;
 
-    @Context
-    private HttpRequest request;
-
     /**
      * Get keycloak.js file for javascript clients
      *
@@ -127,7 +124,7 @@ public class JsResource {
         }
 
         String contentType = "text/javascript";
-        Cors cors = Cors.add(request).allowAllOrigins();
+        Cors cors = Cors.add(session.getContext().getContextObject(HttpRequest.class)).allowAllOrigins();
 
         ResourceEncodingProvider encodingProvider = ResourceEncodingHelper.getResourceEncodingProvider(session, contentType);
 

--- a/services/src/main/java/org/keycloak/services/resources/LoginActionsService.java
+++ b/services/src/main/java/org/keycloak/services/resources/LoginActionsService.java
@@ -29,6 +29,7 @@ import org.keycloak.authentication.RequiredActionFactory;
 import org.keycloak.authentication.RequiredActionProvider;
 import org.keycloak.authentication.actiontoken.ActionTokenContext;
 import org.keycloak.authentication.actiontoken.ActionTokenHandler;
+import org.keycloak.common.util.Resteasy;
 import org.keycloak.models.DefaultActionTokenKey;
 import org.keycloak.authentication.actiontoken.ExplainedTokenVerificationException;
 import org.keycloak.authentication.actiontoken.resetcred.ResetCredentialsActionTokenHandler;
@@ -91,7 +92,6 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
@@ -129,11 +129,9 @@ public class LoginActionsService {
 
     private final RealmModel realm;
 
-    @Context
-    private HttpRequest request;
+    private final HttpRequest request;
 
-    @Context
-    protected HttpHeaders headers;
+    protected final HttpHeaders headers;
 
     private final ClientConnection clientConnection;
 
@@ -180,6 +178,8 @@ public class LoginActionsService {
         this.realm = session.getContext().getRealm();
         this.event = event;
         CacheControlUtil.noBackButtonCacheControlHeader();
+        this.request = session.getContext().getContextObject(HttpRequest.class);
+        this.headers = session.getContext().getRequestHeaders();
     }
 
     private boolean checkSsl() {

--- a/services/src/main/java/org/keycloak/services/resources/PublicRealmResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/PublicRealmResource.java
@@ -31,7 +31,6 @@ import javax.ws.rs.GET;
 import javax.ws.rs.OPTIONS;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
@@ -45,11 +44,9 @@ import javax.ws.rs.core.UriInfo;
 public class PublicRealmResource {
     protected static final Logger logger = Logger.getLogger(PublicRealmResource.class);
 
-    @Context
-    protected HttpRequest request;
+    protected final HttpRequest request;
 
-    @Context
-    protected HttpResponse response;
+    protected final HttpResponse response;
 
     protected final KeycloakSession session;
 
@@ -58,6 +55,8 @@ public class PublicRealmResource {
     public PublicRealmResource(KeycloakSession session) {
         this.session = session;
         this.realm = session.getContext().getRealm();
+        this.request = session.getContext().getContextObject(HttpRequest.class);
+        this.response = session.getContext().getContextObject(HttpResponse.class);
     }
 
     /**

--- a/services/src/main/java/org/keycloak/services/resources/WelcomeResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/WelcomeResource.java
@@ -68,9 +68,6 @@ public class WelcomeResource {
     private static final String KEYCLOAK_STATE_CHECKER = "WELCOME_STATE_CHECKER";
 
     @Context
-    protected HttpHeaders headers;
-
-    @Context
     private KeycloakSession session;
 
     public WelcomeResource() {
@@ -246,7 +243,7 @@ public class WelcomeResource {
             ClientConnection clientConnection = session.getContext().getConnection();
             InetAddress remoteInetAddress = InetAddress.getByName(clientConnection.getRemoteAddr());
             InetAddress localInetAddress = InetAddress.getByName(clientConnection.getLocalAddr());
-            String xForwardedFor = headers.getHeaderString("X-Forwarded-For");
+            String xForwardedFor = session.getContext().getRequestHeaders().getHeaderString("X-Forwarded-For");
             logger.debugf("Checking WelcomePage. Remote address: %s, Local address: %s, X-Forwarded-For header: %s", remoteInetAddress.toString(), localInetAddress.toString(), xForwardedFor);
 
             // Access through AJP protocol (loadbalancer) may cause that remoteAddress is "127.0.0.1".
@@ -277,7 +274,7 @@ public class WelcomeResource {
 
     private void csrfCheck(final MultivaluedMap<String, String> formData) {
         String formStateChecker = formData.getFirst("stateChecker");
-        Cookie cookie = headers.getCookies().get(KEYCLOAK_STATE_CHECKER);
+        Cookie cookie = session.getContext().getRequestHeaders().getCookies().get(KEYCLOAK_STATE_CHECKER);
         if (cookie == null) {
             throw new ForbiddenException();
         }

--- a/services/src/main/java/org/keycloak/services/resources/account/AccountLoader.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountLoader.java
@@ -19,7 +19,6 @@ package org.keycloak.services.resources.account;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.spi.HttpRequest;
 import org.jboss.resteasy.spi.HttpResponse;
-import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.keycloak.common.enums.AccountRestApiVersion;
 import org.keycloak.events.EventBuilder;
 import org.keycloak.models.ClientModel;
@@ -39,7 +38,6 @@ import javax.ws.rs.NotFoundException;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.UriInfo;
@@ -54,16 +52,16 @@ public class AccountLoader {
     private final KeycloakSession session;
     private final EventBuilder event;
 
-    @Context
-    private HttpRequest request;
-    @Context
-    private HttpResponse response;
+    private final HttpRequest request;
+    private final HttpResponse response;
 
     private static final Logger logger = Logger.getLogger(AccountLoader.class);
 
     public AccountLoader(KeycloakSession session, EventBuilder event) {
         this.session = session;
         this.event = event;
+        this.request = session.getContext().getContextObject(HttpRequest.class);
+        this.response = session.getContext().getContextObject(HttpResponse.class);
     }
 
     @Path("/")
@@ -87,7 +85,6 @@ public class AccountLoader {
         } else {
             if (deprecatedAccount) {
                 AccountFormService accountFormService = new AccountFormService(session, client, event);
-                ResteasyProviderFactory.getInstance().injectProperties(accountFormService);
                 accountFormService.init();
                 return accountFormService;
             } else {
@@ -150,9 +147,7 @@ public class AccountLoader {
             }
         }
 
-        AccountRestService accountRestService = new AccountRestService(session, auth, event, version);
-        ResteasyProviderFactory.getInstance().injectProperties(accountRestService);
-        return accountRestService;
+        return new AccountRestService(session, auth, event, version);
     }
 
     private ClientModel getAccountManagementClient(RealmModel realm) {

--- a/services/src/main/java/org/keycloak/services/resources/account/AccountRestService.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountRestService.java
@@ -44,7 +44,6 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -100,10 +99,9 @@ import org.keycloak.validate.Validators;
  */
 public class AccountRestService {
 
-    @Context
-    private HttpRequest request;
-    @Context
-    protected HttpHeaders headers;
+    private final HttpRequest request;
+
+    protected final HttpHeaders headers;
 
     protected final ClientConnection clientConnection;
 
@@ -126,6 +124,8 @@ public class AccountRestService {
         this.locale = session.getContext().resolveLocale(user);
         this.version = version;
         event.client(auth.getClient()).user(auth.getUser());
+        this.request = session.getContext().getContextObject(HttpRequest.class);
+        this.headers = session.getContext().getRequestHeaders();
     }
     
     /**

--- a/services/src/main/java/org/keycloak/services/resources/admin/AdminConsole.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/AdminConsole.java
@@ -52,8 +52,6 @@ import javax.ws.rs.OPTIONS;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.net.URI;
@@ -75,11 +73,9 @@ public class AdminConsole {
 
     protected final ClientConnection clientConnection;
 
-    @Context
-    protected HttpRequest request;
+    protected final HttpRequest request;
 
-    @Context
-    protected HttpResponse response;
+    protected final HttpResponse response;
 
     protected final KeycloakSession session;
 
@@ -89,6 +85,8 @@ public class AdminConsole {
         this.session = session;
         this.realm = session.getContext().getRealm();
         this.clientConnection = session.getContext().getConnection();
+        this.request = session.getContext().getContextObject(HttpRequest.class);
+        this.response = session.getContext().getContextObject(HttpResponse.class);
     }
 
     public static class WhoAmI {
@@ -200,12 +198,12 @@ public class AdminConsole {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @NoCache
-    public Response whoAmI(final @Context HttpHeaders headers) {
+    public Response whoAmI() {
         RealmManager realmManager = new RealmManager(session);
         AuthenticationManager.AuthResult authResult = new AppAuthManager.BearerTokenAuthenticator(session)
                 .setRealm(realm)
                 .setConnection(clientConnection)
-                .setHeaders(headers)
+                .setHeaders(session.getContext().getRequestHeaders())
                 .authenticate();
 
         if (authResult == null) {

--- a/services/src/main/java/org/keycloak/services/resources/admin/AttackDetectionResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/AttackDetectionResource.java
@@ -34,7 +34,6 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import java.util.HashMap;
@@ -57,8 +56,7 @@ public class AttackDetectionResource {
 
     protected final ClientConnection connection;
 
-    @Context
-    protected HttpHeaders headers;
+    protected final HttpHeaders headers;
 
     public AttackDetectionResource(KeycloakSession session, AdminPermissionEvaluator auth, AdminEventBuilder adminEvent) {
         this.session = session;
@@ -66,6 +64,7 @@ public class AttackDetectionResource {
         this.realm = session.getContext().getRealm();
         this.connection = session.getContext().getConnection();
         this.adminEvent = adminEvent.realm(realm).resource(ResourceType.USER_LOGIN_FAILURE);
+        this.headers = session.getContext().getRequestHeaders();
     }
 
     /**

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientInitialAccessResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientInitialAccessResource.java
@@ -35,7 +35,6 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -70,7 +69,7 @@ public class ClientInitialAccessResource {
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    public ClientInitialAccessPresentation create(ClientInitialAccessCreatePresentation config, @Context final HttpResponse response) {
+    public ClientInitialAccessPresentation create(ClientInitialAccessCreatePresentation config) {
         auth.clients().requireManage();
 
         int expiration = config.getExpiration() != null ? config.getExpiration() : 0;
@@ -84,6 +83,8 @@ public class ClientInitialAccessResource {
 
         String token = ClientRegistrationTokenUtils.createInitialAccessToken(session, realm, clientInitialAccessModel);
         rep.setToken(token);
+
+        HttpResponse response = session.getContext().getContextObject(HttpResponse.class);
 
         response.setStatus(Response.Status.CREATED.getStatusCode());
         response.getOutputHeaders().add(HttpHeaders.LOCATION, session.getContext().getUri().getAbsolutePathBuilder().path(clientInitialAccessModel.getId()).build().toString());

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientPoliciesResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientPoliciesResource.java
@@ -22,7 +22,6 @@ import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Produces;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
@@ -40,11 +39,9 @@ import org.keycloak.services.resources.admin.permissions.AdminPermissionEvaluato
 public class ClientPoliciesResource {
     protected static final Logger logger = Logger.getLogger(ClientPoliciesResource.class);
 
-    @Context
-    protected HttpRequest request;
+    protected final HttpRequest request;
 
-    @Context
-    protected HttpResponse response;
+    protected final HttpResponse response;
 
     protected final KeycloakSession session;
 
@@ -55,6 +52,8 @@ public class ClientPoliciesResource {
         this.session = session;
         this.realm = session.getContext().getRealm();
         this.auth = auth;
+        this.request = session.getContext().getContextObject(HttpRequest.class);
+        this.response = session.getContext().getContextObject(HttpResponse.class);
     }
 
     @GET

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientProfilesResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientProfilesResource.java
@@ -23,7 +23,6 @@ import javax.ws.rs.GET;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
@@ -41,11 +40,9 @@ import org.keycloak.services.resources.admin.permissions.AdminPermissionEvaluato
 public class ClientProfilesResource {
     protected static final Logger logger = Logger.getLogger(ClientProfilesResource.class);
 
-    @Context
-    protected HttpRequest request;
+    protected final HttpRequest request;
 
-    @Context
-    protected HttpResponse response;
+    protected final HttpResponse response;
 
     protected final KeycloakSession session;
 
@@ -56,6 +53,8 @@ public class ClientProfilesResource {
         this.session = session;
         this.realm = session.getContext().getRealm();
         this.auth = auth;
+        this.request = session.getContext().getContextObject(HttpRequest.class);
+        this.response = session.getContext().getContextObject(HttpResponse.class);
     }
 
     @GET

--- a/services/src/main/java/org/keycloak/services/resources/admin/ComponentResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ComponentResource.java
@@ -52,7 +52,6 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -82,8 +81,7 @@ public class ComponentResource {
 
     protected final KeycloakSession session;
 
-    @Context
-    protected HttpHeaders headers;
+    protected final HttpHeaders headers;
 
     public ComponentResource(KeycloakSession session, AdminPermissionEvaluator auth, AdminEventBuilder adminEvent) {
         this.session = session;
@@ -91,6 +89,7 @@ public class ComponentResource {
         this.realm = session.getContext().getRealm();
         this.adminEvent = adminEvent.resource(ResourceType.COMPONENT);
         this.clientConnection = session.getContext().getConnection();
+        this.headers = session.getContext().getRequestHeaders();
     }
 
     @GET

--- a/services/src/main/java/org/keycloak/services/resources/admin/GroupResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/GroupResource.java
@@ -18,7 +18,6 @@ package org.keycloak.services.resources.admin;
 
 import org.jboss.resteasy.annotations.cache.NoCache;
 import javax.ws.rs.NotFoundException;
-import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.keycloak.common.util.ObjectUtil;
 import org.keycloak.events.admin.OperationType;
 import org.keycloak.events.admin.ResourceType;
@@ -237,9 +236,7 @@ public class GroupResource {
     public RoleMapperResource getRoleMappings() {
         AdminPermissionEvaluator.RequirePermissionCheck manageCheck = () -> auth.groups().requireManage(group);
         AdminPermissionEvaluator.RequirePermissionCheck viewCheck = () -> auth.groups().requireView(group);
-        RoleMapperResource resource =  new RoleMapperResource(session, auth, group, adminEvent, manageCheck, viewCheck);
-        ResteasyProviderFactory.getInstance().injectProperties(resource);
-        return resource;
+        return new RoleMapperResource(session, auth, group, adminEvent, manageCheck, viewCheck);
 
     }
 

--- a/services/src/main/java/org/keycloak/services/resources/admin/RealmAdminResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RealmAdminResource.java
@@ -42,7 +42,6 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -132,8 +131,7 @@ public class RealmAdminResource {
 
     protected final ClientConnection connection;
 
-    @Context
-    protected HttpHeaders headers;
+    protected final HttpHeaders headers;
 
     public RealmAdminResource(KeycloakSession session, AdminPermissionEvaluator auth, AdminEventBuilder adminEvent) {
         this.session = session;
@@ -141,6 +139,7 @@ public class RealmAdminResource {
         this.realm = session.getContext().getRealm();
         this.connection = session.getContext().getConnection();
         this.adminEvent = adminEvent.resource(ResourceType.REALM);
+        this.headers = session.getContext().getRequestHeaders();
     }
 
     /**
@@ -174,9 +173,7 @@ public class RealmAdminResource {
      */
     @Path("attack-detection")
     public AttackDetectionResource getAttackDetection() {
-        AttackDetectionResource resource = new AttackDetectionResource(session, auth, adminEvent);
-        ResteasyProviderFactory.getInstance().injectProperties(resource);
-        return resource;
+        return new AttackDetectionResource(session, auth, adminEvent);
     }
 
     /**
@@ -329,9 +326,7 @@ public class RealmAdminResource {
      */
     @Path("components")
     public ComponentResource getComponents() {
-        ComponentResource resource = new ComponentResource(session, auth, adminEvent);
-        ResteasyProviderFactory.getInstance().injectProperties(resource);
-        return resource;
+        return new ComponentResource(session, auth, adminEvent);
     }
 
     /**
@@ -462,10 +457,7 @@ public class RealmAdminResource {
      */
     @Path("users")
     public UsersResource users() {
-        UsersResource users = new UsersResource(session, auth, adminEvent);
-        ResteasyProviderFactory.getInstance().injectProperties(users);
-        //resourceContext.initResource(users);
-        return users;
+        return new UsersResource(session, auth, adminEvent);
     }
 
     @NoCache
@@ -1092,16 +1084,12 @@ public class RealmAdminResource {
     @Path("client-policies/policies")
     public ClientPoliciesResource getClientPoliciesResource() {
         ProfileHelper.requireFeature(Profile.Feature.CLIENT_POLICIES);
-        ClientPoliciesResource resource = new ClientPoliciesResource(session, auth);
-        ResteasyProviderFactory.getInstance().injectProperties(resource);
-        return resource;
+        return new ClientPoliciesResource(session, auth);
     }
 
     @Path("client-policies/profiles")
     public ClientProfilesResource getClientProfilesResource() {
         ProfileHelper.requireFeature(Profile.Feature.CLIENT_POLICIES);
-        ClientProfilesResource resource = new ClientProfilesResource(session, auth);
-        ResteasyProviderFactory.getInstance().injectProperties(resource);
-        return resource;
+        return new ClientProfilesResource(session, auth);
     }
 }

--- a/services/src/main/java/org/keycloak/services/resources/admin/RealmsAdminResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RealmsAdminResource.java
@@ -18,7 +18,6 @@ package org.keycloak.services.resources.admin;
 
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.annotations.cache.NoCache;
-import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.keycloak.common.ClientConnection;
 import org.keycloak.models.AdminRoles;
 import org.keycloak.models.ClientModel;
@@ -47,8 +46,6 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.CacheControl;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.io.InputStream;
@@ -168,8 +165,7 @@ public class RealmsAdminResource {
      * @return
      */
     @Path("{realm}")
-    public RealmAdminResource getRealmAdmin(@Context final HttpHeaders headers,
-                                            @PathParam("realm") final String name) {
+    public RealmAdminResource getRealmAdmin(@PathParam("realm") final String name) {
         RealmManager realmManager = new RealmManager(session);
         RealmModel realm = realmManager.getRealmByName(name);
         if (realm == null) throw new NotFoundException("Realm not found.");
@@ -183,10 +179,7 @@ public class RealmsAdminResource {
         AdminEventBuilder adminEvent = new AdminEventBuilder(realm, auth, session, clientConnection);
         session.getContext().setRealm(realm);
 
-        RealmAdminResource adminResource = new RealmAdminResource(session, realmAuth, adminEvent);
-        ResteasyProviderFactory.getInstance().injectProperties(adminResource);
-        //resourceContext.initResource(adminResource);
-        return adminResource;
+        return new RealmAdminResource(session, realmAuth, adminEvent);
     }
 
 }

--- a/services/src/main/java/org/keycloak/services/resources/admin/RoleMapperResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RoleMapperResource.java
@@ -47,7 +47,6 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -87,8 +86,7 @@ public class RoleMapperResource {
 
     protected final KeycloakSession session;
 
-    @Context
-    protected HttpHeaders headers;
+    protected final HttpHeaders headers;
 
     public RoleMapperResource(KeycloakSession session,
                               AdminPermissionEvaluator auth,
@@ -104,6 +102,7 @@ public class RoleMapperResource {
         this.roleMapper = roleMapper;
         this.managePermission = manageCheck;
         this.viewPermission = viewCheck;
+        this.headers = session.getContext().getRequestHeaders();
 
     }
 

--- a/services/src/main/java/org/keycloak/services/resources/admin/UserResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UserResource.java
@@ -18,7 +18,6 @@ package org.keycloak.services.resources.admin;
 
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.annotations.cache.NoCache;
-import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.keycloak.authentication.RequiredActionProvider;
 import org.keycloak.authentication.actiontoken.execactions.ExecuteActionsActionToken;
 import org.keycloak.common.ClientConnection;
@@ -92,7 +91,6 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -140,8 +138,7 @@ public class UserResource {
 
     protected final KeycloakSession session;
 
-    @Context
-    protected HttpHeaders headers;
+    protected final HttpHeaders headers;
     
     public UserResource(KeycloakSession session, UserModel user, AdminPermissionEvaluator auth, AdminEventBuilder adminEvent) {
         this.session = session;
@@ -150,6 +147,7 @@ public class UserResource {
         this.clientConnection = session.getContext().getConnection();
         this.user = user;
         this.adminEvent = adminEvent.resource(ResourceType.USER);
+        this.headers = session.getContext().getRequestHeaders();
     }
     
     /**
@@ -581,10 +579,7 @@ public class UserResource {
     public RoleMapperResource getRoleMappings() {
         AdminPermissionEvaluator.RequirePermissionCheck manageCheck = () -> auth.users().requireMapRoles(user);
         AdminPermissionEvaluator.RequirePermissionCheck viewCheck = () -> auth.users().requireView(user);
-        RoleMapperResource resource =  new RoleMapperResource(session, auth, user, adminEvent, manageCheck, viewCheck);
-        ResteasyProviderFactory.getInstance().injectProperties(resource);
-        return resource;
-
+        return new RoleMapperResource(session, auth, user, adminEvent, manageCheck, viewCheck);
     }
 
     /**

--- a/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
@@ -18,7 +18,6 @@ package org.keycloak.services.resources.admin;
 
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.annotations.cache.NoCache;
-import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.keycloak.common.ClientConnection;
 import org.keycloak.common.Profile;
 import org.keycloak.common.util.ObjectUtil;
@@ -31,7 +30,6 @@ import org.keycloak.models.ModelDuplicateException;
 import org.keycloak.models.ModelException;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
-import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.models.utils.ModelToRepresentation;
 import org.keycloak.models.utils.RepresentationToModel;
 import org.keycloak.policy.PasswordPolicyNotMetException;
@@ -91,8 +89,7 @@ public class UsersResource {
 
     protected final KeycloakSession session;
 
-    @Context
-    protected HttpHeaders headers;
+    protected final HttpHeaders headers;
 
     public UsersResource(KeycloakSession session, AdminPermissionEvaluator auth, AdminEventBuilder adminEvent) {
         this.session = session;
@@ -100,6 +97,7 @@ public class UsersResource {
         this.auth = auth;
         this.realm = session.getContext().getRealm();
         this.adminEvent = adminEvent.resource(ResourceType.USER);
+        this.headers = session.getContext().getRequestHeaders();
     }
 
     /**
@@ -226,10 +224,8 @@ public class UsersResource {
             if (auth.users().canQuery()) throw new NotFoundException("User not found");
             else throw new ForbiddenException();
         }
-        UserResource resource = new UserResource(session, user, auth, adminEvent);
-        ResteasyProviderFactory.getInstance().injectProperties(resource);
-        //resourceContext.initResource(users);
-        return resource;
+
+        return new UserResource(session, user, auth, adminEvent);
     }
 
     /**

--- a/services/src/main/java/org/keycloak/social/twitter/TwitterIdentityProvider.java
+++ b/services/src/main/java/org/keycloak/social/twitter/TwitterIdentityProvider.java
@@ -52,7 +52,6 @@ import twitter4j.conf.ConfigurationBuilder;
 import javax.ws.rs.GET;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
@@ -171,8 +170,7 @@ public class TwitterIdentityProvider extends AbstractIdentityProvider<OAuth2Iden
 
         protected final ClientConnection clientConnection;
 
-        @Context
-        protected HttpHeaders headers;
+        protected final HttpHeaders headers;
 
         public Endpoint(KeycloakSession session, AuthenticationCallback callback, EventBuilder event, TwitterIdentityProvider provider) {
             this.session = session;
@@ -181,6 +179,7 @@ public class TwitterIdentityProvider extends AbstractIdentityProvider<OAuth2Iden
             this.callback = callback;
             this.event = event;
             this.provider = provider;
+            this.headers = session.getContext().getRequestHeaders();
         }
 
         @GET

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/rest/TestApplicationResourceProvider.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/rest/TestApplicationResourceProvider.java
@@ -42,7 +42,6 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
@@ -69,8 +68,7 @@ public class TestApplicationResourceProvider implements RealmResourceProvider {
     private final ConcurrentMap<String, ClientNotificationEndpointRequest> cibaClientNotifications;
     private final ConcurrentMap<String, String> intentClientBindings;
 
-    @Context
-    HttpRequest request;
+    private final HttpRequest request;
 
     public TestApplicationResourceProvider(KeycloakSession session, BlockingQueue<LogoutAction> adminLogoutActions,
             BlockingQueue<LogoutToken> backChannelLogoutTokens,
@@ -91,6 +89,7 @@ public class TestApplicationResourceProvider implements RealmResourceProvider {
         this.authenticationChannelRequests = authenticationChannelRequests;
         this.cibaClientNotifications = cibaClientNotifications;
         this.intentClientBindings = intentClientBindings;
+        this.request = session.getContext().getContextObject(HttpRequest.class);
     }
 
     @POST

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/rest/TestApplicationResourceProviderFactory.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/rest/TestApplicationResourceProviderFactory.java
@@ -17,9 +17,7 @@
 
 package org.keycloak.testsuite.rest;
 
-import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.keycloak.Config.Scope;
-import org.keycloak.crypto.Algorithm;
 import org.keycloak.crypto.KeyType;
 import org.keycloak.crypto.KeyUse;
 import org.keycloak.models.KeycloakSession;
@@ -59,12 +57,8 @@ public class TestApplicationResourceProviderFactory implements RealmResourceProv
 
     @Override
     public RealmResourceProvider create(KeycloakSession session) {
-        TestApplicationResourceProvider provider = new TestApplicationResourceProvider(session, adminLogoutActions,
+        return new TestApplicationResourceProvider(session, adminLogoutActions,
                 backChannelLogoutTokens, frontChannelLogoutTokens, pushNotBeforeActions, testAvailabilityActions, oidcClientData, authenticationChannelRequests, cibaClientNotifications, intentClientBindings);
-
-        ResteasyProviderFactory.getInstance().injectProperties(provider);
-
-        return provider;
     }
 
     @Override

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/rest/TestingResourceProvider.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/rest/TestingResourceProvider.java
@@ -20,7 +20,6 @@ package org.keycloak.testsuite.rest;
 import org.jboss.resteasy.annotations.cache.NoCache;
 import org.jboss.resteasy.spi.HttpRequest;
 import org.keycloak.Config;
-import org.keycloak.authorization.policy.evaluation.Realm;
 import org.keycloak.common.Profile;
 import org.keycloak.common.util.HtmlUtils;
 import org.keycloak.common.util.Time;
@@ -96,7 +95,6 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Cookie;
 import javax.ws.rs.core.Response;
 import java.io.File;
@@ -126,8 +124,7 @@ public class TestingResourceProvider implements RealmResourceProvider {
     private final KeycloakSession session;
     private final Map<String, TimerProvider.TimerTaskContext> suspendedTimerTasks;
 
-    @Context
-    private HttpRequest request;
+    private final HttpRequest request;
 
     @Override
     public Object getResource() {
@@ -137,6 +134,7 @@ public class TestingResourceProvider implements RealmResourceProvider {
     public TestingResourceProvider(KeycloakSession session, Map<String, TimerProvider.TimerTaskContext> suspendedTimerTasks) {
         this.session = session;
         this.suspendedTimerTasks = suspendedTimerTasks;
+        this.request = session.getContext().getContextObject(HttpRequest.class);
     }
 
     @POST

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/rest/TestingResourceProviderFactory.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/rest/TestingResourceProviderFactory.java
@@ -20,7 +20,6 @@ package org.keycloak.testsuite.rest;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.keycloak.Config.Scope;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
@@ -37,9 +36,7 @@ public class TestingResourceProviderFactory implements RealmResourceProviderFact
 
     @Override
     public RealmResourceProvider create(KeycloakSession session) {
-        TestingResourceProvider testProvider = new TestingResourceProvider(session, suspendedTimerTasks);
-        ResteasyProviderFactory.getInstance().injectProperties(testProvider);
-        return testProvider;
+        return new TestingResourceProvider(session, suspendedTimerTasks);
     }
 
     @Override


### PR DESCRIPTION
Relates #15374
Closes https://github.com/keycloak/keycloak/issues/15602

* Removes injection points for Resteasy objects such as `HttpRequest` and resolve them from the `KeycloakContext` instead
* Avoids creating proxies at runtime as well as a lot of reflection code when processing requests because JAX-RS (sub)resources do not rely on context and dependency injection anymore but only the `KeycloakContext`

There are still some points where we are supporting context and dependency injection as they are related to SPIs that allow extending our REST APIs. For those, we are going to handle it in a separate PR with the updates to the migration guide.

We are not yet removing all references to Resteasy API here as it would be done in a separate PR too.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
