### PR TITLE
Doublecheck if we need to override properties in java.security

### DIFF
--- a/.github/scripts/run-fips-it.sh
+++ b/.github/scripts/run-fips-it.sh
@@ -14,4 +14,5 @@ echo "STRICT_OPTIONS: $STRICT_OPTIONS"
 TESTS=`testsuite/integration-arquillian/tests/base/testsuites/suite.sh fips`
 echo "Tests: $TESTS"
 export JAVA_HOME=/etc/alternatives/java_sdk_17
+set -o pipefail
 ./mvnw test -Dsurefire.rerunFailingTestsCount=$SUREFIRE_RERUN_FAILING_COUNT -nsu -B -Pauth-server-quarkus,auth-server-fips140-2 -Dcom.redhat.fips=false $STRICT_OPTIONS -Dtest=$TESTS -pl testsuite/integration-arquillian/tests/base | misc/log/trimmer.sh

--- a/crypto/fips1402/src/main/java/org/keycloak/crypto/fips/KeycloakFipsSecurityProvider.java
+++ b/crypto/fips1402/src/main/java/org/keycloak/crypto/fips/KeycloakFipsSecurityProvider.java
@@ -48,7 +48,7 @@ public class KeycloakFipsSecurityProvider extends Provider {
             isSystemFipsEnabled.setAccessible(true);
             return (boolean) isSystemFipsEnabled.invoke(null);
         } catch (Throwable ignore) {
-            logger.warn("Could not detect if FIPS is enabled from the host");
+            logger.debug("Could not detect if FIPS is enabled from the host");
         } finally {
             if (isSystemFipsEnabled != null) {
                 isSystemFipsEnabled.setAccessible(false);

--- a/integration/client-cli/admin-cli/src/main/bin/kcadm.bat
+++ b/integration/client-cli/admin-cli/src/main/bin/kcadm.bat
@@ -5,4 +5,4 @@ if "%OS%" == "Windows_NT" (
 ) else (
   set DIRNAME=.\
 )
-java %KC_OPTS% -cp "%DIRNAME%\client\keycloak-admin-cli-${project.version}.jar" -Dkc.lib.dir="%DIRNAME%\client\lib" org.keycloak.client.admin.cli.KcAdmMain %*
+java %KC_OPTS% -cp "%DIRNAME%\client\keycloak-admin-cli-${project.version}.jar" --add-opens=java.base/java.security=ALL-UNNAMED -Dkc.lib.dir="%DIRNAME%\client\lib" org.keycloak.client.admin.cli.KcAdmMain %*

--- a/integration/client-cli/admin-cli/src/main/bin/kcadm.sh
+++ b/integration/client-cli/admin-cli/src/main/bin/kcadm.sh
@@ -29,4 +29,4 @@ if [ "x$JAVA" = "x" ]; then
     fi
 fi
 
-"$JAVA" $KC_OPTS -cp $DIRNAME/client/keycloak-admin-cli-${project.version}.jar -Dkc.lib.dir=$DIRNAME/client/lib org.keycloak.client.admin.cli.KcAdmMain "$@"
+"$JAVA" $KC_OPTS -cp $DIRNAME/client/keycloak-admin-cli-${project.version}.jar --add-opens=java.base/java.security=ALL-UNNAMED -Dkc.lib.dir=$DIRNAME/client/lib org.keycloak.client.admin.cli.KcAdmMain "$@"

--- a/integration/client-cli/client-registration-cli/src/main/bin/kcreg.bat
+++ b/integration/client-cli/client-registration-cli/src/main/bin/kcreg.bat
@@ -5,4 +5,4 @@ if "%OS%" == "Windows_NT" (
 ) else (
   set DIRNAME=.\
 )
-java %KC_OPTS% -cp "%DIRNAME%\client\keycloak-client-registration-cli-${project.version}.jar" -Dkc.lib.dir="%DIRNAME%\client\lib" org.keycloak.client.registration.cli.KcRegMain %*
+java %KC_OPTS% -cp "%DIRNAME%\client\keycloak-client-registration-cli-${project.version}.jar" --add-opens=java.base/java.security=ALL-UNNAMED -Dkc.lib.dir="%DIRNAME%\client\lib" org.keycloak.client.registration.cli.KcRegMain %*

--- a/integration/client-cli/client-registration-cli/src/main/bin/kcreg.sh
+++ b/integration/client-cli/client-registration-cli/src/main/bin/kcreg.sh
@@ -28,4 +28,4 @@ if [ "x$JAVA" = "x" ]; then
 fi
 
 DIRNAME=`dirname "$RESOLVED_NAME"`
-"$JAVA" $KC_OPTS -cp $DIRNAME/client/keycloak-client-registration-cli-${project.version}.jar -Dkc.lib.dir=$DIRNAME/client/lib org.keycloak.client.registration.cli.KcRegMain "$@"
+"$JAVA" $KC_OPTS -cp $DIRNAME/client/keycloak-client-registration-cli-${project.version}.jar --add-opens=java.base/java.security=ALL-UNNAMED -Dkc.lib.dir=$DIRNAME/client/lib org.keycloak.client.registration.cli.KcRegMain "$@"

--- a/quarkus/dist/src/main/content/bin/kc.bat
+++ b/quarkus/dist/src/main/content/bin/kc.bat
@@ -81,7 +81,7 @@ if not "x%JAVA_OPTS%" == "x" (
 if not "x%JAVA_ADD_OPENS%" == "x" (
   echo "JAVA_ADD_OPENS already set in environment; overriding default settings with values: %JAVA_ADD_OPENS%"
 ) else (
-  set "JAVA_ADD_OPENS=--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED"
+  set "JAVA_ADD_OPENS=--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.base/java.security=ALL-UNNAMED"
 )
 set "JAVA_OPTS=%JAVA_OPTS% %JAVA_ADD_OPENS%"
 

--- a/quarkus/dist/src/main/content/bin/kc.sh
+++ b/quarkus/dist/src/main/content/bin/kc.sh
@@ -92,7 +92,7 @@ fi
 
 # See also https://github.com/wildfly/wildfly-core/blob/7e5624cf92ebe4b64a4793a8c0b2a340c0d6d363/core-feature-pack/common/src/main/resources/content/bin/common.sh#L57-L60
 if [ "x$JAVA_ADD_OPENS" = "x" ]; then
-   JAVA_ADD_OPENS="--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED"
+   JAVA_ADD_OPENS="--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.base/java.security=ALL-UNNAMED"
 else
    echo "JAVA_ADD_OPENS already set in environment; overriding default settings with values: $JAVA_ADD_OPENS"
 fi

--- a/testsuite/integration-arquillian/servers/auth-server/common/fips/kc.java.security
+++ b/testsuite/integration-arquillian/servers/auth-server/common/fips/kc.java.security
@@ -5,55 +5,10 @@
 # and the non-fips based (EG. when running the tests on GH actions)
 
 #
-# List of providers and their preference orders (see above). Used on the host without FIPS (EG. when running the tests on GH actions)
-# Uses only BouncyCastle FIPS providers to make sure to use only FIPS compliant cryptography.
-#
-#security.provider.1=org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider
-#security.provider.2=org.bouncycastle.jsse.provider.BouncyCastleJsseProvider fips:BCFIPS
-#security.provider.3=
-
-#
 # Security providers used when global crypto-policies are set to FIPS (Usually it is used when FIPS enabled on system/JVM level)
 #
 # NOTE: This list of providers is needed to be override just because XMLDSig provider is not yet present on the OpenJDK 17 by default on the RHEL FIPS host on OpenJDK 17.0.3.
 # However once it is present, there won't be a need to override this and this part can be fully commented/removed.
 # TODO: Comment/remove this once https://bugzilla.redhat.com/show_bug.cgi?id=1940064 is fixed and OpenJDK 17 updated to corresponding version where XMLDSig is available by default
 #
-fips.provider.1=SunPKCS11 ${java.home}/conf/security/nss.fips.cfg
-fips.provider.2=SUN
-fips.provider.3=SunEC
-fips.provider.4=SunJSSE
-fips.provider.5=SunJCE
-fips.provider.6=SunRsaSign
 fips.provider.7=XMLDSig
-
-# Commented this provider for now (and also other providers) as it uses lots of non-FIPS services.
-# See https://access.redhat.com/documentation/en-us/openjdk/11/html-single/configuring_openjdk_11_on_rhel_with_fips/index#ref_openjdk-default-fips-configuration_openjdk
-# fips.provider.2=SUN
-
-#
-# Default keystore type.
-#
-keystore.type=PKCS12
-fips.keystore.type=PKCS12
-
-# This is needed especially if we cannot add security provider "com.sun.net.ssl.internal.ssl.Provider BCFIPS" as a security provider.
-# OpenJDK has "SunX509" as default algorithm, but that one is not supported by BCJSSE. So adding the Sun provider delegating to BCFIPS is needed (as above)
-# or changing default algorithm as described here
-ssl.KeyManagerFactory.algorithm=PKIX
-fips.ssl.KeyManagerFactory.algorithm=PKIX
-
-ssl.TrustManagerFactory.algorithm=PKIX
-fips.ssl.TrustManagerFactory.algorithm=PKIX
-
-#
-# Controls compatibility mode for JKS and PKCS12 keystore types.
-#
-# When set to 'true', both JKS and PKCS12 keystore types support loading
-# keystore files in either JKS or PKCS12 format. When set to 'false' the
-# JKS keystore type supports loading only JKS keystore files and the PKCS12
-# keystore type supports loading only PKCS12 keystore files.
-#
-# This is set to true as when set to false on OpenJDK 17 and PKCS12 is default keystore type, loading of default truststore (from java cacerts) fails.
-#keystore.type.compat=false
-#fips.keystore.type.compat=false


### PR DESCRIPTION
Closes https://github.com/keycloak/keycloak/issues/16702

Changing our `kc.java.security` to be again default `ssl.KeyManagerFactory.algorithm=SunX509`. The `FIPS1402Provider` now forces implementations for `KeyManagerFactory` and `TrustManagerFactory` if the default one is missing when inserting the BCJSSE provider.

Setting `--add-opens=java.base/java.security=ALL-UNNAMED` to the scripts after https://github.com/keycloak/keycloak/issues/12428 to enable the FIPS detection in RH JDK 17. Changing warn message to debug too because JDK-17 tests fail with non RH JDKs (temurin for example with `KcAdmTest` or `KcRegTest`, the warn message interferes with the output and the tests fail). I have also added `set -o pipefail` to the IT script because the pipe make it return 0 with failed maven. So this also closes #17106 and #17108.

With this one the only addition needed is `fips.provider.7=XMLDSig` which is pending in [openjdk](https://bugzilla.redhat.com/show_bug.cgi?id=1940064).
