### PR TITLE
Fix query to work on OracleDB CLOB when clearing admin events

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/RealmAttributeEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/RealmAttributeEntity.java
@@ -36,7 +36,8 @@ import java.io.Serializable;
  * @version $Revision: 1 $
  */
 @NamedQueries({
-        @NamedQuery(name="deleteRealmAttributesByRealm", query="delete from RealmAttributeEntity attr where attr.realm = :realm")
+        @NamedQuery(name="deleteRealmAttributesByRealm", query="delete from RealmAttributeEntity attr where attr.realm = :realm"),
+        @NamedQuery(name="selectRealmAttributesNotEmptyByName", query="select ra from RealmAttributeEntity ra WHERE ra.name = :name and length(ra.value) > 0")
 })
 @Table(name="REALM_ATTRIBUTE")
 @Entity

--- a/testsuite/integration-arquillian/pom.xml
+++ b/testsuite/integration-arquillian/pom.xml
@@ -469,6 +469,7 @@
         <profile>
             <id>db-allocator-db-mysql</id>
             <properties>
+                <keycloak.storage.connections.vendor>mysql</keycloak.storage.connections.vendor>
                 <dballocator.type>mysql80</dballocator.type>
                 <dballocator.skip>false</dballocator.skip>
             </properties>
@@ -502,6 +503,7 @@
         <profile>
             <id>db-allocator-db-postgres</id>
             <properties>
+                <keycloak.storage.connections.vendor>postgres</keycloak.storage.connections.vendor>
                 <dballocator.type>postgresql132</dballocator.type>
                 <dballocator.skip>false</dballocator.skip>
             </properties>
@@ -509,6 +511,7 @@
         <profile>
             <id>db-allocator-db-postgresplus</id>
             <properties>
+                <keycloak.storage.connections.vendor>postgres</keycloak.storage.connections.vendor>
                 <dballocator.type>postgresplus131</dballocator.type>
                 <dballocator.skip>false</dballocator.skip>
             </properties>
@@ -543,6 +546,7 @@
         <profile>
             <id>db-allocator-db-mariadb</id>
             <properties>
+                <keycloak.storage.connections.vendor>mariadb</keycloak.storage.connections.vendor>
                 <dballocator.type>mariadb_galera_103</dballocator.type>
                 <dballocator.skip>false</dballocator.skip>
             </properties>
@@ -577,6 +581,7 @@
         <profile>
             <id>db-allocator-db-mssql2019</id>
             <properties>
+                <keycloak.storage.connections.vendor>mssql</keycloak.storage.connections.vendor>
                 <dballocator.type>mssql2019</dballocator.type>
                 <dballocator.skip>false</dballocator.skip>
             </properties>
@@ -613,6 +618,7 @@
         <profile>
             <id>db-allocator-db-oracleRAC</id>
             <properties>
+                <keycloak.storage.connections.vendor>oracle</keycloak.storage.connections.vendor>
                 <dballocator.type>oracle19cRAC</dballocator.type>
                 <dballocator.skip>false</dballocator.skip>
             </properties>


### PR DESCRIPTION
When implementing this change I found that the new admin UI puts an empty string into the attribute when no value has been set. So checking for the length seems to be the way to go.

The previous implementation and also the implementation for the user events use `0` to not do any expiry, so this implementation keeps it this way. Similar to the user events. Side note: This isn't documented in the tooltips nor the docs, and it will be a surprise to the user.

Closes #15528
Closes #15643

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
