### PR TITLE
Fixing classloading issue due to the curated application being eagerly closed

### DIFF
--- a/testsuite/integration-arquillian/tests/base/pom.xml
+++ b/testsuite/integration-arquillian/tests/base/pom.xml
@@ -1137,10 +1137,10 @@
         <profile>
             <id>auth-server-quarkus-embedded</id>
             <properties>
-                <surefire.memory.Xms>1024m</surefire.memory.Xms>
-                <surefire.memory.Xmx>1024m</surefire.memory.Xmx>
+                <surefire.memory.Xms>2048m</surefire.memory.Xms>
+                <surefire.memory.Xmx>2048m</surefire.memory.Xmx>
                 <surefire.memory.metaspace>512m</surefire.memory.metaspace>
-                <surefire.memory.metaspace.max>512m</surefire.memory.metaspace.max>
+                <surefire.memory.metaspace.max>1024m</surefire.memory.metaspace.max>
             </properties>
             <dependencies>
                 <dependency>

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/containers/KeycloakQuarkusEmbeddedDeployableContainer.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/containers/KeycloakQuarkusEmbeddedDeployableContainer.java
@@ -42,7 +42,7 @@ public class KeycloakQuarkusEmbeddedDeployableContainer extends AbstractQuarkusD
                 .setHomeDir(configuration.getProvidersPath())
                 .setVersion(KEYCLOAK_VERSION)
                 .addDependency("org.keycloak.testsuite", "integration-arquillian-testsuite-providers", KEYCLOAK_VERSION)
-                .addDependency("org.keycloak.testsuite", "integration-arquillian-testsuite-providers", KEYCLOAK_VERSION)
+                .addDependency("org.keycloak.testsuite", "integration-arquillian-testsuite-providers-deployment", KEYCLOAK_VERSION)
                 .addDependency("org.keycloak.testsuite", "integration-arquillian-tests-base", KEYCLOAK_VERSION)
                 .addDependency("org.keycloak.testsuite", "integration-arquillian-tests-base", KEYCLOAK_VERSION, "tests");
     }


### PR DESCRIPTION
* Executing `LoginTest` would take ~50s. Now it runs on ~26s (locally)
* Works better on JDK 17 and default G1 GC. In JDK 11, OOM might happen due to metaspace growing and full GCs not happening.