### PR TITLE
Do not allow add sub-flow to built-in workflow

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/AuthenticationManagementResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/AuthenticationManagementResource.java
@@ -410,6 +410,9 @@ public class AuthenticationManagementResource {
         if (parentFlow == null) {
             throw ErrorResponse.error("Parent flow doesn't exist", Response.Status.BAD_REQUEST);
         }
+        if (parentFlow.isBuiltIn()) {
+            throw new BadRequestException("It is illegal to add sub-flow to a built in flow");
+        }
         String alias = data.get("alias");
         String type = data.get("type");
         String provider = data.get("provider");


### PR DESCRIPTION
Closes https://github.com/keycloak/keycloak/issues/15536

Minor issue, just adding the check for the sub-flow too. Little test added to check the errors are returned for the built in workflows.
