### PR TITLE
Bump NPM versions in `set-version.sh`

### DIFF
--- a/set-version.sh
+++ b/set-version.sh
@@ -2,6 +2,13 @@
 
 NEW_VERSION=$1
 
+# Maven
 mvn versions:set -DnewVersion=$NEW_VERSION -DgenerateBackupPoms=false -DgroupId=org.keycloak* -DartifactId=*
 
+# Docker
 sed -i "s/ENV KEYCLOAK_VERSION .*/ENV KEYCLOAK_VERSION $NEW_VERSION/" quarkus/container/Dockerfile
+
+# NPM
+cd js
+npm version $NEW_VERSION --allow-same-version --no-git-tag-version --workspaces
+cd -


### PR DESCRIPTION
Bumps the versions of NPM packages in the `js/` workspace from `set-version.sh`. This is used to set the versions during the release process.