### PR TITLE
Increase timeout for Store Model Test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,7 +309,7 @@ jobs:
     name: Store Model Tests
     runs-on: ubuntu-latest
     needs: build
-    timeout-minutes: 60
+    timeout-minutes: 75
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
Store Model Tests have timed out a few times lately, see https://stianst.github.io/keycloak-dashboard/tests#recently-failed