### PR TITLE
Ignore HibernateOrmProcessor logs related to persistence.xml

### DIFF
--- a/quarkus/runtime/src/main/resources/application.properties
+++ b/quarkus/runtime/src/main/resources/application.properties
@@ -41,6 +41,7 @@ quarkus.http.non-application-root-path=/${quarkus.http.root-path}
 
 # Disable specific categories from logs
 quarkus.log.category."io.quarkus.config".level=off
+quarkus.log.category."io.quarkus.hibernate.orm.deployment.HibernateOrmProcessor".level=warn
 
 # Set default directory name for the location of the transaction logs
 quarkus.transaction-manager.object-store-directory=${kc.home.dir:default}${file.separator}data${file.separator}transaction-logs


### PR DESCRIPTION
Closes #19995

@pedroigor @vmuzikar Could you please check it? 

When the server starts, these mentioned logs are not part of the log anymore. 