### PR TITLE
Improvements on Operator Integration Tests to make sure that Config set in CR takes precedence

### DIFF
--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakDeploymentTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakDeploymentTest.java
@@ -46,7 +46,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Collectors;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -125,25 +124,60 @@ public class KeycloakDeploymentTest extends BaseOperatorTest {
     @Test
     public void testConfigInCRTakesPrecedence() {
         try {
-            var kc = getDefaultKeycloakDeployment();
-            var health = new ValueOrSecret("health-enabled", "false");
-            var e = new EnvVarBuilder()
-                    .withName(KeycloakDistConfigurator.getKeycloakOptionEnvVarName(health.getName()))
-                    .withValue(health.getValue())
-                    .build();
-            kc.getSpec().getAdditionalOptions().add(health);
-            deployKeycloak(k8sclient, kc, false);
+            var defaultKCDeploy = getDefaultKeycloakDeployment();
 
-            assertThat(Constants.DEFAULT_DIST_CONFIG.get(health.getName())).isEqualTo("true"); // just a sanity check default values did not change
+            var valueSecretHealthProp = new ValueOrSecret("health-enabled", "false");
+            var valueSecretProxyProp = new ValueOrSecret("proxy", "reencrypt");
+
+            var healthEnvVar = new EnvVarBuilder()
+                    .withName(KeycloakDistConfigurator.getKeycloakOptionEnvVarName(valueSecretHealthProp.getName()))
+                    .withValue(valueSecretHealthProp.getValue())
+                    .build();
+
+            var proxyEnvVar = new EnvVarBuilder()
+                    .withName(KeycloakDistConfigurator.getKeycloakOptionEnvVarName(valueSecretProxyProp.getName()))
+                    .withValue(valueSecretProxyProp.getValue())
+                    .build();
+
+            defaultKCDeploy.getSpec().getAdditionalOptions().add(valueSecretHealthProp);
+            defaultKCDeploy.getSpec().getAdditionalOptions().add(valueSecretProxyProp);
+
+            deployKeycloak(k8sclient, defaultKCDeploy, false);
+
+            assertThat(
+                    Constants.DEFAULT_DIST_CONFIG.get(valueSecretHealthProp.getName())
+            ).isEqualTo("true"); // just a sanity check default values did not change
+
+            assertThat(
+                    Constants.DEFAULT_DIST_CONFIG.get(valueSecretProxyProp.getName())
+            ).isEqualTo("passthrough"); // just a sanity check default values did not change
 
             Awaitility.await()
                     .ignoreExceptions()
                     .untilAsserted(() -> {
-                        Log.info("Asserting default value was overwritten by CR value");
-                        var c = k8sclient.apps().statefulSets().inNamespace(namespace).withName(kc.getMetadata().getName()).get()
-                                .getSpec().getTemplate().getSpec().getContainers().get(0);
 
-                        assertThat(c.getEnv()).contains(e);
+                        Log.info("Asserting default value was overwritten by CR value");
+
+                        var deployedKCStatefullSet = k8sclient.apps()
+                                .statefulSets()
+                                .inNamespace(namespace)
+                                .withName(defaultKCDeploy.getMetadata().getName());
+
+                        var firstKCContainer = deployedKCStatefullSet.get()
+                                .getSpec()
+                                .getTemplate()
+                                .getSpec()
+                                .getContainers()
+                                .get(0);
+
+                        assertThat(firstKCContainer.getEnv().stream()
+                                .filter(oneEnvVar -> oneEnvVar.getName().equalsIgnoreCase(healthEnvVar.getName())))
+                                .containsExactly(healthEnvVar);
+
+                        assertThat(firstKCContainer.getEnv().stream()
+                                .filter(oneEnvVar -> oneEnvVar.getName().equalsIgnoreCase(proxyEnvVar.getName())))
+                                .containsExactly(proxyEnvVar);
+
                     });
         } catch (Exception e) {
             savePodLogs();


### PR DESCRIPTION
In order to make sure that the Config set in CR takes Precedence over the default values and hence none Environment Variable gets duplicated in Deployment, then just some improvements on Operator Integration Tests were implemented.

Closes #13114 
