### PR TITLE
Add inter-module dependencies to enable parallel builds with mvnd

### DIFF
--- a/adapters/oidc/js/pom.xml
+++ b/adapters/oidc/js/pom.xml
@@ -79,4 +79,19 @@
             </plugin>
         </plugins>
     </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-js-adapter</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
 </project>

--- a/docs/documentation/dist/pom.xml
+++ b/docs/documentation/dist/pom.xml
@@ -35,4 +35,19 @@
             </plugin>
         </plugins>
     </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.keycloak.documentation</groupId>
+            <artifactId>aggregation</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
 </project>

--- a/js/apps/admin-ui/pom.xml
+++ b/js/apps/admin-ui/pom.xml
@@ -116,4 +116,31 @@
             </plugin>
         </plugins>
     </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-js-admin-client</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-js-adapter</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
 </project>

--- a/js/libs/keycloak-admin-client/pom.xml
+++ b/js/libs/keycloak-admin-client/pom.xml
@@ -72,4 +72,19 @@
             </plugin>
         </plugins>
     </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-js-parent</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
 </project>

--- a/js/libs/keycloak-js/pom.xml
+++ b/js/libs/keycloak-js/pom.xml
@@ -72,4 +72,19 @@
             </plugin>
         </plugins>
     </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-js-parent</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
 </project>


### PR DESCRIPTION
Mvnd (Apache Maven Daemon) can speed up builds by building modules in parallel and caching. However, Keycloak does not record all dependencies and therefore parallel builds fail very often. 

This PR is an attempt to add missing inter-module dependencies that allows stable parallel builds. It uses approach mentioned here https://github.com/apache/maven-mvnd/issues/264.

Successful mvnd clean install 01:02, compared to mvn 02:28 on laptop with Intel i9, 14 cores.

Fixes #19247

TODO Remaining errors
- [x] `keycloak-documentation`: Failed to create assembly: Error creating assembly archive docs-dist: You must set at least one file.
- [x] `keycloak-js-adapter-jar`: Failed to run task: 'npm run build --workspace=keycloak-js' failed. 
- [ ]  `keycloak-js-admin-client`, `keycloak-js-adapter` and `keycloak-admin-ui` fail randomly: Failed to run task: 'npm ci --ignore-scripts' failed.
- [ ] `keycloak-model-map-hot-rod`: cannot find symbol, class HotRodTypesUtils
- [ ] `keycloak-model-map`: cannot find symbol, class MapClientEntityFields, NodeProperties, MapClientEntityFields (package org.keycloak.models.map.*)
- [ ] `keycloak-config-api`: AutogeneratedHotRodDescriptors does not exist
- [ ] `keycloak-quarkus-server-app`: ClassNotFoundException: org.keycloak.quarkus.deployment.KeycloakProcessor/LiquibaseProcessor