### PR TITLE
Adding SAML tests for FIPS - with addition of XMLDSig security provider

### DIFF
--- a/testsuite/integration-arquillian/servers/auth-server/common/fips/kc.java.security
+++ b/testsuite/integration-arquillian/servers/auth-server/common/fips/kc.java.security
@@ -15,13 +15,17 @@
 #
 # Security providers used when global crypto-policies are set to FIPS (Usually it is used when FIPS enabled on system/JVM level)
 #
-#fips.provider.1=SunPKCS11 ${java.home}/conf/security/nss.fips.cfg
-#fips.provider.2=SUN
-#fips.provider.3=SunEC
-#fips.provider.4=com.sun.net.ssl.internal.ssl.Provider SunPKCS11-NSS-FIPS
-#fips.provider.5=SunJGSS
-#fips.provider.6=XMLDSig
-#fips.provider.5=
+# NOTE: This list of providers is needed to be override just because XMLDSig provider is not yet present on the OpenJDK 17 by default on the RHEL FIPS host on OpenJDK 17.0.3.
+# However once it is present, there won't be a need to override this and this part can be fully commented/removed.
+# TODO: Comment/remove this once https://bugzilla.redhat.com/show_bug.cgi?id=1940064 is fixed and OpenJDK 17 updated to corresponding version where XMLDSig is available by default
+#
+fips.provider.1=SunPKCS11 ${java.home}/conf/security/nss.fips.cfg
+fips.provider.2=SUN
+fips.provider.3=SunEC
+fips.provider.4=SunJSSE
+fips.provider.5=SunJCE
+fips.provider.6=SunRsaSign
+fips.provider.7=XMLDSig
 
 # Commented this provider for now (and also other providers) as it uses lots of non-FIPS services.
 # See https://access.redhat.com/documentation/en-us/openjdk/11/html-single/configuring_openjdk_11_on_rhel_with_fips/index#ref_openjdk-default-fips-configuration_openjdk

--- a/testsuite/integration-arquillian/tests/base/testsuites/fips-suite
+++ b/testsuite/integration-arquillian/tests/base/testsuites/fips-suite
@@ -13,3 +13,8 @@ KcRegTest
 KcRegCreateTest
 KcAdmTest
 KcAdmCreateTest
+SAMLServletAdapterTest
+SamlSignatureTest
+KcSamlBrokerTest
+KcSamlFirstBrokerLoginTest
+KcSamlEncryptedIdTest


### PR DESCRIPTION
Closes #14969

Sent PR for adding SAML tests into FIPS. The SAML requires `XMLDSig` security provider to be available in `java.security` properties, which is not by default on the FIPS enabled platform in OpenJDK 17.0.3.

However it is confirmed by OpenJDK team that `XMLDSig` provider is FIPS compliant. It just needs to be added manually to kc.java.security in our testsuite due the fact that it is not yet available in java.security by default in latest OpenJDK 17.0.3. Latest details in: https://bugzilla.redhat.com/show_bug.cgi?id=1940064 .

Once it is added by default in OpenJDK 17 future release (Hopefully 17.0.4 in February/March 2023), the change in `kc.java.security` can be reverted from our testsuite as we will be able to stick to the default providers. Follow-up issue for this is #16326
