### PR TITLE
Flaky test KcOidcBrokerTokenExchangeTest

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerTokenExchangeTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerTokenExchangeTest.java
@@ -61,6 +61,7 @@ import org.keycloak.testsuite.util.OAuthClient;
 import org.keycloak.util.BasicAuthHelper;
 import com.google.common.collect.ImmutableMap;
 
+@EnableFeatures({ @EnableFeature(Profile.Feature.TOKEN_EXCHANGE), @EnableFeature(Profile.Feature.ADMIN_FINE_GRAINED_AUTHZ) })
 public final class KcOidcBrokerTokenExchangeTest extends AbstractInitializedBaseBrokerTest {
 
     @Override
@@ -69,7 +70,6 @@ public final class KcOidcBrokerTokenExchangeTest extends AbstractInitializedBase
     }
 
     @Test
-    @EnableFeatures({ @EnableFeature(Profile.Feature.TOKEN_EXCHANGE), @EnableFeature(Profile.Feature.ADMIN_FINE_GRAINED_AUTHZ) })
     public void testExternalInternalTokenExchange() throws Exception {
         RealmResource providerRealm = realmsResouce().realm(bc.providerRealmName());
         ClientsResource clients = providerRealm.clients();


### PR DESCRIPTION
Closes #16896

The core issue is in our test suite and it might impact other tests using `EnableFeature` annotation at the method level.

By moving to the annotation at the class level makes the test more stable as the admin client is kept the same when running the after steps.
