### PR TITLE
Do not verify identity cookie when processing required actions

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/AuthorizationEndpointBase.java
+++ b/services/src/main/java/org/keycloak/protocol/AuthorizationEndpointBase.java
@@ -198,7 +198,11 @@ public abstract class AuthorizationEndpointBase {
                     AuthenticationManager.backchannelLogout(session, userSession, true);
                 } else {
                     String userSessionId = userSession.getId();
-                    rootAuthSession = session.authenticationSessions().createRootAuthenticationSession(realm, userSessionId);
+                    rootAuthSession = session.authenticationSessions().getRootAuthenticationSession(realm, userSessionId);
+                    if (rootAuthSession == null) {
+                        // depending on the storage layer we don't want to re-create the root authentication session
+                        rootAuthSession = session.authenticationSessions().createRootAuthenticationSession(realm, userSessionId);
+                    }
                     authSession = rootAuthSession.createAuthenticationSession(client);
                     logger.debugf("Sent request to authz endpoint. We don't have root authentication session with ID '%s' but we have userSession." +
                             "Re-created root authentication session with same ID. Client is: %s . New authentication session tab ID: %s", userSessionId, client.getClientId(), authSession.getTabId());

--- a/services/src/main/java/org/keycloak/services/resources/SessionCodeChecks.java
+++ b/services/src/main/java/org/keycloak/services/resources/SessionCodeChecks.java
@@ -17,8 +17,8 @@
 
 package org.keycloak.services.resources;
 
-import static org.keycloak.services.managers.AuthenticationManager.KEYCLOAK_IDENTITY_COOKIE;
 import static org.keycloak.services.managers.AuthenticationManager.authenticateIdentityCookie;
+import static org.keycloak.services.managers.AuthenticationSessionManager.AUTH_SESSION_ID;
 import static org.keycloak.utils.LockObjectsForModification.lockUserSessionsForModification;
 
 import java.net.URI;
@@ -184,8 +184,10 @@ public class SessionCodeChecks {
         // See if we are already authenticated and userSession with same ID exists.
         UserSessionModel userSession = authSessionManager.getUserSessionFromAuthCookie(realm);
 
-        if (userSession == null) {
-            // fallback to check if there is an identity cookie
+        boolean authenticating = !CookieHelper.getCookieValue(session, AUTH_SESSION_ID).isEmpty();
+
+        if (authenticating) {
+            // if there is an auth session, make sure the user is not yet authenticated
             AuthenticationManager.AuthResult authResult = lockUserSessionsForModification(session, () -> authenticateIdentityCookie(session, realm, false));
 
             if (authResult != null) {


### PR DESCRIPTION
Closes #17539

* Only check if the user is logged in when requests have the authentication session cookie set. When set, it indicates the authentication is still happening.
* Missing test coverage when there is no authentication session cookie but the identity cookie is still valid and maps to an existing user session. In this case, the server should continue with the required action without complaining about "user logged in" as there is no authentication/action yet happening.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
