### PR TITLE
Fix deserialization issue for Tokens when custom claims added to 'address' property

### DIFF
--- a/core/src/main/java/org/keycloak/representations/AddressClaimSet.java
+++ b/core/src/main/java/org/keycloak/representations/AddressClaimSet.java
@@ -17,7 +17,12 @@
 
 package org.keycloak.representations;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
 * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -48,6 +53,25 @@ public class AddressClaimSet {
 
     @JsonProperty(COUNTRY)
     protected String country;
+
+    protected Map<String, Object> otherClaims = new HashMap<>();
+
+    /**
+     * This is a map of any other claims and data that might be set in the address claim.
+     * Generally these are custom claims set up by the auth server
+     *
+     * @return otherClaims
+     */
+    @JsonAnyGetter
+    public Map<String, Object> getOtherClaims() {
+        return otherClaims;
+    }
+
+    @JsonAnySetter
+    public void setOtherClaims(String name, Object value) {
+        otherClaims.put(name, value);
+    }
+
 
     public String getFormattedAddress() {
         return this.formattedAddress;


### PR DESCRIPTION
Fix deserialization issue for Tokens when custom claims added to 'address' property

Followed the approach used in the JsonWebToken class for 'otherClaims' and applied that to the AddressClaimSet class This should be a catch-all for any custom claims mapped under the 'address' property.

Closes keycloak/keycloak#19808
