### PR TITLE
Don't remove session and don't reset restart cookie if passive check error

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocol.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocol.java
@@ -325,8 +325,13 @@ public class OIDCLoginProtocol implements LoginProtocol {
         if (state != null) {
             redirectUri.addParam(OAuth2Constants.STATE, state);
         }
-        
-        new AuthenticationSessionManager(session).removeAuthenticationSession(realm, authSession, true);
+
+        if (error == Error.PASSIVE_LOGIN_REQUIRED || error == Error.PASSIVE_INTERACTION_REQUIRED) {
+            // passive check error, just delete the tabId maintaining session and don't reset the restart cookie
+            new AuthenticationSessionManager(session).removeTabIdInAuthenticationSession(realm, authSession);
+        } else {
+            new AuthenticationSessionManager(session).removeAuthenticationSession(realm, authSession, true);
+        }
         return redirectUri.build();
     }
 

--- a/services/src/main/java/org/keycloak/services/managers/AuthenticationSessionManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/AuthenticationSessionManager.java
@@ -225,6 +225,14 @@ public class AuthenticationSessionManager {
         }
     }
 
+    public void removeTabIdInAuthenticationSession(RealmModel realm, AuthenticationSessionModel authSession) {
+        RootAuthenticationSessionModel rootAuthSession = authSession.getParentSession();
+        rootAuthSession.removeAuthenticationSessionByTabId(authSession.getTabId());
+        if (rootAuthSession.getAuthenticationSessions().isEmpty()) {
+            // no more tabs, remove the session completely
+            removeAuthenticationSession(realm, authSession, false);
+        }
+    }
 
     // Check to see if we already have authenticationSession with same ID
     public UserSessionModel getUserSession(AuthenticationSessionModel authSession) {


### PR DESCRIPTION
Closes https://github.com/keycloak/keycloak/issues/11340

In the case of an error in passive check the session is only removed if no more tabs exist, the restart cookie is never reset. A passive check doesn't start a real login so no need to reset the restart cookie.