### PR TITLE
Handle requests with a `FormData` payload

### DIFF
--- a/js/libs/keycloak-admin-client/src/resources/agent.ts
+++ b/js/libs/keycloak-admin-client/src/resources/agent.ts
@@ -209,6 +209,8 @@ export class Agent {
     } else if (requestHeaders.get("content-type") === "text/plain") {
       // Pass the payload as a plain string if the content type is 'text/plain'.
       requestOptions.body = payload as unknown as string;
+    } else if (payload instanceof FormData) {
+      requestOptions.body = payload;
     } else {
       // Otherwise assume it's JSON and stringify it.
       requestOptions.body = JSON.stringify(
@@ -216,7 +218,7 @@ export class Agent {
       );
     }
 
-    if (!requestHeaders.has("content-type")) {
+    if (!requestHeaders.has("content-type") && !(payload instanceof FormData)) {
       requestHeaders.set("content-type", "application/json");
     }
 

--- a/js/libs/keycloak-admin-client/src/resources/clients.ts
+++ b/js/libs/keycloak-admin-client/src/resources/clients.ts
@@ -979,7 +979,10 @@ export class Clients extends Resource<{ realm?: string }> {
     },
   });
 
-  public uploadKey = this.makeUpdateRequest<{ id: string; attr: string }, any>({
+  public uploadKey = this.makeUpdateRequest<
+    { id: string; attr: string },
+    FormData
+  >({
     method: "POST",
     path: "/{id}/certificates/{attr}/upload",
     urlParamKeys: ["id", "attr"],
@@ -987,7 +990,7 @@ export class Clients extends Resource<{ realm?: string }> {
 
   public uploadCertificate = this.makeUpdateRequest<
     { id: string; attr: string },
-    any
+    FormData
   >({
     method: "POST",
     path: "/{id}/certificates/{attr}/upload-certificate",


### PR DESCRIPTION
Updates the admin client so that it can properly handle payloads that are [`FormData`](https://developer.mozilla.org/en-US/docs/Web/API/FormData).