### PR TITLE
Fix incorrect log-format parameter in documentation

### DIFF
--- a/docs/guides/src/main/server/logging.adoc
+++ b/docs/guides/src/main/server/logging.adoc
@@ -108,7 +108,7 @@ To set the logging format for a logged line, perform these steps:
 . Build your desired format template using the preceding table.
 . Enter the following command:
 +
-<@kc.start parameters="--log-format=\"\'<format>\'\""/>
+<@kc.start parameters="--log-console-format=\"\'<format>\'\""/>
 
 Note that you need to escape characters when invoking commands containing special shell characters such as `;` using the CLI. Therefore, consider setting it in the configuration file instead.
 


### PR DESCRIPTION
Fixes #15646

A possible enhancement could be actually introducing this parameter, and making an invocation of:

``
kc.sh --log-format="<format>"
``

act like the user typed

``
kc.sh --log-console-format="<format>" --log-file-format="<format>"
``

But this seems like a rather small gain to me, so I'm not really sure it's worth doing.