### PR TITLE
Fix update of group mappers on certain changes of the group path

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
@@ -441,10 +441,12 @@ public class JpaRealmProvider implements RealmProvider, ClientProvider, ClientSc
         if (toParent != null && group.getId().equals(toParent.getId())) {
             return;
         }
+
+        GroupModel previousParent = group.getParent();
+
         if (group.getParentId() != null) {
             group.getParent().removeChild(group);
         }
-        GroupModel previousParent = group.getParent();
         group.setParent(toParent);
         if (toParent != null) toParent.addChild(group);
         else session.groups().addTopLevelGroup(realm, group);

--- a/server-spi-private/src/main/java/org/keycloak/broker/provider/mappersync/GroupConfigPropertyByPathSynchronizer.java
+++ b/server-spi-private/src/main/java/org/keycloak/broker/provider/mappersync/GroupConfigPropertyByPathSynchronizer.java
@@ -24,6 +24,8 @@ import org.keycloak.models.utils.KeycloakModelUtils;
 
 import java.util.function.Consumer;
 
+import static org.keycloak.models.utils.KeycloakModelUtils.GROUP_PATH_SEPARATOR;
+
 /**
  * Updates a group reference in a mapper config, when the path of a group changes.
  *
@@ -58,10 +60,17 @@ public class GroupConfigPropertyByPathSynchronizer extends AbstractConfigPropert
         String configuredGroupPath = KeycloakModelUtils.normalizeGroupPath(currentPropertyValue);
 
         String previousGroupPath = event.getPreviousPath();
-        if (previousGroupPath.equals(configuredGroupPath)) {
+        if (configuredGroupPath.equals(previousGroupPath)) {
             String newPath = event.getNewPath();
             propertyUpdater.accept(newPath);
+        } else if (isSubGroupOf(configuredGroupPath, previousGroupPath)) {
+            String newPath = event.getNewPath() + configuredGroupPath.substring(previousGroupPath.length());
+            propertyUpdater.accept(newPath);
         }
+    }
+
+    private static boolean isSubGroupOf(String groupPath, String potentialParentGroupPath) {
+        return groupPath.startsWith(potentialParentGroupPath + GROUP_PATH_SEPARATOR);
     }
 
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractAdvancedGroupMapperTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractAdvancedGroupMapperTest.java
@@ -175,8 +175,8 @@ public abstract class AbstractAdvancedGroupMapperTest extends AbstractGroupMappe
     }
 
     @Override
-    protected String setupScenarioWithMatchingGroup() {
-        String mapperId = createAdvancedGroupMapper(CLAIMS_OR_ATTRIBUTES, false, MAPPER_TEST_GROUP_PATH);
+    protected String setupScenarioWithGroupPath(String groupPath) {
+        String mapperId = createAdvancedGroupMapper(CLAIMS_OR_ATTRIBUTES, false, groupPath);
         createUserInProviderRealm(createMatchingAttributes());
         return mapperId;
     }


### PR DESCRIPTION
The group reference in the mapper was not updated in the following cases:
- group rename: when an ancestor group was renamed
- (only for JpaRealmProvider, NOT for MapRealmProvider/MapGroupProvider) group move: when a group was converted from subgroup to top-level or when a subgroup's parent was changed

Closes #15614

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
