### PR TITLE
Update Readme - removed links from relocated repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,8 @@ Before contributing to Keycloak, please read our [contributing guidelines](CONTR
 ## Other Keycloak Projects
 
 * [Keycloak](https://github.com/keycloak/keycloak) - Keycloak Server and Java adapters
-* [Keycloak Documentation](https://github.com/keycloak/keycloak-documentation) - Documentation for Keycloak
 * [Keycloak QuickStarts](https://github.com/keycloak/keycloak-quickstarts) - QuickStarts for getting started with Keycloak
 * [Keycloak Node.js Connect](https://github.com/keycloak/keycloak-nodejs-connect) - Node.js adapter for Keycloak
-* [Keycloak Node.js Admin Client](https://github.com/keycloak/keycloak-nodejs-admin-client) - Node.js library for Keycloak Admin REST API
 
 
 ## License


### PR DESCRIPTION
The projects "Keycloak Node,js Admin Client" and "Keycloak Documentation" have been moved to this repository, so the links can be removed.