### PR TITLE
Allow configuring the referrer policy

### DIFF
--- a/js/apps/admin-ui/public/locales/en/realm-settings.json
+++ b/js/apps/admin-ui/public/locales/en/realm-settings.json
@@ -861,6 +861,7 @@
   "xRobotsTag": "X-Robots-Tag",
   "xXSSProtection": "X-XSS-Protection",
   "strictTransportSecurity": "HTTP Strict Transport Security (HSTS)",
+  "referrerPolicy": "Referrer Policy",
   "failureFactor": "Max login failures",
   "permanentLockout": "Permanent lockout",
   "waitIncrementSeconds": "Wait increment",

--- a/js/apps/admin-ui/src/realm-settings/security-defences/HeadersForm.tsx
+++ b/js/apps/admin-ui/src/realm-settings/security-defences/HeadersForm.tsx
@@ -64,8 +64,8 @@ export const HeadersForm = ({ realm, save }: HeadersFormProps) => {
           url="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security"
         />
         <HelpLinkTextInput
-            fieldName="browserSecurityHeaders.referrerPolicy"
-            url="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy"
+          fieldName="browserSecurityHeaders.referrerPolicy"
+          url="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy"
         />
 
         <ActionGroup>

--- a/js/apps/admin-ui/src/realm-settings/security-defences/HeadersForm.tsx
+++ b/js/apps/admin-ui/src/realm-settings/security-defences/HeadersForm.tsx
@@ -63,6 +63,10 @@ export const HeadersForm = ({ realm, save }: HeadersFormProps) => {
           fieldName="browserSecurityHeaders.strictTransportSecurity"
           url="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security"
         />
+        <HelpLinkTextInput
+            fieldName="browserSecurityHeaders.referrerPolicy"
+            url="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy"
+        />
 
         <ActionGroup>
           <Button

--- a/server-spi-private/src/main/java/org/keycloak/models/BrowserSecurityHeaders.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/BrowserSecurityHeaders.java
@@ -30,8 +30,7 @@ public enum BrowserSecurityHeaders {
     X_ROBOTS_TAG("xRobotsTag", "X-Robots-Tag", "none"),
     X_XSS_PROTECTION("xXSSProtection", "X-XSS-Protection", "1; mode=block"),
     STRICT_TRANSPORT_SECURITY("strictTransportSecurity", "Strict-Transport-Security", "max-age=31536000; includeSubDomains"),
-    REFERRER_POLICY("referrerPolicy", "Referrer-Policy", "no-referrer"),
-    ;
+    REFERRER_POLICY("referrerPolicy", "Referrer-Policy", "no-referrer");
 
     private final String key;
     private final String headerName;
@@ -68,6 +67,7 @@ public enum BrowserSecurityHeaders {
         dh.put(X_ROBOTS_TAG.getKey(), X_ROBOTS_TAG.getDefaultValue());
         dh.put(X_XSS_PROTECTION.getKey(), X_XSS_PROTECTION.getDefaultValue());
         dh.put(STRICT_TRANSPORT_SECURITY.getKey(), STRICT_TRANSPORT_SECURITY.getDefaultValue());
+        dh.put(REFERRER_POLICY.getKey(), REFERRER_POLICY.getDefaultValue());
 
         realmDefaultHeaders = Collections.unmodifiableMap(dh);
     }

--- a/server-spi-private/src/test/java/org/keycloak/models/BrowserSecurityHeadersTest.java
+++ b/server-spi-private/src/test/java/org/keycloak/models/BrowserSecurityHeadersTest.java
@@ -3,6 +3,18 @@ package org.keycloak.models;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.keycloak.models.BrowserSecurityHeaders.CONTENT_SECURITY_POLICY;
+import static org.keycloak.models.BrowserSecurityHeaders.CONTENT_SECURITY_POLICY_REPORT_ONLY;
+import static org.keycloak.models.BrowserSecurityHeaders.REFERRER_POLICY;
+import static org.keycloak.models.BrowserSecurityHeaders.STRICT_TRANSPORT_SECURITY;
+import static org.keycloak.models.BrowserSecurityHeaders.X_CONTENT_TYPE_OPTIONS;
+import static org.keycloak.models.BrowserSecurityHeaders.X_FRAME_OPTIONS;
+import static org.keycloak.models.BrowserSecurityHeaders.X_ROBOTS_TAG;
+import static org.keycloak.models.BrowserSecurityHeaders.X_XSS_PROTECTION;
+import static org.keycloak.models.BrowserSecurityHeaders.realmDefaultHeaders;
+
+import java.util.Arrays;
+import java.util.List;
 
 public class BrowserSecurityHeadersTest {
 
@@ -14,4 +26,23 @@ public class BrowserSecurityHeadersTest {
         assertEquals("frame-src 'custom-frame-src'; frame-ancestors 'custom-frame-ancestors'; object-src 'none';", ContentSecurityPolicyBuilder.create().frameSrc("'custom-frame-src'").frameAncestors("'custom-frame-ancestors'").build());
     }
 
+    @Test
+    public void testDefaultHeaders() {
+        List<BrowserSecurityHeaders> expectedHeaders = Arrays.asList(
+                X_FRAME_OPTIONS,
+                CONTENT_SECURITY_POLICY,
+                CONTENT_SECURITY_POLICY_REPORT_ONLY,
+                X_CONTENT_TYPE_OPTIONS,
+                X_ROBOTS_TAG,
+                X_XSS_PROTECTION,
+                STRICT_TRANSPORT_SECURITY,
+                REFERRER_POLICY
+        );
+
+        assertEquals(expectedHeaders.size(), realmDefaultHeaders.size());
+
+        for (BrowserSecurityHeaders header : expectedHeaders) {
+            assertEquals(header.getDefaultValue(), realmDefaultHeaders.get(header.getKey()));
+        }
+    }
 }


### PR DESCRIPTION
Closes #17288

* Makes it possible to configure the referer policy and keep consistency with other headers

Not sure if we want migration for this change?

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
