### PR TITLE
Suspend scheduled tasks if time offset is set to a large value

### DIFF
--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/rest/TestingResourceProvider.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/rest/TestingResourceProvider.java
@@ -237,11 +237,17 @@ public class TestingResourceProvider implements RealmResourceProvider {
     @Produces(MediaType.APPLICATION_JSON)
     public Map<String, String> setTimeOffset(Map<String, String> time) {
         int offset = Integer.parseInt(time.get("offset"));
+
+        if (offset > 60) {
+            suspendTask(ClearExpiredUserSessions.TASK_NAME);
+        }
+
         Time.setOffset(offset);
 
         // Time offset was restarted
         if (offset == 0) {
             session.getKeycloakSessionFactory().publish(new ResetTimeOffsetEvent());
+            restorePeriodicTasks();
         }
 
         return getTimeOffset();


### PR DESCRIPTION
A few tests have been failing due to admin client not being able to refresh the token. What was common here was setting the offset to a high number. What could happen is:

1. Set time offset to a large number
2. Session is expired and user session garbage collection runs
3. Time offset is reset
4. Admin client fails to use tokens as the session has been garbage collected

This PR temporarily pauses the garbage collection while the time offset is set to a high number.

Closes #16143