### PR TITLE
Manage JsonProcessingException to not return error 500 when json data is wrong

### DIFF
--- a/services/src/main/java/org/keycloak/services/error/KeycloakErrorHandler.java
+++ b/services/src/main/java/org/keycloak/services/error/KeycloakErrorHandler.java
@@ -1,6 +1,6 @@
 package org.keycloak.services.error;
 
-import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.spi.Failure;
 import org.keycloak.Config;
@@ -106,7 +106,7 @@ public class KeycloakErrorHandler implements ExceptionMapper<Throwable> {
             Failure f = (Failure) throwable;
             status = f.getErrorCode();
         }
-        if (throwable instanceof JsonParseException) {
+        if (throwable instanceof JsonProcessingException) {
             status = Response.Status.BAD_REQUEST.getStatusCode();
         }
         


### PR DESCRIPTION
Closes https://github.com/keycloak/keycloak/issues/11517

I'm just changing `JsonParseException` for `JsonProcessingException` (the former extends the latter, so we are covering more now). This way some other exceptions like `MismatchedInputException` (for example if a json array is sent but a json object is expected) are also captured and error 400 returned. Little test added.