### PR TITLE
DateTimeParse failures in New Account Console tests

### DIFF
--- a/testsuite/integration-arquillian/tests/other/base-ui/src/main/java/org/keycloak/testsuite/ui/account2/page/SigningInPage.java
+++ b/testsuite/integration-arquillian/tests/other/base-ui/src/main/java/org/keycloak/testsuite/ui/account2/page/SigningInPage.java
@@ -32,7 +32,7 @@ import static org.keycloak.testsuite.util.UIUtils.getTextFromElement;
  * @author Vaclav Muzikar <vmuzikar@redhat.com>
  */
 public class SigningInPage extends AbstractLoggedInPage {
-    public static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("MMMM d, yyyy, h:mm a", Locale.ENGLISH);
+    public static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("MMMM d, yyyy 'at' h:mm a", Locale.ENGLISH);
 
     private static final String CATEG_TITLE = "-categ-title";
 

--- a/testsuite/integration-arquillian/tests/other/base-ui/src/test/java/org/keycloak/testsuite/ui/account2/AbstractAccountTest.java
+++ b/testsuite/integration-arquillian/tests/other/base-ui/src/test/java/org/keycloak/testsuite/ui/account2/AbstractAccountTest.java
@@ -26,7 +26,9 @@ import org.keycloak.testsuite.ui.AbstractUiTest;
 import org.keycloak.testsuite.ui.account2.page.PageNotFound;
 import org.keycloak.testsuite.ui.account2.page.WelcomeScreen;
 
+import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Locale;
 
 import static org.keycloak.testsuite.util.URLAssert.assertCurrentUrlStartsWithLoginUrlOf;
 
@@ -36,7 +38,7 @@ import static org.keycloak.testsuite.util.URLAssert.assertCurrentUrlStartsWithLo
 @EnableFeature(value = Profile.Feature.ACCOUNT2, skipRestart = true)
 public abstract class AbstractAccountTest extends AbstractUiTest {
     public static final String ACCOUNT_THEME_NAME_KC = "keycloak.v2";
-    public static final String ACCOUNT_THEME_NAME_RHSSO = "rh-sso.v2";
+    public static final DateTimeFormatter DEFAULT_TIME_FORMATTER = DateTimeFormatter.ofPattern("MMMM d, yyyy 'at' h:mm a", Locale.ENGLISH);
 
     @Page
     protected WelcomeScreen accountWelcomeScreen;
@@ -67,6 +69,6 @@ public abstract class AbstractAccountTest extends AbstractUiTest {
     }
 
     protected String getAccountThemeName() {
-        return getProjectName().equals(Profile.PRODUCT_NAME) ? ACCOUNT_THEME_NAME_RHSSO : ACCOUNT_THEME_NAME_KC;
+        return ACCOUNT_THEME_NAME_KC;
     }
 }

--- a/testsuite/integration-arquillian/tests/other/base-ui/src/test/java/org/keycloak/testsuite/ui/account2/DeviceActivityTest.java
+++ b/testsuite/integration-arquillian/tests/other/base-ui/src/test/java/org/keycloak/testsuite/ui/account2/DeviceActivityTest.java
@@ -230,11 +230,10 @@ public class DeviceActivityTest extends BaseAccountPageTest {
 
     @Test
     public void timesTests() {
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("MMMM d, yyyy, h:mm a", Locale.ENGLISH);
         LocalDateTime now = LocalDateTime.now();
         LocalDateTime nowPlus1 = now.plusMinutes(1);
-        String nowStr = now.format(formatter);
-        String nowStrPlus1 = nowPlus1.format(formatter);
+        String nowStr = now.format(DEFAULT_TIME_FORMATTER);
+        String nowStrPlus1 = nowPlus1.format(DEFAULT_TIME_FORMATTER);
 
         String sessionId = createSession(Browsers.CHROME);
 
@@ -251,9 +250,9 @@ public class DeviceActivityTest extends BaseAccountPageTest {
         assertThat(session.isPresent(), is(true));
 
         String startedAtStr = session.get().getStarted();
-        LocalDateTime startedAt = LocalDateTime.parse(startedAtStr, formatter);
-        LocalDateTime lastAccessed = LocalDateTime.parse(session.get().getLastAccess(), formatter);
-        LocalDateTime expiresAt = LocalDateTime.parse(session.get().getExpires(), formatter);
+        LocalDateTime startedAt = LocalDateTime.parse(startedAtStr, DEFAULT_TIME_FORMATTER);
+        LocalDateTime lastAccessed = LocalDateTime.parse(session.get().getLastAccess(), DEFAULT_TIME_FORMATTER);
+        LocalDateTime expiresAt = LocalDateTime.parse(session.get().getExpires(), DEFAULT_TIME_FORMATTER);
 
         assertTrue("Last access should be after started at", lastAccessed.isAfter(startedAt));
         assertTrue("Expires at should be after last access", expiresAt.isAfter(lastAccessed));
@@ -276,7 +275,7 @@ public class DeviceActivityTest extends BaseAccountPageTest {
 
         refreshPageAndWaitForLoad();
 
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("d. MMMM yyyy, H:mm", locale);
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("d. MMMM yyyy 'um' H:mm", locale);
         Optional<DeviceActivityPage.Session> session = deviceActivityPage.getSession(sessionId);
         assertThat(session.isPresent(), is(true));
         try {

--- a/testsuite/integration-arquillian/tests/other/base-ui/src/test/java/org/keycloak/testsuite/ui/account2/InternationalizationTest.java
+++ b/testsuite/integration-arquillian/tests/other/base-ui/src/test/java/org/keycloak/testsuite/ui/account2/InternationalizationTest.java
@@ -112,9 +112,8 @@ public class InternationalizationTest extends AbstractAccountTest {
         SigningInPage.UserCredential passwordCred =
                 passwordCredentialType.getUserCredential(testUserResource().credentials().get(0).getId());
 
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("MMMM d, yyyy, h:mm a", Locale.ENGLISH);
         try {
-            LocalDateTime.parse(passwordCred.getCreatedAtStr(), formatter);
+            LocalDateTime.parse(passwordCred.getCreatedAtStr(), DEFAULT_TIME_FORMATTER);
         } catch (DateTimeParseException e) {
             fail("Time was not formatted with the locale");
         }
@@ -124,7 +123,7 @@ public class InternationalizationTest extends AbstractAccountTest {
         loginPage.localeDropdown().selectAndAssert("Deutsch");
         loginPage.form().login(testUser);
 
-        DateTimeFormatter formatterDe = DateTimeFormatter.ofPattern("d. MMMM yyyy, H:mm", Locale.GERMAN);
+        DateTimeFormatter formatterDe = DateTimeFormatter.ofPattern("d. MMMM yyyy 'um' H:mm", Locale.GERMAN);
 
         try {
             LocalDateTime.parse(passwordCred.getCreatedAtStr(), formatterDe);


### PR DESCRIPTION
Fixes #16514

Executed these tests:
```
DeviceActivityTest.timeLocaleTest
InternationalizationTest.shouldDisplayTimeUsingSelectedLocale
DeviceActivityTest.timesTests
SigningInTest.otpTest
SigningInTest.updatePasswordTest
SigningInTest.updatePasswordTestForUserWithoutPassword
```

All of them passed, except `InternationalizationTest` as it's affected by #16515 

@miquelsi Could you please check it?