### PR TITLE
Initialize CryptoIntegration before loading adapter config

### DIFF
--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/KeycloakDeploymentBuilder.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/KeycloakDeploymentBuilder.java
@@ -201,6 +201,7 @@ public class KeycloakDeploymentBuilder {
 
 
     public static KeycloakDeployment build(AdapterConfig adapterConfig) {
+        CryptoIntegration.init(KeycloakDeploymentBuilder.class.getClassLoader());
         return new KeycloakDeploymentBuilder().internalBuild(adapterConfig);
     }
 


### PR DESCRIPTION
Initialize CryptoIntegration before building KeycloakDeploymentBuilder, same way as in public static KeycloakDeployment build(InputStream is) method

Closes #15767