### PR TITLE
Add access object to full group tree.  Fix access for members tab. 

### DIFF
--- a/js/apps/admin-ui/public/resources/en/groups.json
+++ b/js/apps/admin-ui/public/resources/en/groups.json
@@ -66,5 +66,6 @@
   "groupUpdateError": "Error updating group {{error}}",
   "roleMapping": "Role mapping",
   "noRoles": "No roles for this group",
-  "noRolesInstructions": "You haven't created any roles for this group. Create a role to get started."
+  "noRolesInstructions": "You haven't created any roles for this group. Create a role to get started.",
+  "noViewRights": "You do not have rights to view this group."
 }

--- a/js/apps/admin-ui/src/groups/GroupTable.tsx
+++ b/js/apps/admin-ui/src/groups/GroupTable.tsx
@@ -39,7 +39,7 @@ export const GroupTable = ({
   const [showDelete, toggleShowDelete] = useToggle();
   const [move, setMove] = useState<GroupRepresentation>();
 
-  const { subGroups, currentGroup, setSubGroups } = useSubGroups();
+  const { currentGroup } = useSubGroups();
 
   const [key, setKey] = useState(0);
   const refresh = () => setKey(key + 1);
@@ -212,7 +212,7 @@ export const GroupTable = ({
                 <Link
                   key={group.id}
                   to={`${location.pathname}/${group.id}`}
-                  onClick={() => setSubGroups([...subGroups, group])}
+                  onClick={() => navigate(toGroups({ realm, id: group.id }))}
                 >
                   {group.name}
                 </Link>

--- a/js/apps/admin-ui/src/groups/GroupsSection.tsx
+++ b/js/apps/admin-ui/src/groups/GroupsSection.tsx
@@ -69,6 +69,10 @@ export default function GroupsSection() {
   const canViewDetails =
     hasAccess("query-groups", "view-users") ||
     hasAccess("manage-users", "query-groups");
+  const canViewMembers =
+    hasAccess("view-users") ||
+    currentGroup()?.access?.viewMembers ||
+    currentGroup()?.access?.manageMembers;
 
   useFetch(
     async () => {
@@ -177,13 +181,15 @@ export default function GroupsSection() {
                           canViewDetails={canViewDetails}
                         />
                       </Tab>
-                      <Tab
-                        data-testid="members"
-                        eventKey={1}
-                        title={<TabTitleText>{t("members")}</TabTitleText>}
-                      >
-                        <Members />
-                      </Tab>
+                      {canViewMembers && (
+                        <Tab
+                          data-testid="members"
+                          eventKey={1}
+                          title={<TabTitleText>{t("members")}</TabTitleText>}
+                        >
+                          <Members />
+                        </Tab>
+                      )}
                       <Tab
                         data-testid="attributes"
                         eventKey={2}

--- a/services/src/main/java/org/keycloak/services/resources/admin/permissions/GroupPermissionEvaluator.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/permissions/GroupPermissionEvaluator.java
@@ -53,7 +53,9 @@ public interface GroupPermissionEvaluator {
     boolean canManageMembers(GroupModel group);
 
     boolean canManageMembership(GroupModel group);
-
+    
+    boolean canViewMembers(GroupModel group);
+    
     void requireManageMembership(GroupModel group);
 
     void requireManageMembers(GroupModel group);

--- a/services/src/main/java/org/keycloak/services/resources/admin/permissions/GroupPermissions.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/permissions/GroupPermissions.java
@@ -344,6 +344,20 @@ class GroupPermissions implements GroupPermissionEvaluator, GroupPermissionManag
     }
 
     @Override
+    public boolean canViewMembers(GroupModel group) {
+        if (root.users().canView()) return true;
+
+        if (!root.isAdminSameRealm()) {
+            return false;
+        }
+        
+        ResourceServer server = root.realmResourceServer();
+        if (server == null) return false;
+
+        return hasPermission(group, VIEW_MEMBERS_SCOPE);
+    }
+    
+    @Override
     public boolean canManageMembers(GroupModel group) {
         if (root.users().canManage()) return true;
 
@@ -367,7 +381,7 @@ class GroupPermissions implements GroupPermissionEvaluator, GroupPermissionManag
 
         return hasPermission(group, MANAGE_MEMBERSHIP_SCOPE);
     }
-
+    
     @Override
     public void requireManageMembership(GroupModel group) {
         if (!canManageMembership(group)) {
@@ -388,6 +402,8 @@ class GroupPermissions implements GroupPermissionEvaluator, GroupPermissionManag
         map.put("view", canView(group));
         map.put("manage", canManage(group));
         map.put("manageMembership", canManageMembership(group));
+        map.put("viewMembers", canViewMembers(group));
+        map.put("manageMembers", canManageMembers(group));
         return map;
     }
 


### PR DESCRIPTION
Add missing props to Access object.
Fixes #17589

On the server side, the fine-grained access object for groups had "manage-members" and "view-members" missing.  As a result, this didn't really work correctly in the old console either.