### PR TITLE
Avoid resolving expressions twice but rely on MP config expression support

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/PropertyMappingInterceptor.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/PropertyMappingInterceptor.java
@@ -16,14 +16,16 @@
  */
 package org.keycloak.quarkus.runtime.configuration;
 
-import static org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider.NS_QUARKUS;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import javax.annotation.Priority;
 
-import io.quarkus.runtime.configuration.AbstractRawDefaultConfigSource;
 import io.smallrye.config.ConfigSourceInterceptor;
 import io.smallrye.config.ConfigSourceInterceptorContext;
 import io.smallrye.config.ConfigValue;
-import org.keycloak.common.util.StringPropertyReplacer;
-import org.keycloak.quarkus.runtime.Environment;
+import io.smallrye.config.Priorities;
+
 import org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper;
 import org.keycloak.quarkus.runtime.configuration.mappers.PropertyMappers;
 
@@ -36,31 +38,16 @@ import org.keycloak.quarkus.runtime.configuration.mappers.PropertyMappers;
  * <p>The {@link PropertyMapper} can either perform a 1:1 mapping where the value of a property from
  * Keycloak (e.g.: https.port) is mapped to a single properties in Quarkus, or perform a 1:N mapping where the value of a property
  * from Keycloak (e.g.: database) is mapped to multiple properties in Quarkus.
+ *
+ * <p>This interceptor should execute between the {@link io.smallrye.config.ExpressionConfigSourceInterceptor} and the {@link io.smallrye.config.ProfileConfigSourceInterceptor}
+ * so that expressions are properly resolved after executing this interceptor while still able to resolve properties based on the current
+ * profile.
  */
+@Priority(Priorities.LIBRARY + 201)
 public class PropertyMappingInterceptor implements ConfigSourceInterceptor {
 
     @Override
     public ConfigValue getValue(ConfigSourceInterceptorContext context, String name) {
-        ConfigValue value = PropertyMappers.getValue(context, name);
-        
-        if (value == null || value.getValue() == null) {
-            return null;
-        }
-
-        if (value.getValue().indexOf("${") == -1) {
-            return value;
-        }
-        
-        return value.withValue(
-                StringPropertyReplacer.replaceProperties(value.getValue(),
-                        property -> {
-                            ConfigValue prop = context.proceed(property);
-                            
-                            if (prop == null) {
-                                return null;
-                            }
-                            
-                            return prop.getValue();
-                        }));
+        return PropertyMappers.getValue(context, name);
     }
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMappers.java
@@ -14,9 +14,7 @@ import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Function;
-import java.util.function.Predicate;
 
 public final class PropertyMappers {
 
@@ -44,19 +42,7 @@ public final class PropertyMappers {
 
     public static ConfigValue getValue(ConfigSourceInterceptorContext context, String name) {
         PropertyMapper mapper = MAPPERS.getOrDefault(name, PropertyMapper.IDENTITY);
-        ConfigValue configValue = mapper.getConfigValue(name, context);
-
-        if (configValue == null) {
-            Optional<String> prefixedMapper = getPrefixedMapper(name);
-
-            if (prefixedMapper.isPresent()) {
-                return MAPPERS.get(prefixedMapper.get()).getConfigValue(name, context);
-            }
-        } else {
-            configValue.withName(mapper.getTo());
-        }
-
-        return configValue;
+        return mapper.getConfigValue(name, context);
     }
 
     public static boolean isBuildTimeProperty(String name) {
@@ -66,14 +52,6 @@ public final class PropertyMappers {
 
         PropertyMapper mapper = MAPPERS.get(name);
         boolean isBuildTimeProperty = mapper == null ? false : mapper.isBuildTime();
-
-        if (mapper == null && !isBuildTimeProperty) {
-            Optional<String> prefixedMapper = PropertyMappers.getPrefixedMapper(name);
-
-            if (prefixedMapper.isPresent()) {
-                isBuildTimeProperty = MAPPERS.get(prefixedMapper.get()).isBuildTime();
-            }
-        }
 
         return isBuildTimeProperty
                 && !"kc.version".equals(name)
@@ -134,25 +112,6 @@ public final class PropertyMappers {
 
     public static boolean isSupported(PropertyMapper mapper) {
         return mapper.getCategory().getSupportLevel().equals(ConfigSupportLevel.SUPPORTED);
-    }
-
-    private static Optional<String> getPrefixedMapper(String name) {
-        return MAPPERS.entrySet().stream().filter(
-                new Predicate<Map.Entry<String, PropertyMapper>>() {
-                    @Override
-                    public boolean test(Map.Entry<String, PropertyMapper> entry) {
-                        String key = entry.getKey();
-
-                        if (!key.endsWith(".")) {
-                            return false;
-                        }
-
-                        // checks both to and from mapping
-                        return name.startsWith(key) || name.startsWith(entry.getValue().getFrom());
-                    }
-                })
-                .map(Map.Entry::getKey)
-                .findAny();
     }
 
     private static class MappersConfig extends HashMap<String, PropertyMapper> {

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/ConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/ConfigurationTest.java
@@ -294,6 +294,15 @@ public class ConfigurationTest {
     }
 
     @Test
+    public void testRemoveSpaceFromValue() {
+        System.setProperty(CLI_ARGS, "--db=postgres      ");
+        SmallRyeConfig config = createConfig();
+        assertEquals("io.quarkus.hibernate.orm.runtime.dialect.QuarkusPostgreSQL10Dialect",
+                config.getConfigValue("quarkus.hibernate-orm.dialect").getValue());
+        assertEquals("postgres", config.getConfigValue("quarkus.datasource.db-kind").getRawValue());
+    }
+
+    @Test
     public void testDefaultDbPortGetApplied() {
         System.setProperty(CLI_ARGS, "--db=mssql" + ARG_SEPARATOR + "--db-url-host=myhost" + ARG_SEPARATOR + "--db-url-database=kcdb" + ARG_SEPARATOR + "--db-url-port=1234" + ARG_SEPARATOR + "--db-url-properties=?foo=bar");
         SmallRyeConfig config = createConfig();


### PR DESCRIPTION
Closes #16573

* Removes unnecessary code to resolve expressions from values (e.g.: ${expression}) and rely on MP config built-in support for expressions. For that, the `PropertyMappingInterceptor` runs after the MP expression interceptor and before the profile interceptor.
* Removes unnecessary code to resolve "prefixed" options as they were only used to support the vault extension, which  no longer exists. This "prefixed" mapping of properties is also a bad pattern because we should have all properties mapped and documented on our side.
* Fixes unexpected behavior when option values are set with trailing spaces 

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
