### PR TITLE
add user events on ldap synchronisation

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPConfig.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPConfig.java
@@ -25,7 +25,6 @@ import javax.naming.directory.SearchControls;
 
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProviderFactory.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProviderFactory.java
@@ -19,14 +19,18 @@ package org.keycloak.storage.ldap;
 
 import org.jboss.logging.Logger;
 import org.keycloak.Config;
+import org.keycloak.common.ClientConnection;
 import org.keycloak.common.constants.KerberosConstants;
 import org.keycloak.component.ComponentModel;
 import org.keycloak.component.ComponentValidationException;
+import org.keycloak.events.admin.OperationType;
+import org.keycloak.events.admin.ResourceType;
 import org.keycloak.federation.kerberos.CommonKerberosConfig;
 import org.keycloak.federation.kerberos.impl.KerberosServerSubjectAuthenticator;
 import org.keycloak.federation.kerberos.impl.KerberosUsernamePasswordAuthenticator;
 import org.keycloak.federation.kerberos.impl.SPNEGOAuthenticator;
 import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.models.KeycloakSessionTask;
@@ -36,9 +40,14 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.cache.UserCache;
 import org.keycloak.models.utils.KeycloakModelUtils;
+import org.keycloak.models.utils.ModelToRepresentation;
+import org.keycloak.models.utils.StripSecretsUtils;
 import org.keycloak.provider.ProviderConfigProperty;
 import org.keycloak.provider.ProviderConfigurationBuilder;
 import org.keycloak.representations.idm.CredentialRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.services.resources.admin.AdminAuth;
+import org.keycloak.services.resources.admin.AdminEventBuilder;
 import org.keycloak.storage.UserStoragePrivateUtil;
 import org.keycloak.storage.UserStorageProvider;
 import org.keycloak.storage.UserStorageProviderFactory;
@@ -90,13 +99,6 @@ public class LDAPStorageProviderFactory implements UserStorageProviderFactory<LD
     }
 
     private static List<ProviderConfigProperty> getConfigProps(ComponentModel parent) {
-        boolean readOnly = false;
-        if (parent != null) {
-            LDAPConfig config = new LDAPConfig(parent.getConfig());
-            readOnly = config.getEditMode() != UserStorageProvider.EditMode.WRITABLE;
-        }
-
-
         return ProviderConfigurationBuilder.create()
                 .property().name(LDAPConstants.EDIT_MODE)
                 .type(ProviderConfigProperty.STRING_TYPE)
@@ -615,13 +617,20 @@ public class LDAPStorageProviderFactory implements UserStorageProviderFactory<LD
                         if (!userModelOptional.isPresent() && currentUserLocal == null) {
                             // Add new user to Keycloak
                             exists.value = false;
-                            ldapFedProvider.importUserFromLDAP(session, currentRealm, ldapUser);
+                            UserModel newUser = ldapFedProvider.importUserFromLDAP(session, currentRealm, ldapUser);
+                            
+                            newAdminEventBuilder(currentRealm, session)
+                                .operation(OperationType.CREATE)
+                                .resource(ResourceType.USER)
+                                .representation(StripSecretsUtils.strip(ModelToRepresentation.toRepresentation(session, currentRealm, newUser)))
+                                .resourcePath(session.getContext().getUri())
+                                .success();
+                            
                             syncResult.increaseAdded();
 
                         } else {
                             UserModel currentUser = userModelOptional.isPresent() ? userModelOptional.get() : currentUserLocal;
                             if ((fedModel.getId().equals(currentUser.getFederationLink())) && (ldapUser.getUuid().equals(currentUser.getFirstAttribute(LDAPConstants.LDAP_ID)))) {
-
                                 // Update keycloak user
                                 LDAPMappersComparator ldapMappersComparator = new LDAPMappersComparator(ldapFedProvider.getLdapIdentityStore().getConfig());
                                 currentRealm.getComponentsStream(fedModel.getId(), LDAPStorageMapper.class.getName())
@@ -636,6 +645,12 @@ public class LDAPStorageProviderFactory implements UserStorageProviderFactory<LD
                                     userCache.evict(currentRealm, currentUser);
                                 }
                                 logger.debugf("Updated user from LDAP: %s", currentUser.getUsername());
+                                newAdminEventBuilder(currentRealm, session)
+                                    .operation(OperationType.UPDATE)
+                                    .resource(ResourceType.USER)
+                                    .representation(StripSecretsUtils.strip(ModelToRepresentation.toRepresentation(session, currentRealm, currentUser)))
+                                    .resourcePath(session.getContext().getUri())
+                                    .success();
                                 syncResult.increaseUpdated();
                             } else {
                                 logger.warnf("User with ID '%s' is not updated during sync as he already exists in Keycloak database but is not linked to federation provider '%s'", ldapUser.getUuid(), fedModel.getName());
@@ -683,6 +698,10 @@ public class LDAPStorageProviderFactory implements UserStorageProviderFactory<LD
         }
 
         return syncResult;
+    }
+
+    private AdminEventBuilder newAdminEventBuilder(RealmModel realm, KeycloakSession session) {
+        return new AdminEventBuilder(realm, new AdminAuth(realm, null, null, null), session, session.getContext().getConnection());
     }
 
     protected SPNEGOAuthenticator createSPNEGOAuthenticator(String spnegoToken, CommonKerberosConfig kerberosConfig) {

--- a/services/src/main/java/org/keycloak/services/resources/admin/AdminEventBuilder.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/AdminEventBuilder.java
@@ -78,9 +78,9 @@ public class AdminEventBuilder {
      */
     public AdminEventBuilder clone(KeycloakSession session) {
         RealmModel newEventRealm = session.realms().getRealm(realm.getId());
-        RealmModel newAuthRealm = session.realms().getRealm(this.auth.getRealm().getId());
-        UserModel newAuthUser = session.users().getUserById(newAuthRealm, this.auth.getUser().getId());
-        ClientModel newAuthClient = session.clients().getClientById(newAuthRealm, this.auth.getClient().getId());
+        RealmModel newAuthRealm = this.auth.getRealm() == null ? null : session.realms().getRealm(this.auth.getRealm().getId());
+        UserModel newAuthUser = this.auth.getUser() == null ? null : session.users().getUserById(newAuthRealm, this.auth.getUser().getId());
+        ClientModel newAuthClient = this.auth.getClient() == null ? null : session.clients().getClientById(newAuthRealm, this.auth.getClient().getId());
 
         return new AdminEventBuilder(
                 newEventRealm,
@@ -158,8 +158,8 @@ public class AdminEventBuilder {
         AuthDetails authDetails = adminEvent.getAuthDetails();
         if(authDetails == null) {
             authDetails =  new AuthDetails();
-            authDetails.setRealmId(realm.getId());
-        } else {
+        } 
+        if (realm != null) {
             authDetails.setRealmId(realm.getId());
         }
         adminEvent.setAuthDetails(authDetails);
@@ -170,8 +170,8 @@ public class AdminEventBuilder {
         AuthDetails authDetails = adminEvent.getAuthDetails();
         if(authDetails == null) {
             authDetails =  new AuthDetails();
-            authDetails.setClientId(client.getId());
-        } else {
+        } 
+        if (client != null) {
             authDetails.setClientId(client.getId());
         }
         adminEvent.setAuthDetails(authDetails);
@@ -182,8 +182,8 @@ public class AdminEventBuilder {
         AuthDetails authDetails = adminEvent.getAuthDetails();
         if(authDetails == null) {
             authDetails =  new AuthDetails();
-            authDetails.setUserId(user.getId());
-        } else {
+        } 
+        if (user != null) {
             authDetails.setUserId(user.getId());
         }
         adminEvent.setAuthDetails(authDetails);


### PR DESCRIPTION
Try to fix #16692

 I wasn't sure if it was best to create individual events for each updated users, but it seems to be better to notify a third-party application user by user.
