### PR TITLE
Fix for CVE-2022-0239 and IPv6 support for Operator

### DIFF
--- a/operator/pom.xml
+++ b/operator/pom.xml
@@ -24,6 +24,7 @@
         <resteasy.version>4.7.7.Final</resteasy.version>
         <wildfly.common.version>1.5.4.Final-format-001</wildfly.common.version>
         <kubernetes-client.version>5.12.4</kubernetes-client.version>
+        <okhttp.version>4.10.0</okhttp.version>
 
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <maven.compiler.parameters>true</maven.compiler.parameters>
@@ -57,6 +58,26 @@
             <groupId>io.fabric8</groupId>
             <artifactId>crd-generator-api</artifactId>
             <version>${kubernetes-client.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.squareup.okhttp3</groupId>
+                    <artifactId>okhttp</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.squareup.okhttp3</groupId>
+                    <artifactId>logging-interceptor</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>${okhttp.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>logging-interceptor</artifactId>
+            <version>${okhttp.version}</version>
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>


### PR DESCRIPTION
<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
This PR upgrades okhttp3 in the operator from v3 to v4.

This will fix
- a security vulnerability associated with okhttp3 v3 CVE-2022-0239
- IPv6 support for operator

Fixes #14654 