### PR TITLE
Use java.util.Base64.getUrlEncoder() / .getUrlDecoder() to encode clientID to be URI Friendly

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/broker/provider/util/IdentityBrokerState.java
+++ b/server-spi-private/src/main/java/org/keycloak/broker/provider/util/IdentityBrokerState.java
@@ -51,7 +51,7 @@ public class IdentityBrokerState {
                 bb.putLong(clientDbUuid.getMostSignificantBits());
                 bb.putLong(clientDbUuid.getLeastSignificantBits());
                 byte[] clientUuidBytes = bb.array();
-                clientIdEncoded = Base64.getEncoder().encodeToString(clientUuidBytes).replace("=", "");
+                clientIdEncoded = Base64.getUrlEncoder().encodeToString(clientUuidBytes).replace("=", "");
             } catch (IllegalArgumentException e) {
                 // Ignore...the clientid in the database was not in UUID format. Just use as is.
             }
@@ -73,7 +73,7 @@ public class IdentityBrokerState {
             try {
                 // If this decoding succeeds it was the result of the encoding of a UUID client.id - if it fails we interpret it as client.clientId
                 // in accordance to the method decoded above
-                byte[] decodedClientId = Base64.getDecoder().decode(clientId);
+                byte[] decodedClientId = Base64.getUrlDecoder().decode(clientId);
                 ByteBuffer bb = ByteBuffer.wrap(decodedClientId);
                 long first = bb.getLong();
                 long second = bb.getLong();

--- a/server-spi-private/src/test/java/org/keycloak/broker/provider/util/IdentityBrokerStateTest.java
+++ b/server-spi-private/src/test/java/org/keycloak/broker/provider/util/IdentityBrokerStateTest.java
@@ -46,6 +46,25 @@ public class IdentityBrokerStateTest {
     }
 
     @Test
+    public void testDecodedWithClientIdAnActualUuidBASE64UriFriendly() {
+
+        // Given
+        String state = "gNrGamIDGKpKSI9yOrcFzYTKoFGH779_WNCacAelkhk";
+        String clientId = "c5ac1ea7-6c28-4be1-b7cd-d63a1ba57f78";
+        String clientClientId = "http://i.am.an.url";
+        String tabId = "vpISZLVDAc0";
+
+        // When
+        IdentityBrokerState encodedState = IdentityBrokerState.decoded(state, clientId, clientClientId, tabId);
+
+        // Then
+        Assert.assertNotNull(encodedState);
+        Assert.assertEquals(clientClientId, encodedState.getClientId());
+        Assert.assertEquals(tabId, encodedState.getTabId());
+        Assert.assertEquals("gNrGamIDGKpKSI9yOrcFzYTKoFGH779_WNCacAelkhk.vpISZLVDAc0.xawep2woS-G3zdY6G6V_eA", encodedState.getEncoded());
+    }
+
+    @Test
     public void testEncodedWithClientIdUUid() {
         // Given
         String encoded = "gNrGamIDGKpKSI9yOrcFzYTKoFGH779_WNCacAelkhk.vpISZLVDAc0.7UlEjBTPRx6oOgY9DcO8jA";


### PR DESCRIPTION
    fix #15734
    related #10227 #10231

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
