### PR TITLE
stringify is only needed in authorization

### DIFF
--- a/js/apps/admin-ui/src/authentication/components/ExecutionConfigModal.tsx
+++ b/js/apps/admin-ui/src/authentication/components/ExecutionConfigModal.tsx
@@ -160,6 +160,7 @@ export const ExecutionConfigModal = ({
             </FormGroup>
             <FormProvider {...form}>
               <DynamicComponents
+                stringify
                 properties={configDescription.properties || []}
               />
             </FormProvider>

--- a/js/apps/admin-ui/src/components/dynamic/DynamicComponents.tsx
+++ b/js/apps/admin-ui/src/components/dynamic/DynamicComponents.tsx
@@ -5,8 +5,7 @@ import { convertAttributeNameToForm } from "../../util";
 
 type DynamicComponentProps = {
   properties: ConfigPropertyRepresentation[];
-  selectedValues?: string[];
-  parentCallback?: (data: string[]) => void;
+  stringify?: boolean;
 };
 
 export const DynamicComponents = ({

--- a/js/apps/admin-ui/src/components/dynamic/MultivaluedStringComponent.tsx
+++ b/js/apps/admin-ui/src/components/dynamic/MultivaluedStringComponent.tsx
@@ -11,6 +11,7 @@ export const MultiValuedStringComponent = ({
   label,
   defaultValue,
   helpText,
+  stringify,
   isDisabled = false,
 }: ComponentProps) => {
   const { t } = useTranslation("dynamic");
@@ -32,7 +33,7 @@ export const MultiValuedStringComponent = ({
         addButtonLabel={t("addMultivaluedLabel", {
           fieldLabel: t(label!).toLowerCase(),
         })}
-        stringify
+        stringify={stringify}
       />
     </FormGroup>
   );

--- a/js/apps/admin-ui/src/components/dynamic/components.ts
+++ b/js/apps/admin-ui/src/components/dynamic/components.ts
@@ -16,6 +16,7 @@ import { TextComponent } from "./TextComponent";
 
 export type ComponentProps = Omit<ConfigPropertyRepresentation, "type"> & {
   isDisabled?: boolean;
+  stringify?: boolean;
 };
 
 const ComponentTypes = [


### PR DESCRIPTION
added a property to the component so that we can manually enable it.
It would be better to have this as part of the description of the field.
fixes: #19609
fixes: #19469
fixes: #19513
references: #17851

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
