### PR TITLE
Assign AUTH_SESSION_ID when doing impersonation

### DIFF
--- a/services/src/main/java/org/keycloak/services/managers/AuthenticationSessionManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/AuthenticationSessionManager.java
@@ -18,7 +18,6 @@
 package org.keycloak.services.managers;
 
 import org.jboss.logging.Logger;
-import org.keycloak.common.ClientConnection;
 import org.keycloak.common.util.ServerCookie.SameSiteAttributeValue;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
@@ -60,12 +59,26 @@ public class AuthenticationSessionManager {
     /**
      * Creates a fresh authentication session for the given realm . Optionally sets the browser
      * authentication session cookie {@link #AUTH_SESSION_ID} with the ID of the new session.
-     * @param realm
-     * @param browserCookie Set the cookie in the browser for the
+     * @param realm The realm
+     * @param browserCookie Set the cookie in the browser for the new session
      * @return
      */
     public RootAuthenticationSessionModel createAuthenticationSession(RealmModel realm, boolean browserCookie) {
-        RootAuthenticationSessionModel rootAuthSession = session.authenticationSessions().createRootAuthenticationSession(realm);
+        return createAuthenticationSession(realm, null, browserCookie);
+    }
+
+    /**
+     * Creates a fresh authentication session for the given realm . Optionally sets the browser
+     * authentication session cookie {@link #AUTH_SESSION_ID} with the ID of the new session.
+     * @param realm The realm
+     * @param id The id of the session, if null a new id is generated
+     * @param browserCookie Set the cookie in the browser for the new session
+     * @return
+     */
+    public RootAuthenticationSessionModel createAuthenticationSession(RealmModel realm, String id, boolean browserCookie) {
+        RootAuthenticationSessionModel rootAuthSession = id == null
+                ? session.authenticationSessions().createRootAuthenticationSession(realm)
+                : session.authenticationSessions().createRootAuthenticationSession(realm, id);
 
         if (browserCookie) {
             setAuthSessionCookie(rootAuthSession.getId(), realm);

--- a/services/src/main/java/org/keycloak/services/resources/admin/UserResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UserResource.java
@@ -67,6 +67,7 @@ import org.keycloak.services.ErrorResponseException;
 import org.keycloak.services.ForbiddenException;
 import org.keycloak.services.ServicesLogger;
 import org.keycloak.services.managers.AuthenticationManager;
+import org.keycloak.services.managers.AuthenticationSessionManager;
 import org.keycloak.services.managers.BruteForceProtector;
 import org.keycloak.services.managers.UserConsentManager;
 import org.keycloak.services.managers.UserSessionManager;
@@ -92,7 +93,6 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
-import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -346,6 +346,9 @@ public class UserResource {
         userSession.setNote(IMPERSONATOR_USERNAME.toString(), impersonator);
 
         AuthenticationManager.createLoginCookie(session, realm, userSession.getUser(), userSession, session.getContext().getUri(), clientConnection);
+        // assign the new user session id to the browser via AUTH_SESSION_ID cookie
+        new AuthenticationSessionManager(session).createAuthenticationSession(realm, userSession.getId(), true);
+
         URI redirect = AccountFormService.accountServiceBaseUrl(session.getContext().getUri()).build(realm.getName());
         Map<String, Object> result = new HashMap<>();
         result.put("sameRealm", sameRealm);


### PR DESCRIPTION
Closes https://github.com/keycloak/keycloak/issues/19677

Regression on impersonation after changes done for 20.0.2. After commit https://github.com/keycloak/keycloak/commit/a1ab33778df468d5b9c1828918eedfe7faca1722 all user sessions need to have the corresponding root authenticated session. This doesn't happen with impersonation and it makes impersonation on a SAML client fail. You receive a `You are already logged in` message when redirected for the login in the keycloak login page.

Impersonation test changed to check the AUTH_SESSION_ID cookie is set and the sessions are OK to be used.

@pedroigor I'm going to assign the review to you as I think you know more about impersonation.
