### PR TITLE
Force refreshing token for admin client if time offset is set

### DIFF
--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/rest/TestingResourceProvider.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/rest/TestingResourceProvider.java
@@ -238,16 +238,11 @@ public class TestingResourceProvider implements RealmResourceProvider {
     public Map<String, String> setTimeOffset(Map<String, String> time) {
         int offset = Integer.parseInt(time.get("offset"));
 
-        if (offset > 60) {
-            suspendTask(ClearExpiredUserSessions.TASK_NAME);
-        }
-
         Time.setOffset(offset);
 
         // Time offset was restarted
         if (offset == 0) {
             session.getKeycloakSessionFactory().publish(new ResetTimeOffsetEvent());
-            restorePeriodicTasks();
         }
 
         return getTimeOffset();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/AbstractKeycloakTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/AbstractKeycloakTest.java
@@ -674,6 +674,14 @@ public abstract class AbstractKeycloakTest {
         // adminClient depends on Time.offset for auto-refreshing tokens
         Time.setOffset(offset);
         Map result = testingClient.testing().setTimeOffset(Collections.singletonMap("offset", String.valueOf(offset)));
+
+        // force refreshing token after time offset has changed
+        try {
+            adminClient.tokenManager().refreshToken();
+        } catch (RuntimeException e) {
+            adminClient.tokenManager().grantToken();
+        }
+
         return String.valueOf(result);
     }
 


### PR DESCRIPTION
The previous attempt I had in https://github.com/keycloak/keycloak/pull/16144 did not resolve the issue with a few tests failing after setting time offsets (an example can be seen in https://stianst.github.io/keycloak-dashboard/tests#failed-job-fips-it).

Eventually figured out what is going on with here:

1. InfinispanTestTimeServiceRule is used to set the time on the cache expiration manager to the KC time offset
2. Time offset is set to a large value
3. Infinispan expiration reaper runs and removes user session
4. Test fails

I've managed to reproduce the above by forcing the expiration manager to run with the following snippet added to `LoginTest.loginWithForcePasswordChangePolicy`, which makes the test fail everytime:

```
testingClient.server().run(session -> {
  InfinispanConnectionProvider ispnProvider = session.getProvider(InfinispanConnectionProvider.class);
  Cache<Object, Object> cache = ispnProvider.getCache(InfinispanConnectionProvider.USER_SESSION_CACHE_NAME);
  cache.getAdvancedCache().getExpirationManager().processExpiration();
});
```

With these changes the above works fine.


Closes #16143
