### PR TITLE
Fix configuration for disabled features throwing errors with disabled…

### DIFF
--- a/common/src/main/java/org/keycloak/common/Profile.java
+++ b/common/src/main/java/org/keycloak/common/Profile.java
@@ -254,7 +254,7 @@ public class Profile {
 
     private static void verifyConfig(Map<Feature, Boolean> features) {
         for (Feature f : features.keySet()) {
-            if (f.getDependencies() != null) {
+            if (features.get(f) && f.getDependencies() != null) {
                 for (Feature d : f.getDependencies()) {
                     if (!features.get(d)) {
                         throw new ProfileException("Feature " + f.getKey() + " depends on disabled feature " + d.getKey());

--- a/common/src/test/java/org/keycloak/common/ProfileTest.java
+++ b/common/src/test/java/org/keycloak/common/ProfileTest.java
@@ -92,6 +92,16 @@ public class ProfileTest {
     }
 
     @Test
+    public void checkSuccessIfFeatureDisabledWithDisabledDependencies() {
+        Properties properties = new Properties();
+        properties.setProperty("keycloak.profile.feature.account2", "disabled");
+        properties.setProperty("keycloak.profile.feature.account_api", "disabled");
+        Profile.configure(new PropertiesProfileConfigResolver(properties));
+        Assert.assertFalse(Profile.isFeatureEnabled(Profile.Feature.ACCOUNT2));
+        Assert.assertFalse(Profile.isFeatureEnabled(Profile.Feature.ACCOUNT_API));
+    }
+
+    @Test
     public void checkErrorOnBadConfig() {
         Properties properties = new Properties();
         properties.setProperty("keycloak.profile.feature.account_api", "invalid");


### PR DESCRIPTION
Closes #17322

Resolved the failure when a feature that is disabled has a dependency that is also disabled when kc.bat/sh is run.

Affects the features: admin2, admin-api, account2, account-api
Profile.verifyConfig method will only continue with the feature dependency verification if the current feature is not disabled. So if the account2 feature is disabled the check is the dependency feature account-api won't happen.
