### PR TITLE
Disable cancelling concurrent jobs in Keycloak CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
 
 concurrency:
+  # Only cancel jobs for new commits on PRs, and always do a complete run on other branches (e.g. `main`).
+  # See: https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value
   group: keycloak-ci-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ env:
   DEFAULT_JDK_VERSION: 11
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
 
-concurrency:
+#concurrency:
   # Only run once for latest commit per ref and cancel other (previous) runs.
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # group: ${{ github.workflow }}-${{ github.ref }}
+  # cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
 
 concurrency:
-  group: main-${{ github.head_ref || github.run_id }}
+  group: keycloak-ci-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,9 @@ env:
   DEFAULT_JDK_VERSION: 11
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
 
-#concurrency:
-  # Only run once for latest commit per ref and cancel other (previous) runs.
-  # group: ${{ github.workflow }}-${{ github.ref }}
-  # cancel-in-progress: true
+concurrency:
+  group: main-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   build:


### PR DESCRIPTION
We're currently running Keycloak CI several times nightly to work on stabilizing the testsuite. However, sometimes a run is cancelled due to the concurrency config for the workflow.

I'd like to at least temporarily disable this so all nightly runs complete. I don't think we need this at all to be honest. For schedule runs we'd want those to complete, for push runs (which we don't have atm) we probably also want those to complete, as otherwise it's harder to figure out when an issue was introduced, and for PRs GH actions require a run to complete anyways (and I think it already cancels runs for a previous commit as well automatically).