### PR TITLE
Add admin/client as an area selection when creating a new bug.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -29,6 +29,7 @@ body:
         - admin/cli
         - admin/fine-grained-permissions
         - admin/ui
+        - admin/client
         - authentication
         - authentication/webauthn
         - authorization-services

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -29,7 +29,8 @@ body:
         - admin/cli
         - admin/fine-grained-permissions
         - admin/ui
-        - admin/client
+        - admin/client/node
+        - admin/client/java
         - authentication
         - authentication/webauthn
         - authorization-services


### PR DESCRIPTION
Closes #16918 

We are now officially maintaining the keycloak admin client from the keycloak/keycloak repo and we want new issues for it to be created in that repo. So the user needs to be able to select admin/client and have it automatically assign the area/admin/client label.
