### PR TITLE
Validate without refresh token

### DIFF
--- a/js/libs/keycloak-js/src/keycloak.js
+++ b/js/libs/keycloak-js/src/keycloak.js
@@ -287,9 +287,11 @@ function Keycloak (config) {
                                     initPromise.setError(error);
                                 }
                             });
-                        } else {
+                        } else if (kc.tokenParsed && !kc.isTokenExpired(-1)) {
                             kc.onAuthSuccess && kc.onAuthSuccess();
                             initPromise.setSuccess();
+                        } else {
+                            logInfo('[KEYCLOAK] Token expired');
                         }
                     }
                 } else if (initOptions.onLoad) {

--- a/js/libs/keycloak-js/src/keycloak.js
+++ b/js/libs/keycloak-js/src/keycloak.js
@@ -257,7 +257,7 @@ function Keycloak (config) {
                     initPromise.setError(error);
                 });
             } else if (initOptions) {
-                if (initOptions.token && initOptions.refreshToken) {
+                if (initOptions.token) {
                     setToken(initOptions.token, initOptions.refreshToken, initOptions.idToken);
 
                     if (loginIframe.enable) {
@@ -275,17 +275,22 @@ function Keycloak (config) {
                             });
                         });
                     } else {
-                        kc.updateToken(-1).then(function() {
+                        if (initOptions.refreshToken) {
+                            kc.updateToken(-1).then(function() {
+                                kc.onAuthSuccess && kc.onAuthSuccess();
+                                initPromise.setSuccess();
+                            }).catch(function(error) {
+                                kc.onAuthError && kc.onAuthError();
+                                if (initOptions.onLoad) {
+                                    onLoad();
+                                } else {
+                                    initPromise.setError(error);
+                                }
+                            });
+                        } else {
                             kc.onAuthSuccess && kc.onAuthSuccess();
                             initPromise.setSuccess();
-                        }).catch(function(error) {
-                            kc.onAuthError && kc.onAuthError();
-                            if (initOptions.onLoad) {
-                                onLoad();
-                            } else {
-                                initPromise.setError(error);
-                            }
-                        });
+                        }
                     }
                 } else if (initOptions.onLoad) {
                     onLoad();


### PR DESCRIPTION
This pull request will allow the keycloak client to be initialized with a token but without a refresh token. This is useful in situations where a refresh token is not available.

This should fix issue keycloak/keycloak-js#17 