### PR TITLE
Fix search user groups without limit

### DIFF
--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/UserResource.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/UserResource.java
@@ -74,7 +74,12 @@ public interface UserResource {
     List<GroupRepresentation> groups(@QueryParam("first") Integer firstResult,
                                      @QueryParam("max") Integer maxResults,
                                      @QueryParam("briefRepresentation") @DefaultValue("true") boolean briefRepresentation);
-    
+
+    @Path("groups")
+    @GET
+    List<GroupRepresentation> groups(@QueryParam("search") String search,
+                                     @QueryParam("briefRepresentation") @DefaultValue("true") boolean briefRepresentation);
+
     @Path("groups")
     @GET
     List<GroupRepresentation> groups(@QueryParam("search") String search,

--- a/services/src/main/java/org/keycloak/services/resources/admin/UserResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UserResource.java
@@ -885,12 +885,10 @@ public class UserResource {
                                                        @QueryParam("briefRepresentation") @DefaultValue("true") boolean briefRepresentation) {
         auth.users().requireView(user);
 
-        if (Objects.nonNull(search) && Objects.nonNull(firstResult) && Objects.nonNull(maxResults)) {
+        if (Objects.nonNull(search)) {
             return ModelToRepresentation.searchForGroupByName(user, !briefRepresentation, search.trim(), firstResult, maxResults);
-        } else if(Objects.nonNull(firstResult) && Objects.nonNull(maxResults)) {
-            return ModelToRepresentation.toGroupHierarchy(user, !briefRepresentation, firstResult, maxResults);
         } else {
-            return ModelToRepresentation.toGroupHierarchy(user, !briefRepresentation);
+            return ModelToRepresentation.toGroupHierarchy(user, !briefRepresentation, firstResult, maxResults);
         }
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/UserTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/UserTest.java
@@ -105,6 +105,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -2914,6 +2915,42 @@ public class UserTest extends AbstractAdminTest {
 
             assertFalse(userGroups.isEmpty());
             assertTrue(userGroups.get(0).getAttributes().containsKey("attribute1"));
+        }
+    }
+
+    @Test
+    public void testGetSearchedGroupsForUserFullRepresentation() {
+        RealmResource realm = adminClient.realms().realm("test");
+
+        String userName = "averagejoe";
+        String groupName1 = "group1WithAttribute";
+        String groupName2 = "group2WithAttribute";
+        Map<String, List<String>> attributes1 = new HashMap<String, List<String>>();
+        attributes1.put("attribute1", Arrays.asList("attribute1"));
+        Map<String, List<String>> attributes2 = new HashMap<String, List<String>>();
+        attributes2.put("attribute2", Arrays.asList("attribute2"));
+
+        UserRepresentation userRepresentation = UserBuilder
+                .edit(createUserRepresentation(userName, "joe@average.com", "average", "joe", true))
+                .addPassword("password")
+                .build();
+
+        try (Creator<UserResource> u = Creator.create(realm, userRepresentation);
+             Creator<GroupResource> g1 = Creator.create(realm, GroupBuilder.create().name(groupName1).attributes(attributes1).build());
+             Creator<GroupResource> g2 = Creator.create(realm, GroupBuilder.create().name(groupName2).attributes(attributes2).build())) {
+
+            String group1Id = g1.id();
+            String group2Id = g2.id();
+            UserResource user = u.resource();
+            user.joinGroup(group1Id);
+            user.joinGroup(group2Id);
+
+            List<GroupRepresentation> userGroups = user.groups("group2", false);
+            assertFalse(userGroups.isEmpty());
+            assertTrue(userGroups.stream().collect(Collectors.toMap(GroupRepresentation::getName, Function.identity())).get(groupName2).getAttributes().containsKey("attribute2"));
+
+            userGroups = user.groups("group3", false);
+            assertTrue(userGroups.isEmpty());
         }
     }
 


### PR DESCRIPTION
Closes #12649

@suichangyin Thanks. Only small changes to:

* Do not need to set an initial value to first and max values param
* Fixing test so that we always get the expected group during the assertion

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
