### PR TITLE
Removing references to old admin console test artifacts

### DIFF
--- a/testsuite/integration-arquillian/tests/other/webauthn/pom.xml
+++ b/testsuite/integration-arquillian/tests/other/webauthn/pom.xml
@@ -25,17 +25,6 @@
     <dependencies>
         <dependency>
             <groupId>org.keycloak.testsuite</groupId>
-            <artifactId>integration-arquillian-tests-console</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.keycloak.testsuite</groupId>
-            <artifactId>integration-arquillian-tests-console</artifactId>
-            <version>${project.version}</version>
-            <type>test-jar</type>
-        </dependency>
-        <dependency>
-            <groupId>org.keycloak.testsuite</groupId>
             <artifactId>integration-arquillian-tests-base-ui</artifactId>
             <version>${project.version}</version>
         </dependency>


### PR DESCRIPTION
* Removing references to `org.keycloak.testsuite:integration-arquillian-tests-console` artifact as it does not exist anymore