### PR TITLE
Clarify using of --optimized flag with DBs

### DIFF
--- a/docs/guides/src/main/server/db.adoc
+++ b/docs/guides/src/main/server/db.adoc
@@ -40,6 +40,14 @@ This command includes the minimum settings needed to connect to the database.
 
 The default schema is `keycloak`, but you can change it by using the `db-schema` configuration option.
 
+.Warning:
+[NOTE]
+Do NOT use the `--optimized` flag for the `start` command if you want to use a particular DB (except the H2).
+Executing the build phase before starting the server instance is necessary.
+You can achieve it either by starting the instance without the `--optimized` flag,
+or by executing the `build` command before the optimized start.
+For more information, see <@links.server id="configuration"/>.
+
 == Overriding default connection settings
 
 The server uses JDBC as the underlying technology to communicate with the database. If the default connection settings are insufficient, you can specify a JDBC URL using the `db-url` configuration option.


### PR DESCRIPTION
Closes #16220

@pedroigor Could you please take a look at it? Thanks!

Cross-reference to the Configuration guide works as expected for keycloak-web.