### PR TITLE
Fix connection-pool-size 0 being ignored and being unable to disable the connection pool

### DIFF
--- a/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/HttpClientBuilder.java
+++ b/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/HttpClientBuilder.java
@@ -427,13 +427,11 @@ public class HttpClientBuilder {
                 throw new RuntimeException("Failed to load keystore", e);
             }
         }
-        int size = 10;
-        if (adapterConfig.getConnectionPoolSize() > 0)
-            size = adapterConfig.getConnectionPoolSize();
+
         HttpClientBuilder.HostnameVerificationPolicy policy = HttpClientBuilder.HostnameVerificationPolicy.WILDCARD;
         if (adapterConfig.isAllowAnyHostname())
             policy = HttpClientBuilder.HostnameVerificationPolicy.ANY;
-        connectionPoolSize(size);
+        connectionPoolSize(adapterConfig.getConnectionPoolSize());
         hostnameVerification(policy);
         if (adapterConfig.isDisableTrustManager()) {
             disableTrustManager();

--- a/adapters/saml/core/src/main/java/org/keycloak/adapters/cloned/HttpClientBuilder.java
+++ b/adapters/saml/core/src/main/java/org/keycloak/adapters/cloned/HttpClientBuilder.java
@@ -359,13 +359,11 @@ public class HttpClientBuilder {
                 throw new RuntimeException("Failed to load keystore", e);
             }
         }
-        int size = 10;
-        if (adapterConfig.getConnectionPoolSize() > 0)
-            size = adapterConfig.getConnectionPoolSize();
+
         HttpClientBuilder.HostnameVerificationPolicy policy = HttpClientBuilder.HostnameVerificationPolicy.WILDCARD;
         if (adapterConfig.isAllowAnyHostname())
             policy = HttpClientBuilder.HostnameVerificationPolicy.ANY;
-        connectionPoolSize(size);
+        connectionPoolSize(adapterConfig.getConnectionPoolSize());
         hostnameVerification(policy);
         if (adapterConfig.isDisableTrustManager()) {
             disableTrustManager();


### PR DESCRIPTION
We want to disable connection pooling due to network issues causing long living connections to break down.

We have tried tuning the connection TTL and timeout but we still keep getting broken connection, eventually causing the  pool to have corrupt connections and requests to fail with 'java.net.SocketException: Connection reset' (and users therefor failing to refresh their token and be logged out).

There is support for disabling the apache HTTP client pool by setting the size to 0:

https://github.com/keycloak/keycloak/blob/main/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/HttpClientBuilder.java#L307

Unfortunately when we actually change the size to zero, it internally defaults back to 10:
https://github.com/keycloak/keycloak/blob/main/adapters/oidc/adapter-core/src/main/java/org/keycloak/adapters/HttpClientBuilder.java#L431
I want to delete this arbitrary(?) if-statement and therefore allow the pool to be disabled again.

For context: we currently use keycloak-adapter-core-19.0.3.jar in our java project to talk to a hosted keycloak instance.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
