### PR TITLE
Remove latest vs. archive document header

### DIFF
--- a/docs/documentation/.asciidoctorconfig
+++ b/docs/documentation/.asciidoctorconfig
@@ -1,6 +1,5 @@
 :icons: font
 :idprefix:
 :idseparator: -
-:project_buildType: latest
 ifndef::asciidoctorconfigdir[:asciidoctorconfigdir: .]
 include::{asciidoctorconfigdir}/topics/templates/document-attributes.adoc[]

--- a/docs/documentation/aggregation/navbar-head.html
+++ b/docs/documentation/aggregation/navbar-head.html
@@ -67,41 +67,11 @@
            padding: 7px;
        }
 
-       .versionarchive {
-           display: inline-block;
-       }
+        div.top-menu-version p {
+            margin: 0;
+            padding: 2px 5px 2px 10px;
+        }
 
-       .versionarchive p {
-           margin: 0;
-           padding: 2px 5px 2px 10px;
-       }
-
-       .versionarchive a {
-           background-color: #ffdd57;
-           padding: 0 5px;
-           font-style: normal;
-           border-radius: 5px;
-           margin-left: 10px;
-       }
-
-       .versionlatest {
-           display: inline-block;
-       }
-
-       .versionlatest p {
-           background-color: #eee;
-           border-radius: 5px;
-           margin: 0;
-           padding: 2px 5px 2px 10px;
-       }
-
-       .versionlatest em {
-           background-color: #23d160;
-           padding: 0 5px;
-           font-style: normal;
-           border-radius: 5px;
-           margin-left: 10px;
-       }
 }
 
 /* TOC */

--- a/docs/documentation/pom.xml
+++ b/docs/documentation/pom.xml
@@ -32,8 +32,6 @@
 
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
-
-        <buildType>archive</buildType>
     </properties>
 
     <modules>
@@ -60,17 +58,6 @@
             <modules>
                 <module>tests</module>
             </modules>
-        </profile>
-        <profile>
-            <id>latest</id>
-            <activation>
-                <property>
-                    <name>latest</name>
-                </property>
-            </activation>
-            <properties>
-                <buildType>latest</buildType>
-            </properties>
         </profile>
     </profiles>
 
@@ -169,7 +156,6 @@
                                     <idseparator>-</idseparator>
                                     <docinfo1>true</docinfo1>
                                     <masterFile>${masterFile}</masterFile>
-                                    <project_buildType>${buildType}</project_buildType>
                                 </attributes>
                                 <resources>
                                     <resource>

--- a/docs/documentation/tests/src/test/java/org/keycloak/documentation/test/Config.java
+++ b/docs/documentation/tests/src/test/java/org/keycloak/documentation/test/Config.java
@@ -139,7 +139,7 @@ public class Config {
 
             Map<String, Object> options = OptionsBuilder.options()
                     .inPlace(true)
-                    .attributes(AttributesBuilder.attributes().backend("html5").attribute("project_buildType", buildType).asMap())
+                    .attributes(AttributesBuilder.attributes().backend("html5").asMap())
                     .asMap();
 
             Document document = asciidoctor.loadFile(f, options);

--- a/docs/documentation/topics/templates/document-attributes.adoc
+++ b/docs/documentation/topics/templates/document-attributes.adoc
@@ -11,15 +11,8 @@
 :api-management!:
 :on-prem:
 
-ifeval::["{project_buildType}" == "latest"]
-:project_versionLinks: latest
-endif::[]
-ifeval::["{project_buildType}" == "archive"]
-:project_versionLinks: {project_version}
-endif::[]
-
 :project_images: keycloak-images
-:project_doc_base_url: https://www.keycloak.org/docs/{project_versionLinks}
+:project_doc_base_url: https://www.keycloak.org/docs/{project_version}
 :project_doc_base_url_latest: https://www.keycloak.org/docs/latest
 :project_dirref: KEYCLOAK_HOME
 :project_openshift_product_name: Keycloak for OpenShift

--- a/docs/documentation/topics/templates/release-header.adoc
+++ b/docs/documentation/topics/templates/release-header.adoc
@@ -27,12 +27,5 @@ endif::[]
 
 [.top-menu-version]
 ====
-ifeval::["{project_buildType}" == "latest"]
-[.versionlatest]
-Version *{project_version}* _Latest_
-endif::[]
-ifeval::["{project_buildType}" == "archive"]
-[.versionarchive]
-Version *{project_version}* _{release_header_latest_link}[Click here for latest]_
-endif::[]
+Version *{project_version}*
 ====


### PR DESCRIPTION
This is done as the docs are no longer built twice.

Closes #19974

This is the backport of PR #20103

(cherry picked from commit 75ea22bad27c7bb9ed337074d60c05ac9e8e9c35)

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
