### PR TITLE
Consistent handling of enums in the database schema

### DIFF
--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-22.0.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-22.0.0.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  ~ * Copyright 2023 Red Hat, Inc. and/or its affiliates
+  ~ * and other contributors as indicated by the @author tags.
+  ~ *
+  ~ * Licensed under the Apache License, Version 2.0 (the "License");
+  ~ * you may not use this file except in compliance with the License.
+  ~ * You may obtain a copy of the License at
+  ~ *
+  ~ * http://www.apache.org/licenses/LICENSE-2.0
+  ~ *
+  ~ * Unless required by applicable law or agreed to in writing, software
+  ~ * distributed under the License is distributed on an "AS IS" BASIS,
+  ~ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ * See the License for the specific language governing permissions and
+  ~ * limitations under the License.
+  -->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet author="keycloak" id="22.0.0-19404">
+        <modifyDataType tableName="RESOURCE_SERVER_POLICY" columnName="DECISION_STRATEGY" newDataType="TINYINT" />
+        <modifyDataType tableName="RESOURCE_SERVER_POLICY" columnName="LOGIC" newDataType="TINYINT" />
+        <modifyDataType tableName="RESOURCE_SERVER" columnName="POLICY_ENFORCE_MODE" newDataType="TINYINT" />
+    </changeSet>
+
+</databaseChangeLog>

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-master.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-master.xml
@@ -76,5 +76,6 @@
     <include file="META-INF/jpa-changelog-19.0.0.xml"/>
     <include file="META-INF/jpa-changelog-20.0.0.xml"/>
     <include file="META-INF/jpa-changelog-21.0.2.xml"/>
+    <include file="META-INF/jpa-changelog-22.0.0.xml"/>
 
 </databaseChangeLog>


### PR DESCRIPTION
The column values are already numbers, so there shouldn't be any conversion problems. 

The type `TINYINT` has already been in use for `RESOURCE_SERVER` in column `DECISION_STRATEGY`, so it should be ok to use it here as well.

Closes #19404

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->


