### PR TITLE
Show proper product name in API documentation index page

### DIFF
--- a/distribution/api-docs-dist/src/index.html
+++ b/distribution/api-docs-dist/src/index.html
@@ -24,7 +24,7 @@
 </head>
 
 <body>
-<h1>${product.name.full} API Documentation</h1>
+<h1>Keycloak API Documentation</h1>
 <table>
     <tr>
         <td>Admin REST API</td>


### PR DESCRIPTION
Fixes the naming glitch seen on https://www.keycloak.org/docs-api/20.0.3/:

<img width="594" alt="image" src="https://user-images.githubusercontent.com/1470270/216921566-72c9251f-d34b-4240-ae90-2221deb9e0fd.png">

This is actually a follow-up to the issue originally mentioned at https://github.com/keycloak/keycloak/issues/16067.
