### PR TITLE
Fixing compile time warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1018,6 +1018,11 @@
                 <version>${infinispan.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.infinispan</groupId>
+                <artifactId>infinispan-component-annotations</artifactId>
+                <version>${infinispan.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.infinispan.protostream</groupId>
                 <artifactId>protostream-processor</artifactId>
                 <scope>provided</scope>

--- a/testsuite/model/pom.xml
+++ b/testsuite/model/pom.xml
@@ -127,6 +127,12 @@
             <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
+        <!-- annotations needed to avoid compile time warnings about enums constants -->
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-component-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/testsuite/model/src/main/java/org/keycloak/testsuite/model/HotRodServerRule.java
+++ b/testsuite/model/src/main/java/org/keycloak/testsuite/model/HotRodServerRule.java
@@ -15,7 +15,6 @@ import org.infinispan.server.hotrod.configuration.HotRodServerConfigurationBuild
 import org.junit.rules.ExternalResource;
 import org.keycloak.Config;
 import org.keycloak.connections.infinispan.InfinispanUtil;
-import org.keycloak.models.map.storage.hotRod.common.HotRodUtils;
 
 import java.io.IOException;
 
@@ -99,10 +98,10 @@ public class HotRodServerRule extends ExternalResource {
 
         sessionConfigBuilder1.sites().addBackup()
                 .site("site-2").backupFailurePolicy(BackupFailurePolicy.IGNORE).strategy(BackupConfiguration.BackupStrategy.SYNC)
-                .replicationTimeout(15000).enabled(true);
+                .replicationTimeout(15000);
         sessionConfigBuilder2.sites().addBackup()
                 .site("site-1").backupFailurePolicy(BackupFailurePolicy.IGNORE).strategy(BackupConfiguration.BackupStrategy.SYNC)
-                .replicationTimeout(15000).enabled(true);
+                .replicationTimeout(15000);
 
         Configuration sessionCacheConfiguration1 = sessionConfigBuilder1.build();
         Configuration sessionCacheConfiguration2 = sessionConfigBuilder2.build();


### PR DESCRIPTION
Avoiding calling deprecated methods, and adding compile time dependencies for annotations.

Closes #17499

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
