### PR TITLE
Advanced query language to search for users

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/query/internal/AndCondition.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/query/internal/AndCondition.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.storage.ldap.idm.query.internal;
+
+import org.keycloak.storage.ldap.idm.query.Condition;
+
+/**
+ * @author Nicolas Iannarilli
+ */
+class AndCondition implements Condition {
+
+    private final Condition[] innerConditions;
+
+    public AndCondition(Condition... innerConditions) {
+        this.innerConditions = innerConditions;
+    }
+
+    @Override
+    public String getParameterName() {
+        return null;
+    }
+
+    @Override
+    public void setParameterName(String parameterName) {
+    }
+
+    @Override
+    public void updateParameterName(String modelParamName, String ldapParamName) {
+        for (Condition innerCondition : innerConditions) {
+            innerCondition.updateParameterName(modelParamName, ldapParamName);
+        }
+    }
+
+    @Override
+    public void applyCondition(StringBuilder filter) {
+        filter.append("(&");
+
+        for (Condition innerCondition : innerConditions) {
+            innerCondition.applyCondition(filter);
+        }
+
+        filter.append(")");
+    }
+
+    @Override
+    public void setBinary(boolean binary) {
+    }
+
+    @Override
+    public boolean isBinary() {
+        return false;
+    }
+}

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/query/internal/LDAPQueryConditionsBuilder.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/query/internal/LDAPQueryConditionsBuilder.java
@@ -57,11 +57,25 @@ public class LDAPQueryConditionsBuilder {
         return new BetweenCondition(paramName, x, y);
     }
 
+    public Condition andCondition(Condition... conditions) {
+        if (conditions == null || conditions.length == 0) {
+            throw new ModelException("At least one condition should be provided to AND query");
+        }
+        return new AndCondition(conditions);
+    }
+
     public Condition orCondition(Condition... conditions) {
         if (conditions == null || conditions.length == 0) {
             throw new ModelException("At least one condition should be provided to OR query");
         }
         return new OrCondition(conditions);
+    }
+
+    public Condition notCondition(Condition condition) {
+        if (condition == null) {
+            throw new ModelException("One condition should be provided to NOT query");
+        }
+        return new NotCondition(condition);
     }
 
     public Condition addCustomLDAPFilter(String filter) {

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/query/internal/NotCondition.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/query/internal/NotCondition.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.storage.ldap.idm.query.internal;
+
+import org.keycloak.storage.ldap.idm.query.Condition;
+
+/**
+ * @author Nicolas Iannarilli
+ */
+class NotCondition implements Condition {
+
+    private final Condition innerCondition;
+
+    public NotCondition(Condition innerCondition) {
+        this.innerCondition = innerCondition;
+    }
+
+    @Override
+    public String getParameterName() {
+        return null;
+    }
+
+    @Override
+    public void setParameterName(String parameterName) {
+    }
+
+    @Override
+    public void updateParameterName(String modelParamName, String ldapParamName) {
+        innerCondition.updateParameterName(modelParamName, ldapParamName);
+    }
+
+    @Override
+    public void applyCondition(StringBuilder filter) {
+        filter.append("(!");
+        innerCondition.applyCondition(filter);
+        filter.append(")");
+    }
+
+    @Override
+    public void setBinary(boolean binary) {
+    }
+
+    @Override
+    public boolean isBinary() {
+        return false;
+    }
+}

--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/UsersResource.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/UsersResource.java
@@ -215,6 +215,13 @@ public interface UsersResource {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
+    List<UserRepresentation> searchJson(@QueryParam("query") String query,
+                                    @QueryParam("first") Integer firstResult,
+                                    @QueryParam("max") Integer maxResults,
+                                    @QueryParam("briefRepresentation") Boolean briefRepresentation);    
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
     List<UserRepresentation> list(@QueryParam("first") Integer firstResult,
                                   @QueryParam("max") Integer maxResults);
 
@@ -247,6 +254,18 @@ public interface UsersResource {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     Integer count(@QueryParam("search") String search);
+
+    /**
+     * Returns the number of users that can be viewed and match the given search criteria.
+     * If none is specified this is equivalent to {{@link #count()}}.
+     *
+     * @param search criteria to search for
+     * @return number of users matching the search criteria
+     */
+    @Path("count")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    Integer countJson(@QueryParam("query") String query);
 
     /**
      * Returns the number of users that can be viewed and match the given filters.

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/UserCacheSession.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/UserCacheSession.java
@@ -53,6 +53,7 @@ import org.keycloak.models.cache.infinispan.events.UserFederationLinkUpdatedEven
 import org.keycloak.models.cache.infinispan.events.UserFullInvalidationEvent;
 import org.keycloak.models.cache.infinispan.events.UserUpdatedEvent;
 import org.keycloak.models.cache.infinispan.stream.InIdentityProviderPredicate;
+import org.keycloak.models.search.SearchQueryJson;
 import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.models.utils.ReadOnlyUserModelDelegate;
 import org.keycloak.storage.CacheableStorageProviderModel;
@@ -603,6 +604,11 @@ public class UserCacheSession implements UserCache, OnCreateComponent, OnUpdateC
     @Override
     public Stream<UserModel> searchForUserByUserAttributeStream(RealmModel realm, String attrName, String attrValue) {
         return getDelegate().searchForUserByUserAttributeStream(realm, attrName, attrValue);
+    }
+
+    @Override
+    public Stream<UserModel> searchForUserStream(RealmModel realm, SearchQueryJson query, Integer firstResult, Integer maxResults)  {
+        return getDelegate().searchForUserStream(realm, query, firstResult, maxResults);
     }
 
     @Override

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserSearchQueryJsonMapper.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserSearchQueryJsonMapper.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.models.jpa;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiFunction;
+
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaBuilder.In;
+import javax.persistence.criteria.Expression;
+import javax.persistence.criteria.Join;
+import javax.persistence.criteria.JoinType;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
+
+import org.keycloak.models.jpa.entities.UserEntity;
+import org.keycloak.models.search.SearchQueryJson;
+import org.keycloak.models.search.SearchQueryJsonAnd;
+import org.keycloak.models.search.SearchQueryJsonEquals;
+import org.keycloak.models.search.SearchQueryJsonGt;
+import org.keycloak.models.search.SearchQueryJsonGte;
+import org.keycloak.models.search.SearchQueryJsonIn;
+import org.keycloak.models.search.SearchQueryJsonLike;
+import org.keycloak.models.search.SearchQueryJsonLt;
+import org.keycloak.models.search.SearchQueryJsonLte;
+import org.keycloak.models.search.SearchQueryJsonNot;
+import org.keycloak.models.search.SearchQueryJsonOr;
+import org.keycloak.models.ModelException;
+import org.keycloak.models.UserModel;
+
+
+/**
+ * @author <a href="mailto:niannarilli@efalia.com">Nicolas iannarilli</a>
+ * @version $Revision: 1 $
+ */
+public class JpaUserSearchQueryJsonMapper {
+    private static final String EMAIL = "email";
+    private static final String EMAIL_VERIFIED = "emailVerified";
+    private static final String USERNAME = "username";
+    private static final String FIRST_NAME = "firstName";
+    private static final String LAST_NAME = "lastName";
+
+    private JpaUserSearchQueryJsonMapper() {}
+    
+    public static Predicate build (Root<UserEntity> root, CriteriaBuilder builder, SearchQueryJson query) {
+        Map<String, Join<Object, Object>> joinByKey = new HashMap<>();
+        
+        return buildCondition(root, builder, joinByKey, query);
+    }
+
+    /** Build predicate from search json query. */
+    private static Predicate buildCondition(Root<UserEntity> root, CriteriaBuilder builder, Map<String, Join<Object, Object>> joinByKey, SearchQueryJson query){
+        switch (query.getOperator()) {
+            case AND:
+                SearchQueryJsonAnd queryAnd = (SearchQueryJsonAnd) query;
+                return builder.and(queryAnd.getValues().stream().map(c -> JpaUserSearchQueryJsonMapper.buildCondition(root, builder, joinByKey, c)).toArray(Predicate[]::new));
+            case OR:
+                SearchQueryJsonOr queryOr = (SearchQueryJsonOr) query;
+                return builder.or(queryOr.getValues().stream().map(c -> JpaUserSearchQueryJsonMapper.buildCondition(root, builder, joinByKey, c)).toArray(Predicate[]::new));
+            case IN:
+                SearchQueryJsonIn queryIn = (SearchQueryJsonIn) query;
+                return JpaUserSearchQueryJsonMapper.<List<String>>buildConditionAttribute(builder, root, joinByKey, queryIn.getProperty(), (k, v) -> {
+                        In<String> inClause = builder.in(builder.lower(root.get(queryIn.getProperty())));
+                        v.stream().map(String::toLowerCase).forEach(inClause::value);
+                        return inClause;
+                    })
+                    .apply(queryIn.getProperty(), queryIn.getValues());
+            case NOT:
+                SearchQueryJsonNot queryNot = (SearchQueryJsonNot) query;
+                return builder.not(buildCondition(root, builder, joinByKey, queryNot));
+            case EQUALS:
+                SearchQueryJsonEquals queryEquals = (SearchQueryJsonEquals) query;
+                return JpaUserSearchQueryJsonMapper.<String>buildConditionAttribute(builder, root, joinByKey, queryEquals.getProperty(), (k, v) -> builder.equal(builder.lower(k), v.toLowerCase()))
+                    .apply(queryEquals.getProperty(), queryEquals.getValue());
+            case LIKE:
+                SearchQueryJsonLike queryLike = (SearchQueryJsonLike) query;
+                return JpaUserSearchQueryJsonMapper.<String>buildConditionAttribute(builder, root, joinByKey, queryLike.getProperty(), (k, v) -> builder.like(builder.lower(k), v.toLowerCase()))
+                    .apply(queryLike.getProperty(), queryLike.getValue().replaceAll("*", "%"));
+            case GT:
+                SearchQueryJsonGt queryGt = (SearchQueryJsonGt) query;
+                return JpaUserSearchQueryJsonMapper.<String>buildConditionAttribute(builder, root, joinByKey, queryGt.getProperty(), (k, v) -> builder.greaterThan(builder.lower(k), v))
+                    .apply(queryGt.getProperty(), queryGt.getValue());
+            case GTE:
+                SearchQueryJsonGte queryGte = (SearchQueryJsonGte) query;
+                return JpaUserSearchQueryJsonMapper.<String>buildConditionAttribute(builder, root, joinByKey, queryGte.getProperty(), (k, v) -> builder.greaterThanOrEqualTo(builder.lower(k), v))
+                    .apply(queryGte.getProperty(), queryGte.getValue());
+            case LT:
+                SearchQueryJsonLt queryLt = (SearchQueryJsonLt) query;
+                return JpaUserSearchQueryJsonMapper.<String>buildConditionAttribute(builder, root, joinByKey, queryLt.getProperty(), (k, v) -> builder.lessThan(builder.lower(k), v))
+                    .apply(queryLt.getProperty(), queryLt.getValue());
+            case LTE:
+                SearchQueryJsonLte queryLte = (SearchQueryJsonLte) query;
+                return JpaUserSearchQueryJsonMapper.<String>buildConditionAttribute(builder, root, joinByKey, queryLte.getProperty(), (k, v) -> builder.lessThanOrEqualTo(builder.lower(k), v))
+                    .apply(queryLte.getProperty(), queryLte.getValue());
+            default:
+                throw new ModelException("No implementation to build condition available for " + query.getOperator().name());
+        }
+    }
+
+    /** Build condition with join if needed. */
+    private static <T> BiFunction<String, T, Predicate> buildConditionAttribute(CriteriaBuilder builder, Root<UserEntity> root, Map<String, Join<Object, Object>> joinByKey, String property, BiFunction<Expression<String>, T, Predicate> condition) {
+        switch (property) {
+            case FIRST_NAME:
+            case LAST_NAME:
+            case USERNAME:
+            case EMAIL:
+                return (k, v) -> condition.apply(root.get(k), v);
+            case EMAIL_VERIFIED:
+            case UserModel.ENABLED:
+                return (k, v) -> builder.equal(root.get(k), Boolean.parseBoolean(v.toString()));
+            case UserModel.IDP_ALIAS:
+                return (k, v) -> builder.equal(joinByKey.computeIfAbsent("federatedIdentities", m -> root.join("federatedIdentities"))
+                    .get("identityProvider"), v);
+            case UserModel.IDP_USER_ID:
+                return (k, v) -> builder.equal(joinByKey.computeIfAbsent("federatedIdentities", m -> root.join("federatedIdentities"))
+                    .get("userId"), v);
+            default:
+                return (k, v) -> (builder.and(
+                    builder.equal(builder.lower(joinByKey.computeIfAbsent("attributes", m -> root.join("attributes", JoinType.LEFT)).get("name")), k.toLowerCase()),
+                    condition.apply(builder.lower(joinByKey.get("attributes").get("value")), v)));
+        }
+    }
+}

--- a/server-spi/src/main/java/org/keycloak/models/UserModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/UserModel.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.models;
 
+import org.keycloak.models.search.SearchQueryJson;
 import org.keycloak.provider.ProviderEvent;
 import org.keycloak.storage.SearchableModelField;
 
@@ -97,6 +98,8 @@ public interface UserModel extends RoleMapperModel {
          * or potentially many for e.g. IN) is checked per the operator.
          */
         public static final SearchableModelField<UserModel> ATTRIBUTE       = new SearchableModelField<>("attribute", String[].class);
+
+        public static final SearchableModelField<UserModel> QUERY       = new SearchableModelField<>("query", String.class); // SearchQueryJson.class);
     }
 
     interface UserRemovedEvent extends ProviderEvent {

--- a/server-spi/src/main/java/org/keycloak/models/search/SearchQueryBuilder.java
+++ b/server-spi/src/main/java/org/keycloak/models/search/SearchQueryBuilder.java
@@ -1,0 +1,48 @@
+package org.keycloak.models.search;
+
+import java.util.Arrays;
+
+public class SearchQueryBuilder {
+
+	private SearchQueryBuilder() {}
+	
+	public static SearchQueryJson and(SearchQueryJson... values) {
+		return new SearchQueryJsonAnd(Arrays.asList(values));
+	}
+	
+	public static SearchQueryJson equals(String property, String value) {
+		return new SearchQueryJsonEquals(property, value);
+	}
+	
+	public static SearchQueryJson greaterThan(String property, String value) {
+		return new SearchQueryJsonGt(property, value);
+	}
+	
+	public static SearchQueryJson greaterThanOrEquals(String property, String value) {
+		return new SearchQueryJsonGte(property, value);
+	}
+	
+	public static SearchQueryJson in(String property, String... values) {
+		return new SearchQueryJsonIn(property, Arrays.asList(values));
+	}
+	
+	public static SearchQueryJson like(String property, String value) {
+		return new SearchQueryJsonLike(property, value);
+	}
+	
+	public static SearchQueryJson lessThan(String property, String value) {
+		return new SearchQueryJsonLt(property, value);
+	}
+	
+	public static SearchQueryJson lessThanOrEquals(String property, String value) {
+		return new SearchQueryJsonLte(property, value);
+	}
+	
+	public static SearchQueryJson not(SearchQueryJson value) {
+		return new SearchQueryJsonNot(value);
+	}
+	
+	public static SearchQueryJson or(SearchQueryJson... values) {
+		return new SearchQueryJsonOr(Arrays.asList(values));
+	}	
+}

--- a/server-spi/src/main/java/org/keycloak/models/search/SearchQueryJson.java
+++ b/server-spi/src/main/java/org/keycloak/models/search/SearchQueryJson.java
@@ -1,0 +1,37 @@
+package org.keycloak.models.search;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
+
+/**
+ * @author <a href="mailto:niannarilli@efalia.com">Nicolas iannarilli</a>
+ */
+@JsonTypeInfo(use = Id.NAME, include = As.EXISTING_PROPERTY, property = "operator")
+@JsonSubTypes({
+	@Type(value = SearchQueryJsonAnd.class, name = "and"),
+	@Type(value = SearchQueryJsonOr.class, name = "or"),
+	@Type(value = SearchQueryJsonNot.class, name = "not"),
+	@Type(value = SearchQueryJsonEquals.class, name = "equals"),
+	@Type(value = SearchQueryJsonLike.class, name = "like"),
+	@Type(value = SearchQueryJsonIn.class, name = "in"),
+	@Type(value = SearchQueryJsonGt.class, name = "gt"),
+	@Type(value = SearchQueryJsonGte.class, name = "gte"),
+	@Type(value = SearchQueryJsonLt.class, name = "lt"),
+	@Type(value = SearchQueryJsonLte.class, name = "lte")
+})
+public abstract class SearchQueryJson {
+	@JsonProperty("operator")
+	protected final SearchQueryOperator operator;
+
+	protected SearchQueryJson(SearchQueryOperator operator) {
+		this.operator = operator;
+	}
+	
+	public SearchQueryOperator getOperator() {
+		return operator;
+	}
+}

--- a/server-spi/src/main/java/org/keycloak/models/search/SearchQueryJsonAnd.java
+++ b/server-spi/src/main/java/org/keycloak/models/search/SearchQueryJsonAnd.java
@@ -1,0 +1,28 @@
+package org.keycloak.models.search;
+
+import static org.keycloak.models.search.SearchQueryOperator.AND;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+/**
+ * @author <a href="mailto:niannarilli@efalia.com">Nicolas iannarilli</a>
+ */
+@JsonPropertyOrder({ "operator", "values" })
+public class SearchQueryJsonAnd extends SearchQueryJson {
+	@JsonProperty(required = true)
+	private final List<SearchQueryJson> values;
+	
+	@JsonCreator
+	public SearchQueryJsonAnd(@JsonProperty("values") List<SearchQueryJson> values) {
+		super(AND);
+		this.values = values;
+	}
+	
+	public List<SearchQueryJson> getValues() {
+		return values;
+	}
+}

--- a/server-spi/src/main/java/org/keycloak/models/search/SearchQueryJsonEquals.java
+++ b/server-spi/src/main/java/org/keycloak/models/search/SearchQueryJsonEquals.java
@@ -1,0 +1,33 @@
+package org.keycloak.models.search;
+
+import static org.keycloak.models.search.SearchQueryOperator.EQUALS;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+/**
+ * @author <a href="mailto:niannarilli@efalia.com">Nicolas iannarilli</a>
+ */
+@JsonPropertyOrder({ "operator", "property", "value" })
+public class SearchQueryJsonEquals extends SearchQueryJson {
+	@JsonProperty(required = true)
+	private final String property;
+	@JsonProperty(required = true)
+	private final String value;
+	
+	@JsonCreator
+	public SearchQueryJsonEquals(@JsonProperty("property") String property, @JsonProperty("value") String value) {
+		super(EQUALS);
+		this.property = property;
+		this.value = value;
+	}
+
+	public String getProperty() {
+		return property;
+	}
+
+	public String getValue() {
+		return value;
+	}
+}

--- a/server-spi/src/main/java/org/keycloak/models/search/SearchQueryJsonGt.java
+++ b/server-spi/src/main/java/org/keycloak/models/search/SearchQueryJsonGt.java
@@ -1,0 +1,33 @@
+package org.keycloak.models.search;
+
+import static org.keycloak.models.search.SearchQueryOperator.GT;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+/**
+ * @author <a href="mailto:niannarilli@efalia.com">Nicolas iannarilli</a>
+ */
+@JsonPropertyOrder({ "operator", "property", "value" })
+public class SearchQueryJsonGt extends SearchQueryJson {
+	@JsonProperty(required = true)
+	private final String property;
+	@JsonProperty(required = true)
+	private final String value;
+	
+	@JsonCreator
+	public SearchQueryJsonGt(@JsonProperty("property") String property, @JsonProperty("value") String value) {
+		super(GT);
+		this.property = property;
+		this.value = value;
+	}
+
+	public String getProperty() {
+		return property;
+	}
+
+	public String getValue() {
+		return value;
+	}
+}

--- a/server-spi/src/main/java/org/keycloak/models/search/SearchQueryJsonGte.java
+++ b/server-spi/src/main/java/org/keycloak/models/search/SearchQueryJsonGte.java
@@ -1,0 +1,33 @@
+package org.keycloak.models.search;
+
+import static org.keycloak.models.search.SearchQueryOperator.GTE;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+/**
+ * @author <a href="mailto:niannarilli@efalia.com">Nicolas iannarilli</a>
+ */
+@JsonPropertyOrder({ "operator", "property", "value" })
+public class SearchQueryJsonGte extends SearchQueryJson {
+	@JsonProperty(required = true)
+	private final String property;
+	@JsonProperty(required = true)
+	private final String value;
+	
+	@JsonCreator
+	public SearchQueryJsonGte(@JsonProperty("property") String property, @JsonProperty("value") String value) {
+		super(GTE);
+		this.property = property;
+		this.value = value;
+	}
+
+	public String getProperty() {
+		return property;
+	}
+
+	public String getValue() {
+		return value;
+	}
+}

--- a/server-spi/src/main/java/org/keycloak/models/search/SearchQueryJsonIn.java
+++ b/server-spi/src/main/java/org/keycloak/models/search/SearchQueryJsonIn.java
@@ -1,0 +1,35 @@
+package org.keycloak.models.search;
+
+import static org.keycloak.models.search.SearchQueryOperator.IN;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+/**
+ * @author <a href="mailto:niannarilli@efalia.com">Nicolas iannarilli</a>
+ */
+@JsonPropertyOrder({ "operator", "property", "values" })
+public class SearchQueryJsonIn extends SearchQueryJson {
+	@JsonProperty(required = true)
+	private final String property;
+	@JsonProperty(required = true)
+	private final List<String> values;
+	
+	@JsonCreator
+	public SearchQueryJsonIn(@JsonProperty("property") String property, @JsonProperty("values") List<String> values) {
+		super(IN);
+		this.property = property;
+		this.values = values;
+	}
+
+	public String getProperty() {
+		return property;
+	}
+
+	public List<String> getValues() {
+		return values;
+	}
+}

--- a/server-spi/src/main/java/org/keycloak/models/search/SearchQueryJsonLike.java
+++ b/server-spi/src/main/java/org/keycloak/models/search/SearchQueryJsonLike.java
@@ -1,0 +1,33 @@
+package org.keycloak.models.search;
+
+import static org.keycloak.models.search.SearchQueryOperator.LIKE;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+/**
+ * @author <a href="mailto:niannarilli@efalia.com">Nicolas iannarilli</a>
+ */
+@JsonPropertyOrder({ "operator", "property", "value" })
+public class SearchQueryJsonLike extends SearchQueryJson {
+	@JsonProperty(required = true)
+	private final String property;
+	@JsonProperty(required = true)
+	private final String value;
+	
+	@JsonCreator
+	public SearchQueryJsonLike(@JsonProperty("property") String property, @JsonProperty("value") String value) {
+		super(LIKE);
+		this.property = property;
+		this.value = value;
+	}
+
+	public String getProperty() {
+		return property;
+	}
+
+	public String getValue() {
+		return value;
+	}
+}

--- a/server-spi/src/main/java/org/keycloak/models/search/SearchQueryJsonLt.java
+++ b/server-spi/src/main/java/org/keycloak/models/search/SearchQueryJsonLt.java
@@ -1,0 +1,33 @@
+package org.keycloak.models.search;
+
+import static org.keycloak.models.search.SearchQueryOperator.LT;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+/**
+ * @author <a href="mailto:niannarilli@efalia.com">Nicolas iannarilli</a>
+ */
+@JsonPropertyOrder({ "operator", "property", "value" })
+public class SearchQueryJsonLt extends SearchQueryJson {
+	@JsonProperty(required = true)
+	private final String property;
+	@JsonProperty(required = true)
+	private final String value;
+	
+	@JsonCreator
+	public SearchQueryJsonLt(@JsonProperty("property") String property, @JsonProperty("value") String value) {
+		super(LT);
+		this.property = property;
+		this.value = value;
+	}
+
+	public String getProperty() {
+		return property;
+	}
+
+	public String getValue() {
+		return value;
+	}
+}

--- a/server-spi/src/main/java/org/keycloak/models/search/SearchQueryJsonLte.java
+++ b/server-spi/src/main/java/org/keycloak/models/search/SearchQueryJsonLte.java
@@ -1,0 +1,33 @@
+package org.keycloak.models.search;
+
+import static org.keycloak.models.search.SearchQueryOperator.LTE;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+/**
+ * @author <a href="mailto:niannarilli@efalia.com">Nicolas iannarilli</a>
+ */
+@JsonPropertyOrder({ "operator", "property", "value" })
+public class SearchQueryJsonLte extends SearchQueryJson {
+	@JsonProperty(required = true)
+	private final String property;
+	@JsonProperty(required = true)
+	private final String value;
+	
+	@JsonCreator
+	public SearchQueryJsonLte(@JsonProperty("property") String property, @JsonProperty("value") String value) {
+		super(LTE);
+		this.property = property;
+		this.value = value;
+	}
+
+	public String getProperty() {
+		return property;
+	}
+
+	public String getValue() {
+		return value;
+	}
+}

--- a/server-spi/src/main/java/org/keycloak/models/search/SearchQueryJsonNot.java
+++ b/server-spi/src/main/java/org/keycloak/models/search/SearchQueryJsonNot.java
@@ -1,0 +1,26 @@
+package org.keycloak.models.search;
+
+import static org.keycloak.models.search.SearchQueryOperator.NOT;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+/**
+ * @author <a href="mailto:niannarilli@efalia.com">Nicolas iannarilli</a>
+ */
+@JsonPropertyOrder({ "operator", "value" })
+public class SearchQueryJsonNot extends SearchQueryJson {
+	@JsonProperty(required = true)
+	private final SearchQueryJson value;
+	
+	@JsonCreator
+	public SearchQueryJsonNot(@JsonProperty("value") SearchQueryJson value) {
+		super(NOT);
+		this.value = value;
+	}
+
+	public SearchQueryJson getValue() {
+		return value;
+	}
+}

--- a/server-spi/src/main/java/org/keycloak/models/search/SearchQueryJsonOr.java
+++ b/server-spi/src/main/java/org/keycloak/models/search/SearchQueryJsonOr.java
@@ -1,0 +1,28 @@
+package org.keycloak.models.search;
+
+import static org.keycloak.models.search.SearchQueryOperator.OR;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+/**
+ * @author <a href="mailto:niannarilli@efalia.com">Nicolas iannarilli</a>
+ */
+@JsonPropertyOrder({ "operator", "values" })
+public class SearchQueryJsonOr extends SearchQueryJson {
+	@JsonProperty(required = true)
+	private final List<SearchQueryJson> values;
+	
+	@JsonCreator
+	public SearchQueryJsonOr(@JsonProperty("values") List<SearchQueryJson> values) {
+		super(OR);
+		this.values = values;
+	}
+
+	public List<SearchQueryJson> getValues() {
+		return values;
+	}
+}

--- a/server-spi/src/main/java/org/keycloak/models/search/SearchQueryOperator.java
+++ b/server-spi/src/main/java/org/keycloak/models/search/SearchQueryOperator.java
@@ -1,0 +1,25 @@
+package org.keycloak.models.search;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * @author <a href="mailto:niannarilli@efalia.com">Nicolas iannarilli</a>
+ */
+public enum SearchQueryOperator {
+	AND,
+	EQUALS,
+	IN,
+	LIKE,
+	NOT,
+	OR,
+	GT,
+	GTE,
+	LT,
+	LTE;
+	
+	@JsonValue
+	@Override
+	public String toString() {
+		return super.toString().toLowerCase();
+	}
+}

--- a/server-spi/src/main/java/org/keycloak/storage/user/UserQueryProvider.java
+++ b/server-spi/src/main/java/org/keycloak/storage/user/UserQueryProvider.java
@@ -20,6 +20,7 @@ import org.keycloak.models.GroupModel;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.RoleModel;
 import org.keycloak.models.UserModel;
+import org.keycloak.models.search.SearchQueryJson;
 
 import java.util.Collections;
 import java.util.List;
@@ -103,6 +104,24 @@ public interface UserQueryProvider {
      */
     default int getUsersCount(RealmModel realm, Map<String, String> params) {
         return (int) searchForUserStream(realm, params).count();
+    }
+
+    /**
+     * Returns the number of users that match the given filter parameters.
+     *
+     * @param realm  the realm
+     * @param query search filter in json
+     * @return number of users that match the given filters
+     */
+    default int getUsersCount(RealmModel realm, SearchQueryJson query) {
+        return getUsersCount(query, realm);
+    }
+    /**
+     * @deprecated Use {@link #getUsersCount(RealmModel, Set) getUsersCount} instead.
+     */
+    @Deprecated
+    default int getUsersCount(SearchQueryJson query, RealmModel realm) {
+        return (int) searchForUserStream(realm, query, null, null).count();
     }
 
     /**
@@ -316,6 +335,37 @@ public interface UserQueryProvider {
     Stream<UserModel> searchForUserByUserAttributeStream(RealmModel realm, String attrName, String attrValue);
 
     /**
+     * Searches for user by json query. 
+     *
+     * This method is used by the REST API when querying users.
+     *
+     * @param realm a reference to the realm.
+     * @param query a query containing the search parameters.
+     * @return a non-null {@link Stream} of users that match the search criteria.
+     */
+    default Stream<UserModel> searchForUserStream(RealmModel realm, SearchQueryJson query) {
+        return searchForUserStream(realm, query, null, null);
+    }
+
+    /**
+     * Searches for user by json query. 
+     *
+     * This method is used by the REST API when querying users.
+     *
+     * @param realm a reference to the realm.
+     * @param query a query containing the search parameters.
+     * @param firstResult first result to return. Ignored if negative, zero, or {@code null}.
+     * @param maxResults maximum number of results to return. Ignored if negative or {@code null}.
+     * @return a non-null {@link Stream} of users that match the search criteria.
+     */
+    Stream<UserModel> searchForUserStream(RealmModel realm, SearchQueryJson query, Integer firstResult, Integer maxResults);
+
+    /**
+     * The {@link Streams} interface makes all collection-based methods in {@link UserQueryProvider} default by
+     * providing implementations that delegate to the {@link Stream}-based variants instead of the other way around.
+     * <p/>
+     * It allows for implementations to focus on the {@link Stream}-based approach for processing sets of data and benefit
+     * from the potential memory and performance optimizations of that approach.
      * @deprecated This interface is no longer necessary, collection-based methods were removed from the parent interface
      * and therefore the parent interface can be used directly
      */

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/federation/BackwardsCompatibilityUserStorage.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/federation/BackwardsCompatibilityUserStorage.java
@@ -42,6 +42,7 @@ import org.keycloak.models.UserCredentialModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.cache.UserCache;
 import org.keycloak.models.credential.PasswordUserCredentialModel;
+import org.keycloak.models.search.SearchQueryJson;
 import org.keycloak.models.utils.TimeBasedOTP;
 import org.keycloak.storage.StorageId;
 import org.keycloak.storage.UserStorageProvider;
@@ -375,6 +376,12 @@ public class BackwardsCompatibilityUserStorage implements UserLookupProvider, Us
     }
 
     @Override
+    public Stream<UserModel> searchForUserStream(RealmModel realm, SearchQueryJson query, Integer firstResult, Integer maxResults) {
+        // Assume that this is not supported
+        return Stream.empty();
+    }
+
+    @Override
     public void close() {
     }
 
@@ -412,5 +419,4 @@ public class BackwardsCompatibilityUserStorage implements UserLookupProvider, Us
             throw new AssertionError("Objects not equals");
         }
     }
-
 }

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/federation/FailableHardcodedStorageProvider.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/federation/FailableHardcodedStorageProvider.java
@@ -27,6 +27,7 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserCredentialModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.credential.PasswordCredentialModel;
+import org.keycloak.models.search.SearchQueryJson;
 import org.keycloak.models.utils.UserModelDelegate;
 import org.keycloak.storage.UserStoragePrivateUtil;
 import org.keycloak.storage.UserStorageProvider;
@@ -281,6 +282,12 @@ public class FailableHardcodedStorageProvider implements UserStorageProvider, Us
 
     @Override
     public Stream<UserModel> searchForUserByUserAttributeStream(RealmModel realm, String attrName, String attrValue) {
+        checkForceFail();
+        return Stream.empty();
+    }
+
+    @Override
+    public Stream<UserModel> searchForUserStream(RealmModel realm, SearchQueryJson query, Integer firstResult, Integer maxResults) {
         checkForceFail();
         return Stream.empty();
     }

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/federation/UserPropertyFileStorage.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/federation/UserPropertyFileStorage.java
@@ -28,6 +28,7 @@ import org.keycloak.models.SubjectCredentialManager;
 import org.keycloak.models.UserCredentialModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.credential.PasswordCredentialModel;
+import org.keycloak.models.search.SearchQueryJson;
 import org.keycloak.storage.StorageId;
 import org.keycloak.storage.UserStorageProvider;
 import org.keycloak.storage.adapter.AbstractUserAdapter;
@@ -244,6 +245,11 @@ public class UserPropertyFileStorage implements UserLookupProvider, UserStorageP
 
     @Override
     public Stream<UserModel> searchForUserByUserAttributeStream(RealmModel realm, String attrName, String attrValue) {
+        return Stream.empty();
+    }
+
+    @Override
+    public Stream<UserModel> searchForUserStream(RealmModel realm, SearchQueryJson query, Integer firstResult, Integer maxResults) {
         return Stream.empty();
     }
 


### PR DESCRIPTION
Feature summary

This enhancement would add a new way to create queries for searching users. Using a JSON description of the search criteria, one would be able to craft complex queries like:

```json
{
    "operator": "and",
    "values": [
        {
            "operator": "equals",
            "property": "username",
            "value": "sjohn"
        },
        {
            "operator": "like",
            "property": "firstName",
            "value": "*jo*"
        }
    ]
}
```

See #14478 for more information.