### PR TITLE
Read-Only attributes should be modified if creation is delayed for LDAP

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPIdentityStore.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPIdentityStore.java
@@ -550,8 +550,8 @@ public class LDAPIdentityStore implements IdentityStore {
                 // Ignore empty attributes on create (changetype: add)
                 !(isCreate && attrValue.isEmpty()) &&
 
-                // Since we're extracting for saving, skip read-only attributes. ldapObject.getReadOnlyAttributeNames() are lower-cased
-                !ldapObject.getReadOnlyAttributeNames().contains(attrNameLowercased) &&
+                // Skip read-only attributes for saving if not create. ldapObject.getReadOnlyAttributeNames() are lower-cased
+                (isCreate || !ldapObject.getReadOnlyAttributeNames().contains(attrNameLowercased)) &&
 
                 // Only extract RDN for create since it can't be changed on update
                 (isCreate || !rdnAttrNamesLowerCased.contains(attrNameLowercased))


### PR DESCRIPTION
Closes https://github.com/keycloak/keycloak/issues/16848

Little regression after https://github.com/keycloak/keycloak/issues/14286. When a hardcoded attribute mapper is configured and the creation in LDAP is delayed because mandatory attributes are not filled, the hardcoded value is not set as it's considered read-only. Modifying the `extractAttributesForSaving` to always include read-only attributes in creation if they have a value. @mposolda Double check this when you have time.

The delayed creation test has been modified to include a hardcoded value that should be there in the LDAP entry after registration.
