### PR TITLE
Remove check on @ in username

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/models/utils/KeycloakModelUtils.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/KeycloakModelUtils.java
@@ -239,7 +239,7 @@ public final class KeycloakModelUtils {
      * @return found user
      */
     public static UserModel findUserByNameOrEmail(KeycloakSession session, RealmModel realm, String username) {
-        if (realm.isLoginWithEmailAllowed() && username.indexOf('@') != -1) {
+        if (realm.isLoginWithEmailAllowed()) {
             UserModel user = session.users().getUserByEmail(realm, username);
             if (user != null) {
                 return user;


### PR DESCRIPTION
Actually there is a strange check on username when keycloak tries to find a user.
It does not look for a valid email it only check if there is an '@' in the string given by the client.

In the PR i've only removed the check on the '@' so now if the realm allows login by email, it will try to find user with the email attribute and if no user found it will try to find user with the username attribute.