### PR TITLE
Fix OpenshiftClientStorageTest.testCodeGrantFlowWithServiceAccountUsingOAuthRedirectReference (#15741)

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/openshift/OpenshiftClientStorageTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/openshift/OpenshiftClientStorageTest.java
@@ -173,12 +173,12 @@ public final class OpenshiftClientStorageTest extends AbstractTestRealmKeycloakT
     @Test
     public void testCodeGrantFlowWithServiceAccountUsingOAuthRedirectReference() {
         String clientId = "system:serviceaccount:default:sa-oauth-redirect-reference";
-        testCodeGrantFlow(clientId, "https://myapp.org/callback", () -> assertSuccessfulResponseWithoutConsent(clientId));
+        testCodeGrantFlow(clientId, "http://127.0.0.1:8180/callback", () -> assertSuccessfulResponseWithoutConsent(clientId));
     }
 
     @Test
     public void failCodeGrantFlowWithServiceAccountUsingOAuthRedirectReference() throws Exception {
-        testCodeGrantFlow("system:serviceaccount:default:sa-oauth-redirect-reference", "http://myapp.org/callback", () -> assertEquals(OAuthErrorException.INVALID_REDIRECT_URI, events.poll().getError()));
+        testCodeGrantFlow("system:serviceaccount:default:sa-oauth-redirect-reference", "http://invalid/callback", () -> assertEquals(OAuthErrorException.INVALID_REDIRECT_URI, events.poll().getError()));
     }
 
     @Test
@@ -214,7 +214,7 @@ public final class OpenshiftClientStorageTest extends AbstractTestRealmKeycloakT
 
     @Test
     public void failCodeGrantFlowWithServiceAccountUsingOAuthRedirectUri() throws Exception {
-        testCodeGrantFlow("system:serviceaccount:default:sa-oauth-redirect-uri", "http://myapp.org/callback", () -> assertEquals(OAuthErrorException.INVALID_REDIRECT_URI, events.poll().getError()));
+        testCodeGrantFlow("system:serviceaccount:default:sa-oauth-redirect-uri", "http://invalid/callback", () -> assertEquals(OAuthErrorException.INVALID_REDIRECT_URI, events.poll().getError()));
     }
 
     private void testCodeGrantFlow(String clientId, String expectedRedirectUri, Runnable assertThat) {

--- a/testsuite/integration-arquillian/tests/base/src/test/resources/openshift/client-storage/route-response.json
+++ b/testsuite/integration-arquillian/tests/base/src/test/resources/openshift/client-storage/route-response.json
@@ -13,22 +13,18 @@
     }
   },
   "spec": {
-    "host": "myapp.org",
+    "host": "127.0.0.1",
     "to": {
       "kind": "Service",
       "name": "proxy",
       "weight": 100
-    },
-    "tls": {
-      "termination": "reencrypt",
-      "destinationCACertificate": "-----BEGIN COMMENT-----\nThis is an empty PEM file created to provide backwards compatibility\nfor reencrypt routes that have no destinationCACertificate. This \ncontent will only appear for routes accessed via /oapi/v1/routes.\n-----END COMMENT-----\n"
     },
     "wildcardPolicy": "None"
   },
   "status": {
     "ingress": [
       {
-        "host": "myapp.org",
+        "host": "127.0.0.1",
         "routerName": "router",
         "conditions": [
           {


### PR DESCRIPTION
Closes #15565

This is a backport of #15741

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
