### PR TITLE
CVE-2022-45047 - Deserialization of Untrusted Data vulnerability in org.apache.sshd:sshd-common

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,8 @@
         <okhttp.version>4.10.0</okhttp.version>
         <!-- Override of SnakeYAML to fix multiple CVEs -->
         <org.yaml.snakeyaml.version>1.33</org.yaml.snakeyaml.version>
+        <!-- Override sshd-common to fix CVE-2022-45047 -->
+        <org.apache.sshd.version>2.9.2</org.apache.sshd.version>
 
         <!-- Openshift -->
         <version.com.openshift.openshift-restclient-java>9.0.5.Final</version.com.openshift.openshift-restclient-java>
@@ -316,6 +318,11 @@
                 <groupId>org.yaml</groupId>
                 <artifactId>snakeyaml</artifactId>
                 <version>${org.yaml.snakeyaml.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.sshd</groupId>
+                <artifactId>sshd-common</artifactId>
+                <version>${org.apache.sshd.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.jboss</groupId>


### PR DESCRIPTION

Backport of #16779

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
