### PR TITLE
Invalid parameter redirect_uri when using an invalid client_id

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpoint.java
@@ -255,7 +255,7 @@ public class AuthorizationEndpoint extends AuthorizationEndpointBase {
         client = realm.getClientByClientId(clientId);
         if (client == null) {
             event.error(Errors.CLIENT_NOT_FOUND);
-            throw new ErrorPageException(session, authenticationSession, Response.Status.BAD_REQUEST, Messages.INVALID_PARAMETER, OIDCLoginProtocol.REDIRECT_URI_PARAM);
+            throw new ErrorPageException(session, authenticationSession, Response.Status.BAD_REQUEST, Messages.CLIENT_NOT_FOUND);
         }
 
         if (!client.isEnabled()) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/error/UncaughtErrorPageTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/error/UncaughtErrorPageTest.java
@@ -184,7 +184,7 @@ public class UncaughtErrorPageTest extends AbstractKeycloakTest {
         oauth.openLoginForm();
 
         assertTrue(errorPage.isCurrent());
-        assertEquals("Invalid parameter: redirect_uri", errorPage.getError());
+        assertEquals("Client not found.", errorPage.getError());
     }
 
     @Test


### PR DESCRIPTION
closes #19662

@stianst @pedroigor Anyone of you available to review this please?