### PR TITLE
Write AsciiDoc output as UTF-8 independent of system file encoding

### DIFF
--- a/docs/guides/src/main/server/reverseproxy.adoc
+++ b/docs/guides/src/main/server/reverseproxy.adoc
@@ -49,7 +49,7 @@ This precaution can be more critical if you do any deny or allow listing of IP a
 
 Keycloak assumes it is exposed through the reverse proxy under the same context path as Keycloak is configured for. By default Keycloak is exposed through the root (`/`), which means it expects to be exposed through the reverse proxy on `/` as well.
 You can use `hostname-path` or `hostname-url` in these cases, for example using `--hostname-path=/auth` if Keycloak is exposed through the reverse proxy on `/auth`.
- 
+
 Alternatively you can also change the context path of Keycloak itself to match the context path for the reverse proxy using the `http-relative-path` option, which will change the context-path of Keycloak itself to match the context path used by the reverse proxy.
 
 == Trust the proxy to set hostname
@@ -72,11 +72,11 @@ It is beneficial if particular session entity is always available locally, which
 
 * User sends initial request to see the Keycloak login screen
 
-* This request is served by the frontend load balancer, which forwards it to some random node (eg. node1). Strictly said, the node doesn’t need to be random, but can be chosen according to some other criterias (client IP address etc). It all depends on the implementation and configuration of underlying load balancer (reverse proxy).
+* This request is served by the frontend load balancer, which forwards it to some random node (eg. node1). Strictly said, the node doesn't need to be random, but can be chosen according to some other criterias (client IP address etc). It all depends on the implementation and configuration of underlying load balancer (reverse proxy).
 
 * Keycloak creates authentication session with random ID (eg. 123) and saves it to the Infinispan cache.
 
-* Infinispan distributed cache assigns the primary owner of the session based on the hash of session ID. See Infinispan documentation for more details around this. Let’s assume that Infinispan assigned node2 to be the owner of this session.
+* Infinispan distributed cache assigns the primary owner of the session based on the hash of session ID. See Infinispan documentation for more details around this. Let's assume that Infinispan assigned node2 to be the owner of this session.
 
 * Keycloak creates the cookie AUTH_SESSION_ID with the format like <session-id>.<owner-node-id> . In our example case, it will be 123.node2 .
 
@@ -216,7 +216,7 @@ to load additional certificates from headers `CERT_CHAIN_0` to `CERT_CHAIN_9` if
 
 ==== Configuring the NGINX provider
 
-The NGINX SSL/TLS module does not expose the client certificate chain. Keycloak’s NGINX certificate lookup provider rebuilds it by using the Keycloak truststore.
+The NGINX SSL/TLS module does not expose the client certificate chain. Keycloak's NGINX certificate lookup provider rebuilds it by using the Keycloak truststore.
 
 If you are using this provider, please take a look at the <@links.server id="keycloak-truststore"/> guide about how
 to configure a Keycloak Truststore.

--- a/docs/maven-plugin/pom.xml
+++ b/docs/maven-plugin/pom.xml
@@ -31,6 +31,12 @@
     <description>Keycloak Guides Maven Plugin</description>
     <packaging>maven-plugin</packaging>
 
+    <properties>
+        <maven.compiler.release>11</maven.compiler.release>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.maven</groupId>

--- a/docs/maven-plugin/src/main/java/org/keycloak/guides/maven/FreeMarker.java
+++ b/docs/maven-plugin/src/main/java/org/keycloak/guides/maven/FreeMarker.java
@@ -9,6 +9,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -40,7 +41,7 @@ public class FreeMarker {
         HashMap<String, Object> attrs = new HashMap<>(attributes);
         attrs.put("id", template.split("/")[1].replace(".adoc", ""));
 
-        Writer w = new FileWriter(out);
+        Writer w = new FileWriter(out, StandardCharsets.UTF_8);
         t.process(attrs, w);
     }
 


### PR DESCRIPTION
This is a backport of commit d32b443a27fb48379c249b958eeb1beff209e87c

This preserves the UTF-8 encoding of the AsciiDoc input files.

Closes #17417

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
