### PR TITLE
lastSync value into COMPONENT_CONFIG is always updated

### DIFF
--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/federation/sync/IgnoredDummyUserFederationProviderFactory.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/federation/sync/IgnoredDummyUserFederationProviderFactory.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite.federation.sync;
+
+import java.util.Date;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.storage.UserStorageProviderModel;
+import org.keycloak.storage.user.SynchronizationResult;
+import org.keycloak.testsuite.federation.DummyUserFederationProviderFactory;
+
+/**
+ * <p>Test UserStorageProviderFactory in which sync methods are always ignored.</p>
+ *
+ * @author rmartinc
+ */
+public class IgnoredDummyUserFederationProviderFactory extends DummyUserFederationProviderFactory {
+
+    public static final String IGNORED_PROVIDER_ID = "ignored-dummy";
+
+    @Override
+    public String getId() {
+        return IGNORED_PROVIDER_ID;
+    }
+
+    @Override
+    public SynchronizationResult sync(KeycloakSessionFactory sessionFactory, String realmId, UserStorageProviderModel model) {
+        return SynchronizationResult.ignored();
+    }
+
+    @Override
+    public SynchronizationResult syncSince(Date lastSync, KeycloakSessionFactory sessionFactory, String realmId, UserStorageProviderModel model) {
+        return SynchronizationResult.ignored();
+    }
+}

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/resources/META-INF/services/org.keycloak.storage.UserStorageProviderFactory
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/resources/META-INF/services/org.keycloak.storage.UserStorageProviderFactory
@@ -5,3 +5,4 @@ org.keycloak.testsuite.federation.UserMapStorageFactory
 org.keycloak.testsuite.federation.UserPropertyFileStorageFactory
 org.keycloak.testsuite.federation.PassThroughFederatedUserStorageProviderFactory
 org.keycloak.testsuite.federation.sync.SyncDummyUserFederationProviderFactory
+org.keycloak.testsuite.federation.sync.IgnoredDummyUserFederationProviderFactory

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/sync/SyncFederationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/sync/SyncFederationTest.java
@@ -320,6 +320,46 @@ public class SyncFederationTest extends AbstractAuthTest {
         });
     }
 
+    @Test
+    public void test04IgnoredSync() throws Exception {
+        // Add IgnoredDummyUserFederationProviderFactory provider
+        testingClient.server().run(session -> {
+            RealmModel appRealm = session.realms().getRealmByName(AuthRealm.TEST);
+            UserStorageProviderModel model = new UserStorageProviderModel();
+            model.setProviderId(IgnoredDummyUserFederationProviderFactory.IGNORED_PROVIDER_ID);
+            model.setPriority(1);
+            model.setName("test-sync-dummy");
+            model.setFullSyncPeriod(-1);
+            model.setChangedSyncPeriod(-1);
+            model.setLastSync(0);
+            appRealm.addComponentModel(model);
+        });
+
+        // run both sync methods that will be ignored
+        testingClient.server().run(session -> {
+            RealmModel appRealm = session.realms().getRealmByName(AuthRealm.TEST);
+            UserStorageProviderModel dummyModel = findDummyProviderModel(appRealm);
+            KeycloakSessionFactory sessionFactory = session.getKeycloakSessionFactory();
+            SynchronizationResult syncResult = UserStorageSyncManager.syncAllUsers(sessionFactory, appRealm.getId(), dummyModel);
+            Assert.assertTrue(syncResult.isIgnored());
+            syncResult = UserStorageSyncManager.syncChangedUsers(sessionFactory, appRealm.getId(), dummyModel);
+            Assert.assertTrue(syncResult.isIgnored());
+        });
+
+        // assert the last sync is not updated
+        testingClient.server().run(session -> {
+            RealmModel appRealm = session.realms().getRealmByName(AuthRealm.TEST);
+            UserStorageProviderModel dummyModel = findDummyProviderModel(appRealm);
+            Assert.assertEquals(0, dummyModel.getLastSync());
+        });
+
+        // remove provider
+        testingClient.server().run(session -> {
+            RealmModel appRealm = session.realms().getRealmByName(AuthRealm.TEST);
+            UserStorageProviderModel dummyModel = findDummyProviderModel(appRealm);
+            appRealm.removeComponent(dummyModel);
+        });
+    }
 
     private static void sleep(long ms) {
         try {


### PR DESCRIPTION
Closes https://github.com/keycloak/keycloak/issues/17022

Just updating the `lastSync` if the result is not ignored. Following the proposal in the issue description, except that the time is taken before start the sync process to not lose possible changes generated during sync.

Little test added with a provider that always ignores any change.
