### PR TITLE
Allow pre-filled GitHub issue forms via links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -55,36 +55,42 @@ body:
     validations:
       required: true
   - type: textarea
+    id: description
     attributes:
       label: Describe the bug
       description: Provide a clear and concise description of what the problem is.
     validations:
       required: true
   - type: input
+    id: version
     attributes:
       label: Version
       description: What version of Keycloak are you running?
     validations:
       required: true
   - type: textarea
+    id: behaviorExpected
     attributes:
       label: Expected behavior
       description: Describe the expected behavior clearly and concisely.
     validations:
       required: true
   - type: textarea
+    id: behaviorActual
     attributes:
       label: Actual behavior
       description: Describe the actual behavior clearly and concisely.
     validations:
       required: true
   - type: textarea
+    id: reproducer
     attributes:
       label: How to Reproduce?
       description: Provide clear and concise steps to reproduce the problem.
     validations:
       required: true
   - type: textarea
+    id: other
     attributes:
       label: Anything else?
       description: Links? References? Anything that will give us more context about the issue you are encountering!

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -3,12 +3,14 @@ description: Request an enhancement to an existing feature
 labels: ["kind/enhancement", "status/triage"]
 body:
   - type: textarea
+    id: description
     attributes:
       label: Description
       description: Describe the enhancement at a high-level.
     validations:
       required: true
   - type: input
+    id: discussion
     attributes:
       label: Discussion
       description: |
@@ -18,12 +20,14 @@ body:
     validations:
       required: false
   - type: textarea
+    id: motivation
     attributes:
       label: Motivation
       description: Describe why the feature should be added.
     validations:
       required: false
   - type: textarea
+    id: details
     attributes:
       label: Details
       description: More details? Implementation ideas? Anything that will give us more context about the enhancement you are proposing!

--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -3,12 +3,14 @@ description: A large feature that is broken down into multiple linked issues.
 labels: ["kind/epic", "status/triage"]
 body:
   - type: textarea
+    id: description
     attributes:
       label: Description
       description: Describe the feature at a high-level.
     validations:
       required: true
   - type: input
+    id: discussion
     attributes:
       label: Discussion
       description: |
@@ -16,6 +18,7 @@ body:
     validations:
       required: true
   - type: textarea
+    id: issues
     attributes:
       label: Issues
       description: List the issues related to this epic.
@@ -25,6 +28,7 @@ body:
     validations:
       required: false
   - type: textarea
+    id: motivation
     attributes:
       label: Motivation
       description: Provide a brief explanation of why the feature should be added.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -3,12 +3,14 @@ description: Request a new feature to be added to Keycloak
 labels: ["kind/feature", "status/triage"]
 body:
   - type: textarea
+    id: description
     attributes:
       label: Description
       description: Describe the feature at a high-level.
     validations:
       required: true
   - type: input
+    id: discussion
     attributes:
       label: Discussion
       description: |
@@ -18,12 +20,14 @@ body:
     validations:
       required: false
   - type: textarea
+    id: motivation
     attributes:
       label: Motivation
       description: Describe why the feature should be added.
     validations:
       required: false
   - type: textarea
+    id: details
     attributes:
       label: Details
       description: Design ideas? Implementation ideas? Anything that will give us more context about the feature you are proposing!

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -3,6 +3,7 @@ description: Any tasks that are not directly adding a new feature, enhancement o
 labels: ["kind/task"]
 body:
   - type: textarea
+    id: description
     attributes:
       label: Description
       description: Describe the task.


### PR DESCRIPTION
Closes #19924

Note: a bug form has a lot of fields, and "actual behavior" vs. "expected behavior" sound very strange when used together with documentation. At the same time using a different issue time would make documentation bugs less important. With the placeholder comments below, I try to give users additional guidance, and those mandatory fields are pre-filled.

Feedback is welcome.

Old docs URL:

```
https://issues.redhat.com/secure/CreateIssueDetails!init.jspa?pid=12313920&components=12323375&issuetype=1&priority=3&description=File:%20securing_apps/topics/overview/overview.adoc
```

New docs URL - transposed to ahus1's repo. Will be added to the old style docs. 

```
https://github.com/ahus1/keycloak/issues/new?template=bug.yml&title=Docs:%20securing_apps/topics/overview/overview.adoc&description=%0A%0AFile:%20securing_apps/topics&version=21.1.0&behaviorExpected=%3C!--%20describe%20what%20you%20want%20to%20see%20in%20the%20docs%20--%3E&behaviorActual=%3C!--%20describe%20what%20is%20currently%20wrong%20or%20missing%20in%20the%20docs%20--%3E&reproducer=%3C!--%20list%20steps%20in%20the%20application%20that%20show%20behavior%20that%20should%20be%20documented%20--%3E
```