### PR TITLE
Build the operator container via Dockerfile

### DIFF
--- a/.github/workflows/operator-ci.yml
+++ b/.github/workflows/operator-ci.yml
@@ -145,7 +145,7 @@ jobs:
               -Dquarkus.container-image.build=true \
               -Dquarkus.kubernetes.image-pull-policy=IfNotPresent \
               -Doperator.keycloak.image=keycloak:${{ env.version_remote }} \
-              -Dquarkus.jib.jvm-arguments="-Djava.util.logging.manager=org.jboss.logmanager.LogManager","-Doperator.keycloak.image-pull-policy=Never" \
+              -Dquarkus.kubernetes.env.vars.operator-keycloak-image-pull-policy=Never \
               -Dtest.operator.custom.image=custom-keycloak:${{ env.version_remote }} \
               --no-transfer-progress -Dtest.operator.deployment=remote \
               -Dtest.operator.kubernetes.ip=$(minikube ip)

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -1,0 +1,21 @@
+FROM registry.access.redhat.com/ubi9 AS ubi-micro-build
+
+ADD target/ubi-null.sh /tmp/
+RUN bash /tmp/ubi-null.sh java-17-openjdk-headless glibc-langpack-en
+
+FROM registry.access.redhat.com/ubi9-micro
+ENV LANG en_US.UTF-8
+
+COPY --from=ubi-micro-build /tmp/null/rootfs/ /
+
+ADD --chown=1000:0 target/quarkus-app/ /opt/keycloak
+
+RUN chmod -R g+rwX /opt/keycloak && \
+    echo "keycloak:x:0:root" >> /etc/group && \
+    echo "keycloak:x:1000:0:keycloak user:/opt/keycloak:/sbin/nologin" >> /etc/passwd
+
+USER 1000
+
+WORKDIR /opt/keycloak
+
+ENTRYPOINT [ "java", "-Djava.util.logging.manager=org.jboss.logmanager.LogManager", "-jar", "quarkus-run.jar" ]

--- a/operator/README.md
+++ b/operator/README.md
@@ -19,6 +19,12 @@ Build the Docker image with:
 mvn clean package -Doperator -Dquarkus.container-image.build=true
 ```
 
+This will build a container image from `src/main/docker/Dockerfile.jvm`, using `docker` by default. `podman` is also supported if you do these steps beforehand:
+
+- Follow [this guide](https://quarkus.io/guides/podman#setting-docker_host-on-linux) to enable the podman user socket
+- Set the `DOCKER_HOST` environment variable to point at this user socket. For example: `DOCKER_HOST=unix:///run/user/1000/podman/podman.sock`.
+- You may also have to set `QUARKUS_DOCKER_EXECUTABLE_NAME=podman`
+
 ## Configuration
 
 The Keycloak image can be configured, when starting the operator, using the Java property:

--- a/operator/assembly.xml
+++ b/operator/assembly.xml
@@ -1,0 +1,26 @@
+<assembly>
+
+    <id>operator</id>
+
+    <formats>
+        <format>zip</format>
+    </formats>
+
+    <includeBaseDirectory>true</includeBaseDirectory>
+
+    <fileSets>
+        <fileSet>
+            <directory>${project.build.directory}/quarkus-app/</directory>
+            <outputDirectory></outputDirectory>
+            <includes>
+                <include>**/**</include>
+            </includes>
+            <excludes>
+            </excludes>
+        </fileSet>
+    </fileSets>
+
+    <files>
+    </files>
+
+</assembly>

--- a/operator/pom.xml
+++ b/operator/pom.xml
@@ -35,7 +35,6 @@
         <quarkus.operator.sdk.version>4.0.7</quarkus.operator.sdk.version>
         <quarkus.version>2.13.7.Final</quarkus.version>
         <quarkus.container-image.group>keycloak</quarkus.container-image.group>
-        <quarkus.jib.base-jvm-image>registry.access.redhat.com/ubi9/openjdk-11-runtime</quarkus.jib.base-jvm-image>
     </properties>
     
     <dependencyManagement>
@@ -92,6 +91,10 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-kubernetes-client</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>io.quarkus</groupId>
+          <artifactId>quarkus-container-image-docker</artifactId>
         </dependency>
 
         <!-- Keycloak -->
@@ -202,6 +205,24 @@
                             </resources>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>copy-ubi-null</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${basedir}/../quarkus/container/</directory>
+                                    <includes>
+                                        <include>**/ubi-null.sh</include>
+                                    </includes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
 
@@ -255,6 +276,27 @@
                         <goals>
                             <goal>test</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>assemble</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>assembly.xml</descriptor>
+                            </descriptors>
+                            <appendAssemblyId>false</appendAssemblyId>
+                            <workDirectory>${project.build.directory}/assembly/work</workDirectory>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/operator/src/main/resources/application.properties
+++ b/operator/src/main/resources/application.properties
@@ -1,5 +1,6 @@
 quarkus.operator-sdk.crd.apply=true
-quarkus.container-image.builder=jib
+quarkus.container-image.builder=docker
+quarkus.docker.dockerfile-jvm-path=Dockerfile
 quarkus.operator-sdk.crd.validate=false
 
 # Operator config

--- a/quarkus/container/ubi-null.sh
+++ b/quarkus/container/ubi-null.sh
@@ -44,7 +44,7 @@ dnf install -y findutils diffutils
 # Install core packages to chroot
 rootfs="$(realpath rootfs)"
 mkdir -p "$rootfs"
-<keep xargs dnf install -y --installroot "$rootfs" --releasever 8 --setopt install_weak_deps=false --nodocs
+<keep xargs dnf install -y --installroot "$rootfs" --releasever 9 --setopt install_weak_deps=false --nodocs
 dnf --installroot "$rootfs" clean all
 rm -rf "$rootfs"/var/cache/* "$rootfs"/var/log/dnf* "$rootfs"/var/log/yum.*
 { set +x; } 2>/dev/null


### PR DESCRIPTION
This adds a Dockerfile as an alternative build method for the operator container, alongside Jib. It might be possible to remove Jib entirely, but would require reinventing the wheel, as far as the Kubernetes integration and testing stuff. If we want to go there, I can look into it.

I've tried the image locally, and it seems to boot the same as the the one created by Jib. However, since it just crashes without Kubernetes, I haven't tested it further.

I'm not happy with the copy-paste I had to do for ubi-null.sh, but it seems to be only thing I can do to make it available here without restructuring the whole git repo. Docker/podman only make the build directory available to the image as it's being built, and don't respect symlinks outside of that subtree. The only way to avoid duplicating ubi-null.sh would be to have both the server and operator Dockerfiles under the same directory.

The Dockerfile itself is also very similar to the server Dockerfile, largely copy-paste again. However, I didn't set it up with the assumption that it would be downloading the tar from some public-facing website, since it doesn't make sense to distribute the operator via tar.

Closes #16967