### PR TITLE
Implement UserInfoTokenMapper in HardcodedRole and RoleNameMapper mappers

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/HardcodedRole.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/HardcodedRole.java
@@ -26,6 +26,7 @@ import org.keycloak.protocol.ProtocolMapperUtils;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.provider.ProviderConfigProperty;
 import org.keycloak.representations.AccessToken;
+import org.keycloak.representations.IDToken;
 import org.keycloak.utils.RoleResolveUtil;
 
 import java.util.ArrayList;
@@ -39,7 +40,7 @@ import java.util.Map;
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
  */
-public class HardcodedRole extends AbstractOIDCProtocolMapper implements OIDCAccessTokenMapper {
+public class HardcodedRole extends AbstractOIDCProtocolMapper implements OIDCAccessTokenMapper, UserInfoTokenMapper {
 
     private static final List<ProviderConfigProperty> configProperties = new ArrayList<>();
 
@@ -88,8 +89,24 @@ public class HardcodedRole extends AbstractOIDCProtocolMapper implements OIDCAcc
     }
 
     @Override
+    public AccessToken transformUserInfoToken(AccessToken token, ProtocolMapperModel mappingModel, KeycloakSession session,
+                                              UserSessionModel userSession, ClientSessionContext clientSessionCtx) {
+        // the mapper is always executed and then other role mappers decide if the claims are really set to the token
+        setClaim(token, mappingModel, userSession, session, clientSessionCtx);
+        return token;
+    }
+
+    @Override
     public AccessToken transformAccessToken(AccessToken token, ProtocolMapperModel mappingModel, KeycloakSession session,
                                             UserSessionModel userSession, ClientSessionContext clientSessionCtx) {
+        // the mapper is always executed and then other role mappers decide if the claims are really set to the token
+        setClaim(token, mappingModel, userSession, session, clientSessionCtx);
+        return token;
+    }
+
+    @Override
+    protected void setClaim(IDToken token, ProtocolMapperModel mappingModel, UserSessionModel userSession, KeycloakSession session,
+                            ClientSessionContext clientSessionCtx) {
 
         String role = mappingModel.getConfig().get(ROLE_CONFIG);
         String[] scopedRole = KeycloakModelUtils.parseRole(role);
@@ -102,8 +119,6 @@ public class HardcodedRole extends AbstractOIDCProtocolMapper implements OIDCAcc
             AccessToken.Access access = RoleResolveUtil.getResolvedRealmRoles(session, clientSessionCtx, true);
             access.addRole(role);
         }
-
-        return token;
     }
 
     public static ProtocolMapperModel create(String name,

--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/RoleNameMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/RoleNameMapper.java
@@ -26,6 +26,7 @@ import org.keycloak.protocol.ProtocolMapperUtils;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.provider.ProviderConfigProperty;
 import org.keycloak.representations.AccessToken;
+import org.keycloak.representations.IDToken;
 import org.keycloak.utils.RoleResolveUtil;
 
 import java.util.ArrayList;
@@ -39,7 +40,7 @@ import java.util.Map;
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
  */
-public class RoleNameMapper extends AbstractOIDCProtocolMapper implements OIDCAccessTokenMapper {
+public class RoleNameMapper extends AbstractOIDCProtocolMapper implements OIDCAccessTokenMapper, UserInfoTokenMapper {
 
     private static final List<ProviderConfigProperty> configProperties = new ArrayList<>();
 
@@ -95,8 +96,24 @@ public class RoleNameMapper extends AbstractOIDCProtocolMapper implements OIDCAc
     }
 
     @Override
+    public AccessToken transformUserInfoToken(AccessToken token, ProtocolMapperModel mappingModel, KeycloakSession session,
+                                              UserSessionModel userSession, ClientSessionContext clientSessionCtx) {
+        // the mapper is always executed and then other role mappers decide if the claims are really set to the token
+        setClaim(token, mappingModel, userSession, session, clientSessionCtx);
+        return token;
+    }
+
+    @Override
     public AccessToken transformAccessToken(AccessToken token, ProtocolMapperModel mappingModel, KeycloakSession session,
                                             UserSessionModel userSession, ClientSessionContext clientSessionCtx) {
+        // the mapper is always executed and then other role mappers decide if the claims are really set to the token
+        setClaim(token, mappingModel, userSession, session, clientSessionCtx);
+        return token;
+    }
+
+    @Override
+    protected void setClaim(IDToken token, ProtocolMapperModel mappingModel, UserSessionModel userSession, KeycloakSession session,
+                            ClientSessionContext clientSessionCtx) {
         String role = mappingModel.getConfig().get(ROLE_CONFIG);
         String newName = mappingModel.getConfig().get(NEW_ROLE_NAME);
 
@@ -106,12 +123,12 @@ public class RoleNameMapper extends AbstractOIDCProtocolMapper implements OIDCAc
         String roleName = scopedRole[1];
         if (appName != null) {
             AccessToken.Access access = RoleResolveUtil.getResolvedClientRoles(session, clientSessionCtx, appName, false);
-            if (access == null) return token;
-            if (!access.getRoles().contains(roleName)) return token;
+            if (access == null) return;
+            if (!access.getRoles().contains(roleName)) return;
             access.getRoles().remove(roleName);
         } else {
             AccessToken.Access access = RoleResolveUtil.getResolvedRealmRoles(session, clientSessionCtx, false);
-            if (access == null || !access.getRoles().contains(roleName)) return token;
+            if (access == null || !access.getRoles().contains(roleName)) return;
             access.getRoles().remove(roleName);
         }
 
@@ -125,7 +142,6 @@ public class RoleNameMapper extends AbstractOIDCProtocolMapper implements OIDCAc
         }
 
         access.addRole(newRoleName);
-        return token;
     }
 
     public static ProtocolMapperModel create(String name,

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/admin/ApiUtil.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/admin/ApiUtil.java
@@ -115,6 +115,15 @@ public class ApiUtil {
         return null;
     }
 
+    public static ProtocolMapperRepresentation findProtocolMapperByName(ClientScopeResource scope, String name) {
+        for (ProtocolMapperRepresentation p : scope.getProtocolMappers().getMappers()) {
+            if (p.getName().equals(name)) {
+                return p;
+            }
+        }
+        return null;
+    }
+
     public static ClientScopeResource findClientScopeByName(RealmResource realm, String clientScopeName) {
         for (ClientScopeRepresentation clientScope : realm.clientScopes().findAll()) {
             if (clientScopeName.equals(clientScope.getName())) {


### PR DESCRIPTION
Closes https://github.com/keycloak/keycloak/issues/15624

Just adding implementation for `UserInfoTokenMapper` and creating two tests for each mapper to check when the roles are assigned to the the three types harcoded and mapped roles are there.
