### PR TITLE
Fix NPE in MigrateTo21_0_0 when admin theme is not set explicitly (#17249)

### DIFF
--- a/model/legacy-private/src/main/java/org/keycloak/migration/migrators/MigrateTo21_0_0.java
+++ b/model/legacy-private/src/main/java/org/keycloak/migration/migrators/MigrateTo21_0_0.java
@@ -25,7 +25,7 @@ public class MigrateTo21_0_0 implements Migration {
 
     private void updateAdminTheme(RealmModel realm) {
         String adminTheme = realm.getAdminTheme();
-        if (adminTheme.equals("keycloak") || adminTheme.equals("rh-sso")) {
+        if ("keycloak".equals(adminTheme) || "rh-sso".equals(adminTheme)) {
             realm.setAdminTheme("keycloak.v2");
         }
     }


### PR DESCRIPTION
Only update admin-console theme to keycloak.v2 if it is explicitly set to "keycloak" or "rh-sso".

Fixes #17248

Signed-off-by: Thomas Darimont <thomas.darimont@googlemail.com>
Co-authored-by: Stian Thorgersen <stian@redhat.com>