### PR TITLE
Bump infinispan to 14.0.7.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
         <jakarta.persistence.version>2.2.3</jakarta.persistence.version>
         <hibernate-orm.version>5.6.14.Final</hibernate-orm.version>
         <hibernate.c3p0.version>${hibernate-orm.version}</hibernate.c3p0.version>
-        <infinispan.version>14.0.4.Final</infinispan.version>
+        <infinispan.version>14.0.7.Final</infinispan.version>
         <infinispan.protostream.processor.version>4.6.0.Final</infinispan.protostream.processor.version>
         <jackson.version>2.13.4</jackson.version>
         <jackson.databind.version>2.13.4.2</jackson.databind.version>


### PR DESCRIPTION
Update infinispan to latest in order to bring in JGroups feature: [SSL_KEY_EXCHANGE: Support reloading keystore from disk and allow user to provide explicit truststore](https://issues.redhat.com/browse/JGRP-2667) (uplifted to infinispan [here](https://issues.redhat.com/browse/ISPN-14476)).