### PR TITLE
Fix the performance issue when keycloak admin logs into the web console

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmCacheSession.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmCacheSession.java
@@ -1447,4 +1447,14 @@ public class RealmCacheSession implements CacheRealmProvider {
         }
         return null;
     }
+
+    @Override
+    public List<RealmModel> getRealmsFromDB(boolean briefRepresentation) {
+        throw new RuntimeException("This method does not support-----getRealmsFromDB");
+    }
+
+    @Override
+    public Map<String, Set<String>> getAllRoleName() {
+        throw new RuntimeException("This method does not support-----getAllRoleName");
+    }
 }

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
@@ -1144,31 +1144,25 @@ public class JpaRealmProvider implements RealmProvider, ClientProvider, ClientSc
     }
 
     public List<RealmModel> getRealmsFromDB(boolean briefRepresentation) {
-        String sql = "SELECT id, access_code_lifespan, user_action_lifespan, access_token_lifespan, "
-                + "enabled, events_enabled, events_expiration, login_theme, name, not_before, "
-                + "registration_allowed, remember_me, reset_password_allowed, social, ssl_required, sso_idle_timeout, "
-                + "sso_max_lifespan, update_profile_on_soc_login, verify_email, master_admin_client, login_lifespan, "
-                + "internationalization_enabled, default_locale, reg_email_as_username, admin_events_enabled, admin_events_details_enabled, "
-                + "edit_username_allowed, otp_policy_counter, otp_policy_window, otp_policy_period, otp_policy_digits, otp_policy_alg, "
-                + "otp_policy_type, browser_flow, registration_flow, direct_grant_flow, reset_credentials_flow, client_auth_flow, "
-                + "offline_session_idle_timeout, revoke_refresh_token, access_token_life_implicit, login_with_email_allowed, "
-                + "duplicate_emails_allowed, docker_auth_flow, refresh_token_max_reuse, allow_user_managed_access, sso_max_lifespan_remember_me, "
-                + "sso_idle_timeout_remember_me, default_role FROM realm";
+        List list;
         if (briefRepresentation){
-            sql = "select id, name, enabled,master_admin_client,default_role from realm";
+            String sql = "select id, name, enabled,master_admin_client,default_role from realm";
+            Query query = em.createNativeQuery(sql);
+            list = query.unwrap(NativeQueryImpl.class).setResultTransformer(Transformers.ALIAS_TO_ENTITY_MAP).list();
+        } else {
+            String sql = "SELECT * FROM realm";
+            Query query = em.createNativeQuery(sql, RealmEntity.class);
+            list = query.getResultList();
         }
-        Query query = em.createNativeQuery(sql);
-        List list = query.unwrap(NativeQueryImpl.class).setResultTransformer(Transformers.ALIAS_TO_ENTITY_MAP).list();
         List<RealmModel> models = new ArrayList<>();
         Map<String, RealmEntity> entityMap = new HashMap<>();
         for (Object obj : list){
-            Map map = (Map) obj;
             RealmEntity entity;
             if (briefRepresentation){
+                Map map = (Map) obj;
                 entity = covertBriefFromMap(map);
             } else {
-                entity = covertAllFromMap(map);
-
+                entity = (RealmEntity) obj;
             }
             models.add(new RealmAdapter(session, em, entity));
             entityMap.put(entity.getId(), entity);
@@ -1183,12 +1177,11 @@ public class JpaRealmProvider implements RealmProvider, ClientProvider, ClientSc
     private void queryAllAttributes(Map<String, RealmEntity> realmMap){
         Query query = em.createNativeQuery("select realm_id, name, value from realm_attribute");
         List list = query.unwrap(NativeQueryImpl.class).setResultTransformer(Transformers.ALIAS_TO_ENTITY_MAP).list();
-        List<RealmAttributeEntity> models = new ArrayList<>();
         for (Object obj : list){
             Map map = (Map) obj;
-            String realmId = map.get("realm_id").toString();
-            String name = map.get("name").toString();
-            String value = map.get("value").toString();
+            String realmId = (String) map.get("realm_id");
+            String name = (String) map.get("name");
+            String value = (String) map.get("value");
             RealmAttributeEntity entity = new RealmAttributeEntity();
             RealmEntity realm = realmMap.get(realmId);
             if (realm != null){
@@ -1202,164 +1195,15 @@ public class JpaRealmProvider implements RealmProvider, ClientProvider, ClientSc
 
     private RealmEntity covertBriefFromMap(Map map){
         RealmEntity entity = new RealmEntity();
-        String realmId = map.get("id").toString();
-        String name = map.get("name").toString();
-        String defaultRole = map.get("default_role").toString();
-        String masterAdminClient = map.get("master_admin_client").toString();
-        boolean enabled = Boolean.getBoolean(map.get("enabled").toString());
+        String realmId = (String) map.get("id");
+        String name = (String) map.get("name");
+        String defaultRole = (String) map.get("default_role");
+        String masterAdminClient = (String) map.get("master_admin_client");
+        boolean enabled = Boolean.getBoolean((String) map.get("enabled"));
         entity.setId(realmId);
         entity.setName(name);
         entity.setEnabled(enabled);
         entity.setMasterAdminClient(masterAdminClient);
-        entity.setDefaultRoleId(defaultRole);
-
-        return entity;
-    }
-    private RealmEntity covertAllFromMap(Map map){
-        RealmEntity entity = new RealmEntity();
-
-        String realmId = map.get("id").toString();
-        entity.setId(realmId);
-
-        int accessCodeLifespan = Integer.parseInt(map.get("access_code_lifespan").toString());
-        entity.setAccessCodeLifespan(accessCodeLifespan);
-
-        int userActionLifespan = Integer.parseInt(map.get("user_action_lifespan").toString());
-        entity.setAccessCodeLifespanUserAction(userActionLifespan);
-
-        int accessTokenLifespan = Integer.parseInt(map.get("access_token_lifespan").toString());
-        entity.setAccessTokenLifespan(accessTokenLifespan);
-
-        boolean enabled = Boolean.getBoolean(map.get("enabled").toString());
-        entity.setEnabled(enabled);
-
-        boolean eventsEnabled = Boolean.getBoolean(map.get("events_enabled").toString());
-        entity.setEventsEnabled(eventsEnabled);
-
-        int eventsExpiration = Integer.parseInt(map.get("events_expiration").toString());
-        entity.setEventsExpiration(eventsExpiration);
-
-        String loginTheme = (String) map.get("login_theme");
-        entity.setLoginTheme(loginTheme);
-
-        String name = map.get("name").toString();
-        entity.setName(name);
-
-        int notBefore = Integer.parseInt(map.get("not_before").toString());
-        entity.setNotBefore(notBefore);
-
-        boolean registrationAllowed = Boolean.getBoolean(map.get("registration_allowed").toString());
-        entity.setRegistrationAllowed(registrationAllowed);
-
-        boolean rememberMe = Boolean.getBoolean(map.get("remember_me").toString());
-        entity.setRememberMe(rememberMe);
-
-        boolean resetPasswordAllowed = Boolean.getBoolean(map.get("reset_password_allowed").toString());
-        entity.setResetPasswordAllowed(resetPasswordAllowed);
-
-        boolean social = Boolean.getBoolean(map.get("social").toString());
-
-        String sslRequired = map.get("ssl_required").toString();
-        entity.setSslRequired(sslRequired);
-
-        int ssoIdleTimeout = Integer.parseInt(map.get("sso_idle_timeout").toString());
-        entity.setSsoSessionIdleTimeout(ssoIdleTimeout);
-
-        int ssoMaxLifespan = Integer.parseInt(map.get("sso_max_lifespan").toString());
-        entity.setSsoSessionMaxLifespan(ssoMaxLifespan);
-
-        boolean updateProfileOnSocLogin = Boolean.getBoolean(map.get("update_profile_on_soc_login").toString());
-
-        boolean verifyEmail = Boolean.getBoolean(map.get("verify_email").toString());
-        entity.setVerifyEmail(verifyEmail);
-
-        String masterAdminClient = map.get("master_admin_client").toString();
-        entity.setMasterAdminClient(masterAdminClient);
-
-        int loginLifespan = Integer.parseInt(map.get("login_lifespan").toString());
-        entity.setAccessCodeLifespanLogin(loginLifespan);
-
-        boolean internationalizationEnabled = Boolean.getBoolean(map.get("internationalization_enabled").toString());
-        entity.setInternationalizationEnabled(internationalizationEnabled);
-
-        String defaultLocale = (String) map.get("default_locale");
-        entity.setDefaultLocale(defaultLocale);
-
-        boolean regEmailAsUsername = Boolean.getBoolean(map.get("reg_email_as_username").toString());
-        entity.setRegistrationEmailAsUsername(regEmailAsUsername);
-
-        boolean adminEventsEnabled = Boolean.getBoolean(map.get("admin_events_enabled").toString());
-        entity.setAdminEventsEnabled(adminEventsEnabled);
-        boolean adminEventsDetailsEnabled = Boolean.getBoolean(map.get("admin_events_details_enabled").toString());
-        entity.setAdminEventsDetailsEnabled(adminEventsDetailsEnabled);
-
-        boolean editUsernameAllowed = Boolean.getBoolean(map.get("edit_username_allowed").toString());
-        entity.setEditUsernameAllowed(editUsernameAllowed);
-
-        int otpPolicyCounter = Integer.parseInt(map.get("otp_policy_counter").toString());
-        entity.setOtpPolicyInitialCounter(otpPolicyCounter);
-
-        int otpPolicyWindow = Integer.parseInt(map.get("otp_policy_window").toString());
-        entity.setOtpPolicyLookAheadWindow(otpPolicyWindow);
-
-        int otpPolicyPeriod = Integer.parseInt(map.get("otp_policy_period").toString());
-        entity.setOtpPolicyPeriod(otpPolicyPeriod);
-
-        int otpPolicyDigits = Integer.parseInt(map.get("otp_policy_digits").toString());
-        entity.setOtpPolicyDigits(otpPolicyDigits);
-
-        String otpPolicyAlg = map.get("otp_policy_alg").toString();
-        entity.setOtpPolicyAlgorithm(otpPolicyAlg);
-
-        String otpPolicyType = map.get("otp_policy_type").toString();
-        entity.setOtpPolicyType(otpPolicyType);
-
-        String browserFlow = map.get("browser_flow").toString();
-        entity.setBrowserFlow(browserFlow);
-
-        String registrationFlow = map.get("registration_flow").toString();
-        entity.setRegistrationFlow(registrationFlow);
-
-        String directGrantFlow = map.get("direct_grant_flow").toString();
-        entity.setDirectGrantFlow(directGrantFlow);
-
-        String resetCredentialsFlow = map.get("reset_credentials_flow").toString();
-        entity.setResetCredentialsFlow(resetCredentialsFlow);
-
-        String clientAuthFlow = map.get("client_auth_flow").toString();
-        entity.setClientAuthenticationFlow(clientAuthFlow);
-
-        int offlineSessionIdleTimeout = Integer.parseInt(map.get("offline_session_idle_timeout").toString());
-        entity.setOfflineSessionIdleTimeout(offlineSessionIdleTimeout);
-
-        boolean revokeRefreshToken = Boolean.getBoolean(map.get("revoke_refresh_token").toString());
-        entity.setRevokeRefreshToken(revokeRefreshToken);
-
-        int accessTokenLifeImplicit = Integer.parseInt(map.get("access_token_life_implicit").toString());
-        entity.setAccessTokenLifespanForImplicitFlow(accessTokenLifeImplicit);
-
-        boolean loginWithEmailAllowed = Boolean.getBoolean(map.get("login_with_email_allowed").toString());
-        entity.setLoginWithEmailAllowed(loginWithEmailAllowed);
-
-        boolean duplicateEmailsAllowed = Boolean.getBoolean(map.get("duplicate_emails_allowed").toString());
-        entity.setDuplicateEmailsAllowed(duplicateEmailsAllowed);
-
-        String dockerAuthFlow = map.get("docker_auth_flow").toString();
-        entity.setDockerAuthenticationFlow(dockerAuthFlow);
-
-        int refreshTokenMaxReuse = Integer.parseInt(map.get("refresh_token_max_reuse").toString());
-        entity.setRefreshTokenMaxReuse(refreshTokenMaxReuse);
-
-        boolean allowUserManagedAccess = Boolean.getBoolean(map.get("allow_user_managed_access").toString());
-        entity.setAllowUserManagedAccess(allowUserManagedAccess);
-
-        int ssoMaxLifespanRememberMe = Integer.parseInt(map.get("sso_max_lifespan_remember_me").toString());
-        entity.setSsoSessionMaxLifespanRememberMe(ssoMaxLifespanRememberMe);
-
-        int ssoIdleTimeoutRememberMe = Integer.parseInt(map.get("sso_idle_timeout_remember_me").toString());
-        entity.setSsoSessionIdleTimeout(ssoIdleTimeoutRememberMe);
-
-        String defaultRole = map.get("default_role").toString();
         entity.setDefaultRoleId(defaultRole);
 
         return entity;

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
@@ -1200,7 +1200,7 @@ public class JpaRealmProvider implements RealmProvider, ClientProvider, ClientSc
         String name = (String) map.get("name");
         String defaultRole = (String) map.get("default_role");
         String masterAdminClient = (String) map.get("master_admin_client");
-        boolean enabled = Boolean.getBoolean((String) map.get("enabled"));
+        boolean enabled = (Boolean) map.get("enabled");
         entity.setId(realmId);
         entity.setName(name);
         entity.setEnabled(enabled);

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
@@ -1142,7 +1142,8 @@ public class JpaRealmProvider implements RealmProvider, ClientProvider, ClientSc
     public Set<String> getClientSearchableAttributes() {
         return clientSearchableAttributes;
     }
-
+    
+    @Override
     public List<RealmModel> getRealmsFromDB(boolean briefRepresentation) {
         List list;
         if (briefRepresentation){
@@ -1209,6 +1210,7 @@ public class JpaRealmProvider implements RealmProvider, ClientProvider, ClientSc
         return entity;
     }
 
+    @Override
     public Map<String, Set<String>> getAllRoleName() {
         Query query = em.createNativeQuery("select r.name as realm_name, kr.name as role_name from KEYCLOAK_ROLE kr "
                 + "left join realm r on kr.client=r.master_admin_client group by r.name, kr.name order by r.name");

--- a/model/map/src/main/java/org/keycloak/models/map/realm/MapRealmProvider.java
+++ b/model/map/src/main/java/org/keycloak/models/map/realm/MapRealmProvider.java
@@ -18,6 +18,7 @@
 package org.keycloak.models.map.realm;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -482,5 +483,15 @@ public class MapRealmProvider implements RealmProvider {
 
     @Override
     public void close() {
+    }
+
+    @Override
+    public List<RealmModel> getRealmsFromDB(boolean briefRepresentation) {
+        throw new RuntimeException("This method does not support-----getRealmsFromDB");
+    }
+
+    @Override
+    public Map<String, Set<String>> getAllRoleName() {
+        throw new RuntimeException("This method does not support-----getAllRoleName");
     }
 }

--- a/server-spi/src/main/java/org/keycloak/models/RealmProvider.java
+++ b/server-spi/src/main/java/org/keycloak/models/RealmProvider.java
@@ -287,4 +287,8 @@ public interface RealmProvider extends Provider /* TODO: Remove in future versio
      * @deprecated Use the corresponding method from {@link GroupProvider}. */
     @Override
     void addTopLevelGroup(RealmModel realm, GroupModel subGroup);
+
+    List<RealmModel> getRealmsFromDB(boolean briefRepresentation);
+
+    Map<String, Set<String>> getAllRoleName();
 }

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -74,11 +74,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.keycloak</groupId>
-            <artifactId>keycloak-model-jpa</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.twitter4j</groupId>
             <artifactId>twitter4j-core</artifactId>
         </dependency>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -74,6 +74,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-model-jpa</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.twitter4j</groupId>
             <artifactId>twitter4j-core</artifactId>
         </dependency>

--- a/services/src/main/java/org/keycloak/services/resources/admin/AdminConsole.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/AdminConsole.java
@@ -19,11 +19,9 @@ package org.keycloak.services.resources.admin;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.annotations.cache.NoCache;
-import org.keycloak.connections.jpa.JpaConnectionProvider;
 import org.keycloak.http.HttpRequest;
 import org.keycloak.http.HttpResponse;
 
-import javax.persistence.EntityManager;
 import javax.ws.rs.NotFoundException;
 import org.keycloak.Config;
 import org.keycloak.common.ClientConnection;
@@ -36,9 +34,9 @@ import org.keycloak.models.Constants;
 import org.keycloak.models.GroupModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
+import org.keycloak.models.RealmProvider;
 import org.keycloak.models.RoleModel;
 import org.keycloak.models.UserModel;
-import org.keycloak.models.jpa.JpaRealmProvider;
 import org.keycloak.protocol.oidc.OIDCLoginProtocolService;
 import org.keycloak.services.Urls;
 import org.keycloak.services.managers.AppAuthManager;
@@ -254,9 +252,8 @@ public class AdminConsole {
     }
 
     private void addMasterRealmAccess(UserModel user, Map<String, Set<String>> realmAdminAccess) {
-        EntityManager em = session.getProvider(JpaConnectionProvider.class).getEntityManager();
-        JpaRealmProvider roleProvider = new JpaRealmProvider(session, em, null, null);
-        Map<String, Set<String>> realmRoles = roleProvider.getAllRoleName();
+        RealmProvider realmProvider = session.getProvider(RealmProvider.class);
+        Map<String, Set<String>> realmRoles = realmProvider.getAllRoleName();
         Set<String> roleMappingSet = user.getRoleMappingsStream().map(RoleModel::getName).collect(Collectors.toSet());
         Set<String> groupSet = user.getGroupsStream().map(GroupModel::getName).collect(Collectors.toSet());
         for(Map.Entry<String, Set<String>> entry : realmRoles.entrySet()){

--- a/services/src/main/java/org/keycloak/services/resources/admin/RealmsAdminResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RealmsAdminResource.java
@@ -19,13 +19,12 @@ package org.keycloak.services.resources.admin;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.annotations.cache.NoCache;
 import org.keycloak.common.ClientConnection;
-import org.keycloak.connections.jpa.JpaConnectionProvider;
 import org.keycloak.models.AdminRoles;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.ModelDuplicateException;
 import org.keycloak.models.RealmModel;
-import org.keycloak.models.jpa.JpaRealmProvider;
+import org.keycloak.models.RealmProvider;
 import org.keycloak.models.utils.ModelToRepresentation;
 import org.keycloak.policy.PasswordPolicyNotMetException;
 import org.keycloak.protocol.oidc.TokenManager;
@@ -38,7 +37,6 @@ import org.keycloak.services.resources.admin.permissions.AdminPermissions;
 import org.keycloak.storage.DatastoreProvider;
 import org.keycloak.storage.ExportImportManager;
 
-import javax.persistence.EntityManager;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
@@ -103,12 +101,11 @@ public class RealmsAdminResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     public Stream<RealmRepresentation> getRealms(@DefaultValue("false") @QueryParam("briefRepresentation") boolean briefRepresentation) {
-        EntityManager em = session.getProvider(JpaConnectionProvider.class).getEntityManager();
-        JpaRealmProvider roleProvider = new JpaRealmProvider(session, em, null, null);
+        RealmProvider realmProvider = session.getProvider(RealmProvider.class);
 
-        List<RealmModel> modelList = roleProvider.getRealmsFromDB(briefRepresentation);
+        List<RealmModel> modelList = realmProvider.getRealmsFromDB(briefRepresentation);
         List<RealmRepresentation> retList = new ArrayList<>();
-        Map<String, Set<String>> realmRoleMap = roleProvider.getAllRoleName();
+        Map<String, Set<String>> realmRoleMap = realmProvider.getAllRoleName();
         for (RealmModel realmModel : modelList){
             Set<String> roleSet = realmRoleMap.get(realmModel.getName());
             if (hasOneAdminRole(roleSet, AdminRoles.VIEW_REALM, AdminRoles.MANAGE_REALM)){


### PR DESCRIPTION
Problem:
   If we have more than 1000 realms in keycloak, when the keycloak admin logs into the web console, the whoami api is very slow, even may get a 5XX response.

Change:
  I have changed the code in "whoami" and "realms" APIs in admin resource to use native SQL to get data instead of JPA.