### PR TITLE
Add method to determine if enforcement is disabled to PathConfigMethod

### DIFF
--- a/authz/policy-enforcer/src/main/java/org/keycloak/adapters/authorization/PathConfigMatcher.java
+++ b/authz/policy-enforcer/src/main/java/org/keycloak/adapters/authorization/PathConfigMatcher.java
@@ -65,6 +65,20 @@ public class PathConfigMatcher extends PathMatcher<PathConfig> {
         }
     }
 
+    public boolean isEnforcementDisabled(String targetUri) {
+        PathConfig pathConfig = pathCache.get(targetUri);
+
+        if (pathConfig == null && !pathCache.containsKey(targetUri)) {
+            pathConfig = super.matches(targetUri);
+        }
+
+        if (pathConfig == null) {
+            return false;
+        }
+
+        return pathConfig.getEnforcementMode() == PolicyEnforcerConfig.EnforcementMode.DISABLED;
+    }
+
     @Override
     public PathConfig matches(String targetUri) {
         PathConfig pathConfig = pathCache.get(targetUri);

--- a/testsuite/integration-arquillian/tests/base/src/test/resources/authorization-test/enforcer-disabled-enforce-mode-path.json
+++ b/testsuite/integration-arquillian/tests/base/src/test/resources/authorization-test/enforcer-disabled-enforce-mode-path.json
@@ -13,6 +13,11 @@
         "name": "Resource B",
         "path": "/api/resource/public",
         "enforcement-mode": "DISABLED"
+      },
+      {
+        "name": "Resource B",
+        "path": "/api/resource/public-b/*",
+        "enforcement-mode": "DISABLED"
       }
     ]
   }


### PR DESCRIPTION
closes: #17381

Provide a way to determine whether enforcement has been disabled when path config path ends with a wildcard (non-static path) and no path contains pattern. Main difference between newly exposed method and `matches` method is that https://github.com/keycloak/keycloak/blob/main/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/authorization/PolicyEnforcer.java#L276 is avoided.