### PR TITLE
referrer_url is not correctly computed in account console

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/account/AccountConsole.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountConsole.java
@@ -210,7 +210,7 @@ public class AccountConsole {
         return Response.status(302).location(session.getContext().getUri().getRequestUriBuilder().path("../").build()).build();
     }
 
-    // TODO: took this code from elsewhere - refactor
+
     private String[] getReferrer() {
         String referrer = session.getContext().getUri().getQueryParameters().getFirst("referrer");
         if (referrer == null) {
@@ -224,7 +224,7 @@ public class AccountConsole {
             if (referrerUri != null) {
                 referrerUri = RedirectUtils.verifyRedirectUri(session, referrerUri, referrerClient);
             } else {
-                referrerUri = ResolveRelative.resolveRelativeUri(session, client.getRootUrl(), referrerClient.getBaseUrl());
+                referrerUri = ResolveRelative.resolveRelativeUri(session, referrerClient.getRootUrl(), referrerClient.getBaseUrl());
             }
             
             if (referrerUri != null) {
@@ -233,15 +233,6 @@ public class AccountConsole {
                     referrerName = referrer;
                 }
                 return new String[]{referrer, referrerName, referrerUri};
-            }
-        } else if (referrerUri != null) {
-            referrerClient = realm.getClientByClientId(referrer);
-            if (client != null) {
-                referrerUri = RedirectUtils.verifyRedirectUri(session, referrerUri, referrerClient);
-
-                if (referrerUri != null) {
-                    return new String[]{referrer, referrer, referrerUri};
-                }
             }
         }
 

--- a/testsuite/integration-arquillian/tests/other/base-ui/src/main/java/org/keycloak/testsuite/ui/account2/page/WelcomeScreen.java
+++ b/testsuite/integration-arquillian/tests/other/base-ui/src/main/java/org/keycloak/testsuite/ui/account2/page/WelcomeScreen.java
@@ -74,8 +74,10 @@ public class WelcomeScreen extends AbstractAccountPage {
     @Override
     public UriBuilder getUriBuilder() {
         UriBuilder uriBuilder = super.getUriBuilder();
-        if (referrer != null && referrerUri != null) {
+        if (referrer != null) {
             uriBuilder.queryParam("referrer", referrer);
+        }
+        if (referrerUri != null) {
             uriBuilder.queryParam("referrer_uri", referrerUri);
         }
         return uriBuilder;


### PR DESCRIPTION
closes #16484

- When `referrer_url` parameter was not provided, it was computed based on the rootUrl of `account-console` client itself. This was a bug (probably caused by copy/paste this code from somewhere else). It should be instead computed based on the URL of client itself.

- Cleanup the unused code block in AccountConsole class (note that `realm.getClientByClientId(referrer);` is always null here inside `else` block due the previous checks in the code. So whole `else` branch was not correct and effectively useless
