### PR TITLE
The getAttributes method in UserAttributeLDAPStorageMapper does not work for email or other UserModel properties

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/UserAttributeLDAPStorageMapper.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/UserAttributeLDAPStorageMapper.java
@@ -383,11 +383,6 @@ public class UserAttributeLDAPStorageMapper extends AbstractLDAPStorageMapper {
                 public Map<String, List<String>> getAttributes() {
                     Map<String, List<String>> attrs = new HashMap<>(super.getAttributes());
 
-                    // Ignore UserModel properties
-                    if (userModelProperties.get(userModelAttrName.toLowerCase()) != null) {
-                        return attrs;
-                    }
-
                     Set<String> allLdapAttrValues = ldapUser.getAttributeAsSet(ldapAttrName);
                     if (allLdapAttrValues != null) {
                         attrs.put(userModelAttrName, new ArrayList<>(allLdapAttrValues));


### PR DESCRIPTION
Closes https://github.com/keycloak/keycloak/issues/10412

The `getAttributes` method in the proxy for AlwaysReadValueFromLDAP is not returning the LDAP value for model properties (email, firstName, lastName,...). Therefore those attributes are read directly from the internal DB and the data is outdated. This PR makes the `getAttributes` act like `getAttributeStream`. Little test added.

As commented in the issue #10412 the reported problem  was already fixed by a previous commit but the root bug is still there.