### PR TITLE
Cannot find @Generated annotation for ServicesLogger

### DIFF
--- a/services/pom.xml
+++ b/services/pom.xml
@@ -140,6 +140,10 @@
             <artifactId>jackson-annotations</artifactId>
         </dependency>
         <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jdk8</artifactId>
         </dependency>


### PR DESCRIPTION
Fixes #20020

That dependency was always present as a transitive one, and after the upgrade to JakartaEE, it's no longer present in the project. It's needed because the `jboss-logging-processor` support JavaEE, and there's no updated version with JakartaEE support. 

@pskopek @miquelsi Could you please check it? Thanks