### PR TITLE
Fix ID token not being sent after expiration for OIDC logout

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractKcOidcBrokerLogoutTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractKcOidcBrokerLogoutTest.java
@@ -1,0 +1,41 @@
+package org.keycloak.testsuite.broker;
+
+import org.junit.Before;
+import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.representations.idm.UserRepresentation;
+
+import static org.keycloak.testsuite.admin.ApiUtil.createUserWithAdminClient;
+import static org.keycloak.testsuite.admin.ApiUtil.resetUserPassword;
+
+public abstract class AbstractKcOidcBrokerLogoutTest extends AbstractBaseBrokerTest {
+
+    @Before
+    public void createUser() {
+        log.debug("creating user for realm " + bc.providerRealmName());
+
+        final UserRepresentation user = new UserRepresentation();
+        user.setUsername(bc.getUserLogin());
+        user.setEmail(bc.getUserEmail());
+        user.setEmailVerified(true);
+        user.setEnabled(true);
+
+        final RealmResource realmResource = adminClient.realm(bc.providerRealmName());
+        final String userId = createUserWithAdminClient(realmResource, user);
+
+        resetUserPassword(realmResource.users().get(userId), bc.getUserPassword(), false);
+    }
+
+    @Before
+    public void addIdentityProviderToProviderRealm() {
+        log.debug("adding identity provider to realm " + bc.consumerRealmName());
+
+        final RealmResource realm = adminClient.realm(bc.consumerRealmName());
+        realm.identityProviders().create(bc.setUpIdentityProvider()).close();
+    }
+
+    @Before
+    public void addClients() {
+        addClientsToProviderAndConsumer();
+    }
+
+}

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerLogoutFrontChannelTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerLogoutFrontChannelTest.java
@@ -1,0 +1,76 @@
+package org.keycloak.testsuite.broker;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.keycloak.OAuth2Constants;
+import org.keycloak.TokenVerifier;
+import org.keycloak.common.VerificationException;
+import org.keycloak.models.IdentityProviderSyncMode;
+import org.keycloak.representations.IDToken;
+import org.keycloak.testsuite.AssertEvents;
+import org.keycloak.testsuite.util.OAuthClient;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.keycloak.testsuite.broker.BrokerTestConstants.REALM_CONS_NAME;
+import static org.keycloak.testsuite.broker.BrokerTestConstants.REALM_PROV_NAME;
+import static org.keycloak.testsuite.broker.BrokerTestTools.getConsumerRoot;
+import static org.keycloak.testsuite.broker.BrokerTestTools.getProviderRoot;
+import static org.keycloak.testsuite.broker.BrokerTestTools.waitForPage;
+
+public class KcOidcBrokerLogoutFrontChannelTest extends AbstractKcOidcBrokerLogoutTest {
+    @Rule public AssertEvents events = new AssertEvents(this);
+
+    @Override
+    protected BrokerConfiguration getBrokerConfiguration() {
+        return new KcOidcBrokerConfigurationIdpLogoutFrontChannel();
+    }
+
+    private static class KcOidcBrokerConfigurationIdpLogoutFrontChannel
+        extends KcOidcBrokerConfiguration {
+
+        @Override
+        protected void applyDefaultConfiguration(
+            Map<String, String> config, IdentityProviderSyncMode syncMode) {
+            super.applyDefaultConfiguration(config, syncMode);
+            config.put("backchannelSupported", "false");
+        }
+    }
+
+    @Test
+    public void logoutAfterIdpTokenExpired() throws VerificationException {
+        driver.navigate().to(getLoginUrl(getConsumerRoot(), bc.consumerRealmName(), "broker-app"));
+        logInWithBroker(bc);
+        updateAccountInformation();
+
+        // Exchange code from "broker-app" client of "consumer" realm for the tokens
+        String code = oauth.getCurrentQuery().get(OAuth2Constants.CODE);
+        OAuthClient.AccessTokenResponse response =
+            oauth
+                .realm(bc.consumerRealmName())
+                .clientId("broker-app")
+                .redirectUri(getConsumerRoot() + "/auth/realms/" + REALM_CONS_NAME + "/app")
+                .doAccessTokenRequest(code, "broker-app-secret");
+        assertEquals(200, response.getStatusCode());
+
+        String idTokenString = response.getIdToken();
+        IDToken idToken = TokenVerifier.create(idTokenString, IDToken.class).getToken();
+        int expiresInMs = (int) (idToken.getExp() - idToken.getIat());
+
+        // simulate token expiration
+        setTimeOffset(expiresInMs * 2);
+
+        logoutFromRealm(
+            getConsumerRoot(),
+            bc.consumerRealmName(),
+            "something-else",
+            idTokenString,
+            "broker-app",
+            getConsumerRoot() + "/auth/realms/" + REALM_CONS_NAME + "/app");
+
+        // user should be logged out successfully from the IDP even though the id_token_hint is expired
+        driver.navigate().to(getAccountUrl(getProviderRoot(), REALM_PROV_NAME));
+        waitForPage(driver, "sign in to provider", true);
+    }
+}

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerLogoutTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerLogoutTest.java
@@ -1,26 +1,24 @@
 package org.keycloak.testsuite.broker;
 
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.keycloak.OAuth2Constants;
-import org.keycloak.admin.client.resource.RealmResource;
-import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.TokenVerifier;
+import org.keycloak.common.VerificationException;
+import org.keycloak.representations.IDToken;
 import org.keycloak.services.managers.AuthenticationManager;
 import org.keycloak.services.util.CookieHelper;
 import org.keycloak.testsuite.AssertEvents;
 import org.keycloak.testsuite.util.OAuthClient;
 
 import static org.junit.Assert.assertEquals;
-import static org.keycloak.testsuite.admin.ApiUtil.createUserWithAdminClient;
-import static org.keycloak.testsuite.admin.ApiUtil.resetUserPassword;
 import static org.keycloak.testsuite.broker.BrokerTestConstants.REALM_CONS_NAME;
 import static org.keycloak.testsuite.broker.BrokerTestConstants.REALM_PROV_NAME;
-import static org.keycloak.testsuite.broker.BrokerTestTools.waitForPage;
 import static org.keycloak.testsuite.broker.BrokerTestTools.getConsumerRoot;
 import static org.keycloak.testsuite.broker.BrokerTestTools.getProviderRoot;
+import static org.keycloak.testsuite.broker.BrokerTestTools.waitForPage;
 
-public class KcOidcBrokerLogoutTest extends AbstractBaseBrokerTest {
+public class KcOidcBrokerLogoutTest extends AbstractKcOidcBrokerLogoutTest {
 
     @Rule
     public AssertEvents events = new AssertEvents(this);
@@ -28,35 +26,6 @@ public class KcOidcBrokerLogoutTest extends AbstractBaseBrokerTest {
     @Override
     protected BrokerConfiguration getBrokerConfiguration() {
         return KcOidcBrokerConfiguration.INSTANCE;
-    }
-
-    @Before
-    public void createUser() {
-        log.debug("creating user for realm " + bc.providerRealmName());
-
-        final UserRepresentation user = new UserRepresentation();
-        user.setUsername(bc.getUserLogin());
-        user.setEmail(bc.getUserEmail());
-        user.setEmailVerified(true);
-        user.setEnabled(true);
-
-        final RealmResource realmResource = adminClient.realm(bc.providerRealmName());
-        final String userId = createUserWithAdminClient(realmResource, user);
-
-        resetUserPassword(realmResource.users().get(userId), bc.getUserPassword(), false);
-    }
-
-    @Before
-    public void addIdentityProviderToProviderRealm() {
-        log.debug("adding identity provider to realm " + bc.consumerRealmName());
-
-        final RealmResource realm = adminClient.realm(bc.consumerRealmName());
-        realm.identityProviders().create(bc.setUpIdentityProvider()).close();
-    }
-
-    @Before
-    public void addClients() {
-        addClientsToProviderAndConsumer();
     }
 
     @Test
@@ -115,6 +84,41 @@ public class KcOidcBrokerLogoutTest extends AbstractBaseBrokerTest {
         logoutFromRealm(getConsumerRoot(), bc.consumerRealmName(), null, idToken);
         driver.navigate().to(getAccountUrl(getProviderRoot(), REALM_PROV_NAME));
 
+        waitForPage(driver, "sign in to provider", true);
+    }
+
+    @Test
+    public void logoutAfterIdpTokenExpired() throws VerificationException {
+        driver.navigate().to(getLoginUrl(getConsumerRoot(), bc.consumerRealmName(), "broker-app"));
+        logInWithBroker(bc);
+        updateAccountInformation();
+
+        // Exchange code from "broker-app" client of "consumer" realm for the tokens
+        String code = oauth.getCurrentQuery().get(OAuth2Constants.CODE);
+        OAuthClient.AccessTokenResponse response = oauth.realm(bc.consumerRealmName())
+                .clientId("broker-app")
+                .redirectUri(getConsumerRoot() + "/auth/realms/" + REALM_CONS_NAME + "/app")
+                .doAccessTokenRequest(code, "broker-app-secret");
+        assertEquals(200, response.getStatusCode());
+
+        String idTokenString = response.getIdToken();
+        IDToken idToken = TokenVerifier.create(idTokenString, IDToken.class).getToken();
+        int expiresInMs = (int) (idToken.getExp() - idToken.getIat());
+
+        // simulate token expiration
+        setTimeOffset(expiresInMs * 2);
+
+        logoutFromRealm(
+                getConsumerRoot(),
+                bc.consumerRealmName(),
+                "something-else",
+                idTokenString,
+                "broker-app",
+                getConsumerRoot() + "/auth/realms/" + REALM_CONS_NAME + "/app"
+        );
+
+        // user should be logged out successfully from the IDP even though the id_token_hint is expired
+        driver.navigate().to(getAccountUrl(getProviderRoot(), REALM_PROV_NAME));
         waitForPage(driver, "sign in to provider", true);
     }
 }


### PR DESCRIPTION
Closes #10164

OIDC spec recommend sending id_token_hint regardless of expiration

https://openid.net/specs/openid-connect-rpinitiated-1_0.html

Quotes:

### id_token_hint
**RECOMMENDED**. ID Token previously issued by the OP to the RP passed to the Logout Endpoint as a hint about the End-User's current authenticated session with the Client. This is used as an indication of the identity of the End-User that the RP is requesting be logged out by the OP.
...
When an id_token_hint parameter is present, the OP MUST validate that it was the issuer of the ID Token. The OP SHOULD accept ID Tokens when the RP identified by the ID Token's aud claim and/or sid claim has a current session or had a recent session at the OP, **even when the exp time has passed**. If the ID Token's sid claim does not correspond to the RP's current session or a recent session at the OP, the OP SHOULD treat the logout request as suspect, and MAY decline to act upon it.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
