### PR TITLE
Stabilize Account Console UI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -477,23 +477,17 @@ jobs:
     timeout-minutes: 75
     strategy:
       matrix:
-        browser: [firefox] # Chrome not working for now
+        browser: [chrome]
       fail-fast: false
     steps:
       - uses: actions/checkout@v3
-
-      - name: Setup firefox
-        uses: browser-actions/setup-firefox@latest
-        with:
-          firefox-version: latest
-      - run: firefox --version
 
       - id: integration-test-setup
         name: Integration test setup
         uses: ./.github/actions/integration-test-setup
 
       - name: Run Account Console IT
-        run: ./mvnw test -Dsurefire.rerunFailingTestsCount=${{ env.SUREFIRE_RERUN_FAILING_COUNT }} -nsu -B -Pauth-server-quarkus -Dtest=**.account2.**,!SigningInTest#passwordlessWebAuthnTest,!SigningInTest#twoFactorWebAuthnTest -Dbrowser=${{ matrix.browser }} -f testsuite/integration-arquillian/tests/other/base-ui/pom.xml | misc/log/trimmer.sh
+        run: ./mvnw test -Dsurefire.rerunFailingTestsCount=${{ env.SUREFIRE_RERUN_FAILING_COUNT }} -nsu -B -Pauth-server-quarkus -Dtest=**.account2.**,!SigningInTest#passwordlessWebAuthnTest,!SigningInTest#twoFactorWebAuthnTest -Dbrowser=${{ matrix.browser }} "-Dwebdriver.chrome.driver=$CHROMEWEBDRIVER/chromedriver" -f testsuite/integration-arquillian/tests/other/base-ui/pom.xml | misc/log/trimmer.sh
 
       - name: Upload JVM Heapdumps
         if: always()

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/WaitUtils.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/WaitUtils.java
@@ -17,6 +17,8 @@
 package org.keycloak.testsuite.util;
 
 import org.jboss.arquillian.graphene.wait.ElementBuilder;
+import org.keycloak.common.Profile;
+import org.keycloak.testsuite.ProfileAssume;
 import org.openqa.selenium.By;
 import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebDriver;
@@ -51,7 +53,7 @@ public final class WaitUtils {
 
     public static final Integer PAGELOAD_TIMEOUT_MILLIS = Integer.parseInt(System.getProperty(PAGELOAD_TIMEOUT_PROP, "10000"));
 
-    public static final int IMPLICIT_ELEMENT_WAIT_MILLIS = 1500; // high value means more stable but slower tests; it needs to be balanced
+    public static final int IMPLICIT_ELEMENT_WAIT_MILLIS = 2000; // high value means more stable but slower tests; it needs to be balanced
 
     // Should be no longer necessary for finding elements since we have implicit wait
     public static ElementBuilder<Void> waitUntilElement(By by) {
@@ -160,7 +162,7 @@ public final class WaitUtils {
                     + "}");
         }
         else if (
-                currentUrl.matches("^[^\\/]+:\\/\\/[^\\/]+\\/auth\\/realms\\/[^\\/]+\\/account\\/.*#/.+$") // check for new Account Console URL
+                ProfileAssume.isFeatureEnabled(Profile.Feature.ACCOUNT2) && currentUrl.matches("^[^\\/]+:\\/\\/[^\\/]+\\/auth\\/realms\\/[^\\/]+\\/account\\/.*$") // check for new Account Console URL
         ) {
             pause(2000); // TODO rework this temporary workaround once KEYCLOAK-11201 and/or KEYCLOAK-8181 are fixed
         }

--- a/testsuite/integration-arquillian/tests/other/base-ui/src/main/java/org/keycloak/testsuite/ui/account2/page/MyResourcesPage.java
+++ b/testsuite/integration-arquillian/tests/other/base-ui/src/main/java/org/keycloak/testsuite/ui/account2/page/MyResourcesPage.java
@@ -13,6 +13,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.jboss.arquillian.graphene.Graphene.waitGui;
 import static org.junit.Assert.assertEquals;
+import static org.keycloak.testsuite.util.UIUtils.clickLink;
 
 public class MyResourcesPage extends AbstractLoggedInPage {
 
@@ -32,7 +33,7 @@ public class MyResourcesPage extends AbstractLoggedInPage {
     }
 
     public void clickRefreshButton() {
-        refreshButton.click();
+        clickLink(refreshButton);
     }
 
     public void clickExpandButton(int row) {

--- a/testsuite/integration-arquillian/tests/other/base-ui/src/test/java/org/keycloak/testsuite/ui/account2/WelcomeScreenTest.java
+++ b/testsuite/integration-arquillian/tests/other/base-ui/src/test/java/org/keycloak/testsuite/ui/account2/WelcomeScreenTest.java
@@ -19,7 +19,6 @@ package org.keycloak.testsuite.ui.account2;
 
 import org.jboss.arquillian.graphene.page.Page;
 import org.junit.Test;
-import org.keycloak.common.util.Retry;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.testsuite.ui.account2.page.ApplicationsPage;
 import org.keycloak.testsuite.ui.account2.page.DeviceActivityPage;
@@ -28,7 +27,6 @@ import org.keycloak.testsuite.ui.account2.page.MyResourcesPage;
 import org.keycloak.testsuite.ui.account2.page.PersonalInfoPage;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.keycloak.testsuite.util.URLAssert.assertCurrentUrlStartsWithLoginUrlOf;
 
 /**
@@ -143,10 +141,10 @@ public class WelcomeScreenTest extends AbstractAccountTest {
 
         // test my resources appeared
         accountWelcomeScreen.navigateTo();
-        Retry.execute(() -> accountWelcomeScreen.assertMyResourcesCardVisible(true), 10, 500);
+        accountWelcomeScreen.assertMyResourcesCardVisible(true);
         accountWelcomeScreen.clickMyResourcesLink();
         loginToAccount();
-        Retry.execute(() -> myResourcesPage.assertCurrent(), 10, 500);
+        myResourcesPage.assertCurrent();
         // no need to disable user managed access
     }
 }

--- a/testsuite/integration-arquillian/tests/pom.xml
+++ b/testsuite/integration-arquillian/tests/pom.xml
@@ -224,7 +224,7 @@
         <firefoxUserPreferences/>
         <firefoxHeadless>true</firefoxHeadless>
         <chromeBinary/>
-        <chromeArguments>--headless</chromeArguments>
+        <chromeArguments>--headless --window-size=1920,1080</chromeArguments>
         <chromeDriverVersion/>
 
         <appium.platformName/>


### PR DESCRIPTION
This PR should resolve all flaky `account2` tests by introducing a few tweaks to the testsuite. It also switches from Firefox to Chrome (that is already [installed](https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md#browsers-and-drivers) on the runners incl. matching driver) as it is much more stable.

Stability tested [here](https://github.com/vmuzikar/keycloak/actions/runs/4245326128/attempts/1), [here](https://github.com/vmuzikar/keycloak/actions/runs/4245326128/attempts/2) and [here](https://github.com/vmuzikar/keycloak/actions/runs/4245326128/attempts/3) by triggering 3*10 test runs.

Closes #17178
Closes #17102
Closes #17070
Closes #17045
Closes #17044
Closes #16875
Closes #16870
Closes #16715
Closes #16670
Closes #16646
Closes #16627
Closes #16620

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
