### PR TITLE
Don't print warning when heapdump not found

### DIFF
--- a/.github/actions/upload-heapdumps/action.yml
+++ b/.github/actions/upload-heapdumps/action.yml
@@ -10,3 +10,4 @@ runs:
       with:
         name: jvm-heap-dumps
         path: '**/java_pid*.hprof'
+        if-no-files-found: ignore


### PR DESCRIPTION
Fixes: #16125

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
