### PR TITLE
count endpoint with search field has different behavior than users query endpoint

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserProvider.java
@@ -619,8 +619,11 @@ public class JpaUserProvider implements UserProvider, UserCredentialStore {
         List<Predicate> predicates = new ArrayList<>();
 
         predicates.add(builder.equal(root.get("realmId"), realm.getId()));
-        predicates.add(builder.or(getSearchOptionPredicateArray(search, builder, root)));
-
+        
+        for (String stringToSearch : search.trim().split("\\s+")) {
+            predicates.add(builder.or(getSearchOptionPredicateArray(stringToSearch, builder, root)));
+        }
+        
         queryBuilder.where(predicates.toArray(new Predicate[0]));
 
         return em.createQuery(queryBuilder).getSingleResult().intValue();
@@ -643,7 +646,11 @@ public class JpaUserProvider implements UserProvider, UserCredentialStore {
         List<Predicate> predicates = new ArrayList<>();
 
         predicates.add(builder.equal(userJoin.get("realmId"), realm.getId()));
-        predicates.add(builder.or(getSearchOptionPredicateArray(search, builder, userJoin)));
+        
+        for (String stringToSearch : search.trim().split("\\s+")) {
+            predicates.add(builder.or(getSearchOptionPredicateArray(stringToSearch, builder, userJoin)));
+        }
+        
         predicates.add(groupMembership.get("groupId").in(groupIds));
 
         queryBuilder.where(predicates.toArray(new Predicate[0]));

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/UsersTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/UsersTest.java
@@ -74,6 +74,17 @@ public class UsersTest extends AbstractAdminTest {
 
         assertCaseInsensitiveSearch();
     }
+    
+    @Test
+    public void searchUserMatchUsersCount() {
+        createUser(REALM_NAME, "john.doe", "password", "John", "Doe Smith", "john.doe@keycloak.org");
+        String search = "jo do";
+
+        assertThat(adminClient.realm(REALM_NAME).users().count(search), is(1));
+        List<UserRepresentation> users = adminClient.realm(REALM_NAME).users().search(search, null, null);
+        assertThat(users, hasSize(1));
+        assertThat(users.get(0).getUsername(), is("john.doe"));
+    }
 
     @Test
     public void searchUserCaseSensitiveFirst() throws Exception {


### PR DESCRIPTION
I have added the following code on ` public int getUsersCount(RealmModel realm, String search) {...}` and `public int getUsersCount(RealmModel realm, String search, Set<String> groupIds) {` at `JpaUserProvider.java`. class

~~~
for (String stringToSearch : search.trim().split("\\s+")) {
            predicates.add(builder.or(getSearchOptionPredicateArray(stringToSearch, builder, root)));
        }
~~~ 

I don't know if we need to change other super classes like `UserPropertyFileStorage` etc.

Please, let me know if we need some other changes.

Closes #17620
