### PR TITLE
add validations to validator when creating new

### DIFF
--- a/js/apps/admin-ui/src/realm-settings/NewAttributeSettings.tsx
+++ b/js/apps/admin-ui/src/realm-settings/NewAttributeSettings.tsx
@@ -217,6 +217,7 @@ export default function NewAttributeSettings() {
             selector: profileConfig.selector,
             permissions: profileConfig.permissions!,
             annotations,
+            validations,
           },
           profileConfig.isRequired
             ? { required: profileConfig.required }


### PR DESCRIPTION
This fixes the fact that when creating a new attribute the validators are not saved

Closes #19875