### PR TITLE
Fixes SAML tests in testsuite

### DIFF
--- a/boms/pom.xml
+++ b/boms/pom.xml
@@ -22,6 +22,7 @@
         <groupId>org.jboss</groupId>
         <artifactId>jboss-parent</artifactId>
         <version>39</version>
+        <relativePath/>
     </parent>
 
     <groupId>org.keycloak.bom</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -114,10 +114,9 @@
         <slf4j-api.version>1.7.30</slf4j-api.version>
         <slf4j.version>1.7.30</slf4j.version>
         <sun.istack.version>3.0.10</sun.istack.version>
+        <sun.saaj.version>2.0.1</sun.saaj.version>
         <sun.xml.bind.version>2.3.3-b02</sun.xml.bind.version>
-        <javax.xml.bind.jaxb.version>2.4.0-b180830.0359</javax.xml.bind.jaxb.version>
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
-        <sun.xml.ws.version>2.3.1</sun.xml.ws.version>
         <sun.activation.version>1.2.2</sun.activation.version>
         <org.glassfish.jaxb.xsom.version>2.3.3-b02</org.glassfish.jaxb.xsom.version>
         <undertow.version>2.2.22.Final</undertow.version>
@@ -347,9 +346,9 @@
                 <version>${sun.istack.version}</version>
             </dependency>
             <dependency>
-                <groupId>javax.xml.bind</groupId>
-                <artifactId>jaxb-api</artifactId>
-                <version>${javax.xml.bind.jaxb.version}</version>
+                <groupId>com.sun.xml.messaging.saaj</groupId>
+                <artifactId>saaj-impl</artifactId>
+                <version>${sun.saaj.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.sun.xml.bind.external</groupId>

--- a/saml-core-api/pom.xml
+++ b/saml-core-api/pom.xml
@@ -57,6 +57,10 @@
             <groupId>jakarta.xml.ws</groupId>
             <artifactId>jakarta.xml.ws-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.sun.xml.messaging.saaj</groupId>
+            <artifactId>saaj-impl</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <resources>

--- a/testsuite/integration-arquillian/test-apps/app-profile-jee/src/main/webapp/WEB-INF/web.xml
+++ b/testsuite/integration-arquillian/test-apps/app-profile-jee/src/main/webapp/WEB-INF/web.xml
@@ -15,15 +15,16 @@
  * License for the specific language governing permissions and limitations under
  * the License.
 -->
-<web-app xmlns="http://java.sun.com/xml/ns/javaee"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
-         version="3.0">
+<web-app xmlns = "https://jakarta.ee/xml/ns/jakartaee"
+         xmlns:xsi = "http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation = "https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd"
+         version = "5.0">
 
     <module-name>app-profile-jee</module-name>
 
     <security-constraint>
         <web-resource-collection>
+            <web-resource-name>Protected</web-resource-name>
             <url-pattern>/profile.jsp</url-pattern>
         </web-resource-collection>
         <auth-constraint>

--- a/testsuite/integration-arquillian/test-apps/cors/database-service/src/main/webapp/WEB-INF/web.xml
+++ b/testsuite/integration-arquillian/test-apps/cors/database-service/src/main/webapp/WEB-INF/web.xml
@@ -16,15 +16,16 @@
   ~ limitations under the License.
   -->
 
-<web-app xmlns="http://java.sun.com/xml/ns/javaee"
-      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
-      version="3.0">
+<web-app xmlns = "https://jakarta.ee/xml/ns/jakartaee"
+         xmlns:xsi = "http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation = "https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd"
+         version = "5.0">
 
 	<module-name>cors-database</module-name>
 	
     <security-constraint>
         <web-resource-collection>
+            <web-resource-name>All Resources</web-resource-name>
             <url-pattern>/*</url-pattern>
         </web-resource-collection>
 <!--        <user-data-constraint>

--- a/testsuite/integration-arquillian/test-apps/hello-world-authz-service/src/main/webapp/WEB-INF/web.xml
+++ b/testsuite/integration-arquillian/test-apps/hello-world-authz-service/src/main/webapp/WEB-INF/web.xml
@@ -17,10 +17,10 @@
   ~
   -->
 
-<web-app xmlns="http://java.sun.com/xml/ns/javaee"
-		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
-		 version="3.0">
+<web-app xmlns = "https://jakarta.ee/xml/ns/jakartaee"
+		 xmlns:xsi = "http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation = "https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd"
+		 version = "5.0">
 
 	<module-name>hello-world-authz-service</module-name>
 

--- a/testsuite/integration-arquillian/test-apps/photoz/photoz-restful-api/src/main/webapp/WEB-INF/web.xml
+++ b/testsuite/integration-arquillian/test-apps/photoz/photoz-restful-api/src/main/webapp/WEB-INF/web.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<web-app xmlns="http://java.sun.com/xml/ns/javaee"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
-         version="3.0">
+<web-app xmlns = "https://jakarta.ee/xml/ns/jakartaee"
+         xmlns:xsi = "http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation = "https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd"
+         version = "5.0">
 
     <module-name>photoz-restful-api</module-name>
 

--- a/testsuite/integration-arquillian/test-apps/servlet-authz/src/main/webapp/WEB-INF/web.xml
+++ b/testsuite/integration-arquillian/test-apps/servlet-authz/src/main/webapp/WEB-INF/web.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<web-app xmlns="http://java.sun.com/xml/ns/javaee"
-		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
-		 version="3.0">
+<web-app xmlns = "https://jakarta.ee/xml/ns/jakartaee"
+		 xmlns:xsi = "http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation = "https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd"
+		 version = "5.0">
 
 	<module-name>servlet-authz-app</module-name>
 

--- a/testsuite/integration-arquillian/test-apps/servlet-policy-enforcer/src/main/webapp/WEB-INF/web.xml
+++ b/testsuite/integration-arquillian/test-apps/servlet-policy-enforcer/src/main/webapp/WEB-INF/web.xml
@@ -17,10 +17,10 @@
   ~
   -->
 
-<web-app xmlns="http://java.sun.com/xml/ns/javaee"
-		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
-		 version="3.0">
+<web-app xmlns = "https://jakarta.ee/xml/ns/jakartaee"
+		 xmlns:xsi = "http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation = "https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd"
+		 version = "5.0">
 
 	<module-name>servlet-policy-enforcer</module-name>
 

--- a/testsuite/integration-arquillian/tests/base/pom.xml
+++ b/testsuite/integration-arquillian/tests/base/pom.xml
@@ -98,13 +98,13 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>org.subethamail</groupId>
-            <artifactId>subethasmtp</artifactId>
+            <groupId>com.icegreen</groupId>
+            <artifactId>greenmail</artifactId>
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>com.icegreen</groupId>
-            <artifactId>greenmail</artifactId>
+            <groupId>org.subethamail</groupId>
+            <artifactId>subethasmtp</artifactId>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
- adds dependency to saaj-impl in saml core public
- updates test apps' web.xml files to use jakarta namespaces
- small cleanup in main pom
- changes order of e-mail servers in testsuite pom to enforce usage of greenmail (changes order in Undertow's classpath)

Closes #16711

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
