### PR TITLE
Update auth.ts

### DIFF
--- a/js/libs/keycloak-admin-client/src/utils/auth.ts
+++ b/js/libs/keycloak-admin-client/src/utils/auth.ts
@@ -79,7 +79,7 @@ export const getToken = async (settings: Settings): Promise<TokenResponse> => {
   if (credentials.clientSecret) {
     headers.set(
       "Authorization",
-      atob(credentials.clientId + ":" + credentials.clientSecret)
+      "Basic " + btoa(credentials.clientId + ":" + credentials.clientSecret)
     );
   }
 

--- a/js/libs/keycloak-admin-client/src/utils/auth.ts
+++ b/js/libs/keycloak-admin-client/src/utils/auth.ts
@@ -77,8 +77,7 @@ export const getToken = async (settings: Settings): Promise<TokenResponse> => {
   const headers = new Headers(options.headers);
 
   if (credentials.clientSecret) {
-    const authHeaderValue = `Basic ${btoa(`${credentials.clientId}:${credentials.clientSecret}`)}`;
-    headers.set("Authorization", authHeaderValue);
+    headers.set("Authorization", `Basic ${btoa(`${credentials.clientId}:${credentials.clientSecret}`)}`);
   }
 
   headers.set("content-type", "application/x-www-form-urlencoded");

--- a/js/libs/keycloak-admin-client/src/utils/auth.ts
+++ b/js/libs/keycloak-admin-client/src/utils/auth.ts
@@ -77,7 +77,10 @@ export const getToken = async (settings: Settings): Promise<TokenResponse> => {
   const headers = new Headers(options.headers);
 
   if (credentials.clientSecret) {
-    headers.set("Authorization", `Basic ${btoa(`${credentials.clientId}:${credentials.clientSecret}`)}`);
+    headers.set(
+      "Authorization",
+      `Basic ${btoa(`${credentials.clientId}:${credentials.clientSecret}`)}`
+    );
   }
 
   headers.set("content-type", "application/x-www-form-urlencoded");

--- a/js/libs/keycloak-admin-client/src/utils/auth.ts
+++ b/js/libs/keycloak-admin-client/src/utils/auth.ts
@@ -77,10 +77,8 @@ export const getToken = async (settings: Settings): Promise<TokenResponse> => {
   const headers = new Headers(options.headers);
 
   if (credentials.clientSecret) {
-    headers.set(
-      "Authorization",
-      "Basic " + btoa(credentials.clientId + ":" + credentials.clientSecret)
-    );
+    const authHeaderValue = `Basic ${btoa(`${credentials.clientId}:${credentials.clientSecret}`)}`;
+    headers.set("Authorization", authHeaderValue);
   }
 
   headers.set("content-type", "application/x-www-form-urlencoded");


### PR DESCRIPTION
Correct getToken error

This fix a regression on migration from Axios To FetchAPI Credential header must be encoded not decoded.

This fix #19879

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
