### PR TITLE
Built-in support for Jakarta Servlet

### DIFF
--- a/authz/policy-enforcer/src/main/java/org/keycloak/adapters/authorization/integration/elytron/ElytronPolicyEnforcerFilter.java
+++ b/authz/policy-enforcer/src/main/java/org/keycloak/adapters/authorization/integration/elytron/ElytronPolicyEnforcerFilter.java
@@ -1,0 +1,53 @@
+package org.keycloak.adapters.authorization.integration.elytron;
+
+import java.security.Principal;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.keycloak.adapters.authorization.PolicyEnforcer;
+import org.keycloak.adapters.authorization.integration.jakarta.ServletPolicyEnforcerFilter;
+import org.keycloak.adapters.authorization.spi.ConfigurationResolver;
+import org.keycloak.representations.adapters.config.PolicyEnforcerConfig;
+import org.wildfly.security.http.oidc.OidcClientConfiguration;
+import org.wildfly.security.http.oidc.OidcPrincipal;
+import org.wildfly.security.http.oidc.RefreshableOidcSecurityContext;
+
+public class ElytronPolicyEnforcerFilter extends ServletPolicyEnforcerFilter {
+
+    public ElytronPolicyEnforcerFilter(ConfigurationResolver configResolver) {
+        super(configResolver);
+    }
+
+    @Override
+    protected String extractBearerToken(HttpServletRequest request) {
+        Principal principal = request.getUserPrincipal();
+
+        if (principal == null) {
+            return null;
+        }
+
+        OidcPrincipal oidcPrincipal = (OidcPrincipal) principal;
+        RefreshableOidcSecurityContext securityContext = (RefreshableOidcSecurityContext) oidcPrincipal.getOidcSecurityContext();
+
+        if (securityContext == null) {
+            return null;
+        }
+
+        return securityContext.getTokenString();
+    }
+
+    @Override
+    protected PolicyEnforcer createPolicyEnforcer(HttpServletRequest servletRequest, PolicyEnforcerConfig enforcerConfig) {
+        RefreshableOidcSecurityContext securityContext = (RefreshableOidcSecurityContext) ((OidcPrincipal) servletRequest.getUserPrincipal()).getOidcSecurityContext();
+        OidcClientConfiguration configuration = securityContext.getOidcClientConfiguration();
+        String authServerUrl = configuration.getAuthServerBaseUrl();
+
+        return PolicyEnforcer.builder()
+                .authServerUrl(authServerUrl)
+                .realm(configuration.getRealm())
+                .clientId(configuration.getClientId())
+                .credentials(configuration.getResourceCredentials())
+                .bearerOnly(false)
+                .enforcerConfig(enforcerConfig)
+                .httpClient(configuration.getClient()).build();
+    }
+}

--- a/authz/policy-enforcer/src/main/java/org/keycloak/adapters/authorization/integration/elytron/PolicyEnforcerServletContextListener.java
+++ b/authz/policy-enforcer/src/main/java/org/keycloak/adapters/authorization/integration/elytron/PolicyEnforcerServletContextListener.java
@@ -66,7 +66,7 @@ public class PolicyEnforcerServletContextListener implements ServletContextListe
 
         logger.debug("Policy enforcement filter is enabled.");
 
-        servletContext.addFilter("keycloak-policy-enforcer", new PolicyEnforcerFilter(configResolver))
+        servletContext.addFilter("keycloak-policy-enforcer", new ElytronPolicyEnforcerFilter(configResolver))
                 .addMappingForUrlPatterns(EnumSet.of(DispatcherType.REQUEST), false, "/*");
     }
 

--- a/authz/policy-enforcer/src/main/java/org/keycloak/adapters/authorization/integration/elytron/ServletHttpRequest.java
+++ b/authz/policy-enforcer/src/main/java/org/keycloak/adapters/authorization/integration/elytron/ServletHttpRequest.java
@@ -45,7 +45,15 @@ public class ServletHttpRequest implements HttpRequest {
 
     @Override
     public String getRelativePath() {
-        return request.getServletPath();
+        String uri = request.getRequestURI();
+        String contextPath = request.getContextPath();
+        String servletPath = uri.substring(uri.indexOf(contextPath) + contextPath.length());
+
+        if ("".equals(servletPath)) {
+            servletPath = "/";
+        }
+
+        return servletPath;
     }
 
     @Override


### PR DESCRIPTION
* Making the policy enforcer generic enough for Jakarta Servlet applications
* Elytron OIDC implementation based on the Jakarta policy enforcer

These changes are needed to properly integrate with Spring when the underlying container is Jakarta-based.