### PR TITLE
Fixing parameter which should be a string plus dependencies

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/models/jpa/session/JpaUserSessionPersisterProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/session/JpaUserSessionPersisterProvider.java
@@ -310,7 +310,7 @@ public class JpaUserSessionPersisterProvider implements UserSessionPersisterProv
         return persistentUserSessions.findAny().map(userSession -> {
 
             TypedQuery<PersistentClientSessionEntity> clientSessionQuery = em.createNamedQuery("findClientSessionsByUserSession", PersistentClientSessionEntity.class);
-            clientSessionQuery.setParameter("userSessionId", Collections.singleton(userSessionId));
+            clientSessionQuery.setParameter("userSessionId", userSessionId);
             clientSessionQuery.setParameter("offline", offlineStr);
 
             Set<String> removedClientUUIDs = new HashSet<>();

--- a/testsuite/integration-arquillian/tests/pom.xml
+++ b/testsuite/integration-arquillian/tests/pom.xml
@@ -1834,7 +1834,7 @@
                 </dependency>
                 <dependency>
                     <groupId>org.infinispan</groupId>
-                    <artifactId>infinispan-core</artifactId>
+                    <artifactId>infinispan-core-jakarta</artifactId>
                 </dependency>
 
                 <dependency>


### PR DESCRIPTION
Closes #16649

Analyzing the tests runs in the main branch showed that despite the type mismatch, the query still succeeds / matches results. So there is no need to merge this into the main branch to fix a misbehaving Keycloak.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
