### PR TITLE
"Failed to add user '%s' to realm '%s': user with username exists" Error displayed in logs if any user already exists in master realm  #16961

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakMain.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakMain.java
@@ -162,10 +162,7 @@ public class KeycloakMain implements QuarkusApplication {
         try {
             KeycloakModelUtils.runJobInTransaction(sessionFactory, session -> {
                 new ApplianceBootstrap(session).createMasterRealmUser(adminUserName, adminPassword);
-                ServicesLogger.LOGGER.addUserSuccess(adminUserName, Config.getAdminRealm());
             });
-        } catch (IllegalStateException e) {
-            ServicesLogger.LOGGER.addUserFailedUserExists(adminUserName, Config.getAdminRealm());
         } catch (Throwable t) {
             ServicesLogger.LOGGER.addUserFailed(t, adminUserName, Config.getAdminRealm());
         }

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/BuildAndStartDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/BuildAndStartDistTest.java
@@ -17,15 +17,19 @@
 
 package org.keycloak.it.cli.dist;
 
+import io.quarkus.test.junit.main.Launch;
+import io.quarkus.test.junit.main.LaunchResult;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.keycloak.it.junit5.extension.CLIResult;
 import org.keycloak.it.junit5.extension.DistributionTest;
 import org.keycloak.it.junit5.extension.RawDistOnly;
+import org.keycloak.it.junit5.extension.WithEnvVars;
 import org.keycloak.it.utils.KeycloakDistribution;
 import org.keycloak.it.utils.RawKeycloakDistribution;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.keycloak.quarkus.runtime.cli.command.AbstractStartCommand.OPTIMIZED_BUILD_OPTION_LONG;
 
 @DistributionTest
@@ -62,5 +66,35 @@ public class BuildAndStartDistTest {
         cliResult = rawDist.run("start");
         cliResult.assertBuild();
         cliResult.assertStarted();
+    }
+
+    @Test
+    @WithEnvVars({"KEYCLOAK_ADMIN", "admin123", "KEYCLOAK_ADMIN_PASSWORD", "admin123"})
+    @Launch({"start-dev"})
+    void testCreateAdmin(KeycloakDistribution dist, LaunchResult result) {
+        assertTrue(result.getOutput().contains("Added user 'admin123' to realm 'master'"),
+                () -> "The Output:\n" + result.getOutput() + "doesn't contains the expected string.");
+
+        dist.setEnvVar("KEYCLOAK_ADMIN","admin123");
+        dist.setEnvVar("KEYCLOAK_ADMIN_PASSWORD","admin123");
+        CLIResult cliResult = dist.run("start-dev");
+
+        cliResult.assertMessage("Failed to add user 'admin123' to realm 'master'");
+        cliResult.assertStartedDevMode();
+    }
+
+    @Test
+    @WithEnvVars({"KEYCLOAK_ADMIN", "admin123", "KEYCLOAK_ADMIN_PASSWORD", "admin123"})
+    @Launch({"start-dev"})
+    void testCreateDifferentAdmin(KeycloakDistribution dist, LaunchResult result) {
+        assertTrue(result.getOutput().contains("Added user 'admin123' to realm 'master'"),
+                () -> "The Output:\n" + result.getOutput() + "doesn't contains the expected string.");
+
+        dist.setEnvVar("KEYCLOAK_ADMIN","new-admin");
+        dist.setEnvVar("KEYCLOAK_ADMIN_PASSWORD","new-admin");
+        CLIResult cliResult = dist.run("start-dev");
+
+        cliResult.assertNoMessage("Failed to add user 'new-admin' to realm 'master'");
+        cliResult.assertStartedDevMode();
     }
 }

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/BuildAndStartDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/BuildAndStartDistTest.java
@@ -71,7 +71,7 @@ public class BuildAndStartDistTest {
     @Test
     @WithEnvVars({"KEYCLOAK_ADMIN", "admin123", "KEYCLOAK_ADMIN_PASSWORD", "admin123"})
     @Launch({"start-dev"})
-    void testCreateAdmin(KeycloakDistribution dist, LaunchResult result) {
+    void testCreateExistingAdmin(KeycloakDistribution dist, LaunchResult result) {
         assertTrue(result.getOutput().contains("Added user 'admin123' to realm 'master'"),
                 () -> "The Output:\n" + result.getOutput() + "doesn't contains the expected string.");
 
@@ -79,14 +79,14 @@ public class BuildAndStartDistTest {
         dist.setEnvVar("KEYCLOAK_ADMIN_PASSWORD","admin123");
         CLIResult cliResult = dist.run("start-dev");
 
-        cliResult.assertMessage("Failed to add user 'admin123' to realm 'master'");
+        cliResult.assertMessage("Skipping create admin user.  User 'admin123' already exists in realm 'master'.");
         cliResult.assertStartedDevMode();
     }
 
     @Test
     @WithEnvVars({"KEYCLOAK_ADMIN", "admin123", "KEYCLOAK_ADMIN_PASSWORD", "admin123"})
     @Launch({"start-dev"})
-    void testCreateDifferentAdmin(KeycloakDistribution dist, LaunchResult result) {
+    void testCreateNewAdmin(KeycloakDistribution dist, LaunchResult result) {
         assertTrue(result.getOutput().contains("Added user 'admin123' to realm 'master'"),
                 () -> "The Output:\n" + result.getOutput() + "doesn't contains the expected string.");
 
@@ -94,7 +94,7 @@ public class BuildAndStartDistTest {
         dist.setEnvVar("KEYCLOAK_ADMIN_PASSWORD","new-admin");
         CLIResult cliResult = dist.run("start-dev");
 
-        cliResult.assertNoMessage("Failed to add user 'new-admin' to realm 'master'");
+        cliResult.assertNoMessage("Added user 'new-admin' to realm 'master'");
         cliResult.assertStartedDevMode();
     }
 }

--- a/services/src/main/java/org/keycloak/services/ServicesLogger.java
+++ b/services/src/main/java/org/keycloak/services/ServicesLogger.java
@@ -85,7 +85,7 @@ public interface ServicesLogger extends BasicLogger {
     @Message(id=9, value="Added user '%s' to realm '%s'")
     void addUserSuccess(String user, String realm);
 
-    @LogMessage(level = INFO)
+    @LogMessage(level = ERROR)
     @Message(id=10, value="Failed to add user '%s' to realm '%s': user with username exists")
     void addUserFailedUserExists(String user, String realm);
 
@@ -472,4 +472,7 @@ public interface ServicesLogger extends BasicLogger {
     @Message(id=107, value="User '%s' in realm '%s' is not assigned %s role")
     void userNotAssignedRole(String user, String realm, String role);
 
+    @LogMessage(level = INFO)
+    @Message(id=108, value="Skipping create admin user.  User '%s' already exists in realm '%s'.")
+    void addAdminUserUserExists(String user, String realm);
 }

--- a/services/src/main/java/org/keycloak/services/ServicesLogger.java
+++ b/services/src/main/java/org/keycloak/services/ServicesLogger.java
@@ -85,7 +85,7 @@ public interface ServicesLogger extends BasicLogger {
     @Message(id=9, value="Added user '%s' to realm '%s'")
     void addUserSuccess(String user, String realm);
 
-    @LogMessage(level = ERROR)
+    @LogMessage(level = INFO)
     @Message(id=10, value="Failed to add user '%s' to realm '%s': user with username exists")
     void addUserFailedUserExists(String user, String realm);
 
@@ -467,4 +467,9 @@ public interface ServicesLogger extends BasicLogger {
     @Message(id=106, value="Created script engine '%s', version '%s' for the mime type '%s'")
     @Once
     void scriptEngineCreated(String engineName, String engineVersion, String mimeType);
+
+    @LogMessage(level = ERROR)
+    @Message(id=107, value="User '%s' in realm '%s' is not assigned %s role")
+    void userNotAssignedRole(String user, String realm, String role);
+
 }

--- a/services/src/main/java/org/keycloak/services/managers/ApplianceBootstrap.java
+++ b/services/src/main/java/org/keycloak/services/managers/ApplianceBootstrap.java
@@ -30,8 +30,6 @@ import org.keycloak.models.utils.DefaultKeyProviders;
 import org.keycloak.representations.idm.CredentialRepresentation;
 import org.keycloak.services.ServicesLogger;
 
-import org.keycloak.models.ModelDuplicateException;
-
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
@@ -101,7 +99,7 @@ public class ApplianceBootstrap {
         if (existingUser != null) {
             RoleModel adminRole = realm.getRole(AdminRoles.ADMIN);
             if (existingUser.hasRole(adminRole)) {
-               ServicesLogger.LOGGER.addUserFailedUserExists(username, Config.getAdminRealm());
+               ServicesLogger.LOGGER.addAdminUserUserExists(username, Config.getAdminRealm());
             } else {
                ServicesLogger.LOGGER.userNotAssignedRole(username, Config.getAdminRealm(), AdminRoles.ADMIN);
             }


### PR DESCRIPTION
Add user specified by environment variables KEYCLOAK_ADMIN and KEYCLOAK_ADMIN_PASSWORD.  Show different error if user exists with or without admin role.

Closes #16961

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
