### PR TITLE
fix(account): do not leak into messages property

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/account/AccountConsole.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountConsole.java
@@ -111,7 +111,8 @@ public class AccountConsole {
             if (auth != null) user = auth.getUser();
             Locale locale = session.getContext().resolveLocale(user);
             map.put("locale", locale.toLanguageTag());
-            Properties messages = theme.getMessages(locale);
+            Properties messages = new Properties();
+            messages.putAll(theme.getMessages(locale));
             if(StringUtil.isNotBlank(realm.getDefaultLocale())) {
                 messages.putAll(realm.getRealmLocalizationTextsByLocale(realm.getDefaultLocale()));
             }


### PR DESCRIPTION
Closes #16211

Essentially ensures that the actual `Properties` object inside the cached theme instance is not reused for `putAll`, which will not remove deleted instance translations.