### PR TITLE
Build distribution module in order to build WildFly adapters

### DIFF
--- a/.github/actions/build-keycloak/action.yml
+++ b/.github/actions/build-keycloak/action.yml
@@ -43,13 +43,27 @@ runs:
       name: NPM cache
       uses: ./.github/actions/npm-cache
 
+    # Remove once https://github.com/keycloak/keycloak/issues/19299 is solved
+    ########################################################################################################
+    - id: check-wf-adapters
+      name: Check whether HEAD^ contains WildFly adapters relevant changes
+      shell: bash
+      run: echo "GIT_WF_ADAPTERS_DIFF=$( git diff origin/${{ github.base_ref }} --name-only | egrep -ic -e '^adapters/oidc/wildfly|^adapters/saml/wildfly' )" >> $GITHUB_ENV
+
+    - id: set-wf-adapters-profile
+      if: ${{ github.event_name != 'pull_request' || env.GIT_WF_ADAPTERS_DIFF != 0 }}
+      name: Set profile for building WildFly adapters
+      shell: bash
+      run: MVN_PROFILES="-Pbuild-wildfly-adapters"
+    ########################################################################################################
+
     - id: build-keycloak
       name: Build Keycloak
       shell: bash
       # By using "dependency:resolve", it will download all dependencies used in later stages for running the tests
       run: |
         MVN_HTTP_CONFIG="-Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.httpconnectionManager.ttlSeconds=120"
-        ./mvnw install dependency:resolve -nsu -B -e -DskipTests -DskipExamples $MVN_HTTP_CONFIG
+        ./mvnw install dependency:resolve -nsu -B -e -DskipTests -DskipExamples $MVN_PROFILES $MVN_HTTP_CONFIG
 
     - id: compress-keycloak-maven-repository
       name: Compress Keycloak Maven artifacts

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,6 @@
         <dom4j.version>2.1.3</dom4j.version>
         <h2.version>2.1.214</h2.version>
         <jakarta.persistence.version>2.2.3</jakarta.persistence.version>
-        <jakarta.servlet.jakarta-servlet-api.version>6.0.0</jakarta.servlet.jakarta-servlet-api.version>
         <hibernate-orm.version>6.2.0.Final</hibernate-orm.version>
         <hibernate.c3p0.version>${hibernate-orm.version}</hibernate.c3p0.version>
         <infinispan.version>14.0.7.Final</infinispan.version>
@@ -635,11 +634,6 @@
                 <groupId>jakarta.persistence</groupId>
                 <artifactId>jakarta.persistence-api</artifactId>
                 <version>${jakarta.persistence.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>jakarta.servlet</groupId>
-                <artifactId>jakarta.servlet-api</artifactId>
-                <version>${jakarta.servlet.jakarta-servlet-api.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.h2database</groupId>
@@ -2154,6 +2148,18 @@
             <id>distribution</id>
             <modules>
                 <module>distribution</module>
+            </modules>
+        </profile>
+
+        <!-- Remove once https://github.com/keycloak/keycloak/issues/19299 is solved -->
+        <profile>
+            <id>build-wildfly-adapters</id>
+            <modules>
+                <module>distribution/licenses-common</module>
+                <module>distribution/maven-plugins/licenses-processor</module>
+                <module>distribution/feature-packs/adapter-feature-pack</module>
+                <module>distribution/adapters/wildfly-adapter</module>
+                <module>distribution/saml-adapters/wildfly-adapter</module>
             </modules>
         </profile>
 

--- a/testsuite/integration-arquillian/servers/app-server/jboss/pom.xml
+++ b/testsuite/integration-arquillian/servers/app-server/jboss/pom.xml
@@ -70,6 +70,13 @@
                     <exists>src</exists>
                 </file>
             </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.keycloak</groupId>
+                    <artifactId>${app.server.oidc.adapter.artifactId}</artifactId>
+                    <version>${oidc-adapter.version}</version>
+                </dependency>
+            </dependencies>
             <build>
                 <plugins>
 


### PR DESCRIPTION
Remove once https://github.com/keycloak/keycloak/issues/19299 is solved

@vmuzikar We've encountered an issue in the pipeline, and we need this for proper building WildFly adapters used for `app-server-wildfly`. Could you please merge it, after reviewing it, in order to include it in the proposed PR(https://github.com/keycloak/keycloak/pull/19919)? Thanks