### PR TITLE
Allow application/jwt media type for userinfo endpoint

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/UserInfoEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/UserInfoEndpoint.java
@@ -121,7 +121,7 @@ public class UserInfoEndpoint {
     @Path("/")
     @GET
     @NoCache
-    @Produces(javax.ws.rs.core.MediaType.APPLICATION_JSON)
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_JWT})
     public Response issueUserInfoGet() {
         setupCors();
         String accessToken = this.appAuthManager.extractAuthorizationHeaderTokenOrReturnNull(session.getContext().getRequestHeaders());
@@ -132,7 +132,7 @@ public class UserInfoEndpoint {
     @Path("/")
     @POST
     @NoCache
-    @Produces(javax.ws.rs.core.MediaType.APPLICATION_JSON)
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_JWT})
     public Response issueUserInfoPost() {
         setupCors();
 

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/UserInfoClientUtil.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/UserInfoClientUtil.java
@@ -23,6 +23,7 @@ import org.keycloak.representations.UserInfo;
 import org.keycloak.utils.MediaType;
 
 import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Invocation;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
@@ -35,11 +36,18 @@ import java.net.URI;
 public class UserInfoClientUtil {
 
     public static Response executeUserInfoRequest_getMethod(Client client, String accessToken) {
+        return executeUserInfoRequest_getMethod(client, accessToken, null);
+    }
+
+    public static Response executeUserInfoRequest_getMethod(Client client, String accessToken, String acceptHeader) {
         WebTarget userInfoTarget = getUserInfoWebTarget(client);
 
-        return userInfoTarget.request()
-                .header(HttpHeaders.AUTHORIZATION, "bearer " + accessToken)
-                .get();
+        Invocation.Builder builder = userInfoTarget.request()
+                .header(HttpHeaders.AUTHORIZATION, "bearer " + accessToken);
+        if (acceptHeader != null) {
+            builder.header(HttpHeaders.ACCEPT, acceptHeader);
+        }
+        return builder.get();
     }
 
     public static WebTarget getUserInfoWebTarget(Client client) {


### PR DESCRIPTION
Closes: https://github.com/keycloak/keycloak/issues/19346

Finally I decided to include both media types in the endpoint and do nothing else. The request cannot change the response media type via accept, jwt or json is selected by configuration.  There are other options:

1. Remove the @Produces and allow any media type as before. But as #15811 changed this I have continued with it.
2. Take the accept header into consideration and return json or jwt depending the accept. But this can be a security risk (for example if json is requested and the client was configured to sign/encrypt the response) and IMO it's against the OIDC spec too.
3. Return a 406 if the accept is not correct (for example if requested json only and client is configured to sign userinfo). But this can trigger new issues cos before anything was accepted. (We can mix 2 and 3 too.)

:smile: So I decided to not complicate it, just include both media types and work exactly as before. Just let me know if you disagree and want to do something different.