### PR TITLE
Upgrade agroal

### DIFF
--- a/quarkus/pom.xml
+++ b/quarkus/pom.xml
@@ -46,6 +46,7 @@
         <org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec.version>2.0.1.Final</org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec.version>
         <sun.saaj-impl.version>1.4.1.SP1</sun.saaj-impl.version>
         <org.jvnet.staxex.version>1.8.3</org.jvnet.staxex.version>
+        <io.agroal.version>1.17</io.agroal.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
@@ -84,6 +85,22 @@
                 <groupId>org.infinispan</groupId>
                 <artifactId>infinispan-client-hotrod</artifactId>
                 <version>${infinispan.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.agroal</groupId>
+                <artifactId>agroal-api</artifactId>
+                <version>${io.agroal.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.agroal</groupId>
+                <artifactId>agroal-narayana</artifactId>
+                <version>${io.agroal.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.agroal</groupId>
+                <artifactId>agroal-pool</artifactId>
+                <version>${io.agroal.version}</version>
             </dependency>
 
 


### PR DESCRIPTION
Closes #17161

Upgrading just 21.0 branch for now. Main will soon be on Quarkus 3 where this is [fixed](https://github.com/quarkusio/quarkus/blob/d1c9c141037822675ea7b000a951a01783f4d904/bom/application/pom.xml#L107) already. Let me know if you want me to temporarily override the agroal version in main too.

Didn't override agroal in guides and operator where it's a transitive dependency.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
