### PR TITLE
Extended user attribute checks to the joined groups

### DIFF
--- a/docs/documentation/server_admin/topics/authentication/conditions.adoc
+++ b/docs/documentation/server_admin/topics/authentication/conditions.adoc
@@ -24,7 +24,7 @@ This checks if the other executions in the flow are configured for the user.
 The Execution requirements section includes an example of the OTP form.
 
 `Condition - User Attribute`::
-This checks if the user has set up the required attribute.
+This checks if the user or any of the joined groups have set up the required attribute.
 There is a possibility to negate output, which means the user should not have the attribute.
 The xref:proc-configuring-user-attributes_{context}[User Attributes] section shows how to add a custom attribute.
 You can provide these fields:

--- a/services/src/main/java/org/keycloak/authentication/authenticators/conditional/ConditionalUserAttributeValue.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/conditional/ConditionalUserAttributeValue.java
@@ -45,6 +45,9 @@ public class ConditionalUserAttributeValue implements ConditionalAuthenticator {
         }
 
         boolean result = user.getAttributeStream(attributeName).anyMatch(attr -> Objects.equals(attr, attributeValue));
+        if (!result) {
+            result = user.getGroupsStream().anyMatch(group -> group.getAttributeStream(attributeName).anyMatch(attr -> Objects.equals(attr, attributeValue)));
+        }
         return negateOutput != result;
     }
 


### PR DESCRIPTION
Extends the conditional user attribute authenticator to check the attributes of the joined groups.
Also includes a small change to the documentation to clarify this behavior.

Closes #20007 

