### PR TITLE
Align route object type with React Router

### DIFF
--- a/js/apps/admin-ui/src/App.tsx
+++ b/js/apps/admin-ui/src/App.tsx
@@ -21,7 +21,7 @@ import { ForbiddenSection } from "./ForbiddenSection";
 import { SubGroups } from "./groups/SubGroupsContext";
 import { Header } from "./PageHeader";
 import { PageNav } from "./PageNav";
-import { RouteDef, routes } from "./route-config";
+import { AppRouteObject, routes } from "./routes";
 
 export const mainPageContentId = "kc-main-content-page-container";
 
@@ -58,7 +58,7 @@ const AppContexts = ({
 
 // If someone tries to go directly to a route they don't
 // have access to, show forbidden page.
-type SecuredRouteProps = { route: RouteDef };
+type SecuredRouteProps = { route: AppRouteObject };
 const SecuredRoute = ({ route }: SecuredRouteProps) => {
   const { hasAccess } = useAccess();
   const accessAllowed =

--- a/js/apps/admin-ui/src/PageNav.tsx
+++ b/js/apps/admin-ui/src/PageNav.tsx
@@ -14,7 +14,7 @@ import { RealmSelector } from "./components/realm-selector/RealmSelector";
 import { useAccess } from "./context/access/Access";
 import { useRealm } from "./context/realm-context/RealmContext";
 import { AddRealmRoute } from "./realm/routes/AddRealm";
-import { routes } from "./route-config";
+import { routes } from "./routes";
 
 import "./page-nav.css";
 

--- a/js/apps/admin-ui/src/authentication/routes.ts
+++ b/js/apps/admin-ui/src/authentication/routes.ts
@@ -1,4 +1,4 @@
-import type { RouteDef } from "../route-config";
+import type { AppRouteObject } from "../routes";
 import {
   AuthenticationRoute,
   AuthenticationRouteWithTab,
@@ -6,7 +6,7 @@ import {
 import { CreateFlowRoute } from "./routes/CreateFlow";
 import { FlowRoute, FlowWithBuiltInRoute } from "./routes/Flow";
 
-const routes: RouteDef[] = [
+const routes: AppRouteObject[] = [
   AuthenticationRoute,
   AuthenticationRouteWithTab,
   CreateFlowRoute,

--- a/js/apps/admin-ui/src/authentication/routes/Authentication.tsx
+++ b/js/apps/admin-ui/src/authentication/routes/Authentication.tsx
@@ -1,7 +1,7 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type AuthenticationTab = "flows" | "required-actions" | "policies";
 
@@ -9,7 +9,7 @@ export type AuthenticationParams = { realm: string; tab?: AuthenticationTab };
 
 const AuthenticationSection = lazy(() => import("../AuthenticationSection"));
 
-export const AuthenticationRoute: RouteDef = {
+export const AuthenticationRoute: AppRouteObject = {
   path: "/:realm/authentication",
   element: <AuthenticationSection />,
   breadcrumb: (t) => t("authentication"),
@@ -18,7 +18,7 @@ export const AuthenticationRoute: RouteDef = {
   },
 };
 
-export const AuthenticationRouteWithTab: RouteDef = {
+export const AuthenticationRouteWithTab: AppRouteObject = {
   ...AuthenticationRoute,
   path: "/:realm/authentication/:tab",
 };

--- a/js/apps/admin-ui/src/authentication/routes/CreateFlow.tsx
+++ b/js/apps/admin-ui/src/authentication/routes/CreateFlow.tsx
@@ -1,13 +1,13 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type CreateFlowParams = { realm: string };
 
 const CreateFlow = lazy(() => import("../form/CreateFlow"));
 
-export const CreateFlowRoute: RouteDef = {
+export const CreateFlowRoute: AppRouteObject = {
   path: "/:realm/authentication/flows/create",
   element: <CreateFlow />,
   breadcrumb: (t) => t("authentication:createFlow"),

--- a/js/apps/admin-ui/src/authentication/routes/Flow.tsx
+++ b/js/apps/admin-ui/src/authentication/routes/Flow.tsx
@@ -1,7 +1,7 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type FlowParams = {
   realm: string;
@@ -12,7 +12,7 @@ export type FlowParams = {
 
 const FlowDetails = lazy(() => import("../FlowDetails"));
 
-export const FlowRoute: RouteDef = {
+export const FlowRoute: AppRouteObject = {
   path: "/:realm/authentication/:id/:usedBy",
   element: <FlowDetails />,
   breadcrumb: (t) => t("authentication:flowDetails"),
@@ -21,7 +21,7 @@ export const FlowRoute: RouteDef = {
   },
 };
 
-export const FlowWithBuiltInRoute: RouteDef = {
+export const FlowWithBuiltInRoute: AppRouteObject = {
   ...FlowRoute,
   path: "/:realm/authentication/:id/:usedBy/:builtIn",
 };

--- a/js/apps/admin-ui/src/client-scopes/routes.ts
+++ b/js/apps/admin-ui/src/client-scopes/routes.ts
@@ -1,10 +1,10 @@
-import type { RouteDef } from "../route-config";
+import type { AppRouteObject } from "../routes";
 import { ClientScopeRoute } from "./routes/ClientScope";
 import { ClientScopesRoute } from "./routes/ClientScopes";
 import { MapperRoute } from "./routes/Mapper";
 import { NewClientScopeRoute } from "./routes/NewClientScope";
 
-const routes: RouteDef[] = [
+const routes: AppRouteObject[] = [
   NewClientScopeRoute,
   MapperRoute,
   ClientScopeRoute,

--- a/js/apps/admin-ui/src/client-scopes/routes/ClientScope.tsx
+++ b/js/apps/admin-ui/src/client-scopes/routes/ClientScope.tsx
@@ -1,7 +1,7 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type ClientScopeTab = "settings" | "mappers" | "scope";
 
@@ -13,7 +13,7 @@ export type ClientScopeParams = {
 
 const EditClientScope = lazy(() => import("../EditClientScope"));
 
-export const ClientScopeRoute: RouteDef = {
+export const ClientScopeRoute: AppRouteObject = {
   path: "/:realm/client-scopes/:id/:tab",
   element: <EditClientScope />,
   breadcrumb: (t) => t("client-scopes:clientScopeDetails"),

--- a/js/apps/admin-ui/src/client-scopes/routes/ClientScopes.tsx
+++ b/js/apps/admin-ui/src/client-scopes/routes/ClientScopes.tsx
@@ -1,13 +1,13 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type ClientScopesParams = { realm: string };
 
 const ClientScopesSection = lazy(() => import("../ClientScopesSection"));
 
-export const ClientScopesRoute: RouteDef = {
+export const ClientScopesRoute: AppRouteObject = {
   path: "/:realm/client-scopes",
   element: <ClientScopesSection />,
   breadcrumb: (t) => t("client-scopes:clientScopeList"),

--- a/js/apps/admin-ui/src/client-scopes/routes/Mapper.tsx
+++ b/js/apps/admin-ui/src/client-scopes/routes/Mapper.tsx
@@ -1,7 +1,7 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type MapperParams = {
   realm: string;
@@ -11,7 +11,7 @@ export type MapperParams = {
 
 const MappingDetails = lazy(() => import("../details/MappingDetails"));
 
-export const MapperRoute: RouteDef = {
+export const MapperRoute: AppRouteObject = {
   path: "/:realm/client-scopes/:id/mappers/:mapperId",
   element: <MappingDetails />,
   breadcrumb: (t) => t("common:mappingDetails"),

--- a/js/apps/admin-ui/src/client-scopes/routes/NewClientScope.tsx
+++ b/js/apps/admin-ui/src/client-scopes/routes/NewClientScope.tsx
@@ -1,13 +1,13 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type NewClientScopeParams = { realm: string };
 
 const CreateClientScope = lazy(() => import("../CreateClientScope"));
 
-export const NewClientScopeRoute: RouteDef = {
+export const NewClientScopeRoute: AppRouteObject = {
   path: "/:realm/client-scopes/new",
   element: <CreateClientScope />,
   breadcrumb: (t) => t("client-scopes:createClientScope"),

--- a/js/apps/admin-ui/src/clients/routes.ts
+++ b/js/apps/admin-ui/src/clients/routes.ts
@@ -1,4 +1,4 @@
-import type { RouteDef } from "../route-config";
+import type { AppRouteObject } from "../routes";
 import { AddClientRoute } from "./routes/AddClient";
 import {
   AddRegistrationProviderRoute,
@@ -36,7 +36,7 @@ import {
   ScopeDetailsWithScopeIdRoute,
 } from "./routes/Scope";
 
-const routes: RouteDef[] = [
+const routes: AppRouteObject[] = [
   ClientRegistrationRoute,
   AddRegistrationProviderRoute,
   EditRegistrationProviderRoute,

--- a/js/apps/admin-ui/src/clients/routes/AddClient.tsx
+++ b/js/apps/admin-ui/src/clients/routes/AddClient.tsx
@@ -1,13 +1,13 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type AddClientParams = { realm: string };
 
 const NewClientForm = lazy(() => import("../add/NewClientForm"));
 
-export const AddClientRoute: RouteDef = {
+export const AddClientRoute: AppRouteObject = {
   path: "/:realm/clients/add-client",
   element: <NewClientForm />,
   breadcrumb: (t) => t("clients:createClient"),

--- a/js/apps/admin-ui/src/clients/routes/AddRegistrationProvider.tsx
+++ b/js/apps/admin-ui/src/clients/routes/AddRegistrationProvider.tsx
@@ -1,7 +1,7 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 import { ClientRegistrationTab } from "./ClientRegistration";
 
 export type RegistrationProviderParams = {
@@ -13,7 +13,7 @@ export type RegistrationProviderParams = {
 
 const DetailProvider = lazy(() => import("../registration/DetailProvider"));
 
-export const AddRegistrationProviderRoute: RouteDef = {
+export const AddRegistrationProviderRoute: AppRouteObject = {
   path: "/:realm/clients/client-registration/:subTab/:providerId",
   element: <DetailProvider />,
   breadcrumb: (t) => t("clients:clientSettings"),
@@ -22,7 +22,7 @@ export const AddRegistrationProviderRoute: RouteDef = {
   },
 };
 
-export const EditRegistrationProviderRoute: RouteDef = {
+export const EditRegistrationProviderRoute: AppRouteObject = {
   ...AddRegistrationProviderRoute,
   path: "/:realm/clients/client-registration/:subTab/:providerId/:id",
 };

--- a/js/apps/admin-ui/src/clients/routes/AuthenticationTab.tsx
+++ b/js/apps/admin-ui/src/clients/routes/AuthenticationTab.tsx
@@ -1,7 +1,7 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type AuthorizationTab =
   | "settings"
@@ -20,7 +20,7 @@ export type AuthorizationParams = {
 
 const ClientDetails = lazy(() => import("../ClientDetails"));
 
-export const AuthorizationRoute: RouteDef = {
+export const AuthorizationRoute: AppRouteObject = {
   path: "/:realm/clients/:clientId/authorization/:tab",
   element: <ClientDetails />,
   breadcrumb: (t) => t("clients:clientSettings"),

--- a/js/apps/admin-ui/src/clients/routes/Client.tsx
+++ b/js/apps/admin-ui/src/clients/routes/Client.tsx
@@ -1,7 +1,7 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type ClientTab =
   | "settings"
@@ -24,7 +24,7 @@ export type ClientParams = {
 
 const ClientDetails = lazy(() => import("../ClientDetails"));
 
-export const ClientRoute: RouteDef = {
+export const ClientRoute: AppRouteObject = {
   path: "/:realm/clients/:clientId/:tab",
   element: <ClientDetails />,
   breadcrumb: (t) => t("clients:clientSettings"),

--- a/js/apps/admin-ui/src/clients/routes/ClientRegistration.tsx
+++ b/js/apps/admin-ui/src/clients/routes/ClientRegistration.tsx
@@ -1,7 +1,7 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type ClientRegistrationTab = "anonymous" | "authenticated";
 
@@ -12,7 +12,7 @@ export type ClientRegistrationParams = {
 
 const ClientsSection = lazy(() => import("../ClientsSection"));
 
-export const ClientRegistrationRoute: RouteDef = {
+export const ClientRegistrationRoute: AppRouteObject = {
   path: "/:realm/clients/client-registration/:subTab",
   element: <ClientsSection />,
   breadcrumb: (t) => t("clients:clientRegistration"),

--- a/js/apps/admin-ui/src/clients/routes/ClientRole.tsx
+++ b/js/apps/admin-ui/src/clients/routes/ClientRole.tsx
@@ -1,7 +1,7 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type ClientRoleTab =
   | "details"
@@ -18,14 +18,14 @@ export type ClientRoleParams = {
 
 const RealmRoleTabs = lazy(() => import("../../realm-roles/RealmRoleTabs"));
 
-export const ClientRoleRoute: RouteDef = {
+export const ClientRoleRoute: AppRouteObject = {
   path: "/:realm/clients/:clientId/roles/:id/:tab" as const,
   element: <RealmRoleTabs />,
   breadcrumb: (t) => t("roles:roleDetails"),
   handle: {
     access: "view-realm",
   },
-} satisfies RouteDef;
+} satisfies AppRouteObject;
 
 export const toClientRole = (params: ClientRoleParams): Partial<Path> => ({
   pathname: generatePath(ClientRoleRoute.path, params),

--- a/js/apps/admin-ui/src/clients/routes/ClientScopeTab.tsx
+++ b/js/apps/admin-ui/src/clients/routes/ClientScopeTab.tsx
@@ -1,7 +1,7 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type ClientScopesTab = "setup" | "evaluate";
 
@@ -13,7 +13,7 @@ export type ClientScopesParams = {
 
 const ClientDetails = lazy(() => import("../ClientDetails"));
 
-export const ClientScopesRoute: RouteDef = {
+export const ClientScopesRoute: AppRouteObject = {
   path: "/:realm/clients/:clientId/clientScopes/:tab",
   element: <ClientDetails />,
   breadcrumb: (t) => t("clients:clientSettings"),

--- a/js/apps/admin-ui/src/clients/routes/Clients.tsx
+++ b/js/apps/admin-ui/src/clients/routes/Clients.tsx
@@ -1,7 +1,7 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type ClientsTab =
   | "list"
@@ -15,7 +15,7 @@ export type ClientsParams = {
 
 const ClientsSection = lazy(() => import("../ClientsSection"));
 
-export const ClientsRoute: RouteDef = {
+export const ClientsRoute: AppRouteObject = {
   path: "/:realm/clients",
   element: <ClientsSection />,
   breadcrumb: (t) => t("clients:clientList"),
@@ -24,7 +24,7 @@ export const ClientsRoute: RouteDef = {
   },
 };
 
-export const ClientsRouteWithTab: RouteDef = {
+export const ClientsRouteWithTab: AppRouteObject = {
   ...ClientsRoute,
   path: "/:realm/clients/:tab",
 };

--- a/js/apps/admin-ui/src/clients/routes/CreateInitialAccessToken.tsx
+++ b/js/apps/admin-ui/src/clients/routes/CreateInitialAccessToken.tsx
@@ -1,7 +1,7 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type CreateInitialAccessTokenParams = { realm: string };
 
@@ -9,7 +9,7 @@ const CreateInitialAccessToken = lazy(
   () => import("../initial-access/CreateInitialAccessToken")
 );
 
-export const CreateInitialAccessTokenRoute: RouteDef = {
+export const CreateInitialAccessTokenRoute: AppRouteObject = {
   path: "/:realm/clients/initialAccessToken/create",
   element: <CreateInitialAccessToken />,
   breadcrumb: (t) => t("clients:createToken"),

--- a/js/apps/admin-ui/src/clients/routes/DedicatedScopeDetails.tsx
+++ b/js/apps/admin-ui/src/clients/routes/DedicatedScopeDetails.tsx
@@ -1,7 +1,7 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type DedicatedScopeTab = "mappers" | "scope";
 
@@ -13,7 +13,7 @@ export type DedicatedScopeDetailsParams = {
 
 const DedicatedScopes = lazy(() => import("../scopes/DedicatedScopes"));
 
-export const DedicatedScopeDetailsRoute: RouteDef = {
+export const DedicatedScopeDetailsRoute: AppRouteObject = {
   path: "/:realm/clients/:clientId/clientScopes/dedicated",
   element: <DedicatedScopes />,
   breadcrumb: (t) => t("clients:dedicatedScopes"),
@@ -22,7 +22,7 @@ export const DedicatedScopeDetailsRoute: RouteDef = {
   },
 };
 
-export const DedicatedScopeDetailsWithTabRoute: RouteDef = {
+export const DedicatedScopeDetailsWithTabRoute: AppRouteObject = {
   ...DedicatedScopeDetailsRoute,
   path: "/:realm/clients/:clientId/clientScopes/dedicated/:tab",
 };

--- a/js/apps/admin-ui/src/clients/routes/ImportClient.tsx
+++ b/js/apps/admin-ui/src/clients/routes/ImportClient.tsx
@@ -1,13 +1,13 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type ImportClientParams = { realm: string };
 
 const ImportForm = lazy(() => import("../import/ImportForm"));
 
-export const ImportClientRoute: RouteDef = {
+export const ImportClientRoute: AppRouteObject = {
   path: "/:realm/clients/import-client",
   element: <ImportForm />,
   breadcrumb: (t) => t("clients:importClient"),

--- a/js/apps/admin-ui/src/clients/routes/Mapper.tsx
+++ b/js/apps/admin-ui/src/clients/routes/Mapper.tsx
@@ -1,7 +1,7 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type MapperParams = {
   realm: string;
@@ -13,7 +13,7 @@ const MappingDetails = lazy(
   () => import("../../client-scopes/details/MappingDetails")
 );
 
-export const MapperRoute: RouteDef = {
+export const MapperRoute: AppRouteObject = {
   path: "/:realm/clients/:id/clientScopes/dedicated/mappers/:mapperId",
   element: <MappingDetails />,
   breadcrumb: (t) => t("common:mappingDetails"),

--- a/js/apps/admin-ui/src/clients/routes/NewPermission.tsx
+++ b/js/apps/admin-ui/src/clients/routes/NewPermission.tsx
@@ -1,7 +1,7 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type PermissionType = "resource" | "scope";
 
@@ -16,7 +16,7 @@ const PermissionDetails = lazy(
   () => import("../authorization/PermissionDetails")
 );
 
-export const NewPermissionRoute: RouteDef = {
+export const NewPermissionRoute: AppRouteObject = {
   path: "/:realm/clients/:id/authorization/permission/new/:permissionType",
   element: <PermissionDetails />,
   breadcrumb: (t) => t("clients:createPermission"),
@@ -25,7 +25,7 @@ export const NewPermissionRoute: RouteDef = {
   },
 };
 
-export const NewPermissionWithSelectedIdRoute: RouteDef = {
+export const NewPermissionWithSelectedIdRoute: AppRouteObject = {
   ...NewPermissionRoute,
   path: "/:realm/clients/:id/authorization/permission/new/:permissionType/:selectedId",
 };

--- a/js/apps/admin-ui/src/clients/routes/NewPolicy.tsx
+++ b/js/apps/admin-ui/src/clients/routes/NewPolicy.tsx
@@ -1,7 +1,7 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type NewPolicyParams = { realm: string; id: string; policyType: string };
 
@@ -9,7 +9,7 @@ const PolicyDetails = lazy(
   () => import("../authorization/policy/PolicyDetails")
 );
 
-export const NewPolicyRoute: RouteDef = {
+export const NewPolicyRoute: AppRouteObject = {
   path: "/:realm/clients/:id/authorization/policy/new/:policyType",
   element: <PolicyDetails />,
   breadcrumb: (t) => t("clients:createPolicy"),

--- a/js/apps/admin-ui/src/clients/routes/NewResource.tsx
+++ b/js/apps/admin-ui/src/clients/routes/NewResource.tsx
@@ -1,13 +1,13 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type NewResourceParams = { realm: string; id: string };
 
 const ResourceDetails = lazy(() => import("../authorization/ResourceDetails"));
 
-export const NewResourceRoute: RouteDef = {
+export const NewResourceRoute: AppRouteObject = {
   path: "/:realm/clients/:id/authorization/resource/new",
   element: <ResourceDetails />,
   breadcrumb: (t) => t("clients:createResource"),

--- a/js/apps/admin-ui/src/clients/routes/NewRole.tsx
+++ b/js/apps/admin-ui/src/clients/routes/NewRole.tsx
@@ -1,13 +1,13 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type NewRoleParams = { realm: string; clientId: string };
 
 const CreateClientRole = lazy(() => import("../roles/CreateClientRole"));
 
-export const NewRoleRoute: RouteDef = {
+export const NewRoleRoute: AppRouteObject = {
   path: "/:realm/clients/:clientId/roles/new",
   element: <CreateClientRole />,
   breadcrumb: (t) => t("roles:createRole"),

--- a/js/apps/admin-ui/src/clients/routes/NewScope.tsx
+++ b/js/apps/admin-ui/src/clients/routes/NewScope.tsx
@@ -1,13 +1,13 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type NewScopeParams = { realm: string; id: string };
 
 const ScopeDetails = lazy(() => import("../authorization/ScopeDetails"));
 
-export const NewScopeRoute: RouteDef = {
+export const NewScopeRoute: AppRouteObject = {
   path: "/:realm/clients/:id/authorization/scope/new",
   element: <ScopeDetails />,
   breadcrumb: (t) => t("clients:createAuthorizationScope"),

--- a/js/apps/admin-ui/src/clients/routes/PermissionDetails.tsx
+++ b/js/apps/admin-ui/src/clients/routes/PermissionDetails.tsx
@@ -1,7 +1,7 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 import type { PermissionType } from "./NewPermission";
 
 export type PermissionDetailsParams = {
@@ -15,7 +15,7 @@ const PermissionDetails = lazy(
   () => import("../authorization/PermissionDetails")
 );
 
-export const PermissionDetailsRoute: RouteDef = {
+export const PermissionDetailsRoute: AppRouteObject = {
   path: "/:realm/clients/:id/authorization/permission/:permissionType/:permissionId",
   element: <PermissionDetails />,
   breadcrumb: (t) => t("clients:permissionDetails"),

--- a/js/apps/admin-ui/src/clients/routes/PolicyDetails.tsx
+++ b/js/apps/admin-ui/src/clients/routes/PolicyDetails.tsx
@@ -1,7 +1,7 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type PolicyDetailsParams = {
   realm: string;
@@ -14,7 +14,7 @@ const PolicyDetails = lazy(
   () => import("../authorization/policy/PolicyDetails")
 );
 
-export const PolicyDetailsRoute: RouteDef = {
+export const PolicyDetailsRoute: AppRouteObject = {
   path: "/:realm/clients/:id/authorization/policy/:policyId/:policyType",
   element: <PolicyDetails />,
   breadcrumb: (t) => t("clients:createPolicy"),

--- a/js/apps/admin-ui/src/clients/routes/Resource.tsx
+++ b/js/apps/admin-ui/src/clients/routes/Resource.tsx
@@ -1,7 +1,7 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type ResourceDetailsParams = {
   realm: string;
@@ -11,7 +11,7 @@ export type ResourceDetailsParams = {
 
 const ResourceDetails = lazy(() => import("../authorization/ResourceDetails"));
 
-export const ResourceDetailsRoute: RouteDef = {
+export const ResourceDetailsRoute: AppRouteObject = {
   path: "/:realm/clients/:id/authorization/resource",
   element: <ResourceDetails />,
   breadcrumb: (t) => t("clients:createResource"),
@@ -20,7 +20,7 @@ export const ResourceDetailsRoute: RouteDef = {
   },
 };
 
-export const ResourceDetailsWithResourceIdRoute: RouteDef = {
+export const ResourceDetailsWithResourceIdRoute: AppRouteObject = {
   ...ResourceDetailsRoute,
   path: "/:realm/clients/:id/authorization/resource/:resourceId",
 };

--- a/js/apps/admin-ui/src/clients/routes/Scope.tsx
+++ b/js/apps/admin-ui/src/clients/routes/Scope.tsx
@@ -1,7 +1,7 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type ScopeDetailsParams = {
   realm: string;
@@ -11,7 +11,7 @@ export type ScopeDetailsParams = {
 
 const ScopeDetails = lazy(() => import("../authorization/ScopeDetails"));
 
-export const ScopeDetailsRoute: RouteDef = {
+export const ScopeDetailsRoute: AppRouteObject = {
   path: "/:realm/clients/:id/authorization/scope",
   element: <ScopeDetails />,
   breadcrumb: (t) => t("clients:createAuthorizationScope"),
@@ -20,7 +20,7 @@ export const ScopeDetailsRoute: RouteDef = {
   },
 };
 
-export const ScopeDetailsWithScopeIdRoute: RouteDef = {
+export const ScopeDetailsWithScopeIdRoute: AppRouteObject = {
   ...ScopeDetailsRoute,
   path: "/:realm/clients/:id/authorization/scope/:scopeId",
 };

--- a/js/apps/admin-ui/src/components/bread-crumb/PageBreadCrumbs.tsx
+++ b/js/apps/admin-ui/src/components/bread-crumb/PageBreadCrumbs.tsx
@@ -9,7 +9,7 @@ import useBreadcrumbs, {
 } from "use-react-router-breadcrumbs";
 
 import { useRealm } from "../../context/realm-context/RealmContext";
-import { routes } from "../../route-config";
+import { routes } from "../../routes";
 
 export const PageBreadCrumbs = () => {
   const { t } = useTranslation();

--- a/js/apps/admin-ui/src/dashboard/routes.ts
+++ b/js/apps/admin-ui/src/dashboard/routes.ts
@@ -1,11 +1,11 @@
-import type { RouteDef } from "../route-config";
+import type { AppRouteObject } from "../routes";
 import {
   DashboardRoute,
   DashboardRouteWithRealm,
   DashboardRouteWithTab,
 } from "./routes/Dashboard";
 
-const routes: RouteDef[] = [
+const routes: AppRouteObject[] = [
   DashboardRoute,
   DashboardRouteWithRealm,
   DashboardRouteWithTab,

--- a/js/apps/admin-ui/src/dashboard/routes/Dashboard.tsx
+++ b/js/apps/admin-ui/src/dashboard/routes/Dashboard.tsx
@@ -1,7 +1,7 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type DashboardTab = "info" | "providers";
 
@@ -9,7 +9,7 @@ export type DashboardParams = { realm?: string; tab?: DashboardTab };
 
 const Dashboard = lazy(() => import("../Dashboard"));
 
-export const DashboardRoute: RouteDef = {
+export const DashboardRoute: AppRouteObject = {
   path: "/",
   element: <Dashboard />,
   breadcrumb: (t) => t("common:home"),
@@ -18,12 +18,12 @@ export const DashboardRoute: RouteDef = {
   },
 };
 
-export const DashboardRouteWithRealm: RouteDef = {
+export const DashboardRouteWithRealm: AppRouteObject = {
   ...DashboardRoute,
   path: "/:realm",
 };
 
-export const DashboardRouteWithTab: RouteDef = {
+export const DashboardRouteWithTab: AppRouteObject = {
   ...DashboardRoute,
   path: "/:realm/:tab",
 };

--- a/js/apps/admin-ui/src/events/routes.ts
+++ b/js/apps/admin-ui/src/events/routes.ts
@@ -1,6 +1,6 @@
-import type { RouteDef } from "../route-config";
+import type { AppRouteObject } from "../routes";
 import { EventsRoute, EventsRouteWithTab } from "./routes/Events";
 
-const routes: RouteDef[] = [EventsRoute, EventsRouteWithTab];
+const routes: AppRouteObject[] = [EventsRoute, EventsRouteWithTab];
 
 export default routes;

--- a/js/apps/admin-ui/src/events/routes/Events.tsx
+++ b/js/apps/admin-ui/src/events/routes/Events.tsx
@@ -1,7 +1,7 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type EventsTab = "user-events" | "admin-events";
 
@@ -12,7 +12,7 @@ export type EventsParams = {
 
 const EventsSection = lazy(() => import("../EventsSection"));
 
-export const EventsRoute: RouteDef = {
+export const EventsRoute: AppRouteObject = {
   path: "/:realm/events",
   element: <EventsSection />,
   breadcrumb: (t) => t("events:title"),
@@ -21,7 +21,7 @@ export const EventsRoute: RouteDef = {
   },
 };
 
-export const EventsRouteWithTab: RouteDef = {
+export const EventsRouteWithTab: AppRouteObject = {
   ...EventsRoute,
   path: "/:realm/events/:tab",
 };

--- a/js/apps/admin-ui/src/groups/routes.ts
+++ b/js/apps/admin-ui/src/groups/routes.ts
@@ -1,6 +1,6 @@
-import type { RouteDef } from "../route-config";
+import type { AppRouteObject } from "../routes";
 import { GroupsRoute, GroupsWithIdRoute } from "./routes/Groups";
 
-const routes: RouteDef[] = [GroupsRoute, GroupsWithIdRoute];
+const routes: AppRouteObject[] = [GroupsRoute, GroupsWithIdRoute];
 
 export default routes;

--- a/js/apps/admin-ui/src/groups/routes/Groups.tsx
+++ b/js/apps/admin-ui/src/groups/routes/Groups.tsx
@@ -1,13 +1,13 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type GroupsParams = { realm: string; id?: string };
 
 const GroupsSection = lazy(() => import("../GroupsSection"));
 
-export const GroupsRoute: RouteDef = {
+export const GroupsRoute: AppRouteObject = {
   path: "/:realm/groups/*",
   element: <GroupsSection />,
   handle: {
@@ -15,7 +15,7 @@ export const GroupsRoute: RouteDef = {
   },
 };
 
-export const GroupsWithIdRoute: RouteDef = {
+export const GroupsWithIdRoute: AppRouteObject = {
   ...GroupsRoute,
   path: "/:realm/groups/:id",
 };

--- a/js/apps/admin-ui/src/identity-providers/routes.ts
+++ b/js/apps/admin-ui/src/identity-providers/routes.ts
@@ -1,4 +1,4 @@
-import type { RouteDef } from "../route-config";
+import type { AppRouteObject } from "../routes";
 import { IdentityProviderRoute } from "./routes/IdentityProvider";
 import { IdentityProviderKeycloakOidcRoute } from "./routes/IdentityProviderKeycloakOidc";
 import { IdentityProviderOidcRoute } from "./routes/IdentityProviderOidc";
@@ -8,7 +8,7 @@ import { IdentityProviderAddMapperRoute } from "./routes/AddMapper";
 import { IdentityProviderEditMapperRoute } from "./routes/EditMapper";
 import { IdentityProviderCreateRoute } from "./routes/IdentityProviderCreate";
 
-const routes: RouteDef[] = [
+const routes: AppRouteObject[] = [
   IdentityProviderAddMapperRoute,
   IdentityProviderEditMapperRoute,
   IdentityProvidersRoute,

--- a/js/apps/admin-ui/src/identity-providers/routes/AddMapper.tsx
+++ b/js/apps/admin-ui/src/identity-providers/routes/AddMapper.tsx
@@ -1,7 +1,7 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type IdentityProviderAddMapperParams = {
   realm: string;
@@ -12,7 +12,7 @@ export type IdentityProviderAddMapperParams = {
 
 const AddMapper = lazy(() => import("../add/AddMapper"));
 
-export const IdentityProviderAddMapperRoute: RouteDef = {
+export const IdentityProviderAddMapperRoute: AppRouteObject = {
   path: "/:realm/identity-providers/:providerId/:alias/:tab/create",
   element: <AddMapper />,
   breadcrumb: (t) => t("identity-providers:addIdPMapper"),

--- a/js/apps/admin-ui/src/identity-providers/routes/EditMapper.tsx
+++ b/js/apps/admin-ui/src/identity-providers/routes/EditMapper.tsx
@@ -1,7 +1,7 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type IdentityProviderEditMapperParams = {
   realm: string;
@@ -12,7 +12,7 @@ export type IdentityProviderEditMapperParams = {
 
 const AddMapper = lazy(() => import("../add/AddMapper"));
 
-export const IdentityProviderEditMapperRoute: RouteDef = {
+export const IdentityProviderEditMapperRoute: AppRouteObject = {
   path: "/:realm/identity-providers/:providerId/:alias/mappers/:id",
   element: <AddMapper />,
   breadcrumb: (t) => t("identity-providers:editIdPMapper"),

--- a/js/apps/admin-ui/src/identity-providers/routes/IdentityProvider.tsx
+++ b/js/apps/admin-ui/src/identity-providers/routes/IdentityProvider.tsx
@@ -1,7 +1,7 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type IdentityProviderTab = "settings" | "mappers" | "permissions";
 
@@ -14,7 +14,7 @@ export type IdentityProviderParams = {
 
 const DetailSettings = lazy(() => import("../add/DetailSettings"));
 
-export const IdentityProviderRoute: RouteDef = {
+export const IdentityProviderRoute: AppRouteObject = {
   path: "/:realm/identity-providers/:providerId/:alias/:tab",
   element: <DetailSettings />,
   breadcrumb: (t) => t("identity-providers:providerDetails"),

--- a/js/apps/admin-ui/src/identity-providers/routes/IdentityProviderCreate.tsx
+++ b/js/apps/admin-ui/src/identity-providers/routes/IdentityProviderCreate.tsx
@@ -1,7 +1,7 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type IdentityProviderCreateParams = {
   realm: string;
@@ -10,7 +10,7 @@ export type IdentityProviderCreateParams = {
 
 const AddIdentityProvider = lazy(() => import("../add/AddIdentityProvider"));
 
-export const IdentityProviderCreateRoute: RouteDef = {
+export const IdentityProviderCreateRoute: AppRouteObject = {
   path: "/:realm/identity-providers/:providerId/add",
   element: <AddIdentityProvider />,
   breadcrumb: (t) => t("identity-providers:addProvider"),

--- a/js/apps/admin-ui/src/identity-providers/routes/IdentityProviderKeycloakOidc.tsx
+++ b/js/apps/admin-ui/src/identity-providers/routes/IdentityProviderKeycloakOidc.tsx
@@ -1,13 +1,13 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type IdentityProviderKeycloakOidcParams = { realm: string };
 
 const AddOpenIdConnect = lazy(() => import("../add/AddOpenIdConnect"));
 
-export const IdentityProviderKeycloakOidcRoute: RouteDef = {
+export const IdentityProviderKeycloakOidcRoute: AppRouteObject = {
   path: "/:realm/identity-providers/keycloak-oidc/add",
   element: <AddOpenIdConnect />,
   breadcrumb: (t) => t("identity-providers:addKeycloakOpenIdProvider"),

--- a/js/apps/admin-ui/src/identity-providers/routes/IdentityProviderOidc.tsx
+++ b/js/apps/admin-ui/src/identity-providers/routes/IdentityProviderOidc.tsx
@@ -1,13 +1,13 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type IdentityProviderOidcParams = { realm: string };
 
 const AddOpenIdConnect = lazy(() => import("../add/AddOpenIdConnect"));
 
-export const IdentityProviderOidcRoute: RouteDef = {
+export const IdentityProviderOidcRoute: AppRouteObject = {
   path: "/:realm/identity-providers/oidc/add",
   element: <AddOpenIdConnect />,
   breadcrumb: (t) => t("identity-providers:addOpenIdProvider"),

--- a/js/apps/admin-ui/src/identity-providers/routes/IdentityProviderSaml.tsx
+++ b/js/apps/admin-ui/src/identity-providers/routes/IdentityProviderSaml.tsx
@@ -1,13 +1,13 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type IdentityProviderSamlParams = { realm: string };
 
 const AddSamlConnect = lazy(() => import("../add/AddSamlConnect"));
 
-export const IdentityProviderSamlRoute: RouteDef = {
+export const IdentityProviderSamlRoute: AppRouteObject = {
   path: "/:realm/identity-providers/saml/add",
   element: <AddSamlConnect />,
   breadcrumb: (t) => t("identity-providers:addSamlProvider"),

--- a/js/apps/admin-ui/src/identity-providers/routes/IdentityProviders.tsx
+++ b/js/apps/admin-ui/src/identity-providers/routes/IdentityProviders.tsx
@@ -1,7 +1,7 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type IdentityProvidersParams = { realm: string };
 
@@ -9,7 +9,7 @@ const IdentityProvidersSection = lazy(
   () => import("../IdentityProvidersSection")
 );
 
-export const IdentityProvidersRoute: RouteDef = {
+export const IdentityProvidersRoute: AppRouteObject = {
   path: "/:realm/identity-providers",
   element: <IdentityProvidersSection />,
   breadcrumb: (t) => t("identityProviders"),

--- a/js/apps/admin-ui/src/realm-roles/routes.ts
+++ b/js/apps/admin-ui/src/realm-roles/routes.ts
@@ -1,8 +1,12 @@
-import type { RouteDef } from "../route-config";
+import type { AppRouteObject } from "../routes";
 import { AddRoleRoute } from "./routes/AddRole";
 import { RealmRoleRoute } from "./routes/RealmRole";
 import { RealmRolesRoute } from "./routes/RealmRoles";
 
-const routes: RouteDef[] = [RealmRolesRoute, AddRoleRoute, RealmRoleRoute];
+const routes: AppRouteObject[] = [
+  RealmRolesRoute,
+  AddRoleRoute,
+  RealmRoleRoute,
+];
 
 export default routes;

--- a/js/apps/admin-ui/src/realm-roles/routes/AddRole.tsx
+++ b/js/apps/admin-ui/src/realm-roles/routes/AddRole.tsx
@@ -1,13 +1,13 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type AddRoleParams = { realm: string };
 
 const CreateRealmRole = lazy(() => import("../CreateRealmRole"));
 
-export const AddRoleRoute: RouteDef = {
+export const AddRoleRoute: AppRouteObject = {
   path: "/:realm/roles/new",
   element: <CreateRealmRole />,
   breadcrumb: (t) => t("roles:createRole"),

--- a/js/apps/admin-ui/src/realm-roles/routes/RealmRole.tsx
+++ b/js/apps/admin-ui/src/realm-roles/routes/RealmRole.tsx
@@ -2,7 +2,7 @@ import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
 
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type RealmRoleTab =
   | "details"
@@ -19,7 +19,7 @@ export type RealmRoleParams = {
 
 const RealmRoleTabs = lazy(() => import("../RealmRoleTabs"));
 
-export const RealmRoleRoute: RouteDef = {
+export const RealmRoleRoute: AppRouteObject = {
   path: "/:realm/roles/:id/:tab",
   element: <RealmRoleTabs />,
   breadcrumb: (t) => t("roles:roleDetails"),

--- a/js/apps/admin-ui/src/realm-roles/routes/RealmRoles.tsx
+++ b/js/apps/admin-ui/src/realm-roles/routes/RealmRoles.tsx
@@ -1,13 +1,13 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type RealmRolesParams = { realm: string };
 
 const RealmRolesSection = lazy(() => import("../RealmRolesSection"));
 
-export const RealmRolesRoute: RouteDef = {
+export const RealmRolesRoute: AppRouteObject = {
   path: "/:realm/roles",
   element: <RealmRolesSection />,
   breadcrumb: (t) => t("roles:realmRolesList"),

--- a/js/apps/admin-ui/src/realm-settings/routes.ts
+++ b/js/apps/admin-ui/src/realm-settings/routes.ts
@@ -1,4 +1,4 @@
-import type { RouteDef } from "../route-config";
+import type { AppRouteObject } from "../routes";
 import { KeyProviderFormRoute } from "./routes/KeyProvider";
 import {
   RealmSettingsRoute,
@@ -20,7 +20,7 @@ import { AttributeRoute } from "./routes/Attribute";
 import { NewAttributesGroupRoute } from "./routes/NewAttributesGroup";
 import { EditAttributesGroupRoute } from "./routes/EditAttributesGroup";
 
-const routes: RouteDef[] = [
+const routes: AppRouteObject[] = [
   RealmSettingsRoute,
   RealmSettingsRouteWithTab,
   KeysRoute,

--- a/js/apps/admin-ui/src/realm-settings/routes/AddAttribute.tsx
+++ b/js/apps/admin-ui/src/realm-settings/routes/AddAttribute.tsx
@@ -1,7 +1,7 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type AddAttributeParams = {
   realm: string;
@@ -9,7 +9,7 @@ export type AddAttributeParams = {
 
 const NewAttributeSettings = lazy(() => import("../NewAttributeSettings"));
 
-export const AddAttributeRoute: RouteDef = {
+export const AddAttributeRoute: AppRouteObject = {
   path: "/:realm/realm-settings/user-profile/attributes/add-attribute",
   element: <NewAttributeSettings />,
   breadcrumb: (t) => t("realm-settings:createAttribute"),

--- a/js/apps/admin-ui/src/realm-settings/routes/AddClientPolicy.tsx
+++ b/js/apps/admin-ui/src/realm-settings/routes/AddClientPolicy.tsx
@@ -1,13 +1,13 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type AddClientPolicyParams = { realm: string };
 
 const NewClientPolicyForm = lazy(() => import("../NewClientPolicyForm"));
 
-export const AddClientPolicyRoute: RouteDef = {
+export const AddClientPolicyRoute: AppRouteObject = {
   path: "/:realm/realm-settings/client-policies/policies/add-client-policy",
   element: <NewClientPolicyForm />,
   breadcrumb: (t) => t("realm-settings:createPolicy"),

--- a/js/apps/admin-ui/src/realm-settings/routes/AddClientProfile.tsx
+++ b/js/apps/admin-ui/src/realm-settings/routes/AddClientProfile.tsx
@@ -1,7 +1,7 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type AddClientProfileParams = {
   realm: string;
@@ -10,7 +10,7 @@ export type AddClientProfileParams = {
 
 const ClientProfileForm = lazy(() => import("../ClientProfileForm"));
 
-export const AddClientProfileRoute: RouteDef = {
+export const AddClientProfileRoute: AppRouteObject = {
   path: "/:realm/realm-settings/client-policies/:tab/add-profile",
   element: <ClientProfileForm />,
   breadcrumb: (t) => t("realm-settings:newClientProfile"),

--- a/js/apps/admin-ui/src/realm-settings/routes/AddCondition.tsx
+++ b/js/apps/admin-ui/src/realm-settings/routes/AddCondition.tsx
@@ -1,7 +1,7 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type NewClientPolicyConditionParams = {
   realm: string;
@@ -12,7 +12,7 @@ const NewClientPolicyCondition = lazy(
   () => import("../NewClientPolicyCondition")
 );
 
-export const NewClientPolicyConditionRoute: RouteDef = {
+export const NewClientPolicyConditionRoute: AppRouteObject = {
   path: "/:realm/realm-settings/client-policies/:policyName/edit-policy/create-condition",
   element: <NewClientPolicyCondition />,
   breadcrumb: (t) => t("realm-settings:addCondition"),

--- a/js/apps/admin-ui/src/realm-settings/routes/AddExecutor.tsx
+++ b/js/apps/admin-ui/src/realm-settings/routes/AddExecutor.tsx
@@ -1,7 +1,7 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type AddExecutorParams = {
   realm: string;
@@ -10,7 +10,7 @@ export type AddExecutorParams = {
 
 const ExecutorForm = lazy(() => import("../ExecutorForm"));
 
-export const AddExecutorRoute: RouteDef = {
+export const AddExecutorRoute: AppRouteObject = {
   path: "/:realm/realm-settings/client-policies/:profileName/add-executor",
   element: <ExecutorForm />,
   breadcrumb: (t) => t("realm-settings:addExecutor"),

--- a/js/apps/admin-ui/src/realm-settings/routes/Attribute.tsx
+++ b/js/apps/admin-ui/src/realm-settings/routes/Attribute.tsx
@@ -1,7 +1,7 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type AttributeParams = {
   realm: string;
@@ -10,7 +10,7 @@ export type AttributeParams = {
 
 const NewAttributeSettings = lazy(() => import("../NewAttributeSettings"));
 
-export const AttributeRoute: RouteDef = {
+export const AttributeRoute: AppRouteObject = {
   path: "/:realm/realm-settings/user-profile/attributes/:attributeName/edit-attribute",
   element: <NewAttributeSettings />,
   breadcrumb: (t) => t("realm-settings:editAttribute"),

--- a/js/apps/admin-ui/src/realm-settings/routes/ClientPolicies.tsx
+++ b/js/apps/admin-ui/src/realm-settings/routes/ClientPolicies.tsx
@@ -1,7 +1,7 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type ClientPoliciesTab = "profiles" | "policies";
 
@@ -12,7 +12,7 @@ export type ClientPoliciesParams = {
 
 const RealmSettingsSection = lazy(() => import("../RealmSettingsSection"));
 
-export const ClientPoliciesRoute: RouteDef = {
+export const ClientPoliciesRoute: AppRouteObject = {
   path: "/:realm/realm-settings/client-policies/:tab",
   element: <RealmSettingsSection />,
   breadcrumb: (t) => t("realm-settings:clientPolicies"),

--- a/js/apps/admin-ui/src/realm-settings/routes/ClientProfile.tsx
+++ b/js/apps/admin-ui/src/realm-settings/routes/ClientProfile.tsx
@@ -1,7 +1,7 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type ClientProfileParams = {
   realm: string;
@@ -10,7 +10,7 @@ export type ClientProfileParams = {
 
 const ClientProfileForm = lazy(() => import("../ClientProfileForm"));
 
-export const ClientProfileRoute: RouteDef = {
+export const ClientProfileRoute: AppRouteObject = {
   path: "/:realm/realm-settings/client-policies/:profileName/edit-profile",
   element: <ClientProfileForm />,
   breadcrumb: (t) => t("realm-settings:clientProfile"),

--- a/js/apps/admin-ui/src/realm-settings/routes/EditAttributesGroup.tsx
+++ b/js/apps/admin-ui/src/realm-settings/routes/EditAttributesGroup.tsx
@@ -1,7 +1,7 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type EditAttributesGroupParams = {
   realm: string;
@@ -12,7 +12,7 @@ const AttributesGroupDetails = lazy(
   () => import("../user-profile/AttributesGroupDetails")
 );
 
-export const EditAttributesGroupRoute: RouteDef = {
+export const EditAttributesGroupRoute: AppRouteObject = {
   path: "/:realm/realm-settings/user-profile/attributesGroup/edit/:name",
   element: <AttributesGroupDetails />,
   breadcrumb: (t) => t("realm-settings:editGroupText"),

--- a/js/apps/admin-ui/src/realm-settings/routes/EditClientPolicy.tsx
+++ b/js/apps/admin-ui/src/realm-settings/routes/EditClientPolicy.tsx
@@ -1,7 +1,7 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type EditClientPolicyParams = {
   realm: string;
@@ -10,7 +10,7 @@ export type EditClientPolicyParams = {
 
 const NewClientPolicyForm = lazy(() => import("../NewClientPolicyForm"));
 
-export const EditClientPolicyRoute: RouteDef = {
+export const EditClientPolicyRoute: AppRouteObject = {
   path: "/:realm/realm-settings/client-policies/:policyName/edit-policy",
   element: <NewClientPolicyForm />,
   breadcrumb: (t) => t("realm-settings:policyDetails"),

--- a/js/apps/admin-ui/src/realm-settings/routes/EditCondition.tsx
+++ b/js/apps/admin-ui/src/realm-settings/routes/EditCondition.tsx
@@ -1,7 +1,7 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type EditClientPolicyConditionParams = {
   realm: string;
@@ -13,7 +13,7 @@ const NewClientPolicyCondition = lazy(
   () => import("../NewClientPolicyCondition")
 );
 
-export const EditClientPolicyConditionRoute: RouteDef = {
+export const EditClientPolicyConditionRoute: AppRouteObject = {
   path: "/:realm/realm-settings/client-policies/:policyName/edit-policy/:conditionName/edit-condition",
   element: <NewClientPolicyCondition />,
   breadcrumb: (t) => t("realm-settings:editCondition"),

--- a/js/apps/admin-ui/src/realm-settings/routes/Executor.tsx
+++ b/js/apps/admin-ui/src/realm-settings/routes/Executor.tsx
@@ -1,7 +1,7 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type ExecutorParams = {
   realm: string;
@@ -11,7 +11,7 @@ export type ExecutorParams = {
 
 const ExecutorForm = lazy(() => import("../ExecutorForm"));
 
-export const ExecutorRoute: RouteDef = {
+export const ExecutorRoute: AppRouteObject = {
   path: "/:realm/realm-settings/client-policies/:profileName/edit-profile/:executorName",
   element: <ExecutorForm />,
   breadcrumb: (t) => t("realm-settings:executorDetails"),

--- a/js/apps/admin-ui/src/realm-settings/routes/KeyProvider.tsx
+++ b/js/apps/admin-ui/src/realm-settings/routes/KeyProvider.tsx
@@ -1,7 +1,7 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type ProviderType =
   | "aes-generated"
@@ -23,7 +23,7 @@ const KeyProviderForm = lazy(
   () => import("../keys/key-providers/KeyProviderForm")
 );
 
-export const KeyProviderFormRoute: RouteDef = {
+export const KeyProviderFormRoute: AppRouteObject = {
   path: "/:realm/realm-settings/keys/providers/:id/:providerType/settings",
   element: <KeyProviderForm />,
   breadcrumb: (t) => t("realm-settings:editProvider"),

--- a/js/apps/admin-ui/src/realm-settings/routes/KeysTab.tsx
+++ b/js/apps/admin-ui/src/realm-settings/routes/KeysTab.tsx
@@ -1,7 +1,7 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type KeySubTab = "list" | "providers";
 
@@ -12,7 +12,7 @@ export type KeysParams = {
 
 const RealmSettingsSection = lazy(() => import("../RealmSettingsSection"));
 
-export const KeysRoute: RouteDef = {
+export const KeysRoute: AppRouteObject = {
   path: "/:realm/realm-settings/keys/:tab",
   element: <RealmSettingsSection />,
   breadcrumb: (t) => t("realm-settings:keys"),

--- a/js/apps/admin-ui/src/realm-settings/routes/NewAttributesGroup.tsx
+++ b/js/apps/admin-ui/src/realm-settings/routes/NewAttributesGroup.tsx
@@ -1,7 +1,7 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type NewAttributesGroupParams = {
   realm: string;
@@ -11,7 +11,7 @@ const AttributesGroupDetails = lazy(
   () => import("../user-profile/AttributesGroupDetails")
 );
 
-export const NewAttributesGroupRoute: RouteDef = {
+export const NewAttributesGroupRoute: AppRouteObject = {
   path: "/:realm/realm-settings/user-profile/attributesGroup/new",
   element: <AttributesGroupDetails />,
   breadcrumb: (t) => t("realm-settings:createGroupText"),

--- a/js/apps/admin-ui/src/realm-settings/routes/RealmSettings.tsx
+++ b/js/apps/admin-ui/src/realm-settings/routes/RealmSettings.tsx
@@ -1,7 +1,7 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type RealmSettingsTab =
   | "general"
@@ -25,7 +25,7 @@ export type RealmSettingsParams = {
 
 const RealmSettingsSection = lazy(() => import("../RealmSettingsSection"));
 
-export const RealmSettingsRoute: RouteDef = {
+export const RealmSettingsRoute: AppRouteObject = {
   path: "/:realm/realm-settings",
   element: <RealmSettingsSection />,
   breadcrumb: (t) => t("realmSettings"),
@@ -34,7 +34,7 @@ export const RealmSettingsRoute: RouteDef = {
   },
 };
 
-export const RealmSettingsRouteWithTab: RouteDef = {
+export const RealmSettingsRouteWithTab: AppRouteObject = {
   ...RealmSettingsRoute,
   path: "/:realm/realm-settings/:tab",
 };

--- a/js/apps/admin-ui/src/realm-settings/routes/UserProfile.tsx
+++ b/js/apps/admin-ui/src/realm-settings/routes/UserProfile.tsx
@@ -1,7 +1,7 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type UserProfileTab = "attributes" | "attributes-group" | "json-editor";
 
@@ -12,7 +12,7 @@ export type UserProfileParams = {
 
 const RealmSettingsSection = lazy(() => import("../RealmSettingsSection"));
 
-export const UserProfileRoute: RouteDef = {
+export const UserProfileRoute: AppRouteObject = {
   path: "/:realm/realm-settings/user-profile/:tab",
   element: <RealmSettingsSection />,
   breadcrumb: (t) => t("realm-settings:userProfile"),

--- a/js/apps/admin-ui/src/realm/routes.ts
+++ b/js/apps/admin-ui/src/realm/routes.ts
@@ -1,6 +1,6 @@
-import type { RouteDef } from "../route-config";
+import type { AppRouteObject } from "../routes";
 import { AddRealmRoute } from "./routes/AddRealm";
 
-const routes: RouteDef[] = [AddRealmRoute];
+const routes: AppRouteObject[] = [AddRealmRoute];
 
 export default routes;

--- a/js/apps/admin-ui/src/realm/routes/AddRealm.tsx
+++ b/js/apps/admin-ui/src/realm/routes/AddRealm.tsx
@@ -1,13 +1,13 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type AddRealmParams = { realm: string };
 
 const NewRealmForm = lazy(() => import("../add/NewRealmForm"));
 
-export const AddRealmRoute: RouteDef = {
+export const AddRealmRoute: AppRouteObject = {
   path: "/:realm/add-realm",
   element: <NewRealmForm />,
   breadcrumb: (t) => t("realm:createRealm"),

--- a/js/apps/admin-ui/src/routes.tsx
+++ b/js/apps/admin-ui/src/routes.tsx
@@ -1,7 +1,7 @@
 import type { AccessType } from "@keycloak/keycloak-admin-client/lib/defs/whoAmIRepresentation";
 import type { TFunction } from "i18next";
 import type { ComponentType } from "react";
-import { RouteObject } from "react-router-dom";
+import type { NonIndexRouteObject } from "react-router";
 
 import authenticationRoutes from "./authentication/routes";
 import clientScopesRoutes from "./client-scopes/routes";
@@ -18,17 +18,17 @@ import sessionRoutes from "./sessions/routes";
 import userFederationRoutes from "./user-federation/routes";
 import userRoutes from "./user/routes";
 
-export type RouteObjectHandle = {
+export type AppRouteObjectHandle = {
   access: AccessType | AccessType[];
 };
 
-export type RouteDef = Required<Pick<RouteObject, "element">> & {
+export interface AppRouteObject extends NonIndexRouteObject {
   path: string;
   breadcrumb?: (t: TFunction) => string | ComponentType<any>;
-  handle: RouteObjectHandle;
-};
+  handle: AppRouteObjectHandle;
+}
 
-const NotFoundRoute: RouteDef = {
+const NotFoundRoute: AppRouteObject = {
   path: "*",
   element: <PageNotFoundSection />,
   handle: {
@@ -36,7 +36,7 @@ const NotFoundRoute: RouteDef = {
   },
 };
 
-export const routes: RouteDef[] = [
+export const routes: AppRouteObject[] = [
   ...authenticationRoutes,
   ...clientRoutes,
   ...clientScopesRoutes,

--- a/js/apps/admin-ui/src/sessions/routes.ts
+++ b/js/apps/admin-ui/src/sessions/routes.ts
@@ -1,6 +1,6 @@
-import type { RouteDef } from "../route-config";
+import type { AppRouteObject } from "../routes";
 import { SessionsRoute } from "./routes/Sessions";
 
-const routes: RouteDef[] = [SessionsRoute];
+const routes: AppRouteObject[] = [SessionsRoute];
 
 export default routes;

--- a/js/apps/admin-ui/src/sessions/routes/Sessions.tsx
+++ b/js/apps/admin-ui/src/sessions/routes/Sessions.tsx
@@ -1,13 +1,13 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type SessionsParams = { realm: string };
 
 const SessionsSection = lazy(() => import("../SessionsSection"));
 
-export const SessionsRoute: RouteDef = {
+export const SessionsRoute: AppRouteObject = {
   path: "/:realm/sessions",
   element: <SessionsSection />,
   breadcrumb: (t) => t("sessions:title"),

--- a/js/apps/admin-ui/src/user-federation/routes.ts
+++ b/js/apps/admin-ui/src/user-federation/routes.ts
@@ -1,4 +1,4 @@
-import type { RouteDef } from "../route-config";
+import type { AppRouteObject } from "../routes";
 import { CustomUserFederationRoute } from "./routes/CustomUserFederation";
 import { NewCustomUserFederationRoute } from "./routes/NewCustomUserFederation";
 import { NewKerberosUserFederationRoute } from "./routes/NewKerberosUserFederation";
@@ -13,7 +13,7 @@ import { UserFederationLdapMapperRoute } from "./routes/UserFederationLdapMapper
 import { UserFederationsKerberosRoute } from "./routes/UserFederationsKerberos";
 import { UserFederationsLdapRoute } from "./routes/UserFederationsLdap";
 
-const routes: RouteDef[] = [
+const routes: AppRouteObject[] = [
   UserFederationRoute,
   UserFederationsKerberosRoute,
   NewKerberosUserFederationRoute,

--- a/js/apps/admin-ui/src/user-federation/routes/CustomUserFederation.tsx
+++ b/js/apps/admin-ui/src/user-federation/routes/CustomUserFederation.tsx
@@ -2,7 +2,7 @@ import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
 
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type CustomUserFederationRouteParams = {
   realm: string;
@@ -14,7 +14,7 @@ const CustomProviderSettings = lazy(
   () => import("../custom/CustomProviderSettings")
 );
 
-export const CustomUserFederationRoute: RouteDef = {
+export const CustomUserFederationRoute: AppRouteObject = {
   path: "/:realm/user-federation/:providerId/:id",
   element: <CustomProviderSettings />,
   breadcrumb: (t) => t("user-federation:providerDetails"),

--- a/js/apps/admin-ui/src/user-federation/routes/NewCustomUserFederation.tsx
+++ b/js/apps/admin-ui/src/user-federation/routes/NewCustomUserFederation.tsx
@@ -2,7 +2,7 @@ import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
 
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type NewCustomUserFederationRouteParams = {
   realm: string;
@@ -13,7 +13,7 @@ const CustomProviderSettings = lazy(
   () => import("../custom/CustomProviderSettings")
 );
 
-export const NewCustomUserFederationRoute: RouteDef = {
+export const NewCustomUserFederationRoute: AppRouteObject = {
   path: "/:realm/user-federation/:providerId/new",
   element: <CustomProviderSettings />,
   breadcrumb: (t) => t("user-federation:addCustomProvider"),

--- a/js/apps/admin-ui/src/user-federation/routes/NewKerberosUserFederation.tsx
+++ b/js/apps/admin-ui/src/user-federation/routes/NewKerberosUserFederation.tsx
@@ -1,7 +1,7 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type NewKerberosUserFederationParams = { realm: string };
 
@@ -9,7 +9,7 @@ const UserFederationKerberosSettings = lazy(
   () => import("../UserFederationKerberosSettings")
 );
 
-export const NewKerberosUserFederationRoute: RouteDef = {
+export const NewKerberosUserFederationRoute: AppRouteObject = {
   path: "/:realm/user-federation/kerberos/new",
   element: <UserFederationKerberosSettings />,
   breadcrumb: (t) => t("common:settings"),

--- a/js/apps/admin-ui/src/user-federation/routes/NewLdapUserFederation.tsx
+++ b/js/apps/admin-ui/src/user-federation/routes/NewLdapUserFederation.tsx
@@ -1,7 +1,7 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type NewLdapUserFederationParams = { realm: string };
 
@@ -9,7 +9,7 @@ const CreateUserFederationLdapSettings = lazy(
   () => import("../CreateUserFederationLdapSettings")
 );
 
-export const NewLdapUserFederationRoute: RouteDef = {
+export const NewLdapUserFederationRoute: AppRouteObject = {
   path: "/:realm/user-federation/ldap/new",
   element: <CreateUserFederationLdapSettings />,
   breadcrumb: (t) =>

--- a/js/apps/admin-ui/src/user-federation/routes/UserFederation.tsx
+++ b/js/apps/admin-ui/src/user-federation/routes/UserFederation.tsx
@@ -1,13 +1,13 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type UserFederationParams = { realm: string };
 
 const UserFederationSection = lazy(() => import("../UserFederationSection"));
 
-export const UserFederationRoute: RouteDef = {
+export const UserFederationRoute: AppRouteObject = {
   path: "/:realm/user-federation",
   element: <UserFederationSection />,
   breadcrumb: (t) => t("userFederation"),

--- a/js/apps/admin-ui/src/user-federation/routes/UserFederationKerberos.tsx
+++ b/js/apps/admin-ui/src/user-federation/routes/UserFederationKerberos.tsx
@@ -1,7 +1,7 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type UserFederationKerberosParams = {
   realm: string;
@@ -12,7 +12,7 @@ const UserFederationKerberosSettings = lazy(
   () => import("../UserFederationKerberosSettings")
 );
 
-export const UserFederationKerberosRoute: RouteDef = {
+export const UserFederationKerberosRoute: AppRouteObject = {
   path: "/:realm/user-federation/kerberos/:id",
   element: <UserFederationKerberosSettings />,
   breadcrumb: (t) => t("common:settings"),

--- a/js/apps/admin-ui/src/user-federation/routes/UserFederationLdap.tsx
+++ b/js/apps/admin-ui/src/user-federation/routes/UserFederationLdap.tsx
@@ -1,7 +1,7 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type UserFederationLdapTab = "settings" | "mappers";
 
@@ -15,7 +15,7 @@ const UserFederationLdapSettings = lazy(
   () => import("../UserFederationLdapSettings")
 );
 
-export const UserFederationLdapRoute: RouteDef = {
+export const UserFederationLdapRoute: AppRouteObject = {
   path: "/:realm/user-federation/ldap/:id",
   element: <UserFederationLdapSettings />,
   breadcrumb: (t) => t("common:settings"),
@@ -24,7 +24,7 @@ export const UserFederationLdapRoute: RouteDef = {
   },
 };
 
-export const UserFederationLdapWithTabRoute: RouteDef = {
+export const UserFederationLdapWithTabRoute: AppRouteObject = {
   ...UserFederationLdapRoute,
   path: "/:realm/user-federation/ldap/:id/:tab",
 };

--- a/js/apps/admin-ui/src/user-federation/routes/UserFederationLdapMapper.tsx
+++ b/js/apps/admin-ui/src/user-federation/routes/UserFederationLdapMapper.tsx
@@ -1,7 +1,7 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type UserFederationLdapMapperParams = {
   realm: string;
@@ -13,7 +13,7 @@ const LdapMapperDetails = lazy(
   () => import("../ldap/mappers/LdapMapperDetails")
 );
 
-export const UserFederationLdapMapperRoute: RouteDef = {
+export const UserFederationLdapMapperRoute: AppRouteObject = {
   path: "/:realm/user-federation/ldap/:id/mappers/:mapperId",
   element: <LdapMapperDetails />,
   breadcrumb: (t) => t("common:mappingDetails"),

--- a/js/apps/admin-ui/src/user-federation/routes/UserFederationsKerberos.tsx
+++ b/js/apps/admin-ui/src/user-federation/routes/UserFederationsKerberos.tsx
@@ -1,13 +1,13 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type UserFederationsKerberosParams = { realm: string };
 
 const UserFederationSection = lazy(() => import("../UserFederationSection"));
 
-export const UserFederationsKerberosRoute: RouteDef = {
+export const UserFederationsKerberosRoute: AppRouteObject = {
   path: "/:realm/user-federation/kerberos",
   element: <UserFederationSection />,
   handle: {

--- a/js/apps/admin-ui/src/user-federation/routes/UserFederationsLdap.tsx
+++ b/js/apps/admin-ui/src/user-federation/routes/UserFederationsLdap.tsx
@@ -1,13 +1,13 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type UserFederationsLdapParams = { realm: string };
 
 const UserFederationSection = lazy(() => import("../UserFederationSection"));
 
-export const UserFederationsLdapRoute: RouteDef = {
+export const UserFederationsLdapRoute: AppRouteObject = {
   path: "/:realm/user-federation/ldap",
   element: <UserFederationSection />,
   handle: {

--- a/js/apps/admin-ui/src/user/routes.ts
+++ b/js/apps/admin-ui/src/user/routes.ts
@@ -1,9 +1,9 @@
-import type { RouteDef } from "../route-config";
+import type { AppRouteObject } from "../routes";
 import { AddUserRoute } from "./routes/AddUser";
 import { UserRoute } from "./routes/User";
 import { UsersRoute, UsersRouteWithTab } from "./routes/Users";
 
-const routes: RouteDef[] = [
+const routes: AppRouteObject[] = [
   AddUserRoute,
   UsersRoute,
   UsersRouteWithTab,

--- a/js/apps/admin-ui/src/user/routes/AddUser.tsx
+++ b/js/apps/admin-ui/src/user/routes/AddUser.tsx
@@ -2,13 +2,13 @@ import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
 
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type AddUserParams = { realm: string };
 
 const CreateUser = lazy(() => import("../CreateUser"));
 
-export const AddUserRoute: RouteDef = {
+export const AddUserRoute: AppRouteObject = {
   path: "/:realm/users/add-user",
   element: <CreateUser />,
   breadcrumb: (t) => t("users:createUser"),

--- a/js/apps/admin-ui/src/user/routes/User.tsx
+++ b/js/apps/admin-ui/src/user/routes/User.tsx
@@ -1,7 +1,7 @@
 import { lazy } from "react";
 import type { Path } from "react-router-dom";
 import { generatePath } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type UserTab =
   | "settings"
@@ -21,7 +21,7 @@ export type UserParams = {
 
 const EditUser = lazy(() => import("../EditUser"));
 
-export const UserRoute: RouteDef = {
+export const UserRoute: AppRouteObject = {
   path: "/:realm/users/:id/:tab",
   element: <EditUser />,
   breadcrumb: (t) => t("users:userDetails"),

--- a/js/apps/admin-ui/src/user/routes/Users.tsx
+++ b/js/apps/admin-ui/src/user/routes/Users.tsx
@@ -1,7 +1,7 @@
 import { lazy } from "react";
 import { generatePath } from "react-router-dom";
 import type { Path } from "react-router-dom";
-import type { RouteDef } from "../../route-config";
+import type { AppRouteObject } from "../../routes";
 
 export type UserTab = "list" | "permissions";
 
@@ -9,7 +9,7 @@ export type UsersParams = { realm: string; tab?: UserTab };
 
 const UsersSection = lazy(() => import("../UsersSection"));
 
-export const UsersRoute: RouteDef = {
+export const UsersRoute: AppRouteObject = {
   path: "/:realm/users",
   element: <UsersSection />,
   breadcrumb: (t) => t("users:title"),
@@ -18,7 +18,7 @@ export const UsersRoute: RouteDef = {
   },
 };
 
-export const UsersRouteWithTab: RouteDef = {
+export const UsersRouteWithTab: AppRouteObject = {
   ...UsersRoute,
   path: "/:realm/users/:tab",
 };


### PR DESCRIPTION
Aligns the route object type with the one from React Router so it can be used later on to use the [new router APIs](https://reactrouter.com/en/6.9.0/routers/picking-a-router). Works towards closing #19308.