### PR TITLE
Fixed serious a11y violations for Members tabs under Groups

### DIFF
--- a/js/apps/admin-ui/src/groups/Members.tsx
+++ b/js/apps/admin-ui/src/groups/Members.tsx
@@ -117,8 +117,16 @@ export const Members = () => {
 
   const removeAriaHidden = () => {
     const appDiv = document.getElementById("app");
+    const element = document.querySelector(
+      'div[aria-hidden="true"]:nth-child(5)'
+    );
+
     if (appDiv) {
       appDiv.removeAttribute("aria-hidden");
+    }
+
+    if (element) {
+      element.removeAttribute("aria-hidden");
     }
   };
 
@@ -129,8 +137,8 @@ export const Members = () => {
           groupId={id!}
           onClose={() => {
             setAddMembers(false);
-            refresh();
             removeAriaHidden();
+            refresh();
           }}
         />
       )}
@@ -226,7 +234,7 @@ export const Members = () => {
                     } catch (error) {
                       addError("groups:usersLeftError", error);
                     }
-
+                    removeAriaHidden();
                     return true;
                   },
                 } as Action<UserRepresentation>,

--- a/js/apps/admin-ui/src/groups/Members.tsx
+++ b/js/apps/admin-ui/src/groups/Members.tsx
@@ -115,6 +115,13 @@ export const Members = () => {
     });
   };
 
+  const removeAriaHidden = () => {
+    const appDiv = document.getElementById("app");
+    if (appDiv) {
+      appDiv.removeAttribute("aria-hidden");
+    }
+  };
+
   return (
     <>
       {addMembers && (
@@ -123,6 +130,7 @@ export const Members = () => {
           onClose={() => {
             setAddMembers(false);
             refresh();
+            removeAriaHidden();
           }}
         />
       )}
@@ -189,6 +197,7 @@ export const Members = () => {
                         }
 
                         refresh();
+                        removeAriaHidden();
                       }}
                     >
                       {t("leave")}


### PR DESCRIPTION
Closes https://github.com/keycloak/keycloak/issues/19319

The solution is effective in both cases, regardless of whether the alerts are currently visible or not.

1. Confirmation (with alerts not visible)
![Screenshot 2023-03-31 at 13 57 15](https://user-images.githubusercontent.com/4890675/229127132-9174452e-b09a-41bc-9d54-267709e3e101.png)

![Screenshot 2023-03-31 at 14 02 06](https://user-images.githubusercontent.com/4890675/229127250-1553c641-d215-411c-968c-2e84636686c6.png)

2. Confirmation (with alerts visible)
![Screenshot 2023-03-31 at 13 58 04](https://user-images.githubusercontent.com/4890675/229127739-6c359532-eb37-499e-aca5-124cc30edfed.png)

![Screenshot 2023-03-31 at 14 00 31](https://user-images.githubusercontent.com/4890675/229127740-e153bd57-159b-44eb-b517-353418fdc066.png)


