### PR TITLE
Explicltly set version for specific packages only

### DIFF
--- a/set-version.sh
+++ b/set-version.sh
@@ -10,11 +10,9 @@ sed -i "s/ENV KEYCLOAK_VERSION .*/ENV KEYCLOAK_VERSION $NEW_VERSION/" quarkus/co
 
 # NPM
 cd js
-npm --workspaces pkg set "dependencies.keycloak-js=$NEW_VERSION"
-npm --workspaces pkg set "dependencies.@keycloak/keycloak-admin-client=$NEW_VERSION"
-npm --workspaces pkg set "dependencies.keycloak-masthead=$NEW_VERSION"
-npm --workspaces pkg set "dependencies.ui-shared=$NEW_VERSION"
-npm version $NEW_VERSION --allow-same-version --no-git-tag-version --workspaces
+npm --workspace=admin-ui --workspace=account-ui --workspace=keycloak-masthead pkg set "dependencies.keycloak-js=$NEW_VERSION"
+npm --workspace=admin-ui pkg set "dependencies.@keycloak/keycloak-admin-client=$NEW_VERSION"
+npm --workspace=keycloak-js --workspace=@keycloak/keycloak-admin-client version $NEW_VERSION --allow-same-version --no-git-tag-version
 cd -
 
 # Documentation


### PR DESCRIPTION
The changes from #19796 caused all of the packages to depend on each other, even those that are never published to NPM. This is now causing issues for users trying to install Keycloak JS or the Admin Client from NPM, as their dependencies will never resolve.

Closes #19800