### PR TITLE
Allow  'view-users' permission to see the user credentials tab.

### DIFF
--- a/js/apps/admin-ui/src/user/EditUser.tsx
+++ b/js/apps/admin-ui/src/user/EditUser.tsx
@@ -233,7 +233,7 @@ const EditUserForm = ({ user, bruteForced, refresh }: EditUserFormProps) => {
               </Tab>
               <Tab
                 data-testid="credentials"
-                isHidden={!user.access?.manage}
+                isHidden={!user.access?.view}
                 title={<TabTitleText>{t("common:credentials")}</TabTitleText>}
                 {...credentialsTab}
               >

--- a/services/src/main/java/org/keycloak/services/resources/admin/UserResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UserResource.java
@@ -651,7 +651,7 @@ public class UserResource {
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
     public Stream<CredentialRepresentation> credentials(){
-        auth.users().requireManage(user);
+        auth.users().requireView(user);
         return user.credentialManager().getStoredCredentialsStream()
                 .map(ModelToRepresentation::toRepresentation)
                 .peek(credentialRepresentation -> credentialRepresentation.setSecretData(null));


### PR DESCRIPTION
This tab was available for users with 'manage-users' permission before this change

Closes #17174
