### PR TITLE
Update containers.adoc

### DIFF
--- a/docs/guides/src/main/server/containers.adoc
+++ b/docs/guides/src/main/server/containers.adoc
@@ -40,6 +40,7 @@ FROM quay.io/keycloak/keycloak:latest
 COPY --from=builder /opt/keycloak/ /opt/keycloak/
 
 # change these values to point to a running postgres instance
+ENV KC_DB=postgres
 ENV KC_DB_URL=<DBURL>
 ENV KC_DB_USERNAME=<DBUSERNAME>
 ENV KC_DB_PASSWORD=<DBPASSWORD>


### PR DESCRIPTION
You have to set also variable KC_DB after building image, otherwise Keycloak will default to H2 database

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
