### PR TITLE
Update containers.adoc #17301

### DIFF
--- a/docs/guides/src/main/server/containers.adoc
+++ b/docs/guides/src/main/server/containers.adoc
@@ -59,7 +59,7 @@ To install custom providers, you just need to define a step to include the JAR f
 [source, dockerfile]
 ----
 # A example build step that downloads a JAR file from a URL and adds it to the providers directory
-RUN curl -sL <MY_PROVIDER_JAR_URL> -o /opt/keycloak/providers/myprovider.jar
+ADD <MY_PROVIDER_JAR_URL> /opt/keycloak/providers/myprovider.jar
 ----
 
 === Building the docker image


### PR DESCRIPTION
The Keycloak base image does not include curl. And it does not include dnf to set up curl.

To get the provider module over the network as in the original documentation, replacing it with the ADD command is closest in feel.