### PR TITLE
Set working directory in Dockerfile

### DIFF
--- a/quarkus/container/Dockerfile
+++ b/quarkus/container/Dockerfile
@@ -29,8 +29,9 @@ RUN echo "keycloak:x:0:root" >> /etc/group && \
     echo "keycloak:x:1000:0:keycloak user:/opt/keycloak:/sbin/nologin" >> /etc/passwd
 
 USER 1000
+WORKDIR /opt/keycloak
 
 EXPOSE 8080
 EXPOSE 8443
 
-ENTRYPOINT [ "/opt/keycloak/bin/kc.sh" ]
+ENTRYPOINT [ "bin/kc.sh" ]


### PR DESCRIPTION
This PR adds the `WORKDIR /opt/keycloak` instruction into the Dockerfile. Without this instruction, Keycloak would run in the root directory (`/`). 
This modification is essential for starting Keycloak container with the `QUARKUS_TRANSACTION_MANAGER_ENABLE_RECOVERY=true` environment variable. #15255