### PR TITLE
Fix usage typo of config truststore command of admin-cli

### DIFF
--- a/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/admin/cli/commands/ConfigTruststoreCmd.java
+++ b/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/admin/cli/commands/ConfigTruststoreCmd.java
@@ -189,7 +189,7 @@ public class ConfigTruststoreCmd extends AbstractAuthOptionsCmd {
         out.println("  " + PROMPT + " " + CMD + " config truststore " + OS_ARCH.path("~/.keycloak/truststore.jks"));
         out.println();
         out.println("Specify a truststore, and password - truststore will automatically be used without prompting for password:");
-        out.println("  " + PROMPT + " " + CMD + " config truststore --storepass " + OS_ARCH.envVar("PASSWORD") + " " + OS_ARCH.path("~/.keycloak/truststore.jks"));
+        out.println("  " + PROMPT + " " + CMD + " config truststore --trustpass " + OS_ARCH.envVar("PASSWORD") + " " + OS_ARCH.path("~/.keycloak/truststore.jks"));
         out.println();
         out.println("Remove truststore configuration:");
         out.println("  " + PROMPT + " " + CMD + " config truststore --delete");


### PR DESCRIPTION
The option to save the truststore password in config truststore command of admin-cli is -trustpass, not -storepass.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
