### PR TITLE
Enable all test methods in ConcurrentLoginTest for JPA Map Storage

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/AuthenticationProcessor.java
+++ b/services/src/main/java/org/keycloak/authentication/AuthenticationProcessor.java
@@ -39,6 +39,7 @@ import org.keycloak.models.UserModel;
 import org.keycloak.models.UserSessionModel;
 import org.keycloak.models.utils.AuthenticationFlowResolver;
 import org.keycloak.models.utils.FormMessage;
+import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.protocol.LoginProtocol;
 import org.keycloak.protocol.LoginProtocol.Error;
 import org.keycloak.protocol.oidc.TokenManager;
@@ -822,6 +823,13 @@ public class AuthenticationProcessor {
                 return ErrorPage.error(session, authenticationSession, Response.Status.BAD_REQUEST, Messages.INVALID_USER);
             }
 
+        } else if (KeycloakModelUtils.isExceptionRetriable(failure)) {
+            // let calling code decide if whole action should be retried.
+            if (failure instanceof RuntimeException) {
+                throw (RuntimeException) failure;
+            } else {
+                throw new RuntimeException(failure);
+            }
         } else {
             ServicesLogger.LOGGER.failedAuthentication(failure);
             event.error(Errors.INVALID_USER_CREDENTIALS);

--- a/services/src/main/java/org/keycloak/common/util/ResponseSessionTask.java
+++ b/services/src/main/java/org/keycloak/common/util/ResponseSessionTask.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.common.util;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.KeycloakContext;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionTaskWithResult;
+import org.keycloak.models.RealmModel;
+import org.keycloak.sessions.RootAuthenticationSessionModel;
+
+/**
+ * A {@link KeycloakSessionTaskWithResult} that is aimed to be used by endpoints that want to produce a {@link Response} in
+ * a retriable transaction. It takes care of the boilerplate code that is common to be seen in this scenario, allowing the
+ * endpoint to focus on the actual code that has to be executed in a retriable manner.
+ * </p>
+ * More specifically, this task:
+ * <li>
+ *     <ul>pushes the task's session into the resteasy context, restoring the original value after the task is over. This allows
+ *     for endpoints to create new instances of themselves and inject the resteasy properties correctly;</ul>
+ *     <ul>sets up the task's session context, based on model values found in the original session's context;</ul>
+ *     <ul>handles {@link WebApplicationException} when it is thrown by the task.</ul>
+ * </li>
+ *
+ * @author <a href="mailto:sguilhen@redhat.com">Stefan Guilhen</a>
+ */
+public abstract class ResponseSessionTask implements KeycloakSessionTaskWithResult<Response> {
+
+    private final KeycloakSession originalSession;
+
+    /**
+     * Constructs a new instance of this task.
+     *
+     * @param originalSession the original {@link KeycloakSession} that was active when the task was created.
+     */
+    public ResponseSessionTask(final KeycloakSession originalSession) {
+        this.originalSession = originalSession;
+    }
+
+    @Override
+    public Response run(final KeycloakSession session) {
+        // save the session that was originally in the resteasy context, so it can be restored once the task finishes.
+        KeycloakSession originalContextSession = Resteasy.getContextData(KeycloakSession.class);
+        try {
+            // set up the current session context based on the original session context.
+            this.setupSessionContext(session);
+            // push the current session into the resteasy context.
+            Resteasy.pushContext(KeycloakSession.class, session);
+            // run the actual task.
+            return runInternal(session);
+        } catch (WebApplicationException we) {
+            // If the exception is capable of producing a complete response, including a message entity, we return the response
+            // here so that the overall transaction is still committed. If the message entity is missing, we throw the exception
+            // so that KeycloakError handler is invoked later on to produce a valid response and the transaction is rolled back.
+            //
+            // Another reason to convert the web application exception into a response here is because some exception subtypes use
+            // the Keycloak session to construct the response. As a result, the conversion has to happen before the session is closed.
+            Response response = we.getResponse();
+            if (response.getEntity() != null) {
+                return response;
+            }
+            throw we;
+        } finally {
+            // restore original session in resteasy context.
+            Resteasy.pushContext(KeycloakSession.class, originalContextSession);
+        }
+    }
+
+    /**
+     * Sets up the context for the specified session. The original realm's context is used to determine what models
+     * need to be re-loaded using the current session.
+     *
+     * @param session the session whose context is to be prepared.
+     */
+    private void setupSessionContext(final KeycloakSession session) {
+        if (this.originalSession == null) return;
+        KeycloakContext context = this.originalSession.getContext();
+        // setup realm model if necessary.
+        RealmModel realmModel = null;
+        if (context.getRealm() != null) {
+            realmModel = session.realms().getRealm(context.getRealm().getId());
+            session.getContext().setRealm(realmModel);
+        }
+        // setup client model if necessary.
+        ClientModel clientModel = null;
+        if (context.getClient() != null) {
+            clientModel = session.clients().getClientById(realmModel, context.getClient().getId());
+            session.getContext().setClient(clientModel);
+        }
+        // setup auth session model if necessary.
+        if (context.getAuthenticationSession() != null) {
+            RootAuthenticationSessionModel rootAuthSession = session.authenticationSessions().getRootAuthenticationSession(realmModel,
+                    context.getAuthenticationSession().getParentSession().getId());
+            if (rootAuthSession != null) {
+                session.getContext().setAuthenticationSession(rootAuthSession.getAuthenticationSession(clientModel,
+                        context.getAuthenticationSession().getTabId()));
+            }
+        }
+    }
+
+    /**
+     * Builds the response that is to be returned.
+     *
+     * @param session a reference the {@link KeycloakSession}.
+     * @return the constructed {@link Response}.
+     */
+    public abstract Response runInternal(final KeycloakSession session);
+}

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
@@ -30,7 +30,7 @@ import org.keycloak.common.ClientConnection;
 import org.keycloak.common.Profile;
 import org.keycloak.common.constants.ServiceAccountConstants;
 import org.keycloak.common.util.KeycloakUriBuilder;
-import org.keycloak.common.util.Resteasy;
+import org.keycloak.common.util.ResponseSessionTask;
 import org.keycloak.constants.AdapterConstants;
 import org.keycloak.events.Details;
 import org.keycloak.events.Errors;
@@ -106,7 +106,6 @@ import javax.ws.rs.InternalServerErrorException;
 import javax.ws.rs.OPTIONS;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
-import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedHashMap;
@@ -175,26 +174,16 @@ public class TokenEndpoint {
     public Response processGrantRequest() {
         // grant request needs to be run in a retriable transaction as concurrent execution of this action can lead to
         // exceptions on DBs with SERIALIZABLE isolation level.
-        Object result = KeycloakModelUtils.runJobInRetriableTransaction(this.session.getKeycloakSessionFactory(), kcSession -> {
-            try {
-                RealmModel realmModel = kcSession.realms().getRealm(realm.getId());
-                kcSession.getContext().setRealm(realmModel);
-                // create another instance of the endpoint that will be run within the new session.
-                Resteasy.pushContext(KeycloakSession.class, kcSession);
-                TokenEndpoint other = new TokenEndpoint(session, new TokenManager(), new EventBuilder(realmModel, kcSession, clientConnection));
+        return KeycloakModelUtils.runJobInRetriableTransaction(session.getKeycloakSessionFactory(), new ResponseSessionTask(session) {
+            @Override
+            public Response runInternal(KeycloakSession session) {
+                // create another instance of the endpoint to isolate each run.
+                TokenEndpoint other = new TokenEndpoint(session, new TokenManager(),
+                        new EventBuilder(session.getContext().getRealm(), session, clientConnection));
+                // process the request in the created instance.
                 return other.processGrantRequestInternal();
-            } catch (WebApplicationException we) {
-                // WebApplicationException needs to be returned and treated (rethrown) by the calling code because the new transaction
-                // still needs to be committed when this exception is thrown. It captures final business states that won't change when
-                // being retried, like an invalid code.
-                return we;
             }
         }, 10, 100);
-        if (WebApplicationException.class.isInstance(result)) {
-            throw (WebApplicationException) result;
-        } else {
-            return (Response) result;
-        }
     }
 
     private Response processGrantRequestInternal() {


### PR DESCRIPTION
- Tests still disabled for Hotrod and CHM
- Fixes concurrent login issues with CRDB. Verified with both PostgreSQL and CockroachDB.

Closes #12707
Closes #13210

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
