### PR TITLE
fix(userprofile): trim provided attribute values

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/userprofile/DefaultAttributes.java
+++ b/server-spi-private/src/main/java/org/keycloak/userprofile/DefaultAttributes.java
@@ -271,6 +271,8 @@ public class DefaultAttributes extends HashMap<String, List<String>> implements 
                     values = (List<String>) value;
                 }
 
+                values = values.stream().map(String::trim).collect(Collectors.toList());
+
                 newAttributes.put(key, Collections.unmodifiableList(values));
             }
         }


### PR DESCRIPTION
Hi Keycloak-team,

Keycloak does not trim user-supplied values in username, first-/lastname, etc. Especially when mobile devices are used, auto-completion/word-completion often ends words (such as a users first name) with a spaces, resulting in spaces at the end of first-/lastname, but also the username.
This allows users to create accounts with spaces at the end of their username, which prevents them from logging in, as the username is trimmed during login:
https://github.com/keycloak/keycloak/blob/a08ffdd293b7e4334a92b4caa6b6003fd6a046e0/services/src/main/java/org/keycloak/authentication/authenticators/browser/AbstractUsernameFormAuthenticator.java#L181

Also, the EmailValidator fails if spaces are present, showing an error during registration that the E-Mail is not valid, however, there is no hint why it's invalid (as it "looks" valid, due to the whitespace being invisible):
https://github.com/keycloak/keycloak/blob/a08ffdd293b7e4334a92b4caa6b6003fd6a046e0/server-spi-private/src/main/java/org/keycloak/validate/validators/EmailValidator.java#L43

To ensure that no leading or trailing spaces are present in username, email or other user-supplied attributes, this change runs String::trim on all attribute values, effectively preventing the user from accidentially entering invalid/useless values.

Closes #17482
Closes #11452