### PR TITLE
update okhttp 20.0.x

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmAdapter.java
@@ -1051,6 +1051,7 @@ public class RealmAdapter implements CachedRealmModel {
 
     @Override
     public RoleModel getDefaultRole() {
+        if (isUpdated()) return updated.getDefaultRole();
         return cached.getDefaultRoleId() == null ? null : cacheSession.getRoleById(this, cached.getDefaultRoleId());
     }
 

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
@@ -40,7 +40,7 @@ import javax.persistence.criteria.Join;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 
-import org.apache.commons.lang.BooleanUtils;
+import org.hibernate.Session;
 import org.jboss.logging.Logger;
 import org.keycloak.common.util.Time;
 import org.keycloak.connections.jpa.util.JpaUtils;
@@ -776,6 +776,9 @@ public class JpaRealmProvider implements RealmProvider, ClientProvider, ClientSc
 
         predicates.add(builder.equal(root.get("realmId"), realm.getId()));
 
+        //noinspection resource
+        String dbProductName = em.unwrap(Session.class).doReturningWork(connection -> connection.getMetaData().getDatabaseProductName());
+
         for (Map.Entry<String, String> entry : filteredAttributes.entrySet()) {
             String key = entry.getKey();
             String value = entry.getValue();
@@ -783,7 +786,19 @@ public class JpaRealmProvider implements RealmProvider, ClientProvider, ClientSc
             Join<ClientEntity, ClientAttributeEntity> attributeJoin = root.join("attributes");
 
             Predicate attrNamePredicate = builder.equal(attributeJoin.get("name"), key);
-            Predicate attrValuePredicate = builder.equal(attributeJoin.get("value"), value);
+
+            Predicate attrValuePredicate;
+            if (dbProductName.equals("Oracle")) {
+                // SELECT * FROM client_attributes WHERE ... DBMS_LOB.COMPARE(value, '0') = 0 ...;
+                // Oracle is not able to compare a CLOB with a VARCHAR unless it being converted with TO_CHAR
+                // But for this all values in the table need to be smaller than 4K, otherwise the cast will fail with
+                // "ORA-22835: Buffer too small for CLOB to CHAR" (even if it is in another row).
+                // This leaves DBMS_LOB.COMPARE as the option to compare the CLOB with the value.
+                attrValuePredicate = builder.equal(builder.function("DBMS_LOB.COMPARE", Integer.class, attributeJoin.get("value"), builder.literal(value)), 0);
+            } else {
+                attrValuePredicate = builder.equal(attributeJoin.get("value"), value);
+            }
+
             predicates.add(builder.and(attrNamePredicate, attrValuePredicate));
         }
 

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/RealmAttributeEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/RealmAttributeEntity.java
@@ -36,7 +36,8 @@ import java.io.Serializable;
  * @version $Revision: 1 $
  */
 @NamedQueries({
-        @NamedQuery(name="deleteRealmAttributesByRealm", query="delete from RealmAttributeEntity attr where attr.realm = :realm")
+        @NamedQuery(name="deleteRealmAttributesByRealm", query="delete from RealmAttributeEntity attr where attr.realm = :realm"),
+        @NamedQuery(name="selectRealmAttributesNotEmptyByName", query="select ra from RealmAttributeEntity ra WHERE ra.name = :name and length(ra.value) > 0")
 })
 @Table(name="REALM_ATTRIBUTE")
 @Entity

--- a/model/map-jpa/pom.xml
+++ b/model/map-jpa/pom.xml
@@ -57,7 +57,7 @@
             <plugin>
                 <groupId>org.hibernate.orm.tooling</groupId>
                 <artifactId>hibernate-enhance-maven-plugin</artifactId>
-                <version>${hibernate.core.version}</version>
+                <version>${hibernate-orm.version}</version>
                 <executions>
                     <execution>
                         <configuration>

--- a/operator/src/main/java/org/keycloak/operator/controllers/WatchedSecretsStore.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/WatchedSecretsStore.java
@@ -111,13 +111,12 @@ public class WatchedSecretsStore extends OperatorManagedResource {
 
                 Log.infof("Adding label to Secret \"%s\"", secret.getMetadata().getName());
 
-                secret = new SecretBuilder(secret)
-                        .editMetadata()
-                        .addToLabels(Constants.KEYCLOAK_COMPONENT_LABEL, WATCHED_SECRETS_LABEL_VALUE)
-                        .endMetadata()
-                        .build();
-
-                client.secrets().inNamespace(secret.getMetadata().getNamespace()).withName(secret.getMetadata().getName()).patch(secret);
+                client.secrets().inNamespace(secret.getMetadata().getNamespace()).withName(secret.getMetadata().getName())
+                        .edit(s -> new SecretBuilder(s)
+                                .editMetadata()
+                                .addToLabels(Constants.KEYCLOAK_COMPONENT_LABEL, WATCHED_SECRETS_LABEL_VALUE)
+                                .endMetadata()
+                                .build());
             }
         }
     }
@@ -194,8 +193,13 @@ public class WatchedSecretsStore extends OperatorManagedResource {
     }
 
     private static void cleanObsoleteLabelFromSecret(KubernetesClient client, Secret secret) {
-        secret.getMetadata().getLabels().remove(Constants.KEYCLOAK_COMPONENT_LABEL);
-        client.secrets().inNamespace(secret.getMetadata().getNamespace()).withName(secret.getMetadata().getName()).patch(secret);
+        client.secrets().inNamespace(secret.getMetadata().getNamespace()).withName(secret.getMetadata().getName())
+                .edit(s -> new SecretBuilder(s)
+                        .editMetadata()
+                        .removeFromLabels(Constants.KEYCLOAK_COMPONENT_LABEL)
+                        .endMetadata()
+                        .build()
+                );
     }
 
     public static EventSource getWatchedSecretsEventSource(KubernetesClient client, String namespace) {

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/BaseOperatorTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/BaseOperatorTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
 import org.keycloak.operator.Constants;
 import org.keycloak.operator.crds.v2alpha1.deployment.Keycloak;
 
@@ -103,8 +104,11 @@ public abstract class BaseOperatorTest {
   }
 
   @BeforeEach
-  public void beforeEach() {
-    Log.info(((operatorDeployment == OperatorDeployment.remote) ? "Remote " : "Local ") + "Run Test :" + namespace);
+  public void beforeEach(TestInfo testInfo) {
+    String testClassName = testInfo.getTestClass().map(c -> c.getSimpleName() + ".").orElse("");
+    Log.info("\n------- STARTING: " + testClassName + testInfo.getDisplayName() + "\n"
+            + "------- Namespace: " + namespace + "\n"
+            + "------- Mode: " + ((operatorDeployment == OperatorDeployment.remote) ? "remote" : "local"));
   }
 
   private static void createK8sClient() {

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/RealmImportTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/RealmImportTest.java
@@ -24,6 +24,7 @@ import io.quarkus.test.junit.QuarkusTest;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.keycloak.operator.testsuite.utils.CRAssert;
 import org.keycloak.operator.controllers.KeycloakService;
@@ -49,8 +50,8 @@ public class RealmImportTest extends BaseOperatorTest {
 
     @Override
     @BeforeEach
-    public void beforeEach() {
-        super.beforeEach();
+    public void beforeEach(TestInfo testInfo) {
+        super.beforeEach(testInfo);
         // Recreating the database and the realm import CR to keep this test isolated
         k8sclient.load(getClass().getResourceAsStream("/example-realm.yaml")).inNamespace(namespace).delete();
         k8sclient.load(getClass().getResourceAsStream("/incorrect-realm.yaml")).inNamespace(namespace).delete();

--- a/pom.xml
+++ b/pom.xml
@@ -65,12 +65,12 @@
         <apache.httpcomponents.httpcore.version>4.4.14</apache.httpcomponents.httpcore.version>
         <apache.mime4j.version>0.6</apache.mime4j.version>
         <jboss.dmr.version>1.5.1.Final</jboss.dmr.version>
-        <bouncycastle.version>1.68</bouncycastle.version>
+        <bouncycastle.version>1.70</bouncycastle.version>
 
         <!-- TODO Are these correct versions? -->
         <bouncycastle.fips.version>1.0.2.3</bouncycastle.fips.version>
-        <bouncycastle.pkixfips.version>1.0.5</bouncycastle.pkixfips.version>
-        <bouncycastle.tlsfips.version>1.0.12.2</bouncycastle.tlsfips.version>
+        <bouncycastle.pkixfips.version>1.0.7</bouncycastle.pkixfips.version>
+        <bouncycastle.tlsfips.version>1.0.14</bouncycastle.tlsfips.version>
 
         <cxf.version>3.3.10</cxf.version>
         <cxf.jetty.version>3.3.10</cxf.jetty.version>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <jboss.snapshots.repo.id>jboss-snapshots-repository</jboss.snapshots.repo.id>
         <jboss.snapshots.repo.url>https://s01.oss.sonatype.org/content/repositories/snapshots/</jboss.snapshots.repo.url>
 
-        <quarkus.version>2.13.5.Final</quarkus.version>
+        <quarkus.version>2.13.6.Final</quarkus.version>
 
         <project.build-time>${timestamp}</project.build-time>
 
@@ -145,7 +145,7 @@
         <mysql.version>8.0.23</mysql.version>
         <mysql-jdbc.version>8.0.30</mysql-jdbc.version>
         <postgresql.version>13.2</postgresql.version>
-        <postgresql-jdbc.version>42.5.0</postgresql-jdbc.version>
+        <postgresql-jdbc.version>42.5.1</postgresql-jdbc.version>
         <mariadb.version>10.3.27</mariadb.version>
         <mariadb-jdbc.version>2.7.2</mariadb-jdbc.version>
         <mssql.version>2019-CU10-ubuntu-20.04</mssql.version>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <jboss.snapshots.repo.id>jboss-snapshots-repository</jboss.snapshots.repo.id>
         <jboss.snapshots.repo.url>https://s01.oss.sonatype.org/content/repositories/snapshots/</jboss.snapshots.repo.url>
 
-        <quarkus.version>2.13.3.Final</quarkus.version>
+        <quarkus.version>2.13.5.Final</quarkus.version>
 
         <project.build-time>${timestamp}</project.build-time>
 

--- a/pom.xml
+++ b/pom.xml
@@ -79,8 +79,8 @@
         <dom4j.version>2.1.3</dom4j.version>
         <h2.version>2.1.214</h2.version>
         <jakarta.persistence.version>2.2.3</jakarta.persistence.version>
-        <hibernate.core.version>5.6.10.Final</hibernate.core.version>
-        <hibernate.c3p0.version>5.6.10.Final</hibernate.c3p0.version>
+        <hibernate-orm.version>5.6.14.Final</hibernate-orm.version>
+        <hibernate.c3p0.version>${hibernate-orm.version}</hibernate.c3p0.version>
         <infinispan.version>13.0.10.Final</infinispan.version>
         <infinispan.protostream.processor.version>4.4.1.Final</infinispan.protostream.processor.version>
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
@@ -96,7 +96,7 @@
         <jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec.version>2.0.1.Final</jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec.version>
         <jboss.spec.javax.servlet.jsp.jboss-jsp-api_2.3_spec.version>2.0.0.Final</jboss.spec.javax.servlet.jsp.jboss-jsp-api_2.3_spec.version>
         <log4j.version>1.2.17</log4j.version>
-        <resteasy.version>4.7.4.Final</resteasy.version>
+        <resteasy.version>4.7.7.Final</resteasy.version>
         <resteasy.undertow.version>${resteasy.version}</resteasy.undertow.version>
         <owasp.html.sanitizer.version>20211018.2</owasp.html.sanitizer.version>
         <slf4j-api.version>1.7.30</slf4j-api.version>
@@ -108,7 +108,7 @@
         <sun.activation.version>1.2.2</sun.activation.version>
         <org.glassfish.jaxb.xsom.version>2.3.3-b02</org.glassfish.jaxb.xsom.version>
         <undertow.version>2.2.19.Final</undertow.version>
-        <elytron.version>1.18.3.Final</elytron.version>
+        <wildfly-elytron.version>1.20.1.Final</wildfly-elytron.version>
         <elytron.undertow-server.version>1.9.0.Final</elytron.undertow-server.version>
         <jetty94.version>9.4.40.v20210413</jetty94.version>
         <woodstox.version>6.0.3</woodstox.version>
@@ -143,13 +143,15 @@
 
         <!-- Databases -->
         <mysql.version>8.0.23</mysql.version>
-        <mysql.driver.version>8.0.28</mysql.driver.version>
+        <mysql-jdbc.version>8.0.30</mysql-jdbc.version>
         <postgresql.version>13.2</postgresql.version>
-        <postgresql.driver.version>42.3.3</postgresql.driver.version>
+        <postgresql-jdbc.version>42.5.0</postgresql-jdbc.version>
         <mariadb.version>10.3.27</mariadb.version>
-        <mariadb.driver.version>2.7.2</mariadb.driver.version>
+        <mariadb-jdbc.version>2.7.2</mariadb-jdbc.version>
         <mssql.version>2019-CU10-ubuntu-20.04</mssql.version>
-        <mssql.driver.version>9.2.0.jre8</mssql.driver.version>
+        <mssql-jdbc.version>9.2.0.jre8</mssql-jdbc.version>
+        <!-- this is the oracle driver version also used in the Quarkus BOM -->
+        <oracle-jdbc.version>21.5.0.0</oracle-jdbc.version>
 
         <!-- Test -->
         <greenmail.version>1.3.1b</greenmail.version>
@@ -158,6 +160,8 @@
         <junit.version>4.13.2</junit.version>
         <picketlink.version>2.7.0.Final</picketlink.version>
         <selenium.version>2.35.0</selenium.version>
+        <!-- Needs to be aligned with Quarkus, see e.g. https://github.com/quarkusio/quarkus-quickstarts/blob/2.13.5.Final/getting-started-async/pom.xml#L14 -->
+        <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
         <xml-apis.version>1.4.01</xml-apis.version>
         <subethasmtp.version>3.1.7</subethasmtp.version>
         <awaitility.version>4.1.1</awaitility.version>
@@ -165,8 +169,8 @@
         <!-- KEYCLOAK-17585 Prevent microprofile-metrics-api upgrades from version "2.3" due to:
              https://issues.redhat.com/browse/KEYCLOAK-17585?focusedCommentId=16002705&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-16002705
         -->
-        <microprofile-metrics-api.version>2.3</microprofile-metrics-api.version>
-        <testcontainers.version>1.16.3</testcontainers.version>
+        <microprofile-metrics-api.version>3.0.1</microprofile-metrics-api.version>
+        <testcontainers.version>1.17.5</testcontainers.version>
 
         <!-- Maven Plugins -->
         <replacer.plugin.version>1.3.5</replacer.plugin.version>
@@ -571,7 +575,7 @@
             <dependency>
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-core</artifactId>
-                <version>${hibernate.core.version}</version>
+                <version>${hibernate-orm.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.hibernate</groupId>
@@ -731,7 +735,7 @@
             <dependency>
                 <groupId>mysql</groupId>
                 <artifactId>mysql-connector-java</artifactId>
-                <version>${mysql.driver.version}</version>
+                <version>${mysql-jdbc.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -902,7 +906,7 @@
             <dependency>
                 <groupId>org.wildfly.security</groupId>
                 <artifactId>wildfly-elytron</artifactId>
-                <version>${elytron.version}</version>
+                <version>${wildfly-elytron.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wildfly.common</groupId>
@@ -1762,7 +1766,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.0.0-M7</version>
+                    <version>${surefire-plugin.version}</version>
                     <configuration>
                         <forkMode>once</forkMode>
                         <argLine>-Djava.awt.headless=true ${surefire.memory.settings} ${surefire.system.args} -Duser.language=en -Duser.region=US</argLine>
@@ -1972,7 +1976,7 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <configuration>
-                            <additionalparam>-Xdoclint:none</additionalparam>
+                            <doclint>none</doclint>
                             <failOnError>false</failOnError>
                             <excludePackageNames>cx.*:org.freedesktop*:org.jvnet*</excludePackageNames>
                         </configuration>

--- a/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
+++ b/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
@@ -20,6 +20,7 @@ package org.keycloak.quarkus.deployment;
 import static org.keycloak.quarkus.runtime.KeycloakRecorder.DEFAULT_HEALTH_ENDPOINT;
 import static org.keycloak.quarkus.runtime.KeycloakRecorder.DEFAULT_METRICS_ENDPOINT;
 import static org.keycloak.quarkus.runtime.Providers.getProviderManager;
+import static org.keycloak.quarkus.runtime.configuration.Configuration.getConfig;
 import static org.keycloak.quarkus.runtime.configuration.Configuration.getPropertyNames;
 import static org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider.NS_QUARKUS;
 import static org.keycloak.quarkus.runtime.configuration.QuarkusPropertiesConfigSource.QUARKUS_PROPERTY_ENABLED;
@@ -49,6 +50,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.function.Consumer;
@@ -81,6 +83,7 @@ import io.smallrye.config.ConfigValue;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.jpa.boot.internal.ParsedPersistenceXmlDescriptor;
 import org.hibernate.jpa.boot.internal.PersistenceXmlParser;
+import org.hibernate.resource.jdbc.spi.PhysicalConnectionHandlingMode;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.ClassInfo;
@@ -93,6 +96,7 @@ import org.keycloak.Config;
 import org.keycloak.common.crypto.FipsMode;
 import org.keycloak.config.SecurityOptions;
 import org.keycloak.config.StorageOptions;
+import org.keycloak.config.TransactionOptions;
 import org.keycloak.connections.jpa.JpaConnectionProvider;
 import org.keycloak.connections.jpa.JpaConnectionSpi;
 import org.keycloak.models.map.storage.jpa.JpaMapStorageProviderFactory;
@@ -273,7 +277,25 @@ class KeycloakProcessor {
         Properties unitProperties = descriptor.getProperties();
 
         unitProperties.setProperty(AvailableSettings.DIALECT, config.defaultPersistenceUnit.dialect.dialect.orElse(null));
-        unitProperties.setProperty(AvailableSettings.JPA_TRANSACTION_TYPE, PersistenceUnitTransactionType.JTA.name());
+        if (Objects.equals(getConfig().getConfigValue("kc.transaction-jta-enabled").getValue(), "disabled")) {
+            unitProperties.setProperty(AvailableSettings.JPA_TRANSACTION_TYPE, PersistenceUnitTransactionType.RESOURCE_LOCAL.name());
+
+            // Only changing this for the new map storage to keep the legacy JPA store untouched as it wasn't tested for the legacy store.
+            // follow-up on this in https://github.com/keycloak/keycloak/issues/13222 to re-visit the auto-commit handling
+            String storage = Configuration.getRawValue(
+                    MicroProfileConfigProvider.NS_KEYCLOAK_PREFIX.concat(StorageOptions.STORAGE.getKey()));
+            if (storage != null) {
+                // Needed to change the connection handling to avoid Hibernate returning the connection too early,
+                // which then interfered with the auto-commit reset that's done at the end of the transaction and PgConnection throwing a "Cannot commit when autoCommit is enabled."
+                // The current default is DELAYED_ACQUISITION_AND_RELEASE_BEFORE_TRANSACTION_COMPLETION which would only make sense for JTA IMHO.
+                // https://github.com/quarkusio/quarkus/blob/8d89101ffa65465b33d06360047095046bb726e4/extensions/hibernate-orm/runtime/src/main/java/io/quarkus/hibernate/orm/runtime/boot/FastBootMetadataBuilder.java#L287-L288
+                unitProperties.setProperty(AvailableSettings.CONNECTION_HANDLING, PhysicalConnectionHandlingMode.DELAYED_ACQUISITION_AND_RELEASE_AFTER_TRANSACTION.name());
+            }
+        } else {
+            // will happen for both "enabled" and "xa"
+            unitProperties.setProperty(AvailableSettings.JPA_TRANSACTION_TYPE, PersistenceUnitTransactionType.JTA.name());
+        }
+
         unitProperties.setProperty(AvailableSettings.QUERY_STARTUP_CHECKING, Boolean.FALSE.toString());
 
         String dbKind = jdbcDataSources.get(0).getDbKind();

--- a/quarkus/dist/src/main/content/bin/kc.bat
+++ b/quarkus/dist/src/main/content/bin/kc.bat
@@ -124,7 +124,7 @@ if "x%JAVA_HOME%" == "x" (
   )
 )
 
-set "CLASSPATH_OPTS=%DIRNAME%..\lib\quarkus-run.jar:%DIRNAME%..\lib\bootstrap\*"
+set "CLASSPATH_OPTS=%DIRNAME%..\lib\quarkus-run.jar;%DIRNAME%..\lib\bootstrap\*"
 
 set "JAVA_RUN_OPTS=%JAVA_OPTS% -Dkc.home.dir="%DIRNAME%.." -Djboss.server.config.dir="%DIRNAME%..\conf" -Dkeycloak.theme.dir="%DIRNAME%..\themes" %SERVER_OPTS% -cp "%CLASSPATH_OPTS%" io.quarkus.bootstrap.runner.QuarkusEntryPoint %CONFIG_ARGS%"
 

--- a/quarkus/pom.xml
+++ b/quarkus/pom.xml
@@ -31,25 +31,12 @@
     <packaging>pom</packaging>
 
     <properties>
-        <!--
-            Do not change the properties bellow.
-            Their names should match the name used by Quarkus BOM and the versions are automatically set when running the 'set-quarkus-version.sh' script.
-        -->
-        <resteasy.version>4.7.7.Final</resteasy.version>
-        <hibernate-orm.version>5.6.14.Final</hibernate-orm.version>
-        <mysql-jdbc.version>8.0.30</mysql-jdbc.version>
-        <postgresql-jdbc.version>42.5.0</postgresql-jdbc.version>
         <wildfly-common.version>1.5.4.Final-format-001</wildfly-common.version>
-        <wildfly-elytron.version>1.20.1.Final</wildfly-elytron.version>
-        <microprofile-metrics-api.version>3.0.1</microprofile-metrics-api.version>
 
         <!--
             We need to override certain dependencies from the parent POM.
             TODO: remove these properties after changing the parent POM to use the same property names used by Quarkus BOM.
         -->
-        <hibernate.core.version>${hibernate-orm.version}</hibernate.core.version>
-        <mysql.driver.version>${mysql-jdbc.version}</mysql.driver.version>
-        <postgresql.version>${postgresql-jdbc.version}</postgresql.version>
         <wildfly.common.version>${wildfly-common.version}</wildfly.common.version>
 
         <!--
@@ -70,9 +57,6 @@
         <maven.compiler.release>11</maven.compiler.release>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-
-        <!-- Needs to be aligned with Quarkus, see e.g. https://github.com/quarkusio/quarkus-quickstarts/blob/2.7.6.Final/getting-started-async/pom.xml#L14 -->
-        <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     </properties>
 
     <dependencyManagement>
@@ -106,6 +90,7 @@
                 <artifactId>infinispan-client-hotrod</artifactId>
                 <version>${infinispan.version}</version>
             </dependency>
+
 
             <!-- Dependencies removed from JDK 11 and in compliance with those used by Wildfly. -->
             <dependency>

--- a/quarkus/pom.xml
+++ b/quarkus/pom.xml
@@ -36,7 +36,7 @@
             Their names should match the name used by Quarkus BOM and the versions are automatically set when running the 'set-quarkus-version.sh' script.
         -->
         <resteasy.version>4.7.7.Final</resteasy.version>
-        <hibernate-orm.version>5.6.12.Final</hibernate-orm.version>
+        <hibernate-orm.version>5.6.14.Final</hibernate-orm.version>
         <mysql-jdbc.version>8.0.30</mysql-jdbc.version>
         <postgresql-jdbc.version>42.5.0</postgresql-jdbc.version>
         <wildfly-common.version>1.5.4.Final-format-001</wildfly-common.version>

--- a/quarkus/pom.xml
+++ b/quarkus/pom.xml
@@ -84,6 +84,12 @@
                 <groupId>org.infinispan</groupId>
                 <artifactId>infinispan-server-hotrod</artifactId>
                 <version>${infinispan.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.squareup.okhttp3</groupId>
+                        <artifactId>okhttp</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.infinispan</groupId>
@@ -131,6 +137,33 @@
                         <artifactId>activation</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+
+            <!-- Openshift -->
+            <dependency>
+                <groupId>com.openshift</groupId>
+                <artifactId>openshift-restclient-java</artifactId>
+                <version>${version.com.openshift.openshift-restclient-java}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>log4j</groupId>
+                        <artifactId>log4j</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-log4j12</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.squareup.okhttp3</groupId>
+                        <artifactId>okhttp</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>com.squareup.okhttp3</groupId>
+                <artifactId>okhttp</artifactId>
+                <version>4.9.3</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/quarkus/runtime/pom.xml
+++ b/quarkus/runtime/pom.xml
@@ -91,7 +91,6 @@
         <dependency>
             <groupId>org.wildfly.security</groupId>
             <artifactId>wildfly-elytron</artifactId>
-            <version>${wildfly-elytron.version}</version>
         </dependency>
         <dependency>
             <groupId>io.quarkiverse.vault</groupId>
@@ -345,7 +344,6 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-multipart-provider</artifactId>
-            <version>${resteasy.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>
@@ -700,7 +698,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>${surefire-plugin.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/server-spi-private/src/main/java/org/keycloak/broker/provider/util/IdentityBrokerState.java
+++ b/server-spi-private/src/main/java/org/keycloak/broker/provider/util/IdentityBrokerState.java
@@ -20,10 +20,10 @@ package org.keycloak.broker.provider.util;
 import org.keycloak.authorization.policy.evaluation.Realm;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.RealmModel;
+import org.keycloak.common.util.Base64Url;
 
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
-import java.util.Base64;
 import java.util.UUID;
 import java.util.regex.Pattern;
 
@@ -51,8 +51,8 @@ public class IdentityBrokerState {
                 bb.putLong(clientDbUuid.getMostSignificantBits());
                 bb.putLong(clientDbUuid.getLeastSignificantBits());
                 byte[] clientUuidBytes = bb.array();
-                clientIdEncoded = Base64.getEncoder().encodeToString(clientUuidBytes).replace("=", "");
-            } catch (IllegalArgumentException e) {
+                clientIdEncoded = Base64Url.encode(clientUuidBytes);
+            } catch (RuntimeException e) {
                 // Ignore...the clientid in the database was not in UUID format. Just use as is.
             }
         }
@@ -73,7 +73,7 @@ public class IdentityBrokerState {
             try {
                 // If this decoding succeeds it was the result of the encoding of a UUID client.id - if it fails we interpret it as client.clientId
                 // in accordance to the method decoded above
-                byte[] decodedClientId = Base64.getDecoder().decode(clientId);
+                byte[] decodedClientId = Base64Url.decode(clientId);
                 ByteBuffer bb = ByteBuffer.wrap(decodedClientId);
                 long first = bb.getLong();
                 long second = bb.getLong();
@@ -83,7 +83,7 @@ public class IdentityBrokerState {
                 if (clientModel != null) {
                     clientId = clientModel.getClientId();
                 }
-            } catch (IllegalArgumentException | BufferUnderflowException e) {
+            } catch (RuntimeException e) {
                 // Ignore...the clientid was not in encoded uuid format. Just use as it is.
             }
         }

--- a/server-spi-private/src/test/java/org/keycloak/broker/provider/util/IdentityBrokerStateTest.java
+++ b/server-spi-private/src/test/java/org/keycloak/broker/provider/util/IdentityBrokerStateTest.java
@@ -46,6 +46,25 @@ public class IdentityBrokerStateTest {
     }
 
     @Test
+    public void testDecodedWithClientIdAnActualUuidBASE64UriFriendly() {
+
+        // Given
+        String state = "gNrGamIDGKpKSI9yOrcFzYTKoFGH779_WNCacAelkhk";
+        String clientId = "c5ac1ea7-6c28-4be1-b7cd-d63a1ba57f78";
+        String clientClientId = "http://i.am.an.url";
+        String tabId = "vpISZLVDAc0";
+
+        // When
+        IdentityBrokerState encodedState = IdentityBrokerState.decoded(state, clientId, clientClientId, tabId);
+
+        // Then
+        Assert.assertNotNull(encodedState);
+        Assert.assertEquals(clientClientId, encodedState.getClientId());
+        Assert.assertEquals(tabId, encodedState.getTabId());
+        Assert.assertEquals("gNrGamIDGKpKSI9yOrcFzYTKoFGH779_WNCacAelkhk.vpISZLVDAc0.xawep2woS-G3zdY6G6V_eA", encodedState.getEncoded());
+    }
+
+    @Test
     public void testEncodedWithClientIdUUid() {
         // Given
         String encoded = "gNrGamIDGKpKSI9yOrcFzYTKoFGH779_WNCacAelkhk.vpISZLVDAc0.7UlEjBTPRx6oOgY9DcO8jA";

--- a/server-spi/src/main/java/org/keycloak/theme/ThemeSelectorProvider.java
+++ b/server-spi/src/main/java/org/keycloak/theme/ThemeSelectorProvider.java
@@ -19,13 +19,15 @@ package org.keycloak.theme;
 
 import org.keycloak.Config;
 import org.keycloak.common.Profile;
-import org.keycloak.common.Version;
 import org.keycloak.provider.Provider;
 
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
  */
 public interface ThemeSelectorProvider extends Provider {
+
+    String DEFAULT = "keycloak";
+    String DEFAULT_V2 = "keycloak.v2";
 
     /**
      * Return the theme name to use for the specified type
@@ -36,13 +38,20 @@ public interface ThemeSelectorProvider extends Provider {
     String getThemeName(Theme.Type type);
 
     default String getDefaultThemeName(Theme.Type type) {
-        String name = Config.scope("theme").get("default", Version.NAME.toLowerCase());
-        if ((type == Theme.Type.ACCOUNT) && Profile.isFeatureEnabled(Profile.Feature.ACCOUNT2)) {
-            name = name.concat(".v2");
-        } else if ((type == Theme.Type.ADMIN) && Profile.isFeatureEnabled(Profile.Feature.ADMIN2)) {
-            name = name.concat(".v2");
+        String name = Config.scope("theme").get("default");
+        if (name != null && !name.isEmpty()) {
+            return name;
         }
-        return name;
+
+        if ((type == Theme.Type.ACCOUNT) && Profile.isFeatureEnabled(Profile.Feature.ACCOUNT2)) {
+            return DEFAULT_V2;
+        }
+
+        if ((type == Theme.Type.ADMIN) && Profile.isFeatureEnabled(Profile.Feature.ADMIN2)) {
+            return DEFAULT_V2;
+        }
+
+        return DEFAULT;
     }
 
 }

--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocolFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocolFactory.java
@@ -110,6 +110,7 @@ public class OIDCLoginProtocolFactory extends AbstractLoginProtocolFactory {
 
     @Override
     public void init(Config.Scope config) {
+        initBuiltIns();
         this.providerConfig = new OIDCProviderConfig(config);
         if (providerConfig.isLegacyLogoutRedirectUri()) {
             logger.warnf("Deprecated switch '%s' is enabled. Please try to disable it and update your clients to use OpenID Connect compliant way for RP-initiated logout.", CONFIG_LEGACY_LOGOUT_REDIRECT_URI);
@@ -129,9 +130,9 @@ public class OIDCLoginProtocolFactory extends AbstractLoginProtocolFactory {
         return builtins;
     }
 
-    static Map<String, ProtocolMapperModel> builtins = new HashMap<>();
+    private Map<String, ProtocolMapperModel> builtins = new HashMap<>();
 
-    static {
+    void initBuiltIns() {
                 ProtocolMapperModel model;
         model = UserPropertyMapper.createClaimMapper(USERNAME,
                 "username",
@@ -218,7 +219,7 @@ public class OIDCLoginProtocolFactory extends AbstractLoginProtocolFactory {
         }
     }
 
-    private static void createUserAttributeMapper(String name, String attrName, String claimName, String type) {
+    private void createUserAttributeMapper(String name, String attrName, String claimName, String type) {
         ProtocolMapperModel model = UserAttributeMapper.createClaimMapper(name,
                 attrName,
                 claimName, type,
@@ -297,7 +298,7 @@ public class OIDCLoginProtocolFactory extends AbstractLoginProtocolFactory {
     }
 
 
-    public static ClientScopeModel addRolesClientScope(RealmModel newRealm) {
+    public ClientScopeModel addRolesClientScope(RealmModel newRealm) {
         ClientScopeModel rolesScope = KeycloakModelUtils.getClientScopeByName(newRealm, ROLES_SCOPE);
         if (rolesScope == null) {
             rolesScope = newRealm.addClientScope(ROLES_SCOPE);
@@ -320,7 +321,7 @@ public class OIDCLoginProtocolFactory extends AbstractLoginProtocolFactory {
     }
 
 
-    public static ClientScopeModel addWebOriginsClientScope(RealmModel newRealm) {
+    public ClientScopeModel addWebOriginsClientScope(RealmModel newRealm) {
         ClientScopeModel originsScope = KeycloakModelUtils.getClientScopeByName(newRealm, WEB_ORIGINS_SCOPE);
         if (originsScope == null) {
             originsScope = newRealm.addClientScope(WEB_ORIGINS_SCOPE);
@@ -347,7 +348,7 @@ public class OIDCLoginProtocolFactory extends AbstractLoginProtocolFactory {
      * @param newRealm the realm to which the {@code microprofile-jwt} scope is to be added.
      * @return a reference to the {@code microprofile-jwt} client scope that was either created or already exists in the realm.
      */
-    public static ClientScopeModel addMicroprofileJWTClientScope(RealmModel newRealm) {
+    public ClientScopeModel addMicroprofileJWTClientScope(RealmModel newRealm) {
         ClientScopeModel microprofileScope = KeycloakModelUtils.getClientScopeByName(newRealm, MICROPROFILE_JWT_SCOPE);
         if (microprofileScope == null) {
             microprofileScope = newRealm.addClientScope(MICROPROFILE_JWT_SCOPE);
@@ -366,7 +367,7 @@ public class OIDCLoginProtocolFactory extends AbstractLoginProtocolFactory {
     }
 
 
-    public static void addAcrClientScope(RealmModel newRealm) {
+    public void addAcrClientScope(RealmModel newRealm) {
         if (Profile.isFeatureEnabled(Profile.Feature.STEP_UP_AUTHENTICATION)) {
             ClientScopeModel acrScope = KeycloakModelUtils.getClientScopeByName(newRealm, ACR_SCOPE);
             if (acrScope == null) {

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/LogoutEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/LogoutEndpoint.java
@@ -379,6 +379,8 @@ public class LogoutEndpoint {
                 session.getProvider(LoginFormsProvider.class).setAttribute(Constants.SKIP_LINK, true);
             }
 
+            event.error(Errors.SESSION_EXPIRED);
+
             return ErrorPage.error(session, logoutSession, Response.Status.BAD_REQUEST, Messages.FAILED_LOGOUT);
         }
 
@@ -414,6 +416,7 @@ public class LogoutEndpoint {
 
             AuthenticationManager.AuthResult authResult = AuthenticationManager.authenticateIdentityCookie(session, realm, false);
             if (authResult != null) {
+                event.error(Errors.LOGOUT_FAILED);
                 return ErrorPage.error(session, logoutSession, Response.Status.BAD_REQUEST, Messages.FAILED_LOGOUT);
             } else {
                 // Probably changing locale on logout screen after logout was already performed. If there is no session in the browser, we can just display that logout was already finished
@@ -440,7 +443,10 @@ public class LogoutEndpoint {
             try {
                 userSession = lockUserSessionsForModification(session, () -> session.sessions().getUserSession(realm, userSessionIdFromIdToken));
 
-                if (userSession != null) {
+                if (userSession == null) {
+                    event.event(EventType.LOGOUT);
+                    event.error(Errors.SESSION_EXPIRED);
+                } else {
                     Integer idTokenIssuedAt = Integer.parseInt(idTokenIssuedAtStr);
                     checkTokenIssuedAt(idTokenIssuedAt, userSession);
                 }

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/LogoutEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/LogoutEndpoint.java
@@ -246,10 +246,9 @@ public class LogoutEndpoint {
                 OIDCAdvancedConfigWrapper wrapper = OIDCAdvancedConfigWrapper.fromClientModel(client);
                 Set<String> postLogoutRedirectUris = wrapper.getPostLogoutRedirectUris() != null ? new HashSet(wrapper.getPostLogoutRedirectUris()) : new HashSet<>();
                 validatedRedirectUri = RedirectUtils.verifyRedirectUri(session, client.getRootUrl(), redirectUri, postLogoutRedirectUris, true);
-            } else if (clientId == null) {
+            } else if (clientId == null && providerConfig.isLegacyLogoutRedirectUri()) {
                 /*
-                 * Only call verifyRealmRedirectUri, in case both clientId and client are null - otherwise
-                 * the logout uri contains a non-existing client, and we should show an INVALID_REDIRECT_URI error
+                 * Only call verifyRealmRedirectUri against all in the realm, in case when "Legacy" switch is enabled and when we don't have a client - usually due both clientId and client are null
                  */
                 validatedRedirectUri = RedirectUtils.verifyRealmRedirectUri(session, redirectUri);
             }

--- a/services/src/main/java/org/keycloak/services/managers/UserSessionCrossDCManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/UserSessionCrossDCManager.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.services.managers;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -26,6 +27,7 @@ import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserSessionModel;
 
+import static org.keycloak.services.managers.AuthenticationManager.authenticateIdentityCookie;
 import static org.keycloak.utils.LockObjectsForModification.lockUserSessionsForModification;
 
 /**
@@ -64,6 +66,18 @@ public class UserSessionCrossDCManager {
     // Just check if userSession also exists on remoteCache. It can happen that logout happened on 2nd DC and userSession is already removed on remoteCache and this DC wasn't yet notified
     public UserSessionModel getUserSessionIfExistsRemotely(AuthenticationSessionManager asm, RealmModel realm) {
         List<String> sessionCookies = asm.getAuthSessionCookies(realm);
+
+        if (sessionCookies.isEmpty()) {
+            // ideally, we should not rely on auth session id to retrieve user sessions
+            // in case the auth session was removed, we fall back to the identity cookie
+            // we are here doing the user session lookup twice, however the second lookup is going to make sure the
+            // session exists in remote caches
+            AuthenticationManager.AuthResult authResult = lockUserSessionsForModification(kcSession, () -> authenticateIdentityCookie(kcSession, realm, true));
+
+            if (authResult != null && authResult.getSession() != null) {
+                sessionCookies = Collections.singletonList(authResult.getSession().getId());
+            }
+        }
 
         return sessionCookies.stream().map(oldEncodedId -> {
             AuthSessionId authSessionId = asm.decodeAuthSessionId(oldEncodedId);

--- a/services/src/main/java/org/keycloak/services/migration/DefaultMigrationProvider.java
+++ b/services/src/main/java/org/keycloak/services/migration/DefaultMigrationProvider.java
@@ -23,17 +23,15 @@ import org.keycloak.models.ClientScopeModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.ProtocolMapperModel;
 import org.keycloak.models.RealmModel;
-import org.keycloak.models.utils.ModelToRepresentation;
 import org.keycloak.protocol.LoginProtocol;
 import org.keycloak.protocol.LoginProtocolFactory;
+import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.protocol.oidc.OIDCLoginProtocolFactory;
-import org.keycloak.provider.ProviderFactory;
 import org.keycloak.representations.idm.ProtocolMapperRepresentation;
 import org.keycloak.services.managers.RealmManager;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -84,26 +82,29 @@ public class DefaultMigrationProvider implements MigrationProvider {
         new RealmManager(session).setupAdminCli(realm);
     }
 
+    private OIDCLoginProtocolFactory getOIDCLoginProtocolFactory() {
+        return (OIDCLoginProtocolFactory) session.getKeycloakSessionFactory().getProviderFactory(LoginProtocol.class, OIDCLoginProtocol.LOGIN_PROTOCOL);
+    }
 
     @Override
     public ClientScopeModel addOIDCRolesClientScope(RealmModel realm) {
-        return OIDCLoginProtocolFactory.addRolesClientScope(realm);
+        return getOIDCLoginProtocolFactory().addRolesClientScope(realm);
     }
 
 
     @Override
     public ClientScopeModel addOIDCWebOriginsClientScope(RealmModel realm) {
-        return OIDCLoginProtocolFactory.addWebOriginsClientScope(realm);
+        return getOIDCLoginProtocolFactory().addWebOriginsClientScope(realm);
     }
 
     @Override
     public ClientScopeModel addOIDCMicroprofileJWTClientScope(RealmModel realm) {
-        return OIDCLoginProtocolFactory.addMicroprofileJWTClientScope(realm);
+        return getOIDCLoginProtocolFactory().addMicroprofileJWTClientScope(realm);
     }
 
     @Override
     public void addOIDCAcrClientScope(RealmModel realm) {
-        OIDCLoginProtocolFactory.addAcrClientScope(realm);
+        getOIDCLoginProtocolFactory().addAcrClientScope(realm);
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/services/resources/SessionCodeChecks.java
+++ b/services/src/main/java/org/keycloak/services/resources/SessionCodeChecks.java
@@ -17,6 +17,10 @@
 
 package org.keycloak.services.resources;
 
+import static org.keycloak.services.managers.AuthenticationManager.KEYCLOAK_IDENTITY_COOKIE;
+import static org.keycloak.services.managers.AuthenticationManager.authenticateIdentityCookie;
+import static org.keycloak.utils.LockObjectsForModification.lockUserSessionsForModification;
+
 import java.net.URI;
 
 import javax.ws.rs.core.Cookie;
@@ -42,11 +46,13 @@ import org.keycloak.protocol.AuthorizationEndpointBase;
 import org.keycloak.protocol.RestartLoginCookie;
 import org.keycloak.services.ErrorPage;
 import org.keycloak.services.ServicesLogger;
+import org.keycloak.services.managers.AuthenticationManager;
 import org.keycloak.services.managers.AuthenticationSessionManager;
 import org.keycloak.services.managers.ClientSessionCode;
 import org.keycloak.services.messages.Messages;
 import org.keycloak.services.util.BrowserHistoryHelper;
 import org.keycloak.services.util.AuthenticationFlowURLHelper;
+import org.keycloak.services.util.CookieHelper;
 import org.keycloak.sessions.AuthenticationSessionModel;
 import org.keycloak.sessions.RootAuthenticationSessionModel;
 
@@ -177,6 +183,15 @@ public class SessionCodeChecks {
 
         // See if we are already authenticated and userSession with same ID exists.
         UserSessionModel userSession = authSessionManager.getUserSessionFromAuthCookie(realm);
+
+        if (userSession == null) {
+            // fallback to check if there is an identity cookie
+            AuthenticationManager.AuthResult authResult = lockUserSessionsForModification(session, () -> authenticateIdentityCookie(session, realm, false));
+
+            if (authResult != null) {
+                userSession = authResult.getSession();
+            }
+        }
 
         if (userSession != null) {
             LoginFormsProvider loginForm = session.getProvider(LoginFormsProvider.class).setAuthenticationSession(authSession)

--- a/services/src/main/java/org/keycloak/theme/DefaultThemeSelectorProvider.java
+++ b/services/src/main/java/org/keycloak/theme/DefaultThemeSelectorProvider.java
@@ -1,8 +1,6 @@
 package org.keycloak.theme;
 
 import org.keycloak.Config;
-import org.keycloak.common.Profile;
-import org.keycloak.common.Version;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 

--- a/testsuite/integration-arquillian/pom.xml
+++ b/testsuite/integration-arquillian/pom.xml
@@ -458,7 +458,7 @@
                 <!-- for the particular EAP version -->
                 <jdbc.mvn.groupId>mysql</jdbc.mvn.groupId>
                 <jdbc.mvn.artifactId>mysql-connector-java</jdbc.mvn.artifactId>
-                <jdbc.mvn.version>${mysql.driver.version}</jdbc.mvn.version>
+                <jdbc.mvn.version>${mysql-jdbc.version}</jdbc.mvn.version>
                 <docker.database.image>mysql:${mysql.version}</docker.database.image>
                 <docker.database.port>3306</docker.database.port>
                 <docker.database.skip>false</docker.database.skip>
@@ -492,7 +492,7 @@
                 <!-- for the particular EAP version -->
                 <jdbc.mvn.groupId>org.postgresql</jdbc.mvn.groupId>
                 <jdbc.mvn.artifactId>postgresql</jdbc.mvn.artifactId>
-                <jdbc.mvn.version>${postgresql.driver.version}</jdbc.mvn.version>
+                <jdbc.mvn.version>${postgresql-jdbc.version}</jdbc.mvn.version>
                 <docker.database.image>postgres:${postgresql.version}</docker.database.image>
                 <docker.database.port>5432</docker.database.port>
                 <docker.database.skip>false</docker.database.skip>
@@ -534,7 +534,7 @@
                 <!-- for the particular EAP version -->
                 <jdbc.mvn.groupId>org.mariadb.jdbc</jdbc.mvn.groupId>
                 <jdbc.mvn.artifactId>mariadb-java-client</jdbc.mvn.artifactId>
-                <jdbc.mvn.version>${mariadb.driver.version}</jdbc.mvn.version>
+                <jdbc.mvn.version>${mariadb-jdbc.version}</jdbc.mvn.version>
                 <docker.database.image>mariadb:${mariadb.version}</docker.database.image>
                 <docker.database.port>3306</docker.database.port>
                 <docker.database.skip>false</docker.database.skip>
@@ -575,7 +575,7 @@
                 <!-- for the particular EAP version -->
                 <jdbc.mvn.groupId>com.microsoft.sqlserver</jdbc.mvn.groupId>
                 <jdbc.mvn.artifactId>mssql-jdbc</jdbc.mvn.artifactId>
-                <jdbc.mvn.version>${mssql.driver.version}</jdbc.mvn.version>
+                <jdbc.mvn.version>${mssql-jdbc.version}</jdbc.mvn.version>
             </properties>
         </profile>
         <profile>
@@ -610,9 +610,9 @@
                 <!-- JDBC properties point to "default" JDBC driver for the particular DB -->
                 <!-- For EAP testing, it is recommended to override those with system properties pointing to GAV of more appropriate JDBC driver -->
                 <!-- for the particular EAP version -->
-                <jdbc.mvn.groupId>com.oracle</jdbc.mvn.groupId>
-                <jdbc.mvn.artifactId>ojdbc7</jdbc.mvn.artifactId>
-                <jdbc.mvn.version>12.1.0</jdbc.mvn.version>
+                <jdbc.mvn.groupId>com.oracle.database.jdbc</jdbc.mvn.groupId>
+                <jdbc.mvn.artifactId>ojdbc11</jdbc.mvn.artifactId>
+                <jdbc.mvn.version>${oracle-jdbc.version}</jdbc.mvn.version>
             </properties>
         </profile>
         <profile>

--- a/testsuite/integration-arquillian/pom.xml
+++ b/testsuite/integration-arquillian/pom.xml
@@ -469,6 +469,7 @@
         <profile>
             <id>db-allocator-db-mysql</id>
             <properties>
+                <keycloak.storage.connections.vendor>mysql</keycloak.storage.connections.vendor>
                 <dballocator.type>mysql80</dballocator.type>
                 <dballocator.skip>false</dballocator.skip>
             </properties>
@@ -502,6 +503,7 @@
         <profile>
             <id>db-allocator-db-postgres</id>
             <properties>
+                <keycloak.storage.connections.vendor>postgres</keycloak.storage.connections.vendor>
                 <dballocator.type>postgresql132</dballocator.type>
                 <dballocator.skip>false</dballocator.skip>
             </properties>
@@ -509,6 +511,7 @@
         <profile>
             <id>db-allocator-db-postgresplus</id>
             <properties>
+                <keycloak.storage.connections.vendor>postgres</keycloak.storage.connections.vendor>
                 <dballocator.type>postgresplus131</dballocator.type>
                 <dballocator.skip>false</dballocator.skip>
             </properties>
@@ -543,6 +546,7 @@
         <profile>
             <id>db-allocator-db-mariadb</id>
             <properties>
+                <keycloak.storage.connections.vendor>mariadb</keycloak.storage.connections.vendor>
                 <dballocator.type>mariadb_galera_103</dballocator.type>
                 <dballocator.skip>false</dballocator.skip>
             </properties>
@@ -577,6 +581,7 @@
         <profile>
             <id>db-allocator-db-mssql2019</id>
             <properties>
+                <keycloak.storage.connections.vendor>mssql</keycloak.storage.connections.vendor>
                 <dballocator.type>mssql2019</dballocator.type>
                 <dballocator.skip>false</dballocator.skip>
             </properties>
@@ -613,6 +618,7 @@
         <profile>
             <id>db-allocator-db-oracleRAC</id>
             <properties>
+                <keycloak.storage.connections.vendor>oracle</keycloak.storage.connections.vendor>
                 <dballocator.type>oracle19cRAC</dballocator.type>
                 <dballocator.skip>false</dballocator.skip>
             </properties>

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OAuthRedirectUriTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OAuthRedirectUriTest.java
@@ -337,6 +337,20 @@ public class OAuthRedirectUriTest extends AbstractKeycloakTest {
         checkRedirectUri("http://localhost:8280/foo/bar", true, true);
         checkRedirectUri("http://example.com/foobar", false);
         checkRedirectUri("http://localhost:8280/foobar", false, true);
+
+        checkRedirectUri("http://example.com/foo/../", false);
+        checkRedirectUri("http://example.com/foo/%2E%2E/", false); // url-encoded "http://example.com/foobar/../"
+        checkRedirectUri("http://example.com/foo%2F%2E%2E%2F", false); // url-encoded "http://example.com/foobar/../"
+        checkRedirectUri("http://example.com/foo/%252E%252E/", false); // double-encoded "http://example.com/foobar/../"
+        checkRedirectUri("http://example.com/foo/%252E%252E/?some_query_param=some_value", false); // double-encoded "http://example.com/foobar/../?some_query_param=some_value"
+        checkRedirectUri("http://example.com/foo/%252E%252E/?encodeTest=a%3Cb", false); // double-encoded "http://example.com/foobar/../?encodeTest=a<b"
+        checkRedirectUri("http://example.com/foo/%252E%252E/#encodeTest=a%3Cb", false); // double-encoded "http://example.com/foobar/../?encodeTest=a<b"
+        checkRedirectUri("http://example.com/foo/%25252E%25252E/", false); // triple-encoded "http://example.com/foobar/../"
+        checkRedirectUri("http://example.com/foo/%2525252525252E%2525252525252E/", false); // seventh-encoded "http://example.com/foobar/../"
+
+        checkRedirectUri("http://example.com/foo?encodeTest=a%3Cb", true);
+        checkRedirectUri("http://example.com/foo?encodeTest=a%3Cb#encode2=a%3Cb", true);
+        checkRedirectUri("http://example.com/foo/#encode2=a%3Cb", true);
     }
 
     @Test
@@ -381,7 +395,7 @@ public class OAuthRedirectUriTest extends AbstractKeycloakTest {
         oauth.clientId("test-relative-url");
 
         checkRedirectUri("http://with-dash.example.local/foo", false);
-        checkRedirectUri("http://localhost:8180/auth", true);
+        checkRedirectUri(OAuthClient.AUTH_SERVER_ROOT, true);
     }
 
     @Test
@@ -455,6 +469,7 @@ public class OAuthRedirectUriTest extends AbstractKeycloakTest {
             if (!checkCodeToToken) {
                 oauth.openLoginForm();
                 Assert.assertTrue(loginPage.isCurrent());
+                Assert.assertFalse(errorPage.isCurrent());
             } else {
                 oauth.doLogin("test-user@localhost", "password");
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/RPInitiatedLogoutTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/RPInitiatedLogoutTest.java
@@ -237,7 +237,7 @@ public class RPInitiatedLogoutTest extends AbstractTestRealmKeycloakTest {
         driver.navigate().to(logoutUrl);
         logoutConfirmPage.assertCurrent();
         logoutConfirmPage.confirmLogout();
-        events.expectLogout(sessionId2).detail(Details.REDIRECT_URI, redirectUri).assertEvent();
+        events.expectLogoutError(Errors.SESSION_EXPIRED);
         MatcherAssert.assertThat(false, is(isSessionActive(sessionId2)));
         assertCurrentUrlEquals(redirectUri + "&state=something");
     }
@@ -260,7 +260,7 @@ public class RPInitiatedLogoutTest extends AbstractTestRealmKeycloakTest {
 
             // should not throw an internal server error. But no logout event is sent as nothing was logged-out
             appPage.assertCurrent();
-            events.assertEmpty();
+            events.expectLogoutError(Errors.SESSION_EXPIRED);
             MatcherAssert.assertThat(false, is(isSessionActive(tokenResponse.getSessionState())));
 
             // check if the back channel logout succeeded
@@ -317,7 +317,7 @@ public class RPInitiatedLogoutTest extends AbstractTestRealmKeycloakTest {
         // Try logout even if user already logged-out by admin. Should redirect back to the application, but no logout-event should be triggered
         String logoutUrl = oauth.getLogoutUrl().postLogoutRedirectUri(APP_REDIRECT_URI).idTokenHint(idTokenString).build();
         driver.navigate().to(logoutUrl);
-        events.assertEmpty();
+        events.expectLogoutError(Errors.SESSION_EXPIRED);
         assertCurrentUrlEquals(APP_REDIRECT_URI);
 
         // Login again in the browser. Ensure to use newest idTokenHint after logout
@@ -377,7 +377,7 @@ public class RPInitiatedLogoutTest extends AbstractTestRealmKeycloakTest {
             assertThat(response, Matchers.statusCodeIsHC(Response.Status.FOUND));
             assertThat(response.getFirstHeader(HttpHeaders.LOCATION).getValue(), is(APP_REDIRECT_URI));
         }
-        events.assertEmpty();
+        events.expectLogoutError(Errors.SESSION_EXPIRED);
 
         MatcherAssert.assertThat(false, is(isSessionActive(tokenResponse.getSessionState())));
     }
@@ -400,7 +400,7 @@ public class RPInitiatedLogoutTest extends AbstractTestRealmKeycloakTest {
             assertThat(response, Matchers.statusCodeIsHC(Response.Status.FOUND));
             assertThat(response.getFirstHeader(HttpHeaders.LOCATION).getValue(), is(APP_REDIRECT_URI));
         }
-        events.assertEmpty();
+        events.expectLogoutError(Errors.SESSION_EXPIRED);
 
         MatcherAssert.assertThat(false, is(isSessionActive(tokenResponse.getSessionState())));
     }
@@ -931,7 +931,7 @@ public class RPInitiatedLogoutTest extends AbstractTestRealmKeycloakTest {
         errorPage.assertCurrent();
         Assert.assertEquals("Logout failed", errorPage.getError());
 
-        events.expectLogoutError(Errors.SESSION_EXPIRED).assertEvent();
+        events.expectLogoutError(Errors.LOGOUT_FAILED).assertEvent();
     }
 
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/RefreshTokenTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/RefreshTokenTest.java
@@ -17,7 +17,9 @@
 package org.keycloak.testsuite.oauth;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.gargoylesoftware.htmlunit.WebClient;
 import org.hamcrest.CoreMatchers;
+import org.jboss.arquillian.drone.webdriver.htmlunit.DroneHtmlUnitDriver;
 import org.jboss.arquillian.graphene.page.Page;
 import org.junit.Assert;
 import org.junit.Before;
@@ -27,6 +29,7 @@ import org.keycloak.OAuth2Constants;
 import org.keycloak.OAuthErrorException;
 import org.keycloak.admin.client.resource.ClientResource;
 import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.admin.client.resource.RealmsResource;
 import org.keycloak.admin.client.resource.UserResource;
 import org.keycloak.common.enums.SslRequired;
 import org.keycloak.crypto.Algorithm;
@@ -36,6 +39,7 @@ import org.keycloak.jose.jws.JWSHeader;
 import org.keycloak.jose.jws.JWSInput;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
+import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.models.utils.SessionTimeoutHelper;
 import org.keycloak.protocol.oidc.OIDCConfigAttributes;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
@@ -47,6 +51,7 @@ import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.EventRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.UserSessionRepresentation;
+import org.keycloak.services.managers.AuthenticationSessionManager;
 import org.keycloak.testsuite.AbstractKeycloakTest;
 import org.keycloak.testsuite.AssertEvents;
 import org.keycloak.testsuite.admin.ApiUtil;
@@ -59,11 +64,13 @@ import org.keycloak.testsuite.util.OAuthClient;
 import org.keycloak.testsuite.util.RealmBuilder;
 import org.keycloak.testsuite.util.RealmManager;
 import org.keycloak.testsuite.util.TokenSignatureUtil;
+import org.keycloak.testsuite.util.UserBuilder;
 import org.keycloak.testsuite.util.UserInfoClientUtil;
 import org.keycloak.testsuite.util.UserManager;
 import org.keycloak.testsuite.util.WaitUtils;
 import org.keycloak.util.BasicAuthHelper;
 import org.keycloak.util.JsonSerialization;
+import org.openqa.selenium.Cookie;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.Entity;
@@ -74,6 +81,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
 import java.net.URI;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.greaterThan;
@@ -83,6 +91,7 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -288,6 +297,120 @@ public class RefreshTokenTest extends AbstractKeycloakTest {
         Assert.assertNotEquals(200, response.getStatusCode());
 
         setTimeOffset(0);
+    }
+
+    @Test
+    public void testDoNotResolveOfflineUserSessionIfAuthenticationSessionIsInvalidated() {
+        oauth.scope("offline_access");
+        testDoNotResolveUserSessionIfAuthenticationSessionIsInvalidated();
+    }
+
+    @Test
+    public void testDoNotResolveUserSessionIfAuthenticationSessionIsInvalidated() {
+        String realmName = KeycloakModelUtils.generateId();
+        RealmsResource realmsResource = realmsResouce();
+        realmsResource.create(RealmBuilder.create().name(realmName).build());
+        RealmResource realmResource = realmsResource.realm(realmName);
+        RealmRepresentation realm = realmResource.toRepresentation();
+
+        try {
+            realm.setSsoSessionMaxLifespan((int) TimeUnit.MINUTES.toSeconds(2));
+            realm.setSsoSessionIdleTimeout((int) TimeUnit.MINUTES.toSeconds(2));
+            realm.setAccessTokenLifespan((int) TimeUnit.MINUTES.toSeconds(1));
+            realmResource.update(realm);
+
+            realmResource.clients().create(org.keycloak.testsuite.util.ClientBuilder.create()
+                    .clientId("public-client")
+                    .redirectUris("*")
+                    .publicClient()
+                    .build());
+
+            realmResource.users()
+                    .create(UserBuilder.create().username("alice").password("alice").addRoles("offline_access").build());
+            realmResource.users()
+                    .create(UserBuilder.create().username("bob").password("bob").addRoles("offline_access").build());
+
+            oauth.realm(realmName);
+            oauth.clientId("public-client");
+
+            oauth.doLogin("alice", "alice");
+            String aliceCode = oauth.getCurrentQuery().get(OAuth2Constants.CODE);
+            OAuthClient.AccessTokenResponse tokenResponse = oauth.doAccessTokenRequest(aliceCode, "password");
+            AccessToken aliceAt = oauth.verifyToken(tokenResponse.getAccessToken());
+
+            setTimeOffset((int) TimeUnit.MINUTES.toSeconds(2));
+
+            oauth.doLogin("bob", "bob");
+            String bobCode = oauth.getCurrentQuery().get(OAuth2Constants.CODE);
+
+            assertNotEquals(aliceCode, bobCode);
+
+            tokenResponse = oauth.doAccessTokenRequest(bobCode, "password");
+            String refreshToken = tokenResponse.getRefreshToken();
+            tokenResponse = oauth.doRefreshTokenRequest(refreshToken, null);
+            AccessToken bobAt = oauth.verifyToken(tokenResponse.getAccessToken());
+
+            assertNotEquals(aliceAt.getSessionId(), bobAt.getSessionId());
+            assertEquals("bob", bobAt.getPreferredUsername());
+        } finally {
+            setTimeOffset(0);
+
+            realm.setSsoSessionMaxLifespan(null);
+            realm.setSsoSessionIdleTimeout(null);
+            realm.setAccessTokenLifespan(null);
+            realmResource.update(realm);
+        }
+    }
+
+    @Test
+    public void testTimeoutWhenReUsingPreviousAuthenticationSession() {
+        String realmName = KeycloakModelUtils.generateId();
+        RealmsResource realmsResource = realmsResouce();
+        realmsResource.create(RealmBuilder.create().name(realmName).build());
+        RealmResource realmResource = realmsResource.realm(realmName);
+        RealmRepresentation realm = realmResource.toRepresentation();
+
+        try {
+            realm.setSsoSessionMaxLifespan((int) TimeUnit.MINUTES.toSeconds(2));
+            realm.setSsoSessionIdleTimeout((int) TimeUnit.MINUTES.toSeconds(2));
+            realm.setAccessTokenLifespan((int) TimeUnit.MINUTES.toSeconds(1));
+            realmResource.update(realm);
+
+            realmResource.clients().create(org.keycloak.testsuite.util.ClientBuilder.create()
+                    .clientId("public-client")
+                    .redirectUris("*")
+                    .publicClient()
+                    .build());
+
+            realmResource.users()
+                    .create(UserBuilder.create().username("alice").password("alice").addRoles("offline_access").build());
+            realmResource.users()
+                    .create(UserBuilder.create().username("bob").password("bob").addRoles("offline_access").build());
+
+            oauth.realm(realmName);
+            oauth.clientId("public-client");
+
+            oauth.openLoginForm();
+
+            Cookie authSessionCookie = driver.manage().getCookieNamed(AuthenticationSessionManager.AUTH_SESSION_ID);
+
+            oauth.fillLoginForm("alice", "alice");
+
+            String aliceCode = oauth.getCurrentQuery().get(OAuth2Constants.CODE);
+            WebClient webClient = DroneHtmlUnitDriver.class.cast(driver).getWebClient();
+            webClient.getCookieManager().clearCookies();
+            oauth.openLoginForm();
+            driver.manage().addCookie(authSessionCookie);
+            oauth.fillLoginForm("bob", "bob");
+            assertEquals("Your login attempt timed out. Login will start from the beginning.", loginPage.getError());
+        } finally {
+            setTimeOffset(0);
+
+            realm.setSsoSessionMaxLifespan(null);
+            realm.setSsoSessionIdleTimeout(null);
+            realm.setAccessTokenLifespan(null);
+            realmResource.update(realm);
+        }
     }
 
     /**

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/openshift/OpenshiftClientStorageTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/openshift/OpenshiftClientStorageTest.java
@@ -173,12 +173,12 @@ public final class OpenshiftClientStorageTest extends AbstractTestRealmKeycloakT
     @Test
     public void testCodeGrantFlowWithServiceAccountUsingOAuthRedirectReference() {
         String clientId = "system:serviceaccount:default:sa-oauth-redirect-reference";
-        testCodeGrantFlow(clientId, "https://myapp.org/callback", () -> assertSuccessfulResponseWithoutConsent(clientId));
+        testCodeGrantFlow(clientId, "http://127.0.0.1:8180/callback", () -> assertSuccessfulResponseWithoutConsent(clientId));
     }
 
     @Test
     public void failCodeGrantFlowWithServiceAccountUsingOAuthRedirectReference() throws Exception {
-        testCodeGrantFlow("system:serviceaccount:default:sa-oauth-redirect-reference", "http://myapp.org/callback", () -> assertEquals(OAuthErrorException.INVALID_REDIRECT_URI, events.poll().getError()));
+        testCodeGrantFlow("system:serviceaccount:default:sa-oauth-redirect-reference", "http://invalid/callback", () -> assertEquals(OAuthErrorException.INVALID_REDIRECT_URI, events.poll().getError()));
     }
 
     @Test
@@ -214,7 +214,7 @@ public final class OpenshiftClientStorageTest extends AbstractTestRealmKeycloakT
 
     @Test
     public void failCodeGrantFlowWithServiceAccountUsingOAuthRedirectUri() throws Exception {
-        testCodeGrantFlow("system:serviceaccount:default:sa-oauth-redirect-uri", "http://myapp.org/callback", () -> assertEquals(OAuthErrorException.INVALID_REDIRECT_URI, events.poll().getError()));
+        testCodeGrantFlow("system:serviceaccount:default:sa-oauth-redirect-uri", "http://invalid/callback", () -> assertEquals(OAuthErrorException.INVALID_REDIRECT_URI, events.poll().getError()));
     }
 
     private void testCodeGrantFlow(String clientId, String expectedRedirectUri, Runnable assertThat) {

--- a/testsuite/integration-arquillian/tests/base/src/test/resources/openshift/client-storage/route-response.json
+++ b/testsuite/integration-arquillian/tests/base/src/test/resources/openshift/client-storage/route-response.json
@@ -13,22 +13,18 @@
     }
   },
   "spec": {
-    "host": "myapp.org",
+    "host": "127.0.0.1",
     "to": {
       "kind": "Service",
       "name": "proxy",
       "weight": 100
-    },
-    "tls": {
-      "termination": "reencrypt",
-      "destinationCACertificate": "-----BEGIN COMMENT-----\nThis is an empty PEM file created to provide backwards compatibility\nfor reencrypt routes that have no destinationCACertificate. This \ncontent will only appear for routes accessed via /oapi/v1/routes.\n-----END COMMENT-----\n"
     },
     "wildcardPolicy": "None"
   },
   "status": {
     "ingress": [
       {
-        "host": "myapp.org",
+        "host": "127.0.0.1",
         "routerName": "router",
         "conditions": [
           {

--- a/testsuite/model/pom.xml
+++ b/testsuite/model/pom.xml
@@ -113,7 +113,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>${postgresql.driver.version}</version>
+            <version>${postgresql-jdbc.version}</version>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>

--- a/testsuite/model/src/test/java/org/keycloak/testsuite/model/DBLockTest.java
+++ b/testsuite/model/src/test/java/org/keycloak/testsuite/model/DBLockTest.java
@@ -23,6 +23,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.jboss.logging.Logger;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
@@ -115,6 +116,7 @@ public class DBLockTest extends KeycloakModelTest {
     }
 
     @Test
+    @Ignore("Ignored as it is unstable. Analysis pending in https://github.com/keycloak/keycloak/issues/15487")
     public void testLockConcurrentlyOffline() throws Exception {
         inComittedTransaction(1, (session , i) -> {
             testLockConcurrentlyInternal(session, DBLockProvider.Namespace.OFFLINE_SESSIONS);

--- a/testsuite/model/src/test/java/org/keycloak/testsuite/model/DBLockTest.java
+++ b/testsuite/model/src/test/java/org/keycloak/testsuite/model/DBLockTest.java
@@ -108,6 +108,7 @@ public class DBLockTest extends KeycloakModelTest {
     }
 
     @Test
+    @Ignore("Ignored as it is unstable. Analysis pending in https://github.com/keycloak/keycloak/issues/15487")
     public void testLockConcurrentlyGeneral() throws Exception {
         inComittedTransaction(1, (session , i) -> {
             testLockConcurrentlyInternal(session, DBLockProvider.Namespace.DATABASE);

--- a/testsuite/model/src/test/java/org/keycloak/testsuite/model/authz/ConcurrentAuthzTest.java
+++ b/testsuite/model/src/test/java/org/keycloak/testsuite/model/authz/ConcurrentAuthzTest.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.testsuite.model.authz;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.keycloak.authorization.AuthorizationProvider;
 import org.keycloak.authorization.model.Policy;
@@ -132,6 +133,7 @@ public class ConcurrentAuthzTest extends KeycloakModelTest {
     }
 
     @Test
+    @Ignore // This is ignored due to intermittent failure, see https://github.com/keycloak/keycloak/issues/14917
     public void testStaleCacheConcurrent() {
         String permissionId = withRealm(realmId, (session, realm) -> {
             AuthorizationProvider authorization = session.getProvider(AuthorizationProvider.class);

--- a/testsuite/utils/pom.xml
+++ b/testsuite/utils/pom.xml
@@ -254,17 +254,23 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>${postgresql.driver.version}</version>
+            <version>${postgresql-jdbc.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.oracle.database.jdbc</groupId>
+            <artifactId>ojdbc11</artifactId>
+            <version>${oracle-jdbc.version}</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.mariadb.jdbc</groupId>
             <artifactId>mariadb-java-client</artifactId>
-            <version>${mariadb.driver.version}</version>
+            <version>${mariadb-jdbc.version}</version>
         </dependency>
         <dependency>
             <groupId>com.microsoft.sqlserver</groupId>
             <artifactId>mssql-jdbc</artifactId>
-            <version>${mssql.driver.version}</version>
+            <version>${mssql-jdbc.version}</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
- Allow a partial import to overwrite the default role (#15316)
- Fix classpath separator for windows startup script (#15300) (#15377)
- Use RESOURCE_LOCAL transactions for JPA map storage (#15315)
- Upgrade Bouncycastle from 1.68 to 1.70 (#14198) (#15379)
- Fix race condition while updating Secrets labels in Operator
- Backport fixes from profile refactor (#15495)
- Stop adding .v2 to default theme if set in server config (#15501)
- Fix query to work on OracleDB CLOB
- Make tests run on Oracle DB on the internal pipeline
- Use LOB handling query to select clients on Oracle
- Use org.keycloak.common.util.Base64Url to encode/decode clientID
- Fix OpenshiftClientStorageTest.testCodeGrantFlowWithServiceAccountUsingOAuthRedirectReference (#15741)
- Sync commits (#15981)
- Ignore test until the intermittent failure from #14917 is resolved
- Update to Quarkus 2.13.5
- Disabling unstable test until further analysis is complete
- Disabling unstable test until further analysis is complete
- Cleanup dependencies and align with Quarkus
- Update to Quarkus 2.13.6.Final
- The redirect URI cannot be verified during logout in the case when client was removed closes #15866
- Update to okhttp 4.9.3
