### PR TITLE
Applying documentation style to the Operator Guide

### DIFF
--- a/docs/guides/src/main/operator/advanced-configuration.adoc
+++ b/docs/guides/src/main/operator/advanced-configuration.adoc
@@ -7,15 +7,13 @@
 title="Advanced configuration"
 summary="How to tune advanced aspects of the Keycloak CR">
 
-== Advanced Configuration
-In this guide, you'll learn how to configure your Keycloak deployment using advanced concepts and options provided by Custom Resources (CR).
+== Advanced configuration
+This guide describes how to use Custom Resources (CRs) for advanced configuration of your Keycloak deployment.
 
-=== Server Configuration details
+=== Server configuration details
 
-Many server options are exposed as first-class citizen fields in the Keycloak CR. The structure of the CR is inspired
-by the configuration structure of Keycloak itself. E.g. in order to configure `https-port` of the server, simply follow
-similar pattern in the CR and use `httpsPort` field. The following example with a more complex server configuration
-should give you a better picture of the relationship between server options and the Keycloak CR:
+Many server options are exposed as first-class citizen fields in the Keycloak CR. The structure of the CR is based on the configuration structure of Keycloak. For example, to configure the `https-port` of the server, follow a 
+similar pattern in the CR and use the `httpsPort` field. The following example is a complex server configuration; however, it illustrates the relationship between server options and the Keycloak CR:
 
 [source,yaml]
 ----
@@ -60,21 +58,21 @@ spec:
     xaEnabled: false
 ----
 
-For all available options please see the Keycloak CRD. For a documentation of the individual options, refer to <@links.server id="all-config"/>.
+For a list of options, see the Keycloak CRD. For details on configuring options, see <@links.server id="all-config"/>.
 
 ==== Additional options
 
-Some of the expert server options are not available as dedicated fields in the Keycloak CR. Omitted are mostly fields
-that require deeper understanding of underlying Keycloak implementation and/or their usability is limited in a Kubernetes
-environment. Omitted are also options for providers configuration as they are dynamic based on the used provider
-implementation.
+Some expert server options are unavailable as dedicated fields in the Keycloak CR. The following are examples of omitted fields:
 
-The `additionalOptions` field of the Keycloak CR allows to pass to Keycloak any available configuration in the form of key-value pairs.
-This allows you to specify any of the options that are omitted in the Keycloak CR.
-For all the available configuration options, refer to <@links.server id="all-config"/>.
+* Fields that require deep understanding of the underlying Keycloak implementation 
+* Fields that are not relevant to a Kubernetes environment
+* Fields for provider configuration because they are dynamic based on the used provider implementation
 
-The values can be expressed as plain text strings or Kubernetes Secret references.
-e.g:
+The `additionalOptions` field of the Keycloak CR enables Keycloak to accept any available configuration in the form of key-value pairs.
+You can use this field to include any option that is omitted in the Keycloak CR.
+For details on configuring options, see <@links.server id="all-config"/>.
+
+The values can be expressed as plain text strings or Kubernetes Secret references as shown in this example:
 
 [source,yaml]
 ----
@@ -95,12 +93,12 @@ spec:
 
 === Secret References
 
-A Secret References are used by some of the dedicated options in the Keycloak CR (e.g. `tlsSecret`) or as a value in `additionalOptions`.
+Secret References are used by some dedicated options in the Keycloak CR, such as `tlsSecret`, or as a value in `additionalOptions`.
 
-When specifying a Secret Reference, you have to make sure that a Secret containing the referenced keys is present in the same namespace as the CR referencing it.
-Along with the Keycloak Server Deployment, the operator adds special labels to the referenced Secrets in order to watch for changes.
+When specifying a Secret Reference, make sure that a Secret containing the referenced keys is present in the same namespace as the CR referencing it.
+Along with the Keycloak Server Deployment, the Operator adds special labels to the referenced Secrets to watch for changes.
 
-When a referenced Secret is modified, the operator automatically performs a rolling restart of the Keycloak Deployment to pick up the changes.
+When a referenced Secret is modified, the Operator performs a rolling restart of the Keycloak Deployment to pick up the changes.
 
 === Unsupported features
 
@@ -108,14 +106,13 @@ The `unsupported` field of the CR contains highly experimental configuration opt
 
 ==== Pod Template
 
-Pod Template is a raw API representation that is used for the Kubernetes Deployment Template.
-This field is intended to be used as a temporary workaround if there is no officially supported field at the top level of the CR to cover your use-case.
-Please consider opening an issue on GitHub to help us make the experience better.
+The Pod Template is a raw API representation that is used for the Kubernetes Deployment Template.
+This field is a temporary workaround in case no supported field exists at the top level of the CR for your use case. For a long-term solution, consider opening a GitHub issue to address your needs.
 
-The operator will merge the fields of the provided template with the values generated by the operator for the specific Deployment.
-Using this feature, you have access to a high level of customizations, but there are no guarantees that the Deployment will work as expected.
+The Operator merges the fields of the provided template with the values generated by the Operator for the specific Deployment.
+With this feature, you have access to a high level of customizations. However, no guarantee exists that the Deployment will work as expected.
 
-As an example you can inject labels, annotations, or even volumes and volume mounts:
+The following example illustrates injecting labels, annotations, volumes, and volume mounts:
 
 [source,yaml]
 ----
@@ -143,8 +140,8 @@ spec:
 
 === Disabling required options
 
-By default, Keycloak and its Operator are designed to provide you with the best production-ready experience with security in mind.
-Although, for development purposes, you can still disable key security features.
+Keycloak and the Keycloak Operator provide the best production-ready experience with security in mind.
+However, during the development phase, you can disable key security features.
 
 Specifically, you can disable the hostname and TLS as shown in the following example:
 

--- a/docs/guides/src/main/operator/basic-deployment.adoc
+++ b/docs/guides/src/main/operator/basic-deployment.adoc
@@ -4,15 +4,16 @@
 <#import "/templates/links.adoc" as links>
 
 <@tmpl.guide
-title="Basic Keycloak Deployment"
+title="Basic Keycloak deployment"
 priority=20
 summary="How to install Keycloak using the Operator on Kubernetes or OpenShift">
 
-== Basic Keycloak Deployment
-In this guide we will show how to have a basic Keycloak Deployment on Kubernetes or OpenShift using the Operator.
-We assume that the Operator is correctly installed and running in the cluster namespace.
+== Performing a basic Keycloak deployment
+This guide describes how to perform a basic Keycloak Deployment on Kubernetes or OpenShift using the Operator.
 
-=== Pre-requisites
+=== Preparing for deployment
+
+Once the Keycloak Operator is installed and running in the cluster namespace, you can set up the other deployment prerequisites.
 
 * Database
 * Hostname
@@ -20,13 +21,11 @@ We assume that the Operator is correctly installed and running in the cluster na
 
 ==== Database
 
-A database should be available and accessible from the cluster namespace where you want to install Keycloak.
-Please refer to <@links.server id="db"/> for the list of supported databases.
-The Keycloak Operator does not manage the database and you need to provision it yourself, we suggest to verify your cloud provider offering or use a database Operator such as https://access.crunchydata.com/documentation/postgres-operator/latest/[Crunchy].
+A database should be available and accessible from the cluster namespace where Keycloak is installed.
+For a list of supported databases, see <@links.server id="db"/>.
+The Keycloak Operator does not manage the database and you need to provision it yourself. Consider verifying your cloud provider offering or using a database operator such as https://access.crunchydata.com/documentation/postgres-operator/latest/[Crunchy].
 
-
-For development purposes you can use an ephemeral Postgres pod installation.
-You can provision it using the following commands:
+For development purposes, you can use an ephemeral PostgreSQL pod installation. To provision it, enter the following commands:
 
 [source,bash]
 ----
@@ -74,23 +73,23 @@ kubectl apply -f example-postgres.yaml
 
 ==== Hostname
 
-To have a production ready installation you need to provide the hostname that will be used to contact Keycloak.
-Please refer to <@links.server id="hostname"/> for the available configurations.
+For a production ready installation, you need a hostname that can be used to contact Keycloak.
+See <@links.server id="hostname"/> for the available configurations.
 
-For development purposes we will use from now on `test.keycloak.org`.
+For development purposes, this guide will use `test.keycloak.org`.
 
 ==== TLS Certificate and key
 
-Please refer to Certification Authority of choice to obtain the certificate and the key.
+See your Certification Authority to obtain the certificate and the key.
 
-For development purposes you can use this command to obtain a self-signed certificate:
+For development purposes, you can enter this command to obtain a self-signed certificate:
 
 [source,bash]
 ----
 openssl req -subj '/CN=test.keycloak.org/O=Test Keycloak./C=US' -newkey rsa:2048 -nodes -keyout key.pem -x509 -days 365 -out certificate.pem
 ----
 
-and you should install it in the cluster namespace as a Secret by running:
+You should install it in the cluster namespace as a Secret by entering this command:
 
 [source,bash]
 ----
@@ -99,9 +98,9 @@ kubectl create secret tls example-tls-secret --cert certificate.pem --key key.pe
 
 === Deploying Keycloak
 
-To deploy Keycloak you have to create a Custom Resource (CR from now on) shaped after the Keycloak Custom Resource Definition (CRD).
+To deploy Keycloak, you create a Custom Resource (CR) based on the Keycloak Custom Resource Definition (CRD).
 
-We suggest you to first store the Database credentials in a separate Secret, you can do it for example by running:
+Consider storing the Database credentials in a separate Secret. Enter the following commands:
 [source,bash]
 ----
 kubectl create secret generic keycloak-db-secret \
@@ -109,7 +108,7 @@ kubectl create secret generic keycloak-db-secret \
   --from-literal=password=[your_database_password]
 ----
 
-The Keycloak CRD allow you to customize several fields but, for a simple deployment you can use the following example:
+You can customize several fields using the Keycloak CRD. However, for a basic deployment, you can enter the following example commands:
 
 [source,bash]
 ----
@@ -137,32 +136,32 @@ EOF
 kubectl apply -f example-kc.yaml
 ----
 
-And you can check that the Keycloak instance has been provisioned in the cluster by looking at the status of the created CR:
+To check that the Keycloak instance has been provisioned in the cluster, check the status of the created CR by entering the following command:
 
 [source,bash]
 ----
 kubectl get keycloaks/example-kc -o go-template='{{range .status.conditions}}CONDITION: {{.type}}{{"\n"}}  STATUS: {{.status}}{{"\n"}}  MESSAGE: {{.message}}{{"\n"}}{{end}}'
 ----
 
-When the Deployment is ready the output will look like the following:
+When the deployment is ready, look for output similar to the following:
 
 [source,bash]
 ----
 CONDITION: Ready
   STATUS: true
-  MESSAGE: 
+  MESSAGE:
 CONDITION: HasErrors
   STATUS: false
-  MESSAGE: 
+  MESSAGE:
 CONDITION: RollingUpdate
   STATUS: false
   MESSAGE:
 ----
 
-=== Accessing the Keycloak Deployment
+=== Accessing the Keycloak deployment
 
-The Keycloak deployment is, by default, exposed through a basic Ingress and it will be accessible through the provided hostname.
-If the default ingress doesn't fit your use-case, disable it by setting `ingress` spec with `enabled` property to `false` value:
+The Keycloak deployment is exposed through a basic Ingress and is accessible through the provided hostname.
+If the default ingress does not fit your use case, disable it by setting `ingress` spec with `enabled` property to `false` value:
 
 [source,bash]
 ----
@@ -178,26 +177,27 @@ spec:
 EOF
 kubectl apply -f example-kc.yaml
 ----
-And you can provide an alternative ingress resource pointing to the service `<keycloak-cr-name>-service`.
+You can provide an alternative ingress resource pointing to the service `<keycloak-cr-name>-service`.
 
-For debugging and development purposes we suggest you to directly connect to the Keycloak service using a port forward:
+For debugging and development purposes, consider directly connecting to the Keycloak service using a port forward. For example, enter this command:
 
 [source,bash]
 ----
 kubectl port-forward service/example-kc-service 8443:8443
 ----
 
-==== Accessing the Admin Console
+=== Accessing the Admin Console
 
 When deploying Keycloak, the operator generates an arbitrary initial admin `username` and `password` and stores those credentials as a Kubernetes basic-auth Secret in the same namespace as the CR.
 
-.Warning:
-[NOTE]
+[WARNING]
+====
 Change the default admin credentials and enable MFA in Keycloak before going to production.
+====
 
-To fetch the initial admin credentials you have to read and decode a Kubernetes Secret.
+To fetch the initial admin credentials, you have to read and decode a Kubernetes Secret.
 The Secret name is derived from the Keycloak CR name plus the fixed suffix `-initial-admin`.
-To get the username and password for the `example-kc` CR use the following command:
+To get the username and password for the `example-kc` CR, enter the following commands:
 
 [source,bash]
 ----

--- a/docs/guides/src/main/operator/customizing-keycloak.adoc
+++ b/docs/guides/src/main/operator/customizing-keycloak.adoc
@@ -7,26 +7,26 @@
 title="Using custom Keycloak images"
 summary="How to customize and optimize the Keycloak Container">
 
-== Keycloak custom image with Operator
+== Keycloak custom image with the Operator
 
-The Keycloak Custom Resource (CR) give you the possibility to specify a custom container image for the Keycloak server.
+With the Keycloak Custom Resource (CR), you can specify a custom container image for the Keycloak server.
 
 [NOTE]
 To ensure full compatibility of Operator and Operand,
 make sure that the version of Keycloak release used in the custom image is aligned with the version of the operator.
 
-=== Best Practice
+=== Best practice
 
-When using the default Keycloak image the server will perform a costly re-augmentation every time a Pod starts.
-This can be avoided by providing a Custom Image where the augmentation already happened during the build time of the image.
+When using the default Keycloak image, the server will perform a costly re-augmentation every time a Pod starts.
+To avoid this delay, you can provide a custom image with the augmentation built-in from the build time of the image.
 
-A custom image additionally allows to specify Keycloak's "build-time" configurations and extensions during the build of the container.
+With a custom image, you can also specify the Keycloak _build-time_ configurations and extensions during the build of the container.
 
-For instructions on how to build such image refer to <@links.server id="containers"/>.
+For instructions on how to build such an image, see <@links.server id="containers"/>.
 
-=== Providing Custom Keycloak image
+=== Providing a custom Keycloak image
 
-To provide a custom image you have to define the `image` field in the Keycloak CR, for example:
+To provide a custom image, you define the `image` field in the Keycloak CR as shown in this example:
 
 [source,yaml]
 ----
@@ -44,6 +44,8 @@ spec:
 ----
 
 [NOTE]
-Using custom images, every build time option passed either through a dedicated field or the `additionalOptions` key will be ignored.
+====
+With custom images, every build time option passed either through a dedicated field or the `additionalOptions` is ignored.
+====
 
 </@tmpl.guide>

--- a/docs/guides/src/main/operator/installation.adoc
+++ b/docs/guides/src/main/operator/installation.adoc
@@ -8,48 +8,58 @@ title="Keycloak Operator Installation"
 priority=10
 summary="How to install the Keycloak Operator on Kubernetes and OpenShift">
 
-== Keycloak Operator Installation
-In this guide we will show how to install the Keycloak Operator in your Kubernetes or OpenShift cluster.
+== Installing the Keycloak Operator
+This guide describes how to install the Keycloak Operator in a Kubernetes or OpenShift cluster.
 
-=== OLM Installation
+=== Installing by using the Operator Lifecycle Manager
 
 The recommended way to install the Keycloak Operator in Kubernetes environments is to use the Operator Lifecycle Manager (OLM).
 
 ==== Prerequisites
-Make sure OLM is installed in your environment. For Guidance on how to install OLM, follow this https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/install/install.md#install-a-release[guide].
+*  Make sure OLM is installed in your environment. For details, see https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/install/install.md#install-a-release[Installing OLM].
 
-The Keycloak Operator OLM package can be installed from the OLM catalog. For general instructions on how to install operators using OLM, follow the https://olm.operatorframework.io/docs/tasks/install-operator-with-olm/[instructions] on the OLM page.
-In the default Catalog, the Keycloak Operator is named `keycloak-operator`. Make sure to use the `candidate` channel to find the operator.
+* Be sure that you have cluster-admin permission or an equivalent level of permissions granted by an administrator.
 
-==== OpenShift UI
+==== Using the OpenShift web console
 
-On OpenShift, use the built-in OLM UI to install the Keycloak Operator.
-Navigate to `Home`, `Operators`, `OperatorHub` using the menu on the left side of the OpenShift Console.
-Search for "keycloak" on the search input box:
+The following procedure describes how to install the Keycloak Operator. However, for general instructions on installing Operators using OLM, see https://olm.operatorframework.io/docs/tasks/install-operator-with-olm/[Install your operator with OLM]. In the default Catalog, the Keycloak Operator is named `keycloak-operator`. Make sure to use the `fast` channel to find the operator.
 
+Perform this procedure on an OpenShift cluster.
+
+. Open the OpenShift Container Platform web console.
+
+. In the left column, click *Home*, *Operators*, *OperatorHub*.
+
+. Search for "keycloak" on the search input box.
++
 image::select-operator.jpeg["Select the Keycloak Operator in the UI"]
 
-Select the Keycloak Operator from the list of results. After that, follow the instructions on the screen. Make sure you are installing from the `fast` channel:
-
+. Select the Keycloak Operator from the list of results.
+. Follow the instructions on the screen.
++
+Make sure you are installing from the *fast* channel:
++
 image::configure-operator.jpeg["Configure Keycloak Operator"]
 
-=== Vanilla Kubernetes Installation
+=== Installing by using kubectl without Operator Lifecycle Manager
 
-To install the operator on a vanilla Kubernetes cluster, you first need to install its CRDs by running the following commands:
+You can install the Operator on a vanilla Kubernetes cluster by using `kubectl` commands:
 
+. Install the CRDs by entering the following commands:
++
 [source,bash,subs="attributes+"]
 ----
 kubectl apply -f https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/{version}/kubernetes/keycloaks.k8s.keycloak.org-v1.yml
 kubectl apply -f https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/{version}/kubernetes/keycloakrealmimports.k8s.keycloak.org-v1.yml
 ----
 
-After successful CRD installation, install the Keycloak Operator deployment by running the following command:
-
+. Install the Keycloak Operator deployment by entering the following command:
++
 [source,bash,subs="attributes+"]
 ----
 kubectl apply -f https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/{version}/kubernetes/kubernetes.yml
 ----
 
-Currently the operator watches only the namespace where the operator is installed.
+Currently the Operator watches only the namespace where the Operator is installed.
 
 </@tmpl.guide>

--- a/docs/guides/src/main/operator/realm-import.adoc
+++ b/docs/guides/src/main/operator/realm-import.adoc
@@ -8,20 +8,20 @@ title="Keycloak Realm Import"
 priority=30
 summary="How to perform an automated Keycloak Realm Import using the operator">
 
-== Keycloak Realm Import
+== Importing a Keycloak Realm
 
-The Keycloak Operator ships with the ability to automatically perform a realm import for the Keycloak Deployment.
-
-[NOTE]
-If a Realm with the same name already exists in Keycloak it will not be overwritten.
+Using the Keycloak Operator, you can perform a realm import for the Keycloak Deployment.
 
 [NOTE]
-The Realm Import CR only supports creation of new realms and doesn't update or delete those. +
-Changes to the realm performed directly on Keycloak are not synced back in the CR.
+====
+* If a Realm with the same name already exists in Keycloak, it will not be overwritten.
 
-=== Writing Realm Import CR
+* The Realm Import CR only supports creation of new realms and does not update or delete those. Changes to the realm performed directly on Keycloak are not synced back in the CR.
+====
 
-A Realm Import Custom Resource (CR) looks like follows:
+=== Creating a Realm Import Custom Resource
+
+The following is an example of a Realm Import Custom Resource (CR):
 
 [source,yaml]
 ----
@@ -38,11 +38,11 @@ spec:
 This CR should be created in the same namespace as the Keycloak Deployment CR, defined in the field `keycloakCRName`.
 The `realm` field accepts a full https://www.keycloak.org/docs-api/{majorMinorVersion}/rest-api/index.html#_realmrepresentation[RealmRepresentation].
 
-The recommended way to obtain a `RealmRepresentation` is leveraging the export functionality <@links.server id="importExport"/>
+The recommended way to obtain a `RealmRepresentation` is by leveraging the export functionality <@links.server id="importExport"/>.
 
-* export the Realm to a single file
-* convert the json to yaml
-* copy-paste the obtained yaml as body for the `realm` key (make sure the indentation is correct)
+. Export the Realm to a single file.
+. Convert the JSON file to YAML.
+. Copy and paste the obtained YAML file as body for the `realm` key, making sure the indentation is correct.
 
 === Applying the Realm Import CR
 
@@ -66,14 +66,14 @@ EOF
 kubectl apply -f example-realm-import.yaml
 ----
 
-You can check the status of the running import by using the following command:
+To check the status of the running import, enter the following command:
 
 [source,bash]
 ----
 kubectl get keycloakrealmimports/my-realm-kc -o go-template='{{range .status.conditions}}CONDITION: {{.type}}{{"\n"}}  STATUS: {{.status}}{{"\n"}}  MESSAGE: {{.message}}{{"\n"}}{{end}}'
 ----
 
-When the import has successfully completed, the output will look like the example below:
+When the import has successfully completed, the output will look like the following example:
 
 [source,bash]
 ----


### PR DESCRIPTION
Closes #17177
@ahus1, @stianst, @DGuhr, @pedroigor Please review

I had to change some Freemarker links to sections of the Server guide to be HTTPS links so they would work in RHBK.  However, they would still need to be converted to RHBK guidename links.  So I could revert those changes for now if you prefer.