### PR TITLE
Cleanup dependencies and align with Quarkus

### DIFF
--- a/model/map-jpa/pom.xml
+++ b/model/map-jpa/pom.xml
@@ -57,7 +57,7 @@
             <plugin>
                 <groupId>org.hibernate.orm.tooling</groupId>
                 <artifactId>hibernate-enhance-maven-plugin</artifactId>
-                <version>${hibernate.core.version}</version>
+                <version>${hibernate-orm.version}</version>
                 <executions>
                     <execution>
                         <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -79,8 +79,8 @@
         <dom4j.version>2.1.3</dom4j.version>
         <h2.version>2.1.214</h2.version>
         <jakarta.persistence.version>2.2.3</jakarta.persistence.version>
-        <hibernate.core.version>5.6.10.Final</hibernate.core.version>
-        <hibernate.c3p0.version>5.6.10.Final</hibernate.c3p0.version>
+        <hibernate-orm.version>5.6.14.Final</hibernate-orm.version>
+        <hibernate.c3p0.version>${hibernate-orm.version}</hibernate.c3p0.version>
         <infinispan.version>14.0.2.Final</infinispan.version>
         <infinispan.protostream.processor.version>4.5.0.Final</infinispan.protostream.processor.version>
         <jackson.version>2.13.4</jackson.version>
@@ -107,7 +107,7 @@
         <sun.activation.version>1.2.2</sun.activation.version>
         <org.glassfish.jaxb.xsom.version>2.3.3-b02</org.glassfish.jaxb.xsom.version>
         <undertow.version>2.2.19.Final</undertow.version>
-        <elytron.version>1.18.3.Final</elytron.version>
+        <wildfly-elytron.version>1.20.1.Final</wildfly-elytron.version>
         <elytron.undertow-server.version>1.9.0.Final</elytron.undertow-server.version>
         <jetty94.version>9.4.40.v20210413</jetty94.version>
         <woodstox.version>6.0.3</woodstox.version>
@@ -142,15 +142,15 @@
 
         <!-- Databases -->
         <mysql.version>8.0.23</mysql.version>
-        <mysql.driver.version>8.0.28</mysql.driver.version>
+        <mysql-jdbc.version>8.0.30</mysql-jdbc.version>
         <postgresql.version>13.2</postgresql.version>
-        <postgresql.driver.version>42.3.3</postgresql.driver.version>
+        <postgresql-jdbc.version>42.5.0</postgresql-jdbc.version>
         <mariadb.version>10.3.27</mariadb.version>
-        <mariadb.driver.version>2.7.2</mariadb.driver.version>
+        <mariadb-jdbc.version>2.7.2</mariadb-jdbc.version>
         <mssql.version>2019-CU10-ubuntu-20.04</mssql.version>
-        <mssql.driver.version>9.2.0.jre8</mssql.driver.version>
+        <mssql-jdbc.version>9.2.0.jre8</mssql-jdbc.version>
         <!-- this is the oracle driver version also used in the Quarkus BOM -->
-        <oracle.driver.version>21.5.0.0</oracle.driver.version>
+        <oracle-jdbc.version>21.5.0.0</oracle-jdbc.version>
 
         <!-- Test -->
         <greenmail.version>1.3.1b</greenmail.version>
@@ -159,6 +159,8 @@
         <junit.version>4.13.2</junit.version>
         <picketlink.version>2.7.0.Final</picketlink.version>
         <selenium.version>2.35.0</selenium.version>
+        <!-- Needs to be aligned with Quarkus, see e.g. https://github.com/quarkusio/quarkus-quickstarts/blob/2.13.5.Final/getting-started-async/pom.xml#L14 -->
+        <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
         <xml-apis.version>1.4.01</xml-apis.version>
         <subethasmtp.version>3.1.7</subethasmtp.version>
         <awaitility.version>4.1.1</awaitility.version>
@@ -166,7 +168,7 @@
         <!-- KEYCLOAK-17585 Prevent microprofile-metrics-api upgrades from version "2.3" due to:
              https://issues.redhat.com/browse/KEYCLOAK-17585?focusedCommentId=16002705&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-16002705
         -->
-        <microprofile-metrics-api.version>2.3</microprofile-metrics-api.version>
+        <microprofile-metrics-api.version>3.0.1</microprofile-metrics-api.version>
         <testcontainers.version>1.17.5</testcontainers.version>
 
         <!-- Maven Plugins -->
@@ -572,7 +574,7 @@
             <dependency>
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-core</artifactId>
-                <version>${hibernate.core.version}</version>
+                <version>${hibernate-orm.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.hibernate</groupId>
@@ -732,7 +734,7 @@
             <dependency>
                 <groupId>mysql</groupId>
                 <artifactId>mysql-connector-java</artifactId>
-                <version>${mysql.driver.version}</version>
+                <version>${mysql-jdbc.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -903,7 +905,7 @@
             <dependency>
                 <groupId>org.wildfly.security</groupId>
                 <artifactId>wildfly-elytron</artifactId>
-                <version>${elytron.version}</version>
+                <version>${wildfly-elytron.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wildfly.common</groupId>
@@ -1768,7 +1770,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.0.0-M7</version>
+                    <version>${surefire-plugin.version}</version>
                     <configuration>
                         <forkMode>once</forkMode>
                         <argLine>-Djava.awt.headless=true ${surefire.memory.settings} ${surefire.system.args} -Duser.language=en -Duser.region=US</argLine>
@@ -1978,7 +1980,7 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <configuration>
-                            <additionalparam>-Xdoclint:none</additionalparam>
+                            <doclint>none</doclint>
                             <failOnError>false</failOnError>
                             <excludePackageNames>cx.*:org.freedesktop*:org.jvnet*</excludePackageNames>
                         </configuration>

--- a/quarkus/pom.xml
+++ b/quarkus/pom.xml
@@ -31,25 +31,12 @@
     <packaging>pom</packaging>
 
     <properties>
-        <!--
-            Do not change the properties bellow.
-            Their names should match the name used by Quarkus BOM and the versions are automatically set when running the 'set-quarkus-version.sh' script.
-        -->
-        <resteasy.version>4.7.7.Final</resteasy.version>
-        <hibernate-orm.version>5.6.14.Final</hibernate-orm.version>
-        <mysql-jdbc.version>8.0.30</mysql-jdbc.version>
-        <postgresql-jdbc.version>42.5.0</postgresql-jdbc.version>
         <wildfly-common.version>1.5.4.Final-format-001</wildfly-common.version>
-        <wildfly-elytron.version>1.20.1.Final</wildfly-elytron.version>
-        <microprofile-metrics-api.version>3.0.1</microprofile-metrics-api.version>
 
         <!--
             We need to override certain dependencies from the parent POM.
             TODO: remove these properties after changing the parent POM to use the same property names used by Quarkus BOM.
         -->
-        <hibernate.core.version>${hibernate-orm.version}</hibernate.core.version>
-        <mysql.driver.version>${mysql-jdbc.version}</mysql.driver.version>
-        <postgresql.version>${postgresql-jdbc.version}</postgresql.version>
         <wildfly.common.version>${wildfly-common.version}</wildfly.common.version>
 
         <!--
@@ -70,9 +57,6 @@
         <maven.compiler.release>11</maven.compiler.release>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-
-        <!-- Needs to be aligned with Quarkus, see e.g. https://github.com/quarkusio/quarkus-quickstarts/blob/2.7.6.Final/getting-started-async/pom.xml#L14 -->
-        <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     </properties>
 
     <dependencyManagement>
@@ -106,6 +90,7 @@
                 <artifactId>infinispan-client-hotrod</artifactId>
                 <version>${infinispan.version}</version>
             </dependency>
+
 
             <!-- Dependencies removed from JDK 11 and in compliance with those used by Wildfly. -->
             <dependency>

--- a/quarkus/runtime/pom.xml
+++ b/quarkus/runtime/pom.xml
@@ -95,7 +95,6 @@
         <dependency>
             <groupId>org.wildfly.security</groupId>
             <artifactId>wildfly-elytron</artifactId>
-            <version>${wildfly-elytron.version}</version>
         </dependency>
         <dependency>
             <groupId>io.quarkiverse.vault</groupId>
@@ -359,7 +358,6 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-multipart-provider</artifactId>
-            <version>${resteasy.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>
@@ -714,7 +712,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>${surefire-plugin.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/testsuite/integration-arquillian/pom.xml
+++ b/testsuite/integration-arquillian/pom.xml
@@ -458,7 +458,7 @@
                 <!-- for the particular EAP version -->
                 <jdbc.mvn.groupId>mysql</jdbc.mvn.groupId>
                 <jdbc.mvn.artifactId>mysql-connector-java</jdbc.mvn.artifactId>
-                <jdbc.mvn.version>${mysql.driver.version}</jdbc.mvn.version>
+                <jdbc.mvn.version>${mysql-jdbc.version}</jdbc.mvn.version>
                 <docker.database.image>mysql:${mysql.version}</docker.database.image>
                 <docker.database.port>3306</docker.database.port>
                 <docker.database.skip>false</docker.database.skip>
@@ -492,7 +492,7 @@
                 <!-- for the particular EAP version -->
                 <jdbc.mvn.groupId>org.postgresql</jdbc.mvn.groupId>
                 <jdbc.mvn.artifactId>postgresql</jdbc.mvn.artifactId>
-                <jdbc.mvn.version>${postgresql.driver.version}</jdbc.mvn.version>
+                <jdbc.mvn.version>${postgresql-jdbc.version}</jdbc.mvn.version>
                 <docker.database.image>postgres:${postgresql.version}</docker.database.image>
                 <docker.database.port>5432</docker.database.port>
                 <docker.database.skip>false</docker.database.skip>
@@ -534,7 +534,7 @@
                 <!-- for the particular EAP version -->
                 <jdbc.mvn.groupId>org.mariadb.jdbc</jdbc.mvn.groupId>
                 <jdbc.mvn.artifactId>mariadb-java-client</jdbc.mvn.artifactId>
-                <jdbc.mvn.version>${mariadb.driver.version}</jdbc.mvn.version>
+                <jdbc.mvn.version>${mariadb-jdbc.version}</jdbc.mvn.version>
                 <docker.database.image>mariadb:${mariadb.version}</docker.database.image>
                 <docker.database.port>3306</docker.database.port>
                 <docker.database.skip>false</docker.database.skip>
@@ -575,7 +575,7 @@
                 <!-- for the particular EAP version -->
                 <jdbc.mvn.groupId>com.microsoft.sqlserver</jdbc.mvn.groupId>
                 <jdbc.mvn.artifactId>mssql-jdbc</jdbc.mvn.artifactId>
-                <jdbc.mvn.version>${mssql.driver.version}</jdbc.mvn.version>
+                <jdbc.mvn.version>${mssql-jdbc.version}</jdbc.mvn.version>
             </properties>
         </profile>
         <profile>
@@ -612,7 +612,7 @@
                 <!-- for the particular EAP version -->
                 <jdbc.mvn.groupId>com.oracle.database.jdbc</jdbc.mvn.groupId>
                 <jdbc.mvn.artifactId>ojdbc11</jdbc.mvn.artifactId>
-                <jdbc.mvn.version>${oracle.driver.version}</jdbc.mvn.version>
+                <jdbc.mvn.version>${oracle-jdbc.version}</jdbc.mvn.version>
             </properties>
         </profile>
         <profile>

--- a/testsuite/model/pom.xml
+++ b/testsuite/model/pom.xml
@@ -113,7 +113,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>${postgresql.driver.version}</version>
+            <version>${postgresql-jdbc.version}</version>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>

--- a/testsuite/utils/pom.xml
+++ b/testsuite/utils/pom.xml
@@ -254,23 +254,23 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>${postgresql.driver.version}</version>
+            <version>${postgresql-jdbc.version}</version>
         </dependency>
         <dependency>
             <groupId>com.oracle.database.jdbc</groupId>
             <artifactId>ojdbc11</artifactId>
-            <version>${oracle.driver.version}</version>
+            <version>${oracle-jdbc.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.mariadb.jdbc</groupId>
             <artifactId>mariadb-java-client</artifactId>
-            <version>${mariadb.driver.version}</version>
+            <version>${mariadb-jdbc.version}</version>
         </dependency>
         <dependency>
             <groupId>com.microsoft.sqlserver</groupId>
             <artifactId>mssql-jdbc</artifactId>
-            <version>${mssql.driver.version}</version>
+            <version>${mssql-jdbc.version}</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
* deleted version properties from the Quarkus POM
* deleted star exclusions from the Quarkus runtime module
* aligned versions in the parent POM

Closes #15325, closes #14915

Signed-off-by: Peter Zaoral <pzaoral@redhat.com>

Based on the earlier discussion I created an initial dependency cleanup within the Quarkus module. I might've missed some of the requirements, thus the Draft label.

@pedroigor @vmuzikar PTAL, any feedback is welcomed.
