### PR TITLE
16319 added quotes for start script config parameters

### DIFF
--- a/quarkus/dist/src/main/content/bin/kc.sh
+++ b/quarkus/dist/src/main/content/bin/kc.sh
@@ -63,7 +63,7 @@ do
             if [[ "$1" = "start-dev" ]]; then
               CONFIG_ARGS="$CONFIG_ARGS --profile=dev $1"
             else
-              CONFIG_ARGS="$CONFIG_ARGS $1"
+              CONFIG_ARGS="$CONFIG_ARGS \"$1\""
             fi
           else
             SERVER_OPTS="$SERVER_OPTS $1"
@@ -120,7 +120,7 @@ if [ "$PRINT_ENV" = "true" ]; then
   echo "Using JAVA_RUN_OPTS: $JAVA_RUN_OPTS"
 fi
 
-if [[ (! $CONFIG_ARGS = *"--optimized"*) ]] && [[ ! "$CONFIG_ARGS" == " build"* ]] && [[ ! "$CONFIG_ARGS" == *"-h" ]] && [[ ! "$CONFIG_ARGS" == *"--help"* ]]; then
+if [[ ! $CONFIG_ARGS = *"--optimized"* ]] && [[ ! $CONFIG_ARGS = " \"build"* ]] && [[ ! $CONFIG_ARGS = *"-h\"" ]] && [[ ! $CONFIG_ARGS = *"--help"* ]]; then
     eval "'$JAVA'" -Dkc.config.build-and-exit=true $JAVA_RUN_OPTS
     EXIT_CODE=$?
     JAVA_RUN_OPTS="-Dkc.config.built=true $JAVA_RUN_OPTS"

--- a/quarkus/tests/integration/src/main/java/org/keycloak/it/junit5/extension/CLIResult.java
+++ b/quarkus/tests/integration/src/main/java/org/keycloak/it/junit5/extension/CLIResult.java
@@ -82,6 +82,11 @@ public interface CLIResult extends LaunchResult {
                 () -> "The Error Output:\n " + getErrorOutput() + "\ndoesn't contains " + msg);
     }
 
+    default void assertNoError(String msg) {
+        assertFalse(getErrorOutput().contains(msg),
+                () -> "The Error Output:\n " + getErrorOutput() + "\n contains the error " + msg);
+    }
+
     default void assertHelp() {
         try (NamedEnvironment env = KcNamerFactory.asWindowsOsSpecificTest()) {
             Approvals.verify(getOutput());

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/CustomLegacyUserProviderDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/CustomLegacyUserProviderDistTest.java
@@ -36,7 +36,7 @@ public class CustomLegacyUserProviderDistTest {
 
     @Test
     @TestProvider(CustomLegacyUserProvider.class)
-    @Launch({ "start-dev", "--spi-user-provider=custom_jpa --spi-user-jpa-enabled=false" })
+    @Launch({ "start-dev", "--spi-user-provider=custom_jpa", "--spi-user-jpa-enabled=false" })
     void testUserManagedEntityNotAddedToDefaultPU(LaunchResult result) {
         CLIResult cliResult = (CLIResult) result;
         cliResult.assertMessage("KC-SERVICES0047: custom_jpa (com.acme.provider.legacy.jpa.user.MyUserProviderFactory) is implementing the internal SPI user. This SPI is internal and may change without notice");

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/LoggingDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/LoggingDistTest.java
@@ -104,7 +104,7 @@ public class LoggingDistTest {
 
     @Test
     @EnabledOnOs(value = { OS.LINUX, OS.MAC }, disabledReason = "different shell escaping behaviour on Windows.")
-    @Launch({ "start-dev", "--log-console-format=\"%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c{1.}] %s%e%n\"" })
+    @Launch({ "start-dev", "--log-console-format=%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c{1.}] %s%e%n" })
     void testSetLogFormat(LaunchResult result) {
         CLIResult cliResult = (CLIResult) result;
         assertFalse(cliResult.getOutput().contains("(keycloak-cache-init)"));
@@ -160,7 +160,7 @@ public class LoggingDistTest {
 
     @Test
     @EnabledOnOs(value = { OS.LINUX, OS.MAC }, disabledReason = "different shell escaping behaviour on Windows.")
-    @Launch({ "start-dev", "--log=console,file", "--log-file-format=\"%d{HH:mm:ss} %-5p [%c{1.}] (%t) %s%e%n\""})
+    @Launch({ "start-dev", "--log=console,file", "--log-file-format=%d{HH:mm:ss} %-5p [%c{1.}] (%t) %s%e%n"})
     void testFileLoggingHasDifferentFormat(RawDistRootPath path) throws IOException {
         Path logFilePath = Paths.get(path.getDistRootPath() + File.separator + LoggingOptions.DEFAULT_LOG_PATH);
         File logFile = new File(logFilePath.toString());

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartCommandDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartCommandDistTest.java
@@ -99,4 +99,11 @@ public class StartCommandDistTest {
         cliResult.assertError("Unknown option: '--cache'");
     }
 
+    @Test
+    @Launch({ "start", "--optimized", "--hostname-strict=false", "--https-key-store-file=/tmp/te st.jks" })
+    void testStartParamWithBlank(LaunchResult result) {
+        CLIResult cliResult = (CLIResult) result;
+        cliResult.assertNoError("Option '--https-key-store-file' expects a single value (file)");
+    }
+
 }


### PR DESCRIPTION
Fixes #16319 for `kc.sh`. 
