### PR TITLE
Cookies processing refactoring

### DIFF
--- a/common/src/main/java/org/keycloak/common/util/ServerCookie.java
+++ b/common/src/main/java/org/keycloak/common/util/ServerCookie.java
@@ -28,6 +28,7 @@ import java.util.TimeZone;
 /**
  * Server-side cookie representation.  borrowed from Tomcat.
  */
+@Deprecated
 public class ServerCookie implements Serializable {
     private static final String tspecials = ",; ";
     private static final String tspecials2 = "()<>@,;:\\\"/[]?={} \t";

--- a/examples/providers/authenticator/src/main/java/org/keycloak/examples/authenticator/SecretQuestionAuthenticator.java
+++ b/examples/providers/authenticator/src/main/java/org/keycloak/examples/authenticator/SecretQuestionAuthenticator.java
@@ -17,24 +17,23 @@
 
 package org.keycloak.examples.authenticator;
 
-import org.keycloak.http.HttpResponse;
 import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.authentication.AuthenticationFlowError;
 import org.keycloak.authentication.Authenticator;
 import org.keycloak.authentication.CredentialValidator;
 import org.keycloak.authentication.RequiredActionFactory;
 import org.keycloak.authentication.RequiredActionProvider;
-import org.keycloak.common.util.ServerCookie;
 import org.keycloak.credential.CredentialProvider;
 import org.keycloak.models.AuthenticatorConfigModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserCredentialModel;
 import org.keycloak.models.UserModel;
+import org.keycloak.services.util.CookieBuilder;
 
 import javax.ws.rs.core.Cookie;
-import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.NewCookie;
 import javax.ws.rs.core.Response;
 import java.net.URI;
 import java.util.Collections;
@@ -88,19 +87,15 @@ public class SecretQuestionAuthenticator implements Authenticator, CredentialVal
 
         }
         URI uri = context.getUriInfo().getBaseUriBuilder().path("realms").path(context.getRealm().getName()).build();
-        addCookie(context, "SECRET_QUESTION_ANSWERED", "true",
-                uri.getRawPath(),
-                null, null,
-                maxCookieAge,
-                false, true);
-    }
 
-    public void addCookie(AuthenticationFlowContext context, String name, String value, String path, String domain, String comment, int maxAge, boolean secure, boolean httpOnly) {
-        HttpResponse response = context.getSession().getContext().getHttpResponse();
-        StringBuffer cookieBuf = new StringBuffer();
-        ServerCookie.appendCookieValue(cookieBuf, 1, name, value, path, domain, comment, maxAge, secure, httpOnly, null);
-        String cookie = cookieBuf.toString();
-        response.addHeader(HttpHeaders.SET_COOKIE, cookie);
+        final NewCookie cookie = new CookieBuilder("SECRET_QUESTION_ANSWERED", "true")
+                .path(uri.getRawPath())
+                .maxAge(maxCookieAge)
+                .secure(false)
+                .httpOnly(true)
+                .build();
+
+        context.getSession().getContext().getHttpResponse().addCookie(cookie);
     }
 
 

--- a/server-spi/src/main/java/org/keycloak/http/HttpResponse.java
+++ b/server-spi/src/main/java/org/keycloak/http/HttpResponse.java
@@ -16,6 +16,9 @@
  */
 
 package org.keycloak.http;
+
+import javax.ws.rs.core.NewCookie;
+
 /**
  * <p>Represents an out coming HTTP response.
  *
@@ -41,8 +44,15 @@ public interface HttpResponse {
     /**
      * Set a header. Any existing values will be replaced.
      *
-     * @param name the header name
+     * @param name  the header name
      * @param value the header value
      */
     void setHeader(String name, String value);
+
+    /**
+     * Add a cookie to a response.
+     *
+     * @param cookie the cookie
+     */
+    void addCookie(NewCookie cookie);
 }

--- a/services/src/main/java/org/keycloak/protocol/RestartLoginCookie.java
+++ b/services/src/main/java/org/keycloak/protocol/RestartLoginCookie.java
@@ -28,11 +28,13 @@ import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.services.managers.AuthenticationManager;
 import org.keycloak.services.managers.AuthenticationSessionManager;
+import org.keycloak.services.util.CookieBuilder;
 import org.keycloak.services.util.CookieHelper;
 import org.keycloak.sessions.AuthenticationSessionModel;
 import org.keycloak.sessions.RootAuthenticationSessionModel;
 
 import javax.ws.rs.core.Cookie;
+import javax.ws.rs.core.NewCookie;
 import javax.ws.rs.core.UriInfo;
 import java.util.HashMap;
 import java.util.Map;
@@ -125,7 +127,13 @@ public class RestartLoginCookie implements Token {
         String encoded = session.tokens().encode(restart);
         String path = AuthenticationManager.getRealmCookiePath(realm, uriInfo);
         boolean secureOnly = realm.getSslRequired().isRequired(connection);
-        CookieHelper.addCookie(KC_RESTART, encoded, path, null, null, -1, secureOnly, true, session);
+
+        final NewCookie cookie = new CookieBuilder(KC_RESTART, encoded)
+                .path(path)
+                .secure(secureOnly)
+                .httpOnly(true)
+                .build();
+        session.getContext().getHttpResponse().addCookie(cookie);
     }
 
     public static void expireRestartCookie(RealmModel realm, UriInfo uriInfo, KeycloakSession session) {
@@ -133,7 +141,7 @@ public class RestartLoginCookie implements Token {
         ClientConnection connection = context.getConnection();
         String path = AuthenticationManager.getRealmCookiePath(realm, uriInfo);
         boolean secureOnly = realm.getSslRequired().isRequired(connection);
-        CookieHelper.addCookie(KC_RESTART, "", path, null, null, 0, secureOnly, true, session);
+        CookieHelper.expireCookie(context.getHttpResponse(),KC_RESTART, path, secureOnly, true);
     }
 
     public static Cookie getRestartCookie(KeycloakSession session){

--- a/services/src/main/java/org/keycloak/services/HttpResponseImpl.java
+++ b/services/src/main/java/org/keycloak/services/HttpResponseImpl.java
@@ -18,10 +18,11 @@
 package org.keycloak.services;
 
 import org.keycloak.http.HttpResponse;
+import javax.ws.rs.core.NewCookie;
 
 public class HttpResponseImpl implements HttpResponse {
 
-    private org.jboss.resteasy.spi.HttpResponse delegate;
+    private final org.jboss.resteasy.spi.HttpResponse delegate;
 
     public HttpResponseImpl(org.jboss.resteasy.spi.HttpResponse delegate) {
         this.delegate = delegate;
@@ -40,5 +41,10 @@ public class HttpResponseImpl implements HttpResponse {
     @Override
     public void setHeader(String name, String value) {
         delegate.getOutputHeaders().putSingle(name, value);
+    }
+
+    @Override
+    public void addCookie(NewCookie cookie) {
+        delegate.addNewCookie(cookie);
     }
 }

--- a/services/src/main/java/org/keycloak/services/managers/AuthenticationSessionManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/AuthenticationSessionManager.java
@@ -18,18 +18,18 @@
 package org.keycloak.services.managers;
 
 import org.jboss.logging.Logger;
-import org.keycloak.common.ClientConnection;
-import org.keycloak.common.util.ServerCookie.SameSiteAttributeValue;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserSessionModel;
 import org.keycloak.protocol.RestartLoginCookie;
+import org.keycloak.services.util.CookieBuilder;
 import org.keycloak.services.util.CookieHelper;
 import org.keycloak.sessions.AuthenticationSessionModel;
 import org.keycloak.sessions.RootAuthenticationSessionModel;
 import org.keycloak.sessions.StickySessionEncoderProvider;
 
+import javax.ws.rs.core.NewCookie;
 import javax.ws.rs.core.UriInfo;
 import java.util.List;
 import java.util.Objects;
@@ -150,7 +150,13 @@ public class AuthenticationSessionManager {
         StickySessionEncoderProvider encoder = session.getProvider(StickySessionEncoderProvider.class);
         String encodedAuthSessionId = encoder.encodeSessionId(authSessionId);
 
-        CookieHelper.addCookie(AUTH_SESSION_ID, encodedAuthSessionId, cookiePath, null, null, -1, sslRequired, true, SameSiteAttributeValue.NONE, session);
+        final NewCookie cookie = new CookieBuilder(AUTH_SESSION_ID, encodedAuthSessionId)
+                .path(cookiePath)
+                .secure(sslRequired)
+                .httpOnly(true)
+                .build();
+
+        session.getContext().getHttpResponse().addCookie(cookie);
 
         log.debugf("Set AUTH_SESSION_ID cookie with value %s", encodedAuthSessionId);
     }
@@ -185,7 +191,7 @@ public class AuthenticationSessionManager {
      * @return list of the values of AUTH_SESSION_ID cookies. It is assumed that values could be encoded with route added (EG. "5e161e00-d426-4ea6-98e9-52eb9844e2d7.node1" )
      */
     List<String> getAuthSessionCookies(RealmModel realm) {
-        Set<String> cookiesVal = CookieHelper.getCookieValue(session, AUTH_SESSION_ID);
+        Set<String> cookiesVal = CookieHelper.getCookieValue(session.getContext().getRequestHeaders(), AUTH_SESSION_ID);
 
         if (cookiesVal.size() > 1) {
             AuthenticationManager.expireOldAuthSessionCookie(realm, session.getContext().getUri(), session);

--- a/services/src/main/java/org/keycloak/services/resources/WelcomeResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/WelcomeResource.java
@@ -23,11 +23,13 @@ import org.keycloak.common.Version;
 import org.keycloak.common.util.Base64Url;
 import org.keycloak.common.util.MimeTypeUtil;
 import org.keycloak.common.util.SecretGenerator;
+import org.keycloak.models.KeycloakContext;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.services.ForbiddenException;
 import org.keycloak.services.ServicesLogger;
 import org.keycloak.services.managers.ApplianceBootstrap;
 import org.keycloak.services.util.CacheControlUtil;
+import org.keycloak.services.util.CookieBuilder;
 import org.keycloak.services.util.CookieHelper;
 import org.keycloak.theme.Theme;
 import org.keycloak.theme.freemarker.FreeMarkerProvider;
@@ -45,6 +47,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Cookie;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.NewCookie;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.Response.Status;
@@ -260,16 +263,28 @@ public class WelcomeResource {
 
     private String setCsrfCookie() {
         String stateChecker = Base64Url.encode(SecretGenerator.getInstance().randomBytes());
-        String cookiePath = session.getContext().getUri().getPath();
-        boolean secureOnly = session.getContext().getUri().getRequestUri().getScheme().equalsIgnoreCase("https");
-        CookieHelper.addCookie(KEYCLOAK_STATE_CHECKER, stateChecker, cookiePath, null, null, 300, secureOnly, true, session);
+        final KeycloakContext context = session.getContext();
+
+        String cookiePath = context.getUri().getPath();
+        boolean secureOnly = context.getUri().getRequestUri().getScheme().equalsIgnoreCase("https");
+
+        final NewCookie cookie = new CookieBuilder(KEYCLOAK_STATE_CHECKER, stateChecker)
+                .path(cookiePath)
+                .maxAge(300)
+                .secure(secureOnly)
+                .httpOnly(true)
+                .build();
+        context.getHttpResponse().addCookie(cookie);
+
         return stateChecker;
     }
 
     private void expireCsrfCookie() {
-        String cookiePath = session.getContext().getUri().getPath();
-        boolean secureOnly = session.getContext().getUri().getRequestUri().getScheme().equalsIgnoreCase("https");
-        CookieHelper.addCookie(KEYCLOAK_STATE_CHECKER, "", cookiePath, null, null, 0, secureOnly, true, session);
+        final KeycloakContext context = session.getContext();
+
+        String cookiePath = context.getUri().getPath();
+        boolean secureOnly = context.getUri().getRequestUri().getScheme().equalsIgnoreCase("https");
+        CookieHelper.expireCookie(context.getHttpResponse(), KEYCLOAK_STATE_CHECKER, cookiePath, secureOnly, true);
     }
 
     private void csrfCheck(final MultivaluedMap<String, String> formData) {

--- a/services/src/main/java/org/keycloak/services/util/CookieBuilder.java
+++ b/services/src/main/java/org/keycloak/services/util/CookieBuilder.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.services.util;
+
+import javax.ws.rs.core.NewCookie;
+import java.util.Date;
+
+/**
+ * @author <a href="mailto:mabartos@redhat.com">Martin Bartos</a>
+ */
+public class CookieBuilder {
+    private final String name;
+    private final String value;
+
+    private String path;
+    private String domain;
+    private String comment;
+    private int version;
+    private int maxAge;
+    private boolean secure;
+    private boolean httpOnly;
+    private Date expiry;
+
+    public CookieBuilder(String name, String value) {
+        this.name = name;
+        this.value = value;
+    }
+
+    public CookieBuilder path(String path) {
+        this.path = path;
+        return this;
+    }
+
+    public CookieBuilder domain(String domain) {
+        this.domain = domain;
+        return this;
+    }
+
+    public CookieBuilder comment(String comment) {
+        this.comment = comment;
+        return this;
+    }
+
+    public CookieBuilder version(int version) {
+        this.version = version;
+        return this;
+    }
+
+    public CookieBuilder maxAge(int maxAge) {
+        this.maxAge = maxAge;
+        return this;
+    }
+
+    public CookieBuilder secure(boolean secure) {
+        this.secure = secure;
+        return this;
+    }
+
+    public CookieBuilder httpOnly(boolean httpOnly) {
+        this.httpOnly = httpOnly;
+        return this;
+    }
+
+    public CookieBuilder expiry(Date expireDate) {
+        this.expiry = expireDate;
+        return this;
+    }
+
+    public NewCookie build() {
+        return new NewCookie(name, value, path, domain, version, comment, maxAge, expiry, secure, httpOnly);
+    }
+}

--- a/services/src/main/java/org/keycloak/services/util/CookieHelper.java
+++ b/services/src/main/java/org/keycloak/services/util/CookieHelper.java
@@ -18,21 +18,18 @@
 package org.keycloak.services.util;
 
 import org.jboss.logging.Logger;
-import org.keycloak.http.HttpResponse;
 import org.jboss.resteasy.util.CookieParser;
-import org.keycloak.common.util.Resteasy;
-import org.keycloak.common.util.ServerCookie;
+import org.keycloak.http.HttpResponse;
 import org.keycloak.models.KeycloakSession;
 
 import javax.ws.rs.core.Cookie;
 import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.NewCookie;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
-
-import static org.keycloak.common.util.ServerCookie.SameSiteAttributeValue;
-
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -40,76 +37,15 @@ import static org.keycloak.common.util.ServerCookie.SameSiteAttributeValue;
  */
 public class CookieHelper {
 
-    public static final String LEGACY_COOKIE = "_LEGACY";
-
     private static final Logger logger = Logger.getLogger(CookieHelper.class);
 
-    /**
-     * Set a response cookie.  This solely exists because JAX-RS 1.1 does not support setting HttpOnly cookies
-     * @param name
-     * @param value
-     * @param path
-     * @param domain
-     * @param comment
-     * @param maxAge
-     * @param secure
-     * @param httpOnly
-     * @param sameSite
-     */
-    public static void addCookie(String name, String value, String path, String domain, String comment, int maxAge, boolean secure, boolean httpOnly, SameSiteAttributeValue sameSite, KeycloakSession session) {
-        SameSiteAttributeValue sameSiteParam = sameSite;
-        // when expiring a cookie we shouldn't set the sameSite attribute; if we set e.g. SameSite=None when expiring a cookie, the new cookie (with maxAge == 0)
-        // might be rejected by the browser in some cases resulting in leaving the original cookie untouched; that can even prevent user from accessing their application
-        if (maxAge == 0) {
-            sameSite = null;
-        }
-
-        boolean secure_sameSite = sameSite == SameSiteAttributeValue.NONE || secure; // when SameSite=None, Secure attribute must be set
-
-        HttpResponse response = session.getContext().getHttpResponse();
-        StringBuffer cookieBuf = new StringBuffer();
-        ServerCookie.appendCookieValue(cookieBuf, 1, name, value, path, domain, comment, maxAge, secure_sameSite, httpOnly, sameSite);
-        String cookie = cookieBuf.toString();
-        response.addHeader(HttpHeaders.SET_COOKIE, cookie);
-
-        // a workaround for browser in older Apple OSs – browsers ignore cookies with SameSite=None
-        if (sameSiteParam == SameSiteAttributeValue.NONE) {
-            addCookie(name + LEGACY_COOKIE, value, path, domain, comment, maxAge, secure, httpOnly, null, session);
-        }
+    public static void addCookie(KeycloakSession session, NewCookie cookie){
+        session.getContext().getHttpResponse().addCookie(cookie);
     }
 
-    /**
-     * Set a response cookie avoiding SameSite parameter
-     * @param name
-     * @param value
-     * @param path
-     * @param domain
-     * @param comment
-     * @param maxAge
-     * @param secure
-     * @param httpOnly
-     */
-    public static void addCookie(String name, String value, String path, String domain, String comment, int maxAge, boolean secure, boolean httpOnly, KeycloakSession session) {
-        addCookie(name, value, path, domain, comment, maxAge, secure, httpOnly, null, session);
-    }
-
-
-    public static Set<String> getCookieValue(KeycloakSession session, String name) {
-        Set<String> ret = getInternalCookieValue(session, name);
-        if (ret.size() == 0) {
-            String legacy = name + LEGACY_COOKIE;
-            logger.debugv("Could not find any cookies with name '{0}', trying '{1}'", name, legacy);
-            ret = getInternalCookieValue(session, legacy);
-        }
-        return ret;
-    }
-
-    private static Set<String> getInternalCookieValue(KeycloakSession session, String name) {
-        HttpHeaders headers = session.getContext().getHttpRequest().getHttpHeaders();
-        Set<String> cookiesVal = new HashSet<>();
-
+    public static Set<String> getCookieValue(HttpHeaders headers, String name) {
         // check for cookies in the request headers
-        cookiesVal.addAll(parseCookie(headers.getRequestHeaders().getFirst(HttpHeaders.COOKIE), name));
+        Set<String> cookiesVal = new HashSet<>(parseCookie(headers.getRequestHeaders().getFirst(HttpHeaders.COOKIE), name));
 
         // get cookies from the cookie field
         Cookie cookie = headers.getCookies().get(name);
@@ -117,7 +53,6 @@ public class CookieHelper {
             logger.debugv("{0} cookie found in the cookie field", name);
             cookiesVal.add(cookie.getValue());
         }
-
 
         return cookiesVal;
     }
@@ -140,15 +75,21 @@ public class CookieHelper {
         return values;
     }
 
-    public static Cookie getCookie(Map<String, Cookie> cookies, String name) {
-        Cookie cookie = cookies.get(name);
-        if (cookie != null) {
-            return cookie;
-        }
-        else {
-            String legacy = name + LEGACY_COOKIE;
-            logger.debugv("Could not find cookie {0}, trying {1}", name, legacy);
-            return cookies.get(legacy);
-        }
+    public static Optional<Cookie> getCookie(Map<String, Cookie> cookies, String name) {
+        return Optional.ofNullable(cookies.get(name));
+    }
+
+    public static void expireCookie(HttpResponse response, String name, String path, boolean secure, boolean httpOnly) {
+        logger.debugf("Expiring cookie: %s path: %s", name, path);
+
+        final NewCookie cookie = new CookieBuilder(name, "")
+                .path(path)
+                .comment("Expiring cookie")
+                .maxAge(0)
+                .secure(secure)
+                .httpOnly(httpOnly)
+                .build();
+
+        response.addCookie(cookie);
     }
 }

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/rest/TestingResourceProvider.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/rest/TestingResourceProvider.java
@@ -109,6 +109,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -586,9 +587,8 @@ public class TestingResourceProvider implements RealmResourceProvider {
     @Produces(MediaType.APPLICATION_JSON)
     public String getSSOCookieValue() {
         Map<String, Cookie> cookies = request.getHttpHeaders().getCookies();
-        Cookie cookie = CookieHelper.getCookie(cookies, AuthenticationManager.KEYCLOAK_IDENTITY_COOKIE);
-        if (cookie == null) return null;
-        return cookie.getValue();
+        Optional<Cookie> cookie = CookieHelper.getCookie(cookies, AuthenticationManager.KEYCLOAK_IDENTITY_COOKIE);
+        return cookie.map(Cookie::getValue).orElse(null);
     }
 
 

--- a/testsuite/integration-arquillian/servers/auth-server/undertow/src/main/java/org/keycloak/testsuite/arquillian/undertow/lb/SimpleUndertowLoadBalancer.java
+++ b/testsuite/integration-arquillian/servers/auth-server/undertow/src/main/java/org/keycloak/testsuite/arquillian/undertow/lb/SimpleUndertowLoadBalancer.java
@@ -52,7 +52,6 @@ import java.util.LinkedHashMap;
 import java.util.StringTokenizer;
 
 import static org.keycloak.services.managers.AuthenticationSessionManager.AUTH_SESSION_ID;
-import static org.keycloak.services.util.CookieHelper.LEGACY_COOKIE;
 
 /**
  * Loadbalancer on embedded undertow. Supports sticky session over "AUTH_SESSION_ID" cookie and failover to different node when sticky node not available.
@@ -177,7 +176,6 @@ public class SimpleUndertowLoadBalancer {
     private HttpHandler createHandler() throws Exception {
 
         // TODO: configurable options if needed
-        String[] sessionIds = {AUTH_SESSION_ID, AUTH_SESSION_ID + LEGACY_COOKIE};
         int connectionsPerThread = 20;
         int problemServerRetry = 5; // In case of unavailable node, we will try to ping him every 5 seconds to check if it's back
         int maxTime = 3600000; // 1 hour for proxy request timeout, so we can debug the backend keycloak servers
@@ -191,10 +189,8 @@ public class SimpleUndertowLoadBalancer {
                 .setMaxQueueSize(requestQueueSize)
                 .setSoftMaxConnectionsPerThread(cachedConnectionsPerThread)
                 .setTtl(connectionIdleTimeout)
-                .setProblemServerRetry(problemServerRetry);
-        for (String id : sessionIds) {
-            lb.addSessionCookieName(id);
-        }
+                .setProblemServerRetry(problemServerRetry)
+                .addSessionCookieName(AUTH_SESSION_ID);
 
         return new ProxyHandler(lb, maxTime, ResponseCodeHandler.HANDLE_404);
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerLogoutTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerLogoutTest.java
@@ -107,10 +107,8 @@ public class KcOidcBrokerLogoutTest extends AbstractBaseBrokerTest {
         String idToken = response.getIdToken();
 
         // simulate browser restart by deleting an identity cookie
-        log.debugf("Deleting %s and %s cookies", AuthenticationManager.KEYCLOAK_IDENTITY_COOKIE,
-                AuthenticationManager.KEYCLOAK_IDENTITY_COOKIE + CookieHelper.LEGACY_COOKIE);
+        log.debugf("Deleting %s cookie", AuthenticationManager.KEYCLOAK_IDENTITY_COOKIE);
         driver.manage().deleteCookieNamed(AuthenticationManager.KEYCLOAK_IDENTITY_COOKIE);
-        driver.manage().deleteCookieNamed(AuthenticationManager.KEYCLOAK_IDENTITY_COOKIE + CookieHelper.LEGACY_COOKIE);
 
         logoutFromRealm(getConsumerRoot(), bc.consumerRealmName(), null, idToken);
         driver.navigate().to(getAccountUrl(getProviderRoot(), REALM_PROV_NAME));

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/cluster/AuthenticationSessionFailoverClusterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/cluster/AuthenticationSessionFailoverClusterTest.java
@@ -114,9 +114,6 @@ public class AuthenticationSessionFailoverClusterTest extends AbstractFailoverCl
 
     public static String getAuthSessionCookieValue(WebDriver driver) {
         Cookie authSessionCookie = driver.manage().getCookieNamed(AuthenticationSessionManager.AUTH_SESSION_ID);
-        if (authSessionCookie == null) {
-            authSessionCookie = driver.manage().getCookieNamed(AuthenticationSessionManager.AUTH_SESSION_ID + CookieHelper.LEGACY_COOKIE);
-        }
         Assert.assertNotNull(authSessionCookie);
         return authSessionCookie.getValue();
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/storage/UserStorageTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/storage/UserStorageTest.java
@@ -84,7 +84,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.keycloak.models.UserModel.RequiredAction.UPDATE_PROFILE;
 import static org.keycloak.services.managers.AuthenticationManager.KEYCLOAK_SESSION_COOKIE;
-import static org.keycloak.services.util.CookieHelper.LEGACY_COOKIE;
 import static org.keycloak.storage.UserStorageProviderModel.CACHE_POLICY;
 import static org.keycloak.storage.UserStorageProviderModel.EVICTION_DAY;
 import static org.keycloak.storage.UserStorageProviderModel.EVICTION_HOUR;
@@ -254,15 +253,10 @@ public class UserStorageTest extends AbstractAuthTest {
         assertCurrentUrlStartsWith(testRealmAccountPage);
 
         Cookie sameSiteSessionCookie = driver.manage().getCookieNamed(KEYCLOAK_SESSION_COOKIE);
-        Cookie legacySessionCookie = driver.manage().getCookieNamed(KEYCLOAK_SESSION_COOKIE + LEGACY_COOKIE);
 
         String cookieValue = sameSiteSessionCookie.getValue();
         Assert.assertThat(cookieValue.contains("spécial"), is(false));
         Assert.assertThat(cookieValue.contains("sp%C3%A9cial"), is(true));
-
-        String legacyCookieValue = legacySessionCookie.getValue();
-        Assert.assertThat(legacyCookieValue.contains("spécial"), is(false));
-        Assert.assertThat(legacyCookieValue.contains("sp%C3%A9cial"), is(true));
 
         testRealmAccountPage.logOut();
     }


### PR DESCRIPTION
ONLY DRAFT

Slightly refactored processing of cookies. Just attempt to improve it a little bit, I'm not sure what the pitfalls are here. I've also removed the legacy cookies, but it might be good to ensure backward compatibility. We could leave the logic up to the HttpResponse#addCookie(), how exactly to tell the client how to set the cookies. We don't even use Same-site for our cookies now, so it's not necessary to keep the particular logic there. Moreover, once we need set Same-site, we should probably do it slightly differently than using the current ServerCookie, which is a complete mess.