### PR TITLE
Introduce CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,10 +16,10 @@
 *                                                           @keycloak/maintainers
 
 ###################################################################################################
-# Testing (@keycloak/testing-maintainers)
+# Testsuite
 ###################################################################################################
 
-/testsuite/                                                 @keycloak/testing-maintainers
+/testsuite/                                                 @keycloak/core-maintainers @keycloak/cloud-native-maintainers @keycloak/store-maintainers
 
 ###################################################################################################
 # Core (@keycloak/core-maintainers)

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -50,3 +50,4 @@
 /adapters/oidc/js/                                          @keycloak/ui-maintainers
 /rest/admin-ui-ext/                                         @keycloak/ui-maintainers
 /themes/src/main/resources/theme/keycloak.v2/account/       @keycloak/ui-maintainers
+/testsuite/integration-arquillian/tests/other/base-ui/      @keycloak/ui-maintainers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,50 @@
+###################################################################################################
+# Overview
+#
+# Pattern used to match files follows most of the same rules as used in gitignore files. Order is
+# important; the last matching pattern takes precendence.
+#
+# For more info see:
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+###################################################################################################
+
+
+###################################################################################################
+# Global (@keycloak/maintainers)
+###################################################################################################
+
+/**                                                         @keycloak/maintainers
+
+###################################################################################################
+# Testing (@keycloak/testing-maintainers)
+###################################################################################################
+
+/testsuite/**                                               @keycloak/testing-maintainers
+
+###################################################################################################
+# Core (@keycloak/core-maintainers)
+###################################################################################################
+
+
+###################################################################################################
+# Cloud Native (@keycloak/cloud-native-maintainers)
+###################################################################################################
+
+/operator/**                                                @keycloak/cloud-native-maintainers
+/quarkus/**                                                 @keycloak/cloud-native-maintainers
+
+###################################################################################################
+# Store (@keycloak/store-maintainers)
+###################################################################################################
+
+/model/**                                                   @keycloak/store-maintainers
+/testsuite/model/**                                         @keycloak/store-maintainers
+
+###################################################################################################
+# UI (@keycloak/ui-maintainers)
+###################################################################################################
+
+/js/**                                                      @keycloak/ui-maintainers
+/adapters/oidc/js/**                                        @keycloak/ui-maintainers
+/rest/admin-ui-ext/**                                       @keycloak/ui-maintainers
+/themes/src/main/resources/theme/keycloak.v2/account/**     @keycloak/ui-maintainers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,13 +13,13 @@
 # Global (@keycloak/maintainers)
 ###################################################################################################
 
-/**                                                         @keycloak/maintainers
+*                                                           @keycloak/maintainers
 
 ###################################################################################################
 # Testing (@keycloak/testing-maintainers)
 ###################################################################################################
 
-/testsuite/**                                               @keycloak/testing-maintainers
+/testsuite/                                                 @keycloak/testing-maintainers
 
 ###################################################################################################
 # Core (@keycloak/core-maintainers)
@@ -30,21 +30,23 @@
 # Cloud Native (@keycloak/cloud-native-maintainers)
 ###################################################################################################
 
-/operator/**                                                @keycloak/cloud-native-maintainers
-/quarkus/**                                                 @keycloak/cloud-native-maintainers
+/operator/                                                  @keycloak/cloud-native-maintainers
+/quarkus/                                                   @keycloak/cloud-native-maintainers
+/docs/guides/src/main/server/                               @keycloak/cloud-native-maintainers
+/docs/guides/src/main/operator/                             @keycloak/cloud-native-maintainers
 
 ###################################################################################################
 # Store (@keycloak/store-maintainers)
 ###################################################################################################
 
-/model/**                                                   @keycloak/store-maintainers
-/testsuite/model/**                                         @keycloak/store-maintainers
+/model/                                                     @keycloak/store-maintainers
+/testsuite/model/                                           @keycloak/store-maintainers
 
 ###################################################################################################
 # UI (@keycloak/ui-maintainers)
 ###################################################################################################
 
-/js/**                                                      @keycloak/ui-maintainers
-/adapters/oidc/js/**                                        @keycloak/ui-maintainers
-/rest/admin-ui-ext/**                                       @keycloak/ui-maintainers
-/themes/src/main/resources/theme/keycloak.v2/account/**     @keycloak/ui-maintainers
+/js/                                                        @keycloak/ui-maintainers
+/adapters/oidc/js/                                          @keycloak/ui-maintainers
+/rest/admin-ui-ext/                                         @keycloak/ui-maintainers
+/themes/src/main/resources/theme/keycloak.v2/account/       @keycloak/ui-maintainers

--- a/PR-CHECKLIST.md
+++ b/PR-CHECKLIST.md
@@ -1,0 +1,19 @@
+# Checklist for merging PRs
+
+Before merging a PR the PR should follow these rules:
+
+* The PR does not have the label "hold"
+* There is an associated GitHub Issue linked to the PR
+* There is sufficient test coverage
+* Required documentation is included in the PR or an associated PR
+* There are no negative reviews, or unresolved comments
+* The PR does not contain changes not relevant to the GitHub Issue
+* PRs has been reviewed by the relevant team, and approved by either a global maintainer or a team maintainer
+* All required status checks have passed successfully
+* If the PR is affected by unstable workflows or tests verify the issues are not introduced by the PR
+
+Merging a PR:
+
+* In most cases a PR should be merged by a team maintainer in the affected area
+* Global maintainers can merge any PRs, but this is considered a fallback
+* If a PR affects multiple areas it can be merged by any of the affected team maintainers

--- a/PR-CHECKLIST.md
+++ b/PR-CHECKLIST.md
@@ -6,8 +6,8 @@ Before merging a PR the PR should follow these rules:
 * There is an associated GitHub Issue linked to the PR
   * A GitHub Issue is not required if the PR is not introducing a new feature or enhancement to Keycloak, or is resolving a bug where released versions of Keycloak are not affected
 * There is sufficient test coverage
-* Required documentation is included in the PR or an associated PR
-* There are no negative reviews, or unresolved comments
+* Required documentation is included in the PR or an associated PR. Including updates to release notes and upgrade guide if applicable
+* There are no unresolved negative reviews, or unresolved comments
 * The PR does not contain changes not relevant to the GitHub Issue
 * PRs has been reviewed by the relevant team, and approved by either a global maintainer or a team maintainer
 * All required status checks have passed successfully

--- a/PR-CHECKLIST.md
+++ b/PR-CHECKLIST.md
@@ -4,6 +4,7 @@ Before merging a PR the PR should follow these rules:
 
 * The PR does not have the label "hold"
 * There is an associated GitHub Issue linked to the PR
+  * A GitHub Issue is not required if the PR is not introducing a new feature or enhancement to Keycloak, or is resolving a bug where released versions of Keycloak are not affected
 * There is sufficient test coverage
 * Required documentation is included in the PR or an associated PR
 * There are no negative reviews, or unresolved comments

--- a/PR-CHECKLIST.md
+++ b/PR-CHECKLIST.md
@@ -17,4 +17,4 @@ Merging a PR:
 
 * In most cases a PR should be merged by a team maintainer in the affected area
 * Global maintainers can merge any PRs, but this is considered a fallback
-* If a PR affects multiple areas it can be merged by any of the affected team maintainers
+* If a PR affects multiple areas it can be merged by any of the affected team maintainers as long as someone from each affected team has completed a review.


### PR DESCRIPTION
GitHub states _This CODEOWNERS file contains errors_. I've checked all teams exists and the correct name is used in the CODEOWNERS file, but it is complaining since those teams do not have write access to the repository. I will set that up, but only after this PR is merged.

PR-CHECKLIST is my proposal for a list of things for a maintainer to remember prior to merging a PR. As much of these should be verified automatically in the future, but for now some checks remain a manual task, and some things will always be.

Closes #16636
