### PR TITLE
Recovery codes input error not displayed in the standardized way

### DIFF
--- a/themes/src/main/resources/theme/base/login/login-recovery-authn-code-input.ftl
+++ b/themes/src/main/resources/theme/base/login/login-recovery-authn-code-input.ftl
@@ -1,5 +1,5 @@
 <#import "template.ftl" as layout>
-<@layout.registrationLayout; section>
+<@layout.registrationLayout displayMessage=!messagesPerField.existsError('recoveryCodeInput'); section>
 
     <#if section = "header">
         ${msg("auth-recovery-code-header")}
@@ -11,7 +11,19 @@
                 </div>
 
                 <div class="${properties.kcInputWrapperClass!}">
-                    <input id="recoveryCodeInput" name="recoveryCodeInput" autocomplete="off" type="text" class="${properties.kcInputClass!}" autofocus/>
+                    <input tabindex="1" id="recoveryCodeInput"
+                           name="recoveryCodeInput"
+                           aria-invalid="<#if messagesPerField.existsError('recoveryCodeInput')>true</#if>"
+                           autocomplete="off"
+                           type="text"
+                           class="${properties.kcInputClass!}"
+                           autofocus/>
+
+                    <#if messagesPerField.existsError('recoveryCodeInput')>
+                        <span id="input-error" class="${properties.kcInputErrorMessageClass!}" aria-live="polite">
+                            ${kcSanitize(messagesPerField.get('recoveryCodeInput'))?no_esc}
+                        </span>
+                    </#if>
                 </div>
             </div>
 


### PR DESCRIPTION
Closes #16921

@ssilvert Could you please check it? Thanks

Old:
<image src="https://user-images.githubusercontent.com/38039883/217605218-6533f100-927c-4908-a16a-ffd4cbb4442f.png" width="400"/>

New:
<image src="https://user-images.githubusercontent.com/38039883/217605396-85dd25a5-5713-47a4-a002-4ec231d59e3b.png" width="400"/>