### PR TITLE
Trivy Workflow failing with context deadline exceeded

### DIFF
--- a/.github/workflows/trivy-analysis.yml
+++ b/.github/workflows/trivy-analysis.yml
@@ -29,6 +29,8 @@ jobs:
           output: trivy-results.sarif
           severity: MEDIUM,CRITICAL,HIGH
           ignore-unfixed: true
+          security-checks: vuln
+          timeout: 15m
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v2.2.1


### PR DESCRIPTION
The changes proposed here introduce two new settings to the workflow: 
1. security-checks: prevents Trivy for scanning the container image for secrets and focus only on CVEs on third-party dependencies. More details: https://aquasecurity.github.io/trivy/v0.28.1/docs/secret/scanning/
2. timeout: increases the timeout, the default was 5 minutes.

Closes #16974

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->

### Evidence of a successful run with the changes proposed here:
- https://github.com/keycloak-poc/keycloak/actions/runs/4135877800