### PR TITLE
Add job for Keycloak Masthead to JS workflow

### DIFF
--- a/.github/workflows/js-ci.yml
+++ b/.github/workflows/js-ci.yml
@@ -66,6 +66,23 @@ jobs:
 
       - run: npm run build --workspace=${{ env.WORKSPACE }}
 
+  keycloak-masthead:
+    name: Keycloak Masthead
+    needs: conditional
+    if: needs.conditional.outputs.js-ci == 'true'
+    runs-on: ubuntu-latest
+    env:
+      WORKSPACE: keycloak-masthead
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: ./.github/actions/npm-setup
+        with:
+          working-directory: js
+
+      - run: npm run lint --workspace=${{ env.WORKSPACE }}
+      - run: npm run build --workspace=${{ env.WORKSPACE }}
+
   account-ui:
     name: Account UI
     needs: conditional
@@ -106,8 +123,9 @@ jobs:
   check-set-status:
     name: Set check conclusion
     needs:
-      - keycloak-js
       - admin-client
+      - keycloak-js
+      - keycloak-masthead
       - account-ui
       - admin-ui
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add a job for the Keycloak Masthead to the JavaScript workflow to run tasks on CI.