### PR TITLE
Keep consistency when importing realms at startup when they are exported via the export command

### DIFF
--- a/docs/guides/src/main/server/importExport.adoc
+++ b/docs/guides/src/main/server/importExport.adoc
@@ -79,12 +79,16 @@ You are also able to import realms when the server is starting by using the `--i
 
 <@kc.start parameters="--import-realm"/>
 
-When you set the `--import-realm` option, the server is going to try to import any realm configuration file from the `data/import` directory. Each file in this directory should
-contain a single realm configuration. Only regular files using the `.json` extension are read from this directory, sub-directories are ignored.
+When you set the `--import-realm` option, the server is going to try to import any realm configuration file from the `data/import` directory. Only regular files using the `.json` extension are read from this directory, sub-directories are ignored.
 
 NOTE: For the https://quay.io/keycloak/keycloak[published containers], the import directory is `/opt/keycloak/data/import`
 
-If a realm already exists in the server, the import operation is skipped.
+If a realm already exists in the server, the import operation is skipped. The main reason behind this behavior is to avoid re-creating
+realms and potentially loose state between server restarts.
+
+To re-create realms you should explicitly run the `import` command prior to starting the server.
+
+Importing the `master` realm is not supported because as it is a very sensitive operation.
 
 === Using Environment Variables within the Realm Configuration Files
 

--- a/model/legacy-services/src/main/java/org/keycloak/exportimport/AbstractFileBasedImportProvider.java
+++ b/model/legacy-services/src/main/java/org/keycloak/exportimport/AbstractFileBasedImportProvider.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.exportimport;
+
+import static org.keycloak.common.util.StringPropertyReplacer.replaceProperties;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.util.Optional;
+import org.keycloak.common.util.StringPropertyReplacer;
+
+public abstract class AbstractFileBasedImportProvider implements ImportProvider {
+
+    private static final StringPropertyReplacer.PropertyResolver ENV_VAR_PROPERTY_RESOLVER = new StringPropertyReplacer.PropertyResolver() {
+        @Override
+        public String resolve(String property) {
+            return Optional.ofNullable(property).map(System::getenv).orElse(null);
+        }
+    };
+
+    protected InputStream parseFile(File importFile) throws IOException {
+        if (ExportImportConfig.isReplacePlaceholders()) {
+            String raw = new String(Files.readAllBytes(importFile.toPath()), "UTF-8");
+            String parsed = replaceProperties(raw, ENV_VAR_PROPERTY_RESOLVER);
+            return new ByteArrayInputStream(parsed.getBytes());
+        }
+
+        return new FileInputStream(importFile);
+    }
+
+}

--- a/model/legacy-services/src/main/java/org/keycloak/exportimport/singlefile/SingleFileImportProvider.java
+++ b/model/legacy-services/src/main/java/org/keycloak/exportimport/singlefile/SingleFileImportProvider.java
@@ -19,7 +19,7 @@ package org.keycloak.exportimport.singlefile;
 
 import org.jboss.logging.Logger;
 import org.keycloak.Config;
-import org.keycloak.exportimport.ImportProvider;
+import org.keycloak.exportimport.AbstractFileBasedImportProvider;
 import org.keycloak.exportimport.Strategy;
 import org.keycloak.exportimport.util.ExportImportSessionTask;
 import org.keycloak.exportimport.util.ImportUtils;
@@ -30,14 +30,14 @@ import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.util.JsonSerialization;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Map;
 
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
  */
-public class SingleFileImportProvider implements ImportProvider {
+public class SingleFileImportProvider extends AbstractFileBasedImportProvider {
 
     private static final Logger logger = Logger.getLogger(SingleFileImportProvider.class);
 
@@ -73,7 +73,7 @@ public class SingleFileImportProvider implements ImportProvider {
 
     protected void checkRealmReps() throws IOException {
         if (realmReps == null) {
-            FileInputStream is = new FileInputStream(file);
+            InputStream is = parseFile(file);
             realmReps = ImportUtils.getRealmsFromStream(JsonSerialization.mapper, is);
         }
     }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/ImportRealmMixin.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/ImportRealmMixin.java
@@ -40,13 +40,7 @@ public final class ImportRealmMixin {
         File importDir = Environment.getHomePath().resolve("data").resolve("import").toFile();
 
         if (importDir.exists()) {
-            StringBuilder filesToImport = new StringBuilder();
-
-            for (File realmFile : importDir.listFiles()) {
-                filesToImport.append(realmFile.getAbsolutePath()).append(",");
-            }
-
-            System.setProperty("keycloak.import", filesToImport.toString());
+            System.setProperty("keycloak.import", importDir.getAbsolutePath());
         }
     }
 }

--- a/services/src/main/java/org/keycloak/exportimport/ExportImportConfig.java
+++ b/services/src/main/java/org/keycloak/exportimport/ExportImportConfig.java
@@ -39,6 +39,9 @@ public class ExportImportConfig {
     // used for "singleFile" provider
     public static final String FILE = PREFIX + "file";
 
+    // used for replacing placeholders
+    public static final String REPLACE_PLACEHOLDERS = PREFIX + "replace-placeholders";
+
     // How to export users when realm export is requested for "dir" provider
     public static final String USERS_EXPORT_STRATEGY = PREFIX + "usersExportStrategy";
     public static final UsersExportStrategy DEFAULT_USERS_EXPORT_STRATEGY = UsersExportStrategy.DIFFERENT_FILES;
@@ -116,5 +119,13 @@ public class ExportImportConfig {
     public static Strategy getStrategy() {
         String strategy = System.getProperty(STRATEGY, DEFAULT_STRATEGY.toString());
         return Enum.valueOf(Strategy.class, strategy);
+    }
+
+    public static boolean isReplacePlaceholders() {
+        return Boolean.getBoolean(REPLACE_PLACEHOLDERS);
+    }
+
+    public static void setReplacePlaceholders(boolean replacePlaceholders) {
+        System.setProperty(REPLACE_PLACEHOLDERS, String.valueOf(replacePlaceholders));
     }
 }


### PR DESCRIPTION
Closes #16281

* Importing realms at start-up is now relying on the existent import providers (e.g.: `singleFile` and `dir`)
* Importing realms at start-up can now use files created when running `export --dir`
* Importing realms at start-up can now use files with multiple realms in it

I did not want to create a separate provider but leverage what we have. 

This code is for legacy and ideally, we should have it within `legacy-services`. But that would require a follow-up.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
