### PR TITLE
Remove duplicated set-cookie header from response when expiring cookies

### DIFF
--- a/adapters/spi/servlet-adapter-spi/src/main/java/org/keycloak/adapters/servlet/ServletHttpFacade.java
+++ b/adapters/spi/servlet-adapter-spi/src/main/java/org/keycloak/adapters/servlet/ServletHttpFacade.java
@@ -207,7 +207,7 @@ public class ServletHttpFacade implements HttpFacade {
 
         @Override
         public void setCookie(String name, String value, String path, String domain, int maxAge, boolean secure, boolean httpOnly) {
-            StringBuffer cookieBuf = new StringBuffer();
+            StringBuilder cookieBuf = new StringBuilder();
             ServerCookie.appendCookieValue(cookieBuf, 1, name, value, path, domain, null, maxAge, secure, httpOnly, null);
             String cookie = cookieBuf.toString();
             response.addHeader("Set-Cookie", cookie);

--- a/adapters/spi/tomcat-adapter-spi/src/main/java/org/keycloak/adapters/tomcat/CatalinaHttpFacade.java
+++ b/adapters/spi/tomcat-adapter-spi/src/main/java/org/keycloak/adapters/tomcat/CatalinaHttpFacade.java
@@ -218,7 +218,7 @@ public class CatalinaHttpFacade implements HttpFacade {
 
         @Override
         public void setCookie(String name, String value, String path, String domain, int maxAge, boolean secure, boolean httpOnly) {
-            StringBuffer cookieBuf = new StringBuffer();
+            StringBuilder cookieBuf = new StringBuilder();
             ServerCookie.appendCookieValue(cookieBuf, 1, name, value, path, domain, null, maxAge, secure, httpOnly, null);
             String cookie = cookieBuf.toString();
             response.addHeader("Set-Cookie", cookie);

--- a/common/src/main/java/org/keycloak/common/util/ServerCookie.java
+++ b/common/src/main/java/org/keycloak/common/util/ServerCookie.java
@@ -178,7 +178,7 @@ public class ServerCookie implements Serializable {
 
 
     // TODO RFC2965 fields also need to be passed
-    public static void appendCookieValue(StringBuffer headerBuf,
+    public static void appendCookieValue(StringBuilder headerBuf,
                                          int version,
                                          String name,
                                          String value,

--- a/examples/providers/authenticator/src/main/java/org/keycloak/examples/authenticator/SecretQuestionAuthenticator.java
+++ b/examples/providers/authenticator/src/main/java/org/keycloak/examples/authenticator/SecretQuestionAuthenticator.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.examples.authenticator;
 
+import org.keycloak.http.HttpCookie;
 import org.keycloak.http.HttpResponse;
 import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.authentication.AuthenticationFlowError;
@@ -24,7 +25,6 @@ import org.keycloak.authentication.Authenticator;
 import org.keycloak.authentication.CredentialValidator;
 import org.keycloak.authentication.RequiredActionFactory;
 import org.keycloak.authentication.RequiredActionProvider;
-import org.keycloak.common.util.ServerCookie;
 import org.keycloak.credential.CredentialProvider;
 import org.keycloak.models.AuthenticatorConfigModel;
 import org.keycloak.models.KeycloakSession;
@@ -33,7 +33,6 @@ import org.keycloak.models.UserCredentialModel;
 import org.keycloak.models.UserModel;
 
 import javax.ws.rs.core.Cookie;
-import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 import java.net.URI;
@@ -97,10 +96,7 @@ public class SecretQuestionAuthenticator implements Authenticator, CredentialVal
 
     public void addCookie(AuthenticationFlowContext context, String name, String value, String path, String domain, String comment, int maxAge, boolean secure, boolean httpOnly) {
         HttpResponse response = context.getSession().getContext().getHttpResponse();
-        StringBuffer cookieBuf = new StringBuffer();
-        ServerCookie.appendCookieValue(cookieBuf, 1, name, value, path, domain, comment, maxAge, secure, httpOnly, null);
-        String cookie = cookieBuf.toString();
-        response.addHeader(HttpHeaders.SET_COOKIE, cookie);
+        response.setCookieIfAbsent(new HttpCookie(1, name, value, path, domain, comment, maxAge, secure, httpOnly, null));
     }
 
 

--- a/server-spi/src/main/java/org/keycloak/http/HttpCookie.java
+++ b/server-spi/src/main/java/org/keycloak/http/HttpCookie.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.http;
+
+import org.keycloak.common.util.ServerCookie;
+import org.keycloak.common.util.ServerCookie.SameSiteAttributeValue;
+
+/**
+ * An extension of {@link javax.ws.rs.core.Cookie} in order to support additional
+ * fields and behavior.
+ */
+public final class HttpCookie extends javax.ws.rs.core.Cookie {
+
+    private final String comment;
+    private final int maxAge;
+    private final boolean secure;
+    private final boolean httpOnly;
+    private final SameSiteAttributeValue sameSite;
+
+    public HttpCookie(int version, String name, String value, String path, String domain, String comment, int maxAge, boolean secure, boolean httpOnly, SameSiteAttributeValue sameSite) {
+        super(name, value, path, domain, version);
+        this.comment = comment;
+        this.maxAge = maxAge;
+        this.secure = secure;
+        this.httpOnly = httpOnly;
+        this.sameSite = sameSite;
+    }
+
+    public String toHeaderValue() {
+        StringBuilder cookieBuf = new StringBuilder();
+        ServerCookie.appendCookieValue(cookieBuf, getVersion(), getName(), getValue(), getPath(), getDomain(), comment, maxAge, secure, httpOnly, sameSite);
+        return cookieBuf.toString();
+    }
+}

--- a/server-spi/src/main/java/org/keycloak/http/HttpResponse.java
+++ b/server-spi/src/main/java/org/keycloak/http/HttpResponse.java
@@ -16,6 +16,7 @@
  */
 
 package org.keycloak.http;
+
 /**
  * <p>Represents an out coming HTTP response.
  *
@@ -45,4 +46,20 @@ public interface HttpResponse {
      * @param value the header value
      */
     void setHeader(String name, String value);
+
+    /**
+     * Sets a new cookie only if not yet set.
+     *
+     * @param cookie the cookie
+     */
+    void setCookieIfAbsent(HttpCookie cookie);
+
+    /**
+     * Adding cookies at the end of the transaction helps when retrying a transaction might add the
+     * cookie multiple times. In some scenarios it must not be added at the end of the transaction,
+     * as at that time the response has already been sent to the caller ("committed"), so the code
+     * needs to make a choice. As retrying transactions is the exception, adding cookies at the end
+     * of the transaction is also the exception and needs to be switched on where necessary.
+     */
+    void setWriteCookiesOnTransactionComplete();
 }

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpoint.java
@@ -49,7 +49,6 @@ import org.keycloak.services.clientpolicy.context.PreAuthorizationRequestContext
 import org.keycloak.services.messages.Messages;
 import org.keycloak.services.resources.LoginActionsService;
 import org.keycloak.services.util.CacheControlUtil;
-import org.keycloak.services.util.CookieHelper;
 import org.keycloak.sessions.AuthenticationSessionModel;
 import org.keycloak.util.TokenUtil;
 
@@ -133,7 +132,7 @@ public class AuthorizationEndpoint extends AuthorizationEndpointBase {
         return KeycloakModelUtils.runJobInRetriableTransaction(session.getKeycloakSessionFactory(), new ResponseSessionTask(session) {
             @Override
             public Response runInternal(KeycloakSession session) {
-                CookieHelper.addCookiesAtEndOfTransaction(session);
+                session.getContext().getHttpResponse().setWriteCookiesOnTransactionComplete();
                 // create another instance of the endpoint to isolate each run.
                 AuthorizationEndpoint other = new AuthorizationEndpoint(session,
                         new EventBuilder(session.getContext().getRealm(), session, clientConnection), action);

--- a/services/src/main/java/org/keycloak/services/DefaultKeycloakContext.java
+++ b/services/src/main/java/org/keycloak/services/DefaultKeycloakContext.java
@@ -176,6 +176,6 @@ public class DefaultKeycloakContext implements KeycloakContext {
     }
 
     protected HttpResponse createHttpResponse() {
-        return new HttpResponseImpl(getContextObject(org.jboss.resteasy.spi.HttpResponse.class));
+        return new HttpResponseImpl(session, getContextObject(org.jboss.resteasy.spi.HttpResponse.class));
     }
 }

--- a/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
@@ -909,7 +909,6 @@ public class AuthenticationManager {
         AuthResult authResult = verifyIdentityToken(session, realm, session.getContext().getUri(), session.getContext().getConnection(), checkActive, false, null, true, tokenString, session.getContext().getRequestHeaders(), VALIDATE_IDENTITY_COOKIE);
         if (authResult == null) {
             expireIdentityCookie(realm, session.getContext().getUri(), session);
-            expireOldIdentityCookie(realm, session.getContext().getUri(), session);
             return null;
         }
         authResult.getSession().setLastSessionRefresh(Time.currentTime());

--- a/services/src/main/java/org/keycloak/services/resources/LoginActionsService.java
+++ b/services/src/main/java/org/keycloak/services/resources/LoginActionsService.java
@@ -81,7 +81,6 @@ import org.keycloak.services.messages.Messages;
 import org.keycloak.services.util.AuthenticationFlowURLHelper;
 import org.keycloak.services.util.BrowserHistoryHelper;
 import org.keycloak.services.util.CacheControlUtil;
-import org.keycloak.services.util.CookieHelper;
 import org.keycloak.services.util.LocaleUtil;
 import org.keycloak.sessions.AuthenticationSessionCompoundId;
 import org.keycloak.sessions.AuthenticationSessionModel;
@@ -261,7 +260,7 @@ public class LoginActionsService {
             @Override
             public Response runInternal(KeycloakSession session) {
                 // create another instance of the endpoint to isolate each run.
-                CookieHelper.addCookiesAtEndOfTransaction(session);
+                session.getContext().getHttpResponse().setWriteCookiesOnTransactionComplete();
                 LoginActionsService other = new LoginActionsService(session, new EventBuilder(session.getContext().getRealm(), session, clientConnection));
                 // process the request in the created instance.
                 return other.authenticateInternal(authSessionId, code, execution, clientId, tabId);


### PR DESCRIPTION
Closes #17192

* Removes `CookieTransaction` in favor of supporting transaction events on the `HttpResponse`.
* Cookie state is shared during the `KeycloakSession` lifetime in order to allow checking for duplicates.
* Introduces a `HttpCookie` type and cookie-related methods to the `HttpResponse` to represent/manage cookies

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
