### PR TITLE
EAP7 and wildfly adapter tests fixes. Execute enable-elytron-se17.clifor EAP7 and JDK-17.

### DIFF
--- a/adapters/oidc/servlet-filter/pom.xml
+++ b/adapters/oidc/servlet-filter/pom.xml
@@ -64,6 +64,10 @@
             <artifactId>keycloak-adapter-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-policy-enforcer</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
         </dependency>

--- a/distribution/saml-adapters/wildfly-adapter/wildfly-modules/src/main/resources/modules/org/keycloak/keycloak-saml-adapter-core/main/module.xml
+++ b/distribution/saml-adapters/wildfly-adapter/wildfly-modules/src/main/resources/modules/org/keycloak/keycloak-saml-adapter-core/main/module.xml
@@ -38,6 +38,11 @@
         <module name="org.keycloak.keycloak-core"/>
         <module name="org.keycloak.keycloak-crypto-default" services="import"/>
         <module name="org.apache.httpcomponents"/>
+        <module name="org.apache.santuario.xmlsec">
+            <imports>
+                <exclude path="javax/*"/>
+            </imports>
+        </module>
     </dependencies>
 
 </module>

--- a/testsuite/integration-arquillian/servers/app-server/jboss/common/cli/add-secured-deployments.cli
+++ b/testsuite/integration-arquillian/servers/app-server/jboss/common/cli/add-secured-deployments.cli
@@ -6,7 +6,6 @@ embed-server --server-config=standalone.xml
     auth-server-url=${auth.server.actual.protocol:https}://${auth.server.host:localhost}:${auth.server.https.port:8543}/auth, \
     ssl-required=EXTERNAL, \
     disable-trust-manager=true, \
-    realm-public-key=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCrVrCuTtArbgaZzL1hvh0xtL5mc7o0NqPVnYXkLvgcwiC3BjLGw1tGEGoJaXDuSaRllobm53JBhjx33UNv+5z/UMG4kytBWxheNVKnL6GgqlNabMaFfPLPCF8kAgKnsi79NMo+n6KnSY8YeUmec/p2vjO2NjsSAVcWEQMVhJ31LwIDAQAB \
 )
 /subsystem=keycloak/secure-deployment=customer-portal-subsystem.war/credential=secret/:add(value=password)
 
@@ -16,6 +15,5 @@ embed-server --server-config=standalone.xml
     auth-server-url=${auth.server.actual.protocol:https}://${auth.server.host:localhost}:${auth.server.https.port:8543}/auth, \
     ssl-required=EXTERNAL, \
     disable-trust-manager=true, \
-    realm-public-key=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCrVrCuTtArbgaZzL1hvh0xtL5mc7o0NqPVnYXkLvgcwiC3BjLGw1tGEGoJaXDuSaRllobm53JBhjx33UNv+5z/UMG4kytBWxheNVKnL6GgqlNabMaFfPLPCF8kAgKnsi79NMo+n6KnSY8YeUmec/p2vjO2NjsSAVcWEQMVhJ31LwIDAQAB \
 )
 /subsystem=keycloak/secure-deployment=product-portal-subsystem.war/credential=secret/:add(value=password)

--- a/testsuite/integration-arquillian/servers/app-server/jboss/eap/pom.xml
+++ b/testsuite/integration-arquillian/servers/app-server/jboss/eap/pom.xml
@@ -69,6 +69,15 @@
                 <app.server.jboss.unpacked.folder.name>jboss-eap-7.1</app.server.jboss.unpacked.folder.name>
             </properties>
         </profile>
+        <profile>
+            <id>app-server-eap-java17</id>
+            <activation>
+                <jdk>[17,)</jdk>
+            </activation>
+            <properties>
+                <skip.java17.enablement>false</skip.java17.enablement>
+            </properties>
+        </profile>
     </profiles>
 
 </project>

--- a/testsuite/integration-arquillian/servers/app-server/jboss/pom.xml
+++ b/testsuite/integration-arquillian/servers/app-server/jboss/pom.xml
@@ -38,6 +38,7 @@
         <saml-adapter.version>${project.version}</saml-adapter.version>
         <skip.elytron.adapter.installation>true</skip.elytron.adapter.installation>
         <skip.adapter.offline.installation>true</skip.adapter.offline.installation>
+        <skip.java17.enablement>true</skip.java17.enablement>
         <!-- Workaround for WFCORE-5335 issue -->
         <cli.executable>bash</cli.executable>
         <cli.jboss-cli.arg>jboss-cli.${script.suffix}</cli.jboss-cli.arg>
@@ -525,6 +526,49 @@
                                     </arguments>
                                 </configuration>
                             </execution>
+
+                            <execution>
+                                <!-- needed for eap with java 17 -->
+                                <id>enable-java-17</id>
+                                <phase>process-resources</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <skip>${skip.java17.enablement}</skip>
+                                    <executable>${cli.executable}</executable>
+                                    <workingDirectory>${cli.working.dir}</workingDirectory>
+                                    <environmentVariables>
+                                        <JAVA_HOME>${app.server.java.home}</JAVA_HOME>
+                                    </environmentVariables>
+                                    <arguments>
+                                        <argument>${cli.jboss-cli.arg}</argument>
+                                        <argument>--file=${app.server.jboss.home}/docs/examples/enable-elytron-se17.cli</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <!-- needed for eap with java 17 -->
+                                <id>enable-java-17-ha</id>
+                                <phase>process-resources</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <skip>${skip.java17.enablement}</skip>
+                                    <executable>${cli.executable}</executable>
+                                    <workingDirectory>${cli.working.dir}</workingDirectory>
+                                    <environmentVariables>
+                                        <JAVA_HOME>${app.server.java.home}</JAVA_HOME>
+                                    </environmentVariables>
+                                    <arguments>
+                                        <argument>${cli.jboss-cli.arg}</argument>
+                                        <argument>--file=${app.server.jboss.home}/docs/examples/enable-elytron-se17.cli</argument>
+                                        <argument>-Dconfig=standalone-ha.xml</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+
                             <execution>
                                 <id>add-secured-deployments</id>
                                 <phase>generate-test-sources</phase>

--- a/testsuite/integration-arquillian/servers/pom.xml
+++ b/testsuite/integration-arquillian/servers/pom.xml
@@ -33,7 +33,7 @@
         <script.suffix>sh</script.suffix>
 
         <!--app container versions-->
-        <eap.version>7.4.0.GA-redhat-00005</eap.version>
+        <eap.version>7.4.9.GA-redhat-00003</eap.version>
         <eap71.version>7.1.5.GA-redhat-00002</eap71.version>
         <jboss.as.version>7.1.1.Final</jboss.as.version>
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/example/cors/CorsExampleAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/example/cors/CorsExampleAdapterTest.java
@@ -25,7 +25,6 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jetbrains.annotations.Nullable;
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
 import org.keycloak.common.Profile;
@@ -35,23 +34,19 @@ import org.keycloak.testsuite.adapter.page.AngularCorsProductTestApp;
 import org.keycloak.testsuite.adapter.page.CorsDatabaseServiceTestApp;
 import org.keycloak.testsuite.arquillian.annotation.AppServerContainer;
 import org.keycloak.testsuite.arquillian.annotation.DisableFeature;
-import org.keycloak.testsuite.arquillian.annotation.EnableFeature;
 import org.keycloak.testsuite.utils.arquillian.ContainerConstants;
 import org.keycloak.testsuite.auth.page.account.Account;
 import org.keycloak.testsuite.auth.page.login.OIDCLogin;
 import org.keycloak.testsuite.util.JavascriptBrowser;
-import org.keycloak.testsuite.util.WaitUtils;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import static junit.framework.TestCase.assertNotNull;
-import org.junit.Assume;
 import org.keycloak.testsuite.util.DroneUtils;
 
 import static org.keycloak.testsuite.utils.io.IOUtil.loadRealm;
@@ -73,7 +68,6 @@ import static org.keycloak.testsuite.util.WaitUtils.waitUntilElement;
 @AppServerContainer(ContainerConstants.APP_SERVER_EAP)
 @AppServerContainer(ContainerConstants.APP_SERVER_EAP6)
 @AppServerContainer(ContainerConstants.APP_SERVER_EAP71)
-@DisableFeature(value = Profile.Feature.ACCOUNT2, skipRestart = true) // TODO remove this (KEYCLOAK-16228)
 public class CorsExampleAdapterTest extends AbstractExampleAdapterTest {
 
     public static final String CORS = "cors";
@@ -180,17 +174,13 @@ public class CorsExampleAdapterTest extends AbstractExampleAdapterTest {
     @Nullable
     private String getAuthServerVersion() {
         DroneUtils.getCurrentDriver().navigate().to(suiteContext.getAuthServerInfo().getContextRoot().toString() +
-                "/auth/admin/master/console/#/server-info");
+                "/auth/admin/master/console/#/master/info");
         jsDriverTestRealmLoginPage.form().login("admin", "admin");
-
-        Pattern pattern = Pattern.compile("<td [^>]+>Server Version</td>" +
-                "\\s+<td [^>]+>([^<]+)</td>");
-        Matcher matcher = pattern.matcher(DroneUtils.getCurrentDriver().getPageSource());
-
-        if (matcher.find()) {
-            return matcher.group(1);
+        // just get the first list description which is the version
+        List<WebElement> elements = jsDriver.findElements(By.xpath(".//dd[@class='pf-c-description-list__description']"));
+        if (!elements.isEmpty()) {
+            return elements.get(0).getText();
         }
-
         return null;
     }
 }


### PR DESCRIPTION
Closes https://github.com/keycloak/keycloak/issues/19273

Several changes for the adapter tests when using wildfly/eap:

* The servlet-filter needs to have the dependency over the new policy enforcer.
* Execute `enable-elytron-se17.cli` for eap7 when using jdk-17 to create the app server.
* Update eap to 7.4.9 (jdk-17 support started in cp7 or cp8).
* Other minor issues in a few tests.