### PR TITLE
Fix required action path URI building

### DIFF
--- a/services/src/main/java/org/keycloak/services/Urls.java
+++ b/services/src/main/java/org/keycloak/services/Urls.java
@@ -174,7 +174,7 @@ public class Urls {
     }
 
     public static UriBuilder requiredActionBase(URI baseUri) {
-        return loginActionsBase(baseUri).path(LoginActionsService.class, "requiredAction");
+        return loginActionsBase(baseUri).path(LoginActionsService.REQUIRED_ACTION);
     }
 
 


### PR DESCRIPTION
When building the URI to process required actions, the resolution of the path section is done by looking for the `@Path` of a method with a specific name. The method was renamed and split long ago, which broke this way to resolve it.
This commit changes this by building the path the same way it is done for reset password: by appending the actual path as it is defined in a constant and used in the methods that map to it.