### PR TITLE
Increase timeout for base testsuite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,7 +197,7 @@ jobs:
     name: Base testsuite
     needs: build
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 100
     strategy:
       matrix:
         server: ['quarkus', 'quarkus-map', 'quarkus-map-hot-rod', 'quarkus-map-jpa']


### PR DESCRIPTION
Base testsuite (quarkus-map-jpa, group2) has been cancelled twice in the last 7 days.

https://github.com/keycloak/keycloak/actions/runs/3483837388/jobs/5827905518
https://github.com/keycloak/keycloak/actions/runs/3485514883/jobs/5831297233