### PR TITLE
always return `registrationEmailAsUsername` setting

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/RealmAdminResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RealmAdminResource.java
@@ -360,6 +360,10 @@ public class RealmAdminResource {
             RealmRepresentation rep = new RealmRepresentation();
             rep.setRealm(realm.getName());
 
+            if (auth.users().canView()) {
+                rep.setRegistrationEmailAsUsername(realm.isRegistrationEmailAsUsername());
+            }
+
             if (auth.realm().canViewIdentityProviders()) {
                 RealmRepresentation r = ModelToRepresentation.toRepresentation(session, realm, false);
                 rep.setIdentityProviders(r.getIdentityProviders());

--- a/services/src/main/java/org/keycloak/services/resources/admin/RealmAdminResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RealmAdminResource.java
@@ -359,6 +359,7 @@ public class RealmAdminResource {
 
             RealmRepresentation rep = new RealmRepresentation();
             rep.setRealm(realm.getName());
+            rep.setRegistrationEmailAsUsername(realm.isRegistrationEmailAsUsername());
 
             if (auth.realm().canViewIdentityProviders()) {
                 RealmRepresentation r = ModelToRepresentation.toRepresentation(session, realm, false);

--- a/services/src/main/java/org/keycloak/services/resources/admin/permissions/RealmPermissions.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/permissions/RealmPermissions.java
@@ -77,7 +77,7 @@ class RealmPermissions implements RealmPermissionEvaluator {
 
     @Override
     public boolean canListRealms() {
-        return canViewRealm() || root.hasOneAdminRole(AdminRoles.ALL_QUERY_ROLES);
+        return root.isAdmin();
     }
 
     @Override

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/PermissionsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/PermissionsTest.java
@@ -297,7 +297,22 @@ public class PermissionsTest extends AbstractKeycloakTest {
                 realm.toRepresentation();
             }
         }, Resource.REALM, false, true);
-        assertGettersEmpty(clients.get(AdminRoles.QUERY_REALMS).realm(REALM_NAME).toRepresentation());
+
+        {
+            RealmRepresentation realm = clients.get(AdminRoles.QUERY_REALMS).realm(REALM_NAME).toRepresentation();
+            assertGettersEmpty(realm);
+            assertNull(realm.isRegistrationEmailAsUsername());
+
+            realm = clients.get(AdminRoles.VIEW_USERS).realm(REALM_NAME).toRepresentation();
+            assertNotNull(realm.isRegistrationEmailAsUsername());
+
+            realm = clients.get(AdminRoles.MANAGE_USERS).realm(REALM_NAME).toRepresentation();
+            assertNotNull(realm.isRegistrationEmailAsUsername());
+
+            // query users only if granted through fine-grained admin
+            realm = clients.get(AdminRoles.QUERY_USERS).realm(REALM_NAME).toRepresentation();
+            assertNull(realm.isRegistrationEmailAsUsername());
+        }
 
         // this should pass given that users granted with "query" roles are allowed to access the realm with limited access
         for (String role : AdminRoles.ALL_QUERY_ROLES) {


### PR DESCRIPTION
so users that only have rights to create users can do so
fixes: #17591

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
