### PR TITLE
change value column on user attribute

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/UserAttributeEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/UserAttributeEntity.java
@@ -57,7 +57,7 @@ public class UserAttributeEntity {
     @Column(name = "NAME")
     protected String name;
     @Nationalized
-    @Column(name = "VALUE")
+    @Column(name = "VALUE", columnDefinition = "TEXT")
     protected String value;
 
     public String getId() {


### PR DESCRIPTION
The default value which seems to be varchar(255) is a limitation when user attributes need to store more than that.

Related to #9758