### PR TITLE
Fix Base Testsuite timeouts on Windows

### DIFF
--- a/quarkus/dist/src/main/content/bin/kc.bat
+++ b/quarkus/dist/src/main/content/bin/kc.bat
@@ -128,7 +128,7 @@ if "x%JAVA_HOME%" == "x" (
        echo "%JAVA_HOME%\bin\java.exe" does not exist
        goto END
      )
-    set JAVA=%JAVA_HOME%\bin\java
+    set "JAVA=%JAVA_HOME%\bin\java"
   )
 )
 
@@ -159,7 +159,7 @@ set START_SERVER=true
 if "!CONFIG_ARGS:%OPTIMIZED_OPTION%=!"=="!CONFIG_ARGS!" if "!CONFIG_ARGS:%BUILD_OPTION%=!"=="!CONFIG_ARGS!" if "!CONFIG_ARGS:%HELP_LONG_OPTION%=!"=="!CONFIG_ARGS!" if "%IS_HELP_SHORT%" == "false" (
     setlocal enabledelayedexpansion
 
-    %JAVA% -Dkc.config.build-and-exit=true %JAVA_RUN_OPTS%
+    "%JAVA%" -Dkc.config.build-and-exit=true %JAVA_RUN_OPTS%
 
     if not !errorlevel! == 0 (
         set START_SERVER=false
@@ -169,7 +169,7 @@ if "!CONFIG_ARGS:%OPTIMIZED_OPTION%=!"=="!CONFIG_ARGS!" if "!CONFIG_ARGS:%BUILD_
 )
 
 if "%START_SERVER%" == "true" (
-    %JAVA% %JAVA_RUN_OPTS%
+    "%JAVA%" %JAVA_RUN_OPTS%
 )
 
 :END

--- a/testsuite/integration-arquillian/servers/auth-server/quarkus/ant/configure.xml
+++ b/testsuite/integration-arquillian/servers/auth-server/quarkus/ant/configure.xml
@@ -8,8 +8,7 @@
             <arg value="--http-relative-path=/auth"/>
             <arg value="--cache=local"/>
         </exec>
-        <exec osfamily="windows" executable="cmd" dir="${auth.server.home}/bin" failonerror="true">
-            <arg value="kc.bat" />
+        <exec osfamily="windows" executable="${auth.server.home}/bin/kc.bat" failonerror="true">
             <arg value="build"/>
             <arg value="--http-relative-path=/auth"/>
             <arg value="--cache=local"/>


### PR DESCRIPTION
* reverted keycloak/keycloak@ca9c6dd (Ant's configure.xml changes)
* edited kc.bat to prevent 'C:\Program' is not recognized as a command error (Ant BuildException)
* fixed the internal pipeline build errors

Signed-off-by: Peter Zaoral <pzaoral@redhat.com>

The timeout issue was caused by the recent cleanup of kc.bat (#16229), where the majority of the double quote encapsulation was removed. This typically may cause a problem, when there is a space in a path of a binary (in this case java.exe). Therefore, at least `%JAVA%` variable should stay enquoted (the binary is by default placed into Program Files, so the path may contain a space). 

I also used this PR as an opportunity to get rid of a warning about the usage of the unix file separators.

