### PR TITLE
Operator: use TLS Edge termination when back-end protocol is HTTP

### DIFF
--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakIngress.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakIngress.java
@@ -65,13 +65,14 @@ public class KeycloakIngress extends OperatorManagedResource implements StatusUp
     private Ingress newIngress() {
         var port = KeycloakService.getServicePort(keycloak);
         var backendProtocol = (!isTlsConfigured(keycloak)) ? "HTTP" : "HTTPS";
+        var tlsTermination = "HTTP".equals(backendProtocol) ? "edge" : "passthrough";
 
         Ingress ingress = new IngressBuilder()
                 .withNewMetadata()
                     .withName(getName())
                     .withNamespace(getNamespace())
                     .addToAnnotations("nginx.ingress.kubernetes.io/backend-protocol", backendProtocol)
-                    .addToAnnotations("route.openshift.io/termination", "passthrough")
+                    .addToAnnotations("route.openshift.io/termination", tlsTermination)
                 .endMetadata()
                 .withNewSpec()
                     .withNewDefaultBackend()

--- a/operator/src/test/java/org/keycloak/operator/testsuite/unit/IngressLogicTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/unit/IngressLogicTest.java
@@ -17,14 +17,19 @@
 
 package org.keycloak.operator.testsuite.unit;
 
-import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
-import io.fabric8.kubernetes.api.model.networking.v1.IngressBuilder;
+import java.util.Optional;
+
 import org.junit.jupiter.api.Test;
 import org.keycloak.operator.controllers.KeycloakIngress;
-import org.keycloak.operator.crds.v2alpha1.deployment.spec.IngressSpec;
 import org.keycloak.operator.crds.v2alpha1.deployment.Keycloak;
+import org.keycloak.operator.crds.v2alpha1.deployment.spec.IngressSpec;
 import org.keycloak.operator.testsuite.utils.K8sUtils;
 
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
+import io.fabric8.kubernetes.api.model.networking.v1.IngressBuilder;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -32,24 +37,36 @@ public class IngressLogicTest {
 
     static class MockKeycloakIngress extends KeycloakIngress {
 
-        private static Keycloak getKeycloak(Boolean defaultIngressEnabled, boolean ingressSpecDefined) {
+        private static Keycloak getKeycloak(Boolean defaultIngressEnabled, boolean ingressSpecDefined, boolean tlsConfigured) {
             var kc = K8sUtils.getDefaultKeycloakDeployment();
             if (ingressSpecDefined) {
                 kc.getSpec().setIngressSpec(new IngressSpec());
                 if (defaultIngressEnabled != null) kc.getSpec().getIngressSpec().setIngressEnabled(defaultIngressEnabled);
             }
+            if (!tlsConfigured) {
+                kc.getSpec().getHttpSpec().setTlsSecret(null);
+            }
             return kc;
         }
 
         public static MockKeycloakIngress build(Boolean defaultIngressEnabled, boolean ingressExists, boolean ingressSpecDefined) {
+            return build(defaultIngressEnabled, ingressExists, ingressSpecDefined, true);
+        }
+
+        public static MockKeycloakIngress build(Boolean defaultIngressEnabled, boolean ingressExists, boolean ingressSpecDefined, boolean tlsConfigured) {
             MockKeycloakIngress.ingressExists = ingressExists;
-            return new MockKeycloakIngress(defaultIngressEnabled, ingressSpecDefined);
+            return new MockKeycloakIngress(defaultIngressEnabled, ingressSpecDefined, tlsConfigured);
         }
 
         public static boolean ingressExists = false;
         private boolean deleted = false;
-        public MockKeycloakIngress(Boolean defaultIngressEnabled, boolean ingressSpecDefined) {
-            super(null, getKeycloak(defaultIngressEnabled, ingressSpecDefined));
+        public MockKeycloakIngress(Boolean defaultIngressEnabled, boolean ingressSpecDefined, boolean tlsConfigured) {
+            super(null, getKeycloak(defaultIngressEnabled, ingressSpecDefined, tlsConfigured));
+        }
+
+        @Override
+        public Optional<HasMetadata> getReconciledResource() {
+            return super.getReconciledResource();
         }
 
         public boolean reconciled() {
@@ -115,5 +132,25 @@ public class IngressLogicTest {
         var kc = MockKeycloakIngress.build(null, false, true);
         assertTrue(kc.reconciled());
         assertFalse(kc.deleted());
+    }
+
+    @Test
+    public void testHttpSpecWithTlsSecret() {
+        var kc = MockKeycloakIngress.build(null, false, true, true);
+        Optional<HasMetadata> reconciled = kc.getReconciledResource();
+        assertTrue(reconciled.isPresent());
+        assertFalse(kc.deleted());
+        assertEquals("HTTPS", reconciled.get().getMetadata().getAnnotations().get("nginx.ingress.kubernetes.io/backend-protocol"));
+        assertEquals("passthrough", reconciled.get().getMetadata().getAnnotations().get("route.openshift.io/termination"));
+    }
+
+    @Test
+    public void testHttpSpecWithoutTlsSecret() {
+        var kc = MockKeycloakIngress.build(null, false, true, false);
+        Optional<HasMetadata> reconciled = kc.getReconciledResource();
+        assertTrue(reconciled.isPresent());
+        assertFalse(kc.deleted());
+        assertEquals("HTTP", reconciled.get().getMetadata().getAnnotations().get("nginx.ingress.kubernetes.io/backend-protocol"));
+        assertEquals("edge", reconciled.get().getMetadata().getAnnotations().get("route.openshift.io/termination"));
     }
 }


### PR DESCRIPTION
Keycloak Operator - Use TLS `edge` termination for ingress when the Keycloak back-end protocol is plain HTTP.

Fixes #16807

Signed-off-by: Michael Edgar <michael@xlate.io>

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
