### PR TITLE
Fix errors pointed out by Hibernate 6 in the queries

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/authorization/jpa/entities/ResourceEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/authorization/jpa/entities/ResourceEntity.java
@@ -65,7 +65,7 @@ import org.hibernate.annotations.FetchMode;
                 @NamedQuery(name="findResourceIdByTypeNoOwner", query="select r from ResourceEntity r left join fetch r.scopes s where  r.resourceServer = :serverId  and r.type = :type"),
                 @NamedQuery(name="findResourceIdByTypeInstance", query="select r from ResourceEntity r left join fetch r.scopes s where  r.resourceServer = :serverId and r.type = :type and r.owner <> :serverId"),
                 @NamedQuery(name="findResourceIdByServerId", query="select r.id from ResourceEntity r where  r.resourceServer = :serverId "),
-                @NamedQuery(name="findResourceIdByScope", query="select r from ResourceEntity r inner join r.scopes s where r.resourceServer = :serverId and (s.resourceServer = :serverId and s.id in (:scopeIds))"),
+                @NamedQuery(name="findResourceIdByScope", query="select r from ResourceEntity r inner join r.scopes s where r.resourceServer = :serverId and (s.resourceServer.id = :serverId and s.id in (:scopeIds))"),
                 @NamedQuery(name="deleteResourceByResourceServer", query="delete from ResourceEntity r where r.resourceServer = :serverId")
         }
 )

--- a/model/jpa/src/main/java/org/keycloak/authorization/jpa/store/JPAPermissionTicketStore.java
+++ b/model/jpa/src/main/java/org/keycloak/authorization/jpa/store/JPAPermissionTicketStore.java
@@ -64,16 +64,16 @@ public class JPAPermissionTicketStore implements PermissionTicketStore {
     @Override
     public long count(ResourceServer resourceServer, Map<PermissionTicket.FilterOption, String> attributes) {
         CriteriaBuilder builder = entityManager.getCriteriaBuilder();
-        CriteriaQuery<Long> querybuilder = builder.createQuery(Long.class);
+        CriteriaQuery<String> querybuilder = builder.createQuery(String.class);
         Root<PermissionTicketEntity> root = querybuilder.from(PermissionTicketEntity.class);
 
         querybuilder.select(root.get("id"));
 
         List<Predicate> predicates = getPredicates(builder, root, resourceServer, attributes);
 
-        querybuilder.where(predicates.toArray(new Predicate[predicates.size()])).orderBy(builder.asc(root.get("id")));
+        querybuilder.where(predicates.toArray(new Predicate[0])).orderBy(builder.asc(root.get("id")));
 
-        TypedQuery query = entityManager.createQuery(querybuilder);
+        TypedQuery<String> query = entityManager.createQuery(querybuilder);
 
         return closing(query.getResultStream()).count();
     }

--- a/model/jpa/src/main/java/org/keycloak/authorization/jpa/store/JPAResourceStore.java
+++ b/model/jpa/src/main/java/org/keycloak/authorization/jpa/store/JPAResourceStore.java
@@ -154,10 +154,10 @@ public class JPAResourceStore implements ResourceStore {
     @Override
     public List<Resource> find(RealmModel realm, ResourceServer resourceServer, Map<Resource.FilterOption, String[]> attributes, Integer firstResult, Integer maxResults) {
         CriteriaBuilder builder = entityManager.getCriteriaBuilder();
-        CriteriaQuery<ResourceEntity> querybuilder = builder.createQuery(ResourceEntity.class);
+        CriteriaQuery<String> querybuilder = builder.createQuery(String.class);
         Root<ResourceEntity> root = querybuilder.from(ResourceEntity.class);
         querybuilder.select(root.get("id"));
-        List<Predicate> predicates = new ArrayList();
+        List<Predicate> predicates = new ArrayList<>();
 
         if (resourceServer != null) {
             predicates.add(builder.equal(root.get("resourceServer"), resourceServer.getId()));
@@ -196,9 +196,9 @@ public class JPAResourceStore implements ResourceStore {
             }
         });
 
-        querybuilder.where(predicates.toArray(new Predicate[predicates.size()])).orderBy(builder.asc(root.get("name")));
+        querybuilder.where(predicates.toArray(new Predicate[0])).orderBy(builder.asc(root.get("name")));
 
-        TypedQuery query = entityManager.createQuery(querybuilder);
+        TypedQuery<String> query = entityManager.createQuery(querybuilder);
 
         List<String> result = paginateQuery(query, firstResult, maxResults).getResultList();
         List<Resource> list = new LinkedList<>();

--- a/model/jpa/src/main/java/org/keycloak/authorization/jpa/store/JPAScopeStore.java
+++ b/model/jpa/src/main/java/org/keycloak/authorization/jpa/store/JPAScopeStore.java
@@ -133,10 +133,10 @@ public class JPAScopeStore implements ScopeStore {
     @Override
     public List<Scope> findByResourceServer(ResourceServer resourceServer, Map<Scope.FilterOption, String[]> attributes, Integer firstResult, Integer maxResults) {
         CriteriaBuilder builder = entityManager.getCriteriaBuilder();
-        CriteriaQuery<ScopeEntity> querybuilder = builder.createQuery(ScopeEntity.class);
+        CriteriaQuery<String> querybuilder = builder.createQuery(String.class);
         Root<ScopeEntity> root = querybuilder.from(ScopeEntity.class);
         querybuilder.select(root.get("id"));
-        List<Predicate> predicates = new ArrayList();
+        List<Predicate> predicates = new ArrayList<>();
 
         predicates.add(builder.equal(root.get("resourceServer").get("id"), resourceServer.getId()));
 
@@ -153,14 +153,14 @@ public class JPAScopeStore implements ScopeStore {
             }
         });
 
-        querybuilder.where(predicates.toArray(new Predicate[predicates.size()])).orderBy(builder.asc(root.get("name")));
+        querybuilder.where(predicates.toArray(new Predicate[0])).orderBy(builder.asc(root.get("name")));
 
-        TypedQuery query = entityManager.createQuery(querybuilder);
+        TypedQuery<String> query = entityManager.createQuery(querybuilder);
 
-        List result = paginateQuery(query, firstResult, maxResults).getResultList();
+        List<String> result = paginateQuery(query, firstResult, maxResults).getResultList();
         List<Scope> list = new LinkedList<>();
-        for (Object id : result) {
-            list.add(provider.getStoreFactory().getScopeStore().findById(JPAAuthorizationStoreFactory.NULL_REALM, resourceServer, (String)id));
+        for (String id : result) {
+            list.add(provider.getStoreFactory().getScopeStore().findById(JPAAuthorizationStoreFactory.NULL_REALM, resourceServer, id));
         }
         return list;
 


### PR DESCRIPTION
This fixes several integration tests around AuthZ: 

* o.k.t.authz.AuthorizationTest
* o.k.t.authz.AuthzClientCredentialsTest
* o.k.t.authz.ConflictingScopePermissionTest
* o.k.t.authz.EntitlementAPITest (for all tests to pass here, it also needs #16650 to be merged)
* o.k.t.authz.PermissionClaimTest
* o.k.t.authz.PermissionManagementTest
* o.k.t.authz.UmaGrantTypeTest
* o.k.t.authz.UserManagedPermissionServiceTest
* o.k.t.authz.admin.AuthorizationTest
* o.k.t.authz.admin.ClaimInformationPointProviderTest
* o.k.t.authz.admin.EnforcerConfigTest
* o.k.t.authz.admin.ExportAuthorizationSettingsTest
* o.k.t.authz.admin.GenericPolicyManagementAdminEventTest
* o.k.t.authz.admin.GenericPolicyManagementTest
* o.k.t.authz.admin.PolicyEnforcerClaimsTest
* o.k.t.authz.admin.PolicyEnforcerTest
* o.k.t.authz.admin.ResourceManagementTest
* o.k.t.authz.admin.ResourceManagementWithAuthzClientTest
* o.k.t.authz.admin.ResourceServerManagementTest
* o.k.t.account.ResourcesRestServiceTest

Closes #16337

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
