### PR TITLE
Add the ability to use wrapper JDBC drivers.

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/Environment.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/Environment.java
@@ -47,6 +47,8 @@ public final class Environment {
     public static final String DEV_PROFILE_VALUE = "dev";
     public static final String PROD_PROFILE_VALUE = "prod";
     public static final String LAUNCH_MODE = "kc.launch.mode";
+    public static final String LAZY_LOAD_DB_DRIVERS = "kc.config.classloading.lazy-load-db-drivers";
+
     private Environment() {}
 
     public static Boolean isRebuild() {
@@ -234,5 +236,15 @@ public final class Environment {
 
     public static void setHomeDir(Path path) {
         System.setProperty("kc.home.dir", path.toFile().getAbsolutePath());
+    }
+
+    public static boolean isDbDriverLazyLoadingEnabled(boolean defaultValue) {
+        String lazyLoadProperty = System.getProperty(LAZY_LOAD_DB_DRIVERS);
+
+        if (lazyLoadProperty != null) {
+            return Boolean.parseBoolean(lazyLoadProperty);
+        }
+
+        return defaultValue;
     }
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakClassLoader.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakClassLoader.java
@@ -24,16 +24,20 @@ import java.util.Collections;
 import java.util.Enumeration;
 
 public class KeycloakClassLoader extends ClassLoader {
+    public static final boolean DEFAULT_LAZY_LOAD_DATABASE_DRIVERS = true;
 
-    KeycloakClassLoader() {
-        super(Thread.currentThread().getContextClassLoader());
+    private final boolean lazyLoadDatabaseDrivers;
+
+    KeycloakClassLoader(ClassLoader parent, boolean lazyLoadDatabaseDrivers) {
+        super(parent);
+        this.lazyLoadDatabaseDrivers = lazyLoadDatabaseDrivers;
     }
 
     @Override
     public Enumeration<URL> getResources(String name) throws IOException {
         // drivers are going to be loaded lazily, and we avoid loading all available drivers
         // see https://github.com/quarkusio/quarkus/pull/7089
-        if (name.contains(Driver.class.getName())) {
+        if (lazyLoadDatabaseDrivers && name.contains(Driver.class.getName())) {
             return Collections.emptyEnumeration();
         }
 

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakMain.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakMain.java
@@ -97,7 +97,9 @@ public class KeycloakMain implements QuarkusApplication {
         ClassLoader originalCl = Thread.currentThread().getContextClassLoader();
 
         try {
-            Thread.currentThread().setContextClassLoader(new KeycloakClassLoader());
+            boolean lazyLoadDatabaseDrivers = Environment.isDbDriverLazyLoadingEnabled(KeycloakClassLoader.DEFAULT_LAZY_LOAD_DATABASE_DRIVERS);
+            ClassLoader kcLoader = new KeycloakClassLoader(originalCl, lazyLoadDatabaseDrivers);
+            Thread.currentThread().setContextClassLoader(kcLoader);
 
             Quarkus.run(KeycloakMain.class, (exitCode, cause) -> {
                 if (cause != null) {

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/EnvironmentTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/EnvironmentTest.java
@@ -1,0 +1,28 @@
+package org.keycloak.quarkus.runtime;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class EnvironmentTest {
+    private static final String LAZY_LOADING_EXPECTED_PROPERTY_NAME = "kc.config.classloading.lazy-load-db-drivers";
+
+    @After
+    public void onAfter() {
+        System.getProperties().remove(LAZY_LOADING_EXPECTED_PROPERTY_NAME);
+    }
+    @Test
+    public void testIsDbDriverLazyLoadingEnabledWithPropertyNotSet() {
+        Assert.assertTrue(Environment.isDbDriverLazyLoadingEnabled(true));
+        Assert.assertFalse(Environment.isDbDriverLazyLoadingEnabled(false));
+    }
+
+    @Test
+    public void testIsDbDriverLazyLoadingEnabledWithPropertySet() {
+        System.setProperty(LAZY_LOADING_EXPECTED_PROPERTY_NAME, "true");
+        Assert.assertTrue(Environment.isDbDriverLazyLoadingEnabled(false));
+
+        System.setProperty(LAZY_LOADING_EXPECTED_PROPERTY_NAME, "false");
+        Assert.assertFalse(Environment.isDbDriverLazyLoadingEnabled(true));
+    }
+}

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/KeycloakClassLoaderTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/KeycloakClassLoaderTest.java
@@ -1,0 +1,75 @@
+package org.keycloak.quarkus.runtime;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.sql.Driver;
+import java.util.*;
+
+public class KeycloakClassLoaderTest {
+    private static final Map<String, List<URL>> NAME_TO_RESOURCES;
+    static {
+        try {
+            Map<String, List<URL>> enumerationMap = new HashMap<>();
+
+            List<URL> urls = new ArrayList<>();
+            urls.add(new URL("file://Test.class"));
+            urls.add(new URL("file://foo.Test.class"));
+            enumerationMap.put("Test", urls);
+
+            urls = new ArrayList<>();
+            urls.add(new URL("file://Driver.class"));
+            urls.add(new URL("file://Other.class"));
+            urls.add(new URL("file://TestDriver.class"));
+            urls.add(new URL("file://TestWrapperDriver.class"));
+            enumerationMap.put(Driver.class.getName(), urls);
+
+            NAME_TO_RESOURCES = Collections.unmodifiableMap(enumerationMap);
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void testGetResourcesWithLazyLoadingDrivers() throws Exception {
+        ClassLoader kcLoader = new KeycloakClassLoader(new DummyClassLoader(), true);
+
+        Enumeration<URL> kcLoaderResources = kcLoader.getResources("Test");
+        assertEquals(NAME_TO_RESOURCES.get("Test"), kcLoaderResources);
+
+        kcLoaderResources = kcLoader.getResources(Driver.class.getName());
+        Assert.assertFalse(kcLoaderResources.hasMoreElements());
+    }
+
+    @Test
+    public void testGetResourcesWithoutLazyLoadingDrivers() throws Exception {
+        ClassLoader kcLoader = new KeycloakClassLoader(new DummyClassLoader(), false);
+
+        Enumeration<URL> kcLoaderResources = kcLoader.getResources("Test");
+        assertEquals(NAME_TO_RESOURCES.get("Test"), kcLoaderResources);
+
+        kcLoaderResources = kcLoader.getResources(Driver.class.getName());
+        assertEquals(NAME_TO_RESOURCES.get(Driver.class.getName()), kcLoaderResources);
+    }
+
+    @Test
+    public void testDefaultBehaviorIsLazyLoad() {
+        Assert.assertTrue(KeycloakClassLoader.DEFAULT_LAZY_LOAD_DATABASE_DRIVERS);
+    }
+
+    private void assertEquals(List<?> expectedList, Enumeration<?> actual) {
+
+        List<Object> actualList = new ArrayList<>();
+        actual.asIterator().forEachRemaining(e -> actualList.add(e));
+
+        Assert.assertEquals(expectedList, actualList);
+    }
+
+    private static class DummyClassLoader extends ClassLoader {
+        public Enumeration<URL> getResources(String name) {
+            return Collections.enumeration(NAME_TO_RESOURCES.get(name));
+        }
+    }
+}


### PR DESCRIPTION
Keycloak has implemented a custom ClassLoader that ignores requests to load anything containing the word "Driver" to prevent eagerly loading all JDBC drivers that ship with Keycloak and then allows Quarkus to lazily load the specified driver itself.

The issue with this is that when using a wrapper driver (e.g., AWS' advanced JDBC driver), that driver has to delegate to an underlying "real" driver (e.g., Postgres, MySQL, etc).  The KeycloakClassLoader ignores anything containing the word "Driver", so the wrapper driver is never loaded or registered with the DriverManager for the wrapper driver to be able to access the real driver.

This change fixes that issue by adding a flag to the KeyCloakLoader that allows disabling lazy class loading of Drivers.  By default the ClassLoader will continue to ignore all requests to load Driver classes to match the current behavior, but this behavior can be changed with a System property.

For more information, see https://github.com/keycloak/keycloak/discussions/19189 and https://github.com/keycloak/keycloak/issues/13205.

Closes #13205

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
