### PR TITLE
Run Cypress tests only on the main repo

### DIFF
--- a/.github/workflows/js-ci.yml
+++ b/.github/workflows/js-ci.yml
@@ -190,7 +190,7 @@ jobs:
     needs:
       - conditional
       - build-keycloak
-    if: needs.conditional.outputs.js-ci == 'true'
+    if: needs.conditional.outputs.js-ci == 'true' && github.repository == 'keycloak/keycloak'
     runs-on: ubuntu-latest
     env:
       WORKSPACE: admin-ui
@@ -243,6 +243,7 @@ jobs:
           CYPRESS_BASE_URL: http://localhost:8080/admin/
           CYPRESS_KEYCLOAK_SERVER: http://localhost:8080
           CYPRESS_RECORD_KEY: b8f1d15e-eab8-4ee7-8e44-c6d7cd8fc0eb
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload server logs
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
Only runs the Cypress tests on the main repo. This prevents forks from running on `push` and overwhelming our budget and adding comments to PRs that do not modify the front-end. This PR also:

- ~Fetches the record key from the secrets for security.~ (this doesn't work, removed it)
- Passes the GitHub token to detect new build vs re-run build in the Cypress Cloud.