### PR TITLE
Regressions in redirect URL verification when redirect_uri has encode…

### DIFF
--- a/common/src/main/java/org/keycloak/common/util/KeycloakUriBuilder.java
+++ b/common/src/main/java/org/keycloak/common/util/KeycloakUriBuilder.java
@@ -37,6 +37,8 @@ public class KeycloakUriBuilder {
     private String scheme;
     private int port = -1;
 
+    private boolean preserveDefaultPort = false;
+
     private String userInfo;
     private String path;
     private String query;
@@ -290,6 +292,19 @@ public class KeycloakUriBuilder {
         return this;
     }
 
+    /**
+     * When this is called, then the port will be preserved in the build URL even if it is default port for the protocol (http, https)
+     *
+     * For example:
+     * - KeycloakUriBuilder.fromUri("https://localhost:443/path").buildAsString() will return "https://localhost/path" (port not preserved)
+     * - KeycloakUriBuilder.fromUri("https://localhost:443/path").preserveDefaultPort().buildAsString() will return "https://localhost:443/path" (port is preserved even if default port)
+     * - KeycloakUriBuilder.fromUri("https://localhost/path").preserveDefaultPort().buildAsString() will return "https://localhost/path" (port not included even if "preserveDefaultPort" as it was not in the original URL)
+     */
+    public KeycloakUriBuilder preserveDefaultPort() {
+        this.preserveDefaultPort = true;
+        return this;
+    }
+
     protected static String paths(boolean encode, String basePath, String... segments) {
         String path = basePath;
         if (path == null) path = "";
@@ -429,7 +444,7 @@ public class KeycloakUriBuilder {
                 if ("".equals(host)) throw new RuntimeException("empty host name");
                 replaceParameter(paramMap, fromEncodedMap, isTemplate, host, buffer, encodeSlash);
             }
-            if (port != -1 && !(("http".equals(scheme) && port == 80) || ("https".equals(scheme) && port == 443))) {
+            if (port != -1 && (preserveDefaultPort || !(("http".equals(scheme) && port == 80) || ("https".equals(scheme) && port == 443)))) {
                 buffer.append(":").append(Integer.toString(port));
             }
         } else if (authority != null) {

--- a/common/src/test/java/org/keycloak/common/util/KeycloakUriBuilderTest.java
+++ b/common/src/test/java/org/keycloak/common/util/KeycloakUriBuilderTest.java
@@ -51,4 +51,25 @@ public class KeycloakUriBuilderTest {
                 KeycloakUriBuilder.fromUri("https://localhost:8443/path?attr1={value}")
                         .buildFromMap(Collections.singletonMap("value", "value1")).toString());
     }
+
+    @Test
+    public void testPort() {
+        Assert.assertEquals("https://localhost:8443/path", KeycloakUriBuilder.fromUri("https://localhost:8443/path").buildAsString());
+        Assert.assertEquals("https://localhost:8443/path", KeycloakUriBuilder.fromUri("https://localhost:8443/path").preserveDefaultPort().buildAsString());
+
+        Assert.assertEquals("https://localhost/path", KeycloakUriBuilder.fromUri("https://localhost:443/path").buildAsString());
+        Assert.assertEquals("https://localhost:443/path", KeycloakUriBuilder.fromUri("https://localhost:443/path").preserveDefaultPort().buildAsString());
+
+        Assert.assertEquals("http://localhost/path", KeycloakUriBuilder.fromUri("http://localhost:80/path").buildAsString());
+        Assert.assertEquals("http://localhost:80/path", KeycloakUriBuilder.fromUri("http://localhost:80/path").preserveDefaultPort().buildAsString());
+
+        // Port always preserved (even if preserverPort not specified) due the port 80 doesn't match "https" scheme
+        Assert.assertEquals("https://localhost:80/path", KeycloakUriBuilder.fromUri("https://localhost:80/path").buildAsString());
+
+        // Port not in the build URL when it was not specified in the original URL (even if preserverPort() is true)
+        Assert.assertEquals("http://localhost/path", KeycloakUriBuilder.fromUri("http://localhost/path").buildAsString());
+        Assert.assertEquals("http://localhost/path", KeycloakUriBuilder.fromUri("http://localhost/path").preserveDefaultPort().buildAsString());
+        Assert.assertEquals("https://localhost/path", KeycloakUriBuilder.fromUri("https://localhost/path").buildAsString());
+        Assert.assertEquals("https://localhost/path", KeycloakUriBuilder.fromUri("https://localhost/path").preserveDefaultPort().buildAsString());
+    }
 }

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
@@ -386,6 +386,7 @@ public class TokenEndpoint {
 
         if (redirectUri != null && !redirectUri.equals(redirectUriParam)) {
             event.error(Errors.INVALID_CODE);
+            logger.tracef("Parameter 'redirect_uri' did not match originally saved redirect URI used in initial OIDC request. Saved redirectUri: %s, redirectUri parameter: %s", redirectUri, redirectUriParam);
             throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_GRANT, "Incorrect redirect_uri", Response.Status.BAD_REQUEST);
         }
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/utils/RedirectUtils.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/utils/RedirectUtils.java
@@ -93,20 +93,6 @@ public class RedirectUtils {
         KeycloakUriInfo uriInfo = session.getContext().getUri();
         RealmModel realm = session.getContext().getRealm();
 
-        redirectUri = decodeRedirectUri(redirectUri);
-        if (redirectUri != null) {
-            try {
-                URI uri = URI.create(redirectUri);
-                redirectUri = uri.normalize().toString();
-            } catch (IllegalArgumentException cause) {
-                logger.debug("Invalid redirect uri", cause);
-                return null;
-            } catch (Exception cause) {
-                logger.debug("Unexpected error when parsing redirect uri", cause);
-                return null;
-            }
-        }
-
         if (redirectUri == null) {
             if (!requireRedirectUri) {
                 redirectUri = getSingleValidRedirectUri(validRedirects);
@@ -120,12 +106,15 @@ public class RedirectUtils {
             logger.debug("No Redirect URIs supplied");
             redirectUri = null;
         } else {
-            redirectUri = lowerCaseHostname(redirectUri);
+            // Make the validations against fully decoded and normalized redirect-url. This also allows wildcards (case when client configured "Valid redirect-urls" contain wildcards)
+            String decodedRedirectUri = decodeRedirectUri(redirectUri);
+            decodedRedirectUri = getNormalizedRedirectUri(decodedRedirectUri);
+            if (decodedRedirectUri == null) return null;
 
-            String r = redirectUri;
+            String r = decodedRedirectUri;
             Set<String> resolveValidRedirects = resolveValidRedirects(session, rootUrl, validRedirects);
 
-            boolean valid = matchesRedirects(resolveValidRedirects, r);
+            boolean valid = matchesRedirects(resolveValidRedirects, r, true);
 
             if (!valid && (r.startsWith(Constants.INSTALLED_APP_URL) || r.startsWith(Constants.INSTALLED_APP_LOOPBACK)) && r.indexOf(':', Constants.INSTALLED_APP_URL.length()) >= 0) {
                 int i = r.indexOf(':', Constants.INSTALLED_APP_URL.length());
@@ -140,8 +129,17 @@ public class RedirectUtils {
 
                 r = sb.toString();
 
-                valid = matchesRedirects(resolveValidRedirects, r);
+                valid = matchesRedirects(resolveValidRedirects, r, true);
             }
+
+            // Return the original redirectUri, which can be partially encoded - for example http://localhost:8280/foo/bar%20bar%2092%2F72/3 . Just make sure it is normalized
+            redirectUri = getNormalizedRedirectUri(redirectUri);
+
+            // We try to check validity also for original (encoded) redirectUrl, but just in case it exactly matches some "Valid Redirect URL" specified for client (not wildcards allowed)
+            if (!valid) {
+                valid = matchesRedirects(resolveValidRedirects, redirectUri, false);
+            }
+
             if (valid && redirectUri.startsWith("/")) {
                 redirectUri = relativeToAbsoluteURI(session, rootUrl, redirectUri);
             }
@@ -155,6 +153,23 @@ public class RedirectUtils {
         }
     }
 
+    private static String getNormalizedRedirectUri(String redirectUri) {
+        if (redirectUri != null) {
+            try {
+                URI uri = URI.create(redirectUri);
+                redirectUri = uri.normalize().toString();
+            } catch (IllegalArgumentException cause) {
+                logger.debug("Invalid redirect uri", cause);
+                return null;
+            } catch (Exception cause) {
+                logger.debug("Unexpected error when parsing redirect uri", cause);
+                return null;
+            }
+            redirectUri = lowerCaseHostname(redirectUri);
+        }
+        return redirectUri;
+    }
+
     // Decode redirectUri. We don't decode query and fragment as those can be encoded in the original URL.
     // URL can be decoded multiple times (in case it was encoded multiple times, or some of it's parts were encoded multiple times)
     private static String decodeRedirectUri(String redirectUri) {
@@ -162,7 +177,7 @@ public class RedirectUtils {
         int MAX_DECODING_COUNT = 5; // Max count of attempts for decoding URL (in case it was encoded multiple times)
 
         try {
-            KeycloakUriBuilder uriBuilder = KeycloakUriBuilder.fromUri(redirectUri);
+            KeycloakUriBuilder uriBuilder = KeycloakUriBuilder.fromUri(redirectUri).preserveDefaultPort();
             String origQuery = uriBuilder.getQuery();
             String origFragment = uriBuilder.getFragment();
             String encodedRedirectUri = uriBuilder
@@ -175,7 +190,7 @@ public class RedirectUtils {
                 decodedRedirectUri = Encode.decode(encodedRedirectUri);
                 if (decodedRedirectUri.equals(encodedRedirectUri)) {
                     // URL is decoded. We can return it (after attach original query and fragment)
-                    return KeycloakUriBuilder.fromUri(decodedRedirectUri)
+                    return KeycloakUriBuilder.fromUri(decodedRedirectUri).preserveDefaultPort()
                             .replaceQuery(origQuery)
                             .fragment(origFragment)
                             .buildAsString();
@@ -214,9 +229,10 @@ public class RedirectUtils {
         return sb.toString();
     }
 
-    private static boolean matchesRedirects(Set<String> validRedirects, String redirect) {
+    private static boolean matchesRedirects(Set<String> validRedirects, String redirect, boolean allowWildcards) {
+        logger.tracef("matchesRedirects: redirect URL to check: %s, allow wildcards: %b, Configured valid redirect URLs: %s", redirect, allowWildcards, validRedirects);
         for (String validRedirect : validRedirects) {
-            if (validRedirect.endsWith("*") && !validRedirect.contains("?")) {
+            if (validRedirect.endsWith("*") && !validRedirect.contains("?") && allowWildcards) {
                 // strip off the query component - we don't check them when wildcards are effective
                 String r = redirect.contains("?") ? redirect.substring(0, redirect.indexOf("?")) : redirect;
                 // strip off *


### PR DESCRIPTION
…d path or default port

closes #16851
closes #16587

@pedroigor Are you please able to review this?

This is fix for some regressions caused by the security fix https://github.com/keycloak/keycloak/commit/1987c942f527b9f3bbf2a86ba71ba8ae0154ac37 . The issues are:

- When people added default port in their URL like "https://some-host:443/foo" their redirect URLs were not considered valid anymore. This is due how `KeycloakUriBuilder` works as it ommits the default protocol port from the URL by default. For redirect-url check, we may need to preserve the port to make sure configured URL matches with used URL. Some details in #16587

- Sometimes people used encoding in the path of URL and this also stopped working (due the security fix decodes the redirect-url before check them). Some details in #16851
