### PR TITLE
NPE on welcome page when 'spi-theme-default' doesn't exists #15476

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/services/resources/QuarkusWelcomeResource.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/services/resources/QuarkusWelcomeResource.java
@@ -36,6 +36,8 @@ import org.keycloak.theme.freemarker.FreeMarkerProvider;
 import org.keycloak.urls.UrlType;
 import org.keycloak.utils.MediaType;
 
+import io.quarkus.logging.Log;
+
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -58,6 +60,7 @@ import java.net.URISyntaxException;
 import java.net.UnknownHostException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -160,6 +163,15 @@ public class QuarkusWelcomeResource {
     private Response createWelcomePage(String successMessage, String errorMessage) {
         try {
             Theme theme = getTheme();
+            
+            if(Objects.isNull(theme)) {
+                Log.error("Theme is null please check the \"--spi-theme-default\" parameter");
+                errorMessage = "The theme is null";
+                ResponseBuilder rb = Response.status(Status.BAD_REQUEST)
+                        .entity(errorMessage)
+                        .cacheControl(CacheControlUtil.noCache());
+                return rb.build();
+            }
 
             Map<String, Object> map = new HashMap<>();
 


### PR DESCRIPTION
closes #15476

Hi Team, 

I have added the following message when `theme` is null:

```{bash}
2023-03-26 19:41:57,618 ERROR [org.keycloak.quarkus.runtime.services.resources.QuarkusWelcomeResource] (executor-thread-0) Theme is null please check the "--spi-theme-default" parameter
```

Also, I am sending the message **The theme is null** during the `null` verification:

```{java}
Theme theme = getTheme();
            
            if(Objects.isNull(theme)) {
                Log.error("Theme is null please check the \"--spi-theme-default\" parameter");
                errorMessage = "The theme is null";
                ResponseBuilder rb = Response.status(Status.BAD_REQUEST)
                        .entity(errorMessage)
                        .cacheControl(CacheControlUtil.noCache());
                return rb.build();
            }
```

Please, let me know if there's some improvement that I can do.
