### PR TITLE
Use new Root API to render Admin UI

### DIFF
--- a/js/apps/admin-ui/src/main.tsx
+++ b/js/apps/admin-ui/src/main.tsx
@@ -2,7 +2,7 @@ import "@patternfly/react-core/dist/styles/base.css";
 import "@patternfly/patternfly/patternfly-addons.css";
 
 import { StrictMode } from "react";
-import { render } from "react-dom";
+import { createRoot } from "react-dom/client";
 import { createHashRouter, RouterProvider } from "react-router-dom";
 
 import { RootRoute } from "./routes";
@@ -11,10 +11,10 @@ import "./index.css";
 
 const router = createHashRouter([RootRoute]);
 const container = document.getElementById("app");
+const root = createRoot(container!);
 
-render(
+root.render(
   <StrictMode>
     <RouterProvider router={router} />
-  </StrictMode>,
-  container
+  </StrictMode>
 );


### PR DESCRIPTION
This PR changes the default renderer for the Admin UI to the new [Root API](https://react.dev/reference/react-dom/client/createRoot). This is the last upgrade needed to get React 18 fully working, as per the [upgrade guide](https://react.dev/blog/2022/03/08/react-18-upgrade-guide#updates-to-client-rendering-apis):

> React 18 introduces a new root API which provides better ergonomics for managing roots. The new root API also enables the new concurrent renderer, which allows you to opt-into concurrent features.