### PR TITLE
Set default object store directory via application.properties

### DIFF
--- a/quarkus/runtime/src/main/resources/application.properties
+++ b/quarkus/runtime/src/main/resources/application.properties
@@ -41,3 +41,6 @@ quarkus.http.non-application-root-path=/${quarkus.http.root-path}
 
 # Disable specific categories from logs
 quarkus.log.category."io.quarkus.config".level=off
+
+# Set default directory name for the location of the transaction logs
+quarkus.transaction-manager.object-store-directory=${kc.home.dir:default}${file.separator}data${file.separator}transaction-logs


### PR DESCRIPTION
Set default directory name for the location of the transaction logs

Can be overriden by setting the [quarkus.transaction-manager.object-store-directory](https://quarkus.io/guides/all-config#quarkus-narayana-jta_quarkus.transaction-manager.object-store-directory) property in the quarkus.properties file or by setting the environment variable QUARKUS_TRANSACTION_MANAGER_OBJECT_STORE_DIRECTORY

Closes #15255