### PR TITLE
Inherit view-members permission to childgroups

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserProvider.java
@@ -873,6 +873,9 @@ public class JpaUserProvider implements UserProvider, UserCredentialStore {
 
             subPredicates.add(from.get("groupId").in(userGroups));
             subPredicates.add(builder.equal(from.get("user").get("id"), root.get("id")));
+            /*
+                TODO clarify: A sub group might not have a resource - therefore this check might fail for sub groups.
+                              Can it be removed without consequences?
 
             Subquery subquery1 = queryBuilder.subquery(String.class);
 
@@ -887,6 +890,7 @@ public class JpaUserProvider implements UserProvider, UserCredentialStore {
             subquery1.where(subs.toArray(new Predicate[subs.size()]));
 
             subPredicates.add(builder.exists(subquery1));
+            */
 
             subquery.where(subPredicates.toArray(new Predicate[subPredicates.size()]));
 

--- a/services/src/main/java/org/keycloak/services/resources/admin/permissions/AdminPermissionManagement.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/permissions/AdminPermissionManagement.java
@@ -19,6 +19,7 @@ package org.keycloak.services.resources.admin.permissions;
 import org.keycloak.authorization.AuthorizationProvider;
 import org.keycloak.authorization.model.ResourceServer;
 import org.keycloak.models.ClientModel;
+import org.keycloak.models.RealmModel;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -30,7 +31,7 @@ public interface AdminPermissionManagement {
     public static final String TOKEN_EXCHANGE ="token-exchange";
 
     ClientModel getRealmManagementClient();
-
+    RealmModel getRealm();
     AuthorizationProvider authz();
 
     RolePermissionManagement roles();

--- a/services/src/main/java/org/keycloak/services/resources/admin/permissions/GroupPermissionEvaluator.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/permissions/GroupPermissionEvaluator.java
@@ -46,7 +46,7 @@ public interface GroupPermissionEvaluator {
 
     void requireView();
 
-    boolean getGroupsWithViewPermission(GroupModel group);
+    boolean canViewMembers(GroupModel group);
 
     void requireViewMembers(GroupModel group);
 

--- a/services/src/main/java/org/keycloak/services/resources/admin/permissions/GroupPermissions.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/permissions/GroupPermissions.java
@@ -296,7 +296,7 @@ class GroupPermissions implements GroupPermissionEvaluator, GroupPermissionManag
     }
 
     @Override
-    public boolean getGroupsWithViewPermission(GroupModel group) {
+    public boolean canViewMembers(GroupModel group) {
         if (root.users().canView() || root.users().canManage()) {
             return true;
         }
@@ -355,7 +355,7 @@ class GroupPermissions implements GroupPermissionEvaluator, GroupPermissionManag
 
     @Override
     public void requireViewMembers(GroupModel group) {
-        if (!getGroupsWithViewPermission(group)) {
+        if (!canViewMembers(group)) {
             throw new ForbiddenException();
         }
     }

--- a/services/src/main/java/org/keycloak/services/resources/admin/permissions/MgmtPermissions.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/permissions/MgmtPermissions.java
@@ -389,7 +389,8 @@ class MgmtPermissions implements AdminPermissionEvaluator, AdminPermissionManage
         }
     }
 
-
-
-
+    @Override
+    public RealmModel getRealm() {
+        return realm;
+    }
 }

--- a/services/src/main/java/org/keycloak/services/resources/admin/permissions/UserPermissions.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/permissions/UserPermissions.java
@@ -29,7 +29,6 @@ import org.keycloak.authorization.permission.ResourcePermission;
 import org.keycloak.authorization.policy.evaluation.EvaluationContext;
 import org.keycloak.authorization.store.PolicyStore;
 import org.keycloak.authorization.store.ResourceStore;
-import org.keycloak.common.Profile;
 import org.keycloak.models.AdminRoles;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.GroupModel;
@@ -593,7 +592,7 @@ class UserPermissions implements UserPermissionEvaluator, UserPermissionManageme
     }
     private boolean canViewByGroup(UserModel user) {
         if (authz == null) return false;
-        return evaluateHierarchy(user, (group) -> root.groups().getGroupsWithViewPermission(group));
+        return evaluateHierarchy(user, (group) -> root.groups().canViewMembers(group));
     }
 
     public boolean canViewDefault() {


### PR DESCRIPTION
Fixes #16966 

These changes allow to see members of child groups when having the view-members permission on the parent group. Basically the  `getGroupsWithViewPermission(...)` function did not return the ids of the subgroups of a group with view-members permission. Additionally in the `JpaUserProvider` it was checked whether a resource for the group exists, which would in the case of inheriting the permissions not necessarily be the case.

It has to be clarified whether group permissions should be extended to child groups in general (see discussion https://github.com/keycloak/keycloak/discussions/16915). Having a look at the UserPermission service we can see that for view and manage of a user the group hierarchy is evaluated: If there is a group with view/manage permissions in the hierarchy the action is granted.

The changes on the JpaUserProvider have to be reviewed and it has to be checked whether these changes also need to be done in different UserProvider implementations. 

Feel free to provide feedback or comments :)
