### PR TITLE
SOAP backchannel logout for SAML protocol - AdminUI field for logout URL

### DIFF
--- a/js/apps/admin-ui/public/resources/en/clients-help.json
+++ b/js/apps/admin-ui/public/resources/en/clients-help.json
@@ -115,6 +115,7 @@
   "assertionConsumerServiceRedirectBindingURL": "SAML Redirect Binding URL for the client's assertion consumer service (login responses). You can leave this blank if you do not have a URL for this binding.",
   "logoutServicePostBindingURL": "SAML POST Binding URL for the client's single logout service. You can leave this blank if you are using a different binding",
   "logoutServiceRedirectBindingURL": "SAML Redirect Binding URL for the client's single logout service. You can leave this blank if you are using a different binding.",
+  "logoutServiceSoapBindingUrl": "SAML SOAP Binding URL for the client's single logout service. You can leave this blank if you are using a different binding.",
   "logoutServiceArtifactBindingUrl": "SAML ARTIFACT Binding URL for the client's single logout service. You can leave this blank if you are using a different binding.",
   "artifactBindingUrl": "URL to send the HTTP ARTIFACT messages to. You can leave this blank if you are using a different binding. This value should be set when forcing ARTIFACT binding together with IdP initiated login.",
   "frontchannelLogout": "When true, logout requires a browser redirect to client. When false, server performs a background invocation for logout.",

--- a/js/apps/admin-ui/public/resources/en/clients.json
+++ b/js/apps/admin-ui/public/resources/en/clients.json
@@ -495,6 +495,7 @@
   "assertionConsumerServiceRedirectBindingURL": "Assertion Consumer Service Redirect Binding URL",
   "logoutServicePostBindingURL": "Logout Service POST Binding URL",
   "logoutServiceRedirectBindingURL": "Logout Service Redirect Binding URL",
+  "logoutServiceSoapBindingUrl": "Logout Service SOAP Binding URL",
   "logoutServiceArtifactBindingUrl": "Logout Service ARTIFACT Binding URL",
   "artifactBindingUrl": "Artifact Binding URL",
   "artifactResolutionService": "Artifact Resolution Service",

--- a/js/apps/admin-ui/src/clients/advanced/FineGrainSamlEndpointConfig.tsx
+++ b/js/apps/admin-ui/src/clients/advanced/FineGrainSamlEndpointConfig.tsx
@@ -88,6 +88,22 @@ export const FineGrainSamlEndpointConfig = ({
         />
       </FormGroup>
       <FormGroup
+        label={t("logoutServiceSoapBindingUrl")}
+        fieldId="logoutServiceSoapBindingUrl"
+        labelIcon={
+          <HelpItem
+            helpText="clients-help:logoutServiceSoapBindingUrl"
+            fieldLabelId="clients:logoutServiceSoapBindingUrl"
+          />
+        }
+      >
+        <KeycloakTextInput
+          id="logoutServiceSoapBindingUrl"
+          type="url"
+          {...register("attributes.saml_single_logout_service_url_soap")}
+        />
+      </FormGroup>
+      <FormGroup
         label={t("logoutServiceArtifactBindingUrl")}
         fieldId="logoutServiceArtifactBindingUrl"
         labelIcon={


### PR DESCRIPTION
### Motivation
Add SAML SOAP backchannel logout URL on SAML client
Replaces initial PR on keycloak-ui repo: https://github.com/keycloak/keycloak-ui/pull/4138

UI complement of PR: https://github.com/keycloak/keycloak/pull/16291
Closes https://github.com/keycloak/keycloak/issues/16293

### Brief Description
A new URL is needed in the SAML client parameters to be able to execute a SOAP Backchannel logout request from Keycloak to the client during single logout process.

### Verification Steps
Open the SAML client, go to the tab "Advanced".
In the "Fine Grain SAML Endpoint Configuration" section, the field "Logout Service SOAP Binding URL" should be displayed.