### PR TITLE
Improve `ModelCriteriaBuilder` and `QueryParameters`

### DIFF
--- a/model/map/src/main/java/org/keycloak/models/map/storage/QueryParameters.java
+++ b/model/map/src/main/java/org/keycloak/models/map/storage/QueryParameters.java
@@ -1,6 +1,7 @@
 package org.keycloak.models.map.storage;
 
 import org.keycloak.models.map.storage.criteria.DefaultModelCriteria;
+import org.keycloak.models.map.storage.criteria.ModelCriteriaNode.AtomicFormulaInstantiator;
 import org.keycloak.storage.SearchableModelField;
 
 import java.util.LinkedList;
@@ -27,6 +28,14 @@ public class QueryParameters<M> {
 
     public QueryParameters(DefaultModelCriteria<M> mcb) {
         this.mcb = mcb;
+    }
+
+    public QueryParameters<M> transform(AtomicFormulaInstantiator<M> transformer) {
+        QueryParameters<M> res = new QueryParameters<>(mcb == null ? null : mcb.partiallyEvaluate(transformer));
+        res.limit = limit;
+        res.offset = offset;
+        res.orderBy.addAll(orderBy);
+        return res;
     }
 
     /**


### PR DESCRIPTION
This PR enhances partial evaluation of model criteria in `DefaultModelCriteria` and extracts this functionality to `QueryParameters`. This will be later used in tree storage.

Closes: #15593

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
