### PR TITLE
Incrementally cache consents on a per client basis

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/entities/CachedUserConsent.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/entities/CachedUserConsent.java
@@ -32,6 +32,7 @@ public class CachedUserConsent {
     private final Set<String> clientScopeIds = new HashSet<>();
     private final Long createdDate;
     private final Long lastUpdatedDate;
+    private boolean notExistent;
 
     public CachedUserConsent(UserConsentModel consentModel) {
         this.clientDbId = consentModel.getClient().getId();
@@ -40,6 +41,13 @@ public class CachedUserConsent {
         }
         this.createdDate = consentModel.getCreatedDate();
         this.lastUpdatedDate = consentModel.getLastUpdatedDate();
+    }
+
+    public CachedUserConsent(String clientDbId) {
+        this.clientDbId = clientDbId;
+        this.createdDate = null;
+        this.lastUpdatedDate = null;
+        this.notExistent = true;
     }
 
     public String getClientDbId() {
@@ -56,5 +64,9 @@ public class CachedUserConsent {
 
     public Long getLastUpdatedDate() {
         return lastUpdatedDate;
+    }
+
+    public boolean isNotExistent() {
+        return notExistent;
     }
 }

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/entities/CachedUserConsents.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/entities/CachedUserConsents.java
@@ -29,14 +29,21 @@ import java.util.List;
 public class CachedUserConsents extends AbstractRevisioned implements InRealm {
     private HashMap<String, CachedUserConsent> consents = new HashMap<>();
     private final String realmId;
+    private boolean allConsents;
 
     public CachedUserConsents(Long revision, String id, RealmModel realm,
-                              List<UserConsentModel> consents) {
+                              List<CachedUserConsent> consents) {
+        this(revision, id, realm, consents, true);
+    }
+
+    public CachedUserConsents(Long revision, String id, RealmModel realm,
+            List<CachedUserConsent> consents, boolean allConsents) {
         super(revision, id);
         this.realmId = realm.getId();
+        this.allConsents = allConsents;
         if (consents != null) {
-            for (UserConsentModel consent : consents) {
-                this.consents.put(consent.getClient().getId(), new CachedUserConsent(consent));
+            for (CachedUserConsent consent : consents) {
+                this.consents.put(consent.getClientDbId(), consent);
             }
         }
     }
@@ -49,5 +56,9 @@ public class CachedUserConsents extends AbstractRevisioned implements InRealm {
 
     public HashMap<String, CachedUserConsent> getConsents() {
         return consents;
+    }
+
+    public boolean isAllConsents() {
+        return allConsents;
     }
 }


### PR DESCRIPTION
Closes #16224

* As discussed with @mposolda, avoid querying consents when introducing new entries to the cached entry (it is a local cache).
* Also avoiding unnecessary queries if no consent is granted to a particular client, as suggested by @hmlnarik 

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
