### PR TITLE
Use parent versions of WildFly for Galleon Feature Pack

### DIFF
--- a/distribution/galleon-feature-packs/saml-adapter-galleon-pack/pom.xml
+++ b/distribution/galleon-feature-packs/saml-adapter-galleon-pack/pom.xml
@@ -31,12 +31,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <wildfly.version>27.0.0.Final</wildfly.version>
-        <wildfly.build-tools.version>1.2.13.Final</wildfly.build-tools.version>
-        <wildfly.core.version>19.0.0.Final</wildfly.core.version>
-
         <feature-pack.resources.directory>${basedir}/../../saml-adapters/wildfly-adapter/wildfly-jakarta-modules/src/main/resources</feature-pack.resources.directory>
-        <version.org.wildfly.galleon-plugins>6.4.0.Final</version.org.wildfly.galleon-plugins>
         <xmlFileSource>${basedir}/src/main/resources/licenses/keycloak/licenses.xml</xmlFileSource>
         <outputDirectory>${basedir}/target/resources/packages/licenses/content/docs/licenses-keycloak</outputDirectory>
     </properties>
@@ -221,24 +216,6 @@
             <plugin>
                 <groupId>org.wildfly.galleon-plugins</groupId>
                 <artifactId>wildfly-galleon-maven-plugin</artifactId>
-                <version>${version.org.wildfly.galleon-plugins}</version>
-                <dependencies>
-                    <!--
-                        feature-spec-gen uses wildfly-embedded to generate the feature specs, hence the designated
-                        wildfly-embedded version must match the pack one
-                    -->
-                    <dependency>
-                        <groupId>org.wildfly.core</groupId>
-                        <artifactId>wildfly-embedded</artifactId>
-                        <version>${wildfly.core.version}</version>
-                    </dependency>
-                    <!-- If you add a dependency on wildfly-embedded you need to bring your own transitives -->
-                    <dependency>
-                        <groupId>org.wildfly.common</groupId>
-                        <artifactId>wildfly-common</artifactId>
-                        <version>${wildfly.common.version}</version>
-                    </dependency>
-                </dependencies>
                 <executions>
                     <execution>
                         <id>keycloak-saml-adapter-galleon-pack-build</id>
@@ -249,7 +226,7 @@
                         <configuration>
                             <wildfly-channel-resolution-mode>REQUIRED</wildfly-channel-resolution-mode>
                             <generate-channel-manifest>true</generate-channel-manifest>
-                     git        <add-feature-packs-as-required-manifests>false</add-feature-packs-as-required-manifests>
+                            <add-feature-packs-as-required-manifests>false</add-feature-packs-as-required-manifests>
                             <fork-embedded>false</fork-embedded>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -224,7 +224,7 @@
         <org.apache.kerby.kerby-asn1.version>2.0.3</org.apache.kerby.kerby-asn1.version>
 
         <!-- WildFly Galleon Build related properties -->
-        <org.wildfly.galleon-plugins.version>5.2.7.Final</org.wildfly.galleon-plugins.version>
+        <org.wildfly.galleon-plugins.version>6.4.0.Final</org.wildfly.galleon-plugins.version>
         <org.jboss.galleon.version>4.2.8.Final</org.jboss.galleon.version>
 
         <!-- Galleon -->


### PR DESCRIPTION
@pskopek Do we need to have explicitly specified WildFly versions? We can use already fixed global versions of deps/plugins, right?

I've encountered it during solving possible issues with the `saml-adapter-galleon-pack` in the build pipeline.