### PR TITLE
Fix the issue with LDAP connectionUrl containing multiple hosts

### DIFF
--- a/crypto/fips1402/pom.xml
+++ b/crypto/fips1402/pom.xml
@@ -30,6 +30,12 @@
     <name>Keycloak Crypto FIPS 140-2 Integration</name>
     <description/>
 
+    <properties>
+        <maven.compiler.release>11</maven.compiler.release>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.keycloak</groupId>

--- a/crypto/fips1402/src/main/java/org/keycloak/crypto/fips/AbstractDelegatingSSLSocket.java
+++ b/crypto/fips1402/src/main/java/org/keycloak/crypto/fips/AbstractDelegatingSSLSocket.java
@@ -1,0 +1,318 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates
+ *  and other contributors as indicated by the @author tags.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.keycloak.crypto.fips;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.SocketAddress;
+import java.net.SocketException;
+import java.nio.channels.SocketChannel;
+import java.util.List;
+import java.util.function.BiFunction;
+
+import javax.net.ssl.HandshakeCompletedListener;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.SSLSocket;
+
+/**
+ * Forked from wildfly-elytron
+ *
+ * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
+ */
+abstract class AbstractDelegatingSSLSocket extends SSLSocket {
+
+    private final SSLSocket delegate;
+
+    AbstractDelegatingSSLSocket(final SSLSocket delegate) {
+        this.delegate = delegate;
+    }
+
+    public String getApplicationProtocol() {
+        return delegate.getApplicationProtocol();
+    }
+
+    public String getHandshakeApplicationProtocol() {
+        return delegate.getHandshakeApplicationProtocol();
+    }
+
+    public void setHandshakeApplicationProtocolSelector(BiFunction<SSLSocket, List<String>, String> selector) {
+        delegate.setHandshakeApplicationProtocolSelector(selector);
+    }
+
+    public BiFunction<SSLSocket, List<String>, String> getHandshakeApplicationProtocolSelector() {
+        return delegate.getHandshakeApplicationProtocolSelector();
+    }
+
+    public String[] getSupportedCipherSuites() {
+        return delegate.getSupportedCipherSuites();
+    }
+
+    public String[] getEnabledCipherSuites() {
+        return delegate.getEnabledCipherSuites();
+    }
+
+    public void setEnabledCipherSuites(final String[] suites) {
+        delegate.setEnabledCipherSuites(suites);
+    }
+
+    public String[] getSupportedProtocols() {
+        return delegate.getSupportedProtocols();
+    }
+
+    public String[] getEnabledProtocols() {
+        return delegate.getEnabledProtocols();
+    }
+
+    public void setEnabledProtocols(final String[] protocols) {
+        delegate.setEnabledProtocols(protocols);
+    }
+
+    public SSLSession getSession() {
+        return delegate.getSession();
+    }
+
+    public SSLSession getHandshakeSession() {
+        return delegate.getHandshakeSession();
+    }
+
+    public void addHandshakeCompletedListener(final HandshakeCompletedListener listener) {
+        delegate.addHandshakeCompletedListener(listener);
+    }
+
+    public void removeHandshakeCompletedListener(final HandshakeCompletedListener listener) {
+        delegate.removeHandshakeCompletedListener(listener);
+    }
+
+    public void startHandshake() throws IOException {
+        delegate.startHandshake();
+    }
+
+    public void setUseClientMode(final boolean mode) {
+        delegate.setUseClientMode(mode);
+    }
+
+    public boolean getUseClientMode() {
+        return delegate.getUseClientMode();
+    }
+
+    public void setNeedClientAuth(final boolean need) {
+        delegate.setNeedClientAuth(need);
+    }
+
+    public boolean getNeedClientAuth() {
+        return delegate.getNeedClientAuth();
+    }
+
+    public void setWantClientAuth(final boolean want) {
+        delegate.setWantClientAuth(want);
+    }
+
+    public boolean getWantClientAuth() {
+        return delegate.getWantClientAuth();
+    }
+
+    public void setEnableSessionCreation(final boolean flag) {
+        delegate.setEnableSessionCreation(flag);
+    }
+
+    public boolean getEnableSessionCreation() {
+        return delegate.getEnableSessionCreation();
+    }
+
+    public SSLParameters getSSLParameters() {
+        return delegate.getSSLParameters();
+    }
+
+    public void setSSLParameters(final SSLParameters params) {
+        delegate.setSSLParameters(params);
+    }
+
+    public void connect(final SocketAddress endpoint) throws IOException {
+        delegate.connect(endpoint);
+    }
+
+    public void connect(final SocketAddress endpoint, final int timeout) throws IOException {
+        delegate.connect(endpoint, timeout);
+    }
+
+    public void bind(final SocketAddress bindpoint) throws IOException {
+        delegate.bind(bindpoint);
+    }
+
+    public InetAddress getInetAddress() {
+        return delegate.getInetAddress();
+    }
+
+    public InetAddress getLocalAddress() {
+        return delegate.getLocalAddress();
+    }
+
+    public int getPort() {
+        return delegate.getPort();
+    }
+
+    public int getLocalPort() {
+        return delegate.getLocalPort();
+    }
+
+    public SocketAddress getRemoteSocketAddress() {
+        return delegate.getRemoteSocketAddress();
+    }
+
+    public SocketAddress getLocalSocketAddress() {
+        return delegate.getLocalSocketAddress();
+    }
+
+    public SocketChannel getChannel() {
+        return delegate.getChannel();
+    }
+
+    public InputStream getInputStream() throws IOException {
+        return delegate.getInputStream();
+    }
+
+    public OutputStream getOutputStream() throws IOException {
+        return delegate.getOutputStream();
+    }
+
+    public void setTcpNoDelay(final boolean on) throws SocketException {
+        delegate.setTcpNoDelay(on);
+    }
+
+    public boolean getTcpNoDelay() throws SocketException {
+        return delegate.getTcpNoDelay();
+    }
+
+    public void setSoLinger(final boolean on, final int linger) throws SocketException {
+        delegate.setSoLinger(on, linger);
+    }
+
+    public int getSoLinger() throws SocketException {
+        return delegate.getSoLinger();
+    }
+
+    public void sendUrgentData(final int data) throws IOException {
+        delegate.sendUrgentData(data);
+    }
+
+    public void setOOBInline(final boolean on) throws SocketException {
+        delegate.setOOBInline(on);
+    }
+
+    public boolean getOOBInline() throws SocketException {
+        return delegate.getOOBInline();
+    }
+
+    public void setSoTimeout(final int timeout) throws SocketException {
+        delegate.setSoTimeout(timeout);
+    }
+
+    public int getSoTimeout() throws SocketException {
+        return delegate.getSoTimeout();
+    }
+
+    public void setSendBufferSize(final int size) throws SocketException {
+        delegate.setSendBufferSize(size);
+    }
+
+    public int getSendBufferSize() throws SocketException {
+        return delegate.getSendBufferSize();
+    }
+
+    public void setReceiveBufferSize(final int size) throws SocketException {
+        delegate.setReceiveBufferSize(size);
+    }
+
+    public int getReceiveBufferSize() throws SocketException {
+        return delegate.getReceiveBufferSize();
+    }
+
+    public void setKeepAlive(final boolean on) throws SocketException {
+        delegate.setKeepAlive(on);
+    }
+
+    public boolean getKeepAlive() throws SocketException {
+        return delegate.getKeepAlive();
+    }
+
+    public void setTrafficClass(final int tc) throws SocketException {
+        delegate.setTrafficClass(tc);
+    }
+
+    public int getTrafficClass() throws SocketException {
+        return delegate.getTrafficClass();
+    }
+
+    public void setReuseAddress(final boolean on) throws SocketException {
+        delegate.setReuseAddress(on);
+    }
+
+    public boolean getReuseAddress() throws SocketException {
+        return delegate.getReuseAddress();
+    }
+
+    public void close() throws IOException {
+        delegate.close();
+    }
+
+    public void shutdownInput() throws IOException {
+        delegate.shutdownInput();
+    }
+
+    public void shutdownOutput() throws IOException {
+        delegate.shutdownOutput();
+    }
+
+    public String toString() {
+        return delegate.toString();
+    }
+
+    public boolean isConnected() {
+        return delegate.isConnected();
+    }
+
+    public boolean isBound() {
+        return delegate.isBound();
+    }
+
+    public boolean isClosed() {
+        return delegate.isClosed();
+    }
+
+    public boolean isInputShutdown() {
+        return delegate.isInputShutdown();
+    }
+
+    public boolean isOutputShutdown() {
+        return delegate.isOutputShutdown();
+    }
+
+    public void setPerformancePreferences(final int connectionTime, final int latency, final int bandwidth) {
+        delegate.setPerformancePreferences(connectionTime, latency, bandwidth);
+    }
+
+    protected SSLSocket getDelegate() {
+        return delegate;
+    }
+}
+

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPUtils.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPUtils.java
@@ -32,11 +32,8 @@ import java.util.stream.Collectors;
 import javax.naming.directory.SearchControls;
 
 import org.jboss.logging.Logger;
-import org.keycloak.common.util.UriUtils;
 import org.keycloak.component.ComponentModel;
 import org.keycloak.component.ComponentValidationException;
-import org.keycloak.models.Constants;
-import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.LDAPConstants;
 import org.keycloak.models.ModelException;
 import org.keycloak.models.RealmModel;
@@ -379,11 +376,5 @@ public class LDAPUtils {
         }
 
         return userModelProperties;
-    }
-
-    public static void setLDAPHostnameToKeycloakSession(KeycloakSession session,LDAPConfig ldapConfig) {
-        String hostname = UriUtils.getHost(ldapConfig.getConnectionUrl());
-        session.setAttribute(Constants.SSL_SERVER_HOST_ATTR, hostname);
-        log.tracef("Setting LDAP server hostname '%s' as KeycloakSession attribute", hostname);
     }
 }

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPContextManager.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPContextManager.java
@@ -4,7 +4,6 @@ import org.jboss.logging.Logger;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.LDAPConstants;
 import org.keycloak.storage.ldap.LDAPConfig;
-import org.keycloak.storage.ldap.LDAPUtils;
 import org.keycloak.truststore.TruststoreProvider;
 import org.keycloak.vault.VaultCharSecret;
 
@@ -67,8 +66,6 @@ public final class LDAPContextManager implements AutoCloseable {
     }
 
     private void createLdapContext() throws NamingException {
-        LDAPUtils.setLDAPHostnameToKeycloakSession(session, ldapConfig);
-
         Hashtable<Object, Object> connProp = getConnectionProperties(ldapConfig);
 
         if (!LDAPConstants.AUTH_TYPE_NONE.equals(ldapConfig.getAuthType())) {

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPOperationManager.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPOperationManager.java
@@ -23,7 +23,6 @@ import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.LDAPConstants;
 import org.keycloak.models.ModelException;
 import org.keycloak.storage.ldap.LDAPConfig;
-import org.keycloak.storage.ldap.LDAPUtils;
 import org.keycloak.storage.ldap.idm.model.LDAPDn;
 import org.keycloak.storage.ldap.idm.query.internal.LDAPQuery;
 import org.keycloak.storage.ldap.idm.store.ldap.extended.PasswordModifyRequest;
@@ -497,8 +496,6 @@ public class LDAPOperationManager {
         StartTlsResponse tlsResponse = null;
 
         try {
-            LDAPUtils.setLDAPHostnameToKeycloakSession(session, config);
-
             Hashtable<Object, Object> env = LDAPContextManager.getNonAuthConnectionProperties(config);
 
             // Never use connection pool to prevent password caching

--- a/model/map-ldap/src/main/java/org/keycloak/models/map/storage/ldap/store/LdapMapContextManager.java
+++ b/model/map-ldap/src/main/java/org/keycloak/models/map/storage/ldap/store/LdapMapContextManager.java
@@ -82,8 +82,6 @@ public final class LdapMapContextManager implements AutoCloseable {
     }
 
     private void createLdapContext() throws NamingException {
-        LdapMapUtil.setLDAPHostnameToKeycloakSession(session, ldapMapConfig);
-
         Hashtable<Object, Object> connProp = getConnectionProperties(ldapMapConfig);
 
         if (!LDAPConstants.AUTH_TYPE_NONE.equals(ldapMapConfig.getAuthType())) {

--- a/model/map-ldap/src/main/java/org/keycloak/models/map/storage/ldap/store/LdapMapOperationManager.java
+++ b/model/map-ldap/src/main/java/org/keycloak/models/map/storage/ldap/store/LdapMapOperationManager.java
@@ -390,8 +390,6 @@ public class LdapMapOperationManager implements AutoCloseable {
         StartTlsResponse tlsResponse = null;
 
         try {
-            LdapMapUtil.setLDAPHostnameToKeycloakSession(session, config);
-
             Hashtable<Object, Object> env = LdapMapContextManager.getNonAuthConnectionProperties(config);
 
             // Never use connection pool to prevent password caching

--- a/model/map-ldap/src/main/java/org/keycloak/models/map/storage/ldap/store/LdapMapUtil.java
+++ b/model/map-ldap/src/main/java/org/keycloak/models/map/storage/ldap/store/LdapMapUtil.java
@@ -18,11 +18,7 @@
 package org.keycloak.models.map.storage.ldap.store;
 
 import org.jboss.logging.Logger;
-import org.keycloak.common.util.UriUtils;
-import org.keycloak.models.Constants;
-import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.ModelException;
-import org.keycloak.models.map.storage.ldap.config.LdapMapConfig;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -256,12 +252,5 @@ public class LdapMapUtil {
             return Integer.toHexString(value);
         }
     }
-
-    public static void setLDAPHostnameToKeycloakSession(KeycloakSession session, LdapMapConfig ldapConfig) {
-        String hostname = UriUtils.getHost(ldapConfig.getConnectionUrl());
-        session.setAttribute(Constants.SSL_SERVER_HOST_ATTR, hostname);
-        logger.tracef("Setting LDAP server hostname '%s' as KeycloakSession attribute", hostname);
-    }
-
 
 }

--- a/server-spi-private/src/main/java/org/keycloak/models/Constants.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/Constants.java
@@ -147,8 +147,4 @@ public final class Constants {
     public static final Boolean REALM_ATTR_USERNAME_CASE_SENSITIVE_DEFAULT = Boolean.FALSE;
     public static final String REALM_ATTR_USERNAME_CASE_SENSITIVE = "keycloak.username-search.case-sensitive";
 
-    /**
-     * Attribute of KeycloakSession where the hostname of the SSL server can be saved. This can be used by org.keycloak.truststore.SSLSocketFactory
-     */
-    public static final String SSL_SERVER_HOST_ATTR = "sslServerHost";
 }

--- a/server-spi-private/src/main/java/org/keycloak/models/LDAPConstants.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/LDAPConstants.java
@@ -17,6 +17,9 @@
 
 package org.keycloak.models;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -163,11 +166,24 @@ public class LDAPConstants {
         } else if (useTruststoreSpi != null && useTruststoreSpi.equals(LDAPConstants.USE_TRUSTSTORE_NEVER)) {
             shouldSetTruststore = false;
         } else {
-            shouldSetTruststore = (url != null && url.toLowerCase().startsWith("ldaps"));
+            shouldSetTruststore = toLdapUrls(url).stream()
+                            .anyMatch(urlPart -> urlPart.toLowerCase().startsWith("ldaps"));
         }
 
         if (shouldSetTruststore) {
             env.put("java.naming.ldap.factory.socket", "org.keycloak.truststore.SSLSocketFactory");
         }
+    }
+
+
+    /**
+     * @see com.sun.jndi.ldap.LdapURL#fromList(String) (Not using it directly to avoid usage of internal Java classes)
+     *
+     * @param ldapUrlList LDAP URL, which can possibly consists from multiple URLs like "ldaps://host1:636 ldaps://host2:636"
+     * @return List of all URLs
+     */
+    public static List<String> toLdapUrls(String ldapUrlList) {
+        if (ldapUrlList == null) return Collections.emptyList();
+        return  Arrays.asList(ldapUrlList.split(" "));
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/UserFederationLdapConnectionTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/UserFederationLdapConnectionTest.java
@@ -109,6 +109,34 @@ public class UserFederationLdapConnectionTest extends AbstractAdminTest {
     }
 
     @Test
+    public void testLdapConnectionMoreServers() {
+        // Both servers work
+        Response response = realm.testLDAPConnection(new TestLdapConnectionRepresentation(LDAPServerCapabilitiesManager.TEST_AUTHENTICATION, "ldap://localhost:10389 ldaps://localhost:10636", "uid=admin,ou=system", "secret", "true", null));
+        assertStatus(response, 204);
+
+        // Only 1st server works
+        response = realm.testLDAPConnection(new TestLdapConnectionRepresentation(LDAPServerCapabilitiesManager.TEST_AUTHENTICATION, "ldap://localhost:10389 ldap://localhostt:10389", "uid=admin,ou=system", "secret", "true", null));
+        assertStatus(response, 204);
+
+        // Only 1st server works - variant with connectionTimeout (important to test as com.sun.jndi.ldap.Connection.createSocket implementation differs based on whether connectionTimeout is used)
+        response = realm.testLDAPConnection(new TestLdapConnectionRepresentation(LDAPServerCapabilitiesManager.TEST_AUTHENTICATION, "ldap://localhost:10389 ldap://localhostt:10389", "uid=admin,ou=system", "secret", "true", "10000"));
+        assertStatus(response, 204);
+
+        // Only 2nd server works
+        response = realm.testLDAPConnection(new TestLdapConnectionRepresentation(LDAPServerCapabilitiesManager.TEST_AUTHENTICATION, "ldap://localhostt:10389 ldaps://localhost:10636", "uid=admin,ou=system", "secret", "true", null));
+        assertStatus(response, 204);
+
+        // Only 2nd server works - variant with connectionTimeout
+        response = realm.testLDAPConnection(new TestLdapConnectionRepresentation(LDAPServerCapabilitiesManager.TEST_AUTHENTICATION, "ldap://localhostt:10389 ldaps://localhost:10636", "uid=admin,ou=system", "secret", "true", "10000"));
+        assertStatus(response, 204);
+
+        // None of servers work
+        response = realm.testLDAPConnection(new TestLdapConnectionRepresentation(LDAPServerCapabilitiesManager.TEST_AUTHENTICATION, "ldap://localhostt:10389 ldaps://localhostt:10636", "uid=admin,ou=system", "secret", "true", null));
+        assertStatus(response, 400);
+
+    }
+
+    @Test
     public void testLdapCapabilities() {
 
         // Query the rootDSE success


### PR DESCRIPTION
Closes #17359

@ahus1 Could you please review this PR?

Few point:
- I've followed your suggestion and removed the attribute from the KeycloakSession entirely

- As you pointed, I needed to override some methods from `CustomSSLSocketFactory` in `FIPS1402Provider.wrapFactoryForTruststore`. The most tricky part is the method `createSocket()`, which creates "unconnected" socket, which is supposed to be connected later (FYI. this part is used for LDAP connection in `com.sun.jndi.ldap.Connection.createSocket` in case that `connectionTimeout > 0`). For make this working and being able to configure SNI in the socket at the time of connection, I forked class `AbstractDelegatingSSLSocket` class from Elytron
