### PR TITLE
Add retry logic to LoginActionsService#authenticate

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/models/utils/KeycloakModelUtils.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/KeycloakModelUtils.java
@@ -311,6 +311,7 @@ public final class KeycloakModelUtils {
                 } else {
                     if (retryCount == attemptsCount) {
                         logger.debug("Exhausted all retry attempts for request.");
+                        throw new RuntimeException("retries exceeded", re);
                     }
                     throw re;
                 }

--- a/services/src/main/java/org/keycloak/services/HttpResponseImpl.java
+++ b/services/src/main/java/org/keycloak/services/HttpResponseImpl.java
@@ -21,7 +21,7 @@ import org.keycloak.http.HttpResponse;
 
 public class HttpResponseImpl implements HttpResponse {
 
-    private org.jboss.resteasy.spi.HttpResponse delegate;
+    private final org.jboss.resteasy.spi.HttpResponse delegate;
 
     public HttpResponseImpl(org.jboss.resteasy.spi.HttpResponse delegate) {
         this.delegate = delegate;
@@ -34,11 +34,25 @@ public class HttpResponseImpl implements HttpResponse {
 
     @Override
     public void addHeader(String name, String value) {
+        checkCommitted();
         delegate.getOutputHeaders().add(name, value);
     }
 
     @Override
     public void setHeader(String name, String value) {
+        checkCommitted();
         delegate.getOutputHeaders().putSingle(name, value);
     }
+
+    /**
+     * Validate that the response has not been committed.
+     * If the response is already committed, the headers and part of the response have been sent already.
+     * Therefore, additional headers including cookies won't be delivered to the caller.
+     */
+    private void checkCommitted() {
+        if (delegate.isCommitted()) {
+            throw new IllegalStateException("response already committed, can't be changed");
+        }
+    }
+
 }

--- a/services/src/main/java/org/keycloak/services/resources/LoginActionsService.java
+++ b/services/src/main/java/org/keycloak/services/resources/LoginActionsService.java
@@ -17,6 +17,7 @@
 package org.keycloak.services.resources;
 
 import org.jboss.logging.Logger;
+import org.keycloak.common.util.ResponseSessionTask;
 import org.keycloak.http.HttpRequest;
 import org.keycloak.OAuth2Constants;
 import org.keycloak.TokenVerifier;
@@ -255,6 +256,20 @@ public class LoginActionsService {
                                  @QueryParam(Constants.EXECUTION) String execution,
                                  @QueryParam(Constants.CLIENT_ID) String clientId,
                                  @QueryParam(Constants.TAB_ID) String tabId) {
+        return KeycloakModelUtils.runJobInRetriableTransaction(session.getKeycloakSessionFactory(), new ResponseSessionTask(session) {
+            @Override
+            public Response runInternal(KeycloakSession session) {
+                // create another instance of the endpoint to isolate each run.
+                LoginActionsService other = new LoginActionsService(session, new EventBuilder(session.getContext().getRealm(), session, clientConnection));
+                // process the request in the created instance.
+                return other.authenticateInternal(authSessionId, code, execution, clientId, tabId);
+            }
+        }, 10, 100);
+
+    }
+
+    private Response authenticateInternal(final String authSessionId, final String code, final String execution,
+                                          final String clientId, final String tabId) {
         event.event(EventType.LOGIN);
 
         SessionCodeChecks checks = checksForCode(authSessionId, code, execution, clientId, tabId, AUTHENTICATE_PATH);


### PR DESCRIPTION
In addition to that, avoid adding cookies on each retry.

This addresses an issue found when running Keycloak on Minikube/Kubernetes: The nginx Ingress has a limited buffer for headers, which triggered a (hard to find) error on requests that were retried. This is a common scenarios, and Keycloak should add the Cookies only when the retry is successful. 

Closes #15849

Supersedes #16772 
