### PR TITLE
SOAP backchannel logout for SAML protocol

### DIFF
--- a/saml-core/src/main/java/org/keycloak/saml/BaseSAML2BindingBuilder.java
+++ b/saml-core/src/main/java/org/keycloak/saml/BaseSAML2BindingBuilder.java
@@ -212,6 +212,28 @@ public class BaseSAML2BindingBuilder<T extends BaseSAML2BindingBuilder> {
         }
     }
 
+    public static class BaseSoapBindingBuilder {
+        protected Document document;
+        protected BaseSAML2BindingBuilder builder;
+
+        public BaseSoapBindingBuilder(BaseSAML2BindingBuilder builder, Document document) throws ProcessingException {
+            this.builder = builder;
+            this.document = document;
+            if (builder.signAssertions) {
+                builder.signAssertion(document);
+            }
+            if (builder.encrypt) builder.encryptDocument(document);
+            if (builder.sign) {
+                builder.signDocument(document);
+            }
+        }
+
+        public Document getDocument() {
+            return document;
+        }
+
+    }
+
     public BaseRedirectBindingBuilder redirectBinding(Document document) throws ProcessingException {
         return new BaseRedirectBindingBuilder(this, document);
 
@@ -222,7 +244,9 @@ public class BaseSAML2BindingBuilder<T extends BaseSAML2BindingBuilder> {
 
     }
 
-
+    public BaseSoapBindingBuilder soapBinding(Document document) throws ProcessingException {
+        return new BaseSoapBindingBuilder(this, document);
+    }
 
     public String getSAMLNSPrefix(Document samlResponseDocument) {
         Node assertionElement = samlResponseDocument.getDocumentElement()

--- a/saml-core/src/main/java/org/keycloak/saml/processing/api/saml/v2/response/SAML2Response.java
+++ b/saml-core/src/main/java/org/keycloak/saml/processing/api/saml/v2/response/SAML2Response.java
@@ -66,6 +66,7 @@ import javax.xml.datatype.XMLGregorianCalendar;
 import javax.xml.namespace.QName;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Writer;
@@ -394,6 +395,21 @@ public class SAML2Response {
     }
 
     /**
+     * Get the Underlying SAML2Object from a document
+     * @param samlDocument a Document containing a SAML2Object
+     * @return a SAMLDocumentHolder
+     * @throws ProcessingException
+     * @throws ParsingException
+     */
+    public static SAMLDocumentHolder getSAML2ObjectFromDocument(Document samlDocument) throws ProcessingException, ParsingException {
+        SAMLParser samlParser = SAMLParser.getInstance();
+        JAXPValidationUtil.checkSchemaValidation(samlDocument);
+        SAML2Object responseType = (SAML2Object) samlParser.parse(samlDocument);
+
+        return new SAMLDocumentHolder(responseType, samlDocument);
+    }
+
+    /**
      * Convert an EncryptedElement into a Document
      *
      * @param encryptedElementType
@@ -423,7 +439,7 @@ public class SAML2Response {
      * @throws ConfigurationException
      * @throws ProcessingException
      */
-    public Document convert(StatusResponseType responseType) throws ProcessingException, ConfigurationException,
+    public static Document convert(StatusResponseType responseType) throws ProcessingException, ConfigurationException,
             ParsingException {
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
 

--- a/services/src/main/java/org/keycloak/protocol/saml/EntityDescriptorDescriptionConverter.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/EntityDescriptorDescriptionConverter.java
@@ -194,6 +194,8 @@ public class EntityDescriptorDescriptionConverter implements ClientDescriptionCo
         if (logoutPost != null) attributes.put(SamlProtocol.SAML_SINGLE_LOGOUT_SERVICE_URL_POST_ATTRIBUTE, logoutPost);
         String logoutRedirect = getLogoutLocation(spDescriptorType, JBossSAMLURIConstants.SAML_HTTP_REDIRECT_BINDING.get());
         if (logoutRedirect != null) attributes.put(SamlProtocol.SAML_SINGLE_LOGOUT_SERVICE_URL_REDIRECT_ATTRIBUTE, logoutRedirect);
+        String logoutSoap = getLogoutLocation(spDescriptorType, JBossSAMLURIConstants.SAML_SOAP_BINDING.get());
+        if (logoutSoap != null) attributes.put(SamlProtocol.SAML_SINGLE_LOGOUT_SERVICE_URL_SOAP_ATTRIBUTE, logoutSoap);
 
         String assertionConsumerServicePostBinding = getServiceURL(spDescriptorType, JBossSAMLURIConstants.SAML_HTTP_POST_BINDING.get());
         if (assertionConsumerServicePostBinding != null) {

--- a/services/src/main/java/org/keycloak/protocol/saml/IDPMetadataDescriptor.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/IDPMetadataDescriptor.java
@@ -75,6 +75,7 @@ public class IDPMetadataDescriptor {
         spIDPDescriptor.addSingleLogoutService(new EndpointType(SAML_HTTP_POST_BINDING.getUri(), logoutEndpoint));
         spIDPDescriptor.addSingleLogoutService(new EndpointType(SAML_HTTP_REDIRECT_BINDING.getUri(), logoutEndpoint));
         spIDPDescriptor.addSingleLogoutService(new EndpointType(SAML_HTTP_ARTIFACT_BINDING.getUri(), logoutEndpoint));
+        spIDPDescriptor.addSingleLogoutService(new EndpointType(SAML_SOAP_BINDING.getUri(), logoutEndpoint));
         spIDPDescriptor.addSingleSignOnService(new EndpointType(SAML_HTTP_POST_BINDING.getUri(), loginPostEndpoint));
         spIDPDescriptor.addSingleSignOnService(new EndpointType(SAML_HTTP_REDIRECT_BINDING.getUri(), loginRedirectEndpoint));
         spIDPDescriptor.addSingleSignOnService(new EndpointType(SAML_SOAP_BINDING.getUri(), loginPostEndpoint));

--- a/services/src/main/java/org/keycloak/protocol/saml/JaxrsSAML2BindingBuilder.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/JaxrsSAML2BindingBuilder.java
@@ -19,6 +19,7 @@ package org.keycloak.protocol.saml;
 
 import org.keycloak.forms.login.LoginFormsProvider;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.protocol.saml.profile.util.Soap;
 import org.keycloak.saml.BaseSAML2BindingBuilder;
 import org.keycloak.saml.common.constants.GeneralConstants;
 import org.keycloak.saml.common.exceptions.ConfigurationException;
@@ -95,6 +96,22 @@ public class JaxrsSAML2BindingBuilder extends BaseSAML2BindingBuilder<JaxrsSAML2
 
     }
 
+    public static class SoapBindingBuilder extends BaseSoapBindingBuilder {
+        public SoapBindingBuilder(JaxrsSAML2BindingBuilder builder, Document document) throws ProcessingException {
+            super(builder, document);
+        }
+
+        public Response response() throws ConfigurationException, ProcessingException, IOException {
+            try {
+                Soap.SoapMessageBuilder messageBuilder = Soap.createMessage();
+                messageBuilder.addToBody(document);
+                return messageBuilder.build();
+            } catch (Exception e) {
+                throw new RuntimeException("Error while creating SAML response.", e);
+            }
+        }
+    }
+
     @Override
     public RedirectBindingBuilder redirectBinding(Document document) throws ProcessingException  {
         return new RedirectBindingBuilder(this, document);
@@ -105,7 +122,8 @@ public class JaxrsSAML2BindingBuilder extends BaseSAML2BindingBuilder<JaxrsSAML2
         return new PostBindingBuilder(this, document);
     }
 
-
-
-
+    @Override
+    public SoapBindingBuilder soapBinding(Document document) throws ProcessingException {
+        return new SoapBindingBuilder(this, document);
+    }
 }

--- a/services/src/main/java/org/keycloak/protocol/saml/profile/ecp/SamlEcpProfileService.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/profile/ecp/SamlEcpProfileService.java
@@ -37,6 +37,7 @@ import org.keycloak.saml.common.constants.JBossSAMLURIConstants;
 import org.keycloak.saml.common.exceptions.ConfigurationException;
 import org.keycloak.saml.common.exceptions.ProcessingException;
 import org.keycloak.saml.validators.DestinationValidator;
+import org.keycloak.services.ErrorPage;
 import org.keycloak.services.managers.AuthenticationManager;
 import org.keycloak.sessions.AuthenticationSessionModel;
 import org.w3c.dom.Document;
@@ -68,8 +69,19 @@ public class SamlEcpProfileService extends SamlService {
     public Response authenticate(Document soapMessage) {
         try {
             return new PostBindingProtocol() {
+
+                @Override
+                protected Response error(KeycloakSession session, AuthenticationSessionModel authenticationSession, Response.Status status, String message, Object... parameters) {
+                    return Soap.createFault().code("error").reason(message).build();
+                }
+
                 @Override
                 protected String getBindingType(AuthnRequestType requestAbstractType) {
+                    return SamlProtocol.SAML_SOAP_BINDING;
+                }
+
+                @Override
+                protected String getBindingType() {
                     return SamlProtocol.SAML_SOAP_BINDING;
                 }
 

--- a/services/src/main/java/org/keycloak/protocol/saml/profile/util/Soap.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/profile/util/Soap.java
@@ -23,6 +23,7 @@ import org.apache.http.entity.ContentType;
 import org.keycloak.saml.processing.core.saml.v2.util.DocumentUtil;
 import org.keycloak.saml.processing.web.util.PostBindingUtil;
 import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 
 import javax.ws.rs.core.MediaType;
@@ -101,13 +102,27 @@ public final class Soap {
     public static Document extractSoapMessage(SOAPMessage soapMessage) {
         try {
             SOAPBody soapBody = soapMessage.getSOAPBody();
-            Node authnRequestNode = soapBody.getFirstChild();
+            Node authnRequestNode = getFirstChild(soapBody);
             Document document = DocumentUtil.createDocument();
             document.appendChild(document.importNode(authnRequestNode, true));
             return document;
         } catch (Exception e) {
             throw new RuntimeException("Error creating fault message.", e);
         }
+    }
+
+    /**
+     * Get the first direct child that is an XML element.
+     * In case of pretty-printed XML (with newlines and spaces), this method skips non-element objects (e.g. text)
+     * to really fetch the next XML tag.
+     */
+    public static Node getFirstChild(Node parent) {
+        Node n = parent.getFirstChild();
+        while (n != null && !(n instanceof Element)) {
+            n = n.getNextSibling();
+        }
+        if (n == null) return null;
+        return n;
     }
 
     public static class SoapMessageBuilder {

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/SamlClient.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/SamlClient.java
@@ -75,6 +75,7 @@ import javax.xml.soap.SOAPException;
 import javax.xml.soap.SOAPHeader;
 import javax.xml.soap.SOAPHeaderElement;
 import javax.xml.soap.SOAPMessage;
+import javax.xml.ws.soap.SOAPFaultException;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -348,23 +349,31 @@ public class SamlClient {
             @Override
             public SAMLDocumentHolder extractResponse(CloseableHttpResponse response, String realmPublicKey) throws IOException {
 
-                assertThat(response, statusCodeIsHC(200));
-
-                MessageFactory messageFactory = null;
                 try {
-                    messageFactory = MessageFactory.newInstance();
-                    SOAPMessage soapMessage = messageFactory.createMessage(null, response.getEntity().getContent());
-                    SOAPBody soapBody = soapMessage.getSOAPBody();
-                    Node authnRequestNode = soapBody.getFirstChild();
-                    Document document = DocumentUtil.createDocument();
-                    document.appendChild(document.importNode(authnRequestNode, true));
+                    int statusCode = response.getStatusLine().getStatusCode();
+                    if (statusCode == 200) {
+                        MessageFactory messageFactory = MessageFactory.newInstance();
+                        SOAPMessage soapMessage = messageFactory.createMessage(null, response.getEntity().getContent());
+                        SOAPBody soapBody = soapMessage.getSOAPBody();
+                        Node authnRequestNode = soapBody.getFirstChild();
+                        Document document = DocumentUtil.createDocument();
+                        document.appendChild(document.importNode(authnRequestNode, true));
 
-                    SAMLParser samlParser = SAMLParser.getInstance();
-                    JAXPValidationUtil.checkSchemaValidation(document);
+                        SAMLParser samlParser = SAMLParser.getInstance();
+                        JAXPValidationUtil.checkSchemaValidation(document);
 
-                    SAML2Object responseType = (SAML2Object) samlParser.parse(document);
+                        SAML2Object responseType = (SAML2Object) samlParser.parse(document);
 
-                    return new SAMLDocumentHolder(responseType, document);
+                        return new SAMLDocumentHolder(responseType, document);
+
+                    } else if (statusCode == 500) {
+                        MessageFactory messageFactory = MessageFactory.newInstance();
+                        SOAPMessage soapMessage = messageFactory.createMessage(null, response.getEntity().getContent());
+                        SOAPBody soapBody = soapMessage.getSOAPBody();
+                        throw new SOAPFaultException(soapBody.getFault());
+                    } else {
+                        throw new RuntimeException("Unexpected response status code (" + statusCode + ")");
+                    }
                 } catch (SOAPException | ConfigurationException | ProcessingException | ParsingException e) {
                     throw new RuntimeException(e);
                 }

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/SamlClientBuilder.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/SamlClientBuilder.java
@@ -171,9 +171,14 @@ public class SamlClientBuilder {
         return addStepBuilder(new CreateAuthnRequestStepBuilder(authServerSamlUrl, authnRequestDocument, requestBinding, this));
     }
 
-    /** Issues the given AuthnRequest to the SAML endpoint */
-    public CreateLogoutRequestStepBuilder logoutRequest(URI authServerSamlUrl, String issuer, Binding requestBinding) {
-        return addStepBuilder(new CreateLogoutRequestStepBuilder(authServerSamlUrl, issuer, requestBinding, this));
+    /** Issues the given LogoutRequest to the SAML endpoint */
+    public CreateLogoutRequestStepBuilder logoutRequest(URI logoutServerSamlUrl, String issuer, Binding requestBinding) {
+        return addStepBuilder(new CreateLogoutRequestStepBuilder(logoutServerSamlUrl, issuer, requestBinding, this));
+    }
+
+    /** Issues the given LogoutRequest to the SAML endpoint */
+    public CreateLogoutRequestStepBuilder logoutRequest(URI logoutServerSamlUrl, String issuer, Binding requestBinding, boolean skipSignature) {
+        return addStepBuilder(new CreateLogoutRequestStepBuilder(logoutServerSamlUrl, issuer, requestBinding, this, skipSignature));
     }
 
     /** Issues the given SAML document to the SAML endpoint */

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/saml/SamlBackchannelLogoutReceiver.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/saml/SamlBackchannelLogoutReceiver.java
@@ -1,0 +1,124 @@
+package org.keycloak.testsuite.util.saml;
+
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import org.keycloak.common.util.KeyUtils;
+import org.keycloak.dom.saml.v2.protocol.LogoutRequestType;
+import org.keycloak.dom.saml.v2.protocol.StatusResponseType;
+import org.keycloak.protocol.saml.JaxrsSAML2BindingBuilder;
+import org.keycloak.protocol.saml.SamlConfigAttributes;
+import org.keycloak.protocol.saml.profile.util.Soap;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.saml.SAML2LogoutResponseBuilder;
+import org.keycloak.saml.SignatureAlgorithm;
+import org.keycloak.saml.processing.api.saml.v2.response.SAML2Response;
+import org.keycloak.saml.processing.core.saml.v2.common.SAMLDocumentHolder;
+import org.w3c.dom.Document;
+
+import javax.ws.rs.core.HttpHeaders;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+
+public class SamlBackchannelLogoutReceiver implements AutoCloseable {
+
+    private final HttpServer server;
+    private LogoutRequestType logoutRequest;
+    private final String url;
+    private final ClientRepresentation samlClient;
+    private final PublicKey publicKey;
+    private final PrivateKey privateKey;
+
+    public SamlBackchannelLogoutReceiver(int port, ClientRepresentation samlClient, String publicKeyStr, String privateKeyStr) {
+        this.samlClient = samlClient;
+        publicKey = publicKeyStr == null ? null : org.keycloak.testsuite.util.KeyUtils.publicKeyFromString(publicKeyStr);
+        privateKey = privateKeyStr == null ? null : org.keycloak.testsuite.util.KeyUtils.privateKeyFromString(privateKeyStr);
+        try {
+            InetSocketAddress address = new InetSocketAddress(InetAddress.getByName("localhost"), port);
+            server = HttpServer.create(address, 0);
+            this.url = "http://" + address.getHostString() + ":" + port;
+        } catch (IOException e) {
+            throw new RuntimeException("Cannot create http server", e);
+        }
+
+        server.createContext("/", new SamlBackchannelLogoutReceiver.SamlBackchannelLogoutHandler());
+        server.setExecutor(null);
+        server.start();
+    }
+
+    public SamlBackchannelLogoutReceiver(int port, ClientRepresentation samlClient) {
+        this(port, samlClient, null, null);
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public boolean isLogoutRequestReceived() {
+        return logoutRequest != null;
+    }
+
+    public LogoutRequestType getLogoutRequest() {
+        return logoutRequest;
+    }
+
+    @Override
+    public void close() throws Exception {
+        server.stop(0);
+    }
+
+    private class SamlBackchannelLogoutHandler implements HttpHandler {
+        public void handle(HttpExchange t) throws IOException {
+            try {
+                t.getResponseHeaders().add(HttpHeaders.CONTENT_TYPE, "text/xml");
+                t.sendResponseHeaders(200, 0);
+
+                Document request = Soap.extractSoapMessage(t.getRequestBody());
+                SAMLDocumentHolder samlDoc = SAML2Response.getSAML2ObjectFromDocument(request);
+                if (!(samlDoc.getSamlObject() instanceof LogoutRequestType)) {
+                    throw new RuntimeException("SamlBackchannelLogoutReceiver received a message that was not LogoutRequestType");
+                }
+                logoutRequest = (LogoutRequestType) samlDoc.getSamlObject();
+                StatusResponseType logoutResponse = new SAML2LogoutResponseBuilder()
+                        .issuer(samlClient.getClientId())
+                        .logoutRequestID(logoutRequest.getID())
+                        .buildModel();
+                JaxrsSAML2BindingBuilder soapBinding = new JaxrsSAML2BindingBuilder(null);
+                if (requiresClientSignature(samlClient)) {
+                    soapBinding.signatureAlgorithm(getSignatureAlgorithm(samlClient))
+                            .signWith(KeyUtils.createKeyId(privateKey), privateKey, publicKey, null)
+                            .signDocument();
+                }
+                Document doc = soapBinding.soapBinding(SAML2Response.convert(logoutResponse)).getDocument();
+
+                // send logout response
+                OutputStream os = t.getResponseBody();
+                os.write(Soap.createMessage().addToBody(doc).getBytes());
+                os.close();
+            } catch (Exception ex) {
+                t.sendResponseHeaders(500, 0);
+            }
+        }
+    }
+
+    private SignatureAlgorithm getSignatureAlgorithm(ClientRepresentation client) {
+        String alg = client.getAttributes().get(SamlConfigAttributes.SAML_SIGNATURE_ALGORITHM);
+        if (alg != null) {
+            SignatureAlgorithm algorithm = SignatureAlgorithm.valueOf(alg);
+            if (algorithm != null)
+                return algorithm;
+        }
+        return SignatureAlgorithm.RSA_SHA256;
+    }
+
+    public boolean requiresClientSignature(ClientRepresentation client) {
+        return "true".equals(client.getAttributes().get(SamlConfigAttributes.SAML_CLIENT_SIGNATURE_ATTRIBUTE));
+    }
+}
+
+

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/SAMLClientRegistrationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/SAMLClientRegistrationTest.java
@@ -26,6 +26,7 @@ import org.keycloak.client.registration.ClientRegistrationException;
 import org.keycloak.client.registration.HttpErrorException;
 import org.keycloak.events.Errors;
 import org.keycloak.protocol.saml.SamlConfigAttributes;
+import org.keycloak.protocol.saml.SamlProtocol;
 import org.keycloak.protocol.saml.mappers.AttributeStatementHelper;
 import org.keycloak.protocol.saml.util.ArtifactBindingUtils;
 import org.keycloak.representations.idm.ClientInitialAccessCreatePresentation;
@@ -107,7 +108,8 @@ public class SAMLClientRegistrationTest extends AbstractClientRegistrationTest {
                 "https://LoadBalancer-9.siroe.com:3443/federation/Consumer/metaAlias/sp/artifact"
         ));
 
-        assertThat(response.getAttributes().get("saml_single_logout_service_url_redirect"), is("https://LoadBalancer-9.siroe.com:3443/federation/SPSloRedirect/metaAlias/sp"));
+        assertThat(response.getAttributes().get(SamlProtocol.SAML_SINGLE_LOGOUT_SERVICE_URL_REDIRECT_ATTRIBUTE), is("https://LoadBalancer-9.siroe.com:3443/federation/SPSloRedirect/metaAlias/sp"));
+        assertThat(response.getAttributes().get(SamlProtocol.SAML_SINGLE_LOGOUT_SERVICE_URL_SOAP_ATTRIBUTE), is("https://LoadBalancer-9.siroe.com:3443/federation/SPSloSoap/metaAlias/sp"));
         assertThat(response.getAttributes().get(SamlConfigAttributes.SAML_ARTIFACT_BINDING_IDENTIFIER), is(ArtifactBindingUtils.computeArtifactBindingIdentifierString("loadbalancer-9.siroe.com")));
 
         Assert.assertNotNull(response.getProtocolMappers());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/LogoutTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/LogoutTest.java
@@ -20,8 +20,6 @@ import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.broker.saml.SAMLIdentityProviderConfig;
 import org.keycloak.broker.saml.SAMLIdentityProviderFactory;
 import org.keycloak.dom.saml.v2.SAML2Object;
-import org.keycloak.dom.saml.v2.assertion.AssertionType;
-import org.keycloak.dom.saml.v2.assertion.AuthnStatementType;
 import org.keycloak.dom.saml.v2.assertion.NameIDType;
 import org.keycloak.dom.saml.v2.protocol.AuthnRequestType;
 import org.keycloak.dom.saml.v2.protocol.LogoutRequestType;
@@ -29,6 +27,7 @@ import org.keycloak.dom.saml.v2.protocol.ResponseType;
 import org.keycloak.dom.saml.v2.protocol.StatusResponseType;
 import org.keycloak.events.Details;
 import org.keycloak.events.EventType;
+import org.keycloak.protocol.saml.SamlConfigAttributes;
 import org.keycloak.protocol.saml.SamlProtocol;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.EventRepresentation;
@@ -54,22 +53,25 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriBuilderException;
 import javax.xml.transform.dom.DOMSource;
+import javax.xml.ws.soap.SOAPFaultException;
+
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.junit.Before;
 import org.junit.Test;
+import org.keycloak.testsuite.util.saml.SamlBackchannelLogoutReceiver;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.keycloak.testsuite.util.Matchers.*;
 import static org.keycloak.testsuite.util.SamlClient.Binding.*;
 
@@ -89,11 +91,13 @@ public class LogoutTest extends AbstractSamlTest {
 
     private ClientRepresentation salesRep;
     private ClientRepresentation sales2Rep;
+    private ClientRepresentation salesSigRep;
 
     @Before
     public void setup() {
         salesRep = adminClient.realm(REALM_NAME).clients().findByClientId(SAML_CLIENT_ID_SALES_POST).get(0);
         sales2Rep = adminClient.realm(REALM_NAME).clients().findByClientId(SAML_CLIENT_ID_SALES_POST2).get(0);
+        salesSigRep = adminClient.realm(REALM_NAME).clients().findByClientId(SAML_CLIENT_ID_SALES_POST_SIG).get(0);
 
         adminClient.realm(REALM_NAME)
           .clients().get(salesRep.getId())
@@ -135,17 +139,33 @@ public class LogoutTest extends AbstractSamlTest {
 
     private SamlClientBuilder prepareLogIntoTwoApps() {
         return new SamlClientBuilder()
-          .authnRequest(getAuthServerSamlEndpoint(REALM_NAME), SAML_CLIENT_ID_SALES_POST, SAML_ASSERTION_CONSUMER_URL_SALES_POST, POST).build()
-          .login().user(bburkeUser).build()
-          .processSamlResponse(POST)
-            .transformObject(this::extractNameIdAndSessionIndexAndTerminate)
-            .build()
-          .authnRequest(getAuthServerSamlEndpoint(REALM_NAME), SAML_CLIENT_ID_SALES_POST2, SAML_ASSERTION_CONSUMER_URL_SALES_POST2, POST).build()
-          .login().sso(true).build()    // This is a formal step
-          .processSamlResponse(POST).transformObject(so -> {
-            assertThat(so, isSamlResponse(JBossSAMLURIConstants.STATUS_SUCCESS));
-            return null;    // Do not follow the redirect to the app from the returned response
-          }).build();
+                .authnRequest(getAuthServerSamlEndpoint(REALM_NAME), SAML_CLIENT_ID_SALES_POST, SAML_ASSERTION_CONSUMER_URL_SALES_POST, POST).build()
+                .login().user(bburkeUser).build()
+                .processSamlResponse(POST)
+                .transformObject(this::extractNameIdAndSessionIndexAndTerminate)
+                .build()
+                .authnRequest(getAuthServerSamlEndpoint(REALM_NAME), SAML_CLIENT_ID_SALES_POST2, SAML_ASSERTION_CONSUMER_URL_SALES_POST2, POST).build()
+                .login().sso(true).build()    // This is a formal step
+                .processSamlResponse(POST).transformObject(so -> {
+                    assertThat(so, isSamlResponse(JBossSAMLURIConstants.STATUS_SUCCESS));
+                    return null;    // Do not follow the redirect to the app from the returned response
+                }).build();
+    }
+
+    private SamlClientBuilder prepareLogIntoTwoAppsSig() {
+        return new SamlClientBuilder()
+                .authnRequest(getAuthServerSamlEndpoint(REALM_NAME), SAML_CLIENT_ID_SALES_POST, SAML_ASSERTION_CONSUMER_URL_SALES_POST, POST).build()
+                .login().user(bburkeUser).build()
+                .processSamlResponse(POST)
+                .transformObject(this::extractNameIdAndSessionIndexAndTerminate)
+                .build()
+                .authnRequest(getAuthServerSamlEndpoint(REALM_NAME), SAML_CLIENT_ID_SALES_POST_SIG, SAML_ASSERTION_CONSUMER_URL_SALES_POST_SIG, POST)
+                .signWith(SAML_CLIENT_SALES_POST_SIG_PRIVATE_KEY, SAML_CLIENT_SALES_POST_SIG_PUBLIC_KEY).build()
+                .login().sso(true).build()    // This is a formal step
+                .processSamlResponse(POST).transformObject(so -> {
+                    assertThat(so, isSamlResponse(JBossSAMLURIConstants.STATUS_SUCCESS));
+                    return null;    // Do not follow the redirect to the app from the returned response
+                }).build();
     }
 
     @Test
@@ -193,6 +213,139 @@ public class LogoutTest extends AbstractSamlTest {
 
         assertThat(samlResponse.getSamlObject(), isSamlStatusResponse(JBossSAMLURIConstants.STATUS_SUCCESS));
         assertLogoutEvent(SAML_CLIENT_ID_SALES_POST);
+    }
+
+    /**
+     * Logout triggered with POST binding, with 2 clients to logout in the SLO process.
+     * One of the client is configured with backchannel logout + SOAP logout URL
+     */
+    @Test
+    public void testSoapBackchannelLogout() {
+        try (SamlBackchannelLogoutReceiver backchannelLogoutReceiver = new SamlBackchannelLogoutReceiver(8082, sales2Rep);
+             Closeable sales2 = ClientAttributeUpdater.forClient(adminClient, REALM_NAME, SAML_CLIENT_ID_SALES_POST2)
+                     .setFrontchannelLogout(false)
+                     .setAttribute(SamlProtocol.SAML_SINGLE_LOGOUT_SERVICE_URL_SOAP_ATTRIBUTE, backchannelLogoutReceiver.getUrl())
+                     .setAttribute(SamlConfigAttributes.SAML_SERVER_SIGNATURE, "true") // sign logout requests
+                     .setAttribute(SamlConfigAttributes.SAML_FORCE_NAME_ID_FORMAT_ATTRIBUTE, "true") // Force NameID to username
+                     .setAttribute(SamlConfigAttributes.SAML_NAME_ID_FORMAT_ATTRIBUTE, "username") // Force NameID to username
+                     .update();
+        ) {
+
+            SAMLDocumentHolder samlResponse = prepareLogIntoTwoApps()
+                    .logoutRequest(getAuthServerSamlEndpoint(REALM_NAME), SAML_CLIENT_ID_SALES_POST, POST)
+                    .nameId(nameIdRef::get)
+                    .sessionIndex(sessionIndexRef::get)
+                    .build()
+                    .getSamlResponse(POST);
+
+            assertThat(samlResponse.getSamlObject(), isSamlStatusResponse(JBossSAMLURIConstants.STATUS_SUCCESS));
+            assertLogoutEvent(SAML_CLIENT_ID_SALES_POST);
+
+            // check that the logout request sent to the client is compliant and signed
+            assertTrue(backchannelLogoutReceiver.isLogoutRequestReceived());
+            LogoutRequestType logoutRequest = backchannelLogoutReceiver.getLogoutRequest();
+            assertNotNull(backchannelLogoutReceiver.getLogoutRequest().getSignature());
+            // check nameID
+            assertEquals(logoutRequest.getNameID().getValue(), bburkeUser.getUsername());
+        } catch (Exception ex) {
+            fail("unexpected error");
+        }
+    }
+
+    /**
+     * Logout triggered with POST binding, with 2 clients to logout in the SLO process.
+     * One of the client is configured with backchannel logout + SOAP logout URL
+     * This client is also configured with "client signature required" --> a signature is expected on the logout response
+     */
+    @Test
+    public void testSoapBackchannelLogoutSignedResponseFromClient() {
+        try (SamlBackchannelLogoutReceiver backchannelLogoutReceiver = new SamlBackchannelLogoutReceiver(8082, salesSigRep, SAML_CLIENT_SALES_POST_SIG_PUBLIC_KEY, SAML_CLIENT_SALES_POST_SIG_PRIVATE_KEY);
+             Closeable salesSig = ClientAttributeUpdater.forClient(adminClient, REALM_NAME, SAML_CLIENT_ID_SALES_POST_SIG)
+                     .setFrontchannelLogout(false)
+                     .setAttribute(SamlProtocol.SAML_SINGLE_LOGOUT_SERVICE_URL_SOAP_ATTRIBUTE, backchannelLogoutReceiver.getUrl())
+                     .setAttribute(SamlConfigAttributes.SAML_SERVER_SIGNATURE, "true") // sign logout requests
+                     .setAttribute(SamlConfigAttributes.SAML_FORCE_NAME_ID_FORMAT_ATTRIBUTE, "true") // Force NameID to username
+                     .setAttribute(SamlConfigAttributes.SAML_NAME_ID_FORMAT_ATTRIBUTE, "username") // Force NameID to username
+                     .update();
+        ) {
+
+            SAMLDocumentHolder samlResponse = prepareLogIntoTwoAppsSig()
+                    .logoutRequest(getAuthServerSamlEndpoint(REALM_NAME), SAML_CLIENT_ID_SALES_POST, POST)
+                    .nameId(nameIdRef::get)
+                    .sessionIndex(sessionIndexRef::get)
+                    .signWith(SAML_CLIENT_SALES_POST_SIG_PRIVATE_KEY, SAML_CLIENT_SALES_POST_SIG_PUBLIC_KEY)
+                    .build()
+                    .getSamlResponse(POST);
+
+            assertThat(samlResponse.getSamlObject(), isSamlStatusResponse(JBossSAMLURIConstants.STATUS_SUCCESS));
+            assertLogoutEvent(SAML_CLIENT_ID_SALES_POST);
+        } catch (Exception ex) {
+            fail("unexpected error");
+        }
+    }
+
+    /** Logout triggered with SOAP binding, request is properly signed */
+    @Test
+    public void testSoapBackchannelLogoutFromSamlClient() {
+        try (
+                Closeable sales = ClientAttributeUpdater.forClient(adminClient, REALM_NAME, SAML_CLIENT_ID_SALES_POST_SIG)
+                        .setFrontchannelLogout(false)
+                        .setAttribute(SamlConfigAttributes.SAML_FORCE_NAME_ID_FORMAT_ATTRIBUTE, "true") // Force NameID to username
+                        .setAttribute(SamlConfigAttributes.SAML_NAME_ID_FORMAT_ATTRIBUTE, "username") // Force NameID to username
+                        .update();
+        ) {
+
+            SAMLDocumentHolder samlLogoutResponse = prepareLogIntoTwoAppsSig()
+                    .clearCookies() // remove cookies, since SOAP calls do not embed cookie normally
+                    .logoutRequest(getAuthServerSamlEndpoint(REALM_NAME), SAML_CLIENT_ID_SALES_POST_SIG, SOAP)
+                    .nameId(nameIdRef::get)
+                    .sessionIndex(sessionIndexRef::get)
+                    .signWith(SAML_CLIENT_SALES_POST_SIG_PRIVATE_KEY, SAML_CLIENT_SALES_POST_SIG_PUBLIC_KEY)
+                    .build()
+                    .getSamlResponse(SOAP);
+
+            assertThat(samlLogoutResponse.getSamlObject(), isSamlStatusResponse(JBossSAMLURIConstants.STATUS_SUCCESS));
+            assertSoapLogoutEvent(SAML_CLIENT_ID_SALES_POST_SIG);
+
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            fail("unexpected error");
+        }
+    }
+
+    /** Logout triggered with SOAP binding, request is wrongly not signed --> ensure an error is thrown */
+    @Test
+    public void testSoapBackchannelLogoutFromSamlClientUnsignedRequest() {
+        try (
+                Closeable sales = ClientAttributeUpdater.forClient(adminClient, REALM_NAME, SAML_CLIENT_ID_SALES_POST_SIG)
+                        .setFrontchannelLogout(false)
+                        .setAttribute(SamlConfigAttributes.SAML_FORCE_NAME_ID_FORMAT_ATTRIBUTE, "true") // Force NameID to username
+                        .setAttribute(SamlConfigAttributes.SAML_NAME_ID_FORMAT_ATTRIBUTE, "username") // Force NameID to username
+                        .update();
+        ) {
+
+            try {
+                SAMLDocumentHolder samlLogoutResponse = prepareLogIntoTwoAppsSig()
+                        .clearCookies() // remove cookies, since SOAP calls do not embed cookie normally
+                        .logoutRequest(getAuthServerSamlEndpoint(REALM_NAME), SAML_CLIENT_ID_SALES_POST_SIG, SOAP, true)
+                        .nameId(nameIdRef::get)
+                        .sessionIndex(sessionIndexRef::get)
+                        .build()
+                        .getSamlResponse(SOAP);
+                fail("should have triggered an error");
+            } catch (RuntimeException ex) {
+                // exception expected since the request is not signed
+                if (ex.getCause() instanceof SOAPFaultException) {
+                    SOAPFaultException sfe = (SOAPFaultException) ex.getCause();
+                    assertThat(sfe.getFault().getFaultString(), is("invalidRequesterMessage"));
+                }
+            }
+            assertSoapLogoutErrorEvent(SAML_CLIENT_ID_SALES_POST_SIG);
+
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            fail("unexpected error");
+        }
     }
 
     @Test
@@ -325,6 +478,28 @@ public class LogoutTest extends AbstractSamlTest {
         assertEquals(SamlProtocol.SAML_POST_BINDING, logoutEvent.getDetails().get(Details.RESPONSE_MODE));
         assertEquals("saml", logoutEvent.getDetails().get(Details.AUTH_METHOD));
         assertNotNull(logoutEvent.getDetails().get(SamlProtocol.SAML_LOGOUT_REQUEST_ID));
+    }
+
+    private void assertSoapLogoutEvent(String clientId) {
+        List<EventRepresentation> logoutEvents = adminClient.realm(REALM_NAME)
+                .getEvents(Arrays.asList(EventType.LOGOUT.name()), clientId, null, null, null, null, null, null);
+
+        assertFalse(logoutEvents.isEmpty());
+        assertEquals(1, logoutEvents.size());
+
+        EventRepresentation logoutEvent = logoutEvents.get(0);
+
+        assertEquals(bburkeUser.getUsername(), logoutEvent.getDetails().get(Details.USERNAME));
+        assertEquals(SamlProtocol.SAML_SOAP_BINDING, logoutEvent.getDetails().get(Details.RESPONSE_MODE));
+        assertEquals("saml", logoutEvent.getDetails().get(Details.AUTH_METHOD));
+    }
+
+    private void assertSoapLogoutErrorEvent(String clientId) {
+        List<EventRepresentation> logoutEvents = adminClient.realm(REALM_NAME)
+                .getEvents(Arrays.asList(EventType.LOGOUT_ERROR.name()), null, null, null, null, null, null, null);
+
+        assertFalse(logoutEvents.isEmpty());
+        assertEquals(1, logoutEvents.size());
     }
 
     private IdentityProviderRepresentation addIdentityProvider() {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/SOAPBindingTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/SOAPBindingTest.java
@@ -137,12 +137,13 @@ public class SOAPBindingTest extends AbstractSamlTest {
                 .processSamlResponse(POST)
                 .transformObject(this::extractNameIdAndSessionIndexAndTerminate)
                 .build()
+                .clearCookies()
                 .logoutRequest(getAuthServerSamlEndpoint(REALM_NAME), SAML_CLIENT_ID_ECP_SP, SOAP)
                     .nameId(nameIdRef::get)
                     .sessionIndex(sessionIndexRef::get)
                     .signWith(SAML_CLIENT_SALES_POST_SIG_PRIVATE_KEY, SAML_CLIENT_SALES_POST_SIG_PUBLIC_KEY)
                 .build()
-                .executeAndTransform(POST::extractResponse);
+                .executeAndTransform(SOAP::extractResponse);
 
 
         assertThat(response.getSamlObject(), instanceOf(StatusResponseType.class));
@@ -164,11 +165,12 @@ public class SOAPBindingTest extends AbstractSamlTest {
                 .processSamlResponse(POST)
                     .transformObject(this::extractNameIdAndSessionIndexAndTerminate)
                 .build()
+                .clearCookies()
                 .logoutRequest(getAuthServerSamlEndpoint(REALM_NAME), SAML_CLIENT_ID_ECP_SP, SOAP)
                     .nameId(nameIdRef::get)
                     .sessionIndex(sessionIndexRef::get)
                 .build()
-                .executeAndTransform(POST::extractResponse);
+                .executeAndTransform(SOAP::extractResponse);
 
 
         assertThat(response.getSamlObject(), instanceOf(StatusResponseType.class));
@@ -184,6 +186,7 @@ public class SOAPBindingTest extends AbstractSamlTest {
                 .processSamlResponse(POST)
                     .transformObject(this::extractNameIdAndSessionIndexAndTerminate)
                 .build()
+                .clearCookies()
                 .logoutRequest(getAuthServerSamlEndpoint(REALM_NAME), SAML_CLIENT_ID_ECP_SP, SOAP)
                     .nameId(nameIdRef::get)
                     .sessionIndex(sessionIndexRef::get)
@@ -193,7 +196,7 @@ public class SOAPBindingTest extends AbstractSamlTest {
                         return logoutRequestType;
                     })
                 .build()
-                .executeAndTransform(POST::extractResponse);
+                .executeAndTransform(SOAP::extractResponse);
 
 
         assertThat(response.getSamlObject(), instanceOf(StatusResponseType.class));
@@ -215,6 +218,7 @@ public class SOAPBindingTest extends AbstractSamlTest {
                 .processSamlResponse(POST)
                 .transformObject(this::extractNameIdAndSessionIndexAndTerminate)
                 .build()
+                .clearCookies()
                 .logoutRequest(getAuthServerSamlEndpoint(REALM_NAME), SAML_CLIENT_ID_ECP_SP, SOAP)
                 .nameId(nameIdRef::get)
                 .sessionIndex(sessionIndexRef::get)
@@ -223,7 +227,7 @@ public class SOAPBindingTest extends AbstractSamlTest {
                     return logoutRequestType;
                 })
                 .build()
-                .executeAndTransform(POST::extractResponse);
+                .executeAndTransform(SOAP::extractResponse);
 
 
         assertThat(response.getSamlObject(), instanceOf(StatusResponseType.class));


### PR DESCRIPTION
Closes #16293

- add support to send a SAML Logout request over SOAP binding to any compliant client
- add support for a SAML client to trigger a Single logout process over SOAP binding
