### PR TITLE
Set Snakeyaml to 1.33 in parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -286,7 +286,11 @@
     <dependencyManagement>
 
         <dependencies>
-
+            <dependency>
+                <groupId>org.yaml</groupId>
+                <artifactId>snakeyaml</artifactId>
+                <version>1.33</version>
+            </dependency>
             <dependency>
                 <groupId>org.keycloak</groupId>
                 <artifactId>keycloak-dependencies-admin-ui-wrapper</artifactId>


### PR DESCRIPTION
We actually have 6 different versions of Snakeyaml throughout:
```
 - 1.33 [LATEST] (from org.keycloak:keycloak-quarkus-server)
 - 1.32 (from com.openshift:openshift-restclient-java)
 - 1.29 (from com.github.ua-parser:uap-java)
 - 1.27 (from org.springframework.boot:spring-boot-starter:2.4.13)
 - 1.26 (from com.github.ua-parser:uap-java)
 - 1.19 (from org.springframework.boot:spring-boot-starter:2.0.5)
```

This sets the version in the parent pom to align everything to one version

Closes #15339
