### PR TITLE
Update ExecuteActionsActionTokenHandler.java

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/actiontoken/execactions/ExecuteActionsActionTokenHandler.java
+++ b/services/src/main/java/org/keycloak/authentication/actiontoken/execactions/ExecuteActionsActionTokenHandler.java
@@ -108,7 +108,7 @@ public class ExecuteActionsActionTokenHandler extends AbstractActionTokenHandler
 
         UserModel user = tokenContext.getAuthenticationSession().getAuthenticatedUser();
         // verify user email as we know it is valid as this entry point would never have gotten here.
-        user.setEmailVerified(true);
+        if(token.getEmail() != null) user.setEmailVerified(true);
 
         String nextAction = AuthenticationManager.nextRequiredAction(tokenContext.getSession(), authSession, tokenContext.getRequest(), tokenContext.getEvent());
         return AuthenticationManager.redirectToRequiredActions(tokenContext.getSession(), tokenContext.getRealm(), authSession, tokenContext.getUriInfo(), nextAction);


### PR DESCRIPTION
The user email should be set to verified only if the token contains an email.  ExecuteActionsActionToken can be used to create links which are conveyed to the users directly rather than sent by email. For example, a link to update the password can be displayed as QR-code, or printed, if you don't store user emails.  In this case, you use "public ExecuteActionsActionToken(String userId, int absoluteExpirationInSecs, List<String> requiredActions, String redirectUri, String clientId)" to create the token, and no email is present, and also the handle doesn't complain if there is no email, but then it should be marked verified.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
