### PR TITLE
Make method argument name match query param name in REST resource

### DIFF
--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/UsersResource.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/UsersResource.java
@@ -153,11 +153,11 @@ public interface UsersResource {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    List<UserRepresentation> searchByFirstName(@QueryParam("firstName") String email, @QueryParam("exact") Boolean exact);
+    List<UserRepresentation> searchByFirstName(@QueryParam("firstName") String firstName, @QueryParam("exact") Boolean exact);
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    List<UserRepresentation> searchByLastName(@QueryParam("lastName") String email, @QueryParam("exact") Boolean exact);
+    List<UserRepresentation> searchByLastName(@QueryParam("lastName") String lastName, @QueryParam("exact") Boolean exact);
 
     /**
      * Search for users based on the given filters.


### PR DESCRIPTION
To improve code readability and avoid confusion, here's a small PR to make the name of method arguments match the name of query parameters in `org.keycloak.admin.client.resource.UserResource`.
As it was before:
<img width="662" alt="image" src="https://user-images.githubusercontent.com/1470270/207429920-4c8ea677-7668-47fa-9cf4-635fb97615bc.png">

I discovered it manually, but maybe there exists an automated way to check for other occurrences?