### PR TITLE
Add missing < to Javadoc

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/ScriptBasedAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/ScriptBasedAuthenticator.java
@@ -50,7 +50,7 @@ import java.util.Map;
  * <li>{@code session} the active {@link KeycloakSession}</li>
  * <li>{@code authenticationSession} the current {@link org.keycloak.sessions.AuthenticationSessionModel}</li>
  * <li>{@code httpRequest} the current {@link org.keycloak.http.HttpRequest}</li>
- * <li>{@code LOG} a {@link org.jboss.logging.Logger} scoped to {@link ScriptBasedAuthenticator}/li>
+ * <li>{@code LOG} a {@link org.jboss.logging.Logger} scoped to {@link ScriptBasedAuthenticator}</li>
  * </ol>
  * </p>
  * <p>


### PR DESCRIPTION
The Javadoc for ScriptBasedAuthenticator is missing a `<` to render the list properly; this PR adds it.