### PR TITLE
Use e-mail address as label in OTP key URI where applicable

### DIFF
--- a/server-spi/pom.xml
+++ b/server-spi/pom.xml
@@ -30,6 +30,10 @@
     <name>Keycloak Server SPI</name>
     <description/>
 
+    <properties>
+        <mockito.version>1.9.5</mockito.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.jboss.spec.javax.transaction</groupId>
@@ -59,6 +63,12 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/server-spi/src/main/java/org/keycloak/models/OTPPolicy.java
+++ b/server-spi/src/main/java/org/keycloak/models/OTPPolicy.java
@@ -148,8 +148,9 @@ public class OTPPolicy implements Serializable {
         try {
 
             String displayName = realm.getDisplayName() != null && !realm.getDisplayName().isEmpty() ? realm.getDisplayName() : realm.getName();
-
-            String accountName = URLEncoder.encode(user.getUsername(), "UTF-8");
+            String accountDisplayName = realm.isLoginWithEmailAllowed() && !realm.isRegistrationEmailAsUsername() ? user.getEmail() : user.getUsername();
+            
+            String accountName = URLEncoder.encode(accountDisplayName, "UTF-8");
             String issuerName = URLEncoder.encode(displayName, "UTF-8") .replaceAll("\\+", "%20");
 
             /*

--- a/server-spi/src/test/java/org/keycloak/models/OTPPolicyTest.java
+++ b/server-spi/src/test/java/org/keycloak/models/OTPPolicyTest.java
@@ -1,0 +1,73 @@
+package org.keycloak.models;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.keycloak.crypto.Algorithm;
+import org.keycloak.models.credential.OTPCredentialModel;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(Parameterized.class)
+public class OTPPolicyTest {
+    private RealmModel realm;
+    private UserModel user;
+    private OTPPolicy instance;
+    
+    @Parameterized.Parameter
+    public boolean loginWithEmailAllowed;
+    @Parameterized.Parameter(1)
+    public boolean registrationEmailAsUsername;
+    @Parameterized.Parameter(2)
+    public String expectedLabel;
+    
+    @Before
+    public void initMocks() {
+        realm = mock(RealmModel.class);
+        user = mock(UserModel.class);
+        
+        when(realm.getDisplayName()).thenReturn("Display Name");
+        when(user.getUsername()).thenReturn("user-name");
+        when(user.getEmail()).thenReturn("mock@user.com");
+    }
+    
+    @Before
+    public void initInstance() {
+        instance = new OTPPolicy(
+            OTPCredentialModel.TOTP,
+            Algorithm.RS512,
+            0,
+            6,
+            1,
+            30
+        );
+    }
+    
+    @Test
+    public void getKeyURI_shouldWriteExpectedLabel() {
+        when(realm.isLoginWithEmailAllowed()).thenReturn(loginWithEmailAllowed);
+        when(realm.isRegistrationEmailAsUsername()).thenReturn(registrationEmailAsUsername);
+        
+        final String result = instance.getKeyURI(realm, user, "SECRET");
+        final URI keyUri = URI.create(result);
+        
+        Assert.assertEquals("/Display Name:" + expectedLabel, keyUri.getPath());
+    }
+    
+    @Parameterized.Parameters(name = "loginWithEmailAllowed={0} and registrationEmailAsUsername={1} should yield label {3}")
+    public static Collection<Object[]> testParameters() {
+        return Arrays.asList(new Object[][] {
+            {true, true, "user-name"},
+            {true, false, "mock@user.com"},
+            {false, true, "user-name"},
+            {false, false, "user-name"},
+        });
+    }
+}


### PR DESCRIPTION
See https://github.com/keycloak/keycloak/discussions/16190 and https://github.com/keycloak/keycloak/issues/16325
As suggested in in the discussion, this is the most basic approach: decide whether to use the e-mail address based on the realm settings `loginWithEmailAllowed `and `registrationEmailAsUsername`

Closes #16325
