### PR TITLE
Avoid recording metrics for http server endpoints while they contain resource IDs

### DIFF
--- a/quarkus/runtime/src/main/resources/application.properties
+++ b/quarkus/runtime/src/main/resources/application.properties
@@ -9,6 +9,13 @@ quarkus.banner.enabled=false
 quarkus.health.extensions.enabled=false
 quarkus.datasource.health.enabled=false
 
+# Disable http metrics binder as URL parameters are only shown with placeholders for '/resource' URLs, but not
+# for '/admin' and '/realms'. Neither the IDs of entities nor the realm name should be part of the metric names
+# to avoid an explosion of metric names which would lead to memory exhaustion in Keycloak and to a resource
+# exhaustion in the connected monitoring systems.
+# See https://github.com/keycloak/keycloak/issues/17281 for a discussion
+quarkus.micrometer.binder.http-server.enabled=false
+
 # Enables metrics from other extensions if metrics is enabled
 quarkus.datasource.metrics.enabled=${quarkus.micrometer.enabled}
 


### PR DESCRIPTION
This is a backport of #17326

Closes #17281

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
