### PR TITLE
Fix deployable JS mappers with the same "fileName" overwriting SAML/OpenID provider

### DIFF
--- a/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
+++ b/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
@@ -742,7 +742,7 @@ class KeycloakProcessor {
             metadata.setCode(StreamUtil.readString(in, StandardCharsets.UTF_8));
         }
 
-        metadata.setId(new StringBuilder("script").append("-").append(fileName).toString());
+        metadata.setId(entry.getKey() + "-" + "script" + "-" + fileName);
 
         String name = metadata.getName();
 


### PR DESCRIPTION
When the same script "fileName" is being used inside deployed JAR file (keycloak-scripts.json) for both "mappers" and "saml-mappers", the former one will override latter, and thus - custom OpenID protocol mapper will be created, but the SAML-based one - not. 
That's why it's needed to create distinct IDs for these types of mappers - not relying on name of the file itself, but also prefixing it with type of domain it belongs to ("mappers", "saml-mappers", etc).

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
