### PR TITLE
Reduce the redundant tests in fips-suite

### DIFF
--- a/testsuite/integration-arquillian/tests/base/testsuites/fips-suite
+++ b/testsuite/integration-arquillian/tests/base/testsuites/fips-suite
@@ -1,4 +1,6 @@
-org.keycloak.testsuite.forms.**
+LoginTest
+LoginTotpTest
+PasswordHashingTest
 ClientAuthSignedJWTTest
 CredentialsTest
 JavaKeystoreKeyProviderTest


### PR DESCRIPTION
Closes #16969

@pedroigor @rmartinc Are you guys fine with this change in fips-suite? Should reduce the time needed for `fips-suite` by removing some redundant tests, not strictly relying on crypto/fips stuff. See the issue description for more details.
