### PR TITLE
Upgrade agroal

### DIFF
--- a/quarkus/pom.xml
+++ b/quarkus/pom.xml
@@ -46,6 +46,7 @@
         <org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec.version>2.0.1.Final</org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec.version>
         <sun.saaj-impl.version>1.4.1.SP1</sun.saaj-impl.version>
         <org.jvnet.staxex.version>1.8.3</org.jvnet.staxex.version>
+        <io.agroal.version>1.17</io.agroal.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
@@ -84,6 +85,22 @@
                 <groupId>org.infinispan</groupId>
                 <artifactId>infinispan-client-hotrod</artifactId>
                 <version>${infinispan.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.agroal</groupId>
+                <artifactId>agroal-api</artifactId>
+                <version>${io.agroal.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.agroal</groupId>
+                <artifactId>agroal-narayana</artifactId>
+                <version>${io.agroal.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.agroal</groupId>
+                <artifactId>agroal-pool</artifactId>
+                <version>${io.agroal.version}</version>
             </dependency>
 
 


### PR DESCRIPTION
This is a forward-port from https://github.com/keycloak/keycloak/pull/17642.
This fix was originally intended and released in 21.0.2 but we now need it in main for 21.1.0 too. And since this was already released in 21.0.2, I believe we don't need a GH Issue for it. Let me know if you think otherwise.