### PR TITLE
Fix #16278: isTokenExpired is returning true when should be false

### DIFF
--- a/adapters/oidc/js/src/keycloak.js
+++ b/adapters/oidc/js/src/keycloak.js
@@ -257,7 +257,7 @@ function Keycloak (config) {
                 });
             } else if (initOptions) {
                 if (initOptions.token && initOptions.refreshToken) {
-                    setToken(initOptions.token, initOptions.refreshToken, initOptions.idToken);
+                    setToken(initOptions.token, initOptions.refreshToken, initOptions.idToken, new Date().getTime());
 
                     if (loginIframe.enable) {
                         setupCheckLoginIframe().then(function() {


### PR DESCRIPTION
Fixed isTokenExpired() when it was returning true after a token updated with updateToken()

Issue #16278