### PR TITLE
Registration flow fixed

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/authentication/FormContext.java
+++ b/server-spi-private/src/main/java/org/keycloak/authentication/FormContext.java
@@ -58,7 +58,7 @@ public interface FormContext {
     AuthenticationExecutionModel getExecution();
 
     /**
-     * Current user attached to this flow.  It can return null if no uesr has been identified yet
+     * Current user attached to this flow.  It can return null if no user has been identified yet
      *
      * @return
      */
@@ -66,6 +66,8 @@ public interface FormContext {
 
     /**
      * Attach a specific user to this flow.
+     * 
+     * If there was another user attached to this flow calling this method overrides the previous setting. 
      *
      * @param user
      */

--- a/server-spi-private/src/main/java/org/keycloak/authentication/FormContext.java
+++ b/server-spi-private/src/main/java/org/keycloak/authentication/FormContext.java
@@ -66,8 +66,6 @@ public interface FormContext {
 
     /**
      * Attach a specific user to this flow.
-     * 
-     * If there was another user attached to this flow calling this method overrides the previous setting. 
      *
      * @param user
      */

--- a/services/src/main/java/org/keycloak/authentication/FormAuthenticationFlow.java
+++ b/services/src/main/java/org/keycloak/authentication/FormAuthenticationFlow.java
@@ -101,6 +101,7 @@ public class FormAuthenticationFlow implements AuthenticationFlow {
 
         @Override
         public void setUser(UserModel user) {
+            processor.clearAuthenticatedUser();
             processor.setAutheticatedUser(user);
         }
 

--- a/services/src/main/java/org/keycloak/authentication/FormAuthenticationFlow.java
+++ b/services/src/main/java/org/keycloak/authentication/FormAuthenticationFlow.java
@@ -101,7 +101,6 @@ public class FormAuthenticationFlow implements AuthenticationFlow {
 
         @Override
         public void setUser(UserModel user) {
-            processor.clearAuthenticatedUser();
             processor.setAutheticatedUser(user);
         }
 

--- a/services/src/main/java/org/keycloak/authentication/forms/RegistrationUserCreation.java
+++ b/services/src/main/java/org/keycloak/authentication/forms/RegistrationUserCreation.java
@@ -18,6 +18,8 @@
 package org.keycloak.authentication.forms;
 
 import org.keycloak.Config;
+import org.keycloak.authentication.AuthenticationFlowError;
+import org.keycloak.authentication.AuthenticationFlowException;
 import org.keycloak.authentication.FormAction;
 import org.keycloak.authentication.FormActionFactory;
 import org.keycloak.authentication.FormContext;
@@ -111,6 +113,11 @@ public class RegistrationUserCreation implements FormAction, FormActionFactory {
 
     @Override
     public void success(FormContext context) {
+        if (context.getUser() != null) {
+            // the user probably did some back navigation in the browser, hitting this page in a strange state
+            throw new AuthenticationFlowException(AuthenticationFlowError.USER_CONFLICT);
+        }
+
         MultivaluedMap<String, String> formData = context.getHttpRequest().getDecodedFormParameters();
 
         String email = formData.getFirst(UserModel.EMAIL);

--- a/services/src/main/java/org/keycloak/authentication/forms/RegistrationUserCreation.java
+++ b/services/src/main/java/org/keycloak/authentication/forms/RegistrationUserCreation.java
@@ -115,7 +115,7 @@ public class RegistrationUserCreation implements FormAction, FormActionFactory {
     public void success(FormContext context) {
         if (context.getUser() != null) {
             // the user probably did some back navigation in the browser, hitting this page in a strange state
-            throw new AuthenticationFlowException(AuthenticationFlowError.USER_CONFLICT);
+            throw new AuthenticationFlowException(AuthenticationFlowError.EXPIRED_CODE);
         }
 
         MultivaluedMap<String, String> formData = context.getHttpRequest().getDecodedFormParameters();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/storage/UserStorageTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/storage/UserStorageTest.java
@@ -1105,6 +1105,8 @@ public class UserStorageTest extends AbstractAuthTest {
             driver.navigate().back();
             driver.navigate().back();
             driver.navigate().back();
+            
+            int greenMailMessageCountBeforeRegistrer = greenMail.getReceivedMessages().length;
             registerPage.assertCurrent();
 
             registerPage.registerWithEmailAsUsername(
@@ -1127,11 +1129,14 @@ public class UserStorageTest extends AbstractAuthTest {
                     assertFalse("The user is created even when an error page was shown, yet the user has no password", userByUsername.getCredentials().isEmpty());
                 }
             } else {
-                throw new UnsupportedOperationException("If someone ever refactors the reset password flow, and the previous steps no more cause an error, " +
-                    "then we should check the following: \n" +
-                    " - the newly created user exists\n" +
-                    " - the registration flow is executed until the last step (eg.: the user has a password)\n" +
-                    " - no error page was shown");
+                verifyEmailPage.assertCurrent();
+
+                Assert.assertEquals(1+greenMailMessageCountBeforeRegistrer, greenMail.getReceivedMessages().length);
+                MimeMessage message = greenMail.getReceivedMessages()[greenMailMessageCountBeforeRegistrer];
+                String verificationUrl = getPasswordResetEmailLink(message);
+                
+                driver.navigate().to(verificationUrl.trim());
+                appPage.assertCurrent();
             }
         }
     }


### PR DESCRIPTION
Closes #21514

Hi,

I've reported a bug in #17644. #19488 should have resolved it, but it seems to fail anyhow.

See my comment here: https://github.com/keycloak/keycloak/pull/19488#issuecomment-1497569865

@mposolda @hmlnarik I think we should implement a similar solution in the reset password flow to the idp linking flow's solution. As far as I remember in the IDP Linking flow the attributes of the newly created user is stored in an `AuthNote` - would you mind a solution, where:
 - instead of the `setUser` call in `ResetCredentialChooseUser:119` we store the user's ID (?) in an auth note
   - we should refactor some of the `ResetCredentialChooseUser::authenticate` because of this change
 - in the `ResetCredentialEmail` we should use the previously stored AuthNote instead of the `getUser` method

What do you think about my suggestion? If I'd implement such changes in this PR would you merge it?

Regards,
