### PR TITLE
Adding broker tests for custom display icon

### DIFF
--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/broker/oidc/TestKeycloakOidcIdentityProviderFactory.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/broker/oidc/TestKeycloakOidcIdentityProviderFactory.java
@@ -65,4 +65,14 @@ public class TestKeycloakOidcIdentityProviderFactory extends KeycloakOIDCIdentit
             }
         };
     }
+
+    @Override
+    public OIDCIdentityProviderConfig createConfig() {
+        return new OIDCIdentityProviderConfig(super.createConfig()) {
+            @Override
+            public String getDisplayIconClasses() {
+                return "my-custom-idp-icon";
+            }
+        };
+    }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcCustomOidcBrokerTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcCustomOidcBrokerTest.java
@@ -1,0 +1,56 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2023 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.testsuite.broker;
+
+import static org.keycloak.testsuite.broker.BrokerTestConstants.IDP_OIDC_ALIAS;
+import static org.keycloak.testsuite.broker.BrokerTestTools.createIdentityProvider;
+import static org.keycloak.testsuite.broker.BrokerTestTools.getConsumerRoot;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.keycloak.models.IdentityProviderSyncMode;
+import org.keycloak.representations.idm.IdentityProviderRepresentation;
+import org.keycloak.testsuite.broker.oidc.TestKeycloakOidcIdentityProviderFactory;
+
+/**
+ * Test methods for testing a custom OIDC broker
+ */
+public class KcCustomOidcBrokerTest extends AbstractInitializedBaseBrokerTest {
+
+    @Override
+    protected BrokerConfiguration getBrokerConfiguration() {
+        return new KcOidcCustomBrokerConfiguration();
+    }
+
+    private static class KcOidcCustomBrokerConfiguration extends KcOidcBrokerConfiguration {
+        
+        @Override
+        public IdentityProviderRepresentation setUpIdentityProvider(IdentityProviderSyncMode syncMode) {
+            IdentityProviderRepresentation idp = createIdentityProvider(IDP_OIDC_ALIAS, TestKeycloakOidcIdentityProviderFactory.ID);
+
+            applyDefaultConfiguration(idp.getConfig(), syncMode);
+
+            return idp;
+        }
+    }
+
+    @Test
+    public void testCustomDisplayIcon() {
+        driver.navigate().to(getAccountUrl(getConsumerRoot(), bc.consumerRealmName()));
+        Assert.assertTrue(driver.getPageSource().contains("my-custom-idp-icon"));
+    }
+}


### PR DESCRIPTION
Closes #15687

* Introduces an annotation to the test suite to ignore test methods from parent classes. Useful when you want to leverage capabilities from base/existing test classes without necessarily executing their methods to save test execution time.
* Test class for #15687. Had to do it here, in a separate PR, to keep the relevant change to the new annotation separated. 

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
