### PR TITLE
Ensure requests are cancelled properly in `useFetch()`

### DIFF
--- a/js/apps/admin-ui/src/context/auth/AdminClient.tsx
+++ b/js/apps/admin-ui/src/context/auth/AdminClient.tsx
@@ -38,10 +38,11 @@ export function useFetch<T>(
   deps?: DependencyList
 ) {
   const onError = useErrorHandler();
-  const controller = new AbortController();
-  const { signal } = controller;
 
   useEffect(() => {
+    const controller = new AbortController();
+    const { signal } = controller;
+
     adminClientCall()
       .then((result) => {
         if (!signal.aborted) {


### PR DESCRIPTION
This fixes a bug in the `useFetch()` hook which caused requests not to be cancelled properly. This was caused by the fact that the `AbortController` would be instantiated on every call, when instead it should only be created inside the effect.