### PR TITLE
#14045 -  Handled error during decoding form parameters 

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
@@ -188,8 +188,12 @@ public class TokenEndpoint {
 
     private Response processGrantRequestInternal() {
         cors = Cors.add(request).auth().allowedMethods("POST").auth().exposedHeaders(Cors.ACCESS_CONTROL_ALLOW_METHODS);
-
-        MultivaluedMap<String, String> formParameters = request.getDecodedFormParameters();
+         MultivaluedMap<String, String> formParameters=null;
+        try {
+         formParameters = request.getDecodedFormParameters();}
+        catch(Exception e) {
+        	logger.error("unable to get decoded form parameters");
+        }
 
         if (formParameters == null) {
             formParameters = new MultivaluedHashMap<>();

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
@@ -189,7 +189,11 @@ public class TokenEndpoint {
     private Response processGrantRequestInternal() {
         cors = Cors.add(request).auth().allowedMethods("POST").auth().exposedHeaders(Cors.ACCESS_CONTROL_ALLOW_METHODS);
 
-        MultivaluedMap<String, String> formParameters = request.getDecodedFormParameters();
+        try {
+        MultivaluedMap<String, String> formParameters = request.getDecodedFormParameters();}
+        catch(Exception e) {
+        	logger.error("unable to get decoded form parameters");
+        }
 
         if (formParameters == null) {
             formParameters = new MultivaluedHashMap<>();


### PR DESCRIPTION
#14045 - The error was due to the NPE when trying to get the decoded form params. Handled it by the try catch statement