### PR TITLE
Fix instructions for FIPS container image

### DIFF
--- a/quarkus/container/ubi-null.sh
+++ b/quarkus/container/ubi-null.sh
@@ -31,7 +31,6 @@ python3-libs
 python3-pip-wheel
 python3-setuptools-wheel
 p11-kit
-sqlite-libs
 
 EOF
 


### PR DESCRIPTION
Closes #17253

@pedroigor @rmartinc I figured that the example instructions from our documentation to prepare FIPS container image does not work.

The reason is probably the fact, that Keycloak base image is based on `ubi9-micro` now and it looks it is missing some required stuff needed for `pkcs11` security provider - see the stacktrace from the issue for more details. I did not saw this issue when I've tested before with keycloak nightly image, but now I can see when testing with `latest` based on released Keycloak 21.0.0.

In this PR, I've slightly changed the instructions in a docs in a similar way, which we use for our CI setup. The example FIPS image is based on the `ubi9` image instead of the `keycloak` image and the directory with keycloak server is just copied into that.

Does this approach look ok to you?
