### PR TITLE
Skip on deploy plugin in documentation tests module

### DIFF
--- a/docs/documentation/tests/pom.xml
+++ b/docs/documentation/tests/pom.xml
@@ -30,6 +30,22 @@
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-install-plugin</artifactId>
                 <configuration>
                     <skip>true</skip>


### PR DESCRIPTION
While building product, Tests module failed on deploy target. Deploy plugin should be skipped when building docs/documentation/tests in the pom.

Closes #19211 