### PR TITLE
Upgrade to ubi9 parent image

### DIFF
--- a/quarkus/container/Dockerfile
+++ b/quarkus/container/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8 AS ubi-micro-build
+FROM registry.access.redhat.com/ubi9 AS ubi-micro-build
 
 ENV KEYCLOAK_VERSION 999-SNAPSHOT
 ARG KEYCLOAK_DIST=https://github.com/keycloak/keycloak/releases/download/$KEYCLOAK_VERSION/keycloak-$KEYCLOAK_VERSION.tar.gz
@@ -16,10 +16,10 @@ RUN (cd /tmp/keycloak && \
 RUN mv /tmp/keycloak/keycloak-* /opt/keycloak && mkdir -p /opt/keycloak/data
 RUN chmod -R g+rwX /opt/keycloak
 
-ADD ubi8-null.sh /tmp/
-RUN bash /tmp/ubi8-null.sh java-17-openjdk-headless glibc-langpack-en
+ADD ubi-null.sh /tmp/
+RUN bash /tmp/ubi-null.sh java-17-openjdk-headless glibc-langpack-en
 
-FROM registry.access.redhat.com/ubi8-micro
+FROM registry.access.redhat.com/ubi9-micro
 ENV LANG en_US.UTF-8
 
 COPY --from=ubi-micro-build /tmp/null/rootfs/ /

--- a/quarkus/container/ubi-null.sh
+++ b/quarkus/container/ubi-null.sh
@@ -26,6 +26,7 @@ info
 gawk
 platform-python
 platform-python-setuptools
+python3
 python3-libs
 python3-pip-wheel
 python3-setuptools-wheel
@@ -63,9 +64,10 @@ do
     <keep xargs rpm -r "$rootfs" -q --requires | sort -Vu | cut -d ' ' -f1 \
         | grep -v -e '^rpmlib(' \
         | xargs -d $'\n' rpm -r "$rootfs" -q --whatprovides \
+        | grep -v -e '^no package provides' \
         | sed -r 's/^(.*)-.*-.*$/\1/' \
         | grep -vxF -f disallow  \
-        > new
+        > new || true
 
     # Safely replace the keep list, appending the new names
     mv keep old

--- a/quarkus/tests/integration/src/main/java/org/keycloak/it/utils/DockerKeycloakDistribution.java
+++ b/quarkus/tests/integration/src/main/java/org/keycloak/it/utils/DockerKeycloakDistribution.java
@@ -30,7 +30,7 @@ public final class DockerKeycloakDistribution implements KeycloakDistribution {
 
     private File distributionFile = new File("../../dist/target/keycloak-" + Version.VERSION + ".tar.gz");
     private File dockerFile = new File("../../container/Dockerfile");
-    private File dockerScriptFile = new File("../../container/ubi8-null.sh");
+    private File dockerScriptFile = new File("../../container/ubi-null.sh");
 
     private GenericContainer<?> keycloakContainer = null;
     private String containerId = null;
@@ -49,7 +49,7 @@ public final class DockerKeycloakDistribution implements KeycloakDistribution {
         return new GenericContainer(
                 new ImageFromDockerfile("keycloak-under-test", false)
                         .withFileFromFile("keycloak.tar.gz", distributionFile)
-                        .withFileFromFile("ubi8-null.sh", dockerScriptFile)
+                        .withFileFromFile("ubi-null.sh", dockerScriptFile)
                         .withFileFromFile("Dockerfile", dockerFile)
                         .withBuildArg("KEYCLOAK_DIST", "keycloak.tar.gz")
         )


### PR DESCRIPTION
This PR switches the Quarkus Dockerfile to use `ubi9` parent images instead of `ubi8` ones.

-null.sh has some minor changes to handle differences in RHEL 9. It's also been renamed for ubi9.

Closes #17057

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
