### PR TITLE
Check  Content-Type header in the request HttpRequestImpl

### DIFF
--- a/services/src/main/java/org/keycloak/services/HttpRequestImpl.java
+++ b/services/src/main/java/org/keycloak/services/HttpRequestImpl.java
@@ -59,6 +59,10 @@ public class HttpRequestImpl implements HttpRequest {
         if (delegate == null) {
             return null;
         }
+        MediaType mediaType = getHttpHeaders().getMediaType();
+        if (mediaType.isCompatible(MediaType.valueOf("application/x-www-form-urlencoded"))) {
+            return new MultivaluedHashMap<>();
+        }
         return delegate.getDecodedFormParameters();
     }
 

--- a/services/src/main/java/org/keycloak/services/HttpRequestImpl.java
+++ b/services/src/main/java/org/keycloak/services/HttpRequestImpl.java
@@ -60,7 +60,7 @@ public class HttpRequestImpl implements HttpRequest {
             return null;
         }
         MediaType mediaType = getHttpHeaders().getMediaType();
-        if (mediaType.isCompatible(MediaType.valueOf("application/x-www-form-urlencoded"))) {
+        if (mediaType == null || !mediaType.isCompatible(MediaType.valueOf("application/x-www-form-urlencoded"))) {
             return new MultivaluedHashMap<>();
         }
         return delegate.getDecodedFormParameters();


### PR DESCRIPTION
Added check for the presence of Content-Type header in the request. If the header is not present, I set the MultivaluedHashMap to an empty value to prevent any errors. This change ensures that the code handles the absence of the Content-Type header gracefully.