### PR TITLE
Add missing keycloak-rest-admin-ui-ext to quarkus app #17649

### DIFF
--- a/quarkus/runtime/pom.xml
+++ b/quarkus/runtime/pom.xml
@@ -359,6 +359,17 @@
             </exclusions>
         </dependency>
 
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-rest-admin-ui-ext</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
         <!-- Keycloak Dependencies-->
         <dependency>
             <groupId>org.jboss.resteasy</groupId>


### PR DESCRIPTION
The `keycloak-rest-admin-ui-ext` dependency is missing in the current distribution, which breaks the admin-ui.
This PR adds the missing dependency.

Fixes #17649

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
