### PR TITLE
Add `getUsername` method to TotpBean.java to support otp:// URI scheme

### DIFF
--- a/services/src/main/java/org/keycloak/forms/login/freemarker/model/TotpBean.java
+++ b/services/src/main/java/org/keycloak/forms/login/freemarker/model/TotpBean.java
@@ -47,10 +47,12 @@ public class TotpBean {
     private UriBuilder uriBuilder;
     private final List<CredentialModel> otpCredentials;
     private final List<String> supportedApplications;
+    private final UserModel user;
 
     public TotpBean(KeycloakSession session, RealmModel realm, UserModel user, UriBuilder uriBuilder) {
         this.session = session;
         this.realm = realm;
+        this.user = user;
         this.uriBuilder = uriBuilder;
         this.enabled = user.credentialManager().isConfiguredFor(OTPCredentialModel.TYPE);
         if (enabled) {
@@ -105,6 +107,10 @@ public class TotpBean {
 
     public List<CredentialModel> getOtpCredentials() {
         return otpCredentials;
+    }
+
+    public String getUsername() {
+        return user.getUsername();
     }
 
 }


### PR DESCRIPTION
Implements #16917 

Add a `getUsername()` method to the `TotpBean` class so usernames can be used in the TOTP templates. For example, this will make it possible to add otp:// URIs to the `login-config-totp.ftl` template:

```
<a href="otpauth://totp/${(realm.displayName)?replace(" ", "%20")}:${(totp.username)}?secret=${(totp.totpSecretEncoded)?replace(" ", "")}&period=${(totp.policy["period"])}&algorithm=${(totp.policy["algorithm"])?replace("Hmac", "")}&digits=${(totp.policy["digits"])}">
    Add to OTP App
</a>
```

This is much more convenient for mobile users as opposed to copying over the manual TOTP strings into their OTP app. Since the username field is part of the otp:// URI scheme, having it available for the template is useful.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
