### PR TITLE
Update building.md

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -1,6 +1,6 @@
 ## Building from source
 
-Ensure you have JDK 11 (or newer), Maven 3.5.4 (or newer) and Git installed
+Ensure you have JDK 11 (or newer), Maven 3.6.3 (or newer) and Git installed
 
     java -version
     mvn -version


### PR DESCRIPTION
build project fail, error:

Failed to execute goal com.github.eirslett:frontend-maven-plugin:1.12.1:install-node-and-npm (default) on project keycloak-js-adapter-jar: The plugin com.github.eirslett:frontend-maven-plugin:1.12.1 requires Maven version 3.6.0 -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal com.github.eirslett:frontend-maven-plugin:1.12.1:install-node-and-npm (default) on project keycloak-js-adapter-jar: The plugin com.github.eirslett:frontend-maven-plugin:1.12.1 requires Maven version 3.6.0

Looks like the maven version must  >= 3.6.0

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
