### PR TITLE
Add user id to TOKEN_EXCHANGE events

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/DefaultTokenExchangeProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/DefaultTokenExchangeProvider.java
@@ -411,7 +411,8 @@ public class DefaultTokenExchangeProvider implements TokenExchangeProvider {
         }
 
         AccessTokenResponse res = responseBuilder.build();
-        event.detail(Details.AUDIENCE, targetClient.getClientId());
+        event.detail(Details.AUDIENCE, targetClient.getClientId())
+            .user(targetUser);
 
         event.success();
 
@@ -460,7 +461,9 @@ public class DefaultTokenExchangeProvider implements TokenExchangeProvider {
         res.setExpiresIn(assertionLifespan <= 0 ? realm.getAccessCodeLifespan() : assertionLifespan);
         res.setOtherClaims(OAuth2Constants.ISSUED_TOKEN_TYPE, requestedTokenType);
 
-        event.detail(Details.AUDIENCE, targetClient.getClientId());
+        event.detail(Details.AUDIENCE, targetClient.getClientId())
+            .user(targetUser);
+
         event.success();
 
         return cors.builder(Response.ok(res, MediaType.APPLICATION_JSON_TYPE)).build();


### PR DESCRIPTION
Add the target user id to the `TOKEN_EXCHANGE` event on success.

We already have it for the login event, but also need it to track users using our platform from customers' UIs. We're of course open to alternatives if you have one.

--

On another note, I couldn't for the life of me add an assertion on the events in `ClientTokenExchangeTest::testImpersonation` and `ClientTokenExchangeSAML2Test::testDirectImpersonation`.

Writing
```
var userId = events.expect(EventType.TOKEN_EXCHANGE).assertEvent().getUserId();
```
made the tests fail on `assertEvent()` because the `poll()` wasn't getting any event (`java.lang.AssertionError: Event expected`) even without the modifications.

I don't know what's missing for it to work like in other test classes, but if someone does I'll be happy to add a test.
