### PR TITLE
Support loading TLS keys from a PKCS11 keystore

### DIFF
--- a/docs/guides/src/main/server/enabletls.adoc
+++ b/docs/guides/src/main/server/enabletls.adoc
@@ -34,6 +34,27 @@ You can set a secure password for your keystore using the `https-key-store-passw
 
 If no password is set, the default password `password` is used.
 
+==== Using a PKCS#11 Keystore
+
+Keycloak supports loading key material from a Hardware Security Device (HSM) that is compatible with the PKCS#11 standard so that
+the server can use it as a regular keystore.
+
+Before configuring a PKCS#11 keystore you need to make sure the environment where the server is installed is properly configured with
+the necessary modules and configuration files to make it possible to access your cryptographic device using a PKCS#11 compliant Java Security Provider, usually the `SunPKCS11` security provider.
+For more details, please take a look at https://docs.oracle.com/en/java/javase/17/security/pkcs11-reference-guide1.html[PKCS#11 Reference Guide] from the Java documentation.
+The installation and configuration of such modules is out of the scope of this guide as they are specific to the device you are using.
+
+To configure a PKCS#11 Keystore you need to set the following options:
+
+<@kc.start parameters="--https-key-store-type=PKCS11 --https-key-store-password=mypin --pkcs11-config-file=/path/to/pkcs11-conf-file"/>
+
+The `https-key-store-type` option must be set to `PKCS11` to indicate to the server that key material should be loaded using a PKCS#11 compliant Java
+security provider.
+
+The `https-key-store-password` option must be set to provide the `PIN` that will be used to access your PKCS#11 keystore.
+
+The `pkcs11-config-file` option allows you to dynamically set the configuration for the default PKCS#11 compliant Java security provider.
+
 == Configuring TLS protocols
 By default, Keycloak does not enable deprecated TLS protocols.
 If your client supports only deprecated protocols, consider upgrading the client.

--- a/quarkus/config-api/src/main/java/org/keycloak/config/SecurityOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/SecurityOptions.java
@@ -10,4 +10,10 @@ public class SecurityOptions {
             .description("Sets the FIPS mode. If 'enabled' is set, FIPS is enabled but on non-approved mode. For full FIPS compliance, set 'strict' to run on approved mode.")
             .defaultValue(FipsMode.disabled)
             .build();
+
+    public static final Option<String> PKCS11_CONFIG_FILE = new OptionBuilder<>("pkcs11-config-file", String.class)
+            .category(OptionCategory.SECURITY)
+            .buildTime(true)
+            .description("The path to a file to be used to configure the underlying PKCS11 security provider.")
+            .build();
 }

--- a/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
+++ b/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
@@ -629,8 +629,10 @@ class KeycloakProcessor {
         FipsMode fipsMode = Configuration.getOptionalValue(
                 MicroProfileConfigProvider.NS_KEYCLOAK_PREFIX + SecurityOptions.FIPS_MODE.getKey()).map(
                 FipsMode::valueOf).orElse(FipsMode.disabled);
+        String pkcsConfigFilePath = Configuration.getRawValue(
+                MicroProfileConfigProvider.NS_KEYCLOAK_PREFIX + SecurityOptions.PKCS11_CONFIG_FILE.getKey());
 
-        recorder.setCryptoProvider(fipsMode);
+        recorder.setCryptoProvider(fipsMode, pkcsConfigFilePath);
     }
 
     @BuildStep(onlyIf = IsDevelopment.class)

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/SecurityPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/SecurityPropertyMappers.java
@@ -19,6 +19,9 @@ final class SecurityPropertyMappers {
         return new PropertyMapper[] {
                 fromOption(SecurityOptions.FIPS_MODE).transformer(SecurityPropertyMappers::resolveFipsMode)
                         .paramLabel("mode")
+                        .build(),
+                fromOption(SecurityOptions.PKCS11_CONFIG_FILE)
+                        .paramLabel("path")
                         .build()
         };
     }
@@ -29,17 +32,5 @@ final class SecurityPropertyMappers {
         }
 
         return of(FipsMode.valueOf(value.get()).toString());
-    }
-
-    private static Optional<String> resolveSecurityProvider(Optional<String> value,
-            ConfigSourceInterceptorContext configSourceInterceptorContext) {
-        FipsMode fipsMode = value.map(FipsMode::valueOf)
-                .orElse(FipsMode.disabled);
-
-        if (fipsMode.isFipsEnabled()) {
-            return of("BCFIPS");
-        }
-
-        return value;
     }
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/integration/web/KeycloakHttpServerOptionsCustomizer.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/integration/web/KeycloakHttpServerOptionsCustomizer.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.quarkus.runtime.integration.web;
+
+import static org.eclipse.microprofile.config.inject.ConfigProperty.UNCONFIGURED_VALUE;
+
+import java.security.KeyStore;
+import java.util.Optional;
+import java.util.function.Function;
+import javax.enterprise.context.ApplicationScoped;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.X509KeyManager;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import io.quarkus.vertx.http.HttpServerOptionsCustomizer;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpServerOptions;
+import io.vertx.core.net.JksOptions;
+import io.vertx.core.net.impl.KeyStoreHelper;
+
+@ApplicationScoped
+public class KeycloakHttpServerOptionsCustomizer implements HttpServerOptionsCustomizer {
+
+    private static final String PKCS11_KEY_STORE_TYPE = "PKCS11";
+
+    @ConfigProperty(name = "kc.https-key-store-type", defaultValue = "none")
+    String httpsKeyStoreType;
+
+    @ConfigProperty(name = "kc.https-key-store-password")
+    String httpsKeyStorePassword;
+
+    private KeyStoreHelper keyStoreHelper;
+
+    @Override
+    public void customizeHttpsServer(HttpServerOptions options) {
+        if (PKCS11_KEY_STORE_TYPE.equalsIgnoreCase(httpsKeyStoreType)) {
+            try {
+                keyStoreHelper = new KeyStoreHelper(loadPkcs11KeyStore(), httpsKeyStorePassword, null);
+                options.setKeyStoreOptions(createPkcs11KeyStoreOptions(keyStoreHelper));
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    private KeyStore loadPkcs11KeyStore() {
+        try {
+            KeyStore ks = KeyStore.getInstance(httpsKeyStoreType);
+
+            ks.load(null, Optional.ofNullable(httpsKeyStorePassword).map(String::toCharArray).orElse(null));
+
+            return ks;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private JksOptions createPkcs11KeyStoreOptions(KeyStoreHelper keyStoreHelper) {
+        return new JksOptions() {
+            @Override
+            public JksOptions copy() {
+                return this;
+            }
+
+            @Override
+            public KeyManagerFactory getKeyManagerFactory(Vertx vertx) throws Exception {
+                return keyStoreHelper.getKeyMgrFactory();
+            }
+
+            @Override
+            public Function<String, X509KeyManager> keyManagerMapper(Vertx vertx) throws Exception {
+                return keyStoreHelper::getKeyMgr;
+            }
+        };
+    }
+}

--- a/quarkus/tests/integration/src/test/resources/Dockerfile.pkcs11
+++ b/quarkus/tests/integration/src/test/resources/Dockerfile.pkcs11
@@ -1,0 +1,20 @@
+FROM quay.io/keycloak/keycloak:latest AS keycloak-base
+
+FROM fedora:latest
+ENV LANG en_US.UTF-8
+
+COPY --from=keycloak-base --chown=1000:0 /opt/keycloak /opt/keycloak
+
+RUN echo "keycloak:x:0:root" >> /etc/group && \
+    echo "keycloak:x:1000:0:keycloak user:/opt/keycloak:/sbin/nologin" >> /etc/passwd
+
+RUN dnf update -y && \
+   dnf install -y --nodocs softhsm && \
+   dnf install -y --nodocs java-17-openjdk-headless
+
+USER 1000
+
+EXPOSE 8080
+EXPOSE 8443
+
+ENTRYPOINT [ "/opt/keycloak/bin/kc.sh" ]


### PR DESCRIPTION
Closes #17098

* Allow using PKCS#11 to load key material from a PKCs#11 compliant cryptographic device
* Added a `pkcs11-config-file` build option to make it easier to configure the `SunPKCS11` security provider and avoid users statically/manually setting the provider configuration in the Java security properties.
* Customize Quarkus `HttpServerOptions` to enable HTTPS even though no key store file is provided.
* For now, we assume the `PIN` provided via `https-key-store-password` is the same for any key alias in the keystore.

I'm not sure yet how to test this because we are going to need something [SoftHSM](https://github.com/keycloak/keycloak/issues/17098#issuecomment-1430508939) installed in the CI/CD env. 

We can also use a custom docker file in our test suite to run tests using a container where SoftHSM is pre-installed. I did not manage to achieve that because I'm not able to install SoftHSM using our container image as a base image (even after executing `microdnf` as `root`). Any help is appreciated.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
