### PR TITLE
Ignore user profile attributes for service accounts

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/userprofile/DefaultAttributes.java
+++ b/server-spi-private/src/main/java/org/keycloak/userprofile/DefaultAttributes.java
@@ -295,7 +295,7 @@ public class DefaultAttributes extends HashMap<String, List<String>> implements 
             List<String> username = newAttributes.get(UserModel.USERNAME);
 
             if (username == null || username.isEmpty() || (!realm.isEditUsernameAllowed() && UserProfileContext.USER_API.equals(context))) {
-                newAttributes.put(UserModel.USERNAME, Collections.singletonList(user.getUsername()));
+                setUserName(newAttributes, Collections.singletonList(user.getUsername()));
             }
         }
 
@@ -307,10 +307,17 @@ public class DefaultAttributes extends HashMap<String, List<String>> implements 
                     .map(String::toLowerCase)
                     .collect(Collectors.toList());
 
-            newAttributes.put(UserModel.USERNAME, lowerCaseEmailList);
+            setUserName(newAttributes, lowerCaseEmailList);
         }
 
         return newAttributes;
+    }
+
+    private void setUserName(Map<String, List<String>> newAttributes, List<String> lowerCaseEmailList) {
+        if (user != null && user.getServiceAccountClientLink() != null) {
+            return;
+        }
+        newAttributes.put(UserModel.USERNAME, lowerCaseEmailList);
     }
 
     protected boolean isIncludeAttributeIfNotProvided(AttributeMetadata metadata) {
@@ -341,6 +348,10 @@ public class DefaultAttributes extends HashMap<String, List<String>> implements 
         }
 
         if (isReadOnly(name)) {
+            return true;
+        }
+
+        if (user != null && user.getServiceAccountClientLink() != null) {
             return true;
         }
 

--- a/services/src/main/java/org/keycloak/authentication/authenticators/broker/IdpReviewProfileAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/broker/IdpReviewProfileAuthenticator.java
@@ -146,6 +146,11 @@ public class IdpReviewProfileAuthenticator extends AbstractIdpAuthenticator {
             public String getUsername() {
                 return userCtx.getUsername();
             }
+
+            @Override
+            public String getServiceAccountClientLink() {
+                return null;
+            }
         };
 
         UserProfileProvider profileProvider = context.getSession().getProvider(UserProfileProvider.class);

--- a/services/src/main/java/org/keycloak/userprofile/DeclarativeUserProfileProvider.java
+++ b/services/src/main/java/org/keycloak/userprofile/DeclarativeUserProfileProvider.java
@@ -127,6 +127,9 @@ public class DeclarativeUserProfileProvider extends AbstractUserProfileProvider<
     protected Attributes createAttributes(UserProfileContext context, Map<String, ?> attributes,
             UserModel user, UserProfileMetadata metadata) {
         if (isEnabled(session)) {
+            if (user != null && user.getServiceAccountClientLink() != null) {
+                return new LegacyAttributes(context, attributes, user, metadata, session);
+            }
             return new DefaultAttributes(context, attributes, user, metadata, session);
         }
         return new LegacyAttributes(context, attributes, user, metadata, session);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ServiceAccountUserProfileTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ServiceAccountUserProfileTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite.oauth;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.admin.client.resource.UserResource;
+import org.keycloak.common.Profile;
+import org.keycloak.common.constants.ServiceAccountConstants;
+import org.keycloak.models.utils.KeycloakModelUtils;
+import org.keycloak.protocol.oidc.OIDCConfigAttributes;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.testsuite.AbstractKeycloakTest;
+import org.keycloak.testsuite.AssertEvents;
+import org.keycloak.testsuite.arquillian.annotation.EnableFeature;
+import org.keycloak.testsuite.forms.VerifyProfileTest;
+import org.keycloak.testsuite.util.ClientBuilder;
+import org.keycloak.testsuite.util.RealmBuilder;
+import org.keycloak.testsuite.util.UserBuilder;
+
+/**
+ * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
+ */
+@EnableFeature(Profile.Feature.DECLARATIVE_USER_PROFILE)
+public class ServiceAccountUserProfileTest extends AbstractKeycloakTest {
+
+    private static String userId;
+    private static String userName;
+
+    @Rule
+    public AssertEvents events = new AssertEvents(this);
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+
+    @Override
+    public void addTestRealms(List<RealmRepresentation> testRealms) {
+
+        RealmBuilder realm = RealmBuilder.create().name("test")
+                .privateKey("MIICXAIBAAKBgQCrVrCuTtArbgaZzL1hvh0xtL5mc7o0NqPVnYXkLvgcwiC3BjLGw1tGEGoJaXDuSaRllobm53JBhjx33UNv+5z/UMG4kytBWxheNVKnL6GgqlNabMaFfPLPCF8kAgKnsi79NMo+n6KnSY8YeUmec/p2vjO2NjsSAVcWEQMVhJ31LwIDAQABAoGAfmO8gVhyBxdqlxmIuglbz8bcjQbhXJLR2EoS8ngTXmN1bo2L90M0mUKSdc7qF10LgETBzqL8jYlQIbt+e6TH8fcEpKCjUlyq0Mf/vVbfZSNaVycY13nTzo27iPyWQHK5NLuJzn1xvxxrUeXI6A2WFpGEBLbHjwpx5WQG9A+2scECQQDvdn9NE75HPTVPxBqsEd2z10TKkl9CZxu10Qby3iQQmWLEJ9LNmy3acvKrE3gMiYNWb6xHPKiIqOR1as7L24aTAkEAtyvQOlCvr5kAjVqrEKXalj0Tzewjweuxc0pskvArTI2Oo070h65GpoIKLc9jf+UA69cRtquwP93aZKtW06U8dQJAF2Y44ks/mK5+eyDqik3koCI08qaC8HYq2wVl7G2QkJ6sbAaILtcvD92ToOvyGyeE0flvmDZxMYlvaZnaQ0lcSQJBAKZU6umJi3/xeEbkJqMfeLclD27XGEFoPeNrmdx0q10Azp4NfJAY+Z8KRyQCR2BEG+oNitBOZ+YXF9KCpH3cdmECQHEigJhYg+ykOvr1aiZUMFT72HU0jnmQe2FVekuG+LJUt2Tm7GtMjTFoGpf0JwrVuZN39fOYAlo+nTixgeW7X8Y=")
+                .publicKey("MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCrVrCuTtArbgaZzL1hvh0xtL5mc7o0NqPVnYXkLvgcwiC3BjLGw1tGEGoJaXDuSaRllobm53JBhjx33UNv+5z/UMG4kytBWxheNVKnL6GgqlNabMaFfPLPCF8kAgKnsi79NMo+n6KnSY8YeUmec/p2vjO2NjsSAVcWEQMVhJ31LwIDAQAB")
+                .testEventListener();
+
+        ClientRepresentation enabledApp = ClientBuilder.create()
+                .id(KeycloakModelUtils.generateId())
+                .clientId("service-account-cl-refresh-on")
+                .secret("secret1")
+                .serviceAccountsEnabled(true)
+                .attribute(OIDCConfigAttributes.USE_REFRESH_TOKEN_FOR_CLIENT_CREDENTIALS_GRANT, "true")
+                .build();
+
+        realm.client(enabledApp);
+
+        ClientRepresentation enabledAppWithSkipRefreshToken = ClientBuilder.create()
+                .id(KeycloakModelUtils.generateId())
+                .clientId("service-account-cl")
+                .secret("secret1")
+                .serviceAccountsEnabled(true)
+                .build();
+
+        realm.client(enabledAppWithSkipRefreshToken);
+
+        ClientRepresentation disabledApp = ClientBuilder.create()
+                .id(KeycloakModelUtils.generateId())
+                .clientId("service-account-disabled")
+                .secret("secret1")
+                .build();
+
+        realm.client(disabledApp);
+
+        ClientRepresentation secretsWithSpecialCharacterClient = ClientBuilder.create()
+            .id(KeycloakModelUtils.generateId())
+            .clientId("service-account-cl-special-secrets")
+            .secret("secret/with=special?character")
+            .serviceAccountsEnabled(true)
+            .build();
+
+        realm.client(secretsWithSpecialCharacterClient);
+
+        UserBuilder defaultUser = UserBuilder.create()
+                .id(KeycloakModelUtils.generateId())
+                .username("test-user@localhost");
+        realm.user(defaultUser);
+
+        userId = KeycloakModelUtils.generateId();
+        userName = ServiceAccountConstants.SERVICE_ACCOUNT_USER_PREFIX + enabledApp.getClientId();
+
+        UserBuilder serviceAccountUser = UserBuilder.create()
+                .id(userId)
+                .username(userName)
+                .serviceAccountId(enabledApp.getClientId());
+        realm.user(serviceAccountUser);
+
+        RealmRepresentation realmRep = realm.build();
+        VerifyProfileTest.enableDynamicUserProfile(realmRep);
+        testRealms.add(realmRep);
+    }
+
+    @Test
+    public void testDoNotUpdateUsername() {
+        RealmResource test = adminClient.realm("test");
+        RealmRepresentation realmRepresentation = test.toRepresentation();
+        realmRepresentation.setRegistrationEmailAsUsername(true);
+        test.update(realmRepresentation);
+        UserResource serviceAccount = test.users().get(userId);
+        UserRepresentation representation = serviceAccount.toRepresentation();
+        String username = representation.getUsername();
+
+        assertNull(representation.getEmail());
+
+        serviceAccount.update(representation);
+        representation = serviceAccount.toRepresentation();
+        assertNull(representation.getEmail());
+        assertEquals(username, representation.getUsername());
+
+        representation.setEmail("test@keycloak.org");
+        serviceAccount.update(representation);
+        representation = serviceAccount.toRepresentation();
+        assertNotNull(representation.getEmail());
+        assertEquals(username, representation.getUsername());
+    }
+
+    @Test
+    public void testSetAnyAttribute() {
+        RealmResource test = adminClient.realm("test");
+        UserResource serviceAccount = test.users().get(userId);
+        UserRepresentation representation = serviceAccount.toRepresentation();
+
+        representation.setAttributes(Map.of("attr-1", List.of("attr-1-value")));
+        serviceAccount.update(representation);
+
+        representation = serviceAccount.toRepresentation();
+        assertFalse(representation.getAttributes().isEmpty());
+        assertEquals("attr-1-value", representation.getAttributes().get("attr-1").get(0));
+    }
+}


### PR DESCRIPTION
Closes #13236

* Ignore declarative user profile when processing service accounts
* Do not make it possible to set username for service accounts

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
