### PR TITLE
Fix NPE if user not exists in PolicyEvaluationRequest

### DIFF
--- a/services/src/main/java/org/keycloak/authorization/common/KeycloakIdentity.java
+++ b/services/src/main/java/org/keycloak/authorization/common/KeycloakIdentity.java
@@ -234,6 +234,9 @@ public class KeycloakIdentity implements Identity {
             }
 
             UserModel userSession = getUserFromToken();
+            if (userSession == null) {
+                throw new IllegalArgumentException("User from token not found");
+            }
 
             this.resourceServer = clientUser != null && userSession.getId().equals(clientUser.getId());
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
@@ -356,13 +356,10 @@ public class TokenManager {
 
         // Fallback to lookup user based on username (preferred_username claim)
         if (token.getPreferredUsername() != null) {
-            user = session.users().getUserByUsername(realm, token.getPreferredUsername());
-            if (user != null) {
-                return user;
-            }
+            return session.users().getUserByUsername(realm, token.getPreferredUsername());
         }
 
-        return user;
+        return null;
     }
 
 


### PR DESCRIPTION
Check "userSession.getId().equals(clientUser.getId())" fails if getUserFromToken return non existed user. It is happens when AccessToken.subject relates to non existed user.

![image](https://user-images.githubusercontent.com/669347/210524755-0800e4dd-76ca-4bef-82b0-93250a9b076c.png)

![image](https://user-images.githubusercontent.com/669347/210524888-3f242031-2e91-4768-9446-79ee20f1942e.png)
