### PR TITLE
Polish fips-mode switch for preview

### DIFF
--- a/common/src/main/java/org/keycloak/common/Profile.java
+++ b/common/src/main/java/org/keycloak/common/Profile.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -125,7 +126,7 @@ public class Profile {
             DEFAULT("Default"),
             DISABLED_BY_DEFAULT("Disabled by default"),
             PREVIEW("Preview"),
-            PREVIEW_DISABLED_BY_DEFAULT("Preview disabled by default"),
+            PREVIEW_DISABLED_BY_DEFAULT("Preview disabled by default"), // Preview features, which are not automatically enabled even with enabled preview profile (Needs to be enabled explicitly)
             EXPERIMENTAL("Experimental"),
             DEPRECATED("Deprecated");
 
@@ -200,8 +201,12 @@ public class Profile {
         return features.entrySet().stream().filter(e -> !e.getValue()).map(Map.Entry::getKey).collect(Collectors.toSet());
     }
 
+    /**
+     * @return all features of type "preview" or "preview_disabled_by_default"
+     */
     public Set<Feature> getPreviewFeatures() {
-        return getFeatures(Feature.Type.PREVIEW);
+        return Stream.concat(getFeatures(Feature.Type.PREVIEW).stream(), getFeatures(Feature.Type.PREVIEW_DISABLED_BY_DEFAULT).stream())
+                .collect(Collectors.toSet());
     }
 
     public Set<Feature> getExperimentalFeatures() {
@@ -260,14 +265,18 @@ public class Profile {
     }
 
     private void logUnsupportedFeatures() {
-        logUnsuportedFeatures(Feature.Type.PREVIEW, Logger.Level.INFO);
-        logUnsuportedFeatures(Feature.Type.EXPERIMENTAL, Logger.Level.WARN);
-        logUnsuportedFeatures(Feature.Type.DEPRECATED, Logger.Level.WARN);
+        logUnsuportedFeatures(Feature.Type.PREVIEW, getPreviewFeatures(), Logger.Level.INFO);
+        logUnsuportedFeatures(Feature.Type.EXPERIMENTAL, getExperimentalFeatures(), Logger.Level.WARN);
+        logUnsuportedFeatures(Feature.Type.DEPRECATED, getDeprecatedFeatures(), Logger.Level.WARN);
     }
 
-    private void logUnsuportedFeatures(Feature.Type type, Logger.Level level) {
+    private void logUnsuportedFeatures(Feature.Type type, Set<Feature> checkedFeatures, Logger.Level level) {
+        Set<Feature.Type> checkedFeatureTypes = checkedFeatures.stream()
+                .map(Feature::getType)
+                .collect(Collectors.toSet());
+
         String enabledFeaturesOfType = features.entrySet().stream()
-                .filter(e -> e.getValue() && e.getKey().getType().equals(type))
+                .filter(e -> e.getValue() && checkedFeatureTypes.contains(e.getKey().getType()))
                 .map(e -> e.getKey().getKey()).sorted().collect(Collectors.joining(", "));
 
         if (!enabledFeaturesOfType.isEmpty()) {

--- a/common/src/main/java/org/keycloak/common/Profile.java
+++ b/common/src/main/java/org/keycloak/common/Profile.java
@@ -86,7 +86,9 @@ public class Profile {
 
         UPDATE_EMAIL("Update Email Action", Type.PREVIEW),
 
-        JS_ADAPTER("Host keycloak.js and keycloak-authz.js through the Keycloak sever", Type.DEFAULT);
+        JS_ADAPTER("Host keycloak.js and keycloak-authz.js through the Keycloak sever", Type.DEFAULT),
+
+        FIPS("FIPS 140-2 mode", Type.PREVIEW_DISABLED_BY_DEFAULT);
 
         private final Type type;
         private String label;
@@ -123,6 +125,7 @@ public class Profile {
             DEFAULT("Default"),
             DISABLED_BY_DEFAULT("Disabled by default"),
             PREVIEW("Preview"),
+            PREVIEW_DISABLED_BY_DEFAULT("Preview disabled by default"),
             EXPERIMENTAL("Experimental"),
             DEPRECATED("Deprecated");
 

--- a/common/src/main/java/org/keycloak/common/crypto/FipsMode.java
+++ b/common/src/main/java/org/keycloak/common/crypto/FipsMode.java
@@ -1,21 +1,32 @@
 package org.keycloak.common.crypto;
 
 public enum FipsMode {
-    enabled("org.keycloak.crypto.fips.FIPS1402Provider"),
-    strict("org.keycloak.crypto.fips.Fips1402StrictCryptoProvider"),
-    disabled("org.keycloak.crypto.def.DefaultCryptoProvider");
+    NON_STRICT("org.keycloak.crypto.fips.FIPS1402Provider"),
+    STRICT("org.keycloak.crypto.fips.Fips1402StrictCryptoProvider"),
+    DISABLED("org.keycloak.crypto.def.DefaultCryptoProvider");
 
-    private String providerClassName;
+    private final String providerClassName;
+    private final String optionName;
 
     FipsMode(String providerClassName) {
         this.providerClassName = providerClassName;
+        this.optionName = name().toLowerCase().replace('_', '-');
     }
 
     public boolean isFipsEnabled() {
-        return this.equals(enabled) || this.equals(strict);
+        return this.equals(NON_STRICT) || this.equals(STRICT);
     }
 
     public String getProviderClassName() {
         return providerClassName;
+    }
+
+    public static FipsMode valueOfOption(String name) {
+        return valueOf(name.toUpperCase().replace('-', '_'));
+    }
+
+    @Override
+    public String toString() {
+        return optionName;
     }
 }

--- a/common/src/test/java/org/keycloak/common/ProfileTest.java
+++ b/common/src/test/java/org/keycloak/common/ProfileTest.java
@@ -70,7 +70,7 @@ public class ProfileTest {
         }
 
         Assert.assertEquals(Profile.ProfileName.DEFAULT, profile.getName());
-        Set<Profile.Feature> disabledFeatutes = new HashSet<>(Arrays.asList(Profile.Feature.ADMIN_FINE_GRAINED_AUTHZ, Profile.Feature.DYNAMIC_SCOPES, Profile.Feature.DOCKER, Profile.Feature.RECOVERY_CODES, Profile.Feature.SCRIPTS, Profile.Feature.TOKEN_EXCHANGE, Profile.Feature.OPENSHIFT_INTEGRATION, Profile.Feature.MAP_STORAGE, Profile.Feature.DECLARATIVE_USER_PROFILE, Profile.Feature.CLIENT_SECRET_ROTATION, Profile.Feature.UPDATE_EMAIL));
+        Set<Profile.Feature> disabledFeatutes = new HashSet<>(Arrays.asList(Profile.Feature.FIPS, Profile.Feature.ADMIN_FINE_GRAINED_AUTHZ, Profile.Feature.DYNAMIC_SCOPES, Profile.Feature.DOCKER, Profile.Feature.RECOVERY_CODES, Profile.Feature.SCRIPTS, Profile.Feature.TOKEN_EXCHANGE, Profile.Feature.OPENSHIFT_INTEGRATION, Profile.Feature.MAP_STORAGE, Profile.Feature.DECLARATIVE_USER_PROFILE, Profile.Feature.CLIENT_SECRET_ROTATION, Profile.Feature.UPDATE_EMAIL));
         // KERBEROS can be disabled (i.e. FIPS mode disables SunJGSS provider)
         if (Profile.Feature.KERBEROS.getType() == Profile.Feature.Type.DISABLED_BY_DEFAULT) {
             disabledFeatutes.add(Profile.Feature.KERBEROS);

--- a/common/src/test/java/org/keycloak/common/ProfileTest.java
+++ b/common/src/test/java/org/keycloak/common/ProfileTest.java
@@ -76,7 +76,7 @@ public class ProfileTest {
             disabledFeatutes.add(Profile.Feature.KERBEROS);
         }
         assertEquals(profile.getDisabledFeatures(), disabledFeatutes);
-        assertEquals(profile.getPreviewFeatures(), Profile.Feature.ADMIN_FINE_GRAINED_AUTHZ, Profile.Feature.RECOVERY_CODES, Profile.Feature.SCRIPTS, Profile.Feature.TOKEN_EXCHANGE, Profile.Feature.OPENSHIFT_INTEGRATION, Profile.Feature.DECLARATIVE_USER_PROFILE, Profile.Feature.CLIENT_SECRET_ROTATION, Profile.Feature.UPDATE_EMAIL);
+        assertEquals(profile.getPreviewFeatures(), Profile.Feature.FIPS, Profile.Feature.ADMIN_FINE_GRAINED_AUTHZ, Profile.Feature.RECOVERY_CODES, Profile.Feature.SCRIPTS, Profile.Feature.TOKEN_EXCHANGE, Profile.Feature.OPENSHIFT_INTEGRATION, Profile.Feature.DECLARATIVE_USER_PROFILE, Profile.Feature.CLIENT_SECRET_ROTATION, Profile.Feature.UPDATE_EMAIL);
     }
 
     @Test

--- a/quarkus/config-api/src/main/java/org/keycloak/config/HttpOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/HttpOptions.java
@@ -84,7 +84,7 @@ public class HttpOptions {
             .category(OptionCategory.HTTP)
             .description("The type of the key store file. " +
                     "If not given, the type is automatically detected based on the file name. " +
-                    "If '" + SecurityOptions.FIPS_MODE.getKey() + "' is set to '" + FipsMode.strict.name() + "' and no value is set, it defaults to 'BCFKS'.")
+                    "If '" + SecurityOptions.FIPS_MODE.getKey() + "' is set to '" + FipsMode.STRICT + "' and no value is set, it defaults to 'BCFKS'.")
             .build();
 
     public static final Option HTTPS_TRUST_STORE_FILE = new OptionBuilder<>("https-trust-store-file", File.class)
@@ -101,7 +101,7 @@ public class HttpOptions {
             .category(OptionCategory.HTTP)
             .description("The type of the trust store file. " +
                     "If not given, the type is automatically detected based on the file name. " +
-                    "If '" + SecurityOptions.FIPS_MODE.getKey() + "' is set to '" + FipsMode.strict.name() + "' and no value is set, it defaults to 'BCFKS'.")
+                    "If '" + SecurityOptions.FIPS_MODE.getKey() + "' is set to '" + FipsMode.STRICT + "' and no value is set, it defaults to 'BCFKS'.")
             .build();
 
     public static final Option<Boolean> HTTP_SERVER_ENABLED = new OptionBuilder<>("http-server-enabled", Boolean.class)

--- a/quarkus/config-api/src/main/java/org/keycloak/config/OptionCategory.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/OptionCategory.java
@@ -14,7 +14,7 @@ public enum OptionCategory {
     PROXY("Proxy", 90, ConfigSupportLevel.SUPPORTED),
     VAULT("Vault", 100, ConfigSupportLevel.SUPPORTED),
     LOGGING("Logging", 110, ConfigSupportLevel.SUPPORTED),
-    SECURITY("Security", 120, ConfigSupportLevel.EXPERIMENTAL),
+    SECURITY("Security", 120, ConfigSupportLevel.PREVIEW),
     GENERAL("General", 999, ConfigSupportLevel.SUPPORTED);
 
     private String heading;

--- a/quarkus/config-api/src/main/java/org/keycloak/config/SecurityOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/SecurityOptions.java
@@ -1,13 +1,21 @@
 package org.keycloak.config;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
 import org.keycloak.common.crypto.FipsMode;
 
 public class SecurityOptions {
 
     public static final Option<FipsMode> FIPS_MODE = new OptionBuilder<>("fips-mode", FipsMode.class)
             .category(OptionCategory.SECURITY)
+            .expectedValues(SecurityOptions::getFipsModeValues)
             .buildTime(true)
-            .description("Sets the FIPS mode. If 'enabled' is set, FIPS is enabled but on non-approved mode. For full FIPS compliance, set 'strict' to run on approved mode.")
-            .defaultValue(FipsMode.disabled)
+            .description("Sets the FIPS mode. If '" + FipsMode.NON_STRICT + "' is set, FIPS is enabled but on non-approved mode. For full FIPS compliance, set '" + FipsMode.STRICT + "' to run on approved mode.")
+            .defaultValue(FipsMode.DISABLED)
             .build();
+
+    private static List<String> getFipsModeValues() {
+        return Arrays.asList(FipsMode.NON_STRICT.toString(), FipsMode.STRICT.toString());
+    }
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/ClassLoaderPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/ClassLoaderPropertyMappers.java
@@ -2,17 +2,13 @@ package org.keycloak.quarkus.runtime.configuration.mappers;
 
 import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.fromOption;
 
-import java.util.Optional;
-
-import org.keycloak.common.crypto.FipsMode;
-import org.keycloak.config.ClassLoaderOptions;
-import org.keycloak.config.SecurityOptions;
-import org.keycloak.quarkus.runtime.Environment;
-import org.keycloak.quarkus.runtime.configuration.Configuration;
-import org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider;
-
 import io.smallrye.config.ConfigSourceInterceptorContext;
-import io.smallrye.config.ConfigValue;
+import java.util.Optional;
+import org.keycloak.common.Profile;
+import org.keycloak.common.profile.PropertiesFileProfileConfigResolver;
+import org.keycloak.config.ClassLoaderOptions;
+import org.keycloak.quarkus.runtime.Environment;
+import org.keycloak.quarkus.runtime.QuarkusProfileConfigResolver;
 
 final class ClassLoaderPropertyMappers {
 
@@ -29,10 +25,9 @@ final class ClassLoaderPropertyMappers {
 
     private static Optional<String> resolveIgnoredArtifacts(Optional<String> value, ConfigSourceInterceptorContext context) {
         if (Environment.isRebuildCheck() || Environment.isRebuild()) {
-            ConfigValue fipsEnabled = Configuration.getConfigValue(
-                    MicroProfileConfigProvider.NS_KEYCLOAK_PREFIX + SecurityOptions.FIPS_MODE.getKey());
+            Profile profile = Profile.configure(new QuarkusProfileConfigResolver(), new PropertiesFileProfileConfigResolver());
 
-            if (fipsEnabled != null && FipsMode.valueOf(fipsEnabled.getValue()).isFipsEnabled()) {
+            if (profile.getFeatures().get(Profile.Feature.FIPS)) {
                 return Optional.of(
                         "org.bouncycastle:bcprov-jdk15on,org.bouncycastle:bcpkix-jdk15on,org.bouncycastle:bcutil-jdk15on,org.keycloak:keycloak-crypto-default");
             }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/HttpPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/HttpPropertyMappers.java
@@ -147,7 +147,7 @@ final class HttpPropertyMappers {
             ConfigSourceInterceptorContext configSourceInterceptorContext) {
         if (value.isPresent()) {
             try {
-                if (FipsMode.valueOf(value.get()).equals(FipsMode.strict)) {
+                if (FipsMode.valueOfOption(value.get()).equals(FipsMode.STRICT)) {
                     return of("BCFKS");
                 }
                 return empty();

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/SecurityPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/SecurityPropertyMappers.java
@@ -25,16 +25,16 @@ final class SecurityPropertyMappers {
 
     private static Optional<String> resolveFipsMode(Optional<String> value, ConfigSourceInterceptorContext context) {
         if (value.isEmpty()) {
-            return of(FipsMode.disabled.toString());
+            return of(FipsMode.DISABLED.toString());
         }
 
-        return of(FipsMode.valueOf(value.get()).toString());
+        return of(FipsMode.valueOfOption(value.get()).toString());
     }
 
     private static Optional<String> resolveSecurityProvider(Optional<String> value,
             ConfigSourceInterceptorContext configSourceInterceptorContext) {
-        FipsMode fipsMode = value.map(FipsMode::valueOf)
-                .orElse(FipsMode.disabled);
+        FipsMode fipsMode = value.map(FipsMode::valueOfOption)
+                .orElse(FipsMode.DISABLED);
 
         if (fipsMode.isFipsEnabled()) {
             return of("BCFIPS");

--- a/quarkus/tests/integration/pom.xml
+++ b/quarkus/tests/integration/pom.xml
@@ -118,7 +118,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <argLine>-Djdk.net.hosts.file=${project.build.testOutputDirectory}/hosts_file -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError</argLine>
+                    <argLine>-Djdk.net.hosts.file=${project.build.testOutputDirectory}/hosts_file -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError --add-opens=java.base/java.security=ALL-UNNAMED</argLine>
                     <systemPropertyVariables>
                         <kc.quarkus.tests.dist>${kc.quarkus.tests.dist}</kc.quarkus.tests.dist>
                     </systemPropertyVariables>

--- a/quarkus/tests/integration/src/main/java/org/keycloak/Keycloak.java
+++ b/quarkus/tests/integration/src/main/java/org/keycloak/Keycloak.java
@@ -123,7 +123,7 @@ public class Keycloak {
                 addOptionIfNotSet(args, StorageOptions.STORAGE, StorageOptions.StorageType.chm);
             }
 
-            boolean isFipsEnabled = ofNullable(getOptionValue(args, SecurityOptions.FIPS_MODE)).orElse(FipsMode.disabled).isFipsEnabled();
+            boolean isFipsEnabled = ofNullable(getOptionValue(args, SecurityOptions.FIPS_MODE)).orElse(FipsMode.DISABLED).isFipsEnabled();
 
             if (isFipsEnabled) {
                 String logLevel = getOptionValue(args, LoggingOptions.LOG_LEVEL);

--- a/quarkus/tests/integration/src/main/java/org/keycloak/it/junit5/extension/ServerOptions.java
+++ b/quarkus/tests/integration/src/main/java/org/keycloak/it/junit5/extension/ServerOptions.java
@@ -60,7 +60,6 @@ final class ServerOptions extends ArrayList<String> {
     private Map<String, Predicate<String>> getDefaultOptions(LegacyStore legacyStoreConfig, WithDatabase withDatabase) {
         Map<String, Predicate<String>> defaultOptions = new HashMap<>();
 
-        defaultOptions.put("--storage=chm", ignoreStorageChm(legacyStoreConfig, withDatabase));
         defaultOptions.put("--cache=local", ignoreCacheLocal(legacyStoreConfig));
 
         return defaultOptions;

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/FeaturesDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/FeaturesDistTest.java
@@ -28,6 +28,8 @@ import static org.keycloak.quarkus.runtime.cli.command.AbstractStartCommand.OPTI
 @LegacyStore
 public class FeaturesDistTest {
 
+    private static final String PREVIEW_FEATURES_EXPECTED_LOG = "Preview features enabled: admin-fine-grained-authz, client-secret-rotation, declarative-user-profile, openshift-integration, recovery-codes, scripts, token-exchange, update-email";
+
     @Test
     public void testEnableOnBuild(KeycloakDistribution dist) {
         CLIResult cliResult = dist.run(Build.NAME, "--features=preview");
@@ -45,6 +47,18 @@ public class FeaturesDistTest {
         CLIResult cliResult = (CLIResult) result;
         cliResult.assertStartedDevMode();
         assertPreviewFeaturesEnabled((CLIResult) result);
+    }
+
+    // Should enable "fips" together with all other "preview" features
+    @Test
+    @Launch({StartDev.NAME, "--features=preview,fips"})
+    public void testEnablePreviewFeaturesAndFips(LaunchResult result) {
+        CLIResult cliResult = (CLIResult) result;
+
+        String previewFeaturesWithFipsIncluded = PREVIEW_FEATURES_EXPECTED_LOG.replace("declarative-user-profile", "declarative-user-profile, fips");
+        assertThat(result.getOutput(), CoreMatchers.allOf(
+                containsString(previewFeaturesWithFipsIncluded)));
+        cliResult.assertError("Failed to configure FIPS.");
     }
 
     @Test
@@ -87,6 +101,6 @@ public class FeaturesDistTest {
 
     private void assertPreviewFeaturesEnabled(CLIResult result) {
         assertThat(result.getOutput(), CoreMatchers.allOf(
-                containsString("Preview features enabled: admin-fine-grained-authz, client-secret-rotation, declarative-user-profile, openshift-integration, recovery-codes, scripts, token-exchange, update-email")));
+                containsString(PREVIEW_FEATURES_EXPECTED_LOG)));
     }
 }

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/FipsDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/FipsDistTest.java
@@ -29,14 +29,14 @@ import org.keycloak.it.utils.RawKeycloakDistribution;
 import io.quarkus.test.junit.main.Launch;
 import io.quarkus.test.junit.main.LaunchResult;
 
-@DistributionTest(keepAlive = true, defaultOptions = { "--http-enabled=true", "--hostname-strict=false", "--log-level=org.keycloak.common.crypto.CryptoIntegration:trace" })
+@DistributionTest(keepAlive = true, defaultOptions = { "--features=fips", "--http-enabled=true", "--hostname-strict=false", "--log-level=org.keycloak.common.crypto.CryptoIntegration:trace" })
 @RawDistOnly(reason = "Containers are immutable")
 public class FipsDistTest {
 
     @Test
     void testFipsNonApprovedMode(KeycloakDistribution dist) {
         runOnFipsEnabledDistribution(dist, () -> {
-            CLIResult cliResult = dist.run("start", "--fips-mode=enabled");
+            CLIResult cliResult = dist.run("start");
             cliResult.assertStarted();
             cliResult.assertMessage("Java security providers: [ \n"
                     + " KC(BCFIPS version 1.000203, FIPS-JVM: " + KeycloakFipsSecurityProvider.isSystemFipsEnabled() + ") version 1.0 - class org.keycloak.crypto.fips.KeycloakFipsSecurityProvider");
@@ -64,7 +64,7 @@ public class FipsDistTest {
     }
 
     @Test
-    @Launch({ "start", "--fips-mode=enabled" })
+    @Launch({ "start", "--fips-mode=non-strict" })
     void failStartDueToMissingFipsDependencies(LaunchResult result) {
         CLIResult cliResult = (CLIResult) result;
         cliResult.assertError("Failed to configure FIPS. Make sure you have added the Bouncy Castle FIPS dependencies to the 'providers' directory.");
@@ -116,7 +116,7 @@ public class FipsDistTest {
     void testHttpsPkcs12KeyStoreInNonApprovedMode(KeycloakDistribution dist) {
         runOnFipsEnabledDistribution(dist, () -> {
             dist.copyOrReplaceFileFromClasspath("/server.keystore.pkcs12", Path.of("conf", "server.keystore"));
-            CLIResult cliResult = dist.run("start", "--fips-mode=enabled", "--https-key-store-password=passwordpassword");
+            CLIResult cliResult = dist.run("start", "--fips-mode=non-strict", "--https-key-store-password=passwordpassword");
             cliResult.assertStarted();
         });
     }
@@ -129,8 +129,8 @@ public class FipsDistTest {
             RawKeycloakDistribution rawDist = dist.unwrap(RawKeycloakDistribution.class);
             Path truststorePath = rawDist.getDistPath().resolve("conf").resolve("server.keystore").toAbsolutePath();
 
-            // https-trust-store-type should be automatically set to pkcs12 in fips-mode=enabled
-            CLIResult cliResult = dist.run("--verbose", "start", "--fips-mode=enabled", "--https-key-store-password=passwordpassword",
+            // https-trust-store-type should be automatically set to pkcs12 in fips-mode=non-strict
+            CLIResult cliResult = dist.run("--verbose", "start", "--fips-mode=non-strict", "--https-key-store-password=passwordpassword",
                     "--https-trust-store-file=" + truststorePath, "--https-trust-store-password=passwordpassword");
             cliResult.assertStarted();
         });

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ImportAtStartupDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ImportAtStartupDistTest.java
@@ -75,13 +75,13 @@ public class ImportAtStartupDistTest {
     @Test
     @BeforeStartDistribution(CreateRealmConfigurationFile.class)
     void testImportFromFileCreatedByExportAllRealms(KeycloakDistribution dist) throws IOException {
-        dist.run("start-dev", "--import-realm");
+        dist.run("start-dev", "--import-realm", "--storage=chm");
         dist.run("export", "--file=../data/import/realm.json");
 
         RawKeycloakDistribution rawDist = dist.unwrap(RawKeycloakDistribution.class);
         FileUtil.deleteDirectory(rawDist.getDistPath().resolve("data").resolve("chm").toAbsolutePath());
 
-        CLIResult result = dist.run("start-dev", "--import-realm");
+        CLIResult result = dist.run("start-dev", "--import-realm", "--storage=chm");
         result.assertMessage("Realm 'quickstart-realm' imported");
         result.assertMessage("Realm 'master' already exists. Import skipped");
     }
@@ -89,13 +89,13 @@ public class ImportAtStartupDistTest {
     @Test
     @BeforeStartDistribution(CreateRealmConfigurationFile.class)
     void testImportFromFileCreatedByExportSingleRealm(KeycloakDistribution dist) throws IOException {
-        dist.run("start-dev", "--import-realm");
+        dist.run("start-dev", "--import-realm", "--storage=chm");
         dist.run("export", "--realm=quickstart-realm", "--file=../data/import/realm.json");
 
         RawKeycloakDistribution rawDist = dist.unwrap(RawKeycloakDistribution.class);
         FileUtil.deleteDirectory(rawDist.getDistPath().resolve("data").resolve("chm").toAbsolutePath());
 
-        CLIResult result = dist.run("start-dev", "--import-realm");
+        CLIResult result = dist.run("start-dev", "--import-realm", "--storage=chm");
         result.assertMessage("Realm 'quickstart-realm' imported");
         result.assertNoMessage("Not importing realm master from file");
     }
@@ -103,14 +103,14 @@ public class ImportAtStartupDistTest {
     @Test
     @BeforeStartDistribution(CreateRealmConfigurationFile.class)
     void testImportFromDirCreatedByExport(KeycloakDistribution dist) throws IOException {
-        dist.run("start-dev", "--import-realm");
+        dist.run("start-dev", "--import-realm", "--storage=chm");
         RawKeycloakDistribution rawDist = dist.unwrap(RawKeycloakDistribution.class);
         FileUtil.deleteDirectory(rawDist.getDistPath().resolve("data").resolve("import").toAbsolutePath());
         dist.run("export", "--dir=../data/import");
 
         FileUtil.deleteDirectory(rawDist.getDistPath().resolve("data").resolve("chm").toAbsolutePath());
 
-        CLIResult result = dist.run("start-dev", "--import-realm");
+        CLIResult result = dist.run("start-dev", "--import-realm", "--storage=chm");
         result.assertMessage("Realm 'quickstart-realm' imported");
         result.assertNoMessage("Not importing realm master from file");
     }

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBuildHelp.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBuildHelp.unix.approved.txt
@@ -46,14 +46,14 @@ Feature:
 --features <feature> Enables a set of one or more features. Possible values are: account-api,
                        account2, admin-api, admin-fine-grained-authz, admin2, authorization, ciba,
                        client-policies, client-secret-rotation, declarative-user-profile, docker,
-                       dynamic-scopes, impersonation, js-adapter, kerberos, map-storage,
+                       dynamic-scopes, fips, impersonation, js-adapter, kerberos, map-storage,
                        openshift-integration, par, preview, recovery-codes, scripts,
                        step-up-authentication, token-exchange, update-email, web-authn.
 --features-disabled <feature>
                      Disables a set of one or more features. Possible values are: account-api,
                        account2, admin-api, admin-fine-grained-authz, admin2, authorization, ciba,
                        client-policies, client-secret-rotation, declarative-user-profile, docker,
-                       dynamic-scopes, impersonation, js-adapter, kerberos, map-storage,
+                       dynamic-scopes, fips, impersonation, js-adapter, kerberos, map-storage,
                        openshift-integration, par, preview, recovery-codes, scripts,
                        step-up-authentication, token-exchange, update-email, web-authn.
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBuildHelp.windows.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBuildHelp.windows.approved.txt
@@ -46,14 +46,14 @@ Feature:
 --features <feature> Enables a set of one or more features. Possible values are: account-api,
                        account2, admin-api, admin-fine-grained-authz, admin2, authorization, ciba,
                        client-policies, client-secret-rotation, declarative-user-profile, docker,
-                       dynamic-scopes, impersonation, js-adapter, kerberos, map-storage,
+                       dynamic-scopes, fips, impersonation, js-adapter, kerberos, map-storage,
                        openshift-integration, par, preview, recovery-codes, scripts,
                        step-up-authentication, token-exchange, update-email, web-authn.
 --features-disabled <feature>
                      Disables a set of one or more features. Possible values are: account-api,
                        account2, admin-api, admin-fine-grained-authz, admin2, authorization, ciba,
                        client-policies, client-secret-rotation, declarative-user-profile, docker,
-                       dynamic-scopes, impersonation, js-adapter, kerberos, map-storage,
+                       dynamic-scopes, fips, impersonation, js-adapter, kerberos, map-storage,
                        openshift-integration, par, preview, recovery-codes, scripts,
                        step-up-authentication, token-exchange, update-email, web-authn.
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.unix.approved.txt
@@ -69,14 +69,14 @@ Feature:
 --features <feature> Enables a set of one or more features. Possible values are: account-api,
                        account2, admin-api, admin-fine-grained-authz, admin2, authorization, ciba,
                        client-policies, client-secret-rotation, declarative-user-profile, docker,
-                       dynamic-scopes, impersonation, js-adapter, kerberos, map-storage,
+                       dynamic-scopes, fips, impersonation, js-adapter, kerberos, map-storage,
                        openshift-integration, par, preview, recovery-codes, scripts,
                        step-up-authentication, token-exchange, update-email, web-authn.
 --features-disabled <feature>
                      Disables a set of one or more features. Possible values are: account-api,
                        account2, admin-api, admin-fine-grained-authz, admin2, authorization, ciba,
                        client-policies, client-secret-rotation, declarative-user-profile, docker,
-                       dynamic-scopes, impersonation, js-adapter, kerberos, map-storage,
+                       dynamic-scopes, fips, impersonation, js-adapter, kerberos, map-storage,
                        openshift-integration, par, preview, recovery-codes, scripts,
                        step-up-authentication, token-exchange, update-email, web-authn.
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.windows.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.windows.approved.txt
@@ -69,14 +69,14 @@ Feature:
 --features <feature> Enables a set of one or more features. Possible values are: account-api,
                        account2, admin-api, admin-fine-grained-authz, admin2, authorization, ciba,
                        client-policies, client-secret-rotation, declarative-user-profile, docker,
-                       dynamic-scopes, impersonation, js-adapter, kerberos, map-storage,
+                       dynamic-scopes, fips, impersonation, js-adapter, kerberos, map-storage,
                        openshift-integration, par, preview, recovery-codes, scripts,
                        step-up-authentication, token-exchange, update-email, web-authn.
 --features-disabled <feature>
                      Disables a set of one or more features. Possible values are: account-api,
                        account2, admin-api, admin-fine-grained-authz, admin2, authorization, ciba,
                        client-policies, client-secret-rotation, declarative-user-profile, docker,
-                       dynamic-scopes, impersonation, js-adapter, kerberos, map-storage,
+                       dynamic-scopes, fips, impersonation, js-adapter, kerberos, map-storage,
                        openshift-integration, par, preview, recovery-codes, scripts,
                        step-up-authentication, token-exchange, update-email, web-authn.
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.unix.approved.txt
@@ -129,14 +129,14 @@ Feature:
 --features <feature> Enables a set of one or more features. Possible values are: account-api,
                        account2, admin-api, admin-fine-grained-authz, admin2, authorization, ciba,
                        client-policies, client-secret-rotation, declarative-user-profile, docker,
-                       dynamic-scopes, impersonation, js-adapter, kerberos, map-storage,
+                       dynamic-scopes, fips, impersonation, js-adapter, kerberos, map-storage,
                        openshift-integration, par, preview, recovery-codes, scripts,
                        step-up-authentication, token-exchange, update-email, web-authn.
 --features-disabled <feature>
                      Disables a set of one or more features. Possible values are: account-api,
                        account2, admin-api, admin-fine-grained-authz, admin2, authorization, ciba,
                        client-policies, client-secret-rotation, declarative-user-profile, docker,
-                       dynamic-scopes, impersonation, js-adapter, kerberos, map-storage,
+                       dynamic-scopes, fips, impersonation, js-adapter, kerberos, map-storage,
                        openshift-integration, par, preview, recovery-codes, scripts,
                        step-up-authentication, token-exchange, update-email, web-authn.
 
@@ -280,11 +280,11 @@ Logging:
                        categories and their levels. For the root category, you don't need to
                        specify a category. Default: info.
 
-Security (Experimental):
+Security (Preview):
 
---fips-mode <mode>   Experimental: Sets the FIPS mode. If 'enabled' is set, FIPS is enabled but on
+--fips-mode <mode>   Preview: Sets the FIPS mode. If 'non-strict' is set, FIPS is enabled but on
                        non-approved mode. For full FIPS compliance, set 'strict' to run on approved
-                       mode. Possible values are: enabled, strict, disabled. Default: disabled.
+                       mode. Possible values are: non-strict, strict. Default: disabled.
 
 Do NOT start the server using this command when deploying to production.
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.windows.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.windows.approved.txt
@@ -129,14 +129,14 @@ Feature:
 --features <feature> Enables a set of one or more features. Possible values are: account-api,
                        account2, admin-api, admin-fine-grained-authz, admin2, authorization, ciba,
                        client-policies, client-secret-rotation, declarative-user-profile, docker,
-                       dynamic-scopes, impersonation, js-adapter, kerberos, map-storage,
+                       dynamic-scopes, fips, impersonation, js-adapter, kerberos, map-storage,
                        openshift-integration, par, preview, recovery-codes, scripts,
                        step-up-authentication, token-exchange, update-email, web-authn.
 --features-disabled <feature>
                      Disables a set of one or more features. Possible values are: account-api,
                        account2, admin-api, admin-fine-grained-authz, admin2, authorization, ciba,
                        client-policies, client-secret-rotation, declarative-user-profile, docker,
-                       dynamic-scopes, impersonation, js-adapter, kerberos, map-storage,
+                       dynamic-scopes, fips, impersonation, js-adapter, kerberos, map-storage,
                        openshift-integration, par, preview, recovery-codes, scripts,
                        step-up-authentication, token-exchange, update-email, web-authn.
 
@@ -280,11 +280,11 @@ Logging:
                        categories and their levels. For the root category, you don't need to
                        specify a category. Default: info.
 
-Security (Experimental):
+Security (Preview):
 
---fips-mode <mode>   Experimental: Sets the FIPS mode. If 'enabled' is set, FIPS is enabled but on
+--fips-mode <mode>   Preview: Sets the FIPS mode. If 'non-strict' is set, FIPS is enabled but on
                        non-approved mode. For full FIPS compliance, set 'strict' to run on approved
-                       mode. Possible values are: enabled, strict, disabled. Default: disabled.
+                       mode. Possible values are: non-strict, strict. Default: disabled.
 
 Do NOT start the server using this command when deploying to production.
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.unix.approved.txt
@@ -75,14 +75,14 @@ Feature:
 --features <feature> Enables a set of one or more features. Possible values are: account-api,
                        account2, admin-api, admin-fine-grained-authz, admin2, authorization, ciba,
                        client-policies, client-secret-rotation, declarative-user-profile, docker,
-                       dynamic-scopes, impersonation, js-adapter, kerberos, map-storage,
+                       dynamic-scopes, fips, impersonation, js-adapter, kerberos, map-storage,
                        openshift-integration, par, preview, recovery-codes, scripts,
                        step-up-authentication, token-exchange, update-email, web-authn.
 --features-disabled <feature>
                      Disables a set of one or more features. Possible values are: account-api,
                        account2, admin-api, admin-fine-grained-authz, admin2, authorization, ciba,
                        client-policies, client-secret-rotation, declarative-user-profile, docker,
-                       dynamic-scopes, impersonation, js-adapter, kerberos, map-storage,
+                       dynamic-scopes, fips, impersonation, js-adapter, kerberos, map-storage,
                        openshift-integration, par, preview, recovery-codes, scripts,
                        step-up-authentication, token-exchange, update-email, web-authn.
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.windows.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.windows.approved.txt
@@ -75,14 +75,14 @@ Feature:
 --features <feature> Enables a set of one or more features. Possible values are: account-api,
                        account2, admin-api, admin-fine-grained-authz, admin2, authorization, ciba,
                        client-policies, client-secret-rotation, declarative-user-profile, docker,
-                       dynamic-scopes, impersonation, js-adapter, kerberos, map-storage,
+                       dynamic-scopes, fips, impersonation, js-adapter, kerberos, map-storage,
                        openshift-integration, par, preview, recovery-codes, scripts,
                        step-up-authentication, token-exchange, update-email, web-authn.
 --features-disabled <feature>
                      Disables a set of one or more features. Possible values are: account-api,
                        account2, admin-api, admin-fine-grained-authz, admin2, authorization, ciba,
                        client-policies, client-secret-rotation, declarative-user-profile, docker,
-                       dynamic-scopes, impersonation, js-adapter, kerberos, map-storage,
+                       dynamic-scopes, fips, impersonation, js-adapter, kerberos, map-storage,
                        openshift-integration, par, preview, recovery-codes, scripts,
                        step-up-authentication, token-exchange, update-email, web-authn.
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.unix.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.unix.approved.txt
@@ -135,14 +135,14 @@ Feature:
 --features <feature> Enables a set of one or more features. Possible values are: account-api,
                        account2, admin-api, admin-fine-grained-authz, admin2, authorization, ciba,
                        client-policies, client-secret-rotation, declarative-user-profile, docker,
-                       dynamic-scopes, impersonation, js-adapter, kerberos, map-storage,
+                       dynamic-scopes, fips, impersonation, js-adapter, kerberos, map-storage,
                        openshift-integration, par, preview, recovery-codes, scripts,
                        step-up-authentication, token-exchange, update-email, web-authn.
 --features-disabled <feature>
                      Disables a set of one or more features. Possible values are: account-api,
                        account2, admin-api, admin-fine-grained-authz, admin2, authorization, ciba,
                        client-policies, client-secret-rotation, declarative-user-profile, docker,
-                       dynamic-scopes, impersonation, js-adapter, kerberos, map-storage,
+                       dynamic-scopes, fips, impersonation, js-adapter, kerberos, map-storage,
                        openshift-integration, par, preview, recovery-codes, scripts,
                        step-up-authentication, token-exchange, update-email, web-authn.
 
@@ -286,11 +286,11 @@ Logging:
                        categories and their levels. For the root category, you don't need to
                        specify a category. Default: info.
 
-Security (Experimental):
+Security (Preview):
 
---fips-mode <mode>   Experimental: Sets the FIPS mode. If 'enabled' is set, FIPS is enabled but on
+--fips-mode <mode>   Preview: Sets the FIPS mode. If 'non-strict' is set, FIPS is enabled but on
                        non-approved mode. For full FIPS compliance, set 'strict' to run on approved
-                       mode. Possible values are: enabled, strict, disabled. Default: disabled.
+                       mode. Possible values are: non-strict, strict. Default: disabled.
 
 By default, this command tries to update the server configuration by running a
 'build' before starting the server. You can disable this behavior by using the

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.windows.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.windows.approved.txt
@@ -135,14 +135,14 @@ Feature:
 --features <feature> Enables a set of one or more features. Possible values are: account-api,
                        account2, admin-api, admin-fine-grained-authz, admin2, authorization, ciba,
                        client-policies, client-secret-rotation, declarative-user-profile, docker,
-                       dynamic-scopes, impersonation, js-adapter, kerberos, map-storage,
+                       dynamic-scopes, fips, impersonation, js-adapter, kerberos, map-storage,
                        openshift-integration, par, preview, recovery-codes, scripts,
                        step-up-authentication, token-exchange, update-email, web-authn.
 --features-disabled <feature>
                      Disables a set of one or more features. Possible values are: account-api,
                        account2, admin-api, admin-fine-grained-authz, admin2, authorization, ciba,
                        client-policies, client-secret-rotation, declarative-user-profile, docker,
-                       dynamic-scopes, impersonation, js-adapter, kerberos, map-storage,
+                       dynamic-scopes, fips, impersonation, js-adapter, kerberos, map-storage,
                        openshift-integration, par, preview, recovery-codes, scripts,
                        step-up-authentication, token-exchange, update-email, web-authn.
 
@@ -286,11 +286,11 @@ Logging:
                        categories and their levels. For the root category, you don't need to
                        specify a category. Default: info.
 
-Security (Experimental):
+Security (Preview):
 
---fips-mode <mode>   Experimental: Sets the FIPS mode. If 'enabled' is set, FIPS is enabled but on
+--fips-mode <mode>   Preview: Sets the FIPS mode. If 'non-strict' is set, FIPS is enabled but on
                        non-approved mode. For full FIPS compliance, set 'strict' to run on approved
-                       mode. Possible values are: enabled, strict, disabled. Default: disabled.
+                       mode. Possible values are: non-strict, strict. Default: disabled.
 
 By default, this command tries to update the server configuration by running a
 'build' before starting the server. You can disable this behavior by using the

--- a/testsuite/integration-arquillian/servers/auth-server/quarkus/pom.xml
+++ b/testsuite/integration-arquillian/servers/auth-server/quarkus/pom.xml
@@ -304,7 +304,7 @@
         <profile>
             <id>auth-server-fips140-2</id>
             <properties>
-                <auth.server.fips.mode>enabled</auth.server.fips.mode>
+                <auth.server.fips.mode>non-strict</auth.server.fips.mode>
             </properties>
 
             <dependencies>

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/AuthServerTestEnricher.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/AuthServerTestEnricher.java
@@ -131,7 +131,7 @@ public class AuthServerTestEnricher {
 
     public static final String AUTH_SERVER_FIPS_MODE_PROPERTY = "auth.server.fips.mode";
 
-    public static final FipsMode AUTH_SERVER_FIPS_MODE = FipsMode.valueOf(System.getProperty(AUTH_SERVER_FIPS_MODE_PROPERTY, FipsMode.disabled.toString()));
+    public static final FipsMode AUTH_SERVER_FIPS_MODE = FipsMode.valueOfOption(System.getProperty(AUTH_SERVER_FIPS_MODE_PROPERTY, FipsMode.DISABLED.toString()));
 
     public static final String CACHE_SERVER_LIFECYCLE_SKIP_PROPERTY = "cache.server.lifecycle.skip";
     public static final boolean CACHE_SERVER_LIFECYCLE_SKIP = Boolean.parseBoolean(System.getProperty(CACHE_SERVER_LIFECYCLE_SKIP_PROPERTY, "false"));

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/containers/AbstractQuarkusDeployableContainer.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/containers/AbstractQuarkusDeployableContainer.java
@@ -173,7 +173,7 @@ public abstract class AbstractQuarkusDeployableContainer implements DeployableCo
         log.debugf("FIPS Mode: %s", configuration.getFipsMode());
 
         // only run build during first execution of the server (if the DB is specified), restarts or when running cluster tests
-        if (restart.get() || shouldSetUpDb.get() || "ha".equals(getClusterConfig.get()) || configuration.getFipsMode() != FipsMode.disabled) {
+        if (restart.get() || shouldSetUpDb.get() || "ha".equals(getClusterConfig.get()) || configuration.getFipsMode() != FipsMode.DISABLED) {
             commands.removeIf("--optimized"::equals);
             commands.add("--http-relative-path=/auth");
 
@@ -187,7 +187,7 @@ public abstract class AbstractQuarkusDeployableContainer implements DeployableCo
                 }
             }
 
-            if (configuration.getFipsMode() != FipsMode.disabled) {
+            if (configuration.getFipsMode() != FipsMode.DISABLED) {
                 addFipsOptions(commands);
             }
         }
@@ -325,6 +325,7 @@ public abstract class AbstractQuarkusDeployableContainer implements DeployableCo
     }
 
     private void addFipsOptions(List<String> commands) {
+        commands.add("--features=fips");
         commands.add("--fips-mode=" + configuration.getFipsMode().toString());
 
         log.debugf("Keystore file: %s, truststore file: %s",
@@ -339,7 +340,7 @@ public abstract class AbstractQuarkusDeployableContainer implements DeployableCo
 
         // BCFIPS approved mode requires passwords of at least 112 bits (14 characters) to be used. To bypass this, we use this by default
         // as testsuite uses shorter passwords everywhere
-        if (FipsMode.strict == configuration.getFipsMode()) {
+        if (FipsMode.STRICT == configuration.getFipsMode()) {
             commands.add("--spi-password-hashing-pbkdf2-max-padding-length=14");
             commands.add("--spi-password-hashing-pbkdf2-sha256-max-padding-length=14");
             commands.add("--spi-password-hashing-pbkdf2-sha512-max-padding-length=14");

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/containers/KeycloakQuarkusConfiguration.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/containers/KeycloakQuarkusConfiguration.java
@@ -45,7 +45,7 @@ public class KeycloakQuarkusConfiguration implements ContainerConfiguration {
     private boolean reaugmentBeforeStart;
     private String importFile = System.getProperty("migration.import.file.name");
 
-    private FipsMode fipsMode = FipsMode.valueOf(System.getProperty("auth.server.fips.mode"));
+    private FipsMode fipsMode = FipsMode.valueOfOption(System.getProperty("auth.server.fips.mode"));
 
     @Override
     public void validate() throws ConfigurationException {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/cli/AbstractCliTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/cli/AbstractCliTest.java
@@ -75,7 +75,7 @@ public abstract class AbstractCliTest extends AbstractKeycloakTest {
     }
 
     private boolean isFipsDisabled() {
-        return AuthServerTestEnricher.AUTH_SERVER_FIPS_MODE == FipsMode.disabled;
+        return AuthServerTestEnricher.AUTH_SERVER_FIPS_MODE == FipsMode.DISABLED;
     }
 
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/cli/registration/KcRegCreateTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/cli/registration/KcRegCreateTest.java
@@ -213,7 +213,7 @@ public class KcRegCreateTest extends AbstractRegCliTest {
             }
 
             // TODO: SAML is not tested with FIPS enabled as it does not work. This needs to be revisited when SAML works with FIPS
-            if (AuthServerTestEnricher.AUTH_SERVER_FIPS_MODE == FipsMode.disabled) {
+            if (AuthServerTestEnricher.AUTH_SERVER_FIPS_MODE == FipsMode.DISABLED) {
 
                 // test create saml formated xml - format autodetection
                 File samlSpMetaFile = new File(System.getProperty("user.dir") + "/src/test/resources/cli/kcreg/saml-sp-metadata.xml");

--- a/testsuite/integration-arquillian/tests/pom.xml
+++ b/testsuite/integration-arquillian/tests/pom.xml
@@ -1569,7 +1569,7 @@
         <profile>
             <id>auth-server-fips140-2</id>
             <properties>
-                <auth.server.fips.mode>enabled</auth.server.fips.mode>
+                <auth.server.fips.mode>non-strict</auth.server.fips.mode>
 
                 <auth.server.supported.keystore.types>PKCS12,BCFKS</auth.server.supported.keystore.types>
                 <auth.server.kerberos.supported>false</auth.server.kerberos.supported>


### PR DESCRIPTION
Closes https://github.com/keycloak/keycloak/issues/17208

FipsMode changed to be `disabled`, `strict` and `non-strict`. Adding a new type for features, preview but disabled by default, only for `fips`. Now the `--fips-mode` option works this way:

* Option `disabled` is not allowed while in preview (the feature controls if it's enabled or not). The `disabled` value will be re-enabled when moving out of preview.
* If only `--features=fips` is passed it is configured to be `non-strict`.
* If both options are passed `--features=fips --fips-mode=strict` both are taken into account accordingly.

Tests modified to pass OK. It also closes https://github.com/keycloak/keycloak/issues/17210-
