### PR TITLE
Update CONTRIBUTING.md & GOVERNANCE.md removed links from relocated repositories

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,9 +73,7 @@ in the same way as we have written our tests.
 
 ### Documentation
 
-We require contributions to include relevant documentation. Alongside your PR for code changes, prepare a PR to the [Keycloak Documentation](https://github.com/keycloak/keycloak-documentation).
-
-In the description of your PR include a link to the PR to [Keycloak Documentation](https://github.com/keycloak/keycloak-documentation).
+We require contributions to include relevant documentation. Before submitting your code changes, please take the time to review the [documentation](docs/documentation/README.md) guide and ensure that any necessary documentation changes are included in your pull request.
 
 ### Submitting your PR
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -21,8 +21,6 @@ enabling the less common use cases through custom extensions.
 Keycloak consists of several projects:
 
 * [Keycloak](https://github.com/keycloak/keycloak) - Keycloak Server and Java adapters
-* [Keycloak UI](https://github.com/keycloak/keycloak-ui) - Keycloak Admin and Account user interface
-* [Keycloak Documentation](https://github.com/keycloak/keycloak-documentation) - Documentation for Keycloak
 * [Keycloak QuickStarts](https://github.com/keycloak/keycloak-quickstarts) - QuickStarts for getting started with Keycloak
 * [Keycloak Benchmark](https://github.com/keycloak/keycloak-benchmark) - Load tests for benchmarking Keycloak
 * [Keycloak Community](https://github.com/keycloak/keycloak-community) - Keycloak design documents


### PR DESCRIPTION
The projects "Keycloak UI" and "Keycloak Documentation" have been moved to this repository, so the links can be removed.