### PR TITLE
Get admin console title from theme.properties

### DIFF
--- a/js/apps/admin-ui/pom.xml
+++ b/js/apps/admin-ui/pom.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -79,6 +81,14 @@
                             <value>href="${resourceUrl}/</value>
                         </replacement>
                         <replacement>
+                            <token><![CDATA[<title>Keycloak Administration UI</title>]]></token>
+                            <value xml:space="preserve">
+<![CDATA[
+    <title>${properties.title!"Keycloak Administration UI"}</title>
+]]>
+</value>
+                        </replacement>
+                        <replacement>
                             <token><![CDATA[</body>]]></token>
                             <value xml:space="preserve">
 <![CDATA[
@@ -108,7 +118,7 @@
       </#list>
     </#if>
   </head>
-]]>	
+]]>
 </value>
                         </replacement>
                     </replacements>


### PR DESCRIPTION
Fixes #19733

Now, you can change the title of the admin console by creating a new theme that only includes a simple themes.properties that looks like this:
```
parent=keycloak.v2
title=My Cool Title
```
Just put the themes.properties file in themes/mytheme/admin
