### PR TITLE
Bump webauthn4j to version 0.21.0-RELEASE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -209,8 +209,8 @@
         <spring-boot26.version>2.6.1</spring-boot26.version>
 
         <!-- webauthn support -->
-        <webauthn4j.version>0.20.0.RELEASE</webauthn4j.version>
-        <org.apache.kerby.kerby-asn1.version>2.0.0</org.apache.kerby.kerby-asn1.version>
+        <webauthn4j.version>0.21.0.RELEASE</webauthn4j.version>
+        <org.apache.kerby.kerby-asn1.version>2.0.3</org.apache.kerby.kerby-asn1.version>
 
         <!-- WildFly Galleon Build related properties -->
         <org.wildfly.galleon-plugins.version>5.2.7.Final</org.wildfly.galleon-plugins.version>


### PR DESCRIPTION
Fixes: issue #16730

---
⚠️ Breaking Changes
Remove dependencyManagement from generated pom.xml

⭐ Enhancements
Address sonarqube-plugin parameter change

📦 Dependency Upgrades
Bump org.springframework.boot:spring-boot-dependencies from 2.7.8 to 2.7.9 
Bump org.apache.kerby:kerby-asn1 from 2.0.2 to 2.0.3 
Bump org.checkerframework:checker-qual from 3.30.0 to 3.31.0 
Bump org.checkerframework:checker-qual from 3.29.0 to 3.30.0